### PR TITLE
feat(orchestrator): PR-aware dispatch guard

### DIFF
--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T02:01:15.999Z",
-  "updatedFrom": "8d8d8ca3",
+  "updatedAt": "2026-04-17T02:02:25.421Z",
+  "updatedFrom": "94c9fafb",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 39,
+      "value": 38,
       "violationIds": [
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
@@ -21,15 +21,14 @@
         "38609b096b2ffd19535887a5555ad9a8491a580a6c9cf4368179d8df36a876c6",
         "38609b096b2ffd19535887a5555ad9a8491a580a6c9cf4368179d8df36a876c6",
         "22a8ee1508eb981479f47f1c9ff6b2d69b8291e34b4cf9ebb1b8b322372445b4",
-        "4ec5b89ddfda055b8db8745ac52b3466abc4dce07e39cc246f8a91c300c6756e",
         "10e2748e89679c1901fc3e67f2bed06034d3c4c564b66345ac9418ef9a9685f7",
         "c7b8c706c15e4597f5f37e43332cf6c7434ca6304c16a0779e2369e76c9214e3",
         "a412401eac205ffb264bf787149f356102c5b0ba5b02f8d526083dc4d976115b",
         "1eb37e0977a1b3bd37eaecb872a2588522766006db257b8f96c64d35a52cbe94",
         "d3cfdf50eb93ffa8e766af4e71257175af7f24bb346c3a2f5338c5b6f853382a",
+        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
         "5aa35eb7825bc41fe5a8fc031d0cdedd78703616efd3da15af290eca55184744",
         "ac5d2db9c38d6025f9531c162a198343c5c501a7bd8991906470993853d89055",
-        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
         "fad5da199ad18507ec1727c9a2de48da80fd75f72230cc948df3afd8830308ce",
         "f573d1d3f72b896ef1841f90ce326b1008e05ec90ec72489becbd1a9e4c679fe",
         "6eb4858144d411132d7e376f3dca3820e906d97bfb34d6a690f6ddb3229b8dce",
@@ -45,14 +44,14 @@
         "e7bf797006b720679aa6da3d70bb9a19b06b02a713f6388a16ca0af68ad700e5",
         "12892b0915eb65d0f28f900728db84d7cd04f35deb7fb7c071c71a7de61f3162",
         "b2ae178ccdd3196acf6e7f39e8bf96c556fe598346c1cdce01c02bd98d393c64",
-        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
-        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe",
-        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
         "14715d1f7346442bc17888eecdac07b4a4ae166ad3c8b7d9582e6eec380c98fc",
         "3be6cd991653c54e8c6a0f0942d56fd54892b1afa88855ef11b1ae6dbfbe1676",
         "08151b7f65c324074876ce5f0136a0d749d71b38b05cdda2bea0acca220bce06",
         "f80c1747de98253c8b1f63381609098332795f5a5d5af4bb99131c93fa9860e8",
-        "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13"
+        "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13",
+        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
+        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
+        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe"
       ]
     },
     "coupling": {
@@ -64,7 +63,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 82184,
+      "value": 81844,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",
@@ -73,7 +72,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 333,
+      "value": 332,
       "violationIds": []
     }
   }

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-16T22:50:03.542Z",
-  "updatedFrom": "94c6dd24",
+  "updatedAt": "2026-04-17T02:01:15.999Z",
+  "updatedFrom": "8d8d8ca3",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 38,
+      "value": 39,
       "violationIds": [
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
@@ -21,6 +21,7 @@
         "38609b096b2ffd19535887a5555ad9a8491a580a6c9cf4368179d8df36a876c6",
         "38609b096b2ffd19535887a5555ad9a8491a580a6c9cf4368179d8df36a876c6",
         "22a8ee1508eb981479f47f1c9ff6b2d69b8291e34b4cf9ebb1b8b322372445b4",
+        "4ec5b89ddfda055b8db8745ac52b3466abc4dce07e39cc246f8a91c300c6756e",
         "10e2748e89679c1901fc3e67f2bed06034d3c4c564b66345ac9418ef9a9685f7",
         "c7b8c706c15e4597f5f37e43332cf6c7434ca6304c16a0779e2369e76c9214e3",
         "a412401eac205ffb264bf787149f356102c5b0ba5b02f8d526083dc4d976115b",
@@ -44,14 +45,14 @@
         "e7bf797006b720679aa6da3d70bb9a19b06b02a713f6388a16ca0af68ad700e5",
         "12892b0915eb65d0f28f900728db84d7cd04f35deb7fb7c071c71a7de61f3162",
         "b2ae178ccdd3196acf6e7f39e8bf96c556fe598346c1cdce01c02bd98d393c64",
+        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
+        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe",
+        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
         "14715d1f7346442bc17888eecdac07b4a4ae166ad3c8b7d9582e6eec380c98fc",
         "3be6cd991653c54e8c6a0f0942d56fd54892b1afa88855ef11b1ae6dbfbe1676",
         "08151b7f65c324074876ce5f0136a0d749d71b38b05cdda2bea0acca220bce06",
         "f80c1747de98253c8b1f63381609098332795f5a5d5af4bb99131c93fa9860e8",
-        "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13",
-        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
-        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe",
-        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a"
+        "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13"
       ]
     },
     "coupling": {
@@ -63,7 +64,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 82000,
+      "value": 82184,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",
@@ -72,7 +73,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 335,
+      "value": 333,
       "violationIds": []
     }
   }

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -63,7 +63,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 81847,
+      "value": 81849,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -63,7 +63,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 81844,
+      "value": 81847,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/docs/changes/orchestrator-pr-aware-dispatch/proposal.md
+++ b/docs/changes/orchestrator-pr-aware-dispatch/proposal.md
@@ -1,0 +1,82 @@
+# Orchestrator PR-Aware Dispatch Guard
+
+## Overview
+
+When the orchestrator polls for candidate work items, it dispatches agents to any roadmap feature with an active status (`planned`/`in-progress`) regardless of whether a pull request already exists for that feature. This leads to duplicate PRs, wasted agent compute, and potential merge conflicts.
+
+This change adds a pre-filter step in the orchestrator's tick cycle that checks each candidate's `externalId` against GitHub's PR API. Candidates with open PRs are excluded from dispatch. Closed, merged, or unreachable PRs are treated as dispatchable (fail-open).
+
+### Goals
+
+- Prevent duplicate agent dispatch for features that already have open PRs
+- Zero impact on orchestrator availability — fail open on API errors
+- No changes to the tracker adapter, state machine, or workspace manager interfaces
+
+### Non-Goals
+
+- Resuming work on an existing PR branch (future feature)
+- Caching PR state across ticks
+- Supporting non-GitHub tracker schemes (graceful no-op for now)
+
+## Decisions
+
+| #   | Decision                                                          | Rationale                                                                                                             |
+| --- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| 1   | Skip dispatch if PR is open; allow if closed/merged/absent        | Prevents duplicate work while allowing re-dispatch for abandoned or completed PRs                                     |
+| 2   | Filter in orchestrator tick, not tracker adapter or state machine | Orchestrator already owns `gh` integration; keeps tracker adapter as a pure file read and state machine as pure logic |
+| 3   | Dedicated `isExternalPROpen()` method                             | Purpose-built for the `github:owner/repo#N` format with graceful no-op for unknown schemes                            |
+| 4   | Fail open with warning on API errors                              | Matches existing `branchHasPullRequest()` pattern; orchestrator stays available during GitHub outages                 |
+| 5   | No caching                                                        | Candidate count with externalIds is small; stateless avoids stale-cache bugs                                          |
+
+## Technical Design
+
+### New method: `isExternalPROpen()`
+
+- Location: `packages/orchestrator/src/orchestrator.ts`
+- Parses `externalId` string matching `github:<owner>/<repo>#<number>`
+- Calls `gh pr view <number> --repo <owner>/<repo> --json state --jq .state`
+- Returns `true` if state is `"OPEN"`, `false` otherwise
+- On parse failure (non-github scheme, malformed ID): returns `false` (fail-open, no warning — not a GitHub item)
+- On API failure (network, auth, rate limit): returns `false` (fail-open), logs warning via `this.logger.warn()`
+
+### New method: `filterCandidatesWithOpenPRs()`
+
+- Location: `packages/orchestrator/src/orchestrator.ts`
+- Takes `Issue[]`, returns `Promise<Issue[]>`
+- Runs `isExternalPROpen()` in parallel via `Promise.allSettled()` for all candidates where `externalId` is non-null
+- Candidates with null `externalId` pass through untouched
+- Candidates where the check resolves to `true` (open PR) are excluded
+- Excluded candidates are logged at `info` level: `"Skipping <title>: open PR at <externalId>"`
+
+### Wiring in `asyncTick()`
+
+- Inserted between the `fetchCandidateIssues()` result and the `applyEvent(state, tickEvent)` call
+- The filtered candidates list replaces the raw candidates in the tick event payload
+
+### File Layout
+
+No new files beyond tests:
+
+- `packages/orchestrator/src/orchestrator.ts` — two new private methods + one line change in `asyncTick()`
+- `packages/orchestrator/tests/orchestrator-pr-guard.test.ts` — new test file
+
+### Data Structures
+
+No new types. Operates on existing `Issue` type (reads `externalId: string | null`). No changes to `RoadmapFeature`, `Issue`, or any shared types.
+
+## Success Criteria
+
+1. When [candidate has externalId pointing to an open GitHub PR], the system shall [exclude it from dispatch].
+2. When [candidate has externalId pointing to a closed or merged PR], the system shall [dispatch it normally].
+3. When [candidate has null externalId], the system shall [dispatch it normally].
+4. When [candidate has non-github externalId scheme], the system shall [dispatch it normally without calling gh].
+5. If [`gh` API call fails], then the system shall [dispatch the candidate and log a warning].
+6. The system shall not [modify the Issue type, tracker adapter interface, or state machine logic].
+7. All new code has unit test coverage.
+8. Existing orchestrator tests continue to pass.
+
+## Implementation Order
+
+1. **Phase 1: Core methods** — Implement `isExternalPROpen()` and `filterCandidatesWithOpenPRs()` with unit tests
+2. **Phase 2: Wire into tick** — Insert filter call in `asyncTick()`, integration test with mixed candidates
+3. **Phase 3: Verify** — Run full orchestrator test suite, manual smoke test with a roadmap containing items with open PRs

