### PR TITLE
feat(skills): add universal rationalizations to 8 high-traffic skills

### DIFF
--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-17T02:02:25.421Z",
-  "updatedFrom": "94c9fafb",
+  "updatedAt": "2026-04-19T19:42:42.461Z",
+  "updatedFrom": "f0fcbf4d",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 38,
+      "value": 41,
       "violationIds": [
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
@@ -26,13 +26,16 @@
         "a412401eac205ffb264bf787149f356102c5b0ba5b02f8d526083dc4d976115b",
         "1eb37e0977a1b3bd37eaecb872a2588522766006db257b8f96c64d35a52cbe94",
         "d3cfdf50eb93ffa8e766af4e71257175af7f24bb346c3a2f5338c5b6f853382a",
-        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
+        "4ec5b89ddfda055b8db8745ac52b3466abc4dce07e39cc246f8a91c300c6756e",
         "5aa35eb7825bc41fe5a8fc031d0cdedd78703616efd3da15af290eca55184744",
         "ac5d2db9c38d6025f9531c162a198343c5c501a7bd8991906470993853d89055",
+        "8c23ba5045a4891cc163d7e7c0c00596ed4528737fb13cc459235035b921021d",
+        "d1df3e9a85e96266550913b02709b42228baad0600a76e9249a4481bd71a0f41",
         "fad5da199ad18507ec1727c9a2de48da80fd75f72230cc948df3afd8830308ce",
         "f573d1d3f72b896ef1841f90ce326b1008e05ec90ec72489becbd1a9e4c679fe",
         "6eb4858144d411132d7e376f3dca3820e906d97bfb34d6a690f6ddb3229b8dce",
         "dad32014fb96b44b797cb3005dc093985f1d0508a6f72f2804053a0ebdee4a8d",
+        "1abc91e27cf909a325221b0bcd18f6b07987a07df20e681234939cceae4ccf8e",
         "13310052487ad20819c93bd931a8677f92b706c0e28615319e854b5d682cd247",
         "97d282575446f2807269f1dddf316f20c23527bd5fa4ed0d1901f46717478c68",
         "82c9472c41b16379f2f062e7c8aa27438235e5e7957b205f1491d9bf89aac952",
@@ -50,8 +53,8 @@
         "f80c1747de98253c8b1f63381609098332795f5a5d5af4bb99131c93fa9860e8",
         "18856f23f0a89f2253f080f59d183b0a114c43c6f66e1d761d3c2dfba0975c13",
         "b35564439bfa9d55f539ac3a66fa00d2b87342036ea7ca2effdeb44e3eda41ab",
-        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a",
-        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe"
+        "c8d2bba32ada6b305f18d21984244a099ff99e787d11ed7dbaf68e3c780faefe",
+        "893cd272b54dc976f216de08764fda98e0cd87fb3ce301bb6cc4dbc7fff9207a"
       ]
     },
     "coupling": {
@@ -63,7 +66,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 81849,
+      "value": 82410,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",
@@ -72,7 +75,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 332,
+      "value": 333,
       "violationIds": []
     }
   }

--- a/agents/skills/claude-code/enforce-architecture/SKILL.md
+++ b/agents/skills/claude-code/enforce-architecture/SKILL.md
@@ -272,6 +272,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                  | Reality                                                                                                                              |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | "The violation is minor — just one import"       | One violation sets a precedent. Enforce the constraint or document an explicit exception with rationale.                             |

--- a/agents/skills/claude-code/harness-api-design/SKILL.md
+++ b/agents/skills/claude-code/harness-api-design/SKILL.md
@@ -332,6 +332,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                   | Reality                                                                                                   |
 | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | "It's an internal API, breaking changes are fine" | Internal consumers break too. Version the change or coordinate the migration explicitly.                  |

--- a/agents/skills/claude-code/harness-architecture-advisor/SKILL.md
+++ b/agents/skills/claude-code/harness-architecture-advisor/SKILL.md
@@ -312,11 +312,23 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
-| Rationalization                   | Reality                                                                                             |
-| --------------------------------- | --------------------------------------------------------------------------------------------------- |
-| "This will be easier to maintain" | Easier for whom, and compared to what? Cite the maintenance burden with evidence from the codebase. |
-| "It's the modern approach"        | Modernity is not a design criterion. Fitness for purpose is. State the specific benefit.            |
-| "Other teams do it this way"      | Other teams have different constraints. Evaluate the option on this codebase's specific merits.     |
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
+| Rationalization                                              | Reality                                                                                                                                                                   |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "This will be easier to maintain"                            | Easier for whom, and compared to what? Cite the maintenance burden with evidence from the codebase.                                                                       |
+| "It's the modern approach"                                   | Modernity is not a design criterion. Fitness for purpose is. State the specific benefit.                                                                                  |
+| "Other teams do it this way"                                 | Other teams have different constraints. Evaluate the option on this codebase's specific merits.                                                                           |
 | "I can see the solution already, no need to finish research" | Premature convergence anchors on the first viable option. Complete Phase 2 research before proposing anything in Phase 3. The best option may not be the first one found. |
 
 ## Escalation

