### PR TITLE
test: add unit tests for 14 untested security rules and enforce CI coverage blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           files: packages/core/coverage/coverage-final.json,packages/graph/coverage/coverage-final.json,packages/cli/coverage/coverage-final.json,packages/eslint-plugin/coverage/coverage-final.json,packages/linter-gen/coverage/coverage-final.json,packages/orchestrator/coverage/coverage-final.json,packages/types/coverage/coverage-final.json
           flags: unittests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,12 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        # Coverage regressions block the PR — not just a warning
+        if_ci_failed: error
     patch:
       default:
         target: 80%
+        if_ci_failed: error
   flags:
     unittests:
       paths:

--- a/packages/core/tests/security/rules/insecure-defaults.test.ts
+++ b/packages/core/tests/security/rules/insecure-defaults.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import { insecureDefaultsRules } from '../../../src/security/rules/insecure-defaults';
+
+function findRule(id: string) {
+  const rule = insecureDefaultsRules.find((r) => r.id === id);
+  expect(rule).toBeDefined();
+  return rule!;
+}
+
+function matches(id: string, input: string): boolean {
+  return findRule(id).patterns.some((p) => p.test(input));
+}
+
+describe('Insecure-defaults rules', () => {
+  // --- SEC-DEF-001: Security-Sensitive Fallback ---
+  describe('SEC-DEF-001 — Security-Sensitive Fallback to Hardcoded Default', () => {
+    it('detects SECRET fallback with ||', () => {
+      expect(matches('SEC-DEF-001', `const secret = process.env.SECRET || 'hardcoded123'`)).toBe(
+        true
+      );
+    });
+
+    it('detects KEY fallback with ??', () => {
+      expect(matches('SEC-DEF-001', `const key = process.env.ENCRYPTION_KEY ?? 'default-key'`)).toBe(
+        true
+      );
+    });
+
+    it('detects TOKEN fallback', () => {
+      expect(matches('SEC-DEF-001', `const token = env.JWT_TOKEN || "fallback"`)).toBe(true);
+    });
+
+    it('detects PASSWORD fallback', () => {
+      expect(matches('SEC-DEF-001', `const pw = process.env.DB_PASSWORD ?? "admin"`)).toBe(true);
+    });
+
+    it('detects SALT fallback', () => {
+      expect(matches('SEC-DEF-001', `const salt = config.SALT || "fixed-salt"`)).toBe(true);
+    });
+
+    it('detects SESSION fallback', () => {
+      expect(matches('SEC-DEF-001', `const sess = process.env.SESSION_SECRET || 'abc'`)).toBe(
+        true
+      );
+    });
+
+    it('detects AUTH fallback', () => {
+      expect(matches('SEC-DEF-001', `const auth = env.AUTH_KEY ?? "default"`)).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(matches('SEC-DEF-001', `const s = env.secret_key || "val"`)).toBe(true);
+    });
+
+    it('does not flag non-security env vars', () => {
+      expect(matches('SEC-DEF-001', `const port = process.env.PORT || '3000'`)).toBe(false);
+    });
+
+    it('does not flag without fallback operator', () => {
+      expect(matches('SEC-DEF-001', `const secret = process.env.SECRET`)).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-DEF-001');
+      expect(rule.severity).toBe('warning');
+      expect(rule.confidence).toBe('medium');
+      expect(rule.references).toContain('CWE-1188');
+    });
+  });
+
+  // --- SEC-DEF-002: TLS/SSL Disabled by Default ---
+  describe('SEC-DEF-002 — TLS/SSL Disabled by Default', () => {
+    it('detects tls = false', () => {
+      expect(matches('SEC-DEF-002', 'tls = false')).toBe(true);
+    });
+
+    it('detects ssl: false', () => {
+      expect(matches('SEC-DEF-002', 'ssl: false')).toBe(true);
+    });
+
+    it('detects https = false', () => {
+      expect(matches('SEC-DEF-002', 'https = false')).toBe(true);
+    });
+
+    it('detects secure: false', () => {
+      expect(matches('SEC-DEF-002', 'secure: false')).toBe(true);
+    });
+
+    it('detects tls with config fallback to false', () => {
+      expect(matches('SEC-DEF-002', 'tls = config?.enabled ?? false')).toBe(true);
+    });
+
+    it('detects secure with config fallback to false', () => {
+      expect(matches('SEC-DEF-002', 'secure: config?.value || false')).toBe(true);
+    });
+
+    it('does not flag tls = true', () => {
+      expect(matches('SEC-DEF-002', 'tls = true')).toBe(false);
+    });
+
+    it('does not flag unrelated assignments', () => {
+      expect(matches('SEC-DEF-002', 'debug = false')).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-DEF-002');
+      expect(rule.severity).toBe('warning');
+      expect(rule.confidence).toBe('medium');
+      expect(rule.references).toContain('CWE-1188');
+    });
+  });
+
+  // --- SEC-DEF-003: Swallowed Auth Error ---
+  describe('SEC-DEF-003 — Swallowed Authentication/Authorization Error', () => {
+    it('detects empty catch block', () => {
+      expect(matches('SEC-DEF-003', 'catch(e) { }')).toBe(true);
+    });
+
+    it('detects catch with ignore comment', () => {
+      expect(matches('SEC-DEF-003', 'catch(err) { // ignore }')).toBe(true);
+    });
+
+    it('detects catch with noop comment', () => {
+      expect(matches('SEC-DEF-003', 'catch(e) { // noop }')).toBe(true);
+    });
+
+    it('detects catch with skip comment', () => {
+      expect(matches('SEC-DEF-003', 'catch(error) { // skip }')).toBe(true);
+    });
+
+    it('detects catch with todo comment', () => {
+      expect(matches('SEC-DEF-003', 'catch(e) { // todo handle this }')).toBe(true);
+    });
+
+    it('does not flag catch with actual handler', () => {
+      expect(matches('SEC-DEF-003', 'catch(e) { logger.error(e) }')).toBe(false);
+    });
+
+    it('has auth-related file glob', () => {
+      const rule = findRule('SEC-DEF-003');
+      expect(rule.fileGlob).toContain('*auth*');
+      expect(rule.fileGlob).toContain('*session*');
+      expect(rule.fileGlob).toContain('*token*');
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-DEF-003');
+      expect(rule.severity).toBe('warning');
+      expect(rule.confidence).toBe('low');
+      expect(rule.references).toContain('CWE-754');
+      expect(rule.references).toContain('CWE-390');
+    });
+  });
+
+  // --- SEC-DEF-004: Permissive CORS Fallback ---
+  describe('SEC-DEF-004 — Permissive CORS Fallback', () => {
+    it('detects origin fallback to * with ??', () => {
+      expect(matches('SEC-DEF-004', `const origin = config?.origin ?? '*'`)).toBe(true);
+    });
+
+    it('detects origin fallback to * with ||', () => {
+      expect(matches('SEC-DEF-004', `const origin = options.origin || '*'`)).toBe(true);
+    });
+
+    it('detects cors fallback to *', () => {
+      expect(matches('SEC-DEF-004', `const cors = env.corsOrigin ?? '*'`)).toBe(true);
+    });
+
+    it('does not flag specific origin', () => {
+      expect(
+        matches('SEC-DEF-004', `const origin = config?.origin ?? 'https://example.com'`)
+      ).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-DEF-004');
+      expect(rule.severity).toBe('warning');
+      expect(rule.confidence).toBe('medium');
+      expect(rule.references).toContain('CWE-942');
+    });
+  });
+
+  // --- SEC-DEF-005: Rate Limiting Disabled by Default ---
+  describe('SEC-DEF-005 — Rate Limiting Disabled by Default', () => {
+    it('detects rateLimit fallback to false', () => {
+      expect(matches('SEC-DEF-005', 'rateLimit = config?.rateLimit ?? false')).toBe(true);
+    });
+
+    it('detects rateLimiting fallback to 0', () => {
+      expect(matches('SEC-DEF-005', 'rateLimiting = options.rateLimiting || 0')).toBe(true);
+    });
+
+    it('detects throttle fallback to null', () => {
+      expect(matches('SEC-DEF-005', 'throttle = config?.throttle ?? null')).toBe(true);
+    });
+
+    it('detects fallback to undefined', () => {
+      expect(matches('SEC-DEF-005', 'rateLimit = env.rateLimit || undefined')).toBe(true);
+    });
+
+    it('does not flag rateLimit set to a number', () => {
+      expect(matches('SEC-DEF-005', 'rateLimit = config?.rateLimit ?? 100')).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-DEF-005');
+      expect(rule.severity).toBe('info');
+      expect(rule.confidence).toBe('low');
+      expect(rule.references).toContain('CWE-770');
+    });
+  });
+
+  // --- Structural checks ---
+  describe('structural', () => {
+    it('exports all 5 rules', () => {
+      expect(insecureDefaultsRules).toHaveLength(5);
+    });
+
+    it('all rules have unique IDs', () => {
+      const ids = insecureDefaultsRules.map((r) => r.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('all rules have category "insecure-defaults"', () => {
+      for (const rule of insecureDefaultsRules) {
+        expect(rule.category).toBe('insecure-defaults');
+      }
+    });
+
+    it('all rules have at least one pattern', () => {
+      for (const rule of insecureDefaultsRules) {
+        expect(rule.patterns.length).toBeGreaterThanOrEqual(1);
+      }
+    });
+
+    it('all rules have CWE references', () => {
+      for (const rule of insecureDefaultsRules) {
+        expect(rule.references).toBeDefined();
+        expect(rule.references!.length).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+});

--- a/packages/core/tests/security/rules/medium-confidence.test.ts
+++ b/packages/core/tests/security/rules/medium-confidence.test.ts
@@ -10,6 +10,39 @@ describe('Path traversal rules', () => {
     expect(rule!.severity).toBe('warning');
     expect(rule!.patterns.some((p) => p.test('readFile(dir + "/../" + file)'))).toBe(true);
   });
+
+  it('detects ../ in writeFileSync', () => {
+    const rule = pathTraversalRules.find((r) => r.id === 'SEC-PTH-001')!;
+    expect(rule.patterns.some((p) => p.test('writeFileSync("../../etc/passwd", data)'))).toBe(
+      true
+    );
+  });
+
+  it('detects ../ in createReadStream', () => {
+    const rule = pathTraversalRules.find((r) => r.id === 'SEC-PTH-001')!;
+    expect(rule.patterns.some((p) => p.test('createReadStream(dir + "/../secret")'))).toBe(true);
+  });
+
+  it('detects string concatenation in readFile', () => {
+    const rule = pathTraversalRules.find((r) => r.id === 'SEC-PTH-001')!;
+    expect(rule.patterns.some((p) => p.test('readFile(basePath + userInput)'))).toBe(true);
+  });
+
+  it('detects string concatenation in writeFileSync', () => {
+    const rule = pathTraversalRules.find((r) => r.id === 'SEC-PTH-001')!;
+    expect(rule.patterns.some((p) => p.test('writeFileSync(dir + filename, data)'))).toBe(true);
+  });
+
+  it('does not flag safe path.join usage', () => {
+    const rule = pathTraversalRules.find((r) => r.id === 'SEC-PTH-001')!;
+    expect(rule.patterns.some((p) => p.test('readFile(path.join(dir, file))'))).toBe(false);
+  });
+
+  it('has correct metadata', () => {
+    const rule = pathTraversalRules.find((r) => r.id === 'SEC-PTH-001')!;
+    expect(rule.confidence).toBe('medium');
+    expect(rule.references).toContain('CWE-22');
+  });
 });
 
 describe('Network rules', () => {
@@ -41,5 +74,46 @@ describe('Deserialization rules', () => {
     const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001');
     expect(rule).toBeDefined();
     expect(rule!.severity).toBe('warning');
+  });
+
+  it('detects JSON.parse(req.body)', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.patterns.some((p) => p.test('const data = JSON.parse(req.body)'))).toBe(true);
+  });
+
+  it('detects JSON.parse(request.body)', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.patterns.some((p) => p.test('JSON.parse(request.body)'))).toBe(true);
+  });
+
+  it('detects JSON.parse(event)', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.patterns.some((p) => p.test('const obj = JSON.parse(event.body)'))).toBe(true);
+  });
+
+  it('detects JSON.parse(data)', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.patterns.some((p) => p.test('JSON.parse(data)'))).toBe(true);
+  });
+
+  it('detects JSON.parse(payload)', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.patterns.some((p) => p.test('JSON.parse(payload)'))).toBe(true);
+  });
+
+  it('detects JSON.parse(input)', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.patterns.some((p) => p.test('JSON.parse(input)'))).toBe(true);
+  });
+
+  it('does not flag JSON.parse with literal', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.patterns.some((p) => p.test(`JSON.parse('{"a":1}')`))).toBe(false);
+  });
+
+  it('has correct metadata', () => {
+    const rule = deserializationRules.find((r) => r.id === 'SEC-DES-001')!;
+    expect(rule.confidence).toBe('medium');
+    expect(rule.references).toContain('CWE-502');
   });
 });

