### PR TITLE
chore(roadmap): mark Paged MCP Tool Responses as done

### DIFF
--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T02:02:25.421Z",
-  "updatedFrom": "94c9fafb",
+  "updatedAt": "2026-04-17T05:36:24.213Z",
+  "updatedFrom": "b9b6d966",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 38,
+      "value": 39,
       "violationIds": [
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
@@ -21,21 +21,22 @@
         "38609b096b2ffd19535887a5555ad9a8491a580a6c9cf4368179d8df36a876c6",
         "38609b096b2ffd19535887a5555ad9a8491a580a6c9cf4368179d8df36a876c6",
         "22a8ee1508eb981479f47f1c9ff6b2d69b8291e34b4cf9ebb1b8b322372445b4",
+        "4ec5b89ddfda055b8db8745ac52b3466abc4dce07e39cc246f8a91c300c6756e",
         "10e2748e89679c1901fc3e67f2bed06034d3c4c564b66345ac9418ef9a9685f7",
         "c7b8c706c15e4597f5f37e43332cf6c7434ca6304c16a0779e2369e76c9214e3",
         "a412401eac205ffb264bf787149f356102c5b0ba5b02f8d526083dc4d976115b",
         "1eb37e0977a1b3bd37eaecb872a2588522766006db257b8f96c64d35a52cbe94",
         "d3cfdf50eb93ffa8e766af4e71257175af7f24bb346c3a2f5338c5b6f853382a",
-        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
         "5aa35eb7825bc41fe5a8fc031d0cdedd78703616efd3da15af290eca55184744",
         "ac5d2db9c38d6025f9531c162a198343c5c501a7bd8991906470993853d89055",
-        "fad5da199ad18507ec1727c9a2de48da80fd75f72230cc948df3afd8830308ce",
+        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
         "f573d1d3f72b896ef1841f90ce326b1008e05ec90ec72489becbd1a9e4c679fe",
         "6eb4858144d411132d7e376f3dca3820e906d97bfb34d6a690f6ddb3229b8dce",
         "dad32014fb96b44b797cb3005dc093985f1d0508a6f72f2804053a0ebdee4a8d",
         "13310052487ad20819c93bd931a8677f92b706c0e28615319e854b5d682cd247",
         "97d282575446f2807269f1dddf316f20c23527bd5fa4ed0d1901f46717478c68",
         "82c9472c41b16379f2f062e7c8aa27438235e5e7957b205f1491d9bf89aac952",
+        "fad5da199ad18507ec1727c9a2de48da80fd75f72230cc948df3afd8830308ce",
         "b9c470705099779c805d44391d5076452c76b1935647b2c9910173064fc6f4ff",
         "8bd4f38b275035cf506c2b29ae44984af81d48de472e8f78983a993eccbe30ec",
         "90485338280b88af7a8ddaeb88f8c1e0da782014ea2881b52e7de4fba7d7a3a6",
@@ -49,9 +50,9 @@
         "08151b7f65c324074876ce5f0136a0d749d71b38b05cdda2bea0acca220bce06",
         "f80c1747de98253c8b1f63381609098332795f5a5d5af4bb99131c93fa9860e8",
         "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13",
-        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
         "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
-        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe"
+        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe",
+        "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab"
       ]
     },
     "coupling": {
@@ -63,7 +64,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 81849,
+      "value": 82245,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",
@@ -72,7 +73,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 332,
+      "value": 333,
       "violationIds": []
     }
   }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -892,7 +892,7 @@ last_manual_edit: 2026-04-16T16:30:00.000Z
 
 ### Paged MCP Tool Responses
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/paged-mcp-tool-responses/proposal.md
 - **Summary:** Replace lossy truncation with offset/limit pagination for 8 MCP tools (gather_context, query_graph, get_relationships, code_outline, review_changes, run_code_review, detect_anomalies, get_decay_trends). Shared PaginationMeta contract, relevance-sorted pages, per-tool defaults.
 - **Blockers:** —

--- a/harness.config.json
+++ b/harness.config.json
@@ -237,13 +237,11 @@
         "planned": "open",
         "in-progress": "open",
         "done": "closed",
-        "blocked": "open",
-        "needs-human": "open"
+        "blocked": "open"
       },
       "reverseStatusMap": {
         "open": "planned",
-        "closed": "done",
-        "open:needs-human": "needs-human"
+        "closed": "done"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Mark "Paged MCP Tool Responses" roadmap entry as `done` (was `in-progress`)
- Close GitHub issue #145 — all pagination work was merged in PR #146 and #148
- Fix invalid `needs-human` status in `harness.config.json` statusMap (not a valid enum)
- Update architecture baselines to current main state

## Context
The pagination feature is fully implemented and merged:
- `paginate()` utility in `@harness-engineering/core` with 13 unit tests
- All 8 MCP tools wired with offset/limit pagination and relevance sorting
- 14 integration tests covering schema completeness and multi-page fetch
- `PaginationMeta` contract, per-tool defaults, backward compatible

## Test plan
- [x] Core pagination tests pass (13/13)
- [x] CLI pagination integration tests pass (14/14)
- [x] `harness validate` passes (after config fix)
- [x] `harness check-arch` passes with updated baselines