### PR TITLE
fix: serve built client files from dashboard API server

### DIFF
--- a/.changeset/fix-dashboard-static-serving.md
+++ b/.changeset/fix-dashboard-static-serving.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/dashboard': patch
+'@harness-engineering/cli': patch
+---
+
+Fix `harness dashboard` returning 404 on all routes by serving built client static files from the Hono API server with SPA fallback.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-11T02:34:53.866Z",
-  "updatedFrom": "870c28b8",
+  "updatedAt": "2026-04-11T16:12:12.190Z",
+  "updatedFrom": "7aac4486",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -19,20 +19,20 @@
         "5aa35eb7825bc41fe5a8fc031d0cdedd78703616efd3da15af290eca55184744",
         "ac5d2db9c38d6025f9531c162a198343c5c501a7bd8991906470993853d89055",
         "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
-        "fad5da199ad18507ec1727c9a2de48da80fd75f72230cc948df3afd8830308ce",
         "f573d1d3f72b896ef1841f90ce326b1008e05ec90ec72489becbd1a9e4c679fe",
         "6eb4858144d411132d7e376f3dca3820e906d97bfb34d6a690f6ddb3229b8dce",
         "dad32014fb96b44b797cb3005dc093985f1d0508a6f72f2804053a0ebdee4a8d",
         "13310052487ad20819c93bd931a8677f92b706c0e28615319e854b5d682cd247",
         "97d282575446f2807269f1dddf316f20c23527bd5fa4ed0d1901f46717478c68",
         "82c9472c41b16379f2f062e7c8aa27438235e5e7957b205f1491d9bf89aac952",
-        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
-        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
+        "fad5da199ad18507ec1727c9a2de48da80fd75f72230cc948df3afd8830308ce",
         "14715d1f7346442bc17888eecdac07b4a4ae166ad3c8b7d9582e6eec380c98fc",
         "3be6cd991653c54e8c6a0f0942d56fd54892b1afa88855ef11b1ae6dbfbe1676",
         "08151b7f65c324074876ce5f0136a0d749d71b38b05cdda2bea0acca220bce06",
         "f80c1747de98253c8b1f63381609098332795f5a5d5af4bb99131c93fa9860e8",
-        "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13"
+        "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13",
+        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
+        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab"
       ]
     },
     "coupling": {
@@ -44,7 +44,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 66010,
+      "value": 66031,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/cli",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "CLI for Harness Engineering toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/cli",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "CLI for Harness Engineering toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -81,7 +81,8 @@ function runDashboard(opts: DashboardOptions): void {
   const clientPort = Number(opts.port ?? DEFAULT_CLIENT_PORT);
   const apiPort = Number(opts.apiPort ?? DEFAULT_API_PORT);
   const projectPath = resolve(opts.cwd ?? process.cwd());
-  const url = `http://localhost:${clientPort}`;
+  // The Hono server serves both API and built client from the API port
+  const url = `http://localhost:${apiPort}`;
   const server = resolveServerScript();
 
   if (!server) {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/dashboard",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Local web dashboard for harness project health and roadmap visualization",
   "type": "module",
   "exports": {

--- a/packages/dashboard/src/server/index.ts
+++ b/packages/dashboard/src/server/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import { cors } from 'hono/cors';
+import { serveStatic } from '@hono/node-server/serve-static';
 import { buildHealthCheckRouter } from './routes/health-check';
 import { buildOverviewRouter } from './routes/overview';
 import { buildRoadmapRouter } from './routes/roadmap';
@@ -40,6 +41,14 @@ export function buildApp(ctx: ServerContext): Hono {
   app.route('/api', buildActionsRouter(ctx));
   app.route('/api', buildCIRouter(ctx));
   app.route('/api', buildImpactRouter(ctx));
+
+  // Serve built client static files (assets, etc.)
+  const clientRoot = process.env['DASHBOARD_CLIENT_ROOT'];
+  if (clientRoot) {
+    app.use('/assets/*', serveStatic({ root: clientRoot }));
+    // SPA fallback: serve index.html for all non-API routes
+    app.get('*', serveStatic({ root: clientRoot, path: '/index.html' }));
+  }
 
   return app;
 }

--- a/packages/dashboard/src/server/serve.ts
+++ b/packages/dashboard/src/server/serve.ts
@@ -1,6 +1,20 @@
 import { serve } from '@hono/node-server';
-import { app } from './index';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { API_PORT } from '../shared/constants';
+
+// Resolve built client directory relative to this script.
+// In dev mode (__dirname = src/server/), ../client has no built assets — skip.
+// In production (__dirname = dist/server/), ../client has the Vite build output.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const clientDir = resolve(__dirname, '..', 'client');
+if (existsSync(join(clientDir, 'index.html')) && existsSync(join(clientDir, 'assets'))) {
+  process.env['DASHBOARD_CLIENT_ROOT'] = clientDir;
+}
+
+// Import app after setting env so buildApp() picks it up
+const { app } = await import('./index');
 
 const port = Number(process.env['DASHBOARD_API_PORT'] ?? API_PORT);
 


### PR DESCRIPTION
## Summary
- `harness dashboard` was returning 404 on all routes because only the Hono API server was spawned — nothing served the built frontend
- Added `@hono/node-server/serve-static` middleware to serve built client files (`dist/client/`) with SPA fallback for client-side routing
- Updated CLI to open the API port directly since both API and frontend are now served from one port

## Test plan
- [x] `GET /` returns 200 with dashboard HTML
- [x] `GET /assets/*` returns 200 with static JS/CSS
- [x] `GET /roadmap` returns 200 (SPA fallback serves index.html)
- [x] `GET /api/health-check` returns 200 (API still works)
- [x] All 109 existing dashboard tests pass
- [x] `pnpm dev` still works (Vite dev server unaffected — `DASHBOARD_CLIENT_ROOT` not set in dev mode)