--- a/packages/core/tests/security/rules/sharp-edges.test.ts
+++ b/packages/core/tests/security/rules/sharp-edges.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest';
+import { sharpEdgesRules } from '../../../src/security/rules/sharp-edges';
+
+function findRule(id: string) {
+  const rule = sharpEdgesRules.find((r) => r.id === id);
+  expect(rule).toBeDefined();
+  return rule!;
+}
+
+function matches(id: string, input: string): boolean {
+  return findRule(id).patterns.some((p) => p.test(input));
+}
+
+describe('Sharp-edges rules', () => {
+  // --- SEC-EDGE-001: Deprecated createCipher API ---
+  describe('SEC-EDGE-001 — Deprecated createCipher', () => {
+    it('detects crypto.createCipher()', () => {
+      expect(matches('SEC-EDGE-001', "crypto.createCipher('aes192', key)")).toBe(true);
+    });
+
+    it('detects crypto.createCipher with whitespace', () => {
+      expect(matches('SEC-EDGE-001', 'crypto.createCipher  (')).toBe(true);
+    });
+
+    it('does not flag createCipheriv', () => {
+      expect(matches('SEC-EDGE-001', "crypto.createCipheriv('aes-256-gcm', key, iv)")).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-001');
+      expect(rule.severity).toBe('error');
+      expect(rule.confidence).toBe('high');
+      expect(rule.references).toContain('CWE-327');
+    });
+  });
+
+  // --- SEC-EDGE-002: Deprecated createDecipher API ---
+  describe('SEC-EDGE-002 — Deprecated createDecipher', () => {
+    it('detects crypto.createDecipher()', () => {
+      expect(matches('SEC-EDGE-002', "crypto.createDecipher('aes192', key)")).toBe(true);
+    });
+
+    it('does not flag createDecipheriv', () => {
+      expect(matches('SEC-EDGE-002', "crypto.createDecipheriv('aes-256-gcm', key, iv)")).toBe(
+        false
+      );
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-002');
+      expect(rule.severity).toBe('error');
+      expect(rule.confidence).toBe('high');
+    });
+  });
+
+  // --- SEC-EDGE-003: ECB Mode ---
+  describe('SEC-EDGE-003 — ECB Mode Selection', () => {
+    it('detects aes-128-ecb', () => {
+      expect(matches('SEC-EDGE-003', `createCipheriv('aes-128-ecb', key, '')`)).toBe(true);
+    });
+
+    it('detects des-ecb', () => {
+      expect(matches('SEC-EDGE-003', `algorithm = "des-ecb"`)).toBe(true);
+    });
+
+    it('does not flag aes-256-gcm', () => {
+      expect(matches('SEC-EDGE-003', `createCipheriv('aes-256-gcm', key, iv)`)).toBe(false);
+    });
+
+    it('does not flag aes-256-cbc', () => {
+      expect(matches('SEC-EDGE-003', `createCipheriv('aes-256-cbc', key, iv)`)).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-003');
+      expect(rule.severity).toBe('warning');
+      expect(rule.confidence).toBe('high');
+    });
+  });
+
+  // --- SEC-EDGE-004: yaml.load Without Safe Loader ---
+  describe('SEC-EDGE-004 — yaml.load Without Safe Loader', () => {
+    it('detects yaml.load()', () => {
+      expect(matches('SEC-EDGE-004', 'data = yaml.load(file_content)')).toBe(true);
+    });
+
+    it('detects yaml.load with whitespace', () => {
+      expect(matches('SEC-EDGE-004', 'yaml.load  (stream)')).toBe(true);
+    });
+
+    it('has Python file glob', () => {
+      const rule = findRule('SEC-EDGE-004');
+      expect(rule.fileGlob).toBe('**/*.py');
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-004');
+      expect(rule.severity).toBe('error');
+      expect(rule.confidence).toBe('high');
+      expect(rule.references).toContain('CWE-502');
+    });
+  });
+
+  // --- SEC-EDGE-005: Pickle/Marshal Deserialization ---
+  describe('SEC-EDGE-005 — Pickle/Marshal Deserialization', () => {
+    it('detects pickle.load()', () => {
+      expect(matches('SEC-EDGE-005', 'obj = pickle.load(f)')).toBe(true);
+    });
+
+    it('detects pickle.loads()', () => {
+      expect(matches('SEC-EDGE-005', 'obj = pickle.loads(data)')).toBe(true);
+    });
+
+    it('detects marshal.load()', () => {
+      expect(matches('SEC-EDGE-005', 'obj = marshal.load(f)')).toBe(true);
+    });
+
+    it('detects marshal.loads()', () => {
+      expect(matches('SEC-EDGE-005', 'obj = marshal.loads(data)')).toBe(true);
+    });
+
+    it('does not flag json.loads()', () => {
+      expect(matches('SEC-EDGE-005', 'obj = json.loads(data)')).toBe(false);
+    });
+
+    it('has Python file glob', () => {
+      expect(findRule('SEC-EDGE-005').fileGlob).toBe('**/*.py');
+    });
+  });
+
+  // --- SEC-EDGE-006: TOCTOU Sync ---
+  describe('SEC-EDGE-006 — Check-Then-Act (Sync)', () => {
+    it('detects existsSync followed by readFileSync', () => {
+      expect(
+        matches('SEC-EDGE-006', 'if (existsSync(p)) { readFileSync(p) }')
+      ).toBe(true);
+    });
+
+    it('detects accessSync followed by writeFileSync', () => {
+      expect(
+        matches('SEC-EDGE-006', 'accessSync(file); writeFileSync(file, data)')
+      ).toBe(true);
+    });
+
+    it('detects statSync followed by unlinkSync', () => {
+      expect(
+        matches('SEC-EDGE-006', 'statSync(p); unlinkSync(p)')
+      ).toBe(true);
+    });
+
+    it('does not flag standalone readFileSync', () => {
+      expect(matches('SEC-EDGE-006', 'readFileSync(p)')).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-006');
+      expect(rule.severity).toBe('warning');
+      expect(rule.confidence).toBe('medium');
+      expect(rule.references).toContain('CWE-367');
+    });
+  });
+
+  // --- SEC-EDGE-007: TOCTOU Async ---
+  describe('SEC-EDGE-007 — Check-Then-Act (Async)', () => {
+    it('detects access followed by readFile', () => {
+      expect(
+        matches('SEC-EDGE-007', 'access(p).then(() => readFile(p))')
+      ).toBe(true);
+    });
+
+    it('detects stat followed by writeFile', () => {
+      expect(
+        matches('SEC-EDGE-007', 'await stat(file); await writeFile(file, data)')
+      ).toBe(true);
+    });
+
+    it('does not flag standalone writeFile', () => {
+      expect(matches('SEC-EDGE-007', 'await writeFile(p, data)')).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-007');
+      expect(rule.severity).toBe('warning');
+      expect(rule.confidence).toBe('medium');
+      expect(rule.references).toContain('CWE-367');
+    });
+  });
+
+  // --- SEC-EDGE-008: JWT Algorithm "none" ---
+  describe('SEC-EDGE-008 — JWT Algorithm "none"', () => {
+    it('detects algorithms: ["none"]', () => {
+      expect(matches('SEC-EDGE-008', `algorithms: ["none"]`)).toBe(true);
+    });
+
+    it('detects algorithm: "none"', () => {
+      expect(matches('SEC-EDGE-008', `algorithm: "none"`)).toBe(true);
+    });
+
+    it("detects algorithm = 'none'", () => {
+      expect(matches('SEC-EDGE-008', `algorithm = 'none'`)).toBe(true);
+    });
+
+    it("detects alg: 'none'", () => {
+      expect(matches('SEC-EDGE-008', `alg: 'none'`)).toBe(true);
+    });
+
+    it('does not flag algorithm: "HS256"', () => {
+      expect(matches('SEC-EDGE-008', `algorithm: "HS256"`)).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-008');
+      expect(rule.severity).toBe('error');
+      expect(rule.confidence).toBe('high');
+      expect(rule.references).toContain('CWE-345');
+    });
+  });
+
+  // --- SEC-EDGE-009: DES/RC4 Algorithm Selection ---
+  describe('SEC-EDGE-009 — DES/RC4 Algorithm Selection', () => {
+    it('detects "des"', () => {
+      expect(matches('SEC-EDGE-009', `cipher = "des"`)).toBe(true);
+    });
+
+    it('detects "des-ede3"', () => {
+      expect(matches('SEC-EDGE-009', `algorithm: "des-ede3"`)).toBe(true);
+    });
+
+    it('detects "rc4"', () => {
+      expect(matches('SEC-EDGE-009', `cipher = 'rc4'`)).toBe(true);
+    });
+
+    it('detects "blowfish"', () => {
+      expect(matches('SEC-EDGE-009', `algorithm: "blowfish"`)).toBe(true);
+    });
+
+    it('detects "rc2"', () => {
+      expect(matches('SEC-EDGE-009', `cipher = "rc2"`)).toBe(true);
+    });
+
+    it('does not flag "aes-256-gcm"', () => {
+      expect(matches('SEC-EDGE-009', `cipher = "aes-256-gcm"`)).toBe(false);
+    });
+
+    it('has correct metadata', () => {
+      const rule = findRule('SEC-EDGE-009');
+      expect(rule.severity).toBe('error');
+      expect(rule.confidence).toBe('high');
+      expect(rule.references).toContain('CWE-327');
+    });
+  });
+
+  // --- Structural checks ---
+  describe('structural', () => {
+    it('exports all 9 rules', () => {
+      expect(sharpEdgesRules).toHaveLength(9);
+    });
+
+    it('all rules have unique IDs', () => {
+      const ids = sharpEdgesRules.map((r) => r.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('all rules have category "sharp-edges"', () => {
+      for (const rule of sharpEdgesRules) {
+        expect(rule.category).toBe('sharp-edges');
+      }
+    });
+
+    it('all rules have at least one pattern', () => {
+      for (const rule of sharpEdgesRules) {
+        expect(rule.patterns.length).toBeGreaterThanOrEqual(1);
+      }
+    });
+
+    it('all rules have CWE references', () => {
+      for (const rule of sharpEdgesRules) {
+        expect(rule.references).toBeDefined();
+        expect(rule.references!.length).toBeGreaterThanOrEqual(1);
+        expect(rule.references!.every((r) => r.startsWith('CWE-'))).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/core/tests/security/rules/stack-rules.test.ts
+++ b/packages/core/tests/security/rules/stack-rules.test.ts
@@ -21,6 +21,63 @@ describe('Node.js rules', () => {
     // Should NOT match normal bracket access
     expect(rule!.patterns.some((p) => p.test('arr[0] = value'))).toBe(false);
   });
+
+  it('detects prototype[] access', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-001')!;
+    expect(rule.patterns.some((p) => p.test('obj.prototype[key] = val'))).toBe(true);
+  });
+
+  it('detects Object.assign with query input', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-001')!;
+    expect(rule.patterns.some((p) => p.test('Object.assign(target, query)'))).toBe(true);
+  });
+
+  it('detects NoSQL injection with $gt operator', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(rule).toBeDefined();
+    expect(rule.patterns.some((p) => p.test('db.find({ age: { $gt: input } })'))).toBe(true);
+  });
+
+  it('detects NoSQL injection with $ne operator', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(rule.patterns.some((p) => p.test('users.find({ password: { $ne: "" } })'))).toBe(true);
+  });
+
+  it('detects NoSQL injection with $regex operator', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(rule.patterns.some((p) => p.test('col.find({ name: { $regex: userInput } })'))).toBe(
+      true
+    );
+  });
+
+  it('detects NoSQL injection with $where operator', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(
+      rule.patterns.some((p) => p.test('db.find({ $where: "this.a > " + input })'))
+    ).toBe(true);
+  });
+
+  it('detects find with req.body directly', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(rule.patterns.some((p) => p.test('users.find(req.body)'))).toBe(true);
+  });
+
+  it('detects find with req.query directly', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(rule.patterns.some((p) => p.test('db.find(request.query)'))).toBe(true);
+  });
+
+  it('does not flag find with static query', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(rule.patterns.some((p) => p.test('users.find({ active: true })'))).toBe(false);
+  });
+
+  it('has correct metadata for NoSQL injection', () => {
+    const rule = nodeRules.find((r) => r.id === 'SEC-NODE-002')!;
+    expect(rule.severity).toBe('warning');
+    expect(rule.confidence).toBe('medium');
+    expect(rule.references).toContain('CWE-943');
+  });
 });
 
 describe('Express rules', () => {
@@ -29,6 +86,36 @@ describe('Express rules', () => {
       expect(rule.stack).toContain('express');
       expect(rule.id).toMatch(/^SEC-EXPRESS-/);
     }
+  });
+
+  it('detects Express app initialization for missing helmet', () => {
+    const rule = expressRules.find((r) => r.id === 'SEC-EXPRESS-001')!;
+    expect(rule.patterns.some((p) => p.test('const app = express()'))).toBe(true);
+  });
+
+  it('does not flag non-express assignments', () => {
+    const rule = expressRules.find((r) => r.id === 'SEC-EXPRESS-001')!;
+    expect(rule.patterns.some((p) => p.test('const app = createApp()'))).toBe(false);
+  });
+
+  it('detects unprotected POST route', () => {
+    const rule = expressRules.find((r) => r.id === 'SEC-EXPRESS-002')!;
+    expect(rule.patterns.some((p) => p.test("app.post('/api/users', req, res)"))).toBe(true);
+  });
+
+  it('detects unprotected PUT route', () => {
+    const rule = expressRules.find((r) => r.id === 'SEC-EXPRESS-002')!;
+    expect(rule.patterns.some((p) => p.test("app.put('/api/data', request)"))).toBe(true);
+  });
+
+  it('detects unprotected PATCH route', () => {
+    const rule = expressRules.find((r) => r.id === 'SEC-EXPRESS-002')!;
+    expect(rule.patterns.some((p) => p.test("app.patch('/api/item', req, res)"))).toBe(true);
+  });
+
+  it('does not flag GET routes', () => {
+    const rule = expressRules.find((r) => r.id === 'SEC-EXPRESS-002')!;
+    expect(rule.patterns.some((p) => p.test("app.get('/api/users', req, res)"))).toBe(false);
   });
 });
 
