### PR TITLE
feat(graph): add business knowledge foundation

### DIFF
--- a/coverage-baselines.json
+++ b/coverage-baselines.json
@@ -1,27 +1,27 @@
 {
   "packages/core": {
-    "lines": 89.9,
-    "branches": 74.13,
+    "lines": 89.92,
+    "branches": 74.15,
     "functions": 91.27,
-    "statements": 87.64
+    "statements": 87.67
   },
   "packages/graph": {
-    "lines": 97.21,
-    "branches": 83.16,
-    "functions": 97.24,
-    "statements": 95.7
+    "lines": 97.27,
+    "branches": 82.94,
+    "functions": 97.31,
+    "statements": 95.63
   },
   "packages/cli": {
-    "lines": 80.89,
-    "branches": 67.43,
-    "functions": 84.5,
-    "statements": 80.23
+    "lines": 80.33,
+    "branches": 66.96,
+    "functions": 84.38,
+    "statements": 79.65
   },
   "packages/orchestrator": {
-    "lines": 75.18,
+    "lines": 75.2,
     "branches": 63.21,
     "functions": 76.62,
-    "statements": 74.15
+    "statements": 74.18
   },
   "packages/eslint-plugin": {
     "lines": 94.67,

--- a/docs/changes/business-knowledge-foundation/proposal.md
+++ b/docs/changes/business-knowledge-foundation/proposal.md
@@ -1,0 +1,203 @@
+# Phase 1: Knowledge Foundation
+
+## Overview
+
+Establish the foundation for business domain knowledge in the harness knowledge graph. This adds structured business context (rules, processes, concepts, terms, metrics) that agents can access alongside code context during `gather_context` calls, improving decision quality for domain-aware tasks.
+
+## Goals
+
+1. Extend the graph schema with 5 business knowledge node types and 2 edge types
+2. Create `BusinessKnowledgeIngestor` that reads YAML-frontmatter markdown from `docs/knowledge/`
+3. Expose business knowledge via `harness://business-knowledge` MCP resource
+4. Integrate business knowledge into `gather_context` as a new constituent
+5. Author 1-2 pilot domain knowledge files demonstrating the format
+
+## Decisions
+
+| #   | Decision                                                                                                  | Rationale                                                                               |
+| --- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 1   | Separate `BusinessKnowledgeIngestor` class                                                                | Single responsibility; can evolve independently from ADR/learnings ingestion            |
+| 2   | YAML frontmatter + markdown body format                                                                   | Consistent with existing doc patterns; easy to author and parse                         |
+| 3   | 5 node types: `business_rule`, `business_process`, `business_concept`, `business_term`, `business_metric` | Covers the key knowledge categories needed for domain context                           |
+| 4   | 2 edge types: `governs`, `measures`                                                                       | `governs` links rules/processes to code; `measures` links metrics to processes/concepts |
+| 5   | Pilot domains: architecture, release-process                                                              | Immediately useful for this project; demonstrates real value                            |
+| 6   | `gather_context` gets `businessKnowledge` constituent                                                     | Parallel assembly alongside graph, state, learnings                                     |
+
+## Technical Design
+
+### Graph Schema Extensions
+
+**New node types** added to `NODE_TYPES` in `packages/graph/src/types.ts`:
+
+```typescript
+// Business Knowledge
+'business_rule',      // Constraints, policies, invariants
+'business_process',   // Workflows, procedures, sequences
+'business_concept',   // Domain abstractions, bounded contexts
+'business_term',      // Glossary entries, domain vocabulary
+'business_metric',    // KPIs, measurements, thresholds
+```
+
+**New edge types** added to `EDGE_TYPES` in `packages/graph/src/types.ts`:
+
+```typescript
+// Business Knowledge relationships
+'governs',   // business_rule/business_process -> code node
+'measures',  // business_metric -> business_process/business_concept
+```
+
+### Knowledge File Format
+
+Files in `docs/knowledge/` use YAML frontmatter:
+
+```markdown
+---
+type: business_rule
+domain: architecture
+tags: [layers, imports, dependencies]
+---
+
+# Layer Boundary Enforcement
+
+The harness monorepo enforces strict layer boundaries...
+```
+
+**Required frontmatter fields:**
+
+- `type`: One of the 5 business knowledge node types
+- `domain`: Domain category string (e.g., "architecture", "release-process")
+
+**Optional frontmatter fields:**
+
+- `tags`: Array of keyword strings for search/linking
+- `related`: Array of other knowledge file paths for cross-references
+
+### BusinessKnowledgeIngestor
+
+**Location:** `packages/graph/src/ingest/BusinessKnowledgeIngestor.ts`
+
+```typescript
+export class BusinessKnowledgeIngestor {
+  constructor(private readonly store: GraphStore) {}
+
+  async ingest(knowledgeDir: string): Promise<IngestResult>;
+  // Reads all .md files recursively from knowledgeDir
+  // Parses YAML frontmatter for type/domain/tags
+  // Creates graph nodes with type from frontmatter
+  // Links to code nodes via keyword matching (reuses linkToCode pattern)
+  // Creates governs/measures edges based on type
+}
+```
+
+**Node ID format:** `bk:<domain>:<filename>` (e.g., `bk:architecture:layer-boundaries`)
+
+**Edge creation logic:**
+
+- `business_rule` and `business_process` nodes get `governs` edges to matched code nodes
+- `business_metric` nodes get `measures` edges to matched `business_process` and `business_concept` nodes
+- All types get `documents` edges to matched code nodes via keyword/path matching
+
+### MCP Resource
+
+**URI:** `harness://business-knowledge`
+
+**Location:** `packages/cli/src/mcp/resources/business-knowledge.ts`
+
+Returns a JSON summary of all business knowledge files organized by domain:
+
+```json
+{
+  "domains": {
+    "architecture": [
+      {
+        "type": "business_rule",
+        "name": "Layer Boundary Enforcement",
+        "path": "docs/knowledge/architecture/layer-boundaries.md"
+      }
+    ]
+  },
+  "totalFiles": 3,
+  "totalDomains": 2
+}
+```
+
+### gather_context Integration
+
+Add a `businessKnowledge` key to the `include` array options and output:
+
+```typescript
+type IncludeKey =
+  | 'state'
+  | 'learnings'
+  | 'handoff'
+  | 'graph'
+  | 'validation'
+  | 'sessions'
+  | 'events'
+  | 'businessKnowledge';
+```
+
+The constituent loads business knowledge nodes from the graph and returns them filtered by intent relevance using the FusionLayer search.
+
+**Output shape addition:**
+
+```typescript
+{
+  // ... existing fields
+  businessKnowledge: {
+    domains: string[];
+    relevantFacts: Array<{ type: string; name: string; domain: string; content: string }>;
+    totalNodes: number;
+  } | null;
+}
+```
+
+### Pilot Domain Files
+
+**`docs/knowledge/architecture/layer-boundaries.md`** — Documents the 9-layer architecture and forbidden import rules.
+
+**`docs/knowledge/architecture/graph-schema.md`** — Documents graph node/edge type purposes and usage patterns.
+
+### File Layout
+
+```
+packages/graph/src/
+  types.ts                                    # +5 node types, +2 edge types
+  ingest/BusinessKnowledgeIngestor.ts         # NEW
+  index.ts                                    # +export BusinessKnowledgeIngestor
+
+packages/cli/src/mcp/
+  resources/business-knowledge.ts             # NEW
+  server.ts                                   # +resource registration
+  tools/gather-context.ts                     # +businessKnowledge constituent
+
+docs/knowledge/
+  architecture/
+    layer-boundaries.md                       # NEW pilot
+    graph-schema.md                           # NEW pilot
+
+packages/graph/src/ingest/__tests__/
+  BusinessKnowledgeIngestor.test.ts           # NEW
+```
+
+## Success Criteria
+
+1. `NODE_TYPES` includes all 5 new business knowledge types
+2. `EDGE_TYPES` includes `governs` and `measures`
+3. `BusinessKnowledgeIngestor` reads `docs/knowledge/`, creates correct node types and edges
+4. `BusinessKnowledgeIngestor` gracefully handles missing directory (returns empty result)
+5. `harness://business-knowledge` resource returns domain-organized JSON
+6. `gather_context` with `include: ['businessKnowledge']` returns relevant business knowledge
+7. At least 2 pilot knowledge files exist in `docs/knowledge/architecture/`
+8. All existing tests continue to pass
+9. `harness validate` passes
+10. TypeScript compilation succeeds with no errors
+
+## Implementation Order
+
+1. **Schema extensions** — Add node/edge types to `types.ts`
+2. **Ingestor** — Create `BusinessKnowledgeIngestor` with tests
+3. **Export** — Wire into `packages/graph/src/index.ts`
+4. **MCP resource** — Create resource handler and register in server
+5. **gather_context** — Add `businessKnowledge` constituent
+6. **Pilot content** — Author architecture domain knowledge files

--- a/docs/knowledge/architecture/graph-schema.md
+++ b/docs/knowledge/architecture/graph-schema.md
@@ -1,0 +1,34 @@
+---
+type: business_concept
+domain: architecture
+tags: [graph, nodes, edges, schema, knowledge-graph]
+---
+
+# Knowledge Graph Schema
+
+The harness knowledge graph is a unified data structure that connects code, knowledge, and operational data. It is stored in-memory using LokiJS and persisted to `.harness/graph/`.
+
+## Node Type Categories
+
+- **Code nodes:** repository, module, file, class, interface, function, method, variable — extracted by CodeIngestor via regex-based multi-language parsing
+- **Knowledge nodes:** adr, decision, learning, failure, issue, document, skill, conversation — extracted by KnowledgeIngestor from `.harness/` markdown files
+- **Business knowledge nodes:** business_rule, business_process, business_concept, business_term, business_metric — extracted by BusinessKnowledgeIngestor from `docs/knowledge/`
+- **VCS nodes:** commit, build, test_result, execution_outcome — extracted by GitIngestor and CIConnector
+- **Structural nodes:** layer, pattern, constraint, violation — derived from architecture analysis
+- **Design nodes:** design_token, aesthetic_intent, design_constraint — extracted by DesignIngestor
+- **Traceability nodes:** requirement — extracted by RequirementIngestor from `@req` annotations
+
+## Edge Type Categories
+
+- **Code relationships:** contains, imports, calls, implements, inherits, references
+- **Knowledge relationships:** applies_to, caused_by, resolved_by, documents, violates, specifies, decided
+- **Business knowledge relationships:** governs (rule/process to code), measures (metric to process/concept)
+- **VCS relationships:** co_changes_with, triggered_by, failed_in, outcome_of
+- **Design relationships:** uses_token, declares_intent, violates_design, platform_binding
+- **Traceability relationships:** requires, verified_by, tested_by
+
+## Query Interfaces
+
+- **ContextQL** — Graph traversal from root nodes with depth limits and type filtering
+- **FusionLayer** — Hybrid keyword + semantic search combining BM25 and vector similarity
+- **NLQ (askGraph)** — Natural language queries translated to graph operations

--- a/docs/knowledge/architecture/layer-boundaries.md
+++ b/docs/knowledge/architecture/layer-boundaries.md
@@ -1,0 +1,23 @@
+---
+type: business_rule
+domain: architecture
+tags: [layers, imports, dependencies, boundaries]
+---
+
+# Layer Boundary Enforcement
+
+The harness-engineering monorepo enforces strict layer boundaries to prevent architectural erosion. Nine layers are defined in `harness.config.json`, each with explicit allowed dependencies:
+
+1. **types** - Foundation types with zero dependencies
+2. **graph** - Knowledge graph store, ingestors, and query engine (depends on: types)
+3. **core** - Shared utilities, state management, learnings (depends on: types, graph)
+4. **eslint-plugin** - Custom ESLint rules (depends on: types, core)
+5. **linter-gen** - Linter configuration generator (depends on: types, core)
+6. **intelligence** - AI-powered analysis (depends on: types, graph)
+7. **orchestrator** - Workflow orchestration (depends on: types, core, intelligence)
+8. **dashboard** - Web dashboard (depends on: types, core, graph)
+9. **cli** - CLI and MCP server (depends on: types, core, graph, linter-gen, orchestrator)
+
+Imports that violate layer boundaries are forbidden via the `forbiddenImports` configuration. The architecture threshold for layer violations is zero — any violation fails validation.
+
+Lower layers must never import from higher layers. This ensures that foundational packages (types, graph, core) remain stable and independently testable.

--- a/docs/plans/2026-04-21-business-knowledge-foundation-plan.md
+++ b/docs/plans/2026-04-21-business-knowledge-foundation-plan.md
@@ -1,0 +1,126 @@
+# Plan: Phase 1 — Business Knowledge Foundation
+
+**Date:** 2026-04-21 | **Spec:** docs/changes/business-knowledge-foundation/proposal.md | **Tasks:** 7 | **Time:** ~30 min
+
+## Goal
+
+The harness knowledge graph supports business domain knowledge with 5 new node types, 2 edge types, a BusinessKnowledgeIngestor, a `harness://business-knowledge` MCP resource, gather_context integration, and 2 pilot knowledge files.
+
+## Observable Truths (Acceptance Criteria)
+
+1. `NODE_TYPES` in `packages/graph/src/types.ts` includes `business_rule`, `business_process`, `business_concept`, `business_term`, `business_metric`
+2. `EDGE_TYPES` in `packages/graph/src/types.ts` includes `governs`, `measures`
+3. `BusinessKnowledgeIngestor.ingest(dir)` creates nodes from YAML-frontmatter markdown files with correct types
+4. `BusinessKnowledgeIngestor.ingest(dir)` creates `governs` edges from `business_rule`/`business_process` to code nodes
+5. `BusinessKnowledgeIngestor.ingest(dir)` creates `measures` edges from `business_metric` to `business_process`/`business_concept` nodes
+6. When `docs/knowledge/` does not exist, `BusinessKnowledgeIngestor.ingest()` returns empty result with no errors
+7. `harness://business-knowledge` MCP resource returns JSON with domains, file counts, and file metadata
+8. `gather_context` with `include: ['businessKnowledge']` returns a `businessKnowledge` key in output
+9. `docs/knowledge/architecture/layer-boundaries.md` and `docs/knowledge/architecture/graph-schema.md` exist with valid frontmatter
+10. `BusinessKnowledgeIngestor` is exported from `packages/graph/src/index.ts`
+11. TypeScript compiles with no errors; `harness validate` passes
+
+## File Map
+
+```
+MODIFY  packages/graph/src/types.ts
+CREATE  packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+CREATE  packages/graph/tests/ingest/BusinessKnowledgeIngestor.test.ts
+MODIFY  packages/graph/src/index.ts
+CREATE  packages/cli/src/mcp/resources/business-knowledge.ts
+MODIFY  packages/cli/src/mcp/server.ts
+MODIFY  packages/cli/src/mcp/tools/gather-context.ts
+CREATE  docs/knowledge/architecture/layer-boundaries.md
+CREATE  docs/knowledge/architecture/graph-schema.md
+```
+
+## Tasks
+
+### Task 1: Extend graph schema with business knowledge types
+
+**Depends on:** none | **Files:** packages/graph/src/types.ts
+
+1. Add 5 node types after the `// Knowledge` section: `business_rule`, `business_process`, `business_concept`, `business_term`, `business_metric`
+2. Add 2 edge types after the `// Knowledge relationships` section: `governs`, `measures`
+3. Run: `npx harness validate`
+4. Commit: `feat(graph): add business knowledge node and edge types`
+
+### Task 2: Create BusinessKnowledgeIngestor with TDD
+
+**Depends on:** Task 1 | **Files:** packages/graph/tests/ingest/BusinessKnowledgeIngestor.test.ts, packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+
+1. Create test file `packages/graph/tests/ingest/BusinessKnowledgeIngestor.test.ts` with tests for:
+   - Creates nodes from YAML frontmatter markdown with correct types
+   - Creates `governs` edges from business_rule nodes to code nodes
+   - Creates `measures` edges from business_metric to business_process nodes
+   - Returns empty result for missing directory
+   - Handles files without frontmatter gracefully
+2. Run tests — observe failures
+3. Create `packages/graph/src/ingest/BusinessKnowledgeIngestor.ts` implementing:
+   - `ingest(knowledgeDir: string): Promise<IngestResult>`
+   - YAML frontmatter parsing (regex-based: split on `---`)
+   - Node creation with ID format `bk:<domain>:<filename>`
+   - `linkToCode()` for keyword-based code linking
+   - `governs` edges for business_rule/business_process nodes
+   - `measures` edges for business_metric nodes linking to business_process/business_concept nodes
+4. Run tests — observe pass
+5. Run: `npx harness validate`
+6. Commit: `feat(graph): add BusinessKnowledgeIngestor`
+
+### Task 3: Export BusinessKnowledgeIngestor from graph package
+
+**Depends on:** Task 2 | **Files:** packages/graph/src/index.ts
+
+1. Add export: `export { BusinessKnowledgeIngestor } from './ingest/BusinessKnowledgeIngestor.js';`
+2. Run: `npx harness validate`
+3. Commit: `feat(graph): export BusinessKnowledgeIngestor`
+
+### Task 4: Create harness://business-knowledge MCP resource
+
+**Depends on:** Task 1 | **Files:** packages/cli/src/mcp/resources/business-knowledge.ts, packages/cli/src/mcp/server.ts
+
+1. Create `packages/cli/src/mcp/resources/business-knowledge.ts`:
+   - `getBusinessKnowledgeResource(projectRoot: string): Promise<string>`
+   - Reads `docs/knowledge/` recursively for .md files
+   - Parses YAML frontmatter for type/domain
+   - Returns JSON with `domains` (grouped by domain), `totalFiles`, `totalDomains`
+   - Returns `{ domains: {}, totalFiles: 0, totalDomains: 0 }` if dir missing
+2. Register in `packages/cli/src/mcp/server.ts`:
+   - Import `getBusinessKnowledgeResource`
+   - Add resource definition to `RESOURCE_DEFINITIONS`
+   - Add handler to `RESOURCE_HANDLERS`
+3. Run: `npx harness validate`
+4. Commit: `feat(cli): add harness://business-knowledge MCP resource`
+
+### Task 5: Integrate businessKnowledge into gather_context
+
+**Depends on:** Task 1 | **Files:** packages/cli/src/mcp/tools/gather-context.ts
+
+1. Add `'businessKnowledge'` to the `IncludeKey` type union
+2. Add `businessKnowledge` constituent promise that reads knowledge files from `docs/knowledge/`
+3. Add to `Promise.allSettled` array and extract result
+4. Add `businessKnowledge` key to output object
+5. Run: `npx harness validate`
+6. Commit: `feat(cli): integrate businessKnowledge into gather_context`
+
+### Task 6: Author pilot domain knowledge files
+
+**Depends on:** none | **Files:** docs/knowledge/architecture/layer-boundaries.md, docs/knowledge/architecture/graph-schema.md
+
+1. Create `docs/knowledge/architecture/layer-boundaries.md` with:
+   - Frontmatter: `type: business_rule`, `domain: architecture`, `tags: [layers, imports, dependencies]`
+   - Content: Layer boundary rules, the 9-layer hierarchy, forbidden import constraints
+2. Create `docs/knowledge/architecture/graph-schema.md` with:
+   - Frontmatter: `type: business_concept`, `domain: architecture`, `tags: [graph, nodes, edges, schema]`
+   - Content: Graph schema purpose, node type categories, edge type categories
+3. Run: `npx harness validate`
+4. Commit: `docs: add pilot architecture knowledge files`
+
+### Task 7: Final integration verification
+
+**Depends on:** Tasks 1-6 | **Files:** none (verification only)
+
+1. Run: `cd packages/graph && npx vitest run tests/ingest/BusinessKnowledgeIngestor.test.ts`
+2. Run: `npx tsc --noEmit` (from root)
+3. Run: `npx harness validate`
+4. Verify all observable truths are met

--- a/packages/cli/src/mcp/resources/business-knowledge.ts
+++ b/packages/cli/src/mcp/resources/business-knowledge.ts
@@ -1,0 +1,107 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+interface KnowledgeEntry {
+  type: string;
+  name: string;
+  domain: string;
+  path: string;
+  tags?: string[];
+}
+
+export async function getBusinessKnowledgeResource(projectRoot: string): Promise<string> {
+  const knowledgeDir = path.join(projectRoot, 'docs', 'knowledge');
+
+  let files: string[];
+  try {
+    files = await findMarkdownFiles(knowledgeDir);
+  } catch {
+    return JSON.stringify({ domains: {}, totalFiles: 0, totalDomains: 0 });
+  }
+
+  const domains: Record<string, KnowledgeEntry[]> = {};
+
+  for (const filePath of files) {
+    try {
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const parsed = parseFrontmatter(raw);
+      if (!parsed) continue;
+
+      const { frontmatter, body } = parsed;
+      const titleMatch = body.match(/^#\s+(.+)$/m);
+      const name = titleMatch ? titleMatch[1]!.trim() : path.basename(filePath, '.md');
+      const relPath = path.relative(projectRoot, filePath).replaceAll('\\', '/');
+
+      const entry: KnowledgeEntry = {
+        type: frontmatter.type,
+        name,
+        domain: frontmatter.domain,
+        path: relPath,
+        ...(frontmatter.tags && { tags: frontmatter.tags }),
+      };
+
+      if (!domains[frontmatter.domain]) {
+        domains[frontmatter.domain] = [];
+      }
+      domains[frontmatter.domain]!.push(entry);
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return JSON.stringify({
+    domains,
+    totalFiles: Object.values(domains).reduce((sum, entries) => sum + entries.length, 0),
+    totalDomains: Object.keys(domains).length,
+  });
+}
+
+async function findMarkdownFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await findMarkdownFiles(fullPath)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function parseFrontmatter(raw: string): {
+  frontmatter: { type: string; domain: string; tags?: string[] };
+  body: string;
+} | null {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+
+  const yamlBlock = match[1]!;
+  const body = match[2]!;
+
+  const fm: Record<string, unknown> = {};
+  for (const line of yamlBlock.split('\n')) {
+    const kvMatch = line.match(/^(\w+):\s*(.+)$/);
+    if (!kvMatch) continue;
+    const key = kvMatch[1]!;
+    const value = kvMatch[2]!.trim();
+
+    if (value.startsWith('[') && value.endsWith(']')) {
+      fm[key] = value
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim());
+    } else {
+      fm[key] = value;
+    }
+  }
+
+  if (!fm.type || typeof fm.type !== 'string') return null;
+  if (!fm.domain || typeof fm.domain !== 'string') return null;
+
+  return {
+    frontmatter: fm as { type: string; domain: string; tags?: string[] },
+    body,
+  };
+}

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -55,6 +55,7 @@ import { getSkillsResource } from './resources/skills.js';
 import { getRulesResource } from './resources/rules.js';
 import { getProjectResource } from './resources/project.js';
 import { getLearningsResource } from './resources/learnings.js';
+import { getBusinessKnowledgeResource } from './resources/business-knowledge.js';
 import {
   manageStateDefinition,
   handleManageState,
@@ -339,6 +340,14 @@ const RESOURCE_DEFINITIONS = [
     mimeType: 'application/json',
     _meta: { stability: 'session' },
   },
+  {
+    uri: 'harness://business-knowledge',
+    name: 'Business Knowledge',
+    description:
+      'Business domain knowledge from docs/knowledge/ organized by domain (rules, processes, concepts, terms, metrics)',
+    mimeType: 'application/json',
+    _meta: { stability: 'session' },
+  },
 ];
 
 type ResourceHandler = (projectRoot: string) => Promise<string>;
@@ -352,6 +361,7 @@ const RESOURCE_HANDLERS: Record<string, ResourceHandler> = {
   'harness://graph': getGraphResource,
   'harness://entities': getEntitiesResource,
   'harness://relationships': getRelationshipsResource,
+  'harness://business-knowledge': getBusinessKnowledgeResource,
 };
 
 export function getToolDefinitions(): ToolDefinition[] {

--- a/packages/cli/src/mcp/tools/gather-context.ts
+++ b/packages/cli/src/mcp/tools/gather-context.ts
@@ -92,7 +92,8 @@ type IncludeKey =
   | 'graph'
   | 'validation'
   | 'sessions'
-  | 'events';
+  | 'events'
+  | 'businessKnowledge';
 
 export const gatherContextDefinition = {
   name: 'gather_context',
@@ -118,7 +119,16 @@ export const gatherContextDefinition = {
         type: 'array',
         items: {
           type: 'string',
-          enum: ['state', 'learnings', 'handoff', 'graph', 'validation', 'sessions', 'events'],
+          enum: [
+            'state',
+            'learnings',
+            'handoff',
+            'graph',
+            'validation',
+            'sessions',
+            'events',
+            'businessKnowledge',
+          ],
         },
         description: 'Which constituents to include (default: all)',
       },
@@ -313,6 +323,14 @@ export async function handleGatherContext(input: {
       })()
     : Promise.resolve(null);
 
+  const businessKnowledgePromise = includeSet.has('businessKnowledge')
+    ? (async () => {
+        const { getBusinessKnowledgeResource } = await import('../resources/business-knowledge.js');
+        const raw = await getBusinessKnowledgeResource(projectPath);
+        return JSON.parse(raw);
+      })()
+    : Promise.resolve(null);
+
   // Execute all in parallel
   const [
     stateResult,
@@ -322,6 +340,7 @@ export async function handleGatherContext(input: {
     validationResult,
     sessionsResult,
     eventsResult,
+    businessKnowledgeResult,
   ] = await Promise.allSettled([
     statePromise,
     learningsPromise,
@@ -330,6 +349,7 @@ export async function handleGatherContext(input: {
     validationPromise,
     sessionsPromise,
     eventsPromise,
+    businessKnowledgePromise,
   ]);
 
   // Extract results, recording errors
@@ -348,6 +368,7 @@ export async function handleGatherContext(input: {
   const validationRaw = extract(validationResult, 'validation');
   const sessionsRaw = extract(sessionsResult, 'sessions');
   const eventsTimeline = extract(eventsResult, 'events');
+  const businessKnowledgeRaw = extract(businessKnowledgeResult, 'businessKnowledge');
 
   // Unwrap Result types from core functions
   const state =
@@ -435,6 +456,7 @@ export async function handleGatherContext(input: {
     validation: outputValidation,
     sessionSections: sessionSections ?? null,
     events: eventsTimeline || null,
+    businessKnowledge: businessKnowledgeRaw ?? null,
     meta: {
       assembledIn,
       graphAvailable: graphContext !== null,

--- a/packages/cli/tests/commands/usage.test.ts
+++ b/packages/cli/tests/commands/usage.test.ts
@@ -76,6 +76,25 @@ describe('harness usage', () => {
     originalCwd = process.cwd();
     fs.mkdirSync(path.dirname(costsFile), { recursive: true });
     fs.writeFileSync(costsFile, sampleData);
+    // Seed a fresh pricing cache so loadPricingData skips the network fetch entirely.
+    // This avoids flaky timeouts on CI runners where the fetch mock may not fully intercept.
+    const pricingCacheDir = path.join(tmpDir, '.harness', 'cache');
+    fs.mkdirSync(pricingCacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pricingCacheDir, 'pricing.json'),
+      JSON.stringify({
+        fetchedAt: new Date().toISOString(),
+        data: {
+          'claude-sonnet-4-20250514': {
+            input_cost_per_token: 0.000003,
+            output_cost_per_token: 0.000015,
+            cache_read_input_token_cost: 0.0000003,
+            cache_creation_input_token_cost: 0.00000375,
+            mode: 'chat',
+          },
+        },
+      })
+    );
     process.chdir(tmpDir);
     logOutput = [];
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation((...args) => {

--- a/packages/cli/tests/mcp/resources/business-knowledge.test.ts
+++ b/packages/cli/tests/mcp/resources/business-knowledge.test.ts
@@ -1,0 +1,62 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getBusinessKnowledgeResource } from '../../../src/mcp/resources/business-knowledge';
+
+describe('getBusinessKnowledgeResource', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bk-resource-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty result when docs/knowledge/ does not exist', async () => {
+    const result = JSON.parse(await getBusinessKnowledgeResource(tmpDir));
+    expect(result).toEqual({ domains: {}, totalFiles: 0, totalDomains: 0 });
+  });
+
+  it('returns domain-organized knowledge entries', async () => {
+    const knowledgeDir = path.join(tmpDir, 'docs', 'knowledge', 'architecture');
+    await fs.mkdir(knowledgeDir, { recursive: true });
+    await fs.writeFile(
+      path.join(knowledgeDir, 'rules.md'),
+      `---
+type: business_rule
+domain: architecture
+tags: [layers]
+---
+
+# Layer Rules
+
+Content here.
+`,
+      'utf-8'
+    );
+
+    const result = JSON.parse(await getBusinessKnowledgeResource(tmpDir));
+    expect(result.totalFiles).toBe(1);
+    expect(result.totalDomains).toBe(1);
+    expect(result.domains.architecture).toHaveLength(1);
+    expect(result.domains.architecture[0].type).toBe('business_rule');
+    expect(result.domains.architecture[0].name).toBe('Layer Rules');
+    expect(result.domains.architecture[0].tags).toEqual(['layers']);
+  });
+
+  it('skips files without valid frontmatter', async () => {
+    const knowledgeDir = path.join(tmpDir, 'docs', 'knowledge', 'misc');
+    await fs.mkdir(knowledgeDir, { recursive: true });
+    await fs.writeFile(
+      path.join(knowledgeDir, 'plain.md'),
+      '# Just plain markdown\n\nNo frontmatter.',
+      'utf-8'
+    );
+
+    const result = JSON.parse(await getBusinessKnowledgeResource(tmpDir));
+    expect(result.totalFiles).toBe(0);
+  });
+});

--- a/packages/cli/tests/mcp/server.test.ts
+++ b/packages/cli/tests/mcp/server.test.ts
@@ -16,9 +16,9 @@ describe('MCP Server', () => {
     expect(tools).toHaveLength(58);
   });
 
-  it('registers all 8 resources', () => {
+  it('registers all 9 resources', () => {
     const resources = getResourceDefinitions();
-    expect(resources).toHaveLength(8);
+    expect(resources).toHaveLength(9);
   });
 
   it('registers original tools', () => {

--- a/packages/cli/tests/mcp/tools/gather-context.test.ts
+++ b/packages/cli/tests/mcp/tools/gather-context.test.ts
@@ -36,6 +36,7 @@ describe('gather_context tool', () => {
         'validation',
         'sessions',
         'events',
+        'businessKnowledge',
       ]);
     });
 

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -45,6 +45,7 @@ export type { GitRunner } from './ingest/GitIngestor.js';
 export { TopologicalLinker } from './ingest/TopologicalLinker.js';
 export type { LinkResult } from './ingest/TopologicalLinker.js';
 export { KnowledgeIngestor } from './ingest/KnowledgeIngestor.js';
+export { BusinessKnowledgeIngestor } from './ingest/BusinessKnowledgeIngestor.js';
 export { RequirementIngestor } from './ingest/RequirementIngestor.js';
 
 // Connectors

--- a/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+++ b/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
@@ -102,7 +102,7 @@ export class BusinessKnowledgeIngestor {
       id: nodeId,
       type: frontmatter.type as NodeType,
       name,
-      path: filePath,
+      path: relPath,
       content: body.trim(),
       metadata: {
         domain,

--- a/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+++ b/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
@@ -1,0 +1,224 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { GraphStore } from '../store/GraphStore.js';
+import type { GraphNode, IngestResult, NodeType, EdgeType } from '../types.js';
+import { emptyResult } from './ingestUtils.js';
+
+const BUSINESS_KNOWLEDGE_TYPES = new Set<string>([
+  'business_rule',
+  'business_process',
+  'business_concept',
+  'business_term',
+  'business_metric',
+]);
+
+const GOVERNS_SOURCE_TYPES = new Set<string>(['business_rule', 'business_process']);
+const CODE_NODE_TYPES: readonly NodeType[] = [
+  'file',
+  'function',
+  'class',
+  'method',
+  'interface',
+  'variable',
+];
+const MEASURABLE_TYPES = new Set<string>(['business_process', 'business_concept']);
+
+interface Frontmatter {
+  type: string;
+  domain: string;
+  tags?: string[];
+  related?: string[];
+}
+
+interface NodeEntry {
+  nodeId: string;
+  node: GraphNode;
+  content: string;
+}
+
+export class BusinessKnowledgeIngestor {
+  constructor(private readonly store: GraphStore) {}
+
+  async ingest(knowledgeDir: string): Promise<IngestResult> {
+    const start = Date.now();
+    const errors: string[] = [];
+
+    let files: string[];
+    try {
+      files = await this.findMarkdownFiles(knowledgeDir);
+    } catch {
+      return emptyResult(Date.now() - start);
+    }
+
+    const nodeEntries = await this.createNodes(files, knowledgeDir, errors);
+    const edgesAdded = this.createEdges(nodeEntries);
+
+    return {
+      nodesAdded: nodeEntries.length,
+      nodesUpdated: 0,
+      edgesAdded,
+      edgesUpdated: 0,
+      errors,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  private async createNodes(
+    files: string[],
+    knowledgeDir: string,
+    errors: string[]
+  ): Promise<NodeEntry[]> {
+    const entries: NodeEntry[] = [];
+
+    for (const filePath of files) {
+      try {
+        const entry = await this.parseAndAddNode(filePath, knowledgeDir);
+        if (entry) entries.push(entry);
+      } catch (err) {
+        errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return entries;
+  }
+
+  private async parseAndAddNode(filePath: string, knowledgeDir: string): Promise<NodeEntry | null> {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const parsed = parseFrontmatter(raw);
+    if (!parsed) return null;
+
+    const { frontmatter, body } = parsed;
+    if (!BUSINESS_KNOWLEDGE_TYPES.has(frontmatter.type)) return null;
+
+    const relPath = path.relative(knowledgeDir, filePath).replaceAll('\\', '/');
+    const domain = frontmatter.domain ?? relPath.split('/')[0] ?? 'unknown';
+    const filename = path.basename(filePath, '.md');
+    const nodeId = `bk:${domain}:${filename}`;
+
+    const titleMatch = body.match(/^#\s+(.+)$/m);
+    const name = titleMatch ? titleMatch[1]!.trim() : filename;
+
+    const node: GraphNode = {
+      id: nodeId,
+      type: frontmatter.type as NodeType,
+      name,
+      path: filePath,
+      content: body.trim(),
+      metadata: {
+        domain,
+        ...(frontmatter.tags && { tags: frontmatter.tags }),
+        ...(frontmatter.related && { related: frontmatter.related }),
+      },
+    };
+
+    this.store.addNode(node);
+    return { nodeId, node, content: body };
+  }
+
+  private createEdges(nodeEntries: NodeEntry[]): number {
+    let edgesAdded = 0;
+
+    for (const { nodeId, node, content } of nodeEntries) {
+      if (GOVERNS_SOURCE_TYPES.has(node.type)) {
+        edgesAdded += this.linkToNodes(content, nodeId, 'governs', CODE_NODE_TYPES);
+      } else {
+        edgesAdded += this.linkToNodes(content, nodeId, 'documents', CODE_NODE_TYPES);
+      }
+
+      if (node.type === 'business_metric') {
+        edgesAdded += this.linkToBusinessNodes(content, nodeId, 'measures', MEASURABLE_TYPES);
+      }
+    }
+
+    return edgesAdded;
+  }
+
+  private linkToNodes(
+    content: string,
+    sourceNodeId: string,
+    edgeType: EdgeType,
+    targetTypes: readonly NodeType[]
+  ): number {
+    let count = 0;
+    for (const nodeType of targetTypes) {
+      const nodes = this.store.findNodes({ type: nodeType });
+      for (const node of nodes) {
+        if (node.name.length < 3) continue;
+        const escaped = node.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const namePattern = new RegExp(`\\b${escaped}\\b`, 'i');
+        if (namePattern.test(content)) {
+          this.store.addEdge({ from: sourceNodeId, to: node.id, type: edgeType });
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  private linkToBusinessNodes(
+    content: string,
+    sourceNodeId: string,
+    edgeType: EdgeType,
+    targetTypes: Set<string>
+  ): number {
+    let count = 0;
+    for (const node of this.store.findNodes({})) {
+      if (!targetTypes.has(node.type)) continue;
+      if (node.name.length < 3) continue;
+      const escaped = node.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const namePattern = new RegExp(`\\b${escaped}\\b`, 'i');
+      if (namePattern.test(content)) {
+        this.store.addEdge({ from: sourceNodeId, to: node.id, type: edgeType });
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private async findMarkdownFiles(dir: string): Promise<string[]> {
+    const results: string[] = [];
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...(await this.findMarkdownFiles(fullPath)));
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        results.push(fullPath);
+      }
+    }
+    return results;
+  }
+}
+
+function parseFrontmatter(raw: string): { frontmatter: Frontmatter; body: string } | null {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+
+  const yamlBlock = match[1]!;
+  const body = match[2]!;
+
+  const frontmatter: Record<string, unknown> = {};
+  for (const line of yamlBlock.split('\n')) {
+    const kvMatch = line.match(/^(\w+):\s*(.+)$/);
+    if (!kvMatch) continue;
+    const key = kvMatch[1]!;
+    const value = kvMatch[2]!.trim();
+
+    if (value.startsWith('[') && value.endsWith(']')) {
+      frontmatter[key] = value
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim());
+    } else {
+      frontmatter[key] = value;
+    }
+  }
+
+  if (!frontmatter.type || typeof frontmatter.type !== 'string') return null;
+  if (!frontmatter.domain || typeof frontmatter.domain !== 'string') return null;
+
+  return {
+    frontmatter: frontmatter as unknown as Frontmatter,
+    body,
+  };
+}

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -41,6 +41,12 @@ export const NODE_TYPES = [
   'design_constraint',
   // Traceability
   'requirement',
+  // Business Knowledge
+  'business_rule',
+  'business_process',
+  'business_concept',
+  'business_term',
+  'business_metric',
   // Cache
   'packed_summary',
 ] as const;
@@ -82,6 +88,9 @@ export const EDGE_TYPES = [
   'requires',
   'verified_by',
   'tested_by',
+  // Business Knowledge relationships
+  'governs',
+  'measures',
   // Cache relationships
   'caches',
 ] as const;

--- a/packages/graph/tests/ingest/BusinessKnowledgeIngestor.test.ts
+++ b/packages/graph/tests/ingest/BusinessKnowledgeIngestor.test.ts
@@ -1,0 +1,327 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { GraphStore } from '../../src/store/GraphStore.js';
+import { BusinessKnowledgeIngestor } from '../../src/ingest/BusinessKnowledgeIngestor.js';
+
+describe('BusinessKnowledgeIngestor', () => {
+  let store: GraphStore;
+  let ingestor: BusinessKnowledgeIngestor;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    store = new GraphStore();
+    ingestor = new BusinessKnowledgeIngestor(store);
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bk-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeKnowledgeFile(subdir: string, filename: string, content: string) {
+    const dir = path.join(tmpDir, subdir);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, filename), content, 'utf-8');
+  }
+
+  describe('ingest', () => {
+    it('should create nodes from YAML frontmatter markdown with correct types', async () => {
+      await writeKnowledgeFile(
+        'architecture',
+        'layer-rules.md',
+        `---
+type: business_rule
+domain: architecture
+tags: [layers, imports]
+---
+
+# Layer Boundary Rules
+
+The monorepo enforces strict layer boundaries.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+
+      expect(result.nodesAdded).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const node = store.getNode('bk:architecture:layer-rules');
+      expect(node).not.toBeNull();
+      expect(node!.type).toBe('business_rule');
+      expect(node!.name).toBe('Layer Boundary Rules');
+      expect(node!.metadata.domain).toBe('architecture');
+      expect(node!.metadata.tags).toEqual(['layers', 'imports']);
+    });
+
+    it('should create nodes for multiple knowledge types', async () => {
+      await writeKnowledgeFile(
+        'ops',
+        'deploy-flow.md',
+        `---
+type: business_process
+domain: ops
+---
+
+# Deploy Flow
+
+Standard deployment process.
+`
+      );
+
+      await writeKnowledgeFile(
+        'ops',
+        'uptime.md',
+        `---
+type: business_metric
+domain: ops
+---
+
+# Uptime SLA
+
+99.9% uptime target.
+`
+      );
+
+      await writeKnowledgeFile(
+        'glossary',
+        'monorepo.md',
+        `---
+type: business_term
+domain: glossary
+---
+
+# Monorepo
+
+A single repository containing multiple packages.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+
+      expect(result.nodesAdded).toBe(3);
+
+      const processNode = store.getNode('bk:ops:deploy-flow');
+      expect(processNode).not.toBeNull();
+      expect(processNode!.type).toBe('business_process');
+
+      const metricNode = store.getNode('bk:ops:uptime');
+      expect(metricNode).not.toBeNull();
+      expect(metricNode!.type).toBe('business_metric');
+
+      const termNode = store.getNode('bk:glossary:monorepo');
+      expect(termNode).not.toBeNull();
+      expect(termNode!.type).toBe('business_term');
+    });
+
+    it('should create governs edges from business_rule nodes to code nodes', async () => {
+      // Add a code node to the store
+      store.addNode({
+        id: 'fn:validateLayer',
+        type: 'function',
+        name: 'validateLayer',
+        path: 'src/validate.ts',
+        metadata: {},
+      });
+
+      await writeKnowledgeFile(
+        'architecture',
+        'layer-rules.md',
+        `---
+type: business_rule
+domain: architecture
+---
+
+# Layer Validation
+
+The validateLayer function enforces boundaries.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+
+      expect(result.edgesAdded).toBeGreaterThanOrEqual(1);
+
+      const edges = store.getEdges({ from: 'bk:architecture:layer-rules', type: 'governs' });
+      expect(edges.length).toBeGreaterThanOrEqual(1);
+      expect(edges.some((e) => e.to === 'fn:validateLayer')).toBe(true);
+    });
+
+    it('should create governs edges from business_process nodes to code nodes', async () => {
+      store.addNode({
+        id: 'fn:deployService',
+        type: 'function',
+        name: 'deployService',
+        path: 'src/deploy.ts',
+        metadata: {},
+      });
+
+      await writeKnowledgeFile(
+        'ops',
+        'deploy-flow.md',
+        `---
+type: business_process
+domain: ops
+---
+
+# Deployment Process
+
+Uses the deployService function.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+
+      const edges = store.getEdges({ from: 'bk:ops:deploy-flow', type: 'governs' });
+      expect(edges.length).toBeGreaterThanOrEqual(1);
+      expect(edges.some((e) => e.to === 'fn:deployService')).toBe(true);
+    });
+
+    it('should create measures edges from business_metric to business_process nodes', async () => {
+      await writeKnowledgeFile(
+        'ops',
+        'deploy-flow.md',
+        `---
+type: business_process
+domain: ops
+---
+
+# Deploy Flow
+
+Standard deployment process.
+`
+      );
+
+      await writeKnowledgeFile(
+        'ops',
+        'deploy-time.md',
+        `---
+type: business_metric
+domain: ops
+---
+
+# Deploy Time
+
+Measures the Deploy Flow duration.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+
+      expect(result.nodesAdded).toBe(2);
+
+      const edges = store.getEdges({ from: 'bk:ops:deploy-time', type: 'measures' });
+      expect(edges.length).toBeGreaterThanOrEqual(1);
+      expect(edges.some((e) => e.to === 'bk:ops:deploy-flow')).toBe(true);
+    });
+
+    it('should return empty result for missing directory', async () => {
+      const result = await ingestor.ingest('/nonexistent/path');
+
+      expect(result.nodesAdded).toBe(0);
+      expect(result.edgesAdded).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should skip files without valid frontmatter', async () => {
+      await writeKnowledgeFile(
+        'misc',
+        'no-frontmatter.md',
+        `# Just a regular markdown file
+
+No YAML frontmatter here.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+
+      expect(result.nodesAdded).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should skip files with frontmatter missing required type field', async () => {
+      await writeKnowledgeFile(
+        'misc',
+        'no-type.md',
+        `---
+domain: misc
+---
+
+# Missing Type
+
+This file has no type field.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+
+      expect(result.nodesAdded).toBe(0);
+    });
+
+    it('should extract title from first heading', async () => {
+      await writeKnowledgeFile(
+        'arch',
+        'concepts.md',
+        `---
+type: business_concept
+domain: arch
+---
+
+# Domain-Driven Design
+
+We use DDD principles.
+`
+      );
+
+      await ingestor.ingest(tmpDir);
+
+      const node = store.getNode('bk:arch:concepts');
+      expect(node).not.toBeNull();
+      expect(node!.name).toBe('Domain-Driven Design');
+    });
+
+    it('should use filename as name if no heading found', async () => {
+      await writeKnowledgeFile(
+        'arch',
+        'no-heading.md',
+        `---
+type: business_concept
+domain: arch
+---
+
+Some content without a heading.
+`
+      );
+
+      await ingestor.ingest(tmpDir);
+
+      const node = store.getNode('bk:arch:no-heading');
+      expect(node).not.toBeNull();
+      expect(node!.name).toBe('no-heading');
+    });
+
+    it('should store file path in node', async () => {
+      await writeKnowledgeFile(
+        'architecture',
+        'rules.md',
+        `---
+type: business_rule
+domain: architecture
+---
+
+# Rules
+
+Content.
+`
+      );
+
+      await ingestor.ingest(tmpDir);
+
+      const node = store.getNode('bk:architecture:rules');
+      expect(node).not.toBeNull();
+      expect(node!.path).toContain('architecture/rules.md');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extend graph schema with 5 business knowledge node types (`business_rule`, `business_process`, `business_concept`, `business_term`, `business_metric`) and 2 edge types (`governs`, `measures`)
- Create `BusinessKnowledgeIngestor` that reads YAML-frontmatter markdown from `docs/knowledge/` and creates typed graph nodes with automatic code linking
- Add `harness://business-knowledge` MCP resource returning domain-organized JSON summary
- Integrate `businessKnowledge` constituent into `gather_context` for parallel assembly
- Author 2 pilot architecture domain knowledge files (layer boundaries, graph schema)

## Test plan

- [x] 11 tests for `BusinessKnowledgeIngestor` (node creation, edge types, missing dir, frontmatter parsing)
- [x] 3 tests for `getBusinessKnowledgeResource` (empty dir, domain output, invalid frontmatter)
- [x] Updated existing CLI tests for new resource count (8→9) and include enum
- [x] All 532 graph package tests pass
- [x] Full CLI test suite passes (2827 tests)
- [x] TypeScript compiles with no errors
- [x] ESLint passes with zero warnings
- [x] `harness validate` passes