--- a/docs/plans/2026-04-16-orchestrator-pr-aware-dispatch-phase1-plan.md
+++ b/docs/plans/2026-04-16-orchestrator-pr-aware-dispatch-phase1-plan.md
@@ -1,0 +1,331 @@
+# Plan: Orchestrator PR-Aware Dispatch -- Phase 1 Core Methods
+
+**Date:** 2026-04-16 | **Spec:** docs/changes/orchestrator-pr-aware-dispatch/proposal.md | **Tasks:** 3 | **Time:** ~12 min
+
+## Goal
+
+Add `isExternalPROpen()` and `filterCandidatesWithOpenPRs()` private methods to the Orchestrator class, with full unit test coverage, so that candidates with open GitHub PRs can be identified and excluded from dispatch.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When `externalId` is `"github:owner/repo#42"` and `gh pr view` returns `"OPEN"`, `isExternalPROpen` returns `true`.
+2. When `externalId` is `"github:owner/repo#42"` and `gh pr view` returns `"CLOSED"` or `"MERGED"`, `isExternalPROpen` returns `false`.
+3. When `externalId` is `null`, `filterCandidatesWithOpenPRs` passes the candidate through untouched (no `gh` call).
+4. When `externalId` uses a non-github scheme (e.g. `"jira:PROJ-1"`), `isExternalPROpen` returns `false` without calling `gh`.
+5. When the `gh` API call fails (network error, auth failure), `isExternalPROpen` returns `false` and logs a warning via `this.logger.warn()`.
+6. `filterCandidatesWithOpenPRs` runs `isExternalPROpen` in parallel via `Promise.allSettled`, excludes candidates where the result is `true`, and logs excluded candidates at info level.
+7. `cd packages/orchestrator && npx vitest run tests/orchestrator-pr-guard.test.ts` passes with 8+ tests.
+8. `cd packages/orchestrator && npx vitest run` passes (existing tests unbroken).
+
+## File Map
+
+- MODIFY `packages/orchestrator/src/orchestrator.ts` (add two private methods after `branchHasPullRequest`)
+- CREATE `packages/orchestrator/tests/orchestrator-pr-guard.test.ts` (new test file)
+
+## Tasks
+
+### Task 1: Write test file with all test cases (red phase)
+
+**Depends on:** none | **Files:** `packages/orchestrator/tests/orchestrator-pr-guard.test.ts`
+
+The tests must exercise `isExternalPROpen` and `filterCandidatesWithOpenPRs` as private methods. Since they are private on the Orchestrator class, we test them indirectly by accessing them via `(orchestrator as any)` -- the same pattern used throughout this codebase for private method testing. We mock `execFile` via `vi.mock('node:child_process')`.
+
+1. Create `packages/orchestrator/tests/orchestrator-pr-guard.test.ts` with the following content:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Orchestrator } from '../src/orchestrator';
+import type { Issue, WorkflowConfig } from '@harness-engineering/types';
+
+// Mock child_process.execFile
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from 'node:child_process';
+
+function makeConfig(): WorkflowConfig {
+  return {
+    tracker: {
+      kind: 'roadmap',
+      activeStates: ['Todo', 'In Progress'],
+      terminalStates: ['Done', 'Cancelled'],
+    },
+    polling: { intervalMs: 30000 },
+    workspace: { root: '/tmp/ws' },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 60000,
+    },
+    agent: {
+      backend: 'mock',
+      maxConcurrentAgents: 3,
+      maxTurns: 20,
+      maxRetryBackoffMs: 300000,
+      maxRetries: 5,
+      maxConcurrentAgentsByState: {},
+      turnTimeoutMs: 3600000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 300000,
+    },
+    server: { port: null },
+  };
+}
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'id-1',
+    identifier: 'TEST-1',
+    title: 'Test issue',
+    description: null,
+    priority: null,
+    state: 'Todo',
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    spec: null,
+    plans: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: null,
+    externalId: null,
+    ...overrides,
+  };
+}
+
+describe('isExternalPROpen', () => {
+  let orchestrator: Orchestrator;
+  let mockExecFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orchestrator = new Orchestrator(makeConfig(), 'test prompt');
+    mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it('returns true when gh reports OPEN state', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: 'OPEN\n', stderr: '' });
+      }
+    );
+
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(true);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'view', '42', '--repo', 'owner/repo', '--json', 'state', '--jq', '.state'],
+      expect.objectContaining({ timeout: 10_000 }),
+      expect.any(Function)
+    );
+  });
+
+  it('returns false when gh reports CLOSED state', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: 'CLOSED\n', stderr: '' });
+      }
+    );
+
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when gh reports MERGED state', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: 'MERGED\n', stderr: '' });
+      }
+    );
+
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(false);
+  });
+
+  it('returns false for non-github scheme without calling gh', async () => {
+    const result = await (orchestrator as any).isExternalPROpen('jira:PROJ-123');
+    expect(result).toBe(false);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('returns false for malformed github externalId', async () => {
+    const result = await (orchestrator as any).isExternalPROpen('github:badformat');
+    expect(result).toBe(false);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('returns false and logs warning when gh command fails', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('gh: not found'), { stdout: '', stderr: '' });
+      }
+    );
+
+    const warnSpy = vi.spyOn((orchestrator as any).logger, 'warn');
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to check PR state'),
+      expect.any(Object)
+    );
+  });
+});
+
+describe('filterCandidatesWithOpenPRs', () => {
+  let orchestrator: Orchestrator;
+  let mockExecFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orchestrator = new Orchestrator(makeConfig(), 'test prompt');
+    mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it('excludes candidates with open PRs', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        // PR #10 is open, PR #20 is closed
+        if (args.includes('10')) {
+          cb(null, { stdout: 'OPEN\n', stderr: '' });
+        } else {
+          cb(null, { stdout: 'CLOSED\n', stderr: '' });
+        }
+      }
+    );
+
+    const candidates = [
+      makeIssue({ id: '1', title: 'Open PR', externalId: 'github:owner/repo#10' }),
+      makeIssue({ id: '2', title: 'Closed PR', externalId: 'github:owner/repo#20' }),
+    ];
+
+    const infoSpy = vi.spyOn((orchestrator as any).logger, 'info');
+    const result = await (orchestrator as any).filterCandidatesWithOpenPRs(candidates);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping Open PR'));
+  });
+
+  it('passes through candidates with null externalId', async () => {
+    const candidates = [makeIssue({ id: '1', title: 'No external', externalId: null })];
+
+    const result = await (orchestrator as any).filterCandidatesWithOpenPRs(candidates);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('passes through candidates when gh fails (fail-open)', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('network timeout'), { stdout: '', stderr: '' });
+      }
+    );
+
+    const candidates = [
+      makeIssue({ id: '1', title: 'Failing check', externalId: 'github:owner/repo#10' }),
+    ];
+
+    const result = await (orchestrator as any).filterCandidatesWithOpenPRs(candidates);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+});
+```
+
+2. Run: `cd /Users/cwarner/Projects/harness-engineering/packages/orchestrator && npx vitest run tests/orchestrator-pr-guard.test.ts`
+3. Observe failures -- the methods do not exist yet.
+
+---
+
+### Task 2: Implement isExternalPROpen and filterCandidatesWithOpenPRs (green phase)
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/src/orchestrator.ts`
+
+Add two private methods to the Orchestrator class, placed immediately after the `branchHasPullRequest` method (line 829).
+
+1. In `packages/orchestrator/src/orchestrator.ts`, insert the following after the closing brace of `branchHasPullRequest` (after line 829):
+
+```typescript
+  /**
+   * Checks whether an external tracker ID points to an open GitHub PR.
+   * Parses `github:<owner>/<repo>#<number>` format. Non-github schemes
+   * return false (fail-open, not a GitHub item). API failures return
+   * false (fail-open) and log a warning.
+   */
+  private async isExternalPROpen(externalId: string): Promise<boolean> {
+    const match = externalId.match(/^github:([^/]+\/[^#]+)#(\d+)$/);
+    if (!match) return false;
+
+    const [, repo, number] = match;
+    try {
+      const exec = promisify(execFile);
+      const { stdout } = await exec(
+        'gh',
+        ['pr', 'view', number, '--repo', repo, '--json', 'state', '--jq', '.state'],
+        {
+          cwd: this.projectRoot,
+          timeout: 10_000,
+        }
+      );
+      return stdout.trim() === 'OPEN';
+    } catch (err) {
+      this.logger.warn(`Failed to check PR state for ${externalId}`, {
+        error: String(err),
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Filters out candidates that have an open GitHub PR, running checks
+   * in parallel via Promise.allSettled. Candidates with null externalId
+   * or non-github schemes pass through. Fail-open on API errors.
+   */
+  private async filterCandidatesWithOpenPRs(candidates: Issue[]): Promise<Issue[]> {
+    const results = await Promise.allSettled(
+      candidates.map(async (candidate) => {
+        if (!candidate.externalId) return { candidate, isOpen: false };
+        const isOpen = await this.isExternalPROpen(candidate.externalId);
+        return { candidate, isOpen };
+      })
+    );
+
+    const filtered: Issue[] = [];
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        // Promise.allSettled should not reject, but fail-open just in case
+        continue;
+      }
+      const { candidate, isOpen } = result.value;
+      if (isOpen) {
+        this.logger.info(
+          `Skipping ${candidate.title}: open PR at ${candidate.externalId}`
+        );
+      } else {
+        filtered.push(candidate);
+      }
+    }
+    return filtered;
+  }
+```
+
+2. Run: `cd /Users/cwarner/Projects/harness-engineering/packages/orchestrator && npx vitest run tests/orchestrator-pr-guard.test.ts`
+3. Observe all tests pass.
+4. Run: `cd /Users/cwarner/Projects/harness-engineering && npx harness validate`
+5. Commit: `feat(orchestrator): add isExternalPROpen and filterCandidatesWithOpenPRs methods`
+
+---
+
+### Task 3: Verify existing tests still pass
+
+**Depends on:** Task 2 | **Files:** none (verification only)
+
+1. Run: `cd /Users/cwarner/Projects/harness-engineering/packages/orchestrator && npx vitest run`
+2. Verify all existing tests pass with no regressions.
+3. Run: `cd /Users/cwarner/Projects/harness-engineering && npx harness validate`
+4. Commit (if any test fixes needed): `fix(orchestrator): address test regressions from PR guard methods`
+
+[checkpoint:human-verify] -- Confirm all tests pass before proceeding to Phase 2 (wiring into asyncTick).

--- a/docs/plans/2026-04-16-orchestrator-pr-aware-dispatch-phase2-plan.md
+++ b/docs/plans/2026-04-16-orchestrator-pr-aware-dispatch-phase2-plan.md
@@ -1,0 +1,176 @@
+# Plan: Orchestrator PR-Aware Dispatch -- Phase 2 Wire into Tick
+
+**Date:** 2026-04-16 | **Spec:** docs/changes/orchestrator-pr-aware-dispatch/proposal.md | **Tasks:** 2 | **Time:** ~8 min
+
+## Goal
+
+Insert the `filterCandidatesWithOpenPRs()` call into `asyncTick()` so that candidates with open GitHub PRs are excluded before reaching the state machine or intelligence pipeline, and add an integration test with mixed candidates to prove the wiring works end-to-end.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When `asyncTick()` fetches candidates including one with an open GitHub PR, that candidate does not appear in the tick event's `candidates` array passed to `applyEvent()`.
+2. When `asyncTick()` fetches candidates with closed/merged PRs or null `externalId`, those candidates pass through to `applyEvent()` normally.
+3. When `asyncTick()` fetches candidates and `gh` fails for one, that candidate still passes through (fail-open).
+4. The filtered candidate list is also used by the intelligence pipeline and retry events (all three usages of `candidatesResult.value` in `asyncTick` are replaced).
+5. `cd packages/orchestrator && npx vitest run tests/orchestrator-pr-guard.test.ts` passes with the new integration tests.
+6. `cd packages/orchestrator && npx vitest run` passes with zero regressions.
+
+## File Map
+
+- MODIFY `packages/orchestrator/src/orchestrator.ts` -- insert filter call in `asyncTick()`, replace 3 references to `candidatesResult.value`
+- MODIFY `packages/orchestrator/tests/orchestrator-pr-guard.test.ts` -- add `asyncTick integration` describe block
+
+## Tasks
+
+### Task 1: Add integration test for asyncTick with mixed candidates (red phase)
+
+**Depends on:** none | **Files:** `packages/orchestrator/tests/orchestrator-pr-guard.test.ts`
+
+Add a new `describe('asyncTick PR filtering')` block to the existing test file. This test constructs an Orchestrator with a mock tracker returning mixed candidates (one with open PR, one with closed PR, one with null externalId), then calls `asyncTick()` and verifies only the non-open-PR candidates reach the state machine.
+
+We cannot directly inspect what `applyEvent` received, but we can verify the outcome: the candidate with the open PR should NOT appear in `state.claimed` or `state.running`, while the other two candidates should be dispatched (appear in `running`).
+
+1. In `packages/orchestrator/tests/orchestrator-pr-guard.test.ts`, append the following `describe` block after the existing `filterCandidatesWithOpenPRs` describe block:
+
+```typescript
+describe('asyncTick PR filtering', () => {
+  let orchestrator: Orchestrator;
+  let mockExecFile: ReturnType<typeof vi.fn>;
+  let mockTracker: ReturnType<typeof makeMockTracker>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTracker = makeMockTracker();
+    orchestrator = new Orchestrator(makeConfig(), 'test prompt', {
+      tracker: mockTracker as any,
+    });
+    mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it('excludes open-PR candidates from tick event while passing others through', async () => {
+    const openPRCandidate = makeIssue({
+      id: 'open-pr',
+      identifier: 'OPEN-1',
+      title: 'Has open PR',
+      state: 'Todo',
+      externalId: 'github:owner/repo#10',
+    });
+    const closedPRCandidate = makeIssue({
+      id: 'closed-pr',
+      identifier: 'CLOSED-1',
+      title: 'Has closed PR',
+      state: 'Todo',
+      externalId: 'github:owner/repo#20',
+    });
+    const noExternalCandidate = makeIssue({
+      id: 'no-external',
+      identifier: 'NONE-1',
+      title: 'No external ID',
+      state: 'Todo',
+      externalId: null,
+    });
+
+    mockTracker.fetchCandidateIssues.mockResolvedValue({
+      ok: true,
+      value: [openPRCandidate, closedPRCandidate, noExternalCandidate],
+    } as Ok<Issue[]>);
+
+    // PR #10 is OPEN, PR #20 is CLOSED
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        if (args.includes('10')) {
+          cb(null, { stdout: 'OPEN\n', stderr: '' });
+        } else {
+          cb(null, { stdout: 'CLOSED\n', stderr: '' });
+        }
+      }
+    );
+
+    await orchestrator.asyncTick();
+
+    const snapshot = orchestrator.getSnapshot();
+    const claimedIds = snapshot.claimed as string[];
+    const runningEntries = snapshot.running as Array<[string, unknown]>;
+    const runningIds = runningEntries.map(([id]) => id);
+
+    // open-PR candidate should NOT be dispatched
+    expect(claimedIds).not.toContain('open-pr');
+    expect(runningIds).not.toContain('open-pr');
+
+    // closed-PR and no-external candidates SHOULD be dispatched
+    expect(claimedIds).toContain('closed-pr');
+    expect(claimedIds).toContain('no-external');
+  });
+
+  it('passes all candidates through when gh fails (fail-open)', async () => {
+    const candidate = makeIssue({
+      id: 'failing-check',
+      identifier: 'FAIL-1',
+      title: 'API failure candidate',
+      state: 'Todo',
+      externalId: 'github:owner/repo#99',
+    });
+
+    mockTracker.fetchCandidateIssues.mockResolvedValue({
+      ok: true,
+      value: [candidate],
+    } as Ok<Issue[]>);
+
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('network timeout'), { stdout: '', stderr: '' });
+      }
+    );
+
+    await orchestrator.asyncTick();
+
+    const snapshot = orchestrator.getSnapshot();
+    const claimedIds = snapshot.claimed as string[];
+
+    // Should still be dispatched (fail-open)
+    expect(claimedIds).toContain('failing-check');
+  });
+});
+```
+
+2. Run: `cd /Users/cwarner/Projects/harness-engineering/packages/orchestrator && npx vitest run tests/orchestrator-pr-guard.test.ts`
+3. Observe that the new `asyncTick PR filtering` tests **fail** because `asyncTick()` does not yet call `filterCandidatesWithOpenPRs()` -- the open-PR candidate will be dispatched, causing the first assertion (`not.toContain('open-pr')`) to fail.
+
+---
+
+### Task 2: Wire filterCandidatesWithOpenPRs into asyncTick (green phase)
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/src/orchestrator.ts`
+
+Insert the filter call after `candidatesResult` is validated, and replace all three downstream references to `candidatesResult.value` with the filtered list.
+
+1. In `packages/orchestrator/src/orchestrator.ts`, locate the block starting at line 666 (the empty line after the early return for failed candidate fetch). Replace the code from line 667 through line 709 with the following. The change is:
+   - Add a `const candidates = await this.filterCandidatesWithOpenPRs(candidatesResult.value);` line after the candidate fetch success check
+   - Replace `candidatesResult.value` with `candidates` in the three places it appears (intelligence pipeline call, tick event construction, retry event construction)
+
+   **Exact edit -- find this block:**
+
+   ```
+    // 2. Fetch current status for running issues
+   ```
+
+   **Insert BEFORE it:**
+
+   ```typescript
+   // 1b. Filter out candidates with open PRs
+   const candidates = await this.filterCandidatesWithOpenPRs(candidatesResult.value);
+   ```
+
+   Then replace all three occurrences of `candidatesResult.value` (lines 680, 689, 709) with `candidates`:
+   - Line 680: `await this.runIntelligencePipeline(candidatesResult.value)` becomes `await this.runIntelligencePipeline(candidates)`
+   - Line 689: `candidates: candidatesResult.value,` becomes `candidates: candidates,` (which can simplify to `candidates,`)
+   - Line 709: `candidates: candidatesResult.value,` becomes `candidates,`
+
+2. Run: `cd /Users/cwarner/Projects/harness-engineering/packages/orchestrator && npx vitest run tests/orchestrator-pr-guard.test.ts`
+3. Observe all tests pass (both existing unit tests and new integration tests).
+4. Run: `cd /Users/cwarner/Projects/harness-engineering/packages/orchestrator && npx vitest run`
+5. Observe full suite passes with zero regressions.
+6. Run: `npx harness validate` (from project root)
+7. Commit: `feat(orchestrator): wire PR-aware candidate filter into asyncTick`
+
+[checkpoint:human-verify] -- Confirm all tests pass before proceeding to Phase 3 (full verification and smoke test).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -953,6 +953,17 @@ last_manual_edit: 2026-04-16T16:30:00.000Z
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#150
 
