### PR TITLE
refactor: reduce structural hotspots — split barrels, extract modules, auto-generate registry

### DIFF
--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -313,7 +313,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 57900,
+      "value": 58027,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",
@@ -322,7 +322,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 269,
+      "value": 271,
       "violationIds": []
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "docs:build": "pnpm --filter docs build",
     "docs:preview": "pnpm --filter docs preview",
     "generate-docs": "node scripts/generate-docs.mjs",
+    "generate-barrel-exports": "node scripts/generate-barrel-exports.mjs",
     "changeset": "changeset",
     "version": "changeset version",
     "release": "pnpm build && changeset publish",

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -1,0 +1,109 @@
+// AUTO-GENERATED — do not edit. Run `pnpm run generate-barrel-exports` to regenerate.
+
+import type { Command } from 'commander';
+
+import { createAddCommand } from './add';
+import { createAgentCommand } from './agent';
+import { createBlueprintCommand } from './blueprint';
+import { createCheckArchCommand } from './check-arch';
+import { createCheckDepsCommand } from './check-deps';
+import { createCheckDocsCommand } from './check-docs';
+import { createCheckPerfCommand } from './check-perf';
+import { createCheckPhaseGateCommand } from './check-phase-gate';
+import { createCheckSecurityCommand } from './check-security';
+import { createCICommand } from './ci';
+import { createCleanupCommand } from './cleanup';
+import { createCreateSkillCommand } from './create-skill';
+import { createDoctorCommand } from './doctor';
+import { createFixDriftCommand } from './fix-drift';
+import { createGenerateAgentDefinitionsCommand } from './generate-agent-definitions';
+import { createGenerateCommand } from './generate';
+import { createGenerateSlashCommandsCommand } from './generate-slash-commands';
+import { createGraphCommand } from './graph';
+import { createHooksCommand } from './hooks';
+import { createImpactPreviewCommand } from './impact-preview';
+import { createIngestCommand } from './graph/ingest';
+import { createInitCommand } from './init';
+import { createInstallCommand } from './install';
+import { createInstallConstraintsCommand } from './install-constraints';
+import { createIntegrationsCommand } from './integrations';
+import { createLearningsCommand } from './learnings';
+import { createLinterCommand } from './linter';
+import { createMcpCommand } from './mcp';
+import { createOrchestratorCommand } from './orchestrator';
+import { createPerfCommand } from './perf';
+import { createPersonaCommand } from './persona';
+import { createPredictCommand } from './predict';
+import { createQueryCommand } from './graph/query';
+import { createRecommendCommand } from './recommend';
+import { createScanCommand } from './graph/scan';
+import { createScanConfigCommand } from './scan-config';
+import { createSetupCommand } from './setup';
+import { createSetupMcpCommand } from './setup-mcp';
+import { createShareCommand } from './share';
+import { createSkillCommand } from './skill';
+import { createSnapshotCommand } from './snapshot';
+import { createStateCommand } from './state';
+import { createTaintCommand } from './taint';
+import { createTraceabilityCommand } from './traceability';
+import { createUninstallCommand } from './uninstall';
+import { createUninstallConstraintsCommand } from './uninstall-constraints';
+import { createUpdateCommand } from './update';
+import { createUsageCommand } from './usage';
+import { createValidateCommand } from './validate';
+
+/**
+ * All discovered command creators, sorted alphabetically.
+ * Used by createProgram() to register commands without manual imports.
+ */
+export const commandCreators: Array<() => Command> = [
+  createAddCommand,
+  createAgentCommand,
+  createBlueprintCommand,
+  createCheckArchCommand,
+  createCheckDepsCommand,
+  createCheckDocsCommand,
+  createCheckPerfCommand,
+  createCheckPhaseGateCommand,
+  createCheckSecurityCommand,
+  createCICommand,
+  createCleanupCommand,
+  createCreateSkillCommand,
+  createDoctorCommand,
+  createFixDriftCommand,
+  createGenerateAgentDefinitionsCommand,
+  createGenerateCommand,
+  createGenerateSlashCommandsCommand,
+  createGraphCommand,
+  createHooksCommand,
+  createImpactPreviewCommand,
+  createIngestCommand,
+  createInitCommand,
+  createInstallCommand,
+  createInstallConstraintsCommand,
+  createIntegrationsCommand,
+  createLearningsCommand,
+  createLinterCommand,
+  createMcpCommand,
+  createOrchestratorCommand,
+  createPerfCommand,
+  createPersonaCommand,
+  createPredictCommand,
+  createQueryCommand,
+  createRecommendCommand,
+  createScanCommand,
+  createScanConfigCommand,
+  createSetupCommand,
+  createSetupMcpCommand,
+  createShareCommand,
+  createSkillCommand,
+  createSnapshotCommand,
+  createStateCommand,
+  createTaintCommand,
+  createTraceabilityCommand,
+  createUninstallCommand,
+  createUninstallConstraintsCommand,
+  createUpdateCommand,
+  createUsageCommand,
+  createValidateCommand,
+];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,57 +10,14 @@
 
 import { Command } from 'commander';
 import { CLI_VERSION } from './version';
-import { createValidateCommand } from './commands/validate';
-import { createCheckDepsCommand } from './commands/check-deps';
-import { createCheckPerfCommand } from './commands/check-perf';
-import { createCheckSecurityCommand } from './commands/check-security';
-import { createPerfCommand } from './commands/perf';
-import { createCheckDocsCommand } from './commands/check-docs';
-import { createInitCommand } from './commands/init';
-import { createCleanupCommand } from './commands/cleanup';
-import { createFixDriftCommand } from './commands/fix-drift';
-import { createAgentCommand } from './commands/agent';
-import { createAddCommand } from './commands/add';
-import { createLinterCommand } from './commands/linter';
-import { createPersonaCommand } from './commands/persona';
-import { createSkillCommand } from './commands/skill';
-import { createStateCommand } from './commands/state';
-import { createCheckPhaseGateCommand } from './commands/check-phase-gate';
-import { createCreateSkillCommand } from './commands/create-skill';
-import { createSetupMcpCommand } from './commands/setup-mcp';
-import { createSetupCommand } from './commands/setup';
-import { createDoctorCommand } from './commands/doctor';
-import { createGenerateSlashCommandsCommand } from './commands/generate-slash-commands';
-import { createCICommand } from './commands/ci';
-import { createHooksCommand } from './commands/hooks';
-import { createUpdateCommand } from './commands/update';
-import { createGenerateAgentDefinitionsCommand } from './commands/generate-agent-definitions';
-import { createGenerateCommand } from './commands/generate';
-import { createScanCommand } from './commands/graph/scan';
-import { createIngestCommand } from './commands/graph/ingest';
-import { createQueryCommand } from './commands/graph/query';
-import { createGraphCommand } from './commands/graph/index';
-import { createMcpCommand } from './commands/mcp';
-import { createImpactPreviewCommand } from './commands/impact-preview';
-import { createCheckArchCommand } from './commands/check-arch';
-import { createBlueprintCommand } from './commands/blueprint';
-import { createShareCommand } from './commands/share';
-import { createInstallCommand } from './commands/install';
-import { createInstallConstraintsCommand } from './commands/install-constraints';
-import { createUninstallConstraintsCommand } from './commands/uninstall-constraints';
-import { createUninstallCommand } from './commands/uninstall';
-import { createOrchestratorCommand } from './commands/orchestrator';
-import { createLearningsCommand } from './commands/learnings';
-import { createIntegrationsCommand } from './commands/integrations/index';
-import { createUsageCommand } from './commands/usage';
-import { createTaintCommand } from './commands/taint';
-import { createScanConfigCommand } from './commands/scan-config';
-import { createSnapshotCommand } from './commands/snapshot';
-import { createPredictCommand } from './commands/predict';
-import { createRecommendCommand } from './commands/recommend';
+import { commandCreators } from './commands/_registry';
 
 /**
  * Creates and configures the main Harness CLI program.
+ *
+ * Commands are auto-discovered from the commands/ directory via _registry.ts.
+ * To add a new command: create it in commands/, export a createXXXCommand()
+ * function, then run `pnpm run generate-barrel-exports` to regenerate the registry.
  *
  * @returns A Commander instance with all subcommands registered.
  */
@@ -76,55 +33,10 @@ export function createProgram(): Command {
     .option('--verbose', 'Verbose output')
     .option('--quiet', 'Minimal output');
 
-  // Register commands
-  program.addCommand(createValidateCommand());
-  program.addCommand(createCheckDepsCommand());
-  program.addCommand(createCheckDocsCommand());
-  program.addCommand(createCheckPerfCommand());
-  program.addCommand(createCheckSecurityCommand());
-  program.addCommand(createPerfCommand());
-  program.addCommand(createInitCommand());
-  program.addCommand(createCleanupCommand());
-  program.addCommand(createFixDriftCommand());
-  program.addCommand(createAgentCommand());
-  program.addCommand(createAddCommand());
-  program.addCommand(createLinterCommand());
-  program.addCommand(createPersonaCommand());
-  program.addCommand(createSkillCommand());
-  program.addCommand(createStateCommand());
-  program.addCommand(createLearningsCommand());
-  program.addCommand(createCheckPhaseGateCommand());
-  program.addCommand(createCreateSkillCommand());
-  program.addCommand(createSetupMcpCommand());
-  program.addCommand(createSetupCommand());
-  program.addCommand(createDoctorCommand());
-  program.addCommand(createGenerateSlashCommandsCommand());
-  program.addCommand(createGenerateAgentDefinitionsCommand());
-  program.addCommand(createGenerateCommand());
-  program.addCommand(createCICommand());
-  program.addCommand(createHooksCommand());
-  program.addCommand(createUpdateCommand());
-  program.addCommand(createScanCommand());
-  program.addCommand(createIngestCommand());
-  program.addCommand(createQueryCommand());
-  program.addCommand(createGraphCommand());
-  program.addCommand(createMcpCommand());
-  program.addCommand(createImpactPreviewCommand());
-  program.addCommand(createCheckArchCommand());
-  program.addCommand(createBlueprintCommand());
-  program.addCommand(createShareCommand());
-  program.addCommand(createInstallCommand());
-  program.addCommand(createInstallConstraintsCommand());
-  program.addCommand(createUninstallConstraintsCommand());
-  program.addCommand(createUninstallCommand());
-  program.addCommand(createOrchestratorCommand());
-  program.addCommand(createIntegrationsCommand());
-  program.addCommand(createUsageCommand());
-  program.addCommand(createTaintCommand());
-  program.addCommand(createScanConfigCommand());
-  program.addCommand(createSnapshotCommand());
-  program.addCommand(createPredictCommand());
-  program.addCommand(createRecommendCommand());
+  // Register all discovered commands
+  for (const creator of commandCreators) {
+    program.addCommand(creator());
+  }
 
   return program;
 }

--- a/packages/core/src/roadmap/sync-engine.ts
+++ b/packages/core/src/roadmap/sync-engine.ts
@@ -12,6 +12,9 @@ import { serializeRoadmap } from './serialize';
 import type { TrackerSyncAdapter, ExternalSyncOptions } from './tracker-sync';
 import { resolveReverseStatus } from './tracker-sync';
 import { isRegression } from './status-rank';
