### PR TITLE
feat(core): add protected code regions with harness-ignore annotations

### DIFF
--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T02:02:25.421Z",
-  "updatedFrom": "94c9fafb",
+  "updatedAt": "2026-04-17T06:15:34.158Z",
+  "updatedFrom": "dc7984d9",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 38,
+      "value": 39,
       "violationIds": [
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
@@ -26,9 +26,10 @@
         "a412401eac205ffb264bf787149f356102c5b0ba5b02f8d526083dc4d976115b",
         "1eb37e0977a1b3bd37eaecb872a2588522766006db257b8f96c64d35a52cbe94",
         "d3cfdf50eb93ffa8e766af4e71257175af7f24bb346c3a2f5338c5b6f853382a",
-        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
+        "4ec5b89ddfda055b8db8745ac52b3466abc4dce07e39cc246f8a91c300c6756e",
         "5aa35eb7825bc41fe5a8fc031d0cdedd78703616efd3da15af290eca55184744",
         "ac5d2db9c38d6025f9531c162a198343c5c501a7bd8991906470993853d89055",
+        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
         "fad5da199ad18507ec1727c9a2de48da80fd75f72230cc948df3afd8830308ce",
         "f573d1d3f72b896ef1841f90ce326b1008e05ec90ec72489becbd1a9e4c679fe",
         "6eb4858144d411132d7e376f3dca3820e906d97bfb34d6a690f6ddb3229b8dce",
@@ -44,14 +45,14 @@
         "e7bf797006b720679aa6da3d70bb9a19b06b02a713f6388a16ca0af68ad700e5",
         "12892b0915eb65d0f28f900728db84d7cd04f35deb7fb7c071c71a7de61f3162",
         "b2ae178ccdd3196acf6e7f39e8bf96c556fe598346c1cdce01c02bd98d393c64",
-        "14715d1f7346442bc17888eecdac07b4a4ae166ad3c8b7d9582e6eec380c98fc",
         "3be6cd991653c54e8c6a0f0942d56fd54892b1afa88855ef11b1ae6dbfbe1676",
         "08151b7f65c324074876ce5f0136a0d749d71b38b05cdda2bea0acca220bce06",
         "f80c1747de98253c8b1f63381609098332795f5a5d5af4bb99131c93fa9860e8",
         "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13",
+        "14715d1f7346442bc17888eecdac07b4a4ae166ad3c8b7d9582e6eec380c98fc",
         "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
-        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
-        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe"
+        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe",
+        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a"
       ]
     },
     "coupling": {
@@ -63,7 +64,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 81849,
+      "value": 82582,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",
@@ -72,7 +73,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 332,
+      "value": 335,
       "violationIds": []
     }
   }

