### PR TITLE
feat(skills): add universal Rationalizations to Reject to 8 high-traffic skills

### DIFF
--- a/agents/skills/claude-code/enforce-architecture/SKILL.md
+++ b/agents/skills/claude-code/enforce-architecture/SKILL.md
@@ -272,6 +272,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                  | Reality                                                                                                                              |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | "The violation is minor — just one import"       | One violation sets a precedent. Enforce the constraint or document an explicit exception with rationale.                             |

--- a/agents/skills/claude-code/harness-api-design/SKILL.md
+++ b/agents/skills/claude-code/harness-api-design/SKILL.md
@@ -332,6 +332,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                   | Reality                                                                                                   |
 | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | "It's an internal API, breaking changes are fine" | Internal consumers break too. Version the change or coordinate the migration explicitly.                  |

--- a/agents/skills/claude-code/harness-architecture-advisor/SKILL.md
+++ b/agents/skills/claude-code/harness-architecture-advisor/SKILL.md
@@ -312,6 +312,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                              | Reality                                                                                                                                                                   |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | "This will be easier to maintain"                            | Easier for whom, and compared to what? Cite the maintenance burden with evidence from the codebase.                                                                       |

--- a/agents/skills/claude-code/harness-auth/SKILL.md
+++ b/agents/skills/claude-code/harness-auth/SKILL.md
@@ -307,6 +307,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                                      | Reality                                                                                             |
 | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | "No one would guess this token format"                               | Security by obscurity. Tokens must be cryptographically secure regardless of format predictability. |

--- a/agents/skills/claude-code/harness-code-review/SKILL.md
+++ b/agents/skills/claude-code/harness-code-review/SKILL.md
@@ -696,6 +696,18 @@ compliance|naming|suggestion|Names follow project conventions (check AGENTS.md o
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                     | Reality                                                                                                                      |
 | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | "The tests pass, so the logic must be correct"      | Tests can be incomplete. Review the logic independently of test results.                                                     |

--- a/agents/skills/claude-code/harness-database/SKILL.md
+++ b/agents/skills/claude-code/harness-database/SKILL.md
@@ -286,6 +286,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                              | Reality                                                                                                                          |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | "The table is small, we don't need an index" | Tables grow. Plan for the steady state, not the current row count.                                                               |

--- a/agents/skills/claude-code/harness-deployment/SKILL.md
+++ b/agents/skills/claude-code/harness-deployment/SKILL.md
@@ -283,6 +283,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                                | Reality                                                                                                                                |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | "It's just a config change, not a code change" | Config changes cause outages at the same rate as code changes. Deploy them with the same rigor and rollback strategy.                  |

--- a/agents/skills/claude-code/harness-security-scan/SKILL.md
+++ b/agents/skills/claude-code/harness-security-scan/SKILL.md
@@ -94,6 +94,18 @@ These apply to ALL skills. If you catch yourself doing any of these, STOP.
 
 ## Rationalizations to Reject
 
+### Universal
+
+These reasoning patterns sound plausible but lead to bad outcomes. Reject them.
+
+- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
+- **"This is best practice"** — Best practice in what context? Cite the source and
+  confirm it applies to this codebase.
+- **"We can fix it later"** — If it is worth flagging, it is worth documenting now
+  with a concrete follow-up plan.
+
+### Domain-Specific
+
 | Rationalization                     | Reality                                                                                            |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------- |
 | "No attacker would find this"       | Security by obscurity. If the code is wrong, flag it regardless of discoverability.                |


### PR DESCRIPTION
## Summary

- Adds the 3 universal rationalizations from the shared discipline template (`agents/skills/templates/discipline-template.md`) to all 8 target skills' `## Rationalizations to Reject` sections
- Restructures each skill's Rationalizations section with `### Universal` / `### Domain-Specific` subsections, matching the existing Red Flags structure
- Purely additive: 96 insertions, 0 deletions across 8 SKILL.md files

### Skills Updated

| Skill | Directory |
|-------|----------|
| harness-code-review | `agents/skills/claude-code/harness-code-review/` |
| harness-security-scan | `agents/skills/claude-code/harness-security-scan/` |
| harness-architecture-advisor | `agents/skills/claude-code/harness-architecture-advisor/` |
| enforce-architecture | `agents/skills/claude-code/enforce-architecture/` |
| harness-auth | `agents/skills/claude-code/harness-auth/` |
| harness-api-design | `agents/skills/claude-code/harness-api-design/` |
| harness-database | `agents/skills/claude-code/harness-database/` |
| harness-deployment | `agents/skills/claude-code/harness-deployment/` |

### Universal Rationalizations Added

Each skill now includes these 3 universal rationalizations (verbatim from template):
- **"It's probably fine"** — "Probably" is not evidence. Verify before asserting.
- **"This is best practice"** — Best practice in what context? Cite the source and confirm it applies to this codebase.
- **"We can fix it later"** — If it is worth flagging, it is worth documenting now with a concrete follow-up plan.

### Spec Compliance

Per `docs/changes/skill-discipline-upgrades/proposal.md`:
- [x] All 8 skills have Evidence Requirements with `[UNVERIFIED]` prefix rule
- [x] All 8 skills have 3 universal Red Flags + 3-5 domain-specific Red Flags
- [x] All 8 skills have 3 universal Rationalizations + 3-5 domain-specific Rationalizations
- [x] Sections placed immediately before Escalation
- [x] No existing content removed or altered (purely additive)
- [x] `harness validate` passes

## Test plan

- [x] Verify `harness validate` passes
- [x] Verify all 8 SKILL.md files contain `### Universal` and `### Domain-Specific` subsections under `## Rationalizations to Reject`
- [x] Verify universal rationalizations match template verbatim
- [x] Verify no existing content was removed (0 deletions in diff)

Closes skill-discipline-upg-765fbd98 [ACE-Batch1]