### PR TITLE
feat(review): advanced review pipeline primitives

### DIFF
--- a/docs/changes/advanced-review-pipeline/proposal.md
+++ b/docs/changes/advanced-review-pipeline/proposal.md
@@ -1,0 +1,322 @@
+# Advanced Review Pipeline
+
+**Date:** 2026-04-16
+**Status:** Proposed
+**Skill:** `harness-code-review` (extension) + `packages/orchestrator`
+**Issue:** advanced-review-pipe-c2940ed8 ([ACE-Batch6])
+**Keywords:** meta-judge, rubric, two-stage, isolation, parallel-groups, tiered-mcp, triage-routing
+
+## Overview
+
+Extend the 7-phase review pipeline (`unified-code-review-pipeline`) and the
+orchestrator dispatch path with five cross-cutting techniques inspired by
+Context Engineering Kit, Superpowers, sudocode, and Claude Task Master. The
+five pieces ship as **pure, reusable primitives** under `packages/core` and
+`packages/orchestrator`, each consumable in isolation so downstream callers
+(review CLI, MCP server, autopilot) can opt in one at a time.
+
+1. **Meta-judge rubric pre-generation** — under `--thorough`, generate a
+   task-specific rubric _before_ seeing the implementation. Prevents the judge
+   from rationalizing the diff after the fact.
+2. **Two-stage isolated review** — split spec-compliance from code-quality into
+   separate passes with _disjoint context_. A spec-compliance reviewer never
+   sees the code-quality rubric; a code-quality reviewer never sees the spec.
+3. **findParallelGroups** — topological grouping algorithm that turns a task
+   dependency graph into sequential waves where every task in a wave is
+   independent.
+4. **Tiered MCP tool loading** (`core` / `standard` / `full`) — measure token
+   baseline before loading all tools; select a tier that fits the budget.
+5. **Triage routing** — characteristic-driven dispatch that extends
+   `routeIssue()` with task _shape_ signals (not just scope tier) so the
+   orchestrator picks the right skill/agent.
+
+### Non-goals
+
+- Replacing the existing 7-phase pipeline — this is additive; defaults unchanged.
+- New LLM provider integrations — tiered MCP is token-budget-aware, not provider-specific.
+- Dynamic task graph generation — `findParallelGroups` consumes graphs, it does not produce them.
+- Rewriting the orchestrator dispatcher — triage routing is a _pre-filter_ on top of `routeIssue()`.
+
+## Decisions
+
+| Decision                        | Choice                                                              | Rationale                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Meta-judge activation           | `--thorough` flag (new), distinct from `--deep`                     | `--deep` already maps to threat modeling; don't overload                                           |
+| Rubric scope                    | Derived from diff metadata + commit message only — no file contents | Pre-generation must not peek at implementation or the anti-rationalization property is lost        |
+| Two-stage isolation             | Sequential passes with separate `ContextBundle`s, not parallel      | Parallel passes would share memory in the agent registry; sequential guarantees context separation |
+| Spec-compliance vs code-quality | Maps onto existing domains: compliance/architecture vs bug/security | Avoid introducing new domains; re-label the fan-out batches                                        |
+| findParallelGroups location     | `packages/core/src/review/parallel-groups.ts`                       | Core has graph/deps utilities; orchestrator depends on core (allowed)                              |
+| Graph input shape               | Generic `{ id: string; dependsOn: string[] }[]`                     | Keeps the algorithm reusable for tasks, review agents, migration scripts                           |
+| Tiered MCP loading              | Ranked tier assignment per tool definition + budget-aware selector  | Extends the existing `TOOL_DEFINITIONS` registry rather than a parallel structure                  |
+| Token measurement               | Character count × 0.25 heuristic + optional tokenizer hook          | No hard dependency on a specific tokenizer; tests stay deterministic                               |
+| Triage routing location         | `packages/orchestrator/src/core/triage-router.ts`                   | Sits beside `model-router.ts`; dispatched before `routeIssue()`                                    |
+| Triage outputs                  | `{ skill: string; agent?: string; reason: string }`                 | Same shape the autopilot already consumes                                                          |
+
+## Technical Design
+
+### 1. Meta-Judge Rubric Pre-Generation
+
+New module: `packages/core/src/review/meta-judge.ts`.
+
+```ts
+export interface RubricItem {
+  id: string; // stable slug, e.g. "spec-acceptance-1"
+  category: 'spec' | 'quality' | 'risk';
+  title: string; // 1-line criterion
+  mustHave: boolean; // critical vs nice-to-have
+  rationale: string; // why this criterion matters for THIS task
+}
+
+export interface Rubric {
+  changeType: ChangeType;
+  items: RubricItem[];
+  generatedAt: string; // ISO timestamp
+  source: 'heuristic' | 'llm' | 'spec-file';
+}
+
+export interface GenerateRubricOptions {
+  diff: DiffInfo;
+  commitMessage: string;
+  specFile?: string; // path to spec doc if present
+  llm?: (prompt: string) => Promise<string>; // optional generator
+}
+
+export async function generateRubric(opts: GenerateRubricOptions): Promise<Rubric>;
+```
+
+Heuristic default path (no LLM) builds `RubricItem`s from commit-message verbs,
+changed-file types, and spec-file bullet points. The LLM path is a future
+extension gated by `opts.llm`.
+
+`PipelineFlags` gains `thorough?: boolean`. When set, `runReviewPipeline()`
+calls `generateRubric()` between Phase 2 and Phase 3, attaches the rubric to
+each `ContextBundle` via a new `rubric?: Rubric` field, and the Phase 4 agents
+consult it to gate which findings to emit.
+
+### 2. Two-Stage Isolated Review
+
+New module: `packages/core/src/review/two-stage.ts`.
+
+The fan-out phase is extended with a `stage` enum. `ContextBundle` gains:
+
+```ts
+stage?: 'spec-compliance' | 'code-quality';
+```
+
+`runReviewPipeline()` gains an `isolated?: boolean` flag. When set:
+
+1. Run Phase 4 on the `spec-compliance` subset (`compliance`, `architecture`)
+   with a context bundle that includes the spec file and rubric items tagged
+   `category: 'spec'` — but _no_ code-quality rubric.
+2. Collect those findings, clear them from the working set.
+3. Run Phase 4 again on the `code-quality` subset (`bug`, `security`) with a
+   context bundle that _excludes_ the spec file and includes only rubric items
+   tagged `category: 'quality' | 'risk'`.
+4. Merge both finding sets through Phase 5/6.
+
+Implementation pattern: a pure helper `splitBundlesByStage(bundles, stage)` returns
+a filtered bundle array. The orchestrator calls `fanOutReview()` twice.
+
+### 3. findParallelGroups Algorithm
+
+New module: `packages/core/src/review/parallel-groups.ts`.
+
+```ts
+export interface GraphNode {
+  id: string;
+  dependsOn: readonly string[]; // IDs of prerequisite nodes
+}
+
+export interface ParallelGroups {
+  waves: string[][]; // waves[i] is the set of IDs runnable in parallel at wave i
+  cyclic: string[]; // IDs that participate in a cycle (returned separately, never scheduled)
+  orphaned: string[]; // IDs whose dependencies do not exist in the input
+}
+
+export function findParallelGroups(nodes: readonly GraphNode[]): ParallelGroups;
+```
+
+Algorithm: Kahn-style BFS.
+
+1. Build an indegree map.
+2. Wave 0 = every node with indegree 0.
+3. For each subsequent wave, decrement indegrees of dependents of completed
+   nodes, then collect the new zero-indegree set.
+4. Any node left after waves are exhausted is marked `cyclic`.
+5. Any `dependsOn` pointing to a non-existent id is collected in `orphaned`.
+
+Guarantees:
+
+- Every node in `waves[i]` depends _only_ on nodes in `waves[0..i-1]`.
+- Returns deterministic output: within each wave, ids are sorted.
+- Does not throw on cycles — cycles are _data_ the caller may choose to error on.
+
+### 4. Tiered MCP Tool Loading
+
+New module: `packages/cli/src/mcp/tool-tiers.ts`.
+
+```ts
+export type McpToolTier = 'core' | 'standard' | 'full';
+
+export interface TierAssignments {
+  core: string[]; // e.g. ['validate_project', 'check_dependencies']
+  standard: string[]; // core + next-most-common
+  full: string[]; // all tools
+}
+
+export interface SelectTierOptions {
+  tokenBudget?: number; // measured baseline; undefined = 'full'
+  overrideTier?: McpToolTier; // explicit opt-in
+  tokensPerTool?: number; // override the 400-token heuristic
+}
+
+export function selectTier(
+  definitions: ToolDefinition[],
+  options: SelectTierOptions
+): { tier: McpToolTier; filter: string[] };
+
+export function estimateBaselineTokens(definitions: ToolDefinition[]): number;
+```
+
+Baseline estimation: sum of description length + input schema JSON length,
+multiplied by the 0.25 chars/token heuristic. Callers can override via
+`tokensPerTool`.
+
+Tier assignment lives in a static table next to each tool in
+`TOOL_TIER_ASSIGNMENTS` (see below). The existing `buildFilteredTools()` in
+`packages/cli/src/mcp/server.ts` already supports a `toolFilter` parameter —
+tier selection just produces that filter.
+
+Tier policy (draft):
+
+- **core** (~10 tools): validate_project, check_dependencies, check_docs,
+  query_graph, get_impact, manage_state, run_skill, code_search, code_outline,
+  compact.
+- **standard** (~30 tools): core + review/scan/analysis tools (run_code_review,
+  run_security_scan, detect_entropy, check_performance, find_context_for,
+  get_relationships, manage_roadmap, etc.).
+- **full**: every tool in `TOOL_DEFINITIONS`.
+
+Token thresholds (defaults, overridable via CLI flag):
+
+- `tokenBudget < 4_000` → `core`
+- `tokenBudget < 12_000` → `standard`
+- otherwise → `full`
+
+The `harness mcp` CLI command gains `--tier <core|standard|full>` and
+`--budget-tokens <n>`; when neither is set, `startServer()` measures baseline
+via `estimateBaselineTokens()` and picks automatically.
+
+### 5. Triage Routing
+
+New module: `packages/orchestrator/src/core/triage-router.ts`.
+
+```ts
+export interface TriageSignals {
+  labels: string[];
+  titlePrefix?: string; // "fix:", "feat:", "docs:", "security:"
+  touchesSecuritySensitivePaths?: boolean;
+  touchesMigrationPaths?: boolean;
+  changedFileCount?: number;
+  hasFailingTests?: boolean;
+  isRollback?: boolean;
+}
+
+export interface TriageDecision {
+  skill: 'code-review' | 'security-review' | 'planning' | 'debugging' | 'refactoring' | 'docs';
+  agent?: string; // optional specific agent within the skill
+  confidence: 'high' | 'medium' | 'low';
+  reasons: string[];
+}
+
+export function triageIssue(
+  issue: Issue,
+  signals: TriageSignals,
+  config?: TriageConfig
+): TriageDecision;
+```
+
+Rule order (first match wins):
+
+1. `isRollback` → `debugging` (high confidence)
+2. `titlePrefix === 'security:'` OR `touchesSecuritySensitivePaths` → `security-review` (high)
+3. `titlePrefix === 'docs:'` OR changed files are 100% `.md` → `docs` (high)
+4. `hasFailingTests` → `debugging` (medium)
+5. `touchesMigrationPaths` → `planning` (high) — migrations need a plan before execute
+6. `titlePrefix === 'fix:'` AND `changedFileCount <= 3` → `code-review` (high)
+7. `titlePrefix === 'feat:'` → `planning` (medium) — features plan first
+8. `titlePrefix === 'refactor:'` → `refactoring` (medium)
+9. Default → `code-review` (low)
+
+Triage runs **before** `routeIssue()` in the orchestrator workflow. The skill
+chosen by triage is persisted on the live session state so downstream
+dispatch reads it instead of re-deriving.
+
+`TriageConfig` allows projects to override path regexes for the security and
+migration detectors. Defaults: security paths match `/(auth|crypto|secret|token|password)/i`;
+migration paths match `/(migration|schema|db\/|database\/)/i`.
+
+## Flags Added
+
+| Flag                            | Surface                | Effect                                                        |
+| ------------------------------- | ---------------------- | ------------------------------------------------------------- |
+| `--thorough`                    | `harness agent review` | Generate rubric before Phase 3; gate findings against rubric  |
+| `--isolated`                    | `harness agent review` | Split Phase 4 into two stages (spec-compliance, code-quality) |
+| `--tier <core\|standard\|full>` | `harness mcp`          | Explicit MCP tool tier                                        |
+| `--budget-tokens <n>`           | `harness mcp`          | Force tier selection using the supplied budget                |
+
+## Type Additions
+
+All additions are _optional_ — existing callers compile unchanged.
+
+- `packages/core/src/review/types/pipeline.ts`:
+  `PipelineFlags.thorough?: boolean`, `PipelineFlags.isolated?: boolean`
+- `packages/core/src/review/types/context.ts`:
+  `ContextBundle.rubric?: Rubric`, `ContextBundle.stage?: 'spec-compliance' | 'code-quality'`
+- `packages/core/src/review/types/fan-out.ts`:
+  `ReviewFinding.rubricItemId?: string` for traceability
+
+## Success Criteria
+
+1. **Meta-judge runs before implementation is read** — the rubric generator has
+   access only to diff metadata (file names, commit message), not file bodies.
+   Enforced by the `GenerateRubricOptions` type (no `fileContents` field).
+2. **Two-stage isolation is verifiable** — spec-compliance bundles contain the
+   spec file; code-quality bundles must not. Asserted by unit tests.
+3. **findParallelGroups is deterministic** — same input produces the same
+   waves, regardless of `dependsOn` ordering; ids within a wave are sorted.
+4. **Cycles do not crash the algorithm** — `cyclic` is returned as data; caller
+   decides policy.
+5. **Tiered MCP selection fits budget** — `selectTier()` never exceeds the
+   configured budget unless `overrideTier` is set.
+6. **Triage routing respects precedence** — rule order is honored; tests cover
+   all first-match paths.
+7. **All new features are opt-in** — defaults preserve existing behavior of the
+   review CLI, the MCP server, and the orchestrator.
+8. **`harness validate` is clean** — no layer violations, no forbidden imports,
+   module sizes within thresholds.
+
+## Implementation Order
+
+1. **findParallelGroups** — purest module, no dependencies, easy to unit test first.
+2. **Meta-judge rubric** — adds types, heuristic generator, unit tests. Wired
+   into `runReviewPipeline()` behind `--thorough`.
+3. **Two-stage isolated review** — builds on the rubric; adds `stage` field and
+   isolation orchestration. Wired behind `--isolated`.
+4. **Tiered MCP tool loading** — assignments table, estimator, selector; wire
+   into `startServer()` and `harness mcp` command.
+5. **Triage routing** — orchestrator module + default rule set; integration
+   into the dispatch path beside `routeIssue()`.
+6. **CLI wiring** — `--thorough`, `--isolated`, `--tier`, `--budget-tokens`
+   added to commander option lists with help text.
+7. **Docs + learnings** — update `.harness/learnings.md` with any surprises.
+
+## Competitive Influence Map
+
+| Source                  | Idea Borrowed                                 | Where Applied      |
+| ----------------------- | --------------------------------------------- | ------------------ |
+| Context Engineering Kit | Pre-generated rubric                          | Meta-judge         |
+| Superpowers             | Stage isolation with separate context windows | Two-stage review   |
+| sudocode                | Dependency-graph scheduling                   | findParallelGroups |
+| Claude Task Master      | Triage/dispatch routing by task shape         | Triage router      |
+| (Internal)              | `buildFilteredTools()` in MCP server          | Tiered MCP loading |

