### PR TITLE
feat: add scheduled maintenance commands to orchestrator

### DIFF
--- a/.harness/security/timeline.json
+++ b/.harness/security/timeline.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "capturedAt": "2026-04-17T20:29:07.746Z",
+      "capturedAt": "2026-04-17T20:30:02.714Z",
       "commitHash": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
       "securityScore": 87,
       "totalFindings": 13,
@@ -93,6 +93,2140 @@
         "e8a97c49175a3b99",
         "24150152dbda1db7",
         "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T20:30:59.204Z",
+      "commitHash": "706c3da0bee7a42e10ee2bbe83ad80dc9893f9fb",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T20:33:55.180Z",
+      "commitHash": "0aa6736001fd59cef5da4d4adae3a10e2eb0fe77",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T20:36:19.751Z",
+      "commitHash": "dd521c58689ddce904a206c284d423449d73f2f6",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T20:38:17.998Z",
+      "commitHash": "5a1a86d1fea9fda251ccb79f234283ff726a71c8",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T20:40:34.758Z",
+      "commitHash": "70f43049027b844d1662777f7d0af9752f418ab4",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T20:46:07.852Z",
+      "commitHash": "6728e6faeb3ca780a7e0b0a7cb4b9a9a59391c0d",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:11:24.531Z",
+      "commitHash": "e5ee62ad24f1315fb13695d6364539d925d1f093",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:15:11.885Z",
+      "commitHash": "dde79fdf3124822bc1dcaa695ce9e84393f47d84",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:16:30.800Z",
+      "commitHash": "9153d34b84b35bcd6eebf573f0c8259e9bdb6d70",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:17:51.535Z",
+      "commitHash": "99e4c6aef7f9ff3df92f1b52de48e55dc5455977",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:18:49.319Z",
+      "commitHash": "1eb36be2c5741fdbe1a765582b95033d7332f96a",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:20:09.649Z",
+      "commitHash": "f0bd6262e6ef68db7cb450618ab7598168cdc295",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:22:57.984Z",
+      "commitHash": "11855d0ea020bf9750f88db05ab2c37131c818a9",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:29:22.249Z",
+      "commitHash": "41d2ec3e93b6d30444a9e5fd0201f1d6827c90b6",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:37:05.498Z",
+      "commitHash": "18dfc806ce2be12551513b655f92bd191058485b",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:38:37.172Z",
+      "commitHash": "9c6ce1e1a53163ce10e057c488e998b032edd19a",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:39:30.619Z",
+      "commitHash": "83dd54f188d88ec8e611dd9011aeba892cd0af83",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:40:19.338Z",
+      "commitHash": "533c5b6e4b105a41e21de10ed93ac73af49433fb",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:41:04.387Z",
+      "commitHash": "e7db240f72cdd3d3dca80244e8704c0cbdc6b610",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:42:11.064Z",
+      "commitHash": "711e87df1277a016bfe4f67f1fdfa5c926cf0c31",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:43:46.040Z",
+      "commitHash": "55e91d794213ec9edf81851c19c2b99e73b35492",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:48:32.517Z",
+      "commitHash": "d311b769f46f5836ade39c7214df464914f0c3c1",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:55:11.039Z",
+      "commitHash": "734cc150de96036424bdc002c2e8524883419cd9",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:56:20.591Z",
+      "commitHash": "4766710f90a7f98a7ee0cd91c3a57203c341c5ba",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:57:16.913Z",
+      "commitHash": "397ee7901eb68f56644105f76db2066d1cfe2c47",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T21:58:49.968Z",
+      "commitHash": "28f8f4ec482a58c673761dd31569eff0078071e7",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T22:00:41.169Z",
+      "commitHash": "f6d0d7056ddc653d170babfeaeb3c199fad67252",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T22:02:17.101Z",
+      "commitHash": "1c72238691b2419e0177d4af3f6ca64f3c4a0226",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-17T22:07:15.910Z",
+      "commitHash": "868a3cd0833f8ab0ba10cc56b4a063801707a9a3",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:14:34.479Z",
+      "commitHash": "870419df94576d7ba2e6a72bff1f88410f4e427b",
+      "securityScore": 86,
+      "totalFindings": 14,
+      "bySeverity": {
+        "error": 0,
+        "warning": 14,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 12,
+          "errorCount": 0,
+          "warningCount": 12,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:19:17.046Z",
+      "commitHash": "339102855e36d1a39af5ed40b3d091bf4cbac2d5",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "3c86dc80741c9c0a",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:20:40.670Z",
+      "commitHash": "607bc769691ee0845b1cc30af71a5f560ae1b818",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "3c86dc80741c9c0a",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:22:09.697Z",
+      "commitHash": "d3de4d1f4698fa85648d2c8f0af9fc1520d258c1",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "3c86dc80741c9c0a",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:25:38.593Z",
+      "commitHash": "656a9a5dbef60b53e1e8703616875e4fb6a0370f",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "3c86dc80741c9c0a",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:26:51.541Z",
+      "commitHash": "848e93ce44a3df6ece32c4706a5acea873d41559",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "3c86dc80741c9c0a",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:30:45.436Z",
+      "commitHash": "7a069114f7577cc80b2946f1e4b9ee09a41efaed",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:37:26.783Z",
+      "commitHash": "af111f87fc692d43db3b75b6172cc07c4ade85e7",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:39:05.068Z",
+      "commitHash": "73632f9521ce5d3f3f5936f02a6c203ee8eac6ec",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:40:20.595Z",
+      "commitHash": "93aabe37875b7438cb85002f1f9e187dceadc916",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:42:09.101Z",
+      "commitHash": "633dc0f9cc9186d3cb8d4f60ab50e31318ae8d51",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:43:42.987Z",
+      "commitHash": "a3819fd722687326afe02b92186df59f077daa6d",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:47:23.532Z",
+      "commitHash": "caa538fe4369d3fe36c084ad60e7a4c50b7c96fc",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
+    },
+    {
+      "capturedAt": "2026-04-18T01:52:58.579Z",
+      "commitHash": "2331bcc28a8ea0d99c4754168244236a9ddc95b0",
+      "securityScore": 85,
+      "totalFindings": 15,
+      "bySeverity": {
+        "error": 0,
+        "warning": 15,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 13,
+          "errorCount": 0,
+          "warningCount": 13,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "8cade84e4dd5b7f9",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "6bdacfce437975de",
         "9d1df5abe906a5e7",
         "60f7b89030b68b4a",
         "dd953fca2b92a7c6",
@@ -384,6 +2518,39 @@
       "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/sessions.ts",
       "firstSeenAt": "2026-04-17T20:28:14.050Z",
       "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "8cade84e4dd5b7f9",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/maintenance/reporter.ts",
+      "firstSeenAt": "2026-04-18T01:13:59.407Z",
+      "firstSeenCommit": "870419df94576d7ba2e6a72bff1f88410f4e427b",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "3c86dc80741c9c0a",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/maintenance.ts",
+      "firstSeenAt": "2026-04-18T01:15:55.488Z",
+      "firstSeenCommit": "339102855e36d1a39af5ed40b3d091bf4cbac2d5",
+      "resolvedAt": "2026-04-18T01:30:45.369Z",
+      "resolvedCommit": "7a069114f7577cc80b2946f1e4b9ee09a41efaed"
+    },
+    {
+      "findingId": "6bdacfce437975de",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/maintenance.ts",
+      "firstSeenAt": "2026-04-18T01:30:45.369Z",
+      "firstSeenCommit": "7a069114f7577cc80b2946f1e4b9ee09a41efaed",
       "resolvedAt": null,
       "resolvedCommit": null
     }

--- a/.harness/security/timeline.json
+++ b/.harness/security/timeline.json
@@ -49,6 +49,55 @@
         "c864cfa8b0ede459",
         "729694623d7f9750"
       ]
+    },
+    {
+      "capturedAt": "2026-04-17T20:29:07.746Z",
+      "commitHash": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "securityScore": 87,
+      "totalFindings": 13,
+      "bySeverity": {
+        "error": 0,
+        "warning": 13,
+        "info": 0
+      },
+      "byCategory": {
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        },
+        "deserialization": {
+          "findingCount": 11,
+          "errorCount": 0,
+          "warningCount": 11,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "f393d9a37b102175",
+        "f4d102463af981f5",
+        "59486b7794d91d74",
+        "2a74142753e97847",
+        "5b7d862e73f3b35e",
+        "4acba46e4b1e8046",
+        "e8a97c49175a3b99",
+        "24150152dbda1db7",
+        "91b930ef98241bc7",
+        "9d1df5abe906a5e7",
+        "60f7b89030b68b4a",
+        "dd953fca2b92a7c6",
+        "dba391093a65ab79"
+      ]
     }
   ],
   "findingLifecycles": [
@@ -60,8 +109,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/cli/src/skill/dispatch-session.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "828750b8ac35e26a",
@@ -71,8 +120,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/dashboard/src/client/hooks/useOrchestratorSocket.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "c1eb9cf95e49d83c",
@@ -82,8 +131,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/dashboard/src/client/pages/Analyze.tsx",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "a8145add39c37fd9",
@@ -93,8 +142,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/dashboard/src/client/utils/chat-stream.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "27fbc3f3f5546c36",
@@ -104,8 +153,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/dashboard/src/server/routes/actions.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "4396de07948daf80",
@@ -115,8 +164,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/analyze.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "9459522898fc3cb3",
@@ -126,8 +175,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/chat-proxy.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "580e3aa6eb1b1732",
@@ -137,8 +186,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/dispatch-actions.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "84d7b1bfc635d0a0",
@@ -148,8 +197,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/interactions.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "e181d1409de6956f",
@@ -159,8 +208,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/plans.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "25edad92611b919c",
@@ -170,8 +219,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/roadmap-actions.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "c864cfa8b0ede459",
@@ -181,8 +230,8 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/sessions.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
     },
     {
       "findingId": "729694623d7f9750",
@@ -192,6 +241,149 @@
       "file": "/Users/cwarner/Projects/harness-engineering/.harness/workspaces/orchestrator-pr-awar-287e45a5/packages/orchestrator/src/server/routes/sessions.ts",
       "firstSeenAt": "2026-04-17T16:00:09.120Z",
       "firstSeenCommit": "9570d10f19220a7649ab1ff1e399696a73c1aa40",
+      "resolvedAt": "2026-04-17T20:28:14.050Z",
+      "resolvedCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796"
+    },
+    {
+      "findingId": "f393d9a37b102175",
+      "ruleId": "SEC-PTH-001",
+      "category": "path-traversal",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/cli/src/skill/dispatch-session.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "f4d102463af981f5",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/dashboard/src/client/hooks/useOrchestratorSocket.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "59486b7794d91d74",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/dashboard/src/client/pages/Analyze.tsx",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "2a74142753e97847",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/dashboard/src/client/utils/chat-stream.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "5b7d862e73f3b35e",
+      "ruleId": "SEC-PTH-001",
+      "category": "path-traversal",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/dashboard/src/server/routes/actions.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "4acba46e4b1e8046",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/analyze.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "e8a97c49175a3b99",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/chat-proxy.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "24150152dbda1db7",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/dispatch-actions.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "91b930ef98241bc7",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/interactions.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "9d1df5abe906a5e7",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/plans.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "60f7b89030b68b4a",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/roadmap-actions.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "dd953fca2b92a7c6",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/sessions.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "dba391093a65ab79",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "/Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/server/routes/sessions.ts",
+      "firstSeenAt": "2026-04-17T20:28:14.050Z",
+      "firstSeenCommit": "df3dd9b75d8db128ab8daeed68a5b200542c3796",
       "resolvedAt": null,
       "resolvedCommit": null
     }

--- a/docs/changes/scheduled-maintenance/proposal.md
+++ b/docs/changes/scheduled-maintenance/proposal.md
@@ -1,0 +1,335 @@
+# Scheduled Maintenance for Orchestrator
+
+## Overview and Goals
+
+The orchestrator gains a `MaintenanceScheduler` module that automatically keeps the codebase healthy by running mechanical checks and AI-powered cleanup tasks on configurable schedules. When issues are found, it creates or updates GitHub PRs with fixes. Multiple orchestrator instances coordinate via leader election so maintenance runs exactly once.
+
+### Goals
+
+1. Automatically detect and fix codebase health issues (architecture violations, dead code, doc drift, security findings, entropy) without human initiation
+2. Minimize token cost by defaulting AI tasks to a local model backend
+3. Keep PR noise low — one branch per maintenance category with additive commits and updated PR descriptions
+4. Provide dashboard visibility into maintenance schedule, status, and history with manual trigger capability
+5. Support multi-orchestrator deployments — only one instance runs maintenance at a time via ClaimManager leader election
+
+### Non-goals
+
+- Replacing manual code review — maintenance PRs still require human approval
+- Adding new maintenance checks — this feature orchestrates existing commands and skills
+- External scheduler integration (GitHub Actions, cron) — the orchestrator owns the schedule internally
+- Auto-merging maintenance PRs
+
+## Decisions
+
+| Decision                        | Choice                                                              | Rationale                                                                            |
+| ------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Module location                 | Separate module within orchestrator package (`src/maintenance/`)    | Clean separation without extraction refactor; reuses all orchestrator infrastructure |
+| Multi-orchestrator coordination | Leader election via ClaimManager                                    | Low-contention (daily/weekly tasks); existing pattern; TTL-based failover            |
+| Mechanical task execution       | Run check first, dispatch AI fix only if fixable issues found       | Minimizes unnecessary model invocations                                              |
+| Pure AI task execution          | Always dispatch on schedule regardless of mechanical results        | Some health tasks (dead code, hotspots, deep security) have no mechanical precursor  |
+| AI backend default              | `local` (Ollama/llama.cpp), configurable per-task                   | Token cost savings; user can override to cloud models for quality-sensitive tasks    |
+| PR lifecycle                    | One branch per category, additive commits, PR body updated each run | Preserves review history; auto-rebase on conflict; fresh branch if rebase fails      |
+| Dashboard integration           | Dedicated `/api/maintenance/*` endpoints + websocket events         | Maintenance is a distinct concern from issue dispatch; enables manual trigger        |
+| Configuration                   | `maintenance` section in `WorkflowConfig`                           | Follows existing config patterns; single source of truth; typed                      |
+
+## Technical Design
+
+### Module Structure
+
+```
+packages/orchestrator/src/maintenance/
+├── index.ts                 # Public API exports
+├── scheduler.ts             # MaintenanceScheduler class — cron evaluation, leader coordination, task dispatch
+├── task-registry.ts         # Built-in task definitions with defaults (schedule, type, branch, commands)
+├── task-runner.ts           # Executes mechanical checks and dispatches AI agents
+├── pr-manager.ts            # Branch lifecycle, PR creation/update, rebase/recreate on conflict
+├── reporter.ts              # Collects run results, exposes data for dashboard
+└── types.ts                 # MaintenanceConfig, TaskDefinition, RunResult, etc.
+```
+
+### Key Types
+
+```typescript
+// In @harness-engineering/types — extends WorkflowConfig
+interface MaintenanceConfig {
+  enabled: boolean;
+  aiBackend?: AgentBackend; // default: 'local'
+  baseBranch?: string; // default: 'main'
+  branchPrefix?: string; // default: 'harness-maint/'
+  leaderClaimTTLMs?: number; // default: 300_000 (5 min)
+  checkIntervalMs?: number; // default: 60_000 (1 min) — how often to evaluate cron
+  tasks?: Record<string, TaskOverride>;
+}
+
+interface TaskOverride {
+  enabled?: boolean;
+  schedule?: string; // cron expression override
+  aiBackend?: AgentBackend; // per-task backend override
+}
+
+// In packages/orchestrator/src/maintenance/types.ts
+type TaskType = 'mechanical-ai' | 'pure-ai' | 'report-only' | 'housekeeping';
+
+interface TaskDefinition {
+  id: string;
+  type: TaskType;
+  description: string;
+  schedule: string; // default cron expression
+  branch: string | null; // null for report-only/housekeeping
+  checkCommand?: string[]; // for mechanical-ai: CLI args to run check
+  fixSkill?: string; // skill to dispatch for AI fix
+  reportOnly?: boolean;
+}
+
+interface RunResult {
+  taskId: string;
+  startedAt: string;
+  completedAt: string;
+  status: 'success' | 'failure' | 'skipped' | 'no-issues';
+  findings: number;
+  fixed: number;
+  prUrl: string | null;
+  prUpdated: boolean;
+  error?: string;
+}
+
+interface MaintenanceStatus {
+  isLeader: boolean;
+  lastLeaderClaim: string | null;
+  schedule: Array<{ taskId: string; nextRun: string; lastRun: RunResult | null }>;
+  activeRun: { taskId: string; startedAt: string } | null;
+  history: RunResult[];
+}
+```
+
+### Task Registry
+
+#### Mechanical to AI Fix (check first, AI agent only if fixable issues found)
+
+| Task ID             | Check Command                       | Default Schedule                | Branch                             |
+| ------------------- | ----------------------------------- | ------------------------------- | ---------------------------------- |
+| `arch-violations`   | `check-arch`                        | `0 2 * * *` (daily 2am)         | `harness-maint/arch-fixes`         |
+| `dep-violations`    | `check-deps`                        | `0 2 * * *` (daily 2am)         | `harness-maint/dep-fixes`          |
+| `doc-drift`         | `check-docs`                        | `0 3 * * *` (daily 3am)         | `harness-maint/doc-fixes`          |
+| `security-findings` | `check-security`                    | `0 1 * * *` (daily 1am)         | `harness-maint/security-fixes`     |
+| `entropy`           | `cleanup` (detect mode)             | `0 3 * * *` (daily 3am)         | `harness-maint/entropy-fixes`      |
+| `traceability`      | `traceability` / `check-phase-gate` | `0 6 * * 1` (weekly Monday 6am) | `harness-maint/traceability-fixes` |
+| `cross-check`       | `validate-cross-check`              | `0 6 * * 1` (weekly Monday 6am) | `harness-maint/cross-check-fixes`  |
+
+#### Pure AI (always dispatch on schedule)
+
+| Task ID               | Skill                                            | Default Schedule                | Branch                        |
+| --------------------- | ------------------------------------------------ | ------------------------------- | ----------------------------- |
+| `dead-code`           | `cleanup-dead-code` / `harness-codebase-cleanup` | `0 2 * * 0` (weekly Sunday 2am) | `harness-maint/dead-code`     |
+| `dependency-health`   | `harness-dependency-health`                      | `0 3 * * 0` (weekly Sunday 3am) | `harness-maint/dep-health`    |
+| `hotspot-remediation` | `harness-hotspot-detector`                       | `0 4 * * 0` (weekly Sunday 4am) | `harness-maint/hotspot-fixes` |
+| `security-review`     | `harness-security-review`                        | `0 1 * * 0` (weekly Sunday 1am) | `harness-maint/security-deep` |
+
+#### Report-only (dashboard metrics, no PR)
+
+| Task ID             | Command                        | Default Schedule                |
+| ------------------- | ------------------------------ | ------------------------------- |
+| `perf-check`        | `check-perf`                   | `0 6 * * 1` (weekly Monday 6am) |
+| `decay-trends`      | `predict` / `get_decay_trends` | `0 7 * * 1` (weekly Monday 7am) |
+| `project-health`    | `assess_project`               | `0 6 * * *` (daily 6am)         |
+| `stale-constraints` | `detect_stale_constraints`     | `0 2 1 * *` (monthly 1st 2am)   |
+| `graph-refresh`     | `graph scan`                   | `0 1 * * *` (daily 1am)         |
+
+#### Housekeeping (mechanical, no AI)
+
+| Task ID           | Command                 | Default Schedule             |
+| ----------------- | ----------------------- | ---------------------------- |
+| `session-cleanup` | `cleanup-sessions`      | `0 0 * * *` (daily midnight) |
+| `perf-baselines`  | `perf baselines update` | `0 7 * * *` (daily 7am)      |
+
+### Scheduler Lifecycle
+
+```
+Orchestrator.start()
+  └── MaintenanceScheduler.start()
+        ├── Loads task registry (built-in defaults merged with config overrides)
+        ├── Starts check interval timer (every 60s):
+        │     ├── Attempt ClaimManager.claim('maintenance-leader', ttl)
+        │     ├── If not leader → skip, log debug
+        │     ├── If leader → evaluate cron for each enabled task
+        │     │     ├── If task is due → enqueue
+        │     │     └── If not due → skip
+        │     └── Process queue sequentially (one task at a time):
+        │           ├── Emit websocket: maintenance:started
+        │           ├── TaskRunner.run(task)
+        │           ├── Emit websocket: maintenance:completed | maintenance:error
+        │           └── Reporter.record(result)
+        └── Registers /api/maintenance/* routes on OrchestratorServer
+```
+
+### Task Execution Flow
+
+**Mechanical to AI:**
+
+```
+TaskRunner.runMechanicalAI(task)
+  ├── Run check command in-process (e.g., runCheckArch())
+  ├── Parse structured output for fixable issues
+  ├── If no fixable issues → return { status: 'no-issues' }
+  ├── If fixable issues found:
+  │     ├── PRManager.ensureBranch(task.branch, baseBranch)
+  │     ├── Dispatch AgentRunner with fixSkill to worktree on branch
+  │     ├── Agent commits fixes
+  │     ├── PRManager.ensurePR(task) — create or update
+  │     └── return { status: 'success', prUrl, findings, fixed }
+  └── On error → return { status: 'failure', error }
+```
+
+**Pure AI:**
+
+```
+TaskRunner.runPureAI(task)
+  ├── PRManager.ensureBranch(task.branch, baseBranch)
+  ├── Dispatch AgentRunner with fixSkill to worktree on branch
+  │     └── Backend forced to config.aiBackend (default: 'local')
+  ├── If agent produced commits:
+  │     ├── PRManager.ensurePR(task) — create or update
+  │     └── return { status: 'success', prUrl }
+  └── If no commits → return { status: 'no-issues' }
+```
+
+**Report-only:**
+
+```
+TaskRunner.runReport(task)
+  ├── Run check command in-process
+  ├── Reporter.recordMetrics(taskId, output)
+  └── return { status: 'success', findings }
+```
+
+### PR Manager Logic
+
+```
+PRManager.ensureBranch(branchName, baseBranch)
+  ├── Check if remote branch exists (git ls-remote)
+  ├── If exists → fetch and checkout
+  │     ├── Attempt rebase onto baseBranch
+  │     ├── If rebase fails → delete branch, recreate from baseBranch
+  │     └── Note in PR body: "Branch recreated due to conflicts"
+  └── If not exists → create from baseBranch
+
+PRManager.ensurePR(task)
+  ├── Check for open PR on branch (gh pr list --head <branch>)
+  ├── If PR exists:
+  │     ├── Push new commits
+  │     ├── Update PR body with latest run summary (gh pr edit)
+  │     └── return { prUpdated: true, prUrl }
+  └── If no PR:
+        ├── Push branch
+        ├── Create PR (gh pr create) with:
+        │     title: "[Maintenance] <task description>"
+        │     body: run summary, findings count, task schedule
+        │     labels: ['harness-maintenance', task.id]
+        └── return { prUpdated: false, prUrl }
+```
+
+### Dashboard API
+
+```
+GET  /api/maintenance/schedule   → MaintenanceStatus.schedule
+GET  /api/maintenance/status     → MaintenanceStatus (full)
+GET  /api/maintenance/history    → RunResult[] (paginated, ?limit=20&offset=0)
+POST /api/maintenance/trigger    → { taskId: string } — bypasses cron, respects leader
+```
+
+Websocket events on existing connection:
+
+```
+{ type: 'maintenance:started',   payload: { taskId, startedAt } }
+{ type: 'maintenance:completed', payload: RunResult }
+{ type: 'maintenance:error',     payload: { taskId, error } }
+```
+
+### File Layout Changes
+
+| Action | File                                                     | Purpose                                        |
+| ------ | -------------------------------------------------------- | ---------------------------------------------- |
+| CREATE | `packages/orchestrator/src/maintenance/index.ts`         | Public exports                                 |
+| CREATE | `packages/orchestrator/src/maintenance/scheduler.ts`     | Main scheduler class                           |
+| CREATE | `packages/orchestrator/src/maintenance/task-registry.ts` | 17 built-in task definitions                   |
+| CREATE | `packages/orchestrator/src/maintenance/task-runner.ts`   | Mechanical/AI/report execution                 |
+| CREATE | `packages/orchestrator/src/maintenance/pr-manager.ts`    | Branch + PR lifecycle                          |
+| CREATE | `packages/orchestrator/src/maintenance/reporter.ts`      | Run result collection + persistence            |
+| CREATE | `packages/orchestrator/src/maintenance/types.ts`         | Type definitions                               |
+| MODIFY | `packages/types/src/orchestrator.ts`                     | Add `MaintenanceConfig` to `WorkflowConfig`    |
+| MODIFY | `packages/orchestrator/src/orchestrator.ts`              | Initialize `MaintenanceScheduler` in `start()` |
+| MODIFY | `packages/orchestrator/src/server/http.ts`               | Register maintenance routes                    |
+| CREATE | `packages/orchestrator/src/server/routes/maintenance.ts` | REST endpoint handlers                         |
+| CREATE | `packages/orchestrator/tests/maintenance/`               | Test suite for all modules                     |
+
+## Success Criteria
+
+1. **Scheduler runs on schedule** — When `maintenance.enabled` is true, tasks execute at their configured cron times. Verified by: unit tests with mocked clock advancing past cron boundaries.
+
+2. **Leader election prevents duplicate runs** — When multiple orchestrators are running, only one claims `maintenance-leader` and executes tasks. Verified by: integration test with two scheduler instances sharing a ClaimManager.
+
+3. **Mechanical checks gate AI dispatch** — For `mechanical-ai` tasks, the AI agent is only dispatched when the check produces fixable findings. Verified by: test with zero-finding check output produces `status: 'no-issues'` and no agent invocation.
+
+4. **Pure AI tasks always dispatch** — `pure-ai` tasks dispatch an agent on schedule regardless of any precondition. Verified by: test confirming agent dispatch with no prior check step.
+
+5. **AI backend defaults to local** — When no override is configured, `AgentRunner` receives `backend: 'local'`. Verified by: asserting backend parameter in agent dispatch call.
+
+6. **PR created on first run with findings** — When a task produces fixes and no PR exists, a new PR is created with the `harness-maintenance` label. Verified by: mocked `gh` calls asserting `pr create` invocation with correct args.
+
+7. **PR updated on subsequent runs** — When a task produces fixes and a PR already exists on the branch, new commits are pushed and the PR body is updated. Verified by: mocked `gh` calls asserting `pr edit` invocation.
+
+8. **Stale branch rebased or recreated** — When a maintenance branch conflicts with the base branch, rebase is attempted. If rebase fails, the branch is recreated from the base. Verified by: test with simulated merge conflict triggering branch recreation.
+
+9. **Dashboard endpoints return correct data** — `GET /api/maintenance/schedule` returns next-run times, `GET /api/maintenance/status` returns current state, `GET /api/maintenance/history` returns past results. Verified by: HTTP tests against running server.
+
+10. **Manual trigger works** — `POST /api/maintenance/trigger` with a valid `taskId` enqueues and executes the task outside the normal schedule. Verified by: HTTP test confirming task execution after POST.
+
+11. **Report-only tasks produce no PR** — Tasks with `type: 'report-only'` record metrics to the reporter but never create branches or PRs. Verified by: asserting no `gh` or `git` calls for report-only task runs.
+
+12. **Config overrides apply** — Per-task `enabled`, `schedule`, and `aiBackend` overrides in `WorkflowConfig.maintenance.tasks` take precedence over built-in defaults. Verified by: unit test with override config asserting changed behavior.
+
+## Implementation Order
+
+### Phase 1: Types and Task Registry
+
+- Add `MaintenanceConfig` and `TaskOverride` to `@harness-engineering/types`
+- Create `types.ts` with internal types (`TaskDefinition`, `RunResult`, `MaintenanceStatus`)
+- Create `task-registry.ts` with all 17 built-in task definitions and default cron schedules
+- Wire `maintenance?` into `WorkflowConfig`
+
+### Phase 2: Scheduler Core
+
+- Create `scheduler.ts` with `MaintenanceScheduler` class
+- Implement cron evaluation loop (check interval timer, cron matching, task queueing)
+- Integrate ClaimManager leader election (`maintenance-leader` claim with TTL)
+- Wire into `Orchestrator.start()` / `Orchestrator.stop()`
+
+### Phase 3: Task Runner
+
+- Create `task-runner.ts` with execution paths for all four task types
+- Mechanical-AI: invoke check command in-process, parse structured output, gate on fixable findings
+- Pure-AI: dispatch AgentRunner with configured backend
+- Report-only: run check, record metrics
+- Housekeeping: run cleanup commands directly
+
+### Phase 4: PR Manager
+
+- Create `pr-manager.ts` with branch and PR lifecycle
+- `ensureBranch()`: create, fetch, rebase, or recreate from base
+- `ensurePR()`: detect existing PR, create or update, manage labels and body
+- Integration with `gh` CLI for PR operations
+
+### Phase 5: Reporter and Dashboard
+
+- Create `reporter.ts` for run result collection and persistence (JSON file in `.harness/maintenance/`)
+- Create `packages/orchestrator/src/server/routes/maintenance.ts` with REST endpoints
+- Add websocket event emissions (`maintenance:started`, `maintenance:completed`, `maintenance:error`)
+- Register routes in `OrchestratorServer`
+
+### Phase 6: Tests
+
+- Unit tests for cron evaluation, task registry merging, config overrides
+- Unit tests for PR manager (branch lifecycle, PR create/update, rebase/recreate)
+- Unit tests for task runner (each task type, backend selection, gating logic)
+- Integration test for leader election (two schedulers, one ClaimManager)
+- HTTP tests for all dashboard endpoints and manual trigger

--- a/docs/plans/2026-04-17-scheduled-maintenance-phase1-types-registry-plan.md
+++ b/docs/plans/2026-04-17-scheduled-maintenance-phase1-types-registry-plan.md
@@ -1,0 +1,784 @@
+# Plan: Scheduled Maintenance -- Phase 1: Types and Task Registry
+
+**Date:** 2026-04-17 | **Spec:** docs/changes/scheduled-maintenance/proposal.md | **Tasks:** 6 | **Time:** ~25 min
+
+## Goal
+
+The types package exports `MaintenanceConfig` and `TaskOverride`, the orchestrator package contains internal maintenance types and a complete task registry with all 17 built-in task definitions, and `WorkflowConfig` accepts an optional `maintenance` property.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When `import type { MaintenanceConfig, TaskOverride } from '@harness-engineering/types'` is written in a consuming file, the TypeScript compiler resolves both types without error.
+2. The system shall expose `WorkflowConfig.maintenance` typed as `MaintenanceConfig | undefined` (optional property on the existing interface).
+3. When `packages/orchestrator/src/maintenance/types.ts` is imported, it exports `TaskType`, `TaskDefinition`, `RunResult`, and `MaintenanceStatus`.
+4. When `packages/orchestrator/src/maintenance/task-registry.ts` is imported, it exports a `BUILT_IN_TASKS` array containing exactly 17 `TaskDefinition` entries.
+5. Each of the 17 task definitions has the correct `id`, `type`, `schedule`, and `branch` matching the spec tables.
+6. When `npx vitest run tests/maintenance/` is executed in the orchestrator package, all tests pass.
+7. When `harness validate` is executed, it passes.
+
+## Decisions
+
+| Decision                             | Choice                                            | Rationale                                                                                                                                                                   |
+| ------------------------------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MaintenanceConfig.aiBackend` type   | `string` (not `AgentBackend` interface)           | The spec says `default: 'local'` which is a string. `AgentConfig.backend` is already typed as `string`. The `AgentBackend` interface has methods and is not a config value. |
+| Location of public maintenance types | `packages/types/src/maintenance.ts`               | Follows existing pattern: domain types in separate files (`ci.ts`, `roadmap.ts`, `telemetry.ts`), re-exported from `index.ts`.                                              |
+| Task registry export shape           | `const BUILT_IN_TASKS: readonly TaskDefinition[]` | Readonly array prevents mutation. Consumers can look up by `id` or filter by `type`.                                                                                        |
+
+## File Map
+
+```
+CREATE  packages/types/src/maintenance.ts
+MODIFY  packages/types/src/orchestrator.ts          (add MaintenanceConfig to WorkflowConfig)
+MODIFY  packages/types/src/index.ts                 (add maintenance exports)
+CREATE  packages/orchestrator/src/maintenance/types.ts
+CREATE  packages/orchestrator/src/maintenance/task-registry.ts
+CREATE  packages/orchestrator/src/maintenance/index.ts
+CREATE  packages/orchestrator/tests/maintenance/types.test.ts
+CREATE  packages/orchestrator/tests/maintenance/task-registry.test.ts
+```
+
+## Tasks
+
+### Task 1: Create public maintenance types in @harness-engineering/types
+
+**Depends on:** none | **Files:** `packages/types/src/maintenance.ts`
+
+1. Create `packages/types/src/maintenance.ts` with the following content:
+
+```typescript
+/**
+ * Per-task overrides in the maintenance configuration.
+ */
+export interface TaskOverride {
+  /** Whether this task is enabled (default: true) */
+  enabled?: boolean;
+  /** Cron expression override for this task's schedule */
+  schedule?: string;
+  /** Backend name override for AI tasks (e.g., 'local', 'claude') */
+  aiBackend?: string;
+}
+
+/**
+ * Configuration for the scheduled maintenance module.
+ * Added as an optional property on WorkflowConfig.
+ */
+export interface MaintenanceConfig {
+  /** Whether scheduled maintenance is enabled */
+  enabled: boolean;
+  /** Default AI backend name for maintenance tasks (default: 'local') */
+  aiBackend?: string;
+  /** Base branch for maintenance PRs (default: 'main') */
+  baseBranch?: string;
+  /** Prefix for maintenance branch names (default: 'harness-maint/') */
+  branchPrefix?: string;
+  /** TTL in ms for the leader election claim (default: 300000) */
+  leaderClaimTTLMs?: number;
+  /** How often in ms to evaluate cron schedules (default: 60000) */
+  checkIntervalMs?: number;
+  /** Per-task overrides keyed by task ID */
+  tasks?: Record<string, TaskOverride>;
+}
+```
+
+2. Run: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx harness validate`
+3. Commit: `feat(types): add MaintenanceConfig and TaskOverride types`
+
+---
+
+### Task 2: Wire MaintenanceConfig into WorkflowConfig and re-export from index
+
+**Depends on:** Task 1 | **Files:** `packages/types/src/orchestrator.ts`, `packages/types/src/index.ts`
+
+1. In `packages/types/src/orchestrator.ts`, add the import at the top (after the existing `import type { Result } from './result';`):
+
+```typescript
+import type { MaintenanceConfig } from './maintenance';
+```
+
+2. In `packages/types/src/orchestrator.ts`, add the `maintenance` property to `WorkflowConfig` (after the `intelligence?` line):
+
+```typescript
+  /** Scheduled maintenance settings */
+  maintenance?: MaintenanceConfig;
+```
+
+3. In `packages/types/src/index.ts`, add a new section after the Orchestrator exports:
+
+```typescript
+// --- Maintenance ---
+export type { MaintenanceConfig, TaskOverride } from './maintenance';
+```
+
+4. Run: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx tsc --noEmit -p packages/types/tsconfig.json`
+5. Run: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx harness validate`
+6. Commit: `feat(types): wire MaintenanceConfig into WorkflowConfig and export`
+
+---
+
+### Task 3: Create internal maintenance types in orchestrator package
+
+**Depends on:** none (parallel with Tasks 1-2) | **Files:** `packages/orchestrator/src/maintenance/types.ts`
+
+1. Create directory: `mkdir -p /Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/src/maintenance`
+2. Create `packages/orchestrator/src/maintenance/types.ts` with the following content:
+
+```typescript
+/**
+ * Internal types for the maintenance module.
+ * Public config types (MaintenanceConfig, TaskOverride) live in @harness-engineering/types.
+ */
+
+/**
+ * Classification of maintenance task execution strategy.
+ *
+ * - mechanical-ai: Run a check command first; dispatch AI agent only if fixable issues are found.
+ * - pure-ai: Always dispatch an AI agent on schedule regardless of preconditions.
+ * - report-only: Run a command and record metrics; never create branches or PRs.
+ * - housekeeping: Run a mechanical command directly; no AI, no PR.
+ */
+export type TaskType = 'mechanical-ai' | 'pure-ai' | 'report-only' | 'housekeeping';
+
+/**
+ * Definition of a built-in maintenance task.
+ */
+export interface TaskDefinition {
+  /** Unique identifier for this task (e.g., 'arch-violations') */
+  id: string;
+  /** Execution strategy */
+  type: TaskType;
+  /** Human-readable description */
+  description: string;
+  /** Default cron expression (e.g., '0 2 * * *' for daily at 2am) */
+  schedule: string;
+  /** Branch name for PRs, or null for report-only/housekeeping tasks */
+  branch: string | null;
+  /** CLI command args for the mechanical check step (mechanical-ai and report-only) */
+  checkCommand?: string[];
+  /** Skill name to dispatch for AI fix (mechanical-ai and pure-ai) */
+  fixSkill?: string;
+}
+
+/**
+ * Result of a single maintenance task run.
+ */
+export interface RunResult {
+  /** ID of the task that was run */
+  taskId: string;
+  /** ISO timestamp when the run started */
+  startedAt: string;
+  /** ISO timestamp when the run completed */
+  completedAt: string;
+  /** Outcome of the run */
+  status: 'success' | 'failure' | 'skipped' | 'no-issues';
+  /** Number of issues/findings detected */
+  findings: number;
+  /** Number of issues fixed */
+  fixed: number;
+  /** URL of the created/updated PR, or null if no PR was created */
+  prUrl: string | null;
+  /** Whether an existing PR was updated (vs newly created) */
+  prUpdated: boolean;
+  /** Error message if status is 'failure' */
+  error?: string;
+}
+
+/**
+ * Schedule entry for a single task, used in MaintenanceStatus.
+ */
+export interface ScheduleEntry {
+  /** Task identifier */
+  taskId: string;
+  /** ISO timestamp of the next scheduled run */
+  nextRun: string;
+  /** Result of the most recent run, or null if never run */
+  lastRun: RunResult | null;
+}
+
+/**
+ * Overall maintenance module status, exposed via dashboard API.
+ */
+export interface MaintenanceStatus {
+  /** Whether this orchestrator instance is the maintenance leader */
+  isLeader: boolean;
+  /** ISO timestamp of the last successful leader claim, or null */
+  lastLeaderClaim: string | null;
+  /** Schedule state for all enabled tasks */
+  schedule: ScheduleEntry[];
+  /** Currently executing task, or null if idle */
+  activeRun: { taskId: string; startedAt: string } | null;
+  /** History of completed runs (most recent first) */
+  history: RunResult[];
+}
+```
+
+3. Run: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx harness validate`
+4. Commit: `feat(orchestrator): add internal maintenance type definitions`
+
+---
+
+### Task 4: Create test file for internal types and task registry
+
+**Depends on:** Task 3 | **Files:** `packages/orchestrator/tests/maintenance/types.test.ts`, `packages/orchestrator/tests/maintenance/task-registry.test.ts`
+
+1. Create directory: `mkdir -p /Users/cwarner/Projects/harness-engineering-maintenance/packages/orchestrator/tests/maintenance`
+
+2. Create `packages/orchestrator/tests/maintenance/types.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import type {
+  TaskType,
+  TaskDefinition,
+  RunResult,
+  MaintenanceStatus,
+  ScheduleEntry,
+} from '../../src/maintenance/types';
+
+describe('maintenance internal types', () => {
+  it('TaskType accepts all four valid values', () => {
+    const types: TaskType[] = ['mechanical-ai', 'pure-ai', 'report-only', 'housekeeping'];
+    expect(types).toHaveLength(4);
+  });
+
+  it('TaskDefinition can be constructed with required fields', () => {
+    const task: TaskDefinition = {
+      id: 'test-task',
+      type: 'mechanical-ai',
+      description: 'A test task',
+      schedule: '0 2 * * *',
+      branch: 'harness-maint/test',
+      checkCommand: ['check-arch'],
+      fixSkill: 'harness-arch-fix',
+    };
+    expect(task.id).toBe('test-task');
+    expect(task.type).toBe('mechanical-ai');
+    expect(task.branch).toBe('harness-maint/test');
+  });
+
+  it('TaskDefinition allows null branch for report-only tasks', () => {
+    const task: TaskDefinition = {
+      id: 'report-task',
+      type: 'report-only',
+      description: 'A report task',
+      schedule: '0 6 * * 1',
+      branch: null,
+      checkCommand: ['check-perf'],
+    };
+    expect(task.branch).toBeNull();
+  });
+
+  it('RunResult can represent a successful run with PR', () => {
+    const result: RunResult = {
+      taskId: 'arch-violations',
+      startedAt: '2026-04-17T02:00:00Z',
+      completedAt: '2026-04-17T02:05:00Z',
+      status: 'success',
+      findings: 3,
+      fixed: 2,
+      prUrl: 'https://github.com/org/repo/pull/42',
+      prUpdated: false,
+    };
+    expect(result.status).toBe('success');
+    expect(result.prUrl).not.toBeNull();
+  });
+
+  it('RunResult can represent a no-issues run', () => {
+    const result: RunResult = {
+      taskId: 'arch-violations',
+      startedAt: '2026-04-17T02:00:00Z',
+      completedAt: '2026-04-17T02:01:00Z',
+      status: 'no-issues',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+    };
+    expect(result.status).toBe('no-issues');
+    expect(result.findings).toBe(0);
+  });
+
+  it('RunResult can represent a failure with error', () => {
+    const result: RunResult = {
+      taskId: 'entropy',
+      startedAt: '2026-04-17T03:00:00Z',
+      completedAt: '2026-04-17T03:00:05Z',
+      status: 'failure',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+      error: 'Command exited with code 1',
+    };
+    expect(result.status).toBe('failure');
+    expect(result.error).toBeDefined();
+  });
+
+  it('MaintenanceStatus represents idle state', () => {
+    const status: MaintenanceStatus = {
+      isLeader: true,
+      lastLeaderClaim: '2026-04-17T02:00:00Z',
+      schedule: [],
+      activeRun: null,
+      history: [],
+    };
+    expect(status.isLeader).toBe(true);
+    expect(status.activeRun).toBeNull();
+  });
+
+  it('ScheduleEntry links a task to its next run and last result', () => {
+    const entry: ScheduleEntry = {
+      taskId: 'arch-violations',
+      nextRun: '2026-04-18T02:00:00Z',
+      lastRun: {
+        taskId: 'arch-violations',
+        startedAt: '2026-04-17T02:00:00Z',
+        completedAt: '2026-04-17T02:05:00Z',
+        status: 'success',
+        findings: 3,
+        fixed: 2,
+        prUrl: 'https://github.com/org/repo/pull/42',
+        prUpdated: true,
+      },
+    };
+    expect(entry.taskId).toBe('arch-violations');
+    expect(entry.lastRun?.status).toBe('success');
+  });
+});
+```
+
+3. Create `packages/orchestrator/tests/maintenance/task-registry.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { BUILT_IN_TASKS } from '../../src/maintenance/task-registry';
+import type { TaskDefinition, TaskType } from '../../src/maintenance/types';
+
+describe('task-registry', () => {
+  it('exports exactly 17 built-in task definitions', () => {
+    expect(BUILT_IN_TASKS).toHaveLength(17);
+  });
+
+  it('every task has a unique id', () => {
+    const ids = BUILT_IN_TASKS.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every task has a non-empty schedule (cron expression)', () => {
+    for (const task of BUILT_IN_TASKS) {
+      expect(task.schedule).toBeTruthy();
+      // Basic cron format: 5 space-separated fields
+      expect(task.schedule.split(' ')).toHaveLength(5);
+    }
+  });
+
+  it('every task has a valid type', () => {
+    const validTypes: TaskType[] = ['mechanical-ai', 'pure-ai', 'report-only', 'housekeeping'];
+    for (const task of BUILT_IN_TASKS) {
+      expect(validTypes).toContain(task.type);
+    }
+  });
+
+  it('mechanical-ai tasks have checkCommand and fixSkill', () => {
+    const mechanicalAi = BUILT_IN_TASKS.filter((t) => t.type === 'mechanical-ai');
+    expect(mechanicalAi.length).toBe(7);
+    for (const task of mechanicalAi) {
+      expect(task.checkCommand).toBeDefined();
+      expect(task.checkCommand!.length).toBeGreaterThan(0);
+      expect(task.fixSkill).toBeDefined();
+      expect(task.branch).not.toBeNull();
+    }
+  });
+
+  it('pure-ai tasks have fixSkill and branch but no checkCommand', () => {
+    const pureAi = BUILT_IN_TASKS.filter((t) => t.type === 'pure-ai');
+    expect(pureAi.length).toBe(4);
+    for (const task of pureAi) {
+      expect(task.fixSkill).toBeDefined();
+      expect(task.branch).not.toBeNull();
+      expect(task.checkCommand).toBeUndefined();
+    }
+  });
+
+  it('report-only tasks have checkCommand and null branch', () => {
+    const reportOnly = BUILT_IN_TASKS.filter((t) => t.type === 'report-only');
+    expect(reportOnly.length).toBe(4);
+    for (const task of reportOnly) {
+      expect(task.checkCommand).toBeDefined();
+      expect(task.branch).toBeNull();
+      expect(task.fixSkill).toBeUndefined();
+    }
+  });
+
+  it('housekeeping tasks have checkCommand and null branch', () => {
+    const housekeeping = BUILT_IN_TASKS.filter((t) => t.type === 'housekeeping');
+    expect(housekeeping.length).toBe(2);
+    for (const task of housekeeping) {
+      expect(task.checkCommand).toBeDefined();
+      expect(task.branch).toBeNull();
+      expect(task.fixSkill).toBeUndefined();
+    }
+  });
+
+  describe('specific task IDs and schedules from spec', () => {
+    const taskMap = new Map<string, TaskDefinition>();
+    for (const t of BUILT_IN_TASKS) {
+      taskMap.set(t.id, t);
+    }
+
+    // Mechanical-AI tasks
+    it('arch-violations: daily 2am, mechanical-ai', () => {
+      const t = taskMap.get('arch-violations')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 2 * * *');
+      expect(t.branch).toBe('harness-maint/arch-fixes');
+      expect(t.checkCommand).toEqual(['check-arch']);
+    });
+
+    it('dep-violations: daily 2am, mechanical-ai', () => {
+      const t = taskMap.get('dep-violations')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 2 * * *');
+      expect(t.branch).toBe('harness-maint/dep-fixes');
+      expect(t.checkCommand).toEqual(['check-deps']);
+    });
+
+    it('doc-drift: daily 3am, mechanical-ai', () => {
+      const t = taskMap.get('doc-drift')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 3 * * *');
+      expect(t.branch).toBe('harness-maint/doc-fixes');
+    });
+
+    it('security-findings: daily 1am, mechanical-ai', () => {
+      const t = taskMap.get('security-findings')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 1 * * *');
+      expect(t.branch).toBe('harness-maint/security-fixes');
+    });
+
+    it('entropy: daily 3am, mechanical-ai', () => {
+      const t = taskMap.get('entropy')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 3 * * *');
+      expect(t.branch).toBe('harness-maint/entropy-fixes');
+    });
+
+    it('traceability: weekly Monday 6am, mechanical-ai', () => {
+      const t = taskMap.get('traceability')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 6 * * 1');
+      expect(t.branch).toBe('harness-maint/traceability-fixes');
+    });
+
+    it('cross-check: weekly Monday 6am, mechanical-ai', () => {
+      const t = taskMap.get('cross-check')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 6 * * 1');
+      expect(t.branch).toBe('harness-maint/cross-check-fixes');
+    });
+
+    // Pure-AI tasks
+    it('dead-code: weekly Sunday 2am, pure-ai', () => {
+      const t = taskMap.get('dead-code')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 2 * * 0');
+      expect(t.branch).toBe('harness-maint/dead-code');
+    });
+
+    it('dependency-health: weekly Sunday 3am, pure-ai', () => {
+      const t = taskMap.get('dependency-health')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 3 * * 0');
+      expect(t.branch).toBe('harness-maint/dep-health');
+    });
+
+    it('hotspot-remediation: weekly Sunday 4am, pure-ai', () => {
+      const t = taskMap.get('hotspot-remediation')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 4 * * 0');
+      expect(t.branch).toBe('harness-maint/hotspot-fixes');
+    });
+
+    it('security-review: weekly Sunday 1am, pure-ai', () => {
+      const t = taskMap.get('security-review')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 1 * * 0');
+      expect(t.branch).toBe('harness-maint/security-deep');
+    });
+
+    // Report-only tasks
+    it('perf-check: weekly Monday 6am, report-only', () => {
+      const t = taskMap.get('perf-check')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 6 * * 1');
+      expect(t.branch).toBeNull();
+    });
+
+    it('decay-trends: weekly Monday 7am, report-only', () => {
+      const t = taskMap.get('decay-trends')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 7 * * 1');
+    });
+
+    it('project-health: daily 6am, report-only', () => {
+      const t = taskMap.get('project-health')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 6 * * *');
+    });
+
+    it('stale-constraints: monthly 1st 2am, report-only', () => {
+      const t = taskMap.get('stale-constraints')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 2 1 * *');
+    });
+
+    // Housekeeping tasks
+    it('session-cleanup: daily midnight, housekeeping', () => {
+      const t = taskMap.get('session-cleanup')!;
+      expect(t.type).toBe('housekeeping');
+      expect(t.schedule).toBe('0 0 * * *');
+      expect(t.branch).toBeNull();
+    });
+
+    it('perf-baselines: daily 7am, housekeeping', () => {
+      const t = taskMap.get('perf-baselines')!;
+      expect(t.type).toBe('housekeeping');
+      expect(t.schedule).toBe('0 7 * * *');
+      expect(t.branch).toBeNull();
+    });
+
+    // graph-refresh was in the spec report-only section but not yet tested
+    it('graph-refresh: daily 1am, report-only', () => {
+      const t = taskMap.get('graph-refresh')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 1 * * *');
+      expect(t.branch).toBeNull();
+    });
+  });
+});
+```
+
+4. Run tests (expect failures since implementation does not exist yet): `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx vitest run tests/maintenance/ --config packages/orchestrator/vitest.config.ts 2>&1 | tail -5` -- confirm test files are found and fail due to missing imports.
+5. Run: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx harness validate`
+6. Commit: `test(orchestrator): add maintenance type and task-registry tests (red)`
+
+---
+
+### Task 5: Create task registry with all 17 built-in definitions
+
+**Depends on:** Task 3 | **Files:** `packages/orchestrator/src/maintenance/task-registry.ts`
+
+1. Create `packages/orchestrator/src/maintenance/task-registry.ts`:
+
+```typescript
+import type { TaskDefinition } from './types';
+
+/**
+ * All 17 built-in maintenance task definitions with default schedules.
+ *
+ * Tasks are grouped by type:
+ * - mechanical-ai (7): Run check first, dispatch AI only if fixable issues found
+ * - pure-ai (4): Always dispatch AI agent on schedule
+ * - report-only (5): Run command, record metrics, no PR
+ * - housekeeping (2): Mechanical command, no AI, no PR
+ */
+export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
+  // --- Mechanical-AI ---
+  {
+    id: 'arch-violations',
+    type: 'mechanical-ai',
+    description: 'Detect and fix architecture violations',
+    schedule: '0 2 * * *',
+    branch: 'harness-maint/arch-fixes',
+    checkCommand: ['check-arch'],
+    fixSkill: 'harness-arch-fix',
+  },
+  {
+    id: 'dep-violations',
+    type: 'mechanical-ai',
+    description: 'Detect and fix dependency violations',
+    schedule: '0 2 * * *',
+    branch: 'harness-maint/dep-fixes',
+    checkCommand: ['check-deps'],
+    fixSkill: 'harness-dep-fix',
+  },
+  {
+    id: 'doc-drift',
+    type: 'mechanical-ai',
+    description: 'Detect and fix documentation drift',
+    schedule: '0 3 * * *',
+    branch: 'harness-maint/doc-fixes',
+    checkCommand: ['check-docs'],
+    fixSkill: 'harness-doc-fix',
+  },
+  {
+    id: 'security-findings',
+    type: 'mechanical-ai',
+    description: 'Detect and fix security findings',
+    schedule: '0 1 * * *',
+    branch: 'harness-maint/security-fixes',
+    checkCommand: ['check-security'],
+    fixSkill: 'harness-security-fix',
+  },
+  {
+    id: 'entropy',
+    type: 'mechanical-ai',
+    description: 'Detect and fix codebase entropy',
+    schedule: '0 3 * * *',
+    branch: 'harness-maint/entropy-fixes',
+    checkCommand: ['cleanup'],
+    fixSkill: 'harness-entropy-fix',
+  },
+  {
+    id: 'traceability',
+    type: 'mechanical-ai',
+    description: 'Detect and fix traceability gaps',
+    schedule: '0 6 * * 1',
+    branch: 'harness-maint/traceability-fixes',
+    checkCommand: ['traceability'],
+    fixSkill: 'harness-traceability-fix',
+  },
+  {
+    id: 'cross-check',
+    type: 'mechanical-ai',
+    description: 'Detect and fix cross-check violations',
+    schedule: '0 6 * * 1',
+    branch: 'harness-maint/cross-check-fixes',
+    checkCommand: ['validate-cross-check'],
+    fixSkill: 'harness-cross-check-fix',
+  },
+
+  // --- Pure-AI ---
+  {
+    id: 'dead-code',
+    type: 'pure-ai',
+    description: 'Find and remove dead code',
+    schedule: '0 2 * * 0',
+    branch: 'harness-maint/dead-code',
+    fixSkill: 'harness-codebase-cleanup',
+  },
+  {
+    id: 'dependency-health',
+    type: 'pure-ai',
+    description: 'Assess and improve dependency health',
+    schedule: '0 3 * * 0',
+    branch: 'harness-maint/dep-health',
+    fixSkill: 'harness-dependency-health',
+  },
+  {
+    id: 'hotspot-remediation',
+    type: 'pure-ai',
+    description: 'Identify and remediate code hotspots',
+    schedule: '0 4 * * 0',
+    branch: 'harness-maint/hotspot-fixes',
+    fixSkill: 'harness-hotspot-detector',
+  },
+  {
+    id: 'security-review',
+    type: 'pure-ai',
+    description: 'Deep security review and fixes',
+    schedule: '0 1 * * 0',
+    branch: 'harness-maint/security-deep',
+    fixSkill: 'harness-security-review',
+  },
+
+  // --- Report-only ---
+  {
+    id: 'perf-check',
+    type: 'report-only',
+    description: 'Run performance checks and record metrics',
+    schedule: '0 6 * * 1',
+    branch: null,
+    checkCommand: ['check-perf'],
+  },
+  {
+    id: 'decay-trends',
+    type: 'report-only',
+    description: 'Compute architecture decay trend metrics',
+    schedule: '0 7 * * 1',
+    branch: null,
+    checkCommand: ['predict'],
+  },
+  {
+    id: 'project-health',
+    type: 'report-only',
+    description: 'Assess overall project health',
+    schedule: '0 6 * * *',
+    branch: null,
+    checkCommand: ['assess_project'],
+  },
+  {
+    id: 'stale-constraints',
+    type: 'report-only',
+    description: 'Detect stale architectural constraints',
+    schedule: '0 2 1 * *',
+    branch: null,
+    checkCommand: ['detect_stale_constraints'],
+  },
+  {
+    id: 'graph-refresh',
+    type: 'report-only',
+    description: 'Refresh the knowledge graph',
+    schedule: '0 1 * * *',
+    branch: null,
+    checkCommand: ['graph', 'scan'],
+  },
+
+  // --- Housekeeping ---
+  {
+    id: 'session-cleanup',
+    type: 'housekeeping',
+    description: 'Clean up stale orchestrator sessions',
+    schedule: '0 0 * * *',
+    branch: null,
+    checkCommand: ['cleanup-sessions'],
+  },
+  {
+    id: 'perf-baselines',
+    type: 'housekeeping',
+    description: 'Update performance baselines',
+    schedule: '0 7 * * *',
+    branch: null,
+    checkCommand: ['perf', 'baselines', 'update'],
+  },
+] as const;
+```
+
+2. Run: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx harness validate`
+3. Commit: `feat(orchestrator): add task registry with 17 built-in maintenance tasks`
+
+---
+
+### Task 6: Create maintenance index.ts, run tests green, final validate
+
+**Depends on:** Tasks 2, 4, 5 | **Files:** `packages/orchestrator/src/maintenance/index.ts`
+
+1. Create `packages/orchestrator/src/maintenance/index.ts`:
+
+```typescript
+/**
+ * Scheduled maintenance module — public exports.
+ *
+ * Phase 1 exports types and the task registry. Subsequent phases add:
+ * - MaintenanceScheduler (Phase 2)
+ * - TaskRunner (Phase 3)
+ * - PRManager (Phase 4)
+ * - Reporter (Phase 5)
+ */
+
+export type {
+  TaskType,
+  TaskDefinition,
+  RunResult,
+  ScheduleEntry,
+  MaintenanceStatus,
+} from './types';
+
+export { BUILT_IN_TASKS } from './task-registry';
+```
+
+2. Run tests: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx vitest run tests/maintenance/ --config packages/orchestrator/vitest.config.ts`
+3. Verify all tests pass (types.test.ts and task-registry.test.ts).
+4. Run typecheck: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx tsc --noEmit -p packages/orchestrator/tsconfig.json`
+5. Run: `cd /Users/cwarner/Projects/harness-engineering-maintenance && npx harness validate`
+6. Commit: `feat(orchestrator): add maintenance module index and verify tests pass`

--- a/docs/plans/2026-04-17-scheduled-maintenance-phase2-scheduler-core-plan.md
+++ b/docs/plans/2026-04-17-scheduled-maintenance-phase2-scheduler-core-plan.md
@@ -1,0 +1,1047 @@
+# Plan: Scheduled Maintenance -- Phase 2: Scheduler Core
+
+**Date:** 2026-04-17 | **Spec:** docs/changes/scheduled-maintenance/proposal.md | **Tasks:** 7 | **Time:** ~30 min
+
+## Goal
+
+The orchestrator has a `MaintenanceScheduler` class that evaluates cron schedules on an interval timer, claims leader election via ClaimManager, enqueues due tasks, and is wired into `Orchestrator.start()` / `Orchestrator.stop()` for lifecycle management.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When `MaintenanceScheduler.start()` is called with a config where `maintenance.enabled` is true, the scheduler starts an interval timer that evaluates cron expressions against the current time every `checkIntervalMs` milliseconds (default: 60000).
+2. When the interval timer fires and this instance successfully claims `maintenance-leader` via `ClaimManager.claimAndVerify`, the scheduler evaluates all enabled tasks and enqueues those whose cron expression matches the current minute.
+3. When the interval timer fires and the leader claim is rejected (another orchestrator holds it), the scheduler logs a debug message and skips cron evaluation.
+4. When a task's cron expression matches the current minute and the task has not already run in the current minute, the task ID is added to the queue.
+5. When `MaintenanceScheduler.stop()` is called, the interval timer is cleared and the `isLeader` flag is set to false.
+6. When `Orchestrator.start()` is called and `config.maintenance?.enabled` is true, a `MaintenanceScheduler` is created and started. When `Orchestrator.stop()` is called, the scheduler is stopped.
+7. When `cronMatchesNow(expression, date)` is called with a 5-field cron expression and a Date, it returns true if and only if the minute, hour, day-of-month, month, and day-of-week fields all match (supporting `*`, ranges, lists, and step values).
+8. When `npx vitest run tests/maintenance/` is executed in the orchestrator package, all tests pass (including new scheduler and cron-matcher tests).
+9. When `harness validate` is executed, it passes.
+
+## Decisions
+
+| Decision              | Choice                                                                          | Rationale                                                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cron library          | Custom `cron-matcher.ts` utility (~60 lines)                                    | No cron dependency exists in the project. The 18 built-in schedules use only `*`, fixed values, and no complex syntax. A minimal matcher avoids a new dependency for simple matching. |
+| Leader claim approach | Reuse `ClaimManager.claimAndVerify` with a synthetic `maintenance-leader` issue | ClaimManager already supports optimistic claim + verify. The maintenance leader claim uses the same pattern as issue claims but with a fixed well-known ID.                           |
+| Task queue            | In-memory array, processed sequentially in the same tick                        | The spec says "Process queue sequentially (one task at a time)." A simple array suffices; no persistence needed since missed runs retry on the next interval.                         |
+| Deduplication         | Track `lastRunMinute` per task ID to prevent re-running within the same minute  | The check interval (60s) could fire multiple times in the same calendar minute due to timer drift. Tracking the last-run minute prevents duplicates.                                  |
+
+## File Map
+
+```
+CREATE  packages/orchestrator/src/maintenance/cron-matcher.ts
+CREATE  packages/orchestrator/src/maintenance/scheduler.ts
+MODIFY  packages/orchestrator/src/maintenance/index.ts         (add MaintenanceScheduler + cronMatchesNow exports)
+MODIFY  packages/orchestrator/src/orchestrator.ts              (add scheduler lifecycle in start/stop)
+CREATE  packages/orchestrator/tests/maintenance/cron-matcher.test.ts
+CREATE  packages/orchestrator/tests/maintenance/scheduler.test.ts
+```
+
+## Tasks
+
+### Task 1: Create cron-matcher utility
+
+**Depends on:** none | **Files:** `packages/orchestrator/src/maintenance/cron-matcher.ts`, `packages/orchestrator/tests/maintenance/cron-matcher.test.ts`
+
+1. Create test file `packages/orchestrator/tests/maintenance/cron-matcher.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { cronMatchesNow } from '../../src/maintenance/cron-matcher';
+
+describe('cronMatchesNow', () => {
+  // Helper: 2026-04-17 is a Friday (day 5)
+  const friday2am = new Date('2026-04-17T02:00:00');
+  const friday230 = new Date('2026-04-17T02:30:00');
+  const monday6am = new Date('2026-04-20T06:00:00');
+  const sunday2am = new Date('2026-04-19T02:00:00');
+  const jan1midnight = new Date('2026-01-01T00:00:00');
+  const firstOfMonth2am = new Date('2026-04-01T02:00:00');
+
+  it('matches wildcard-only cron (* * * * *)', () => {
+    expect(cronMatchesNow('* * * * *', friday2am)).toBe(true);
+  });
+
+  it('matches exact minute and hour (0 2 * * *)', () => {
+    expect(cronMatchesNow('0 2 * * *', friday2am)).toBe(true);
+    expect(cronMatchesNow('0 2 * * *', friday230)).toBe(false);
+  });
+
+  it('matches day of week (0 6 * * 1 = Monday)', () => {
+    expect(cronMatchesNow('0 6 * * 1', monday6am)).toBe(true);
+    expect(cronMatchesNow('0 6 * * 1', friday2am)).toBe(false);
+  });
+
+  it('matches Sunday as day 0 (0 2 * * 0)', () => {
+    expect(cronMatchesNow('0 2 * * 0', sunday2am)).toBe(true);
+    expect(cronMatchesNow('0 2 * * 0', friday2am)).toBe(false);
+  });
+
+  it('matches day of month (0 2 1 * *)', () => {
+    expect(cronMatchesNow('0 2 1 * *', firstOfMonth2am)).toBe(true);
+    expect(cronMatchesNow('0 2 1 * *', friday2am)).toBe(false);
+  });
+
+  it('matches month field (0 0 1 1 *)', () => {
+    expect(cronMatchesNow('0 0 1 1 *', jan1midnight)).toBe(true);
+    expect(cronMatchesNow('0 0 1 1 *', firstOfMonth2am)).toBe(false);
+  });
+
+  it('supports step values (*/15 * * * *)', () => {
+    const min0 = new Date('2026-04-17T02:00:00');
+    const min15 = new Date('2026-04-17T02:15:00');
+    const min7 = new Date('2026-04-17T02:07:00');
+    expect(cronMatchesNow('*/15 * * * *', min0)).toBe(true);
+    expect(cronMatchesNow('*/15 * * * *', min15)).toBe(true);
+    expect(cronMatchesNow('*/15 * * * *', min7)).toBe(false);
+  });
+
+  it('supports list values (0 1,2,3 * * *)', () => {
+    expect(cronMatchesNow('0 1,2,3 * * *', friday2am)).toBe(true);
+    expect(cronMatchesNow('0 1,2,3 * * *', monday6am)).toBe(false);
+  });
+
+  it('supports range values (0 1-3 * * *)', () => {
+    expect(cronMatchesNow('0 1-3 * * *', friday2am)).toBe(true);
+    expect(cronMatchesNow('0 1-3 * * *', monday6am)).toBe(false);
+  });
+
+  it('throws on invalid cron expression (wrong field count)', () => {
+    expect(() => cronMatchesNow('0 2 * *', friday2am)).toThrow();
+  });
+
+  it('matches all 18 built-in schedules against expected times', () => {
+    // Spot-check: daily 2am matches at 2:00, not at 3:00
+    expect(cronMatchesNow('0 2 * * *', new Date('2026-04-17T02:00:00'))).toBe(true);
+    expect(cronMatchesNow('0 2 * * *', new Date('2026-04-17T03:00:00'))).toBe(false);
+    // Weekly Monday 6am
+    expect(cronMatchesNow('0 6 * * 1', new Date('2026-04-20T06:00:00'))).toBe(true);
+    // Monthly 1st 2am
+    expect(cronMatchesNow('0 2 1 * *', new Date('2026-05-01T02:00:00'))).toBe(true);
+  });
+});
+```
+
+2. Run test -- expect failure: `cd packages/orchestrator && npx vitest run tests/maintenance/cron-matcher.test.ts`
+
+3. Create `packages/orchestrator/src/maintenance/cron-matcher.ts`:
+
+```typescript
+/**
+ * Minimal 5-field cron expression matcher.
+ *
+ * Supports: exact values, wildcards (*), ranges (1-5), lists (1,3,5), and step values (star/N).
+ * Does NOT support: L, W, #, ?, or 6/7-field expressions.
+ */
+
+/**
+ * Parse a single cron field into the set of matching integer values.
+ */
+function parseField(field: string, min: number, max: number): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of field.split(',')) {
+    if (part.includes('/')) {
+      // Step: */N or M-N/S
+      const [rangeStr, stepStr] = part.split('/');
+      const step = parseInt(stepStr!, 10);
+      let start = min;
+      let end = max;
+      if (rangeStr !== '*') {
+        if (rangeStr!.includes('-')) {
+          const [a, b] = rangeStr!.split('-');
+          start = parseInt(a!, 10);
+          end = parseInt(b!, 10);
+        } else {
+          start = parseInt(rangeStr!, 10);
+        }
+      }
+      for (let i = start; i <= end; i += step) {
+        values.add(i);
+      }
+    } else if (part === '*') {
+      for (let i = min; i <= max; i++) {
+        values.add(i);
+      }
+    } else if (part.includes('-')) {
+      const [a, b] = part.split('-');
+      const start = parseInt(a!, 10);
+      const end = parseInt(b!, 10);
+      for (let i = start; i <= end; i++) {
+        values.add(i);
+      }
+    } else {
+      values.add(parseInt(part, 10));
+    }
+  }
+
+  return values;
+}
+
+/**
+ * Returns true if the given 5-field cron expression matches the provided Date.
+ *
+ * Fields: minute hour day-of-month month day-of-week
+ * Month is 1-12, day-of-week is 0-6 (0 = Sunday).
+ *
+ * @throws {Error} If the expression does not have exactly 5 fields.
+ */
+export function cronMatchesNow(expression: string, now: Date): boolean {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error(`Invalid cron expression: expected 5 fields, got ${fields.length}`);
+  }
+
+  const minute = now.getMinutes();
+  const hour = now.getHours();
+  const dayOfMonth = now.getDate();
+  const month = now.getMonth() + 1; // JS months are 0-based
+  const dayOfWeek = now.getDay(); // 0 = Sunday
+
+  const [minField, hourField, domField, monthField, dowField] = fields as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+
+  return (
+    parseField(minField, 0, 59).has(minute) &&
+    parseField(hourField, 0, 23).has(hour) &&
+    parseField(domField, 1, 31).has(dayOfMonth) &&
+    parseField(monthField, 1, 12).has(month) &&
+    parseField(dowField, 0, 6).has(dayOfWeek)
+  );
+}
+```
+
+4. Run test -- expect pass: `cd packages/orchestrator && npx vitest run tests/maintenance/cron-matcher.test.ts`
+5. Run: `harness validate`
+6. Commit: `feat(maintenance): add cron expression matcher utility`
+
+---
+
+### Task 2: Create MaintenanceScheduler class -- core structure and config merging
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/src/maintenance/scheduler.ts`
+
+1. Create `packages/orchestrator/tests/maintenance/scheduler.test.ts` with the first set of tests (config merging and task resolution):
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MaintenanceScheduler } from '../../src/maintenance/scheduler';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition } from '../../src/maintenance/types';
+
+// Minimal mock for ClaimManager
+function createMockClaimManager(claimResult: 'claimed' | 'rejected' = 'claimed') {
+  return {
+    claimAndVerify: vi.fn().mockResolvedValue({ ok: true, value: claimResult }),
+  };
+}
+
+// Minimal mock logger
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('MaintenanceScheduler', () => {
+  describe('constructor and config merging', () => {
+    it('merges config overrides with built-in task defaults', () => {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          'arch-violations': { schedule: '0 4 * * *' },
+          'dead-code': { enabled: false },
+        },
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      const tasks = scheduler.getResolvedTasks();
+
+      // arch-violations should have overridden schedule
+      const arch = tasks.find((t) => t.id === 'arch-violations')!;
+      expect(arch.schedule).toBe('0 4 * * *');
+
+      // dead-code should be disabled (filtered out)
+      const dead = tasks.find((t) => t.id === 'dead-code');
+      expect(dead).toBeUndefined();
+
+      // Others should be present with defaults
+      const dep = tasks.find((t) => t.id === 'dep-violations')!;
+      expect(dep.schedule).toBe('0 2 * * *');
+    });
+
+    it('disables tasks with enabled: false override', () => {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          'session-cleanup': { enabled: false },
+          'perf-baselines': { enabled: false },
+        },
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      const tasks = scheduler.getResolvedTasks();
+      expect(tasks.find((t) => t.id === 'session-cleanup')).toBeUndefined();
+      expect(tasks.find((t) => t.id === 'perf-baselines')).toBeUndefined();
+      // Total should be 18 - 2 = 16
+      expect(tasks).toHaveLength(16);
+    });
+
+    it('uses all 18 built-in tasks when no overrides are provided', () => {
+      const config: MaintenanceConfig = { enabled: true };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      expect(scheduler.getResolvedTasks()).toHaveLength(18);
+    });
+  });
+});
+```
+
+2. Run test -- expect failure: `cd packages/orchestrator && npx vitest run tests/maintenance/scheduler.test.ts`
+
+3. Create `packages/orchestrator/src/maintenance/scheduler.ts`:
+
+```typescript
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition, MaintenanceStatus, RunResult, ScheduleEntry } from './types';
+import { BUILT_IN_TASKS } from './task-registry';
+import { cronMatchesNow } from './cron-matcher';
+
+/**
+ * Logger interface matching StructuredLogger's shape.
+ */
+export interface SchedulerLogger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+  debug?(message: string, context?: Record<string, unknown>): void;
+}
+
+/**
+ * Minimal ClaimManager interface used by the scheduler.
+ * Avoids importing the full ClaimManager class (which depends on IssueTrackerClient).
+ */
+export interface SchedulerClaimManager {
+  claimAndVerify(
+    issueId: string
+  ): Promise<{ ok: boolean; value?: 'claimed' | 'rejected'; error?: { message: string } }>;
+}
+
+export interface MaintenanceSchedulerOptions {
+  config: MaintenanceConfig;
+  claimManager: SchedulerClaimManager;
+  logger: SchedulerLogger;
+  /** Callback invoked when a task is due. The scheduler calls this for each queued task sequentially. */
+  onTaskDue: (task: TaskDefinition) => Promise<void>;
+}
+
+/**
+ * MaintenanceScheduler evaluates cron schedules on an interval timer,
+ * claims leader election via ClaimManager, and invokes onTaskDue for
+ * each task whose schedule matches the current time.
+ */
+export class MaintenanceScheduler {
+  private config: MaintenanceConfig;
+  private claimManager: SchedulerClaimManager;
+  private logger: SchedulerLogger;
+  private onTaskDue: (task: TaskDefinition) => Promise<void>;
+
+  private resolvedTasks: TaskDefinition[];
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private isLeader = false;
+  private lastLeaderClaim: string | null = null;
+
+  /** Tracks which minute (as epoch-minute) each task last ran to prevent re-runs. */
+  private lastRunMinute: Map<string, number> = new Map();
+
+  /** History of completed runs (most recent first). */
+  private history: RunResult[] = [];
+  private activeRun: { taskId: string; startedAt: string } | null = null;
+
+  constructor(options: MaintenanceSchedulerOptions) {
+    this.config = options.config;
+    this.claimManager = options.claimManager;
+    this.logger = options.logger;
+    this.onTaskDue = options.onTaskDue;
+
+    this.resolvedTasks = this.resolveTasks();
+  }
+
+  /**
+   * Merge built-in task definitions with config overrides.
+   * Tasks with `enabled: false` are filtered out.
+   * Schedule overrides replace the default cron expression.
+   */
+  private resolveTasks(): TaskDefinition[] {
+    const overrides = this.config.tasks ?? {};
+
+    return BUILT_IN_TASKS.filter((task) => {
+      const override = overrides[task.id];
+      if (override?.enabled === false) return false;
+      return true;
+    }).map((task) => {
+      const override = overrides[task.id];
+      if (!override) return { ...task };
+      return {
+        ...task,
+        ...(override.schedule !== undefined && { schedule: override.schedule }),
+      };
+    });
+  }
+
+  /** Returns the resolved (merged) task list. Useful for testing and dashboard. */
+  getResolvedTasks(): readonly TaskDefinition[] {
+    return this.resolvedTasks;
+  }
+
+  /**
+   * Start the scheduler interval timer.
+   * Immediately performs the first evaluation, then repeats every checkIntervalMs.
+   */
+  start(): void {
+    if (this.interval) return; // Already started
+
+    const intervalMs = this.config.checkIntervalMs ?? 60_000;
+    this.logger.info('MaintenanceScheduler starting', {
+      intervalMs,
+      taskCount: this.resolvedTasks.length,
+    });
+
+    // Run immediately, then on interval
+    void this.evaluate();
+    this.interval = setInterval(() => {
+      void this.evaluate();
+    }, intervalMs);
+  }
+
+  /** Stop the scheduler and clear the interval timer. */
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.isLeader = false;
+    this.logger.info('MaintenanceScheduler stopped');
+  }
+
+  /**
+   * Core evaluation loop. Called every checkIntervalMs.
+   *
+   * 1. Attempt leader claim
+   * 2. If leader, evaluate cron for each task
+   * 3. Process due tasks sequentially
+   */
+  async evaluate(now?: Date): Promise<void> {
+    const evalTime = now ?? new Date();
+    const ttl = this.config.leaderClaimTTLMs ?? 300_000;
+
+    // Step 1: Attempt leader claim
+    try {
+      const result = await this.claimManager.claimAndVerify('maintenance-leader');
+      if (!result.ok) {
+        this.isLeader = false;
+        this.logger.warn('Maintenance leader claim failed', { error: result.error?.message });
+        return;
+      }
+      if (result.value === 'rejected') {
+        this.isLeader = false;
+        if (this.logger.debug) {
+          this.logger.debug('Not the maintenance leader, skipping evaluation');
+        }
+        return;
+      }
+
+      this.isLeader = true;
+      this.lastLeaderClaim = evalTime.toISOString();
+    } catch (err) {
+      this.isLeader = false;
+      this.logger.error('Maintenance leader claim threw', { error: String(err) });
+      return;
+    }
+
+    // Step 2: Evaluate cron for each task, build queue
+    const epochMinute = Math.floor(evalTime.getTime() / 60_000);
+    const queue: TaskDefinition[] = [];
+
+    for (const task of this.resolvedTasks) {
+      // Skip if already run in this minute
+      if (this.lastRunMinute.get(task.id) === epochMinute) continue;
+
+      if (cronMatchesNow(task.schedule, evalTime)) {
+        queue.push(task);
+      }
+    }
+
+    // Step 3: Process queue sequentially
+    for (const task of queue) {
+      this.lastRunMinute.set(task.id, epochMinute);
+      this.activeRun = { taskId: task.id, startedAt: new Date().toISOString() };
+
+      try {
+        await this.onTaskDue(task);
+      } catch (err) {
+        this.logger.error(`Maintenance task ${task.id} failed`, { error: String(err) });
+      }
+
+      this.activeRun = null;
+    }
+  }
+
+  /** Record a completed run result (called by the task runner or orchestrator integration). */
+  recordRun(result: RunResult): void {
+    this.history.unshift(result);
+    // Cap history at 200 entries
+    if (this.history.length > 200) {
+      this.history.length = 200;
+    }
+  }
+
+  /** Returns the current maintenance status for the dashboard API. */
+  getStatus(): MaintenanceStatus {
+    const schedule: ScheduleEntry[] = this.resolvedTasks.map((task) => ({
+      taskId: task.id,
+      nextRun: this.computeNextRun(task.schedule),
+      lastRun: this.history.find((r) => r.taskId === task.id) ?? null,
+    }));
+
+    return {
+      isLeader: this.isLeader,
+      lastLeaderClaim: this.lastLeaderClaim,
+      schedule,
+      activeRun: this.activeRun,
+      history: this.history,
+    };
+  }
+
+  /**
+   * Compute a rough next-run ISO string for a cron expression.
+   * Scans the next 1440 minutes (24 hours) to find the next match.
+   */
+  private computeNextRun(cronExpr: string): string {
+    const now = new Date();
+    // Start from the next minute
+    const start = new Date(now);
+    start.setSeconds(0, 0);
+    start.setMinutes(start.getMinutes() + 1);
+
+    for (let i = 0; i < 1440; i++) {
+      const candidate = new Date(start.getTime() + i * 60_000);
+      if (cronMatchesNow(cronExpr, candidate)) {
+        return candidate.toISOString();
+      }
+    }
+
+    // Fallback: scan up to 31 days for monthly schedules
+    for (let i = 1440; i < 44_640; i++) {
+      const candidate = new Date(start.getTime() + i * 60_000);
+      if (cronMatchesNow(cronExpr, candidate)) {
+        return candidate.toISOString();
+      }
+    }
+
+    return 'unknown';
+  }
+}
+```
+
+4. Run test -- expect pass: `cd packages/orchestrator && npx vitest run tests/maintenance/scheduler.test.ts`
+5. Run: `harness validate`
+6. Commit: `feat(maintenance): add MaintenanceScheduler with config merging`
+
+---
+
+### Task 3: Add scheduler tests -- leader election and cron evaluation
+
+**Depends on:** Task 2 | **Files:** `packages/orchestrator/tests/maintenance/scheduler.test.ts`
+
+1. Append the following test blocks to `packages/orchestrator/tests/maintenance/scheduler.test.ts`:
+
+```typescript
+describe('leader election', () => {
+  it('skips evaluation when leader claim is rejected', async () => {
+    const config: MaintenanceConfig = { enabled: true, checkIntervalMs: 60_000 };
+    const onTaskDue = vi.fn();
+    const claimManager = createMockClaimManager('rejected');
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: claimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue,
+    });
+
+    // Evaluate at a time when daily-2am tasks would be due
+    await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+    expect(claimManager.claimAndVerify).toHaveBeenCalledWith('maintenance-leader');
+    expect(onTaskDue).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with evaluation when leader claim succeeds', async () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const onTaskDue = vi.fn().mockResolvedValue(undefined);
+    const claimManager = createMockClaimManager('claimed');
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: claimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue,
+    });
+
+    // 2am daily: arch-violations, dep-violations should be due
+    await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+    expect(onTaskDue).toHaveBeenCalled();
+    const calledTaskIds = onTaskDue.mock.calls.map((c: any) => c[0].id);
+    expect(calledTaskIds).toContain('arch-violations');
+    expect(calledTaskIds).toContain('dep-violations');
+  });
+
+  it('sets isLeader to false when claim fails with error', async () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const claimManager = {
+      claimAndVerify: vi.fn().mockResolvedValue({ ok: false, error: { message: 'network error' } }),
+    };
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: claimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: vi.fn(),
+    });
+
+    await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+    const status = scheduler.getStatus();
+    expect(status.isLeader).toBe(false);
+  });
+});
+
+describe('cron evaluation and deduplication', () => {
+  it('does not re-run a task in the same calendar minute', async () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const onTaskDue = vi.fn().mockResolvedValue(undefined);
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: createMockClaimManager() as any,
+      logger: createMockLogger() as any,
+      onTaskDue,
+    });
+
+    const time = new Date('2026-04-17T02:00:00');
+
+    await scheduler.evaluate(time);
+    const firstCallCount = onTaskDue.mock.calls.length;
+    expect(firstCallCount).toBeGreaterThan(0);
+
+    // Same minute again
+    await scheduler.evaluate(time);
+    expect(onTaskDue.mock.calls.length).toBe(firstCallCount); // No new calls
+  });
+
+  it('runs the task again in the next matching minute', async () => {
+    const config: MaintenanceConfig = {
+      enabled: true,
+      tasks: {
+        // Disable all except one for easier counting
+        ...Object.fromEntries(
+          Array.from({ length: 18 }, (_, i) => i).map((i) => {
+            const ids = [
+              'arch-violations',
+              'dep-violations',
+              'doc-drift',
+              'security-findings',
+              'entropy',
+              'traceability',
+              'cross-check',
+              'dead-code',
+              'dependency-health',
+              'hotspot-remediation',
+              'security-review',
+              'perf-check',
+              'decay-trends',
+              'project-health',
+              'stale-constraints',
+              'graph-refresh',
+              'session-cleanup',
+              'perf-baselines',
+            ];
+            return [ids[i]!, { enabled: false }];
+          })
+        ),
+        // Re-enable just one with a per-minute schedule for testing
+        'arch-violations': { enabled: true, schedule: '* * * * *' },
+      },
+    };
+    const onTaskDue = vi.fn().mockResolvedValue(undefined);
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: createMockClaimManager() as any,
+      logger: createMockLogger() as any,
+      onTaskDue,
+    });
+
+    await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+    expect(onTaskDue).toHaveBeenCalledTimes(1);
+
+    await scheduler.evaluate(new Date('2026-04-17T02:01:00'));
+    expect(onTaskDue).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+2. Run test -- expect pass: `cd packages/orchestrator && npx vitest run tests/maintenance/scheduler.test.ts`
+3. Run: `harness validate`
+4. Commit: `test(maintenance): add scheduler leader election and dedup tests`
+
+---
+
+### Task 4: Add scheduler tests -- start/stop lifecycle and status
+
+**Depends on:** Task 3 | **Files:** `packages/orchestrator/tests/maintenance/scheduler.test.ts`
+
+1. Append the following test blocks to `packages/orchestrator/tests/maintenance/scheduler.test.ts`:
+
+```typescript
+describe('start and stop lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('start() begins interval and stop() clears it', async () => {
+    const config: MaintenanceConfig = { enabled: true, checkIntervalMs: 1000 };
+    const claimManager = createMockClaimManager('rejected'); // Don't actually run tasks
+    const logger = createMockLogger();
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: claimManager as any,
+      logger: logger as any,
+      onTaskDue: vi.fn(),
+    });
+
+    scheduler.start();
+
+    // Should have called evaluate once immediately
+    // Wait for the initial evaluate promise
+    await vi.advanceTimersByTimeAsync(0);
+    expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(1);
+
+    // Advance past one interval
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+
+    // No more calls after stop
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() sets isLeader to false', async () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: createMockClaimManager() as any,
+      logger: createMockLogger() as any,
+      onTaskDue: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // Manually set leader state by running evaluate
+    await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+    expect(scheduler.getStatus().isLeader).toBe(true);
+
+    scheduler.stop();
+    expect(scheduler.getStatus().isLeader).toBe(false);
+  });
+});
+
+describe('getStatus', () => {
+  it('returns full status with schedule entries', () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: createMockClaimManager() as any,
+      logger: createMockLogger() as any,
+      onTaskDue: vi.fn(),
+    });
+
+    const status = scheduler.getStatus();
+    expect(status.isLeader).toBe(false);
+    expect(status.lastLeaderClaim).toBeNull();
+    expect(status.activeRun).toBeNull();
+    expect(status.schedule).toHaveLength(18);
+    expect(status.history).toHaveLength(0);
+
+    // Each schedule entry should have a taskId and nextRun
+    for (const entry of status.schedule) {
+      expect(entry.taskId).toBeTruthy();
+      expect(entry.nextRun).toBeTruthy();
+      expect(entry.lastRun).toBeNull();
+    }
+  });
+
+  it('records run results in history', () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: createMockClaimManager() as any,
+      logger: createMockLogger() as any,
+      onTaskDue: vi.fn(),
+    });
+
+    scheduler.recordRun({
+      taskId: 'arch-violations',
+      startedAt: '2026-04-17T02:00:00Z',
+      completedAt: '2026-04-17T02:01:00Z',
+      status: 'success',
+      findings: 3,
+      fixed: 2,
+      prUrl: 'https://github.com/example/repo/pull/1',
+      prUpdated: false,
+    });
+
+    const status = scheduler.getStatus();
+    expect(status.history).toHaveLength(1);
+    expect(status.history[0]!.taskId).toBe('arch-violations');
+
+    // The schedule entry for arch-violations should now have lastRun
+    const archEntry = status.schedule.find((s) => s.taskId === 'arch-violations')!;
+    expect(archEntry.lastRun).not.toBeNull();
+    expect(archEntry.lastRun!.status).toBe('success');
+  });
+});
+```
+
+2. Run test -- expect pass: `cd packages/orchestrator && npx vitest run tests/maintenance/scheduler.test.ts`
+3. Run: `harness validate`
+4. Commit: `test(maintenance): add scheduler lifecycle and status tests`
+
+---
+
+### Task 5: Add scheduler tests -- error handling and onTaskDue failures
+
+**Depends on:** Task 4 | **Files:** `packages/orchestrator/tests/maintenance/scheduler.test.ts`
+
+1. Append the following test block to `packages/orchestrator/tests/maintenance/scheduler.test.ts`:
+
+```typescript
+describe('error handling', () => {
+  it('continues processing queue when a task callback throws', async () => {
+    const config: MaintenanceConfig = {
+      enabled: true,
+      tasks: {
+        // Enable only two tasks for easier testing
+        ...Object.fromEntries(
+          [
+            'doc-drift',
+            'security-findings',
+            'entropy',
+            'traceability',
+            'cross-check',
+            'dead-code',
+            'dependency-health',
+            'hotspot-remediation',
+            'security-review',
+            'perf-check',
+            'decay-trends',
+            'project-health',
+            'stale-constraints',
+            'graph-refresh',
+            'session-cleanup',
+            'perf-baselines',
+          ].map((id) => [id, { enabled: false }])
+        ),
+      },
+    };
+    const callOrder: string[] = [];
+    const onTaskDue = vi.fn().mockImplementation(async (task: TaskDefinition) => {
+      callOrder.push(task.id);
+      if (task.id === 'arch-violations') {
+        throw new Error('simulated failure');
+      }
+    });
+    const logger = createMockLogger();
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: createMockClaimManager() as any,
+      logger: logger as any,
+      onTaskDue,
+    });
+
+    // Both arch-violations and dep-violations are due at 2am
+    await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+    // Both tasks should have been attempted despite first one throwing
+    expect(callOrder).toContain('arch-violations');
+    expect(callOrder).toContain('dep-violations');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('handles claimAndVerify throwing an exception', async () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const claimManager = {
+      claimAndVerify: vi.fn().mockRejectedValue(new Error('connection lost')),
+    };
+    const logger = createMockLogger();
+    const onTaskDue = vi.fn();
+
+    const scheduler = new MaintenanceScheduler({
+      config,
+      claimManager: claimManager as any,
+      logger: logger as any,
+      onTaskDue,
+    });
+
+    // Should not throw
+    await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+    expect(onTaskDue).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+```
+
+2. Run test -- expect pass: `cd packages/orchestrator && npx vitest run tests/maintenance/scheduler.test.ts`
+3. Run: `harness validate`
+4. Commit: `test(maintenance): add scheduler error handling tests`
+
+---
+
+### Task 6: Update barrel export to include MaintenanceScheduler and cronMatchesNow
+
+**Depends on:** Task 2 | **Files:** `packages/orchestrator/src/maintenance/index.ts`
+
+1. Replace the contents of `packages/orchestrator/src/maintenance/index.ts` with:
+
+```typescript
+/**
+ * Scheduled maintenance module -- public exports.
+ *
+ * Phase 1 exports types and the task registry.
+ * Phase 2 adds MaintenanceScheduler and cron matching.
+ * Subsequent phases add:
+ * - TaskRunner (Phase 3)
+ * - PRManager (Phase 4)
+ * - Reporter (Phase 5)
+ */
+
+export type {
+  TaskType,
+  TaskDefinition,
+  RunResult,
+  ScheduleEntry,
+  MaintenanceStatus,
+} from './types';
+
+export { BUILT_IN_TASKS } from './task-registry';
+
+export { MaintenanceScheduler } from './scheduler';
+export type {
+  MaintenanceSchedulerOptions,
+  SchedulerLogger,
+  SchedulerClaimManager,
+} from './scheduler';
+
+export { cronMatchesNow } from './cron-matcher';
+```
+
+2. Run all maintenance tests: `cd packages/orchestrator && npx vitest run tests/maintenance/`
+3. Run: `harness validate`
+4. Commit: `feat(maintenance): export MaintenanceScheduler and cronMatchesNow from barrel`
+
+---
+
+### Task 7: Wire MaintenanceScheduler into Orchestrator.start() and Orchestrator.stop()
+
+**Depends on:** Task 6 | **Files:** `packages/orchestrator/src/orchestrator.ts`
+
+[checkpoint:human-verify] -- This task modifies the main Orchestrator class. Verify the integration looks correct before committing.
+
+1. In `packages/orchestrator/src/orchestrator.ts`, add the import at the top (after the ClaimManager import around line 67):
+
+```typescript
+import { MaintenanceScheduler } from './maintenance/scheduler';
+```
+
+2. Add a private field to the `Orchestrator` class (after the `claimManager` field around line 109):
+
+```typescript
+  private maintenanceScheduler: MaintenanceScheduler | null = null;
+```
+
+3. In the `start()` method (around line 1438), after the heartbeat interval setup (after line 1486) and before the closing brace, add:
+
+```typescript
+// Start maintenance scheduler if enabled
+if (this.config.maintenance?.enabled) {
+  this.maintenanceScheduler = new MaintenanceScheduler({
+    config: this.config.maintenance,
+    claimManager: this.claimManager!,
+    logger: this.logger,
+    onTaskDue: async (task) => {
+      this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
+      // Phase 3 will wire this to TaskRunner.run(task)
+    },
+  });
+  this.maintenanceScheduler.start();
+}
+```
+
+4. In the `stop()` method (around line 1492), before `this.logger.info('Orchestrator stopped.')`, add:
+
+```typescript
+if (this.maintenanceScheduler) {
+  this.maintenanceScheduler.stop();
+  this.maintenanceScheduler = null;
+}
+```
+
+5. Add a public accessor for the dashboard (after the `getSnapshot()` method):
+
+```typescript
+  /** Returns the maintenance scheduler status, or null if maintenance is not enabled. */
+  public getMaintenanceStatus(): import('./maintenance/types').MaintenanceStatus | null {
+    return this.maintenanceScheduler?.getStatus() ?? null;
+  }
+```
+
+6. Run all maintenance tests: `cd packages/orchestrator && npx vitest run tests/maintenance/`
+7. Run full orchestrator build: `cd packages/orchestrator && npx tsc --noEmit`
+8. Run: `harness validate`
+9. Commit: `feat(maintenance): wire MaintenanceScheduler into Orchestrator lifecycle`

--- a/docs/plans/2026-04-17-scheduled-maintenance-phase3-task-runner-plan.md
+++ b/docs/plans/2026-04-17-scheduled-maintenance-phase3-task-runner-plan.md
@@ -1,0 +1,964 @@
+# Plan: Scheduled Maintenance Phase 3 -- Task Runner
+
+**Date:** 2026-04-17 | **Spec:** docs/changes/scheduled-maintenance/proposal.md | **Tasks:** 7 | **Time:** ~28 min
+
+## Goal
+
+Create a `TaskRunner` class that accepts a `TaskDefinition` + `MaintenanceConfig` and dispatches the correct execution path for all four task types (`mechanical-ai`, `pure-ai`, `report-only`, `housekeeping`), returning a `RunResult`. Wire it into the orchestrator's `onTaskDue` callback.
+
+## Observable Truths (Acceptance Criteria)
+
+1. **Event-driven (mechanical-ai, findings):** When `TaskRunner.run()` is called with a `mechanical-ai` task whose check produces fixable findings (>0), the runner invokes the agent runner with the task's `fixSkill` and returns `{ status: 'success', findings: N, fixed: N }`.
+2. **Event-driven (mechanical-ai, no findings):** When `TaskRunner.run()` is called with a `mechanical-ai` task whose check produces zero fixable findings, the runner returns `{ status: 'no-issues', findings: 0 }` and does NOT invoke the agent runner.
+3. **Event-driven (pure-ai):** When `TaskRunner.run()` is called with a `pure-ai` task, the runner always invokes the agent runner with the task's `fixSkill`, regardless of any precondition.
+4. **State-driven (AI backend):** While no per-task `aiBackend` override is configured, the system shall use `config.aiBackend` (default: `'local'`) when constructing the agent runner for AI tasks.
+5. **Event-driven (report-only):** When `TaskRunner.run()` is called with a `report-only` task, the runner executes the check command, returns `{ status: 'success', findings: N, prUrl: null }`, and never invokes the agent runner.
+6. **Event-driven (housekeeping):** When `TaskRunner.run()` is called with a `housekeeping` task, the runner executes the command directly, returns `{ status: 'success', prUrl: null }`, and never invokes the agent runner.
+7. **Unwanted (error isolation):** If any execution path throws, then the system shall not propagate the exception -- it shall return `{ status: 'failure', error: <message> }`.
+8. **Ubiquitous (orchestrator wiring):** The `onTaskDue` callback in `orchestrator.ts` calls `TaskRunner.run()` and records the result via `scheduler.recordRun()`.
+9. **Ubiquitous (tests pass):** `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts` passes with all tests green.
+10. **Ubiquitous (harness validate):** `harness validate` passes.
+
+## File Map
+
+```
+CREATE  packages/orchestrator/src/maintenance/task-runner.ts
+CREATE  packages/orchestrator/tests/maintenance/task-runner.test.ts
+MODIFY  packages/orchestrator/src/maintenance/index.ts (add TaskRunner export)
+MODIFY  packages/orchestrator/src/orchestrator.ts (wire onTaskDue to TaskRunner.run)
+```
+
+## Tasks
+
+### Task 1: Create TaskRunner class with constructor and `run()` dispatch
+
+**Depends on:** none | **Files:** `packages/orchestrator/src/maintenance/task-runner.ts`
+
+The TaskRunner needs dependency-injected interfaces for check commands, agent dispatch, and command execution so it is testable without real CLI or agent infrastructure.
+
+1. Create `packages/orchestrator/src/maintenance/task-runner.ts` with the following code:
+
+```typescript
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition, RunResult } from './types';
+
+/**
+ * Interface for running CLI check commands in-process.
+ * Each method returns a structured result with a findings count.
+ */
+export interface CheckCommandRunner {
+  /**
+   * Runs a check command and returns its structured output.
+   * @param command - CLI command args (e.g., ['check-arch'])
+   * @param cwd - Working directory
+   * @returns Object with findings count and whether the check passed
+   */
+  run(command: string[], cwd: string): Promise<CheckCommandResult>;
+}
+
+export interface CheckCommandResult {
+  passed: boolean;
+  findings: number;
+  /** Raw output for logging/reporting */
+  output: string;
+}
+
+/**
+ * Interface for dispatching an AI agent to fix issues.
+ * Wraps AgentRunner.runSession() with maintenance-specific parameters.
+ */
+export interface AgentDispatcher {
+  /**
+   * Dispatch an AI agent to fix issues on a branch.
+   * @param skill - Skill name to dispatch (e.g., 'harness-arch-fix')
+   * @param branch - Branch to work on
+   * @param backendName - Backend name to use (e.g., 'local', 'claude')
+   * @param cwd - Working directory (worktree path)
+   * @returns Whether the agent produced any commits
+   */
+  dispatch(
+    skill: string,
+    branch: string,
+    backendName: string,
+    cwd: string
+  ): Promise<AgentDispatchResult>;
+}
+
+export interface AgentDispatchResult {
+  producedCommits: boolean;
+  fixed: number;
+}
+
+/**
+ * Interface for running housekeeping commands directly.
+ */
+export interface CommandExecutor {
+  /**
+   * Executes a command directly (no AI).
+   * @param command - Command args (e.g., ['cleanup-sessions'])
+   * @param cwd - Working directory
+   */
+  exec(command: string[], cwd: string): Promise<void>;
+}
+
+export interface TaskRunnerOptions {
+  config: MaintenanceConfig;
+  checkRunner: CheckCommandRunner;
+  agentDispatcher: AgentDispatcher;
+  commandExecutor: CommandExecutor;
+  /** Project root directory for running commands */
+  cwd: string;
+}
+
+/**
+ * TaskRunner executes a single maintenance task based on its type.
+ *
+ * Execution paths:
+ * - mechanical-ai: run check -> if findings, dispatch AI agent
+ * - pure-ai: always dispatch AI agent
+ * - report-only: run check, record findings, no AI
+ * - housekeeping: run command directly, no AI
+ */
+export class TaskRunner {
+  private config: MaintenanceConfig;
+  private checkRunner: CheckCommandRunner;
+  private agentDispatcher: AgentDispatcher;
+  private commandExecutor: CommandExecutor;
+  private cwd: string;
+
+  constructor(options: TaskRunnerOptions) {
+    this.config = options.config;
+    this.checkRunner = options.checkRunner;
+    this.agentDispatcher = options.agentDispatcher;
+    this.commandExecutor = options.commandExecutor;
+    this.cwd = options.cwd;
+  }
+
+  /**
+   * Run a maintenance task and return the result.
+   * Dispatches to the appropriate execution path based on task type.
+   * Never throws -- errors are captured in the RunResult.
+   */
+  async run(task: TaskDefinition): Promise<RunResult> {
+    const startedAt = new Date().toISOString();
+    try {
+      switch (task.type) {
+        case 'mechanical-ai':
+          return await this.runMechanicalAI(task, startedAt);
+        case 'pure-ai':
+          return await this.runPureAI(task, startedAt);
+        case 'report-only':
+          return await this.runReportOnly(task, startedAt);
+        case 'housekeeping':
+          return await this.runHousekeeping(task, startedAt);
+        default: {
+          const _exhaustive: never = task.type;
+          return this.failureResult(task.id, startedAt, `Unknown task type: ${_exhaustive}`);
+        }
+      }
+    } catch (err) {
+      return this.failureResult(task.id, startedAt, String(err));
+    }
+  }
+
+  /**
+   * Mechanical-AI: run check command, dispatch AI agent only if fixable findings exist.
+   */
+  private async runMechanicalAI(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.checkCommand || task.checkCommand.length === 0) {
+      return this.failureResult(task.id, startedAt, 'mechanical-ai task missing checkCommand');
+    }
+    if (!task.fixSkill) {
+      return this.failureResult(task.id, startedAt, 'mechanical-ai task missing fixSkill');
+    }
+    if (!task.branch) {
+      return this.failureResult(task.id, startedAt, 'mechanical-ai task missing branch');
+    }
+
+    const checkResult = await this.checkRunner.run(task.checkCommand, this.cwd);
+
+    if (checkResult.findings === 0) {
+      return {
+        taskId: task.id,
+        startedAt,
+        completedAt: new Date().toISOString(),
+        status: 'no-issues',
+        findings: 0,
+        fixed: 0,
+        prUrl: null,
+        prUpdated: false,
+      };
+    }
+
+    const backendName = this.resolveBackend(task.id);
+    const agentResult = await this.agentDispatcher.dispatch(
+      task.fixSkill,
+      task.branch,
+      backendName,
+      this.cwd
+    );
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'success',
+      findings: checkResult.findings,
+      fixed: agentResult.fixed,
+      prUrl: null, // PR creation is handled by PRManager in Phase 4
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Pure-AI: always dispatch agent with configured skill.
+   */
+  private async runPureAI(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.fixSkill) {
+      return this.failureResult(task.id, startedAt, 'pure-ai task missing fixSkill');
+    }
+    if (!task.branch) {
+      return this.failureResult(task.id, startedAt, 'pure-ai task missing branch');
+    }
+
+    const backendName = this.resolveBackend(task.id);
+    const agentResult = await this.agentDispatcher.dispatch(
+      task.fixSkill,
+      task.branch,
+      backendName,
+      this.cwd
+    );
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: agentResult.producedCommits ? 'success' : 'no-issues',
+      findings: 0,
+      fixed: agentResult.fixed,
+      prUrl: null, // PR creation is handled by PRManager in Phase 4
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Report-only: run check command, record metrics, no AI dispatch.
+   */
+  private async runReportOnly(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.checkCommand || task.checkCommand.length === 0) {
+      return this.failureResult(task.id, startedAt, 'report-only task missing checkCommand');
+    }
+
+    const checkResult = await this.checkRunner.run(task.checkCommand, this.cwd);
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'success',
+      findings: checkResult.findings,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Housekeeping: run command directly, no AI, no PR.
+   */
+  private async runHousekeeping(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.checkCommand || task.checkCommand.length === 0) {
+      return this.failureResult(task.id, startedAt, 'housekeeping task missing checkCommand');
+    }
+
+    await this.commandExecutor.exec(task.checkCommand, this.cwd);
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'success',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Resolve which AI backend name to use for a given task.
+   * Priority: per-task override > global config > 'local' default.
+   */
+  private resolveBackend(taskId: string): string {
+    const taskOverride = this.config.tasks?.[taskId]?.aiBackend;
+    if (taskOverride) return taskOverride;
+    return this.config.aiBackend ?? 'local';
+  }
+
+  private failureResult(taskId: string, startedAt: string, error: string): RunResult {
+    return {
+      taskId,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'failure',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+      error,
+    };
+  }
+}
+```
+
+2. Run: `npx harness validate`
+3. Commit: `feat(maintenance): add TaskRunner class with four execution paths`
+
+---
+
+### Task 2: Write tests for mechanical-ai execution path
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/tests/maintenance/task-runner.test.ts`
+
+1. Create `packages/orchestrator/tests/maintenance/task-runner.test.ts` with:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TaskRunner } from '../../src/maintenance/task-runner';
+import type {
+  CheckCommandRunner,
+  AgentDispatcher,
+  CommandExecutor,
+  TaskRunnerOptions,
+} from '../../src/maintenance/task-runner';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition } from '../../src/maintenance/types';
+
+function createMockCheckRunner(
+  result?: Partial<{ passed: boolean; findings: number; output: string }>
+): CheckCommandRunner {
+  return {
+    run: vi.fn().mockResolvedValue({
+      passed: result?.passed ?? true,
+      findings: result?.findings ?? 0,
+      output: result?.output ?? '',
+    }),
+  };
+}
+
+function createMockAgentDispatcher(
+  result?: Partial<{ producedCommits: boolean; fixed: number }>
+): AgentDispatcher {
+  return {
+    dispatch: vi.fn().mockResolvedValue({
+      producedCommits: result?.producedCommits ?? true,
+      fixed: result?.fixed ?? 0,
+    }),
+  };
+}
+
+function createMockCommandExecutor(): CommandExecutor {
+  return {
+    exec: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createRunnerOptions(overrides?: Partial<TaskRunnerOptions>): TaskRunnerOptions {
+  return {
+    config: { enabled: true },
+    checkRunner: createMockCheckRunner(),
+    agentDispatcher: createMockAgentDispatcher(),
+    commandExecutor: createMockCommandExecutor(),
+    cwd: '/test/project',
+    ...overrides,
+  };
+}
+
+const ARCH_TASK: TaskDefinition = {
+  id: 'arch-violations',
+  type: 'mechanical-ai',
+  description: 'Detect and fix architecture violations',
+  schedule: '0 2 * * *',
+  branch: 'harness-maint/arch-fixes',
+  checkCommand: ['check-arch'],
+  fixSkill: 'harness-arch-fix',
+};
+
+describe('TaskRunner', () => {
+  describe('mechanical-ai tasks', () => {
+    it('returns no-issues when check finds zero findings', async () => {
+      const checkRunner = createMockCheckRunner({ findings: 0 });
+      const agentDispatcher = createMockAgentDispatcher();
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.status).toBe('no-issues');
+      expect(result.findings).toBe(0);
+      expect(result.fixed).toBe(0);
+      expect(result.prUrl).toBeNull();
+      expect(checkRunner.run).toHaveBeenCalledWith(['check-arch'], '/test/project');
+      expect(agentDispatcher.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches agent when check finds fixable issues', async () => {
+      const checkRunner = createMockCheckRunner({ findings: 5, passed: false });
+      const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 3 });
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.status).toBe('success');
+      expect(result.findings).toBe(5);
+      expect(result.fixed).toBe(3);
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        'harness-arch-fix',
+        'harness-maint/arch-fixes',
+        'local', // default backend
+        '/test/project'
+      );
+    });
+
+    it('returns failure when checkCommand is missing', async () => {
+      const task: TaskDefinition = { ...ARCH_TASK, checkCommand: undefined };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing checkCommand');
+    });
+
+    it('returns failure when fixSkill is missing', async () => {
+      const task: TaskDefinition = { ...ARCH_TASK, fixSkill: undefined };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing fixSkill');
+    });
+
+    it('returns failure when branch is missing', async () => {
+      const task: TaskDefinition = { ...ARCH_TASK, branch: null };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing branch');
+    });
+  });
+});
+```
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts` -- observe all tests pass.
+3. Run: `npx harness validate`
+4. Commit: `test(maintenance): add task-runner tests for mechanical-ai path`
+
+---
+
+### Task 3: Write tests for pure-ai execution path
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/tests/maintenance/task-runner.test.ts`
+
+1. Append to the test file inside the top-level `describe('TaskRunner')` block, after the `mechanical-ai` describe block:
+
+```typescript
+describe('pure-ai tasks', () => {
+  const DEAD_CODE_TASK: TaskDefinition = {
+    id: 'dead-code',
+    type: 'pure-ai',
+    description: 'Find and remove dead code',
+    schedule: '0 2 * * 0',
+    branch: 'harness-maint/dead-code',
+    fixSkill: 'harness-codebase-cleanup',
+  };
+
+  it('always dispatches agent regardless of check results', async () => {
+    const checkRunner = createMockCheckRunner();
+    const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 2 });
+    const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+    const result = await runner.run(DEAD_CODE_TASK);
+
+    expect(result.status).toBe('success');
+    expect(result.fixed).toBe(2);
+    expect(checkRunner.run).not.toHaveBeenCalled();
+    expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+      'harness-codebase-cleanup',
+      'harness-maint/dead-code',
+      'local',
+      '/test/project'
+    );
+  });
+
+  it('returns no-issues when agent produces no commits', async () => {
+    const agentDispatcher = createMockAgentDispatcher({ producedCommits: false, fixed: 0 });
+    const runner = new TaskRunner(createRunnerOptions({ agentDispatcher }));
+
+    const result = await runner.run(DEAD_CODE_TASK);
+
+    expect(result.status).toBe('no-issues');
+    expect(result.fixed).toBe(0);
+  });
+
+  it('uses per-task aiBackend override when configured', async () => {
+    const config: MaintenanceConfig = {
+      enabled: true,
+      aiBackend: 'local',
+      tasks: { 'dead-code': { aiBackend: 'claude' } },
+    };
+    const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 1 });
+    const runner = new TaskRunner(createRunnerOptions({ config, agentDispatcher }));
+
+    await runner.run(DEAD_CODE_TASK);
+
+    expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+      'harness-codebase-cleanup',
+      'harness-maint/dead-code',
+      'claude', // per-task override
+      '/test/project'
+    );
+  });
+
+  it('uses global aiBackend when no per-task override', async () => {
+    const config: MaintenanceConfig = { enabled: true, aiBackend: 'anthropic' };
+    const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 1 });
+    const runner = new TaskRunner(createRunnerOptions({ config, agentDispatcher }));
+
+    await runner.run(DEAD_CODE_TASK);
+
+    expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+      'harness-codebase-cleanup',
+      'harness-maint/dead-code',
+      'anthropic', // global config
+      '/test/project'
+    );
+  });
+
+  it('defaults to local when no backend configured', async () => {
+    const config: MaintenanceConfig = { enabled: true };
+    const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 1 });
+    const runner = new TaskRunner(createRunnerOptions({ config, agentDispatcher }));
+
+    await runner.run(DEAD_CODE_TASK);
+
+    expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'local', // default
+      expect.any(String)
+    );
+  });
+
+  it('returns failure when fixSkill is missing', async () => {
+    const task: TaskDefinition = { ...DEAD_CODE_TASK, fixSkill: undefined };
+    const runner = new TaskRunner(createRunnerOptions());
+
+    const result = await runner.run(task);
+
+    expect(result.status).toBe('failure');
+    expect(result.error).toContain('missing fixSkill');
+  });
+});
+```
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts` -- observe all tests pass.
+3. Run: `npx harness validate`
+4. Commit: `test(maintenance): add task-runner tests for pure-ai path and backend resolution`
+
+---
+
+### Task 4: Write tests for report-only and housekeeping execution paths
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/tests/maintenance/task-runner.test.ts`
+
+1. Append to the test file inside the top-level `describe('TaskRunner')` block:
+
+```typescript
+describe('report-only tasks', () => {
+  const PERF_TASK: TaskDefinition = {
+    id: 'perf-check',
+    type: 'report-only',
+    description: 'Run performance checks and record metrics',
+    schedule: '0 6 * * 1',
+    branch: null,
+    checkCommand: ['check-perf'],
+  };
+
+  it('runs check and returns findings without dispatching agent', async () => {
+    const checkRunner = createMockCheckRunner({ findings: 3 });
+    const agentDispatcher = createMockAgentDispatcher();
+    const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+    const result = await runner.run(PERF_TASK);
+
+    expect(result.status).toBe('success');
+    expect(result.findings).toBe(3);
+    expect(result.fixed).toBe(0);
+    expect(result.prUrl).toBeNull();
+    expect(checkRunner.run).toHaveBeenCalledWith(['check-perf'], '/test/project');
+    expect(agentDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when checkCommand is missing', async () => {
+    const task: TaskDefinition = { ...PERF_TASK, checkCommand: undefined };
+    const runner = new TaskRunner(createRunnerOptions());
+
+    const result = await runner.run(task);
+
+    expect(result.status).toBe('failure');
+    expect(result.error).toContain('missing checkCommand');
+  });
+});
+
+describe('housekeeping tasks', () => {
+  const SESSION_CLEANUP_TASK: TaskDefinition = {
+    id: 'session-cleanup',
+    type: 'housekeeping',
+    description: 'Clean up stale orchestrator sessions',
+    schedule: '0 0 * * *',
+    branch: null,
+    checkCommand: ['cleanup-sessions'],
+  };
+
+  it('runs command directly and returns success', async () => {
+    const commandExecutor = createMockCommandExecutor();
+    const agentDispatcher = createMockAgentDispatcher();
+    const runner = new TaskRunner(createRunnerOptions({ commandExecutor, agentDispatcher }));
+
+    const result = await runner.run(SESSION_CLEANUP_TASK);
+
+    expect(result.status).toBe('success');
+    expect(result.findings).toBe(0);
+    expect(result.fixed).toBe(0);
+    expect(result.prUrl).toBeNull();
+    expect(commandExecutor.exec).toHaveBeenCalledWith(['cleanup-sessions'], '/test/project');
+    expect(agentDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when command throws', async () => {
+    const commandExecutor: CommandExecutor = {
+      exec: vi.fn().mockRejectedValue(new Error('cleanup failed')),
+    };
+    const runner = new TaskRunner(createRunnerOptions({ commandExecutor }));
+
+    const result = await runner.run(SESSION_CLEANUP_TASK);
+
+    expect(result.status).toBe('failure');
+    expect(result.error).toContain('cleanup failed');
+  });
+
+  it('returns failure when checkCommand is missing', async () => {
+    const task: TaskDefinition = { ...SESSION_CLEANUP_TASK, checkCommand: undefined };
+    const runner = new TaskRunner(createRunnerOptions());
+
+    const result = await runner.run(task);
+
+    expect(result.status).toBe('failure');
+    expect(result.error).toContain('missing checkCommand');
+  });
+});
+```
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts` -- observe all tests pass.
+3. Run: `npx harness validate`
+4. Commit: `test(maintenance): add task-runner tests for report-only and housekeeping paths`
+
+---
+
+### Task 5: Write tests for error handling and edge cases
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/tests/maintenance/task-runner.test.ts`
+
+1. Append to the test file inside the top-level `describe('TaskRunner')` block:
+
+```typescript
+describe('error handling', () => {
+  it('catches check runner errors and returns failure', async () => {
+    const checkRunner: CheckCommandRunner = {
+      run: vi.fn().mockRejectedValue(new Error('check-arch crashed')),
+    };
+    const runner = new TaskRunner(createRunnerOptions({ checkRunner }));
+
+    const result = await runner.run(ARCH_TASK);
+
+    expect(result.status).toBe('failure');
+    expect(result.error).toContain('check-arch crashed');
+  });
+
+  it('catches agent dispatcher errors and returns failure', async () => {
+    const checkRunner = createMockCheckRunner({ findings: 2 });
+    const agentDispatcher: AgentDispatcher = {
+      dispatch: vi.fn().mockRejectedValue(new Error('agent session failed')),
+    };
+    const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+    const result = await runner.run(ARCH_TASK);
+
+    expect(result.status).toBe('failure');
+    expect(result.error).toContain('agent session failed');
+  });
+
+  it('populates startedAt and completedAt timestamps', async () => {
+    const runner = new TaskRunner(
+      createRunnerOptions({
+        checkRunner: createMockCheckRunner({ findings: 0 }),
+      })
+    );
+
+    const result = await runner.run(ARCH_TASK);
+
+    expect(result.startedAt).toBeTruthy();
+    expect(result.completedAt).toBeTruthy();
+    expect(new Date(result.startedAt).getTime()).toBeLessThanOrEqual(
+      new Date(result.completedAt).getTime()
+    );
+  });
+
+  it('includes taskId in all results', async () => {
+    const runner = new TaskRunner(
+      createRunnerOptions({
+        checkRunner: createMockCheckRunner({ findings: 0 }),
+      })
+    );
+
+    const result = await runner.run(ARCH_TASK);
+
+    expect(result.taskId).toBe('arch-violations');
+  });
+});
+```
+
+Note: `ARCH_TASK` is defined at the top of the file (from Task 2) and is accessible here since it is in the same module scope.
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts` -- observe all tests pass.
+3. Run: `npx harness validate`
+4. Commit: `test(maintenance): add task-runner error handling and edge case tests`
+
+---
+
+### Task 6: Export TaskRunner from maintenance index
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/src/maintenance/index.ts`
+
+1. Add TaskRunner export to `packages/orchestrator/src/maintenance/index.ts`. After the `cronMatchesNow` export line, add:
+
+```typescript
+export { TaskRunner } from './task-runner';
+export type {
+  CheckCommandRunner,
+  CheckCommandResult,
+  AgentDispatcher,
+  AgentDispatchResult,
+  CommandExecutor,
+  TaskRunnerOptions,
+} from './task-runner';
+```
+
+Also update the module comment to reflect Phase 3 completion.
+
+The full file should read:
+
+```typescript
+/**
+ * Scheduled maintenance module -- public exports.
+ *
+ * Phase 1 exports types and the task registry.
+ * Phase 2 adds MaintenanceScheduler and cron matching.
+ * Phase 3 adds TaskRunner with four execution paths.
+ * Subsequent phases add:
+ * - PRManager (Phase 4)
+ * - Reporter (Phase 5)
+ */
+
+export type {
+  TaskType,
+  TaskDefinition,
+  RunResult,
+  ScheduleEntry,
+  MaintenanceStatus,
+} from './types';
+
+export { BUILT_IN_TASKS } from './task-registry';
+
+export { MaintenanceScheduler } from './scheduler';
+export type {
+  MaintenanceSchedulerOptions,
+  SchedulerLogger,
+  SchedulerClaimManager,
+} from './scheduler';
+
+export { cronMatchesNow } from './cron-matcher';
+
+export { TaskRunner } from './task-runner';
+export type {
+  CheckCommandRunner,
+  CheckCommandResult,
+  AgentDispatcher,
+  AgentDispatchResult,
+  CommandExecutor,
+  TaskRunnerOptions,
+} from './task-runner';
+```
+
+2. Run: `npx harness validate`
+3. Commit: `feat(maintenance): export TaskRunner from maintenance module index`
+
+---
+
+### Task 7: Wire TaskRunner into orchestrator's onTaskDue callback
+
+**Depends on:** Task 1, Task 6 | **Files:** `packages/orchestrator/src/orchestrator.ts`
+
+1. In `packages/orchestrator/src/orchestrator.ts`, add the import for `TaskRunner` at the top (near the existing `MaintenanceScheduler` import on line 67):
+
+Replace:
+
+```typescript
+import { MaintenanceScheduler } from './maintenance/scheduler';
+```
+
+with:
+
+```typescript
+import { MaintenanceScheduler } from './maintenance/scheduler';
+import { TaskRunner } from './maintenance/task-runner';
+import type {
+  CheckCommandRunner,
+  AgentDispatcher,
+  CommandExecutor,
+} from './maintenance/task-runner';
+```
+
+2. Replace the `onTaskDue` callback in the `start()` method. Find the block (around line 1490-1502):
+
+```typescript
+// Start maintenance scheduler if enabled
+if (this.config.maintenance?.enabled) {
+  this.maintenanceScheduler = new MaintenanceScheduler({
+    config: this.config.maintenance,
+    claimManager: this.claimManager!,
+    logger: this.logger,
+    onTaskDue: async (task) => {
+      this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
+      // Phase 3 will wire this to TaskRunner.run(task)
+    },
+  });
+  this.maintenanceScheduler.start();
+}
+```
+
+Replace with:
+
+```typescript
+// Start maintenance scheduler if enabled
+if (this.config.maintenance?.enabled) {
+  const taskRunner = this.createMaintenanceTaskRunner();
+  this.maintenanceScheduler = new MaintenanceScheduler({
+    config: this.config.maintenance,
+    claimManager: this.claimManager!,
+    logger: this.logger,
+    onTaskDue: async (task) => {
+      this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
+      const result = await taskRunner.run(task);
+      this.maintenanceScheduler!.recordRun(result);
+      this.logger.info(`Maintenance task completed: ${task.id}`, {
+        taskId: task.id,
+        status: result.status,
+        findings: result.findings,
+        fixed: result.fixed,
+      });
+    },
+  });
+  this.maintenanceScheduler.start();
+}
+```
+
+3. Add the `createMaintenanceTaskRunner` private method to the `Orchestrator` class (place it near the `createBackend` method, around line 220):
+
+```typescript
+  /**
+   * Creates a TaskRunner for the maintenance scheduler.
+   * Provides stub implementations for check/agent/command execution.
+   * Phase 4 (PRManager) and Phase 5 (Reporter) will enhance these.
+   */
+  private createMaintenanceTaskRunner(): TaskRunner {
+    const checkRunner: CheckCommandRunner = {
+      run: async (command: string[], cwd: string) => {
+        // Stub: Phase 4 will integrate with real check commands.
+        // For now, return no findings so mechanical-ai tasks skip AI dispatch.
+        this.logger.info('Maintenance check runner invoked (stub)', { command, cwd });
+        return { passed: true, findings: 0, output: '' };
+      },
+    };
+
+    const agentDispatcher: AgentDispatcher = {
+      dispatch: async (skill: string, branch: string, backendName: string, cwd: string) => {
+        // Stub: Phase 4 will integrate with real AgentRunner dispatch.
+        this.logger.info('Maintenance agent dispatcher invoked (stub)', {
+          skill,
+          branch,
+          backendName,
+          cwd,
+        });
+        return { producedCommits: false, fixed: 0 };
+      },
+    };
+
+    const commandExecutor: CommandExecutor = {
+      dispatch: async (command: string[], cwd: string) => {
+        // Stub: Phase 4 will integrate with real command execution.
+        this.logger.info('Maintenance command executor invoked (stub)', { command, cwd });
+      },
+    } as unknown as CommandExecutor;
+
+    return new TaskRunner({
+      config: this.config.maintenance!,
+      checkRunner,
+      agentDispatcher,
+      commandExecutor,
+      cwd: this.projectRoot,
+    });
+  }
+```
+
+Note: The `commandExecutor` stub uses `dispatch` but the interface expects `exec`. Fix the stub to use the correct method name:
+
+```typescript
+const commandExecutor: CommandExecutor = {
+  exec: async (command: string[], cwd: string) => {
+    // Stub: Phase 4 will integrate with real command execution.
+    this.logger.info('Maintenance command executor invoked (stub)', { command, cwd });
+  },
+};
+```
+
+4. Run: `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts`
+5. Run: `npx harness validate`
+6. Commit: `feat(maintenance): wire TaskRunner into orchestrator onTaskDue callback`
+
+`[checkpoint:human-verify]` -- Verify the orchestrator wiring compiles and all existing maintenance tests still pass: `npx vitest run packages/orchestrator/tests/maintenance/`
+
+## Parallel Opportunities
+
+- Tasks 2, 3, 4, and 5 (test tasks) are independent of each other and can be executed in parallel. They all depend only on Task 1.
+- Task 6 depends only on Task 1.
+- Task 7 depends on Tasks 1 and 6.
+
+## Dependencies
+
+```
+Task 1 (TaskRunner class)
+  ├── Task 2 (mechanical-ai tests)
+  ├── Task 3 (pure-ai tests)
+  ├── Task 4 (report-only + housekeeping tests)
+  ├── Task 5 (error handling tests)
+  ├── Task 6 (index export)
+  └── Task 7 (orchestrator wiring) -- also depends on Task 6
+```
+
+## Estimated Total
+
+7 tasks x ~4 min = ~28 minutes

--- a/docs/plans/2026-04-17-scheduled-maintenance-phase4-pr-manager-plan.md
+++ b/docs/plans/2026-04-17-scheduled-maintenance-phase4-pr-manager-plan.md
@@ -1,0 +1,846 @@
+# Plan: Scheduled Maintenance Phase 4 -- PR Manager
+
+**Date:** 2026-04-17 | **Spec:** docs/changes/scheduled-maintenance/proposal.md | **Tasks:** 6 | **Time:** ~25 min
+
+## Goal
+
+PRManager provides branch lifecycle management (create, fetch, rebase, recreate on conflict) and PR lifecycle (create or update via `gh` CLI) for maintenance tasks, populating `prUrl` and `prUpdated` in RunResult.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When `ensureBranch(branchName, baseBranch)` is called and the branch does not exist remotely, the system shall create a new local branch from `baseBranch` and return `{ created: true, recreated: false }`.
+2. When `ensureBranch()` is called and the branch exists remotely, the system shall fetch it, check it out, and rebase onto `baseBranch`, returning `{ created: false, recreated: false }`.
+3. When rebase fails during `ensureBranch()`, the system shall abort the rebase, delete the branch, recreate it from `baseBranch`, and return `{ created: false, recreated: true }`.
+4. When `ensurePR(task, runSummary)` is called and no open PR exists on the branch, the system shall push commits and create a new PR via `gh pr create` with title `[Maintenance] <task.description>`, body containing the run summary, and labels `harness-maintenance` and `task.id`.
+5. When `ensurePR(task, runSummary)` is called and an open PR already exists, the system shall push commits and update the PR body via `gh pr edit`, returning `{ prUpdated: true }`.
+6. `npx vitest run packages/orchestrator/tests/maintenance/pr-manager.test.ts` passes with 10+ tests covering branch creation, fetch+rebase, rebase-failure-recreate, PR creation, and PR update.
+7. TaskRunner integrates PRManager via DI: `runMechanicalAI` and `runPureAI` call `ensureBranch` before agent dispatch and `ensurePR` after successful agent commits, populating `prUrl` and `prUpdated` in RunResult.
+
+## File Map
+
+- CREATE `packages/orchestrator/src/maintenance/pr-manager.ts`
+- CREATE `packages/orchestrator/tests/maintenance/pr-manager.test.ts`
+- MODIFY `packages/orchestrator/src/maintenance/index.ts` (add PRManager + type exports)
+- MODIFY `packages/orchestrator/src/maintenance/task-runner.ts` (add PRManager DI, call in execution paths)
+- MODIFY `packages/orchestrator/tests/maintenance/task-runner.test.ts` (add mock PRManager, update assertions)
+
+## Tasks
+
+### Task 1: Create PRManager with GitExecutor and GhExecutor interfaces
+
+**Depends on:** none | **Files:** `packages/orchestrator/src/maintenance/pr-manager.ts`
+
+Following the DI pattern from TaskRunner (CheckCommandRunner, AgentDispatcher, CommandExecutor), PRManager uses injectable interfaces for git and gh commands. This enables unit testing with mocks and avoids direct `execFile` calls in the class.
+
+1. Create `packages/orchestrator/src/maintenance/pr-manager.ts` with:
+
+```typescript
+import type { TaskDefinition } from './types';
+
+/**
+ * Interface for executing git commands. Injected for testability.
+ */
+export interface GitExecutor {
+  /** Run a git command and return stdout. Throws on non-zero exit. */
+  run(args: string[], cwd: string): Promise<string>;
+}
+
+/**
+ * Interface for executing gh CLI commands. Injected for testability.
+ */
+export interface GhExecutor {
+  /** Run a gh command and return stdout. Throws on non-zero exit. */
+  run(args: string[], cwd: string): Promise<string>;
+}
+
+export interface EnsureBranchResult {
+  /** True if the branch was newly created (did not exist remotely). */
+  created: boolean;
+  /** True if the branch existed but was recreated due to rebase conflict. */
+  recreated: boolean;
+}
+
+export interface EnsurePRResult {
+  /** URL of the PR (created or existing). */
+  prUrl: string;
+  /** True if an existing PR was updated, false if newly created. */
+  prUpdated: boolean;
+}
+
+export interface PRManagerOptions {
+  git: GitExecutor;
+  gh: GhExecutor;
+  /** Project root directory for running commands. */
+  cwd: string;
+  /** Logger for debug/info messages. */
+  logger: PRManagerLogger;
+}
+
+export interface PRManagerLogger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  debug?(message: string, context?: Record<string, unknown>): void;
+}
+
+/**
+ * PRManager handles branch lifecycle (create, fetch, rebase, recreate)
+ * and PR lifecycle (create or update via gh CLI) for maintenance tasks.
+ */
+export class PRManager {
+  private git: GitExecutor;
+  private gh: GhExecutor;
+  private cwd: string;
+  private logger: PRManagerLogger;
+
+  constructor(options: PRManagerOptions) {
+    this.git = options.git;
+    this.gh = options.gh;
+    this.cwd = options.cwd;
+    this.logger = options.logger;
+  }
+
+  /**
+   * Ensure a maintenance branch exists and is up-to-date with the base branch.
+   *
+   * - If the branch does not exist remotely: create from baseBranch.
+   * - If it exists: fetch, checkout, attempt rebase onto baseBranch.
+   * - If rebase fails: abort rebase, delete branch, recreate from baseBranch.
+   */
+  async ensureBranch(branchName: string, baseBranch: string): Promise<EnsureBranchResult> {
+    const remoteExists = await this.remoteBranchExists(branchName);
+
+    if (!remoteExists) {
+      this.logger.info('Creating new maintenance branch', { branchName, baseBranch });
+      await this.git.run(['fetch', 'origin', baseBranch], this.cwd);
+      await this.git.run(['checkout', '-b', branchName, `origin/${baseBranch}`], this.cwd);
+      return { created: true, recreated: false };
+    }
+
+    // Branch exists remotely -- fetch and checkout
+    this.logger.info('Fetching existing maintenance branch', { branchName });
+    await this.git.run(['fetch', 'origin', branchName], this.cwd);
+    await this.git.run(['checkout', branchName], this.cwd);
+    await this.git.run(['reset', '--hard', `origin/${branchName}`], this.cwd);
+
+    // Attempt rebase onto base branch
+    await this.git.run(['fetch', 'origin', baseBranch], this.cwd);
+    const rebaseSucceeded = await this.tryRebase(baseBranch);
+
+    if (rebaseSucceeded) {
+      return { created: false, recreated: false };
+    }
+
+    // Rebase failed -- recreate branch
+    this.logger.warn('Rebase failed, recreating branch from base', { branchName, baseBranch });
+    await this.git.run(['rebase', '--abort'], this.cwd);
+    await this.git.run(['checkout', `origin/${baseBranch}`], this.cwd);
+    await this.git.run(['branch', '-D', branchName], this.cwd);
+    // Also delete the remote branch so we start fresh
+    try {
+      await this.git.run(['push', 'origin', '--delete', branchName], this.cwd);
+    } catch {
+      // Remote branch may already be gone; ignore
+    }
+    await this.git.run(['checkout', '-b', branchName, `origin/${baseBranch}`], this.cwd);
+    return { created: false, recreated: true };
+  }
+
+  /**
+   * Ensure a PR exists for the maintenance task's branch.
+   *
+   * - Push current commits to origin.
+   * - If a PR already exists: update its body via gh pr edit.
+   * - If no PR exists: create one via gh pr create.
+   */
+  async ensurePR(task: TaskDefinition, runSummary: string): Promise<EnsurePRResult> {
+    const branchName = task.branch!;
+
+    // Push commits to remote
+    await this.git.run(['push', 'origin', branchName, '--force-with-lease'], this.cwd);
+
+    // Check for existing PR
+    const existingPrUrl = await this.findOpenPR(branchName);
+
+    if (existingPrUrl) {
+      this.logger.info('Updating existing maintenance PR', { branchName, prUrl: existingPrUrl });
+      await this.gh.run(
+        ['pr', 'edit', existingPrUrl, '--body', this.buildPRBody(task, runSummary)],
+        this.cwd
+      );
+      return { prUrl: existingPrUrl, prUpdated: true };
+    }
+
+    // Create new PR
+    this.logger.info('Creating new maintenance PR', { branchName });
+    const title = `[Maintenance] ${task.description}`;
+    const body = this.buildPRBody(task, runSummary);
+    const prUrl = (
+      await this.gh.run(
+        [
+          'pr',
+          'create',
+          '--head',
+          branchName,
+          '--title',
+          title,
+          '--body',
+          body,
+          '--label',
+          'harness-maintenance',
+          '--label',
+          task.id,
+        ],
+        this.cwd
+      )
+    ).trim();
+
+    return { prUrl, prUpdated: false };
+  }
+
+  /**
+   * Check if a remote branch exists using git ls-remote.
+   */
+  private async remoteBranchExists(branchName: string): Promise<boolean> {
+    try {
+      const output = await this.git.run(['ls-remote', '--heads', 'origin', branchName], this.cwd);
+      return output.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Attempt to rebase current branch onto baseBranch.
+   * Returns true if rebase succeeded, false if conflicts arose.
+   */
+  private async tryRebase(baseBranch: string): Promise<boolean> {
+    try {
+      await this.git.run(['rebase', `origin/${baseBranch}`], this.cwd);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Find an open PR for the given branch head.
+   * Returns the PR URL if found, null otherwise.
+   */
+  private async findOpenPR(branchName: string): Promise<string | null> {
+    try {
+      const output = await this.gh.run(
+        ['pr', 'list', '--head', branchName, '--json', 'url', '--jq', '.[0].url'],
+        this.cwd
+      );
+      const url = output.trim();
+      return url.length > 0 ? url : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Build the PR body with task metadata and run summary.
+   */
+  private buildPRBody(task: TaskDefinition, runSummary: string): string {
+    const lines = [
+      '## Automated Maintenance PR',
+      '',
+      `**Task:** ${task.id}`,
+      `**Type:** ${task.type}`,
+      `**Schedule:** \`${task.schedule}\``,
+      '',
+      '## Latest Run Summary',
+      '',
+      runSummary,
+      '',
+      '---',
+      '_This PR was created and managed automatically by the harness maintenance scheduler._',
+    ];
+    return lines.join('\n');
+  }
+}
+```
+
+2. Run: `npx harness validate` (from project root)
+3. Commit: `feat(maintenance): add PRManager with branch and PR lifecycle`
+
+---
+
+### Task 2: Write tests for PRManager.ensureBranch()
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/tests/maintenance/pr-manager.test.ts`
+
+1. Create `packages/orchestrator/tests/maintenance/pr-manager.test.ts` with:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PRManager } from '../../src/maintenance/pr-manager';
+import type {
+  GitExecutor,
+  GhExecutor,
+  PRManagerLogger,
+  PRManagerOptions,
+} from '../../src/maintenance/pr-manager';
+import type { TaskDefinition } from '../../src/maintenance/types';
+
+function createMockGit(): GitExecutor {
+  return { run: vi.fn().mockResolvedValue('') };
+}
+
+function createMockGh(): GhExecutor {
+  return { run: vi.fn().mockResolvedValue('') };
+}
+
+function createMockLogger(): PRManagerLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function createPRManager(overrides?: Partial<PRManagerOptions>): {
+  prManager: PRManager;
+  git: GitExecutor;
+  gh: GhExecutor;
+  logger: PRManagerLogger;
+} {
+  const git = overrides?.git ?? createMockGit();
+  const gh = overrides?.gh ?? createMockGh();
+  const logger = overrides?.logger ?? createMockLogger();
+  const cwd = overrides?.cwd ?? '/test/project';
+  const prManager = new PRManager({ git, gh, cwd, logger });
+  return { prManager, git, gh, logger };
+}
+
+const ARCH_TASK: TaskDefinition = {
+  id: 'arch-violations',
+  type: 'mechanical-ai',
+  description: 'Detect and fix architecture violations',
+  schedule: '0 2 * * *',
+  branch: 'harness-maint/arch-fixes',
+  checkCommand: ['check-arch'],
+  fixSkill: 'harness-arch-fix',
+};
+
+describe('PRManager', () => {
+  describe('ensureBranch', () => {
+    it('creates new branch when remote does not exist', async () => {
+      const git = createMockGit();
+      // ls-remote returns empty (no remote branch)
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return '';
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: true, recreated: false });
+      expect(git.run).toHaveBeenCalledWith(['fetch', 'origin', 'main'], '/test/project');
+      expect(git.run).toHaveBeenCalledWith(
+        ['checkout', '-b', 'harness-maint/arch-fixes', 'origin/main'],
+        '/test/project'
+      );
+    });
+
+    it('fetches and rebases when remote branch exists', async () => {
+      const git = createMockGit();
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return 'abc123\trefs/heads/harness-maint/arch-fixes';
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: false, recreated: false });
+      expect(git.run).toHaveBeenCalledWith(
+        ['fetch', 'origin', 'harness-maint/arch-fixes'],
+        '/test/project'
+      );
+      expect(git.run).toHaveBeenCalledWith(
+        ['checkout', 'harness-maint/arch-fixes'],
+        '/test/project'
+      );
+      expect(git.run).toHaveBeenCalledWith(['rebase', 'origin/main'], '/test/project');
+    });
+
+    it('recreates branch when rebase fails', async () => {
+      const git = createMockGit();
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return 'abc123\trefs/heads/harness-maint/arch-fixes';
+        if (args[0] === 'rebase' && args[1] === 'origin/main') {
+          throw new Error('CONFLICT');
+        }
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: false, recreated: true });
+      expect(git.run).toHaveBeenCalledWith(['rebase', '--abort'], '/test/project');
+      expect(git.run).toHaveBeenCalledWith(
+        ['branch', '-D', 'harness-maint/arch-fixes'],
+        '/test/project'
+      );
+      expect(git.run).toHaveBeenCalledWith(
+        ['checkout', '-b', 'harness-maint/arch-fixes', 'origin/main'],
+        '/test/project'
+      );
+    });
+
+    it('handles ls-remote failure gracefully (treats as non-existent)', async () => {
+      const git = createMockGit();
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') throw new Error('network error');
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: true, recreated: false });
+    });
+
+    it('ignores failure when deleting remote branch during recreate', async () => {
+      const git = createMockGit();
+      let rebaseAttempted = false;
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return 'abc123\trefs/heads/harness-maint/arch-fixes';
+        if (args[0] === 'rebase' && args[1] === 'origin/main') {
+          rebaseAttempted = true;
+          throw new Error('CONFLICT');
+        }
+        if (args[0] === 'push' && args[2] === '--delete') {
+          throw new Error('remote branch already deleted');
+        }
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(rebaseAttempted).toBe(true);
+      expect(result).toEqual({ created: false, recreated: true });
+    });
+  });
+});
+```
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/pr-manager.test.ts`
+3. Verify all 5 tests pass.
+4. Commit: `test(maintenance): add PRManager.ensureBranch tests`
+
+---
+
+### Task 3: Write tests for PRManager.ensurePR()
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/tests/maintenance/pr-manager.test.ts`
+
+1. Append the following `describe('ensurePR', ...)` block inside the existing `describe('PRManager', ...)` in `packages/orchestrator/tests/maintenance/pr-manager.test.ts`:
+
+```typescript
+describe('ensurePR', () => {
+  it('creates new PR when none exists', async () => {
+    const gh = createMockGh();
+    const git = createMockGit();
+    // gh pr list returns empty (no existing PR)
+    (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') return '';
+      if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/org/repo/pull/42\n';
+      return '';
+    });
+    const { prManager } = createPRManager({ git, gh });
+
+    const result = await prManager.ensurePR(ARCH_TASK, 'Found 3 violations, fixed 2');
+
+    expect(result).toEqual({
+      prUrl: 'https://github.com/org/repo/pull/42',
+      prUpdated: false,
+    });
+    expect(git.run).toHaveBeenCalledWith(
+      ['push', 'origin', 'harness-maint/arch-fixes', '--force-with-lease'],
+      '/test/project'
+    );
+    expect(gh.run).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        'pr',
+        'create',
+        '--title',
+        '[Maintenance] Detect and fix architecture violations',
+      ]),
+      '/test/project'
+    );
+    // Verify labels
+    const createCall = (gh.run as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: [string[], string]) => call[0][0] === 'pr' && call[0][1] === 'create'
+    );
+    expect(createCall![0]).toContain('--label');
+    expect(createCall![0]).toContain('harness-maintenance');
+    expect(createCall![0]).toContain('arch-violations');
+  });
+
+  it('updates existing PR when one exists', async () => {
+    const gh = createMockGh();
+    const git = createMockGit();
+    (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') return 'https://github.com/org/repo/pull/42';
+      return '';
+    });
+    const { prManager } = createPRManager({ git, gh });
+
+    const result = await prManager.ensurePR(ARCH_TASK, 'Found 1 violation, fixed 1');
+
+    expect(result).toEqual({
+      prUrl: 'https://github.com/org/repo/pull/42',
+      prUpdated: true,
+    });
+    expect(gh.run).toHaveBeenCalledWith(
+      expect.arrayContaining(['pr', 'edit', 'https://github.com/org/repo/pull/42', '--body']),
+      '/test/project'
+    );
+  });
+
+  it('PR body contains task metadata and run summary', async () => {
+    const gh = createMockGh();
+    const git = createMockGit();
+    (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') return '';
+      if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/org/repo/pull/99\n';
+      return '';
+    });
+    const { prManager } = createPRManager({ git, gh });
+
+    await prManager.ensurePR(ARCH_TASK, 'Found 5 violations');
+
+    const createCall = (gh.run as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: [string[], string]) => call[0][0] === 'pr' && call[0][1] === 'create'
+    );
+    const bodyIdx = createCall![0].indexOf('--body');
+    const body = createCall![0][bodyIdx + 1] as string;
+    expect(body).toContain('arch-violations');
+    expect(body).toContain('mechanical-ai');
+    expect(body).toContain('Found 5 violations');
+    expect(body).toContain('harness maintenance scheduler');
+  });
+
+  it('handles gh pr list failure gracefully (treats as no PR)', async () => {
+    const gh = createMockGh();
+    const git = createMockGit();
+    (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') throw new Error('gh auth error');
+      if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/org/repo/pull/50\n';
+      return '';
+    });
+    const { prManager } = createPRManager({ git, gh });
+
+    const result = await prManager.ensurePR(ARCH_TASK, 'summary');
+
+    expect(result.prUpdated).toBe(false);
+    expect(result.prUrl).toBe('https://github.com/org/repo/pull/50');
+  });
+
+  it('uses --force-with-lease for push safety', async () => {
+    const git = createMockGit();
+    const gh = createMockGh();
+    (gh.run as ReturnType<typeof vi.fn>).mockResolvedValue('');
+    (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') return '';
+      if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/org/repo/pull/1\n';
+      return '';
+    });
+    const { prManager } = createPRManager({ git, gh });
+
+    await prManager.ensurePR(ARCH_TASK, 'summary');
+
+    expect(git.run).toHaveBeenCalledWith(
+      ['push', 'origin', 'harness-maint/arch-fixes', '--force-with-lease'],
+      '/test/project'
+    );
+  });
+});
+```
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/pr-manager.test.ts`
+3. Verify all 10 tests pass (5 ensureBranch + 5 ensurePR).
+4. Commit: `test(maintenance): add PRManager.ensurePR tests`
+
+---
+
+### Task 4: Export PRManager from barrel index
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/src/maintenance/index.ts`
+
+1. Modify `packages/orchestrator/src/maintenance/index.ts`:
+   - Update the doc comment to note Phase 4 is complete.
+   - Add the PRManager export block after the TaskRunner exports:
+
+```typescript
+export { PRManager } from './pr-manager';
+export type {
+  GitExecutor,
+  GhExecutor,
+  EnsureBranchResult,
+  EnsurePRResult,
+  PRManagerOptions,
+  PRManagerLogger,
+} from './pr-manager';
+```
+
+2. Run: `npx harness validate`
+3. Commit: `feat(maintenance): export PRManager from barrel index`
+
+---
+
+### Task 5: Integrate PRManager into TaskRunner via DI
+
+**Depends on:** Task 1, Task 4 | **Files:** `packages/orchestrator/src/maintenance/task-runner.ts`
+
+The TaskRunner currently returns `prUrl: null` from `runMechanicalAI` and `runPureAI`. Add an optional `PRManager`-shaped interface to `TaskRunnerOptions` and call it in the execution paths when a branch exists.
+
+1. Modify `packages/orchestrator/src/maintenance/task-runner.ts`:
+
+   a. Add a new DI interface at the top of the file (after imports), keeping the same pattern as other interfaces:
+
+   ```typescript
+   /**
+    * Interface for managing branches and PRs for maintenance tasks.
+    * Matches PRManager's public API shape for DI.
+    */
+   export interface PRLifecycleManager {
+     ensureBranch(
+       branchName: string,
+       baseBranch: string
+     ): Promise<{ created: boolean; recreated: boolean }>;
+     ensurePR(
+       task: TaskDefinition,
+       runSummary: string
+     ): Promise<{ prUrl: string; prUpdated: boolean }>;
+   }
+   ```
+
+   b. Add `prManager?: PRLifecycleManager` to `TaskRunnerOptions` (optional to maintain backward compatibility with existing tests).
+
+   c. Add `private prManager: PRLifecycleManager | null` to the class, set in constructor: `this.prManager = options.prManager ?? null`.
+
+   d. Add a `baseBranch` field to `TaskRunnerOptions`: `baseBranch?: string` (defaults to `'main'`). Set in constructor: `this.baseBranch = options.baseBranch ?? 'main'`.
+
+   e. In `runMechanicalAI`, after findings are detected and before agent dispatch, add:
+
+   ```typescript
+   if (this.prManager) {
+     await this.prManager.ensureBranch(task.branch, this.baseBranch);
+   }
+   ```
+
+   f. In `runMechanicalAI`, after agent dispatch succeeds, replace the return with:
+
+   ```typescript
+   let prUrl: string | null = null;
+   let prUpdated = false;
+   if (this.prManager && agentResult.producedCommits) {
+     const summary = `Findings: ${checkResult.findings}, Fixed: ${agentResult.fixed}`;
+     const prResult = await this.prManager.ensurePR(task, summary);
+     prUrl = prResult.prUrl;
+     prUpdated = prResult.prUpdated;
+   }
+
+   return {
+     taskId: task.id,
+     startedAt,
+     completedAt: new Date().toISOString(),
+     status: 'success',
+     findings: checkResult.findings,
+     fixed: agentResult.fixed,
+     prUrl,
+     prUpdated,
+   };
+   ```
+
+   g. In `runPureAI`, add the same `ensureBranch` call before agent dispatch and `ensurePR` call after:
+
+   ```typescript
+   if (this.prManager) {
+     await this.prManager.ensureBranch(task.branch!, this.baseBranch);
+   }
+   ```
+
+   And after dispatch:
+
+   ```typescript
+   let prUrl: string | null = null;
+   let prUpdated = false;
+   if (this.prManager && agentResult.producedCommits) {
+     const summary = `Fixed: ${agentResult.fixed}`;
+     const prResult = await this.prManager.ensurePR(task, summary);
+     prUrl = prResult.prUrl;
+     prUpdated = prResult.prUpdated;
+   }
+
+   return {
+     taskId: task.id,
+     startedAt,
+     completedAt: new Date().toISOString(),
+     status: agentResult.producedCommits ? 'success' : 'no-issues',
+     findings: 0,
+     fixed: agentResult.fixed,
+     prUrl,
+     prUpdated,
+   };
+   ```
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts`
+   - Existing tests should still pass since `prManager` is optional.
+3. Run: `npx harness validate`
+4. Commit: `feat(maintenance): integrate PRManager into TaskRunner via DI`
+
+---
+
+### Task 6: Update TaskRunner tests for PRManager integration
+
+**Depends on:** Task 5 | **Files:** `packages/orchestrator/tests/maintenance/task-runner.test.ts`
+
+1. Modify `packages/orchestrator/tests/maintenance/task-runner.test.ts`:
+
+   a. Add import for the new type:
+
+   ```typescript
+   import type { PRLifecycleManager } from '../../src/maintenance/task-runner';
+   ```
+
+   b. Add a mock factory:
+
+   ```typescript
+   function createMockPRManager(prUrl?: string): PRLifecycleManager {
+     return {
+       ensureBranch: vi.fn().mockResolvedValue({ created: true, recreated: false }),
+       ensurePR: vi.fn().mockResolvedValue({
+         prUrl: prUrl ?? 'https://github.com/org/repo/pull/42',
+         prUpdated: false,
+       }),
+     };
+   }
+   ```
+
+   c. Add new test cases in the `mechanical-ai tasks` describe block:
+
+   ```typescript
+   it('calls prManager.ensureBranch and ensurePR when findings and agent commits exist', async () => {
+     const prManager = createMockPRManager();
+     const runner = new TaskRunner(
+       createRunnerOptions({
+         checkRunner: createMockCheckRunner({ findings: 3 }),
+         agentDispatcher: createMockAgentDispatcher({ producedCommits: true, fixed: 2 }),
+         prManager,
+       })
+     );
+
+     const result = await runner.run(ARCH_TASK);
+
+     expect(prManager.ensureBranch).toHaveBeenCalledWith('harness-maint/arch-fixes', 'main');
+     expect(prManager.ensurePR).toHaveBeenCalledWith(
+       ARCH_TASK,
+       expect.stringContaining('Findings: 3')
+     );
+     expect(result.prUrl).toBe('https://github.com/org/repo/pull/42');
+     expect(result.prUpdated).toBe(false);
+     expect(result.status).toBe('success');
+   });
+
+   it('does not call ensurePR when agent produces no commits', async () => {
+     const prManager = createMockPRManager();
+     const runner = new TaskRunner(
+       createRunnerOptions({
+         checkRunner: createMockCheckRunner({ findings: 3 }),
+         agentDispatcher: createMockAgentDispatcher({ producedCommits: false, fixed: 0 }),
+         prManager,
+       })
+     );
+
+     const result = await runner.run(ARCH_TASK);
+
+     expect(prManager.ensureBranch).toHaveBeenCalled();
+     expect(prManager.ensurePR).not.toHaveBeenCalled();
+     expect(result.prUrl).toBeNull();
+   });
+   ```
+
+   d. Add new test cases in the `pure-ai tasks` describe block:
+
+   ```typescript
+   it('calls prManager.ensureBranch and ensurePR when agent produces commits', async () => {
+     const prManager = createMockPRManager('https://github.com/org/repo/pull/99');
+     const pureAITask: TaskDefinition = {
+       id: 'dead-code',
+       type: 'pure-ai',
+       description: 'Remove dead code',
+       schedule: '0 2 * * 0',
+       branch: 'harness-maint/dead-code',
+       fixSkill: 'cleanup-dead-code',
+     };
+     const runner = new TaskRunner(
+       createRunnerOptions({
+         agentDispatcher: createMockAgentDispatcher({ producedCommits: true, fixed: 5 }),
+         prManager,
+       })
+     );
+
+     const result = await runner.run(pureAITask);
+
+     expect(prManager.ensureBranch).toHaveBeenCalledWith('harness-maint/dead-code', 'main');
+     expect(prManager.ensurePR).toHaveBeenCalledWith(
+       pureAITask,
+       expect.stringContaining('Fixed: 5')
+     );
+     expect(result.prUrl).toBe('https://github.com/org/repo/pull/99');
+     expect(result.status).toBe('success');
+   });
+   ```
+
+   e. Add a test verifying backward compatibility:
+
+   ```typescript
+   it('returns prUrl: null when no prManager is provided (backward compat)', async () => {
+     const runner = new TaskRunner(
+       createRunnerOptions({
+         checkRunner: createMockCheckRunner({ findings: 3 }),
+         agentDispatcher: createMockAgentDispatcher({ producedCommits: true, fixed: 2 }),
+         // No prManager
+       })
+     );
+
+     const result = await runner.run(ARCH_TASK);
+
+     expect(result.prUrl).toBeNull();
+     expect(result.status).toBe('success');
+   });
+   ```
+
+2. Run: `npx vitest run packages/orchestrator/tests/maintenance/task-runner.test.ts`
+3. Run: `npx vitest run packages/orchestrator/tests/maintenance/pr-manager.test.ts`
+4. Run: `npx harness validate`
+5. Commit: `test(maintenance): add TaskRunner tests for PRManager integration`
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (PRManager class)
+  ├── Task 2 (ensureBranch tests) ──┐
+  ├── Task 3 (ensurePR tests)       ├── can run in parallel
+  └── Task 4 (barrel export) ───────┘
+         │
+         v
+      Task 5 (TaskRunner integration)
+         │
+         v
+      Task 6 (TaskRunner integration tests)
+```
+
+## Estimated Total
+
+6 tasks, ~25 minutes.

--- a/docs/plans/2026-04-17-scheduled-maintenance-phase5-reporter-dashboard-plan.md
+++ b/docs/plans/2026-04-17-scheduled-maintenance-phase5-reporter-dashboard-plan.md
@@ -1,0 +1,92 @@
+# Phase 5: Reporter and Dashboard
+
+## Goal
+
+Create the reporter module for run result persistence and the dashboard REST/websocket endpoints for maintenance visibility and manual trigger capability.
+
+## Acceptance Criteria
+
+1. `reporter.ts` persists run results to `.harness/maintenance/history.json` and loads on init.
+2. `GET /api/maintenance/schedule` returns next-run times per task.
+3. `GET /api/maintenance/status` returns full `MaintenanceStatus`.
+4. `GET /api/maintenance/history` returns paginated `RunResult[]` with `?limit=20&offset=0`.
+5. `POST /api/maintenance/trigger` enqueues a task for immediate execution.
+6. Websocket events `maintenance:started`, `maintenance:completed`, `maintenance:error` are emitted.
+7. All new tests pass, existing tests unbroken.
+8. `harness validate` passes.
+
+## File Map
+
+- CREATE `packages/orchestrator/src/maintenance/reporter.ts`
+- CREATE `packages/orchestrator/src/server/routes/maintenance.ts`
+- CREATE `packages/orchestrator/tests/maintenance/reporter.test.ts`
+- CREATE `packages/orchestrator/tests/maintenance/maintenance-routes.test.ts`
+- MODIFY `packages/orchestrator/src/maintenance/index.ts` (exports)
+- MODIFY `packages/orchestrator/src/server/http.ts` (route + broadcast wiring)
+- MODIFY `packages/orchestrator/src/orchestrator.ts` (reporter init, event emissions)
+
+## Tasks
+
+### Task 1: Create Reporter class
+
+**Files:** `packages/orchestrator/src/maintenance/reporter.ts`
+
+Create `MaintenanceReporter` class:
+
+- Constructor takes `{ persistDir: string }` (default `.harness/maintenance/`)
+- `load()`: reads `history.json` from persistDir, returns void. Creates dir if missing.
+- `record(result: RunResult)`: appends to in-memory history, writes to disk. Cap at 500 entries.
+- `getHistory(limit: number, offset: number)`: returns paginated slice of history.
+- Use `fs.promises` for async I/O. Errors in persistence are logged, not thrown.
+
+### Task 2: Create maintenance route handler
+
+**Files:** `packages/orchestrator/src/server/routes/maintenance.ts`
+
+Create `handleMaintenanceRoute(req, res, deps)` following the existing route handler pattern:
+
+- Match on `/api/maintenance/*` prefix
+- `GET /api/maintenance/schedule` → call `scheduler.getStatus().schedule`
+- `GET /api/maintenance/status` → call `scheduler.getStatus()`
+- `GET /api/maintenance/history` → call `reporter.getHistory(limit, offset)` with query params
+- `POST /api/maintenance/trigger` → read body `{ taskId }`, call `triggerFn(taskId)`
+- Return `true` if route matched, `false` otherwise (existing pattern)
+- Dependencies interface: `{ scheduler, reporter, triggerFn }`
+
+### Task 3: Reporter tests
+
+**Files:** `packages/orchestrator/tests/maintenance/reporter.test.ts`
+
+- Test load from empty/missing dir
+- Test record and getHistory
+- Test pagination (limit/offset)
+- Test history cap at 500
+- Test persistence to disk (use temp dir)
+
+### Task 4: Route handler tests
+
+**Files:** `packages/orchestrator/tests/maintenance/maintenance-routes.test.ts`
+
+- Test GET /api/maintenance/schedule returns schedule
+- Test GET /api/maintenance/status returns full status
+- Test GET /api/maintenance/history with pagination params
+- Test POST /api/maintenance/trigger with valid/invalid taskId
+- Test non-matching URLs return false
+
+### Task 5: Wire into OrchestratorServer and Orchestrator
+
+**Files:** `packages/orchestrator/src/server/http.ts`, `packages/orchestrator/src/orchestrator.ts`
+
+1. Add `maintenanceScheduler` and `maintenanceReporter` and `maintenanceTriggerFn` to `ServerDependencies`.
+2. In `handleRequest`, add maintenance route handler before static file serving.
+3. Add `broadcastMaintenance(type, data)` method to `OrchestratorServer`.
+4. In `Orchestrator`, create `MaintenanceReporter` in `start()`, call `load()`.
+5. Wire scheduler's `onTaskDue` to emit websocket events via the server.
+6. Pass reporter, scheduler, and trigger fn to server deps.
+
+### Task 6: Export reporter from barrel and final validation
+
+**Files:** `packages/orchestrator/src/maintenance/index.ts`
+
+- Export `MaintenanceReporter` and its types.
+- Run all tests, run `harness validate`.

--- a/docs/plans/2026-04-17-scheduled-maintenance-phase6-tests-plan.md
+++ b/docs/plans/2026-04-17-scheduled-maintenance-phase6-tests-plan.md
@@ -1,0 +1,662 @@
+# Plan: Scheduled Maintenance Phase 6 -- Integration Tests and Edge Cases
+
+**Date:** 2026-04-17 | **Spec:** docs/changes/scheduled-maintenance/proposal.md | **Tasks:** 5 | **Time:** ~20 min
+
+## Goal
+
+Fill remaining test coverage gaps for the scheduled maintenance module: integration test for leader election across two scheduler instances, integration test for the full maintenance cycle (scheduler to task runner to PR manager to reporter), and edge case tests missed by prior phases.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When two MaintenanceScheduler instances share a single ClaimManager where only one claim succeeds, exactly one scheduler dispatches tasks and the other does not.
+2. When a full maintenance cycle runs (scheduler evaluates -> onTaskDue runs TaskRunner -> TaskRunner calls PRManager -> reporter records result), the reporter contains the correct RunResult with prUrl and findings.
+3. When `gh pr create` fails in PRManager.ensurePR, the error propagates to the caller.
+4. When `git push --force-with-lease` fails in PRManager.ensurePR, the error propagates to the caller.
+5. When the routes handler receives a POST with malformed (non-JSON) body, it returns 400 with `{ error: 'Invalid JSON body' }`.
+6. When the routes handler receives GET /api/maintenance/history?limit=200, the limit is clamped to 100.
+7. When MaintenanceReporter.load encounters corrupted JSON on disk, it starts with empty history and logs an error.
+8. When MaintenanceScheduler.start() is called twice, it does not create duplicate intervals.
+9. `npx vitest run tests/maintenance/` passes with all existing 115 tests plus the new tests (target: ~135 total).
+10. `harness validate` passes.
+
+## File Map
+
+- CREATE packages/orchestrator/tests/maintenance/integration-leader-election.test.ts
+- CREATE packages/orchestrator/tests/maintenance/integration-full-cycle.test.ts
+- MODIFY packages/orchestrator/tests/maintenance/pr-manager.test.ts (add edge case tests)
+- MODIFY packages/orchestrator/tests/maintenance/maintenance-routes.test.ts (add edge case tests)
+- MODIFY packages/orchestrator/tests/maintenance/reporter.test.ts (add corrupted file test)
+- MODIFY packages/orchestrator/tests/maintenance/scheduler.test.ts (add double-start test)
+
+## Tasks
+
+### Task 1: Integration test -- two schedulers, one ClaimManager (leader election)
+
+**Depends on:** none | **Files:** packages/orchestrator/tests/maintenance/integration-leader-election.test.ts
+
+1. Create the test file at `packages/orchestrator/tests/maintenance/integration-leader-election.test.ts` with this content:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { MaintenanceScheduler } from '../../src/maintenance/scheduler';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+
+function createMockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+describe('Integration: leader election with two schedulers', () => {
+  it('only one scheduler dispatches tasks when sharing a ClaimManager', async () => {
+    // ClaimManager that grants the first call and rejects the second
+    let callCount = 0;
+    const sharedClaimManager = {
+      claimAndVerify: vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) return { ok: true, value: 'claimed' as const };
+        return { ok: true, value: 'rejected' as const };
+      }),
+    };
+
+    const config: MaintenanceConfig = {
+      enabled: true,
+      tasks: {
+        // Enable only one task for deterministic counting
+        ...Object.fromEntries(
+          [
+            'dep-violations',
+            'doc-drift',
+            'security-findings',
+            'entropy',
+            'traceability',
+            'cross-check',
+            'dead-code',
+            'dependency-health',
+            'hotspot-remediation',
+            'security-review',
+            'perf-check',
+            'decay-trends',
+            'project-health',
+            'stale-constraints',
+            'graph-refresh',
+            'session-cleanup',
+            'perf-baselines',
+          ].map((id) => [id, { enabled: false }])
+        ),
+      },
+    };
+
+    const onTaskDueA = vi.fn().mockResolvedValue(undefined);
+    const onTaskDueB = vi.fn().mockResolvedValue(undefined);
+
+    const schedulerA = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueA,
+    });
+
+    const schedulerB = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueB,
+    });
+
+    const time = new Date('2026-04-17T02:00:00');
+
+    // Scheduler A evaluates first -- gets leader
+    await schedulerA.evaluate(time);
+    // Scheduler B evaluates second -- rejected
+    await schedulerB.evaluate(time);
+
+    expect(onTaskDueA).toHaveBeenCalledTimes(1);
+    expect(onTaskDueB).not.toHaveBeenCalled();
+    expect(schedulerA.getStatus().isLeader).toBe(true);
+    expect(schedulerB.getStatus().isLeader).toBe(false);
+  });
+
+  it('leadership can transfer when first scheduler loses claim', async () => {
+    let leaderInstance: 'A' | 'B' = 'A';
+    const sharedClaimManager = {
+      claimAndVerify: vi.fn().mockImplementation(async () => {
+        // First two calls: A wins, B loses. Next two: B wins, A loses.
+        const callIdx = sharedClaimManager.claimAndVerify.mock.calls.length;
+        if (callIdx <= 2) {
+          return {
+            ok: true,
+            value: leaderInstance === 'A' ? ('claimed' as const) : ('rejected' as const),
+          };
+        }
+        return {
+          ok: true,
+          value: leaderInstance === 'B' ? ('claimed' as const) : ('rejected' as const),
+        };
+      }),
+    };
+
+    const config: MaintenanceConfig = {
+      enabled: true,
+      tasks: {
+        ...Object.fromEntries(
+          [
+            'dep-violations',
+            'doc-drift',
+            'security-findings',
+            'entropy',
+            'traceability',
+            'cross-check',
+            'dead-code',
+            'dependency-health',
+            'hotspot-remediation',
+            'security-review',
+            'perf-check',
+            'decay-trends',
+            'project-health',
+            'stale-constraints',
+            'graph-refresh',
+            'session-cleanup',
+            'perf-baselines',
+          ].map((id) => [id, { enabled: false }])
+        ),
+        'arch-violations': { enabled: true, schedule: '* * * * *' },
+      },
+    };
+
+    const onTaskDueA = vi.fn().mockResolvedValue(undefined);
+    const onTaskDueB = vi.fn().mockResolvedValue(undefined);
+
+    const schedulerA = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueA,
+    });
+
+    const schedulerB = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueB,
+    });
+
+    // Round 1: A leads
+    await schedulerA.evaluate(new Date('2026-04-17T02:00:00'));
+    await schedulerB.evaluate(new Date('2026-04-17T02:00:00'));
+    expect(onTaskDueA).toHaveBeenCalledTimes(1);
+    expect(onTaskDueB).not.toHaveBeenCalled();
+
+    // Transfer leadership
+    leaderInstance = 'B';
+
+    // Round 2: B leads (different minute so dedup does not block)
+    await schedulerA.evaluate(new Date('2026-04-17T02:01:00'));
+    await schedulerB.evaluate(new Date('2026-04-17T02:01:00'));
+    expect(onTaskDueA).toHaveBeenCalledTimes(1); // No new calls
+    expect(onTaskDueB).toHaveBeenCalledTimes(1);
+    expect(schedulerB.getStatus().isLeader).toBe(true);
+    expect(schedulerA.getStatus().isLeader).toBe(false);
+  });
+});
+```
+
+2. Run test:
+
+   ```
+   cd packages/orchestrator && npx vitest run tests/maintenance/integration-leader-election.test.ts
+   ```
+
+   Observe pass.
+
+3. Run: `harness validate`
+4. Commit: `test(maintenance): add integration test for leader election with two schedulers`
+
+---
+
+### Task 2: Integration test -- full maintenance cycle
+
+**Depends on:** none | **Files:** packages/orchestrator/tests/maintenance/integration-full-cycle.test.ts
+
+1. Create the test file at `packages/orchestrator/tests/maintenance/integration-full-cycle.test.ts` with this content:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { MaintenanceScheduler } from '../../src/maintenance/scheduler';
+import { TaskRunner } from '../../src/maintenance/task-runner';
+import { MaintenanceReporter } from '../../src/maintenance/reporter';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition } from '../../src/maintenance/types';
+import type {
+  CheckCommandRunner,
+  AgentDispatcher,
+  CommandExecutor,
+  PRLifecycleManager,
+} from '../../src/maintenance/task-runner';
+
+function createMockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+describe('Integration: full maintenance cycle', () => {
+  it('scheduler -> task runner -> PR manager -> reporter', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maint-integ-'));
+
+    try {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          // Disable all except arch-violations
+          ...Object.fromEntries(
+            [
+              'dep-violations',
+              'doc-drift',
+              'security-findings',
+              'entropy',
+              'traceability',
+              'cross-check',
+              'dead-code',
+              'dependency-health',
+              'hotspot-remediation',
+              'security-review',
+              'perf-check',
+              'decay-trends',
+              'project-health',
+              'stale-constraints',
+              'graph-refresh',
+              'session-cleanup',
+              'perf-baselines',
+            ].map((id) => [id, { enabled: false }])
+          ),
+        },
+      };
+
+      // Mock dependencies
+      const checkRunner: CheckCommandRunner = {
+        run: vi.fn().mockResolvedValue({ passed: false, findings: 4, output: '4 violations' }),
+      };
+      const agentDispatcher: AgentDispatcher = {
+        dispatch: vi.fn().mockResolvedValue({ producedCommits: true, fixed: 3 }),
+      };
+      const commandExecutor: CommandExecutor = {
+        exec: vi.fn().mockResolvedValue(undefined),
+      };
+      const prManager: PRLifecycleManager = {
+        ensureBranch: vi.fn().mockResolvedValue({ created: true, recreated: false }),
+        ensurePR: vi.fn().mockResolvedValue({
+          prUrl: 'https://github.com/org/repo/pull/100',
+          prUpdated: false,
+        }),
+      };
+
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+
+      const taskRunner = new TaskRunner({
+        config,
+        checkRunner,
+        agentDispatcher,
+        commandExecutor,
+        cwd: '/test/project',
+        prManager,
+      });
+
+      // Wire scheduler's onTaskDue to run task and record result
+      const onTaskDue = async (task: TaskDefinition) => {
+        const result = await taskRunner.run(task);
+        scheduler.recordRun(result);
+        await reporter.record(result);
+      };
+
+      const claimManager = {
+        claimAndVerify: vi.fn().mockResolvedValue({ ok: true, value: 'claimed' }),
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      // Trigger evaluation at 2am when arch-violations is due
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      // Verify the full pipeline executed
+      expect(checkRunner.run).toHaveBeenCalledWith(['check-arch'], '/test/project');
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        'harness-arch-fix',
+        'harness-maint/arch-fixes',
+        'local',
+        '/test/project'
+      );
+      expect(prManager.ensureBranch).toHaveBeenCalledWith('harness-maint/arch-fixes', 'main');
+      expect(prManager.ensurePR).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'arch-violations' }),
+        expect.stringContaining('Findings: 4')
+      );
+
+      // Verify scheduler recorded the run
+      const status = scheduler.getStatus();
+      expect(status.history).toHaveLength(1);
+      expect(status.history[0]!.taskId).toBe('arch-violations');
+      expect(status.history[0]!.status).toBe('success');
+      expect(status.history[0]!.findings).toBe(4);
+      expect(status.history[0]!.fixed).toBe(3);
+      expect(status.history[0]!.prUrl).toBe('https://github.com/org/repo/pull/100');
+
+      // Verify reporter persisted to disk
+      const reporterHistory = reporter.getHistory(100, 0);
+      expect(reporterHistory).toHaveLength(1);
+      expect(reporterHistory[0]!.prUrl).toBe('https://github.com/org/repo/pull/100');
+
+      // Verify persistence on disk
+      const diskData = JSON.parse(fs.readFileSync(path.join(tmpDir, 'history.json'), 'utf-8'));
+      expect(diskData).toHaveLength(1);
+      expect(diskData[0].taskId).toBe('arch-violations');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('full cycle with task failure records error in reporter', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maint-integ-fail-'));
+
+    try {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          ...Object.fromEntries(
+            [
+              'dep-violations',
+              'doc-drift',
+              'security-findings',
+              'entropy',
+              'traceability',
+              'cross-check',
+              'dead-code',
+              'dependency-health',
+              'hotspot-remediation',
+              'security-review',
+              'perf-check',
+              'decay-trends',
+              'project-health',
+              'stale-constraints',
+              'graph-refresh',
+              'session-cleanup',
+              'perf-baselines',
+            ].map((id) => [id, { enabled: false }])
+          ),
+        },
+      };
+
+      const checkRunner: CheckCommandRunner = {
+        run: vi.fn().mockRejectedValue(new Error('check binary not found')),
+      };
+      const agentDispatcher: AgentDispatcher = {
+        dispatch: vi.fn().mockResolvedValue({ producedCommits: false, fixed: 0 }),
+      };
+      const commandExecutor: CommandExecutor = {
+        exec: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+
+      const taskRunner = new TaskRunner({
+        config,
+        checkRunner,
+        agentDispatcher,
+        commandExecutor,
+        cwd: '/test/project',
+      });
+
+      const onTaskDue = async (task: TaskDefinition) => {
+        const result = await taskRunner.run(task);
+        scheduler.recordRun(result);
+        await reporter.record(result);
+      };
+
+      const claimManager = {
+        claimAndVerify: vi.fn().mockResolvedValue({ ok: true, value: 'claimed' }),
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      const status = scheduler.getStatus();
+      expect(status.history).toHaveLength(1);
+      expect(status.history[0]!.status).toBe('failure');
+      expect(status.history[0]!.error).toContain('check binary not found');
+
+      const reporterHistory = reporter.getHistory(100, 0);
+      expect(reporterHistory).toHaveLength(1);
+      expect(reporterHistory[0]!.status).toBe('failure');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+2. Run test:
+
+   ```
+   cd packages/orchestrator && npx vitest run tests/maintenance/integration-full-cycle.test.ts
+   ```
+
+   Observe pass.
+
+3. Run: `harness validate`
+4. Commit: `test(maintenance): add integration test for full maintenance cycle`
+
+---
+
+### Task 3: PRManager edge case tests -- push failure and PR create failure
+
+**Depends on:** none | **Files:** packages/orchestrator/tests/maintenance/pr-manager.test.ts
+
+1. Add the following tests inside the `describe('ensurePR', ...)` block, after the existing `--force-with-lease` test (after line 274):
+
+```typescript
+it('propagates error when git push --force-with-lease fails', async () => {
+  const git = createMockGit();
+  const gh = createMockGh();
+  (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+    if (args[0] === 'push') throw new Error('push rejected: stale ref');
+    return '';
+  });
+  (gh.run as ReturnType<typeof vi.fn>).mockResolvedValue('');
+  const { prManager } = createPRManager({ git, gh });
+
+  await expect(prManager.ensurePR(ARCH_TASK, 'summary')).rejects.toThrow(
+    'push rejected: stale ref'
+  );
+});
+
+it('propagates error when gh pr create fails', async () => {
+  const git = createMockGit();
+  const gh = createMockGh();
+  (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+    if (args[0] === 'pr' && args[1] === 'list') return '';
+    if (args[0] === 'pr' && args[1] === 'create') {
+      throw new Error('gh: label "harness-maintenance" not found');
+    }
+    return '';
+  });
+  const { prManager } = createPRManager({ git, gh });
+
+  await expect(prManager.ensurePR(ARCH_TASK, 'summary')).rejects.toThrow(
+    'label "harness-maintenance" not found'
+  );
+});
+
+it('throws when task.branch is null', async () => {
+  const nullBranchTask: TaskDefinition = { ...ARCH_TASK, branch: null };
+  const { prManager } = createPRManager();
+
+  await expect(prManager.ensurePR(nullBranchTask, 'summary')).rejects.toThrow(
+    'ensurePR requires task.branch'
+  );
+});
+```
+
+2. Run test:
+
+   ```
+   cd packages/orchestrator && npx vitest run tests/maintenance/pr-manager.test.ts
+   ```
+
+   Observe pass (13 tests total for this file).
+
+3. Run: `harness validate`
+4. Commit: `test(maintenance): add PRManager edge case tests for push and create failures`
+
+---
+
+### Task 4: Routes edge cases and scheduler double-start guard
+
+**Depends on:** none | **Files:** packages/orchestrator/tests/maintenance/maintenance-routes.test.ts, packages/orchestrator/tests/maintenance/scheduler.test.ts
+
+1. Add the following test inside `describe('POST /api/maintenance/trigger', ...)` in `maintenance-routes.test.ts`, after the existing "returns 500 when triggerFn throws" test (after line 183):
+
+```typescript
+it('returns 400 for malformed JSON body', async () => {
+  const req = mockReq('POST', '/api/maintenance/trigger', 'not-json{{{');
+  const res = mockRes();
+  handleMaintenanceRoute(req, res, deps);
+  await vi.waitFor(() => expect(res._status).toBe(400));
+  expect(JSON.parse(res._body)).toEqual({ error: 'Invalid JSON body' });
+});
+```
+
+2. Add the following test inside `describe('GET /api/maintenance/history', ...)` in `maintenance-routes.test.ts`, after the existing "returns the history array" test (after line 153):
+
+```typescript
+it('clamps limit to 100 when exceeding maximum', () => {
+  const req = mockReq('GET', '/api/maintenance/history?limit=200');
+  const res = mockRes();
+  handleMaintenanceRoute(req, res, deps);
+  expect(deps.reporter.getHistory).toHaveBeenCalledWith(100, 0);
+});
+
+it('clamps limit to 1 when below minimum', () => {
+  const req = mockReq('GET', '/api/maintenance/history?limit=0');
+  const res = mockRes();
+  handleMaintenanceRoute(req, res, deps);
+  expect(deps.reporter.getHistory).toHaveBeenCalledWith(1, 0);
+});
+```
+
+3. Add the following test inside `describe('start and stop lifecycle', ...)` in `scheduler.test.ts`, after the existing "stop() sets isLeader to false" test (after line 281):
+
+```typescript
+it('start() called twice does not create duplicate intervals', async () => {
+  const config: MaintenanceConfig = { enabled: true, checkIntervalMs: 1000 };
+  const claimManager = createMockClaimManager('rejected');
+  const logger = createMockLogger();
+
+  const scheduler = new MaintenanceScheduler({
+    config,
+    claimManager: claimManager as any,
+    logger: logger as any,
+    onTaskDue: vi.fn(),
+  });
+
+  scheduler.start();
+  scheduler.start(); // Second call should be no-op
+
+  await vi.advanceTimersByTimeAsync(0);
+  // Only one initial evaluate call, not two
+  expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(1);
+
+  await vi.advanceTimersByTimeAsync(1000);
+  // One interval tick, not two
+  expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(2);
+
+  scheduler.stop();
+});
+```
+
+4. Run tests:
+
+   ```
+   cd packages/orchestrator && npx vitest run tests/maintenance/maintenance-routes.test.ts tests/maintenance/scheduler.test.ts
+   ```
+
+   Observe pass.
+
+5. Run: `harness validate`
+6. Commit: `test(maintenance): add route edge cases and scheduler double-start guard test`
+
+---
+
+### Task 5: Reporter corrupted file edge case and final verification
+
+**Depends on:** none | **Files:** packages/orchestrator/tests/maintenance/reporter.test.ts
+
+1. Add the following test inside `describe('load', ...)` in `reporter.test.ts`, after the existing "loads existing history from disk" test (after line 56):
+
+```typescript
+it('handles corrupted JSON on disk gracefully', async () => {
+  const persistDir = path.join(tmpDir, 'corrupted');
+  fs.mkdirSync(persistDir, { recursive: true });
+  fs.writeFileSync(path.join(persistDir, 'history.json'), '{ broken json !!!');
+
+  const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const reporter = new MaintenanceReporter({ persistDir });
+  await reporter.load();
+
+  expect(reporter.getHistory(100, 0)).toEqual([]);
+  expect(consoleSpy).toHaveBeenCalledWith(
+    'MaintenanceReporter: failed to load history',
+    expect.any(SyntaxError)
+  );
+  consoleSpy.mockRestore();
+});
+
+it('handles non-array JSON on disk gracefully', async () => {
+  const persistDir = path.join(tmpDir, 'non-array');
+  fs.mkdirSync(persistDir, { recursive: true });
+  fs.writeFileSync(path.join(persistDir, 'history.json'), '"just a string"');
+
+  const reporter = new MaintenanceReporter({ persistDir });
+  await reporter.load();
+
+  expect(reporter.getHistory(100, 0)).toEqual([]);
+});
+```
+
+2. Also need to add `vi` to the imports at the top of `reporter.test.ts` (line 1 currently imports only `describe, it, expect, beforeEach, afterEach`):
+
+Change:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+```
+
+To:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+```
+
+3. Run all maintenance tests to verify total count:
+
+   ```
+   cd packages/orchestrator && npx vitest run tests/maintenance/ --reporter=verbose
+   ```
+
+   Expect all tests to pass. Target: ~135 tests (115 existing + ~20 new).
+
+4. Run: `harness validate`
+5. Commit: `test(maintenance): add reporter edge case tests and verify full test suite`
+
+[checkpoint:human-verify] -- Confirm all tests pass and total count is satisfactory.

--- a/packages/orchestrator/src/maintenance/cron-matcher.ts
+++ b/packages/orchestrator/src/maintenance/cron-matcher.ts
@@ -8,6 +8,13 @@
 /**
  * Parse a single cron field into the set of matching integer values.
  */
+function validateRange(value: number, min: number, max: number, field: string): number {
+  if (isNaN(value) || value < min || value > max) {
+    throw new Error(`Invalid cron value ${value} in field "${field}": must be ${min}-${max}`);
+  }
+  return value;
+}
+
 function parseField(field: string, min: number, max: number): Set<number> {
   const values = new Set<number>();
 
@@ -15,16 +22,16 @@ function parseField(field: string, min: number, max: number): Set<number> {
     if (part.includes('/')) {
       // Step: */N or M-N/S
       const [rangeStr, stepStr] = part.split('/');
-      const step = parseInt(stepStr!, 10);
+      const step = validateRange(parseInt(stepStr!, 10), 1, max, field);
       let start = min;
       let end = max;
       if (rangeStr !== '*') {
         if (rangeStr!.includes('-')) {
           const [a, b] = rangeStr!.split('-');
-          start = parseInt(a!, 10);
-          end = parseInt(b!, 10);
+          start = validateRange(parseInt(a!, 10), min, max, field);
+          end = validateRange(parseInt(b!, 10), min, max, field);
         } else {
-          start = parseInt(rangeStr!, 10);
+          start = validateRange(parseInt(rangeStr!, 10), min, max, field);
         }
       }
       for (let i = start; i <= end; i += step) {
@@ -36,12 +43,13 @@ function parseField(field: string, min: number, max: number): Set<number> {
       }
     } else if (part.includes('-')) {
       const [a, b] = part.split('-');
-      const start = parseInt(a!, 10);
-      const end = parseInt(b!, 10);
+      const start = validateRange(parseInt(a!, 10), min, max, field);
+      const end = validateRange(parseInt(b!, 10), min, max, field);
       for (let i = start; i <= end; i++) {
         values.add(i);
       }
     } else {
+      validateRange(parseInt(part, 10), min, max, field);
       values.add(parseInt(part, 10));
     }
   }
@@ -77,11 +85,18 @@ export function cronMatchesNow(expression: string, now: Date): boolean {
     string,
   ];
 
+  // Parse all fields eagerly so invalid values always throw, regardless of short-circuit
+  const minutes = parseField(minField, 0, 59);
+  const hours = parseField(hourField, 0, 23);
+  const daysOfMonth = parseField(domField, 1, 31);
+  const months = parseField(monthField, 1, 12);
+  const daysOfWeek = parseField(dowField, 0, 6);
+
   return (
-    parseField(minField, 0, 59).has(minute) &&
-    parseField(hourField, 0, 23).has(hour) &&
-    parseField(domField, 1, 31).has(dayOfMonth) &&
-    parseField(monthField, 1, 12).has(month) &&
-    parseField(dowField, 0, 6).has(dayOfWeek)
+    minutes.has(minute) &&
+    hours.has(hour) &&
+    daysOfMonth.has(dayOfMonth) &&
+    months.has(month) &&
+    daysOfWeek.has(dayOfWeek)
   );
 }

--- a/packages/orchestrator/src/maintenance/cron-matcher.ts
+++ b/packages/orchestrator/src/maintenance/cron-matcher.ts
@@ -1,0 +1,87 @@
+/**
+ * Minimal 5-field cron expression matcher.
+ *
+ * Supports: exact values, wildcards (*), ranges (1-5), lists (1,3,5), and step values (star/N).
+ * Does NOT support: L, W, #, ?, or 6/7-field expressions.
+ */
+
+/**
+ * Parse a single cron field into the set of matching integer values.
+ */
+function parseField(field: string, min: number, max: number): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of field.split(',')) {
+    if (part.includes('/')) {
+      // Step: */N or M-N/S
+      const [rangeStr, stepStr] = part.split('/');
+      const step = parseInt(stepStr!, 10);
+      let start = min;
+      let end = max;
+      if (rangeStr !== '*') {
+        if (rangeStr!.includes('-')) {
+          const [a, b] = rangeStr!.split('-');
+          start = parseInt(a!, 10);
+          end = parseInt(b!, 10);
+        } else {
+          start = parseInt(rangeStr!, 10);
+        }
+      }
+      for (let i = start; i <= end; i += step) {
+        values.add(i);
+      }
+    } else if (part === '*') {
+      for (let i = min; i <= max; i++) {
+        values.add(i);
+      }
+    } else if (part.includes('-')) {
+      const [a, b] = part.split('-');
+      const start = parseInt(a!, 10);
+      const end = parseInt(b!, 10);
+      for (let i = start; i <= end; i++) {
+        values.add(i);
+      }
+    } else {
+      values.add(parseInt(part, 10));
+    }
+  }
+
+  return values;
+}
+
+/**
+ * Returns true if the given 5-field cron expression matches the provided Date.
+ *
+ * Fields: minute hour day-of-month month day-of-week
+ * Month is 1-12, day-of-week is 0-6 (0 = Sunday).
+ *
+ * @throws {Error} If the expression does not have exactly 5 fields.
+ */
+export function cronMatchesNow(expression: string, now: Date): boolean {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error(`Invalid cron expression: expected 5 fields, got ${fields.length}`);
+  }
+
+  const minute = now.getMinutes();
+  const hour = now.getHours();
+  const dayOfMonth = now.getDate();
+  const month = now.getMonth() + 1; // JS months are 0-based
+  const dayOfWeek = now.getDay(); // 0 = Sunday
+
+  const [minField, hourField, domField, monthField, dowField] = fields as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+
+  return (
+    parseField(minField, 0, 59).has(minute) &&
+    parseField(hourField, 0, 23).has(hour) &&
+    parseField(domField, 1, 31).has(dayOfMonth) &&
+    parseField(monthField, 1, 12).has(month) &&
+    parseField(dowField, 0, 6).has(dayOfWeek)
+  );
+}

--- a/packages/orchestrator/src/maintenance/index.ts
+++ b/packages/orchestrator/src/maintenance/index.ts
@@ -35,6 +35,7 @@ export type {
   AgentDispatcher,
   AgentDispatchResult,
   CommandExecutor,
+  PRLifecycleManager,
   TaskRunnerOptions,
 } from './task-runner';
 

--- a/packages/orchestrator/src/maintenance/index.ts
+++ b/packages/orchestrator/src/maintenance/index.ts
@@ -4,8 +4,8 @@
  * Phase 1 exports types and the task registry.
  * Phase 2 adds MaintenanceScheduler and cron matching.
  * Phase 3 adds TaskRunner with four execution paths.
+ * Phase 4 adds PRManager for branch and PR lifecycle.
  * Subsequent phases add:
- * - PRManager (Phase 4)
  * - Reporter (Phase 5)
  */
 
@@ -37,3 +37,13 @@ export type {
   CommandExecutor,
   TaskRunnerOptions,
 } from './task-runner';
+
+export { PRManager } from './pr-manager';
+export type {
+  GitExecutor,
+  GhExecutor,
+  EnsureBranchResult,
+  EnsurePRResult,
+  PRManagerOptions,
+  PRManagerLogger,
+} from './pr-manager';

--- a/packages/orchestrator/src/maintenance/index.ts
+++ b/packages/orchestrator/src/maintenance/index.ts
@@ -3,8 +3,8 @@
  *
  * Phase 1 exports types and the task registry.
  * Phase 2 adds MaintenanceScheduler and cron matching.
+ * Phase 3 adds TaskRunner with four execution paths.
  * Subsequent phases add:
- * - TaskRunner (Phase 3)
  * - PRManager (Phase 4)
  * - Reporter (Phase 5)
  */
@@ -27,3 +27,13 @@ export type {
 } from './scheduler';
 
 export { cronMatchesNow } from './cron-matcher';
+
+export { TaskRunner } from './task-runner';
+export type {
+  CheckCommandRunner,
+  CheckCommandResult,
+  AgentDispatcher,
+  AgentDispatchResult,
+  CommandExecutor,
+  TaskRunnerOptions,
+} from './task-runner';

--- a/packages/orchestrator/src/maintenance/index.ts
+++ b/packages/orchestrator/src/maintenance/index.ts
@@ -1,8 +1,9 @@
 /**
- * Scheduled maintenance module — public exports.
+ * Scheduled maintenance module -- public exports.
  *
- * Phase 1 exports types and the task registry. Subsequent phases add:
- * - MaintenanceScheduler (Phase 2)
+ * Phase 1 exports types and the task registry.
+ * Phase 2 adds MaintenanceScheduler and cron matching.
+ * Subsequent phases add:
  * - TaskRunner (Phase 3)
  * - PRManager (Phase 4)
  * - Reporter (Phase 5)
@@ -17,3 +18,12 @@ export type {
 } from './types';
 
 export { BUILT_IN_TASKS } from './task-registry';
+
+export { MaintenanceScheduler } from './scheduler';
+export type {
+  MaintenanceSchedulerOptions,
+  SchedulerLogger,
+  SchedulerClaimManager,
+} from './scheduler';
+
+export { cronMatchesNow } from './cron-matcher';

--- a/packages/orchestrator/src/maintenance/index.ts
+++ b/packages/orchestrator/src/maintenance/index.ts
@@ -5,8 +5,7 @@
  * Phase 2 adds MaintenanceScheduler and cron matching.
  * Phase 3 adds TaskRunner with four execution paths.
  * Phase 4 adds PRManager for branch and PR lifecycle.
- * Subsequent phases add:
- * - Reporter (Phase 5)
+ * Phase 5 adds MaintenanceReporter for run result persistence.
  */
 
 export type {
@@ -38,6 +37,9 @@ export type {
   PRLifecycleManager,
   TaskRunnerOptions,
 } from './task-runner';
+
+export { MaintenanceReporter } from './reporter';
+export type { MaintenanceReporterOptions } from './reporter';
 
 export { PRManager } from './pr-manager';
 export type {

--- a/packages/orchestrator/src/maintenance/index.ts
+++ b/packages/orchestrator/src/maintenance/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Scheduled maintenance module — public exports.
+ *
+ * Phase 1 exports types and the task registry. Subsequent phases add:
+ * - MaintenanceScheduler (Phase 2)
+ * - TaskRunner (Phase 3)
+ * - PRManager (Phase 4)
+ * - Reporter (Phase 5)
+ */
+
+export type {
+  TaskType,
+  TaskDefinition,
+  RunResult,
+  ScheduleEntry,
+  MaintenanceStatus,
+} from './types';
+
+export { BUILT_IN_TASKS } from './task-registry';

--- a/packages/orchestrator/src/maintenance/index.ts
+++ b/packages/orchestrator/src/maintenance/index.ts
@@ -21,8 +21,10 @@ export { BUILT_IN_TASKS } from './task-registry';
 export { MaintenanceScheduler } from './scheduler';
 export type {
   MaintenanceSchedulerOptions,
+  MaintenanceLogger,
   SchedulerLogger,
   SchedulerClaimManager,
+  RunHistoryProvider,
 } from './scheduler';
 
 export { cronMatchesNow } from './cron-matcher';

--- a/packages/orchestrator/src/maintenance/pr-manager.ts
+++ b/packages/orchestrator/src/maintenance/pr-manager.ts
@@ -43,9 +43,11 @@ export interface PRManagerOptions {
   logger: PRManagerLogger;
 }
 
+/** @deprecated Use MaintenanceLogger from scheduler.ts instead */
 export interface PRManagerLogger {
   info(message: string, context?: Record<string, unknown>): void;
   warn(message: string, context?: Record<string, unknown>): void;
+  error?(message: string, context?: Record<string, unknown>): void;
   debug?(message: string, context?: Record<string, unknown>): void;
 }
 

--- a/packages/orchestrator/src/maintenance/pr-manager.ts
+++ b/packages/orchestrator/src/maintenance/pr-manager.ts
@@ -12,7 +12,11 @@ export interface GitExecutor {
  * Interface for executing gh CLI commands. Injected for testability.
  */
 export interface GhExecutor {
-  /** Run a gh command and return stdout. Throws on non-zero exit. */
+  /**
+   * Run a gh command and return stdout. Throws on non-zero exit.
+   * Implementation MUST use execFile/spawn (array args), not exec (string),
+   * to prevent shell metacharacter injection from PR body content.
+   */
   run(args: string[], cwd: string): Promise<string>;
 }
 
@@ -116,7 +120,10 @@ export class PRManager {
    * - If no PR exists: create one via gh pr create.
    */
   async ensurePR(task: TaskDefinition, runSummary: string): Promise<EnsurePRResult> {
-    const branchName = task.branch!;
+    if (!task.branch) {
+      throw new Error(`ensurePR requires task.branch to be set (task: ${task.id})`);
+    }
+    const branchName = task.branch;
 
     // Push commits to remote
     await this.git.run(['push', 'origin', branchName, '--force-with-lease'], this.cwd);
@@ -165,7 +172,10 @@ export class PRManager {
    */
   private async remoteBranchExists(branchName: string): Promise<boolean> {
     try {
-      const output = await this.git.run(['ls-remote', '--heads', 'origin', branchName], this.cwd);
+      const output = await this.git.run(
+        ['ls-remote', '--heads', 'origin', `refs/heads/${branchName}`],
+        this.cwd
+      );
       return output.trim().length > 0;
     } catch {
       return false;

--- a/packages/orchestrator/src/maintenance/pr-manager.ts
+++ b/packages/orchestrator/src/maintenance/pr-manager.ts
@@ -1,0 +1,225 @@
+import type { TaskDefinition } from './types';
+
+/**
+ * Interface for executing git commands. Injected for testability.
+ */
+export interface GitExecutor {
+  /** Run a git command and return stdout. Throws on non-zero exit. */
+  run(args: string[], cwd: string): Promise<string>;
+}
+
+/**
+ * Interface for executing gh CLI commands. Injected for testability.
+ */
+export interface GhExecutor {
+  /** Run a gh command and return stdout. Throws on non-zero exit. */
+  run(args: string[], cwd: string): Promise<string>;
+}
+
+export interface EnsureBranchResult {
+  /** True if the branch was newly created (did not exist remotely). */
+  created: boolean;
+  /** True if the branch existed but was recreated due to rebase conflict. */
+  recreated: boolean;
+}
+
+export interface EnsurePRResult {
+  /** URL of the PR (created or existing). */
+  prUrl: string;
+  /** True if an existing PR was updated, false if newly created. */
+  prUpdated: boolean;
+}
+
+export interface PRManagerOptions {
+  git: GitExecutor;
+  gh: GhExecutor;
+  /** Project root directory for running commands. */
+  cwd: string;
+  /** Logger for debug/info messages. */
+  logger: PRManagerLogger;
+}
+
+export interface PRManagerLogger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  debug?(message: string, context?: Record<string, unknown>): void;
+}
+
+/**
+ * PRManager handles branch lifecycle (create, fetch, rebase, recreate)
+ * and PR lifecycle (create or update via gh CLI) for maintenance tasks.
+ */
+export class PRManager {
+  private git: GitExecutor;
+  private gh: GhExecutor;
+  private cwd: string;
+  private logger: PRManagerLogger;
+
+  constructor(options: PRManagerOptions) {
+    this.git = options.git;
+    this.gh = options.gh;
+    this.cwd = options.cwd;
+    this.logger = options.logger;
+  }
+
+  /**
+   * Ensure a maintenance branch exists and is up-to-date with the base branch.
+   *
+   * - If the branch does not exist remotely: create from baseBranch.
+   * - If it exists: fetch, checkout, attempt rebase onto baseBranch.
+   * - If rebase fails: abort rebase, delete branch, recreate from baseBranch.
+   */
+  async ensureBranch(branchName: string, baseBranch: string): Promise<EnsureBranchResult> {
+    const remoteExists = await this.remoteBranchExists(branchName);
+
+    if (!remoteExists) {
+      this.logger.info('Creating new maintenance branch', { branchName, baseBranch });
+      await this.git.run(['fetch', 'origin', baseBranch], this.cwd);
+      await this.git.run(['checkout', '-b', branchName, `origin/${baseBranch}`], this.cwd);
+      return { created: true, recreated: false };
+    }
+
+    // Branch exists remotely -- fetch and checkout
+    this.logger.info('Fetching existing maintenance branch', { branchName });
+    await this.git.run(['fetch', 'origin', branchName], this.cwd);
+    await this.git.run(['checkout', branchName], this.cwd);
+    await this.git.run(['reset', '--hard', `origin/${branchName}`], this.cwd);
+
+    // Attempt rebase onto base branch
+    await this.git.run(['fetch', 'origin', baseBranch], this.cwd);
+    const rebaseSucceeded = await this.tryRebase(baseBranch);
+
+    if (rebaseSucceeded) {
+      return { created: false, recreated: false };
+    }
+
+    // Rebase failed -- recreate branch
+    this.logger.warn('Rebase failed, recreating branch from base', { branchName, baseBranch });
+    await this.git.run(['rebase', '--abort'], this.cwd);
+    await this.git.run(['checkout', `origin/${baseBranch}`], this.cwd);
+    await this.git.run(['branch', '-D', branchName], this.cwd);
+    // Also delete the remote branch so we start fresh
+    try {
+      await this.git.run(['push', 'origin', '--delete', branchName], this.cwd);
+    } catch {
+      // Remote branch may already be gone; ignore
+    }
+    await this.git.run(['checkout', '-b', branchName, `origin/${baseBranch}`], this.cwd);
+    return { created: false, recreated: true };
+  }
+
+  /**
+   * Ensure a PR exists for the maintenance task's branch.
+   *
+   * - Push current commits to origin.
+   * - If a PR already exists: update its body via gh pr edit.
+   * - If no PR exists: create one via gh pr create.
+   */
+  async ensurePR(task: TaskDefinition, runSummary: string): Promise<EnsurePRResult> {
+    const branchName = task.branch!;
+
+    // Push commits to remote
+    await this.git.run(['push', 'origin', branchName, '--force-with-lease'], this.cwd);
+
+    // Check for existing PR
+    const existingPrUrl = await this.findOpenPR(branchName);
+
+    if (existingPrUrl) {
+      this.logger.info('Updating existing maintenance PR', { branchName, prUrl: existingPrUrl });
+      await this.gh.run(
+        ['pr', 'edit', existingPrUrl, '--body', this.buildPRBody(task, runSummary)],
+        this.cwd
+      );
+      return { prUrl: existingPrUrl, prUpdated: true };
+    }
+
+    // Create new PR
+    this.logger.info('Creating new maintenance PR', { branchName });
+    const title = `[Maintenance] ${task.description}`;
+    const body = this.buildPRBody(task, runSummary);
+    const prUrl = (
+      await this.gh.run(
+        [
+          'pr',
+          'create',
+          '--head',
+          branchName,
+          '--title',
+          title,
+          '--body',
+          body,
+          '--label',
+          'harness-maintenance',
+          '--label',
+          task.id,
+        ],
+        this.cwd
+      )
+    ).trim();
+
+    return { prUrl, prUpdated: false };
+  }
+
+  /**
+   * Check if a remote branch exists using git ls-remote.
+   */
+  private async remoteBranchExists(branchName: string): Promise<boolean> {
+    try {
+      const output = await this.git.run(['ls-remote', '--heads', 'origin', branchName], this.cwd);
+      return output.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Attempt to rebase current branch onto baseBranch.
+   * Returns true if rebase succeeded, false if conflicts arose.
+   */
+  private async tryRebase(baseBranch: string): Promise<boolean> {
+    try {
+      await this.git.run(['rebase', `origin/${baseBranch}`], this.cwd);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Find an open PR for the given branch head.
+   * Returns the PR URL if found, null otherwise.
+   */
+  private async findOpenPR(branchName: string): Promise<string | null> {
+    try {
+      const output = await this.gh.run(
+        ['pr', 'list', '--head', branchName, '--json', 'url', '--jq', '.[0].url'],
+        this.cwd
+      );
+      const url = output.trim();
+      return url.length > 0 ? url : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Build the PR body with task metadata and run summary.
+   */
+  private buildPRBody(task: TaskDefinition, runSummary: string): string {
+    const lines = [
+      '## Automated Maintenance PR',
+      '',
+      `**Task:** ${task.id}`,
+      `**Type:** ${task.type}`,
+      `**Schedule:** \`${task.schedule}\``,
+      '',
+      '## Latest Run Summary',
+      '',
+      runSummary,
+      '',
+      '---',
+      '_This PR was created and managed automatically by the harness maintenance scheduler._',
+    ];
+    return lines.join('\n');
+  }
+}

--- a/packages/orchestrator/src/maintenance/reporter.ts
+++ b/packages/orchestrator/src/maintenance/reporter.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { RunResult } from './types';
+import type { MaintenanceLogger } from './scheduler';
 
 /**
  * Options for the MaintenanceReporter.
@@ -8,6 +9,8 @@ import type { RunResult } from './types';
 export interface MaintenanceReporterOptions {
   /** Directory where history.json is persisted (default: '.harness/maintenance/') */
   persistDir?: string;
+  /** Logger for structured error/info output. Falls back to console if not provided. */
+  logger?: MaintenanceLogger;
 }
 
 /** Maximum number of history entries kept in memory and on disk. */
@@ -17,12 +20,20 @@ const MAX_HISTORY = 500;
  * MaintenanceReporter persists run results to disk and provides
  * paginated history access for the dashboard API.
  */
+const fallbackLogger: MaintenanceLogger = {
+  info: () => {},
+  warn: () => {},
+  error: (msg, ctx) => console.error(msg, ctx),
+};
+
 export class MaintenanceReporter {
   private persistDir: string;
+  private logger: MaintenanceLogger;
   private history: RunResult[] = [];
 
   constructor(options?: MaintenanceReporterOptions) {
     this.persistDir = options?.persistDir ?? '.harness/maintenance/';
+    this.logger = options?.logger ?? fallbackLogger;
   }
 
   /**
@@ -48,7 +59,7 @@ export class MaintenanceReporter {
         // No history file yet — start with empty history
         return;
       }
-      console.error('MaintenanceReporter: failed to load history', err);
+      this.logger.error('MaintenanceReporter: failed to load history', { error: String(err) });
     }
   }
 
@@ -80,7 +91,7 @@ export class MaintenanceReporter {
       const filePath = path.join(this.persistDir, 'history.json');
       await fs.promises.writeFile(filePath, JSON.stringify(this.history, null, 2), 'utf-8');
     } catch (err) {
-      console.error('MaintenanceReporter: failed to persist history', err);
+      this.logger.error('MaintenanceReporter: failed to persist history', { error: String(err) });
     }
   }
 }

--- a/packages/orchestrator/src/maintenance/reporter.ts
+++ b/packages/orchestrator/src/maintenance/reporter.ts
@@ -1,0 +1,86 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { RunResult } from './types';
+
+/**
+ * Options for the MaintenanceReporter.
+ */
+export interface MaintenanceReporterOptions {
+  /** Directory where history.json is persisted (default: '.harness/maintenance/') */
+  persistDir?: string;
+}
+
+/** Maximum number of history entries kept in memory and on disk. */
+const MAX_HISTORY = 500;
+
+/**
+ * MaintenanceReporter persists run results to disk and provides
+ * paginated history access for the dashboard API.
+ */
+export class MaintenanceReporter {
+  private persistDir: string;
+  private history: RunResult[] = [];
+
+  constructor(options?: MaintenanceReporterOptions) {
+    this.persistDir = options?.persistDir ?? '.harness/maintenance/';
+  }
+
+  /**
+   * Load history from disk. Creates the persist directory if it does not exist.
+   * Errors in persistence are logged to stderr, not thrown.
+   */
+  async load(): Promise<void> {
+    try {
+      await fs.promises.mkdir(this.persistDir, { recursive: true });
+      const filePath = path.join(this.persistDir, 'history.json');
+      const data = await fs.promises.readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(data);
+      if (Array.isArray(parsed)) {
+        this.history = parsed.slice(0, MAX_HISTORY);
+      }
+    } catch (err: unknown) {
+      // File not found is expected on first run; other errors are logged
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
+      ) {
+        // No history file yet — start with empty history
+        return;
+      }
+      console.error('MaintenanceReporter: failed to load history', err);
+    }
+  }
+
+  /**
+   * Record a run result. Appends to in-memory history (most recent first),
+   * caps at MAX_HISTORY, and writes to disk asynchronously.
+   */
+  async record(result: RunResult): Promise<void> {
+    this.history.unshift(result);
+    if (this.history.length > MAX_HISTORY) {
+      this.history.length = MAX_HISTORY;
+    }
+    await this.persist();
+  }
+
+  /**
+   * Returns a paginated slice of the run history (most recent first).
+   */
+  getHistory(limit: number, offset: number): RunResult[] {
+    return this.history.slice(offset, offset + limit);
+  }
+
+  /**
+   * Write history to disk. Errors are logged, not thrown.
+   */
+  private async persist(): Promise<void> {
+    try {
+      await fs.promises.mkdir(this.persistDir, { recursive: true });
+      const filePath = path.join(this.persistDir, 'history.json');
+      await fs.promises.writeFile(filePath, JSON.stringify(this.history, null, 2), 'utf-8');
+    } catch (err) {
+      console.error('MaintenanceReporter: failed to persist history', err);
+    }
+  }
+}

--- a/packages/orchestrator/src/maintenance/scheduler.ts
+++ b/packages/orchestrator/src/maintenance/scheduler.ts
@@ -4,14 +4,18 @@ import { BUILT_IN_TASKS } from './task-registry';
 import { cronMatchesNow } from './cron-matcher';
 
 /**
- * Logger interface matching StructuredLogger's shape.
+ * Unified logger interface for all maintenance classes.
+ * Matches StructuredLogger's shape.
  */
-export interface SchedulerLogger {
+export interface MaintenanceLogger {
   info(message: string, context?: Record<string, unknown>): void;
   warn(message: string, context?: Record<string, unknown>): void;
   error(message: string, context?: Record<string, unknown>): void;
   debug?(message: string, context?: Record<string, unknown>): void;
 }
+
+/** @deprecated Use MaintenanceLogger instead */
+export type SchedulerLogger = MaintenanceLogger;
 
 /**
  * Minimal ClaimManager interface used by the scheduler.
@@ -23,12 +27,19 @@ export interface SchedulerClaimManager {
   ): Promise<{ ok: boolean; value?: 'claimed' | 'rejected'; error?: { message: string } }>;
 }
 
+/** Interface for providing run history to the scheduler's getStatus(). */
+export interface RunHistoryProvider {
+  getHistory(limit: number, offset: number): RunResult[];
+}
+
 export interface MaintenanceSchedulerOptions {
   config: MaintenanceConfig;
   claimManager: SchedulerClaimManager;
-  logger: SchedulerLogger;
+  logger: MaintenanceLogger;
   /** Callback invoked when a task is due. The scheduler calls this for each queued task sequentially. */
   onTaskDue: (task: TaskDefinition) => Promise<void>;
+  /** Optional history provider for getStatus(). When set, getStatus() reads history from here instead of internal state. */
+  historyProvider?: RunHistoryProvider;
 }
 
 /**
@@ -39,8 +50,9 @@ export interface MaintenanceSchedulerOptions {
 export class MaintenanceScheduler {
   private config: MaintenanceConfig;
   private claimManager: SchedulerClaimManager;
-  private logger: SchedulerLogger;
+  private logger: MaintenanceLogger;
   private onTaskDue: (task: TaskDefinition) => Promise<void>;
+  private historyProvider: RunHistoryProvider | null;
 
   private resolvedTasks: TaskDefinition[];
   private interval: ReturnType<typeof setInterval> | null = null;
@@ -50,14 +62,15 @@ export class MaintenanceScheduler {
   /** Tracks which minute (as epoch-minute) each task last ran to prevent re-runs. */
   private lastRunMinute: Map<string, number> = new Map();
 
-  /** History of completed runs (most recent first). */
-  private history: RunResult[] = [];
+  /** Fallback history when no historyProvider is set (for backward compat in tests). */
+  private internalHistory: RunResult[] = [];
   private activeRun: { taskId: string; startedAt: string } | null = null;
 
   constructor(options: MaintenanceSchedulerOptions) {
     this.config = options.config;
     this.claimManager = options.claimManager;
     this.logger = options.logger;
+    this.historyProvider = options.historyProvider ?? null;
     this.onTaskDue = options.onTaskDue;
 
     this.resolvedTasks = this.resolveTasks();
@@ -221,21 +234,29 @@ export class MaintenanceScheduler {
     }
   }
 
-  /** Record a completed run result (called by the task runner or orchestrator integration). */
+  /**
+   * Record a completed run result.
+   * Kept for backward compat (tests that don't inject historyProvider).
+   * In production, the orchestrator records via the reporter directly.
+   */
   recordRun(result: RunResult): void {
-    this.history.unshift(result);
-    // Cap history at 200 entries
-    if (this.history.length > 200) {
-      this.history.length = 200;
+    this.internalHistory.unshift(result);
+    if (this.internalHistory.length > 200) {
+      this.internalHistory.length = 200;
     }
   }
 
   /** Returns the current maintenance status for the dashboard API. */
   getStatus(): MaintenanceStatus {
+    // Use historyProvider (reporter) when available; fall back to internal history
+    const history = this.historyProvider
+      ? this.historyProvider.getHistory(200, 0)
+      : this.internalHistory;
+
     const schedule: ScheduleEntry[] = this.resolvedTasks.map((task) => ({
       taskId: task.id,
       nextRun: this.computeNextRun(task.schedule),
-      lastRun: this.history.find((r) => r.taskId === task.id) ?? null,
+      lastRun: history.find((r) => r.taskId === task.id) ?? null,
     }));
 
     return {
@@ -243,7 +264,7 @@ export class MaintenanceScheduler {
       lastLeaderClaim: this.lastLeaderClaim,
       schedule,
       activeRun: this.activeRun,
-      history: this.history,
+      history,
     };
   }
 

--- a/packages/orchestrator/src/maintenance/scheduler.ts
+++ b/packages/orchestrator/src/maintenance/scheduler.ts
@@ -194,10 +194,22 @@ export class MaintenanceScheduler {
       this.lastRunMinute.set(task.id, epochMinute);
       this.activeRun = { taskId: task.id, startedAt: new Date().toISOString() };
 
+      const startedAt = this.activeRun.startedAt;
       try {
         await this.onTaskDue(task);
       } catch (err) {
         this.logger.error(`Maintenance task ${task.id} failed`, { error: String(err) });
+        this.recordRun({
+          taskId: task.id,
+          startedAt,
+          completedAt: new Date().toISOString(),
+          status: 'failure',
+          findings: 0,
+          fixed: 0,
+          prUrl: null,
+          prUpdated: false,
+          error: String(err),
+        });
       }
 
       this.activeRun = null;

--- a/packages/orchestrator/src/maintenance/scheduler.ts
+++ b/packages/orchestrator/src/maintenance/scheduler.ts
@@ -90,6 +90,11 @@ export class MaintenanceScheduler {
     return this.resolvedTasks;
   }
 
+  /** Returns the onTaskDue callback for direct invocation (manual trigger). */
+  getOnTaskDue(): (task: TaskDefinition) => Promise<void> {
+    return this.onTaskDue;
+  }
+
   /**
    * Start the scheduler interval timer.
    * Immediately performs the first evaluation, then repeats every checkIntervalMs.

--- a/packages/orchestrator/src/maintenance/scheduler.ts
+++ b/packages/orchestrator/src/maintenance/scheduler.ts
@@ -1,0 +1,261 @@
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition, MaintenanceStatus, RunResult, ScheduleEntry } from './types';
+import { BUILT_IN_TASKS } from './task-registry';
+import { cronMatchesNow } from './cron-matcher';
+
+/**
+ * Logger interface matching StructuredLogger's shape.
+ */
+export interface SchedulerLogger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+  debug?(message: string, context?: Record<string, unknown>): void;
+}
+
+/**
+ * Minimal ClaimManager interface used by the scheduler.
+ * Avoids importing the full ClaimManager class (which depends on IssueTrackerClient).
+ */
+export interface SchedulerClaimManager {
+  claimAndVerify(
+    issueId: string
+  ): Promise<{ ok: boolean; value?: 'claimed' | 'rejected'; error?: { message: string } }>;
+}
+
+export interface MaintenanceSchedulerOptions {
+  config: MaintenanceConfig;
+  claimManager: SchedulerClaimManager;
+  logger: SchedulerLogger;
+  /** Callback invoked when a task is due. The scheduler calls this for each queued task sequentially. */
+  onTaskDue: (task: TaskDefinition) => Promise<void>;
+}
+
+/**
+ * MaintenanceScheduler evaluates cron schedules on an interval timer,
+ * claims leader election via ClaimManager, and invokes onTaskDue for
+ * each task whose schedule matches the current time.
+ */
+export class MaintenanceScheduler {
+  private config: MaintenanceConfig;
+  private claimManager: SchedulerClaimManager;
+  private logger: SchedulerLogger;
+  private onTaskDue: (task: TaskDefinition) => Promise<void>;
+
+  private resolvedTasks: TaskDefinition[];
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private isLeader = false;
+  private lastLeaderClaim: string | null = null;
+
+  /** Tracks which minute (as epoch-minute) each task last ran to prevent re-runs. */
+  private lastRunMinute: Map<string, number> = new Map();
+
+  /** History of completed runs (most recent first). */
+  private history: RunResult[] = [];
+  private activeRun: { taskId: string; startedAt: string } | null = null;
+
+  constructor(options: MaintenanceSchedulerOptions) {
+    this.config = options.config;
+    this.claimManager = options.claimManager;
+    this.logger = options.logger;
+    this.onTaskDue = options.onTaskDue;
+
+    this.resolvedTasks = this.resolveTasks();
+  }
+
+  /**
+   * Merge built-in task definitions with config overrides.
+   * Tasks with `enabled: false` are filtered out.
+   * Schedule overrides replace the default cron expression.
+   */
+  private resolveTasks(): TaskDefinition[] {
+    const overrides = this.config.tasks ?? {};
+
+    return BUILT_IN_TASKS.filter((task) => {
+      const override = overrides[task.id];
+      if (override?.enabled === false) return false;
+      return true;
+    }).map((task) => {
+      const override = overrides[task.id];
+      if (!override) return { ...task };
+      return {
+        ...task,
+        ...(override.schedule !== undefined && { schedule: override.schedule }),
+      };
+    });
+  }
+
+  /** Returns the resolved (merged) task list. Useful for testing and dashboard. */
+  getResolvedTasks(): readonly TaskDefinition[] {
+    return this.resolvedTasks;
+  }
+
+  /**
+   * Start the scheduler interval timer.
+   * Immediately performs the first evaluation, then repeats every checkIntervalMs.
+   */
+  start(): void {
+    if (this.interval) return; // Already started
+
+    const intervalMs = this.config.checkIntervalMs ?? 60_000;
+    this.logger.info('MaintenanceScheduler starting', {
+      intervalMs,
+      taskCount: this.resolvedTasks.length,
+    });
+
+    // Run immediately, then on interval
+    void this.evaluate();
+    this.interval = setInterval(() => {
+      void this.evaluate();
+    }, intervalMs);
+  }
+
+  /** Stop the scheduler and clear the interval timer. */
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.isLeader = false;
+    this.logger.info('MaintenanceScheduler stopped');
+  }
+
+  /**
+   * Core evaluation loop. Called every checkIntervalMs.
+   *
+   * 1. Attempt leader claim
+   * 2. If leader, evaluate cron for each task
+   * 3. Process due tasks sequentially
+   */
+  async evaluate(now?: Date): Promise<void> {
+    const evalTime = now ?? new Date();
+
+    const isLeader = await this.attemptLeaderClaim(evalTime);
+    if (!isLeader) return;
+
+    const epochMinute = Math.floor(evalTime.getTime() / 60_000);
+    const queue = this.buildQueue(evalTime, epochMinute);
+    await this.processQueue(queue, epochMinute);
+  }
+
+  /**
+   * Attempt to claim leadership via ClaimManager.
+   * Returns true if this instance is the leader.
+   */
+  private async attemptLeaderClaim(evalTime: Date): Promise<boolean> {
+    try {
+      const result = await this.claimManager.claimAndVerify('maintenance-leader');
+      if (!result.ok) {
+        this.isLeader = false;
+        this.logger.warn('Maintenance leader claim failed', { error: result.error?.message });
+        return false;
+      }
+      if (result.value === 'rejected') {
+        this.isLeader = false;
+        if (this.logger.debug) {
+          this.logger.debug('Not the maintenance leader, skipping evaluation');
+        }
+        return false;
+      }
+
+      this.isLeader = true;
+      this.lastLeaderClaim = evalTime.toISOString();
+      return true;
+    } catch (err) {
+      this.isLeader = false;
+      this.logger.error('Maintenance leader claim threw', { error: String(err) });
+      return false;
+    }
+  }
+
+  /**
+   * Evaluate cron for each task and return those due for execution.
+   * Skips tasks that have already run in the current minute.
+   */
+  private buildQueue(evalTime: Date, epochMinute: number): TaskDefinition[] {
+    const queue: TaskDefinition[] = [];
+
+    for (const task of this.resolvedTasks) {
+      if (this.lastRunMinute.get(task.id) === epochMinute) continue;
+
+      if (cronMatchesNow(task.schedule, evalTime)) {
+        queue.push(task);
+      }
+    }
+
+    return queue;
+  }
+
+  /**
+   * Process queued tasks sequentially, invoking onTaskDue for each.
+   */
+  private async processQueue(queue: TaskDefinition[], epochMinute: number): Promise<void> {
+    for (const task of queue) {
+      this.lastRunMinute.set(task.id, epochMinute);
+      this.activeRun = { taskId: task.id, startedAt: new Date().toISOString() };
+
+      try {
+        await this.onTaskDue(task);
+      } catch (err) {
+        this.logger.error(`Maintenance task ${task.id} failed`, { error: String(err) });
+      }
+
+      this.activeRun = null;
+    }
+  }
+
+  /** Record a completed run result (called by the task runner or orchestrator integration). */
+  recordRun(result: RunResult): void {
+    this.history.unshift(result);
+    // Cap history at 200 entries
+    if (this.history.length > 200) {
+      this.history.length = 200;
+    }
+  }
+
+  /** Returns the current maintenance status for the dashboard API. */
+  getStatus(): MaintenanceStatus {
+    const schedule: ScheduleEntry[] = this.resolvedTasks.map((task) => ({
+      taskId: task.id,
+      nextRun: this.computeNextRun(task.schedule),
+      lastRun: this.history.find((r) => r.taskId === task.id) ?? null,
+    }));
+
+    return {
+      isLeader: this.isLeader,
+      lastLeaderClaim: this.lastLeaderClaim,
+      schedule,
+      activeRun: this.activeRun,
+      history: this.history,
+    };
+  }
+
+  /**
+   * Compute a rough next-run ISO string for a cron expression.
+   * Scans the next 1440 minutes (24 hours) to find the next match.
+   */
+  private computeNextRun(cronExpr: string): string {
+    const now = new Date();
+    // Start from the next minute
+    const start = new Date(now);
+    start.setSeconds(0, 0);
+    start.setMinutes(start.getMinutes() + 1);
+
+    for (let i = 0; i < 1440; i++) {
+      const candidate = new Date(start.getTime() + i * 60_000);
+      if (cronMatchesNow(cronExpr, candidate)) {
+        return candidate.toISOString();
+      }
+    }
+
+    // Fallback: scan up to 31 days for monthly schedules
+    for (let i = 1440; i < 44_640; i++) {
+      const candidate = new Date(start.getTime() + i * 60_000);
+      if (cronMatchesNow(cronExpr, candidate)) {
+        return candidate.toISOString();
+      }
+    }
+
+    return 'unknown';
+  }
+}

--- a/packages/orchestrator/src/maintenance/task-registry.ts
+++ b/packages/orchestrator/src/maintenance/task-registry.ts
@@ -1,7 +1,7 @@
 import type { TaskDefinition } from './types';
 
 /**
- * All 17 built-in maintenance task definitions with default schedules.
+ * All 18 built-in maintenance task definitions with default schedules.
  *
  * Tasks are grouped by type:
  * - mechanical-ai (7): Run check first, dispatch AI only if fixable issues found

--- a/packages/orchestrator/src/maintenance/task-registry.ts
+++ b/packages/orchestrator/src/maintenance/task-registry.ts
@@ -1,0 +1,171 @@
+import type { TaskDefinition } from './types';
+
+/**
+ * All 17 built-in maintenance task definitions with default schedules.
+ *
+ * Tasks are grouped by type:
+ * - mechanical-ai (7): Run check first, dispatch AI only if fixable issues found
+ * - pure-ai (4): Always dispatch AI agent on schedule
+ * - report-only (5): Run command, record metrics, no PR
+ * - housekeeping (2): Mechanical command, no AI, no PR
+ */
+export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
+  // --- Mechanical-AI ---
+  {
+    id: 'arch-violations',
+    type: 'mechanical-ai',
+    description: 'Detect and fix architecture violations',
+    schedule: '0 2 * * *',
+    branch: 'harness-maint/arch-fixes',
+    checkCommand: ['check-arch'],
+    fixSkill: 'harness-arch-fix',
+  },
+  {
+    id: 'dep-violations',
+    type: 'mechanical-ai',
+    description: 'Detect and fix dependency violations',
+    schedule: '0 2 * * *',
+    branch: 'harness-maint/dep-fixes',
+    checkCommand: ['check-deps'],
+    fixSkill: 'harness-dep-fix',
+  },
+  {
+    id: 'doc-drift',
+    type: 'mechanical-ai',
+    description: 'Detect and fix documentation drift',
+    schedule: '0 3 * * *',
+    branch: 'harness-maint/doc-fixes',
+    checkCommand: ['check-docs'],
+    fixSkill: 'harness-doc-fix',
+  },
+  {
+    id: 'security-findings',
+    type: 'mechanical-ai',
+    description: 'Detect and fix security findings',
+    schedule: '0 1 * * *',
+    branch: 'harness-maint/security-fixes',
+    checkCommand: ['check-security'],
+    fixSkill: 'harness-security-fix',
+  },
+  {
+    id: 'entropy',
+    type: 'mechanical-ai',
+    description: 'Detect and fix codebase entropy',
+    schedule: '0 3 * * *',
+    branch: 'harness-maint/entropy-fixes',
+    checkCommand: ['cleanup'],
+    fixSkill: 'harness-entropy-fix',
+  },
+  {
+    id: 'traceability',
+    type: 'mechanical-ai',
+    description: 'Detect and fix traceability gaps',
+    schedule: '0 6 * * 1',
+    branch: 'harness-maint/traceability-fixes',
+    checkCommand: ['traceability'],
+    fixSkill: 'harness-traceability-fix',
+  },
+  {
+    id: 'cross-check',
+    type: 'mechanical-ai',
+    description: 'Detect and fix cross-check violations',
+    schedule: '0 6 * * 1',
+    branch: 'harness-maint/cross-check-fixes',
+    checkCommand: ['validate-cross-check'],
+    fixSkill: 'harness-cross-check-fix',
+  },
+
+  // --- Pure-AI ---
+  {
+    id: 'dead-code',
+    type: 'pure-ai',
+    description: 'Find and remove dead code',
+    schedule: '0 2 * * 0',
+    branch: 'harness-maint/dead-code',
+    fixSkill: 'harness-codebase-cleanup',
+  },
+  {
+    id: 'dependency-health',
+    type: 'pure-ai',
+    description: 'Assess and improve dependency health',
+    schedule: '0 3 * * 0',
+    branch: 'harness-maint/dep-health',
+    fixSkill: 'harness-dependency-health',
+  },
+  {
+    id: 'hotspot-remediation',
+    type: 'pure-ai',
+    description: 'Identify and remediate code hotspots',
+    schedule: '0 4 * * 0',
+    branch: 'harness-maint/hotspot-fixes',
+    fixSkill: 'harness-hotspot-detector',
+  },
+  {
+    id: 'security-review',
+    type: 'pure-ai',
+    description: 'Deep security review and fixes',
+    schedule: '0 1 * * 0',
+    branch: 'harness-maint/security-deep',
+    fixSkill: 'harness-security-review',
+  },
+
+  // --- Report-only ---
+  {
+    id: 'perf-check',
+    type: 'report-only',
+    description: 'Run performance checks and record metrics',
+    schedule: '0 6 * * 1',
+    branch: null,
+    checkCommand: ['check-perf'],
+  },
+  {
+    id: 'decay-trends',
+    type: 'report-only',
+    description: 'Compute architecture decay trend metrics',
+    schedule: '0 7 * * 1',
+    branch: null,
+    checkCommand: ['predict'],
+  },
+  {
+    id: 'project-health',
+    type: 'report-only',
+    description: 'Assess overall project health',
+    schedule: '0 6 * * *',
+    branch: null,
+    checkCommand: ['assess_project'],
+  },
+  {
+    id: 'stale-constraints',
+    type: 'report-only',
+    description: 'Detect stale architectural constraints',
+    schedule: '0 2 1 * *',
+    branch: null,
+    checkCommand: ['detect_stale_constraints'],
+  },
+  {
+    id: 'graph-refresh',
+    type: 'report-only',
+    description: 'Refresh the knowledge graph',
+    schedule: '0 1 * * *',
+    branch: null,
+    checkCommand: ['graph', 'scan'],
+  },
+
+  // --- Housekeeping ---
+  {
+    id: 'session-cleanup',
+    type: 'housekeeping',
+    description: 'Clean up stale orchestrator sessions',
+    schedule: '0 0 * * *',
+    branch: null,
+    checkCommand: ['cleanup-sessions'],
+  },
+  {
+    id: 'perf-baselines',
+    type: 'housekeeping',
+    description: 'Update performance baselines',
+    schedule: '0 7 * * *',
+    branch: null,
+    checkCommand: ['perf', 'baselines', 'update'],
+  },
+] as const;

--- a/packages/orchestrator/src/maintenance/task-runner.ts
+++ b/packages/orchestrator/src/maintenance/task-runner.ts
@@ -1,0 +1,274 @@
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition, RunResult } from './types';
+
+/**
+ * Interface for running CLI check commands in-process.
+ * Each method returns a structured result with a findings count.
+ */
+export interface CheckCommandRunner {
+  /**
+   * Runs a check command and returns its structured output.
+   * @param command - CLI command args (e.g., ['check-arch'])
+   * @param cwd - Working directory
+   * @returns Object with findings count and whether the check passed
+   */
+  run(command: string[], cwd: string): Promise<CheckCommandResult>;
+}
+
+export interface CheckCommandResult {
+  passed: boolean;
+  findings: number;
+  /** Raw output for logging/reporting */
+  output: string;
+}
+
+/**
+ * Interface for dispatching an AI agent to fix issues.
+ * Wraps AgentRunner.runSession() with maintenance-specific parameters.
+ */
+export interface AgentDispatcher {
+  /**
+   * Dispatch an AI agent to fix issues on a branch.
+   * @param skill - Skill name to dispatch (e.g., 'harness-arch-fix')
+   * @param branch - Branch to work on
+   * @param backendName - Backend name to use (e.g., 'local', 'claude')
+   * @param cwd - Working directory (worktree path)
+   * @returns Whether the agent produced any commits
+   */
+  dispatch(
+    skill: string,
+    branch: string,
+    backendName: string,
+    cwd: string
+  ): Promise<AgentDispatchResult>;
+}
+
+export interface AgentDispatchResult {
+  producedCommits: boolean;
+  fixed: number;
+}
+
+/**
+ * Interface for running housekeeping commands directly.
+ */
+export interface CommandExecutor {
+  /**
+   * Executes a command directly (no AI).
+   * @param command - Command args (e.g., ['cleanup-sessions'])
+   * @param cwd - Working directory
+   */
+  exec(command: string[], cwd: string): Promise<void>;
+}
+
+export interface TaskRunnerOptions {
+  config: MaintenanceConfig;
+  checkRunner: CheckCommandRunner;
+  agentDispatcher: AgentDispatcher;
+  commandExecutor: CommandExecutor;
+  /** Project root directory for running commands */
+  cwd: string;
+}
+
+/**
+ * TaskRunner executes a single maintenance task based on its type.
+ *
+ * Execution paths:
+ * - mechanical-ai: run check -> if findings, dispatch AI agent
+ * - pure-ai: always dispatch AI agent
+ * - report-only: run check, record findings, no AI
+ * - housekeeping: run command directly, no AI
+ */
+export class TaskRunner {
+  private config: MaintenanceConfig;
+  private checkRunner: CheckCommandRunner;
+  private agentDispatcher: AgentDispatcher;
+  private commandExecutor: CommandExecutor;
+  private cwd: string;
+
+  constructor(options: TaskRunnerOptions) {
+    this.config = options.config;
+    this.checkRunner = options.checkRunner;
+    this.agentDispatcher = options.agentDispatcher;
+    this.commandExecutor = options.commandExecutor;
+    this.cwd = options.cwd;
+  }
+
+  /**
+   * Run a maintenance task and return the result.
+   * Dispatches to the appropriate execution path based on task type.
+   * Never throws -- errors are captured in the RunResult.
+   */
+  async run(task: TaskDefinition): Promise<RunResult> {
+    const startedAt = new Date().toISOString();
+    try {
+      switch (task.type) {
+        case 'mechanical-ai':
+          return await this.runMechanicalAI(task, startedAt);
+        case 'pure-ai':
+          return await this.runPureAI(task, startedAt);
+        case 'report-only':
+          return await this.runReportOnly(task, startedAt);
+        case 'housekeeping':
+          return await this.runHousekeeping(task, startedAt);
+        default: {
+          const _exhaustive: never = task.type;
+          return this.failureResult(
+            task.id,
+            startedAt,
+            `Unknown task type: ${String(_exhaustive)}`
+          );
+        }
+      }
+    } catch (err) {
+      return this.failureResult(task.id, startedAt, String(err));
+    }
+  }
+
+  /**
+   * Mechanical-AI: run check command, dispatch AI agent only if fixable findings exist.
+   */
+  private async runMechanicalAI(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.checkCommand || task.checkCommand.length === 0) {
+      return this.failureResult(task.id, startedAt, 'mechanical-ai task missing checkCommand');
+    }
+    if (!task.fixSkill) {
+      return this.failureResult(task.id, startedAt, 'mechanical-ai task missing fixSkill');
+    }
+    if (!task.branch) {
+      return this.failureResult(task.id, startedAt, 'mechanical-ai task missing branch');
+    }
+
+    const checkResult = await this.checkRunner.run(task.checkCommand, this.cwd);
+
+    if (checkResult.findings === 0) {
+      return {
+        taskId: task.id,
+        startedAt,
+        completedAt: new Date().toISOString(),
+        status: 'no-issues',
+        findings: 0,
+        fixed: 0,
+        prUrl: null,
+        prUpdated: false,
+      };
+    }
+
+    const backendName = this.resolveBackend(task.id);
+    const agentResult = await this.agentDispatcher.dispatch(
+      task.fixSkill,
+      task.branch,
+      backendName,
+      this.cwd
+    );
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'success',
+      findings: checkResult.findings,
+      fixed: agentResult.fixed,
+      prUrl: null, // PR creation is handled by PRManager in Phase 4
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Pure-AI: always dispatch agent with configured skill.
+   */
+  private async runPureAI(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.fixSkill) {
+      return this.failureResult(task.id, startedAt, 'pure-ai task missing fixSkill');
+    }
+    if (!task.branch) {
+      return this.failureResult(task.id, startedAt, 'pure-ai task missing branch');
+    }
+
+    const backendName = this.resolveBackend(task.id);
+    const agentResult = await this.agentDispatcher.dispatch(
+      task.fixSkill,
+      task.branch,
+      backendName,
+      this.cwd
+    );
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: agentResult.producedCommits ? 'success' : 'no-issues',
+      findings: 0,
+      fixed: agentResult.fixed,
+      prUrl: null, // PR creation is handled by PRManager in Phase 4
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Report-only: run check command, record metrics, no AI dispatch.
+   */
+  private async runReportOnly(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.checkCommand || task.checkCommand.length === 0) {
+      return this.failureResult(task.id, startedAt, 'report-only task missing checkCommand');
+    }
+
+    const checkResult = await this.checkRunner.run(task.checkCommand, this.cwd);
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'success',
+      findings: checkResult.findings,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Housekeeping: run command directly, no AI, no PR.
+   */
+  private async runHousekeeping(task: TaskDefinition, startedAt: string): Promise<RunResult> {
+    if (!task.checkCommand || task.checkCommand.length === 0) {
+      return this.failureResult(task.id, startedAt, 'housekeeping task missing checkCommand');
+    }
+
+    await this.commandExecutor.exec(task.checkCommand, this.cwd);
+
+    return {
+      taskId: task.id,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'success',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+    };
+  }
+
+  /**
+   * Resolve which AI backend name to use for a given task.
+   * Priority: per-task override > global config > 'local' default.
+   */
+  private resolveBackend(taskId: string): string {
+    const taskOverride = this.config.tasks?.[taskId]?.aiBackend;
+    if (taskOverride) return taskOverride;
+    return this.config.aiBackend ?? 'local';
+  }
+
+  private failureResult(taskId: string, startedAt: string, error: string): RunResult {
+    return {
+      taskId,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: 'failure',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+      error,
+    };
+  }
+}

--- a/packages/orchestrator/src/maintenance/task-runner.ts
+++ b/packages/orchestrator/src/maintenance/task-runner.ts
@@ -154,12 +154,28 @@ export class TaskRunner {
     }
 
     const backendName = this.resolveBackend(task.id);
-    const agentResult = await this.agentDispatcher.dispatch(
-      task.fixSkill,
-      task.branch,
-      backendName,
-      this.cwd
-    );
+
+    let agentResult;
+    try {
+      agentResult = await this.agentDispatcher.dispatch(
+        task.fixSkill,
+        task.branch,
+        backendName,
+        this.cwd
+      );
+    } catch (err) {
+      return {
+        taskId: task.id,
+        startedAt,
+        completedAt: new Date().toISOString(),
+        status: 'failure',
+        findings: checkResult.findings,
+        fixed: 0,
+        prUrl: null,
+        prUpdated: false,
+        error: `Agent dispatch failed: ${String(err)}`,
+      };
+    }
 
     return {
       taskId: task.id,

--- a/packages/orchestrator/src/maintenance/task-runner.ts
+++ b/packages/orchestrator/src/maintenance/task-runner.ts
@@ -237,7 +237,7 @@ export class TaskRunner {
     }
 
     if (this.prManager) {
-      await this.prManager.ensureBranch(task.branch!, this.baseBranch);
+      await this.prManager.ensureBranch(task.branch, this.baseBranch);
     }
 
     const backendName = this.resolveBackend(task.id);

--- a/packages/orchestrator/src/maintenance/task-runner.ts
+++ b/packages/orchestrator/src/maintenance/task-runner.ts
@@ -60,6 +60,21 @@ export interface CommandExecutor {
   exec(command: string[], cwd: string): Promise<void>;
 }
 
+/**
+ * Interface for managing branches and PRs for maintenance tasks.
+ * Matches PRManager's public API shape for DI.
+ */
+export interface PRLifecycleManager {
+  ensureBranch(
+    branchName: string,
+    baseBranch: string
+  ): Promise<{ created: boolean; recreated: boolean }>;
+  ensurePR(
+    task: TaskDefinition,
+    runSummary: string
+  ): Promise<{ prUrl: string; prUpdated: boolean }>;
+}
+
 export interface TaskRunnerOptions {
   config: MaintenanceConfig;
   checkRunner: CheckCommandRunner;
@@ -67,6 +82,10 @@ export interface TaskRunnerOptions {
   commandExecutor: CommandExecutor;
   /** Project root directory for running commands */
   cwd: string;
+  /** Optional PR lifecycle manager for branch/PR operations */
+  prManager?: PRLifecycleManager;
+  /** Base branch for PR operations (defaults to 'main') */
+  baseBranch?: string;
 }
 
 /**
@@ -84,6 +103,8 @@ export class TaskRunner {
   private agentDispatcher: AgentDispatcher;
   private commandExecutor: CommandExecutor;
   private cwd: string;
+  private prManager: PRLifecycleManager | null;
+  private baseBranch: string;
 
   constructor(options: TaskRunnerOptions) {
     this.config = options.config;
@@ -91,6 +112,8 @@ export class TaskRunner {
     this.agentDispatcher = options.agentDispatcher;
     this.commandExecutor = options.commandExecutor;
     this.cwd = options.cwd;
+    this.prManager = options.prManager ?? null;
+    this.baseBranch = options.baseBranch ?? 'main';
   }
 
   /**
@@ -153,6 +176,10 @@ export class TaskRunner {
       };
     }
 
+    if (this.prManager) {
+      await this.prManager.ensureBranch(task.branch, this.baseBranch);
+    }
+
     const backendName = this.resolveBackend(task.id);
 
     let agentResult;
@@ -177,6 +204,15 @@ export class TaskRunner {
       };
     }
 
+    let prUrl: string | null = null;
+    let prUpdated = false;
+    if (this.prManager && agentResult.producedCommits) {
+      const summary = `Findings: ${checkResult.findings}, Fixed: ${agentResult.fixed}`;
+      const prResult = await this.prManager.ensurePR(task, summary);
+      prUrl = prResult.prUrl;
+      prUpdated = prResult.prUpdated;
+    }
+
     return {
       taskId: task.id,
       startedAt,
@@ -184,8 +220,8 @@ export class TaskRunner {
       status: 'success',
       findings: checkResult.findings,
       fixed: agentResult.fixed,
-      prUrl: null, // PR creation is handled by PRManager in Phase 4
-      prUpdated: false,
+      prUrl,
+      prUpdated,
     };
   }
 
@@ -200,6 +236,10 @@ export class TaskRunner {
       return this.failureResult(task.id, startedAt, 'pure-ai task missing branch');
     }
 
+    if (this.prManager) {
+      await this.prManager.ensureBranch(task.branch!, this.baseBranch);
+    }
+
     const backendName = this.resolveBackend(task.id);
     const agentResult = await this.agentDispatcher.dispatch(
       task.fixSkill,
@@ -208,6 +248,15 @@ export class TaskRunner {
       this.cwd
     );
 
+    let prUrl: string | null = null;
+    let prUpdated = false;
+    if (this.prManager && agentResult.producedCommits) {
+      const summary = `Fixed: ${agentResult.fixed}`;
+      const prResult = await this.prManager.ensurePR(task, summary);
+      prUrl = prResult.prUrl;
+      prUpdated = prResult.prUpdated;
+    }
+
     return {
       taskId: task.id,
       startedAt,
@@ -215,8 +264,8 @@ export class TaskRunner {
       status: agentResult.producedCommits ? 'success' : 'no-issues',
       findings: 0,
       fixed: agentResult.fixed,
-      prUrl: null, // PR creation is handled by PRManager in Phase 4
-      prUpdated: false,
+      prUrl,
+      prUpdated,
     };
   }
 

--- a/packages/orchestrator/src/maintenance/types.ts
+++ b/packages/orchestrator/src/maintenance/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Internal types for the maintenance module.
+ * Public config types (MaintenanceConfig, TaskOverride) live in @harness-engineering/types.
+ */
+
+/**
+ * Classification of maintenance task execution strategy.
+ *
+ * - mechanical-ai: Run a check command first; dispatch AI agent only if fixable issues are found.
+ * - pure-ai: Always dispatch an AI agent on schedule regardless of preconditions.
+ * - report-only: Run a command and record metrics; never create branches or PRs.
+ * - housekeeping: Run a mechanical command directly; no AI, no PR.
+ */
+export type TaskType = 'mechanical-ai' | 'pure-ai' | 'report-only' | 'housekeeping';
+
+/**
+ * Definition of a built-in maintenance task.
+ */
+export interface TaskDefinition {
+  /** Unique identifier for this task (e.g., 'arch-violations') */
+  id: string;
+  /** Execution strategy */
+  type: TaskType;
+  /** Human-readable description */
+  description: string;
+  /** Default cron expression (e.g., '0 2 * * *' for daily at 2am) */
+  schedule: string;
+  /** Branch name for PRs, or null for report-only/housekeeping tasks */
+  branch: string | null;
+  /** CLI command args for the mechanical check step (mechanical-ai and report-only) */
+  checkCommand?: string[];
+  /** Skill name to dispatch for AI fix (mechanical-ai and pure-ai) */
+  fixSkill?: string;
+}
+
+/**
+ * Result of a single maintenance task run.
+ */
+export interface RunResult {
+  /** ID of the task that was run */
+  taskId: string;
+  /** ISO timestamp when the run started */
+  startedAt: string;
+  /** ISO timestamp when the run completed */
+  completedAt: string;
+  /** Outcome of the run */
+  status: 'success' | 'failure' | 'skipped' | 'no-issues';
+  /** Number of issues/findings detected */
+  findings: number;
+  /** Number of issues fixed */
+  fixed: number;
+  /** URL of the created/updated PR, or null if no PR was created */
+  prUrl: string | null;
+  /** Whether an existing PR was updated (vs newly created) */
+  prUpdated: boolean;
+  /** Error message if status is 'failure' */
+  error?: string;
+}
+
+/**
+ * Schedule entry for a single task, used in MaintenanceStatus.
+ */
+export interface ScheduleEntry {
+  /** Task identifier */
+  taskId: string;
+  /** ISO timestamp of the next scheduled run */
+  nextRun: string;
+  /** Result of the most recent run, or null if never run */
+  lastRun: RunResult | null;
+}
+
+/**
+ * Overall maintenance module status, exposed via dashboard API.
+ */
+export interface MaintenanceStatus {
+  /** Whether this orchestrator instance is the maintenance leader */
+  isLeader: boolean;
+  /** ISO timestamp of the last successful leader claim, or null */
+  lastLeaderClaim: string | null;
+  /** Schedule state for all enabled tasks */
+  schedule: ScheduleEntry[];
+  /** Currently executing task, or null if idle */
+  activeRun: { taskId: string; startedAt: string } | null;
+  /** History of completed runs (most recent first) */
+  history: RunResult[];
+}

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -253,7 +253,9 @@ export class Orchestrator extends EventEmitter {
    * Provides stub implementations for check/agent/command execution.
    * Phase 4 (PRManager) and Phase 5 (Reporter) will enhance these.
    */
-  private createMaintenanceTaskRunner(): TaskRunner {
+  private createMaintenanceTaskRunner(
+    maintenanceConfig: import('@harness-engineering/types').MaintenanceConfig
+  ): TaskRunner {
     const checkRunner: CheckCommandRunner = {
       run: async (command: string[], cwd: string) => {
         // Stub: Phase 4 will integrate with real check commands.
@@ -284,7 +286,7 @@ export class Orchestrator extends EventEmitter {
     };
 
     return new TaskRunner({
-      config: this.config.maintenance!,
+      config: maintenanceConfig,
       checkRunner,
       agentDispatcher,
       commandExecutor,
@@ -1746,7 +1748,7 @@ export class Orchestrator extends EventEmitter {
 
     // Start maintenance scheduler if enabled
     if (this.config.maintenance?.enabled) {
-      const taskRunner = this.createMaintenanceTaskRunner();
+      const taskRunner = this.createMaintenanceTaskRunner(this.config.maintenance);
       this.maintenanceScheduler = new MaintenanceScheduler({
         config: this.config.maintenance,
         claimManager: this.claimManager!,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -68,6 +68,7 @@ import { computeRateLimitDelay } from './core/rate-limiter';
 import type { EscalateEffect, ClaimEffect } from './types/events';
 import { ClaimManager } from './core/claim-manager';
 import { MaintenanceScheduler } from './maintenance/scheduler';
+import { MaintenanceReporter } from './maintenance/reporter';
 import { TaskRunner } from './maintenance/task-runner';
 import type {
   CheckCommandRunner,
@@ -118,6 +119,7 @@ export class Orchestrator extends EventEmitter {
   private graphStore: GraphStore | null = null;
   private claimManager: ClaimManager | null = null;
   private maintenanceScheduler: MaintenanceScheduler | null = null;
+  private maintenanceReporter: MaintenanceReporter | null = null;
   private orchestratorIdPromise: Promise<string>;
 
   /** Project root directory, derived from workspace root. */
@@ -292,6 +294,71 @@ export class Orchestrator extends EventEmitter {
       commandExecutor,
       cwd: this.projectRoot,
     });
+  }
+
+  /**
+   * Initializes the maintenance subsystem: reporter, scheduler, and server route wiring.
+   * Extracted from start() to keep function length under threshold.
+   */
+  private async initMaintenance(
+    maintenanceConfig: import('@harness-engineering/types').MaintenanceConfig
+  ): Promise<void> {
+    this.maintenanceReporter = new MaintenanceReporter({
+      persistDir: path.join(this.projectRoot, '.harness', 'maintenance'),
+    });
+    await this.maintenanceReporter.load();
+
+    const taskRunner = this.createMaintenanceTaskRunner(maintenanceConfig);
+    const reporter = this.maintenanceReporter;
+
+    this.maintenanceScheduler = new MaintenanceScheduler({
+      config: maintenanceConfig,
+      claimManager: this.claimManager!,
+      logger: this.logger,
+      onTaskDue: async (task) => {
+        this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
+        this.server?.broadcastMaintenance('maintenance:started', {
+          taskId: task.id,
+          startedAt: new Date().toISOString(),
+        });
+
+        const result = await taskRunner.run(task);
+        this.maintenanceScheduler!.recordRun(result);
+        await reporter.record(result);
+
+        if (result.status === 'failure') {
+          this.server?.broadcastMaintenance('maintenance:error', {
+            taskId: task.id,
+            error: result.error,
+          });
+        } else {
+          this.server?.broadcastMaintenance('maintenance:completed', result);
+        }
+
+        this.logger.info(`Maintenance task completed: ${task.id}`, {
+          taskId: task.id,
+          status: result.status,
+          findings: result.findings,
+          fixed: result.fixed,
+        });
+      },
+    });
+    this.maintenanceScheduler.start();
+
+    // Wire maintenance route deps into the server
+    if (this.server) {
+      const scheduler = this.maintenanceScheduler;
+      this.server.setMaintenanceDeps({
+        scheduler,
+        reporter,
+        triggerFn: async (taskId: string) => {
+          const tasks = scheduler.getResolvedTasks();
+          const task = tasks.find((t) => t.id === taskId);
+          if (!task) throw new Error(`Unknown task: ${taskId}`);
+          await scheduler.evaluate(new Date());
+        },
+      });
+    }
   }
 
   private createLocalBackend(): AgentBackend | null {
@@ -1748,24 +1815,7 @@ export class Orchestrator extends EventEmitter {
 
     // Start maintenance scheduler if enabled
     if (this.config.maintenance?.enabled) {
-      const taskRunner = this.createMaintenanceTaskRunner(this.config.maintenance);
-      this.maintenanceScheduler = new MaintenanceScheduler({
-        config: this.config.maintenance,
-        claimManager: this.claimManager!,
-        logger: this.logger,
-        onTaskDue: async (task) => {
-          this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
-          const result = await taskRunner.run(task);
-          this.maintenanceScheduler!.recordRun(result);
-          this.logger.info(`Maintenance task completed: ${task.id}`, {
-            taskId: task.id,
-            status: result.status,
-            findings: result.findings,
-            fixed: result.fixed,
-          });
-        },
-      });
-      this.maintenanceScheduler.start();
+      await this.initMaintenance(this.config.maintenance);
     }
   }
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -68,6 +68,12 @@ import { computeRateLimitDelay } from './core/rate-limiter';
 import type { EscalateEffect, ClaimEffect } from './types/events';
 import { ClaimManager } from './core/claim-manager';
 import { MaintenanceScheduler } from './maintenance/scheduler';
+import { TaskRunner } from './maintenance/task-runner';
+import type {
+  CheckCommandRunner,
+  AgentDispatcher,
+  CommandExecutor,
+} from './maintenance/task-runner';
 import { resolveOrchestratorId } from './core/orchestrator-identity';
 
 const CONNECTION_ERROR_PATTERNS = [
@@ -240,6 +246,50 @@ export class Orchestrator extends EventEmitter {
     }
 
     return backend;
+  }
+
+  /**
+   * Creates a TaskRunner for the maintenance scheduler.
+   * Provides stub implementations for check/agent/command execution.
+   * Phase 4 (PRManager) and Phase 5 (Reporter) will enhance these.
+   */
+  private createMaintenanceTaskRunner(): TaskRunner {
+    const checkRunner: CheckCommandRunner = {
+      run: async (command: string[], cwd: string) => {
+        // Stub: Phase 4 will integrate with real check commands.
+        // For now, return no findings so mechanical-ai tasks skip AI dispatch.
+        this.logger.info('Maintenance check runner invoked (stub)', { command, cwd });
+        return { passed: true, findings: 0, output: '' };
+      },
+    };
+
+    const agentDispatcher: AgentDispatcher = {
+      dispatch: async (skill: string, branch: string, backendName: string, cwd: string) => {
+        // Stub: Phase 4 will integrate with real AgentRunner dispatch.
+        this.logger.info('Maintenance agent dispatcher invoked (stub)', {
+          skill,
+          branch,
+          backendName,
+          cwd,
+        });
+        return { producedCommits: false, fixed: 0 };
+      },
+    };
+
+    const commandExecutor: CommandExecutor = {
+      exec: async (command: string[], cwd: string) => {
+        // Stub: Phase 4 will integrate with real command execution.
+        this.logger.info('Maintenance command executor invoked (stub)', { command, cwd });
+      },
+    };
+
+    return new TaskRunner({
+      config: this.config.maintenance!,
+      checkRunner,
+      agentDispatcher,
+      commandExecutor,
+      cwd: this.projectRoot,
+    });
   }
 
   private createLocalBackend(): AgentBackend | null {
@@ -1696,13 +1746,21 @@ export class Orchestrator extends EventEmitter {
 
     // Start maintenance scheduler if enabled
     if (this.config.maintenance?.enabled) {
+      const taskRunner = this.createMaintenanceTaskRunner();
       this.maintenanceScheduler = new MaintenanceScheduler({
         config: this.config.maintenance,
         claimManager: this.claimManager!,
         logger: this.logger,
         onTaskDue: async (task) => {
           this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
-          // Phase 3 will wire this to TaskRunner.run(task)
+          const result = await taskRunner.run(task);
+          this.maintenanceScheduler!.recordRun(result);
+          this.logger.info(`Maintenance task completed: ${task.id}`, {
+            taskId: task.id,
+            status: result.status,
+            findings: result.findings,
+            fixed: result.fixed,
+          });
         },
       });
       this.maintenanceScheduler.start();

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -355,7 +355,9 @@ export class Orchestrator extends EventEmitter {
           const tasks = scheduler.getResolvedTasks();
           const task = tasks.find((t) => t.id === taskId);
           if (!task) throw new Error(`Unknown task: ${taskId}`);
-          await scheduler.evaluate(new Date());
+          // Directly invoke the onTaskDue callback, bypassing cron schedule
+          const onTaskDue = scheduler.getOnTaskDue();
+          await onTaskDue(task);
         },
       });
     }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -258,10 +258,13 @@ export class Orchestrator extends EventEmitter {
   private createMaintenanceTaskRunner(
     maintenanceConfig: import('@harness-engineering/types').MaintenanceConfig
   ): TaskRunner {
+    this.logger.warn(
+      'Maintenance task runner using stub implementations — tasks will not execute real checks or dispatch agents. ' +
+        'Real implementations will be wired in a follow-up.'
+    );
+
     const checkRunner: CheckCommandRunner = {
       run: async (command: string[], cwd: string) => {
-        // Stub: Phase 4 will integrate with real check commands.
-        // For now, return no findings so mechanical-ai tasks skip AI dispatch.
         this.logger.info('Maintenance check runner invoked (stub)', { command, cwd });
         return { passed: true, findings: 0, output: '' };
       },
@@ -269,7 +272,6 @@ export class Orchestrator extends EventEmitter {
 
     const agentDispatcher: AgentDispatcher = {
       dispatch: async (skill: string, branch: string, backendName: string, cwd: string) => {
-        // Stub: Phase 4 will integrate with real AgentRunner dispatch.
         this.logger.info('Maintenance agent dispatcher invoked (stub)', {
           skill,
           branch,
@@ -282,7 +284,6 @@ export class Orchestrator extends EventEmitter {
 
     const commandExecutor: CommandExecutor = {
       exec: async (command: string[], cwd: string) => {
-        // Stub: Phase 4 will integrate with real command execution.
         this.logger.info('Maintenance command executor invoked (stub)', { command, cwd });
       },
     };
@@ -305,6 +306,7 @@ export class Orchestrator extends EventEmitter {
   ): Promise<void> {
     this.maintenanceReporter = new MaintenanceReporter({
       persistDir: path.join(this.projectRoot, '.harness', 'maintenance'),
+      logger: this.logger,
     });
     await this.maintenanceReporter.load();
 
@@ -315,6 +317,7 @@ export class Orchestrator extends EventEmitter {
       config: maintenanceConfig,
       claimManager: this.claimManager!,
       logger: this.logger,
+      historyProvider: reporter,
       onTaskDue: async (task) => {
         this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
         this.server?.broadcastMaintenance('maintenance:started', {
@@ -323,7 +326,6 @@ export class Orchestrator extends EventEmitter {
         });
 
         const result = await taskRunner.run(task);
-        this.maintenanceScheduler!.recordRun(result);
         await reporter.record(result);
 
         if (result.status === 'failure') {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -67,6 +67,7 @@ import { InteractionQueue } from './core/interaction-queue';
 import { computeRateLimitDelay } from './core/rate-limiter';
 import type { EscalateEffect, ClaimEffect } from './types/events';
 import { ClaimManager } from './core/claim-manager';
+import { MaintenanceScheduler } from './maintenance/scheduler';
 import { resolveOrchestratorId } from './core/orchestrator-identity';
 
 const CONNECTION_ERROR_PATTERNS = [
@@ -110,6 +111,7 @@ export class Orchestrator extends EventEmitter {
   private analysisArchive: AnalysisArchive;
   private graphStore: GraphStore | null = null;
   private claimManager: ClaimManager | null = null;
+  private maintenanceScheduler: MaintenanceScheduler | null = null;
   private orchestratorIdPromise: Promise<string>;
 
   /** Project root directory, derived from workspace root. */
@@ -1691,6 +1693,20 @@ export class Orchestrator extends EventEmitter {
         }
       }
     }, heartbeatMs);
+
+    // Start maintenance scheduler if enabled
+    if (this.config.maintenance?.enabled) {
+      this.maintenanceScheduler = new MaintenanceScheduler({
+        config: this.config.maintenance,
+        claimManager: this.claimManager!,
+        logger: this.logger,
+        onTaskDue: async (task) => {
+          this.logger.info(`Maintenance task due: ${task.id}`, { taskId: task.id });
+          // Phase 3 will wire this to TaskRunner.run(task)
+        },
+      });
+      this.maintenanceScheduler.start();
+    }
   }
 
   /**
@@ -1704,6 +1720,10 @@ export class Orchestrator extends EventEmitter {
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);
       this.heartbeatInterval = undefined;
+    }
+    if (this.maintenanceScheduler) {
+      this.maintenanceScheduler.stop();
+      this.maintenanceScheduler = null;
     }
     if (this.server) {
       this.server.stop();
@@ -1749,5 +1769,10 @@ export class Orchestrator extends EventEmitter {
       claimRejections: this.state.claimRejections,
       tickActivity: this.tickActivity,
     };
+  }
+
+  /** Returns the maintenance scheduler status, or null if maintenance is not enabled. */
+  public getMaintenanceStatus(): import('./maintenance/types').MaintenanceStatus | null {
+    return this.maintenanceScheduler?.getStatus() ?? null;
   }
 }

--- a/packages/orchestrator/src/server/http.ts
+++ b/packages/orchestrator/src/server/http.ts
@@ -9,6 +9,8 @@ import { handleRoadmapActionsRoute } from './routes/roadmap-actions';
 import { handleDispatchActionsRoute } from './routes/dispatch-actions';
 import type { DispatchAdHocFn } from './routes/dispatch-actions';
 import { handleAnalysesRoute } from './routes/analyses';
+import { handleMaintenanceRoute } from './routes/maintenance';
+import type { MaintenanceRouteDeps } from './routes/maintenance';
 import { handleSessionsRoute } from './routes/sessions';
 import { handleStaticFile } from './static';
 import { PlanWatcher } from './plan-watcher';
@@ -38,6 +40,8 @@ export interface ServerDependencies {
   dispatchAdHoc?: DispatchAdHocFn | null;
   /** Directory for chat session metadata (default: <cwd>/.harness/sessions) */
   sessionsDir?: string;
+  /** Maintenance scheduler + reporter deps for dashboard routes */
+  maintenanceDeps?: MaintenanceRouteDeps | null;
 }
 
 export class OrchestratorServer {
@@ -54,6 +58,7 @@ export class OrchestratorServer {
   private roadmapPath!: string | null;
   private dispatchAdHoc!: DispatchAdHocFn | null;
   private sessionsDir!: string;
+  private maintenanceDeps: MaintenanceRouteDeps | null = null;
   private planWatcher: PlanWatcher | null = null;
   private stateChangeListener!: (snapshot: unknown) => void;
   private agentEventListener!: (event: unknown) => void;
@@ -80,6 +85,7 @@ export class OrchestratorServer {
     this.roadmapPath = deps?.roadmapPath ?? null;
     this.dispatchAdHoc = deps?.dispatchAdHoc ?? null;
     this.sessionsDir = deps?.sessionsDir ?? path.resolve('.harness', 'sessions');
+    this.maintenanceDeps = deps?.maintenanceDeps ?? null;
   }
 
   private wireEvents(): void {
@@ -99,6 +105,23 @@ export class OrchestratorServer {
    */
   public broadcastInteraction(interaction: PendingInteraction): void {
     this.broadcaster.broadcast('interaction_new', interaction);
+  }
+
+  /**
+   * Broadcast a maintenance event to all WebSocket clients.
+   * @param type - One of 'maintenance:started', 'maintenance:completed', 'maintenance:error'
+   * @param data - Event payload (task info, run result, or error details)
+   */
+  public broadcastMaintenance(type: string, data: unknown): void {
+    this.broadcaster.broadcast(type, data);
+  }
+
+  /**
+   * Set (or update) the maintenance route dependencies after construction.
+   * Called by the Orchestrator once the scheduler and reporter are ready.
+   */
+  public setMaintenanceDeps(deps: MaintenanceRouteDeps): void {
+    this.maintenanceDeps = deps;
   }
 
   private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -159,6 +182,11 @@ export class OrchestratorServer {
 
     // Ad-hoc dispatch route
     if (handleDispatchActionsRoute(req, res, this.dispatchAdHoc)) {
+      return true;
+    }
+
+    // Maintenance dashboard routes
+    if (handleMaintenanceRoute(req, res, this.maintenanceDeps)) {
       return true;
     }
 

--- a/packages/orchestrator/src/server/routes/maintenance.ts
+++ b/packages/orchestrator/src/server/routes/maintenance.ts
@@ -33,7 +33,7 @@ function handleGetHistory(
   queryString: string
 ): void {
   const params = new URLSearchParams(queryString);
-  const limit = Math.max(1, parseInt(params.get('limit') ?? '20', 10) || 20);
+  const limit = Math.min(100, Math.max(1, parseInt(params.get('limit') ?? '20', 10) || 20));
   const offset = Math.max(0, parseInt(params.get('offset') ?? '0', 10) || 0);
   const history = deps.reporter.getHistory(limit, offset);
   sendJSON(res, 200, history);
@@ -47,7 +47,13 @@ function handlePostTrigger(
   void (async () => {
     try {
       const body = await readBody(req);
-      const parsed = JSON.parse(body) as { taskId?: string };
+      let parsed: { taskId?: string };
+      try {
+        parsed = JSON.parse(body) as { taskId?: string };
+      } catch {
+        sendJSON(res, 400, { error: 'Invalid JSON body' });
+        return;
+      }
 
       if (!parsed.taskId || typeof parsed.taskId !== 'string') {
         sendJSON(res, 400, { error: 'Missing taskId string' });

--- a/packages/orchestrator/src/server/routes/maintenance.ts
+++ b/packages/orchestrator/src/server/routes/maintenance.ts
@@ -1,0 +1,114 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { MaintenanceScheduler } from '../../maintenance/scheduler';
+import type { MaintenanceReporter } from '../../maintenance/reporter';
+import { readBody } from '../utils.js';
+
+/**
+ * Dependencies injected into the maintenance route handler.
+ */
+export interface MaintenanceRouteDeps {
+  scheduler: MaintenanceScheduler;
+  reporter: MaintenanceReporter;
+  triggerFn: (taskId: string) => Promise<void>;
+}
+
+function sendJSON(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function handleGetSchedule(res: ServerResponse, deps: MaintenanceRouteDeps): void {
+  const status = deps.scheduler.getStatus();
+  sendJSON(res, 200, status.schedule);
+}
+
+function handleGetStatus(res: ServerResponse, deps: MaintenanceRouteDeps): void {
+  const status = deps.scheduler.getStatus();
+  sendJSON(res, 200, status);
+}
+
+function handleGetHistory(
+  res: ServerResponse,
+  deps: MaintenanceRouteDeps,
+  queryString: string
+): void {
+  const params = new URLSearchParams(queryString);
+  const limit = Math.max(1, parseInt(params.get('limit') ?? '20', 10) || 20);
+  const offset = Math.max(0, parseInt(params.get('offset') ?? '0', 10) || 0);
+  const history = deps.reporter.getHistory(limit, offset);
+  sendJSON(res, 200, history);
+}
+
+function handlePostTrigger(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: MaintenanceRouteDeps
+): void {
+  void (async () => {
+    try {
+      const body = await readBody(req);
+      const parsed = JSON.parse(body) as { taskId?: string };
+
+      if (!parsed.taskId || typeof parsed.taskId !== 'string') {
+        sendJSON(res, 400, { error: 'Missing taskId string' });
+        return;
+      }
+
+      await deps.triggerFn(parsed.taskId);
+      sendJSON(res, 200, { ok: true, taskId: parsed.taskId });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Trigger failed';
+      if (!res.headersSent) {
+        sendJSON(res, 500, { error: msg });
+      }
+    }
+  })();
+}
+
+/**
+ * Handles maintenance dashboard API routes.
+ *
+ * - GET  /api/maintenance/schedule  — next-run times per task
+ * - GET  /api/maintenance/status    — full MaintenanceStatus
+ * - GET  /api/maintenance/history   — paginated RunResult[] (?limit=20&offset=0)
+ * - POST /api/maintenance/trigger   — enqueue a task for immediate execution
+ *
+ * Returns true if the route matched, false otherwise.
+ */
+export function handleMaintenanceRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: MaintenanceRouteDeps | null
+): boolean {
+  const { method, url } = req;
+  // eslint-disable-next-line @harness-engineering/no-hardcoded-path-separator -- URL path, not filesystem
+  if (!url?.startsWith('/api/maintenance/')) return false;
+  if (!deps) {
+    sendJSON(res, 503, { error: 'Maintenance not available' });
+    return true;
+  }
+
+  const [pathname, queryString] = url.split('?');
+
+  if (method === 'GET') {
+    switch (pathname) {
+      case '/api/maintenance/schedule':
+        handleGetSchedule(res, deps);
+        return true;
+      case '/api/maintenance/status':
+        handleGetStatus(res, deps);
+        return true;
+      case '/api/maintenance/history':
+        handleGetHistory(res, deps, queryString ?? '');
+        return true;
+    }
+  }
+
+  if (method === 'POST' && pathname === '/api/maintenance/trigger') {
+    handlePostTrigger(req, res, deps);
+    return true;
+  }
+
+  sendJSON(res, 404, { error: 'Not found' });
+  return true;
+}

--- a/packages/orchestrator/tests/maintenance/cron-matcher.test.ts
+++ b/packages/orchestrator/tests/maintenance/cron-matcher.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { cronMatchesNow } from '../../src/maintenance/cron-matcher';
+
+describe('cronMatchesNow', () => {
+  // Helper: 2026-04-17 is a Friday (day 5)
+  const friday2am = new Date('2026-04-17T02:00:00');
+  const friday230 = new Date('2026-04-17T02:30:00');
+  const monday6am = new Date('2026-04-20T06:00:00');
+  const sunday2am = new Date('2026-04-19T02:00:00');
+  const jan1midnight = new Date('2026-01-01T00:00:00');
+  const firstOfMonth2am = new Date('2026-04-01T02:00:00');
+
+  it('matches wildcard-only cron (* * * * *)', () => {
+    expect(cronMatchesNow('* * * * *', friday2am)).toBe(true);
+  });
+
+  it('matches exact minute and hour (0 2 * * *)', () => {
+    expect(cronMatchesNow('0 2 * * *', friday2am)).toBe(true);
+    expect(cronMatchesNow('0 2 * * *', friday230)).toBe(false);
+  });
+
+  it('matches day of week (0 6 * * 1 = Monday)', () => {
+    expect(cronMatchesNow('0 6 * * 1', monday6am)).toBe(true);
+    expect(cronMatchesNow('0 6 * * 1', friday2am)).toBe(false);
+  });
+
+  it('matches Sunday as day 0 (0 2 * * 0)', () => {
+    expect(cronMatchesNow('0 2 * * 0', sunday2am)).toBe(true);
+    expect(cronMatchesNow('0 2 * * 0', friday2am)).toBe(false);
+  });
+
+  it('matches day of month (0 2 1 * *)', () => {
+    expect(cronMatchesNow('0 2 1 * *', firstOfMonth2am)).toBe(true);
+    expect(cronMatchesNow('0 2 1 * *', friday2am)).toBe(false);
+  });
+
+  it('matches month field (0 0 1 1 *)', () => {
+    expect(cronMatchesNow('0 0 1 1 *', jan1midnight)).toBe(true);
+    expect(cronMatchesNow('0 0 1 1 *', firstOfMonth2am)).toBe(false);
+  });
+
+  it('supports step values (*/15 * * * *)', () => {
+    const min0 = new Date('2026-04-17T02:00:00');
+    const min15 = new Date('2026-04-17T02:15:00');
+    const min7 = new Date('2026-04-17T02:07:00');
+    expect(cronMatchesNow('*/15 * * * *', min0)).toBe(true);
+    expect(cronMatchesNow('*/15 * * * *', min15)).toBe(true);
+    expect(cronMatchesNow('*/15 * * * *', min7)).toBe(false);
+  });
+
+  it('supports list values (0 1,2,3 * * *)', () => {
+    expect(cronMatchesNow('0 1,2,3 * * *', friday2am)).toBe(true);
+    expect(cronMatchesNow('0 1,2,3 * * *', monday6am)).toBe(false);
+  });
+
+  it('supports range values (0 1-3 * * *)', () => {
+    expect(cronMatchesNow('0 1-3 * * *', friday2am)).toBe(true);
+    expect(cronMatchesNow('0 1-3 * * *', monday6am)).toBe(false);
+  });
+
+  it('throws on invalid cron expression (wrong field count)', () => {
+    expect(() => cronMatchesNow('0 2 * *', friday2am)).toThrow();
+  });
+
+  it('matches all 18 built-in schedules against expected times', () => {
+    // Spot-check: daily 2am matches at 2:00, not at 3:00
+    expect(cronMatchesNow('0 2 * * *', new Date('2026-04-17T02:00:00'))).toBe(true);
+    expect(cronMatchesNow('0 2 * * *', new Date('2026-04-17T03:00:00'))).toBe(false);
+    // Weekly Monday 6am
+    expect(cronMatchesNow('0 6 * * 1', new Date('2026-04-20T06:00:00'))).toBe(true);
+    // Monthly 1st 2am
+    expect(cronMatchesNow('0 2 1 * *', new Date('2026-05-01T02:00:00'))).toBe(true);
+  });
+});

--- a/packages/orchestrator/tests/maintenance/cron-matcher.test.ts
+++ b/packages/orchestrator/tests/maintenance/cron-matcher.test.ts
@@ -62,6 +62,14 @@ describe('cronMatchesNow', () => {
     expect(() => cronMatchesNow('0 2 * *', friday2am)).toThrow();
   });
 
+  it('throws on out-of-range values', () => {
+    expect(() => cronMatchesNow('70 * * * *', friday2am)).toThrow(/must be 0-59/);
+    expect(() => cronMatchesNow('0 25 * * *', friday2am)).toThrow(/must be 0-23/);
+    expect(() => cronMatchesNow('0 0 32 * *', friday2am)).toThrow(/must be 1-31/);
+    expect(() => cronMatchesNow('0 0 * 13 *', friday2am)).toThrow(/must be 1-12/);
+    expect(() => cronMatchesNow('0 0 * * 8', friday2am)).toThrow(/must be 0-6/);
+  });
+
   it('matches all 18 built-in schedules against expected times', () => {
     // Spot-check: daily 2am matches at 2:00, not at 3:00
     expect(cronMatchesNow('0 2 * * *', new Date('2026-04-17T02:00:00'))).toBe(true);

--- a/packages/orchestrator/tests/maintenance/integration-full-cycle.test.ts
+++ b/packages/orchestrator/tests/maintenance/integration-full-cycle.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { MaintenanceScheduler } from '../../src/maintenance/scheduler';
+import { TaskRunner } from '../../src/maintenance/task-runner';
+import { MaintenanceReporter } from '../../src/maintenance/reporter';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition } from '../../src/maintenance/types';
+import type {
+  CheckCommandRunner,
+  AgentDispatcher,
+  CommandExecutor,
+  PRLifecycleManager,
+} from '../../src/maintenance/task-runner';
+
+function createMockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+describe('Integration: full maintenance cycle', () => {
+  it('scheduler -> task runner -> PR manager -> reporter', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maint-integ-'));
+
+    try {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          // Disable all except arch-violations
+          ...Object.fromEntries(
+            [
+              'dep-violations',
+              'doc-drift',
+              'security-findings',
+              'entropy',
+              'traceability',
+              'cross-check',
+              'dead-code',
+              'dependency-health',
+              'hotspot-remediation',
+              'security-review',
+              'perf-check',
+              'decay-trends',
+              'project-health',
+              'stale-constraints',
+              'graph-refresh',
+              'session-cleanup',
+              'perf-baselines',
+            ].map((id) => [id, { enabled: false }])
+          ),
+        },
+      };
+
+      // Mock dependencies
+      const checkRunner: CheckCommandRunner = {
+        run: vi.fn().mockResolvedValue({ passed: false, findings: 4, output: '4 violations' }),
+      };
+      const agentDispatcher: AgentDispatcher = {
+        dispatch: vi.fn().mockResolvedValue({ producedCommits: true, fixed: 3 }),
+      };
+      const commandExecutor: CommandExecutor = {
+        exec: vi.fn().mockResolvedValue(undefined),
+      };
+      const prManager: PRLifecycleManager = {
+        ensureBranch: vi.fn().mockResolvedValue({ created: true, recreated: false }),
+        ensurePR: vi.fn().mockResolvedValue({
+          prUrl: 'https://github.com/org/repo/pull/100',
+          prUpdated: false,
+        }),
+      };
+
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+
+      const taskRunner = new TaskRunner({
+        config,
+        checkRunner,
+        agentDispatcher,
+        commandExecutor,
+        cwd: '/test/project',
+        prManager,
+      });
+
+      // Wire scheduler's onTaskDue to run task and record result
+      const onTaskDue = async (task: TaskDefinition) => {
+        const result = await taskRunner.run(task);
+        scheduler.recordRun(result);
+        await reporter.record(result);
+      };
+
+      const claimManager = {
+        claimAndVerify: vi.fn().mockResolvedValue({ ok: true, value: 'claimed' }),
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      // Trigger evaluation at 2am when arch-violations is due
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      // Verify the full pipeline executed
+      expect(checkRunner.run).toHaveBeenCalledWith(['check-arch'], '/test/project');
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        'harness-arch-fix',
+        'harness-maint/arch-fixes',
+        'local',
+        '/test/project'
+      );
+      expect(prManager.ensureBranch).toHaveBeenCalledWith('harness-maint/arch-fixes', 'main');
+      expect(prManager.ensurePR).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'arch-violations' }),
+        expect.stringContaining('Findings: 4')
+      );
+
+      // Verify scheduler recorded the run
+      const status = scheduler.getStatus();
+      expect(status.history).toHaveLength(1);
+      expect(status.history[0]!.taskId).toBe('arch-violations');
+      expect(status.history[0]!.status).toBe('success');
+      expect(status.history[0]!.findings).toBe(4);
+      expect(status.history[0]!.fixed).toBe(3);
+      expect(status.history[0]!.prUrl).toBe('https://github.com/org/repo/pull/100');
+
+      // Verify reporter persisted to disk
+      const reporterHistory = reporter.getHistory(100, 0);
+      expect(reporterHistory).toHaveLength(1);
+      expect(reporterHistory[0]!.prUrl).toBe('https://github.com/org/repo/pull/100');
+
+      // Verify persistence on disk
+      const diskData = JSON.parse(fs.readFileSync(path.join(tmpDir, 'history.json'), 'utf-8'));
+      expect(diskData).toHaveLength(1);
+      expect(diskData[0].taskId).toBe('arch-violations');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('full cycle with task failure records error in reporter', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'maint-integ-fail-'));
+
+    try {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          ...Object.fromEntries(
+            [
+              'dep-violations',
+              'doc-drift',
+              'security-findings',
+              'entropy',
+              'traceability',
+              'cross-check',
+              'dead-code',
+              'dependency-health',
+              'hotspot-remediation',
+              'security-review',
+              'perf-check',
+              'decay-trends',
+              'project-health',
+              'stale-constraints',
+              'graph-refresh',
+              'session-cleanup',
+              'perf-baselines',
+            ].map((id) => [id, { enabled: false }])
+          ),
+        },
+      };
+
+      const checkRunner: CheckCommandRunner = {
+        run: vi.fn().mockRejectedValue(new Error('check binary not found')),
+      };
+      const agentDispatcher: AgentDispatcher = {
+        dispatch: vi.fn().mockResolvedValue({ producedCommits: false, fixed: 0 }),
+      };
+      const commandExecutor: CommandExecutor = {
+        exec: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+
+      const taskRunner = new TaskRunner({
+        config,
+        checkRunner,
+        agentDispatcher,
+        commandExecutor,
+        cwd: '/test/project',
+      });
+
+      const onTaskDue = async (task: TaskDefinition) => {
+        const result = await taskRunner.run(task);
+        scheduler.recordRun(result);
+        await reporter.record(result);
+      };
+
+      const claimManager = {
+        claimAndVerify: vi.fn().mockResolvedValue({ ok: true, value: 'claimed' }),
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      const status = scheduler.getStatus();
+      expect(status.history).toHaveLength(1);
+      expect(status.history[0]!.status).toBe('failure');
+      expect(status.history[0]!.error).toContain('check binary not found');
+
+      const reporterHistory = reporter.getHistory(100, 0);
+      expect(reporterHistory).toHaveLength(1);
+      expect(reporterHistory[0]!.status).toBe('failure');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/orchestrator/tests/maintenance/integration-leader-election.test.ts
+++ b/packages/orchestrator/tests/maintenance/integration-leader-election.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MaintenanceScheduler } from '../../src/maintenance/scheduler';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+
+function createMockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+describe('Integration: leader election with two schedulers', () => {
+  it('only one scheduler dispatches tasks when sharing a ClaimManager', async () => {
+    // ClaimManager that grants the first call and rejects the second
+    let callCount = 0;
+    const sharedClaimManager = {
+      claimAndVerify: vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) return { ok: true, value: 'claimed' as const };
+        return { ok: true, value: 'rejected' as const };
+      }),
+    };
+
+    const config: MaintenanceConfig = {
+      enabled: true,
+      tasks: {
+        // Enable only one task for deterministic counting
+        ...Object.fromEntries(
+          [
+            'dep-violations',
+            'doc-drift',
+            'security-findings',
+            'entropy',
+            'traceability',
+            'cross-check',
+            'dead-code',
+            'dependency-health',
+            'hotspot-remediation',
+            'security-review',
+            'perf-check',
+            'decay-trends',
+            'project-health',
+            'stale-constraints',
+            'graph-refresh',
+            'session-cleanup',
+            'perf-baselines',
+          ].map((id) => [id, { enabled: false }])
+        ),
+      },
+    };
+
+    const onTaskDueA = vi.fn().mockResolvedValue(undefined);
+    const onTaskDueB = vi.fn().mockResolvedValue(undefined);
+
+    const schedulerA = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueA,
+    });
+
+    const schedulerB = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueB,
+    });
+
+    const time = new Date('2026-04-17T02:00:00');
+
+    // Scheduler A evaluates first -- gets leader
+    await schedulerA.evaluate(time);
+    // Scheduler B evaluates second -- rejected
+    await schedulerB.evaluate(time);
+
+    expect(onTaskDueA).toHaveBeenCalledTimes(1);
+    expect(onTaskDueB).not.toHaveBeenCalled();
+    expect(schedulerA.getStatus().isLeader).toBe(true);
+    expect(schedulerB.getStatus().isLeader).toBe(false);
+  });
+
+  it('leadership can transfer when first scheduler loses claim', async () => {
+    // Sequence of claim results: A=claimed, B=rejected, A=rejected, B=claimed
+    const claimResults: Array<'claimed' | 'rejected'> = [
+      'claimed',
+      'rejected',
+      'rejected',
+      'claimed',
+    ];
+    let callIndex = 0;
+    const sharedClaimManager = {
+      claimAndVerify: vi.fn().mockImplementation(async () => {
+        const result = claimResults[callIndex] ?? 'rejected';
+        callIndex++;
+        return { ok: true, value: result };
+      }),
+    };
+
+    const config: MaintenanceConfig = {
+      enabled: true,
+      tasks: {
+        ...Object.fromEntries(
+          [
+            'dep-violations',
+            'doc-drift',
+            'security-findings',
+            'entropy',
+            'traceability',
+            'cross-check',
+            'dead-code',
+            'dependency-health',
+            'hotspot-remediation',
+            'security-review',
+            'perf-check',
+            'decay-trends',
+            'project-health',
+            'stale-constraints',
+            'graph-refresh',
+            'session-cleanup',
+            'perf-baselines',
+          ].map((id) => [id, { enabled: false }])
+        ),
+        'arch-violations': { enabled: true, schedule: '* * * * *' },
+      },
+    };
+
+    const onTaskDueA = vi.fn().mockResolvedValue(undefined);
+    const onTaskDueB = vi.fn().mockResolvedValue(undefined);
+
+    const schedulerA = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueA,
+    });
+
+    const schedulerB = new MaintenanceScheduler({
+      config,
+      claimManager: sharedClaimManager as any,
+      logger: createMockLogger() as any,
+      onTaskDue: onTaskDueB,
+    });
+
+    // Round 1: A leads (call 0=claimed), B loses (call 1=rejected)
+    await schedulerA.evaluate(new Date('2026-04-17T02:00:00'));
+    await schedulerB.evaluate(new Date('2026-04-17T02:00:00'));
+    expect(onTaskDueA).toHaveBeenCalledTimes(1);
+    expect(onTaskDueB).not.toHaveBeenCalled();
+
+    // Round 2: A loses (call 2=rejected), B leads (call 3=claimed)
+    await schedulerA.evaluate(new Date('2026-04-17T02:01:00'));
+    await schedulerB.evaluate(new Date('2026-04-17T02:01:00'));
+    expect(onTaskDueA).toHaveBeenCalledTimes(1); // No new calls
+    expect(onTaskDueB).toHaveBeenCalledTimes(1);
+    expect(schedulerB.getStatus().isLeader).toBe(true);
+    expect(schedulerA.getStatus().isLeader).toBe(false);
+  });
+});

--- a/packages/orchestrator/tests/maintenance/integration-leader-election.test.ts
+++ b/packages/orchestrator/tests/maintenance/integration-leader-election.test.ts
@@ -18,10 +18,12 @@ describe('Integration: leader election with two schedulers', () => {
       }),
     };
 
+    // Explicitly enable only arch-violations with a matching schedule.
+    // All other tasks are disabled to prevent breakage when new tasks are added.
     const config: MaintenanceConfig = {
       enabled: true,
       tasks: {
-        // Enable only one task for deterministic counting
+        'arch-violations': { enabled: true, schedule: '0 2 * * *' },
         ...Object.fromEntries(
           [
             'dep-violations',

--- a/packages/orchestrator/tests/maintenance/maintenance-routes.test.ts
+++ b/packages/orchestrator/tests/maintenance/maintenance-routes.test.ts
@@ -144,6 +144,21 @@ describe('handleMaintenanceRoute', () => {
       expect(deps.reporter.getHistory).toHaveBeenCalledWith(5, 10);
     });
 
+    it('clamps limit to 100 when exceeding maximum', () => {
+      const req = mockReq('GET', '/api/maintenance/history?limit=200');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      expect(deps.reporter.getHistory).toHaveBeenCalledWith(100, 0);
+    });
+
+    it('falls back to default limit when limit=0 (falsy)', () => {
+      const req = mockReq('GET', '/api/maintenance/history?limit=0');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      // parseInt('0') is 0 (falsy), so || 20 fallback applies, then Math.max(1, 20) = 20
+      expect(deps.reporter.getHistory).toHaveBeenCalledWith(20, 0);
+    });
+
     it('returns the history array', () => {
       const req = mockReq('GET', '/api/maintenance/history');
       const res = mockRes();
@@ -179,6 +194,14 @@ describe('handleMaintenanceRoute', () => {
       handleMaintenanceRoute(req, res, deps);
       await vi.waitFor(() => expect(res._status).toBe(500));
       expect(JSON.parse(res._body)).toEqual({ error: 'boom' });
+    });
+
+    it('returns 400 for malformed JSON body', async () => {
+      const req = mockReq('POST', '/api/maintenance/trigger', 'not-json{{{');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      await vi.waitFor(() => expect(res._status).toBe(400));
+      expect(JSON.parse(res._body)).toEqual({ error: 'Invalid JSON body' });
     });
   });
 

--- a/packages/orchestrator/tests/maintenance/maintenance-routes.test.ts
+++ b/packages/orchestrator/tests/maintenance/maintenance-routes.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { handleMaintenanceRoute } from '../../src/server/routes/maintenance';
+import type { MaintenanceRouteDeps } from '../../src/server/routes/maintenance';
+import type { MaintenanceStatus, RunResult } from '../../src/maintenance/types';
+
+/** Minimal mock IncomingMessage with method, url, and event emitter for body. */
+function mockReq(method: string, url: string, body?: string): IncomingMessage {
+  const emitter = new EventEmitter() as IncomingMessage & EventEmitter;
+  (emitter as unknown as Record<string, unknown>).method = method;
+  (emitter as unknown as Record<string, unknown>).url = url;
+  // Simulate body delivery after a microtask
+  if (body !== undefined) {
+    queueMicrotask(() => {
+      emitter.emit('data', Buffer.from(body));
+      emitter.emit('end');
+    });
+  }
+  return emitter;
+}
+
+/** Captures writeHead status and end body. */
+function mockRes(): ServerResponse & {
+  _status: number;
+  _body: string;
+  _headers: Record<string, string>;
+} {
+  const res = {
+    _status: 0,
+    _body: '',
+    _headers: {} as Record<string, string>,
+    headersSent: false,
+    writeHead(status: number, headers?: Record<string, string>) {
+      res._status = status;
+      if (headers) Object.assign(res._headers, headers);
+      return res;
+    },
+    end(body?: string) {
+      res._body = body ?? '';
+      res.headersSent = true;
+    },
+  } as unknown as ServerResponse & {
+    _status: number;
+    _body: string;
+    _headers: Record<string, string>;
+  };
+  return res;
+}
+
+const mockStatus: MaintenanceStatus = {
+  isLeader: true,
+  lastLeaderClaim: '2026-01-01T00:00:00.000Z',
+  schedule: [
+    {
+      taskId: 'arch-violations',
+      nextRun: '2026-01-01T02:00:00.000Z',
+      lastRun: null,
+    },
+  ],
+  activeRun: null,
+  history: [],
+};
+
+const mockHistory: RunResult[] = [
+  {
+    taskId: 'arch-violations',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    completedAt: '2026-01-01T00:01:00.000Z',
+    status: 'success',
+    findings: 3,
+    fixed: 3,
+    prUrl: null,
+    prUpdated: false,
+  },
+];
+
+function createMockDeps(): MaintenanceRouteDeps {
+  return {
+    scheduler: {
+      getStatus: vi.fn().mockReturnValue(mockStatus),
+    } as unknown as MaintenanceRouteDeps['scheduler'],
+    reporter: {
+      getHistory: vi.fn().mockReturnValue(mockHistory),
+    } as unknown as MaintenanceRouteDeps['reporter'],
+    triggerFn: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('handleMaintenanceRoute', () => {
+  let deps: MaintenanceRouteDeps;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+  });
+
+  it('returns false for non-matching URLs', () => {
+    const req = mockReq('GET', '/api/state');
+    const res = mockRes();
+    expect(handleMaintenanceRoute(req, res, deps)).toBe(false);
+  });
+
+  it('returns 503 when deps is null', () => {
+    const req = mockReq('GET', '/api/maintenance/status');
+    const res = mockRes();
+    expect(handleMaintenanceRoute(req, res, null)).toBe(true);
+    expect(res._status).toBe(503);
+  });
+
+  describe('GET /api/maintenance/schedule', () => {
+    it('returns the schedule array from scheduler status', () => {
+      const req = mockReq('GET', '/api/maintenance/schedule');
+      const res = mockRes();
+      expect(handleMaintenanceRoute(req, res, deps)).toBe(true);
+      expect(res._status).toBe(200);
+      const body = JSON.parse(res._body);
+      expect(body).toEqual(mockStatus.schedule);
+    });
+  });
+
+  describe('GET /api/maintenance/status', () => {
+    it('returns full MaintenanceStatus', () => {
+      const req = mockReq('GET', '/api/maintenance/status');
+      const res = mockRes();
+      expect(handleMaintenanceRoute(req, res, deps)).toBe(true);
+      expect(res._status).toBe(200);
+      const body = JSON.parse(res._body);
+      expect(body).toEqual(mockStatus);
+    });
+  });
+
+  describe('GET /api/maintenance/history', () => {
+    it('passes default pagination params', () => {
+      const req = mockReq('GET', '/api/maintenance/history');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      expect(deps.reporter.getHistory).toHaveBeenCalledWith(20, 0);
+    });
+
+    it('passes custom limit and offset from query params', () => {
+      const req = mockReq('GET', '/api/maintenance/history?limit=5&offset=10');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      expect(deps.reporter.getHistory).toHaveBeenCalledWith(5, 10);
+    });
+
+    it('returns the history array', () => {
+      const req = mockReq('GET', '/api/maintenance/history');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      expect(res._status).toBe(200);
+      expect(JSON.parse(res._body)).toEqual(mockHistory);
+    });
+  });
+
+  describe('POST /api/maintenance/trigger', () => {
+    it('triggers with valid taskId', async () => {
+      const req = mockReq('POST', '/api/maintenance/trigger', '{"taskId":"arch-violations"}');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      // Wait for async handler
+      await vi.waitFor(() => expect(res._status).toBe(200));
+      expect(deps.triggerFn).toHaveBeenCalledWith('arch-violations');
+      expect(JSON.parse(res._body)).toEqual({ ok: true, taskId: 'arch-violations' });
+    });
+
+    it('returns 400 for missing taskId', async () => {
+      const req = mockReq('POST', '/api/maintenance/trigger', '{}');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      await vi.waitFor(() => expect(res._status).toBe(400));
+      expect(JSON.parse(res._body)).toEqual({ error: 'Missing taskId string' });
+    });
+
+    it('returns 500 when triggerFn throws', async () => {
+      (deps.triggerFn as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+      const req = mockReq('POST', '/api/maintenance/trigger', '{"taskId":"x"}');
+      const res = mockRes();
+      handleMaintenanceRoute(req, res, deps);
+      await vi.waitFor(() => expect(res._status).toBe(500));
+      expect(JSON.parse(res._body)).toEqual({ error: 'boom' });
+    });
+  });
+
+  it('returns 404 for unknown maintenance sub-routes', () => {
+    const req = mockReq('GET', '/api/maintenance/unknown');
+    const res = mockRes();
+    expect(handleMaintenanceRoute(req, res, deps)).toBe(true);
+    expect(res._status).toBe(404);
+  });
+});

--- a/packages/orchestrator/tests/maintenance/pr-manager.test.ts
+++ b/packages/orchestrator/tests/maintenance/pr-manager.test.ts
@@ -151,4 +151,126 @@ describe('PRManager', () => {
       expect(result).toEqual({ created: false, recreated: true });
     });
   });
+
+  describe('ensurePR', () => {
+    it('creates new PR when none exists', async () => {
+      const gh = createMockGh();
+      const git = createMockGit();
+      // gh pr list returns empty (no existing PR)
+      (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') return '';
+        if (args[0] === 'pr' && args[1] === 'create')
+          return 'https://github.com/org/repo/pull/42\n';
+        return '';
+      });
+      const { prManager } = createPRManager({ git, gh });
+
+      const result = await prManager.ensurePR(ARCH_TASK, 'Found 3 violations, fixed 2');
+
+      expect(result).toEqual({
+        prUrl: 'https://github.com/org/repo/pull/42',
+        prUpdated: false,
+      });
+      expect(git.run).toHaveBeenCalledWith(
+        ['push', 'origin', 'harness-maint/arch-fixes', '--force-with-lease'],
+        '/test/project'
+      );
+      expect(gh.run).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          'pr',
+          'create',
+          '--title',
+          '[Maintenance] Detect and fix architecture violations',
+        ]),
+        '/test/project'
+      );
+      // Verify labels
+      const createCall = (gh.run as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: [string[], string]) => call[0][0] === 'pr' && call[0][1] === 'create'
+      );
+      expect(createCall![0]).toContain('--label');
+      expect(createCall![0]).toContain('harness-maintenance');
+      expect(createCall![0]).toContain('arch-violations');
+    });
+
+    it('updates existing PR when one exists', async () => {
+      const gh = createMockGh();
+      const git = createMockGit();
+      (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') return 'https://github.com/org/repo/pull/42';
+        return '';
+      });
+      const { prManager } = createPRManager({ git, gh });
+
+      const result = await prManager.ensurePR(ARCH_TASK, 'Found 1 violation, fixed 1');
+
+      expect(result).toEqual({
+        prUrl: 'https://github.com/org/repo/pull/42',
+        prUpdated: true,
+      });
+      expect(gh.run).toHaveBeenCalledWith(
+        expect.arrayContaining(['pr', 'edit', 'https://github.com/org/repo/pull/42', '--body']),
+        '/test/project'
+      );
+    });
+
+    it('PR body contains task metadata and run summary', async () => {
+      const gh = createMockGh();
+      const git = createMockGit();
+      (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') return '';
+        if (args[0] === 'pr' && args[1] === 'create')
+          return 'https://github.com/org/repo/pull/99\n';
+        return '';
+      });
+      const { prManager } = createPRManager({ git, gh });
+
+      await prManager.ensurePR(ARCH_TASK, 'Found 5 violations');
+
+      const createCall = (gh.run as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: [string[], string]) => call[0][0] === 'pr' && call[0][1] === 'create'
+      );
+      const bodyIdx = createCall![0].indexOf('--body');
+      const body = createCall![0][bodyIdx + 1] as string;
+      expect(body).toContain('arch-violations');
+      expect(body).toContain('mechanical-ai');
+      expect(body).toContain('Found 5 violations');
+      expect(body).toContain('harness maintenance scheduler');
+    });
+
+    it('handles gh pr list failure gracefully (treats as no PR)', async () => {
+      const gh = createMockGh();
+      const git = createMockGit();
+      (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') throw new Error('gh auth error');
+        if (args[0] === 'pr' && args[1] === 'create')
+          return 'https://github.com/org/repo/pull/50\n';
+        return '';
+      });
+      const { prManager } = createPRManager({ git, gh });
+
+      const result = await prManager.ensurePR(ARCH_TASK, 'summary');
+
+      expect(result.prUpdated).toBe(false);
+      expect(result.prUrl).toBe('https://github.com/org/repo/pull/50');
+    });
+
+    it('uses --force-with-lease for push safety', async () => {
+      const git = createMockGit();
+      const gh = createMockGh();
+      (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') return '';
+        if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/org/repo/pull/1\n';
+        return '';
+      });
+      const { prManager } = createPRManager({ git, gh });
+
+      await prManager.ensurePR(ARCH_TASK, 'summary');
+
+      expect(git.run).toHaveBeenCalledWith(
+        ['push', 'origin', 'harness-maint/arch-fixes', '--force-with-lease'],
+        '/test/project'
+      );
+    });
+  });
 });

--- a/packages/orchestrator/tests/maintenance/pr-manager.test.ts
+++ b/packages/orchestrator/tests/maintenance/pr-manager.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PRManager } from '../../src/maintenance/pr-manager';
+import type {
+  GitExecutor,
+  GhExecutor,
+  PRManagerLogger,
+  PRManagerOptions,
+} from '../../src/maintenance/pr-manager';
+import type { TaskDefinition } from '../../src/maintenance/types';
+
+function createMockGit(): GitExecutor {
+  return { run: vi.fn().mockResolvedValue('') };
+}
+
+function createMockGh(): GhExecutor {
+  return { run: vi.fn().mockResolvedValue('') };
+}
+
+function createMockLogger(): PRManagerLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function createPRManager(overrides?: Partial<PRManagerOptions>): {
+  prManager: PRManager;
+  git: GitExecutor;
+  gh: GhExecutor;
+  logger: PRManagerLogger;
+} {
+  const git = overrides?.git ?? createMockGit();
+  const gh = overrides?.gh ?? createMockGh();
+  const logger = overrides?.logger ?? createMockLogger();
+  const cwd = overrides?.cwd ?? '/test/project';
+  const prManager = new PRManager({ git, gh, cwd, logger });
+  return { prManager, git, gh, logger };
+}
+
+const ARCH_TASK: TaskDefinition = {
+  id: 'arch-violations',
+  type: 'mechanical-ai',
+  description: 'Detect and fix architecture violations',
+  schedule: '0 2 * * *',
+  branch: 'harness-maint/arch-fixes',
+  checkCommand: ['check-arch'],
+  fixSkill: 'harness-arch-fix',
+};
+
+describe('PRManager', () => {
+  describe('ensureBranch', () => {
+    it('creates new branch when remote does not exist', async () => {
+      const git = createMockGit();
+      // ls-remote returns empty (no remote branch)
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return '';
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: true, recreated: false });
+      expect(git.run).toHaveBeenCalledWith(['fetch', 'origin', 'main'], '/test/project');
+      expect(git.run).toHaveBeenCalledWith(
+        ['checkout', '-b', 'harness-maint/arch-fixes', 'origin/main'],
+        '/test/project'
+      );
+    });
+
+    it('fetches and rebases when remote branch exists', async () => {
+      const git = createMockGit();
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return 'abc123\trefs/heads/harness-maint/arch-fixes';
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: false, recreated: false });
+      expect(git.run).toHaveBeenCalledWith(
+        ['fetch', 'origin', 'harness-maint/arch-fixes'],
+        '/test/project'
+      );
+      expect(git.run).toHaveBeenCalledWith(
+        ['checkout', 'harness-maint/arch-fixes'],
+        '/test/project'
+      );
+      expect(git.run).toHaveBeenCalledWith(['rebase', 'origin/main'], '/test/project');
+    });
+
+    it('recreates branch when rebase fails', async () => {
+      const git = createMockGit();
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return 'abc123\trefs/heads/harness-maint/arch-fixes';
+        if (args[0] === 'rebase' && args[1] === 'origin/main') {
+          throw new Error('CONFLICT');
+        }
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: false, recreated: true });
+      expect(git.run).toHaveBeenCalledWith(['rebase', '--abort'], '/test/project');
+      expect(git.run).toHaveBeenCalledWith(
+        ['branch', '-D', 'harness-maint/arch-fixes'],
+        '/test/project'
+      );
+      expect(git.run).toHaveBeenCalledWith(
+        ['checkout', '-b', 'harness-maint/arch-fixes', 'origin/main'],
+        '/test/project'
+      );
+    });
+
+    it('handles ls-remote failure gracefully (treats as non-existent)', async () => {
+      const git = createMockGit();
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') throw new Error('network error');
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(result).toEqual({ created: true, recreated: false });
+    });
+
+    it('ignores failure when deleting remote branch during recreate', async () => {
+      const git = createMockGit();
+      let rebaseAttempted = false;
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'ls-remote') return 'abc123\trefs/heads/harness-maint/arch-fixes';
+        if (args[0] === 'rebase' && args[1] === 'origin/main') {
+          rebaseAttempted = true;
+          throw new Error('CONFLICT');
+        }
+        if (args[0] === 'push' && args[2] === '--delete') {
+          throw new Error('remote branch already deleted');
+        }
+        return '';
+      });
+      const { prManager } = createPRManager({ git });
+
+      const result = await prManager.ensureBranch('harness-maint/arch-fixes', 'main');
+
+      expect(rebaseAttempted).toBe(true);
+      expect(result).toEqual({ created: false, recreated: true });
+    });
+  });
+});

--- a/packages/orchestrator/tests/maintenance/pr-manager.test.ts
+++ b/packages/orchestrator/tests/maintenance/pr-manager.test.ts
@@ -89,6 +89,12 @@ describe('PRManager', () => {
         '/test/project'
       );
       expect(git.run).toHaveBeenCalledWith(['rebase', 'origin/main'], '/test/project');
+      // Verify destructive reset --hard and base branch fetch
+      expect(git.run).toHaveBeenCalledWith(
+        ['reset', '--hard', 'origin/harness-maint/arch-fixes'],
+        '/test/project'
+      );
+      expect(git.run).toHaveBeenCalledWith(['fetch', 'origin', 'main'], '/test/project');
     });
 
     it('recreates branch when rebase fails', async () => {
@@ -106,6 +112,8 @@ describe('PRManager', () => {
 
       expect(result).toEqual({ created: false, recreated: true });
       expect(git.run).toHaveBeenCalledWith(['rebase', '--abort'], '/test/project');
+      // Must checkout detached HEAD before deleting current branch
+      expect(git.run).toHaveBeenCalledWith(['checkout', 'origin/main'], '/test/project');
       expect(git.run).toHaveBeenCalledWith(
         ['branch', '-D', 'harness-maint/arch-fixes'],
         '/test/project'

--- a/packages/orchestrator/tests/maintenance/pr-manager.test.ts
+++ b/packages/orchestrator/tests/maintenance/pr-manager.test.ts
@@ -272,5 +272,46 @@ describe('PRManager', () => {
         '/test/project'
       );
     });
+
+    it('propagates error when git push --force-with-lease fails', async () => {
+      const git = createMockGit();
+      const gh = createMockGh();
+      (git.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'push') throw new Error('push rejected: stale ref');
+        return '';
+      });
+      (gh.run as ReturnType<typeof vi.fn>).mockResolvedValue('');
+      const { prManager } = createPRManager({ git, gh });
+
+      await expect(prManager.ensurePR(ARCH_TASK, 'summary')).rejects.toThrow(
+        'push rejected: stale ref'
+      );
+    });
+
+    it('propagates error when gh pr create fails', async () => {
+      const git = createMockGit();
+      const gh = createMockGh();
+      (gh.run as ReturnType<typeof vi.fn>).mockImplementation(async (args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') return '';
+        if (args[0] === 'pr' && args[1] === 'create') {
+          throw new Error('gh: label "harness-maintenance" not found');
+        }
+        return '';
+      });
+      const { prManager } = createPRManager({ git, gh });
+
+      await expect(prManager.ensurePR(ARCH_TASK, 'summary')).rejects.toThrow(
+        'label "harness-maintenance" not found'
+      );
+    });
+
+    it('throws when task.branch is null', async () => {
+      const nullBranchTask: TaskDefinition = { ...ARCH_TASK, branch: null };
+      const { prManager } = createPRManager();
+
+      await expect(prManager.ensurePR(nullBranchTask, 'summary')).rejects.toThrow(
+        'ensurePR requires task.branch'
+      );
+    });
   });
 });

--- a/packages/orchestrator/tests/maintenance/reporter.test.ts
+++ b/packages/orchestrator/tests/maintenance/reporter.test.ts
@@ -60,16 +60,19 @@ describe('MaintenanceReporter', () => {
       fs.mkdirSync(persistDir, { recursive: true });
       fs.writeFileSync(path.join(persistDir, 'history.json'), '{ broken json !!!');
 
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const reporter = new MaintenanceReporter({ persistDir });
+      const mockLogger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      const reporter = new MaintenanceReporter({ persistDir, logger: mockLogger });
       await reporter.load();
 
       expect(reporter.getHistory(100, 0)).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(mockLogger.error).toHaveBeenCalledWith(
         'MaintenanceReporter: failed to load history',
-        expect.any(SyntaxError)
+        expect.objectContaining({ error: expect.any(String) })
       );
-      consoleSpy.mockRestore();
     });
 
     it('handles non-array JSON on disk gracefully', async () => {

--- a/packages/orchestrator/tests/maintenance/reporter.test.ts
+++ b/packages/orchestrator/tests/maintenance/reporter.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { MaintenanceReporter } from '../../src/maintenance/reporter';
+import type { RunResult } from '../../src/maintenance/types';
+
+function makeResult(taskId: string, index: number): RunResult {
+  return {
+    taskId,
+    startedAt: `2026-01-01T00:${String(index).padStart(2, '0')}:00.000Z`,
+    completedAt: `2026-01-01T00:${String(index).padStart(2, '0')}:30.000Z`,
+    status: 'success',
+    findings: index,
+    fixed: index,
+    prUrl: null,
+    prUpdated: false,
+  };
+}
+
+describe('MaintenanceReporter', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reporter-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('load', () => {
+    it('loads from empty/missing directory without error', async () => {
+      const persistDir = path.join(tmpDir, 'nonexistent');
+      const reporter = new MaintenanceReporter({ persistDir });
+      await reporter.load();
+      expect(reporter.getHistory(100, 0)).toEqual([]);
+    });
+
+    it('creates directory on load if missing', async () => {
+      const persistDir = path.join(tmpDir, 'new-dir');
+      const reporter = new MaintenanceReporter({ persistDir });
+      await reporter.load();
+      expect(fs.existsSync(persistDir)).toBe(true);
+    });
+
+    it('loads existing history from disk', async () => {
+      const persistDir = path.join(tmpDir, 'existing');
+      fs.mkdirSync(persistDir, { recursive: true });
+      const results = [makeResult('task-a', 1), makeResult('task-b', 2)];
+      fs.writeFileSync(path.join(persistDir, 'history.json'), JSON.stringify(results));
+
+      const reporter = new MaintenanceReporter({ persistDir });
+      await reporter.load();
+      expect(reporter.getHistory(100, 0)).toEqual(results);
+    });
+  });
+
+  describe('record and getHistory', () => {
+    it('records results in most-recent-first order', async () => {
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+
+      await reporter.record(makeResult('task-a', 1));
+      await reporter.record(makeResult('task-b', 2));
+
+      const history = reporter.getHistory(100, 0);
+      expect(history).toHaveLength(2);
+      expect(history[0]!.taskId).toBe('task-b');
+      expect(history[1]!.taskId).toBe('task-a');
+    });
+
+    it('persists to disk after record', async () => {
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+      await reporter.record(makeResult('task-a', 1));
+
+      const filePath = path.join(tmpDir, 'history.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(data).toHaveLength(1);
+      expect(data[0].taskId).toBe('task-a');
+    });
+  });
+
+  describe('pagination', () => {
+    it('returns correct slice with limit and offset', async () => {
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+
+      for (let i = 0; i < 10; i++) {
+        await reporter.record(makeResult(`task-${i}`, i));
+      }
+
+      const page = reporter.getHistory(3, 2);
+      expect(page).toHaveLength(3);
+      // History is most-recent-first: [task-9, task-8, task-7, task-6, ...]
+      expect(page[0]!.taskId).toBe('task-7');
+      expect(page[1]!.taskId).toBe('task-6');
+      expect(page[2]!.taskId).toBe('task-5');
+    });
+
+    it('returns empty array when offset exceeds history length', async () => {
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+      await reporter.record(makeResult('task-a', 1));
+
+      expect(reporter.getHistory(10, 100)).toEqual([]);
+    });
+  });
+
+  describe('history cap', () => {
+    it('caps history at 500 entries', async () => {
+      const reporter = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter.load();
+
+      for (let i = 0; i < 510; i++) {
+        await reporter.record(makeResult(`task-${i}`, i % 60));
+      }
+
+      const history = reporter.getHistory(1000, 0);
+      expect(history).toHaveLength(500);
+      // Most recent should be the last recorded
+      expect(history[0]!.taskId).toBe('task-509');
+    });
+  });
+
+  describe('persistence roundtrip', () => {
+    it('survives load -> record -> new instance -> load', async () => {
+      const reporter1 = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter1.load();
+      await reporter1.record(makeResult('task-a', 1));
+      await reporter1.record(makeResult('task-b', 2));
+
+      const reporter2 = new MaintenanceReporter({ persistDir: tmpDir });
+      await reporter2.load();
+      const history = reporter2.getHistory(100, 0);
+      expect(history).toHaveLength(2);
+      expect(history[0]!.taskId).toBe('task-b');
+    });
+  });
+});

--- a/packages/orchestrator/tests/maintenance/reporter.test.ts
+++ b/packages/orchestrator/tests/maintenance/reporter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -53,6 +53,34 @@ describe('MaintenanceReporter', () => {
       const reporter = new MaintenanceReporter({ persistDir });
       await reporter.load();
       expect(reporter.getHistory(100, 0)).toEqual(results);
+    });
+
+    it('handles corrupted JSON on disk gracefully', async () => {
+      const persistDir = path.join(tmpDir, 'corrupted');
+      fs.mkdirSync(persistDir, { recursive: true });
+      fs.writeFileSync(path.join(persistDir, 'history.json'), '{ broken json !!!');
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const reporter = new MaintenanceReporter({ persistDir });
+      await reporter.load();
+
+      expect(reporter.getHistory(100, 0)).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'MaintenanceReporter: failed to load history',
+        expect.any(SyntaxError)
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('handles non-array JSON on disk gracefully', async () => {
+      const persistDir = path.join(tmpDir, 'non-array');
+      fs.mkdirSync(persistDir, { recursive: true });
+      fs.writeFileSync(path.join(persistDir, 'history.json'), '"just a string"');
+
+      const reporter = new MaintenanceReporter({ persistDir });
+      await reporter.load();
+
+      expect(reporter.getHistory(100, 0)).toEqual([]);
     });
   });
 

--- a/packages/orchestrator/tests/maintenance/scheduler.test.ts
+++ b/packages/orchestrator/tests/maintenance/scheduler.test.ts
@@ -89,4 +89,138 @@ describe('MaintenanceScheduler', () => {
       expect(scheduler.getResolvedTasks()).toHaveLength(18);
     });
   });
+
+  describe('leader election', () => {
+    it('skips evaluation when leader claim is rejected', async () => {
+      const config: MaintenanceConfig = { enabled: true, checkIntervalMs: 60_000 };
+      const onTaskDue = vi.fn();
+      const claimManager = createMockClaimManager('rejected');
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      // Evaluate at a time when daily-2am tasks would be due
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      expect(claimManager.claimAndVerify).toHaveBeenCalledWith('maintenance-leader');
+      expect(onTaskDue).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with evaluation when leader claim succeeds', async () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const onTaskDue = vi.fn().mockResolvedValue(undefined);
+      const claimManager = createMockClaimManager('claimed');
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      // 2am daily: arch-violations, dep-violations should be due
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      expect(onTaskDue).toHaveBeenCalled();
+      const calledTaskIds = onTaskDue.mock.calls.map((c: any) => c[0].id);
+      expect(calledTaskIds).toContain('arch-violations');
+      expect(calledTaskIds).toContain('dep-violations');
+    });
+
+    it('sets isLeader to false when claim fails with error', async () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const claimManager = {
+        claimAndVerify: vi
+          .fn()
+          .mockResolvedValue({ ok: false, error: { message: 'network error' } }),
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      const status = scheduler.getStatus();
+      expect(status.isLeader).toBe(false);
+    });
+  });
+
+  describe('cron evaluation and deduplication', () => {
+    it('does not re-run a task in the same calendar minute', async () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const onTaskDue = vi.fn().mockResolvedValue(undefined);
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      const time = new Date('2026-04-17T02:00:00');
+
+      await scheduler.evaluate(time);
+      const firstCallCount = onTaskDue.mock.calls.length;
+      expect(firstCallCount).toBeGreaterThan(0);
+
+      // Same minute again
+      await scheduler.evaluate(time);
+      expect(onTaskDue.mock.calls.length).toBe(firstCallCount); // No new calls
+    });
+
+    it('runs the task again in the next matching minute', async () => {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          // Disable all except one for easier counting
+          ...Object.fromEntries(
+            [
+              'arch-violations',
+              'dep-violations',
+              'doc-drift',
+              'security-findings',
+              'entropy',
+              'traceability',
+              'cross-check',
+              'dead-code',
+              'dependency-health',
+              'hotspot-remediation',
+              'security-review',
+              'perf-check',
+              'decay-trends',
+              'project-health',
+              'stale-constraints',
+              'graph-refresh',
+              'session-cleanup',
+              'perf-baselines',
+            ].map((id) => [id, { enabled: false }])
+          ),
+          // Re-enable just one with a per-minute schedule for testing
+          'arch-violations': { enabled: true, schedule: '* * * * *' },
+        },
+      };
+      const onTaskDue = vi.fn().mockResolvedValue(undefined);
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue,
+      });
+
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+      expect(onTaskDue).toHaveBeenCalledTimes(1);
+
+      await scheduler.evaluate(new Date('2026-04-17T02:01:00'));
+      expect(onTaskDue).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/orchestrator/tests/maintenance/scheduler.test.ts
+++ b/packages/orchestrator/tests/maintenance/scheduler.test.ts
@@ -388,6 +388,13 @@ describe('MaintenanceScheduler', () => {
       expect(callOrder).toContain('arch-violations');
       expect(callOrder).toContain('dep-violations');
       expect(logger.error).toHaveBeenCalled();
+
+      // Failed task should be recorded in history
+      const status = scheduler.getStatus();
+      const failedRun = status.history.find((r) => r.taskId === 'arch-violations');
+      expect(failedRun).toBeDefined();
+      expect(failedRun!.status).toBe('failure');
+      expect(failedRun!.error).toContain('simulated failure');
     });
 
     it('handles claimAndVerify throwing an exception', async () => {

--- a/packages/orchestrator/tests/maintenance/scheduler.test.ts
+++ b/packages/orchestrator/tests/maintenance/scheduler.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MaintenanceScheduler } from '../../src/maintenance/scheduler';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition } from '../../src/maintenance/types';
+
+// Minimal mock for ClaimManager
+function createMockClaimManager(claimResult: 'claimed' | 'rejected' = 'claimed') {
+  return {
+    claimAndVerify: vi.fn().mockResolvedValue({ ok: true, value: claimResult }),
+  };
+}
+
+// Minimal mock logger
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('MaintenanceScheduler', () => {
+  describe('constructor and config merging', () => {
+    it('merges config overrides with built-in task defaults', () => {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          'arch-violations': { schedule: '0 4 * * *' },
+          'dead-code': { enabled: false },
+        },
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      const tasks = scheduler.getResolvedTasks();
+
+      // arch-violations should have overridden schedule
+      const arch = tasks.find((t) => t.id === 'arch-violations')!;
+      expect(arch.schedule).toBe('0 4 * * *');
+
+      // dead-code should be disabled (filtered out)
+      const dead = tasks.find((t) => t.id === 'dead-code');
+      expect(dead).toBeUndefined();
+
+      // Others should be present with defaults
+      const dep = tasks.find((t) => t.id === 'dep-violations')!;
+      expect(dep.schedule).toBe('0 2 * * *');
+    });
+
+    it('disables tasks with enabled: false override', () => {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          'session-cleanup': { enabled: false },
+          'perf-baselines': { enabled: false },
+        },
+      };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      const tasks = scheduler.getResolvedTasks();
+      expect(tasks.find((t) => t.id === 'session-cleanup')).toBeUndefined();
+      expect(tasks.find((t) => t.id === 'perf-baselines')).toBeUndefined();
+      // Total should be 18 - 2 = 16
+      expect(tasks).toHaveLength(16);
+    });
+
+    it('uses all 18 built-in tasks when no overrides are provided', () => {
+      const config: MaintenanceConfig = { enabled: true };
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      expect(scheduler.getResolvedTasks()).toHaveLength(18);
+    });
+  });
+});

--- a/packages/orchestrator/tests/maintenance/scheduler.test.ts
+++ b/packages/orchestrator/tests/maintenance/scheduler.test.ts
@@ -223,4 +223,117 @@ describe('MaintenanceScheduler', () => {
       expect(onTaskDue).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('start and stop lifecycle', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('start() begins interval and stop() clears it', async () => {
+      const config: MaintenanceConfig = { enabled: true, checkIntervalMs: 1000 };
+      const claimManager = createMockClaimManager('rejected'); // Don't actually run tasks
+      const logger = createMockLogger();
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: logger as any,
+        onTaskDue: vi.fn(),
+      });
+
+      scheduler.start();
+
+      // Should have called evaluate once immediately
+      // Wait for the initial evaluate promise
+      await vi.advanceTimersByTimeAsync(0);
+      expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(1);
+
+      // Advance past one interval
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(2);
+
+      scheduler.stop();
+
+      // No more calls after stop
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(2);
+    });
+
+    it('stop() sets isLeader to false', async () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn().mockResolvedValue(undefined),
+      });
+
+      // Manually set leader state by running evaluate
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+      expect(scheduler.getStatus().isLeader).toBe(true);
+
+      scheduler.stop();
+      expect(scheduler.getStatus().isLeader).toBe(false);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns full status with schedule entries', () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      const status = scheduler.getStatus();
+      expect(status.isLeader).toBe(false);
+      expect(status.lastLeaderClaim).toBeNull();
+      expect(status.activeRun).toBeNull();
+      expect(status.schedule).toHaveLength(18);
+      expect(status.history).toHaveLength(0);
+
+      // Each schedule entry should have a taskId and nextRun
+      for (const entry of status.schedule) {
+        expect(entry.taskId).toBeTruthy();
+        expect(entry.nextRun).toBeTruthy();
+        expect(entry.lastRun).toBeNull();
+      }
+    });
+
+    it('records run results in history', () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: createMockLogger() as any,
+        onTaskDue: vi.fn(),
+      });
+
+      scheduler.recordRun({
+        taskId: 'arch-violations',
+        startedAt: '2026-04-17T02:00:00Z',
+        completedAt: '2026-04-17T02:01:00Z',
+        status: 'success',
+        findings: 3,
+        fixed: 2,
+        prUrl: 'https://github.com/example/repo/pull/1',
+        prUpdated: false,
+      });
+
+      const status = scheduler.getStatus();
+      expect(status.history).toHaveLength(1);
+      expect(status.history[0]!.taskId).toBe('arch-violations');
+
+      // The schedule entry for arch-violations should now have lastRun
+      const archEntry = status.schedule.find((s) => s.taskId === 'arch-violations')!;
+      expect(archEntry.lastRun).not.toBeNull();
+      expect(archEntry.lastRun!.status).toBe('success');
+    });
+  });
 });

--- a/packages/orchestrator/tests/maintenance/scheduler.test.ts
+++ b/packages/orchestrator/tests/maintenance/scheduler.test.ts
@@ -336,4 +336,80 @@ describe('MaintenanceScheduler', () => {
       expect(archEntry.lastRun!.status).toBe('success');
     });
   });
+
+  describe('error handling', () => {
+    it('continues processing queue when a task callback throws', async () => {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        tasks: {
+          // Enable only two tasks for easier testing
+          ...Object.fromEntries(
+            [
+              'doc-drift',
+              'security-findings',
+              'entropy',
+              'traceability',
+              'cross-check',
+              'dead-code',
+              'dependency-health',
+              'hotspot-remediation',
+              'security-review',
+              'perf-check',
+              'decay-trends',
+              'project-health',
+              'stale-constraints',
+              'graph-refresh',
+              'session-cleanup',
+              'perf-baselines',
+            ].map((id) => [id, { enabled: false }])
+          ),
+        },
+      };
+      const callOrder: string[] = [];
+      const onTaskDue = vi.fn().mockImplementation(async (task: TaskDefinition) => {
+        callOrder.push(task.id);
+        if (task.id === 'arch-violations') {
+          throw new Error('simulated failure');
+        }
+      });
+      const logger = createMockLogger();
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: createMockClaimManager() as any,
+        logger: logger as any,
+        onTaskDue,
+      });
+
+      // Both arch-violations and dep-violations are due at 2am
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      // Both tasks should have been attempted despite first one throwing
+      expect(callOrder).toContain('arch-violations');
+      expect(callOrder).toContain('dep-violations');
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('handles claimAndVerify throwing an exception', async () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const claimManager = {
+        claimAndVerify: vi.fn().mockRejectedValue(new Error('connection lost')),
+      };
+      const logger = createMockLogger();
+      const onTaskDue = vi.fn();
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: logger as any,
+        onTaskDue,
+      });
+
+      // Should not throw
+      await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
+
+      expect(onTaskDue).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/orchestrator/tests/maintenance/scheduler.test.ts
+++ b/packages/orchestrator/tests/maintenance/scheduler.test.ts
@@ -263,6 +263,32 @@ describe('MaintenanceScheduler', () => {
       expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(2);
     });
 
+    it('start() called twice does not create duplicate intervals', async () => {
+      const config: MaintenanceConfig = { enabled: true, checkIntervalMs: 1000 };
+      const claimManager = createMockClaimManager('rejected');
+      const logger = createMockLogger();
+
+      const scheduler = new MaintenanceScheduler({
+        config,
+        claimManager: claimManager as any,
+        logger: logger as any,
+        onTaskDue: vi.fn(),
+      });
+
+      scheduler.start();
+      scheduler.start(); // Second call should be no-op
+
+      await vi.advanceTimersByTimeAsync(0);
+      // Only one initial evaluate call, not two
+      expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      // One interval tick, not two
+      expect(claimManager.claimAndVerify).toHaveBeenCalledTimes(2);
+
+      scheduler.stop();
+    });
+
     it('stop() sets isLeader to false', async () => {
       const config: MaintenanceConfig = { enabled: true };
       const scheduler = new MaintenanceScheduler({

--- a/packages/orchestrator/tests/maintenance/task-registry.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-registry.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { BUILT_IN_TASKS } from '../../src/maintenance/task-registry';
+import type { TaskDefinition, TaskType } from '../../src/maintenance/types';
+
+describe('task-registry', () => {
+  it('exports exactly 17 built-in task definitions', () => {
+    expect(BUILT_IN_TASKS).toHaveLength(17);
+  });
+
+  it('every task has a unique id', () => {
+    const ids = BUILT_IN_TASKS.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every task has a non-empty schedule (cron expression)', () => {
+    for (const task of BUILT_IN_TASKS) {
+      expect(task.schedule).toBeTruthy();
+      // Basic cron format: 5 space-separated fields
+      expect(task.schedule.split(' ')).toHaveLength(5);
+    }
+  });
+
+  it('every task has a valid type', () => {
+    const validTypes: TaskType[] = ['mechanical-ai', 'pure-ai', 'report-only', 'housekeeping'];
+    for (const task of BUILT_IN_TASKS) {
+      expect(validTypes).toContain(task.type);
+    }
+  });
+
+  it('mechanical-ai tasks have checkCommand and fixSkill', () => {
+    const mechanicalAi = BUILT_IN_TASKS.filter((t) => t.type === 'mechanical-ai');
+    expect(mechanicalAi.length).toBe(7);
+    for (const task of mechanicalAi) {
+      expect(task.checkCommand).toBeDefined();
+      expect(task.checkCommand!.length).toBeGreaterThan(0);
+      expect(task.fixSkill).toBeDefined();
+      expect(task.branch).not.toBeNull();
+    }
+  });
+
+  it('pure-ai tasks have fixSkill and branch but no checkCommand', () => {
+    const pureAi = BUILT_IN_TASKS.filter((t) => t.type === 'pure-ai');
+    expect(pureAi.length).toBe(4);
+    for (const task of pureAi) {
+      expect(task.fixSkill).toBeDefined();
+      expect(task.branch).not.toBeNull();
+      expect(task.checkCommand).toBeUndefined();
+    }
+  });
+
+  it('report-only tasks have checkCommand and null branch', () => {
+    const reportOnly = BUILT_IN_TASKS.filter((t) => t.type === 'report-only');
+    expect(reportOnly.length).toBe(4);
+    for (const task of reportOnly) {
+      expect(task.checkCommand).toBeDefined();
+      expect(task.branch).toBeNull();
+      expect(task.fixSkill).toBeUndefined();
+    }
+  });
+
+  it('housekeeping tasks have checkCommand and null branch', () => {
+    const housekeeping = BUILT_IN_TASKS.filter((t) => t.type === 'housekeeping');
+    expect(housekeeping.length).toBe(2);
+    for (const task of housekeeping) {
+      expect(task.checkCommand).toBeDefined();
+      expect(task.branch).toBeNull();
+      expect(task.fixSkill).toBeUndefined();
+    }
+  });
+
+  describe('specific task IDs and schedules from spec', () => {
+    const taskMap = new Map<string, TaskDefinition>();
+    for (const t of BUILT_IN_TASKS) {
+      taskMap.set(t.id, t);
+    }
+
+    // Mechanical-AI tasks
+    it('arch-violations: daily 2am, mechanical-ai', () => {
+      const t = taskMap.get('arch-violations')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 2 * * *');
+      expect(t.branch).toBe('harness-maint/arch-fixes');
+      expect(t.checkCommand).toEqual(['check-arch']);
+    });
+
+    it('dep-violations: daily 2am, mechanical-ai', () => {
+      const t = taskMap.get('dep-violations')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 2 * * *');
+      expect(t.branch).toBe('harness-maint/dep-fixes');
+      expect(t.checkCommand).toEqual(['check-deps']);
+    });
+
+    it('doc-drift: daily 3am, mechanical-ai', () => {
+      const t = taskMap.get('doc-drift')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 3 * * *');
+      expect(t.branch).toBe('harness-maint/doc-fixes');
+    });
+
+    it('security-findings: daily 1am, mechanical-ai', () => {
+      const t = taskMap.get('security-findings')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 1 * * *');
+      expect(t.branch).toBe('harness-maint/security-fixes');
+    });
+
+    it('entropy: daily 3am, mechanical-ai', () => {
+      const t = taskMap.get('entropy')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 3 * * *');
+      expect(t.branch).toBe('harness-maint/entropy-fixes');
+    });
+
+    it('traceability: weekly Monday 6am, mechanical-ai', () => {
+      const t = taskMap.get('traceability')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 6 * * 1');
+      expect(t.branch).toBe('harness-maint/traceability-fixes');
+    });
+
+    it('cross-check: weekly Monday 6am, mechanical-ai', () => {
+      const t = taskMap.get('cross-check')!;
+      expect(t.type).toBe('mechanical-ai');
+      expect(t.schedule).toBe('0 6 * * 1');
+      expect(t.branch).toBe('harness-maint/cross-check-fixes');
+    });
+
+    // Pure-AI tasks
+    it('dead-code: weekly Sunday 2am, pure-ai', () => {
+      const t = taskMap.get('dead-code')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 2 * * 0');
+      expect(t.branch).toBe('harness-maint/dead-code');
+    });
+
+    it('dependency-health: weekly Sunday 3am, pure-ai', () => {
+      const t = taskMap.get('dependency-health')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 3 * * 0');
+      expect(t.branch).toBe('harness-maint/dep-health');
+    });
+
+    it('hotspot-remediation: weekly Sunday 4am, pure-ai', () => {
+      const t = taskMap.get('hotspot-remediation')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 4 * * 0');
+      expect(t.branch).toBe('harness-maint/hotspot-fixes');
+    });
+
+    it('security-review: weekly Sunday 1am, pure-ai', () => {
+      const t = taskMap.get('security-review')!;
+      expect(t.type).toBe('pure-ai');
+      expect(t.schedule).toBe('0 1 * * 0');
+      expect(t.branch).toBe('harness-maint/security-deep');
+    });
+
+    // Report-only tasks
+    it('perf-check: weekly Monday 6am, report-only', () => {
+      const t = taskMap.get('perf-check')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 6 * * 1');
+      expect(t.branch).toBeNull();
+    });
+
+    it('decay-trends: weekly Monday 7am, report-only', () => {
+      const t = taskMap.get('decay-trends')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 7 * * 1');
+    });
+
+    it('project-health: daily 6am, report-only', () => {
+      const t = taskMap.get('project-health')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 6 * * *');
+    });
+
+    it('stale-constraints: monthly 1st 2am, report-only', () => {
+      const t = taskMap.get('stale-constraints')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 2 1 * *');
+    });
+
+    // Housekeeping tasks
+    it('session-cleanup: daily midnight, housekeeping', () => {
+      const t = taskMap.get('session-cleanup')!;
+      expect(t.type).toBe('housekeeping');
+      expect(t.schedule).toBe('0 0 * * *');
+      expect(t.branch).toBeNull();
+    });
+
+    it('perf-baselines: daily 7am, housekeeping', () => {
+      const t = taskMap.get('perf-baselines')!;
+      expect(t.type).toBe('housekeeping');
+      expect(t.schedule).toBe('0 7 * * *');
+      expect(t.branch).toBeNull();
+    });
+
+    // graph-refresh was in the spec report-only section but not yet tested
+    it('graph-refresh: daily 1am, report-only', () => {
+      const t = taskMap.get('graph-refresh')!;
+      expect(t.type).toBe('report-only');
+      expect(t.schedule).toBe('0 1 * * *');
+      expect(t.branch).toBeNull();
+    });
+  });
+});

--- a/packages/orchestrator/tests/maintenance/task-registry.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-registry.test.ts
@@ -3,8 +3,8 @@ import { BUILT_IN_TASKS } from '../../src/maintenance/task-registry';
 import type { TaskDefinition, TaskType } from '../../src/maintenance/types';
 
 describe('task-registry', () => {
-  it('exports exactly 17 built-in task definitions', () => {
-    expect(BUILT_IN_TASKS).toHaveLength(17);
+  it('exports exactly 18 built-in task definitions', () => {
+    expect(BUILT_IN_TASKS).toHaveLength(18);
   });
 
   it('every task has a unique id', () => {
@@ -50,7 +50,7 @@ describe('task-registry', () => {
 
   it('report-only tasks have checkCommand and null branch', () => {
     const reportOnly = BUILT_IN_TASKS.filter((t) => t.type === 'report-only');
-    expect(reportOnly.length).toBe(4);
+    expect(reportOnly.length).toBe(5);
     for (const task of reportOnly) {
       expect(task.checkCommand).toBeDefined();
       expect(task.branch).toBeNull();

--- a/packages/orchestrator/tests/maintenance/task-runner.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-runner.test.ts
@@ -306,4 +306,59 @@ describe('TaskRunner', () => {
       expect(result.error).toContain('missing checkCommand');
     });
   });
+
+  describe('error handling', () => {
+    it('catches check runner errors and returns failure', async () => {
+      const checkRunner: CheckCommandRunner = {
+        run: vi.fn().mockRejectedValue(new Error('check-arch crashed')),
+      };
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner }));
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('check-arch crashed');
+    });
+
+    it('catches agent dispatcher errors and returns failure', async () => {
+      const checkRunner = createMockCheckRunner({ findings: 2 });
+      const agentDispatcher: AgentDispatcher = {
+        dispatch: vi.fn().mockRejectedValue(new Error('agent session failed')),
+      };
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('agent session failed');
+    });
+
+    it('populates startedAt and completedAt timestamps', async () => {
+      const runner = new TaskRunner(
+        createRunnerOptions({
+          checkRunner: createMockCheckRunner({ findings: 0 }),
+        })
+      );
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.startedAt).toBeTruthy();
+      expect(result.completedAt).toBeTruthy();
+      expect(new Date(result.startedAt).getTime()).toBeLessThanOrEqual(
+        new Date(result.completedAt).getTime()
+      );
+    });
+
+    it('includes taskId in all results', async () => {
+      const runner = new TaskRunner(
+        createRunnerOptions({
+          checkRunner: createMockCheckRunner({ findings: 0 }),
+        })
+      );
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.taskId).toBe('arch-violations');
+    });
+  });
 });

--- a/packages/orchestrator/tests/maintenance/task-runner.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-runner.test.ts
@@ -320,8 +320,8 @@ describe('TaskRunner', () => {
       expect(result.error).toContain('check-arch crashed');
     });
 
-    it('catches agent dispatcher errors and returns failure', async () => {
-      const checkRunner = createMockCheckRunner({ findings: 2 });
+    it('catches agent dispatcher errors for mechanical-ai and preserves findings count', async () => {
+      const checkRunner = createMockCheckRunner({ findings: 5 });
       const agentDispatcher: AgentDispatcher = {
         dispatch: vi.fn().mockRejectedValue(new Error('agent session failed')),
       };
@@ -331,6 +331,29 @@ describe('TaskRunner', () => {
 
       expect(result.status).toBe('failure');
       expect(result.error).toContain('agent session failed');
+      expect(result.findings).toBe(5);
+      expect(result.fixed).toBe(0);
+    });
+
+    it('catches agent dispatcher errors for pure-ai and returns failure', async () => {
+      const agentDispatcher: AgentDispatcher = {
+        dispatch: vi.fn().mockRejectedValue(new Error('local model unavailable')),
+      };
+      const runner = new TaskRunner(createRunnerOptions({ agentDispatcher }));
+
+      const DEAD_CODE_TASK: TaskDefinition = {
+        id: 'dead-code',
+        type: 'pure-ai',
+        description: 'Find and remove dead code',
+        schedule: '0 2 * * 0',
+        branch: 'harness-maint/dead-code',
+        fixSkill: 'harness-codebase-cleanup',
+      };
+
+      const result = await runner.run(DEAD_CODE_TASK);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('local model unavailable');
     });
 
     it('populates startedAt and completedAt timestamps', async () => {

--- a/packages/orchestrator/tests/maintenance/task-runner.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-runner.test.ts
@@ -5,6 +5,7 @@ import type {
   AgentDispatcher,
   CommandExecutor,
   TaskRunnerOptions,
+  PRLifecycleManager,
 } from '../../src/maintenance/task-runner';
 import type { MaintenanceConfig } from '@harness-engineering/types';
 import type { TaskDefinition } from '../../src/maintenance/types';
@@ -35,6 +36,16 @@ function createMockAgentDispatcher(
 function createMockCommandExecutor(): CommandExecutor {
   return {
     exec: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockPRManager(prUrl?: string): PRLifecycleManager {
+  return {
+    ensureBranch: vi.fn().mockResolvedValue({ created: true, recreated: false }),
+    ensurePR: vi.fn().mockResolvedValue({
+      prUrl: prUrl ?? 'https://github.com/org/repo/pull/42',
+      prUpdated: false,
+    }),
   };
 }
 
@@ -122,6 +133,45 @@ describe('TaskRunner', () => {
 
       expect(result.status).toBe('failure');
       expect(result.error).toContain('missing branch');
+    });
+
+    it('calls prManager.ensureBranch and ensurePR when findings and agent commits exist', async () => {
+      const prManager = createMockPRManager();
+      const runner = new TaskRunner(
+        createRunnerOptions({
+          checkRunner: createMockCheckRunner({ findings: 3 }),
+          agentDispatcher: createMockAgentDispatcher({ producedCommits: true, fixed: 2 }),
+          prManager,
+        })
+      );
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(prManager.ensureBranch).toHaveBeenCalledWith('harness-maint/arch-fixes', 'main');
+      expect(prManager.ensurePR).toHaveBeenCalledWith(
+        ARCH_TASK,
+        expect.stringContaining('Findings: 3')
+      );
+      expect(result.prUrl).toBe('https://github.com/org/repo/pull/42');
+      expect(result.prUpdated).toBe(false);
+      expect(result.status).toBe('success');
+    });
+
+    it('does not call ensurePR when agent produces no commits', async () => {
+      const prManager = createMockPRManager();
+      const runner = new TaskRunner(
+        createRunnerOptions({
+          checkRunner: createMockCheckRunner({ findings: 3 }),
+          agentDispatcher: createMockAgentDispatcher({ producedCommits: false, fixed: 0 }),
+          prManager,
+        })
+      );
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(prManager.ensureBranch).toHaveBeenCalled();
+      expect(prManager.ensurePR).not.toHaveBeenCalled();
+      expect(result.prUrl).toBeNull();
     });
   });
 
@@ -220,6 +270,34 @@ describe('TaskRunner', () => {
 
       expect(result.status).toBe('failure');
       expect(result.error).toContain('missing fixSkill');
+    });
+
+    it('calls prManager.ensureBranch and ensurePR when agent produces commits', async () => {
+      const prManager = createMockPRManager('https://github.com/org/repo/pull/99');
+      const pureAITask: TaskDefinition = {
+        id: 'dead-code',
+        type: 'pure-ai',
+        description: 'Remove dead code',
+        schedule: '0 2 * * 0',
+        branch: 'harness-maint/dead-code',
+        fixSkill: 'cleanup-dead-code',
+      };
+      const runner = new TaskRunner(
+        createRunnerOptions({
+          agentDispatcher: createMockAgentDispatcher({ producedCommits: true, fixed: 5 }),
+          prManager,
+        })
+      );
+
+      const result = await runner.run(pureAITask);
+
+      expect(prManager.ensureBranch).toHaveBeenCalledWith('harness-maint/dead-code', 'main');
+      expect(prManager.ensurePR).toHaveBeenCalledWith(
+        pureAITask,
+        expect.stringContaining('Fixed: 5')
+      );
+      expect(result.prUrl).toBe('https://github.com/org/repo/pull/99');
+      expect(result.status).toBe('success');
     });
   });
 
@@ -370,6 +448,21 @@ describe('TaskRunner', () => {
       expect(new Date(result.startedAt).getTime()).toBeLessThanOrEqual(
         new Date(result.completedAt).getTime()
       );
+    });
+
+    it('returns prUrl: null when no prManager is provided (backward compat)', async () => {
+      const runner = new TaskRunner(
+        createRunnerOptions({
+          checkRunner: createMockCheckRunner({ findings: 3 }),
+          agentDispatcher: createMockAgentDispatcher({ producedCommits: true, fixed: 2 }),
+          // No prManager
+        })
+      );
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.prUrl).toBeNull();
+      expect(result.status).toBe('success');
     });
 
     it('includes taskId in all results', async () => {

--- a/packages/orchestrator/tests/maintenance/task-runner.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-runner.test.ts
@@ -222,4 +222,88 @@ describe('TaskRunner', () => {
       expect(result.error).toContain('missing fixSkill');
     });
   });
+
+  describe('report-only tasks', () => {
+    const PERF_TASK: TaskDefinition = {
+      id: 'perf-check',
+      type: 'report-only',
+      description: 'Run performance checks and record metrics',
+      schedule: '0 6 * * 1',
+      branch: null,
+      checkCommand: ['check-perf'],
+    };
+
+    it('runs check and returns findings without dispatching agent', async () => {
+      const checkRunner = createMockCheckRunner({ findings: 3 });
+      const agentDispatcher = createMockAgentDispatcher();
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+      const result = await runner.run(PERF_TASK);
+
+      expect(result.status).toBe('success');
+      expect(result.findings).toBe(3);
+      expect(result.fixed).toBe(0);
+      expect(result.prUrl).toBeNull();
+      expect(checkRunner.run).toHaveBeenCalledWith(['check-perf'], '/test/project');
+      expect(agentDispatcher.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when checkCommand is missing', async () => {
+      const task: TaskDefinition = { ...PERF_TASK, checkCommand: undefined };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing checkCommand');
+    });
+  });
+
+  describe('housekeeping tasks', () => {
+    const SESSION_CLEANUP_TASK: TaskDefinition = {
+      id: 'session-cleanup',
+      type: 'housekeeping',
+      description: 'Clean up stale orchestrator sessions',
+      schedule: '0 0 * * *',
+      branch: null,
+      checkCommand: ['cleanup-sessions'],
+    };
+
+    it('runs command directly and returns success', async () => {
+      const commandExecutor = createMockCommandExecutor();
+      const agentDispatcher = createMockAgentDispatcher();
+      const runner = new TaskRunner(createRunnerOptions({ commandExecutor, agentDispatcher }));
+
+      const result = await runner.run(SESSION_CLEANUP_TASK);
+
+      expect(result.status).toBe('success');
+      expect(result.findings).toBe(0);
+      expect(result.fixed).toBe(0);
+      expect(result.prUrl).toBeNull();
+      expect(commandExecutor.exec).toHaveBeenCalledWith(['cleanup-sessions'], '/test/project');
+      expect(agentDispatcher.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when command throws', async () => {
+      const commandExecutor: CommandExecutor = {
+        exec: vi.fn().mockRejectedValue(new Error('cleanup failed')),
+      };
+      const runner = new TaskRunner(createRunnerOptions({ commandExecutor }));
+
+      const result = await runner.run(SESSION_CLEANUP_TASK);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('cleanup failed');
+    });
+
+    it('returns failure when checkCommand is missing', async () => {
+      const task: TaskDefinition = { ...SESSION_CLEANUP_TASK, checkCommand: undefined };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing checkCommand');
+    });
+  });
 });

--- a/packages/orchestrator/tests/maintenance/task-runner.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-runner.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TaskRunner } from '../../src/maintenance/task-runner';
+import type {
+  CheckCommandRunner,
+  AgentDispatcher,
+  CommandExecutor,
+  TaskRunnerOptions,
+} from '../../src/maintenance/task-runner';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+import type { TaskDefinition } from '../../src/maintenance/types';
+
+function createMockCheckRunner(
+  result?: Partial<{ passed: boolean; findings: number; output: string }>
+): CheckCommandRunner {
+  return {
+    run: vi.fn().mockResolvedValue({
+      passed: result?.passed ?? true,
+      findings: result?.findings ?? 0,
+      output: result?.output ?? '',
+    }),
+  };
+}
+
+function createMockAgentDispatcher(
+  result?: Partial<{ producedCommits: boolean; fixed: number }>
+): AgentDispatcher {
+  return {
+    dispatch: vi.fn().mockResolvedValue({
+      producedCommits: result?.producedCommits ?? true,
+      fixed: result?.fixed ?? 0,
+    }),
+  };
+}
+
+function createMockCommandExecutor(): CommandExecutor {
+  return {
+    exec: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createRunnerOptions(overrides?: Partial<TaskRunnerOptions>): TaskRunnerOptions {
+  return {
+    config: { enabled: true },
+    checkRunner: createMockCheckRunner(),
+    agentDispatcher: createMockAgentDispatcher(),
+    commandExecutor: createMockCommandExecutor(),
+    cwd: '/test/project',
+    ...overrides,
+  };
+}
+
+const ARCH_TASK: TaskDefinition = {
+  id: 'arch-violations',
+  type: 'mechanical-ai',
+  description: 'Detect and fix architecture violations',
+  schedule: '0 2 * * *',
+  branch: 'harness-maint/arch-fixes',
+  checkCommand: ['check-arch'],
+  fixSkill: 'harness-arch-fix',
+};
+
+describe('TaskRunner', () => {
+  describe('mechanical-ai tasks', () => {
+    it('returns no-issues when check finds zero findings', async () => {
+      const checkRunner = createMockCheckRunner({ findings: 0 });
+      const agentDispatcher = createMockAgentDispatcher();
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.status).toBe('no-issues');
+      expect(result.findings).toBe(0);
+      expect(result.fixed).toBe(0);
+      expect(result.prUrl).toBeNull();
+      expect(checkRunner.run).toHaveBeenCalledWith(['check-arch'], '/test/project');
+      expect(agentDispatcher.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches agent when check finds fixable issues', async () => {
+      const checkRunner = createMockCheckRunner({ findings: 5, passed: false });
+      const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 3 });
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+      const result = await runner.run(ARCH_TASK);
+
+      expect(result.status).toBe('success');
+      expect(result.findings).toBe(5);
+      expect(result.fixed).toBe(3);
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        'harness-arch-fix',
+        'harness-maint/arch-fixes',
+        'local', // default backend
+        '/test/project'
+      );
+    });
+
+    it('returns failure when checkCommand is missing', async () => {
+      const task: TaskDefinition = { ...ARCH_TASK, checkCommand: undefined };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing checkCommand');
+    });
+
+    it('returns failure when fixSkill is missing', async () => {
+      const task: TaskDefinition = { ...ARCH_TASK, fixSkill: undefined };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing fixSkill');
+    });
+
+    it('returns failure when branch is missing', async () => {
+      const task: TaskDefinition = { ...ARCH_TASK, branch: null };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing branch');
+    });
+  });
+});

--- a/packages/orchestrator/tests/maintenance/task-runner.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-runner.test.ts
@@ -124,4 +124,102 @@ describe('TaskRunner', () => {
       expect(result.error).toContain('missing branch');
     });
   });
+
+  describe('pure-ai tasks', () => {
+    const DEAD_CODE_TASK: TaskDefinition = {
+      id: 'dead-code',
+      type: 'pure-ai',
+      description: 'Find and remove dead code',
+      schedule: '0 2 * * 0',
+      branch: 'harness-maint/dead-code',
+      fixSkill: 'harness-codebase-cleanup',
+    };
+
+    it('always dispatches agent regardless of check results', async () => {
+      const checkRunner = createMockCheckRunner();
+      const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 2 });
+      const runner = new TaskRunner(createRunnerOptions({ checkRunner, agentDispatcher }));
+
+      const result = await runner.run(DEAD_CODE_TASK);
+
+      expect(result.status).toBe('success');
+      expect(result.fixed).toBe(2);
+      expect(checkRunner.run).not.toHaveBeenCalled();
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        'harness-codebase-cleanup',
+        'harness-maint/dead-code',
+        'local',
+        '/test/project'
+      );
+    });
+
+    it('returns no-issues when agent produces no commits', async () => {
+      const agentDispatcher = createMockAgentDispatcher({ producedCommits: false, fixed: 0 });
+      const runner = new TaskRunner(createRunnerOptions({ agentDispatcher }));
+
+      const result = await runner.run(DEAD_CODE_TASK);
+
+      expect(result.status).toBe('no-issues');
+      expect(result.fixed).toBe(0);
+    });
+
+    it('uses per-task aiBackend override when configured', async () => {
+      const config: MaintenanceConfig = {
+        enabled: true,
+        aiBackend: 'local',
+        tasks: { 'dead-code': { aiBackend: 'claude' } },
+      };
+      const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 1 });
+      const runner = new TaskRunner(createRunnerOptions({ config, agentDispatcher }));
+
+      await runner.run(DEAD_CODE_TASK);
+
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        'harness-codebase-cleanup',
+        'harness-maint/dead-code',
+        'claude', // per-task override
+        '/test/project'
+      );
+    });
+
+    it('uses global aiBackend when no per-task override', async () => {
+      const config: MaintenanceConfig = { enabled: true, aiBackend: 'anthropic' };
+      const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 1 });
+      const runner = new TaskRunner(createRunnerOptions({ config, agentDispatcher }));
+
+      await runner.run(DEAD_CODE_TASK);
+
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        'harness-codebase-cleanup',
+        'harness-maint/dead-code',
+        'anthropic', // global config
+        '/test/project'
+      );
+    });
+
+    it('defaults to local when no backend configured', async () => {
+      const config: MaintenanceConfig = { enabled: true };
+      const agentDispatcher = createMockAgentDispatcher({ producedCommits: true, fixed: 1 });
+      const runner = new TaskRunner(createRunnerOptions({ config, agentDispatcher }));
+
+      await runner.run(DEAD_CODE_TASK);
+
+      expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        'local', // default
+        expect.any(String)
+      );
+    });
+
+    it('returns failure when fixSkill is missing', async () => {
+      const task: TaskDefinition = { ...DEAD_CODE_TASK, fixSkill: undefined };
+      const runner = new TaskRunner(createRunnerOptions());
+
+      const result = await runner.run(task);
+
+      expect(result.status).toBe('failure');
+      expect(result.error).toContain('missing fixSkill');
+    });
+  });
 });

--- a/packages/orchestrator/tests/maintenance/types.test.ts
+++ b/packages/orchestrator/tests/maintenance/types.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  TaskType,
+  TaskDefinition,
+  RunResult,
+  MaintenanceStatus,
+  ScheduleEntry,
+} from '../../src/maintenance/types';
+
+describe('maintenance internal types', () => {
+  it('TaskType accepts all four valid values', () => {
+    const types: TaskType[] = ['mechanical-ai', 'pure-ai', 'report-only', 'housekeeping'];
+    expect(types).toHaveLength(4);
+  });
+
+  it('TaskDefinition can be constructed with required fields', () => {
+    const task: TaskDefinition = {
+      id: 'test-task',
+      type: 'mechanical-ai',
+      description: 'A test task',
+      schedule: '0 2 * * *',
+      branch: 'harness-maint/test',
+      checkCommand: ['check-arch'],
+      fixSkill: 'harness-arch-fix',
+    };
+    expect(task.id).toBe('test-task');
+    expect(task.type).toBe('mechanical-ai');
+    expect(task.branch).toBe('harness-maint/test');
+  });
+
+  it('TaskDefinition allows null branch for report-only tasks', () => {
+    const task: TaskDefinition = {
+      id: 'report-task',
+      type: 'report-only',
+      description: 'A report task',
+      schedule: '0 6 * * 1',
+      branch: null,
+      checkCommand: ['check-perf'],
+    };
+    expect(task.branch).toBeNull();
+  });
+
+  it('RunResult can represent a successful run with PR', () => {
+    const result: RunResult = {
+      taskId: 'arch-violations',
+      startedAt: '2026-04-17T02:00:00Z',
+      completedAt: '2026-04-17T02:05:00Z',
+      status: 'success',
+      findings: 3,
+      fixed: 2,
+      prUrl: 'https://github.com/org/repo/pull/42',
+      prUpdated: false,
+    };
+    expect(result.status).toBe('success');
+    expect(result.prUrl).not.toBeNull();
+  });
+
+  it('RunResult can represent a no-issues run', () => {
+    const result: RunResult = {
+      taskId: 'arch-violations',
+      startedAt: '2026-04-17T02:00:00Z',
+      completedAt: '2026-04-17T02:01:00Z',
+      status: 'no-issues',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+    };
+    expect(result.status).toBe('no-issues');
+    expect(result.findings).toBe(0);
+  });
+
+  it('RunResult can represent a failure with error', () => {
+    const result: RunResult = {
+      taskId: 'entropy',
+      startedAt: '2026-04-17T03:00:00Z',
+      completedAt: '2026-04-17T03:00:05Z',
+      status: 'failure',
+      findings: 0,
+      fixed: 0,
+      prUrl: null,
+      prUpdated: false,
+      error: 'Command exited with code 1',
+    };
+    expect(result.status).toBe('failure');
+    expect(result.error).toBeDefined();
+  });
+
+  it('MaintenanceStatus represents idle state', () => {
+    const status: MaintenanceStatus = {
+      isLeader: true,
+      lastLeaderClaim: '2026-04-17T02:00:00Z',
+      schedule: [],
+      activeRun: null,
+      history: [],
+    };
+    expect(status.isLeader).toBe(true);
+    expect(status.activeRun).toBeNull();
+  });
+
+  it('ScheduleEntry links a task to its next run and last result', () => {
+    const entry: ScheduleEntry = {
+      taskId: 'arch-violations',
+      nextRun: '2026-04-18T02:00:00Z',
+      lastRun: {
+        taskId: 'arch-violations',
+        startedAt: '2026-04-17T02:00:00Z',
+        completedAt: '2026-04-17T02:05:00Z',
+        status: 'success',
+        findings: 3,
+        fixed: 2,
+        prUrl: 'https://github.com/org/repo/pull/42',
+        prUpdated: true,
+      },
+    };
+    expect(entry.taskId).toBe('arch-violations');
+    expect(entry.lastRun?.status).toBe('success');
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -139,3 +139,6 @@ export type {
   ContainerConfig,
   SecretConfig,
 } from './container';
+
+// --- Maintenance ---
+export type { MaintenanceConfig, TaskOverride } from './maintenance';

--- a/packages/types/src/maintenance.ts
+++ b/packages/types/src/maintenance.ts
@@ -1,0 +1,32 @@
+/**
+ * Per-task overrides in the maintenance configuration.
+ */
+export interface TaskOverride {
+  /** Whether this task is enabled (default: true) */
+  enabled?: boolean;
+  /** Cron expression override for this task's schedule */
+  schedule?: string;
+  /** Backend name override for AI tasks (e.g., 'local', 'claude') */
+  aiBackend?: string;
+}
+
+/**
+ * Configuration for the scheduled maintenance module.
+ * Added as an optional property on WorkflowConfig.
+ */
+export interface MaintenanceConfig {
+  /** Whether scheduled maintenance is enabled */
+  enabled: boolean;
+  /** Default AI backend name for maintenance tasks (default: 'local') */
+  aiBackend?: string;
+  /** Base branch for maintenance PRs (default: 'main') */
+  baseBranch?: string;
+  /** Prefix for maintenance branch names (default: 'harness-maint/') */
+  branchPrefix?: string;
+  /** TTL in ms for the leader election claim (default: 300000) */
+  leaderClaimTTLMs?: number;
+  /** How often in ms to evaluate cron schedules (default: 60000) */
+  checkIntervalMs?: number;
+  /** Per-task overrides keyed by task ID */
+  tasks?: Record<string, TaskOverride>;
+}

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -1,5 +1,6 @@
 import type { Result } from './result';
 import type { ContainerConfig, SecretConfig } from './container';
+import type { MaintenanceConfig } from './maintenance';
 
 // --- Token Usage ---
 
@@ -372,6 +373,8 @@ export interface WorkflowConfig {
   server: ServerConfig;
   /** Intelligence pipeline settings */
   intelligence?: IntelligenceConfig;
+  /** Scheduled maintenance settings */
+  maintenance?: MaintenanceConfig;
   /** Optional stable identity for this orchestrator instance. Auto-generated if omitted. */
   orchestratorId?: string;
 }


### PR DESCRIPTION
## Summary

- Adds a `MaintenanceScheduler` module to the orchestrator that automatically runs 18 maintenance tasks on configurable cron schedules
- When issues are found, creates or updates GitHub PRs with fixes (one branch per category, additive commits)
- Multi-orchestrator coordination via ClaimManager leader election — only one instance runs maintenance at a time
- AI tasks default to local model backend to minimize token cost, configurable per-task
- Dashboard REST endpoints (`/api/maintenance/schedule|status|history|trigger`) and websocket events for real-time visibility
- Extends `WorkflowConfig` with a `maintenance` section for all configuration

### Modules created (7 files in `packages/orchestrator/src/maintenance/`)
- **cron-matcher.ts** — 5-field cron expression evaluator with field validation
- **scheduler.ts** — MaintenanceScheduler with leader election, cron evaluation, dedup
- **task-registry.ts** — 18 built-in task definitions across 4 types (mechanical-ai, pure-ai, report-only, housekeeping)
- **task-runner.ts** — Execution engine with 4 paths, DI interfaces, backend resolution
- **pr-manager.ts** — Branch lifecycle (create/rebase/recreate) and PR create/update via `gh`
- **reporter.ts** — Run result persistence to disk with paginated history
- **types.ts** — TaskDefinition, RunResult, MaintenanceStatus, etc.

### Note
CheckCommandRunner, AgentDispatcher, and CommandExecutor are currently stubs — real implementations wiring to `harness` CLI and `AgentRunner` will follow in a separate PR.

## Test plan

- [ ] 128 unit + integration tests pass (`cd packages/orchestrator && npx vitest run tests/maintenance/`)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] `harness validate` passes
- [ ] Integration test verifies two schedulers sharing a ClaimManager only dispatch from one
- [ ] Integration test verifies full cycle: scheduler → task runner → PR manager → reporter
- [ ] Review dashboard endpoints respond correctly (schedule, status, history, trigger)