--- a/docs/changes/protected-code-regions/proposal.md
+++ b/docs/changes/protected-code-regions/proposal.md
@@ -1,0 +1,207 @@
+# Protected Code Regions
+
+## Overview
+
+Agent-driven code modification skills (cleanup-dead-code, enforce-architecture, codebase-cleanup, refactoring) currently have no mechanism to preserve code regions that must not be modified. Performance-critical algorithms, compliance-required implementations, legally-sensitive code, and vendor-locked integrations can all be silently altered during automated cleanup and refactoring operations.
+
+This proposal introduces a `harness-ignore` annotation system for block-level code protection. When an agent encounters a protected region, it skips that region entirely — no findings are generated, no fixes are applied, and an audit trail records the protection.
+
+### Problem
+
+1. **No opt-out for entropy cleanup.** Dead export detection, unused import removal, and commented-code cleanup operate on all code equally. A compliance-required function with zero importers gets flagged as dead code.
+2. **Architecture enforcement can break vendor contracts.** Forbidden-import replacement may swap a legally-mandated SDK import for an alternative that violates licensing terms.
+3. **Performance-critical code is only partially protected.** The `@perf-critical` annotation protects against nested-loop lint violations but not against entropy cleanup or refactoring.
+4. **Existing `harness-ignore` is security-only.** The security scanner supports `// harness-ignore SEC-XXX-NNN: reason` but this pattern is not recognized by entropy or architecture subsystems.
+
+### Goals
+
+- Provide block-level and line-level protection annotations recognized by all code-modifying subsystems.
+- Extend the existing `harness-ignore` syntax for consistency rather than inventing a new annotation.
+- Maintain audit visibility — protected regions are reported but never modified.
+- Support categorized protection reasons (compliance, performance, legal, vendor, custom).
+
+### Non-Goals
+
+- Runtime enforcement (this is a static analysis / agent-time feature).
+- Protection of non-source files (package.json, config files).
+- Integration with external compliance systems.
+
+## Decisions
+
+| Decision           | Choice                                         | Rationale                                                               |
+| ------------------ | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| Annotation syntax  | Extend `harness-ignore`                        | Already established for security; consistent UX                         |
+| Parser location    | `packages/core/src/annotations/`               | Shared across security, entropy, architecture                           |
+| Integration point  | Detection-time filtering                       | Prevents findings from being generated, not just suppressed at fix time |
+| Protected findings | Report as informational with `protected: true` | Audit visibility without modification risk                              |
+| Scope categories   | `entropy`, `architecture`, `security`, `all`   | Granular control; `all` is the default                                  |
+
+## Technical Design
+
+### Annotation Syntax
+
+**Line-level protection** (protects the next non-comment line):
+
+```typescript
+// harness-ignore entropy: SOX audit — approved algorithm
+export function calculateCompliance() { ... }
+```
+
+**Block-level protection** (protects all lines between start/end markers):
+
+```typescript
+// harness-ignore-start entropy: vendor-locked integration
+import { SpecificSDK } from '@vendor/sdk';
+
+export function vendorIntegration() {
+  return SpecificSDK.process();
+}
+// harness-ignore-end
+```
+
+**Multi-scope protection:**
+
+```typescript
+// harness-ignore-start entropy,architecture: legally required implementation
+// ... protected code ...
+// harness-ignore-end
+```
+
+**Protect everything (default when no scope specified):**
+
+```typescript
+// harness-ignore-start: compliance-critical section
+// ... protected from all agent modifications ...
+// harness-ignore-end
+```
+
+### Data Model
+
+```typescript
+/** Scope categories for protection */
+type ProtectionScope = 'entropy' | 'architecture' | 'security' | 'all';
+
+/** A single protected region in a file */
+interface ProtectedRegion {
+  file: string;
+  startLine: number; // 1-indexed, inclusive
+  endLine: number; // 1-indexed, inclusive (same as startLine for line-level)
+  scopes: ProtectionScope[];
+  reason: string | null;
+  type: 'line' | 'block';
+}
+
+/** Result of scanning a file for protected regions */
+interface ProtectedRegionMap {
+  regions: ProtectedRegion[];
+  /** Check if a specific file:line is protected for a given scope */
+  isProtected(file: string, line: number, scope: ProtectionScope): boolean;
+  /** Get all regions for a file */
+  getRegions(file: string): ProtectedRegion[];
+}
+
+/** Validation issues found in annotations */
+interface AnnotationIssue {
+  file: string;
+  line: number;
+  type: 'unclosed-block' | 'orphaned-end' | 'missing-reason' | 'unknown-scope';
+  message: string;
+}
+```
+
+### Parser — `packages/core/src/annotations/protected-regions.ts`
+
+The parser scans source files for `harness-ignore` annotations and builds a `ProtectedRegionMap`:
+
+1. **Line scan:** Read file line-by-line, match against annotation patterns.
+2. **Block tracking:** Maintain a stack for open `harness-ignore-start` markers. When `harness-ignore-end` is encountered, pop and create a region.
+3. **Line-level:** When `harness-ignore <scope>` is found without `-start`, protect the next non-comment, non-blank line.
+4. **Validation:** Report unclosed blocks, orphaned ends, unknown scopes.
+
+Regex patterns:
+
+```
+Line:  /(?:\/\/|#)\s*harness-ignore(?:\s+([\w,]+))?(?::\s*(.+))?$/
+Start: /(?:\/\/|#)\s*harness-ignore-start(?:\s+([\w,]+))?(?::\s*(.+))?$/
+End:   /(?:\/\/|#)\s*harness-ignore-end\s*$/
+```
+
+### Integration Points
+
+**1. Entropy Detectors** (`packages/core/src/entropy/detectors/dead-code.ts`):
+
+- Before reporting a dead export, unused import, or dead file, check `regionMap.isProtected(file, line, 'entropy')`.
+- If protected, skip the finding entirely (do not add to report).
+- For dead files: check if any line in the file is protected; if so, skip.
+
+**2. Entropy Fixers** (`packages/core/src/entropy/fixers/safe-fixes.ts`):
+
+- Defense-in-depth: Even if a finding slips through detection, `applyFixes()` checks protection before applying.
+- Protected fixes are added to `skipped[]` with reason `'protected-region'`.
+
+**3. Cleanup Finding Classification** (`packages/core/src/entropy/fixers/cleanup-finding.ts`):
+
+- New safety level interaction: protected findings override safety classification.
+- If a finding falls in a protected region, set `safety: 'protected'` (new level).
+
+**4. Security Scanner** (`packages/core/src/security/scanner.ts`):
+
+- Already supports `harness-ignore SEC-XXX-NNN`. The new parser should be compatible but not break existing behavior.
+- Security-scoped protection uses the existing per-rule mechanism; the new block-level syntax adds region support.
+
+**5. Architecture Enforcement** (skill + ESLint plugin):
+
+- ESLint rules check `isProtected()` before reporting violations.
+- Skill-driven fixes respect region boundaries.
+
+### Audit Command
+
+`harness audit-protected` — Reports all protected regions across the project:
+
+```
+Protected Regions Report
+========================
+Found 12 protected regions in 8 files
+
+src/compliance/sox.ts:15-42 [entropy] SOX audit — approved algorithm
+src/vendor/sdk-bridge.ts:1-89 [all] vendor-locked integration
+src/crypto/hmac.ts:23 [entropy,architecture] FIPS-certified implementation
+...
+
+Issues:
+  src/old/legacy.ts:10 — unclosed harness-ignore-start block
+```
+
+### File Layout
+
+```
+packages/core/src/annotations/
+  index.ts                    — Public API exports
+  protected-regions.ts        — Parser + ProtectedRegionMap
+  types.ts                    — ProtectionScope, ProtectedRegion, etc.
+
+packages/core/tests/annotations/
+  protected-regions.test.ts   — Parser tests
+
+packages/cli/src/commands/
+  audit-protected.ts          — CLI command for audit reporting
+```
+
+## Success Criteria
+
+1. `// harness-ignore-start` / `// harness-ignore-end` blocks prevent all entropy findings within the block.
+2. `// harness-ignore entropy:` line annotations prevent the next code line from entropy detection.
+3. Dead file detection skips files that contain any protected region (conservative).
+4. Fix application refuses to modify lines within protected regions (defense-in-depth).
+5. `harness audit-protected` lists all protected regions with file, lines, scopes, and reasons.
+6. Unclosed blocks and orphaned ends are reported as annotation validation issues.
+7. Existing `harness-ignore SEC-XXX-NNN` behavior is not broken.
+8. All new code has tests with >90% branch coverage.
+
+## Implementation Order
+
+1. **Phase 1 — Parser & Types:** Create `packages/core/src/annotations/` with the region parser, types, and tests.
+2. **Phase 2 — Entropy Integration:** Wire parser into dead-code detectors and safe-fixes to skip protected regions.
+3. **Phase 3 — Cleanup Finding Integration:** Add `'protected'` safety level and integrate with classification.
+4. **Phase 4 — CLI Audit Command:** Add `harness audit-protected` command.
+5. **Phase 5 — Validation:** End-to-end tests, `harness validate` passes.

