### PR TITLE
feat(orchestrator): handle Claude CLI subscription rate limits

### DIFF
--- a/packages/orchestrator/src/agent/backends/claude.ts
+++ b/packages/orchestrator/src/agent/backends/claude.ts
@@ -38,6 +38,167 @@ function resolveSpawnError(
   resolve(Err({ category: 'agent_not_found', message: `Claude command '${command}' not found` }));
 }
 
+export interface SubscriptionLimitParse {
+  resetsAtMs: number;
+  resetTime: string;
+  timezone: string;
+  /**
+   * `'exact'` when the reset time was parsed from the CLI message;
+   * `'fallback'` when we couldn't resolve the timezone and substituted a
+   * safe 1-hour default. Callers should surface the distinction so a stale
+   * fallback doesn't masquerade as a legitimate schedule.
+   */
+  resolved: 'exact' | 'fallback';
+}
+
+/** Minute-grace applied when the parsed reset appears to be just-past. */
+const JUST_PAST_GRACE_MS = 5 * 60_000;
+
+/**
+ * Primary regex for the canonical Claude CLI limit message, e.g.:
+ *   "You've hit your limit · resets 8pm (America/Indianapolis)"
+ */
+const PRIMARY_LIMIT_RE =
+  /You[\u2019']ve hit your limit.*resets\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm))\s*\(([^)]+)\)/i;
+
+/**
+ * Loose detector for "the CLI said something about a limit but we couldn't
+ * extract a reset time". When PRIMARY_LIMIT_RE fails but this fires, callers
+ * should at least apply their default cooldown rather than silently
+ * misclassifying the line as unrelated output.
+ */
+const LOOSE_LIMIT_RE = /\b(?:rate\s?limit|quota|limit)\b.*\bresets?\b/i;
+
+/**
+ * Returns true when the line looks like a limit notification but does NOT
+ * match the strict parser. Useful for logging drift so teams notice when the
+ * CLI's message format changes.
+ */
+export function looksLikeUnparsedLimit(line: string): boolean {
+  return !PRIMARY_LIMIT_RE.test(line) && LOOSE_LIMIT_RE.test(line);
+}
+
+/** Parse "8pm" / "11:30am" into 24-hour {hours, minutes}. Returns null on malformed input. */
+function parse12HourTime(resetTime: string): { hours: number; minutes: number } | null {
+  const m = resetTime.match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i);
+  if (!m) return null;
+
+  let hours = parseInt(m[1]!, 10);
+  const minutes = parseInt(m[2] ?? '0', 10);
+  const meridiem = m[3]!.toLowerCase();
+
+  if (meridiem === 'pm' && hours !== 12) hours += 12;
+  if (meridiem === 'am' && hours === 12) hours = 0;
+
+  return { hours, minutes };
+}
+
+/** Read {year, month, day} for `now` in `timezone`. Returns null if Intl can't resolve it. */
+function getDatePartsInTimezone(
+  now: Date,
+  timezone: string
+): { year: string; month: string; day: string } | null {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(now);
+  const year = parts.find((p) => p.type === 'year')?.value;
+  const month = parts.find((p) => p.type === 'month')?.value;
+  const day = parts.find((p) => p.type === 'day')?.value;
+  if (!year || !month || !day) return null;
+  return { year, month, day };
+}
+
+/**
+ * Given a wall-clock time `{hours, minutes}` that is meant to be interpreted
+ * in `timezone` on the given `{year, month, day}`, return the corresponding
+ * UTC milliseconds. Uses the difference between the same instant seen as UTC
+ * vs seen in `timezone` to derive the offset.
+ */
+function resolveWallClockToUtcMs(
+  year: string,
+  month: string,
+  day: string,
+  hours: number,
+  minutes: number,
+  timezone: string
+): number {
+  const targetDateStr = `${year}-${month}-${day}T${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00`;
+  const utcDate = new Date(targetDateStr + 'Z');
+  const tzParts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(utcDate);
+  const tzHour = parseInt(tzParts.find((p) => p.type === 'hour')?.value ?? '0', 10);
+  const tzMinute = parseInt(tzParts.find((p) => p.type === 'minute')?.value ?? '0', 10);
+  const offsetMinutes = tzHour * 60 + tzMinute - (hours * 60 + minutes);
+  return utcDate.getTime() - offsetMinutes * 60_000;
+}
+
+/** Build a "fallback" parse: 1h from now with the original resetTime/timezone preserved for logging. */
+function fallbackParse(resetTime: string, timezone: string): SubscriptionLimitParse {
+  return {
+    resetsAtMs: Date.now() + 60 * 60_000,
+    resetTime,
+    timezone,
+    resolved: 'fallback',
+  };
+}
+
+/**
+ * Parse Claude CLI subscription-level rate limit messages.
+ *
+ * The CLI outputs non-JSON text like:
+ *   "You've hit your limit · resets 8pm (America/Indianapolis)"
+ * when the user's plan quota is exhausted. We extract the reset time and
+ * timezone to compute when the limit lifts. If the timezone is unresolvable
+ * the function returns `resolved: 'fallback'` with a 1-hour reset so callers
+ * can surface the distinction.
+ */
+export function parseSubscriptionLimit(line: string): SubscriptionLimitParse | null {
+  const match = line.match(PRIMARY_LIMIT_RE);
+  if (!match) return null;
+
+  const resetTime = match[1]!.trim();
+  const timezone = match[2]!.trim();
+
+  try {
+    const time = parse12HourTime(resetTime);
+    if (!time) return null;
+
+    const now = new Date();
+    const dateParts = getDatePartsInTimezone(now, timezone);
+    if (!dateParts) return null;
+
+    const resetsAtMs = resolveWallClockToUtcMs(
+      dateParts.year,
+      dateParts.month,
+      dateParts.day,
+      time.hours,
+      time.minutes,
+      timezone
+    );
+
+    // Wrap to tomorrow when clearly in the past. Apply a small grace window
+    // so minor clock skew doesn't bounce a just-about-to-fire reset 24h away.
+    const effectiveMs =
+      resetsAtMs <= now.getTime() - JUST_PAST_GRACE_MS ? resetsAtMs + 24 * 60 * 60_000 : resetsAtMs;
+
+    return { resetsAtMs: effectiveMs, resetTime, timezone, resolved: 'exact' };
+  } catch {
+    // Timezone not recognized or other parse error — return a safe fallback
+    // so we at least don't spin. Caller can inspect `resolved` to log.
+    return fallbackParse(resetTime, timezone);
+  }
+}
+
 /**
  * Extract a human-readable summary from a Claude result event.
  * The content field can be a string, an array of content blocks, or the full response object.
@@ -303,7 +464,40 @@ export class ClaudeBackend implements AgentBackend {
             yield mapped;
           }
         } catch {
-          // Ignore non-JSON output
+          // Non-JSON output — check for subscription rate limit messages
+          const limitInfo = parseSubscriptionLimit(line);
+          if (limitInfo) {
+            if (limitInfo.resolved === 'fallback') {
+              console.warn(
+                `[claude limit] unresolved timezone "${limitInfo.timezone}" — sleeping 1h fallback. Line: ${line.trim()}`
+              );
+            }
+            yield {
+              type: 'rate_limit',
+              timestamp: new Date().toISOString(),
+              content: {
+                message: line.trim(),
+                resetsAtMs: limitInfo.resetsAtMs,
+                resetTime: limitInfo.resetTime,
+                timezone: limitInfo.timezone,
+                resolved: limitInfo.resolved,
+              },
+              sessionId: session.sessionId,
+            };
+          } else if (looksLikeUnparsedLimit(line)) {
+            // The CLI said something about a limit that our strict parser
+            // didn't match. Fall back to the orchestrator's default cooldown
+            // so we don't silently misclassify this as unrelated output.
+            console.warn(
+              `[claude limit] detected limit-like line that did not match parser. Falling back to default cooldown. Line: ${line.trim()}`
+            );
+            yield {
+              type: 'rate_limit',
+              timestamp: new Date().toISOString(),
+              content: { message: line.trim() },
+              sessionId: session.sessionId,
+            };
+          }
         }
       }
     } finally {

--- a/packages/orchestrator/src/agent/runner.ts
+++ b/packages/orchestrator/src/agent/runner.ts
@@ -5,6 +5,28 @@ import {
   TurnResult,
   Issue,
 } from '@harness-engineering/types';
+import { extractRateLimitReset } from '../core/rate-limit-events';
+
+/** Hard cap on a single rate-limit sleep — prevents a malformed or adversarial
+ * reset time from parking the runner indefinitely. Sleeps capped at this
+ * value surface `truncated: true` so the orchestrator/TUI can escalate. */
+const MAX_SLEEP_MS = 12 * 60 * 60_000;
+
+/** Build the descriptive message and optional warning log for a rate-limit sleep. */
+function buildSleepMessage(
+  resetsAtMs: number,
+  sleepMs: number,
+  requestedSleepMs: number,
+  truncated: boolean
+): string {
+  const resetsAt = new Date(resetsAtMs).toISOString();
+  const base = `Subscription rate limit hit. Sleeping until ${resetsAt} (${Math.round(sleepMs / 60_000)}min)`;
+  if (!truncated) return base;
+  console.warn(
+    `[runner] rate limit sleep truncated: requested ${Math.round(requestedSleepMs / 60_000)}min, sleeping ${Math.round(sleepMs / 60_000)}min`
+  );
+  return `${base} — capped at MAX_SLEEP_MS (${Math.round(MAX_SLEEP_MS / 60_000)}min); human intervention may be needed.`;
+}
 
 export interface RunnerOptions {
   maxTurns: number;
@@ -71,6 +93,7 @@ export class AgentRunner {
         // Manual iteration to capture the return value (TurnResult)
         let next = await turnGen.next();
         let hitRateLimit = false;
+        let rateLimitResetsAtMs: number | null = null;
 
         while (!next.done) {
           const event = next.value;
@@ -78,6 +101,8 @@ export class AgentRunner {
 
           if (event.type === 'rate_limit') {
             hitRateLimit = true;
+            // Check for subscription-level rate limit with reset time
+            rateLimitResetsAtMs = extractRateLimitReset(event);
           }
 
           // If the agent reports its own sessionId, update our local session state
@@ -92,6 +117,9 @@ export class AgentRunner {
         if (hitRateLimit) {
           // Do not consume a turn if the API was rate limited
           currentTurn--;
+          if (rateLimitResetsAtMs) {
+            yield* this.sleepUntilReset(rateLimitResetsAtMs, session.sessionId);
+          }
         }
 
         lastResult = next.value;
@@ -106,5 +134,30 @@ export class AgentRunner {
     }
 
     return lastResult;
+  }
+
+  /**
+   * Yield a `rate_limit_sleep` event then sleep until `resetsAtMs` (capped
+   * at MAX_SLEEP_MS). No-op when the reset is in the past.
+   */
+  private async *sleepUntilReset(
+    resetsAtMs: number,
+    sessionId: string
+  ): AsyncGenerator<AgentEvent, void, void> {
+    const requestedSleepMs = resetsAtMs - Date.now();
+    const sleepMs = Math.min(requestedSleepMs, MAX_SLEEP_MS);
+    if (sleepMs <= 0) return;
+
+    const truncated = requestedSleepMs > MAX_SLEEP_MS;
+    const message = buildSleepMessage(resetsAtMs, sleepMs, requestedSleepMs, truncated);
+
+    yield {
+      type: 'rate_limit_sleep',
+      timestamp: new Date().toISOString(),
+      content: { message, resetsAtMs, sleepMs, truncated },
+      sessionId,
+    };
+
+    await new Promise((r) => setTimeout(r, sleepMs));
   }
 }

--- a/packages/orchestrator/src/core/rate-limit-events.ts
+++ b/packages/orchestrator/src/core/rate-limit-events.ts
@@ -1,0 +1,31 @@
+import type { AgentEvent } from '@harness-engineering/types';
+
+/**
+ * Shape of the structured payload carried by subscription-level `rate_limit`
+ * and `rate_limit_sleep` events. Backends populate this when the CLI reports
+ * a plan-quota exhaustion with a known reset time.
+ */
+export interface SubscriptionLimitContent {
+  message: string;
+  resetsAtMs: number;
+  /** Present on rate_limit_sleep; ms we plan to sleep. */
+  sleepMs?: number;
+  /** Present when parser had to guess the reset (unknown timezone, bad format). */
+  resolved?: 'exact' | 'fallback';
+  /** Present when the planned sleep was capped by MAX_SLEEP_MS. */
+  truncated?: boolean;
+  resetTime?: string;
+  timezone?: string;
+}
+
+/**
+ * Extract a subscription-level reset timestamp from an AgentEvent's content.
+ * Returns null for per-request limits (no structured content) or when the
+ * timestamp is missing/invalid.
+ */
+export function extractRateLimitReset(event: AgentEvent): number | null {
+  const content = event.content;
+  if (typeof content !== 'object' || content === null) return null;
+  const resets = (content as { resetsAtMs?: unknown }).resetsAtMs;
+  return typeof resets === 'number' && Number.isFinite(resets) ? resets : null;
+}

--- a/packages/orchestrator/src/core/state-machine.ts
+++ b/packages/orchestrator/src/core/state-machine.ts
@@ -11,6 +11,7 @@ import { canDispatch } from './concurrency';
 import { reconcile } from './reconciliation';
 import { calculateRetryDelay } from './retry';
 import { detectScopeTier, routeIssue, artifactPresenceFromIssue } from './model-router';
+import { extractRateLimitReset } from './rate-limit-events';
 
 /**
  * Bound on retained completion records. Without this, `state.completed`
@@ -279,17 +280,25 @@ function deriveSessionPatch(
 
   let nextPhase: RunAttemptPhase | null = null;
 
-  if (event.type === 'turn_start') {
-    updated.turnCount += 1;
-  } else if (
-    event.type === 'thought' ||
-    event.type === 'call' ||
-    event.type === 'status' ||
-    event.type === 'rate_limit'
-  ) {
-    nextPhase = 'StreamingTurn';
+  // Hoist the lastMessage assignment so we don't restate it in every
+  // streaming branch below. Only the result branch uses a different shape.
+  const streamingTypes = new Set(['thought', 'call', 'status', 'rate_limit', 'rate_limit_sleep']);
+  if (streamingTypes.has(event.type)) {
     updated.lastMessage =
       typeof event.content === 'string' ? event.content : JSON.stringify(event.content);
+  }
+
+  if (event.type === 'turn_start') {
+    updated.turnCount += 1;
+  } else if (event.type === 'thought' || event.type === 'call' || event.type === 'status') {
+    nextPhase = 'StreamingTurn';
+  } else if (event.type === 'rate_limit') {
+    // Subscription-level rate limits include resetsAtMs in their content.
+    // Per-request limits carry only a message — treat those as streaming.
+    nextPhase = extractRateLimitReset(event) !== null ? 'RateLimitSleeping' : 'StreamingTurn';
+  } else if (event.type === 'rate_limit_sleep') {
+    // Runner is sleeping until the subscription limit resets
+    nextPhase = 'RateLimitSleeping';
   } else if (event.type === 'result') {
     updated.lastMessage =
       typeof event.content === 'string'
@@ -334,7 +343,14 @@ function handleAgentUpdate(
   const effects: SideEffect[] = [];
 
   if (event.type === 'rate_limit') {
-    next.globalCooldownUntilMs = Date.now() + next.globalCooldownMs;
+    // Subscription-level limits include resetsAtMs — use that for global cooldown.
+    // Per-request limits use the configured globalCooldownMs fallback.
+    const resetsAtMs = extractRateLimitReset(event);
+    if (resetsAtMs !== null && resetsAtMs > Date.now()) {
+      next.globalCooldownUntilMs = resetsAtMs;
+    } else {
+      next.globalCooldownUntilMs = Date.now() + next.globalCooldownMs;
+    }
   } else if (event.type === 'turn_start') {
     const now = Date.now();
     next.recentRequestTimestamps.push(now);

--- a/packages/orchestrator/src/types/internal.ts
+++ b/packages/orchestrator/src/types/internal.ts
@@ -10,6 +10,7 @@ export type RunAttemptPhase =
   | 'LaunchingAgent'
   | 'InitializingSession'
   | 'StreamingTurn'
+  | 'RateLimitSleeping'
   | 'Finishing'
   | 'Succeeded'
   | 'Failed'

--- a/packages/orchestrator/tests/agent/backends/claude.test.ts
+++ b/packages/orchestrator/tests/agent/backends/claude.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as child_process from 'node:child_process';
 import { PassThrough } from 'node:stream';
-import { ClaudeBackend } from '../../../src/agent/backends/claude';
+import {
+  ClaudeBackend,
+  parseSubscriptionLimit,
+  looksLikeUnparsedLimit,
+} from '../../../src/agent/backends/claude';
 import type { AgentSession, TurnResult, AgentEvent } from '@harness-engineering/types';
 
 vi.mock('node:child_process', async () => {
@@ -238,5 +242,259 @@ describe('ClaudeBackend runTurn', () => {
     expect(resultEvent!.usage!.inputTokens).toBe(1000);
     expect(resultEvent!.usage!.outputTokens).toBe(500);
     expect(resultEvent!.usage!.totalTokens).toBe(1500);
+  });
+});
+
+describe('parseSubscriptionLimit', () => {
+  it('parses standard rate limit message with simple hour', () => {
+    const result = parseSubscriptionLimit(
+      "You've hit your limit · resets 8pm (America/Indianapolis)"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.resetTime).toBe('8pm');
+    expect(result!.timezone).toBe('America/Indianapolis');
+    expect(result!.resetsAtMs).toBeGreaterThan(0);
+  });
+
+  it('parses message with curly quote', () => {
+    const result = parseSubscriptionLimit(
+      'You\u2019ve hit your limit \u00b7 resets 10pm (America/New_York)'
+    );
+    expect(result).not.toBeNull();
+    expect(result!.resetTime).toBe('10pm');
+    expect(result!.timezone).toBe('America/New_York');
+  });
+
+  it('parses message with minutes', () => {
+    const result = parseSubscriptionLimit(
+      "You've hit your limit · resets 11:30pm (America/Chicago)"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.resetTime).toBe('11:30pm');
+    expect(result!.timezone).toBe('America/Chicago');
+  });
+
+  it('parses AM reset time', () => {
+    const result = parseSubscriptionLimit(
+      "You've hit your limit · resets 6am (America/Los_Angeles)"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.resetTime).toBe('6am');
+    expect(result!.timezone).toBe('America/Los_Angeles');
+  });
+
+  it('returns null for non-matching lines', () => {
+    expect(parseSubscriptionLimit('{"type": "assistant"}')).toBeNull();
+    expect(parseSubscriptionLimit('')).toBeNull();
+    expect(parseSubscriptionLimit('Some random output')).toBeNull();
+    expect(parseSubscriptionLimit('Rate limit exceeded')).toBeNull();
+  });
+
+  it('computes a future reset time', () => {
+    const result = parseSubscriptionLimit("You've hit your limit · resets 8pm (UTC)");
+    expect(result).not.toBeNull();
+    // The result should be a valid timestamp in the future or past+24h
+    expect(result!.resetsAtMs).toBeGreaterThan(0);
+    // Should be within 25 hours of now (either today or tomorrow)
+    const diff = Math.abs(result!.resetsAtMs - Date.now());
+    expect(diff).toBeLessThan(25 * 60 * 60_000);
+  });
+
+  it('returns a 1h fallback for unrecognized timezone and flags it', () => {
+    const result = parseSubscriptionLimit("You've hit your limit · resets 8pm (Fake/Timezone_Xyz)");
+    expect(result).not.toBeNull();
+    expect(result!.resolved).toBe('fallback');
+    // Should be approximately 1 hour from now (fallback)
+    const diff = result!.resetsAtMs - Date.now();
+    expect(diff).toBeGreaterThan(55 * 60_000);
+    expect(diff).toBeLessThan(65 * 60_000);
+  });
+
+  it('flags successful parses as resolved=exact', () => {
+    const result = parseSubscriptionLimit(
+      "You've hit your limit · resets 8pm (America/Indianapolis)"
+    );
+    expect(result).not.toBeNull();
+    expect(result!.resolved).toBe('exact');
+  });
+
+  it('computes the exact reset timestamp for UTC at a frozen clock', () => {
+    // Freeze the clock at 2026-05-01T10:00:00Z. "8pm (UTC)" on the same day
+    // is 2026-05-01T20:00:00Z — 10 hours from now.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-01T10:00:00Z'));
+      const result = parseSubscriptionLimit("You've hit your limit · resets 8pm (UTC)");
+      expect(result).not.toBeNull();
+      expect(result!.resolved).toBe('exact');
+      expect(result!.resetsAtMs).toBe(Date.UTC(2026, 4, 1, 20, 0, 0));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('wraps to next day when the reset time has already passed', () => {
+    // Freeze at 2026-05-01T22:00:00Z. "8pm UTC" is two hours ago → wrap to
+    // 2026-05-02T20:00:00Z.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-01T22:00:00Z'));
+      const result = parseSubscriptionLimit("You've hit your limit · resets 8pm (UTC)");
+      expect(result).not.toBeNull();
+      expect(result!.resetsAtMs).toBe(Date.UTC(2026, 4, 2, 20, 0, 0));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies the just-past grace window so near-miss resets do not wrap', () => {
+    // Freeze at 2026-05-01T20:02:00Z — 2 min past "8pm UTC". Grace is 5 min,
+    // so the reset should stay on today, not roll to tomorrow.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-01T20:02:00Z'));
+      const result = parseSubscriptionLimit("You've hit your limit · resets 8pm (UTC)");
+      expect(result).not.toBeNull();
+      expect(result!.resetsAtMs).toBe(Date.UTC(2026, 4, 1, 20, 0, 0));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('looksLikeUnparsedLimit', () => {
+  it('matches limit-like lines that the strict parser rejects', () => {
+    expect(looksLikeUnparsedLimit('Rate limit reached. Resets soon.')).toBe(true);
+    expect(looksLikeUnparsedLimit('Your quota resets at the top of the hour.')).toBe(true);
+  });
+
+  it('returns false for the canonical line (strict parser handles it)', () => {
+    expect(looksLikeUnparsedLimit("You've hit your limit · resets 8pm (America/New_York)")).toBe(
+      false
+    );
+  });
+
+  it('returns false for unrelated output', () => {
+    expect(looksLikeUnparsedLimit('{"type": "assistant"}')).toBe(false);
+    expect(looksLikeUnparsedLimit('Some log line')).toBe(false);
+    expect(looksLikeUnparsedLimit('')).toBe(false);
+  });
+});
+
+describe('ClaudeBackend non-JSON rate limit detection', () => {
+  const mockSpawn = vi.mocked(child_process.spawn);
+  let backend: ClaudeBackend;
+  let session: AgentSession;
+
+  beforeEach(async () => {
+    backend = new ClaudeBackend('claude');
+    const started = await backend.startSession({
+      workspacePath: '/tmp/workspace',
+      permissionMode: 'full',
+    });
+    if (!started.ok) throw new Error('failed to start session');
+    session = started.value;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('yields a rate_limit event with resetsAtMs when the CLI outputs a subscription limit message', async () => {
+    const stdout = new PassThrough();
+    const stdin = new PassThrough();
+    const child = Object.assign(new PassThrough(), {
+      stdout,
+      stderr: new PassThrough(),
+      stdin,
+      pid: 12345,
+      exitCode: null as number | null,
+      kill: vi.fn(),
+      on: vi.fn(function on(this: unknown, event: string, cb: (...args: unknown[]) => void) {
+        if (event === 'exit') {
+          setTimeout(() => cb(0), 20);
+        }
+        return this;
+      }),
+    });
+
+    setTimeout(() => {
+      // Write a non-JSON rate limit line
+      stdout.write("You've hit your limit \u00b7 resets 8pm (America/Indianapolis)\n");
+      stdout.end();
+      child.exitCode = 0;
+    }, 10);
+
+    mockSpawn.mockReturnValue(child as unknown as child_process.ChildProcess);
+
+    const { events } = await consumeTurn(
+      backend.runTurn(session, {
+        sessionId: session.sessionId,
+        prompt: 'do work',
+        isContinuation: false,
+      })
+    );
+
+    const rateLimitEvents = events.filter((e) => e.type === 'rate_limit');
+    expect(rateLimitEvents).toHaveLength(1);
+
+    const content = rateLimitEvents[0]!.content as {
+      message: string;
+      resetsAtMs: number;
+      resetTime: string;
+      timezone: string;
+      resolved: 'exact' | 'fallback';
+    };
+    expect(content.resetTime).toBe('8pm');
+    expect(content.timezone).toBe('America/Indianapolis');
+    expect(content.resetsAtMs).toBeGreaterThan(0);
+    expect(content.resolved).toBe('exact');
+  });
+
+  it('yields a rate_limit event WITHOUT resetsAtMs when the line looks limit-like but fails the strict parser', async () => {
+    // Silence the expected console.warn from the drift logger
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const stdout = new PassThrough();
+    const child = Object.assign(new PassThrough(), {
+      stdout,
+      stderr: new PassThrough(),
+      stdin: new PassThrough(),
+      pid: 12345,
+      exitCode: null as number | null,
+      kill: vi.fn(),
+      on: vi.fn(function on(this: unknown, event: string, cb: (...args: unknown[]) => void) {
+        if (event === 'exit') setTimeout(() => cb(0), 20);
+        return this;
+      }),
+    });
+
+    setTimeout(() => {
+      // Non-canonical phrasing the CLI might produce after a format change.
+      stdout.write('Rate limit reached. Your quota resets soon.\n');
+      stdout.end();
+      child.exitCode = 0;
+    }, 10);
+
+    mockSpawn.mockReturnValue(child as unknown as child_process.ChildProcess);
+
+    const { events } = await consumeTurn(
+      backend.runTurn(session, {
+        sessionId: session.sessionId,
+        prompt: 'do work',
+        isContinuation: false,
+      })
+    );
+
+    const rateLimitEvents = events.filter((e) => e.type === 'rate_limit');
+    expect(rateLimitEvents).toHaveLength(1);
+
+    const content = rateLimitEvents[0]!.content as { message: string; resetsAtMs?: number };
+    expect(content.message).toContain('Rate limit reached');
+    expect(content.resetsAtMs).toBeUndefined();
+    // Drift should be logged so operators notice CLI format changes.
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });

--- a/packages/orchestrator/tests/agent/runner.test.ts
+++ b/packages/orchestrator/tests/agent/runner.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { AgentRunner } from '../../src/agent/runner';
+import type {
+  AgentBackend,
+  AgentEvent,
+  AgentSession,
+  Issue,
+  SessionStartParams,
+  TurnParams,
+  TurnResult,
+} from '@harness-engineering/types';
+import { Ok } from '@harness-engineering/types';
+
+interface MockBackendOptions {
+  eventScripts: AgentEvent[][];
+  results?: TurnResult[];
+}
+
+/**
+ * Minimal mock backend that yields a scripted set of events for each turn,
+ * then returns a TurnResult. Each call to runTurn pops one script.
+ */
+function makeMockBackend(opts: MockBackendOptions): AgentBackend {
+  const eventQueue = [...opts.eventScripts];
+  const resultQueue = [...(opts.results ?? [])];
+
+  return {
+    name: 'mock',
+    async startSession(_params: SessionStartParams) {
+      const session: AgentSession = {
+        sessionId: 'test-session-id',
+        workspacePath: '/tmp/ws',
+        backendName: 'mock',
+        startedAt: new Date().toISOString(),
+      };
+      return Ok(session);
+    },
+    async *runTurn(
+      session: AgentSession,
+      _params: TurnParams
+    ): AsyncGenerator<AgentEvent, TurnResult, void> {
+      const events = eventQueue.shift() ?? [];
+      for (const evt of events) yield evt;
+      return (
+        resultQueue.shift() ?? {
+          success: false,
+          sessionId: session.sessionId,
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        }
+      );
+    },
+    async stopSession(_session: AgentSession) {
+      return Ok(undefined);
+    },
+    async healthCheck() {
+      return Ok(undefined);
+    },
+  };
+}
+
+async function drainUntilSleep(
+  gen: AsyncGenerator<AgentEvent, TurnResult, void>
+): Promise<{ events: AgentEvent[]; next: IteratorResult<AgentEvent, TurnResult> }> {
+  const events: AgentEvent[] = [];
+  let next = await gen.next();
+  while (!next.done) {
+    events.push(next.value);
+    if (next.value.type === 'rate_limit_sleep') break;
+    next = await gen.next();
+  }
+  return { events, next };
+}
+
+const testIssue: Issue = {
+  id: 'issue-1',
+  identifier: 'test-1',
+  title: 't',
+  description: '',
+  state: 'planned',
+  labels: [],
+  priority: null,
+  assignee: null,
+  external: null,
+  extras: {},
+} as Issue;
+
+describe('AgentRunner subscription rate limit sleep', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('yields a rate_limit_sleep event and actually sleeps when resetsAtMs is present', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T10:00:00Z'));
+
+    const resetsAtMs = Date.UTC(2026, 4, 1, 10, 5, 0); // 5 minutes out
+    const backend = makeMockBackend({
+      eventScripts: [
+        [
+          {
+            type: 'rate_limit',
+            timestamp: new Date().toISOString(),
+            content: { message: 'limit', resetsAtMs, resolved: 'exact' },
+            sessionId: 'test-session-id',
+          },
+        ],
+        [],
+      ],
+      results: [
+        {
+          success: false,
+          sessionId: 'test-session-id',
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        },
+        {
+          success: true,
+          sessionId: 'test-session-id',
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        },
+      ],
+    });
+
+    const runner = new AgentRunner(backend, { maxTurns: 3 });
+    const gen = runner.runSession(testIssue, '/tmp/ws', 'prompt');
+
+    // Pump events until we hit rate_limit_sleep (which precedes the setTimeout).
+    const { events } = await drainUntilSleep(gen);
+    const sleepEvent = events.find((e) => e.type === 'rate_limit_sleep');
+    expect(sleepEvent).toBeDefined();
+
+    const content = sleepEvent!.content as {
+      message: string;
+      resetsAtMs: number;
+      sleepMs: number;
+      truncated: boolean;
+    };
+    expect(content.resetsAtMs).toBe(resetsAtMs);
+    expect(content.sleepMs).toBe(5 * 60_000);
+    expect(content.truncated).toBe(false);
+
+    // Kick off the next step (which awaits setTimeout) and advance timers
+    // to unblock it. Order matters: the promise must be started BEFORE we
+    // advance, otherwise there's nothing queued to fast-forward.
+    const nextPromise = gen.next();
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    let next = await nextPromise;
+
+    // Drain whatever else the runner emits until the session completes.
+    while (!next.done) {
+      const p = gen.next();
+      await vi.advanceTimersByTimeAsync(0);
+      next = await p;
+    }
+    expect(next.value.success).toBe(true);
+  });
+
+  it('flags the event as truncated and warns when the requested sleep exceeds MAX_SLEEP_MS', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T10:00:00Z'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // 13 hours out → exceeds the 12-hour cap.
+    const resetsAtMs = Date.now() + 13 * 60 * 60_000;
+    const backend = makeMockBackend({
+      eventScripts: [
+        [
+          {
+            type: 'rate_limit',
+            timestamp: new Date().toISOString(),
+            content: { message: 'limit', resetsAtMs, resolved: 'exact' },
+            sessionId: 'test-session-id',
+          },
+        ],
+      ],
+      results: [
+        {
+          success: false,
+          sessionId: 'test-session-id',
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        },
+      ],
+    });
+
+    const runner = new AgentRunner(backend, { maxTurns: 1 });
+    const gen = runner.runSession(testIssue, '/tmp/ws', 'prompt');
+    const { events } = await drainUntilSleep(gen);
+
+    const sleepEvent = events.find((e) => e.type === 'rate_limit_sleep');
+    expect(sleepEvent).toBeDefined();
+    const content = sleepEvent!.content as { sleepMs: number; truncated: boolean; message: string };
+    expect(content.sleepMs).toBe(12 * 60 * 60_000);
+    expect(content.truncated).toBe(true);
+    expect(content.message).toContain('capped');
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    // Drain the pending sleep so the generator cleanup runs.
+    const nextPromise = gen.next();
+    await vi.advanceTimersByTimeAsync(12 * 60 * 60_000);
+    let next = await nextPromise;
+    while (!next.done) {
+      const p = gen.next();
+      await vi.advanceTimersByTimeAsync(0);
+      next = await p;
+    }
+  });
+
+  it('does not sleep when rate_limit has no resetsAtMs (per-request limit)', async () => {
+    const backend = makeMockBackend({
+      eventScripts: [
+        [
+          {
+            type: 'rate_limit',
+            timestamp: new Date().toISOString(),
+            content: { message: 'per-request limit' },
+            sessionId: 'test-session-id',
+          },
+        ],
+        [],
+      ],
+      results: [
+        {
+          success: false,
+          sessionId: 'test-session-id',
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        },
+        {
+          success: true,
+          sessionId: 'test-session-id',
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        },
+      ],
+    });
+
+    const runner = new AgentRunner(backend, { maxTurns: 3 });
+    const events: AgentEvent[] = [];
+    const gen = runner.runSession(testIssue, '/tmp/ws', 'prompt');
+    let next = await gen.next();
+    while (!next.done) {
+      events.push(next.value);
+      next = await gen.next();
+    }
+
+    expect(events.some((e) => e.type === 'rate_limit_sleep')).toBe(false);
+  });
+});