+// Known adapters: adapters/github-issues.ts (GitHubIssuesSyncAdapter).
+// This module consumes adapters via the TrackerSyncAdapter interface.
+// Changes to the interface contract require updating both this file and all adapters.
 
 function emptySyncResult(): SyncResult {
   return { created: [], updated: [], assignmentChanges: [], errors: [] };

--- a/packages/core/src/state/events.ts
+++ b/packages/core/src/state/events.ts
@@ -6,7 +6,7 @@ import type { Result } from '../shared/result';
 import { Ok, Err } from '../shared/result';
 import { getStateDir } from './state-shared';
 import { EVENTS_FILE } from './constants';
-import { computeContentHash } from './learnings';
+import { computeContentHash } from './learnings-content';
 
 /** Event types emitted at skill lifecycle points. */
 export type EventType =

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -21,31 +21,43 @@ export type { HarnessState, FailureEntry, Handoff, GateResult, GateConfig } from
 export { loadState, saveState } from './state-persistence';
 
 /**
- * Learning accumulation and retrieval.
+ * Learning content parsing and deduplication.
  */
 export {
-  clearLearningsCache,
-  appendLearning,
-  loadRelevantLearnings,
-  loadBudgetedLearnings,
+  parseFrontmatter,
+  extractIndexEntry,
   parseDateFromEntry,
+  normalizeLearningContent,
+  computeContentHash,
   analyzeLearningPatterns,
+} from './learnings-content';
+export type {
+  LearningsFrontmatter,
+  LearningsIndexEntry,
+  LearningPattern,
+} from './learnings-content';
+
+/**
+ * Learning file loader with mtime-based cache.
+ */
+export { clearLearningsCache, loadRelevantLearnings } from './learnings-loader';
+
+/**
+ * Learning CRUD operations: append, load index, budgeted retrieval.
+ */
+export { appendLearning, loadBudgetedLearnings, loadIndexEntries } from './learnings';
+export type { BudgetedLearningsOptions } from './learnings';
+
+/**
+ * Learning lifecycle: archival, pruning, session promotion.
+ */
+export {
   archiveLearnings,
   pruneLearnings,
   promoteSessionLearnings,
   countLearningEntries,
-  parseFrontmatter,
-  extractIndexEntry,
-  loadIndexEntries,
-} from './learnings';
-export type {
-  BudgetedLearningsOptions,
-  LearningPattern,
-  PruneResult,
-  PromoteResult,
-  LearningsFrontmatter,
-  LearningsIndexEntry,
-} from './learnings';
+} from './learnings-lifecycle';
+export type { PruneResult, PromoteResult } from './learnings-lifecycle';
 
 /**
  * Failure tracking, loading, and archival.

--- a/packages/core/src/state/learnings-content.ts
+++ b/packages/core/src/state/learnings-content.ts
@@ -1,0 +1,225 @@
+// packages/core/src/state/learnings-content.ts
+//
+// Content deduplication: normalization, hashing, and content hash index management.
+// Extracted from learnings.ts to reduce blast radius.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { CONTENT_HASHES_FILE } from './constants';
+
+// --- Types ---
+
+export interface LearningsFrontmatter {
+  hash: string;
+  tags: string[];
+}
+
+export interface LearningsIndexEntry {
+  hash: string;
+  tags: string[];
+  summary: string;
+  fullText: string;
+}
+
+/** Content hash index: maps content hash -> metadata */
+export interface ContentHashEntry {
+  date: string;
+  line: number;
+}
+
+export type ContentHashIndex = Record<string, ContentHashEntry>;
+
+// --- Parsing ---
+
+/** Parse a frontmatter comment line: <!-- hash:XXXX tags:a,b --> */
+export function parseFrontmatter(line: string): LearningsFrontmatter | null {
+  const match = line.match(/^<!--\s+hash:([a-f0-9]+)(?:\s+tags:([^\s]+))?\s+-->/);
+  if (!match) return null;
+  const hash = match[1]!;
+  const tags = match[2] ? match[2].split(',').filter(Boolean) : [];
+  return { hash, tags };
+}
+
+/**
+ * Parse date from a learning entry. Returns the date string or null.
+ * Entries look like: "- **2026-03-25 [skill:X]:** content"
+ * or heading format: "## 2026-03-25 — Task 3: ..."
+ */
+export function parseDateFromEntry(entry: string): string | null {
+  const match = entry.match(/(\d{4}-\d{2}-\d{2})/);
+  return match ? (match[1] ?? null) : null;
+}
+
+/**
+ * Extract a lightweight index entry from a full learning entry.
+ * Summary = first line only. Tags extracted from [skill:X] and [outcome:Y] markers.
+ * Hash computed from full entry text.
+ */
+export function extractIndexEntry(entry: string): LearningsIndexEntry {
+  const lines = entry.split('\n');
+  const summary = lines[0] ?? entry;
+  const tags: string[] = [];
+  const skillMatch = entry.match(/\[skill:([^\]]+)\]/);
+  if (skillMatch?.[1]) tags.push(skillMatch[1]);
+  const outcomeMatch = entry.match(/\[outcome:([^\]]+)\]/);
+  if (outcomeMatch?.[1]) tags.push(outcomeMatch[1]);
+  return {
+    hash: computeEntryHash(entry),
+    tags,
+    summary,
+    fullText: entry,
+  };
+}
+
+// --- Hashing ---
+
+/** Compute an 8-char hex hash of the entry text. */
+export function computeEntryHash(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex').slice(0, 8);
+}
+
+/**
+ * Normalize learning content for deduplication.
+ * Strips date prefixes, skill/outcome tags, list markers, bold markers;
+ * lowercases; collapses whitespace; trims.
+ */
+export function normalizeLearningContent(text: string): string {
+  let normalized = text;
+  // Strip date prefix (YYYY-MM-DD)
+  normalized = normalized.replace(/\d{4}-\d{2}-\d{2}/g, '');
+  // Strip skill/outcome tags
+  normalized = normalized.replace(/\[skill:[^\]]*\]/g, '');
+  normalized = normalized.replace(/\[outcome:[^\]]*\]/g, '');
+  // Strip list markers (- or *)
+  normalized = normalized.replace(/^[\s]*[-*]\s+/gm, '');
+  // Strip bold markers
+  normalized = normalized.replace(/\*\*/g, '');
+  // Strip colons left after tag removal (e.g., ":]" -> "")
+  normalized = normalized.replace(/:\s*/g, ' ');
+  // Lowercase
+  normalized = normalized.toLowerCase();
+  // Collapse whitespace
+  normalized = normalized.replace(/\s+/g, ' ').trim();
+  return normalized;
+}
+
+/**
+ * Compute a 16-char hex SHA-256 hash of normalized content.
+ */
+export function computeContentHash(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex').slice(0, 16);
+}
+
+// --- Content Hash Index I/O ---
+
+/** Load content hash index from sidecar file. Returns empty object on missing/corrupt. */
+export function loadContentHashes(stateDir: string): ContentHashIndex {
+  const hashesPath = path.join(stateDir, CONTENT_HASHES_FILE);
+  if (!fs.existsSync(hashesPath)) return {};
+  try {
+    const raw = fs.readFileSync(hashesPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+    return parsed as ContentHashIndex;
+  } catch {
+    return {};
+  }
+}
+
+/** Save content hash index to sidecar file. */
+export function saveContentHashes(stateDir: string, index: ContentHashIndex): void {
+  const hashesPath = path.join(stateDir, CONTENT_HASHES_FILE);
+  fs.writeFileSync(hashesPath, JSON.stringify(index, null, 2) + '\n');
+}
+
+/**
+ * Rebuild content hash index from learnings.md.
+ * Used for self-healing when sidecar is missing or corrupted.
+ */
+export function rebuildContentHashes(stateDir: string, learningsFile: string): ContentHashIndex {
+  const learningsPath = path.join(stateDir, learningsFile);
+  if (!fs.existsSync(learningsPath)) return {};
+
+  const content = fs.readFileSync(learningsPath, 'utf-8');
+  const lines = content.split('\n');
+  const index: ContentHashIndex = {};
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const isDatedBullet = /^- \*\*\d{4}-\d{2}-\d{2}/.test(line);
+    if (isDatedBullet) {
+      // Extract the raw learning text from the bullet line
+      const learningMatch = line.match(/:\*\*\s*(.+)$/);
+      if (learningMatch?.[1]) {
+        const normalized = normalizeLearningContent(learningMatch[1]);
+        const hash = computeContentHash(normalized);
+        const dateMatch = line.match(/(\d{4}-\d{2}-\d{2})/);
+        index[hash] = { date: dateMatch?.[1] ?? '', line: i + 1 };
+      }
+    }
+  }
+
+  saveContentHashes(stateDir, index);
+  return index;
+}
+
+// --- Pattern Analysis ---
+
+export interface LearningPattern {
+  tag: string;
+  count: number;
+  entries: string[];
+}
+
+/**
+ * Analyze learning entries for recurring patterns.
+ * Groups entries by [skill:X] and [outcome:Y] tags.
+ * Returns patterns where 3+ entries share the same tag.
+ */
+export function analyzeLearningPatterns(entries: string[]): LearningPattern[] {
+  const tagGroups = new Map<string, string[]>();
+
+  for (const entry of entries) {
+    const tagMatches = entry.matchAll(/\[(skill:[^\]]+)\]|\[(outcome:[^\]]+)\]/g);
+    for (const match of tagMatches) {
+      const tag = match[1] ?? match[2];
+      if (tag) {
+        const group = tagGroups.get(tag) ?? [];
+        group.push(entry);
+        tagGroups.set(tag, group);
+      }
+    }
+  }
+
+  const patterns: LearningPattern[] = [];
+  for (const [tag, groupEntries] of tagGroups) {
+    if (groupEntries.length >= 3) {
+      patterns.push({ tag, count: groupEntries.length, entries: groupEntries });
+    }
+  }
+
+  return patterns.sort((a, b) => b.count - a.count);
+}
+
+/** Estimate token count from a string (chars / 4, ceiling). */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Score how relevant a learning entry is to a given intent.
+ * Returns a number 0-1. Higher = more relevant.
+ * Uses keyword overlap between intent words and entry text.
+ */
+export function scoreRelevance(entry: string, intent: string): number {
+  if (!intent || intent.trim() === '') return 0;
+  const intentWords = intent
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 2); // skip short words like "a", "to", "in"
+  if (intentWords.length === 0) return 0;
+  const entryLower = entry.toLowerCase();
+  const matches = intentWords.filter((word) => entryLower.includes(word));
+  return matches.length / intentWords.length;
+}