--- a/docs/plans/2026-04-17-protected-code-regions-plan.md
+++ b/docs/plans/2026-04-17-protected-code-regions-plan.md
@@ -1,0 +1,151 @@
+# Plan: Protected Code Regions
+
+**Date:** 2026-04-17 | **Spec:** docs/changes/protected-code-regions/proposal.md | **Tasks:** 7 | **Time:** ~30 min
+
+## Goal
+
+All code-modifying harness subsystems (entropy cleanup, architecture enforcement) respect `harness-ignore` block-level and line-level annotations, skipping protected regions during detection and fix application.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When a file contains `// harness-ignore-start` and `// harness-ignore-end`, `parseProtectedRegions()` returns a `ProtectedRegion` with correct start/end lines, scopes, and reason.
+2. When `// harness-ignore entropy: reason` precedes a code line, the parser returns a single-line `ProtectedRegion` covering that code line.
+3. `isProtected(file, line, 'entropy')` returns `true` for lines inside a protected block.
+4. Unclosed `harness-ignore-start` blocks produce an `unclosed-block` validation issue.
+5. Orphaned `harness-ignore-end` markers produce an `orphaned-end` validation issue.
+6. `applyFixes()` skips fixes targeting lines within protected regions, adding them to `skipped[]`.
+7. `npx vitest run packages/core/tests/annotations/` passes with all tests green.
+8. Existing `harness-ignore SEC-XXX-NNN` security scanner behavior is unaffected.
+9. Types and parser are exported from `packages/core/src/index.ts`.
+
+## File Map
+
+```
+CREATE packages/core/src/annotations/types.ts
+CREATE packages/core/src/annotations/protected-regions.ts
+CREATE packages/core/src/annotations/index.ts
+CREATE packages/core/tests/annotations/protected-regions.test.ts
+MODIFY packages/core/src/entropy/fixers/safe-fixes.ts
+MODIFY packages/core/src/entropy/index.ts
+MODIFY packages/core/src/index.ts
+```
+
+## Tasks
+
+### Task 1: Create annotation types
+
+**Depends on:** none | **Files:** packages/core/src/annotations/types.ts
+
+1. Create `packages/core/src/annotations/types.ts` with:
+   - `ProtectionScope` type: `'entropy' | 'architecture' | 'security' | 'all'`
+   - `ProtectedRegion` interface: `file`, `startLine`, `endLine`, `scopes`, `reason`, `type`
+   - `ProtectedRegionMap` interface: `regions`, `isProtected()`, `getRegions()`
+   - `AnnotationIssue` interface: `file`, `line`, `type`, `message`
+2. Commit: `feat(core): add protected region annotation types`
+
+### Task 2: Create protected region parser (TDD)
+
+**Depends on:** Task 1 | **Files:** packages/core/src/annotations/protected-regions.ts, packages/core/tests/annotations/protected-regions.test.ts
+
+1. Create test file `packages/core/tests/annotations/protected-regions.test.ts` with tests:
+   - Parses block regions with `harness-ignore-start` / `harness-ignore-end`
+   - Parses line-level `harness-ignore` annotations (protects next non-comment line)
+   - Parses scope categories (`entropy`, `architecture`, `entropy,architecture`)
+   - Defaults to `all` scope when no scope specified
+   - Extracts reason text after colon
+   - Reports unclosed blocks as validation issues
+   - Reports orphaned ends as validation issues
+   - Reports unknown scopes as validation issues
+   - `isProtected()` returns true for lines in range, false outside
+   - `getRegions()` returns only regions for specified file
+   - Handles `#` comment prefix (Python/shell style)
+   - Handles empty files and files with no annotations
+2. Run tests — observe failures: `npx vitest run packages/core/tests/annotations/protected-regions.test.ts`
+3. Create `packages/core/src/annotations/protected-regions.ts` with:
+   - `parseProtectedRegions(files: Array<{path: string, content: string}>): {regions: ProtectedRegionMap, issues: AnnotationIssue[]}`
+   - `parseFileRegions(filePath: string, content: string): {regions: ProtectedRegion[], issues: AnnotationIssue[]}`
+   - `createRegionMap(regions: ProtectedRegion[]): ProtectedRegionMap`
+   - Regex patterns for line, start, end annotations
+   - Block tracking with stack for nested support
+   - Line-level: scan forward past comments/blanks to find protected line
+4. Run tests — observe pass
+5. Commit: `feat(core): implement protected region parser with TDD`
+
+### Task 3: Create annotations module index
+
+**Depends on:** Task 1, Task 2 | **Files:** packages/core/src/annotations/index.ts
+
+1. Create `packages/core/src/annotations/index.ts` re-exporting:
+   - All types from `./types`
+   - `parseProtectedRegions`, `parseFileRegions`, `createRegionMap` from `./protected-regions`
+2. Commit: `feat(core): add annotations module index`
+
+### Task 4: Wire annotations into entropy exports
+
+**Depends on:** Task 3 | **Files:** packages/core/src/entropy/index.ts, packages/core/src/index.ts
+
+1. Add to `packages/core/src/entropy/index.ts`:
+   ```typescript
+   export { parseProtectedRegions, parseFileRegions, createRegionMap } from '../annotations';
+   export type {
+     ProtectionScope,
+     ProtectedRegion,
+     ProtectedRegionMap,
+     AnnotationIssue,
+   } from '../annotations';
+   ```
+2. Add to `packages/core/src/index.ts`:
+   ```typescript
+   export * from './annotations';
+   ```
+3. Commit: `feat(core): export annotations from entropy and core modules`
+
+### Task 5: Add protection guard to applyFixes (TDD)
+
+**Depends on:** Task 3 | **Files:** packages/core/src/entropy/fixers/safe-fixes.ts, packages/core/tests/entropy/fixers/safe-fixes.test.ts
+
+1. Add test cases to `packages/core/tests/entropy/fixers/safe-fixes.test.ts`:
+   - `applyFixes` with `protectedRegions` skips fixes in protected lines
+   - `applyFixes` without `protectedRegions` applies all fixes (backward compatible)
+   - Protected fix appears in `result.skipped` array
+   - Non-protected fixes still apply normally
+2. Run tests — observe failures
+3. Modify `packages/core/src/entropy/fixers/safe-fixes.ts`:
+   - Import `ProtectedRegionMap` from `../annotations`
+   - Extend `FixConfig` interface: add optional `protectedRegions?: ProtectedRegionMap`
+   - In `applyFixes()`, before applying each fix, check `protectedRegions.isProtected(fix.file, fix.line, 'entropy')`
+   - If protected, add to `skipped[]` and continue
+   - For `delete-file` action, check if any region exists for the file
+4. Run tests — observe pass
+5. Commit: `feat(core): add protected region guard to applyFixes`
+
+### Task 6: Add FixConfig type update for protectedRegions
+
+**Depends on:** Task 5 | **Files:** packages/core/src/entropy/types/fix.ts
+
+1. Add import and optional field to `FixConfig` in `packages/core/src/entropy/types/fix.ts`:
+
+   ```typescript
+   import type { ProtectedRegionMap } from '../../annotations';
+
+   export interface FixConfig {
+     dryRun: boolean;
+     fixTypes: FixType[];
+     createBackup: boolean;
+     backupDir?: string;
+     protectedRegions?: ProtectedRegionMap;
+   }
+   ```
+
+2. Commit: `feat(core): add protectedRegions to FixConfig type`
+
+### Task 7: Final verification
+
+**Depends on:** Task 1-6 | **Files:** none (verification only)
+
+1. Run full test suite: `npx vitest run packages/core/tests/annotations/`
+2. Run existing entropy tests: `npx vitest run packages/core/tests/entropy/fixers/`
+3. Run existing security tests: `npx vitest run packages/core/tests/security/`
+4. Run TypeScript check: `npx tsc --noEmit -p packages/core/tsconfig.json`
+5. Verify all pass
+6. Commit: no commit needed (verification only)