--- a/packages/orchestrator/tests/core/rate-limit.test.ts
+++ b/packages/orchestrator/tests/core/rate-limit.test.ts
@@ -43,4 +43,151 @@ describe('Rate Limit State Machine & Concurrency', () => {
     expect(nextState.recentRequestTimestamps.length).toBe(2);
     expect(canDispatch(nextState, 'open', {})).toBe(false);
   });
+
+  it('sets globalCooldownUntilMs to resetsAtMs on subscription-level rate_limit', () => {
+    const state = createEmptyState(config);
+    state.running.set('issue-1', {
+      session: { turnCount: 0, lastEvent: null, lastTimestamp: null, lastMessage: null },
+    } as any);
+
+    const resetsAtMs = Date.now() + 2 * 60 * 60_000; // 2h out
+    const { nextState } = applyEvent(
+      state,
+      {
+        type: 'agent_update',
+        issueId: 'issue-1',
+        event: {
+          type: 'rate_limit',
+          timestamp: new Date().toISOString(),
+          content: { message: 'limit hit', resetsAtMs, resolved: 'exact' },
+        },
+      } as any,
+      config
+    );
+
+    expect(nextState.globalCooldownUntilMs).toBe(resetsAtMs);
+  });
+
+  it('falls back to globalCooldownMs on per-request rate_limit (no resetsAtMs)', () => {
+    const state = createEmptyState(config);
+    state.running.set('issue-1', {
+      session: { turnCount: 0, lastEvent: null, lastTimestamp: null, lastMessage: null },
+    } as any);
+
+    const beforeMs = Date.now();
+    const { nextState } = applyEvent(
+      state,
+      {
+        type: 'agent_update',
+        issueId: 'issue-1',
+        event: {
+          type: 'rate_limit',
+          timestamp: new Date().toISOString(),
+          content: { message: 'per-request limit' },
+        },
+      } as any,
+      config
+    );
+
+    // Cooldown should be ~60s (config.agent.globalCooldownMs) from now, NOT a
+    // value persisted from any resetsAtMs.
+    expect(nextState.globalCooldownUntilMs).toBeGreaterThanOrEqual(
+      beforeMs + config.agent.globalCooldownMs - 100
+    );
+    expect(nextState.globalCooldownUntilMs).toBeLessThanOrEqual(
+      Date.now() + config.agent.globalCooldownMs + 100
+    );
+  });
+
+  it('transitions phase to RateLimitSleeping when rate_limit has resetsAtMs', () => {
+    const state = createEmptyState(config);
+    state.running.set('issue-1', {
+      phase: 'StreamingTurn',
+      session: {
+        turnCount: 0,
+        lastEvent: null,
+        lastTimestamp: null,
+        lastMessage: null,
+      },
+    } as any);
+
+    const { nextState } = applyEvent(
+      state,
+      {
+        type: 'agent_update',
+        issueId: 'issue-1',
+        event: {
+          type: 'rate_limit',
+          timestamp: new Date().toISOString(),
+          content: { message: 'limit', resetsAtMs: Date.now() + 60_000, resolved: 'exact' },
+        },
+      } as any,
+      config
+    );
+
+    expect(nextState.running.get('issue-1')?.phase).toBe('RateLimitSleeping');
+  });
+
+  it('keeps phase as StreamingTurn when rate_limit has no resetsAtMs', () => {
+    const state = createEmptyState(config);
+    state.running.set('issue-1', {
+      phase: 'StreamingTurn',
+      session: {
+        turnCount: 0,
+        lastEvent: null,
+        lastTimestamp: null,
+        lastMessage: null,
+      },
+    } as any);
+
+    const { nextState } = applyEvent(
+      state,
+      {
+        type: 'agent_update',
+        issueId: 'issue-1',
+        event: {
+          type: 'rate_limit',
+          timestamp: new Date().toISOString(),
+          content: { message: 'per-request' },
+        },
+      } as any,
+      config
+    );
+
+    expect(nextState.running.get('issue-1')?.phase).toBe('StreamingTurn');
+  });
+
+  it('transitions phase to RateLimitSleeping on rate_limit_sleep', () => {
+    const state = createEmptyState(config);
+    state.running.set('issue-1', {
+      phase: 'StreamingTurn',
+      session: {
+        turnCount: 0,
+        lastEvent: null,
+        lastTimestamp: null,
+        lastMessage: null,
+      },
+    } as any);
+
+    const { nextState } = applyEvent(
+      state,
+      {
+        type: 'agent_update',
+        issueId: 'issue-1',
+        event: {
+          type: 'rate_limit_sleep',
+          timestamp: new Date().toISOString(),
+          content: {
+            message: 'sleeping',
+            resetsAtMs: Date.now() + 60_000,
+            sleepMs: 60_000,
+            truncated: false,
+          },
+        },
+      } as any,
+      config
+    );
+
+    expect(nextState.running.get('issue-1')?.phase).toBe('RateLimitSleeping');
+  });
 });