--- a/docs/plans/2026-04-16-advanced-review-pipeline.md
+++ b/docs/plans/2026-04-16-advanced-review-pipeline.md
@@ -1,0 +1,76 @@
+# Plan: Advanced Review Pipeline
+
+**Issue:** advanced-review-pipe-c2940ed8 ([ACE-Batch6])
+**Proposal:** `docs/changes/advanced-review-pipeline/proposal.md`
+**Date:** 2026-04-16
+
+## Task Breakdown
+
+| #   | Task                                                                                                                 | Files                                                                                    | Depends on |
+| --- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------- |
+| 1   | Implement `findParallelGroups()` — Kahn-style BFS with cycle/orphan handling                                         | `packages/core/src/review/parallel-groups.ts` + test                                     | —          |
+| 2   | Add `GraphNode`, `ParallelGroups` types and re-export                                                                | `packages/core/src/review/types/parallel-groups.ts`, `types/index.ts`, `review/index.ts` | 1          |
+| 3   | Implement meta-judge rubric heuristic generator                                                                      | `packages/core/src/review/meta-judge.ts` + test                                          | —          |
+| 4   | Add `Rubric`, `RubricItem` types and extend `ContextBundle` / `PipelineFlags`                                        | `review/types/meta-judge.ts`, extend `types/context.ts`, `types/pipeline.ts`             | 3          |
+| 5   | Wire `--thorough` flag to call `generateRubric()` in `runReviewPipeline()` between Phases 2 and 3, attach to bundles | `review/pipeline-orchestrator.ts`                                                        | 4          |
+| 6   | Implement two-stage isolation helper `splitBundlesByStage()`                                                         | `packages/core/src/review/two-stage.ts` + test                                           | 4          |
+| 7   | Wire `--isolated` flag to run Phase 4 twice in `runReviewPipeline()`                                                 | `review/pipeline-orchestrator.ts`                                                        | 6          |
+| 8   | Implement MCP tier assignments and estimator                                                                         | `packages/cli/src/mcp/tool-tiers.ts` + test                                              | —          |
+| 9   | Wire `selectTier()` into `harness mcp` command / `startServer()`                                                     | `packages/cli/src/commands/mcp.ts`, `mcp/server.ts`                                      | 8          |
+| 10  | Implement triage router module and default rules                                                                     | `packages/orchestrator/src/core/triage-router.ts` + test                                 | —          |
+| 11  | Add `--thorough`, `--isolated` flags to `createReviewCommand()` and thread through `runAgentReview()`                | `packages/cli/src/commands/agent/review.ts`                                              | 5, 7       |
+| 12  | Add `--tier` and `--budget-tokens` flags to `harness mcp`                                                            | `packages/cli/src/commands/mcp.ts`                                                       | 9          |
+| 13  | `harness validate` + unit tests clean                                                                                | —                                                                                        | all        |
+
+## Files Touched Summary
+
+Additions:
+
+- `packages/core/src/review/parallel-groups.ts`
+- `packages/core/src/review/meta-judge.ts`
+- `packages/core/src/review/two-stage.ts`
+- `packages/core/src/review/types/meta-judge.ts`
+- `packages/core/src/review/types/parallel-groups.ts`
+- `packages/cli/src/mcp/tool-tiers.ts`
+- `packages/orchestrator/src/core/triage-router.ts`
+- `packages/core/tests/review/parallel-groups.test.ts`
+- `packages/core/tests/review/meta-judge.test.ts`
+- `packages/core/tests/review/two-stage.test.ts`
+- `packages/cli/tests/mcp/tool-tiers.test.ts` (new dir if absent)
+- `packages/orchestrator/tests/core/triage-router.test.ts`
+
+Modifications:
+
+- `packages/core/src/review/types/context.ts` (+`rubric?`, +`stage?`)
+- `packages/core/src/review/types/pipeline.ts` (+`thorough?`, +`isolated?`)
+- `packages/core/src/review/types/fan-out.ts` (+`rubricItemId?`)
+- `packages/core/src/review/types/index.ts` (barrel exports)
+- `packages/core/src/review/index.ts` (public exports)
+- `packages/core/src/review/pipeline-orchestrator.ts` (rubric + isolation wiring)
+- `packages/cli/src/mcp/server.ts` (optional: expose `getToolDefinitions()` already exists)
+- `packages/cli/src/commands/mcp.ts` (add `--tier`, `--budget-tokens`)
+- `packages/cli/src/commands/agent/review.ts` (add `--thorough`, `--isolated`)
+
+## Architectural Constraints
+
+All additions respect `harness.config.json` layer constraints:
+
+- `packages/core` → may depend on `types` and `graph` only ✓
+- `packages/orchestrator` → may depend on `types` and `core` only ✓
+- `packages/cli` → may depend on all lower layers ✓
+
+No new package dependencies.
+
+## Test Strategy
+
+Every new pure module gets unit tests:
+
+- `parallel-groups.test.ts` — linear, diamond, disconnected, cyclic, orphaned inputs.
+- `meta-judge.test.ts` — rubric generation from feature, fix, docs, refactor commits; verifies no file bodies are read.
+- `two-stage.test.ts` — filtering returns disjoint bundle sets; spec file exclusion.
+- `tool-tiers.test.ts` — estimator math, tier selection across budgets, override precedence.
+- `triage-router.test.ts` — one case per rule branch + default.
+
+Pipeline integration is covered by extending `pipeline-orchestrator.test.ts`
+with a `--thorough` + `--isolated` smoke test that confirms the rubric and
+stages are threaded end-to-end.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -234,6 +234,8 @@ Start the MCP (Model Context Protocol) server on stdio
 **Options:**
 
 - `--tools` — Only register the specified tools (used by Cursor integration)
+- `--tier` — Load a preset tool tier instead of all tools
+- `--budget-tokens` — Auto-select tier to fit this baseline token budget
 
 ### `harness predict`
 
@@ -416,6 +418,8 @@ Run unified code review pipeline on current changes
 - `--ci` — Enable eligibility gate, non-interactive output
 - `--deep` — Add threat modeling pass to security agent
 - `--no-mechanical` — Skip mechanical checks
+- `--thorough` — Generate task-specific rubric before reading implementation
+- `--isolated` — Two-stage review: spec-compliance then code-quality with disjoint context
 
 ### `harness agent run [task]`
 

--- a/packages/cli/src/commands/agent/review.ts
+++ b/packages/cli/src/commands/agent/review.ts
@@ -17,6 +17,8 @@ interface ReviewOptions {
   ci?: boolean;
   deep?: boolean;
   noMechanical?: boolean;
+  thorough?: boolean;
+  isolated?: boolean;
 }
 
 export async function runAgentReview(options: ReviewOptions): Promise<
@@ -89,6 +91,8 @@ export async function runAgentReview(options: ReviewOptions): Promise<
       ci: options.ci ?? false,
       deep: options.deep ?? false,
       noMechanical: options.noMechanical ?? false,
+      ...(options.thorough ? { thorough: true } : {}),
+      ...(options.isolated ? { isolated: true } : {}),
     },
     config: config as unknown as Record<string, unknown>,
   });
