### PR TITLE
feat(config): register intelligence layer in harness architecture

### DIFF
--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T02:02:25.421Z",
-  "updatedFrom": "94c9fafb",
+  "updatedAt": "2026-04-17T04:50:00.000Z",
+  "updatedFrom": "b9b6d966",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 38,
+      "value": 39,
       "violationIds": [
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
@@ -63,7 +63,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 81849,
+      "value": 82245,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",
@@ -72,7 +72,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 332,
+      "value": 333,
       "violationIds": []
     }
   }

--- a/harness.config.json
+++ b/harness.config.json
@@ -28,9 +28,14 @@
       "allowedDependencies": ["types", "core"]
     },
     {
+      "name": "intelligence",
+      "pattern": "packages/intelligence/src/**",
+      "allowedDependencies": ["types", "graph"]
+    },
+    {
       "name": "orchestrator",
       "pattern": "packages/orchestrator/src/**",
-      "allowedDependencies": ["types", "core"]
+      "allowedDependencies": ["types", "core", "intelligence"]
     },
     {
       "name": "dashboard",
@@ -49,6 +54,7 @@
       "disallow": [
         "packages/core/src/**",
         "packages/graph/src/**",
+        "packages/intelligence/src/**",
         "packages/eslint-plugin/src/**",
         "packages/linter-gen/src/**",
         "packages/orchestrator/src/**",
@@ -60,6 +66,7 @@
       "from": "packages/graph/src/**",
       "disallow": [
         "packages/core/src/**",
+        "packages/intelligence/src/**",
         "packages/eslint-plugin/src/**",
         "packages/linter-gen/src/**",
         "packages/orchestrator/src/**",
@@ -70,6 +77,7 @@
     {
       "from": "packages/core/src/**",
       "disallow": [
+        "packages/intelligence/src/**",
         "packages/eslint-plugin/src/**",
         "packages/linter-gen/src/**",
         "packages/orchestrator/src/**",
@@ -78,14 +86,34 @@
       "message": "Core layer cannot import from higher layers"
     },
     {
+      "from": "packages/intelligence/src/**",
+      "disallow": [
+        "packages/core/src/**",
+        "packages/eslint-plugin/src/**",
+        "packages/linter-gen/src/**",
+        "packages/orchestrator/src/**",
+        "packages/dashboard/src/**",
+        "packages/cli/src/**"
+      ],
+      "message": "Intelligence layer cannot import from core, orchestrator, dashboard, or CLI"
+    },
+    {
       "from": "packages/eslint-plugin/src/**",
-      "disallow": ["packages/orchestrator/src/**", "packages/cli/src/**"],
-      "message": "ESLint plugin cannot import from orchestrator or CLI"
+      "disallow": [
+        "packages/intelligence/src/**",
+        "packages/orchestrator/src/**",
+        "packages/cli/src/**"
+      ],
+      "message": "ESLint plugin cannot import from intelligence, orchestrator, or CLI"
     },
     {
       "from": "packages/linter-gen/src/**",
-      "disallow": ["packages/orchestrator/src/**", "packages/cli/src/**"],
-      "message": "Linter gen cannot import from orchestrator or CLI"
+      "disallow": [
+        "packages/intelligence/src/**",
+        "packages/orchestrator/src/**",
+        "packages/cli/src/**"
+      ],
+      "message": "Linter gen cannot import from intelligence, orchestrator, or CLI"
     },
     {
       "from": "packages/orchestrator/src/**",
@@ -162,6 +190,7 @@
       "packages/types/src/index.ts",
       "packages/core/src/index.ts",
       "packages/graph/src/index.ts",
+      "packages/intelligence/src/index.ts",
       "packages/cli/src/index.ts",
       "packages/cli/src/bin/harness.ts",
       "packages/eslint-plugin/src/index.ts",
@@ -175,6 +204,7 @@
       "packages/types/src/index.ts",
       "packages/core/src/index.ts",
       "packages/graph/src/index.ts",
+      "packages/intelligence/src/index.ts",
       "packages/cli/src/index.ts",
       "packages/cli/src/bin/harness.ts",
       "packages/eslint-plugin/src/index.ts",


### PR DESCRIPTION
## Summary

- Registers the `packages/intelligence/` layer (SEL, CML, PESL) in `harness.config.json` architectural constraints
- Adds `intelligence` layer definition with `allowedDependencies: ["types", "graph"]`
- Adds `intelligence` to orchestrator's `allowedDependencies` (orchestrator imports from intelligence)
- Adds forbidden import rules preventing lower/peer layers from importing intelligence
- Adds intelligence entry point to entropy and performance analysis sections
- Updates architecture baselines for new layer metrics (complexity +1, module-size +396 LOC, dependency-depth +1)

## Context

The intelligence pipeline implementation (114 tests, all passing) was previously merged but its layer was never registered in `harness.config.json`. This meant architectural boundary enforcement was not applied to the intelligence package.

## Test plan

- [x] `npx turbo build --filter=@harness-engineering/intelligence` succeeds
- [x] `npx turbo test --filter=@harness-engineering/intelligence` — 16 test files, 114 tests pass
- [x] Pre-commit hook passes (validate, arch, traceability)
- [x] Pre-push hook passes (format, typecheck, lint, test, coverage, docs, arch)