@@ -53,5 +140,38 @@ describe('Go rules', () => {
       expect(rule.stack).toContain('go');
       expect(rule.id).toMatch(/^SEC-GO-/);
     }
+  });
+
+  it('detects unsafe.Pointer usage', () => {
+    const rule = goRules.find((r) => r.id === 'SEC-GO-001')!;
+    expect(rule.patterns.some((p) => p.test('p := unsafe.Pointer(&x)'))).toBe(true);
+  });
+
+  it('does not flag safe pointer usage', () => {
+    const rule = goRules.find((r) => r.id === 'SEC-GO-001')!;
+    expect(rule.patterns.some((p) => p.test('var p *int = &x'))).toBe(false);
+  });
+
+  it('detects format string injection with variable format', () => {
+    const rule = goRules.find((r) => r.id === 'SEC-GO-002')!;
+    expect(rule.patterns.some((p) => p.test('fmt.Sprintf(userFmt)'))).toBe(true);
+  });
+
+  it('does not flag literal format strings', () => {
+    const rule = goRules.find((r) => r.id === 'SEC-GO-002')!;
+    expect(rule.patterns.some((p) => p.test('fmt.Sprintf("%s", name)'))).toBe(false);
+  });
+
+  it('has correct metadata for unsafe pointer', () => {
+    const rule = goRules.find((r) => r.id === 'SEC-GO-001')!;
+    expect(rule.severity).toBe('warning');
+    expect(rule.confidence).toBe('medium');
+    expect(rule.references).toContain('CWE-119');
+  });
+
+  it('has correct metadata for format string injection', () => {
+    const rule = goRules.find((r) => r.id === 'SEC-GO-002')!;
+    expect(rule.severity).toBe('warning');
+    expect(rule.references).toContain('CWE-134');
   });
 });


### PR DESCRIPTION
## Summary\n\n- Add **sharp-edges.test.ts** — 9 previously untested rules covering deprecated crypto APIs (createCipher/createDecipher), ECB mode, unsafe yaml.load, pickle/marshal deserialization, TOCTOU race conditions, JWT algorithm \"none\", and DES/RC4 selection\n- Add **insecure-defaults.test.ts** — 5 previously untested rules covering hardcoded security fallbacks, TLS disabled by default, swallowed auth errors, permissive CORS fallback, and rate limiting disabled\n- Expand existing test coverage for deserialization, path-traversal, Express, Go, and Node.js NoSQL injection patterns\n- Enforce coverage thresholds as CI blockers (`fail_ci_if_error: true`, `if_ci_failed: error` in codecov.yml)\n\nTotal: **185 security rule tests** across 11 test files (up from ~95 across 9 files).\n\nCloses security-rule-test-c-360d5f38 (E9/E10).\n\n## Test plan\n\n- [x] All 185 security rule tests pass (`pnpm vitest run tests/security/rules/`)\n- [x] All 265 security tests pass (`pnpm vitest run tests/security/`)\n- [x] No regressions in full core test suite (971 tests pass)\n- [ ] CI pipeline enforces coverage thresholds as blockers