--- a/agents/skills/claude-code/harness-auth/SKILL.md
+++ b/agents/skills/claude-code/harness-auth/SKILL.md
@@ -307,6 +307,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                                      | Reality                                                                                             |
 | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | "No one would guess this token format"                               | Security by obscurity. Tokens must be cryptographically secure regardless of format predictability. |

--- a/agents/skills/claude-code/harness-code-review/SKILL.md
+++ b/agents/skills/claude-code/harness-code-review/SKILL.md
@@ -586,6 +586,7 @@ compliance|naming|suggestion|Names follow project conventions (check AGENTS.md o
 **Why:** Verbose rubric prose inflates context by 2-5x without improving review accuracy. Dense single-line rubrics give the agent the same signal in fewer tokens, leaving more budget for actual code analysis.
 
 **Rules:**
+
 - Maximum 80 characters per criterion text
 - Domain must match the subagent's scope (compliance, bug, security, architecture)
 - Severity must be one of: critical, important, suggestion
@@ -695,11 +696,23 @@ compliance|naming|suggestion|Names follow project conventions (check AGENTS.md o
 
 ## Rationalizations to Reject
 
-| Rationalization                                     | Reality                                                                                     |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| "The tests pass, so the logic must be correct"      | Tests can be incomplete. Review the logic independently of test results.                    |
-| "This is how it was done elsewhere in the codebase" | Existing patterns can be wrong. Evaluate the pattern on its merits, not just its precedent. |
-| "It's just a refactor, low risk"                    | Refactors change behavior surfaces. Review them with the same rigor as feature changes.     |
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
+| Rationalization                                     | Reality                                                                                                                      |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| "The tests pass, so the logic must be correct"      | Tests can be incomplete. Review the logic independently of test results.                                                     |
+| "This is how it was done elsewhere in the codebase" | Existing patterns can be wrong. Evaluate the pattern on its merits, not just its precedent.                                  |
+| "It's just a refactor, low risk"                    | Refactors change behavior surfaces. Review them with the same rigor as feature changes.                                      |
 | "The fix is trivial, I'll just apply it inline"     | Trivial fixes still skip review when applied by the reviewer. Suggest the fix; let the author apply and re-review. Iron Law. |
 
 ## Escalation

--- a/agents/skills/claude-code/harness-database/SKILL.md
+++ b/agents/skills/claude-code/harness-database/SKILL.md
@@ -286,6 +286,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                              | Reality                                                                                                                          |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | "The table is small, we don't need an index" | Tables grow. Plan for the steady state, not the current row count.                                                               |

--- a/agents/skills/claude-code/harness-deployment/SKILL.md
+++ b/agents/skills/claude-code/harness-deployment/SKILL.md
@@ -283,6 +283,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                | Reality                                                                                                                                |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | "It's just a config change, not a code change" | Config changes cause outages at the same rate as code changes. Deploy them with the same rigor and rollback strategy.                  |

--- a/agents/skills/claude-code/harness-planning/SKILL.md
+++ b/agents/skills/claude-code/harness-planning/SKILL.md
@@ -67,6 +67,7 @@ Work backward from the goal. Start with "what must be true when we are done?"
    - **Deferrable:** Does not affect task decomposition. Note for execution phase.
 
    Format:
+
    ```
    ## Uncertainties
    - [BLOCKING] How should the API handle partial failures? (Spec does not define.)

--- a/agents/skills/claude-code/harness-security-scan/SKILL.md
+++ b/agents/skills/claude-code/harness-security-scan/SKILL.md
@@ -94,6 +94,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                     | Reality                                                                                            |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------- |
 | "No attacker would find this"       | Security by obscurity. If the code is wrong, flag it regardless of discoverability.                |

--- a/agents/skills/claude-code/harness-skill-authoring/SKILL.md
+++ b/agents/skills/claude-code/harness-skill-authoring/SKILL.md
@@ -286,14 +286,17 @@ Apply test-driven thinking to skill authoring. A skill is not complete until it 
    ## Skill Test Scenarios
 
    ### Scenario 1: Red Flag — [quoted phrase from Red Flags section]
+
    Input: [describe the situation]
    Expected: Agent stops, cites the Red Flag, and takes corrective action
 
    ### Scenario 2: Rationalization — [quoted phrase from Rationalizations section]
+
    Input: [describe the tempting shortcut]
    Expected: Agent rejects the rationalization and follows the prescribed process
 
    ### Scenario 3: Gate — [gate condition]
+
    Input: [describe a state that violates the gate]
    Expected: Agent halts and does not proceed past the gate
    ```
@@ -343,13 +346,13 @@ Use this checklist as a final quality gate before declaring a skill complete.
 
 ## Rationalizations to Reject
 
-| Rationalization                                                         | Reality                                                                                                                                  |
-| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| "This skill is too simple to need all required sections"                | Every section exists for a reason. A short section is fine; a missing section means the skill was not fully thought through.             |
-| "The process section covers it — no need for explicit success criteria" | Process describes what to do. Success criteria describe how to know it worked. They serve different purposes.                            |
-| "Rationalizations to Reject is meta — this skill does not need it"      | This section is required for all user-facing skills, including this one. No exceptions.                                                  |
-| "I will add examples later once the skill is proven"                    | Examples are a required section. A skill without examples forces the agent to guess at correct behavior. Write at least one example now. |
-| "The When to Use section is obvious from the name"                      | Negative conditions (when NOT to use) prevent misapplication. The skill name conveys nothing about boundary conditions.                  |
+| Rationalization                                                         | Reality                                                                                                                                                                                                  |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "This skill is too simple to need all required sections"                | Every section exists for a reason. A short section is fine; a missing section means the skill was not fully thought through.                                                                             |
+| "The process section covers it — no need for explicit success criteria" | Process describes what to do. Success criteria describe how to know it worked. They serve different purposes.                                                                                            |
+| "Rationalizations to Reject is meta — this skill does not need it"      | This section is required for all user-facing skills, including this one. No exceptions.                                                                                                                  |
+| "I will add examples later once the skill is proven"                    | Examples are a required section. A skill without examples forces the agent to guess at correct behavior. Write at least one example now.                                                                 |
+| "The When to Use section is obvious from the name"                      | Negative conditions (when NOT to use) prevent misapplication. The skill name conveys nothing about boundary conditions.                                                                                  |
 | "The skill works — I tested it by running it once"                      | A single happy-path run does not test discipline sections. Write scenarios that trigger Red Flags, Gates, and Rationalizations. A skill that passes happy path but fails discipline scenarios is a trap. |
 
 ## Examples

--- a/agents/skills/claude-code/harness-verification/SKILL.md
+++ b/agents/skills/claude-code/harness-verification/SKILL.md
@@ -279,6 +279,7 @@ L2|real-logic|Functions contain meaningful logic, not just hardcoded returns
 **Why:** Verbose checklist prose inflates verification context without improving accuracy. Dense single-line rubrics give the same signal in fewer tokens, leaving more budget for reading and analyzing actual file content.
 
 **Rules:**
+
 - Level prefix must be L1 (EXISTS), L2 (SUBSTANTIVE), or L3 (WIRED)
 - Maximum 80 characters per criterion text
 - Rubric entries are guidance — the verification levels define the authoritative checks

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -727,14 +727,15 @@ last_manual_edit: 2026-04-16T16:30:00.000Z
 
 ### Skill Discipline Upgrades
 
-- **Status:** done
+- **Status:** in-progress
 - **Spec:** docs/changes/skill-discipline-upgrades/proposal.md
 - **Summary:** Evidence Requirements, Red Flags, and Rationalizations to Reject sections for 8 high-traffic skills (code-review, security-scan, architecture-advisor, enforce-architecture, auth, api-design, database, deployment) via shared discipline template. [ACE-Batch1]
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** —
+- **Assignee:** orchestrator-ad1c7656
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#66
+- **Updated-At:** 2026-04-19T19:43:35.830Z
 
 ### Documentation Auto-Generation
 
@@ -949,9 +950,6 @@ last_manual_edit: 2026-04-16T16:30:00.000Z
 - **Summary:** Pre-filter in orchestrator tick that checks candidate externalId against GitHub PR state, skipping dispatch for features with open PRs and failing open on API errors
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** —
-- **Priority:** —
-- **External-ID:** —
 
 ## v3.0 Graph Intelligence
 


### PR DESCRIPTION
## Summary\n\n- Adds Universal/Domain-Specific subsection structure to the **Rationalizations to Reject** sections in all 8 target skills from the [skill-discipline-upgrades proposal](docs/changes/skill-discipline-upgrades/proposal.md)\n- Each skill now includes 3 shared universal rationalizations from `discipline-template.md` (\"It's probably fine\", \"This is best practice\", \"We can fix it later\") alongside existing domain-specific rationalizations\n- Skills upgraded: `harness-code-review`, `harness-security-scan`, `harness-architecture-advisor`, `enforce-architecture`, `harness-auth`, `harness-api-design`, `harness-database`, `harness-deployment`\n- All changes are additive — no existing SKILL.md content removed or altered\n- Fixes pre-existing prettier formatting issues and updates architecture baselines\n\n## Test plan\n\n- [x] `harness validate` passes\n- [x] All 8 SKILL.md files have `### Universal` and `### Domain-Specific` subsections under `## Rationalizations to Reject`\n- [x] Universal rationalizations match discipline-template.md verbatim\n- [x] Existing domain-specific rationalizations preserved in original table format\n- [x] New sections placed immediately before `## Escalation` in every skill\n- [x] `prettier --check` passes across all files