### PR TITLE
docs(orchestrator): align PR-aware dispatch spec with identifier-based implementation

### DIFF
--- a/docs/changes/orchestrator-pr-aware-dispatch/proposal.md
+++ b/docs/changes/orchestrator-pr-aware-dispatch/proposal.md
@@ -4,7 +4,7 @@
 
 When the orchestrator polls for candidate work items, it dispatches agents to any roadmap feature with an active status (`planned`/`in-progress`) regardless of whether a pull request already exists for that feature. This leads to duplicate PRs, wasted agent compute, and potential merge conflicts.
 
-This change adds a pre-filter step in the orchestrator's tick cycle that checks each candidate's `externalId` against GitHub's PR API. Candidates with open PRs are excluded from dispatch. Closed, merged, or unreachable PRs are treated as dispatchable (fail-open).
+This change adds a pre-filter step in the orchestrator's tick cycle that checks each candidate's identifier against GitHub's PR API by looking for open PRs on the `feat/<identifier>` branch. Candidates with open PRs are excluded from dispatch. API errors are handled fail-open so the orchestrator stays available during GitHub outages.
 
 ### Goals
 
@@ -20,63 +20,63 @@ This change adds a pre-filter step in the orchestrator's tick cycle that checks 
 
 ## Decisions
 
-| #   | Decision                                                          | Rationale                                                                                                             |
-| --- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| 1   | Skip dispatch if PR is open; allow if closed/merged/absent        | Prevents duplicate work while allowing re-dispatch for abandoned or completed PRs                                     |
-| 2   | Filter in orchestrator tick, not tracker adapter or state machine | Orchestrator already owns `gh` integration; keeps tracker adapter as a pure file read and state machine as pure logic |
-| 3   | Dedicated `isExternalPROpen()` method                             | Purpose-built for the `github:owner/repo#N` format with graceful no-op for unknown schemes                            |
-| 4   | Fail open with warning on API errors                              | Matches existing `branchHasPullRequest()` pattern; orchestrator stays available during GitHub outages                 |
-| 5   | No caching                                                        | Candidate count with externalIds is small; stateless avoids stale-cache bugs                                          |
+| #   | Decision                                                          | Rationale                                                                                                                                      |
+| --- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Skip dispatch if open PR exists on `feat/<identifier>` branch     | Prevents duplicate work while allowing re-dispatch for abandoned or completed PRs                                                              |
+| 2   | Use identifier-based branch lookup, not externalId PR lookup      | ExternalIds reference GitHub **issues**, not PRs. Branch naming convention (`feat/<identifier>`) is reliable and used by all dispatched agents |
+| 3   | Filter in orchestrator tick, not tracker adapter or state machine | Orchestrator already owns `gh` integration; keeps tracker adapter as a pure file read and state machine as pure logic                          |
+| 4   | Dedicated `hasOpenPRForIdentifier()` method                       | Purpose-built for the `feat/<identifier>` branch naming convention with fail-open semantics                                                    |
+| 5   | Fail open with warning on API errors                              | Matches existing `branchHasPullRequest()` pattern; orchestrator stays available during GitHub outages                                          |
+| 6   | No caching                                                        | Candidate count is small; stateless avoids stale-cache bugs                                                                                    |
 
 ## Technical Design
 
-### New method: `isExternalPROpen()`
+### Method: `hasOpenPRForIdentifier()`
 
 - Location: `packages/orchestrator/src/orchestrator.ts`
-- Parses `externalId` string matching `github:<owner>/<repo>#<number>`
-- Calls `gh pr view <number> --repo <owner>/<repo> --json state --jq .state`
-- Returns `true` if state is `"OPEN"`, `false` otherwise
-- On parse failure (non-github scheme, malformed ID): returns `false` (fail-open, no warning — not a GitHub item)
-- On API failure (network, auth, rate limit): returns `false` (fail-open), logs warning via `this.logger.warn()`
+- Calls `gh pr list --head feat/<identifier> --state open --json number --jq length`
+- Returns `true` if count > 0 (open PR exists), `false` otherwise
+- On API failure (network, auth, rate limit, `gh` not installed): returns `false` (fail-open), logs warning via `this.logger.warn()`
+- Timeout: 10 seconds per check
 
-### New method: `filterCandidatesWithOpenPRs()`
+### Method: `filterCandidatesWithOpenPRs()`
 
 - Location: `packages/orchestrator/src/orchestrator.ts`
 - Takes `Issue[]`, returns `Promise<Issue[]>`
-- Runs `isExternalPROpen()` in parallel via `Promise.allSettled()` for all candidates where `externalId` is non-null
-- Candidates with null `externalId` pass through untouched
+- Runs `hasOpenPRForIdentifier()` in parallel via `Promise.allSettled()` for all candidates
 - Candidates where the check resolves to `true` (open PR) are excluded
-- Excluded candidates are logged at `info` level: `"Skipping <title>: open PR at <externalId>"`
+- Candidates where the promise rejects are included (fail-open)
+- Excluded candidates are logged at `info` level: `"Skipping <title>: open PR exists for feat/<identifier>"`
 
 ### Wiring in `asyncTick()`
 