--- a/packages/core/src/state/learnings-lifecycle.ts
+++ b/packages/core/src/state/learnings-lifecycle.ts
@@ -1,0 +1,252 @@
+// packages/core/src/state/learnings-lifecycle.ts
+//
+// Lifecycle operations: archival, pruning, session promotion, counting.
+// Extracted from learnings.ts to reduce blast radius.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Result } from '../shared/result';
+import { Ok, Err } from '../shared/result';
+import { getStateDir } from './state-shared';
+import { LEARNINGS_FILE } from './constants';
+import { parseDateFromEntry, analyzeLearningPatterns } from './learnings-content';
+import type { LearningPattern } from './learnings-content';
+import { loadRelevantLearnings, invalidateLearningsCacheEntry } from './learnings-loader';
+
+export interface PruneResult {
+  kept: number;
+  archived: number;
+  patterns: LearningPattern[];
+}
+
+/**
+ * Archive learning entries to .harness/learnings-archive/{YYYY-MM}.md.
+ * Appends to existing archive file if one exists for the current month.
+ */
+export async function archiveLearnings(
+  projectPath: string,
+  entries: string[],
+  stream?: string
+): Promise<Result<void, Error>> {
+  try {
+    const dirResult = await getStateDir(projectPath, stream);
+    if (!dirResult.ok) return dirResult;
+    const stateDir = dirResult.value;
+
+    const archiveDir = path.join(stateDir, 'learnings-archive');
+    fs.mkdirSync(archiveDir, { recursive: true });
+
+    const now = new Date();
+    const yearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const archivePath = path.join(archiveDir, `${yearMonth}.md`);
+
+    const archiveContent = entries.join('\n\n') + '\n';
+
+    if (fs.existsSync(archivePath)) {
+      fs.appendFileSync(archivePath, '\n' + archiveContent);
+    } else {
+      fs.writeFileSync(archivePath, `# Learnings Archive\n\n${archiveContent}`);
+    }
+
+    return Ok(undefined);
+  } catch (error) {
+    return Err(
+      new Error(
+        `Failed to archive learnings: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+}
+
+/**
+ * Prune global learnings: analyze patterns, archive old entries, keep 20 most recent.
+ *
+ * Pruning triggers when:
+ * - Entry count exceeds 30, OR
+ * - Entries older than 14 days exist AND total count exceeds 20
+ *
+ * Returns the prune result with pattern analysis and counts.
+ */
+export async function pruneLearnings(
+  projectPath: string,
+  stream?: string
+): Promise<Result<PruneResult, Error>> {
+  try {
+    const dirResult = await getStateDir(projectPath, stream);
+    if (!dirResult.ok) return dirResult;
+    const stateDir = dirResult.value;
+    const learningsPath = path.join(stateDir, LEARNINGS_FILE);
+
+    if (!fs.existsSync(learningsPath)) {
+      return Ok({ kept: 0, archived: 0, patterns: [] });
+    }
+
+    const loadResult = await loadRelevantLearnings(projectPath, undefined, stream);
+    if (!loadResult.ok) return loadResult;
+    const allEntries = loadResult.value;
+
+    if (allEntries.length <= 20) {
+      const cutoffDate = new Date();
+      cutoffDate.setDate(cutoffDate.getDate() - 14);
+      const cutoffStr = cutoffDate.toISOString().split('T')[0];
+
+      const hasOld = allEntries.some((entry) => {
+        const date = parseDateFromEntry(entry);
+        return date !== null && date < cutoffStr!;
+      });
+
+      if (!hasOld) {
+        return Ok({ kept: allEntries.length, archived: 0, patterns: [] });
+      }
+    }
+
+    // Sort by date descending (newest first)
+    const sorted = [...allEntries].sort((a, b) => {
+      const dateA = parseDateFromEntry(a) ?? '0000-00-00';
+      const dateB = parseDateFromEntry(b) ?? '0000-00-00';
+      return dateB.localeCompare(dateA);
+    });
+
+    const toKeep = sorted.slice(0, 20);
+    const toArchive = sorted.slice(20);
+
+    // Analyze patterns in ALL entries before pruning
+    const patterns = analyzeLearningPatterns(allEntries);
+
+    if (toArchive.length > 0) {
+      const archiveResult = await archiveLearnings(projectPath, toArchive, stream);
+      if (!archiveResult.ok) return archiveResult;
+    }
+
+    // Rewrite learnings.md with only kept entries
+    const newContent = '# Learnings\n\n' + toKeep.join('\n\n') + '\n';
+    fs.writeFileSync(learningsPath, newContent);
+
+    // Invalidate cache (targeted — only this file, not all cached entries)
+    invalidateLearningsCacheEntry(learningsPath);
+
+    return Ok({
+      kept: toKeep.length,
+      archived: toArchive.length,
+      patterns,
+    });
+  } catch (error) {
+    return Err(
+      new Error(
+        `Failed to prune learnings: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+}
+
+export interface PromoteResult {
+  promoted: number;
+  skipped: number;
+}
+
+/**
+ * Outcomes considered generalizable (applicable beyond the current session).
+ * Entries with these tags get promoted to global learnings.
+ * Task-completion entries ([outcome:success] with no broader insight,
+ * or entries with no outcome tag) stay in the session.
+ */
+const PROMOTABLE_OUTCOMES = ['gotcha', 'decision', 'observation'];
+
+/**
+ * Check if a learning entry is generalizable (should be promoted to global).
+ * Generalizable = has an outcome tag that indicates a reusable insight.
+ */
+function isGeneralizable(entry: string): boolean {
+  for (const outcome of PROMOTABLE_OUTCOMES) {
+    if (entry.includes(`[outcome:${outcome}]`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Promote generalizable session learnings to global learnings.md.
+ *
+ * Generalizable entries are those tagged with [outcome:gotcha],
+ * [outcome:decision], or [outcome:observation]. These represent
+ * reusable insights that apply beyond the current session.
+ *
+ * Task-specific entries (e.g., [outcome:success] completion summaries,
+ * or entries without outcome tags) stay in the session directory.
+ */
+export async function promoteSessionLearnings(
+  projectPath: string,
+  sessionSlug: string,
+  stream?: string
+): Promise<Result<PromoteResult, Error>> {
+  try {
+    // Load session learnings
+    const sessionResult = await loadRelevantLearnings(projectPath, undefined, stream, sessionSlug);
+    if (!sessionResult.ok) return sessionResult;
+    const sessionEntries = sessionResult.value;
+
+    if (sessionEntries.length === 0) {
+      return Ok({ promoted: 0, skipped: 0 });
+    }
+
+    const toPromote: string[] = [];
+    let skipped = 0;
+
+    for (const entry of sessionEntries) {
+      if (isGeneralizable(entry)) {
+        toPromote.push(entry);
+      } else {
+        skipped++;
+      }
+    }
+
+    if (toPromote.length === 0) {
+      return Ok({ promoted: 0, skipped });
+    }
+
+    // Append promoted entries to global learnings (with dedup for idempotency)
+    const dirResult = await getStateDir(projectPath, stream);
+    if (!dirResult.ok) return dirResult;
+    const stateDir = dirResult.value;
+    const globalPath = path.join(stateDir, LEARNINGS_FILE);
+
+    // Load existing global entries for duplicate detection
+    const existingGlobal = fs.existsSync(globalPath) ? fs.readFileSync(globalPath, 'utf-8') : '';
+    const newEntries = toPromote.filter((entry) => !existingGlobal.includes(entry.trim()));
+
+    if (newEntries.length === 0) {
+      return Ok({ promoted: 0, skipped: skipped + toPromote.length });
+    }
+
+    const promotedContent = newEntries.join('\n\n') + '\n';
+
+    if (!existingGlobal) {
+      fs.writeFileSync(globalPath, `# Learnings\n\n${promotedContent}`);
+    } else {
+      fs.appendFileSync(globalPath, '\n\n' + promotedContent);
+    }
+
+    // Invalidate cache (targeted — only the global file, not all cached entries)
+    invalidateLearningsCacheEntry(globalPath);
+
+    return Ok({
+      promoted: newEntries.length,
+      skipped: skipped + (toPromote.length - newEntries.length),
+    });
+  } catch (error) {
+    return Err(
+      new Error(
+        `Failed to promote session learnings: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+}
+
+/**
+ * Count the number of learning entries in the global learnings.md file.
+ * Useful for checking if pruning should be suggested (threshold: 30).
+ */
+export async function countLearningEntries(projectPath: string, stream?: string): Promise<number> {
+  const loadResult = await loadRelevantLearnings(projectPath, undefined, stream);
+  if (!loadResult.ok) return 0;
+  return loadResult.value.length;
+}

--- a/packages/core/src/state/learnings-loader.ts
+++ b/packages/core/src/state/learnings-loader.ts
@@ -1,0 +1,106 @@
+// packages/core/src/state/learnings-loader.ts
+//
+// Learnings file loader with mtime-based cache.
+// Leaf module — no imports from sibling learnings-* files.
+// Both learnings.ts (CRUD) and learnings-lifecycle.ts (prune/archive/promote)
+// import from here, keeping the dependency graph strictly acyclic.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Result } from '../shared/result';
+import { Ok, Err } from '../shared/result';
+import { getStateDir, LEARNINGS_FILE, evictIfNeeded } from './state-shared';
+
+// --- Cache ---
+
+interface LearningsCache {
+  mtimeMs: number;
+  entries: string[];
+}
+
+const learningsCacheMap = new Map<string, LearningsCache>();
+
+export function clearLearningsCache(): void {
+  learningsCacheMap.clear();
+}
+
+/** Remove a single path from the learnings cache. Used by lifecycle operations for targeted invalidation. */
+export function invalidateLearningsCacheEntry(key: string): void {
+  learningsCacheMap.delete(key);
+}
+
+// --- Loader ---
+
+export async function loadRelevantLearnings(
+  projectPath: string,
+  skillName?: string,
+  stream?: string,
+  session?: string
+): Promise<Result<string[], Error>> {
+  try {
+    const dirResult = await getStateDir(projectPath, stream, session);
+    if (!dirResult.ok) return dirResult;
+    const stateDir = dirResult.value;
+    const learningsPath = path.join(stateDir, LEARNINGS_FILE);
+
+    if (!fs.existsSync(learningsPath)) {
+      return Ok([]);
+    }
+
+    // Cache check: use mtime to determine if re-parse is needed
+    const stats = fs.statSync(learningsPath);
+    const cacheKey = learningsPath;
+    const cached = learningsCacheMap.get(cacheKey);
+
+    let entries: string[];
+
+    if (cached && cached.mtimeMs === stats.mtimeMs) {
+      entries = cached.entries;
+    } else {
+      // Parse file and populate cache
+      const content = fs.readFileSync(learningsPath, 'utf-8');
+      const lines = content.split('\n');
+      entries = [];
+      let currentBlock: string[] = [];
+
+      for (const line of lines) {
+        if (line.startsWith('# ')) continue;
+
+        // Skip frontmatter comment lines — they are metadata, not entry content
+        if (/^<!--\s+hash:[a-f0-9]+/.test(line)) continue;
+
+        const isDatedBullet = /^- \*\*\d{4}-\d{2}-\d{2}/.test(line);
+        const isHeading = /^## \d{4}-\d{2}-\d{2}/.test(line);
+
+        if (isDatedBullet || isHeading) {
+          if (currentBlock.length > 0) {
+            entries.push(currentBlock.join('\n'));
+          }
+          currentBlock = [line];
+        } else if (line.trim() !== '' && currentBlock.length > 0) {
+          currentBlock.push(line);
+        }
+      }
+
+      if (currentBlock.length > 0) {
+        entries.push(currentBlock.join('\n'));
+      }
+
+      learningsCacheMap.set(cacheKey, { mtimeMs: stats.mtimeMs, entries });
+      evictIfNeeded(learningsCacheMap);
+    }
+
+    if (!skillName) {
+      return Ok(entries);
+    }
+
+    const filtered = entries.filter((entry) => entry.includes(`[skill:${skillName}]`));
+    return Ok(filtered);
+  } catch (error) {
+    return Err(
+      new Error(
+        `Failed to load learnings: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+}

--- a/packages/core/src/state/learnings.ts
+++ b/packages/core/src/state/learnings.ts
@@ -1,161 +1,46 @@
 // packages/core/src/state/learnings.ts
+//
+// Core CRUD operations for learnings: append, load index, budgeted loading.
+// Delegates to:
+//   learnings-content.ts — parsing, hashing, dedup (leaf)
+//   learnings-loader.ts  — file loading with cache (leaf)
+//   learnings-lifecycle.ts — prune, archive, promote (imports from loader)
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import type { Result } from '../shared/result';
 import { Ok, Err } from '../shared/result';
-import { getStateDir, LEARNINGS_FILE, evictIfNeeded } from './state-shared';
+import { getStateDir, LEARNINGS_FILE } from './state-shared';
 import { CONTENT_HASHES_FILE } from './constants';
+import {
+  normalizeLearningContent,
+  computeContentHash,
+  loadContentHashes,
+  saveContentHashes,
+  rebuildContentHashes,
+  parseFrontmatter,
+  extractIndexEntry,
+  parseDateFromEntry,
+  scoreRelevance,
+  estimateTokens,
+} from './learnings-content';
+import type {
+  LearningsFrontmatter,
+  LearningsIndexEntry,
+  ContentHashIndex,
+} from './learnings-content';
+import { loadRelevantLearnings, invalidateLearningsCacheEntry } from './learnings-loader';
 
-export interface LearningsFrontmatter {
-  hash: string;
-  tags: string[];
-}
+// --- Core CRUD ---
 
-export interface LearningsIndexEntry {
-  hash: string;
-  tags: string[];
-  summary: string;
-  fullText: string;
-}
-
-/** Parse a frontmatter comment line: <!-- hash:XXXX tags:a,b --> */
-export function parseFrontmatter(line: string): LearningsFrontmatter | null {
-  const match = line.match(/^<!--\s+hash:([a-f0-9]+)(?:\s+tags:([^\s]+))?\s+-->/);
-  if (!match) return null;
-  const hash = match[1]!;
-  const tags = match[2] ? match[2].split(',').filter(Boolean) : [];
-  return { hash, tags };
-}
-
-/** Compute an 8-char hex hash of the entry text. */
-function computeEntryHash(text: string): string {
-  return crypto.createHash('sha256').update(text).digest('hex').slice(0, 8);
-}
-
-// --- Content Deduplication ---
-
-/**
- * Normalize learning content for deduplication.
- * Strips date prefixes, skill/outcome tags, list markers, bold markers;
- * lowercases; collapses whitespace; trims.
- */
-export function normalizeLearningContent(text: string): string {
-  let normalized = text;
-  // Strip date prefix (YYYY-MM-DD)
-  normalized = normalized.replace(/\d{4}-\d{2}-\d{2}/g, '');
-  // Strip skill/outcome tags
-  normalized = normalized.replace(/\[skill:[^\]]*\]/g, '');
-  normalized = normalized.replace(/\[outcome:[^\]]*\]/g, '');
-  // Strip list markers (- or *)
-  normalized = normalized.replace(/^[\s]*[-*]\s+/gm, '');
-  // Strip bold markers
-  normalized = normalized.replace(/\*\*/g, '');
-  // Strip colons left after tag removal (e.g., ":]" -> "")
-  normalized = normalized.replace(/:\s*/g, ' ');
-  // Lowercase
-  normalized = normalized.toLowerCase();
-  // Collapse whitespace
-  normalized = normalized.replace(/\s+/g, ' ').trim();
-  return normalized;
-}
-
-/**
- * Compute a 16-char hex SHA-256 hash of normalized content.
- */
-export function computeContentHash(text: string): string {
-  return crypto.createHash('sha256').update(text).digest('hex').slice(0, 16);
-}
-
-/** Content hash index: maps content hash -> metadata */
-export interface ContentHashEntry {
-  date: string;
-  line: number;
-}
-
-export type ContentHashIndex = Record<string, ContentHashEntry>;
-
-/** Load content hash index from sidecar file. Returns empty object on missing/corrupt. */
-function loadContentHashes(stateDir: string): ContentHashIndex {
-  const hashesPath = path.join(stateDir, CONTENT_HASHES_FILE);
-  if (!fs.existsSync(hashesPath)) return {};
-  try {
-    const raw = fs.readFileSync(hashesPath, 'utf-8');
-    const parsed = JSON.parse(raw);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
-    return parsed as ContentHashIndex;
-  } catch {
-    return {};
-  }
-}
-
-/** Save content hash index to sidecar file. */
-function saveContentHashes(stateDir: string, index: ContentHashIndex): void {
-  const hashesPath = path.join(stateDir, CONTENT_HASHES_FILE);
-  fs.writeFileSync(hashesPath, JSON.stringify(index, null, 2) + '\n');
-}
-
-/**
- * Rebuild content hash index from learnings.md.
- * Used for self-healing when sidecar is missing or corrupted.
- */
-function rebuildContentHashes(stateDir: string): ContentHashIndex {
-  const learningsPath = path.join(stateDir, LEARNINGS_FILE);
-  if (!fs.existsSync(learningsPath)) return {};
-
-  const content = fs.readFileSync(learningsPath, 'utf-8');
-  const lines = content.split('\n');
-  const index: ContentHashIndex = {};
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    const isDatedBullet = /^- \*\*\d{4}-\d{2}-\d{2}/.test(line);
-    if (isDatedBullet) {
-      // Extract the raw learning text from the bullet line
-      const learningMatch = line.match(/:\*\*\s*(.+)$/);
-      if (learningMatch?.[1]) {
-        const normalized = normalizeLearningContent(learningMatch[1]);
-        const hash = computeContentHash(normalized);
-        const dateMatch = line.match(/(\d{4}-\d{2}-\d{2})/);
-        index[hash] = { date: dateMatch?.[1] ?? '', line: i + 1 };
-      }
-    }
-  }
-
-  saveContentHashes(stateDir, index);
-  return index;
-}
-
-/**
- * Extract a lightweight index entry from a full learning entry.
- * Summary = first line only. Tags extracted from [skill:X] and [outcome:Y] markers.
- * Hash computed from full entry text.
- */
-export function extractIndexEntry(entry: string): LearningsIndexEntry {
-  const lines = entry.split('\n');
-  const summary = lines[0] ?? entry;
-  const tags: string[] = [];
-  const skillMatch = entry.match(/\[skill:([^\]]+)\]/);
-  if (skillMatch?.[1]) tags.push(skillMatch[1]);
-  const outcomeMatch = entry.match(/\[outcome:([^\]]+)\]/);
-  if (outcomeMatch?.[1]) tags.push(outcomeMatch[1]);
-  return {
-    hash: computeEntryHash(entry),
-    tags,
-    summary,
-    fullText: entry,
-  };
-}
-
-interface LearningsCache {
-  mtimeMs: number;
-  entries: string[];
-}
-
-const learningsCacheMap = new Map<string, LearningsCache>();
-
-export function clearLearningsCache(): void {
-  learningsCacheMap.clear();
+export interface BudgetedLearningsOptions {
+  intent: string;
+  tokenBudget?: number;
+  skill?: string;
+  session?: string;
+  stream?: string;
+  depth?: 'index' | 'summary' | 'full';
 }
 
 export async function appendLearning(
@@ -185,11 +70,11 @@ export async function appendLearning(
       contentHashes = loadContentHashes(stateDir);
       // If loaded index is empty but learnings exist, sidecar may be corrupted — rebuild
       if (Object.keys(contentHashes).length === 0 && fs.existsSync(learningsPath)) {
-        contentHashes = rebuildContentHashes(stateDir);
+        contentHashes = rebuildContentHashes(stateDir, LEARNINGS_FILE);
       }
     } else if (fs.existsSync(learningsPath)) {
       // Sidecar missing but learnings exist — rebuild (self-healing)
-      contentHashes = rebuildContentHashes(stateDir);
+      contentHashes = rebuildContentHashes(stateDir, LEARNINGS_FILE);
     } else {
       contentHashes = {};
     }
@@ -238,7 +123,7 @@ export async function appendLearning(
     saveContentHashes(stateDir, contentHashes);
 
     // Invalidate cache on write
-    learningsCacheMap.delete(learningsPath);
+    invalidateLearningsCacheEntry(learningsPath);
 
     return Ok(undefined);
   } catch (error) {
@@ -248,83 +133,6 @@ export async function appendLearning(
       )
     );
   }
-}
-
-/** Estimate token count from a string (chars / 4, ceiling). */
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
-}
-
-/**
- * Score how relevant a learning entry is to a given intent.
- * Returns a number 0-1. Higher = more relevant.
- * Uses keyword overlap between intent words and entry text.
- */
-function scoreRelevance(entry: string, intent: string): number {
-  if (!intent || intent.trim() === '') return 0;
-  const intentWords = intent
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((w) => w.length > 2); // skip short words like "a", "to", "in"
-  if (intentWords.length === 0) return 0;
-  const entryLower = entry.toLowerCase();
-  const matches = intentWords.filter((word) => entryLower.includes(word));
-  return matches.length / intentWords.length;
-}
-
-/**
- * Parse date from a learning entry. Returns the date string or null.
- * Entries look like: "- **2026-03-25 [skill:X]:** content"
- * or heading format: "## 2026-03-25 — Task 3: ..."
- */
-export function parseDateFromEntry(entry: string): string | null {
-  const match = entry.match(/(\d{4}-\d{2}-\d{2})/);
-  return match ? (match[1] ?? null) : null;
-}
-
-export interface LearningPattern {
-  tag: string;
-  count: number;
-  entries: string[];
-}
-
-/**
- * Analyze learning entries for recurring patterns.
- * Groups entries by [skill:X] and [outcome:Y] tags.
- * Returns patterns where 3+ entries share the same tag.
- */
-export function analyzeLearningPatterns(entries: string[]): LearningPattern[] {
-  const tagGroups = new Map<string, string[]>();
-
-  for (const entry of entries) {
-    const tagMatches = entry.matchAll(/\[(skill:[^\]]+)\]|\[(outcome:[^\]]+)\]/g);
-    for (const match of tagMatches) {
-      const tag = match[1] ?? match[2];
-      if (tag) {
-        const group = tagGroups.get(tag) ?? [];
-        group.push(entry);
-        tagGroups.set(tag, group);
-      }
-    }
-  }
-
-  const patterns: LearningPattern[] = [];
-  for (const [tag, groupEntries] of tagGroups) {
-    if (groupEntries.length >= 3) {
-      patterns.push({ tag, count: groupEntries.length, entries: groupEntries });
-    }
-  }
-
-  return patterns.sort((a, b) => b.count - a.count);
-}
-
-export interface BudgetedLearningsOptions {
-  intent: string;
-  tokenBudget?: number;
-  skill?: string;
-  session?: string;
-  stream?: string;
-  depth?: 'index' | 'summary' | 'full';
 }
 
 /**
@@ -498,316 +306,4 @@ export async function loadIndexEntries(
       )
     );
   }
-}
-
-export async function loadRelevantLearnings(
-  projectPath: string,
-  skillName?: string,
-  stream?: string,
-  session?: string
-): Promise<Result<string[], Error>> {
-  try {
-    const dirResult = await getStateDir(projectPath, stream, session);
-    if (!dirResult.ok) return dirResult;
-    const stateDir = dirResult.value;
-    const learningsPath = path.join(stateDir, LEARNINGS_FILE);
-
-    if (!fs.existsSync(learningsPath)) {
-      return Ok([]);
-    }
-
-    // Cache check: use mtime to determine if re-parse is needed
-    const stats = fs.statSync(learningsPath);
-    const cacheKey = learningsPath;
-    const cached = learningsCacheMap.get(cacheKey);
-
-    let entries: string[];
-
-    if (cached && cached.mtimeMs === stats.mtimeMs) {
-      entries = cached.entries;
-    } else {
-      // Parse file and populate cache
-      const content = fs.readFileSync(learningsPath, 'utf-8');
-      const lines = content.split('\n');
-      entries = [];
-      let currentBlock: string[] = [];
-
-      for (const line of lines) {
-        if (line.startsWith('# ')) continue;
-
-        // Skip frontmatter comment lines — they are metadata, not entry content
-        if (/^<!--\s+hash:[a-f0-9]+/.test(line)) continue;
-
-        const isDatedBullet = /^- \*\*\d{4}-\d{2}-\d{2}/.test(line);
-        const isHeading = /^## \d{4}-\d{2}-\d{2}/.test(line);
-
-        if (isDatedBullet || isHeading) {
-          if (currentBlock.length > 0) {
-            entries.push(currentBlock.join('\n'));
-          }
-          currentBlock = [line];
-        } else if (line.trim() !== '' && currentBlock.length > 0) {
-          currentBlock.push(line);
-        }
-      }
-
-      if (currentBlock.length > 0) {
-        entries.push(currentBlock.join('\n'));
-      }
-
-      learningsCacheMap.set(cacheKey, { mtimeMs: stats.mtimeMs, entries });
-      evictIfNeeded(learningsCacheMap);
-    }
-
-    if (!skillName) {
-      return Ok(entries);
-    }
-
-    const filtered = entries.filter((entry) => entry.includes(`[skill:${skillName}]`));
-    return Ok(filtered);
-  } catch (error) {
-    return Err(
-      new Error(
-        `Failed to load learnings: ${error instanceof Error ? error.message : String(error)}`
-      )
-    );
-  }
-}
-
-export interface PruneResult {
-  kept: number;
-  archived: number;
-  patterns: LearningPattern[];
-}
-
-/**
- * Archive learning entries to .harness/learnings-archive/{YYYY-MM}.md.
- * Appends to existing archive file if one exists for the current month.
- */
-export async function archiveLearnings(
-  projectPath: string,
-  entries: string[],
-  stream?: string
-): Promise<Result<void, Error>> {
-  try {
-    const dirResult = await getStateDir(projectPath, stream);
-    if (!dirResult.ok) return dirResult;
-    const stateDir = dirResult.value;
-
-    const archiveDir = path.join(stateDir, 'learnings-archive');
-    fs.mkdirSync(archiveDir, { recursive: true });
-
-    const now = new Date();
-    const yearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-    const archivePath = path.join(archiveDir, `${yearMonth}.md`);
-
-    const archiveContent = entries.join('\n\n') + '\n';
-
-    if (fs.existsSync(archivePath)) {
-      fs.appendFileSync(archivePath, '\n' + archiveContent);
-    } else {
-      fs.writeFileSync(archivePath, `# Learnings Archive\n\n${archiveContent}`);
-    }
-
-    return Ok(undefined);
-  } catch (error) {
-    return Err(
-      new Error(
-        `Failed to archive learnings: ${error instanceof Error ? error.message : String(error)}`
-      )
-    );
-  }
-}
-
-/**
- * Prune global learnings: analyze patterns, archive old entries, keep 20 most recent.
- *
- * Pruning triggers when:
- * - Entry count exceeds 30, OR
- * - Entries older than 14 days exist AND total count exceeds 20
- *
- * Returns the prune result with pattern analysis and counts.
- */
-export async function pruneLearnings(
-  projectPath: string,
-  stream?: string
-): Promise<Result<PruneResult, Error>> {
-  try {
-    const dirResult = await getStateDir(projectPath, stream);
-    if (!dirResult.ok) return dirResult;
-    const stateDir = dirResult.value;
-    const learningsPath = path.join(stateDir, LEARNINGS_FILE);
-
-    if (!fs.existsSync(learningsPath)) {
-      return Ok({ kept: 0, archived: 0, patterns: [] });
-    }
-
-    const loadResult = await loadRelevantLearnings(projectPath, undefined, stream);
-    if (!loadResult.ok) return loadResult;
-    const allEntries = loadResult.value;
-
-    if (allEntries.length <= 20) {
-      const cutoffDate = new Date();
-      cutoffDate.setDate(cutoffDate.getDate() - 14);
-      const cutoffStr = cutoffDate.toISOString().split('T')[0];
-
-      const hasOld = allEntries.some((entry) => {
-        const date = parseDateFromEntry(entry);
-        return date !== null && date < cutoffStr!;
-      });
-
-      if (!hasOld) {
-        return Ok({ kept: allEntries.length, archived: 0, patterns: [] });
-      }
-    }
-
-    // Sort by date descending (newest first)
-    const sorted = [...allEntries].sort((a, b) => {
-      const dateA = parseDateFromEntry(a) ?? '0000-00-00';
-      const dateB = parseDateFromEntry(b) ?? '0000-00-00';
-      return dateB.localeCompare(dateA);
-    });
-
-    const toKeep = sorted.slice(0, 20);
-    const toArchive = sorted.slice(20);
-
-    // Analyze patterns in ALL entries before pruning
-    const patterns = analyzeLearningPatterns(allEntries);
-
-    if (toArchive.length > 0) {
-      const archiveResult = await archiveLearnings(projectPath, toArchive, stream);
-      if (!archiveResult.ok) return archiveResult;
-    }
-
-    // Rewrite learnings.md with only kept entries
-    const newContent = '# Learnings\n\n' + toKeep.join('\n\n') + '\n';
-    fs.writeFileSync(learningsPath, newContent);
-
-    // Invalidate cache
-    learningsCacheMap.delete(learningsPath);
-
-    return Ok({
-      kept: toKeep.length,
-      archived: toArchive.length,
-      patterns,
-    });
-  } catch (error) {
-    return Err(
-      new Error(
-        `Failed to prune learnings: ${error instanceof Error ? error.message : String(error)}`
-      )
-    );
-  }
-}
-
-export interface PromoteResult {
-  promoted: number;
-  skipped: number;
-}
-
-/**
- * Outcomes considered generalizable (applicable beyond the current session).
- * Entries with these tags get promoted to global learnings.
- * Task-completion entries ([outcome:success] with no broader insight,
- * or entries with no outcome tag) stay in the session.
- */
-const PROMOTABLE_OUTCOMES = ['gotcha', 'decision', 'observation'];
-
-/**
- * Check if a learning entry is generalizable (should be promoted to global).
- * Generalizable = has an outcome tag that indicates a reusable insight.
- */
-function isGeneralizable(entry: string): boolean {
-  for (const outcome of PROMOTABLE_OUTCOMES) {
-    if (entry.includes(`[outcome:${outcome}]`)) return true;
-  }
-  return false;
-}
-
-/**
- * Promote generalizable session learnings to global learnings.md.
- *
- * Generalizable entries are those tagged with [outcome:gotcha],
- * [outcome:decision], or [outcome:observation]. These represent
- * reusable insights that apply beyond the current session.
- *
- * Task-specific entries (e.g., [outcome:success] completion summaries,
- * or entries without outcome tags) stay in the session directory.
- */
-export async function promoteSessionLearnings(
-  projectPath: string,
-  sessionSlug: string,
-  stream?: string
-): Promise<Result<PromoteResult, Error>> {
-  try {
-    // Load session learnings
-    const sessionResult = await loadRelevantLearnings(projectPath, undefined, stream, sessionSlug);
-    if (!sessionResult.ok) return sessionResult;
-    const sessionEntries = sessionResult.value;
-
-    if (sessionEntries.length === 0) {
-      return Ok({ promoted: 0, skipped: 0 });
-    }
-
-    const toPromote: string[] = [];
-    let skipped = 0;
-
-    for (const entry of sessionEntries) {
-      if (isGeneralizable(entry)) {
-        toPromote.push(entry);
-      } else {
-        skipped++;
-      }
-    }
-
-    if (toPromote.length === 0) {
-      return Ok({ promoted: 0, skipped });
-    }
-
-    // Append promoted entries to global learnings (with dedup for idempotency)
-    const dirResult = await getStateDir(projectPath, stream);
-    if (!dirResult.ok) return dirResult;
-    const stateDir = dirResult.value;
-    const globalPath = path.join(stateDir, LEARNINGS_FILE);
-
-    // Load existing global entries for duplicate detection
-    const existingGlobal = fs.existsSync(globalPath) ? fs.readFileSync(globalPath, 'utf-8') : '';
-    const newEntries = toPromote.filter((entry) => !existingGlobal.includes(entry.trim()));
-
-    if (newEntries.length === 0) {
-      return Ok({ promoted: 0, skipped: skipped + toPromote.length });
-    }
-
-    const promotedContent = newEntries.join('\n\n') + '\n';
-
-    if (!existingGlobal) {
-      fs.writeFileSync(globalPath, `# Learnings\n\n${promotedContent}`);
-    } else {
-      fs.appendFileSync(globalPath, '\n\n' + promotedContent);
-    }
-
-    // Invalidate cache
-    learningsCacheMap.delete(globalPath);
-
-    return Ok({
-      promoted: newEntries.length,
-      skipped: skipped + (toPromote.length - newEntries.length),
-    });
-  } catch (error) {
-    return Err(
-      new Error(
-        `Failed to promote session learnings: ${error instanceof Error ? error.message : String(error)}`
-      )
-    );
-  }
-}
-
-/**
- * Count the number of learning entries in the global learnings.md file.
- * Useful for checking if pruning should be suggested (threshold: 30).
- */
-export async function countLearningEntries(projectPath: string, stream?: string): Promise<number> {
-  const loadResult = await loadRelevantLearnings(projectPath, undefined, stream);
-  if (!loadResult.ok) return 0;
-  return loadResult.value.length;
 }

--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -3,23 +3,22 @@
 // The implementation has been split into focused domain files.
 
 export { loadState, saveState } from './state-persistence';
+export { clearLearningsCache, loadRelevantLearnings } from './learnings-loader';
+export { appendLearning, loadBudgetedLearnings, loadIndexEntries } from './learnings';
 export {
-  clearLearningsCache,
-  appendLearning,
-  loadRelevantLearnings,
-  loadBudgetedLearnings,
   parseDateFromEntry,
   analyzeLearningPatterns,
+  parseFrontmatter,
+  extractIndexEntry,
+  normalizeLearningContent,
+  computeContentHash,
+} from './learnings-content';
+export {
   archiveLearnings,
   pruneLearnings,
   promoteSessionLearnings,
   countLearningEntries,
-  parseFrontmatter,
-  extractIndexEntry,
-  loadIndexEntries,
-  normalizeLearningContent,
-  computeContentHash,
-} from './learnings';
+} from './learnings-lifecycle';
 export { clearFailuresCache, appendFailure, loadFailures, archiveFailures } from './failures';
 export { saveHandoff, loadHandoff } from './handoff';
 export { runMechanicalGate } from './mechanical-gate';

--- a/packages/core/tests/state/learnings-promotion.test.ts
+++ b/packages/core/tests/state/learnings-promotion.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { promoteSessionLearnings, countLearningEntries } from '../../src/state/learnings';
+import { promoteSessionLearnings, countLearningEntries } from '../../src/state/learnings-lifecycle';
 
 describe('promoteSessionLearnings', () => {
   let tmpDir: string;

--- a/packages/core/tests/state/learnings-pruning.test.ts
+++ b/packages/core/tests/state/learnings-pruning.test.ts
@@ -2,12 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import {
-  parseDateFromEntry,
-  analyzeLearningPatterns,
-  archiveLearnings,
-  pruneLearnings,
-} from '../../src/state/learnings';
+import { parseDateFromEntry, analyzeLearningPatterns } from '../../src/state/learnings-content';
+import { archiveLearnings, pruneLearnings } from '../../src/state/learnings-lifecycle';
 
 describe('parseDateFromEntry', () => {
   it('should parse date from tagged bullet entry', () => {

--- a/packages/types/src/ci.ts
+++ b/packages/types/src/ci.ts
@@ -1,0 +1,112 @@
+/**
+ * Names of standard CI checks.
+ */
+export type CICheckName =
+  | 'validate'
+  | 'deps'
+  | 'docs'
+  | 'entropy'
+  | 'security'
+  | 'perf'
+  | 'phase-gate'
+  | 'arch'
+  | 'traceability';
+
+/**
+ * Status of a CI check.
+ */
+export type CICheckStatus = 'pass' | 'fail' | 'warn' | 'skip';
+
+/**
+ * A specific issue found during a CI check.
+ */
+export interface CICheckIssue {
+  /** Severity level */
+  severity: 'error' | 'warning';
+  /** Descriptive message */
+  message: string;
+  /** Path to the affected file */
+  file?: string;
+  /** Line number in the affected file */
+  line?: number;
+}
+
+/**
+ * Result of a single CI check execution.
+ */
+export interface CICheckResult {
+  /** Name of the check */
+  name: CICheckName;
+  /** Final status of the check */
+  status: CICheckStatus;
+  /** List of issues discovered */
+  issues: CICheckIssue[];
+  /** Execution time in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Summary counts for a set of CI checks.
+ */
+export interface CICheckSummary {
+  /** Total number of checks run */
+  total: number;
+  /** Number of passing checks */
+  passed: number;
+  /** Number of failing checks */
+  failed: number;
+  /** Number of checks with warnings */
+  warnings: number;
+  /** Number of skipped checks */
+  skipped: number;
+}
+
+/**
+ * Final report for a CI run.
+ */
+export interface CICheckReport {
+  /** Schema version */
+  version: 1;
+  /** Name of the project */
+  project: string;
+  /** ISO timestamp of the run */
+  timestamp: string;
+  /** Detailed results for each check */
+  checks: CICheckResult[];
+  /** Aggregated summary */
+  summary: CICheckSummary;
+  /** Process exit code suggested for the CI runner */
+  exitCode: 0 | 1 | 2;
+}
+
+/**
+ * Severity level that should trigger a CI failure.
+ */
+export type CIFailOnSeverity = 'error' | 'warning';
+
+/**
+ * Configuration options for the CI command.
+ */
+export interface CICheckOptions {
+  /** Checks to skip */
+  skip?: CICheckName[];
+  /** Severity level that causes failure */
+  failOn?: CIFailOnSeverity;
+  /** Custom config file path */
+  configPath?: string;
+}
+
+/**
+ * Supported CI platforms.
+ */
+export type CIPlatform = 'github' | 'gitlab' | 'generic';
+
+/**
+ * Options for initializing CI configuration.
+ */
+export interface CIInitOptions {
+  /** Target CI platform */
+  platform?: CIPlatform;
+  /** Checks to enable */
+  checks?: CICheckName[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,411 +1,67 @@
 /**
  * @harness-engineering/types
  *
- * Core types and interfaces for Harness Engineering toolkit
+ * Core types and interfaces for Harness Engineering toolkit.
+ *
+ * Types are organized into domain files for reduced blast radius:
+ *   result.ts   — Result<T,E>, Ok, Err, isOk, isErr
+ *   workflow.ts  — WorkflowStep, Workflow, StepOutcome, WorkflowStepResult, WorkflowResult
+ *   skill.ts     — SkillMetadata, SkillContext, TurnContext, SkillError, SkillResult, SkillLifecycleHooks
+ *   ci.ts        — CICheck*, CIInitOptions, CIPlatform
+ *   roadmap.ts   — FeatureStatus, RoadmapFeature, RoadmapMilestone, Roadmap
  */
 
-/**
- * Result type for consistent error handling across the toolkit.
- */
-export type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };
+// --- Result ---
+export { Ok, Err, isOk, isErr } from './result';
+export type { Result } from './result';
 
-/**
- * Creates a successful Result.
- */
-export function Ok<T>(value: T): Result<T, never> {
-  return { ok: true, value };
-}
+// --- Workflow ---
+export type {
+  WorkflowStep,
+  Workflow,
+  StepOutcome,
+  WorkflowStepResult,
+  WorkflowResult,
+} from './workflow';
 
-/**
- * Creates a failed Result.
- */
-export function Err<E>(error: E): Result<never, E> {
-  return { ok: false, error };
-}
+// --- Skill & Pipeline ---
+export { STANDARD_COGNITIVE_MODES } from './skill';
+export type {
+  CognitiveMode,
+  SkillMetadata,
+  SkillContext,
+  TurnContext,
+  SkillError,
+  SkillResult,
+  SkillLifecycleHooks,
+} from './skill';
 
-/**
- * Type guard to check if a Result is successful.
- */
-export function isOk<T, E>(result: Result<T, E>): result is { ok: true; value: T } {
-  return result.ok === true;
-}
+// --- CI/CD ---
+export type {
+  CICheckName,
+  CICheckStatus,
+  CICheckIssue,
+  CICheckResult,
+  CICheckSummary,
+  CICheckReport,
+  CIFailOnSeverity,
+  CICheckOptions,
+  CIPlatform,
+  CIInitOptions,
+} from './ci';
 
-/**
- * Type guard to check if a Result is failed.
- */
-export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error: E } {
-  return result.ok === false;
-}
+// --- Roadmap ---
+export type {
+  FeatureStatus,
+  Priority,
+  RoadmapFeature,
+  RoadmapMilestone,
+  AssignmentRecord,
+  RoadmapFrontmatter,
+  Roadmap,
+} from './roadmap';
 
-// Workflow orchestration types
-
-/**
- * A single step in a multi-skill workflow.
- */
-export interface WorkflowStep {
-  /** The skill to execute (e.g., "detect-doc-drift") */
-  skill: string;
-  /** Name of the artifact this step produces */
-  produces: string;
-  /** Name of the artifact this step expects as input */
-  expects?: string;
-  /** Whether failure of this step stops the workflow */
-  gate?: 'pass-required' | 'advisory';
-}
-
-/**
- * Definition of a sequence of steps to achieve a goal.
- */
-export interface Workflow {
-  /** Descriptive name of the workflow */
-  name: string;
-  /** Ordered list of steps */
-  steps: WorkflowStep[];
-}
-
-/**
- * Possible outcomes for a single workflow step.
- */
-export type StepOutcome = 'pass' | 'fail' | 'skipped';
-
-/**
- * Detailed result of a workflow step execution.
- */
-export interface WorkflowStepResult {
-  /** The step that was executed */
-  step: WorkflowStep;
-  /** The outcome of the execution */
-  outcome: StepOutcome;
-  /** Path to the produced artifact, if any */
-  artifact?: string;
-  /** Error message if outcome is 'fail' */
-  error?: string;
-  /** Execution time in milliseconds */
-  durationMs: number;
-}
-
-/**
- * Final result of a complete workflow execution.
- */
-export interface WorkflowResult {
-  /** The workflow that was executed */
-  workflow: Workflow;
-  /** Results for each step in the workflow */
-  stepResults: WorkflowStepResult[];
-  /** Whether the overall workflow passed (all required gates passed) */
-  pass: boolean;
-  /** Total execution time in milliseconds */
-  totalDurationMs: number;
-}
-
-// --- Skill Metadata Types ---
-
-/**
- * Predefined cognitive modes for skills.
- */
-export const STANDARD_COGNITIVE_MODES = [
-  'adversarial-reviewer',
-  'constructive-architect',
-  'meticulous-implementer',
-  'diagnostic-investigator',
-  'advisory-guide',
-  'meticulous-verifier',
-] as const;
-
-/**
- * Cognitive mode of a skill, determining its behavior and persona.
- */
-export type CognitiveMode = (typeof STANDARD_COGNITIVE_MODES)[number] | (string & {});
-
-/**
- * Static metadata for a skill.
- */
-export interface SkillMetadata {
-  /** Unique name of the skill */
-  name: string;
-  /** Semantic version string */
-  version: string;
-  /** Brief description of what the skill does */
-  description: string;
-  /** The cognitive mode this skill operates in */
-  cognitive_mode?: CognitiveMode;
-}
-
-// --- Pipeline Types ---
-
-/**
- * Contextual information for a skill execution.
- */
-export interface SkillContext {
-  /** Name of the executing skill */
-  skillName: string;
-  /** Current pipeline phase */
-  phase: string;
-  /** Files relevant to the current execution */
-  files: string[];
-  /** Optional token budget — uses a plain record to avoid cross-package deps. */
-  tokenBudget?: Record<string, number>;
-  /** Additional metadata */
-  metadata: Record<string, unknown>;
-}
-
-/**
- * Context for a single turn in a multi-turn skill interaction.
- */
-export interface TurnContext extends SkillContext {
-  /** Current turn number (1-indexed) */
-  turnNumber: number;
-  /** Results from previous turns in the same session */
-  previousResults: unknown[];
-}
-
-/**
- * Error reported by a skill.
- */
-export type SkillError = {
-  /** Machine-readable error code */
-  code: string;
-  /** Human-readable error message */
-  message: string;
-  /** Phase in which the error occurred */
-  phase: string;
-};
-
-// --- CI/CD Integration Types ---
-
-/**
- * Names of standard CI checks.
- */
-export type CICheckName =
-  | 'validate'
-  | 'deps'
-  | 'docs'
-  | 'entropy'
-  | 'security'
-  | 'perf'
-  | 'phase-gate'
-  | 'arch'
-  | 'traceability';
-
-/**
- * Status of a CI check.
- */
-export type CICheckStatus = 'pass' | 'fail' | 'warn' | 'skip';
-
-/**
- * A specific issue found during a CI check.
- */
-export interface CICheckIssue {
-  /** Severity level */
-  severity: 'error' | 'warning';
-  /** Descriptive message */
-  message: string;
-  /** Path to the affected file */
-  file?: string;
-  /** Line number in the affected file */
-  line?: number;
-}
-
-/**
- * Result of a single CI check execution.
- */
-export interface CICheckResult {
-  /** Name of the check */
-  name: CICheckName;
-  /** Final status of the check */
-  status: CICheckStatus;
-  /** List of issues discovered */
-  issues: CICheckIssue[];
-  /** Execution time in milliseconds */
-  durationMs: number;
-}
-
-/**
- * Summary counts for a set of CI checks.
- */
-export interface CICheckSummary {
-  /** Total number of checks run */
-  total: number;
-  /** Number of passing checks */
-  passed: number;
-  /** Number of failing checks */
-  failed: number;
-  /** Number of checks with warnings */
-  warnings: number;
-  /** Number of skipped checks */
-  skipped: number;
-}
-
-/**
- * Final report for a CI run.
- */
-export interface CICheckReport {
-  /** Schema version */
-  version: 1;
-  /** Name of the project */
-  project: string;
-  /** ISO timestamp of the run */
-  timestamp: string;
-  /** Detailed results for each check */
-  checks: CICheckResult[];
-  /** Aggregated summary */
-  summary: CICheckSummary;
-  /** Process exit code suggested for the CI runner */
-  exitCode: 0 | 1 | 2;
-}
-
-/**
- * Severity level that should trigger a CI failure.
- */
-export type CIFailOnSeverity = 'error' | 'warning';
-
-/**
- * Configuration options for the CI command.
- */
-export interface CICheckOptions {
-  /** Checks to skip */
-  skip?: CICheckName[];
-  /** Severity level that causes failure */
-  failOn?: CIFailOnSeverity;
-  /** Custom config file path */
-  configPath?: string;
-}
-
-/**
- * Supported CI platforms.
- */
-export type CIPlatform = 'github' | 'gitlab' | 'generic';
-
-/**
- * Options for initializing CI configuration.
- */
-export interface CIInitOptions {
-  /** Target CI platform */
-  platform?: CIPlatform;
-  /** Checks to enable */
-  checks?: CICheckName[];
-}
-
-/**
- * Result of a skill execution.
- */
-export type SkillResult = {
-  /** Whether the skill achieved its goal */
-  success: boolean;
-  /** List of artifact paths produced */
-  artifacts: string[];
-  /** One-line summary of the outcome */
-  summary: string;
-};
-
-/**
- * Lifecycle hooks for skills.
- */
-export interface SkillLifecycleHooks {
-  /** Called before the skill starts execution */
-  preExecution?: (context: SkillContext) => SkillContext | null;
-  /** Called before each turn in a multi-turn interaction */
-  perTurn?: (context: TurnContext) => TurnContext | null;
-  /** Called after the skill completes execution */
-  postExecution?: (context: SkillContext, result: SkillResult) => void;
-}
-
-// --- Roadmap Types ---
-
-/**
- * Valid statuses for a roadmap feature.
- */
-export type FeatureStatus = 'backlog' | 'planned' | 'in-progress' | 'done' | 'blocked';
-
-/**
- * Priority override levels for roadmap features.
- * When present, priority replaces positional ordering as the primary sort key.
- */
-export type Priority = 'P0' | 'P1' | 'P2' | 'P3';
-
-/**
- * A feature entry in the project roadmap.
- */
-export interface RoadmapFeature {
-  /** Feature name (from the H3 heading, without "Feature:" prefix) */
-  name: string;
-  /** Current status */
-  status: FeatureStatus;
-  /** Relative path to the spec file, or null if none */
-  spec: string | null;
-  /** Relative paths to plan files */
-  plans: string[];
-  /** Names of blocking features (textual references) */
-  blockedBy: string[];
-  /** One-line summary */
-  summary: string;
-  /** GitHub username, email, or display name — null if unassigned */
-  assignee: string | null;
-  /** Optional priority override — null uses positional ordering */
-  priority: Priority | null;
-  /** External tracker ID (e.g., "github:owner/repo#42") — null if not synced */
-  externalId: string | null;
-}
-
-/**
- * A milestone grouping in the roadmap. The special "Backlog" milestone
- * has `isBacklog: true` and appears as `## Backlog` instead of `## Milestone: <name>`.
- */
-export interface RoadmapMilestone {
-  /** Milestone name (e.g., "MVP Release") or "Backlog" */
-  name: string;
-  /** True for the special Backlog section */
-  isBacklog: boolean;
-  /** Features in this milestone, in document order */
-  features: RoadmapFeature[];
-}
-
-/**
- * A single record in the assignment history log.
- * Reassignment produces two records: 'unassigned' for previous, 'assigned' for new.
- */
-export interface AssignmentRecord {
-  /** Feature name */
-  feature: string;
-  /** Assignee identifier (username, email, or display name) */
-  assignee: string;
-  /** What happened */
-  action: 'assigned' | 'completed' | 'unassigned';
-  /** ISO date string (YYYY-MM-DD) */
-  date: string;
-}
-
-/**
- * YAML frontmatter of the roadmap file.
- */
-export interface RoadmapFrontmatter {
-  /** Project name */
-  project: string;
-  /** Schema version (currently 1) */
-  version: number;
-  /** ISO date when roadmap was created */
-  created?: string;
-  /** ISO date when roadmap was last updated */
-  updated?: string;
-  /** ISO timestamp of last automated sync */
-  lastSynced: string;
-  /** ISO timestamp of last manual edit */
-  lastManualEdit: string;
-}
-
-/**
- * Parsed roadmap document.
- */
-export interface Roadmap {
-  /** Parsed frontmatter */
-  frontmatter: RoadmapFrontmatter;
-  /** Milestones in document order (including Backlog) */
-  milestones: RoadmapMilestone[];
-  /** Assignment history records, in document order */
-  assignmentHistory: AssignmentRecord[];
-}
-
-// --- Tracker Sync Types ---
+// --- Tracker Sync ---
 export type {
   ExternalTicket,
   ExternalTicketState,
@@ -413,10 +69,10 @@ export type {
   TrackerSyncConfig,
 } from './tracker-sync';
 
-// --- Usage & Cost Tracking Types ---
+// --- Usage & Cost Tracking ---
 export type { UsageRecord, ModelPricing, DailyUsage, SessionUsage } from './usage';
 
-// --- Session State Types ---
+// --- Session State ---
 export { SESSION_SECTION_NAMES } from './session-state';
 export type {
   SessionSectionName,
@@ -425,7 +81,7 @@ export type {
   SessionSections,
 } from './session-state';
 
-// --- Orchestrator Types ---
+// --- Orchestrator ---
 export type {
   TokenUsage,
   BlockerRef,

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -1,4 +1,4 @@
-import type { Result } from './index';
+import type { Result } from './result';
 
 // --- Token Usage ---
 

--- a/packages/types/src/result.ts
+++ b/packages/types/src/result.ts
@@ -1,0 +1,32 @@
+/**
+ * Result type for consistent error handling across the toolkit.
+ */
+export type Result<T, E = Error> = { ok: true; value: T } | { ok: false; error: E };
+
+/**
+ * Creates a successful Result.
+ */
+export function Ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+/**
+ * Creates a failed Result.
+ */
+export function Err<E>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+/**
+ * Type guard to check if a Result is successful.
+ */
+export function isOk<T, E>(result: Result<T, E>): result is { ok: true; value: T } {
+  return result.ok === true;
+}
+
+/**
+ * Type guard to check if a Result is failed.
+ */
+export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error: E } {
+  return result.ok === false;
+}

--- a/packages/types/src/roadmap.ts
+++ b/packages/types/src/roadmap.ts
@@ -1,0 +1,92 @@
+/**
+ * Valid statuses for a roadmap feature.
+ */
+export type FeatureStatus = 'backlog' | 'planned' | 'in-progress' | 'done' | 'blocked';
+
+/**
+ * Priority override levels for roadmap features.
+ * When present, priority replaces positional ordering as the primary sort key.
+ */
+export type Priority = 'P0' | 'P1' | 'P2' | 'P3';
+
+/**
+ * A feature entry in the project roadmap.
+ */
+export interface RoadmapFeature {
+  /** Feature name (from the H3 heading, without "Feature:" prefix) */
+  name: string;
+  /** Current status */
+  status: FeatureStatus;
+  /** Relative path to the spec file, or null if none */
+  spec: string | null;
+  /** Relative paths to plan files */
+  plans: string[];
+  /** Names of blocking features (textual references) */
+  blockedBy: string[];
+  /** One-line summary */
+  summary: string;
+  /** GitHub username, email, or display name — null if unassigned */
+  assignee: string | null;
+  /** Optional priority override — null uses positional ordering */
+  priority: Priority | null;
+  /** External tracker ID (e.g., "github:owner/repo#42") — null if not synced */
+  externalId: string | null;
+}
+
+/**
+ * A milestone grouping in the roadmap. The special "Backlog" milestone
+ * has `isBacklog: true` and appears as `## Backlog` instead of `## Milestone: <name>`.
+ */
+export interface RoadmapMilestone {
+  /** Milestone name (e.g., "MVP Release") or "Backlog" */
+  name: string;
+  /** True for the special Backlog section */
+  isBacklog: boolean;
+  /** Features in this milestone, in document order */
+  features: RoadmapFeature[];
+}
+
+/**
+ * A single record in the assignment history log.
+ * Reassignment produces two records: 'unassigned' for previous, 'assigned' for new.
+ */
+export interface AssignmentRecord {
+  /** Feature name */
+  feature: string;
+  /** Assignee identifier (username, email, or display name) */
+  assignee: string;
+  /** What happened */
+  action: 'assigned' | 'completed' | 'unassigned';
+  /** ISO date string (YYYY-MM-DD) */
+  date: string;
+}
+
+/**
+ * YAML frontmatter of the roadmap file.
+ */
+export interface RoadmapFrontmatter {
+  /** Project name */
+  project: string;
+  /** Schema version (currently 1) */
+  version: number;
+  /** ISO date when roadmap was created */
+  created?: string;
+  /** ISO date when roadmap was last updated */
+  updated?: string;
+  /** ISO timestamp of last automated sync */
+  lastSynced: string;
+  /** ISO timestamp of last manual edit */
+  lastManualEdit: string;
+}
+
+/**
+ * Parsed roadmap document.
+ */
+export interface Roadmap {
+  /** Parsed frontmatter */
+  frontmatter: RoadmapFrontmatter;
+  /** Milestones in document order (including Backlog) */
+  milestones: RoadmapMilestone[];
+  /** Assignment history records, in document order */
+  assignmentHistory: AssignmentRecord[];
+}

--- a/packages/types/src/skill.ts
+++ b/packages/types/src/skill.ts
@@ -1,0 +1,92 @@
+/**
+ * Predefined cognitive modes for skills.
+ */
+export const STANDARD_COGNITIVE_MODES = [
+  'adversarial-reviewer',
+  'constructive-architect',
+  'meticulous-implementer',
+  'diagnostic-investigator',
+  'advisory-guide',
+  'meticulous-verifier',
+] as const;
+
+/**
+ * Cognitive mode of a skill, determining its behavior and persona.
+ */
+export type CognitiveMode = (typeof STANDARD_COGNITIVE_MODES)[number] | (string & {});
+
+/**
+ * Static metadata for a skill.
+ */
+export interface SkillMetadata {
+  /** Unique name of the skill */
+  name: string;
+  /** Semantic version string */
+  version: string;
+  /** Brief description of what the skill does */
+  description: string;
+  /** The cognitive mode this skill operates in */
+  cognitive_mode?: CognitiveMode;
+}
+
+/**
+ * Contextual information for a skill execution.
+ */
+export interface SkillContext {
+  /** Name of the executing skill */
+  skillName: string;
+  /** Current pipeline phase */
+  phase: string;
+  /** Files relevant to the current execution */
+  files: string[];
+  /** Optional token budget — uses a plain record to avoid cross-package deps. */
+  tokenBudget?: Record<string, number>;
+  /** Additional metadata */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Context for a single turn in a multi-turn skill interaction.
+ */
+export interface TurnContext extends SkillContext {
+  /** Current turn number (1-indexed) */
+  turnNumber: number;
+  /** Results from previous turns in the same session */
+  previousResults: unknown[];
+}
+
+/**
+ * Error reported by a skill.
+ */
+export type SkillError = {
+  /** Machine-readable error code */
+  code: string;
+  /** Human-readable error message */
+  message: string;
+  /** Phase in which the error occurred */
+  phase: string;
+};
+
+/**
+ * Result of a skill execution.
+ */
+export type SkillResult = {
+  /** Whether the skill achieved its goal */
+  success: boolean;
+  /** List of artifact paths produced */
+  artifacts: string[];
+  /** One-line summary of the outcome */
+  summary: string;
+};
+
+/**
+ * Lifecycle hooks for skills.
+ */
+export interface SkillLifecycleHooks {
+  /** Called before the skill starts execution */
+  preExecution?: (context: SkillContext) => SkillContext | null;
+  /** Called before each turn in a multi-turn interaction */
+  perTurn?: (context: TurnContext) => TurnContext | null;
+  /** Called after the skill completes execution */
+  postExecution?: (context: SkillContext, result: SkillResult) => void;
+}

--- a/packages/types/src/tracker-sync.ts
+++ b/packages/types/src/tracker-sync.ts
@@ -1,4 +1,4 @@
-import type { FeatureStatus } from './index';
+import type { FeatureStatus } from './roadmap';
 
 /**
  * Represents a ticket created in an external tracking service.

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -1,0 +1,58 @@
+/**
+ * A single step in a multi-skill workflow.
+ */
+export interface WorkflowStep {
+  /** The skill to execute (e.g., "detect-doc-drift") */
+  skill: string;
+  /** Name of the artifact this step produces */
+  produces: string;
+  /** Name of the artifact this step expects as input */
+  expects?: string;
+  /** Whether failure of this step stops the workflow */
+  gate?: 'pass-required' | 'advisory';
+}
+
+/**
+ * Definition of a sequence of steps to achieve a goal.
+ */
+export interface Workflow {
+  /** Descriptive name of the workflow */
+  name: string;
+  /** Ordered list of steps */
+  steps: WorkflowStep[];
+}
+
+/**
+ * Possible outcomes for a single workflow step.
+ */
+export type StepOutcome = 'pass' | 'fail' | 'skipped';
+
+/**
+ * Detailed result of a workflow step execution.
+ */
+export interface WorkflowStepResult {
+  /** The step that was executed */
+  step: WorkflowStep;
+  /** The outcome of the execution */
+  outcome: StepOutcome;
+  /** Path to the produced artifact, if any */
+  artifact?: string;
+  /** Error message if outcome is 'fail' */
+  error?: string;
+  /** Execution time in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Final result of a complete workflow execution.
+ */
+export interface WorkflowResult {
+  /** The workflow that was executed */
+  workflow: Workflow;
+  /** Results for each step in the workflow */
+  stepResults: WorkflowStepResult[];
+  /** Whether the overall workflow passed (all required gates passed) */
+  pass: boolean;
+  /** Total execution time in milliseconds */
+  totalDurationMs: number;
+}

--- a/scripts/generate-barrel-exports.mjs
+++ b/scripts/generate-barrel-exports.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+/**
+ * Auto-generate barrel export registrations for CLI commands.
+ *
+ * Scans packages/cli/src/commands/ for files exporting createXXXCommand()
+ * functions and generates a command registry module that createProgram()
+ * can import. This eliminates manual import/addCommand churn in index.ts.
+ *
+ * Convention:
+ *   - Top-level .ts files → scanned for createXXXCommand exports
+ *   - Directories with index.ts → index.ts scanned for createXXXCommand
+ *   - EXTRA_TOP_LEVEL_COMMANDS → sub-directory files promoted to top-level
+ *
+ * Usage:
+ *   node scripts/generate-barrel-exports.mjs           # generate
+ *   node scripts/generate-barrel-exports.mjs --check   # verify freshness (CI)
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { resolve, join, relative } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const CLI_COMMANDS_DIR = join(ROOT, 'packages', 'cli', 'src', 'commands');
+const REGISTRY_PATH = join(ROOT, 'packages', 'cli', 'src', 'commands', '_registry.ts');
+const HEADER = '// AUTO-GENERATED — do not edit. Run `pnpm run generate-barrel-exports` to regenerate.\n';
+
+/**
+ * Sub-directory files that are registered as top-level CLI commands.
+ * These are exceptions to the "index.ts only" rule for directories.
+ * Format: relative path from commands/ → file to scan.
+ */
+const EXTRA_TOP_LEVEL_COMMANDS = [
+  'graph/scan.ts',
+  'graph/ingest.ts',
+  'graph/query.ts',
+];
+
+/**
+ * Extract createXXXCommand exports from a single file.
+ */
+function extractCommands(filePath, commandsDir) {
+  const content = readFileSync(filePath, 'utf-8');
+  // Match both `export function createXXXCommand(` and `export const createXXXCommand = (`
+  const matches = [
+    ...content.matchAll(/export\s+function\s+(create\w+Command)\s*\(/g),
+    ...content.matchAll(/export\s+const\s+(create\w+Command)\s*=/g),
+  ];
+  return matches.map((match) => {
+    let importPath = './' + relative(commandsDir, filePath)
+      .replace(/\.ts$/, '')
+      .replace(/\/index$/, '');
+    importPath = importPath.replace(/\\/g, '/');
+    return { importPath, functionName: match[1] };
+  });
+}
+
+/**
+ * Discover all command creator functions from the commands directory.
+ */
+function discoverCommands(dir) {
+  const commands = [];
+
+  // 1. Scan top-level files and directory index files
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    if (entry.startsWith('_') || entry.startsWith('.')) continue;
+
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+
+    let filePath;
+    if (stat.isDirectory()) {
+      filePath = join(fullPath, 'index.ts');
+      if (!existsSync(filePath)) continue;
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts') && !entry.endsWith('.d.ts')) {
+      filePath = fullPath;
+    } else {
+      continue;
+    }
+
+    commands.push(...extractCommands(filePath, dir));
+  }
+
+  // 2. Scan extra top-level commands from sub-directories
+  for (const relPath of EXTRA_TOP_LEVEL_COMMANDS) {
+    const filePath = join(dir, relPath);
+    if (existsSync(filePath)) {
+      commands.push(...extractCommands(filePath, dir));
+    }
+  }
+
+  // Deduplicate by function name (in case index.ts re-exports)
+  const seen = new Set();
+  const unique = commands.filter((c) => {
+    if (seen.has(c.functionName)) return false;
+    seen.add(c.functionName);
+    return true;
+  });
+
+  return unique.sort((a, b) => a.functionName.localeCompare(b.functionName));
+}
+
+function generateRegistry(commands) {
+  const imports = commands
+    .map((c) => `import { ${c.functionName} } from '${c.importPath}';`)
+    .join('\n');
+
+  const registrations = commands
+    .map((c) => `  ${c.functionName},`)
+    .join('\n');
+
+  return `${HEADER}
+import type { Command } from 'commander';
+
+${imports}
+
+/**
+ * All discovered command creators, sorted alphabetically.
+ * Used by createProgram() to register commands without manual imports.
+ */
+export const commandCreators: Array<() => Command> = [
+${registrations}
+];
+`;
+}
+
+// --- Main ---
+
+const commands = discoverCommands(CLI_COMMANDS_DIR);
+const content = generateRegistry(commands);
+
+if (process.argv.includes('--check')) {
+  if (!existsSync(REGISTRY_PATH)) {
+    console.error('Command registry not found. Run: pnpm run generate-barrel-exports');
+    process.exit(1);
+  }
+  const existing = readFileSync(REGISTRY_PATH, 'utf-8');
+  if (existing !== content) {
+    console.error('Command registry is stale. Run: pnpm run generate-barrel-exports');
+    process.exit(1);
+  }
+  console.log('Command registry is up to date.');
+} else {
+  writeFileSync(REGISTRY_PATH, content);
+  console.log(`Generated ${REGISTRY_PATH} with ${commands.length} commands.`);
+}


### PR DESCRIPTION
## Summary

- Split `types/src/index.ts` (450 lines) into 5 domain files + barrel, fixing circular imports
- Split `learnings.ts` (813 lines) into 4 acyclic leaf modules (content, loader, lifecycle, crud)
- Auto-generate CLI command registry via `scripts/generate-barrel-exports.mjs`, replacing 48 manual imports
- Document hidden sync-engine ↔ github-issues coupling
- Update arch baselines for new module count

Re-opened after reverting PR #115 which contained rogue commits.

## Test plan

- [x] All 4,371 tests pass across all packages
- [x] Typecheck and lint pass
- [x] Architecture gate passes with updated baselines