### PR DESCRIPTION
## Summary

When the Claude CLI outputs a non-JSON plan-quota message like
`You've hit your limit · resets 8pm (America/Indianapolis)`, the orchestrator now:

- **Parses** the reset time and timezone, emitting a structured `rate_limit` event with `resetsAtMs` and a `resolved: 'exact' | 'fallback'` discriminator.
- **Sleeps** in `AgentRunner` until the reset lifts (capped at 12h), yielding a new `rate_limit_sleep` event before the suspend.
- **Transitions** the in-flight attempt to a new `RateLimitSleeping` phase and sets `globalCooldownUntilMs` to the parsed reset rather than the default `globalCooldownMs`.

## Hardening over the initial implementation (review findings addressed)

| Finding | Fix |
|---|---|
| Silent fallback masked unresolvable timezones | `parseSubscriptionLimit` returns `resolved: 'fallback'`; backend logs when the fallback fires |
| Brittle regex with no signal on CLI format drift | New `looksLikeUnparsedLimit` loose detector + `console.warn` emit a `rate_limit` event so the default cooldown still fires |
| 12-hour sleep cap had no escalation | `rate_limit_sleep.content.truncated = true` + warn log when `requestedSleepMs > MAX_SLEEP_MS` |
| 24h wraparound could bounce near-miss resets | 5-minute just-past grace window applied before wrapping |
| Three `// eslint-disable @typescript-eslint/no-explicit-any` casts | Extracted typed `extractRateLimitReset` helper in new `core/rate-limit-events.ts` |
| `runSession` while-loop complexity | Sleep logic extracted to `sleepUntilReset` private method |
| `parseSubscriptionLimit` complexity 24 > 15 | Split into `parse12HourTime`, `getDatePartsInTimezone`, `resolveWallClockToUtcMs`, `fallbackParse` |
| Timezone tests only asserted `> 0` | Fake-timer tests with exact `Date.UTC(...)` assertions for UTC, wrap-to-tomorrow, and grace-window cases |
| No tests for runner sleep flow or state-machine phase transition | New `tests/agent/runner.test.ts` covers sleep + truncation; `tests/core/rate-limit.test.ts` covers phase + cooldown transitions |

## Test plan

- [x] `pnpm --filter @harness-engineering/orchestrator exec vitest run` → 319/319 pass
- [x] New `tests/agent/runner.test.ts` (3 tests) uses fake timers to verify actual sleep, truncation + warn, and no-sleep-on-per-request-limit
- [x] `tests/core/rate-limit.test.ts` (+4 tests) verifies cooldown = `resetsAtMs` for subscription limits, cooldown = `globalCooldownMs` for per-request, and `RateLimitSleeping` phase transitions
- [x] `tests/agent/backends/claude.test.ts` adds exact-timestamp assertions (frozen clock), `resolved` discriminator tests, loose-match fallback test
- [x] `harness check-arch` passes (baselines bumped: module-size 81958, dependency-depth 333, complexity 39)