### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/fix-update-all-packages.md
+++ b/.changeset/fix-update-all-packages.md
@@ -1,5 +1,0 @@
----
-'@harness-engineering/cli': patch
----
-
-Fix `harness update` to check all installed packages for updates, not just CLI. Adds `--force` and `--regenerate` flags.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @harness-engineering/cli
 
+## 1.24.1
+
+### Patch Changes
+
+- 5bbad27: Fix `harness update` to check all installed packages for updates, not just CLI. Adds `--force` and `--regenerate` flags.
+
 ## 1.24.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/cli",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "CLI for Harness Engineering toolkit",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps `@harness-engineering/cli` from 1.24.0 → 1.24.1 (patch)
- Consumes changeset from #141
- Triggered by changesets/action but PR creation failed due to repo permissions

Merging this will trigger the npm publish.