### PR TITLE
chore: add changeset to bump CLI for update command fix

### DIFF
--- a/.changeset/fix-update-all-packages.md
+++ b/.changeset/fix-update-all-packages.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix `harness update` to check all installed packages for updates, not just CLI. Adds `--force` and `--regenerate` flags.


### PR DESCRIPTION
## Summary

- Adds a changeset to bump `@harness-engineering/cli` to 1.24.1 (patch)
- The update command fix (#140) merged without a changeset, so the publish pipeline didn't bump the CLI version
- Without this, `harness update` on npm still ships v1.24.0 which has the old CLI-only version check and doesn't bundle the dashboard dependency

## Test plan
- [ ] Merge triggers changeset version bump
- [ ] `npx changeset status` shows pending CLI patch