+### Orchestrator PR-Aware Dispatch Guard
+
+- **Status:** planned
+- **Spec:** docs/changes/orchestrator-pr-aware-dispatch/proposal.md
+- **Summary:** Pre-filter in orchestrator tick that checks candidate externalId against GitHub PR state, skipping dispatch for features with open PRs and failing open on API errors
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** —
+
 ## v3.0 Graph Intelligence
 
 ### Graph Anomaly Detection

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T01:19:59.107Z",
-  "updatedFrom": "9e183626",
+  "updatedAt": "2026-04-17T01:52:30.342Z",
+  "updatedFrom": "8d8d8ca3",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -14,16 +14,16 @@
     "complexity": {
       "value": 10,
       "violationIds": [
-        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
         "e68f61ff42c83a4d05b76c3decdf82e87d1342888c3a00b344e846f5a61a237a",
         "56ed30114fc75ea53f3d6d8bcec62360207b771d92cd3ec41b8747fd68ccfbbd",
         "d4ec740f23a61f0706b5f67aeed0ada23ea0570c711ceb92d7822f25d91e3b8f",
         "3134bf55d29a64d55636e6b6b3eaf5b5edc11bbbd07f56bce0b46e4e3f6af6a1",
         "0f5f3b45355e915c87896c1e259108826fb0d392636db20558e15f3a06605033",
         "7bd411727604fed60bdb72ef0df2d82b5e596bf22323caba71b4a09dffccbdaa",
-        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879",
+        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
         "b966e8d3abfeee3427bfe8a948d1d83ce1e6bffe473e72edb57aab9c0bb95c69",
-        "f685f2882a0af0a5ea9370005bff93b7333fece6e7d171581d4127c62c6e25f8"
+        "f685f2882a0af0a5ea9370005bff93b7333fece6e7d171581d4127c62c6e25f8",
+        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879"
       ]
     },
     "coupling": {

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T01:52:30.342Z",
-  "updatedFrom": "8d8d8ca3",
+  "updatedAt": "2026-04-17T02:22:43.574Z",
+  "updatedFrom": "a135aca0",
   "metrics": {
     "circular-deps": {
       "value": 0,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -665,6 +665,9 @@ export class Orchestrator extends EventEmitter {
       return;
     }
 
+    // 1b. Filter out candidates with open PRs
+    const candidates = await this.filterCandidatesWithOpenPRs(candidatesResult.value);
+
     // 2. Fetch current status for running issues
     const runningIds = Array.from(this.state.running.keys());
     const runningStatesResult = await this.tracker.fetchIssueStatesByIds(runningIds);
@@ -677,7 +680,7 @@ export class Orchestrator extends EventEmitter {
 
     // 3. Pre-process candidates through intelligence pipeline (if enabled)
     const pipelineResult = this.pipeline
-      ? await this.runIntelligencePipeline(candidatesResult.value)
+      ? await this.runIntelligencePipeline(candidates)
       : undefined;
     this.setTickActivity('dispatching', 'Applying state machine');
     const { concernSignals, enrichedSpecs, complexityScores, simulationResults } =
@@ -686,7 +689,7 @@ export class Orchestrator extends EventEmitter {
     // 4. Dispatch tick event to state machine
     const tickEvent: OrchestratorEvent = {
       type: 'tick' as const,
-      candidates: candidatesResult.value,
+      candidates,
       runningStates: runningStatesResult.value,
       nowMs,
       ...(concernSignals !== undefined && { concernSignals }),
@@ -706,7 +709,7 @@ export class Orchestrator extends EventEmitter {
       const retryEvent: OrchestratorEvent = {
         type: 'retry_fired',
         issueId,
-        candidates: candidatesResult.value,
+        candidates,
         nowMs,
       };
       const result = applyEvent(this.state, retryEvent, this.config);

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -838,12 +838,13 @@ export class Orchestrator extends EventEmitter {
     const match = externalId.match(/^github:([^/]+\/[^#]+)#(\d+)$/);
     if (!match) return false;
 
-    const [, repo, number] = match;
+    const [, repo, prNumber] = match;
+    if (!repo || !prNumber) return false;
     try {
       const exec = promisify(execFile);
       const { stdout } = await exec(
         'gh',
-        ['pr', 'view', number, '--repo', repo, '--json', 'state', '--jq', '.state'],
+        ['pr', 'view', prNumber, '--repo', repo, '--json', 'state', '--jq', '.state'],
         {
           cwd: this.projectRoot,
           timeout: 10_000,
@@ -873,9 +874,11 @@ export class Orchestrator extends EventEmitter {
     );
 
     const filtered: Issue[] = [];
-    for (const result of results) {
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
       if (result.status === 'rejected') {
-        // Promise.allSettled should not reject, but fail-open just in case
+        // Unreachable: isExternalPROpen catches internally. Fail-open defensively.
+        filtered.push(candidates[i]);
         continue;
       }
       const { candidate, isOpen } = result.value;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -879,9 +879,9 @@ export class Orchestrator extends EventEmitter {
     const filtered: Issue[] = [];
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
-      if (result.status === 'rejected') {
+      if (!result || result.status === 'rejected') {
         // Unreachable: isExternalPROpen catches internally. Fail-open defensively.
-        filtered.push(candidates[i]);
+        filtered.push(candidates[i]!);
         continue;
       }
       const { candidate, isOpen } = result.value;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -829,6 +829,66 @@ export class Orchestrator extends EventEmitter {
   }
 
   /**
+   * Checks whether an external tracker ID points to an open GitHub PR.
+   * Parses `github:<owner>/<repo>#<number>` format. Non-github schemes
+   * return false (fail-open, not a GitHub item). API failures return
+   * false (fail-open) and log a warning.
+   */
+  private async isExternalPROpen(externalId: string): Promise<boolean> {
+    const match = externalId.match(/^github:([^/]+\/[^#]+)#(\d+)$/);
+    if (!match) return false;
+
+    const [, repo, number] = match;
+    try {
+      const exec = promisify(execFile);
+      const { stdout } = await exec(
+        'gh',
+        ['pr', 'view', number, '--repo', repo, '--json', 'state', '--jq', '.state'],
+        {
+          cwd: this.projectRoot,
+          timeout: 10_000,
+        }
+      );
+      return stdout.trim() === 'OPEN';
+    } catch (err) {
+      this.logger.warn(`Failed to check PR state for ${externalId}`, {
+        error: String(err),
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Filters out candidates that have an open GitHub PR, running checks
+   * in parallel via Promise.allSettled. Candidates with null externalId
+   * or non-github schemes pass through. Fail-open on API errors.
+   */
+  private async filterCandidatesWithOpenPRs(candidates: Issue[]): Promise<Issue[]> {
+    const results = await Promise.allSettled(
+      candidates.map(async (candidate) => {
+        if (!candidate.externalId) return { candidate, isOpen: false };
+        const isOpen = await this.isExternalPROpen(candidate.externalId);
+        return { candidate, isOpen };
+      })
+    );
+
+    const filtered: Issue[] = [];
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        // Promise.allSettled should not reject, but fail-open just in case
+        continue;
+      }
+      const { candidate, isOpen } = result.value;
+      if (isOpen) {
+        this.logger.info(`Skipping ${candidate.title}: open PR at ${candidate.externalId}`);
+      } else {
+        filtered.push(candidate);
+      }
+    }
+    return filtered;
+  }
+
+  /**
    * Handles an escalation effect by writing to the interaction queue and logging.
    */
   private async handleEscalation(effect: EscalateEffect): Promise<void> {

--- a/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
+++ b/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
@@ -246,3 +246,102 @@ describe('filterCandidatesWithOpenPRs', () => {
     expect(result[0].id).toBe('1');
   });
 });
+
+describe('asyncTick PR filtering', () => {
+  let orchestrator: Orchestrator;
+  let mockExecFile: ReturnType<typeof vi.fn>;
+  let mockTracker: ReturnType<typeof makeMockTracker>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTracker = makeMockTracker();
+    orchestrator = new Orchestrator(makeConfig(), 'test prompt', {
+      tracker: mockTracker as any,
+    });
+    mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it('excludes open-PR candidates from tick event while passing others through', async () => {
+    const openPRCandidate = makeIssue({
+      id: 'open-pr',
+      identifier: 'OPEN-1',
+      title: 'Has open PR',
+      state: 'Todo',
+      externalId: 'github:owner/repo#10',
+    });
+    const closedPRCandidate = makeIssue({
+      id: 'closed-pr',
+      identifier: 'CLOSED-1',
+      title: 'Has closed PR',
+      state: 'Todo',
+      externalId: 'github:owner/repo#20',
+    });
+    const noExternalCandidate = makeIssue({
+      id: 'no-external',
+      identifier: 'NONE-1',
+      title: 'No external ID',
+      state: 'Todo',
+      externalId: null,
+    });
+
+    mockTracker.fetchCandidateIssues.mockResolvedValue({
+      ok: true,
+      value: [openPRCandidate, closedPRCandidate, noExternalCandidate],
+    } as Ok<Issue[]>);
+
+    // PR #10 is OPEN, PR #20 is CLOSED
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        if (args.includes('10')) {
+          cb(null, { stdout: 'OPEN\n', stderr: '' });
+        } else {
+          cb(null, { stdout: 'CLOSED\n', stderr: '' });
+        }
+      }
+    );
+
+    await orchestrator.asyncTick();
+
+    const snapshot = orchestrator.getSnapshot();
+    const claimedIds = snapshot.claimed as string[];
+    const runningEntries = snapshot.running as Array<[string, unknown]>;
+    const runningIds = runningEntries.map(([id]) => id);
+
+    // open-PR candidate should NOT be dispatched
+    expect(claimedIds).not.toContain('open-pr');
+    expect(runningIds).not.toContain('open-pr');
+
+    // closed-PR and no-external candidates SHOULD be dispatched
+    expect(claimedIds).toContain('closed-pr');
+    expect(claimedIds).toContain('no-external');
+  });
+
+  it('passes all candidates through when gh fails (fail-open)', async () => {
+    const candidate = makeIssue({
+      id: 'failing-check',
+      identifier: 'FAIL-1',
+      title: 'API failure candidate',
+      state: 'Todo',
+      externalId: 'github:owner/repo#99',
+    });
+
+    mockTracker.fetchCandidateIssues.mockResolvedValue({
+      ok: true,
+      value: [candidate],
+    } as Ok<Issue[]>);
+
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('network timeout'), { stdout: '', stderr: '' });
+      }
+    );
+
+    await orchestrator.asyncTick();
+
+    const snapshot = orchestrator.getSnapshot();
+    const claimedIds = snapshot.claimed as string[];
+
+    // Should still be dispatched (fail-open)
+    expect(claimedIds).toContain('failing-check');
+  });
+});

--- a/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
+++ b/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
@@ -133,6 +133,35 @@ describe('isExternalPROpen', () => {
     expect(mockExecFile).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['github:owner/repo#1; echo pwned', false],
+    ['github:owner repo#1', false],
+  ])('rejects malformed input without calling gh: %s', async (input, _) => {
+    const result = await (orchestrator as any).isExternalPROpen(input);
+    expect(result).toBe(false);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('safely passes adversarial but regex-matching input to execFile (no shell)', async () => {
+    // Inputs like "github:--flag/repo#1" match the regex but are safe
+    // because execFile passes args as an array, not through a shell
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('not found'), { stdout: '', stderr: '' });
+      }
+    );
+
+    const result = await (orchestrator as any).isExternalPROpen('github:--flag/repo#1');
+    expect(result).toBe(false);
+    // execFile was called safely with args array (no shell injection possible)
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['--repo', '--flag/repo']),
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
   it('returns false and logs warning when gh command fails', async () => {
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
@@ -184,6 +213,12 @@ describe('filterCandidatesWithOpenPRs', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('2');
     expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping Open PR'));
+  });
+
+  it('returns empty array for empty candidates', async () => {
+    const result = await (orchestrator as any).filterCandidatesWithOpenPRs([]);
+    expect(result).toHaveLength(0);
+    expect(mockExecFile).not.toHaveBeenCalled();
   });
 
   it('passes through candidates with null externalId', async () => {

--- a/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
+++ b/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Orchestrator } from '../src/orchestrator';
+import type { Issue, WorkflowConfig, Ok } from '@harness-engineering/types';
+
+// Mock child_process.execFile
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from 'node:child_process';
+
+function makeConfig(): WorkflowConfig {
+  return {
+    tracker: {
+      kind: 'mock',
+      activeStates: ['Todo', 'In Progress'],
+      terminalStates: ['Done', 'Cancelled'],
+    },
+    polling: { intervalMs: 30000 },
+    workspace: { root: '/tmp/ws' },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 60000,
+    },
+    agent: {
+      backend: 'mock',
+      maxConcurrentAgents: 3,
+      maxTurns: 20,
+      maxRetryBackoffMs: 300000,
+      maxRetries: 5,
+      maxConcurrentAgentsByState: {},
+      turnTimeoutMs: 3600000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 300000,
+    },
+    server: { port: null },
+  };
+}
+
+function makeMockTracker() {
+  return {
+    fetchCandidateIssues: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+    fetchIssuesByStates: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+    fetchIssueStatesByIds: vi.fn().mockResolvedValue({ ok: true, value: new Map() }),
+    markIssueComplete: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+  };
+}
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: 'id-1',
+    identifier: 'TEST-1',
+    title: 'Test issue',
+    description: null,
+    priority: null,
+    state: 'Todo',
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    spec: null,
+    plans: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: null,
+    externalId: null,
+    ...overrides,
+  };
+}
+
+describe('isExternalPROpen', () => {
+  let orchestrator: Orchestrator;
+  let mockExecFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orchestrator = new Orchestrator(makeConfig(), 'test prompt', {
+      tracker: makeMockTracker() as any,
+    });
+    mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it('returns true when gh reports OPEN state', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: 'OPEN\n', stderr: '' });
+      }
+    );
+
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(true);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'view', '42', '--repo', 'owner/repo', '--json', 'state', '--jq', '.state'],
+      expect.objectContaining({ timeout: 10_000 }),
+      expect.any(Function)
+    );
+  });
+
+  it('returns false when gh reports CLOSED state', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: 'CLOSED\n', stderr: '' });
+      }
+    );
+
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when gh reports MERGED state', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: 'MERGED\n', stderr: '' });
+      }
+    );
+
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(false);
+  });
+
+  it('returns false for non-github scheme without calling gh', async () => {
+    const result = await (orchestrator as any).isExternalPROpen('jira:PROJ-123');
+    expect(result).toBe(false);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('returns false for malformed github externalId', async () => {
+    const result = await (orchestrator as any).isExternalPROpen('github:badformat');
+    expect(result).toBe(false);
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('returns false and logs warning when gh command fails', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('gh: not found'), { stdout: '', stderr: '' });
+      }
+    );
+
+    const warnSpy = vi.spyOn((orchestrator as any).logger, 'warn');
+    const result = await (orchestrator as any).isExternalPROpen('github:owner/repo#42');
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to check PR state'),
+      expect.any(Object)
+    );
+  });
+});
+
+describe('filterCandidatesWithOpenPRs', () => {
+  let orchestrator: Orchestrator;
+  let mockExecFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    orchestrator = new Orchestrator(makeConfig(), 'test prompt', {
+      tracker: makeMockTracker() as any,
+    });
+    mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it('excludes candidates with open PRs', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb: Function) => {
+        // PR #10 is open, PR #20 is closed
+        if (args.includes('10')) {
+          cb(null, { stdout: 'OPEN\n', stderr: '' });
+        } else {
+          cb(null, { stdout: 'CLOSED\n', stderr: '' });
+        }
+      }
+    );
+
+    const candidates = [
+      makeIssue({ id: '1', title: 'Open PR', externalId: 'github:owner/repo#10' }),
+      makeIssue({ id: '2', title: 'Closed PR', externalId: 'github:owner/repo#20' }),
+    ];
+
+    const infoSpy = vi.spyOn((orchestrator as any).logger, 'info');
+    const result = await (orchestrator as any).filterCandidatesWithOpenPRs(candidates);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('2');
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping Open PR'));
+  });
+
+  it('passes through candidates with null externalId', async () => {
+    const candidates = [makeIssue({ id: '1', title: 'No external', externalId: null })];
+
+    const result = await (orchestrator as any).filterCandidatesWithOpenPRs(candidates);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('passes through candidates when gh fails (fail-open)', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('network timeout'), { stdout: '', stderr: '' });
+      }
+    );
+
+    const candidates = [
+      makeIssue({ id: '1', title: 'Failing check', externalId: 'github:owner/repo#10' }),
+    ];
+
+    const result = await (orchestrator as any).filterCandidatesWithOpenPRs(candidates);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `isExternalPROpen()` and `filterCandidatesWithOpenPRs()` to the Orchestrator class
- Wire the filter into `asyncTick()` between candidate fetch and state machine dispatch
- Candidates with open GitHub PRs (via `externalId`) are skipped; closed/merged/unreachable PRs pass through
- Fail-open on all error paths — orchestrator stays available during GitHub outages

## Spec

`docs/changes/orchestrator-pr-aware-dispatch/proposal.md`

## Test plan

- [x] 15 unit + integration tests in `orchestrator-pr-guard.test.ts`
- [x] Covers: OPEN/CLOSED/MERGED states, non-github schemes, malformed IDs, adversarial inputs, API failures, null externalId, empty array, mixed candidate asyncTick integration, fail-open integration
- [x] Full orchestrator suite: 314 tests passing, zero regressions
- [x] TypeScript clean (`tsc --noEmit` passes)
- [x] Architecture baselines updated