### PR TITLE
fix: eliminate baseline merge conflicts with merge=ours + CI refresh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,13 @@
 *.woff2 binary
 *.ttf binary
 *.eot binary
+
+# Auto-generated baseline files — use "ours" merge strategy to avoid
+# conflicts on every branch. Regenerate after merge instead.
+#
+# Requires one-time setup per clone:
+#   git config merge.ours.driver true
+.harness/**/baselines.json merge=ours
+packages/cli/.harness/**/baselines.json merge=ours
+coverage-baselines.json merge=ours
+benchmark-baselines.json merge=ours

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,47 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - run: pnpm test:platform-parity
+
+  # Regenerate auto-generated baselines on main after merge to prevent drift.
+  # These files use merge=ours in .gitattributes, so they need a post-merge
+  # refresh to stay accurate.
+  refresh-baselines:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      # Regenerate coverage baselines
+      - run: pnpm test:ci
+      - run: node scripts/coverage-ratchet.mjs --update
+
+      # Regenerate architecture baselines
+      - run: npx harness check-arch --update-baseline
+      - run: npx harness check-arch --update-baseline --module packages/cli
+
+      # Regenerate benchmark baselines
+      - run: node scripts/benchmark-check.mjs --update
+
+      # Commit and push if anything changed
+      - name: Commit refreshed baselines
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .harness/arch/baselines.json packages/cli/.harness/arch/baselines.json coverage-baselines.json benchmark-baselines.json
+          git diff --cached --quiet || git commit -m "chore: refresh baselines after merge [skip ci]"
+          git push

--- a/coverage-baselines.json
+++ b/coverage-baselines.json
@@ -1,15 +1,15 @@
 {
   "packages/core": {
-    "lines": 90.03,
-    "branches": 73.98,
-    "functions": 91.25,
-    "statements": 87.7
+    "lines": 89.86,
+    "branches": 73.94,
+    "functions": 91.15,
+    "statements": 87.52
   },
   "packages/graph": {
-    "lines": 95.8,
-    "branches": 80.85,
-    "functions": 97.17,
-    "statements": 94.2
+    "lines": 97.21,
+    "branches": 83.16,
+    "functions": 97.24,
+    "statements": 95.7
   },
   "packages/cli": {
     "lines": 81.19,

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T16:19:07.716Z",
-  "updatedFrom": "26823130",
+  "updatedAt": "2026-04-17T18:03:59.783Z",
+  "updatedFrom": "523b3693",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -14,16 +14,16 @@
     "complexity": {
       "value": 10,
       "violationIds": [
-        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
         "e68f61ff42c83a4d05b76c3decdf82e87d1342888c3a00b344e846f5a61a237a",
         "56ed30114fc75ea53f3d6d8bcec62360207b771d92cd3ec41b8747fd68ccfbbd",
         "d4ec740f23a61f0706b5f67aeed0ada23ea0570c711ceb92d7822f25d91e3b8f",
         "3134bf55d29a64d55636e6b6b3eaf5b5edc11bbbd07f56bce0b46e4e3f6af6a1",
         "0f5f3b45355e915c87896c1e259108826fb0d392636db20558e15f3a06605033",
         "7bd411727604fed60bdb72ef0df2d82b5e596bf22323caba71b4a09dffccbdaa",
-        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879",
+        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
         "b966e8d3abfeee3427bfe8a948d1d83ce1e6bffe473e72edb57aab9c0bb95c69",
-        "f685f2882a0af0a5ea9370005bff93b7333fece6e7d171581d4127c62c6e25f8"
+        "f685f2882a0af0a5ea9370005bff93b7333fece6e7d171581d4127c62c6e25f8",
+        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879"
       ]
     },
     "coupling": {


### PR DESCRIPTION
## Summary
- Adds `merge=ours` gitattributes strategy for all 4 auto-generated baseline files (`.harness/arch/baselines.json`, `packages/cli/.harness/arch/baselines.json`, `coverage-baselines.json`, `benchmark-baselines.json`) to prevent merge conflicts
- Adds a `refresh-baselines` CI job that regenerates all baselines from the true codebase state after every merge to `main`, preventing drift

## Problem
Every branch that runs harness validation or coverage updates regenerates baseline files with different timestamps, commit SHAs, and metric values. When two branches both touch these files, merge conflicts are guaranteed — even when the actual metrics are identical. This blocks PRs constantly.

## How it works
1. `.gitattributes` `merge=ours` tells git to keep the target branch's version of baseline files during merge, avoiding conflict markers entirely
2. After `build-and-test` passes on `main`, the `refresh-baselines` job regenerates all baselines from actual current state and auto-commits with `[skip ci]`
3. PR-time ratchet checks are unchanged — code that drops coverage or increases complexity still fails CI

## Setup
Requires one-time per-clone: `git config merge.ours.driver true`

## Test plan
- [ ] Verify `.gitattributes` entries cover all baseline file patterns
- [ ] Verify `refresh-baselines` job only runs on pushes to `main`
- [ ] Verify `refresh-baselines` runs after `build-and-test` succeeds
- [ ] Verify auto-commit uses `[skip ci]` to avoid infinite loop
- [ ] Verify PR-time coverage ratchet check is unaffected