### PR TITLE
fix(telemetry): use distinct_id for PostHog and add identity fallbacks

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -824,6 +824,10 @@ Show current telemetry consent state, install ID, and identity
 
 - `--json` — Output as JSON
 
+### `harness telemetry test`
+
+Send a test event to PostHog and verify connectivity
+
 ## Usage Commands
 
 Token usage and cost tracking

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -1,10 +1,12 @@
 import { Command } from 'commander';
 import { createIdentifyCommand } from './identify';
 import { createStatusCommand } from './status';
+import { createTestCommand } from './test';
 
 export function createTelemetryCommand(): Command {
   const command = new Command('telemetry').description('Telemetry identity and status management');
   command.addCommand(createIdentifyCommand());
   command.addCommand(createStatusCommand());
+  command.addCommand(createTestCommand());
   return command;
 }

--- a/packages/cli/src/commands/telemetry/test.ts
+++ b/packages/cli/src/commands/telemetry/test.ts
@@ -1,0 +1,67 @@
+import { Command } from 'commander';
+import { resolveConsent } from '@harness-engineering/core';
+import { POSTHOG_API_KEY } from '../../bin/command-telemetry';
+import { logger } from '../../output/logger';
+
+const POSTHOG_BATCH_URL = 'https://app.posthog.com/batch';
+
+export function createTestCommand(): Command {
+  return new Command('test')
+    .description('Send a test event to PostHog and verify connectivity')
+    .action(async () => {
+      const cwd = process.cwd();
+      const consent = resolveConsent(cwd, undefined);
+
+      if (!consent.allowed) {
+        logger.error('Telemetry is disabled. Run `harness telemetry status` for details.');
+        process.exitCode = 1;
+        return;
+      }
+
+      const { installId, identity } = consent;
+      const distinctId = identity.alias ?? installId;
+
+      const event = {
+        event: 'telemetry_test',
+        distinct_id: distinctId,
+        timestamp: new Date().toISOString(),
+        properties: {
+          installId,
+          os: process.platform,
+          nodeVersion: process.version,
+          test: true,
+          ...(identity.project ? { project: identity.project } : {}),
+          ...(identity.team ? { team: identity.team } : {}),
+        },
+      };
+
+      const payload = JSON.stringify({ api_key: POSTHOG_API_KEY, batch: [event] });
+
+      logger.info(`Sending test event as "${distinctId}"...`);
+
+      try {
+        const res = await fetch(POSTHOG_BATCH_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: payload,
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        const body = await res.text();
+
+        if (res.ok) {
+          logger.success(`PostHog responded ${res.status} OK — telemetry is working`);
+          logger.info(`  distinct_id: ${distinctId}`);
+          if (identity.project) logger.info(`  project:     ${identity.project}`);
+          if (identity.team) logger.info(`  team:        ${identity.team}`);
+        } else {
+          logger.error(`PostHog responded ${res.status}: ${body}`);
+          process.exitCode = 1;
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`Failed to reach PostHog: ${msg}`);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/packages/cli/src/hooks/telemetry-reporter.js
+++ b/packages/cli/src/hooks/telemetry-reporter.js
@@ -8,6 +8,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import process from 'node:process';
 
 // PostHog project API key — public, write-only (cannot read data)
@@ -51,6 +52,26 @@ function resolveConsent(cwd) {
     if (typeof identityFile.identity.project === 'string') identity.project = identityFile.identity.project;
     if (typeof identityFile.identity.team === 'string') identity.team = identityFile.identity.team;
     if (typeof identityFile.identity.alias === 'string') identity.alias = identityFile.identity.alias;
+  }
+
+  // Fallback: project name from harness.config.json
+  if (!identity.project && typeof config?.name === 'string') {
+    identity.project = config.name;
+  }
+
+  // Fallback: alias from git config user.name
+  if (!identity.alias) {
+    try {
+      const gitName = execFileSync('git', ['config', 'user.name'], {
+        cwd,
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      if (gitName) identity.alias = gitName;
+    } catch {
+      // Git not available or no user.name set
+    }
   }
 
   return { allowed: true, installId, identity };
@@ -119,7 +140,7 @@ function collectEvents(cwd, consent) {
 
   return records.map((record) => ({
     event: 'skill_invocation',
-    distinctId,
+    distinct_id: distinctId,
     timestamp: record.startedAt,
     properties: {
       installId,

--- a/packages/core/src/telemetry/collector.ts
+++ b/packages/core/src/telemetry/collector.ts
@@ -30,7 +30,7 @@ export function collectEvents(
   return records.map(
     (record: SkillInvocationRecord): TelemetryEvent => ({
       event: 'skill_invocation',
-      distinctId,
+      distinct_id: distinctId,
       timestamp: record.startedAt,
       properties: {
         installId,

--- a/packages/core/src/telemetry/consent.ts
+++ b/packages/core/src/telemetry/consent.ts
@@ -1,29 +1,60 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import type { ConsentState, TelemetryConfig, TelemetryIdentity } from '@harness-engineering/types';
 import { getOrCreateInstallId } from './install-id';
 
 /**
- * Reads optional identity fields from `.harness/telemetry.json`.
- * Returns empty object if the file is missing or malformed.
+ * Reads optional identity fields from `.harness/telemetry.json`,
+ * with fallbacks from harness.config.json (project name) and git config (alias).
+ * Returns empty object if no sources are available.
  */
 export function readIdentity(projectRoot: string): TelemetryIdentity {
+  const identity: TelemetryIdentity = {};
+
+  // Primary source: .harness/telemetry.json
   const filePath = path.join(projectRoot, '.harness', 'telemetry.json');
   try {
     const raw = fs.readFileSync(filePath, 'utf-8');
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === 'object' && parsed.identity) {
       const { project, team, alias } = parsed.identity;
-      const identity: TelemetryIdentity = {};
       if (typeof project === 'string') identity.project = project;
       if (typeof team === 'string') identity.team = team;
       if (typeof alias === 'string') identity.alias = alias;
-      return identity;
     }
-    return {};
   } catch {
-    return {};
+    // Missing or malformed — continue with fallbacks
   }
+
+  // Fallback: project name from harness.config.json
+  if (!identity.project) {
+    try {
+      const configPath = path.join(projectRoot, 'harness.config.json');
+      const raw = fs.readFileSync(configPath, 'utf-8');
+      const config = JSON.parse(raw);
+      if (typeof config?.name === 'string') identity.project = config.name;
+    } catch {
+      // Missing or malformed — skip
+    }
+  }
+
+  // Fallback: alias from git config user.name
+  if (!identity.alias) {
+    try {
+      const gitName = execFileSync('git', ['config', 'user.name'], {
+        cwd: projectRoot,
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      if (gitName) identity.alias = gitName;
+    } catch {
+      // Git not available or no user.name set — skip
+    }
+  }
+
+  return identity;
 }
 
 /**

--- a/packages/core/tests/telemetry/collector.test.ts
+++ b/packages/core/tests/telemetry/collector.test.ts
@@ -38,7 +38,7 @@ describe('collectEvents', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]!.event).toBe('skill_invocation');
-    expect(events[0]!.distinctId).toBe('test-uuid-1234');
+    expect(events[0]!.distinct_id).toBe('test-uuid-1234');
     expect(events[0]!.timestamp).toBe('2026-04-10T10:00:00.000Z');
     expect(events[0]!.properties.skillName).toBe('harness-brainstorming');
     expect(events[0]!.properties.duration).toBe(5000);
@@ -50,7 +50,7 @@ describe('collectEvents', () => {
     expect(typeof events[0]!.properties.harnessVersion).toBe('string');
   });
 
-  it('uses alias as distinctId when identity has alias', () => {
+  it('uses alias as distinct_id when identity has alias', () => {
     const consent: ConsentState = {
       allowed: true,
       installId: 'test-uuid-1234',
@@ -68,7 +68,7 @@ describe('collectEvents', () => {
 
     const events = collectEvents(tmpDir, consent);
 
-    expect(events[0]!.distinctId).toBe('cwarner');
+    expect(events[0]!.distinct_id).toBe('cwarner');
     expect(events[0]!.properties.project).toBe('myapp');
     expect(events[0]!.properties.team).toBe('platform');
   });
@@ -91,7 +91,7 @@ describe('collectEvents', () => {
 
     const events = collectEvents(tmpDir, consent);
 
-    expect(events[0]!.distinctId).toBe('test-uuid-1234');
+    expect(events[0]!.distinct_id).toBe('test-uuid-1234');
     expect(events[0]!.properties.project).toBe('myapp');
     expect(events[0]!.properties.team).toBe('platform');
   });

--- a/packages/core/tests/telemetry/consent.test.ts
+++ b/packages/core/tests/telemetry/consent.test.ts
@@ -73,7 +73,10 @@ describe('resolveConsent', () => {
     expect(result.installId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
     );
-    expect(result.identity).toEqual({});
+    // identity.project/team should not be set without telemetry.json or config
+    expect(result.identity.project).toBeUndefined();
+    expect(result.identity.team).toBeUndefined();
+    // alias may be populated from git config user.name if available
   });
 
   it('returns identity fields from .harness/telemetry.json', () => {
@@ -84,18 +87,46 @@ describe('resolveConsent', () => {
     );
     const result = resolveConsent(tmpDir, { enabled: true });
     expect(result.allowed).toBe(true);
-    expect(result.identity).toEqual({ project: 'myapp', team: 'platform' });
+    expect(result.identity).toMatchObject({ project: 'myapp', team: 'platform' });
   });
 
-  it('returns empty identity when telemetry.json does not exist', () => {
+  it('falls back to harness.config.json name when telemetry.json has no project', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'harness.config.json'),
+      JSON.stringify({ name: 'my-project' }),
+      'utf-8'
+    );
     const result = resolveConsent(tmpDir, { enabled: true });
-    expect(result.identity).toEqual({});
+    expect(result.allowed).toBe(true);
+    expect(result.identity.project).toBe('my-project');
   });
 
-  it('returns empty identity when telemetry.json is malformed', () => {
+  it('prefers telemetry.json project over harness.config.json name', () => {
+    fs.writeFileSync(
+      telemetryJsonFile,
+      JSON.stringify({ identity: { project: 'from-telemetry' } }),
+      'utf-8'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'harness.config.json'),
+      JSON.stringify({ name: 'from-config' }),
+      'utf-8'
+    );
+    const result = resolveConsent(tmpDir, { enabled: true });
+    expect(result.identity.project).toBe('from-telemetry');
+  });
+
+  it('returns no project/team when telemetry.json does not exist and no config name', () => {
+    const result = resolveConsent(tmpDir, { enabled: true });
+    expect(result.identity.project).toBeUndefined();
+    expect(result.identity.team).toBeUndefined();
+  });
+
+  it('returns no project/team when telemetry.json is malformed', () => {
     fs.writeFileSync(telemetryJsonFile, 'not json', 'utf-8');
     const result = resolveConsent(tmpDir, { enabled: true });
-    expect(result.identity).toEqual({});
+    expect(result.identity.project).toBeUndefined();
+    expect(result.identity.team).toBeUndefined();
   });
 
   it('defaults config to enabled:true when undefined', () => {

--- a/packages/core/tests/telemetry/transport.test.ts
+++ b/packages/core/tests/telemetry/transport.test.ts
@@ -5,7 +5,7 @@ import type { TelemetryEvent } from '@harness-engineering/types';
 function makeEvent(overrides: Partial<TelemetryEvent> = {}): TelemetryEvent {
   return {
     event: 'skill_invocation',
-    distinctId: 'test-uuid',
+    distinct_id: 'test-uuid',
     timestamp: '2026-04-10T10:00:00.000Z',
     properties: {
       installId: 'test-uuid',

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -31,8 +31,8 @@ export type ConsentState =
 export interface TelemetryEvent {
   /** Event name, e.g. "skill_invocation", "session_end" */
   event: string;
-  /** installId (anonymous) or alias (identified) */
-  distinctId: string;
+  /** installId (anonymous) or alias (identified) — snake_case required by PostHog batch API */
+  distinct_id: string;
   properties: {
     installId: string;
     os: string;


### PR DESCRIPTION
## Summary

- **Root cause**: PostHog batch API requires `distinct_id` (snake_case) but the code sent `distinctId` (camelCase), causing all events to be silently rejected with 400. The 4xx was treated as a permanent failure and silently swallowed — no telemetry has ever reached PostHog.
- Renamed `TelemetryEvent.distinctId` to `distinct_id` across types, core collector, reporter hook (source + deployed), and all tests
- Added identity fallbacks: `harness.config.json` `name` field for project name, `git config user.name` for alias — so users get identified tracking without manual `.harness/telemetry.json` setup
- Added `harness telemetry test` command that sends a real test event and reports the HTTP response

## Test plan

- [x] Live test: `distinct_id` returns 200 OK, `distinctId` returns 400 "event submitted without a distinct_id"
- [x] `harness telemetry test` confirms PostHog connectivity (200 OK with correct identity)
- [x] Core telemetry tests: 37 passed (consent, collector, transport, install-id, reader)
- [x] CLI tests: 2826 passed
- [x] Typecheck passes across types, core, and cli packages
- [ ] Verify events appear in PostHog dashboard after next session