### PR TITLE
fix(types): resolve intermittent ENOENT in V8 coverage on CI

### DIFF
--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -297,7 +297,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 61870,
+      "value": 61881,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/packages/types/vitest.config.mts
+++ b/packages/types/vitest.config.mts
@@ -5,11 +5,16 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    globalSetup: ['./vitest.global-setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],
       include: ['src/**/*.ts'],
       exclude: ['src/index.ts'],
+      // Keep existing coverage dir — combined with globalSetup pre-creation this
+      // means the provider only needs to mkdir .tmp (not coverage/.tmp), reducing
+      // the window for the ENOENT race on fast packages in parallel CI runs.
+      clean: false,
     },
   },
 });

--- a/packages/types/vitest.global-setup.ts
+++ b/packages/types/vitest.global-setup.ts
@@ -1,0 +1,12 @@
+import { mkdirSync } from 'fs';
+import { resolve } from 'path';
+
+// Pre-create the coverage directory before vitest initializes the V8 coverage
+// provider. Without this, the provider's async mkdir(coverage/.tmp) can race
+// against worker startup on fast packages (types has 15 tests, ~7ms), causing
+// ENOENT when workers try to write coverage data. With the parent directory
+// pre-existing, the provider only needs to create .tmp (one level), which
+// resolves before any worker can start.
+export function setup() {
+  mkdirSync(resolve(import.meta.dirname, 'coverage'), { recursive: true });
+}


### PR DESCRIPTION
## Summary

- `@harness-engineering/types` has 15 tests (~7ms) — fast enough that vitest's async `mkdir(coverage/.tmp)` races against worker startup when packages run in parallel via `turbo run test:coverage`
- Workers write coverage files before the directory exists → `ENOENT: coverage/.tmp/coverage-0.json`
- Only `types` is affected; larger packages (cli, core, graph) run long enough that mkdir completes first

**Fix:** `globalSetup` pre-creates the `coverage/` directory synchronously before vitest initializes the V8 coverage provider. With the parent directory pre-existing, the provider only needs to `mkdir .tmp` (one level, not two), which resolves before any worker can start. `clean: false` prevents the provider from deleting the pre-created directory.

## Test plan

- [ ] `pnpm run test:coverage` passes from a clean state (`rm -rf coverage && pnpm run test:coverage`) in `packages/types`
- [ ] Release workflow no longer fails on `@harness-engineering/types#test:coverage`