--- a/packages/core/src/annotations/index.ts
+++ b/packages/core/src/annotations/index.ts
@@ -1,0 +1,13 @@
+// packages/core/src/annotations/index.ts
+
+export type {
+  ProtectionScope,
+  ProtectedRegion,
+  ProtectedRegionMap,
+  AnnotationIssue,
+  AnnotationIssueType,
+} from './types';
+
+export { VALID_SCOPES } from './types';
+
+export { parseProtectedRegions, parseFileRegions, createRegionMap } from './protected-regions';

--- a/packages/core/src/annotations/protected-regions.ts
+++ b/packages/core/src/annotations/protected-regions.ts
@@ -1,0 +1,276 @@
+// packages/core/src/annotations/protected-regions.ts
+
+import type {
+  ProtectionScope,
+  ProtectedRegion,
+  ProtectedRegionMap,
+  AnnotationIssue,
+} from './types';
+import { VALID_SCOPES } from './types';
+
+/**
+ * Regex patterns for harness-ignore annotations.
+ *
+ * Line:  // harness-ignore [scopes]: [reason]
+ * Start: // harness-ignore-start [scopes]: [reason]
+ * End:   // harness-ignore-end
+ *
+ * Also supports # prefix for Python/shell files.
+ * Does NOT match security-scanner patterns like `harness-ignore SEC-XXX-NNN`.
+ */
+const LINE_PATTERN =
+  /^[ \t]*(?:\/\/|#)\s*harness-ignore(?!\s*(?:SEC-|-start|-end))(?:\s+([\w,]+))?(?::\s*(.+))?$/;
+const START_PATTERN = /^[ \t]*(?:\/\/|#)\s*harness-ignore-start(?:\s+([\w,]+))?(?::\s*(.+))?$/;
+const END_PATTERN = /^[ \t]*(?:\/\/|#)\s*harness-ignore-end\s*$/;
+
+/** Check if a line is a comment or blank (for skipping past when finding protected line). */
+function isCommentOrBlank(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed === '') return true;
+  return (
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('/*') ||
+    trimmed.startsWith('*')
+  );
+}
+
+/** Parse scope string into validated ProtectionScope array. Returns unknown scopes separately. */
+function parseScopes(scopeStr: string | undefined): {
+  scopes: ProtectionScope[];
+  unknown: string[];
+} {
+  if (!scopeStr) return { scopes: ['all'], unknown: [] };
+
+  const raw = scopeStr.split(',').map((s) => s.trim());
+  const scopes: ProtectionScope[] = [];
+  const unknown: string[] = [];
+
+  for (const s of raw) {
+    if (VALID_SCOPES.has(s)) {
+      scopes.push(s as ProtectionScope);
+    } else {
+      unknown.push(s);
+    }
+  }
+
+  if (scopes.length === 0) scopes.push('all');
+  return { scopes, unknown };
+}
+
+/** Report unknown scopes as issues when present. */
+function reportUnknownScopes(
+  unknown: string[],
+  filePath: string,
+  lineNum: number,
+  issues: AnnotationIssue[]
+): void {
+  if (unknown.length > 0) {
+    issues.push({
+      file: filePath,
+      line: lineNum,
+      type: 'unknown-scope',
+      message: `Unknown protection scope(s): ${unknown.join(', ')} at line ${lineNum}`,
+    });
+  }
+}
+
+/** Find the next non-comment, non-blank line index after a given position. */
+function findNextCodeLine(lines: string[], startIndex: number): number {
+  for (let j = startIndex; j < lines.length; j++) {
+    if (!isCommentOrBlank(lines[j]!)) return j + 1; // 1-indexed
+  }
+  return startIndex; // fallback: protect the annotation line itself (0-indexed → already 1-indexed from caller)
+}
+
+interface BlockEntry {
+  line: number;
+  scopes: ProtectionScope[];
+  reason: string | null;
+}
+
+/** Handle a block-end annotation. */
+function handleBlockEnd(
+  filePath: string,
+  lineNum: number,
+  blockStack: BlockEntry[],
+  regions: ProtectedRegion[],
+  issues: AnnotationIssue[]
+): void {
+  if (blockStack.length === 0) {
+    issues.push({
+      file: filePath,
+      line: lineNum,
+      type: 'orphaned-end',
+      message: `harness-ignore-end at line ${lineNum} has no matching harness-ignore-start`,
+    });
+    return;
+  }
+
+  const open = blockStack.pop()!;
+  regions.push({
+    file: filePath,
+    startLine: open.line,
+    endLine: lineNum,
+    scopes: open.scopes,
+    reason: open.reason,
+    type: 'block',
+  });
+}
+
+/** Handle a block-start annotation. */
+function handleBlockStart(
+  match: RegExpExecArray,
+  filePath: string,
+  lineNum: number,
+  blockStack: BlockEntry[],
+  issues: AnnotationIssue[]
+): void {
+  const { scopes, unknown } = parseScopes(match[1]);
+  const reason = match[2]?.trim() || null;
+  reportUnknownScopes(unknown, filePath, lineNum, issues);
+  blockStack.push({ line: lineNum, scopes, reason });
+}
+
+/** Handle a line-level annotation. */
+function handleLineAnnotation(
+  match: RegExpExecArray,
+  filePath: string,
+  lineNum: number,
+  lines: string[],
+  lineIndex: number,
+  regions: ProtectedRegion[],
+  issues: AnnotationIssue[]
+): void {
+  const { scopes, unknown } = parseScopes(match[1]);
+  const reason = match[2]?.trim() || null;
+  reportUnknownScopes(unknown, filePath, lineNum, issues);
+
+  const targetLine = findNextCodeLine(lines, lineIndex + 1);
+  regions.push({
+    file: filePath,
+    startLine: targetLine,
+    endLine: targetLine,
+    scopes,
+    reason,
+    type: 'line',
+  });
+}
+
+/** Close any remaining open blocks as unclosed, creating regions to end-of-file. */
+function closeUnclosedBlocks(
+  filePath: string,
+  totalLines: number,
+  blockStack: BlockEntry[],
+  regions: ProtectedRegion[],
+  issues: AnnotationIssue[]
+): void {
+  for (const open of blockStack) {
+    issues.push({
+      file: filePath,
+      line: open.line,
+      type: 'unclosed-block',
+      message: `harness-ignore-start at line ${open.line} has no matching harness-ignore-end`,
+    });
+    regions.push({
+      file: filePath,
+      startLine: open.line,
+      endLine: totalLines,
+      scopes: open.scopes,
+      reason: open.reason,
+      type: 'block',
+    });
+  }
+}
+
+/**
+ * Parse a single file for protected regions and annotation issues.
+ */
+export function parseFileRegions(
+  filePath: string,
+  content: string
+): { regions: ProtectedRegion[]; issues: AnnotationIssue[] } {
+  const regions: ProtectedRegion[] = [];
+  const issues: AnnotationIssue[] = [];
+
+  if (!content) return { regions, issues };
+
+  const lines = content.split('\n');
+  const blockStack: BlockEntry[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const lineNum = i + 1;
+
+    if (END_PATTERN.test(line)) {
+      handleBlockEnd(filePath, lineNum, blockStack, regions, issues);
+      continue;
+    }
+
+    const startMatch = START_PATTERN.exec(line);
+    if (startMatch) {
+      handleBlockStart(startMatch, filePath, lineNum, blockStack, issues);
+      continue;
+    }
+
+    const lineMatch = LINE_PATTERN.exec(line);
+    if (lineMatch) {
+      handleLineAnnotation(lineMatch, filePath, lineNum, lines, i, regions, issues);
+    }
+  }
+
+  closeUnclosedBlocks(filePath, lines.length, blockStack, regions, issues);
+  return { regions, issues };
+}
+
+/**
+ * Create a ProtectedRegionMap from a list of regions with efficient lookup.
+ */
+export function createRegionMap(regions: ProtectedRegion[]): ProtectedRegionMap {
+  const byFile = new Map<string, ProtectedRegion[]>();
+  for (const region of regions) {
+    const existing = byFile.get(region.file) ?? [];
+    existing.push(region);
+    byFile.set(region.file, existing);
+  }
+
+  return {
+    regions,
+
+    isProtected(file: string, line: number, scope: ProtectionScope): boolean {
+      const fileRegions = byFile.get(file);
+      if (!fileRegions) return false;
+
+      return fileRegions.some((r) => {
+        if (line < r.startLine || line > r.endLine) return false;
+        return r.scopes.includes('all') || r.scopes.includes(scope);
+      });
+    },
+
+    getRegions(file: string): ProtectedRegion[] {
+      return byFile.get(file) ?? [];
+    },
+  };
+}
+
+/**
+ * Parse multiple files for protected regions and aggregate results.
+ */
+export function parseProtectedRegions(files: Array<{ path: string; content: string }>): {
+  regions: ProtectedRegionMap;
+  issues: AnnotationIssue[];
+} {
+  const allRegions: ProtectedRegion[] = [];
+  const allIssues: AnnotationIssue[] = [];
+
+  for (const file of files) {
+    const { regions, issues } = parseFileRegions(file.path, file.content);
+    allRegions.push(...regions);
+    allIssues.push(...issues);
+  }
+
+  return {
+    regions: createRegionMap(allRegions),
+    issues: allIssues,
+  };
+}

--- a/packages/core/src/annotations/types.ts
+++ b/packages/core/src/annotations/types.ts
@@ -1,0 +1,53 @@
+// packages/core/src/annotations/types.ts
+
+/** Scope categories for protection annotations. */
+export type ProtectionScope = 'entropy' | 'architecture' | 'security' | 'all';
+
+/** Valid scope values for parsing. */
+export const VALID_SCOPES: ReadonlySet<string> = new Set<string>([
+  'entropy',
+  'architecture',
+  'security',
+  'all',
+]);
+
+/** A single protected region in a file. */
+export interface ProtectedRegion {
+  /** Relative file path. */
+  file: string;
+  /** 1-indexed start line (inclusive). */
+  startLine: number;
+  /** 1-indexed end line (inclusive). Same as startLine for line-level. */
+  endLine: number;
+  /** Which subsystems this region is protected from. */
+  scopes: ProtectionScope[];
+  /** Human-readable reason for the protection, or null if not provided. */
+  reason: string | null;
+  /** Whether this is a line-level or block-level annotation. */
+  type: 'line' | 'block';
+}
+
+/** Map of protected regions with lookup methods. */
+export interface ProtectedRegionMap {
+  /** All regions across all files. */
+  regions: ProtectedRegion[];
+  /** Check if a specific file:line is protected for a given scope. */
+  isProtected(file: string, line: number, scope: ProtectionScope): boolean;
+  /** Get all regions for a specific file. */
+  getRegions(file: string): ProtectedRegion[];
+}
+
+/** Validation issue types for annotation parsing. */
+export type AnnotationIssueType =
+  | 'unclosed-block'
+  | 'orphaned-end'
+  | 'missing-reason'
+  | 'unknown-scope';
+
+/** A validation issue found during annotation parsing. */
+export interface AnnotationIssue {
+  file: string;
+  line: number;
+  type: AnnotationIssueType;
+  message: string;
+}

--- a/packages/core/src/entropy/fixers/safe-fixes.ts
+++ b/packages/core/src/entropy/fixers/safe-fixes.ts
@@ -285,6 +285,15 @@ async function applySingleFix(
   }
 }
 
+/** Check if a fix targets a protected region and should be skipped. */
+function isFixProtected(fix: Fix, config: FixConfig): boolean {
+  if (!config.protectedRegions) return false;
+  const pr = config.protectedRegions;
+  if (fix.action === 'delete-file') return pr.getRegions(fix.file).length > 0;
+  if (fix.line !== undefined) return pr.isProtected(fix.file, fix.line, 'entropy');
+  return false;
+}
+
 /**
  * Apply fixes to codebase
  */
@@ -305,6 +314,12 @@ export async function applyFixes(
   for (const fix of fixes) {
     // Filter by fixTypes
     if (!fullConfig.fixTypes.includes(fix.type)) {
+      skipped.push(fix);
+      continue;
+    }
+
+    // Skip fixes in protected regions
+    if (isFixProtected(fix, fullConfig)) {
       skipped.push(fix);
       continue;
     }

--- a/packages/core/src/entropy/index.ts
+++ b/packages/core/src/entropy/index.ts
@@ -23,6 +23,23 @@ export type { GraphCouplingData } from './detectors/coupling';
 export { detectSizeBudgetViolations, parseSize } from './detectors/size-budget';
 
 /**
+ * Annotation-based protected regions for code that must not be modified.
+ */
+export {
+  parseProtectedRegions,
+  parseFileRegions,
+  createRegionMap,
+  VALID_SCOPES,
+} from '../annotations';
+export type {
+  ProtectionScope,
+  ProtectedRegion,
+  ProtectedRegionMap,
+  AnnotationIssue,
+  AnnotationIssueType,
+} from '../annotations';
+
+/**
  * Fixers for automated remediation of detected issues.
  */
 export {

--- a/packages/core/src/entropy/types/fix.ts
+++ b/packages/core/src/entropy/types/fix.ts
@@ -1,5 +1,7 @@
 // packages/core/src/entropy/types/fix.ts
 
+import type { ProtectedRegionMap } from '../../annotations';
+
 // ============ Fix Types ============
 
 export type FixType =
@@ -19,6 +21,8 @@ export interface FixConfig {
   fixTypes: FixType[];
   createBackup: boolean;
   backupDir?: string;
+  /** When provided, fixes targeting lines within protected regions are skipped. */
+  protectedRegions?: ProtectedRegionMap;
 }
 
 export interface Fix {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,11 @@ export * from './context';
 export * from './constraints';
 
 /**
+ * Annotations module for protected code regions and harness-ignore directives.
+ */
+export * from './annotations';
+
+/**
  * Entropy module for detecting and remediating codebase drift, dead code, and complexity.
  */
 export * from './entropy';

--- a/packages/core/tests/annotations/protected-regions.test.ts
+++ b/packages/core/tests/annotations/protected-regions.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseFileRegions,
+  parseProtectedRegions,
+  createRegionMap,
+} from '../../src/annotations/protected-regions';
+
+describe('parseFileRegions', () => {
+  it('parses a block region with start and end markers', () => {
+    const content = [
+      'const a = 1;',
+      '// harness-ignore-start entropy: SOX audit requirement',
+      'export function audit() {',
+      '  return calculate();',
+      '}',
+      '// harness-ignore-end',
+      'const b = 2;',
+    ].join('\n');
+
+    const { regions, issues } = parseFileRegions('src/audit.ts', content);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]).toEqual({
+      file: 'src/audit.ts',
+      startLine: 2,
+      endLine: 6,
+      scopes: ['entropy'],
+      reason: 'SOX audit requirement',
+      type: 'block',
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  it('parses a line-level annotation protecting the next code line', () => {
+    const content = [
+      '// harness-ignore entropy: compliance',
+      'export function required() {}',
+      'const other = 1;',
+    ].join('\n');
+
+    const { regions, issues } = parseFileRegions('src/comp.ts', content);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]).toEqual({
+      file: 'src/comp.ts',
+      startLine: 2,
+      endLine: 2,
+      scopes: ['entropy'],
+      reason: 'compliance',
+      type: 'line',
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  it('skips comment and blank lines when finding the protected line', () => {
+    const content = [
+      '// harness-ignore entropy: reason',
+      '// this is a comment',
+      '',
+      'export const value = 42;',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('src/val.ts', content);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.startLine).toBe(4);
+    expect(regions[0]!.endLine).toBe(4);
+  });
+
+  it('parses multiple scope categories', () => {
+    const content = [
+      '// harness-ignore-start entropy,architecture: vendor lock-in',
+      'import { SDK } from "@vendor/sdk";',
+      '// harness-ignore-end',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('src/vendor.ts', content);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.scopes).toEqual(['entropy', 'architecture']);
+  });
+
+  it('defaults to "all" scope when no scope specified', () => {
+    const content = [
+      '// harness-ignore-start: critical section',
+      'const x = 1;',
+      '// harness-ignore-end',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('src/crit.ts', content);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.scopes).toEqual(['all']);
+  });
+
+  it('extracts reason text after colon', () => {
+    const content = [
+      '// harness-ignore-start entropy: FIPS-certified implementation',
+      'function hmac() {}',
+      '// harness-ignore-end',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('src/crypto.ts', content);
+    expect(regions[0]!.reason).toBe('FIPS-certified implementation');
+  });
+
+  it('handles null reason when no colon provided', () => {
+    const content = [
+      '// harness-ignore-start entropy',
+      'function hmac() {}',
+      '// harness-ignore-end',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('src/crypto.ts', content);
+    expect(regions[0]!.reason).toBeNull();
+  });
+
+  it('reports unclosed blocks as validation issues', () => {
+    const content = ['// harness-ignore-start entropy: never closed', 'function orphan() {}'].join(
+      '\n'
+    );
+
+    const { regions, issues } = parseFileRegions('src/bad.ts', content);
+
+    // Region still created (covers to end of file)
+    expect(regions).toHaveLength(1);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toEqual({
+      file: 'src/bad.ts',
+      line: 1,
+      type: 'unclosed-block',
+      message: 'harness-ignore-start at line 1 has no matching harness-ignore-end',
+    });
+  });
+
+  it('reports orphaned end markers as validation issues', () => {
+    const content = ['const a = 1;', '// harness-ignore-end'].join('\n');
+
+    const { regions, issues } = parseFileRegions('src/bad2.ts', content);
+
+    expect(regions).toHaveLength(0);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toEqual({
+      file: 'src/bad2.ts',
+      line: 2,
+      type: 'orphaned-end',
+      message: 'harness-ignore-end at line 2 has no matching harness-ignore-start',
+    });
+  });
+
+  it('reports unknown scopes as validation issues', () => {
+    const content = [
+      '// harness-ignore-start bogus: bad scope',
+      'const a = 1;',
+      '// harness-ignore-end',
+    ].join('\n');
+
+    const { regions, issues } = parseFileRegions('src/bad3.ts', content);
+
+    // Region still created with valid scopes filtered
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.type).toBe('unknown-scope');
+    expect(issues[0]!.message).toContain('bogus');
+  });
+
+  it('handles # comment prefix for Python/shell files', () => {
+    const content = [
+      '# harness-ignore-start entropy: legacy script',
+      'def legacy():',
+      '    pass',
+      '# harness-ignore-end',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('scripts/legacy.py', content);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.scopes).toEqual(['entropy']);
+    expect(regions[0]!.reason).toBe('legacy script');
+  });
+
+  it('handles empty files', () => {
+    const { regions, issues } = parseFileRegions('src/empty.ts', '');
+    expect(regions).toHaveLength(0);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('handles files with no annotations', () => {
+    const content = [
+      'const a = 1;',
+      'const b = 2;',
+      'export function foo() { return a + b; }',
+    ].join('\n');
+
+    const { regions, issues } = parseFileRegions('src/clean.ts', content);
+    expect(regions).toHaveLength(0);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('handles multiple block regions in one file', () => {
+    const content = [
+      '// harness-ignore-start entropy: region 1',
+      'const a = 1;',
+      '// harness-ignore-end',
+      'const b = 2;',
+      '// harness-ignore-start architecture: region 2',
+      'import { x } from "forbidden";',
+      '// harness-ignore-end',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('src/multi.ts', content);
+
+    expect(regions).toHaveLength(2);
+    expect(regions[0]!.reason).toBe('region 1');
+    expect(regions[1]!.reason).toBe('region 2');
+  });
+
+  it('does not match harness-ignore SEC- patterns (security scanner syntax)', () => {
+    const content = [
+      '// harness-ignore SEC-CRY-001: false positive',
+      'const key = process.env.API_KEY;',
+    ].join('\n');
+
+    const { regions } = parseFileRegions('src/config.ts', content);
+
+    // SEC-XXX-NNN is handled by security scanner, not by protected regions
+    expect(regions).toHaveLength(0);
+  });
+});
+
+describe('createRegionMap', () => {
+  it('isProtected returns true for lines inside a block region', () => {
+    const map = createRegionMap([
+      {
+        file: 'src/audit.ts',
+        startLine: 3,
+        endLine: 8,
+        scopes: ['entropy'],
+        reason: 'test',
+        type: 'block',
+      },
+    ]);
+
+    expect(map.isProtected('src/audit.ts', 3, 'entropy')).toBe(true);
+    expect(map.isProtected('src/audit.ts', 5, 'entropy')).toBe(true);
+    expect(map.isProtected('src/audit.ts', 8, 'entropy')).toBe(true);
+  });
+
+  it('isProtected returns false for lines outside a block region', () => {
+    const map = createRegionMap([
+      {
+        file: 'src/audit.ts',
+        startLine: 3,
+        endLine: 8,
+        scopes: ['entropy'],
+        reason: 'test',
+        type: 'block',
+      },
+    ]);
+
+    expect(map.isProtected('src/audit.ts', 2, 'entropy')).toBe(false);
+    expect(map.isProtected('src/audit.ts', 9, 'entropy')).toBe(false);
+  });
+
+  it('isProtected respects scope — wrong scope returns false', () => {
+    const map = createRegionMap([
+      {
+        file: 'src/audit.ts',
+        startLine: 3,
+        endLine: 8,
+        scopes: ['entropy'],
+        reason: 'test',
+        type: 'block',
+      },
+    ]);
+
+    expect(map.isProtected('src/audit.ts', 5, 'architecture')).toBe(false);
+  });
+
+  it('isProtected matches "all" scope against any query scope', () => {
+    const map = createRegionMap([
+      {
+        file: 'src/crit.ts',
+        startLine: 1,
+        endLine: 5,
+        scopes: ['all'],
+        reason: 'critical',
+        type: 'block',
+      },
+    ]);
+
+    expect(map.isProtected('src/crit.ts', 3, 'entropy')).toBe(true);
+    expect(map.isProtected('src/crit.ts', 3, 'architecture')).toBe(true);
+    expect(map.isProtected('src/crit.ts', 3, 'security')).toBe(true);
+  });
+
+  it('isProtected returns false for wrong file', () => {
+    const map = createRegionMap([
+      {
+        file: 'src/audit.ts',
+        startLine: 1,
+        endLine: 10,
+        scopes: ['all'],
+        reason: null,
+        type: 'block',
+      },
+    ]);
+
+    expect(map.isProtected('src/other.ts', 5, 'entropy')).toBe(false);
+  });
+
+  it('getRegions returns only regions for specified file', () => {
+    const map = createRegionMap([
+      {
+        file: 'src/a.ts',
+        startLine: 1,
+        endLine: 5,
+        scopes: ['entropy'],
+        reason: null,
+        type: 'block',
+      },
+      {
+        file: 'src/b.ts',
+        startLine: 1,
+        endLine: 3,
+        scopes: ['all'],
+        reason: null,
+        type: 'block',
+      },
+    ]);
+
+    expect(map.getRegions('src/a.ts')).toHaveLength(1);
+    expect(map.getRegions('src/b.ts')).toHaveLength(1);
+    expect(map.getRegions('src/c.ts')).toHaveLength(0);
+  });
+
+  it('handles empty regions array', () => {
+    const map = createRegionMap([]);
+
+    expect(map.regions).toHaveLength(0);
+    expect(map.isProtected('any.ts', 1, 'entropy')).toBe(false);
+    expect(map.getRegions('any.ts')).toHaveLength(0);
+  });
+});
+
+describe('parseProtectedRegions', () => {
+  it('parses multiple files and aggregates regions', () => {
+    const files = [
+      {
+        path: 'src/a.ts',
+        content: [
+          '// harness-ignore-start entropy: reason a',
+          'const a = 1;',
+          '// harness-ignore-end',
+        ].join('\n'),
+      },
+      {
+        path: 'src/b.ts',
+        content: ['// harness-ignore architecture: reason b', 'import { x } from "y";'].join('\n'),
+      },
+    ];
+
+    const { regions, issues } = parseProtectedRegions(files);
+
+    expect(regions.regions).toHaveLength(2);
+    expect(regions.isProtected('src/a.ts', 2, 'entropy')).toBe(true);
+    expect(regions.isProtected('src/b.ts', 2, 'architecture')).toBe(true);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('aggregates issues from multiple files', () => {
+    const files = [
+      {
+        path: 'src/bad1.ts',
+        content: '// harness-ignore-start entropy: unclosed',
+      },
+      {
+        path: 'src/bad2.ts',
+        content: '// harness-ignore-end',
+      },
+    ];
+
+    const { issues } = parseProtectedRegions(files);
+
+    expect(issues).toHaveLength(2);
+    expect(issues[0]!.type).toBe('unclosed-block');
+    expect(issues[1]!.type).toBe('orphaned-end');
+  });
+});

--- a/packages/core/tests/entropy/fixers/safe-fixes.test.ts
+++ b/packages/core/tests/entropy/fixers/safe-fixes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createFixes, previewFix, applyFixes } from '../../../src/entropy/fixers/safe-fixes';
 import type { DeadCodeReport, Fix } from '../../../src/entropy/types';
+import { createRegionMap } from '../../../src/annotations';
 import * as fs from 'fs';
 import { promisify } from 'util';
 import * as path from 'path';
@@ -351,6 +352,189 @@ describe('applyFixes', () => {
       const backupFiles = fs.readdirSync(backupDir);
       expect(backupFiles.length).toBe(1);
       expect(backupFiles[0]).toContain('backup-me.ts');
+    }
+  });
+});
+
+describe('applyFixes with protectedRegions', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = path.join(os.tmpdir(), `safe-fixes-protected-${Date.now()}`);
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips fixes in protected lines', async () => {
+    const testFile = path.join(tmpDir, 'protected.ts');
+    await writeFile(testFile, 'import { unused } from "mod";\nconst a = 1;\n');
+
+    const protectedRegions = createRegionMap([
+      {
+        file: testFile,
+        startLine: 1,
+        endLine: 1,
+        scopes: ['entropy'],
+        reason: 'protected import',
+        type: 'line',
+      },
+    ]);
+
+    const fixes: Fix[] = [
+      {
+        type: 'unused-imports',
+        file: testFile,
+        description: 'Remove unused import',
+        action: 'delete-lines',
+        line: 1,
+        safe: true,
+        reversible: true,
+      },
+    ];
+
+    const result = await applyFixes(fixes, {
+      fixTypes: ['unused-imports'],
+      dryRun: false,
+      createBackup: false,
+      protectedRegions,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.applied).toHaveLength(0);
+      expect(result.value.skipped).toHaveLength(1);
+      // File should be unchanged
+      const content = await readFile(testFile, 'utf-8');
+      expect(content).toBe('import { unused } from "mod";\nconst a = 1;\n');
+    }
+  });
+
+  it('applies fixes when no protectedRegions provided (backward compatible)', async () => {
+    const testFile = path.join(tmpDir, 'unprotected.ts');
+    await writeFile(testFile, 'import { unused } from "mod";\nconst a = 1;\n');
+
+    const fixes: Fix[] = [
+      {
+        type: 'unused-imports',
+        file: testFile,
+        description: 'Remove unused import',
+        action: 'delete-lines',
+        line: 1,
+        safe: true,
+        reversible: true,
+      },
+    ];
+
+    const result = await applyFixes(fixes, {
+      fixTypes: ['unused-imports'],
+      dryRun: false,
+      createBackup: false,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.applied).toHaveLength(1);
+      expect(result.value.skipped).toHaveLength(0);
+    }
+  });
+
+  it('skips delete-file when file has any protected region', async () => {
+    const testFile = path.join(tmpDir, 'protected-file.ts');
+    await writeFile(testFile, 'const a = 1;\n');
+
+    const protectedRegions = createRegionMap([
+      {
+        file: testFile,
+        startLine: 1,
+        endLine: 1,
+        scopes: ['all'],
+        reason: 'do not delete',
+        type: 'line',
+      },
+    ]);
+
+    const fixes: Fix[] = [
+      {
+        type: 'dead-files',
+        file: testFile,
+        description: 'Delete dead file',
+        action: 'delete-file',
+        safe: true,
+        reversible: true,
+      },
+    ];
+
+    const result = await applyFixes(fixes, {
+      fixTypes: ['dead-files'],
+      dryRun: false,
+      createBackup: false,
+      protectedRegions,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.applied).toHaveLength(0);
+      expect(result.value.skipped).toHaveLength(1);
+      // File should still exist
+      expect(await exists(testFile)).toBe(true);
+    }
+  });
+
+  it('applies non-protected fixes normally when protectedRegions is set', async () => {
+    const testFile = path.join(tmpDir, 'mixed.ts');
+    await writeFile(
+      testFile,
+      'import { used } from "mod";\nimport { unused } from "other";\nconst a = 1;\n'
+    );
+
+    const protectedRegions = createRegionMap([
+      {
+        file: testFile,
+        startLine: 1,
+        endLine: 1,
+        scopes: ['entropy'],
+        reason: 'keep this import',
+        type: 'line',
+      },
+    ]);
+
+    const fixes: Fix[] = [
+      {
+        type: 'unused-imports',
+        file: testFile,
+        description: 'Remove protected import',
+        action: 'delete-lines',
+        line: 1,
+        safe: true,
+        reversible: true,
+      },
+      {
+        type: 'unused-imports',
+        file: testFile,
+        description: 'Remove unprotected import',
+        action: 'delete-lines',
+        line: 2,
+        safe: true,
+        reversible: true,
+      },
+    ];
+
+    const result = await applyFixes(fixes, {
+      fixTypes: ['unused-imports'],
+      dryRun: false,
+      createBackup: false,
+      protectedRegions,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.applied).toHaveLength(1);
+      expect(result.value.skipped).toHaveLength(1);
+      expect(result.value.applied[0]!.description).toBe('Remove unprotected import');
+      expect(result.value.skipped[0]!.description).toBe('Remove protected import');
     }
   });
 });


### PR DESCRIPTION
## Summary

- Introduces a `harness-ignore` annotation system for block-level and line-level code protection  
- Extends the existing `harness-ignore` security scanner pattern to cover entropy and architecture scopes

## Changes

- New `packages/core/src/annotations/` module with parser, types, and region map
- Scope categories: entropy, architecture, security, all (default)
- Validation: unclosed blocks, orphaned ends, unknown scopes
- Defense-in-depth: applyFixes() checks ProtectedRegionMap before applying
- 28 new tests, backward compatible

## Test plan

- [x] 24 annotation parser tests pass
- [x] 15 safe-fixes tests pass (4 new)
- [x] 198+ security scanner tests unaffected
- [x] All harness CI checks pass