-- Inserted between the `fetchCandidateIssues()` result and the `applyEvent(state, tickEvent)` call
+- Inserted between the `fetchCandidateIssues()` result and the `applyEvent(state, tickEvent)` call (step 1b)
 - The filtered candidates list replaces the raw candidates in the tick event payload
 
 ### File Layout
 
 No new files beyond tests:
 
-- `packages/orchestrator/src/orchestrator.ts` — two new private methods + one line change in `asyncTick()`
-- `packages/orchestrator/tests/orchestrator-pr-guard.test.ts` — new test file
+- `packages/orchestrator/src/orchestrator.ts` — two private methods + one line change in `asyncTick()`
+- `packages/orchestrator/tests/orchestrator-pr-guard.test.ts` — dedicated test file
 
 ### Data Structures
 
-No new types. Operates on existing `Issue` type (reads `externalId: string | null`). No changes to `RoadmapFeature`, `Issue`, or any shared types.
+No new types. Operates on existing `Issue` type (reads `identifier: string`). No changes to `RoadmapFeature`, `Issue`, or any shared types.
 
 ## Success Criteria
 
-1. When [candidate has externalId pointing to an open GitHub PR], the system shall [exclude it from dispatch].
-2. When [candidate has externalId pointing to a closed or merged PR], the system shall [dispatch it normally].
-3. When [candidate has null externalId], the system shall [dispatch it normally].
-4. When [candidate has non-github externalId scheme], the system shall [dispatch it normally without calling gh].
-5. If [`gh` API call fails], then the system shall [dispatch the candidate and log a warning].
+1. When [candidate has an open PR on its `feat/<identifier>` branch], the system shall [exclude it from dispatch].
+2. When [candidate has no open PR on its `feat/<identifier>` branch], the system shall [dispatch it normally].
+3. When [candidate has a closed or merged PR], the system shall [dispatch it normally].
+4. If [`gh` API call fails], then the system shall [dispatch the candidate and log a warning].
+5. If [`gh` command is not available or times out], then the system shall [dispatch the candidate and log a warning].
 6. The system shall not [modify the Issue type, tracker adapter interface, or state machine logic].
-7. All new code has unit test coverage.
+7. All new code has unit test coverage (8 tests across 3 suites).
 8. Existing orchestrator tests continue to pass.
 
 ## Implementation Order
 
-1. **Phase 1: Core methods** — Implement `isExternalPROpen()` and `filterCandidatesWithOpenPRs()` with unit tests
+1. **Phase 1: Core methods** — Implement `hasOpenPRForIdentifier()` and `filterCandidatesWithOpenPRs()` with unit tests
 2. **Phase 2: Wire into tick** — Insert filter call in `asyncTick()`, integration test with mixed candidates
 3. **Phase 3: Verify** — Run full orchestrator test suite, manual smoke test with a roadmap containing items with open PRs

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T11:51:53.001Z",
-  "updatedFrom": "10e16219",
+  "updatedAt": "2026-04-17T13:11:17.404Z",
+  "updatedFrom": "ff2423c6",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -14,16 +14,16 @@
     "complexity": {
       "value": 10,
       "violationIds": [
-        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
         "e68f61ff42c83a4d05b76c3decdf82e87d1342888c3a00b344e846f5a61a237a",
         "56ed30114fc75ea53f3d6d8bcec62360207b771d92cd3ec41b8747fd68ccfbbd",
         "d4ec740f23a61f0706b5f67aeed0ada23ea0570c711ceb92d7822f25d91e3b8f",
         "3134bf55d29a64d55636e6b6b3eaf5b5edc11bbbd07f56bce0b46e4e3f6af6a1",
         "0f5f3b45355e915c87896c1e259108826fb0d392636db20558e15f3a06605033",
         "7bd411727604fed60bdb72ef0df2d82b5e596bf22323caba71b4a09dffccbdaa",
-        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879",
+        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
         "b966e8d3abfeee3427bfe8a948d1d83ce1e6bffe473e72edb57aab9c0bb95c69",
-        "f685f2882a0af0a5ea9370005bff93b7333fece6e7d171581d4127c62c6e25f8"
+        "f685f2882a0af0a5ea9370005bff93b7333fece6e7d171581d4127c62c6e25f8",
+        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879"
       ]
     },
     "coupling": {


### PR DESCRIPTION
## Summary

- Updates the PR-aware dispatch guard proposal spec to reflect the actual implementation
- The spec previously described the original `externalId`-based approach (`isExternalPROpen` using `gh pr view <number>`), which was replaced by identifier-based branch lookup (`hasOpenPRForIdentifier` using `gh pr list --head feat/<identifier>`) in commit 59ea2049
- Aligns decisions, technical design, and success criteria with the current codebase

## Test plan

- [x] PR guard tests pass (8/8 in `orchestrator-pr-guard.test.ts`)
- [x] Full build passes
- [x] Pre-push hooks pass (format, typecheck, build, test)
- [x] No code changes — docs-only update