@@ -149,6 +153,11 @@ export function createReviewCommand(): Command {
     .option('--ci', 'Enable eligibility gate, non-interactive output')
     .option('--deep', 'Add threat modeling pass to security agent')
     .option('--no-mechanical', 'Skip mechanical checks')
+    .option('--thorough', 'Generate task-specific rubric before reading implementation')
+    .option(
+      '--isolated',
+      'Two-stage review: spec-compliance then code-quality with disjoint context'
+    )
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const mode = resolveReviewMode(globalOpts);
@@ -162,6 +171,8 @@ export function createReviewCommand(): Command {
         ci: opts.ci,
         deep: opts.deep,
         noMechanical: opts.mechanical === false,
+        thorough: opts.thorough,
+        isolated: opts.isolated,
       });
 
       if (!result.ok) {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,11 +1,60 @@
 import { Command } from 'commander';
+import type { McpToolTier } from '../mcp/tool-tiers.js';
+
+const VALID_TIERS: ReadonlySet<string> = new Set(['core', 'standard', 'full']);
+
+function parseTier(value: string): McpToolTier {
+  const lower = value.toLowerCase();
+  if (!VALID_TIERS.has(lower)) {
+    throw new Error(`Invalid tier "${value}". Expected one of: core, standard, full.`);
+  }
+  return lower as McpToolTier;
+}
+
+function parseBudget(value: string): number {
+  const n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`Invalid --budget-tokens "${value}". Expected a non-negative integer.`);
+  }
+  return n;
+}
 
 export function createMcpCommand(): Command {
   return new Command('mcp')
     .description('Start the MCP (Model Context Protocol) server on stdio')
     .option('--tools <tools...>', 'Only register the specified tools (used by Cursor integration)')
-    .action(async (opts: { tools?: string[] }) => {
-      const { startServer } = await import('../mcp/index.js');
-      await startServer(opts.tools);
+    .option(
+      '--tier <core|standard|full>',
+      'Load a preset tool tier instead of all tools',
+      parseTier
+    )
+    .option(
+      '--budget-tokens <n>',
+      'Auto-select tier to fit this baseline token budget',
+      parseBudget
+    )
+    .action(async (opts: { tools?: string[]; tier?: McpToolTier; budgetTokens?: number }) => {
+      const [{ startServer, getToolDefinitions }, { selectTier }] = await Promise.all([
+        import('../mcp/index.js'),
+        import('../mcp/tool-tiers.js'),
+      ]);
+
+      // Explicit --tools list wins over tier/budget selection.
+      if (opts.tools && opts.tools.length > 0) {
+        await startServer(opts.tools);
+        return;
+      }
+
+      if (opts.tier || opts.budgetTokens !== undefined) {
+        const definitions = getToolDefinitions();
+        const selection = selectTier(definitions, {
+          ...(opts.tier ? { overrideTier: opts.tier } : {}),
+          ...(opts.budgetTokens !== undefined ? { tokenBudget: opts.budgetTokens } : {}),
+        });
+        await startServer(selection.filter);
+        return;
+      }
+
+      await startServer();
     });
 }

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -136,7 +136,7 @@ import { predictFailuresDefinition, handlePredictFailures } from './tools/predic
 import { recommendSkillsDefinition, handleRecommendSkills } from './tools/recommend-skills.js';
 import { compactToolDefinition, handleCompact } from './tools/compact.js';
 
-type ToolDefinition = {
+export type ToolDefinition = {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;

--- a/packages/cli/src/mcp/tool-tiers.ts
+++ b/packages/cli/src/mcp/tool-tiers.ts
@@ -1,0 +1,181 @@
+import type { ToolDefinition } from './server.js';
+
+/**
+ * Abstract MCP tool tier. Higher tiers include more tools.
+ *
+ * Policy:
+ *  - core: smallest useful set for validation, state, and navigation.
+ *  - standard: core + review/scan/analysis tools for day-to-day work.
+ *  - full: every tool in the registry.
+ */
+export type McpToolTier = 'core' | 'standard' | 'full';
+
+/**
+ * Tool-name allow-lists per tier. `standard` is a superset of `core`.
+ *
+ * Unknown tools (added after this table was last maintained) are
+ * included in `full` only, so adding a tool can never silently enter
+ * the `core` or `standard` set.
+ */
+export const CORE_TOOL_NAMES: readonly string[] = [
+  'validate_project',
+  'check_dependencies',
+  'check_docs',
+  'query_graph',
+  'get_impact',
+  'manage_state',
+  'run_skill',
+  'code_search',
+  'code_outline',
+  'compact',
+];
+
+const STANDARD_EXTRA: readonly string[] = [
+  // Review / scan / analysis
+  'run_code_review',
+  'run_security_scan',
+  'detect_entropy',
+  'check_performance',
+  'review_changes',
+  'analyze_diff',
+  // Graph navigation
+  'find_context_for',
+  'get_relationships',
+  'search_similar',
+  'compute_blast_radius',
+  'ask_graph',
+  // Workflow
+  'manage_roadmap',
+  'check_phase_gate',
+  'gather_context',
+  'assess_project',
+  'recommend_skills',
+  'search_skills',
+  'code_unfold',
+];
+
+export const STANDARD_TOOL_NAMES: readonly string[] = [...CORE_TOOL_NAMES, ...STANDARD_EXTRA];
+
+/**
+ * Default tokens-per-character heuristic — roughly 4 chars per token.
+ * Exposed so callers/tests can override deterministically.
+ */
+export const DEFAULT_CHARS_PER_TOKEN = 4;
+
+/**
+ * Estimate baseline tokens consumed by registering the given tool definitions.
+ * Uses a deterministic char-length / CHARS_PER_TOKEN heuristic.
+ *
+ * @param definitions Tools the server would expose.
+ * @param charsPerToken Override the default heuristic (e.g. for tests).
+ */
+export function estimateBaselineTokens(
+  definitions: readonly ToolDefinition[],
+  charsPerToken = DEFAULT_CHARS_PER_TOKEN
+): number {
+  if (charsPerToken <= 0) {
+    throw new Error('charsPerToken must be > 0');
+  }
+  let totalChars = 0;
+  for (const def of definitions) {
+    totalChars += def.name.length;
+    totalChars += def.description.length;
+    totalChars += JSON.stringify(def.inputSchema).length;
+  }
+  return Math.ceil(totalChars / charsPerToken);
+}
+
+/**
+ * Default token budget thresholds. Under each threshold the corresponding
+ * tier is selected. Callers can override via SelectTierOptions.
+ */
+export const DEFAULT_BUDGETS = {
+  coreMax: 4_000,
+  standardMax: 12_000,
+} as const;
+
+export interface SelectTierOptions {
+  /** Measured or configured token budget. Undefined means "use full". */
+  tokenBudget?: number;
+  /** Explicit tier override — skips automatic selection. */
+  overrideTier?: McpToolTier;
+  /** Override the default char/token heuristic. */
+  charsPerToken?: number;
+  /** Override the default budget thresholds. */
+  budgets?: { coreMax: number; standardMax: number };
+}
+
+export interface TierSelection {
+  tier: McpToolTier;
+  /** Tool names to pass to buildFilteredTools (undefined for 'full' = no filter). */
+  filter: string[] | undefined;
+  /** Estimated tokens for the chosen set. */
+  estimatedTokens: number;
+  /** Reason for selection (for logging). */
+  reason: string;
+}
+
+/**
+ * Select an MCP tool tier given a budget and the full list of definitions.
+ *
+ * Resolution order:
+ *  1. If `overrideTier` is set, use it (still filters to known tools).
+ *  2. If `tokenBudget` is undefined, use `full`.
+ *  3. If `tokenBudget < budgets.coreMax`, use `core`.
+ *  4. If `tokenBudget < budgets.standardMax`, use `standard`.
+ *  5. Otherwise, `full`.
+ */
+export function selectTier(
+  definitions: readonly ToolDefinition[],
+  options: SelectTierOptions = {}
+): TierSelection {
+  const budgets = options.budgets ?? DEFAULT_BUDGETS;
+  const charsPerToken = options.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+
+  const tier = resolveTier(options, budgets);
+  const filter = filterForTier(tier, definitions);
+  const effectiveDefs =
+    filter === undefined ? definitions : definitions.filter((d) => filter.includes(d.name));
+  const estimatedTokens = estimateBaselineTokens(effectiveDefs, charsPerToken);
+
+  return {
+    tier,
+    filter,
+    estimatedTokens,
+    reason: explainTier(tier, options, budgets),
+  };
+}
+
+function resolveTier(
+  options: SelectTierOptions,
+  budgets: { coreMax: number; standardMax: number }
+): McpToolTier {
+  if (options.overrideTier) return options.overrideTier;
+  const budget = options.tokenBudget;
+  if (budget === undefined) return 'full';
+  if (budget < budgets.coreMax) return 'core';
+  if (budget < budgets.standardMax) return 'standard';
+  return 'full';
+}
+
+function filterForTier(
+  tier: McpToolTier,
+  definitions: readonly ToolDefinition[]
+): string[] | undefined {
+  if (tier === 'full') return undefined;
+  const allow = tier === 'core' ? CORE_TOOL_NAMES : STANDARD_TOOL_NAMES;
+  const allowSet = new Set(allow);
+  const present = new Set(definitions.map((d) => d.name));
+  // Intersect with present names so missing entries in the allow-list don't pollute.
+  return allow.filter((name) => present.has(name) && allowSet.has(name));
+}
+
+function explainTier(
+  tier: McpToolTier,
+  options: SelectTierOptions,
+  budgets: { coreMax: number; standardMax: number }
+): string {
+  if (options.overrideTier) return `override: ${options.overrideTier}`;
+  if (options.tokenBudget === undefined) return 'no budget specified; defaulting to full';
+  return `tokenBudget=${options.tokenBudget} → ${tier} (thresholds: core<${budgets.coreMax}, standard<${budgets.standardMax})`;
+}

--- a/packages/cli/tests/mcp/tool-tiers.test.ts
+++ b/packages/cli/tests/mcp/tool-tiers.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CORE_TOOL_NAMES,
+  STANDARD_TOOL_NAMES,
+  DEFAULT_BUDGETS,
+  DEFAULT_CHARS_PER_TOKEN,
+  estimateBaselineTokens,
+  selectTier,
+} from '../../src/mcp/tool-tiers';
+import type { ToolDefinition } from '../../src/mcp/server';
+
+function def(name: string, descLen = 40, schemaDepth = 1): ToolDefinition {
+  return {
+    name,
+    description: 'd'.repeat(descLen),
+    inputSchema: schemaDepth > 0 ? { type: 'object', properties: {} } : {},
+  };
+}
+
+describe('CORE_TOOL_NAMES', () => {
+  it('is non-empty', () => {
+    expect(CORE_TOOL_NAMES.length).toBeGreaterThan(0);
+  });
+  it('is a strict subset of STANDARD_TOOL_NAMES', () => {
+    const std = new Set(STANDARD_TOOL_NAMES);
+    for (const name of CORE_TOOL_NAMES) expect(std.has(name)).toBe(true);
+    expect(STANDARD_TOOL_NAMES.length).toBeGreaterThan(CORE_TOOL_NAMES.length);
+  });
+});
+
+describe('estimateBaselineTokens()', () => {
+  it('returns 0 for empty input', () => {
+    expect(estimateBaselineTokens([])).toBe(0);
+  });
+
+  it('sums name + description + schema JSON length / CHARS_PER_TOKEN', () => {
+    const defs = [def('a', 40), def('b', 40)];
+    // name(1) + desc(40) + schema('{"type":"object","properties":{}}' = 33) = 74 per def
+    // total = 148 / 4 = 37
+    expect(estimateBaselineTokens(defs, DEFAULT_CHARS_PER_TOKEN)).toBe(37);
+  });
+
+  it('respects custom charsPerToken override', () => {
+    const defs = [def('a', 40)];
+    const base = estimateBaselineTokens(defs, 1);
+    const halved = estimateBaselineTokens(defs, 2);
+    expect(halved).toBe(Math.ceil(base / 2));
+  });
+
+  it('rejects zero or negative charsPerToken', () => {
+    expect(() => estimateBaselineTokens([], 0)).toThrow();
+    expect(() => estimateBaselineTokens([], -1)).toThrow();
+  });
+});
+
+describe('selectTier()', () => {
+  const allDefs: ToolDefinition[] = [
+    // known core tools
+    def('validate_project'),
+    def('check_dependencies'),
+    def('check_docs'),
+    def('query_graph'),
+    def('get_impact'),
+    def('manage_state'),
+    def('run_skill'),
+    def('code_search'),
+    def('code_outline'),
+    def('compact'),
+    // additional standard tools
+    def('run_code_review'),
+    def('run_security_scan'),
+    // extras not in any tier
+    def('fancy_new_tool'),
+    def('yet_another_tool'),
+  ];
+
+  it('returns full when no budget specified', () => {
+    const result = selectTier(allDefs);
+    expect(result.tier).toBe('full');
+    expect(result.filter).toBeUndefined();
+  });
+
+  it('returns core when budget is tight', () => {
+    const result = selectTier(allDefs, { tokenBudget: 2_000 });
+    expect(result.tier).toBe('core');
+    expect(new Set(result.filter)).toEqual(new Set(CORE_TOOL_NAMES));
+  });
+
+  it('returns standard when budget is between core and full thresholds', () => {
+    const result = selectTier(allDefs, { tokenBudget: 8_000 });
+    expect(result.tier).toBe('standard');
+    // Must include every core tool
+    for (const name of CORE_TOOL_NAMES) {
+      expect(result.filter).toContain(name);
+    }
+    // Must NOT include tools that aren't in standard
+    expect(result.filter).not.toContain('fancy_new_tool');
+  });
+
+  it('returns full when budget exceeds standard threshold', () => {
+    const result = selectTier(allDefs, { tokenBudget: 20_000 });
+    expect(result.tier).toBe('full');
+    expect(result.filter).toBeUndefined();
+  });
+
+  it('honors overrideTier regardless of budget', () => {
+    const result = selectTier(allDefs, { tokenBudget: 100_000, overrideTier: 'core' });
+    expect(result.tier).toBe('core');
+  });
+
+  it('respects custom budgets', () => {
+    const result = selectTier(allDefs, {
+      tokenBudget: 500,
+      budgets: { coreMax: 100, standardMax: 1_000 },
+    });
+    expect(result.tier).toBe('standard');
+  });
+
+  it('filters out tier names that are not actually registered', () => {
+    const limitedDefs = [def('validate_project'), def('check_docs')];
+    const result = selectTier(limitedDefs, { overrideTier: 'core' });
+    expect(result.filter).toEqual(['validate_project', 'check_docs']);
+  });
+
+  it('provides a human-readable reason for the decision', () => {
+    const override = selectTier(allDefs, { overrideTier: 'standard' });
+    expect(override.reason).toContain('override');
+    const budgeted = selectTier(allDefs, { tokenBudget: 1_000 });
+    expect(budgeted.reason).toContain('tokenBudget');
+    const none = selectTier(allDefs);
+    expect(none.reason).toContain('no budget');
+  });
+
+  it('DEFAULT_BUDGETS has core < standard', () => {
+    expect(DEFAULT_BUDGETS.coreMax).toBeLessThan(DEFAULT_BUDGETS.standardMax);
+  });
+
+  it('estimatedTokens reflects the filter size', () => {
+    const core = selectTier(allDefs, { tokenBudget: 2_000 });
+    const full = selectTier(allDefs, { tokenBudget: 20_000 });
+    expect(core.estimatedTokens).toBeLessThan(full.estimatedTokens);
+  });
+});

--- a/packages/core/src/review/index.ts
+++ b/packages/core/src/review/index.ts
@@ -99,3 +99,15 @@ export { checkEvidenceCoverage, tagUncitedFindings } from './evidence-gate';
 // Pipeline orchestrator
 export { runReviewPipeline } from './pipeline-orchestrator';
 export type { RunPipelineOptions } from './pipeline-orchestrator';
+
+// Parallel-group scheduling (reusable beyond review)
+export { findParallelGroups } from './parallel-groups';
+export type { GraphNode, ParallelGroups } from './types';
+
+// Meta-judge rubric
+export { generateRubric } from './meta-judge';
+export type { GenerateRubricOptions } from './meta-judge';
+export type { Rubric, RubricItem, ReviewStage } from './types';
+
+// Two-stage isolation
+export { splitBundlesByStage, stageDomains } from './two-stage';

--- a/packages/core/src/review/meta-judge.ts
+++ b/packages/core/src/review/meta-judge.ts
@@ -1,0 +1,281 @@
+import type { ChangeType, DiffInfo, Rubric, RubricItem } from './types';
+import { detectChangeType } from './change-type';
+
+/**
+ * Options for generating a rubric.
+ *
+ * Note the absence of a `fileContents` field — this is intentional.
+ * The rubric generator must not see the implementation, otherwise the
+ * anti-rationalization property is lost. Only metadata is accepted.
+ */
+export interface GenerateRubricOptions {
+  /** Diff metadata (file paths and counts only — no contents). */
+  diff: DiffInfo;
+  /** Most recent commit message. */
+  commitMessage: string;
+  /** Optional path to a spec document (title/summary is extracted at load time). */
+  specFile?: string;
+  /**
+   * Optional LLM hook. When provided, its output is parsed as JSON
+   * `{ items: RubricItem[] }` and returned. Callers supply their own
+   * tokenizer/provider.
+   */
+  llm?: (prompt: string) => Promise<string>;
+  /**
+   * Optional deterministic clock for tests. Defaults to `() => new Date()`.
+   */
+  now?: () => Date;
+}
+
+const SECURITY_SENSITIVE_PATH = /(auth|crypto|secret|token|password|session|permission)/i;
+const MIGRATION_PATH = /(migration|schema|db\/|database\/)/i;
+const TEST_PATH = /\.(test|spec)\.(ts|tsx|js|jsx|mts|cts)$/;
+const CONFIG_PATH = /\.(json|yml|yaml|toml|ini|env)$/;
+
+/**
+ * Generate a task-specific rubric from change metadata only.
+ *
+ * Produces a deterministic, diff-shape-aware set of criteria *before*
+ * the implementation is inspected. The rubric is later attached to
+ * each ContextBundle so review agents can cite which criterion a
+ * finding maps to.
+ */
+export async function generateRubric(opts: GenerateRubricOptions): Promise<Rubric> {
+  const { diff, commitMessage, specFile, llm, now } = opts;
+  const changeType = detectChangeType(commitMessage, diff);
+  const timestamp = (now ?? (() => new Date()))().toISOString();
+
+  // LLM path: caller is responsible for schema-compatible output.
+  if (llm) {
+    try {
+      const prompt = buildRubricPrompt({
+        changeType,
+        diff,
+        commitMessage,
+        ...(specFile !== undefined ? { specFile } : {}),
+      });
+      const raw = await llm(prompt);
+      const parsed = parseLlmRubric(raw);
+      if (parsed) {
+        return {
+          changeType,
+          items: parsed,
+          generatedAt: timestamp,
+          source: 'llm',
+        };
+      }
+      // Fall through to heuristic if LLM output was unparseable.
+    } catch {
+      // Fall through to heuristic on any LLM failure.
+    }
+  }
+
+  const items = buildHeuristicItems(changeType, diff, specFile);
+  const sorted = sortRubricItems(items);
+
+  return {
+    changeType,
+    items: sorted,
+    generatedAt: timestamp,
+    source: specFile ? 'spec-file' : 'heuristic',
+  };
+}
+
+function buildHeuristicItems(
+  changeType: ChangeType,
+  diff: DiffInfo,
+  specFile?: string
+): RubricItem[] {
+  const items: RubricItem[] = [];
+
+  // Spec criteria ------------------------------------------------------
+  if (specFile) {
+    items.push({
+      id: 'spec-acceptance',
+      category: 'spec',
+      title: 'Implementation satisfies documented acceptance criteria',
+      mustHave: true,
+      rationale: `Spec file ${specFile} defines explicit acceptance criteria that must be met.`,
+    });
+    items.push({
+      id: 'spec-scope',
+      category: 'spec',
+      title: 'Changes remain within the scope described by the spec',
+      mustHave: true,
+      rationale: 'Scope creep introduces unreviewed risk and complicates rollback.',
+    });
+  }
+
+  // Change-type-specific -----------------------------------------------
+  if (changeType === 'feature') {
+    items.push({
+      id: 'feature-api-surface',
+      category: 'quality',
+      title: 'New public API surface is minimal and intentional',
+      mustHave: true,
+      rationale: 'New features are the primary source of long-term maintenance cost.',
+    });
+    items.push({
+      id: 'feature-tests',
+      category: 'quality',
+      title: 'New behavior is covered by tests',
+      mustHave: true,
+      rationale: 'Features without tests regress silently.',
+    });
+  } else if (changeType === 'bugfix') {
+    items.push({
+      id: 'bugfix-regression-test',
+      category: 'quality',
+      title: 'A regression test exercises the fixed path',
+      mustHave: true,
+      rationale: 'Without a regression test, the bug can recur unnoticed.',
+    });
+    items.push({
+      id: 'bugfix-root-cause',
+      category: 'quality',
+      title: 'Fix addresses the root cause, not just the symptom',
+      mustHave: false,
+      rationale: 'Symptomatic fixes tend to re-surface in adjacent paths.',
+    });
+  } else if (changeType === 'refactor') {
+    items.push({
+      id: 'refactor-no-behavior-change',
+      category: 'quality',
+      title: 'No behavioral change versus existing tests',
+      mustHave: true,
+      rationale: 'A refactor that changes behavior is actually a feature or fix in disguise.',
+    });
+  } else if (changeType === 'docs') {
+    items.push({
+      id: 'docs-accuracy',
+      category: 'spec',
+      title: 'Documentation reflects current code behavior',
+      mustHave: true,
+      rationale: 'Stale docs mislead future readers more than missing docs.',
+    });
+  }
+
+  // Risk-surface criteria ---------------------------------------------
+  const touchesSecurity = diff.changedFiles.some((f) => SECURITY_SENSITIVE_PATH.test(f));
+  if (touchesSecurity) {
+    items.push({
+      id: 'risk-security-sensitive',
+      category: 'risk',
+      title: 'Security-sensitive paths are handled with defensive defaults',
+      mustHave: true,
+      rationale:
+        'Diff touches auth/crypto/secret/token paths — input validation, error handling, and logging must be defensive.',
+    });
+  }
+
+  const touchesMigration = diff.changedFiles.some((f) => MIGRATION_PATH.test(f));
+  if (touchesMigration) {
+    items.push({
+      id: 'risk-migration-rollback',
+      category: 'risk',
+      title: 'Migration changes have a rollback path',
+      mustHave: true,
+      rationale: 'Unrolled-backable migrations require a plan before execute.',
+    });
+  }
+
+  const newNonTest = diff.newFiles.filter(
+    (f) => !TEST_PATH.test(f) && !CONFIG_PATH.test(f) && !f.endsWith('.md')
+  );
+  if (newNonTest.length >= 3) {
+    items.push({
+      id: 'quality-module-boundaries',
+      category: 'quality',
+      title: 'New modules respect established layer/boundary conventions',
+      mustHave: false,
+      rationale: `Diff introduces ${newNonTest.length} new non-test modules — check layer placement.`,
+    });
+  }
+
+  if (diff.deletedFiles.length > 0) {
+    items.push({
+      id: 'quality-no-orphaned-references',
+      category: 'quality',
+      title: 'No orphaned references to deleted files remain',
+      mustHave: true,
+      rationale: `Diff deletes ${diff.deletedFiles.length} file(s) — imports, docs, and tests must follow.`,
+    });
+  }
+
+  // Always-on baseline criterion --------------------------------------
+  items.push({
+    id: 'quality-observability',
+    category: 'quality',
+    title: 'Errors and side effects are observable via logs or metrics',
+    mustHave: false,
+    rationale: 'Silent failure is the most expensive kind.',
+  });
+
+  return items;
+}
+
+function sortRubricItems(items: readonly RubricItem[]): RubricItem[] {
+  // Stable sort: mustHave first, then by category order (spec < quality < risk),
+  // then by id for determinism.
+  const categoryWeight: Record<RubricItem['category'], number> = {
+    spec: 0,
+    quality: 1,
+    risk: 2,
+  };
+  return [...items].sort((a, b) => {
+    if (a.mustHave !== b.mustHave) return a.mustHave ? -1 : 1;
+    const catDiff = categoryWeight[a.category] - categoryWeight[b.category];
+    if (catDiff !== 0) return catDiff;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function buildRubricPrompt(args: {
+  changeType: ChangeType;
+  diff: DiffInfo;
+  commitMessage: string;
+  specFile?: string;
+}): string {
+  const { changeType, diff, commitMessage, specFile } = args;
+  return [
+    'Generate a review rubric BEFORE reading the implementation.',
+    `Change type: ${changeType}`,
+    `Commit: ${commitMessage}`,
+    `Files changed: ${diff.changedFiles.length}`,
+    specFile ? `Spec file: ${specFile}` : 'Spec file: (none)',
+    '',
+    'Respond with JSON: { "items": RubricItem[] } where each item has',
+    'id, category (spec|quality|risk), title, mustHave (bool), rationale.',
+  ].join('\n');
+}
+
+function parseLlmRubric(raw: string): RubricItem[] | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'items' in parsed &&
+      Array.isArray((parsed as { items: unknown }).items)
+    ) {
+      const items = (parsed as { items: unknown[] }).items;
+      const valid = items.filter(isRubricItem);
+      return valid.length > 0 ? sortRubricItems(valid) : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isRubricItem(value: unknown): value is RubricItem {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    (v.category === 'spec' || v.category === 'quality' || v.category === 'risk') &&
+    typeof v.title === 'string' &&
+    typeof v.mustHave === 'boolean' &&
+    typeof v.rationale === 'string'
+  );
+}

--- a/packages/core/src/review/parallel-groups.ts
+++ b/packages/core/src/review/parallel-groups.ts
@@ -1,0 +1,120 @@
+import type { GraphNode, ParallelGroups } from './types';
+
+interface GraphIndex {
+  dependents: Map<string, Set<string>>;
+  indegree: Map<string, number>;
+  orphaned: Set<string>;
+}
+
+/**
+ * Build the indexed form of the graph: dependent sets, indegrees, and
+ * a list of dependency ids that did not appear in the input.
+ */
+function indexGraph(nodes: readonly GraphNode[]): GraphIndex {
+  const knownIds = new Set(nodes.map((n) => n.id));
+  const orphaned = new Set<string>();
+  const dependents = new Map<string, Set<string>>();
+  const indegree = new Map<string, number>();
+
+  for (const node of nodes) {
+    if (!indegree.has(node.id)) indegree.set(node.id, 0);
+    if (!dependents.has(node.id)) dependents.set(node.id, new Set());
+  }
+
+  for (const node of nodes) {
+    for (const dep of node.dependsOn) {
+      if (!knownIds.has(dep)) {
+        orphaned.add(dep);
+        continue;
+      }
+      addEdge(dependents, indegree, dep, node.id);
+    }
+  }
+
+  return { dependents, indegree, orphaned };
+}
+
+/**
+ * Record a (dep -> dependent) edge, deduplicating so repeated entries
+ * in `dependsOn` do not inflate the indegree.
+ */
+function addEdge(
+  dependents: Map<string, Set<string>>,
+  indegree: Map<string, number>,
+  dep: string,
+  dependent: string
+): void {
+  const depSet = dependents.get(dep);
+  if (!depSet) return;
+  if (depSet.has(dependent)) return;
+  depSet.add(dependent);
+  indegree.set(dependent, (indegree.get(dependent) ?? 0) + 1);
+}
+
+/**
+ * Kahn-style BFS: repeatedly collect zero-indegree nodes, decrement
+ * indegrees of their dependents, and emit a new wave.
+ */
+function sweepWaves(index: GraphIndex): { waves: string[][]; scheduled: Set<string> } {
+  const { dependents, indegree } = index;
+  const waves: string[][] = [];
+  const scheduled = new Set<string>();
+
+  let current = [...indegree.entries()]
+    .filter(([, deg]) => deg === 0)
+    .map(([id]) => id)
+    .sort();
+
+  while (current.length > 0) {
+    waves.push(current);
+    for (const id of current) scheduled.add(id);
+    current = advanceWave(current, dependents, indegree);
+  }
+
+  return { waves, scheduled };
+}
+
+function advanceWave(
+  current: readonly string[],
+  dependents: Map<string, Set<string>>,
+  indegree: Map<string, number>
+): string[] {
+  const next: string[] = [];
+  for (const id of current) {
+    for (const dependent of dependents.get(id) ?? []) {
+      const remaining = (indegree.get(dependent) ?? 0) - 1;
+      indegree.set(dependent, remaining);
+      if (remaining === 0) next.push(dependent);
+    }
+  }
+  return next.sort();
+}
+
+/**
+ * Group dependency-graph nodes into sequential waves that can each be
+ * dispatched in parallel.
+ *
+ * Algorithm: Kahn-style BFS over indegrees.
+ *
+ * Guarantees:
+ *   - Every id in `waves[i]` depends solely on ids in `waves[0..i-1]`.
+ *   - Output is deterministic: each wave's ids are sorted lexicographically.
+ *   - Cycles are reported via `cyclic` rather than throwing.
+ *   - Dependencies pointing at unknown ids are reported via `orphaned`
+ *     but do not prevent the referencing node from running.
+ *
+ * @param nodes - Dependency graph. Order of input does not affect output.
+ * @returns waves, plus cyclic and orphaned id lists.
+ */
+export function findParallelGroups(nodes: readonly GraphNode[]): ParallelGroups {
+  const index = indexGraph(nodes);
+  const { waves, scheduled } = sweepWaves(index);
+
+  const cyclic = [...index.indegree.keys()].filter((id) => !scheduled.has(id)).sort();
+
+  return {
+    waves,
+    cyclic,
+    orphaned: [...index.orphaned].sort(),
+  };
+}

--- a/packages/core/src/review/pipeline-orchestrator.ts
+++ b/packages/core/src/review/pipeline-orchestrator.ts
@@ -11,6 +11,8 @@ import type {
   MechanicalCheckResult,
   CommitHistoryEntry,
   EvidenceCoverageReport,
+  ContextBundle,
+  Rubric,
 } from './types';
 import { checkEligibility } from './eligibility-gate';
 import { runMechanicalChecks } from './mechanical-checks';
@@ -19,6 +21,8 @@ import { scopeContext } from './context-scoper';
 import { fanOutReview } from './fan-out';
 import { validateFindings } from './validate-findings';
 import { deduplicateFindings } from './deduplicate-findings';
+import { generateRubric } from './meta-judge';
+import { splitBundlesByStage } from './two-stage';
 import {
   formatTerminalOutput,
   formatGitHubComment,
@@ -152,8 +156,21 @@ export async function runReviewPipeline(
     }
   }
 
+  // --- Phase 2.5: META-JUDGE RUBRIC (thorough mode only) ---
+  // Generated BEFORE the agents see the implementation. The generator
+  // is only given diff metadata + commit message — never file contents.
+  let rubric: Rubric | undefined;
+  if (flags.thorough) {
+    try {
+      rubric = await generateRubric({ diff, commitMessage });
+    } catch {
+      // Rubric generation is advisory — never block the pipeline on failure.
+      rubric = undefined;
+    }
+  }
+
   // --- Phase 3: CONTEXT ---
-  let contextBundles;
+  let contextBundles: ContextBundle[];
   try {
     contextBundles = await scopeContext({
       projectRoot,
@@ -177,8 +194,27 @@ export async function runReviewPipeline(
     }));
   }
 
+  // Attach rubric to every bundle so agents can reference it.
+  if (rubric) {
+    contextBundles = contextBundles.map((b) => ({ ...b, rubric }));
+  }
+
   // --- Phase 4: FAN-OUT ---
-  const agentResults = await fanOutReview({ bundles: contextBundles });
+  // In isolated mode, run fan-out twice with disjoint context bundles:
+  // spec-compliance first (compliance + architecture see the spec),
+  // then code-quality (bug + security do NOT see the spec).
+  let agentResults;
+  if (flags.isolated) {
+    const specBundles = splitBundlesByStage(contextBundles, 'spec-compliance');
+    const qualityBundles = splitBundlesByStage(contextBundles, 'code-quality');
+    const [specResults, qualityResults] = await Promise.all([
+      fanOutReview({ bundles: specBundles }),
+      fanOutReview({ bundles: qualityBundles }),
+    ]);
+    agentResults = [...specResults, ...qualityResults];
+  } else {
+    agentResults = await fanOutReview({ bundles: contextBundles });
+  }
   const rawFindings: ReviewFinding[] = agentResults.flatMap((r) => r.findings);
 
   // --- Phase 5: VALIDATE ---

--- a/packages/core/src/review/two-stage.ts
+++ b/packages/core/src/review/two-stage.ts
@@ -1,0 +1,81 @@
+import type { ContextBundle, ContextFile, ReviewDomain, ReviewStage, Rubric } from './types';
+
+/**
+ * Which review domains belong to each isolation stage.
+ *
+ * Spec-compliance: reviewers that check the change against the spec,
+ * conventions, and layer boundaries. These reviewers see the spec file
+ * and spec-category rubric items.
+ *
+ * Code-quality: reviewers that check bugs and security risks. These
+ * reviewers do NOT see the spec file — their judgment is based on the
+ * code alone plus quality/risk rubric items.
+ */
+export const STAGE_DOMAINS: Record<ReviewStage, readonly ReviewDomain[]> = {
+  'spec-compliance': ['compliance', 'architecture'],
+  'code-quality': ['bug', 'security'],
+};
+
+/**
+ * Return the domain list for the given stage.
+ */
+export function stageDomains(stage: ReviewStage): readonly ReviewDomain[] {
+  return STAGE_DOMAINS[stage];
+}
+
+/**
+ * Filter a list of context bundles down to a single stage, stripping
+ * stage-inappropriate content.
+ *
+ * For `spec-compliance`:
+ *   - Keeps bundles whose domain is in STAGE_DOMAINS['spec-compliance'].
+ *   - Keeps only rubric items in `spec` category.
+ *   - Leaves context files untouched (spec-compliance needs them).
+ *
+ * For `code-quality`:
+ *   - Keeps bundles whose domain is in STAGE_DOMAINS['code-quality'].
+ *   - Keeps only rubric items in `quality` or `risk` categories.
+ *   - Drops context files whose `reason === 'spec'` so code-quality
+ *     reviewers are not biased by spec content.
+ *
+ * Pure function — does not mutate the input bundles.
+ */
+export function splitBundlesByStage(
+  bundles: readonly ContextBundle[],
+  stage: ReviewStage
+): ContextBundle[] {
+  const domains = new Set(STAGE_DOMAINS[stage]);
+  return bundles.filter((b) => domains.has(b.domain)).map((b) => applyStageIsolation(b, stage));
+}
+
+function applyStageIsolation(bundle: ContextBundle, stage: ReviewStage): ContextBundle {
+  const filteredRubric = filterRubricByStage(bundle.rubric, stage);
+  const filteredContextFiles =
+    stage === 'code-quality'
+      ? bundle.contextFiles.filter((f) => !isSpecReason(f))
+      : bundle.contextFiles;
+
+  const contextLines = filteredContextFiles.reduce((sum, f) => sum + f.lines, 0);
+
+  return {
+    ...bundle,
+    stage,
+    contextFiles: filteredContextFiles,
+    contextLines,
+    ...(filteredRubric ? { rubric: filteredRubric } : {}),
+  };
+}
+
+function isSpecReason(file: ContextFile): boolean {
+  return file.reason === 'spec';
+}
+
+function filterRubricByStage(rubric: Rubric | undefined, stage: ReviewStage): Rubric | undefined {
+  if (!rubric) return undefined;
+  const allowedCategories =
+    stage === 'spec-compliance'
+      ? new Set<Rubric['items'][number]['category']>(['spec'])
+      : new Set<Rubric['items'][number]['category']>(['quality', 'risk']);
+  const items = rubric.items.filter((item) => allowedCategories.has(item.category));
+  return { ...rubric, items };
+}

--- a/packages/core/src/review/types/context.ts
+++ b/packages/core/src/review/types/context.ts
@@ -1,9 +1,18 @@
 // --- Phase 3: Context Scoping types ---
 
+import type { Rubric } from './meta-judge';
+
 /**
  * Change type detected from commit message prefix or diff heuristic.
  */
 export type ChangeType = 'feature' | 'bugfix' | 'refactor' | 'docs';
+
+/**
+ * Isolation stage for two-stage review.
+ * - `spec-compliance`: evaluates spec adherence; receives spec context.
+ * - `code-quality`: evaluates bugs, security, style; does NOT receive spec context.
+ */
+export type ReviewStage = 'spec-compliance' | 'code-quality';
 
 /**
  * Review domain — each gets its own scoped context bundle.
@@ -68,6 +77,17 @@ export interface ContextBundle {
   diffLines: number;
   /** Total lines of context gathered */
   contextLines: number;
+  /**
+   * Rubric generated before the bundle was assembled (thorough mode only).
+   * Agents use this to gate which findings to emit.
+   */
+  rubric?: Rubric;
+  /**
+   * Two-stage isolation marker (isolated mode only). When present, the
+   * bundle belongs to exactly one stage and its context is filtered
+   * accordingly.
+   */
+  stage?: ReviewStage;
 }
 
 /**

--- a/packages/core/src/review/types/fan-out.ts
+++ b/packages/core/src/review/types/fan-out.ts
@@ -50,6 +50,11 @@ export interface ReviewFinding {
   remediation?: string;
   /** Links to CWE/OWASP reference docs (security domain only) */
   references?: string[];
+  /**
+   * ID of the RubricItem this finding was produced against (thorough mode only).
+   * Lets consumers trace a finding back to the pre-generated criterion.
+   */
+  rubricItemId?: string;
 }
 
 /**

--- a/packages/core/src/review/types/index.ts
+++ b/packages/core/src/review/types/index.ts
@@ -3,3 +3,5 @@ export * from './context';
 export * from './fan-out';
 export * from './output';
 export * from './pipeline';
+export * from './parallel-groups';
+export * from './meta-judge';

--- a/packages/core/src/review/types/meta-judge.ts
+++ b/packages/core/src/review/types/meta-judge.ts
@@ -1,0 +1,48 @@
+// --- Meta-judge rubric types ---
+
+// NOTE: This file must not import from `./context` — `context.ts`
+// imports Rubric from here, and a cycle would form. `ChangeType` is
+// redeclared inline below to keep the boundary clean.
+
+type ChangeType = 'feature' | 'bugfix' | 'refactor' | 'docs';
+
+/**
+ * A single rubric criterion used to evaluate a change.
+ *
+ * Rubrics are generated *before* the reviewer sees the implementation
+ * to prevent after-the-fact rationalization ("the diff looks fine, so
+ * my criteria must be met"). Each item has a category that feeds the
+ * two-stage isolation split.
+ */
+export interface RubricItem {
+  /** Stable slug used to correlate findings back to a criterion. */
+  id: string;
+  /**
+   * Rubric category. Drives two-stage isolation:
+   *  - spec: spec-compliance stage
+   *  - quality: code-quality stage
+   *  - risk: code-quality stage (security/operational risk)
+   */
+  category: 'spec' | 'quality' | 'risk';
+  /** One-line criterion statement. */
+  title: string;
+  /** True if this criterion is critical — failing it blocks approval. */
+  mustHave: boolean;
+  /** Why this criterion applies to this particular change. */
+  rationale: string;
+}
+
+/**
+ * A task-specific rubric generated from change metadata before the
+ * implementation is read.
+ */
+export interface Rubric {
+  /** Change type this rubric was generated for. */
+  changeType: ChangeType;
+  /** Criteria in priority order (mustHave first, then suggestions). */
+  items: RubricItem[];
+  /** ISO-8601 timestamp of generation. */
+  generatedAt: string;
+  /** How the rubric was produced. */
+  source: 'heuristic' | 'llm' | 'spec-file';
+}

--- a/packages/core/src/review/types/parallel-groups.ts
+++ b/packages/core/src/review/types/parallel-groups.ts
@@ -1,0 +1,29 @@
+// --- Parallel grouping types ---
+
+/**
+ * A node in a dependency graph consumed by findParallelGroups.
+ *
+ * Generic enough to represent tasks, review agents, migration steps,
+ * build targets, etc. The algorithm only cares about id + dependsOn.
+ */
+export interface GraphNode {
+  /** Stable identifier for the node. Must be unique within the input set. */
+  id: string;
+  /** IDs of nodes that must complete before this one can run. */
+  dependsOn: readonly string[];
+}
+
+/**
+ * Result of topologically grouping nodes into parallel-executable waves.
+ *
+ * Every id in `waves[i]` depends exclusively on ids in `waves[0..i-1]`,
+ * so the entire wave may be dispatched concurrently.
+ */
+export interface ParallelGroups {
+  /** Sorted waves; each wave is a sorted list of ids runnable in parallel. */
+  waves: string[][];
+  /** IDs that participate in a cycle and were not scheduled. */
+  cyclic: string[];
+  /** IDs whose dependsOn points to an id not in the input. */
+  orphaned: string[];
+}

--- a/packages/core/src/review/types/pipeline.ts
+++ b/packages/core/src/review/types/pipeline.ts
@@ -44,6 +44,18 @@ export interface PipelineFlags {
   deep: boolean;
   /** Skip mechanical checks */
   noMechanical: boolean;
+  /**
+   * Enable meta-judge rubric pre-generation. When true, a rubric is
+   * generated from diff metadata + commit message BEFORE the agents
+   * read the implementation, then attached to each ContextBundle.
+   */
+  thorough?: boolean;
+  /**
+   * Split Phase 4 into two stages (spec-compliance then code-quality)
+   * with disjoint context bundles. Prevents spec context from biasing
+   * code-quality review and vice versa.
+   */
+  isolated?: boolean;
 }
 
 /**

--- a/packages/core/tests/review/meta-judge.test.ts
+++ b/packages/core/tests/review/meta-judge.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { generateRubric } from '../../src/review/meta-judge';
+import type { DiffInfo } from '../../src/review/types';
+
+function diffInfo(overrides: Partial<DiffInfo> = {}): DiffInfo {
+  return {
+    changedFiles: [],
+    newFiles: [],
+    deletedFiles: [],
+    totalDiffLines: 0,
+    fileDiffs: new Map(),
+    ...overrides,
+  };
+}
+
+function FIXED_NOW(): Date {
+  return new Date('2026-04-16T12:00:00.000Z');
+}
+
+describe('generateRubric()', () => {
+  it('returns a rubric with the detected changeType and heuristic source', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['packages/core/src/foo.ts'] }),
+      commitMessage: 'feat: add foo',
+      now: FIXED_NOW,
+    });
+    expect(rubric.changeType).toBe('feature');
+    expect(rubric.source).toBe('heuristic');
+    expect(rubric.generatedAt).toBe('2026-04-16T12:00:00.000Z');
+    expect(rubric.items.length).toBeGreaterThan(0);
+  });
+
+  it('marks rubric source as spec-file when a specFile is provided', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/foo.ts'] }),
+      commitMessage: 'feat: foo',
+      specFile: 'docs/changes/foo/proposal.md',
+      now: FIXED_NOW,
+    });
+    expect(rubric.source).toBe('spec-file');
+    expect(rubric.items.some((item) => item.id === 'spec-acceptance')).toBe(true);
+  });
+
+  it('emits a regression-test criterion for bugfix changes', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/bar.ts'] }),
+      commitMessage: 'fix: off-by-one in bar',
+      now: FIXED_NOW,
+    });
+    expect(rubric.changeType).toBe('bugfix');
+    expect(rubric.items.some((item) => item.id === 'bugfix-regression-test')).toBe(true);
+  });
+
+  it('emits a no-behavior-change criterion for refactor', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/baz.ts'] }),
+      commitMessage: 'refactor: extract helper',
+      now: FIXED_NOW,
+    });
+    expect(rubric.changeType).toBe('refactor');
+    expect(rubric.items.some((item) => item.id === 'refactor-no-behavior-change')).toBe(true);
+  });
+
+  it('emits a docs accuracy criterion for docs-only change', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['README.md'] }),
+      commitMessage: 'docs: update readme',
+      now: FIXED_NOW,
+    });
+    expect(rubric.changeType).toBe('docs');
+    expect(rubric.items.some((item) => item.id === 'docs-accuracy')).toBe(true);
+  });
+
+  it('flags security-sensitive paths as risk criteria', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/auth/session.ts'] }),
+      commitMessage: 'feat: refresh session',
+      now: FIXED_NOW,
+    });
+    const sec = rubric.items.find((item) => item.id === 'risk-security-sensitive');
+    expect(sec).toBeDefined();
+    expect(sec?.category).toBe('risk');
+    expect(sec?.mustHave).toBe(true);
+  });
+
+  it('flags migration paths with a rollback criterion', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['db/migrations/0042_users.sql'] }),
+      commitMessage: 'feat: add users table',
+      now: FIXED_NOW,
+    });
+    expect(rubric.items.some((item) => item.id === 'risk-migration-rollback')).toBe(true);
+  });
+
+  it('adds orphaned-reference criterion when files are deleted', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({
+        changedFiles: ['src/stale.ts'],
+        deletedFiles: ['src/stale.ts'],
+      }),
+      commitMessage: 'refactor: remove stale helper',
+      now: FIXED_NOW,
+    });
+    expect(rubric.items.some((item) => item.id === 'quality-no-orphaned-references')).toBe(true);
+  });
+
+  it('sorts mustHave items before nice-to-have', async () => {
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/foo.ts'] }),
+      commitMessage: 'feat: foo',
+      now: FIXED_NOW,
+    });
+    let seenNiceToHave = false;
+    for (const item of rubric.items) {
+      if (!item.mustHave) seenNiceToHave = true;
+      else if (seenNiceToHave) {
+        throw new Error(`mustHave item ${item.id} appeared after a nice-to-have`);
+      }
+    }
+    expect(seenNiceToHave).toBe(true);
+  });
+
+  it('is deterministic for identical inputs', async () => {
+    const options = {
+      diff: diffInfo({
+        changedFiles: ['src/auth/login.ts', 'src/auth/token.ts'],
+        newFiles: ['src/auth/token.ts'],
+      }),
+      commitMessage: 'feat: add token rotation',
+      now: FIXED_NOW,
+    };
+    const a = await generateRubric(options);
+    const b = await generateRubric(options);
+    expect(a).toEqual(b);
+  });
+
+  it('never sees file contents (type enforces diff-only metadata)', async () => {
+    // This is a type-level guarantee; the test documents the invariant.
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/foo.ts'] }),
+      commitMessage: 'feat: foo',
+      now: FIXED_NOW,
+    });
+    // No criterion should quote code — all rationales are about metadata.
+    for (const item of rubric.items) {
+      expect(item.rationale).not.toMatch(/function\s+\w+\s*\(/);
+    }
+  });
+
+  it('uses LLM output when provided and schema-valid', async () => {
+    const llm = async () =>
+      JSON.stringify({
+        items: [
+          {
+            id: 'llm-1',
+            category: 'spec',
+            title: 'LLM criterion',
+            mustHave: true,
+            rationale: 'because',
+          },
+        ],
+      });
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/foo.ts'] }),
+      commitMessage: 'feat: foo',
+      llm,
+      now: FIXED_NOW,
+    });
+    expect(rubric.source).toBe('llm');
+    expect(rubric.items).toHaveLength(1);
+    expect(rubric.items[0]?.id).toBe('llm-1');
+  });
+
+  it('falls back to heuristic when LLM output is unparseable', async () => {
+    const llm = async () => 'this is not json';
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/foo.ts'] }),
+      commitMessage: 'feat: foo',
+      llm,
+      now: FIXED_NOW,
+    });
+    expect(rubric.source).toBe('heuristic');
+    expect(rubric.items.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to heuristic when LLM throws', async () => {
+    const llm = async () => {
+      throw new Error('network');
+    };
+    const rubric = await generateRubric({
+      diff: diffInfo({ changedFiles: ['src/foo.ts'] }),
+      commitMessage: 'feat: foo',
+      llm,
+      now: FIXED_NOW,
+    });
+    expect(rubric.source).toBe('heuristic');
+  });
+});

--- a/packages/core/tests/review/parallel-groups.test.ts
+++ b/packages/core/tests/review/parallel-groups.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { findParallelGroups } from '../../src/review/parallel-groups';
+import type { GraphNode } from '../../src/review/types';
+
+describe('findParallelGroups()', () => {
+  it('returns empty result for empty input', () => {
+    const result = findParallelGroups([]);
+    expect(result.waves).toEqual([]);
+    expect(result.cyclic).toEqual([]);
+    expect(result.orphaned).toEqual([]);
+  });
+
+  it('places all independent nodes in a single wave, sorted', () => {
+    const nodes: GraphNode[] = [
+      { id: 'c', dependsOn: [] },
+      { id: 'a', dependsOn: [] },
+      { id: 'b', dependsOn: [] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.waves).toEqual([['a', 'b', 'c']]);
+  });
+
+  it('produces sequential waves for linear chain', () => {
+    const nodes: GraphNode[] = [
+      { id: 'a', dependsOn: [] },
+      { id: 'b', dependsOn: ['a'] },
+      { id: 'c', dependsOn: ['b'] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.waves).toEqual([['a'], ['b'], ['c']]);
+  });
+
+  it('handles diamond dependency — fanout then fanin', () => {
+    const nodes: GraphNode[] = [
+      { id: 'root', dependsOn: [] },
+      { id: 'left', dependsOn: ['root'] },
+      { id: 'right', dependsOn: ['root'] },
+      { id: 'sink', dependsOn: ['left', 'right'] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.waves).toEqual([['root'], ['left', 'right'], ['sink']]);
+  });
+
+  it('is deterministic regardless of input order', () => {
+    const ordered: GraphNode[] = [
+      { id: 'a', dependsOn: [] },
+      { id: 'b', dependsOn: ['a'] },
+      { id: 'c', dependsOn: ['a'] },
+      { id: 'd', dependsOn: ['b', 'c'] },
+    ];
+    const shuffled: GraphNode[] = [
+      { id: 'd', dependsOn: ['c', 'b'] },
+      { id: 'c', dependsOn: ['a'] },
+      { id: 'a', dependsOn: [] },
+      { id: 'b', dependsOn: ['a'] },
+    ];
+    expect(findParallelGroups(ordered)).toEqual(findParallelGroups(shuffled));
+  });
+
+  it('returns disconnected subgraphs in the same waves as their depth allows', () => {
+    const nodes: GraphNode[] = [
+      { id: 'a1', dependsOn: [] },
+      { id: 'a2', dependsOn: ['a1'] },
+      { id: 'b1', dependsOn: [] },
+      { id: 'b2', dependsOn: ['b1'] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.waves).toEqual([
+      ['a1', 'b1'],
+      ['a2', 'b2'],
+    ]);
+  });
+
+  it('reports cyclic nodes without throwing', () => {
+    const nodes: GraphNode[] = [
+      { id: 'a', dependsOn: ['c'] },
+      { id: 'b', dependsOn: ['a'] },
+      { id: 'c', dependsOn: ['b'] },
+      { id: 'free', dependsOn: [] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.waves).toEqual([['free']]);
+    expect(result.cyclic.sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reports orphaned dependency ids separately', () => {
+    const nodes: GraphNode[] = [
+      { id: 'a', dependsOn: ['missing'] },
+      { id: 'b', dependsOn: ['a'] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.orphaned).toEqual(['missing']);
+    // 'missing' is not a known id; it should not block 'a'
+    expect(result.waves).toEqual([['a'], ['b']]);
+  });
+
+  it('deduplicates redundant dependsOn entries', () => {
+    const nodes: GraphNode[] = [
+      { id: 'root', dependsOn: [] },
+      { id: 'leaf', dependsOn: ['root', 'root', 'root'] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.waves).toEqual([['root'], ['leaf']]);
+    expect(result.cyclic).toEqual([]);
+  });
+
+  it('sorts cyclic ids lexicographically', () => {
+    const nodes: GraphNode[] = [
+      { id: 'z', dependsOn: ['y'] },
+      { id: 'y', dependsOn: ['x'] },
+      { id: 'x', dependsOn: ['z'] },
+    ];
+    const result = findParallelGroups(nodes);
+    expect(result.cyclic).toEqual(['x', 'y', 'z']);
+  });
+});

--- a/packages/core/tests/review/two-stage.test.ts
+++ b/packages/core/tests/review/two-stage.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { splitBundlesByStage, stageDomains, STAGE_DOMAINS } from '../../src/review/two-stage';
+import type { ContextBundle, ContextFile, ReviewDomain, Rubric } from '../../src/review/types';
+
+function file(path: string, reason: ContextFile['reason']): ContextFile {
+  return { path, content: '', reason, lines: 10 };
+}
+
+function bundle(domain: ReviewDomain, overrides: Partial<ContextBundle> = {}): ContextBundle {
+  return {
+    domain,
+    changeType: 'feature',
+    changedFiles: [],
+    contextFiles: [],
+    commitHistory: [],
+    diffLines: 0,
+    contextLines: 0,
+    ...overrides,
+  };
+}
+
+const RUBRIC: Rubric = {
+  changeType: 'feature',
+  items: [
+    { id: 'spec-1', category: 'spec', title: 'spec item', mustHave: true, rationale: 'r' },
+    { id: 'qual-1', category: 'quality', title: 'q item', mustHave: true, rationale: 'r' },
+    { id: 'risk-1', category: 'risk', title: 'r item', mustHave: true, rationale: 'r' },
+  ],
+  generatedAt: '2026-04-16T00:00:00Z',
+  source: 'heuristic',
+};
+
+describe('STAGE_DOMAINS / stageDomains()', () => {
+  it('maps spec-compliance to compliance + architecture', () => {
+    expect(stageDomains('spec-compliance')).toEqual(['compliance', 'architecture']);
+  });
+  it('maps code-quality to bug + security', () => {
+    expect(stageDomains('code-quality')).toEqual(['bug', 'security']);
+  });
+  it('stages are disjoint', () => {
+    const spec = new Set(STAGE_DOMAINS['spec-compliance']);
+    for (const d of STAGE_DOMAINS['code-quality']) {
+      expect(spec.has(d)).toBe(false);
+    }
+  });
+});
+
+describe('splitBundlesByStage()', () => {
+  it('keeps only spec-compliance domains for spec-compliance stage', () => {
+    const bundles: ContextBundle[] = [
+      bundle('compliance'),
+      bundle('architecture'),
+      bundle('bug'),
+      bundle('security'),
+    ];
+    const result = splitBundlesByStage(bundles, 'spec-compliance');
+    expect(result.map((b) => b.domain)).toEqual(['compliance', 'architecture']);
+    expect(result.every((b) => b.stage === 'spec-compliance')).toBe(true);
+  });
+
+  it('keeps only code-quality domains for code-quality stage', () => {
+    const bundles: ContextBundle[] = [
+      bundle('compliance'),
+      bundle('architecture'),
+      bundle('bug'),
+      bundle('security'),
+    ];
+    const result = splitBundlesByStage(bundles, 'code-quality');
+    expect(result.map((b) => b.domain)).toEqual(['bug', 'security']);
+    expect(result.every((b) => b.stage === 'code-quality')).toBe(true);
+  });
+
+  it('filters rubric to spec items for spec-compliance', () => {
+    const input = bundle('compliance', { rubric: RUBRIC });
+    const [result] = splitBundlesByStage([input], 'spec-compliance');
+    expect(result?.rubric?.items.map((i) => i.id)).toEqual(['spec-1']);
+  });
+
+  it('filters rubric to quality+risk items for code-quality', () => {
+    const input = bundle('bug', { rubric: RUBRIC });
+    const [result] = splitBundlesByStage([input], 'code-quality');
+    expect(result?.rubric?.items.map((i) => i.id).sort()).toEqual(['qual-1', 'risk-1']);
+  });
+
+  it('strips spec-reason context files from code-quality bundles', () => {
+    const input = bundle('bug', {
+      contextFiles: [
+        file('docs/changes/foo/proposal.md', 'spec'),
+        file('src/helpers.ts', 'import'),
+      ],
+      contextLines: 20,
+    });
+    const [result] = splitBundlesByStage([input], 'code-quality');
+    const paths = result?.contextFiles.map((f) => f.path) ?? [];
+    expect(paths).toEqual(['src/helpers.ts']);
+    expect(result?.contextLines).toBe(10);
+  });
+
+  it('keeps spec-reason context files in spec-compliance bundles', () => {
+    const input = bundle('compliance', {
+      contextFiles: [
+        file('docs/changes/foo/proposal.md', 'spec'),
+        file('src/helpers.ts', 'import'),
+      ],
+      contextLines: 20,
+    });
+    const [result] = splitBundlesByStage([input], 'spec-compliance');
+    const reasons = result?.contextFiles.map((f) => f.reason).sort() ?? [];
+    expect(reasons).toEqual(['import', 'spec']);
+    expect(result?.contextLines).toBe(20);
+  });
+
+  it('does not mutate the input bundles', () => {
+    const input = bundle('bug', {
+      contextFiles: [file('x.md', 'spec')],
+      rubric: RUBRIC,
+    });
+    const snapshot = JSON.parse(JSON.stringify(input));
+    splitBundlesByStage([input], 'code-quality');
+    expect(input).toEqual(snapshot);
+  });
+
+  it('handles bundles without a rubric', () => {
+    const input = bundle('compliance');
+    const [result] = splitBundlesByStage([input], 'spec-compliance');
+    expect(result?.rubric).toBeUndefined();
+    expect(result?.stage).toBe('spec-compliance');
+  });
+});

--- a/packages/orchestrator/src/core/index.ts
+++ b/packages/orchestrator/src/core/index.ts
@@ -4,6 +4,8 @@ export { getAvailableSlots, getPerStateCount, canDispatch } from './concurrency'
 export { reconcile } from './reconciliation';
 export { detectScopeTier, routeIssue, artifactPresenceFromIssue } from './model-router';
 export type { ArtifactPresence } from './model-router';
+export { triageIssue, extractTitlePrefix } from './triage-router';
+export type { TriageSkill, TriageSignals, TriageDecision, TriageConfig } from './triage-router';
 export { InteractionQueue } from './interaction-queue';
 export type { PendingInteraction } from './interaction-queue';
 export { AnalysisArchive } from './analysis-archive';

--- a/packages/orchestrator/src/core/triage-router.ts
+++ b/packages/orchestrator/src/core/triage-router.ts
@@ -1,0 +1,177 @@
+import type { Issue } from '@harness-engineering/types';
+
+/**
+ * Candidate skills the orchestrator may dispatch to. Keep this set
+ * small on purpose — the triage router is a coarse routing layer, not
+ * a skill registry.
+ */
+export type TriageSkill =
+  | 'code-review'
+  | 'security-review'
+  | 'planning'
+  | 'debugging'
+  | 'refactoring'
+  | 'docs';
+
+/**
+ * Shape-of-work signals the triage router consumes. These are derived
+ * from the Issue plus diff metadata by the caller.
+ */
+export interface TriageSignals {
+  /** Raw title/body prefix, e.g. "feat:", "fix:", "docs:", "security:" */
+  titlePrefix?: string;
+  /** True if the diff touches auth, crypto, session, or similar paths */
+  touchesSecuritySensitivePaths?: boolean;
+  /** True if the diff touches a migrations or schema directory */
+  touchesMigrationPaths?: boolean;
+  /** Count of changed files in the diff */
+  changedFileCount?: number;
+  /** Whether tests are failing on the issue branch */
+  hasFailingTests?: boolean;
+  /** Whether the issue is marked or labeled as a rollback */
+  isRollback?: boolean;
+  /** True if every changed file is `.md` */
+  isDocsOnly?: boolean;
+}
+
+/**
+ * Structured decision the orchestrator persists and consumes.
+ */
+export interface TriageDecision {
+  /** Target skill for dispatch. */
+  skill: TriageSkill;
+  /** Specific agent within the skill, optional. */
+  agent?: string;
+  /** Router confidence in the decision. */
+  confidence: 'high' | 'medium' | 'low';
+  /** Human-readable justifications (one entry per rule that matched). */
+  reasons: string[];
+}
+
+/**
+ * Optional user/project overrides for path heuristics and rule thresholds.
+ */
+export interface TriageConfig {
+  /** Max changed files for a fix to still route to code-review (default 3). */
+  smallFixChangedFileMax?: number;
+}
+
+const DEFAULT_CONFIG: Required<TriageConfig> = {
+  smallFixChangedFileMax: 3,
+};
+
+const SECURITY_LABELS = new Set(['security', 'sec', 'security-review']);
+const ROLLBACK_LABELS = new Set(['rollback', 'revert']);
+
+const PREFIX_RE = /^([a-z][a-z0-9-]*)(\([^)]*\))?:/i;
+
+/**
+ * Extract the conventional-commit prefix (lowercased) from a title.
+ * Returns undefined if no prefix is present.
+ */
+export function extractTitlePrefix(title: string | null | undefined): string | undefined {
+  if (!title) return undefined;
+  const match = PREFIX_RE.exec(title.trim());
+  return match?.[1]?.toLowerCase();
+}
+
+/**
+ * Decide which skill/agent the orchestrator should dispatch this issue to.
+ *
+ * Rule order (first match wins):
+ *  1. isRollback                          → debugging (high)
+ *  2. security prefix or security paths   → security-review (high)
+ *  3. docs prefix or docs-only diff       → docs (high)
+ *  4. hasFailingTests                     → debugging (medium)
+ *  5. touchesMigrationPaths               → planning (high)
+ *  6. fix: with small change              → code-review (high)
+ *  7. feat:                               → planning (medium)
+ *  8. refactor:                           → refactoring (medium)
+ *  9. default                             → code-review (low)
+ *
+ * Triage is meant to run BEFORE `routeIssue()`; the selected skill is
+ * persisted on the live session so downstream dispatch does not
+ * re-derive it.
+ */
+export function triageIssue(
+  issue: Issue,
+  signals: TriageSignals,
+  config?: TriageConfig
+): TriageDecision {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  const reasons: string[] = [];
+  const prefix = signals.titlePrefix ?? extractTitlePrefix(issue.title);
+
+  const hasLabel = (set: ReadonlySet<string>): boolean =>
+    issue.labels.some((l) => set.has(l.toLowerCase()));
+
+  // 1. Rollback
+  if (signals.isRollback || hasLabel(ROLLBACK_LABELS)) {
+    reasons.push('Rollback flagged — route to debugging for root-cause review.');
+    return { skill: 'debugging', confidence: 'high', reasons };
+  }
+
+  // 2. Security
+  if (prefix === 'security' || signals.touchesSecuritySensitivePaths || hasLabel(SECURITY_LABELS)) {
+    if (prefix === 'security') reasons.push('Security prefix in title.');
+    if (signals.touchesSecuritySensitivePaths)
+      reasons.push('Diff touches security-sensitive paths.');
+    if (hasLabel(SECURITY_LABELS)) reasons.push('Issue has a security label.');
+    return { skill: 'security-review', confidence: 'high', reasons };
+  }
+
+  // 3. Docs
+  if (prefix === 'docs' || prefix === 'doc' || signals.isDocsOnly) {
+    if (prefix === 'docs' || prefix === 'doc') reasons.push('Docs prefix in title.');
+    if (signals.isDocsOnly) reasons.push('All changed files are markdown.');
+    return { skill: 'docs', confidence: 'high', reasons };
+  }
+
+  // 4. Failing tests
+  if (signals.hasFailingTests) {
+    reasons.push('Tests are failing on the branch — route to debugging.');
+    return { skill: 'debugging', confidence: 'medium', reasons };
+  }
+
+  // 5. Migration paths
+  if (signals.touchesMigrationPaths) {
+    reasons.push('Diff touches migration/schema paths — planning required before execution.');
+    return { skill: 'planning', confidence: 'high', reasons };
+  }
+
+  // 6. Small fix — eligible for quick code-review shortcut
+  if (
+    (prefix === 'fix' || prefix === 'bugfix') &&
+    (signals.changedFileCount ?? Infinity) <= cfg.smallFixChangedFileMax
+  ) {
+    reasons.push(`Small ${prefix} (≤${cfg.smallFixChangedFileMax} files) — code-review.`);
+    return { skill: 'code-review', confidence: 'high', reasons };
+  }
+
+  // 6a. Large fix — investigation-level, route to planning
+  if (
+    (prefix === 'fix' || prefix === 'bugfix') &&
+    (signals.changedFileCount ?? 0) > cfg.smallFixChangedFileMax
+  ) {
+    reasons.push(
+      `Large ${prefix} (${signals.changedFileCount ?? 0} files > ${cfg.smallFixChangedFileMax}) — planning.`
+    );
+    return { skill: 'planning', confidence: 'medium', reasons };
+  }
+
+  // 7. Feature
+  if (prefix === 'feat' || prefix === 'feature') {
+    reasons.push('Feature prefix — planning skill produces a plan before execution.');
+    return { skill: 'planning', confidence: 'medium', reasons };
+  }
+
+  // 8. Refactor
+  if (prefix === 'refactor') {
+    reasons.push('Refactor prefix — refactoring skill enforces behavioral invariants.');
+    return { skill: 'refactoring', confidence: 'medium', reasons };
+  }
+
+  // 9. Default
+  reasons.push('No specific routing signal matched — default to code-review.');
+  return { skill: 'code-review', confidence: 'low', reasons };
+}

--- a/packages/orchestrator/tests/core/triage-router.test.ts
+++ b/packages/orchestrator/tests/core/triage-router.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { triageIssue, extractTitlePrefix } from '../../src/core/triage-router';
+import type { Issue } from '@harness-engineering/types';
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'id-1',
+    identifier: 'TEST-1',
+    title: 'Test issue',
+    description: null,
+    priority: null,
+    state: 'Todo',
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    spec: null,
+    plans: [],
+    createdAt: '2026-04-16T00:00:00Z',
+    updatedAt: null,
+    externalId: null,
+    ...overrides,
+  };
+}
+
+describe('extractTitlePrefix()', () => {
+  it('extracts simple prefixes', () => {
+    expect(extractTitlePrefix('feat: add foo')).toBe('feat');
+    expect(extractTitlePrefix('fix: bar')).toBe('fix');
+    expect(extractTitlePrefix('docs: readme')).toBe('docs');
+  });
+
+  it('extracts prefixes with a scope', () => {
+    expect(extractTitlePrefix('feat(auth): foo')).toBe('feat');
+  });
+
+  it('returns undefined when no prefix present', () => {
+    expect(extractTitlePrefix('Just some title')).toBeUndefined();
+    expect(extractTitlePrefix('')).toBeUndefined();
+    expect(extractTitlePrefix(null)).toBeUndefined();
+  });
+
+  it('lowercases the prefix', () => {
+    expect(extractTitlePrefix('FEAT: foo')).toBe('feat');
+  });
+});
+
+describe('triageIssue()', () => {
+  it('rule 1 — rollback wins even over security signals', () => {
+    const decision = triageIssue(makeIssue({ labels: ['security'] }), {
+      isRollback: true,
+      touchesSecuritySensitivePaths: true,
+    });
+    expect(decision.skill).toBe('debugging');
+    expect(decision.confidence).toBe('high');
+    expect(decision.reasons.some((r) => /rollback/i.test(r))).toBe(true);
+  });
+
+  it('rule 2 — security prefix routes to security-review', () => {
+    const decision = triageIssue(makeIssue({ title: 'security: patch SSRF' }), {});
+    expect(decision.skill).toBe('security-review');
+    expect(decision.confidence).toBe('high');
+  });
+
+  it('rule 2 — security label routes to security-review', () => {
+    const decision = triageIssue(makeIssue({ labels: ['security'] }), {});
+    expect(decision.skill).toBe('security-review');
+  });
+
+  it('rule 2 — security path signal routes to security-review', () => {
+    const decision = triageIssue(makeIssue({ title: 'refactor: foo' }), {
+      touchesSecuritySensitivePaths: true,
+    });
+    expect(decision.skill).toBe('security-review');
+  });
+
+  it('rule 3 — docs prefix routes to docs', () => {
+    const decision = triageIssue(makeIssue({ title: 'docs: update readme' }), {});
+    expect(decision.skill).toBe('docs');
+    expect(decision.confidence).toBe('high');
+  });
+
+  it('rule 3 — docs-only diff routes to docs without prefix', () => {
+    const decision = triageIssue(makeIssue({ title: 'update readme' }), { isDocsOnly: true });
+    expect(decision.skill).toBe('docs');
+  });
+
+  it('rule 4 — failing tests route to debugging', () => {
+    const decision = triageIssue(makeIssue({ title: 'chore: misc' }), { hasFailingTests: true });
+    expect(decision.skill).toBe('debugging');
+    expect(decision.confidence).toBe('medium');
+  });
+
+  it('rule 5 — migration paths route to planning', () => {
+    const decision = triageIssue(makeIssue({ title: 'feat: users table' }), {
+      touchesMigrationPaths: true,
+    });
+    expect(decision.skill).toBe('planning');
+    expect(decision.confidence).toBe('high');
+  });
+
+  it('rule 6 — small fix routes to code-review', () => {
+    const decision = triageIssue(makeIssue({ title: 'fix: typo' }), { changedFileCount: 1 });
+    expect(decision.skill).toBe('code-review');
+    expect(decision.confidence).toBe('high');
+  });
+
+  it('rule 6 — large fix does not take the code-review shortcut', () => {
+    const decision = triageIssue(makeIssue({ title: 'fix: major rewrite' }), {
+      changedFileCount: 20,
+    });
+    expect(decision.skill).not.toBe('code-review');
+  });
+
+  it('rule 7 — feature routes to planning', () => {
+    const decision = triageIssue(makeIssue({ title: 'feat: new module' }), {
+      changedFileCount: 10,
+    });
+    expect(decision.skill).toBe('planning');
+    expect(decision.confidence).toBe('medium');
+  });
+
+  it('rule 8 — refactor routes to refactoring', () => {
+    const decision = triageIssue(makeIssue({ title: 'refactor: extract helper' }), {});
+    expect(decision.skill).toBe('refactoring');
+  });
+
+  it('rule 9 — default is code-review with low confidence', () => {
+    const decision = triageIssue(makeIssue({ title: 'Something ambiguous' }), {});
+    expect(decision.skill).toBe('code-review');
+    expect(decision.confidence).toBe('low');
+  });
+
+  it('respects custom smallFixChangedFileMax', () => {
+    const decision = triageIssue(
+      makeIssue({ title: 'fix: many files' }),
+      { changedFileCount: 5 },
+      { smallFixChangedFileMax: 10 }
+    );
+    expect(decision.skill).toBe('code-review');
+  });
+
+  it('rollback label triggers rule 1', () => {
+    const decision = triageIssue(makeIssue({ labels: ['Rollback'] }), {});
+    expect(decision.skill).toBe('debugging');
+  });
+
+  it('reasons array always contains at least one entry', () => {
+    const decision = triageIssue(makeIssue({ title: 'something' }), {});
+    expect(decision.reasons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('falls back to extracting prefix from issue title when signals.titlePrefix is absent', () => {
+    const decision = triageIssue(makeIssue({ title: 'refactor(core): split file' }), {});
+    expect(decision.skill).toBe('refactoring');
+  });
+
+  it('signals.titlePrefix overrides the derived prefix', () => {
+    const decision = triageIssue(makeIssue({ title: 'feat: normally a feature' }), {
+      titlePrefix: 'docs',
+    });
+    expect(decision.skill).toBe('docs');
+  });
+});


### PR DESCRIPTION
## Summary

Adds five composable primitives behind the upcoming `--thorough` / `--isolated` review modes and orchestrator dispatch:

- **`findParallelGroups()`** — Kahn-style BFS turns a generic `{ id, dependsOn }[]` dependency graph into deterministic parallel waves; cycles and orphaned refs surface as data, never thrown.
- **Meta-judge rubric** (`generateRubric()`) — task-specific rubric generated from *diff metadata + commit message only* BEFORE the agents read the implementation, preventing after-the-fact rationalization. Wired into `runReviewPipeline()` behind `--thorough`.
- **Two-stage isolation** (`splitBundlesByStage()`) — under `--isolated`, Phase 4 fan-out runs twice: spec-compliance (compliance + architecture, sees spec file + spec rubric items) then code-quality (bug + security, spec context and spec rubric items are filtered out). Keeps the anti-bias guarantee a property of data rather than runtime state.
- **Tiered MCP tool loading** (`selectTier()`, `CORE_TOOL_NAMES`, `STANDARD_TOOL_NAMES`) — token-budget-aware allow-list layered on top of the existing `buildFilteredTools()` filter path. Adds `harness mcp --tier <core|standard|full>` and `--budget-tokens`.
- **Triage routing** (`triageIssue()`) — first-match-wins router from `Issue` + signals to a target skill (code-review / security-review / planning / debugging / refactoring / docs). Designed to run before `routeIssue()`.

All additions are opt-in and strictly additive; defaults preserve current behavior of the review CLI, MCP server, and orchestrator dispatch.

Design doc: [`docs/changes/advanced-review-pipeline/proposal.md`](docs/changes/advanced-review-pipeline/proposal.md). Plan: [`docs/plans/2026-04-16-advanced-review-pipeline.md`](docs/plans/2026-04-16-advanced-review-pipeline.md).

Closes: `advanced-review-pipe-c2940ed8` [ACE-Batch6]

## Test plan

- [x] `pnpm --filter @harness-engineering/core test` — 1923/1923 pass
- [x] `pnpm --filter @harness-engineering/cli test` — 2750/2750 pass
- [x] `pnpm --filter @harness-engineering/orchestrator test` — 285/285 pass
- [x] `harness validate` — pass
- [x] `harness check-deps` — no circular deps added
- [x] `harness check-arch` — no new threshold violations (pre-existing complexity flags unchanged)
- [ ] `harness agent review --thorough --isolated` smoke test once a change type is ready to exercise end-to-end
- [ ] `harness mcp --tier core` smoke test for Cursor/LLM-constrained contexts