### PR TITLE
feat(graph): Phase 2 Code Signal Extractors

### DIFF
--- a/.harness/docs/plans/2026-04-23-orchestrator-session-af3554b3-plan.md
+++ b/.harness/docs/plans/2026-04-23-orchestrator-session-af3554b3-plan.md
@@ -41,15 +41,18 @@ All 7 tasks complete. Here's a summary of everything that was changed:
 ## Changes Made
 
 ### 1. `packages/orchestrator/src/core/pr-detector.ts`
+
 - **`branchHasPullRequest`** now uses `--state all` to find PRs in any state (open, closed, merged) — fixes the race where a PR merges before cleanup runs
 - Returns `{ found: boolean; error?: string }` instead of bare `boolean`, so callers can distinguish "no PR" from "gh CLI failed"
 
 ### 2. `packages/orchestrator/src/workspace/manager.ts`
+
 - **`findPushedBranch`** now requires returned branch names to contain `/` (positive-pattern validation) — catches symbolic refs and non-agent branches that slip past the skip-list
 - **`branchExistsOnRemote`** (new) — verifies a branch actually exists on the remote via `git ls-remote`
 - **`sweepStaleBranches`** (new) — deletes remote branches that are >7 days old and have merged PRs, with concurrency-limited `gh` API calls
 
 ### 3. `packages/orchestrator/src/orchestrator.ts`
+
 - **`cleanWorkspaceWithGuard`** rewritten with three safety layers:
   1. Verifies branch exists on remote before checking PRs
   2. On PR check error: preserves worktree but **does not escalate** (avoids false positives from network failures)
@@ -57,9 +60,11 @@ All 7 tasks complete. Here's a summary of everything that was changed:
 - **Stale branch sweep** integrated into tick cycle, runs at most once per hour
 
 ### 4. `packages/orchestrator/src/completion/handler.ts`
+
 - Updated to use the new discriminated result from `branchHasPullRequest`
 
 ### 5. Tests (2 files, 14 new test cases)
+
 - `branchHasPullRequest`: `--state all`, discriminated results, error handling
 - `findPushedBranch`: slash validation, positive/negative cases
 - `branchExistsOnRemote`: found, not found, error
@@ -70,15 +75,18 @@ All 7 tasks complete. Here's a summary of everything that was changed:
 ## Changes Made
 
 ### 1. `packages/orchestrator/src/core/pr-detector.ts`
+
 - **`branchHasPullRequest`** now uses `--state all` to find PRs in any state (open, closed, merged) — fixes the race where a PR merges before cleanup runs
 - Returns `{ found: boolean; error?: string }` instead of bare `boolean`, so callers can distinguish "no PR" from "gh CLI failed"
 
 ### 2. `packages/orchestrator/src/workspace/manager.ts`
+
 - **`findPushedBranch`** now requires returned branch names to contain `/` (positive-pattern validation) — catches symbolic refs and non-agent branches that slip past the skip-list
 - **`branchExistsOnRemote`** (new) — verifies a branch actually exists on the remote via `git ls-remote`
 - **`sweepStaleBranches`** (new) — deletes remote branches that are >7 days old and have merged PRs, with concurrency-limited `gh` API calls
 
 ### 3. `packages/orchestrator/src/orchestrator.ts`
+
 - **`cleanWorkspaceWithGuard`** rewritten with three safety layers:
   1. Verifies branch exists on remote before checking PRs
   2. On PR check error: preserves worktree but **does not escalate** (avoids false positives from network failures)
@@ -86,9 +94,11 @@ All 7 tasks complete. Here's a summary of everything that was changed:
 - **Stale branch sweep** integrated into tick cycle, runs at most once per hour
 
 ### 4. `packages/orchestrator/src/completion/handler.ts`
+
 - Updated to use the new discriminated result from `branchHasPullRequest`
 
 ### 5. Tests (2 files, 14 new test cases)
+
 - `branchHasPullRequest`: `--state all`, discriminated results, error handling
 - `findPushedBranch`: slash validation, positive/negative cases
 - `branchExistsOnRemote`: found, not found, error

--- a/.harness/docs/plans/2026-04-23-orchestrator-session-af3554b3-plan.md
+++ b/.harness/docs/plans/2026-04-23-orchestrator-session-af3554b3-plan.md
@@ -1,0 +1,97 @@
+Let me start implementing. I'll work through the tasks in dependency order, parallelizing where possible.
+
+Now let me implement the discriminated result type. I need to check how `branchHasPullRequest` is used across the codebase.
+
+There's a second call site in `completion/handler.ts`. Let me read that context.
+
+Now let me update `branchHasPullRequest` with the discriminated result type. The `completion/handler.ts` call site just uses it for optional PR linking, so it can simply check `.found`.
+
+Now update the two call sites. First, `orchestrator.ts`:
+
+Now update the `completion/handler.ts` call site:
+
+Tasks 2 and 4 are done (pre-escalation verification was folded into the `cleanWorkspaceWithGuard` rewrite). Now let me do Task 3 — positive-pattern validation in `findPushedBranch` — and Task 5 — `sweepStaleBranches` and `branchExistsOnRemote`.
+
+Now let me read the full `WorkspaceManager` to understand the class structure before adding `branchExistsOnRemote` and `sweepStaleBranches`.
+
+Now integrate the sweep into the orchestrator tick.
+
+Let me find the tick method and the class fields to understand where to add the sweep integration.
+
+I'll add the stale branch sweep right after step 7 (stream sweep), with a timestamp guard. Let me add the field and the sweep call.
+
+Now let me verify the code compiles before writing tests.
+
+Clean type-check. Now let me write the tests. First let me re-read the existing test files to understand patterns.
+
+Good, I can see the `TestableWorkspaceManager` pattern. Now let me add the new tests.
+
+Now update the PR detector tests to cover the new discriminated result and `--state all`.
+
+Now I need to add a new `describe('branchHasPullRequest')` block. Let me find where to insert it — right after the existing `hasOpenPRForIdentifier` block.
+
+Now let me run the tests to verify everything passes.
+
+All 57 tests pass. Let me also run the full orchestrator test suite to check for regressions.
+
+All 635 tests pass with zero regressions. Let me also run the type-check one more time to be safe.
+
+All 7 tasks complete. Here's a summary of everything that was changed:
+
+## Changes Made
+
+### 1. `packages/orchestrator/src/core/pr-detector.ts`
+- **`branchHasPullRequest`** now uses `--state all` to find PRs in any state (open, closed, merged) — fixes the race where a PR merges before cleanup runs
+- Returns `{ found: boolean; error?: string }` instead of bare `boolean`, so callers can distinguish "no PR" from "gh CLI failed"
+
+### 2. `packages/orchestrator/src/workspace/manager.ts`
+- **`findPushedBranch`** now requires returned branch names to contain `/` (positive-pattern validation) — catches symbolic refs and non-agent branches that slip past the skip-list
+- **`branchExistsOnRemote`** (new) — verifies a branch actually exists on the remote via `git ls-remote`
+- **`sweepStaleBranches`** (new) — deletes remote branches that are >7 days old and have merged PRs, with concurrency-limited `gh` API calls
+
+### 3. `packages/orchestrator/src/orchestrator.ts`
+- **`cleanWorkspaceWithGuard`** rewritten with three safety layers:
+  1. Verifies branch exists on remote before checking PRs
+  2. On PR check error: preserves worktree but **does not escalate** (avoids false positives from network failures)
+  3. Only escalates when the PR check conclusively returns "no PR found"
+- **Stale branch sweep** integrated into tick cycle, runs at most once per hour
+
+### 4. `packages/orchestrator/src/completion/handler.ts`
+- Updated to use the new discriminated result from `branchHasPullRequest`
+
+### 5. Tests (2 files, 14 new test cases)
+- `branchHasPullRequest`: `--state all`, discriminated results, error handling
+- `findPushedBranch`: slash validation, positive/negative cases
+- `branchExistsOnRemote`: found, not found, error
+- `sweepStaleBranches`: old+merged, recent, no-PR, error, empty
+
+**All 635 orchestrator tests pass. Type-check clean.**All 7 tasks complete. Here's a summary of everything that was changed:
+
+## Changes Made
+
+### 1. `packages/orchestrator/src/core/pr-detector.ts`
+- **`branchHasPullRequest`** now uses `--state all` to find PRs in any state (open, closed, merged) — fixes the race where a PR merges before cleanup runs
+- Returns `{ found: boolean; error?: string }` instead of bare `boolean`, so callers can distinguish "no PR" from "gh CLI failed"
+
+### 2. `packages/orchestrator/src/workspace/manager.ts`
+- **`findPushedBranch`** now requires returned branch names to contain `/` (positive-pattern validation) — catches symbolic refs and non-agent branches that slip past the skip-list
+- **`branchExistsOnRemote`** (new) — verifies a branch actually exists on the remote via `git ls-remote`
+- **`sweepStaleBranches`** (new) — deletes remote branches that are >7 days old and have merged PRs, with concurrency-limited `gh` API calls
+
+### 3. `packages/orchestrator/src/orchestrator.ts`
+- **`cleanWorkspaceWithGuard`** rewritten with three safety layers:
+  1. Verifies branch exists on remote before checking PRs
+  2. On PR check error: preserves worktree but **does not escalate** (avoids false positives from network failures)
+  3. Only escalates when the PR check conclusively returns "no PR found"
+- **Stale branch sweep** integrated into tick cycle, runs at most once per hour
+
+### 4. `packages/orchestrator/src/completion/handler.ts`
+- Updated to use the new discriminated result from `branchHasPullRequest`
+
+### 5. Tests (2 files, 14 new test cases)
+- `branchHasPullRequest`: `--state all`, discriminated results, error handling
+- `findPushedBranch`: slash validation, positive/negative cases
+- `branchExistsOnRemote`: found, not found, error
+- `sweepStaleBranches`: old+merged, recent, no-PR, error, empty
+
+**All 635 orchestrator tests pass. Type-check clean.**

--- a/docs/changes/code-signal-extractors/proposal.md
+++ b/docs/changes/code-signal-extractors/proposal.md
@@ -1,0 +1,223 @@
+# Code Signal Extractors — Business Knowledge from Source Code
+
+## Overview
+
+Phase 2 of the Business Knowledge System (ADR: `.harness/architecture/business-knowledge-system/ADR-001.md`). Four pluggable extractors mine business-relevant signals from source code — test descriptions, enum/constant vocabularies, validation rules, and API route definitions — across all 6 supported languages (TypeScript, JavaScript, Python, Go, Rust, Java). Each extractor independently scans files, writes structured JSONL to `.harness/knowledge/extracted/`, and creates provisional graph nodes for immediate queryability. A shared `ExtractionRunner` handles file walking, language detection, JSONL persistence, graph node creation, and stable-ID diffing with stale marking.
+
+### Goals
+
+1. Extract business knowledge embedded in code patterns that humans write but never explicitly document
+2. Make extracted knowledge immediately available to skills via graph queries (`ask_graph`, `gather_context`)
+3. Produce auditable JSONL output compatible with the Phase 4 knowledge pipeline's promotion flow
+4. Support all 6 CodeIngestor languages with uniform coverage across all 4 extractors
+5. Integrate into the existing `harness ingest` pipeline as a new `business-signals` source type
+
+### Non-Goals
+
+- KnowledgeLinker post-processing (Phase 3)
+- Knowledge pipeline / drift detection convergence loop (Phase 4)
+- LLM-assisted extraction or semantic analysis — extractors are purely pattern-based
+- Diagram-as-code parsing (Phase 4)
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Parsing strategy | File-first | Extractors independently scan files rather than querying graph. Self-contained, testable, works without prior ingestion |
+| Language scope | All 6 (TS/JS, Python, Go, Rust, Java) | Full parity with CodeIngestor from day one |
+| Coverage model | Uniform | Every extractor covers every language, using confidence scores to signal extraction depth |
+| Output model | JSONL + graph nodes | JSONL for audit trail and promotion flow; provisional graph nodes for immediate skill queryability |
+| Trigger mechanism | New `business-signals` ingest source | Follows existing pattern, included in `harness ingest --all` automatically |
+| Re-extraction | Stable-ID diff | Deterministic IDs survive re-runs; removed signals marked stale, not deleted |
+| Architecture | Pluggable extractor registry | `SignalExtractor` interface with shared `ExtractionRunner`; each extractor independently testable |
+
+## Technical Design
+
+### Extractor Interface
+
+```typescript
+// packages/graph/src/ingest/extractors/types.ts
+
+type Language = 'typescript' | 'javascript' | 'python' | 'go' | 'rust' | 'java';
+
+interface ExtractionRecord {
+  id: string;              // deterministic: extracted:<extractor>:<sha256(filePath+':'+patternKey)>
+  extractor: string;       // 'test-descriptions' | 'enum-constants' | 'validation-rules' | 'api-paths'
+  language: Language;
+  filePath: string;        // relative to project root
+  line: number;            // start line of the extracted pattern
+  nodeType: NodeType;      // which business_* node type this maps to
+  name: string;            // human-readable label for the extracted fact
+  content: string;         // the raw extracted text
+  confidence: number;      // 0.0-1.0
+  metadata: Record<string, unknown>; // extractor-specific fields
+}
+
+interface SignalExtractor {
+  readonly name: string;
+  readonly supportedExtensions: readonly string[];
+  extract(content: string, filePath: string, language: Language): ExtractionRecord[];
+}
+```
+
+### Four Extractors
+
+#### TestDescriptionExtractor
+
+Extracts human-written test descriptions that encode business rules in natural language.
+
+| Language | Patterns | Example |
+|----------|----------|---------|
+| TypeScript/JavaScript | `describe()`, `it()`, `test()` string arguments (vitest, jest, mocha) | `it('should reject expired tokens')` |
+| Python | `def test_*` function names + docstrings, `pytest.mark.parametrize` labels | `def test_expired_token_rejected():` |
+| Go | `func Test*` function names + `t.Run()` subtests, `//` doc comments | `t.Run("rejects expired tokens", ...)` |
+| Rust | `#[test]` function names + `///` doc comments, `#[rstest]` case labels | `fn test_reject_expired_token()` |
+| Java | `@Test` method names + `@DisplayName` annotations, JUnit 5 nested classes | `@DisplayName("should reject expired tokens")` |
+
+Maps to: `business_rule` nodes. Confidence: 0.7 (structured test with description string) to 0.5 (bare function name only).
+
+#### EnumConstantExtractor
+
+Extracts domain vocabulary from enumeration and constant definitions.
+
+| Language | Patterns | Example |
+|----------|----------|---------|
+| TypeScript | `enum` declarations, `as const` objects, union types | `enum OrderStatus { PENDING, FULFILLED }` |
+| JavaScript | `Object.freeze({})` patterns, `const` objects with UPPER_CASE keys | `const STATUS = Object.freeze({ PENDING: 'pending' })` |
+| Python | `Enum` subclasses, `Literal` type annotations, `IntEnum`/`StrEnum` | `class OrderStatus(StrEnum):` |
+| Go | `iota` const blocks, typed const groups | `const ( Pending Status = iota; Fulfilled )` |
+| Rust | `enum` declarations (unit variants and data variants) | `enum OrderStatus { Pending, Fulfilled }` |
+| Java | `enum` classes with constants | `enum OrderStatus { PENDING, FULFILLED }` |
+
+Maps to: `business_term` nodes. Confidence: 0.8 (named enum with members) to 0.6 (unnamed const group).
+
+#### ValidationRuleExtractor
+
+Extracts business constraints encoded in validation schemas and decorators.
+
+| Language | Patterns | Example |
+|----------|----------|---------|
+| TypeScript/JavaScript | Zod schemas (`.string()`, `.min()`, `.regex()`), Joi schemas, Yup schemas | `z.string().email().min(5)` |
+| Python | Pydantic `BaseModel` fields with `Field()` constraints, `@validator` decorators | `amount: Decimal = Field(gt=0, le=1000000)` |
+| Go | Struct tags with `validate:"required,min=1"` (go-playground/validator) | `` `validate:"required,email"` `` |
+| Rust | `#[validate]` derive macros, `#[garde]` attribute macros | `#[validate(length(min = 1, max = 255))]` |
+| Java | Bean Validation: `@NotNull`, `@Size`, `@Pattern`, `@Min`, `@Max`, `@Email` | `@Size(min = 1, max = 255) String name` |
+
+Maps to: `business_rule` nodes. Confidence: 0.8 (explicit schema with named constraints) to 0.5 (simple required field).
+
+#### ApiPathExtractor
+
+Extracts domain model from route definitions revealing the API surface.
+
+| Language | Patterns | Example |
+|----------|----------|---------|
+| TypeScript/JavaScript | Express `app.get()`, Hono `app.get()`, Fastify `fastify.route()`, Next.js file routes | `app.get('/api/orders/:id', handler)` |
+| Python | FastAPI `@app.get()` decorators, Flask `@app.route()`, Django `path()` in urlpatterns | `@app.get("/orders/{order_id}")` |
+| Go | `http.HandleFunc()`, Gin `r.GET()`, Echo `e.GET()`, Chi `r.Get()` | `r.GET("/orders/:id", getOrder)` |
+| Rust | Actix `#[get()]` macros, Axum `Router::new().route()` | `#[get("/orders/{id}")]` |
+| Java | Spring `@GetMapping`, `@PostMapping`, `@RequestMapping`, JAX-RS `@Path` | `@GetMapping("/orders/{id}")` |
+
+Maps to: `business_process` nodes. Confidence: 0.9 (annotated route with HTTP method + path) to 0.6 (dynamic route registration).
+
+### ExtractionRunner
+
+```
+packages/graph/src/ingest/extractors/
+  types.ts                        — SignalExtractor interface, ExtractionRecord, Language
+  ExtractionRunner.ts             — Shared infrastructure
+  TestDescriptionExtractor.ts     — Test description patterns
+  EnumConstantExtractor.ts        — Enum/constant patterns
+  ValidationRuleExtractor.ts      — Validation rule patterns
+  ApiPathExtractor.ts             — API path patterns
+  index.ts                        — Registry: exports all extractors + runner
+```
+
+`ExtractionRunner` responsibilities:
+
+1. **Walk** — Recursively walk project directory, respecting `.gitignore` and `node_modules`/`vendor`/`target`/`build` exclusions
+2. **Detect** — Map file extensions to `Language` (`.ts`/`.tsx` → typescript, `.py` → python, `.go` → go, `.rs` → rust, `.java` → java)
+3. **Dispatch** — For each file, run all registered extractors whose `supportedExtensions` match
+4. **Write JSONL** — One file per extractor in `.harness/knowledge/extracted/<extractor-name>.jsonl`
+5. **Graph persist** — Create/update `business_*` graph nodes with `metadata.source: 'code-extractor'` and `governs`/`documents` edges to the source `file` node
+6. **Stable diff** — Load existing extracted nodes from graph (by `metadata.source === 'code-extractor'`), compare IDs, mark missing as `metadata.stale: true` with `metadata.staleAt: <ISO timestamp>`
+7. **Return** — Aggregate `IngestResult` across all extractors
+
+### JSONL Output Format
+
+Each line in a `.jsonl` file is one `ExtractionRecord` serialized as JSON:
+
+```json
+{"id":"extracted:test-descriptions:a1b2c3","extractor":"test-descriptions","language":"typescript","filePath":"src/auth/auth.service.test.ts","line":42,"nodeType":"business_rule","name":"should reject expired tokens","content":"describe('AuthService') > it('should reject expired tokens')","confidence":0.7,"metadata":{"suite":"AuthService","framework":"vitest"}}
+```
+
+### Graph Node Mapping
+
+| Extractor | Node Type | Edge Type | Edge Target |
+|-----------|-----------|-----------|-------------|
+| test-descriptions | `business_rule` | `governs` | source `file` node |
+| enum-constants | `business_term` | `documents` | source `file` node |
+| validation-rules | `business_rule` | `governs` | source `file` node |
+| api-paths | `business_process` | `documents` | source `file` node |
+
+All nodes include:
+- `metadata.source: 'code-extractor'` — distinguishes from human-authored knowledge
+- `metadata.extractor: '<extractor-name>'` — identifies which extractor produced the node
+- `metadata.confidence: <0.0-1.0>` — extraction pattern strength
+
+### Stable ID Generation
+
+IDs are deterministic to survive re-extraction:
+
+```
+extracted:<extractor>:<sha256(filePath + ':' + patternKey)>
+```
+
+Where `patternKey` is extractor-specific:
+- **test-descriptions:** full nested path (`describe > describe > it` chain)
+- **enum-constants:** enum name + member name
+- **validation-rules:** schema variable name or decorator target
+- **api-paths:** HTTP method + path pattern
+
+### Integration Points
+
+| Component | File | Change |
+|-----------|------|--------|
+| Ingest CLI | `packages/cli/src/commands/graph/ingest.ts` | Add `'business-signals'` to source options, instantiate `ExtractionRunner` |
+| Ingest MCP | `packages/cli/src/mcp/tools/graph/ingest-source.ts` | Add `'business-signals'` to source enum, wire `ExtractionRunner` |
+| Graph exports | `packages/graph/src/index.ts` | Export `ExtractionRunner`, `SignalExtractor`, `ExtractionRecord` |
+| Graph types | `packages/graph/src/types.ts` | No changes — existing `business_*` node types and `governs`/`documents` edges suffice |
+
+## Success Criteria
+
+1. **All 4 extractors produce valid JSONL** — Running `harness ingest --source business-signals` on a multi-language project writes 4 JSONL files to `.harness/knowledge/extracted/`, each containing well-formed `ExtractionRecord` entries
+2. **Graph nodes created** — After extraction, `business_rule`, `business_term`, and `business_process` nodes with `metadata.source === 'code-extractor'` exist in the graph and are queryable via `ask_graph` and `gather_context`
+3. **All 6 languages covered** — Each extractor produces at least one extraction from TS/JS, Python, Go, Rust, and Java fixture files
+4. **Confidence scores assigned** — Every extracted record has a `confidence` value between 0.0 and 1.0 reflecting extraction pattern strength
+5. **Stable IDs** — Running extraction twice on unchanged code produces identical JSONL output and does not create duplicate graph nodes
+6. **Stale detection** — Removing a test/enum/validator/route from source code and re-running extraction marks the corresponding graph node as `metadata.stale: true` without deleting it
+7. **Included in `--all`** — `harness ingest --all` runs code signal extraction alongside existing sources
+8. **MCP parity** — `ingest_source` MCP tool accepts `'business-signals'` and produces the same result as the CLI
+9. **No regression** — Existing ingest sources (code, knowledge, git, etc.) continue to function unchanged
+10. **Performance** — Extraction completes in under 10 seconds on a 10,000-file project
+
+## Implementation Order
+
+### Wave 1: Foundation
+
+- `SignalExtractor` interface, `ExtractionRecord` type, `Language` type in `extractors/types.ts`
+- `ExtractionRunner` with file walking, language detection, JSONL writing, graph persistence, stable-ID diff
+- Wire into `ingest.ts` CLI and `ingest-source.ts` MCP as `'business-signals'`
+
+### Wave 2: Extractors (parallelizable)
+
+- `TestDescriptionExtractor` — all 6 languages
+- `EnumConstantExtractor` — all 6 languages
+- `ValidationRuleExtractor` — all 6 languages
+- `ApiPathExtractor` — all 6 languages
+
+### Wave 3: Integration & Polish
+
+- End-to-end tests with multi-language fixture projects
+- Stale detection verification
+- Performance benchmarks on large codebases
+- Graph query integration tests (verify `ask_graph` and `gather_context` surface extracted nodes)

--- a/docs/changes/code-signal-extractors/proposal.md
+++ b/docs/changes/code-signal-extractors/proposal.md
@@ -21,15 +21,15 @@ Phase 2 of the Business Knowledge System (ADR: `.harness/architecture/business-k
 
 ## Decisions
 
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Parsing strategy | File-first | Extractors independently scan files rather than querying graph. Self-contained, testable, works without prior ingestion |
-| Language scope | All 6 (TS/JS, Python, Go, Rust, Java) | Full parity with CodeIngestor from day one |
-| Coverage model | Uniform | Every extractor covers every language, using confidence scores to signal extraction depth |
-| Output model | JSONL + graph nodes | JSONL for audit trail and promotion flow; provisional graph nodes for immediate skill queryability |
-| Trigger mechanism | New `business-signals` ingest source | Follows existing pattern, included in `harness ingest --all` automatically |
-| Re-extraction | Stable-ID diff | Deterministic IDs survive re-runs; removed signals marked stale, not deleted |
-| Architecture | Pluggable extractor registry | `SignalExtractor` interface with shared `ExtractionRunner`; each extractor independently testable |
+| Decision          | Choice                                | Rationale                                                                                                               |
+| ----------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Parsing strategy  | File-first                            | Extractors independently scan files rather than querying graph. Self-contained, testable, works without prior ingestion |
+| Language scope    | All 6 (TS/JS, Python, Go, Rust, Java) | Full parity with CodeIngestor from day one                                                                              |
+| Coverage model    | Uniform                               | Every extractor covers every language, using confidence scores to signal extraction depth                               |
+| Output model      | JSONL + graph nodes                   | JSONL for audit trail and promotion flow; provisional graph nodes for immediate skill queryability                      |
+| Trigger mechanism | New `business-signals` ingest source  | Follows existing pattern, included in `harness ingest --all` automatically                                              |
+| Re-extraction     | Stable-ID diff                        | Deterministic IDs survive re-runs; removed signals marked stale, not deleted                                            |
+| Architecture      | Pluggable extractor registry          | `SignalExtractor` interface with shared `ExtractionRunner`; each extractor independently testable                       |
 
 ## Technical Design
 
@@ -41,15 +41,15 @@ Phase 2 of the Business Knowledge System (ADR: `.harness/architecture/business-k
 type Language = 'typescript' | 'javascript' | 'python' | 'go' | 'rust' | 'java';
 
 interface ExtractionRecord {
-  id: string;              // deterministic: extracted:<extractor>:<sha256(filePath+':'+patternKey)>
-  extractor: string;       // 'test-descriptions' | 'enum-constants' | 'validation-rules' | 'api-paths'
+  id: string; // deterministic: extracted:<extractor>:<sha256(filePath+':'+patternKey)>
+  extractor: string; // 'test-descriptions' | 'enum-constants' | 'validation-rules' | 'api-paths'
   language: Language;
-  filePath: string;        // relative to project root
-  line: number;            // start line of the extracted pattern
-  nodeType: NodeType;      // which business_* node type this maps to
-  name: string;            // human-readable label for the extracted fact
-  content: string;         // the raw extracted text
-  confidence: number;      // 0.0-1.0
+  filePath: string; // relative to project root
+  line: number; // start line of the extracted pattern
+  nodeType: NodeType; // which business_* node type this maps to
+  name: string; // human-readable label for the extracted fact
+  content: string; // the raw extracted text
+  confidence: number; // 0.0-1.0
   metadata: Record<string, unknown>; // extractor-specific fields
 }
 
@@ -66,13 +66,13 @@ interface SignalExtractor {
 
 Extracts human-written test descriptions that encode business rules in natural language.
 
-| Language | Patterns | Example |
-|----------|----------|---------|
-| TypeScript/JavaScript | `describe()`, `it()`, `test()` string arguments (vitest, jest, mocha) | `it('should reject expired tokens')` |
-| Python | `def test_*` function names + docstrings, `pytest.mark.parametrize` labels | `def test_expired_token_rejected():` |
-| Go | `func Test*` function names + `t.Run()` subtests, `//` doc comments | `t.Run("rejects expired tokens", ...)` |
-| Rust | `#[test]` function names + `///` doc comments, `#[rstest]` case labels | `fn test_reject_expired_token()` |
-| Java | `@Test` method names + `@DisplayName` annotations, JUnit 5 nested classes | `@DisplayName("should reject expired tokens")` |
+| Language              | Patterns                                                                   | Example                                        |
+| --------------------- | -------------------------------------------------------------------------- | ---------------------------------------------- |
+| TypeScript/JavaScript | `describe()`, `it()`, `test()` string arguments (vitest, jest, mocha)      | `it('should reject expired tokens')`           |
+| Python                | `def test_*` function names + docstrings, `pytest.mark.parametrize` labels | `def test_expired_token_rejected():`           |
+| Go                    | `func Test*` function names + `t.Run()` subtests, `//` doc comments        | `t.Run("rejects expired tokens", ...)`         |
+| Rust                  | `#[test]` function names + `///` doc comments, `#[rstest]` case labels     | `fn test_reject_expired_token()`               |
+| Java                  | `@Test` method names + `@DisplayName` annotations, JUnit 5 nested classes  | `@DisplayName("should reject expired tokens")` |
 
 Maps to: `business_rule` nodes. Confidence: 0.7 (structured test with description string) to 0.5 (bare function name only).
 
@@ -80,14 +80,14 @@ Maps to: `business_rule` nodes. Confidence: 0.7 (structured test with descriptio
 
 Extracts domain vocabulary from enumeration and constant definitions.
 
-| Language | Patterns | Example |
-|----------|----------|---------|
-| TypeScript | `enum` declarations, `as const` objects, union types | `enum OrderStatus { PENDING, FULFILLED }` |
+| Language   | Patterns                                                           | Example                                                |
+| ---------- | ------------------------------------------------------------------ | ------------------------------------------------------ |
+| TypeScript | `enum` declarations, `as const` objects, union types               | `enum OrderStatus { PENDING, FULFILLED }`              |
 | JavaScript | `Object.freeze({})` patterns, `const` objects with UPPER_CASE keys | `const STATUS = Object.freeze({ PENDING: 'pending' })` |
-| Python | `Enum` subclasses, `Literal` type annotations, `IntEnum`/`StrEnum` | `class OrderStatus(StrEnum):` |
-| Go | `iota` const blocks, typed const groups | `const ( Pending Status = iota; Fulfilled )` |
-| Rust | `enum` declarations (unit variants and data variants) | `enum OrderStatus { Pending, Fulfilled }` |
-| Java | `enum` classes with constants | `enum OrderStatus { PENDING, FULFILLED }` |
+| Python     | `Enum` subclasses, `Literal` type annotations, `IntEnum`/`StrEnum` | `class OrderStatus(StrEnum):`                          |
+| Go         | `iota` const blocks, typed const groups                            | `const ( Pending Status = iota; Fulfilled )`           |
+| Rust       | `enum` declarations (unit variants and data variants)              | `enum OrderStatus { Pending, Fulfilled }`              |
+| Java       | `enum` classes with constants                                      | `enum OrderStatus { PENDING, FULFILLED }`              |
 
 Maps to: `business_term` nodes. Confidence: 0.8 (named enum with members) to 0.6 (unnamed const group).
 
@@ -95,13 +95,13 @@ Maps to: `business_term` nodes. Confidence: 0.8 (named enum with members) to 0.6
 
 Extracts business constraints encoded in validation schemas and decorators.
 
-| Language | Patterns | Example |
-|----------|----------|---------|
-| TypeScript/JavaScript | Zod schemas (`.string()`, `.min()`, `.regex()`), Joi schemas, Yup schemas | `z.string().email().min(5)` |
-| Python | Pydantic `BaseModel` fields with `Field()` constraints, `@validator` decorators | `amount: Decimal = Field(gt=0, le=1000000)` |
-| Go | Struct tags with `validate:"required,min=1"` (go-playground/validator) | `` `validate:"required,email"` `` |
-| Rust | `#[validate]` derive macros, `#[garde]` attribute macros | `#[validate(length(min = 1, max = 255))]` |
-| Java | Bean Validation: `@NotNull`, `@Size`, `@Pattern`, `@Min`, `@Max`, `@Email` | `@Size(min = 1, max = 255) String name` |
+| Language              | Patterns                                                                        | Example                                     |
+| --------------------- | ------------------------------------------------------------------------------- | ------------------------------------------- |
+| TypeScript/JavaScript | Zod schemas (`.string()`, `.min()`, `.regex()`), Joi schemas, Yup schemas       | `z.string().email().min(5)`                 |
+| Python                | Pydantic `BaseModel` fields with `Field()` constraints, `@validator` decorators | `amount: Decimal = Field(gt=0, le=1000000)` |
+| Go                    | Struct tags with `validate:"required,min=1"` (go-playground/validator)          | `` `validate:"required,email"` ``           |
+| Rust                  | `#[validate]` derive macros, `#[garde]` attribute macros                        | `#[validate(length(min = 1, max = 255))]`   |
+| Java                  | Bean Validation: `@NotNull`, `@Size`, `@Pattern`, `@Min`, `@Max`, `@Email`      | `@Size(min = 1, max = 255) String name`     |
 
 Maps to: `business_rule` nodes. Confidence: 0.8 (explicit schema with named constraints) to 0.5 (simple required field).
 
@@ -109,13 +109,13 @@ Maps to: `business_rule` nodes. Confidence: 0.8 (explicit schema with named cons
 
 Extracts domain model from route definitions revealing the API surface.
 
-| Language | Patterns | Example |
-|----------|----------|---------|
+| Language              | Patterns                                                                              | Example                               |
+| --------------------- | ------------------------------------------------------------------------------------- | ------------------------------------- |
 | TypeScript/JavaScript | Express `app.get()`, Hono `app.get()`, Fastify `fastify.route()`, Next.js file routes | `app.get('/api/orders/:id', handler)` |
-| Python | FastAPI `@app.get()` decorators, Flask `@app.route()`, Django `path()` in urlpatterns | `@app.get("/orders/{order_id}")` |
-| Go | `http.HandleFunc()`, Gin `r.GET()`, Echo `e.GET()`, Chi `r.Get()` | `r.GET("/orders/:id", getOrder)` |
-| Rust | Actix `#[get()]` macros, Axum `Router::new().route()` | `#[get("/orders/{id}")]` |
-| Java | Spring `@GetMapping`, `@PostMapping`, `@RequestMapping`, JAX-RS `@Path` | `@GetMapping("/orders/{id}")` |
+| Python                | FastAPI `@app.get()` decorators, Flask `@app.route()`, Django `path()` in urlpatterns | `@app.get("/orders/{order_id}")`      |
+| Go                    | `http.HandleFunc()`, Gin `r.GET()`, Echo `e.GET()`, Chi `r.Get()`                     | `r.GET("/orders/:id", getOrder)`      |
+| Rust                  | Actix `#[get()]` macros, Axum `Router::new().route()`                                 | `#[get("/orders/{id}")]`              |
+| Java                  | Spring `@GetMapping`, `@PostMapping`, `@RequestMapping`, JAX-RS `@Path`               | `@GetMapping("/orders/{id}")`         |
 
 Maps to: `business_process` nodes. Confidence: 0.9 (annotated route with HTTP method + path) to 0.6 (dynamic route registration).
 
@@ -147,19 +147,31 @@ packages/graph/src/ingest/extractors/
 Each line in a `.jsonl` file is one `ExtractionRecord` serialized as JSON:
 
 ```json
-{"id":"extracted:test-descriptions:a1b2c3","extractor":"test-descriptions","language":"typescript","filePath":"src/auth/auth.service.test.ts","line":42,"nodeType":"business_rule","name":"should reject expired tokens","content":"describe('AuthService') > it('should reject expired tokens')","confidence":0.7,"metadata":{"suite":"AuthService","framework":"vitest"}}
+{
+  "id": "extracted:test-descriptions:a1b2c3",
+  "extractor": "test-descriptions",
+  "language": "typescript",
+  "filePath": "src/auth/auth.service.test.ts",
+  "line": 42,
+  "nodeType": "business_rule",
+  "name": "should reject expired tokens",
+  "content": "describe('AuthService') > it('should reject expired tokens')",
+  "confidence": 0.7,
+  "metadata": { "suite": "AuthService", "framework": "vitest" }
+}
 ```
 
 ### Graph Node Mapping
 
-| Extractor | Node Type | Edge Type | Edge Target |
-|-----------|-----------|-----------|-------------|
-| test-descriptions | `business_rule` | `governs` | source `file` node |
-| enum-constants | `business_term` | `documents` | source `file` node |
-| validation-rules | `business_rule` | `governs` | source `file` node |
-| api-paths | `business_process` | `documents` | source `file` node |
+| Extractor         | Node Type          | Edge Type   | Edge Target        |
+| ----------------- | ------------------ | ----------- | ------------------ |
+| test-descriptions | `business_rule`    | `governs`   | source `file` node |
+| enum-constants    | `business_term`    | `documents` | source `file` node |
+| validation-rules  | `business_rule`    | `governs`   | source `file` node |
+| api-paths         | `business_process` | `documents` | source `file` node |
 
 All nodes include:
+
 - `metadata.source: 'code-extractor'` — distinguishes from human-authored knowledge
 - `metadata.extractor: '<extractor-name>'` — identifies which extractor produced the node
 - `metadata.confidence: <0.0-1.0>` — extraction pattern strength
@@ -173,6 +185,7 @@ extracted:<extractor>:<sha256(filePath + ':' + patternKey)>
 ```
 
 Where `patternKey` is extractor-specific:
+
 - **test-descriptions:** full nested path (`describe > describe > it` chain)
 - **enum-constants:** enum name + member name
 - **validation-rules:** schema variable name or decorator target
@@ -180,12 +193,12 @@ Where `patternKey` is extractor-specific:
 
 ### Integration Points
 
-| Component | File | Change |
-|-----------|------|--------|
-| Ingest CLI | `packages/cli/src/commands/graph/ingest.ts` | Add `'business-signals'` to source options, instantiate `ExtractionRunner` |
-| Ingest MCP | `packages/cli/src/mcp/tools/graph/ingest-source.ts` | Add `'business-signals'` to source enum, wire `ExtractionRunner` |
-| Graph exports | `packages/graph/src/index.ts` | Export `ExtractionRunner`, `SignalExtractor`, `ExtractionRecord` |
-| Graph types | `packages/graph/src/types.ts` | No changes — existing `business_*` node types and `governs`/`documents` edges suffice |
+| Component     | File                                                | Change                                                                                |
+| ------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Ingest CLI    | `packages/cli/src/commands/graph/ingest.ts`         | Add `'business-signals'` to source options, instantiate `ExtractionRunner`            |
+| Ingest MCP    | `packages/cli/src/mcp/tools/graph/ingest-source.ts` | Add `'business-signals'` to source enum, wire `ExtractionRunner`                      |
+| Graph exports | `packages/graph/src/index.ts`                       | Export `ExtractionRunner`, `SignalExtractor`, `ExtractionRecord`                      |
+| Graph types   | `packages/graph/src/types.ts`                       | No changes — existing `business_*` node types and `governs`/`documents` edges suffice |
 
 ## Success Criteria
 

--- a/docs/plans/2026-04-22-code-signal-extractors-plan.md
+++ b/docs/plans/2026-04-22-code-signal-extractors-plan.md
@@ -1,0 +1,305 @@
+# Plan: Code Signal Extractors
+
+**Date:** 2026-04-22 | **Spec:** docs/changes/code-signal-extractors/proposal.md | **Tasks:** 12 | **Time:** ~50 min
+
+## Goal
+
+When this plan is complete, `harness ingest --source business-signals` extracts business knowledge from source code (test descriptions, enum/constants, validation rules, API paths) across 6 languages, writes JSONL to `.harness/knowledge/extracted/`, creates provisional graph nodes, and handles stale detection on re-extraction. The MCP `ingest_source` tool accepts `'business-signals'` with identical behavior.
+
+## Observable Truths
+
+1. `harness ingest --source business-signals` writes 4 JSONL files to `.harness/knowledge/extracted/`
+2. Each JSONL line is a valid `ExtractionRecord` with all required fields
+3. After extraction, `business_rule`, `business_term`, `business_process` graph nodes exist with `metadata.source === 'code-extractor'`
+4. Each graph node has a `governs` or `documents` edge to its source `file` node
+5. Each extractor produces extractions from TS/JS, Python, Go, Rust, and Java fixtures
+6. Running extraction twice on unchanged code produces identical JSONL and no duplicate nodes
+7. Removing a signal from source and re-extracting marks the node `metadata.stale: true`
+8. `harness ingest --all` includes business-signals extraction
+9. `ingest_source` MCP tool accepts `'business-signals'`
+10. Existing ingest sources continue unchanged
+
+## Uncertainties
+
+- [ASSUMPTION] `findNodes` filters by `type` only. Stale detection will iterate business-type nodes and filter `metadata.source === 'code-extractor'` in code.
+- [DEFERRABLE] Exact confidence thresholds — using values from approved spec.
+- [ASSUMPTION] Language detection reimplemented in runner (trivial extension mapping), not shared from CodeIngestor (private method).
+
+## File Map
+
+```
+CREATE packages/graph/src/ingest/extractors/types.ts
+CREATE packages/graph/src/ingest/extractors/ExtractionRunner.ts
+CREATE packages/graph/src/ingest/extractors/TestDescriptionExtractor.ts
+CREATE packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
+CREATE packages/graph/src/ingest/extractors/ValidationRuleExtractor.ts
+CREATE packages/graph/src/ingest/extractors/ApiPathExtractor.ts
+CREATE packages/graph/src/ingest/extractors/index.ts
+CREATE packages/graph/__fixtures__/extractor-project/ (16 multi-language fixture files)
+CREATE packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts
+CREATE packages/graph/tests/ingest/extractors/TestDescriptionExtractor.test.ts
+CREATE packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts
+CREATE packages/graph/tests/ingest/extractors/ValidationRuleExtractor.test.ts
+CREATE packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts
+MODIFY packages/graph/src/index.ts (add extractor exports)
+MODIFY packages/cli/src/commands/graph/ingest.ts (add 'business-signals' case)
+MODIFY packages/cli/src/mcp/tools/graph/ingest-source.ts (add 'business-signals' to enum + handler)
+```
+
+## Tasks
+
+### Task 1: Foundation types (`extractors/types.ts`)
+
+**Files:** `packages/graph/src/ingest/extractors/types.ts`
+
+Create the `Language` type, `ExtractionRecord` interface, and `SignalExtractor` interface exactly as specified in the proposal.
+
+**Test:** `npx vitest run packages/graph/tests/ingest/extractors/types.test.ts` — import types, validate ExtractionRecord shape with a sample object.
+
+**Commit:** `feat(graph): add code signal extractor types`
+
+---
+
+### Task 2: Test fixtures (multi-language)
+
+**Files:** Create `packages/graph/__fixtures__/extractor-project/` with fixture files covering all 4 extractor categories across all 6 languages.
+
+Required fixtures:
+
+- `auth.test.ts` — TypeScript tests with `describe`/`it`/`test`
+- `auth_test.py` — Python tests with `def test_*` and docstrings
+- `auth_test.go` — Go tests with `func Test*` and `t.Run()`
+- `auth_test.rs` — Rust tests with `#[test]` and doc comments
+- `AuthTest.java` — Java tests with `@Test` and `@DisplayName`
+- `enums.ts` — TypeScript enums and `as const`
+- `enums.py` — Python Enum subclasses
+- `enums.go` — Go iota const blocks
+- `enums.rs` — Rust enums
+- `Enums.java` — Java enums
+- `validators.ts` — Zod schemas
+- `validators.py` — Pydantic models
+- `validators.go` — Go struct tags with validate
+- `validators.rs` — Rust validate derive macros
+- `Validators.java` — Java Bean Validation annotations
+- `routes.ts` — Express/Hono route definitions
+- `routes.py` — FastAPI/Flask decorators
+- `routes.go` — Go HTTP handler registrations
+- `routes.rs` — Actix/Axum route macros
+- `Routes.java` — Spring `@GetMapping`/`@PostMapping`
+
+Each fixture should contain 3-5 extractable patterns per category for comprehensive coverage.
+
+**Test:** Verify files exist and are syntactically representative (no compilation needed — regex-based extraction).
+
+**Commit:** `test(graph): add multi-language extractor fixtures`
+
+---
+
+### Task 3: ExtractionRunner core (file walking, language detection, JSONL write)
+
+**Files:** `packages/graph/src/ingest/extractors/ExtractionRunner.ts`, `packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts`
+
+Implement:
+
+- `findSourceFiles(dir)` — recursive walk, skip `node_modules`/`dist`/`target`/`build`/`.git`/etc. (same skip list as CodeIngestor)
+- `detectLanguage(filePath)` — extension to Language mapping
+- `writeJsonl(records, outputDir, extractorName)` — write JSONL file
+- `run(projectDir, store, outputDir)` — orchestrate: walk files, dispatch to extractors, write JSONL, persist to graph, return IngestResult
+- Constructor takes `SignalExtractor[]` registry
+
+**Test:** ExtractionRunner finds files in fixture dir, detects languages correctly, writes JSONL to temp dir.
+
+**Commit:** `feat(graph): add ExtractionRunner with file walking and JSONL output`
+
+---
+
+### Task 4: ExtractionRunner graph persistence and stale detection
+
+**Files:** `packages/graph/src/ingest/extractors/ExtractionRunner.ts` (extend), `packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts` (extend)
+
+Implement:
+
+- `persistToGraph(records, store)` — create `business_*` nodes with `metadata.source: 'code-extractor'`, `metadata.extractor`, `metadata.confidence`, and `governs`/`documents` edges to source `file` nodes
+- `markStale(store, currentIds)` — find existing extractor nodes (`metadata.source === 'code-extractor'`), compare IDs, set `metadata.stale: true` and `metadata.staleAt` on missing nodes
+- Stable ID generation: `extracted:<extractor>:<sha256(filePath + ':' + patternKey)>` using `hash()` from ingestUtils
+
+**Test:** Persist records to GraphStore, verify nodes/edges created. Remove a record, re-run, verify stale marking.
+
+**Commit:** `feat(graph): add graph persistence and stale detection to ExtractionRunner`
+
+---
+
+### Task 5: TestDescriptionExtractor
+
+**Files:** `packages/graph/src/ingest/extractors/TestDescriptionExtractor.ts`, `packages/graph/tests/ingest/extractors/TestDescriptionExtractor.test.ts`
+
+Implement regex patterns for all 6 languages:
+
+- **TS/JS:** `describe('...')`, `it('...')`, `test('...')`
+- **Python:** `def test_*` names + docstrings, `pytest.mark.parametrize`
+- **Go:** `func Test*` names + `t.Run("...")` subtests
+- **Rust:** `#[test] fn test_*` names + `///` doc comments
+- **Java:** `@Test` methods + `@DisplayName("...")`
+
+Maps to `business_rule` nodes. Confidence: 0.7 (structured test with description string), 0.5 (bare function name).
+
+**Test:** Extract from each language fixture, verify correct records with expected names, confidence, nodeType.
+
+**Commit:** `feat(graph): add TestDescriptionExtractor for 6 languages`
+
+---
+
+### Task 6: EnumConstantExtractor
+
+**Files:** `packages/graph/src/ingest/extractors/EnumConstantExtractor.ts`, `packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts`
+
+Implement regex patterns for all 6 languages:
+
+- **TypeScript:** `enum` declarations, `as const` objects, union types
+- **JavaScript:** `Object.freeze({})`, `const` with UPPER_CASE keys
+- **Python:** `Enum`/`StrEnum`/`IntEnum` subclasses, `Literal` types
+- **Go:** `iota` const blocks, typed const groups
+- **Rust:** `enum` declarations (unit + data variants)
+- **Java:** `enum` classes
+
+Maps to `business_term` nodes. Confidence: 0.8 (named enum), 0.6 (unnamed const group).
+
+**Test:** Extract from each language fixture, verify correct records.
+
+**Commit:** `feat(graph): add EnumConstantExtractor for 6 languages`
+
+---
+
+### Task 7: ValidationRuleExtractor
+
+**Files:** `packages/graph/src/ingest/extractors/ValidationRuleExtractor.ts`, `packages/graph/tests/ingest/extractors/ValidationRuleExtractor.test.ts`
+
+Implement regex patterns for all 6 languages:
+
+- **TS/JS:** Zod `.string()`, `.min()`, `.regex()`, `.email()` chains; Joi/Yup schemas
+- **Python:** Pydantic `BaseModel` fields with `Field()` constraints, `@validator`
+- **Go:** struct tags `validate:"required,min=1,email"`
+- **Rust:** `#[validate]` derive macros, `#[garde]` attributes
+- **Java:** `@NotNull`, `@Size`, `@Pattern`, `@Min`, `@Max`, `@Email`
+
+Maps to `business_rule` nodes. Confidence: 0.8 (explicit schema), 0.5 (simple required).
+
+**Test:** Extract from each language fixture, verify correct records.
+
+**Commit:** `feat(graph): add ValidationRuleExtractor for 6 languages`
+
+---
+
+### Task 8: ApiPathExtractor
+
+**Files:** `packages/graph/src/ingest/extractors/ApiPathExtractor.ts`, `packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts`
+
+Implement regex patterns for all 6 languages:
+
+- **TS/JS:** Express `app.get()`, Hono `app.get()`, Fastify `fastify.route()`
+- **Python:** FastAPI `@app.get()`, Flask `@app.route()`, Django `path()`
+- **Go:** `http.HandleFunc()`, Gin `r.GET()`, Echo `e.GET()`, Chi `r.Get()`
+- **Rust:** Actix `#[get()]` macros, Axum `Router::new().route()`
+- **Java:** Spring `@GetMapping`, `@PostMapping`, `@RequestMapping`, JAX-RS `@Path`
+
+Maps to `business_process` nodes. Confidence: 0.9 (annotated route), 0.6 (dynamic registration).
+
+**Test:** Extract from each language fixture, verify correct records.
+
+**Commit:** `feat(graph): add ApiPathExtractor for 6 languages`
+
+---
+
+### Task 9: Extractor index and graph package exports
+
+**Files:** `packages/graph/src/ingest/extractors/index.ts`, `packages/graph/src/index.ts`
+
+Create `extractors/index.ts`:
+
+- Export all 4 extractors, ExtractionRunner, types
+- Export `ALL_EXTRACTORS` array with all 4 instantiated
+- Export a convenience `createExtractionRunner()` factory
+
+Add to `packages/graph/src/index.ts`:
+
+- Export `ExtractionRunner`, `SignalExtractor`, `ExtractionRecord`, `ALL_EXTRACTORS`, `createExtractionRunner`
+
+**Test:** Import from `@harness-engineering/graph` in existing test, verify exports resolve.
+
+**Commit:** `feat(graph): export code signal extractors from graph package`
+
+---
+
+### Task 10: CLI integration
+
+**Files:** `packages/cli/src/commands/graph/ingest.ts`
+
+Add `'business-signals'` to the ingest command:
+
+- Add case in `switch(source)` that instantiates `ExtractionRunner` via `createExtractionRunner()`, calls `run(projectPath, store, extractedDir)`
+- Add to `--all` flow after knowledge ingestion
+- Update error message to list `business-signals` as available source
+- Update `--source` option description
+
+**Test:** Build succeeds, `harness ingest --source business-signals` runs on fixture project.
+
+**Commit:** `feat(cli): wire business-signals source into ingest command`
+
+---
+
+### Task 11: MCP integration
+
+**Files:** `packages/cli/src/mcp/tools/graph/ingest-source.ts`
+
+Add `'business-signals'` to MCP tool:
+
+- Add to `source` enum array: `['code', 'knowledge', 'git', 'business-signals', 'all']`
+- Add handler block: if source is `'business-signals'` or `'all'`, run `ExtractionRunner`
+- Import `createExtractionRunner` from `@harness-engineering/graph`
+
+**Test:** TypeScript compiles, MCP schema includes `business-signals`.
+
+**Commit:** `feat(cli): wire business-signals into MCP ingest_source tool`
+
+---
+
+### Task 12: End-to-end integration test
+
+**Files:** `packages/graph/tests/ingest/extractors/integration.test.ts`
+
+Full pipeline test:
+
+1. Create ExtractionRunner with all 4 extractors
+2. Run on `__fixtures__/extractor-project/`
+3. Verify 4 JSONL files written with correct records
+4. Verify graph nodes created with correct types and metadata
+5. Verify edges to source file nodes
+6. Re-run on same files — verify no duplicates
+7. Modify fixture (remove one pattern), re-run — verify stale marking
+8. Verify each extractor produced results from each language
+
+**Test:** `npx vitest run packages/graph/tests/ingest/extractors/integration.test.ts`
+
+**Commit:** `test(graph): add end-to-end integration test for code signal extractors`
+
+---
+
+## Task Sequence
+
+```
+Task 1: types.ts (no deps)
+Task 2: fixtures (no deps)
+  ↓
+Task 3: ExtractionRunner core (depends: 1)
+Task 4: ExtractionRunner stale (depends: 3)
+  ↓
+Tasks 5-8: Four extractors (depend: 1, 2 — parallelizable with each other)
+  ↓
+Task 9: Index + exports (depends: 3, 4, 5-8)
+Task 10: CLI integration (depends: 9)
+Task 11: MCP integration (depends: 9)
+  ↓
+Task 12: E2E test (depends: all above)
+```
+
+**Parallel opportunities:** Tasks 5, 6, 7, 8 are independent and parallelizable. Tasks 10 and 11 are independent and parallelizable.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -184,7 +184,7 @@ Ingest data into the knowledge graph
 
 **Options:**
 
-- `--source` — Source to ingest (code, knowledge, git, jira, slack, ci, confluence)
+- `--source` — Source to ingest (code, knowledge, git, business-signals, jira, slack, ci, confluence)
 - `--all` — Run all sources (code, knowledge, git, and configured connectors)
 - `--full` — Force full re-ingestion
 

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-23T13:09:52.893Z",
-  "updatedFrom": "4179d9de",
+  "updatedAt": "2026-04-23T13:19:12.640Z",
+  "updatedFrom": "c9747d5f",
   "metrics": {
     "circular-deps": {
       "value": 0,

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-23T13:19:12.640Z",
-  "updatedFrom": "c9747d5f",
+  "updatedAt": "2026-04-23T17:02:29.073Z",
+  "updatedFrom": "7c253105",
   "metrics": {
     "circular-deps": {
       "value": 0,

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-04-22T22:45:57.888Z",
-  "updatedFrom": "806074e6",
+  "updatedAt": "2026-04-23T13:09:52.893Z",
+  "updatedFrom": "4179d9de",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -30,7 +30,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 27155,
+      "value": 27177,
       "violationIds": []
     },
     "dependency-depth": {

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -66,6 +66,11 @@ export async function runIngest(
     const knowledgeResult = await new KnowledgeIngestor(store).ingestAll(projectPath);
     const gitResult = await new GitIngestor(store).ingest(projectPath);
 
+    // Run code signal extractors (business-signals)
+    const { createExtractionRunner } = await import('@harness-engineering/graph');
+    const extractedDir = path.join(projectPath, '.harness', 'knowledge', 'extracted');
+    const signalsResult = await createExtractionRunner().run(projectPath, store, extractedDir);
+
     // Also run configured external connectors via SyncManager
     const syncManager = new SyncManager(store, graphDir);
     const connectorMap: Record<string, () => GraphConnector> = {
@@ -82,7 +87,13 @@ export async function runIngest(
     const connectorResult = await syncManager.syncAll();
 
     await store.save(graphDir);
-    const merged = mergeResults(codeResult, knowledgeResult, gitResult, connectorResult);
+    const merged = mergeResults(
+      codeResult,
+      knowledgeResult,
+      gitResult,
+      signalsResult,
+      connectorResult
+    );
     return { ...merged, durationMs: Date.now() - startMs };
   }
 
@@ -98,12 +109,18 @@ export async function runIngest(
     case 'git':
       result = await new GitIngestor(store).ingest(projectPath);
       break;
+    case 'business-signals': {
+      const { createExtractionRunner } = await import('@harness-engineering/graph');
+      const extractedDir = path.join(projectPath, '.harness', 'knowledge', 'extracted');
+      result = await createExtractionRunner().run(projectPath, store, extractedDir);
+      break;
+    }
     default: {
       // Check if source is a known external connector before trying to instantiate
       const knownConnectors = ['jira', 'slack', 'ci', 'confluence'];
       if (!knownConnectors.includes(source)) {
         throw new Error(
-          `Unknown source: ${source}. Available: code, knowledge, git, jira, slack, ci, confluence`
+          `Unknown source: ${source}. Available: code, knowledge, git, business-signals, jira, slack, ci, confluence`
         );
       }
       if (!SyncManager) {
@@ -136,7 +153,7 @@ export function createIngestCommand(): Command {
     .description('Ingest data into the knowledge graph')
     .option(
       '--source <name>',
-      'Source to ingest (code, knowledge, git, jira, slack, ci, confluence)'
+      'Source to ingest (code, knowledge, git, business-signals, jira, slack, ci, confluence)'
     )
     .option('--all', 'Run all sources (code, knowledge, git, and configured connectors)')
     .option('--full', 'Force full re-ingestion')

--- a/packages/cli/src/mcp/tools/graph/ingest-source.ts
+++ b/packages/cli/src/mcp/tools/graph/ingest-source.ts
@@ -11,7 +11,7 @@ export const ingestSourceDefinition = {
       path: { type: 'string', description: 'Path to project root' },
       source: {
         type: 'string',
-        enum: ['code', 'knowledge', 'git', 'all'],
+        enum: ['code', 'knowledge', 'git', 'business-signals', 'all'],
         description: 'Type of source to ingest',
       },
     },
@@ -21,7 +21,7 @@ export const ingestSourceDefinition = {
 
 export async function handleIngestSource(input: {
   path: string;
-  source: 'code' | 'knowledge' | 'git' | 'all';
+  source: 'code' | 'knowledge' | 'git' | 'business-signals' | 'all';
 }) {
   try {
     const projectPath = sanitizePath(input.path);
@@ -59,6 +59,13 @@ export async function handleIngestSource(input: {
       const gitIngestor = new GitIngestor(store);
       const gitResult = await gitIngestor.ingest(projectPath);
       results.push(gitResult);
+    }
+
+    if (input.source === 'business-signals' || input.source === 'all') {
+      const { createExtractionRunner } = await import('@harness-engineering/graph');
+      const extractedDir = path.join(projectPath, '.harness', 'knowledge', 'extracted');
+      const signalsResult = await createExtractionRunner().run(projectPath, store, extractedDir);
+      results.push(signalsResult);
     }
 
     // Save the graph

--- a/packages/cli/src/mcp/tools/interaction-renderer.ts
+++ b/packages/cli/src/mcp/tools/interaction-renderer.ts
@@ -50,7 +50,7 @@ export function renderQuestion(question: InteractionQuestion): string {
     if (opt) {
       const recLabel = `${columnLabel(recommendation.optionIndex)}) ${opt.label}`;
       prompt += `\n\n**Recommendation:** ${recLabel} (confidence: ${recommendation.confidence})`;
-      
+
       const cleanReason = recommendation.reason.trim();
       const cleanText = text.trim();
       if (cleanReason && cleanReason !== cleanText && !cleanReason.startsWith(cleanText)) {

--- a/packages/cli/tests/commands/graph-ingest.test.ts
+++ b/packages/cli/tests/commands/graph-ingest.test.ts
@@ -36,6 +36,15 @@ const mockGitIngest = vi.fn().mockResolvedValue({
   durationMs: 80,
 });
 
+const mockExtractionRun = vi.fn().mockResolvedValue({
+  nodesAdded: 4,
+  nodesUpdated: 0,
+  edgesAdded: 0,
+  edgesUpdated: 0,
+  errors: [],
+  durationMs: 60,
+});
+
 const mockRegisterConnector = vi.fn();
 const mockSyncAll = vi.fn().mockResolvedValue({
   nodesAdded: 5,
@@ -94,6 +103,7 @@ vi.mock('@harness-engineering/graph', () => ({
   ConfluenceConnector: class {
     name = 'confluence';
   },
+  createExtractionRunner: () => ({ run: mockExtractionRun }),
 }));
 
 // Mock node:fs/promises for loadConnectorConfig
@@ -261,9 +271,9 @@ describe('runIngest', () => {
       // 4 connectors registered
       expect(mockRegisterConnector).toHaveBeenCalledTimes(4);
       expect(mockStore.save).toHaveBeenCalled();
-      // Merged totals: 10+3+20+5 = 38
-      expect(result.nodesAdded).toBe(38);
-      // Merged edges: 5+2+15+3 = 25
+      // Merged totals: 10+3+20+4+5 = 42 (code+knowledge+git+signals+connectors)
+      expect(result.nodesAdded).toBe(42);
+      // Merged edges: 5+2+15+0+3 = 25
       expect(result.edgesAdded).toBe(25);
     });
 

--- a/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
+++ b/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
@@ -11,7 +11,7 @@ import type {
   StatusBlock,
   TextBlock,
 } from '../../types/chat';
-// Loader2 removed — no longer used after streaming indicator refactor
+import { NeuralOrganism } from './NeuralOrganism';
 
 const PROCESSING_PHRASES = [
   'Thinking deeply…',
@@ -37,104 +37,37 @@ const PROCESSING_PHRASES = [
 ];
 
 /**
- * ─── STREAMING INDICATOR: "THE SPRITE" ───
+ * ─── STREAMING INDICATOR ───
  *
- * Animated using Disney's 12 Principles:
- *  1. Squash & Stretch  → The blob body breathes, compressing on exhale
- *  2. Anticipation      → Before shifting position, it coils slightly
- *  3. Staging           → Clear silhouette against dark background
- *  4. Follow-through    → The aura trails behind position shifts
- *  5. Slow in/out       → All easing uses spring or cubic-bezier curves
- *  6. Arcs              → Position shifts follow curved paths (y dips)
- *  7. Secondary action  → Aura breathes on its own offset cycle
- *  8. Timing            → Breathing is slow (4s), gestures are quick snaps
- *  9. Exaggeration      → Scale overshoots on inhale, squishes on exhale
- * 10. Appeal            → Soft gradients, warm glow, friendly personality
+ * The NeuralOrganism radiates energy while processing. Activity bars
+ * emanate outward from the creature, and a bioluminescent glow field
+ * pulses behind it. The composition should feel like the creature is
+ * *working* — alive, focused, radiating.
  */
 
-/** The creature's body — a morphing blob */
-function SpriteBody() {
-  return (
-    <div className="relative w-8 h-8 shrink-0">
-      {/* Layer 1: Outer aura — breathes on its own slower cycle */}
-      <motion.div
-        className="absolute inset-[-8px] rounded-full"
-        animate={{
-          scale: [1, 1.3, 1.1, 1.25, 1],
-          opacity: [0.1, 0.3, 0.15, 0.25, 0.1],
-        }}
-        transition={{
-          duration: 5,
-          repeat: Infinity,
-          ease: 'easeInOut',
-        }}
-        style={{
-          background: 'radial-gradient(circle, var(--color-primary-500), transparent 70%)',
-          filter: 'blur(10px)',
-        }}
-      />
-
-      {/* Layer 2: The blob body — squash & stretch breathing */}
-      <motion.div
-        className="absolute inset-0 rounded-full sprite-blob"
-        animate={{
-          scaleX: [1, 0.9, 1.1, 0.95, 1],
-          scaleY: [1, 1.15, 0.9, 1.08, 1],
-        }}
-        transition={{
-          duration: 4,
-          repeat: Infinity,
-          ease: [0.37, 0, 0.63, 1],
-        }}
-        style={{
-          background:
-            'radial-gradient(circle at 35% 35%, var(--color-secondary-400), var(--color-primary-500) 70%)',
-          boxShadow: '0 0 20px 4px var(--color-primary-500), inset 0 -2px 8px rgba(0,0,0,0.4)',
-        }}
-      />
-
-      {/* Subtle internal pulse — makes it feel "alive" without a distinct eye */}
-      <motion.div
-        className="absolute inset-1.5 rounded-full"
-        animate={{
-          opacity: [0.2, 0.6, 0.3, 0.5, 0.2],
-          scale: [0.8, 1.1, 0.85, 1, 0.8],
-        }}
-        transition={{
-          duration: 3,
-          repeat: Infinity,
-          ease: 'easeInOut',
-        }}
-        style={{
-          background: 'radial-gradient(circle, white, transparent 60%)',
-          filter: 'blur(3px)',
-        }}
-      />
-    </div>
-  );
-}
-
-/** Voice bars — emanate from the sprite, staggered with organic timing */
-function VoiceBar({ index, total }: { index: number; total: number }) {
+/** Activity bars — radiate outward from the organism with staggered organic timing */
+function ActivityBar({ index, total }: { index: number; total: number }) {
   const centerFactor = 1 - Math.abs(index - total / 2) / (total / 2);
-  const maxHeight = 0.5 + centerFactor * 0.5;
-  const baseHeight = 0.2 + centerFactor * 0.1;
-  const duration = 1.5 + (1 - centerFactor) * 1.5;
+  const maxHeight = 0.4 + centerFactor * 0.6;
+  const baseHeight = 0.1 + centerFactor * 0.1;
+  const duration = 1.2 + (1 - centerFactor) * 2;
+  const opacity = 0.3 + centerFactor * 0.5;
 
   return (
     <motion.div
       animate={{
-        scaleY: [baseHeight, maxHeight, baseHeight * 1.2, maxHeight * 0.8, baseHeight],
+        scaleY: [baseHeight, maxHeight, baseHeight * 1.3, maxHeight * 0.7, baseHeight],
+        opacity: [opacity * 0.6, opacity, opacity * 0.7, opacity * 0.9, opacity * 0.6],
       }}
       transition={{
         duration,
         repeat: Infinity,
-        delay: index * 0.1,
+        delay: index * 0.08,
         ease: 'easeInOut',
       }}
-      className="w-[2px] h-8 rounded-full origin-bottom"
+      className="w-[1.5px] h-5 rounded-full origin-bottom"
       style={{
-        background: `linear-gradient(to top, var(--color-primary-500), var(--color-secondary-400))`,
+        background: `linear-gradient(to top, rgba(139,92,246,0.8), rgba(34,211,238,0.6))`,
       }}
     />
   );
@@ -177,51 +110,69 @@ function StreamingIndicator() {
 
   return (
     <motion.div
-      initial={{ opacity: 0, scale: 0.98 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.6 }}
-      className="flex items-center gap-5 py-4 px-3"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.8 }}
+      className="relative flex items-center gap-4 py-5 px-4"
     >
-      {/* The creature */}
+      {/* Ambient glow field behind organism */}
+      <div className="absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none">
+        <motion.div
+          className="w-24 h-24 rounded-full"
+          animate={{
+            opacity: [0.06, 0.12, 0.08, 0.1, 0.06],
+            scale: [0.9, 1.1, 0.95, 1.05, 0.9],
+          }}
+          transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
+          style={{
+            background:
+              'radial-gradient(circle, rgba(139,92,246,0.4) 0%, rgba(79,70,229,0.1) 50%, transparent 70%)',
+            filter: 'blur(14px)',
+            transform: 'translate(-30%, -50%)',
+          }}
+        />
+      </div>
+
+      {/* The creature — gentle hover */}
       <motion.div
-        animate={{ y: [0, -2.5, 1.5, -1, 0] }}
-        transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
-        className="shrink-0"
+        animate={{ y: [0, -2, 1, -1.5, 0] }}
+        transition={{ duration: 7, repeat: Infinity, ease: 'easeInOut' }}
+        className="shrink-0 relative z-10"
       >
-        <SpriteBody />
+        <NeuralOrganism size={40} />
       </motion.div>
 
-      {/* Relative container for Text + Background Voice Bars */}
+      {/* Activity bars + text — connected composition */}
       <div className="relative flex-1 min-w-0 flex items-center h-10">
-        {/* Ghostly Voice Bars behind text */}
-        <div className="absolute inset-0 flex items-end justify-start gap-[3px] opacity-[0.1] pointer-events-none px-1 overflow-hidden blur-[1.5px]">
-          {Array.from({ length: 24 }).map((_, i) => (
-            <VoiceBar key={i} index={i} total={24} />
+        {/* Activity bars — ghostly, behind text */}
+        <div className="absolute inset-0 flex items-end justify-start gap-[2.5px] opacity-[0.15] pointer-events-none overflow-hidden blur-[0.5px]">
+          {Array.from({ length: 20 }).map((_, i) => (
+            <ActivityBar key={i} index={i} total={20} />
           ))}
         </div>
 
-        {/* The phrase */}
+        {/* Phrase + elapsed */}
         <div className="relative z-10 flex flex-col justify-center">
           <AnimatePresence mode="wait">
             <motion.span
               key={phraseIndex}
-              initial={{ opacity: 0, filter: 'blur(4px)' }}
-              animate={{ opacity: 1, filter: 'blur(0px)' }}
-              exit={{ opacity: 0, filter: 'blur(2px)' }}
-              transition={{ duration: 0.5 }}
-              className="text-[13px] font-bold tracking-wider text-neutral-text uppercase leading-none"
+              initial={{ opacity: 0, x: -4, filter: 'blur(3px)' }}
+              animate={{ opacity: 0.9, x: 0, filter: 'blur(0px)' }}
+              exit={{ opacity: 0, x: 4, filter: 'blur(2px)' }}
+              transition={{ duration: 0.4 }}
+              className="text-[11px] font-semibold tracking-[0.08em] text-neutral-muted uppercase leading-none"
             >
               {PROCESSING_PHRASES[phraseIndex]}
             </motion.span>
           </AnimatePresence>
-          <div className="h-3.5 flex items-center mt-0.5">
+          <div className="h-3.5 flex items-center mt-1">
             {elapsed > 2 && (
               <motion.span
                 initial={{ opacity: 0 }}
-                animate={{ opacity: 0.35 }}
-                className="text-[9px] font-mono text-neutral-muted tabular-nums uppercase tracking-widest"
+                animate={{ opacity: 0.3 }}
+                className="text-[8px] font-mono text-neutral-muted/60 tabular-nums tracking-[0.15em]"
               >
-                T+ {formatElapsed(elapsed)}
+                T+{formatElapsed(elapsed)}
               </motion.span>
             )}
           </div>

--- a/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
+++ b/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
@@ -136,7 +136,7 @@ function StreamingIndicator() {
         transition={{ duration: 7, repeat: Infinity, ease: 'easeInOut' }}
         className="shrink-0 relative z-10"
       >
-        <NeuralOrganism size={40} />
+        <NeuralOrganism size={56} />
       </motion.div>
 
       {/* Activity bars + text — connected composition */}

--- a/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
+++ b/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
@@ -116,22 +116,19 @@ function StreamingIndicator() {
       className="relative flex items-center gap-4 py-5 px-4"
     >
       {/* Ambient glow field behind organism */}
-      <div className="absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none">
-        <motion.div
-          className="w-24 h-24 rounded-full"
-          animate={{
-            opacity: [0.06, 0.12, 0.08, 0.1, 0.06],
-            scale: [0.9, 1.1, 0.95, 1.05, 0.9],
-          }}
-          transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
-          style={{
-            background:
-              'radial-gradient(circle, rgba(139,92,246,0.4) 0%, rgba(79,70,229,0.1) 50%, transparent 70%)',
-            filter: 'blur(14px)',
-            transform: 'translate(-30%, -50%)',
-          }}
-        />
-      </div>
+      <motion.div
+        className="absolute left-0 top-1/2 w-20 h-20 -translate-x-1/4 -translate-y-1/2 rounded-full pointer-events-none"
+        animate={{
+          opacity: [0.05, 0.1, 0.07, 0.09, 0.05],
+          scale: [0.95, 1.08, 0.98, 1.04, 0.95],
+        }}
+        transition={{ duration: 7, repeat: Infinity, ease: 'easeInOut' }}
+        style={{
+          background:
+            'radial-gradient(circle, rgba(139,92,246,0.35) 0%, rgba(79,70,229,0.08) 50%, transparent 70%)',
+          filter: 'blur(12px)',
+        }}
+      />
 
       {/* The creature — gentle hover */}
       <motion.div

--- a/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
+++ b/packages/dashboard/src/client/components/chat/AssistantBlocks.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Markdown from 'react-markdown';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import remarkGfm from 'remark-gfm';
@@ -11,6 +11,225 @@ import type {
   StatusBlock,
   TextBlock,
 } from '../../types/chat';
+// Loader2 removed — no longer used after streaming indicator refactor
+
+const PROCESSING_PHRASES = [
+  'Thinking deeply…',
+  'Analyzing the codebase…',
+  'Connecting the dots…',
+  'Weaving through the code…',
+  'Exploring possibilities…',
+  'Building a mental model…',
+  'Following the thread…',
+  'Mapping dependencies…',
+  'Tracing the logic…',
+  'Piecing it together…',
+  'Diving into the details…',
+  'Reasoning through options…',
+  'Scanning for patterns…',
+  'Synthesizing insights…',
+  'Crafting a response…',
+  'Running the numbers…',
+  'Almost there…',
+  'Working through it…',
+  'Processing your request…',
+  'Engineering a solution…',
+];
+
+/**
+ * ─── STREAMING INDICATOR: "THE SPRITE" ───
+ *
+ * Animated using Disney's 12 Principles:
+ *  1. Squash & Stretch  → The blob body breathes, compressing on exhale
+ *  2. Anticipation      → Before shifting position, it coils slightly
+ *  3. Staging           → Clear silhouette against dark background
+ *  4. Follow-through    → The aura trails behind position shifts
+ *  5. Slow in/out       → All easing uses spring or cubic-bezier curves
+ *  6. Arcs              → Position shifts follow curved paths (y dips)
+ *  7. Secondary action  → Aura breathes on its own offset cycle
+ *  8. Timing            → Breathing is slow (4s), gestures are quick snaps
+ *  9. Exaggeration      → Scale overshoots on inhale, squishes on exhale
+ * 10. Appeal            → Soft gradients, warm glow, friendly personality
+ */
+
+/** The creature's body — a morphing blob */
+function SpriteBody() {
+  return (
+    <div className="relative w-8 h-8 shrink-0">
+      {/* Layer 1: Outer aura — breathes on its own slower cycle */}
+      <motion.div
+        className="absolute inset-[-8px] rounded-full"
+        animate={{
+          scale: [1, 1.3, 1.1, 1.25, 1],
+          opacity: [0.1, 0.3, 0.15, 0.25, 0.1],
+        }}
+        transition={{
+          duration: 5,
+          repeat: Infinity,
+          ease: 'easeInOut',
+        }}
+        style={{
+          background: 'radial-gradient(circle, var(--color-primary-500), transparent 70%)',
+          filter: 'blur(10px)',
+        }}
+      />
+
+      {/* Layer 2: The blob body — squash & stretch breathing */}
+      <motion.div
+        className="absolute inset-0 rounded-full sprite-blob"
+        animate={{
+          scaleX: [1, 0.9, 1.1, 0.95, 1],
+          scaleY: [1, 1.15, 0.9, 1.08, 1],
+        }}
+        transition={{
+          duration: 4,
+          repeat: Infinity,
+          ease: [0.37, 0, 0.63, 1],
+        }}
+        style={{
+          background:
+            'radial-gradient(circle at 35% 35%, var(--color-secondary-400), var(--color-primary-500) 70%)',
+          boxShadow: '0 0 20px 4px var(--color-primary-500), inset 0 -2px 8px rgba(0,0,0,0.4)',
+        }}
+      />
+
+      {/* Subtle internal pulse — makes it feel "alive" without a distinct eye */}
+      <motion.div
+        className="absolute inset-1.5 rounded-full"
+        animate={{
+          opacity: [0.2, 0.6, 0.3, 0.5, 0.2],
+          scale: [0.8, 1.1, 0.85, 1, 0.8],
+        }}
+        transition={{
+          duration: 3,
+          repeat: Infinity,
+          ease: 'easeInOut',
+        }}
+        style={{
+          background: 'radial-gradient(circle, white, transparent 60%)',
+          filter: 'blur(3px)',
+        }}
+      />
+    </div>
+  );
+}
+
+/** Voice bars — emanate from the sprite, staggered with organic timing */
+function VoiceBar({ index, total }: { index: number; total: number }) {
+  const centerFactor = 1 - Math.abs(index - total / 2) / (total / 2);
+  const maxHeight = 0.5 + centerFactor * 0.5;
+  const baseHeight = 0.2 + centerFactor * 0.1;
+  const duration = 1.5 + (1 - centerFactor) * 1.5;
+
+  return (
+    <motion.div
+      animate={{
+        scaleY: [baseHeight, maxHeight, baseHeight * 1.2, maxHeight * 0.8, baseHeight],
+      }}
+      transition={{
+        duration,
+        repeat: Infinity,
+        delay: index * 0.1,
+        ease: 'easeInOut',
+      }}
+      className="w-[2px] h-8 rounded-full origin-bottom"
+      style={{
+        background: `linear-gradient(to top, var(--color-primary-500), var(--color-secondary-400))`,
+      }}
+    />
+  );
+}
+
+function StreamingIndicator() {
+  const [phraseIndex, setPhraseIndex] = useState(() =>
+    Math.floor(Math.random() * PROCESSING_PHRASES.length)
+  );
+  const [elapsed, setElapsed] = useState(0);
+  const startRef = useRef(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => {
+        setPhraseIndex((prev) => {
+          let next: number;
+          do {
+            next = Math.floor(Math.random() * PROCESSING_PHRASES.length);
+          } while (next === prev && PROCESSING_PHRASES.length > 1);
+          return next;
+        });
+      },
+      4500 + Math.random() * 2000
+    );
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const formatElapsed = (s: number) => {
+    if (s < 60) return `${s}s`;
+    return `${Math.floor(s / 60)}m ${s % 60}s`;
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.6 }}
+      className="flex items-center gap-5 py-4 px-3"
+    >
+      {/* The creature */}
+      <motion.div
+        animate={{ y: [0, -2.5, 1.5, -1, 0] }}
+        transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
+        className="shrink-0"
+      >
+        <SpriteBody />
+      </motion.div>
+
+      {/* Relative container for Text + Background Voice Bars */}
+      <div className="relative flex-1 min-w-0 flex items-center h-10">
+        {/* Ghostly Voice Bars behind text */}
+        <div className="absolute inset-0 flex items-end justify-start gap-[3px] opacity-[0.1] pointer-events-none px-1 overflow-hidden blur-[1.5px]">
+          {Array.from({ length: 24 }).map((_, i) => (
+            <VoiceBar key={i} index={i} total={24} />
+          ))}
+        </div>
+
+        {/* The phrase */}
+        <div className="relative z-10 flex flex-col justify-center">
+          <AnimatePresence mode="wait">
+            <motion.span
+              key={phraseIndex}
+              initial={{ opacity: 0, filter: 'blur(4px)' }}
+              animate={{ opacity: 1, filter: 'blur(0px)' }}
+              exit={{ opacity: 0, filter: 'blur(2px)' }}
+              transition={{ duration: 0.5 }}
+              className="text-[13px] font-bold tracking-wider text-neutral-text uppercase leading-none"
+            >
+              {PROCESSING_PHRASES[phraseIndex]}
+            </motion.span>
+          </AnimatePresence>
+          <div className="h-3.5 flex items-center mt-0.5">
+            {elapsed > 2 && (
+              <motion.span
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.35 }}
+                className="text-[9px] font-mono text-neutral-muted tabular-nums uppercase tracking-widest"
+              >
+                T+ {formatElapsed(elapsed)}
+              </motion.span>
+            )}
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
 
 function ThinkingBlockView({ block }: { block: ThinkingBlock }) {
   return (
@@ -38,7 +257,7 @@ function formatToolArgs(tool: string, args?: string) {
     }
     if (toolLower === 'bash' && (parsed.command || parsed.args)) {
       const cmd = parsed.command || parsed.args;
-      // Clean up common long paths in bash commands if they exist
+      // If we have a description, the command itself is now the "args preview"
       return cmd.replace(/cd\s+("[^"]+"|'[^']+'|[^\s]+)\s*&&\s*/g, '').slice(0, 100);
     }
     if (toolLower === 'agent' || toolLower === 'subagent' || parsed.subagent_type) {
@@ -64,14 +283,21 @@ function ToolUseBlockView({
   block,
   forceResult,
   isPending = false,
+  attribution,
 }: {
   block: ToolUseBlock;
   forceResult?: string;
   isPending?: boolean;
+  attribution?: string;
 }) {
   const [isOpen, setIsOpen] = useState(() => {
     const t = block.tool.toLowerCase();
-    return t.includes('interaction') || t.includes('question') || t.includes('ask') || t.includes('human');
+    return (
+      t.includes('interaction') ||
+      t.includes('question') ||
+      t.includes('ask') ||
+      t.includes('human')
+    );
   });
   const result = block.result || forceResult;
   const hasResult = result !== undefined;
@@ -112,12 +338,27 @@ function ToolUseBlockView({
         >
           &#9654;
         </motion.span>
-        <span className="text-[10px] font-black tracking-[0.2em] text-neutral-text capitalize">
-          {block.tool.replace(/_/g, ' ')}
+        <span className="text-[10px] font-black tracking-[0.2em] text-neutral-text capitalize truncate max-w-[300px]">
+          {(() => {
+            if (block.tool.toLowerCase() === 'bash' && block.args) {
+              try {
+                const parsed = JSON.parse(block.args);
+                if (parsed.description) return parsed.description;
+              } catch {
+                // ignore
+              }
+            }
+            return block.tool.replace(/_/g, ' ');
+          })()}
         </span>
         {block.args && (
           <span className="truncate font-mono text-[9px] text-neutral-muted/60" title={block.args}>
             {formatToolArgs(block.tool, block.args)}
+          </span>
+        )}
+        {attribution && (
+          <span className="ml-2 inline-flex items-center gap-1 rounded bg-secondary-500/10 px-1.5 py-0.5 text-[8px] font-bold uppercase tracking-wider text-secondary-400 border border-secondary-400/20">
+            {attribution}
           </span>
         )}
         {hasResult && (
@@ -149,120 +390,131 @@ function ToolUseBlockView({
             <Markdown remarkPlugins={[remarkGfm]}>{result}</Markdown>
 
             {hasResult && !isPending && block.tool.toLowerCase().includes('emit_interaction') && (
-               <div className="mt-4 flex flex-wrap gap-2 border-t border-neutral-border/50 pt-3 not-prose">
-                 {(() => {
-                   try {
-                     const payload = JSON.parse(block.args || '{}');
-                     const dispatchSend = (text: string) => {
-                       window.dispatchEvent(new CustomEvent('chat-action-send', { detail: text }));
-                     };
+              <div className="mt-4 flex flex-wrap gap-2 border-t border-neutral-border/50 pt-3 not-prose">
+                {(() => {
+                  try {
+                    const payload = JSON.parse(block.args || '{}');
+                    const dispatchSend = (text: string) => {
+                      window.dispatchEvent(new CustomEvent('chat-action-send', { detail: text }));
+                    };
 
-                     if (payload.type === 'question') {
-                       const els = [];
+                    if (payload.type === 'question') {
+                      const els = [];
 
-                       if (payload.question?.options && payload.question.options.length > 0) {
-                         const { options, recommendation } = payload.question;
-                         if (recommendation !== undefined && options[recommendation.optionIndex]) {
-                           els.push(
-                             <button
-                               key="approve-rec"
-                               onClick={() => dispatchSend(`Approve recommendation: ${options[recommendation.optionIndex].label}`)}
-                               className="rounded bg-primary-500 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-primary-400 transition-colors"
-                             >
-                               Approve Recommendation ({String.fromCharCode(65 + recommendation.optionIndex)})
-                             </button>
-                           );
-                         }
-                         options.forEach((opt: any, i: number) => {
-                           if (recommendation?.optionIndex === i) return;
-                           const label = typeof opt === 'string' ? opt : opt.label;
-                           els.push(
-                             <button
-                               key={`opt-${i}`}
-                               onClick={() => dispatchSend(`Approve option ${String.fromCharCode(65 + i)}: ${label}`)}
-                               className="rounded bg-neutral-surface/60 border border-neutral-border hover:bg-white/5 px-3 py-1.5 text-[10px] font-medium text-neutral-text transition-colors"
-                             >
-                               Option {String.fromCharCode(65 + i)}
-                             </button>
-                           );
-                         });
-                       }
+                      if (payload.question?.options && payload.question.options.length > 0) {
+                        const { options, recommendation } = payload.question;
+                        if (recommendation !== undefined && options[recommendation.optionIndex]) {
+                          els.push(
+                            <button
+                              key="approve-rec"
+                              onClick={() =>
+                                dispatchSend(
+                                  `Approve recommendation: ${options[recommendation.optionIndex].label}`
+                                )
+                              }
+                              className="rounded bg-primary-500 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-primary-400 transition-colors"
+                            >
+                              Approve Recommendation (
+                              {String.fromCharCode(65 + recommendation.optionIndex)})
+                            </button>
+                          );
+                        }
+                        options.forEach((opt: { label?: string } | string, i: number) => {
+                          if (recommendation?.optionIndex === i) return;
+                          const label = typeof opt === 'string' ? opt : opt.label;
+                          els.push(
+                            <button
+                              key={`opt-${i}`}
+                              onClick={() =>
+                                dispatchSend(
+                                  `Approve option ${String.fromCharCode(65 + i)}: ${label}`
+                                )
+                              }
+                              className="rounded bg-neutral-surface/60 border border-neutral-border hover:bg-white/5 px-3 py-1.5 text-[10px] font-medium text-neutral-text transition-colors"
+                            >
+                              Option {String.fromCharCode(65 + i)}
+                            </button>
+                          );
+                        });
+                      }
 
-                       els.push(
-                         <button
-                           key="continue-btn"
-                           onClick={() => dispatchSend('Continue')}
-                           className="rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 px-4 py-1.5 text-[10px] font-bold hover:bg-emerald-500/30 transition-colors"
-                         >
-                           Continue
-                         </button>
-                       );
+                      els.push(
+                        <button
+                          key="continue-btn"
+                          onClick={() => dispatchSend('Continue')}
+                          className="rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 px-4 py-1.5 text-[10px] font-bold hover:bg-emerald-500/30 transition-colors"
+                        >
+                          Continue
+                        </button>
+                      );
 
-                       return els;
-                     }
+                      return els;
+                    }
 
-                     if (payload.type === 'confirmation') {
-                       return (
-                         <>
-                           <button
-                             onClick={() => dispatchSend('Yes, proceed')}
-                             className="rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 px-4 py-1.5 text-xs font-bold hover:bg-emerald-500/30 transition-colors"
-                           >
-                             Confirm & Proceed
-                           </button>
-                           <button
-                             onClick={() => dispatchSend('No, stop')}
-                             className="rounded bg-red-500/20 text-red-400 border border-red-500/30 px-4 py-1.5 text-xs font-bold hover:bg-red-500/30 transition-colors"
-                           >
-                             Cancel
-                           </button>
-                         </>
-                       );
-                     }
+                    if (payload.type === 'confirmation') {
+                      return (
+                        <>
+                          <button
+                            onClick={() => dispatchSend('Yes, proceed')}
+                            className="rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 px-4 py-1.5 text-xs font-bold hover:bg-emerald-500/30 transition-colors"
+                          >
+                            Confirm & Proceed
+                          </button>
+                          <button
+                            onClick={() => dispatchSend('No, stop')}
+                            className="rounded bg-red-500/20 text-red-400 border border-red-500/30 px-4 py-1.5 text-xs font-bold hover:bg-red-500/30 transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      );
+                    }
 
-                     if (payload.type === 'transition' && payload.transition?.requiresConfirmation) {
-                       return (
-                         <>
-                           <button
-                             onClick={() => dispatchSend(`Yes, proceed to ${payload.transition.suggestedNext}`)}
-                             className="rounded bg-primary-500 px-4 py-1.5 text-xs font-bold text-white shadow hover:bg-primary-400 transition-colors"
-                           >
-                             Proceed to {payload.transition.suggestedNext}
-                           </button>
-                           <button
-                             onClick={() => dispatchSend('No, stay here')}
-                             className="rounded bg-neutral-surface/60 border border-neutral-border hover:bg-white/5 px-4 py-1.5 text-[10px] font-medium text-neutral-text transition-colors"
-                           >
-                             Stay in {payload.transition.completedPhase}
-                           </button>
-                         </>
-                       );
-                     }
+                    if (payload.type === 'transition' && payload.transition?.requiresConfirmation) {
+                      return (
+                        <>
+                          <button
+                            onClick={() =>
+                              dispatchSend(`Yes, proceed to ${payload.transition.suggestedNext}`)
+                            }
+                            className="rounded bg-primary-500 px-4 py-1.5 text-xs font-bold text-white shadow hover:bg-primary-400 transition-colors"
+                          >
+                            Proceed to {payload.transition.suggestedNext}
+                          </button>
+                          <button
+                            onClick={() => dispatchSend('No, stay here')}
+                            className="rounded bg-neutral-surface/60 border border-neutral-border hover:bg-white/5 px-4 py-1.5 text-[10px] font-medium text-neutral-text transition-colors"
+                          >
+                            Stay in {payload.transition.completedPhase}
+                          </button>
+                        </>
+                      );
+                    }
 
-                     if (payload.type === 'batch') {
-                       return (
-                         <>
-                           <button
-                             onClick={() => dispatchSend('Approve all decisions')}
-                             className="rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 px-4 py-1.5 text-xs font-bold hover:bg-emerald-500/30 transition-colors"
-                           >
-                             Approve All
-                           </button>
-                           <button
-                             onClick={() => dispatchSend('Reject batch')}
-                             className="rounded bg-red-500/20 text-red-400 border border-red-500/30 px-4 py-1.5 text-xs font-bold hover:bg-red-500/30 transition-colors"
-                           >
-                             Reject
-                           </button>
-                         </>
-                       );
-                     }
-                   } catch {
-                     // Parse failed, UI untouched
-                   }
-                   return null;
-                 })()}
-               </div>
+                    if (payload.type === 'batch') {
+                      return (
+                        <>
+                          <button
+                            onClick={() => dispatchSend('Approve all decisions')}
+                            className="rounded bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 px-4 py-1.5 text-xs font-bold hover:bg-emerald-500/30 transition-colors"
+                          >
+                            Approve All
+                          </button>
+                          <button
+                            onClick={() => dispatchSend('Reject batch')}
+                            className="rounded bg-red-500/20 text-red-400 border border-red-500/30 px-4 py-1.5 text-xs font-bold hover:bg-red-500/30 transition-colors"
+                          >
+                            Reject
+                          </button>
+                        </>
+                      );
+                    }
+                  } catch {
+                    // Parse failed, UI untouched
+                  }
+                  return null;
+                })()}
+              </div>
             )}
           </div>
         </motion.div>
@@ -271,7 +523,7 @@ function ToolUseBlockView({
   );
 }
 
-function AgentBlockView({ block }: { block: ToolUseBlock }) {
+function AgentBlockView({ block, children }: { block: ToolUseBlock; children?: React.ReactNode }) {
   let parsedArgs: Record<string, string | undefined> = {};
   if (block.args) {
     try {
@@ -281,7 +533,8 @@ function AgentBlockView({ block }: { block: ToolUseBlock }) {
     }
   }
 
-  const isSkill = block.tool.toLowerCase() === 'skill';
+  const toolLower = block.tool.toLowerCase();
+  const isSkill = toolLower === 'skill' || toolLower.startsWith('harness:');
   const containerClasses = isSkill
     ? 'border-emerald-400/20 bg-emerald-400/5'
     : 'border-secondary-400/20 bg-secondary-400/5';
@@ -296,7 +549,7 @@ function AgentBlockView({ block }: { block: ToolUseBlock }) {
   const borderDescClasses = isSkill ? 'border-emerald-400/10' : 'border-secondary-400/10';
 
   const titleText = isSkill
-    ? `Skill: ${parsedArgs.skill || 'Execution'}`
+    ? `Skill: ${parsedArgs.skill || (toolLower.startsWith('harness:') ? block.tool.split(':')[1] : 'Execution')}`
     : `Subagent: ${parsedArgs.subagent_type || parsedArgs.type || 'Execution'}`;
 
   const mainDesc = isSkill ? undefined : parsedArgs.description;
@@ -352,6 +605,15 @@ function AgentBlockView({ block }: { block: ToolUseBlock }) {
             <Markdown remarkPlugins={[remarkGfm]}>{block.result}</Markdown>
           </div>
         )}
+        {children &&
+          (Array.isArray(children) ? (children as React.ReactNode[]).length > 0 : true) && (
+            <div className={`mt-2 pt-2 border-t ${borderDescClasses} flex flex-col gap-1`}>
+              <div className="text-[10px] uppercase tracking-widest font-black text-neutral-muted/50 mb-1">
+                Activity Trace
+              </div>
+              {children}
+            </div>
+          )}
       </div>
     </div>
   );
@@ -519,7 +781,10 @@ function TextBlockView({ block }: { block: TextBlock }) {
   }
 
   const packedMatches = [...block.text.matchAll(/<?!--\s*packed:\s*(.*?)\s*-->?/g)];
-  const cleanText = block.text.replace(/<?!--\s*packed:\s*(.*?)\s*-->?/g, '').replace(/\n{3,}/g, '\n\n').trim();
+  const cleanText = block.text
+    .replace(/<?!--\s*packed:\s*(.*?)\s*-->?/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
 
   return (
     <div className="flex flex-col gap-2 relative">
@@ -531,8 +796,18 @@ function TextBlockView({ block }: { block: TextBlock }) {
               className="inline-flex items-center gap-1.5 rounded-full bg-secondary-500/10 px-2.5 py-0.5 text-[10px] font-medium text-secondary-300 border border-secondary-500/20"
               title="Graph context packing applied"
             >
-              <svg className="w-3 h-3 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+              <svg
+                className="w-3 h-3 text-secondary-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"
+                />
               </svg>
               <span>Packed: {m[1]}</span>
             </span>
@@ -542,59 +817,59 @@ function TextBlockView({ block }: { block: TextBlock }) {
       {cleanText.length > 0 && (
         <div className="prose prose-invert prose-sm max-w-none py-1 selection:bg-primary-500/30">
           <Markdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          code(props) {
-            const {
-              node: _node,
-              className,
-              children,
-              ...rest
-            } = props as React.HTMLAttributes<HTMLElement> & { node?: unknown };
-            const inline = !(className && /language-(\w+)/.test(className));
-            const match = /language-(\w+)/.exec(className ?? '');
-            return !inline && match ? (
-              <div className="relative group my-4">
-                <div className="absolute -inset-2 bg-gradient-to-r from-primary-500/10 to-secondary-400/10 rounded-xl blur opacity-0 group-hover:opacity-100 transition-opacity" />
-                <div className="relative rounded-lg border border-neutral-border overflow-hidden shadow-2xl">
-                  <div className="flex items-center justify-between px-4 py-2 bg-neutral-surface/80 border-b border-neutral-border">
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-neutral-muted">
-                      {match[1]}
-                    </span>
-                    <div className="flex gap-1">
-                      <div className="h-1.5 w-1.5 rounded-full bg-neutral-border" />
-                      <div className="h-1.5 w-1.5 rounded-full bg-neutral-border" />
+            remarkPlugins={[remarkGfm]}
+            components={{
+              code(props) {
+                const {
+                  node: _node,
+                  className,
+                  children,
+                  ...rest
+                } = props as React.HTMLAttributes<HTMLElement> & { node?: unknown };
+                const inline = !(className && /language-(\w+)/.test(className));
+                const match = /language-(\w+)/.exec(className ?? '');
+                return !inline && match ? (
+                  <div className="relative group my-4">
+                    <div className="absolute -inset-2 bg-gradient-to-r from-primary-500/10 to-secondary-400/10 rounded-xl blur opacity-0 group-hover:opacity-100 transition-opacity" />
+                    <div className="relative rounded-lg border border-neutral-border overflow-hidden shadow-2xl">
+                      <div className="flex items-center justify-between px-4 py-2 bg-neutral-surface/80 border-b border-neutral-border">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-neutral-muted">
+                          {match[1]}
+                        </span>
+                        <div className="flex gap-1">
+                          <div className="h-1.5 w-1.5 rounded-full bg-neutral-border" />
+                          <div className="h-1.5 w-1.5 rounded-full bg-neutral-border" />
+                        </div>
+                      </div>
+                      <SyntaxHighlighter
+                        {...rest}
+                        style={vscDarkPlus}
+                        language={match[1]}
+                        PreTag="div"
+                        className="!bg-neutral-surface/40 !m-0 !p-4 !text-[11px] font-mono leading-relaxed"
+                      >
+                        {(Array.isArray(children)
+                          ? children.join('')
+                          : typeof children === 'string'
+                            ? children
+                            : ''
+                        ).replace(/\n$/, '')}
+                      </SyntaxHighlighter>
                     </div>
                   </div>
-                  <SyntaxHighlighter
+                ) : (
+                  <code
+                    className={`${className} bg-neutral-surface/60 px-1.5 py-0.5 rounded text-secondary-400 font-mono text-[11px] border border-neutral-border`}
                     {...rest}
-                    style={vscDarkPlus}
-                    language={match[1]}
-                    PreTag="div"
-                    className="!bg-neutral-surface/40 !m-0 !p-4 !text-[11px] font-mono leading-relaxed"
                   >
-                    {(Array.isArray(children)
-                      ? children.join('')
-                      : typeof children === 'string'
-                        ? children
-                        : ''
-                    ).replace(/\n$/, '')}
-                  </SyntaxHighlighter>
-                </div>
-              </div>
-            ) : (
-              <code
-                className={`${className} bg-neutral-surface/60 px-1.5 py-0.5 rounded text-secondary-400 font-mono text-[11px] border border-neutral-border`}
-                {...rest}
-              >
-                {children}
-              </code>
-            );
-          },
-        }}
-      >
-        {cleanText}
-      </Markdown>
+                    {children}
+                  </code>
+                );
+              },
+            }}
+          >
+            {cleanText}
+          </Markdown>
         </div>
       )}
     </div>
@@ -760,127 +1035,172 @@ export function AssistantBlocks({
   isStreaming: boolean;
 }) {
   if (blocks.length === 0 && isStreaming) {
-    return (
-      <motion.div
-        animate={{ opacity: [0.4, 1, 0.4] }}
-        transition={{ duration: 1.5, repeat: Infinity }}
-        className="flex gap-1 py-2"
-      >
-        <div className="h-1.5 w-1.5 rounded-full bg-secondary-400 shadow-[0_0_8px_var(--color-secondary-400)]" />
-        <div className="h-1.5 w-1.5 rounded-full bg-secondary-400 shadow-[0_0_8px_var(--color-secondary-400)] delay-100" />
-        <div className="h-1.5 w-1.5 rounded-full bg-secondary-400 shadow-[0_0_8px_var(--color-secondary-400)] delay-200" />
-      </motion.div>
-    );
+    return <StreamingIndicator />;
   }
 
   const elements: React.ReactNode[] = [];
+  const consumedIndices = new Set<number>();
+
+  /**
+   * Helper: check if a tool_use block is a "container" type (agent/subagent/skill).
+   */
+  function isContainerTool(tool: string): boolean {
+    const t = tool.toLowerCase();
+    return t === 'agent' || t === 'subagent' || t === 'skill' || t.startsWith('harness:');
+  }
+
+  /**
+   * Helper: given a subagent/agent/skill block at index `agentIdx`, collect
+   * all "child" block indices that follow it. A child is any block that appears
+   * after the agent AND before the next conversational text (non-log) or
+   * another agent/todo/interaction block.
+   */
+  function collectChildIndices(agentIdx: number): number[] {
+    const children: number[] = [];
+    for (let j = agentIdx + 1; j < blocks.length; j++) {
+      if (consumedIndices.has(j)) continue;
+      const b = blocks[j]!;
+
+      // Stop collecting at another container tool
+      if (b.kind === 'tool_use') {
+        const t = b.tool.toLowerCase();
+        if (isContainerTool(b.tool)) break;
+        if (t.includes('todo')) break;
+        if (
+          t.includes('interaction') ||
+          t.includes('question') ||
+          t.includes('ask') ||
+          t.includes('human')
+        )
+          break;
+      }
+
+      // Stop at conversational text (non-log output)
+      if (b.kind === 'text' && !isLogOutput(b.text)) break;
+
+      children.push(j);
+    }
+    return children;
+  }
+
+  /** Render a set of child block indices as an ActivityGroup */
+  function renderChildBlocks(childIndices: number[]): React.ReactNode[] {
+    if (childIndices.length === 0) return [];
+    const childBlocks: ContentBlock[] = [];
+    const innerConsumed = new Set<number>();
+
+    for (const idx of childIndices) {
+      if (innerConsumed.has(idx)) continue;
+      let block = blocks[idx]!;
+
+      // Pair tool_use with following text/status results
+      if (block.kind === 'tool_use') {
+        const forceResultChunks: string[] = [];
+        let lookAhead = idx + 1;
+        while (lookAhead < blocks.length && childIndices.includes(lookAhead)) {
+          if (innerConsumed.has(lookAhead)) {
+            lookAhead++;
+            continue;
+          }
+          const nextB = blocks[lookAhead]!;
+          if (nextB.kind === 'tool_use' || nextB.kind === 'thinking') break;
+          if (nextB.kind === 'text') {
+            if (isLogOutput(nextB.text, block.tool)) {
+              forceResultChunks.push(nextB.text);
+              innerConsumed.add(lookAhead);
+            } else {
+              break;
+            }
+          } else if (nextB.kind === 'status') {
+            forceResultChunks.push(nextB.text);
+            innerConsumed.add(lookAhead);
+          }
+          lookAhead++;
+        }
+        if (forceResultChunks.length > 0) {
+          const chunkString = forceResultChunks.join('\n\n');
+          block = {
+            ...block,
+            result: block.result ? `${chunkString}\n\n${block.result}` : chunkString,
+          } as ToolUseBlock;
+        }
+      }
+
+      childBlocks.push(block);
+    }
+
+    if (childBlocks.length === 0) return [];
+    return [
+      <ActivityGroup
+        key={`ag-child-${childIndices[0]}`}
+        blocks={childBlocks}
+        startIndex={childIndices[0]!}
+        isStreaming={isStreaming}
+        isLastGroup={childIndices[childIndices.length - 1] === blocks.length - 1}
+      />,
+    ];
+  }
+
+  // Main rendering loop
   let activityGroup: ContentBlock[] = [];
   let activityGroupStart = 0;
-  const consumedIndices = new Set<number>();
+
+  const flushActivityGroup = () => {
+    if (activityGroup.length === 0) return;
+    elements.push(
+      <ActivityGroup
+        key={`ag-${activityGroupStart}`}
+        blocks={activityGroup}
+        startIndex={activityGroupStart}
+        isStreaming={isStreaming}
+        isLastGroup={false}
+      />
+    );
+    activityGroup = [];
+  };
 
   for (let i = 0; i < blocks.length; i++) {
     if (consumedIndices.has(i)) continue;
+
     let block = blocks[i]!;
-    let isActivity = false;
 
     if (block.kind === 'tool_use') {
-      isActivity = true;
-      let forceResultChunks: string[] = [];
+      const t = block.tool.toLowerCase();
 
-      // Look ahead to aggressively pair ALL text/status log chunks following tool_use as results,
-      let lookAhead = i + 1;
-      while (lookAhead < blocks.length) {
-        if (consumedIndices.has(lookAhead)) {
-          lookAhead++;
-          continue;
-        }
-        const nextB = blocks[lookAhead]!;
-        if (nextB.kind === 'tool_use' || nextB.kind === 'thinking') break; // Next tool_use or thinking interrupts pairing
-
-        if (nextB.kind === 'text') {
-          if (isLogOutput(nextB.text, block.tool)) {
-            forceResultChunks.push(nextB.text);
-            consumedIndices.add(lookAhead);
-          } else {
-            break; // Stop at first conversational text block
-          }
-        } else if (nextB.kind === 'status') {
-          forceResultChunks.push(nextB.text);
-          consumedIndices.add(lookAhead);
-        }
-        lookAhead++;
-      }
-
-      const chunkString = forceResultChunks.length > 0 ? forceResultChunks.join('\n\n') : undefined;
-      const resolvedResult = chunkString
-        ? block.result
-          ? `${chunkString}\n\n${block.result}`
-          : chunkString
-        : block.result;
-      block = {
-        ...block,
-        ...(resolvedResult !== undefined && { result: resolvedResult }),
-      };
-
-      const isTodoWrite = block.tool.toLowerCase().includes('todo');
-      const isAgent =
-        block.tool.toLowerCase() === 'agent' || block.tool.toLowerCase() === 'subagent';
-      const isSkill = block.tool.toLowerCase() === 'skill';
-      const isInteraction =
-        block.tool.toLowerCase().includes('interaction') ||
-        block.tool.toLowerCase().includes('question') ||
-        block.tool.toLowerCase().includes('ask') ||
-        block.tool.toLowerCase().includes('human');
-      if (isTodoWrite || isAgent || isSkill || isInteraction) {
-        isActivity = false;
-      }
-    } else if (block.kind === 'thinking' || block.kind === 'status') {
-      isActivity = true;
-    } else if (block.kind === 'text' && isLogOutput(block.text)) {
-      isActivity = true;
-    }
-
-    if (isActivity) {
-      if (activityGroup.length === 0) activityGroupStart = i;
-      activityGroup.push(block);
-    } else {
-      if (activityGroup.length > 0) {
+      // --- Container tools: agent/subagent/skill ---
+      if (isContainerTool(block.tool)) {
+        flushActivityGroup();
+        const childIndices = collectChildIndices(i);
+        childIndices.forEach((idx) => consumedIndices.add(idx));
         elements.push(
-          <ActivityGroup
-            key={`ag-${activityGroupStart}`}
-            blocks={activityGroup}
-            startIndex={activityGroupStart}
-            isStreaming={isStreaming}
-            isLastGroup={false}
-          />
+          <motion.div key={i} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
+            <AgentBlockView block={block as ToolUseBlock}>
+              {renderChildBlocks(childIndices)}
+            </AgentBlockView>
+          </motion.div>
         );
-        activityGroup = [];
+        continue;
       }
 
-      if (block.kind === 'tool_use' && block.tool.toLowerCase().includes('todo')) {
+      // --- Todo blocks ---
+      if (t.includes('todo')) {
+        flushActivityGroup();
         elements.push(
           <motion.div key={i} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
             <TodoBlockView block={block as ToolUseBlock} />
           </motion.div>
         );
-      } else if (
-        block.kind === 'tool_use' &&
-        (block.tool.toLowerCase() === 'agent' ||
-          block.tool.toLowerCase() === 'subagent' ||
-          block.tool.toLowerCase() === 'skill')
+        continue;
+      }
+
+      // --- Interaction blocks ---
+      if (
+        t.includes('interaction') ||
+        t.includes('question') ||
+        t.includes('ask') ||
+        t.includes('human')
       ) {
-        elements.push(
-          <motion.div key={i} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
-            <AgentBlockView block={block as ToolUseBlock} />
-          </motion.div>
-        );
-      } else if (
-        block.kind === 'tool_use' &&
-        (block.tool.toLowerCase().includes('interaction') ||
-          block.tool.toLowerCase().includes('question') ||
-          block.tool.toLowerCase().includes('ask') ||
-          block.tool.toLowerCase().includes('human'))
-      ) {
+        flushActivityGroup();
         elements.push(
           <motion.div key={i} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
             <ToolUseBlockView
@@ -889,16 +1209,60 @@ export function AssistantBlocks({
             />
           </motion.div>
         );
-      } else {
-        elements.push(
-          <motion.div key={i} initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-            <TextBlockView block={block as TextBlock} />
-          </motion.div>
-        );
+        continue;
       }
+
+      // --- Regular tool_use: pair with following output, add to activity group ---
+      const forceResultChunks: string[] = [];
+      let lookAhead = i + 1;
+      while (lookAhead < blocks.length) {
+        if (consumedIndices.has(lookAhead)) {
+          lookAhead++;
+          continue;
+        }
+        const nextB = blocks[lookAhead]!;
+        if (nextB.kind === 'tool_use' || nextB.kind === 'thinking') break;
+        if (nextB.kind === 'text') {
+          if (isLogOutput(nextB.text, block.tool)) {
+            forceResultChunks.push(nextB.text);
+            consumedIndices.add(lookAhead);
+          } else {
+            break;
+          }
+        } else if (nextB.kind === 'status') {
+          forceResultChunks.push(nextB.text);
+          consumedIndices.add(lookAhead);
+        }
+        lookAhead++;
+      }
+      if (forceResultChunks.length > 0) {
+        const chunkString = forceResultChunks.join('\n\n');
+        block = {
+          ...block,
+          result: block.result ? `${chunkString}\n\n${block.result}` : chunkString,
+        } as ToolUseBlock;
+      }
+
+      if (activityGroup.length === 0) activityGroupStart = i;
+      activityGroup.push(block);
+    } else if (block.kind === 'thinking' || block.kind === 'status') {
+      if (activityGroup.length === 0) activityGroupStart = i;
+      activityGroup.push(block);
+    } else if (block.kind === 'text' && isLogOutput(block.text)) {
+      if (activityGroup.length === 0) activityGroupStart = i;
+      activityGroup.push(block);
+    } else {
+      // Conversational text — flush and render inline
+      flushActivityGroup();
+      elements.push(
+        <motion.div key={i} initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+          <TextBlockView block={block as TextBlock} />
+        </motion.div>
+      );
     }
   }
 
+  // Flush final activity group
   if (activityGroup.length > 0) {
     elements.push(
       <ActivityGroup
@@ -908,6 +1272,19 @@ export function AssistantBlocks({
         isStreaming={isStreaming}
         isLastGroup={true}
       />
+    );
+  }
+
+  if (isStreaming && blocks.length > 0) {
+    elements.push(
+      <motion.div
+        key="streaming-indicator"
+        initial={{ opacity: 0, y: 5 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="mt-2 border-t border-white/5"
+      >
+        <StreamingIndicator />
+      </motion.div>
     );
   }
 

--- a/packages/dashboard/src/client/components/chat/ChatPanel.tsx
+++ b/packages/dashboard/src/client/components/chat/ChatPanel.tsx
@@ -430,7 +430,7 @@ export function ChatPanel({ isOpen, onClose, maximized = false }: Props) {
               </button>
             )}
             <div className="relative">
-              <NeuralOrganism size={32} />
+              <NeuralOrganism size={48} />
             </div>
             <div>
               <h3 className="text-sm font-bold tracking-tight text-white">

--- a/packages/dashboard/src/client/components/chat/ChatPanel.tsx
+++ b/packages/dashboard/src/client/components/chat/ChatPanel.tsx
@@ -1,12 +1,13 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Cpu, Loader2, Sparkles, X, Save, ArrowLeft } from 'lucide-react';
+import { Loader2, Sparkles, X, Save, ArrowLeft } from 'lucide-react';
 import { MessageStream } from './MessageStream';
 import { ChatInput } from './ChatInput';
 import { CommandPalette } from './CommandPalette';
 import { ChatContextPane } from './ChatContextPane';
 import { SessionTabBar } from './SessionTabBar';
+import { NeuralOrganism } from './NeuralOrganism';
 import { streamChat, applyChunk } from '../../utils/chat-stream';
 import { useChatContext } from '../../hooks/useChatContext';
 import { useChatPanel } from '../../hooks/useChatPanel';
@@ -408,8 +409,17 @@ export function ChatPanel({ isOpen, onClose, maximized = false }: Props) {
   const dialogContent = (
     <>
       {/* Header */}
-      <div className="flex flex-col border-b border-white/10 flex-shrink-0">
-        <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col border-b border-white/10 flex-shrink-0 relative overflow-hidden">
+        {/* Ambient glow from organism that bleeds into header bg */}
+        <div
+          className="absolute left-6 top-1/2 -translate-y-1/2 w-32 h-32 pointer-events-none"
+          style={{
+            background:
+              'radial-gradient(circle, rgba(139,92,246,0.08) 0%, rgba(79,70,229,0.03) 50%, transparent 70%)',
+            filter: 'blur(16px)',
+          }}
+        />
+        <div className="relative flex items-center justify-between px-6 py-4">
           <div className="flex items-center gap-3">
             {maximized && (
               <button
@@ -419,15 +429,15 @@ export function ChatPanel({ isOpen, onClose, maximized = false }: Props) {
                 <ArrowLeft size={20} />
               </button>
             )}
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary-500/10 text-primary-500 shadow-[0_0_15px_rgba(79,70,229,0.2)]">
-              <Cpu size={18} />
+            <div className="relative">
+              <NeuralOrganism size={32} />
             </div>
             <div>
               <h3 className="text-sm font-bold tracking-tight text-white">
                 {interaction ? interaction.context.issueTitle : 'Neural Uplink'}
               </h3>
               <div className="flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-[0.1em] text-neutral-muted">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.5)]" />
                 {activeSessionId ? 'Direct Connection Active' : 'Standby Mode'}
               </div>
             </div>

--- a/packages/dashboard/src/client/components/chat/MessageStream.tsx
+++ b/packages/dashboard/src/client/components/chat/MessageStream.tsx
@@ -62,7 +62,7 @@ export function MessageStream({ messages, streaming, className }: Props) {
               animate={{ scale: 1, opacity: 1 }}
               transition={{ duration: 1.5, ease: [0.16, 1, 0.3, 1], delay: 0.2 }}
             >
-              <NeuralOrganism size={80} />
+              <NeuralOrganism size={120} />
             </motion.div>
           </div>
 

--- a/packages/dashboard/src/client/components/chat/MessageStream.tsx
+++ b/packages/dashboard/src/client/components/chat/MessageStream.tsx
@@ -53,8 +53,7 @@ export function MessageStream({ messages, streaming, className }: Props) {
                 delay: 0.5,
               }}
               style={{
-                background:
-                  'radial-gradient(circle, rgba(34,211,238,0.15) 0%, transparent 60%)',
+                background: 'radial-gradient(circle, rgba(34,211,238,0.15) 0%, transparent 60%)',
                 filter: 'blur(12px)',
               }}
             />
@@ -109,10 +108,7 @@ export function MessageStream({ messages, streaming, className }: Props) {
                 </div>
               </motion.div>
             ) : (
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-              >
+              <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
                 <div className="px-1 py-1">
                   <AssistantBlocks
                     blocks={msg.blocks}

--- a/packages/dashboard/src/client/components/chat/MessageStream.tsx
+++ b/packages/dashboard/src/client/components/chat/MessageStream.tsx
@@ -1,9 +1,9 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { motion } from 'framer-motion';
-import { Cpu } from 'lucide-react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import type { ChatMessage } from '../../types/chat';
 import { AssistantBlocks } from './AssistantBlocks';
+import { NeuralOrganism } from './NeuralOrganism';
 
 interface Props {
   messages: ChatMessage[];
@@ -22,16 +22,67 @@ export function MessageStream({ messages, streaming, className }: Props) {
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
+          transition={{ duration: 1.2, ease: 'easeOut' }}
           className="absolute inset-0 flex flex-col items-center justify-center text-center p-6"
         >
-          <div className="mb-4 rounded-full bg-primary-500/10 p-4 text-primary-500">
-            <Cpu size={32} className="drop-shadow-[0_0_10px_var(--color-primary-500)]" />
+          {/* Atmospheric bioluminescent field behind organism */}
+          <div className="relative mb-6">
+            <motion.div
+              className="absolute inset-0 -m-16 rounded-full"
+              animate={{
+                opacity: [0.04, 0.08, 0.05, 0.07, 0.04],
+                scale: [1, 1.15, 1.05, 1.1, 1],
+              }}
+              transition={{ duration: 12, repeat: Infinity, ease: 'easeInOut' }}
+              style={{
+                background:
+                  'radial-gradient(circle, rgba(139,92,246,0.3) 0%, rgba(79,70,229,0.1) 40%, transparent 70%)',
+                filter: 'blur(20px)',
+              }}
+            />
+            <motion.div
+              className="absolute inset-0 -m-10 rounded-full"
+              animate={{
+                opacity: [0.06, 0.12, 0.08, 0.1, 0.06],
+                scale: [1, 1.08, 1.02, 1.06, 1],
+              }}
+              transition={{
+                duration: 8,
+                repeat: Infinity,
+                ease: 'easeInOut',
+                delay: 0.5,
+              }}
+              style={{
+                background:
+                  'radial-gradient(circle, rgba(34,211,238,0.15) 0%, transparent 60%)',
+                filter: 'blur(12px)',
+              }}
+            />
+            <motion.div
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 1.5, ease: [0.16, 1, 0.3, 1], delay: 0.2 }}
+            >
+              <NeuralOrganism size={80} />
+            </motion.div>
           </div>
-          <h2 className="mb-1 text-lg font-bold">Neural Engine Ready</h2>
-          <p className="max-w-xs text-xs text-neutral-muted">
-            Initiate prompt sequence. The context from the escalated issue is pre-loaded into
-            working memory.
-          </p>
+
+          <motion.h2
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.6, duration: 0.8 }}
+            className="mb-2 text-base font-bold tracking-tight text-neutral-text"
+          >
+            Neural Engine Ready
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.8, duration: 0.8 }}
+            className="max-w-[280px] text-[11px] leading-relaxed text-neutral-muted"
+          >
+            Awaiting prompt sequence. Issue context is pre-loaded into working memory.
+          </motion.p>
         </motion.div>
       )}
       <Virtuoso
@@ -41,44 +92,35 @@ export function MessageStream({ messages, streaming, className }: Props) {
         initialTopMostItemIndex={messages.length - 1}
         itemContent={(i, msg) => (
           <div className="px-6 py-3">
-            <motion.div
-              initial={{ opacity: 0, y: 10, scale: 0.98 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
-            >
-              <div className={`max-w-[85%] ${msg.role === 'user' ? 'text-right' : 'text-left'}`}>
-                <div className="mb-1 flex items-center gap-2 text-[9px] font-bold uppercase tracking-widest text-neutral-muted">
-                  {msg.role === 'user' ? (
-                    <>
-                      <span>Operator</span>
-                      <div className="h-1.5 w-1.5 rounded-full bg-neutral-muted" />
-                    </>
-                  ) : (
-                    <>
-                      <div className="h-1.5 w-1.5 rounded-full bg-primary-500 shadow-[0_0_5px_var(--color-primary-500)]" />
-                      <span>Harness Agent</span>
-                    </>
-                  )}
-                </div>
-                <div
-                  className={[
-                    'rounded-2xl px-5 py-3 text-sm leading-relaxed',
-                    msg.role === 'user'
-                      ? 'bg-primary-500 text-white shadow-lg'
-                      : 'bg-neutral-surface/60 border border-neutral-border backdrop-blur-xl text-neutral-text',
-                  ].join(' ')}
-                >
-                  {msg.role === 'user' ? (
+            {msg.role === 'user' ? (
+              <motion.div
+                initial={{ opacity: 0, y: 10, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                className="flex justify-end"
+              >
+                <div className="max-w-[85%] text-right">
+                  <div className="mb-1.5 flex items-center justify-end gap-2 text-[9px] font-bold uppercase tracking-widest text-neutral-muted">
+                    <span>Operator</span>
+                    <div className="h-1.5 w-1.5 rounded-full bg-neutral-muted/60" />
+                  </div>
+                  <div className="rounded-2xl px-5 py-3 text-sm leading-relaxed bg-primary-500 text-white shadow-[0_4px_24px_-4px_rgba(79,70,229,0.4)]">
                     <pre className="whitespace-pre-wrap font-sans">{msg.content}</pre>
-                  ) : (
-                    <AssistantBlocks
-                      blocks={msg.blocks}
-                      isStreaming={streaming && i === messages.length - 1}
-                    />
-                  )}
+                  </div>
                 </div>
-              </div>
-            </motion.div>
+              </motion.div>
+            ) : (
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                <div className="px-1 py-1">
+                  <AssistantBlocks
+                    blocks={msg.blocks}
+                    isStreaming={streaming && i === messages.length - 1}
+                  />
+                </div>
+              </motion.div>
+            )}
           </div>
         )}
       />

--- a/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
+++ b/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
@@ -1,0 +1,279 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { motion } from 'framer-motion';
+
+/**
+ * Bioluminescent neural organism with deep chaos.
+ * Every render randomizes timing, positions, and paths.
+ * Spontaneous sparks fire unpredictably. Somas drift. Nothing repeats.
+ */
+
+/** Random jitter: returns base ± range */
+function jitter(base: number, range: number): number {
+  return base + (Math.random() - 0.5) * 2 * range;
+}
+
+/** Perturb a bezier Q control point for organic variation */
+function perturbPath(d: string, amount: number): string {
+  return d.replace(/Q\s+([\d.]+)\s+([\d.]+)/, (_, qx, qy) => {
+    const nx = parseFloat(qx) + (Math.random() - 0.5) * 2 * amount;
+    const ny = parseFloat(qy) + (Math.random() - 0.5) * 2 * amount;
+    return `Q ${nx.toFixed(1)} ${ny.toFixed(1)}`;
+  });
+}
+
+interface NeuralAxonProps {
+  d: string;
+  len: number;
+  delay: number;
+  duration: number;
+  color: string;
+  repeatDelay?: number;
+}
+
+function NeuralAxon({ d, len, delay, duration, color, repeatDelay = 1.5 }: NeuralAxonProps) {
+  return (
+    <>
+      <path d={d} stroke={color} strokeWidth="0.75" opacity="0.12" fill="none" strokeLinecap="round" />
+      <motion.path
+        d={d}
+        stroke={color}
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+        strokeDasharray={`5 ${len + 10}`}
+        animate={{ strokeDashoffset: [8, -(len + 8)] }}
+        transition={{ duration, delay, repeat: Infinity, ease: 'linear', repeatDelay }}
+        style={{ opacity: 0.85 }}
+      />
+    </>
+  );
+}
+
+function NeuralSoma({ cx, cy, r, delay, color }: { cx: number; cy: number; r: number; delay: number; color: string }) {
+  const drift = useMemo(() => ({
+    x: [0, jitter(0, 2.5), jitter(0, 2), jitter(0, 3), 0],
+    y: [0, jitter(0, 2), jitter(0, 3), jitter(0, 2.5), 0],
+    dur: jitter(8, 4),
+  }), []);
+
+  const breathDur = useMemo(() => jitter(2.2, 0.8), []);
+  const glowDur = useMemo(() => jitter(2.8, 1.2), []);
+
+  return (
+    <motion.g
+      animate={{ x: drift.x, y: drift.y }}
+      transition={{ duration: drift.dur, repeat: Infinity, ease: 'easeInOut' }}
+    >
+      <motion.circle
+        cx={cx} cy={cy} r={r + 4}
+        fill={color}
+        animate={{ opacity: [0, jitter(0.14, 0.06), 0], r: [r + 2, r + jitter(7, 2), r + 2] }}
+        transition={{ duration: glowDur, delay, repeat: Infinity, ease: 'easeInOut' }}
+      />
+      <motion.circle
+        cx={cx} cy={cy} r={r}
+        fill={color}
+        animate={{ opacity: [0.4, 1, 0.4], r: [r * 0.8, r * jitter(1.05, 0.15), r * 0.8] }}
+        transition={{ duration: breathDur, delay, repeat: Infinity, ease: 'easeInOut' }}
+      />
+    </motion.g>
+  );
+}
+
+function SpontaneousSpark({ d, len, color }: { d: string; len: number; color: string }) {
+  return (
+    <motion.path
+      d={d}
+      stroke={color}
+      strokeWidth="2"
+      fill="none"
+      strokeLinecap="round"
+      strokeDasharray={`3 ${len + 5}`}
+      initial={{ strokeDashoffset: 5, opacity: 0 }}
+      animate={{ strokeDashoffset: -(len + 5), opacity: [0, 1, 0.8, 0] }}
+      transition={{ duration: jitter(0.6, 0.2), ease: 'easeOut' }}
+    />
+  );
+}
+
+function NeuralMembrane({ color }: { color: string }) {
+  const center = 28;
+  const points = 16; // Even more points for high-fidelity liquid morphing
+
+  const generateSmoothPath = (baseRadius: number, variance: number) => {
+    const coords = [];
+    for (let i = 0; i < points; i++) {
+        const angle = (i / points) * Math.PI * 2;
+        // High variance for "lumpy" organic feel
+        const r = baseRadius + (Math.random() - 0.5) * variance;
+        coords.push({
+            x: center + Math.cos(angle) * r,
+            y: center + Math.sin(angle) * r
+        });
+    }
+
+    let d = `M ${coords[0]!.x.toFixed(1)} ${coords[0]!.y.toFixed(1)}`;
+    for (let i = 0; i < points; i++) {
+        const next = coords[(i + 1) % points]!;
+        const curr = coords[i]!;
+        const midX = (curr.x + next.x) / 2;
+        const midY = (curr.y + next.y) / 2;
+        d += ` Q ${curr.x.toFixed(1)} ${curr.y.toFixed(1)}, ${midX.toFixed(1)} ${midY.toFixed(1)}`;
+    }
+    d += ' Z';
+    return d;
+  };
+
+  // Atmospheric halo layer - extremely soft
+  const haloVariants = useMemo(() => {
+    return Array.from({ length: 5 }, () => generateSmoothPath(28, 10));
+  }, []);
+
+  // Outer membrane layer
+  const outerVariants = useMemo(() => {
+    return Array.from({ length: 6 }, () => generateSmoothPath(26, 8));
+  }, []);
+
+  // Inner cytoplasm layer
+  const innerVariants = useMemo(() => {
+    return Array.from({ length: 7 }, () => generateSmoothPath(20, 6));
+  }, []);
+
+  return (
+    <>
+      {/* 1. Atmospheric Halo - the fuzzy border expansion */}
+      <motion.path
+        d={haloVariants[0]}
+        animate={{ d: haloVariants }}
+        transition={{
+          duration: jitter(12, 3),
+          repeat: Infinity,
+          ease: "easeInOut",
+          repeatType: "reverse"
+        }}
+        fill={color.replace('1)', '0.02)')}
+        stroke={color}
+        strokeWidth="0.2"
+        strokeOpacity="0.05"
+        style={{ filter: 'blur(4px)' }}
+      />
+      {/* 2. Outer Membrane - defining the soft boundary */}
+      <motion.path
+        d={outerVariants[0]}
+        animate={{ d: outerVariants }}
+        transition={{
+          duration: jitter(8, 2),
+          repeat: Infinity,
+          ease: "easeInOut",
+          repeatType: "reverse"
+        }}
+        fill={color.replace('1)', '0.03)')}
+        stroke={color}
+        strokeWidth="0.4"
+        strokeOpacity="0.1"
+        style={{ filter: 'blur(2.5px)' }}
+      />
+      {/* 3. Inner Cytoplasm - internal density */}
+      <motion.path
+        d={innerVariants[0]}
+        animate={{ d: innerVariants }}
+        transition={{
+          duration: jitter(10, 4),
+          repeat: Infinity,
+          ease: "easeInOut",
+          repeatType: "reverse"
+        }}
+        fill={color.replace('1)', '0.05)')}
+        stroke={color}
+        strokeWidth="0.6"
+        strokeOpacity="0.15"
+        style={{ filter: 'blur(1.5px)' }}
+      />
+    </>
+  );
+}
+
+const AXON_TEMPLATES = [
+  { d: 'M 28 28 Q 20 18 28 6',   baselen: 25, color: 'rgba(167,139,250,1)' },
+  { d: 'M 28 28 Q 40 18 49 14',  baselen: 26, color: 'rgba(139,92,246,1)' },
+  { d: 'M 28 28 Q 42 30 52 30',  baselen: 26, color: 'rgba(109,40,217,1)' },
+  { d: 'M 28 28 Q 38 40 42 50',  baselen: 26, color: 'rgba(167,139,250,1)' },
+  { d: 'M 28 28 Q 16 40 12 50',  baselen: 26, color: 'rgba(139,92,246,1)' },
+  { d: 'M 28 28 Q 14 30 4 30',   baselen: 26, color: 'rgba(109,40,217,1)' },
+  { d: 'M 28 28 Q 16 18 7 14',   baselen: 26, color: 'rgba(167,139,250,1)' },
+  { d: 'M 28 6 Q 40 8 49 14',    baselen: 23, color: 'rgba(45,212,191,1)' },
+  { d: 'M 49 14 Q 54 22 52 30',  baselen: 20, color: 'rgba(45,212,191,1)' },
+  { d: 'M 7 14 Q 4 22 4 30',     baselen: 20, color: 'rgba(34,211,238,1)' },
+  { d: 'M 12 50 Q 6 40 4 30',    baselen: 24, color: 'rgba(34,211,238,1)' },
+];
+
+const SPARK_COLORS = [
+  'rgba(251,191,36,0.9)',
+  'rgba(52,211,153,0.9)',
+  'rgba(248,113,113,0.8)',
+  'rgba(96,165,250,0.9)',
+  'rgba(167,139,250,1)',
+  'rgba(45,212,191,1)',
+];
+
+export function NeuralOrganism({ size = 56 }: { size?: number }) {
+  const axons: NeuralAxonProps[] = useMemo(() =>
+    AXON_TEMPLATES.map((t) => ({
+      d: perturbPath(t.d, 4),
+      len: t.baselen,
+      delay: Math.random() * 3,
+      duration: jitter(1.2, 0.5),
+      color: t.color,
+      repeatDelay: jitter(2.0, 1.2),
+    })),
+  []);
+
+  const somaPositions = useMemo(() => [
+    { cx: 28, cy: 28, r: jitter(3.5, 0.5), color: 'rgba(167,139,250,1)' },
+    { cx: jitter(28, 2), cy: jitter(6, 2),  r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
+    { cx: jitter(49, 2), cy: jitter(14, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
+    { cx: jitter(52, 2), cy: jitter(30, 2), r: jitter(2, 0.4), color: 'rgba(109,40,217,0.9)' },
+    { cx: jitter(42, 2), cy: jitter(50, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
+    { cx: jitter(12, 2), cy: jitter(50, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
+    { cx: jitter(4, 2),  cy: jitter(30, 2), r: jitter(2, 0.4), color: 'rgba(109,40,217,0.9)' },
+    { cx: jitter(7, 2),  cy: jitter(14, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
+  ], []);
+
+  const [sparks, setSparks] = useState<Array<{ id: number; d: string; len: number; color: string }>>([]);
+  const sparkIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fire = () => {
+      if (cancelled) return;
+      const template = AXON_TEMPLATES[Math.floor(Math.random() * AXON_TEMPLATES.length)]!;
+      const sparkId = ++sparkIdRef.current;
+      setSparks(prev => [...prev, {
+        id: sparkId,
+        d: perturbPath(template.d, 6),
+        len: template.baselen,
+        color: SPARK_COLORS[Math.floor(Math.random() * SPARK_COLORS.length)]!,
+      }]);
+      setTimeout(() => {
+        setSparks(prev => prev.filter(s => s.id !== sparkId));
+      }, 1200);
+      const nextDelay = 800 + Math.random() * 3200;
+      setTimeout(fire, nextDelay);
+    };
+    const initialDelay = setTimeout(fire, 500 + Math.random() * 2000);
+    return () => { cancelled = true; clearTimeout(initialDelay); };
+  }, []);
+
+  return (
+    <svg width={size} height={size} viewBox="0 0 56 56" fill="none" className="flex-shrink-0 overflow-visible">
+      {/* Cell Membrane Shell */}
+      <NeuralMembrane color="rgba(167,139,250,1)" />
+      {/* Base axons */}
+      {axons.map((a, i) => <NeuralAxon key={i} {...a} />)}
+      {sparks.map(s => <SpontaneousSpark key={s.id} d={s.d} len={s.len} color={s.color} />)}
+      {somaPositions.map((s, i) => (
+        <NeuralSoma key={i} cx={s.cx} cy={s.cy} r={s.r} delay={Math.random() * 2} color={s.color} />
+      ))}
+    </svg>
+  );
+}

--- a/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
+++ b/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
@@ -1,18 +1,23 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 
 /**
- * Bioluminescent neural organism with deep chaos.
- * Every render randomizes timing, positions, and paths.
- * Spontaneous sparks fire unpredictably. Somas drift. Nothing repeats.
+ * Bioluminescent neural organism — the system's living avatar.
+ *
+ * Disney's 12 Principles applied throughout. See individual components.
+ *
+ * Fidelity tiers:
+ *   ≤ 40px  →  compact: core soma + membrane only
+ *   ≤ 72px  →  standard: + axons, sparks, plankton (6)
+ *   > 72px  →  full: + halo, heartbeat, all somas, plankton (14)
  */
 
-/** Random jitter: returns base ± range */
+/* ── Utilities ─────────────────────────────────────────────── */
+
 function jitter(base: number, range: number): number {
   return base + (Math.random() - 0.5) * 2 * range;
 }
 
-/** Perturb a bezier Q control point for organic variation */
 function perturbPath(d: string, amount: number): string {
   return d.replace(/Q\s+([\d.]+)\s+([\d.]+)/, (_, qx, qy) => {
     const nx = parseFloat(qx) + (Math.random() - 0.5) * 2 * amount;
@@ -21,43 +26,209 @@ function perturbPath(d: string, amount: number): string {
   });
 }
 
+function generateSmoothPath(
+  center: number,
+  points: number,
+  baseRadius: number,
+  variance: number
+): string {
+  const coords = [];
+  for (let i = 0; i < points; i++) {
+    const angle = (i / points) * Math.PI * 2;
+    const r = baseRadius + (Math.random() - 0.5) * variance;
+    coords.push({
+      x: center + Math.cos(angle) * r,
+      y: center + Math.sin(angle) * r,
+    });
+  }
+  let d = `M ${coords[0]!.x.toFixed(1)} ${coords[0]!.y.toFixed(1)}`;
+  for (let i = 0; i < points; i++) {
+    const next = coords[(i + 1) % points]!;
+    const curr = coords[i]!;
+    const midX = (curr.x + next.x) / 2;
+    const midY = (curr.y + next.y) / 2;
+    d += ` Q ${curr.x.toFixed(1)} ${curr.y.toFixed(1)}, ${midX.toFixed(1)} ${midY.toFixed(1)}`;
+  }
+  d += ' Z';
+  return d;
+}
+
+/* ── Easing ────────────────────────────────────────────────── */
+
+const BREATH_EASE: [number, number, number, number] = [0.4, 0, 0.2, 1];
+const SPARK_EASE: [number, number, number, number] = [0.16, 1, 0.3, 1];
+const AXON_EASE: [number, number, number, number] = [0.7, 0, 0.3, 1];
+
+/* ── Sub-components ────────────────────────────────────────── */
+
 interface NeuralAxonProps {
   d: string;
   len: number;
   delay: number;
   duration: number;
   color: string;
-  repeatDelay?: number;
+  repeatDelay: number;
+  weight: number;
+  /** Increments each time a spark hits this axon, triggering a wobble */
+  hitCount: number;
 }
 
-function NeuralAxon({ d, len, delay, duration, color, repeatDelay = 1.5 }: NeuralAxonProps) {
+function NeuralAxon({ d, len, delay, duration, color, repeatDelay, weight, hitCount }: NeuralAxonProps) {
+  const traceOpacity = 0.04 + weight * 0.08;
+  const traceWidth = 0.4 + weight * 0.4;
+  const pulseWidth = 0.8 + weight * 0.6;
+
   return (
     <>
-      <path d={d} stroke={color} strokeWidth="0.75" opacity="0.12" fill="none" strokeLinecap="round" />
+      <path
+        d={d}
+        stroke={color}
+        strokeWidth={traceWidth}
+        opacity={traceOpacity}
+        fill="none"
+        strokeLinecap="round"
+      />
+      {/* Spark-induced whip wobble — energy wave propagates down the axon.
+          Two overlapping waves at different phases create the ripple effect.
+          Remounts on each hit via key, plays once then fades. */}
+      {hitCount > 0 && (
+        <>
+          {/* Primary wave — fast, bright, short dash */}
+          <motion.path
+            key={`whip-a-${hitCount}`}
+            d={d}
+            stroke="rgba(255,255,255,1)"
+            strokeWidth={traceWidth + 1.5}
+            fill="none"
+            strokeLinecap="round"
+            strokeDasharray={`2 4`}
+            initial={{ strokeDashoffset: 0, opacity: 0.5 }}
+            animate={{
+              strokeDashoffset: [0, -(len + 10)],
+              opacity: [0.5, 0.35, 0.15, 0],
+            }}
+            transition={{ duration: 0.35, ease: SPARK_EASE }}
+            style={{ filter: 'blur(0.5px)' }}
+          />
+          {/* Secondary wave — slower, wider, softer. Follow-through. */}
+          <motion.path
+            key={`whip-b-${hitCount}`}
+            d={d}
+            stroke={color}
+            strokeWidth={traceWidth + 2.5}
+            fill="none"
+            strokeLinecap="round"
+            strokeDasharray={`3 5`}
+            initial={{ strokeDashoffset: 2, opacity: 0.3 }}
+            animate={{
+              strokeDashoffset: [2, -(len + 8)],
+              opacity: [0.3, 0.2, 0.08, 0],
+            }}
+            transition={{ duration: 0.5, ease: 'easeOut', delay: 0.06 }}
+            style={{ filter: 'blur(1.5px)' }}
+          />
+        </>
+      )}
       <motion.path
         d={d}
         stroke={color}
-        strokeWidth="1.5"
+        strokeWidth={pulseWidth + 2}
         fill="none"
         strokeLinecap="round"
-        strokeDasharray={`5 ${len + 10}`}
+        strokeDasharray={`6 ${len + 6}`}
         animate={{ strokeDashoffset: [8, -(len + 8)] }}
-        transition={{ duration, delay, repeat: Infinity, ease: 'linear', repeatDelay }}
-        style={{ opacity: 0.85 }}
+        transition={{ duration, delay, repeat: Infinity, ease: AXON_EASE, repeatDelay }}
+        style={{ opacity: 0.15, filter: 'blur(1.5px)' }}
+      />
+      <motion.path
+        d={d}
+        stroke={color}
+        strokeWidth={pulseWidth}
+        fill="none"
+        strokeLinecap="round"
+        strokeDasharray={`3.5 ${len + 8}`}
+        animate={{ strokeDashoffset: [8, -(len + 8)] }}
+        transition={{ duration, delay, repeat: Infinity, ease: AXON_EASE, repeatDelay }}
+        style={{ opacity: 0.75 }}
       />
     </>
   );
 }
 
-function NeuralSoma({ cx, cy, r, delay, color }: { cx: number; cy: number; r: number; delay: number; color: string }) {
-  const drift = useMemo(() => ({
-    x: [0, jitter(0, 2.5), jitter(0, 2), jitter(0, 3), 0],
-    y: [0, jitter(0, 2), jitter(0, 3), jitter(0, 2.5), 0],
-    dur: jitter(8, 4),
-  }), []);
+function CoreSoma({ cx, cy, r }: { cx: number; cy: number; r: number }) {
+  const breathDur = useMemo(() => jitter(4, 0.8), []);
+  const glowDur = useMemo(() => jitter(4.5, 1), []);
+  const drift = useMemo(
+    () => ({
+      x: [0, jitter(0, 1.2), jitter(0, 0.8), jitter(0, 1), 0],
+      y: [0, jitter(0, 0.8), jitter(0, 1.2), jitter(0, 1), 0],
+    }),
+    []
+  );
 
-  const breathDur = useMemo(() => jitter(2.2, 0.8), []);
-  const glowDur = useMemo(() => jitter(2.8, 1.2), []);
+  return (
+    <motion.g
+      animate={{ x: drift.x, y: drift.y }}
+      transition={{ duration: 12, repeat: Infinity, ease: 'easeInOut' }}
+    >
+      <motion.circle
+        cx={cx}
+        cy={cy}
+        r={r + 4}
+        fill="rgba(196,167,255,1)"
+        animate={{
+          opacity: [0, 0.18, 0.06, 0.14, 0],
+          r: [r + 2, r + 9, r + 4, r + 7, r + 2],
+        }}
+        transition={{ duration: glowDur, repeat: Infinity, ease: BREATH_EASE }}
+      />
+      <motion.circle
+        cx={cx}
+        cy={cy}
+        r={r}
+        fill="rgba(196,167,255,1)"
+        animate={{
+          opacity: [0.3, 1, 0.45, 0.85, 0.3],
+          scaleX: [1, 0.92, 1.06, 0.96, 1],
+          scaleY: [1, 1.1, 0.94, 1.05, 1],
+        }}
+        transition={{ duration: breathDur, repeat: Infinity, ease: BREATH_EASE }}
+        style={{ transformOrigin: `${cx}px ${cy}px` }}
+      />
+      <motion.circle
+        cx={cx}
+        cy={cy}
+        r={r * 0.4}
+        fill="rgba(255,255,255,1)"
+        animate={{ opacity: [0.15, 0.5, 0.2, 0.4, 0.15] }}
+        transition={{ duration: breathDur, repeat: Infinity, ease: BREATH_EASE }}
+      />
+    </motion.g>
+  );
+}
+
+function RingSoma({
+  cx,
+  cy,
+  r,
+  delay,
+  color,
+}: {
+  cx: number;
+  cy: number;
+  r: number;
+  delay: number;
+  color: string;
+}) {
+  const drift = useMemo(
+    () => ({
+      x: [0, jitter(0, 2), jitter(0, 1.5), jitter(0, 2.5), 0],
+      y: [0, jitter(0, 1.5), jitter(0, 2.5), jitter(0, 2), 0],
+      dur: jitter(8, 3),
+    }),
+    []
+  );
+  const breathDur = useMemo(() => jitter(2, 0.5), []);
 
   return (
     <motion.g
@@ -65,215 +236,481 @@ function NeuralSoma({ cx, cy, r, delay, color }: { cx: number; cy: number; r: nu
       transition={{ duration: drift.dur, repeat: Infinity, ease: 'easeInOut' }}
     >
       <motion.circle
-        cx={cx} cy={cy} r={r + 4}
+        cx={cx}
+        cy={cy}
+        r={r + 2.5}
         fill={color}
-        animate={{ opacity: [0, jitter(0.14, 0.06), 0], r: [r + 2, r + jitter(7, 2), r + 2] }}
-        transition={{ duration: glowDur, delay, repeat: Infinity, ease: 'easeInOut' }}
+        animate={{
+          opacity: [0, jitter(0.1, 0.04), 0],
+          r: [r + 1.5, r + jitter(5, 1), r + 1.5],
+        }}
+        transition={{ duration: breathDur * 1.3, delay, repeat: Infinity, ease: BREATH_EASE }}
       />
       <motion.circle
-        cx={cx} cy={cy} r={r}
+        cx={cx}
+        cy={cy}
+        r={r}
         fill={color}
-        animate={{ opacity: [0.4, 1, 0.4], r: [r * 0.8, r * jitter(1.05, 0.15), r * 0.8] }}
-        transition={{ duration: breathDur, delay, repeat: Infinity, ease: 'easeInOut' }}
+        animate={{
+          opacity: [0.35, 0.9, 0.35],
+          r: [r * 0.85, r * jitter(1.08, 0.1), r * 0.85],
+        }}
+        transition={{ duration: breathDur, delay, repeat: Infinity, ease: BREATH_EASE }}
       />
     </motion.g>
   );
 }
 
-function SpontaneousSpark({ d, len, color }: { d: string; len: number; color: string }) {
-  return (
-    <motion.path
-      d={d}
-      stroke={color}
-      strokeWidth="2"
-      fill="none"
-      strokeLinecap="round"
-      strokeDasharray={`3 ${len + 5}`}
-      initial={{ strokeDashoffset: 5, opacity: 0 }}
-      animate={{ strokeDashoffset: -(len + 5), opacity: [0, 1, 0.8, 0] }}
-      transition={{ duration: jitter(0.6, 0.2), ease: 'easeOut' }}
-    />
-  );
-}
-
-function NeuralMembrane({ color }: { color: string }) {
-  const center = 28;
-  const points = 16; // Even more points for high-fidelity liquid morphing
-
-  const generateSmoothPath = (baseRadius: number, variance: number) => {
-    const coords = [];
-    for (let i = 0; i < points; i++) {
-        const angle = (i / points) * Math.PI * 2;
-        // High variance for "lumpy" organic feel
-        const r = baseRadius + (Math.random() - 0.5) * variance;
-        coords.push({
-            x: center + Math.cos(angle) * r,
-            y: center + Math.sin(angle) * r
-        });
-    }
-
-    let d = `M ${coords[0]!.x.toFixed(1)} ${coords[0]!.y.toFixed(1)}`;
-    for (let i = 0; i < points; i++) {
-        const next = coords[(i + 1) % points]!;
-        const curr = coords[i]!;
-        const midX = (curr.x + next.x) / 2;
-        const midY = (curr.y + next.y) / 2;
-        d += ` Q ${curr.x.toFixed(1)} ${curr.y.toFixed(1)}, ${midX.toFixed(1)} ${midY.toFixed(1)}`;
-    }
-    d += ' Z';
-    return d;
-  };
-
-  // Atmospheric halo layer - extremely soft
-  const haloVariants = useMemo(() => {
-    return Array.from({ length: 5 }, () => generateSmoothPath(28, 10));
-  }, []);
-
-  // Outer membrane layer
-  const outerVariants = useMemo(() => {
-    return Array.from({ length: 6 }, () => generateSmoothPath(26, 8));
-  }, []);
-
-  // Inner cytoplasm layer
-  const innerVariants = useMemo(() => {
-    return Array.from({ length: 7 }, () => generateSmoothPath(20, 6));
-  }, []);
-
+function SpontaneousSpark({
+  d,
+  len,
+  color,
+  speed,
+  intensity,
+}: {
+  d: string;
+  len: number;
+  color: string;
+  speed: number;
+  intensity: number;
+}) {
+  const width = 1 + intensity * 1.5;
   return (
     <>
-      {/* 1. Atmospheric Halo - the fuzzy border expansion */}
       <motion.path
-        d={haloVariants[0]}
-        animate={{ d: haloVariants }}
-        transition={{
-          duration: jitter(12, 3),
-          repeat: Infinity,
-          ease: "easeInOut",
-          repeatType: "reverse"
-        }}
-        fill={color.replace('1)', '0.02)')}
+        d={d}
         stroke={color}
-        strokeWidth="0.2"
-        strokeOpacity="0.05"
-        style={{ filter: 'blur(4px)' }}
+        strokeWidth={width + 2.5}
+        fill="none"
+        strokeLinecap="round"
+        strokeDasharray={`5 ${len + 4}`}
+        initial={{ strokeDashoffset: 6, opacity: 0 }}
+        animate={{ strokeDashoffset: -(len + 4), opacity: [0, intensity * 0.35, 0] }}
+        transition={{ duration: speed * 1.3, ease: 'easeOut' }}
+        style={{ filter: 'blur(2px)' }}
       />
-      {/* 2. Outer Membrane - defining the soft boundary */}
       <motion.path
-        d={outerVariants[0]}
-        animate={{ d: outerVariants }}
-        transition={{
-          duration: jitter(8, 2),
-          repeat: Infinity,
-          ease: "easeInOut",
-          repeatType: "reverse"
-        }}
-        fill={color.replace('1)', '0.03)')}
+        d={d}
         stroke={color}
-        strokeWidth="0.4"
-        strokeOpacity="0.1"
-        style={{ filter: 'blur(2.5px)' }}
-      />
-      {/* 3. Inner Cytoplasm - internal density */}
-      <motion.path
-        d={innerVariants[0]}
-        animate={{ d: innerVariants }}
-        transition={{
-          duration: jitter(10, 4),
-          repeat: Infinity,
-          ease: "easeInOut",
-          repeatType: "reverse"
-        }}
-        fill={color.replace('1)', '0.05)')}
-        stroke={color}
-        strokeWidth="0.6"
-        strokeOpacity="0.15"
-        style={{ filter: 'blur(1.5px)' }}
+        strokeWidth={width}
+        fill="none"
+        strokeLinecap="round"
+        strokeDasharray={`3 ${len + 5}`}
+        initial={{ strokeDashoffset: 5, opacity: 0 }}
+        animate={{ strokeDashoffset: -(len + 5), opacity: [0, intensity, intensity * 0.7, 0] }}
+        transition={{ duration: speed, ease: SPARK_EASE }}
       />
     </>
   );
 }
 
+function HeartbeatPulse() {
+  const dur = useMemo(() => jitter(7, 1.5), []);
+  return (
+    <>
+      <motion.circle
+        cx="28"
+        cy="28"
+        r="3"
+        fill="none"
+        stroke="rgba(196,167,255,1)"
+        strokeWidth="0.8"
+        animate={{ r: [3, 28], opacity: [0.35, 0], strokeWidth: [0.8, 0.15] }}
+        transition={{ duration: 2.5, repeat: Infinity, repeatDelay: dur, ease: SPARK_EASE }}
+      />
+      <motion.circle
+        cx="28"
+        cy="28"
+        r="3"
+        fill="none"
+        stroke="rgba(34,211,238,1)"
+        strokeWidth="0.5"
+        animate={{ r: [3, 24], opacity: [0.2, 0], strokeWidth: [0.5, 0.08] }}
+        transition={{
+          duration: 2,
+          repeat: Infinity,
+          repeatDelay: dur + 0.5,
+          delay: 0.4,
+          ease: SPARK_EASE,
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * Plankton — tiny bioluminescent particles drifting through the space.
+ * Each mote has its own drift path, blink rhythm, and size.
+ * They drift lazily, flickering in and out like marine snow.
+ */
+function Plankton({ count }: { count: number }) {
+  const motes = useMemo(
+    () =>
+      Array.from({ length: count }, () => {
+        // Scatter in the full viewbox, weighted toward the periphery
+        const angle = Math.random() * Math.PI * 2;
+        const dist = 12 + Math.random() * 18;
+        const cx = 28 + Math.cos(angle) * dist;
+        const cy = 28 + Math.sin(angle) * dist;
+        const r = 0.25 + Math.random() * 0.55;
+
+        // Lazy drift — wanders a small area
+        const driftX = [0, jitter(0, 4), jitter(0, 3), jitter(0, 5), 0];
+        const driftY = [0, jitter(0, 5), jitter(0, 3), jitter(0, 4), 0];
+        const driftDur = jitter(18, 8);
+
+        // Blink — some fast flickers, some slow pulses
+        const blinkDur = jitter(3, 1.5);
+        const blinkPeak = jitter(0.5, 0.25);
+        const blinkDelay = Math.random() * 6;
+
+        // Color — mostly violet/cyan family, dim
+        const colors = [
+          'rgba(167,139,250,1)',
+          'rgba(139,92,246,1)',
+          'rgba(34,211,238,1)',
+          'rgba(45,212,191,1)',
+          'rgba(196,167,255,1)',
+        ];
+        const color = colors[Math.floor(Math.random() * colors.length)]!;
+
+        return { cx, cy, r, driftX, driftY, driftDur, blinkDur, blinkPeak, blinkDelay, color };
+      }),
+    [count]
+  );
+
+  return (
+    <>
+      {motes.map((m, i) => (
+        <motion.circle
+          key={`plankton-${i}`}
+          cx={m.cx}
+          cy={m.cy}
+          r={m.r}
+          fill={m.color}
+          animate={{
+            x: m.driftX,
+            y: m.driftY,
+            opacity: [0, m.blinkPeak, 0.05, m.blinkPeak * 0.6, 0],
+          }}
+          transition={{
+            x: { duration: m.driftDur, repeat: Infinity, ease: 'easeInOut' },
+            y: { duration: m.driftDur * 1.1, repeat: Infinity, ease: 'easeInOut' },
+            opacity: {
+              duration: m.blinkDur,
+              delay: m.blinkDelay,
+              repeat: Infinity,
+              ease: 'easeInOut',
+            },
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+function NeuralMembrane({
+  color,
+  tier,
+}: {
+  color: string;
+  tier: 'compact' | 'standard' | 'full';
+}) {
+  const center = 28;
+  const pts = 14;
+
+  const innerVariants = useMemo(
+    () => Array.from({ length: 8 }, () => generateSmoothPath(center, pts, 18, 5)),
+    []
+  );
+  const outerVariants = useMemo(
+    () => Array.from({ length: 8 }, () => generateSmoothPath(center, pts, 24, 7)),
+    []
+  );
+  const haloVariants = useMemo(
+    () => Array.from({ length: 8 }, () => generateSmoothPath(center, pts, 27, 9)),
+    []
+  );
+
+  const innerDur = useMemo(() => jitter(12, 2), []);
+  const outerDur = useMemo(() => jitter(15, 2), []);
+  const haloDur = useMemo(() => jitter(18, 3), []);
+
+  return (
+    <>
+      {tier === 'full' && (
+        <motion.path
+          d={haloVariants[0]}
+          animate={{ d: haloVariants }}
+          transition={{
+            duration: haloDur,
+            repeat: Infinity,
+            ease: 'easeInOut',
+            repeatType: 'reverse',
+          }}
+          fill={color.replace('1)', '0.012)')}
+          stroke={color}
+          strokeWidth="0.15"
+          strokeOpacity="0.04"
+          style={{ filter: 'blur(3px)' }}
+        />
+      )}
+
+      {tier !== 'compact' && (
+        <motion.path
+          d={outerVariants[0]}
+          animate={{ d: outerVariants }}
+          transition={{
+            duration: outerDur,
+            repeat: Infinity,
+            ease: 'easeInOut',
+            repeatType: 'reverse',
+          }}
+          fill={color.replace('1)', '0.02)')}
+          stroke={color}
+          strokeWidth="0.3"
+          strokeOpacity="0.07"
+          style={{ filter: 'blur(2px)' }}
+        />
+      )}
+
+      <motion.path
+        d={innerVariants[0]}
+        animate={{ d: innerVariants }}
+        transition={{
+          duration: innerDur,
+          repeat: Infinity,
+          ease: 'easeInOut',
+          repeatType: 'reverse',
+        }}
+        fill={color.replace('1)', '0.035)')}
+        stroke={color}
+        strokeWidth={tier === 'compact' ? '0.4' : '0.5'}
+        strokeOpacity={tier === 'compact' ? '0.12' : '0.14'}
+        style={{ filter: tier === 'compact' ? 'blur(1px)' : 'blur(1.5px)' }}
+      />
+    </>
+  );
+}
+
+/* ── Constants ─────────────────────────────────────────────── */
+
 const AXON_TEMPLATES = [
-  { d: 'M 28 28 Q 20 18 28 6',   baselen: 25, color: 'rgba(167,139,250,1)' },
-  { d: 'M 28 28 Q 40 18 49 14',  baselen: 26, color: 'rgba(139,92,246,1)' },
-  { d: 'M 28 28 Q 42 30 52 30',  baselen: 26, color: 'rgba(109,40,217,1)' },
-  { d: 'M 28 28 Q 38 40 42 50',  baselen: 26, color: 'rgba(167,139,250,1)' },
-  { d: 'M 28 28 Q 16 40 12 50',  baselen: 26, color: 'rgba(139,92,246,1)' },
-  { d: 'M 28 28 Q 14 30 4 30',   baselen: 26, color: 'rgba(109,40,217,1)' },
-  { d: 'M 28 28 Q 16 18 7 14',   baselen: 26, color: 'rgba(167,139,250,1)' },
-  { d: 'M 28 6 Q 40 8 49 14',    baselen: 23, color: 'rgba(45,212,191,1)' },
-  { d: 'M 49 14 Q 54 22 52 30',  baselen: 20, color: 'rgba(45,212,191,1)' },
-  { d: 'M 7 14 Q 4 22 4 30',     baselen: 20, color: 'rgba(34,211,238,1)' },
-  { d: 'M 12 50 Q 6 40 4 30',    baselen: 24, color: 'rgba(34,211,238,1)' },
+  { d: 'M 28 28 Q 20 18 28 6', baselen: 25, color: 'rgba(167,139,250,1)', weight: 0.9 },
+  { d: 'M 28 28 Q 40 18 49 14', baselen: 26, color: 'rgba(139,92,246,1)', weight: 0.8 },
+  { d: 'M 28 28 Q 42 30 52 30', baselen: 26, color: 'rgba(109,40,217,1)', weight: 0.7 },
+  { d: 'M 28 28 Q 38 40 42 50', baselen: 26, color: 'rgba(167,139,250,1)', weight: 0.8 },
+  { d: 'M 28 28 Q 16 40 12 50', baselen: 26, color: 'rgba(139,92,246,1)', weight: 0.7 },
+  { d: 'M 28 28 Q 14 30 4 30', baselen: 26, color: 'rgba(109,40,217,1)', weight: 0.8 },
+  { d: 'M 28 28 Q 16 18 7 14', baselen: 26, color: 'rgba(167,139,250,1)', weight: 0.9 },
+  { d: 'M 28 6 Q 40 8 49 14', baselen: 23, color: 'rgba(45,212,191,1)', weight: 0.4 },
+  { d: 'M 49 14 Q 54 22 52 30', baselen: 20, color: 'rgba(45,212,191,1)', weight: 0.3 },
+  { d: 'M 7 14 Q 4 22 4 30', baselen: 20, color: 'rgba(34,211,238,1)', weight: 0.35 },
+  { d: 'M 12 50 Q 6 40 4 30', baselen: 24, color: 'rgba(34,211,238,1)', weight: 0.4 },
 ];
 
 const SPARK_COLORS = [
-  'rgba(251,191,36,0.9)',
+  'rgba(251,191,36,0.95)',
   'rgba(52,211,153,0.9)',
-  'rgba(248,113,113,0.8)',
+  'rgba(248,113,113,0.85)',
   'rgba(96,165,250,0.9)',
   'rgba(167,139,250,1)',
   'rgba(45,212,191,1)',
 ];
 
+/* ── Main component ────────────────────────────────────────── */
+
 export function NeuralOrganism({ size = 56 }: { size?: number }) {
-  const axons: NeuralAxonProps[] = useMemo(() =>
-    AXON_TEMPLATES.map((t) => ({
-      d: perturbPath(t.d, 4),
-      len: t.baselen,
-      delay: Math.random() * 3,
-      duration: jitter(1.2, 0.5),
-      color: t.color,
-      repeatDelay: jitter(2.0, 1.2),
-    })),
-  []);
+  const tier = size <= 40 ? 'compact' : size <= 72 ? 'standard' : 'full';
 
-  const somaPositions = useMemo(() => [
-    { cx: 28, cy: 28, r: jitter(3.5, 0.5), color: 'rgba(167,139,250,1)' },
-    { cx: jitter(28, 2), cy: jitter(6, 2),  r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
-    { cx: jitter(49, 2), cy: jitter(14, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
-    { cx: jitter(52, 2), cy: jitter(30, 2), r: jitter(2, 0.4), color: 'rgba(109,40,217,0.9)' },
-    { cx: jitter(42, 2), cy: jitter(50, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
-    { cx: jitter(12, 2), cy: jitter(50, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
-    { cx: jitter(4, 2),  cy: jitter(30, 2), r: jitter(2, 0.4), color: 'rgba(109,40,217,0.9)' },
-    { cx: jitter(7, 2),  cy: jitter(14, 2), r: jitter(2, 0.4), color: 'rgba(139,92,246,0.9)' },
-  ], []);
+  /**
+   * Wandering rotation — the organism slowly drifts rotationally,
+   * reversing direction unpredictably. Multi-keyframe path through
+   * random angles prevents mechanical spinning.
+   */
+  const rotation = useMemo(
+    () => ({
+      angles: [
+        0,
+        jitter(12, 8),
+        jitter(-6, 5),
+        jitter(18, 10),
+        jitter(-10, 8),
+        jitter(8, 6),
+        0,
+      ],
+      dur: jitter(40, 12),
+    }),
+    []
+  );
 
-  const [sparks, setSparks] = useState<Array<{ id: number; d: string; len: number; color: string }>>([]);
+  const axons = useMemo(
+    () =>
+      tier === 'compact'
+        ? []
+        : AXON_TEMPLATES.map((t) => ({
+            d: perturbPath(t.d, 4),
+            len: t.baselen,
+            delay: Math.random() * 4,
+            duration: jitter(1.4, 0.6),
+            color: t.color,
+            repeatDelay: jitter(2.5, 1.5),
+            weight: t.weight,
+          })),
+    [tier]
+  );
+
+  const ringSomas = useMemo(() => {
+    if (tier === 'compact') return [];
+    return [
+      { cx: jitter(28, 1.5), cy: jitter(6, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
+      { cx: jitter(49, 1.5), cy: jitter(14, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
+      { cx: jitter(52, 1.5), cy: jitter(30, 1.5), r: jitter(1.6, 0.3), color: 'rgba(109,40,217,0.9)' },
+      { cx: jitter(42, 1.5), cy: jitter(50, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
+      { cx: jitter(12, 1.5), cy: jitter(50, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
+      { cx: jitter(4, 1.5), cy: jitter(30, 1.5), r: jitter(1.6, 0.3), color: 'rgba(109,40,217,0.9)' },
+      { cx: jitter(7, 1.5), cy: jitter(14, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
+    ];
+  }, [tier]);
+
+  const planktonCount = tier === 'full' ? 14 : tier === 'standard' ? 6 : 0;
+
+  // Sparks with anticipation + axon hit tracking
+  const [sparks, setSparks] = useState<
+    Array<{ id: number; d: string; len: number; color: string; speed: number; intensity: number }>
+  >([]);
+  const [anticipate, setAnticipate] = useState(false);
+  // Counts how many times each axon template has been hit by a spark.
+  // Incrementing triggers the wobble animation via key remount.
+  const [axonHits, setAxonHits] = useState<number[]>(() => AXON_TEMPLATES.map(() => 0));
   const sparkIdRef = useRef(0);
+  const cancelledRef = useRef(false);
 
   useEffect(() => {
-    let cancelled = false;
+    if (tier === 'compact') return;
+    cancelledRef.current = false;
+
     const fire = () => {
-      if (cancelled) return;
-      const template = AXON_TEMPLATES[Math.floor(Math.random() * AXON_TEMPLATES.length)]!;
-      const sparkId = ++sparkIdRef.current;
-      setSparks(prev => [...prev, {
-        id: sparkId,
-        d: perturbPath(template.d, 6),
-        len: template.baselen,
-        color: SPARK_COLORS[Math.floor(Math.random() * SPARK_COLORS.length)]!,
-      }]);
+      if (cancelledRef.current) return;
+
+      setAnticipate(true);
       setTimeout(() => {
-        setSparks(prev => prev.filter(s => s.id !== sparkId));
-      }, 1200);
-      const nextDelay = 800 + Math.random() * 3200;
+        if (cancelledRef.current) return;
+        setAnticipate(false);
+
+        const templateIdx = Math.floor(Math.random() * AXON_TEMPLATES.length);
+        const template = AXON_TEMPLATES[templateIdx]!;
+        const sparkId = ++sparkIdRef.current;
+        const speed = jitter(0.5, 0.2);
+        const intensity = jitter(0.8, 0.2);
+
+        // Register hit on this axon — triggers wobble
+        setAxonHits((prev) => {
+          const next = [...prev];
+          next[templateIdx] = (next[templateIdx] ?? 0) + 1;
+          return next;
+        });
+
+        setSparks((prev) => [
+          ...prev,
+          {
+            id: sparkId,
+            d: perturbPath(template.d, 6),
+            len: template.baselen,
+            color: SPARK_COLORS[Math.floor(Math.random() * SPARK_COLORS.length)]!,
+            speed,
+            intensity,
+          },
+        ]);
+        setTimeout(() => {
+          setSparks((prev) => prev.filter((s) => s.id !== sparkId));
+        }, speed * 1.3 * 1000 + 400);
+      }, 180);
+
+      const nextDelay =
+        tier === 'full' ? 600 + Math.random() * 2000 : 1000 + Math.random() * 3500;
       setTimeout(fire, nextDelay);
     };
-    const initialDelay = setTimeout(fire, 500 + Math.random() * 2000);
-    return () => { cancelled = true; clearTimeout(initialDelay); };
-  }, []);
+
+    const initialDelay = setTimeout(fire, 400 + Math.random() * 1500);
+    return () => {
+      cancelledRef.current = true;
+      clearTimeout(initialDelay);
+    };
+  }, [tier]);
+
+  const coreR = useMemo(() => jitter(3.8, 0.3), []);
 
   return (
-    <svg width={size} height={size} viewBox="0 0 56 56" fill="none" className="flex-shrink-0 overflow-visible">
-      {/* Cell Membrane Shell */}
-      <NeuralMembrane color="rgba(167,139,250,1)" />
-      {/* Base axons */}
-      {axons.map((a, i) => <NeuralAxon key={i} {...a} />)}
-      {sparks.map(s => <SpontaneousSpark key={s.id} d={s.d} len={s.len} color={s.color} />)}
-      {somaPositions.map((s, i) => (
-        <NeuralSoma key={i} cx={s.cx} cy={s.cy} r={s.r} delay={Math.random() * 2} color={s.color} />
-      ))}
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 56 56"
+      fill="none"
+      className="flex-shrink-0 overflow-visible"
+    >
+      {/* Plankton — behind everything, drifting in the medium */}
+      {planktonCount > 0 && <Plankton count={planktonCount} />}
+
+      {/* Wandering rotation wrapper — organism body rotates slowly, changing direction */}
+      <motion.g
+        animate={{ rotate: rotation.angles }}
+        transition={{
+          duration: rotation.dur,
+          repeat: Infinity,
+          ease: 'easeInOut',
+          repeatType: 'reverse',
+        }}
+        style={{ transformOrigin: '28px 28px' }}
+      >
+        <NeuralMembrane color="rgba(167,139,250,1)" tier={tier} />
+
+        {tier === 'full' && <HeartbeatPulse />}
+
+        {axons.map((a, i) => (
+          <NeuralAxon key={i} {...a} hitCount={axonHits[i] ?? 0} />
+        ))}
+
+        {sparks.map((s) => (
+          <SpontaneousSpark
+            key={s.id}
+            d={s.d}
+            len={s.len}
+            color={s.color}
+            speed={s.speed}
+            intensity={s.intensity}
+          />
+        ))}
+
+        {ringSomas.map((s, i) => (
+          <RingSoma
+            key={i}
+            cx={s.cx}
+            cy={s.cy}
+            r={s.r}
+            delay={Math.random() * 2}
+            color={s.color}
+          />
+        ))}
+
+        <CoreSoma cx={28} cy={28} r={coreR} />
+
+        <AnimatePresence>
+          {anticipate && tier !== 'compact' && (
+            <motion.circle
+              key="anticipation"
+              cx="28"
+              cy="28"
+              r={coreR + 3}
+              fill="rgba(255,255,255,1)"
+              initial={{ opacity: 0, r: coreR }}
+              animate={{ opacity: 0.35, r: coreR + 3 }}
+              exit={{ opacity: 0, r: coreR + 5 }}
+              transition={{ duration: 0.15, ease: 'easeOut' }}
+            />
+          )}
+        </AnimatePresence>
+      </motion.g>
     </svg>
   );
 }

--- a/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
+++ b/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 /**
  * Bioluminescent neural organism — the system's living avatar.
@@ -73,7 +73,16 @@ interface NeuralAxonProps {
   hitCount: number;
 }
 
-function NeuralAxon({ d, len, delay, duration, color, repeatDelay, weight, hitCount }: NeuralAxonProps) {
+function NeuralAxon({
+  d,
+  len,
+  delay,
+  duration,
+  color,
+  repeatDelay,
+  weight,
+  hitCount,
+}: NeuralAxonProps) {
   const traceOpacity = 0.04 + weight * 0.08;
   const traceWidth = 0.4 + weight * 0.4;
   const pulseWidth = 0.8 + weight * 0.6;
@@ -409,13 +418,7 @@ function Plankton({ count }: { count: number }) {
   );
 }
 
-function NeuralMembrane({
-  color,
-  tier,
-}: {
-  color: string;
-  tier: 'compact' | 'standard' | 'full';
-}) {
+function NeuralMembrane({ color, tier }: { color: string; tier: 'compact' | 'standard' | 'full' }) {
   const center = 28;
   const pts = 14;
 
@@ -521,7 +524,7 @@ const SPARK_COLORS = [
 /* ── Main component ────────────────────────────────────────── */
 
 export function NeuralOrganism({ size = 56 }: { size?: number }) {
-  const tier = size <= 40 ? 'compact' : size <= 72 ? 'standard' : 'full';
+  const tier = size <= 40 ? 'compact' : size <= 80 ? 'standard' : 'full';
 
   /**
    * Wandering rotation — the organism slowly drifts rotationally,
@@ -530,15 +533,7 @@ export function NeuralOrganism({ size = 56 }: { size?: number }) {
    */
   const rotation = useMemo(
     () => ({
-      angles: [
-        0,
-        jitter(12, 8),
-        jitter(-6, 5),
-        jitter(18, 10),
-        jitter(-10, 8),
-        jitter(8, 6),
-        0,
-      ],
+      angles: [0, jitter(12, 8), jitter(-6, 5), jitter(18, 10), jitter(-10, 8), jitter(8, 6), 0],
       dur: jitter(40, 12),
     }),
     []
@@ -563,13 +558,48 @@ export function NeuralOrganism({ size = 56 }: { size?: number }) {
   const ringSomas = useMemo(() => {
     if (tier === 'compact') return [];
     return [
-      { cx: jitter(28, 1.5), cy: jitter(6, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
-      { cx: jitter(49, 1.5), cy: jitter(14, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
-      { cx: jitter(52, 1.5), cy: jitter(30, 1.5), r: jitter(1.6, 0.3), color: 'rgba(109,40,217,0.9)' },
-      { cx: jitter(42, 1.5), cy: jitter(50, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
-      { cx: jitter(12, 1.5), cy: jitter(50, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
-      { cx: jitter(4, 1.5), cy: jitter(30, 1.5), r: jitter(1.6, 0.3), color: 'rgba(109,40,217,0.9)' },
-      { cx: jitter(7, 1.5), cy: jitter(14, 1.5), r: jitter(1.6, 0.3), color: 'rgba(139,92,246,0.9)' },
+      {
+        cx: jitter(28, 1.5),
+        cy: jitter(6, 1.5),
+        r: jitter(1.6, 0.3),
+        color: 'rgba(139,92,246,0.9)',
+      },
+      {
+        cx: jitter(49, 1.5),
+        cy: jitter(14, 1.5),
+        r: jitter(1.6, 0.3),
+        color: 'rgba(139,92,246,0.9)',
+      },
+      {
+        cx: jitter(52, 1.5),
+        cy: jitter(30, 1.5),
+        r: jitter(1.6, 0.3),
+        color: 'rgba(109,40,217,0.9)',
+      },
+      {
+        cx: jitter(42, 1.5),
+        cy: jitter(50, 1.5),
+        r: jitter(1.6, 0.3),
+        color: 'rgba(139,92,246,0.9)',
+      },
+      {
+        cx: jitter(12, 1.5),
+        cy: jitter(50, 1.5),
+        r: jitter(1.6, 0.3),
+        color: 'rgba(139,92,246,0.9)',
+      },
+      {
+        cx: jitter(4, 1.5),
+        cy: jitter(30, 1.5),
+        r: jitter(1.6, 0.3),
+        color: 'rgba(109,40,217,0.9)',
+      },
+      {
+        cx: jitter(7, 1.5),
+        cy: jitter(14, 1.5),
+        r: jitter(1.6, 0.3),
+        color: 'rgba(139,92,246,0.9)',
+      },
     ];
   }, [tier]);
 
@@ -622,13 +652,15 @@ export function NeuralOrganism({ size = 56 }: { size?: number }) {
             intensity,
           },
         ]);
-        setTimeout(() => {
-          setSparks((prev) => prev.filter((s) => s.id !== sparkId));
-        }, speed * 1.3 * 1000 + 400);
+        setTimeout(
+          () => {
+            setSparks((prev) => prev.filter((s) => s.id !== sparkId));
+          },
+          speed * 1.3 * 1000 + 400
+        );
       }, 180);
 
-      const nextDelay =
-        tier === 'full' ? 600 + Math.random() * 2000 : 1000 + Math.random() * 3500;
+      const nextDelay = tier === 'full' ? 600 + Math.random() * 2000 : 1000 + Math.random() * 3500;
       setTimeout(fire, nextDelay);
     };
 
@@ -683,14 +715,7 @@ export function NeuralOrganism({ size = 56 }: { size?: number }) {
         ))}
 
         {ringSomas.map((s, i) => (
-          <RingSoma
-            key={i}
-            cx={s.cx}
-            cy={s.cy}
-            r={s.r}
-            delay={Math.random() * 2}
-            color={s.color}
-          />
+          <RingSoma key={i} cx={s.cx} cy={s.cy} r={s.r} delay={Math.random() * 2} color={s.color} />
         ))}
 
         <CoreSoma cx={28} cy={28} r={coreR} />

--- a/packages/dashboard/src/client/pages/Overview.tsx
+++ b/packages/dashboard/src/client/pages/Overview.tsx
@@ -287,8 +287,7 @@ export function Overview() {
               }}
               transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut', delay: 1.5 }}
               style={{
-                background:
-                  'radial-gradient(circle, rgba(34,211,238,0.12) 0%, transparent 60%)',
+                background: 'radial-gradient(circle, rgba(34,211,238,0.12) 0%, transparent 60%)',
                 filter: 'blur(14px)',
               }}
             />

--- a/packages/dashboard/src/client/pages/Overview.tsx
+++ b/packages/dashboard/src/client/pages/Overview.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
 import { Activity, ShieldCheck, Zap, Share2, Compass, type LucideIcon } from 'lucide-react';
 import { SSE_ENDPOINT } from '@shared/constants';
 import { useProjectPulse } from '../hooks/useProjectPulse';
-import { NeuralDecryptionLoader } from '../components/NeuralDecryptionLoader';
+import { NeuralOrganism } from '../components/chat/NeuralOrganism';
 import {
   isRoadmapData,
   isHealthData,
@@ -255,11 +255,54 @@ export function Overview() {
 
       {!data && !error && (
         <div className="flex flex-col items-center justify-center py-32 text-neutral-muted relative">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(99,102,241,0.1),transparent_50%)] animate-pulse" />
-          <NeuralDecryptionLoader />
-          <p className="text-sm font-mono tracking-widest uppercase relative z-10">
+          {/* Deep atmospheric gradient */}
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(99,102,241,0.06),transparent_50%)]" />
+
+          <motion.div
+            className="relative z-10 mb-10"
+            initial={{ scale: 0.85, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ duration: 1.4, ease: [0.16, 1, 0.3, 1] }}
+          >
+            {/* Outer violet atmospheric glow */}
+            <motion.div
+              className="absolute inset-0 -m-16 rounded-full pointer-events-none"
+              animate={{
+                opacity: [0.04, 0.09, 0.05, 0.07, 0.04],
+                scale: [1, 1.1, 1.03, 1.07, 1],
+              }}
+              transition={{ duration: 12, repeat: Infinity, ease: 'easeInOut' }}
+              style={{
+                background:
+                  'radial-gradient(circle, rgba(139,92,246,0.25) 0%, rgba(79,70,229,0.08) 45%, transparent 70%)',
+                filter: 'blur(22px)',
+              }}
+            />
+            {/* Inner cyan accent glow — offset cycle */}
+            <motion.div
+              className="absolute inset-0 -m-8 rounded-full pointer-events-none"
+              animate={{
+                opacity: [0.03, 0.07, 0.04, 0.06, 0.03],
+                scale: [1, 1.06, 1.02, 1.04, 1],
+              }}
+              transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut', delay: 1.5 }}
+              style={{
+                background:
+                  'radial-gradient(circle, rgba(34,211,238,0.12) 0%, transparent 60%)',
+                filter: 'blur(14px)',
+              }}
+            />
+            <NeuralOrganism size={120} />
+          </motion.div>
+
+          <motion.p
+            className="text-sm font-mono tracking-widest uppercase relative z-10"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.8, duration: 0.8 }}
+          >
             <ScrambleText text="Decrypting Telemetry..." />
-          </p>
+          </motion.p>
         </div>
       )}
 

--- a/packages/dashboard/src/client/types/orchestrator.ts
+++ b/packages/dashboard/src/client/types/orchestrator.ts
@@ -156,6 +156,7 @@ export type ChatSSEEvent =
   | { type: 'text'; text: string }
   | { type: 'thinking'; text: string }
   | { type: 'tool_use'; tool: string; args?: string }
+  | { type: 'tool_args_delta'; text: string }
   | { type: 'tool_result'; content: string; isError?: boolean }
   | { type: 'status'; text: string }
   | { type: 'error'; error: string };

--- a/packages/dashboard/src/client/utils/chat-stream.ts
+++ b/packages/dashboard/src/client/utils/chat-stream.ts
@@ -91,6 +91,9 @@ export function applyChunk(blocks: ContentBlock[], event: ChatSSEEvent): void {
         ...(event.args != null ? { args: event.args } : {}),
       });
       break;
+    case 'tool_args_delta':
+      handleToolArgsDelta(blocks, event.text);
+      break;
     case 'tool_result':
       handleToolResultBlock(blocks, event.content, event.isError);
       break;
@@ -122,6 +125,16 @@ function handleThinkingBlock(
     blocks[blocks.length - 1] = { kind: 'thinking', text: lastBlock.text + text };
   } else {
     blocks.push({ kind: 'thinking', text });
+  }
+}
+
+function handleToolArgsDelta(blocks: ContentBlock[], text: string) {
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i]!;
+    if (b.kind === 'tool_use' && b.result === undefined) {
+      blocks[i] = { ...b, args: (b.args ?? '') + text };
+      break;
+    }
   }
 }
 

--- a/packages/graph/__fixtures__/extractor-project/AuthTest.java
+++ b/packages/graph/__fixtures__/extractor-project/AuthTest.java
@@ -1,0 +1,39 @@
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+
+class AuthTest {
+
+    @Test
+    @DisplayName("should reject expired tokens")
+    void rejectExpiredTokens() {
+        assert true;
+    }
+
+    @Test
+    @DisplayName("should accept valid JWT tokens")
+    void acceptValidJwt() {
+        assert true;
+    }
+
+    @Nested
+    @DisplayName("Login Flow")
+    class LoginFlow {
+        @Test
+        @DisplayName("should require email and password")
+        void requireCredentials() {
+            assert true;
+        }
+
+        @Test
+        @DisplayName("should lock account after 5 failed attempts")
+        void lockAfterFailedAttempts() {
+            assert true;
+        }
+    }
+
+    @Test
+    void testPasswordHashing() {
+        assert true;
+    }
+}

--- a/packages/graph/__fixtures__/extractor-project/Enums.java
+++ b/packages/graph/__fixtures__/extractor-project/Enums.java
@@ -1,0 +1,27 @@
+public enum OrderStatus {
+    PENDING,
+    CONFIRMED,
+    SHIPPED,
+    DELIVERED,
+    CANCELLED
+}
+
+public enum Priority {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL
+}
+
+public enum PaymentMethod {
+    CREDIT_CARD("credit_card"),
+    DEBIT_CARD("debit_card"),
+    PAYPAL("paypal"),
+    BANK_TRANSFER("bank_transfer");
+
+    private final String value;
+
+    PaymentMethod(String value) {
+        this.value = value;
+    }
+}

--- a/packages/graph/__fixtures__/extractor-project/Routes.java
+++ b/packages/graph/__fixtures__/extractor-project/Routes.java
@@ -1,0 +1,40 @@
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+
+    @GetMapping("/users")
+    public List<User> listUsers() {
+        return null;
+    }
+
+    @GetMapping("/users/{id}")
+    public User getUser(@PathVariable Long id) {
+        return null;
+    }
+
+    @PostMapping("/users")
+    public User createUser(@RequestBody User user) {
+        return null;
+    }
+
+    @PutMapping("/users/{id}")
+    public User updateUser(@PathVariable Long id, @RequestBody User user) {
+        return null;
+    }
+
+    @DeleteMapping("/users/{id}")
+    public void deleteUser(@PathVariable Long id) {
+    }
+
+    @GetMapping("/orders")
+    public List<Order> listOrders() {
+        return null;
+    }
+
+    @PostMapping("/orders")
+    public Order createOrder(@RequestBody Order order) {
+        return null;
+    }
+}

--- a/packages/graph/__fixtures__/extractor-project/Validators.java
+++ b/packages/graph/__fixtures__/extractor-project/Validators.java
@@ -1,0 +1,52 @@
+import javax.validation.constraints.*;
+
+public class User {
+    @NotNull
+    @Email
+    private String email;
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    private String name;
+
+    @Min(0)
+    @Max(150)
+    private int age;
+
+    @NotNull
+    @Size(min = 8)
+    private String password;
+}
+
+public class Order {
+    @NotNull
+    @DecimalMin("0.01")
+    @DecimalMax("1000000")
+    private BigDecimal amount;
+
+    @NotNull
+    @Pattern(regexp = "^(USD|EUR|GBP)$")
+    private String currency;
+
+    @NotNull
+    @Size(min = 1)
+    private List<String> items;
+}
+
+public class Address {
+    @NotNull
+    @Size(min = 1)
+    private String street;
+
+    @NotNull
+    @Size(min = 1)
+    private String city;
+
+    @NotNull
+    @Pattern(regexp = "^\\d{5}(-\\d{4})?$")
+    private String zipCode;
+
+    @NotNull
+    @Size(min = 2, max = 2)
+    private String country;
+}

--- a/packages/graph/__fixtures__/extractor-project/auth.test.ts
+++ b/packages/graph/__fixtures__/extractor-project/auth.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, test, expect } from 'vitest';
+
+describe('AuthService', () => {
+  describe('token validation', () => {
+    it('should reject expired tokens', () => {
+      expect(true).toBe(true);
+    });
+
+    it('should accept valid JWT tokens', () => {
+      expect(true).toBe(true);
+    });
+
+    test('handles malformed token gracefully', () => {
+      expect(true).toBe(true);
+    });
+  });
+
+  describe('login', () => {
+    it('should require email and password', () => {
+      expect(true).toBe(true);
+    });
+
+    it('should lock account after 5 failed attempts', () => {
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/packages/graph/__fixtures__/extractor-project/auth_test.go
+++ b/packages/graph/__fixtures__/extractor-project/auth_test.go
@@ -1,0 +1,29 @@
+package auth
+
+import "testing"
+
+func TestTokenValidation(t *testing.T) {
+	t.Run("rejects expired tokens", func(t *testing.T) {
+		if false {
+			t.Fatal("should reject")
+		}
+	})
+
+	t.Run("accepts valid JWT tokens", func(t *testing.T) {
+		if false {
+			t.Fatal("should accept")
+		}
+	})
+}
+
+func TestLoginFlow(t *testing.T) {
+	t.Run("requires email and password", func(t *testing.T) {
+	})
+
+	t.Run("locks account after 5 failed attempts", func(t *testing.T) {
+	})
+}
+
+// TestPasswordHashing verifies bcrypt hashing
+func TestPasswordHashing(t *testing.T) {
+}

--- a/packages/graph/__fixtures__/extractor-project/auth_test.py
+++ b/packages/graph/__fixtures__/extractor-project/auth_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+class TestAuthService:
+    def test_reject_expired_tokens(self):
+        """Expired tokens should be rejected with 401"""
+        assert True
+
+    def test_accept_valid_jwt(self):
+        """Valid JWT tokens grant access"""
+        assert True
+
+    def test_lock_account_after_failed_attempts(self):
+        assert True
+
+
+@pytest.mark.parametrize("role", ["admin", "user", "guest"])
+def test_role_based_access(role):
+    """Each role should have appropriate permissions"""
+    assert role in ["admin", "user", "guest"]
+
+
+def test_password_hashing():
+    assert True

--- a/packages/graph/__fixtures__/extractor-project/auth_test.rs
+++ b/packages/graph/__fixtures__/extractor-project/auth_test.rs
@@ -1,0 +1,26 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Expired tokens should be rejected with 401
+    #[test]
+    fn test_reject_expired_tokens() {
+        assert!(true);
+    }
+
+    /// Valid JWT tokens grant access
+    #[test]
+    fn test_accept_valid_jwt() {
+        assert!(true);
+    }
+
+    #[test]
+    fn test_lock_account_after_failed_attempts() {
+        assert!(true);
+    }
+
+    #[test]
+    fn test_password_hashing() {
+        assert!(true);
+    }
+}

--- a/packages/graph/__fixtures__/extractor-project/enums.go
+++ b/packages/graph/__fixtures__/extractor-project/enums.go
@@ -1,0 +1,29 @@
+package enums
+
+type OrderStatus int
+
+const (
+	Pending OrderStatus = iota
+	Confirmed
+	Shipped
+	Delivered
+	Cancelled
+)
+
+type Priority int
+
+const (
+	Low Priority = iota
+	Medium
+	High
+	Critical
+)
+
+type PaymentMethod string
+
+const (
+	CreditCard   PaymentMethod = "credit_card"
+	DebitCard     PaymentMethod = "debit_card"
+	PayPal        PaymentMethod = "paypal"
+	BankTransfer  PaymentMethod = "bank_transfer"
+)

--- a/packages/graph/__fixtures__/extractor-project/enums.py
+++ b/packages/graph/__fixtures__/extractor-project/enums.py
@@ -1,0 +1,27 @@
+from enum import Enum, StrEnum, IntEnum
+from typing import Literal
+
+
+class OrderStatus(StrEnum):
+    PENDING = "pending"
+    CONFIRMED = "confirmed"
+    SHIPPED = "shipped"
+    DELIVERED = "delivered"
+    CANCELLED = "cancelled"
+
+
+class Priority(IntEnum):
+    LOW = 0
+    MEDIUM = 1
+    HIGH = 2
+    CRITICAL = 3
+
+
+UserRole = Literal["admin", "editor", "viewer", "guest"]
+
+
+class PaymentMethod(Enum):
+    CREDIT_CARD = "credit_card"
+    DEBIT_CARD = "debit_card"
+    PAYPAL = "paypal"
+    BANK_TRANSFER = "bank_transfer"

--- a/packages/graph/__fixtures__/extractor-project/enums.rs
+++ b/packages/graph/__fixtures__/extractor-project/enums.rs
@@ -1,0 +1,27 @@
+pub enum OrderStatus {
+    Pending,
+    Confirmed,
+    Shipped,
+    Delivered,
+    Cancelled,
+}
+
+pub enum Priority {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+pub enum PaymentMethod {
+    CreditCard,
+    DebitCard,
+    PayPal,
+    BankTransfer,
+}
+
+pub enum ShippingType {
+    Standard(u32),
+    Express(u32),
+    Overnight,
+}

--- a/packages/graph/__fixtures__/extractor-project/enums.ts
+++ b/packages/graph/__fixtures__/extractor-project/enums.ts
@@ -1,0 +1,23 @@
+export enum OrderStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  SHIPPED = 'shipped',
+  DELIVERED = 'delivered',
+  CANCELLED = 'cancelled',
+}
+
+export const PaymentMethod = {
+  CREDIT_CARD: 'credit_card',
+  DEBIT_CARD: 'debit_card',
+  PAYPAL: 'paypal',
+  BANK_TRANSFER: 'bank_transfer',
+} as const;
+
+export type UserRole = 'admin' | 'editor' | 'viewer' | 'guest';
+
+export enum Priority {
+  LOW,
+  MEDIUM,
+  HIGH,
+  CRITICAL,
+}

--- a/packages/graph/__fixtures__/extractor-project/routes.go
+++ b/packages/graph/__fixtures__/extractor-project/routes.go
@@ -1,0 +1,22 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterRoutes(r *gin.Engine) {
+	r.GET("/api/users", listUsers)
+	r.GET("/api/users/:id", getUser)
+	r.POST("/api/users", createUser)
+	r.PUT("/api/users/:id", updateUser)
+	r.DELETE("/api/users/:id", deleteUser)
+
+	r.GET("/api/orders", listOrders)
+	r.POST("/api/orders", createOrder)
+}
+
+func RegisterHTTPRoutes() {
+	http.HandleFunc("/api/health", healthCheck)
+}

--- a/packages/graph/__fixtures__/extractor-project/routes.py
+++ b/packages/graph/__fixtures__/extractor-project/routes.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter()
+
+
+@app.get("/api/users")
+async def list_users():
+    pass
+
+
+@app.get("/api/users/{user_id}")
+async def get_user(user_id: int):
+    pass
+
+
+@app.post("/api/users")
+async def create_user():
+    pass
+
+
+@app.put("/api/users/{user_id}")
+async def update_user(user_id: int):
+    pass
+
+
+@app.delete("/api/users/{user_id}")
+async def delete_user(user_id: int):
+    pass
+
+
+@router.get("/api/orders")
+async def list_orders():
+    pass
+
+
+@router.post("/api/orders")
+async def create_order():
+    pass

--- a/packages/graph/__fixtures__/extractor-project/routes.rs
+++ b/packages/graph/__fixtures__/extractor-project/routes.rs
@@ -1,0 +1,36 @@
+use actix_web::{get, post, put, delete, web, HttpResponse};
+
+#[get("/api/users")]
+async fn list_users() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+#[get("/api/users/{id}")]
+async fn get_user(id: web::Path<u32>) -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+#[post("/api/users")]
+async fn create_user() -> HttpResponse {
+    HttpResponse::Created().finish()
+}
+
+#[put("/api/users/{id}")]
+async fn update_user(id: web::Path<u32>) -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+#[delete("/api/users/{id}")]
+async fn delete_user(id: web::Path<u32>) -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+#[get("/api/orders")]
+async fn list_orders() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+#[post("/api/orders")]
+async fn create_order() -> HttpResponse {
+    HttpResponse::Created().finish()
+}

--- a/packages/graph/__fixtures__/extractor-project/routes.ts
+++ b/packages/graph/__fixtures__/extractor-project/routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/api/users', listUsers);
+router.get('/api/users/:id', getUser);
+router.post('/api/users', createUser);
+router.put('/api/users/:id', updateUser);
+router.delete('/api/users/:id', deleteUser);
+
+router.get('/api/orders', listOrders);
+router.post('/api/orders', createOrder);
+router.get('/api/orders/:id', getOrder);
+
+app.get('/api/health', healthCheck);
+
+export default router;

--- a/packages/graph/__fixtures__/extractor-project/validators.go
+++ b/packages/graph/__fixtures__/extractor-project/validators.go
@@ -1,0 +1,21 @@
+package validators
+
+type User struct {
+	Email    string `json:"email" validate:"required,email"`
+	Name     string `json:"name" validate:"required,min=1,max=255"`
+	Age      int    `json:"age" validate:"gte=0,lte=150"`
+	Password string `json:"password" validate:"required,min=8"`
+}
+
+type Order struct {
+	Amount   float64 `json:"amount" validate:"required,gt=0,lte=1000000"`
+	Currency string  `json:"currency" validate:"required,oneof=USD EUR GBP"`
+	Items    []string `json:"items" validate:"required,min=1"`
+}
+
+type Address struct {
+	Street  string `json:"street" validate:"required,min=1"`
+	City    string `json:"city" validate:"required,min=1"`
+	ZipCode string `json:"zip_code" validate:"required"`
+	Country string `json:"country" validate:"required,len=2"`
+}

--- a/packages/graph/__fixtures__/extractor-project/validators.py
+++ b/packages/graph/__fixtures__/extractor-project/validators.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field, validator
+from decimal import Decimal
+
+
+class UserModel(BaseModel):
+    email: str = Field(..., pattern=r'^[\w.-]+@[\w.-]+\.\w+$')
+    name: str = Field(..., min_length=1, max_length=255)
+    age: int = Field(..., ge=0, le=150)
+    password: str = Field(..., min_length=8)
+
+
+class OrderModel(BaseModel):
+    amount: Decimal = Field(gt=0, le=1000000)
+    currency: str = Field(..., pattern=r'^(USD|EUR|GBP)$')
+    items: list[str] = Field(..., min_length=1)
+
+    @validator('amount')
+    def validate_amount_precision(cls, v):
+        if v.as_tuple().exponent < -2:
+            raise ValueError('Amount cannot have more than 2 decimal places')
+        return v
+
+
+class AddressModel(BaseModel):
+    street: str = Field(..., min_length=1)
+    city: str = Field(..., min_length=1)
+    zip_code: str = Field(..., pattern=r'^\d{5}(-\d{4})?$')
+    country: str = Field(..., min_length=2, max_length=2)

--- a/packages/graph/__fixtures__/extractor-project/validators.rs
+++ b/packages/graph/__fixtures__/extractor-project/validators.rs
@@ -1,0 +1,43 @@
+use validator::Validate;
+
+#[derive(Validate)]
+pub struct User {
+    #[validate(email)]
+    pub email: String,
+
+    #[validate(length(min = 1, max = 255))]
+    pub name: String,
+
+    #[validate(range(min = 0, max = 150))]
+    pub age: u32,
+
+    #[validate(length(min = 8))]
+    pub password: String,
+}
+
+#[derive(Validate)]
+pub struct Order {
+    #[validate(range(min = 0.01, max = 1000000.0))]
+    pub amount: f64,
+
+    #[validate(length(equal = 3))]
+    pub currency: String,
+
+    #[validate(length(min = 1))]
+    pub items: Vec<String>,
+}
+
+#[derive(Validate)]
+pub struct Address {
+    #[validate(length(min = 1))]
+    pub street: String,
+
+    #[validate(length(min = 1))]
+    pub city: String,
+
+    #[validate(regex(path = "ZIP_RE"))]
+    pub zip_code: String,
+
+    #[validate(length(equal = 2))]
+    pub country: String,
+}

--- a/packages/graph/__fixtures__/extractor-project/validators.ts
+++ b/packages/graph/__fixtures__/extractor-project/validators.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const UserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1).max(255),
+  age: z.number().int().min(0).max(150),
+  password: z.string().min(8).regex(/[A-Z]/).regex(/[0-9]/),
+});
+
+export const OrderSchema = z.object({
+  amount: z.number().positive().max(1000000),
+  currency: z.enum(['USD', 'EUR', 'GBP']),
+  items: z.array(z.string()).min(1),
+});
+
+export const AddressSchema = z.object({
+  street: z.string().min(1),
+  city: z.string().min(1),
+  zip: z.string().regex(/^\d{5}(-\d{4})?$/),
+  country: z.string().length(2),
+});

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -127,6 +127,19 @@ export type {
   GraphLayerViolation,
 } from './constraints/GraphConstraintAdapter.js';
 
+// Code Signal Extractors
+export {
+  ExtractionRunner,
+  createExtractionRunner,
+  ALL_EXTRACTORS,
+  TestDescriptionExtractor,
+  EnumConstantExtractor,
+  ValidationRuleExtractor,
+  ApiPathExtractor,
+  detectLanguage,
+} from './ingest/extractors/index.js';
+export type { ExtractionRecord, SignalExtractor, Language } from './ingest/extractors/index.js';
+
 // Design Ingest
 export { DesignIngestor } from './ingest/DesignIngestor.js';
 

--- a/packages/graph/src/ingest/extractors/ApiPathExtractor.ts
+++ b/packages/graph/src/ingest/extractors/ApiPathExtractor.ts
@@ -1,0 +1,270 @@
+import { hash } from '../ingestUtils.js';
+import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
+
+/**
+ * Extracts API route definitions revealing the domain model.
+ * Finds Express/Hono routes (TS/JS), FastAPI/Flask decorators (Python),
+ * Gin/Echo/http handlers (Go), Actix macros (Rust), Spring annotations (Java).
+ */
+export class ApiPathExtractor implements SignalExtractor {
+  readonly name = 'api-paths';
+  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+
+  extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    switch (language) {
+      case 'typescript':
+      case 'javascript':
+        return this.extractJsTs(content, filePath, language);
+      case 'python':
+        return this.extractPython(content, filePath, language);
+      case 'go':
+        return this.extractGo(content, filePath, language);
+      case 'rust':
+        return this.extractRust(content, filePath, language);
+      case 'java':
+        return this.extractJava(content, filePath, language);
+    }
+  }
+
+  private extractJsTs(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    // Express/Hono/Fastify patterns: app.get('/path', ...) or router.get('/path', ...)
+    const routePattern =
+      /(?:app|router|server|fastify)\.(get|post|put|patch|delete|head|options)\s*\(\s*(['"`])([^'"`]+)\2/i;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      const match = line.match(routePattern);
+      if (match) {
+        const method = match[1]!.toUpperCase();
+        const routePath = match[3]!;
+        const patternKey = `${method} ${routePath}`;
+
+        records.push({
+          id: `extracted:api-paths:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'api-paths',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_process',
+          name: patternKey,
+          content: `${method} ${routePath}`,
+          confidence: 0.9,
+          metadata: { method, path: routePath, framework: 'express' },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private extractPython(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    // FastAPI/Flask decorator patterns: @app.get("/path") or @router.get("/path")
+    const decoratorPattern =
+      /@(?:app|router)\.(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"']+)["']/i;
+
+    // Flask @app.route pattern
+    const flaskPattern =
+      /@(?:app|blueprint)\.route\s*\(\s*["']([^"']+)["'](?:\s*,\s*methods\s*=\s*\[([^\]]+)\])?/i;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const fastApiMatch = line.match(decoratorPattern);
+      if (fastApiMatch) {
+        const method = fastApiMatch[1]!.toUpperCase();
+        const routePath = fastApiMatch[2]!;
+        const patternKey = `${method} ${routePath}`;
+
+        records.push({
+          id: `extracted:api-paths:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'api-paths',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_process',
+          name: patternKey,
+          content: `${method} ${routePath}`,
+          confidence: 0.9,
+          metadata: { method, path: routePath, framework: 'fastapi' },
+        });
+        continue;
+      }
+
+      const flaskMatch = line.match(flaskPattern);
+      if (flaskMatch) {
+        const routePath = flaskMatch[1]!;
+        const methods = flaskMatch[2]
+          ? flaskMatch[2].split(',').map((m) => m.trim().replace(/["']/g, ''))
+          : ['GET'];
+
+        for (const method of methods) {
+          const patternKey = `${method} ${routePath}`;
+          records.push({
+            id: `extracted:api-paths:${hash(filePath + ':' + patternKey)}`,
+            extractor: 'api-paths',
+            language,
+            filePath,
+            line: i + 1,
+            nodeType: 'business_process',
+            name: patternKey,
+            content: `${method} ${routePath}`,
+            confidence: 0.9,
+            metadata: { method, path: routePath, framework: 'flask' },
+          });
+        }
+      }
+    }
+
+    return records;
+  }
+
+  private extractGo(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    // Gin/Echo/Chi pattern: r.GET("/path", handler)
+    const ginPattern = /(?:\w+)\.(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*"([^"]+)"/i;
+
+    // http.HandleFunc pattern
+    const httpPattern = /http\.HandleFunc\s*\(\s*"([^"]+)"/;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const ginMatch = line.match(ginPattern);
+      if (ginMatch) {
+        const method = ginMatch[1]!.toUpperCase();
+        const routePath = ginMatch[2]!;
+        const patternKey = `${method} ${routePath}`;
+
+        records.push({
+          id: `extracted:api-paths:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'api-paths',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_process',
+          name: patternKey,
+          content: `${method} ${routePath}`,
+          confidence: 0.9,
+          metadata: { method, path: routePath, framework: 'gin' },
+        });
+        continue;
+      }
+
+      const httpMatch = line.match(httpPattern);
+      if (httpMatch) {
+        const routePath = httpMatch[1]!;
+        const patternKey = `ANY ${routePath}`;
+
+        records.push({
+          id: `extracted:api-paths:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'api-paths',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_process',
+          name: patternKey,
+          content: `ANY ${routePath}`,
+          confidence: 0.6,
+          metadata: { method: 'ANY', path: routePath, framework: 'net/http' },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private extractRust(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    // Actix macro patterns: #[get("/path")]
+    const actixPattern = /#\[(get|post|put|patch|delete|head|options)\s*\(\s*"([^"]+)"\s*\)\s*\]/i;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const match = line.match(actixPattern);
+      if (match) {
+        const method = match[1]!.toUpperCase();
+        const routePath = match[2]!;
+        const patternKey = `${method} ${routePath}`;
+
+        records.push({
+          id: `extracted:api-paths:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'api-paths',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_process',
+          name: patternKey,
+          content: `${method} ${routePath}`,
+          confidence: 0.9,
+          metadata: { method, path: routePath, framework: 'actix' },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private extractJava(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    // Spring annotation patterns
+    const springPattern =
+      /@(GetMapping|PostMapping|PutMapping|PatchMapping|DeleteMapping|RequestMapping)\s*\(\s*(?:value\s*=\s*)?["']([^"']+)["']/;
+
+    // Base path from @RequestMapping on class
+    let basePath = '';
+    for (const line of lines) {
+      const baseMatch = line.match(/@RequestMapping\s*\(\s*(?:value\s*=\s*)?["']([^"']+)["']\s*\)/);
+      if (baseMatch && line.match(/class\s/) === null) {
+        basePath = baseMatch[1]!;
+      }
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const match = line.match(springPattern);
+      if (match) {
+        const annotation = match[1]!;
+        const routePath = basePath + match[2]!;
+        const methodMap: Record<string, string> = {
+          GetMapping: 'GET',
+          PostMapping: 'POST',
+          PutMapping: 'PUT',
+          PatchMapping: 'PATCH',
+          DeleteMapping: 'DELETE',
+          RequestMapping: 'ANY',
+        };
+        const method = methodMap[annotation] ?? 'ANY';
+        const patternKey = `${method} ${routePath}`;
+
+        records.push({
+          id: `extracted:api-paths:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'api-paths',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_process',
+          name: patternKey,
+          content: `${method} ${routePath}`,
+          confidence: 0.9,
+          metadata: { method, path: routePath, framework: 'spring' },
+        });
+      }
+    }
+
+    return records;
+  }
+}

--- a/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
+++ b/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
@@ -1,0 +1,420 @@
+import { hash } from '../ingestUtils.js';
+import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
+
+/**
+ * Extracts domain vocabulary from enum and constant definitions.
+ * Finds enum declarations (all langs), as const objects (TS),
+ * Object.freeze (JS), StrEnum/IntEnum (Python), iota (Go).
+ */
+export class EnumConstantExtractor implements SignalExtractor {
+  readonly name = 'enum-constants';
+  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+
+  extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    switch (language) {
+      case 'typescript':
+        return this.extractTypeScript(content, filePath, language);
+      case 'javascript':
+        return this.extractJavaScript(content, filePath, language);
+      case 'python':
+        return this.extractPython(content, filePath, language);
+      case 'go':
+        return this.extractGo(content, filePath, language);
+      case 'rust':
+        return this.extractRust(content, filePath, language);
+      case 'java':
+        return this.extractJava(content, filePath, language);
+    }
+  }
+
+  private extractTypeScript(
+    content: string,
+    filePath: string,
+    language: Language
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // enum declarations
+      const enumMatch = line.match(/(?:export\s+)?enum\s+(\w+)/);
+      if (enumMatch) {
+        const enumName = enumMatch[1]!;
+        // Collect members until closing brace
+        const members = this.collectEnumMembers(lines, i + 1);
+        records.push({
+          id: `extracted:enum-constants:${hash(filePath + ':' + enumName)}`,
+          extractor: 'enum-constants',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_term',
+          name: enumName,
+          content: `enum ${enumName} { ${members.join(', ')} }`,
+          confidence: 0.8,
+          metadata: { kind: 'enum', members },
+        });
+      }
+
+      // as const objects
+      const constMatch = line.match(/(?:export\s+)?const\s+(\w+)\s*=\s*\{/);
+      if (constMatch && content.includes('as const')) {
+        // Check if this particular const has `as const`
+        const blockEnd = this.findClosingBrace(lines, i);
+        const block = lines.slice(i, blockEnd + 1).join('\n');
+        if (block.includes('as const')) {
+          const constName = constMatch[1]!;
+          const members = this.collectObjectKeys(lines, i + 1);
+          records.push({
+            id: `extracted:enum-constants:${hash(filePath + ':' + constName)}`,
+            extractor: 'enum-constants',
+            language,
+            filePath,
+            line: i + 1,
+            nodeType: 'business_term',
+            name: constName,
+            content: `const ${constName} = { ${members.join(', ')} } as const`,
+            confidence: 0.8,
+            metadata: { kind: 'as-const', members },
+          });
+        }
+      }
+
+      // Union types
+      const unionMatch = line.match(
+        /(?:export\s+)?type\s+(\w+)\s*=\s*(['"`][\w]+['"`](?:\s*\|\s*['"`][\w]+['"`])+)/
+      );
+      if (unionMatch) {
+        const typeName = unionMatch[1]!;
+        const values = unionMatch[2]!.split('|').map((v) => v.trim().replace(/['"`]/g, ''));
+        records.push({
+          id: `extracted:enum-constants:${hash(filePath + ':' + typeName)}`,
+          extractor: 'enum-constants',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_term',
+          name: typeName,
+          content: `type ${typeName} = ${values.map((v) => `'${v}'`).join(' | ')}`,
+          confidence: 0.7,
+          metadata: { kind: 'union-type', members: values },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private extractJavaScript(
+    content: string,
+    filePath: string,
+    language: Language
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // Object.freeze patterns
+      const freezeMatch = line.match(/(?:export\s+)?const\s+(\w+)\s*=\s*Object\.freeze\s*\(\s*\{/);
+      if (freezeMatch) {
+        const name = freezeMatch[1]!;
+        const members = this.collectObjectKeys(lines, i + 1);
+        records.push({
+          id: `extracted:enum-constants:${hash(filePath + ':' + name)}`,
+          extractor: 'enum-constants',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_term',
+          name,
+          content: `const ${name} = Object.freeze({ ${members.join(', ')} })`,
+          confidence: 0.8,
+          metadata: { kind: 'frozen-object', members },
+        });
+      }
+
+      // Const objects with UPPER_CASE keys
+      const constMatch = line.match(/(?:export\s+)?const\s+([A-Z][A-Z_\d]*)\s*=\s*\{/);
+      if (constMatch && !freezeMatch) {
+        const name = constMatch[1]!;
+        const members = this.collectObjectKeys(lines, i + 1);
+        if (members.length > 0 && members.every((m) => /^[A-Z][A-Z_\d]*$/.test(m))) {
+          records.push({
+            id: `extracted:enum-constants:${hash(filePath + ':' + name)}`,
+            extractor: 'enum-constants',
+            language,
+            filePath,
+            line: i + 1,
+            nodeType: 'business_term',
+            name,
+            content: `const ${name} = { ${members.join(', ')} }`,
+            confidence: 0.6,
+            metadata: { kind: 'const-object', members },
+          });
+        }
+      }
+    }
+
+    return records;
+  }
+
+  private extractPython(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // Enum subclasses
+      const enumMatch = line.match(
+        /^class\s+(\w+)\s*\(\s*(?:str\s*,\s*)?(?:Enum|StrEnum|IntEnum|Flag|IntFlag)\s*\)/
+      );
+      if (enumMatch) {
+        const enumName = enumMatch[1]!;
+        const members = this.collectPythonEnumMembers(lines, i + 1);
+        records.push({
+          id: `extracted:enum-constants:${hash(filePath + ':' + enumName)}`,
+          extractor: 'enum-constants',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_term',
+          name: enumName,
+          content: `class ${enumName}(Enum) { ${members.join(', ')} }`,
+          confidence: 0.8,
+          metadata: { kind: 'enum', members },
+        });
+      }
+
+      // Literal type annotation
+      const literalMatch = line.match(/(\w+)\s*=\s*Literal\s*\[([^\]]+)\]/);
+      if (literalMatch) {
+        const typeName = literalMatch[1]!;
+        const values = literalMatch[2]!.split(',').map((v) => v.trim().replace(/["']/g, ''));
+        records.push({
+          id: `extracted:enum-constants:${hash(filePath + ':' + typeName)}`,
+          extractor: 'enum-constants',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_term',
+          name: typeName,
+          content: `${typeName} = Literal[${values.map((v) => `"${v}"`).join(', ')}]`,
+          confidence: 0.7,
+          metadata: { kind: 'literal-type', members: values },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private extractGo(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // Type declaration before iota
+      const typeMatch = line.match(/^type\s+(\w+)\s+(?:int|string|uint|int32|int64|uint32|uint64)/);
+      if (typeMatch) {
+        // type declaration — just note the name for const blocks
+      }
+
+      // const block with iota or typed consts
+      const constBlockMatch = line.match(/^const\s*\(/);
+      if (constBlockMatch) {
+        const consts: string[] = [];
+        let typeName: string | undefined;
+        for (let j = i + 1; j < lines.length; j++) {
+          const constLine = lines[j]!.trim();
+          if (constLine === ')') break;
+          if (constLine === '' || constLine.startsWith('//')) continue;
+
+          // First const with type + iota
+          const iotaMatch = constLine.match(/^(\w+)\s+(\w+)\s*=\s*iota/);
+          if (iotaMatch) {
+            typeName = iotaMatch[2]!;
+            consts.push(iotaMatch[1]!);
+            continue;
+          }
+
+          // Typed const with value
+          const typedMatch = constLine.match(/^(\w+)\s+(\w+)\s*=\s*"[^"]*"/);
+          if (typedMatch) {
+            typeName = typeName ?? typedMatch[2]!;
+            consts.push(typedMatch[1]!);
+            continue;
+          }
+
+          // Bare name (continuation of iota)
+          const bareMatch = constLine.match(/^(\w+)\s*$/);
+          if (bareMatch) {
+            consts.push(bareMatch[1]!);
+          }
+        }
+
+        if (consts.length > 0) {
+          const name = typeName ?? consts[0]!;
+          records.push({
+            id: `extracted:enum-constants:${hash(filePath + ':' + name)}`,
+            extractor: 'enum-constants',
+            language,
+            filePath,
+            line: i + 1,
+            nodeType: 'business_term',
+            name,
+            content: `const ( ${consts.join(', ')} )`,
+            confidence: typeName ? 0.8 : 0.6,
+            metadata: { kind: typeName ? 'typed-const' : 'const-block', members: consts },
+          });
+        }
+      }
+    }
+
+    return records;
+  }
+
+  private extractRust(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const enumMatch = line.match(/^(?:pub\s+)?enum\s+(\w+)/);
+      if (enumMatch) {
+        const enumName = enumMatch[1]!;
+        const members = this.collectRustEnumVariants(lines, i + 1);
+        records.push({
+          id: `extracted:enum-constants:${hash(filePath + ':' + enumName)}`,
+          extractor: 'enum-constants',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_term',
+          name: enumName,
+          content: `enum ${enumName} { ${members.join(', ')} }`,
+          confidence: 0.8,
+          metadata: { kind: 'enum', members },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private extractJava(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const enumMatch = line.match(/(?:public\s+|private\s+|protected\s+)?enum\s+(\w+)/);
+      if (enumMatch) {
+        const enumName = enumMatch[1]!;
+        const members = this.collectJavaEnumConstants(lines, i + 1);
+        records.push({
+          id: `extracted:enum-constants:${hash(filePath + ':' + enumName)}`,
+          extractor: 'enum-constants',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_term',
+          name: enumName,
+          content: `enum ${enumName} { ${members.join(', ')} }`,
+          confidence: 0.8,
+          metadata: { kind: 'enum', members },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  // --- Helper methods ---
+
+  private collectEnumMembers(lines: string[], startLine: number): string[] {
+    const members: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!.trim();
+      if (line === '}') break;
+      if (line === '' || line.startsWith('//')) continue;
+      const match = line.match(/^(\w+)/);
+      if (match) members.push(match[1]!);
+    }
+    return members;
+  }
+
+  private collectObjectKeys(lines: string[], startLine: number): string[] {
+    const keys: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!.trim();
+      if (line.startsWith('}')) break;
+      if (line === '' || line.startsWith('//')) continue;
+      const match = line.match(/^(\w+)\s*:/);
+      if (match) keys.push(match[1]!);
+    }
+    return keys;
+  }
+
+  private findClosingBrace(lines: string[], startLine: number): number {
+    let depth = 0;
+    for (let i = startLine; i < lines.length; i++) {
+      for (const ch of lines[i]!) {
+        if (ch === '{') depth++;
+        if (ch === '}') {
+          depth--;
+          if (depth === 0) return i;
+        }
+      }
+    }
+    return lines.length - 1;
+  }
+
+  private collectPythonEnumMembers(lines: string[], startLine: number): string[] {
+    const members: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (/^\S/.test(line) && line.trim() !== '') break; // unindented line = end of class
+      const match = line.match(/^\s+(\w+)\s*=/);
+      if (match) members.push(match[1]!);
+    }
+    return members;
+  }
+
+  private collectRustEnumVariants(lines: string[], startLine: number): string[] {
+    const variants: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!.trim();
+      if (line === '}') break;
+      if (line === '' || line.startsWith('//')) continue;
+      const match = line.match(/^(\w+)/);
+      if (match) variants.push(match[1]!);
+    }
+    return variants;
+  }
+
+  private collectJavaEnumConstants(lines: string[], startLine: number): string[] {
+    const constants: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!.trim();
+      if (line === '}') break;
+      if (line === '' || line.startsWith('//') || line.startsWith('/*')) continue;
+      // Stop at first method/field (non-constant)
+      if (line.match(/^\s*(?:private|public|protected|static)/)) break;
+      const match = line.match(/^(\w+)[\s(,;]/);
+      if (match) constants.push(match[1]!);
+      // Single-word constant at end
+      const singleMatch = line.match(/^(\w+)$/);
+      if (singleMatch) constants.push(singleMatch[1]!);
+    }
+    return constants;
+  }
+}

--- a/packages/graph/src/ingest/extractors/ExtractionRunner.ts
+++ b/packages/graph/src/ingest/extractors/ExtractionRunner.ts
@@ -1,0 +1,275 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { GraphStore } from '../../store/GraphStore.js';
+import type { IngestResult, GraphNode, GraphEdge, EdgeType } from '../../types.js';
+import { hash } from '../ingestUtils.js';
+import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
+
+/** Directories to skip during file walking (matches CodeIngestor). */
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'target',
+  'build',
+  '.git',
+  '__pycache__',
+  '.venv',
+  '.turbo',
+  '.harness',
+  '.next',
+  '.vscode',
+  '.idea',
+  'vendor',
+  'out',
+  '.gradle',
+  '.gradle-home',
+  'bin',
+  'obj',
+  'venv',
+  '_build',
+  'deps',
+  'coverage',
+  '.nyc_output',
+]);
+
+/** Map file extensions to Language. */
+const EXT_TO_LANGUAGE: Record<string, Language> = {
+  '.ts': 'typescript',
+  '.tsx': 'typescript',
+  '.js': 'javascript',
+  '.jsx': 'javascript',
+  '.py': 'python',
+  '.go': 'go',
+  '.rs': 'rust',
+  '.java': 'java',
+};
+
+/** Extensions we skip even if they match (e.g. .d.ts). */
+const SKIP_EXTENSIONS = new Set(['.d.ts']);
+
+/** Detect language from a file path. Returns undefined if unsupported. */
+export function detectLanguage(filePath: string): Language | undefined {
+  const name = path.basename(filePath);
+  // Check skip extensions first
+  for (const skip of SKIP_EXTENSIONS) {
+    if (name.endsWith(skip)) return undefined;
+  }
+  const ext = path.extname(filePath);
+  return EXT_TO_LANGUAGE[ext];
+}
+
+/** Edge type mapping by extractor per the spec. */
+const EXTRACTOR_EDGE_TYPE: Record<string, EdgeType> = {
+  'test-descriptions': 'governs',
+  'enum-constants': 'documents',
+  'validation-rules': 'governs',
+  'api-paths': 'documents',
+};
+
+/**
+ * Orchestrates code signal extraction across a project.
+ * Walks files, dispatches to registered extractors, writes JSONL,
+ * persists to graph, and handles stale detection.
+ */
+export class ExtractionRunner {
+  constructor(private readonly extractors: readonly SignalExtractor[]) {}
+
+  /**
+   * Run all extractors against a project directory.
+   * @param projectDir - Project root directory
+   * @param store - GraphStore for node/edge persistence
+   * @param outputDir - Directory for JSONL output (e.g. .harness/knowledge/extracted/)
+   */
+  async run(projectDir: string, store: GraphStore, outputDir: string): Promise<IngestResult> {
+    const start = Date.now();
+    const errors: string[] = [];
+    let nodesAdded = 0;
+    let nodesUpdated = 0;
+    let edgesAdded = 0;
+
+    // Ensure output directory exists
+    await fs.mkdir(outputDir, { recursive: true });
+
+    // Walk project for source files
+    const files = await this.findSourceFiles(projectDir);
+
+    // Collect records per extractor
+    const recordsByExtractor = new Map<string, ExtractionRecord[]>();
+    for (const ext of this.extractors) {
+      recordsByExtractor.set(ext.name, []);
+    }
+
+    // Process each file
+    for (const filePath of files) {
+      const language = detectLanguage(filePath);
+      if (!language) continue;
+
+      const ext = path.extname(filePath);
+      let content: string;
+      try {
+        content = await fs.readFile(filePath, 'utf-8');
+      } catch (err) {
+        errors.push(
+          `Failed to read ${filePath}: ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
+
+      const relativePath = path.relative(projectDir, filePath).replaceAll('\\', '/');
+
+      for (const extractor of this.extractors) {
+        if (!extractor.supportedExtensions.includes(ext)) continue;
+        try {
+          const records = extractor.extract(content, relativePath, language);
+          recordsByExtractor.get(extractor.name)!.push(...records);
+        } catch (err) {
+          errors.push(
+            `Extractor ${extractor.name} failed on ${relativePath}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    }
+
+    // Write JSONL files and persist to graph
+    const allCurrentIds = new Set<string>();
+
+    for (const [extractorName, records] of recordsByExtractor) {
+      // Write JSONL
+      await this.writeJsonl(records, outputDir, extractorName);
+
+      // Persist to graph
+      for (const record of records) {
+        allCurrentIds.add(record.id);
+        const result = this.persistRecord(record, store);
+        nodesAdded += result.nodesAdded;
+        nodesUpdated += result.nodesUpdated;
+        edgesAdded += result.edgesAdded;
+      }
+    }
+
+    // Mark stale nodes
+    const staleCount = this.markStale(store, allCurrentIds);
+    nodesUpdated += staleCount;
+
+    return {
+      nodesAdded,
+      nodesUpdated,
+      edgesAdded,
+      edgesUpdated: 0,
+      errors,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  /** Write extraction records to JSONL file. */
+  async writeJsonl(
+    records: readonly ExtractionRecord[],
+    outputDir: string,
+    extractorName: string
+  ): Promise<void> {
+    const filePath = path.join(outputDir, `${extractorName}.jsonl`);
+    const lines = records.map((r) => JSON.stringify(r));
+    await fs.writeFile(filePath, lines.join('\n') + (lines.length > 0 ? '\n' : ''));
+  }
+
+  /** Create or update a graph node from an extraction record. */
+  private persistRecord(
+    record: ExtractionRecord,
+    store: GraphStore
+  ): { nodesAdded: number; nodesUpdated: number; edgesAdded: number } {
+    const existing = store.getNode(record.id);
+
+    const node: GraphNode = {
+      id: record.id,
+      type: record.nodeType,
+      name: record.name,
+      path: record.filePath,
+      location: {
+        fileId: `file:${hash(record.filePath)}`,
+        startLine: record.line,
+        endLine: record.line,
+      },
+      content: record.content,
+      metadata: {
+        ...record.metadata,
+        source: 'code-extractor',
+        extractor: record.extractor,
+        confidence: record.confidence,
+        language: record.language,
+        stale: false,
+      },
+    };
+
+    store.addNode(node);
+
+    // Create edge to source file node
+    const fileNodeId = `file:${hash(record.filePath)}`;
+    const edgeType = EXTRACTOR_EDGE_TYPE[record.extractor] ?? 'documents';
+    const edge: GraphEdge = {
+      from: record.id,
+      to: fileNodeId,
+      type: edgeType,
+      confidence: record.confidence,
+      metadata: { source: 'code-extractor' },
+    };
+    store.addEdge(edge);
+
+    return {
+      nodesAdded: existing ? 0 : 1,
+      nodesUpdated: existing ? 1 : 0,
+      edgesAdded: existing ? 0 : 1,
+    };
+  }
+
+  /**
+   * Mark nodes from previous extractions that are no longer present as stale.
+   * Returns the number of nodes marked stale.
+   */
+  markStale(store: GraphStore, currentIds: Set<string>): number {
+    let count = 0;
+    const businessTypes = ['business_rule', 'business_process', 'business_term'] as const;
+
+    for (const type of businessTypes) {
+      const nodes = store.findNodes({ type });
+      for (const node of nodes) {
+        if (
+          node.metadata.source === 'code-extractor' &&
+          !node.metadata.stale &&
+          !currentIds.has(node.id)
+        ) {
+          // Mark as stale by re-adding with stale metadata
+          store.addNode({
+            ...node,
+            metadata: {
+              ...node.metadata,
+              stale: true,
+              staleAt: new Date().toISOString(),
+            },
+          });
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  /** Recursively find source files, skipping common non-source directories. */
+  async findSourceFiles(dir: string): Promise<string[]> {
+    const results: string[] = [];
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return results;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+        results.push(...(await this.findSourceFiles(fullPath)));
+      } else if (entry.isFile() && detectLanguage(fullPath) !== undefined) {
+        results.push(fullPath);
+      }
+    }
+    return results;
+  }
+}

--- a/packages/graph/src/ingest/extractors/TestDescriptionExtractor.ts
+++ b/packages/graph/src/ingest/extractors/TestDescriptionExtractor.ts
@@ -1,0 +1,347 @@
+import { hash } from '../ingestUtils.js';
+import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
+
+/** Regex patterns for extracting test descriptions by language. */
+const PATTERNS: Record<Language, RegExp[]> = {
+  typescript: [/(?:describe|it|test)\s*\(\s*(['"`])((?:(?!\1).)*)\1/g],
+  javascript: [/(?:describe|it|test)\s*\(\s*(['"`])((?:(?!\1).)*)\1/g],
+  python: [/def\s+(test_\w+)\s*\(/g, /"""((?:(?!""").)*?)"""/gs, /class\s+(Test\w+)/g],
+  go: [/func\s+(Test\w+)\s*\(/g, /t\.Run\(\s*"([^"]+)"/g],
+  rust: [/#\[test\]\s*\n\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/g, /\/\/\/\s*(.+)/g],
+  java: [
+    /@DisplayName\s*\(\s*"([^"]+)"\s*\)/g,
+    /@Test\s*\n\s*(?:public\s+|private\s+|protected\s+)?(?:static\s+)?(?:void|[\w<>]+)\s+(\w+)\s*\(/g,
+  ],
+};
+
+/**
+ * Extracts business rules from test descriptions.
+ * Finds describe/it/test blocks (TS/JS), test_ functions (Python),
+ * Test* functions + t.Run subtests (Go), #[test] fns (Rust),
+ * @Test + @DisplayName (Java).
+ */
+export class TestDescriptionExtractor implements SignalExtractor {
+  readonly name = 'test-descriptions';
+  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+
+  extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const patterns = PATTERNS[language];
+    if (!patterns) return records;
+
+    const lines = content.split('\n');
+
+    // Track describe context for TS/JS
+    if (language === 'typescript' || language === 'javascript') {
+      return this.extractJsTs(content, filePath, language, lines);
+    }
+
+    if (language === 'python') {
+      return this.extractPython(content, filePath, language, lines);
+    }
+
+    if (language === 'go') {
+      return this.extractGo(content, filePath, language, lines);
+    }
+
+    if (language === 'rust') {
+      return this.extractRust(content, filePath, language, lines);
+    }
+
+    if (language === 'java') {
+      return this.extractJava(content, filePath, language, lines);
+    }
+
+    return records;
+  }
+
+  private extractJsTs(
+    _content: string,
+    filePath: string,
+    language: Language,
+    lines: string[]
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const describeStack: string[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // Track describe blocks
+      const describeMatch = line.match(/describe\s*\(\s*(['"`])((?:(?!\1).)*)\1/);
+      if (describeMatch) {
+        describeStack.push(describeMatch[2]!);
+      }
+
+      // Extract it/test descriptions
+      const itMatch = line.match(/(?:it|test)\s*\(\s*(['"`])((?:(?!\1).)*)\1/);
+      if (itMatch) {
+        const testName = itMatch[2]!;
+        const fullPath = [...describeStack, testName].join(' > ');
+        const patternKey = fullPath;
+
+        records.push({
+          id: `extracted:test-descriptions:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'test-descriptions',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_rule',
+          name: testName,
+          content: fullPath,
+          confidence: 0.7,
+          metadata: {
+            suite: describeStack.length > 0 ? describeStack[describeStack.length - 1] : undefined,
+            framework: 'vitest',
+          },
+        });
+      }
+
+      // Pop describe on closing — simplified heuristic: count closing parens after describe
+      if (line.match(/^\s*\}\s*\)\s*;?\s*$/) && describeStack.length > 0) {
+        describeStack.pop();
+      }
+    }
+
+    return records;
+  }
+
+  private extractPython(
+    _content: string,
+    filePath: string,
+    language: Language,
+    lines: string[]
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    let currentClass: string | undefined;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const classMatch = line.match(/^class\s+(Test\w+)/);
+      if (classMatch) {
+        currentClass = classMatch[1]!;
+      }
+
+      const funcMatch = line.match(/^\s*def\s+(test_\w+)\s*\(/);
+      if (funcMatch) {
+        const testName = funcMatch[1]!;
+        const humanName = testName.replace(/^test_/, '').replace(/_/g, ' ');
+
+        // Look for docstring on next line
+        let docstring: string | undefined;
+        if (i + 1 < lines.length) {
+          const nextLine = lines[i + 1]!.trim();
+          const docMatch = nextLine.match(/^"""(.+?)"""/);
+          if (docMatch) {
+            docstring = docMatch[1];
+          }
+        }
+
+        const patternKey = currentClass ? `${currentClass}.${testName}` : testName;
+
+        records.push({
+          id: `extracted:test-descriptions:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'test-descriptions',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_rule',
+          name: docstring ?? humanName,
+          content: patternKey,
+          confidence: docstring ? 0.7 : 0.5,
+          metadata: {
+            suite: currentClass,
+            framework: 'pytest',
+            functionName: testName,
+          },
+        });
+      }
+
+      // Reset class context on unindented non-class line
+      if (
+        currentClass &&
+        /^\S/.test(line) &&
+        !line.startsWith('class ') &&
+        !line.startsWith('#') &&
+        line.trim() !== ''
+      ) {
+        currentClass = undefined;
+      }
+    }
+
+    return records;
+  }
+
+  private extractGo(
+    _content: string,
+    filePath: string,
+    language: Language,
+    lines: string[]
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    let currentTest: string | undefined;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const funcMatch = line.match(/^func\s+(Test\w+)\s*\(/);
+      if (funcMatch) {
+        currentTest = funcMatch[1]!;
+        const humanName = currentTest
+          .replace(/^Test/, '')
+          .replace(/([A-Z])/g, ' $1')
+          .trim();
+
+        records.push({
+          id: `extracted:test-descriptions:${hash(filePath + ':' + currentTest)}`,
+          extractor: 'test-descriptions',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_rule',
+          name: humanName,
+          content: currentTest,
+          confidence: 0.5,
+          metadata: { framework: 'testing' },
+        });
+      }
+
+      const runMatch = line.match(/t\.Run\(\s*"([^"]+)"/);
+      if (runMatch && currentTest) {
+        const subtestName = runMatch[1]!;
+        const patternKey = `${currentTest} > ${subtestName}`;
+
+        records.push({
+          id: `extracted:test-descriptions:${hash(filePath + ':' + patternKey)}`,
+          extractor: 'test-descriptions',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_rule',
+          name: subtestName,
+          content: patternKey,
+          confidence: 0.7,
+          metadata: {
+            suite: currentTest,
+            framework: 'testing',
+          },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private extractRust(
+    _content: string,
+    filePath: string,
+    language: Language,
+    lines: string[]
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      if (line.trim() === '#[test]') {
+        // Next non-empty line should be the fn declaration
+        for (let j = i + 1; j < lines.length && j <= i + 3; j++) {
+          const fnLine = lines[j]!;
+          const fnMatch = fnLine.match(/(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/);
+          if (fnMatch) {
+            const testName = fnMatch[1]!;
+            const humanName = testName.replace(/^test_/, '').replace(/_/g, ' ');
+
+            // Look for doc comment above #[test]
+            let docComment: string | undefined;
+            if (i > 0) {
+              const prevLine = lines[i - 1]!.trim();
+              const docMatch = prevLine.match(/^\/\/\/\s*(.+)/);
+              if (docMatch) {
+                docComment = docMatch[1];
+              }
+            }
+
+            records.push({
+              id: `extracted:test-descriptions:${hash(filePath + ':' + testName)}`,
+              extractor: 'test-descriptions',
+              language,
+              filePath,
+              line: j + 1,
+              nodeType: 'business_rule',
+              name: docComment ?? humanName,
+              content: testName,
+              confidence: docComment ? 0.7 : 0.5,
+              metadata: { framework: 'rust-test' },
+            });
+            break;
+          }
+        }
+      }
+    }
+
+    return records;
+  }
+
+  private extractJava(
+    _content: string,
+    filePath: string,
+    language: Language,
+    lines: string[]
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      const testMatch = line.match(/@Test\s*$/);
+      if (testMatch) {
+        // Scan nearby lines for @DisplayName and method declaration
+        let displayName: string | undefined;
+
+        // Look backward for @DisplayName (up to 3 lines before @Test)
+        for (let k = Math.max(0, i - 3); k < i; k++) {
+          const prevLine = lines[k]!;
+          const dm = prevLine.match(/@DisplayName\s*\(\s*"([^"]+)"\s*\)/);
+          if (dm) displayName = dm[1]!;
+        }
+
+        // Look forward for @DisplayName and method declaration
+        for (let j = i + 1; j < lines.length && j <= i + 5; j++) {
+          const scanLine = lines[j]!;
+
+          const adjacentDisplay = scanLine.match(/@DisplayName\s*\(\s*"([^"]+)"\s*\)/);
+          if (adjacentDisplay) {
+            displayName = adjacentDisplay[1]!;
+            continue;
+          }
+
+          const methodMatch = scanLine.match(
+            /^\s*(?:(?:public|private|protected)\s+)?(?:static\s+)?(?:void|[\w<>[\]]+)\s+(\w+)\s*\(/
+          );
+          if (methodMatch) {
+            const methodName = methodMatch[1]!;
+            const name = displayName ?? methodName;
+            const patternKey = displayName ?? methodName;
+
+            records.push({
+              id: `extracted:test-descriptions:${hash(filePath + ':' + patternKey)}`,
+              extractor: 'test-descriptions',
+              language,
+              filePath,
+              line: j + 1,
+              nodeType: 'business_rule',
+              name,
+              content: patternKey,
+              confidence: displayName ? 0.7 : 0.5,
+              metadata: { framework: 'junit5' },
+            });
+            break;
+          }
+        }
+      }
+    }
+
+    return records;
+  }
+}

--- a/packages/graph/src/ingest/extractors/ValidationRuleExtractor.ts
+++ b/packages/graph/src/ingest/extractors/ValidationRuleExtractor.ts
@@ -1,0 +1,357 @@
+import { hash } from '../ingestUtils.js';
+import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
+
+/**
+ * Extracts business constraints from validation schemas and decorators.
+ * Finds Zod schemas (TS/JS), Pydantic models (Python), struct validate
+ * tags (Go), #[validate] macros (Rust), Bean Validation (Java).
+ */
+export class ValidationRuleExtractor implements SignalExtractor {
+  readonly name = 'validation-rules';
+  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+
+  extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    switch (language) {
+      case 'typescript':
+      case 'javascript':
+        return this.extractZod(content, filePath, language);
+      case 'python':
+        return this.extractPydantic(content, filePath, language);
+      case 'go':
+        return this.extractGoValidate(content, filePath, language);
+      case 'rust':
+        return this.extractRustValidate(content, filePath, language);
+      case 'java':
+        return this.extractBeanValidation(content, filePath, language);
+    }
+  }
+
+  private extractZod(content: string, filePath: string, language: Language): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // Zod schema declarations: const XSchema = z.object({...})
+      const schemaMatch = line.match(/(?:export\s+)?const\s+(\w+)\s*=\s*z\.object\s*\(\s*\{/);
+      if (schemaMatch) {
+        const schemaName = schemaMatch[1]!;
+        // Collect field-level validations
+        const constraints = this.collectZodConstraints(lines, i + 1);
+
+        records.push({
+          id: `extracted:validation-rules:${hash(filePath + ':' + schemaName)}`,
+          extractor: 'validation-rules',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_rule',
+          name: schemaName,
+          content: `${schemaName}: ${constraints.join('; ')}`,
+          confidence: 0.8,
+          metadata: { kind: 'zod-schema', constraints, framework: 'zod' },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private collectZodConstraints(lines: string[], startLine: number): string[] {
+    const constraints: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!.trim();
+      if (line.startsWith('}') || line.startsWith(')')) break;
+      if (line === '' || line.startsWith('//')) continue;
+
+      // Match field: z.type().constraint()
+      const fieldMatch = line.match(/(\w+)\s*:\s*z\.(.+?)(?:,?\s*$)/);
+      if (fieldMatch) {
+        const fieldName = fieldMatch[1]!;
+        const chain = fieldMatch[2]!;
+        constraints.push(`${fieldName}: ${chain}`);
+      }
+    }
+    return constraints;
+  }
+
+  private extractPydantic(
+    content: string,
+    filePath: string,
+    language: Language
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // Pydantic BaseModel classes
+      const modelMatch = line.match(/^class\s+(\w+)\s*\(\s*BaseModel\s*\)/);
+      if (modelMatch) {
+        const modelName = modelMatch[1]!;
+        const constraints = this.collectPydanticConstraints(lines, i + 1);
+
+        records.push({
+          id: `extracted:validation-rules:${hash(filePath + ':' + modelName)}`,
+          extractor: 'validation-rules',
+          language,
+          filePath,
+          line: i + 1,
+          nodeType: 'business_rule',
+          name: modelName,
+          content: `${modelName}: ${constraints.join('; ')}`,
+          confidence: 0.8,
+          metadata: { kind: 'pydantic-model', constraints, framework: 'pydantic' },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private collectPydanticConstraints(lines: string[], startLine: number): string[] {
+    const constraints: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (/^\S/.test(line) && line.trim() !== '') break;
+      if (line.trim() === '' || line.trim().startsWith('#')) continue;
+
+      // Match field: type = Field(...)
+      const fieldMatch = line.match(/^\s+(\w+)\s*:\s*(.+?)(?:\s*$)/);
+      if (fieldMatch) {
+        constraints.push(`${fieldMatch[1]}: ${fieldMatch[2]}`);
+      }
+    }
+    return constraints;
+  }
+
+  private extractGoValidate(
+    content: string,
+    filePath: string,
+    language: Language
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // Struct type declarations
+      const structMatch = line.match(/^type\s+(\w+)\s+struct\s*\{/);
+      if (structMatch) {
+        const structName = structMatch[1]!;
+        const constraints = this.collectGoValidateTags(lines, i + 1);
+
+        if (constraints.length > 0) {
+          records.push({
+            id: `extracted:validation-rules:${hash(filePath + ':' + structName)}`,
+            extractor: 'validation-rules',
+            language,
+            filePath,
+            line: i + 1,
+            nodeType: 'business_rule',
+            name: structName,
+            content: `${structName}: ${constraints.join('; ')}`,
+            confidence: 0.8,
+            metadata: { kind: 'struct-tags', constraints, framework: 'go-playground/validator' },
+          });
+        }
+      }
+    }
+
+    return records;
+  }
+
+  private collectGoValidateTags(lines: string[], startLine: number): string[] {
+    const constraints: string[] = [];
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!.trim();
+      if (line === '}') break;
+      if (line === '' || line.startsWith('//')) continue;
+
+      const tagMatch = line.match(/(\w+)\s+\S+\s+`[^`]*validate:"([^"]+)"[^`]*`/);
+      if (tagMatch) {
+        constraints.push(`${tagMatch[1]}: ${tagMatch[2]}`);
+      }
+    }
+    return constraints;
+  }
+
+  private extractRustValidate(
+    content: string,
+    filePath: string,
+    language: Language
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+
+      // #[derive(Validate)] struct
+      const deriveMatch = line.match(/#\[derive\([^)]*Validate[^)]*\)\]/);
+      if (deriveMatch) {
+        // Next line should be struct declaration
+        for (let j = i + 1; j < lines.length && j <= i + 3; j++) {
+          const structLine = lines[j]!;
+          const structMatch = structLine.match(/^(?:pub\s+)?struct\s+(\w+)/);
+          if (structMatch) {
+            const structName = structMatch[1]!;
+            const constraints = this.collectRustValidateAttrs(lines, j + 1);
+
+            if (constraints.length > 0) {
+              records.push({
+                id: `extracted:validation-rules:${hash(filePath + ':' + structName)}`,
+                extractor: 'validation-rules',
+                language,
+                filePath,
+                line: j + 1,
+                nodeType: 'business_rule',
+                name: structName,
+                content: `${structName}: ${constraints.join('; ')}`,
+                confidence: 0.8,
+                metadata: { kind: 'validate-derive', constraints, framework: 'validator' },
+              });
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    return records;
+  }
+
+  private collectRustValidateAttrs(lines: string[], startLine: number): string[] {
+    const constraints: string[] = [];
+    let pendingValidate: string | undefined;
+
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i]!.trim();
+      if (line === '}') break;
+
+      const attrMatch = line.match(/#\[validate\((.+?)\)\]/);
+      if (attrMatch) {
+        pendingValidate = attrMatch[1]!;
+        continue;
+      }
+
+      if (pendingValidate) {
+        const fieldMatch = line.match(/(?:pub\s+)?(\w+)\s*:/);
+        if (fieldMatch) {
+          constraints.push(`${fieldMatch[1]}: ${pendingValidate}`);
+          pendingValidate = undefined;
+        }
+      }
+    }
+    return constraints;
+  }
+
+  private extractBeanValidation(
+    content: string,
+    filePath: string,
+    language: Language
+  ): ExtractionRecord[] {
+    const records: ExtractionRecord[] = [];
+    const lines = content.split('\n');
+
+    // Find classes with validation annotations
+    const classRanges = this.findJavaClasses(lines);
+
+    for (const { name: className, startLine, endLine } of classRanges) {
+      const constraints = this.collectBeanConstraints(lines, startLine, endLine);
+      if (constraints.length > 0) {
+        records.push({
+          id: `extracted:validation-rules:${hash(filePath + ':' + className)}`,
+          extractor: 'validation-rules',
+          language,
+          filePath,
+          line: startLine + 1,
+          nodeType: 'business_rule',
+          name: className,
+          content: `${className}: ${constraints.join('; ')}`,
+          confidence: 0.8,
+          metadata: { kind: 'bean-validation', constraints, framework: 'javax.validation' },
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private findJavaClasses(
+    lines: string[]
+  ): Array<{ name: string; startLine: number; endLine: number }> {
+    const classes: Array<{ name: string; startLine: number; endLine: number }> = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      const match = line.match(/(?:public\s+|private\s+|protected\s+)?class\s+(\w+)/);
+      if (match) {
+        const endLine = this.findClosingBrace(lines, i);
+        classes.push({ name: match[1]!, startLine: i, endLine });
+      }
+    }
+    return classes;
+  }
+
+  private findClosingBrace(lines: string[], startLine: number): number {
+    let depth = 0;
+    for (let i = startLine; i < lines.length; i++) {
+      for (const ch of lines[i]!) {
+        if (ch === '{') depth++;
+        if (ch === '}') {
+          depth--;
+          if (depth === 0) return i;
+        }
+      }
+    }
+    return lines.length - 1;
+  }
+
+  private collectBeanConstraints(lines: string[], startLine: number, endLine: number): string[] {
+    const constraints: string[] = [];
+    const validationAnnotations = [
+      '@NotNull',
+      '@NotBlank',
+      '@NotEmpty',
+      '@Size',
+      '@Min',
+      '@Max',
+      '@DecimalMin',
+      '@DecimalMax',
+      '@Email',
+      '@Pattern',
+      '@Positive',
+      '@Negative',
+      '@Past',
+      '@Future',
+    ];
+
+    let pendingAnnotations: string[] = [];
+
+    for (let i = startLine + 1; i < endLine; i++) {
+      const line = lines[i]!.trim();
+
+      // Check for validation annotations
+      for (const anno of validationAnnotations) {
+        if (line.startsWith(anno)) {
+          pendingAnnotations.push(line.replace(/;?\s*$/, ''));
+        }
+      }
+
+      // Field declaration after annotations
+      if (pendingAnnotations.length > 0) {
+        const fieldMatch = line.match(
+          /(?:private|public|protected)\s+(?:[\w<>[\]]+)\s+(\w+)\s*[;=]/
+        );
+        if (fieldMatch) {
+          constraints.push(`${fieldMatch[1]}: ${pendingAnnotations.join(', ')}`);
+          pendingAnnotations = [];
+        }
+      }
+    }
+    return constraints;
+  }
+}

--- a/packages/graph/src/ingest/extractors/index.ts
+++ b/packages/graph/src/ingest/extractors/index.ts
@@ -1,0 +1,26 @@
+export type { ExtractionRecord, SignalExtractor, Language } from './types.js';
+export { ExtractionRunner, detectLanguage } from './ExtractionRunner.js';
+export { TestDescriptionExtractor } from './TestDescriptionExtractor.js';
+export { EnumConstantExtractor } from './EnumConstantExtractor.js';
+export { ValidationRuleExtractor } from './ValidationRuleExtractor.js';
+export { ApiPathExtractor } from './ApiPathExtractor.js';
+
+import { TestDescriptionExtractor } from './TestDescriptionExtractor.js';
+import { EnumConstantExtractor } from './EnumConstantExtractor.js';
+import { ValidationRuleExtractor } from './ValidationRuleExtractor.js';
+import { ApiPathExtractor } from './ApiPathExtractor.js';
+import { ExtractionRunner } from './ExtractionRunner.js';
+import type { SignalExtractor } from './types.js';
+
+/** All built-in code signal extractors. */
+export const ALL_EXTRACTORS: readonly SignalExtractor[] = [
+  new TestDescriptionExtractor(),
+  new EnumConstantExtractor(),
+  new ValidationRuleExtractor(),
+  new ApiPathExtractor(),
+];
+
+/** Create an ExtractionRunner with all built-in extractors. */
+export function createExtractionRunner(): ExtractionRunner {
+  return new ExtractionRunner(ALL_EXTRACTORS);
+}

--- a/packages/graph/src/ingest/extractors/types.ts
+++ b/packages/graph/src/ingest/extractors/types.ts
@@ -1,0 +1,44 @@
+import type { NodeType } from '../../types.js';
+
+/** Languages supported by the code signal extractors. */
+export type Language = 'typescript' | 'javascript' | 'python' | 'go' | 'rust' | 'java';
+
+/**
+ * A single business-signal extraction record.
+ * Written to JSONL and used to create provisional graph nodes.
+ */
+export interface ExtractionRecord {
+  /** Deterministic ID: `extracted:<extractor>:<hash(filePath+':'+patternKey)>` */
+  readonly id: string;
+  /** Which extractor produced this record. */
+  readonly extractor: string;
+  /** Source language of the file. */
+  readonly language: Language;
+  /** File path relative to project root. */
+  readonly filePath: string;
+  /** Start line of the extracted pattern (1-based). */
+  readonly line: number;
+  /** Graph node type this maps to. */
+  readonly nodeType: NodeType;
+  /** Human-readable label for the extracted fact. */
+  readonly name: string;
+  /** Raw extracted text. */
+  readonly content: string;
+  /** Extraction confidence (0.0-1.0). */
+  readonly confidence: number;
+  /** Extractor-specific metadata. */
+  readonly metadata: Record<string, unknown>;
+}
+
+/**
+ * Interface for pluggable code signal extractors.
+ * Each extractor scans file content and returns extraction records.
+ */
+export interface SignalExtractor {
+  /** Unique extractor identifier (e.g. 'test-descriptions'). */
+  readonly name: string;
+  /** File extensions this extractor can process. */
+  readonly supportedExtensions: readonly string[];
+  /** Extract signals from a single file's content. */
+  extract(content: string, filePath: string, language: Language): ExtractionRecord[];
+}

--- a/packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts
+++ b/packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'path';
+import { ApiPathExtractor } from '../../../src/ingest/extractors/ApiPathExtractor.js';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-project');
+const extractor = new ApiPathExtractor();
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURE_DIR, name), 'utf-8');
+}
+
+describe('ApiPathExtractor', () => {
+  it('extracts Express routes from TypeScript', () => {
+    const content = readFixture('routes.ts');
+    const records = extractor.extract(content, 'routes.ts', 'typescript');
+
+    expect(records.length).toBeGreaterThanOrEqual(5);
+    expect(records.every((r) => r.nodeType === 'business_process')).toBe(true);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('GET /api/users');
+    expect(names).toContain('POST /api/users');
+    expect(names).toContain('GET /api/users/:id');
+    expect(names).toContain('GET /api/orders');
+
+    const getUsers = records.find((r) => r.name === 'GET /api/users');
+    expect(getUsers!.confidence).toBe(0.9);
+    expect(getUsers!.metadata.method).toBe('GET');
+    expect(getUsers!.metadata.path).toBe('/api/users');
+  });
+
+  it('extracts FastAPI decorators from Python', () => {
+    const content = readFixture('routes.py');
+    const records = extractor.extract(content, 'routes.py', 'python');
+
+    expect(records.length).toBeGreaterThanOrEqual(5);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('GET /api/users');
+    expect(names).toContain('POST /api/users');
+    expect(names).toContain('GET /api/users/{user_id}');
+  });
+
+  it('extracts Gin routes from Go', () => {
+    const content = readFixture('routes.go');
+    const records = extractor.extract(content, 'routes.go', 'go');
+
+    expect(records.length).toBeGreaterThanOrEqual(5);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('GET /api/users');
+    expect(names).toContain('POST /api/users');
+    expect(names).toContain('GET /api/users/:id');
+
+    // http.HandleFunc should have lower confidence
+    const healthCheck = records.find((r) => r.metadata.framework === 'net/http');
+    expect(healthCheck).toBeDefined();
+    expect(healthCheck!.confidence).toBe(0.6);
+  });
+
+  it('extracts Actix macros from Rust', () => {
+    const content = readFixture('routes.rs');
+    const records = extractor.extract(content, 'routes.rs', 'rust');
+
+    expect(records.length).toBeGreaterThanOrEqual(5);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('GET /api/users');
+    expect(names).toContain('POST /api/users');
+    expect(names).toContain('GET /api/users/{id}');
+    expect(names).toContain('GET /api/orders');
+  });
+
+  it('extracts Spring annotations from Java', () => {
+    const content = readFixture('Routes.java');
+    const records = extractor.extract(content, 'Routes.java', 'java');
+
+    expect(records.length).toBeGreaterThanOrEqual(5);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('GET /api/users');
+    expect(names).toContain('POST /api/users');
+    expect(names).toContain('GET /api/orders');
+
+    const getUsers = records.find((r) => r.name === 'GET /api/users');
+    expect(getUsers!.metadata.framework).toBe('spring');
+  });
+
+  it('generates stable IDs', () => {
+    const content = readFixture('routes.ts');
+    const records1 = extractor.extract(content, 'routes.ts', 'typescript');
+    const records2 = extractor.extract(content, 'routes.ts', 'typescript');
+
+    expect(records1.map((r) => r.id)).toEqual(records2.map((r) => r.id));
+  });
+});

--- a/packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts
+++ b/packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'path';
+import { EnumConstantExtractor } from '../../../src/ingest/extractors/EnumConstantExtractor.js';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-project');
+const extractor = new EnumConstantExtractor();
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURE_DIR, name), 'utf-8');
+}
+
+describe('EnumConstantExtractor', () => {
+  it('extracts enums, as const, and union types from TypeScript', () => {
+    const content = readFixture('enums.ts');
+    const records = extractor.extract(content, 'enums.ts', 'typescript');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+    expect(records.every((r) => r.nodeType === 'business_term')).toBe(true);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('OrderStatus');
+    expect(names).toContain('PaymentMethod');
+    expect(names).toContain('UserRole');
+
+    // Enum should have high confidence
+    const orderStatus = records.find((r) => r.name === 'OrderStatus');
+    expect(orderStatus!.confidence).toBe(0.8);
+    expect(orderStatus!.metadata.members).toContain('PENDING');
+  });
+
+  it('extracts Enum subclasses from Python', () => {
+    const content = readFixture('enums.py');
+    const records = extractor.extract(content, 'enums.py', 'python');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('OrderStatus');
+    expect(names).toContain('Priority');
+  });
+
+  it('extracts iota const blocks from Go', () => {
+    const content = readFixture('enums.go');
+    const records = extractor.extract(content, 'enums.go', 'go');
+
+    expect(records.length).toBeGreaterThanOrEqual(2);
+
+    const orderStatus = records.find(
+      (r) => r.name === 'OrderStatus' || (r.metadata.members as string[])?.includes('Pending')
+    );
+    expect(orderStatus).toBeDefined();
+  });
+
+  it('extracts enum declarations from Rust', () => {
+    const content = readFixture('enums.rs');
+    const records = extractor.extract(content, 'enums.rs', 'rust');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('OrderStatus');
+    expect(names).toContain('Priority');
+    expect(names).toContain('PaymentMethod');
+  });
+
+  it('extracts enum classes from Java', () => {
+    const content = readFixture('Enums.java');
+    const records = extractor.extract(content, 'Enums.java', 'java');
+
+    expect(records.length).toBeGreaterThanOrEqual(2);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('OrderStatus');
+    expect(names).toContain('Priority');
+  });
+
+  it('generates stable IDs', () => {
+    const content = readFixture('enums.ts');
+    const records1 = extractor.extract(content, 'enums.ts', 'typescript');
+    const records2 = extractor.extract(content, 'enums.ts', 'typescript');
+
+    expect(records1.map((r) => r.id)).toEqual(records2.map((r) => r.id));
+  });
+});

--- a/packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts
+++ b/packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'path';
+import * as fs from 'node:fs/promises';
+import * as os from 'os';
+import {
+  ExtractionRunner,
+  detectLanguage,
+} from '../../../src/ingest/extractors/ExtractionRunner.js';
+import { GraphStore } from '../../../src/store/GraphStore.js';
+import type {
+  ExtractionRecord,
+  Language,
+  SignalExtractor,
+} from '../../../src/ingest/extractors/types.js';
+import { hash } from '../../../src/ingest/ingestUtils.js';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-project');
+
+/** Simple stub extractor for testing the runner. */
+function createStubExtractor(name: string): SignalExtractor {
+  return {
+    name,
+    supportedExtensions: ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'],
+    extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
+      return [
+        {
+          id: `extracted:${name}:${hash(filePath + ':stub')}`,
+          extractor: name,
+          language,
+          filePath,
+          line: 1,
+          nodeType: 'business_rule',
+          name: `stub from ${path.basename(filePath)}`,
+          content: 'stub content',
+          confidence: 0.7,
+          metadata: {},
+        },
+      ];
+    },
+  };
+}
+
+describe('detectLanguage', () => {
+  it('maps .ts to typescript', () => {
+    expect(detectLanguage('src/foo.ts')).toBe('typescript');
+  });
+  it('maps .tsx to typescript', () => {
+    expect(detectLanguage('src/foo.tsx')).toBe('typescript');
+  });
+  it('maps .js to javascript', () => {
+    expect(detectLanguage('src/foo.js')).toBe('javascript');
+  });
+  it('maps .py to python', () => {
+    expect(detectLanguage('src/foo.py')).toBe('python');
+  });
+  it('maps .go to go', () => {
+    expect(detectLanguage('src/foo.go')).toBe('go');
+  });
+  it('maps .rs to rust', () => {
+    expect(detectLanguage('src/foo.rs')).toBe('rust');
+  });
+  it('maps .java to java', () => {
+    expect(detectLanguage('src/Foo.java')).toBe('java');
+  });
+  it('returns undefined for .d.ts', () => {
+    expect(detectLanguage('src/foo.d.ts')).toBeUndefined();
+  });
+  it('returns undefined for unsupported extensions', () => {
+    expect(detectLanguage('src/foo.md')).toBeUndefined();
+  });
+});
+
+describe('ExtractionRunner', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'extractor-test-'));
+  });
+
+  it('finds source files in fixture directory', async () => {
+    const runner = new ExtractionRunner([]);
+    const files = await runner.findSourceFiles(FIXTURE_DIR);
+    expect(files.length).toBeGreaterThan(0);
+    // Should find TypeScript, Python, Go, Rust, Java files
+    const extensions = new Set(files.map((f) => path.extname(f)));
+    expect(extensions).toContain('.ts');
+    expect(extensions).toContain('.py');
+    expect(extensions).toContain('.go');
+    expect(extensions).toContain('.rs');
+    expect(extensions).toContain('.java');
+  });
+
+  it('writes JSONL output for each extractor', async () => {
+    const stubExtractor = createStubExtractor('test-stub');
+    const runner = new ExtractionRunner([stubExtractor]);
+    const store = new GraphStore();
+
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    const jsonlPath = path.join(tmpDir, 'test-stub.jsonl');
+    const content = await fs.readFile(jsonlPath, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines.length).toBeGreaterThan(0);
+
+    // Each line should be valid JSON ExtractionRecord
+    for (const line of lines) {
+      const record = JSON.parse(line) as ExtractionRecord;
+      expect(record.id).toMatch(/^extracted:test-stub:/);
+      expect(record.extractor).toBe('test-stub');
+      expect(record.confidence).toBeGreaterThanOrEqual(0);
+      expect(record.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('creates graph nodes with correct metadata', async () => {
+    const stubExtractor = createStubExtractor('test-stub');
+    const runner = new ExtractionRunner([stubExtractor]);
+    const store = new GraphStore();
+
+    const result = await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    expect(result.nodesAdded).toBeGreaterThan(0);
+    expect(result.edgesAdded).toBeGreaterThan(0);
+
+    const nodes = store.findNodes({ type: 'business_rule' });
+    const extractorNodes = nodes.filter((n) => n.metadata.source === 'code-extractor');
+    expect(extractorNodes.length).toBeGreaterThan(0);
+    for (const node of extractorNodes) {
+      expect(node.metadata.extractor).toBe('test-stub');
+      expect(node.metadata.confidence).toBe(0.7);
+      expect(node.metadata.stale).toBe(false);
+    }
+  });
+
+  it('produces identical results on re-run (stable IDs)', async () => {
+    const stubExtractor = createStubExtractor('test-stub');
+    const runner = new ExtractionRunner([stubExtractor]);
+    const store = new GraphStore();
+
+    const result1 = await runner.run(FIXTURE_DIR, store, tmpDir);
+    const nodesBefore = store.findNodes({ type: 'business_rule' }).length;
+
+    const result2 = await runner.run(FIXTURE_DIR, store, tmpDir);
+    const nodesAfter = store.findNodes({ type: 'business_rule' }).length;
+
+    // No new nodes on second run
+    expect(nodesAfter).toBe(nodesBefore);
+    expect(result2.nodesAdded).toBe(0);
+  });
+
+  it('marks stale nodes when signals disappear', async () => {
+    // First run: create some nodes
+    const stubExtractor = createStubExtractor('test-stub');
+    const runner = new ExtractionRunner([stubExtractor]);
+    const store = new GraphStore();
+
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    const nodesBefore = store
+      .findNodes({ type: 'business_rule' })
+      .filter((n) => n.metadata.source === 'code-extractor');
+    expect(nodesBefore.length).toBeGreaterThan(0);
+
+    // Second run: empty extractor returns nothing
+    const emptyExtractor: SignalExtractor = {
+      name: 'test-stub',
+      supportedExtensions: ['.ts'],
+      extract() {
+        return [];
+      },
+    };
+    const runner2 = new ExtractionRunner([emptyExtractor]);
+    await runner2.run(FIXTURE_DIR, store, tmpDir);
+
+    // All previous nodes should be marked stale
+    const nodesAfter = store
+      .findNodes({ type: 'business_rule' })
+      .filter((n) => n.metadata.source === 'code-extractor');
+    const staleNodes = nodesAfter.filter((n) => n.metadata.stale === true);
+    expect(staleNodes.length).toBe(nodesBefore.length);
+    for (const stale of staleNodes) {
+      expect(stale.metadata.staleAt).toBeDefined();
+    }
+  });
+});

--- a/packages/graph/tests/ingest/extractors/TestDescriptionExtractor.test.ts
+++ b/packages/graph/tests/ingest/extractors/TestDescriptionExtractor.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'path';
+import { TestDescriptionExtractor } from '../../../src/ingest/extractors/TestDescriptionExtractor.js';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-project');
+const extractor = new TestDescriptionExtractor();
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURE_DIR, name), 'utf-8');
+}
+
+describe('TestDescriptionExtractor', () => {
+  it('extracts describe/it/test from TypeScript', () => {
+    const content = readFixture('auth.test.ts');
+    const records = extractor.extract(content, 'auth.test.ts', 'typescript');
+
+    expect(records.length).toBeGreaterThanOrEqual(5);
+    expect(records.every((r) => r.nodeType === 'business_rule')).toBe(true);
+    expect(records.every((r) => r.extractor === 'test-descriptions')).toBe(true);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('should reject expired tokens');
+    expect(names).toContain('should accept valid JWT tokens');
+    expect(names).toContain('handles malformed token gracefully');
+
+    // High confidence for string-described tests
+    const tokenTest = records.find((r) => r.name === 'should reject expired tokens');
+    expect(tokenTest?.confidence).toBe(0.7);
+  });
+
+  it('extracts test_ functions from Python', () => {
+    const content = readFixture('auth_test.py');
+    const records = extractor.extract(content, 'auth_test.py', 'python');
+
+    expect(records.length).toBeGreaterThanOrEqual(4);
+
+    // Docstring-based should have higher confidence
+    const expiredTest = records.find((r) => r.content.includes('test_reject_expired_tokens'));
+    expect(expiredTest).toBeDefined();
+    expect(expiredTest!.confidence).toBe(0.7); // has docstring
+  });
+
+  it('extracts Test* and t.Run from Go', () => {
+    const content = readFixture('auth_test.go');
+    const records = extractor.extract(content, 'auth_test.go', 'go');
+
+    expect(records.length).toBeGreaterThanOrEqual(4);
+
+    // Top-level test function (lower confidence)
+    const topLevel = records.find((r) => r.content === 'TestTokenValidation');
+    expect(topLevel).toBeDefined();
+    expect(topLevel!.confidence).toBe(0.5);
+
+    // Subtests (higher confidence)
+    const subtests = records.filter((r) => r.confidence === 0.7);
+    expect(subtests.length).toBeGreaterThanOrEqual(2);
+    const subtestNames = subtests.map((r) => r.name);
+    expect(subtestNames).toContain('rejects expired tokens');
+  });
+
+  it('extracts #[test] functions from Rust', () => {
+    const content = readFixture('auth_test.rs');
+    const records = extractor.extract(content, 'auth_test.rs', 'rust');
+
+    expect(records.length).toBeGreaterThanOrEqual(4);
+
+    // Doc-commented tests should have higher confidence
+    const docTest = records.find((r) => r.content === 'test_reject_expired_tokens');
+    expect(docTest).toBeDefined();
+    expect(docTest!.confidence).toBe(0.7); // has doc comment
+  });
+
+  it('extracts @Test/@DisplayName from Java', () => {
+    const content = readFixture('AuthTest.java');
+    const records = extractor.extract(content, 'AuthTest.java', 'java');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+
+    // @DisplayName tests should have higher confidence
+    const displayNameTest = records.find((r) => r.name === 'should reject expired tokens');
+    expect(displayNameTest).toBeDefined();
+    expect(displayNameTest!.confidence).toBe(0.7);
+
+    // Bare @Test should have lower confidence
+    const bareTest = records.find((r) => r.name === 'testPasswordHashing');
+    expect(bareTest).toBeDefined();
+    expect(bareTest!.confidence).toBe(0.5);
+  });
+
+  it('generates stable IDs', () => {
+    const content = readFixture('auth.test.ts');
+    const records1 = extractor.extract(content, 'auth.test.ts', 'typescript');
+    const records2 = extractor.extract(content, 'auth.test.ts', 'typescript');
+
+    expect(records1.map((r) => r.id)).toEqual(records2.map((r) => r.id));
+  });
+});

--- a/packages/graph/tests/ingest/extractors/ValidationRuleExtractor.test.ts
+++ b/packages/graph/tests/ingest/extractors/ValidationRuleExtractor.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'path';
+import { ValidationRuleExtractor } from '../../../src/ingest/extractors/ValidationRuleExtractor.js';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-project');
+const extractor = new ValidationRuleExtractor();
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURE_DIR, name), 'utf-8');
+}
+
+describe('ValidationRuleExtractor', () => {
+  it('extracts Zod schemas from TypeScript', () => {
+    const content = readFixture('validators.ts');
+    const records = extractor.extract(content, 'validators.ts', 'typescript');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+    expect(records.every((r) => r.nodeType === 'business_rule')).toBe(true);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('UserSchema');
+    expect(names).toContain('OrderSchema');
+    expect(names).toContain('AddressSchema');
+
+    const userSchema = records.find((r) => r.name === 'UserSchema');
+    expect(userSchema!.confidence).toBe(0.8);
+    expect(userSchema!.metadata.framework).toBe('zod');
+  });
+
+  it('extracts Pydantic models from Python', () => {
+    const content = readFixture('validators.py');
+    const records = extractor.extract(content, 'validators.py', 'python');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('UserModel');
+    expect(names).toContain('OrderModel');
+    expect(names).toContain('AddressModel');
+
+    const userModel = records.find((r) => r.name === 'UserModel');
+    expect(userModel!.metadata.framework).toBe('pydantic');
+  });
+
+  it('extracts validate struct tags from Go', () => {
+    const content = readFixture('validators.go');
+    const records = extractor.extract(content, 'validators.go', 'go');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('User');
+    expect(names).toContain('Order');
+    expect(names).toContain('Address');
+
+    const user = records.find((r) => r.name === 'User');
+    expect(user!.metadata.framework).toBe('go-playground/validator');
+  });
+
+  it('extracts #[validate] derive macros from Rust', () => {
+    const content = readFixture('validators.rs');
+    const records = extractor.extract(content, 'validators.rs', 'rust');
+
+    expect(records.length).toBeGreaterThanOrEqual(3);
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('User');
+    expect(names).toContain('Order');
+    expect(names).toContain('Address');
+  });
+
+  it('extracts Bean Validation annotations from Java', () => {
+    const content = readFixture('Validators.java');
+    const records = extractor.extract(content, 'Validators.java', 'java');
+
+    expect(records.length).toBeGreaterThanOrEqual(2);
+
+    const userRecord = records.find((r) => r.name === 'User');
+    expect(userRecord).toBeDefined();
+    expect(userRecord!.metadata.framework).toBe('javax.validation');
+  });
+
+  it('generates stable IDs', () => {
+    const content = readFixture('validators.ts');
+    const records1 = extractor.extract(content, 'validators.ts', 'typescript');
+    const records2 = extractor.extract(content, 'validators.ts', 'typescript');
+
+    expect(records1.map((r) => r.id)).toEqual(records2.map((r) => r.id));
+  });
+});

--- a/packages/graph/tests/ingest/extractors/integration.test.ts
+++ b/packages/graph/tests/ingest/extractors/integration.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'path';
+import * as fs from 'node:fs/promises';
+import * as os from 'os';
+import { GraphStore } from '../../../src/store/GraphStore.js';
+import { createExtractionRunner } from '../../../src/ingest/extractors/index.js';
+import type { ExtractionRecord } from '../../../src/ingest/extractors/types.js';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-project');
+
+describe('Code Signal Extractors — End-to-End', () => {
+  let tmpDir: string;
+  let store: GraphStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'extractor-e2e-'));
+    store = new GraphStore();
+  });
+
+  it('writes 4 JSONL files to output directory', async () => {
+    const runner = createExtractionRunner();
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    const files = await fs.readdir(tmpDir);
+    expect(files).toContain('test-descriptions.jsonl');
+    expect(files).toContain('enum-constants.jsonl');
+    expect(files).toContain('validation-rules.jsonl');
+    expect(files).toContain('api-paths.jsonl');
+  });
+
+  it('produces valid ExtractionRecord entries in JSONL', async () => {
+    const runner = createExtractionRunner();
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    for (const fileName of [
+      'test-descriptions.jsonl',
+      'enum-constants.jsonl',
+      'validation-rules.jsonl',
+      'api-paths.jsonl',
+    ]) {
+      const content = await fs.readFile(path.join(tmpDir, fileName), 'utf-8');
+      const lines = content.trim().split('\n');
+      expect(lines.length).toBeGreaterThan(0);
+
+      for (const line of lines) {
+        const record = JSON.parse(line) as ExtractionRecord;
+        expect(record.id).toMatch(/^extracted:/);
+        expect(record.extractor).toBeTruthy();
+        expect(record.language).toBeTruthy();
+        expect(record.filePath).toBeTruthy();
+        expect(record.line).toBeGreaterThan(0);
+        expect(record.nodeType).toBeTruthy();
+        expect(record.name).toBeTruthy();
+        expect(record.confidence).toBeGreaterThanOrEqual(0);
+        expect(record.confidence).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it('creates graph nodes with correct types and metadata', async () => {
+    const runner = createExtractionRunner();
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    // business_rule nodes (from test-descriptions and validation-rules)
+    const rules = store.findNodes({ type: 'business_rule' });
+    const extractorRules = rules.filter((n) => n.metadata.source === 'code-extractor');
+    expect(extractorRules.length).toBeGreaterThan(0);
+
+    // business_term nodes (from enum-constants)
+    const terms = store.findNodes({ type: 'business_term' });
+    const extractorTerms = terms.filter((n) => n.metadata.source === 'code-extractor');
+    expect(extractorTerms.length).toBeGreaterThan(0);
+
+    // business_process nodes (from api-paths)
+    const processes = store.findNodes({ type: 'business_process' });
+    const extractorProcesses = processes.filter((n) => n.metadata.source === 'code-extractor');
+    expect(extractorProcesses.length).toBeGreaterThan(0);
+
+    // All extractor nodes should have required metadata
+    const allExtractorNodes = [...extractorRules, ...extractorTerms, ...extractorProcesses];
+    for (const node of allExtractorNodes) {
+      expect(node.metadata.source).toBe('code-extractor');
+      expect(node.metadata.extractor).toBeTruthy();
+      expect(node.metadata.confidence).toBeGreaterThanOrEqual(0);
+      expect(node.metadata.stale).toBe(false);
+    }
+  });
+
+  it('creates edges from extracted nodes to source file nodes', async () => {
+    const runner = createExtractionRunner();
+    const result = await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    expect(result.edgesAdded).toBeGreaterThan(0);
+  });
+
+  it('covers all 6 languages across extractors', async () => {
+    const runner = createExtractionRunner();
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    // Check JSONL files for language coverage
+    for (const fileName of [
+      'test-descriptions.jsonl',
+      'enum-constants.jsonl',
+      'validation-rules.jsonl',
+      'api-paths.jsonl',
+    ]) {
+      const content = await fs.readFile(path.join(tmpDir, fileName), 'utf-8');
+      const records = content
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as ExtractionRecord);
+
+      const languages = new Set(records.map((r) => r.language));
+      // Each extractor should cover at least TS and Python
+      expect(languages.size).toBeGreaterThanOrEqual(2);
+    }
+
+    // Across all extractors, all 6 languages should appear
+    const allLanguages = new Set<string>();
+    for (const fileName of [
+      'test-descriptions.jsonl',
+      'enum-constants.jsonl',
+      'validation-rules.jsonl',
+      'api-paths.jsonl',
+    ]) {
+      const content = await fs.readFile(path.join(tmpDir, fileName), 'utf-8');
+      const records = content
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as ExtractionRecord);
+      for (const r of records) {
+        allLanguages.add(r.language);
+      }
+    }
+
+    expect(allLanguages).toContain('typescript');
+    expect(allLanguages).toContain('python');
+    expect(allLanguages).toContain('go');
+    expect(allLanguages).toContain('rust');
+    expect(allLanguages).toContain('java');
+  });
+
+  it('produces identical results on re-run (stable IDs)', async () => {
+    const runner = createExtractionRunner();
+
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+    const nodeCountBefore = [
+      ...store.findNodes({ type: 'business_rule' }),
+      ...store.findNodes({ type: 'business_term' }),
+      ...store.findNodes({ type: 'business_process' }),
+    ].filter((n) => n.metadata.source === 'code-extractor').length;
+
+    // Second run with same store
+    const result2 = await runner.run(FIXTURE_DIR, store, tmpDir);
+    const nodeCountAfter = [
+      ...store.findNodes({ type: 'business_rule' }),
+      ...store.findNodes({ type: 'business_term' }),
+      ...store.findNodes({ type: 'business_process' }),
+    ].filter((n) => n.metadata.source === 'code-extractor').length;
+
+    // No new nodes
+    expect(nodeCountAfter).toBe(nodeCountBefore);
+    expect(result2.nodesAdded).toBe(0);
+
+    // JSONL should be identical
+    const jsonl1 = await fs.readFile(path.join(tmpDir, 'test-descriptions.jsonl'), 'utf-8');
+    const jsonl2 = await fs.readFile(path.join(tmpDir, 'test-descriptions.jsonl'), 'utf-8');
+    expect(jsonl1).toBe(jsonl2);
+  });
+
+  it('marks stale nodes when signals disappear', async () => {
+    const runner = createExtractionRunner();
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    const extractorNodesBefore = [
+      ...store.findNodes({ type: 'business_rule' }),
+      ...store.findNodes({ type: 'business_term' }),
+      ...store.findNodes({ type: 'business_process' }),
+    ].filter((n) => n.metadata.source === 'code-extractor' && !n.metadata.stale);
+    expect(extractorNodesBefore.length).toBeGreaterThan(0);
+
+    // Create an empty temp dir with no source files → all signals disappear
+    const emptyDir = await fs.mkdtemp(path.join(os.tmpdir(), 'extractor-empty-'));
+    const emptyRunner = createExtractionRunner();
+    await emptyRunner.run(emptyDir, store, tmpDir);
+
+    // All previous nodes should now be stale
+    const staleNodes = [
+      ...store.findNodes({ type: 'business_rule' }),
+      ...store.findNodes({ type: 'business_term' }),
+      ...store.findNodes({ type: 'business_process' }),
+    ].filter((n) => n.metadata.source === 'code-extractor' && n.metadata.stale === true);
+    expect(staleNodes.length).toBe(extractorNodesBefore.length);
+  });
+
+  it('returns aggregated IngestResult', async () => {
+    const runner = createExtractionRunner();
+    const result = await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    expect(result.nodesAdded).toBeGreaterThan(0);
+    expect(result.edgesAdded).toBeGreaterThan(0);
+    expect(result.errors).toEqual([]);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/graph/tests/ingest/extractors/types.test.ts
+++ b/packages/graph/tests/ingest/extractors/types.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  ExtractionRecord,
+  SignalExtractor,
+  Language,
+} from '../../../src/ingest/extractors/types.js';
+
+describe('ExtractionRecord', () => {
+  it('should accept a well-formed record', () => {
+    const record: ExtractionRecord = {
+      id: 'extracted:test-descriptions:a1b2c3d4',
+      extractor: 'test-descriptions',
+      language: 'typescript',
+      filePath: 'src/auth/auth.service.test.ts',
+      line: 42,
+      nodeType: 'business_rule',
+      name: 'should reject expired tokens',
+      content: "describe('AuthService') > it('should reject expired tokens')",
+      confidence: 0.7,
+      metadata: { suite: 'AuthService', framework: 'vitest' },
+    };
+
+    expect(record.id).toBe('extracted:test-descriptions:a1b2c3d4');
+    expect(record.extractor).toBe('test-descriptions');
+    expect(record.language).toBe('typescript');
+    expect(record.nodeType).toBe('business_rule');
+    expect(record.confidence).toBeGreaterThanOrEqual(0);
+    expect(record.confidence).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('SignalExtractor interface', () => {
+  it('should be implementable', () => {
+    const extractor: SignalExtractor = {
+      name: 'test-extractor',
+      supportedExtensions: ['.ts', '.js'],
+      extract(_content: string, _filePath: string, _language: Language): ExtractionRecord[] {
+        return [];
+      },
+    };
+
+    expect(extractor.name).toBe('test-extractor');
+    expect(extractor.supportedExtensions).toContain('.ts');
+    expect(extractor.extract('', 'test.ts', 'typescript')).toEqual([]);
+  });
+});
+
+describe('Language type', () => {
+  it('should accept all 6 supported languages', () => {
+    const languages: Language[] = ['typescript', 'javascript', 'python', 'go', 'rust', 'java'];
+    expect(languages).toHaveLength(6);
+  });
+});

--- a/packages/orchestrator/src/completion/handler.ts
+++ b/packages/orchestrator/src/completion/handler.ts
@@ -167,8 +167,8 @@ export class CompletionHandler {
 
       // Try to detect and link PR
       if (entry) {
-        const hasPR = await this.ctx.prDetector.branchHasPullRequest(entry.identifier);
-        if (hasPR) {
+        const prResult = await this.ctx.prDetector.branchHasPullRequest(entry.identifier);
+        if (prResult.found) {
           // We don't have the PR number directly from branchHasPullRequest, so
           // the linkage will happen when the sweep detects PR status. For now,
           // focus on highlight extraction and comment posting.

--- a/packages/orchestrator/src/core/pr-detector.ts
+++ b/packages/orchestrator/src/core/pr-detector.ts
@@ -47,26 +47,28 @@ export class PRDetector {
   }
 
   /**
-   * Checks whether a remote branch has an open pull request via `gh`.
-   * Returns true if a PR exists, false otherwise. Failures are treated
-   * as "no PR" to err on the side of preserving work.
+   * Checks whether a remote branch has a pull request (any state) via `gh`.
+   * Returns `{ found: true }` if a PR exists, `{ found: false }` if none,
+   * or `{ found: false, error }` if the check itself failed (gh not installed,
+   * network error, etc.). Callers should distinguish "no PR" from "check failed"
+   * to avoid false escalations.
    */
-  async branchHasPullRequest(branch: string): Promise<boolean> {
+  async branchHasPullRequest(branch: string): Promise<{ found: boolean; error?: string }> {
     try {
       const exec = promisify(this.execFileFn);
       const { stdout } = await exec(
         'gh',
-        ['pr', 'list', '--head', branch, '--json', 'number', '--jq', 'length'],
+        ['pr', 'list', '--head', branch, '--state', 'all', '--json', 'number', '--jq', 'length'],
         {
           cwd: this.projectRoot,
           timeout: 10_000,
         }
       );
-      return parseInt(stdout.trim(), 10) > 0;
-    } catch {
-      // If gh fails (not installed, no auth, network error), assume no PR
-      // so the worktree is preserved rather than lost.
-      return false;
+      return { found: parseInt(stdout.trim(), 10) > 0 };
+    } catch (err) {
+      // If gh fails (not installed, no auth, network error), report the error
+      // so callers can preserve worktrees without raising false escalations.
+      return { found: false, error: String(err) };
     }
   }
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -105,6 +105,8 @@ export class Orchestrator extends EventEmitter {
   private analysisFailureCache: Map<string, number> = new Map();
   /** Guards against overlapping ticks when a tick takes longer than the polling interval */
   private tickInProgress = false;
+  /** Timestamp of the last stale branch sweep (at most once per hour) */
+  private lastBranchSweepMs = 0;
   /** Current tick-phase activity visible to the dashboard */
   private tickActivity: {
     phase: 'idle' | 'fetching' | 'analyzing' | 'dispatching';
@@ -637,6 +639,21 @@ export class Orchestrator extends EventEmitter {
     }
     this.recorder.sweepExpired(openPrNumbers);
 
+    // 8. Sweep stale remote branches (at most once per hour)
+    const BRANCH_SWEEP_INTERVAL_MS = 3_600_000;
+    if (nowMs - this.lastBranchSweepMs >= BRANCH_SWEEP_INTERVAL_MS) {
+      this.lastBranchSweepMs = nowMs;
+      const deleted = await this.workspace.sweepStaleBranches({
+        maxAgeDays: 7,
+        checkPR: (branch) => this.prDetector.branchHasPullRequest(branch),
+      });
+      if (deleted.length > 0) {
+        this.logger.info(`Swept ${deleted.length} stale remote branch(es)`, {
+          branches: deleted,
+        });
+      }
+    }
+
     this.setTickActivity('idle');
   }
 
@@ -698,8 +715,30 @@ export class Orchestrator extends EventEmitter {
   private async cleanWorkspaceWithGuard(identifier: string, issueId: string): Promise<void> {
     const branch = await this.workspace.findPushedBranch(identifier);
     if (branch) {
-      const hasPR = await this.branchHasPullRequest(branch);
-      if (!hasPR) {
+      // Verify the branch actually exists on the remote before checking PRs.
+      // Handles cases where the push failed or the branch was already deleted by a merge.
+      const existsOnRemote = await this.workspace.branchExistsOnRemote(branch);
+      if (!existsOnRemote) {
+        this.logger.info(
+          `Branch "${branch}" not found on remote for ${identifier}, cleaning up worktree`,
+          { issueId }
+        );
+        await this.workspace.removeWorkspace(identifier);
+        return;
+      }
+
+      const result = await this.prDetector.branchHasPullRequest(branch);
+      if (result.error) {
+        // PR check failed (gh not installed, network error, etc.) — preserve the
+        // worktree as a safety measure but don't escalate since we can't confirm
+        // whether a PR exists.
+        this.logger.warn(
+          `PR check failed for ${identifier} branch "${branch}", preserving worktree`,
+          { issueId, error: result.error }
+        );
+        return;
+      }
+      if (!result.found) {
         this.logger.warn(
           `Preserving worktree for ${identifier}: branch "${branch}" was pushed but no PR exists`,
           { issueId }
@@ -723,14 +762,6 @@ export class Orchestrator extends EventEmitter {
       }
     }
     await this.workspace.removeWorkspace(identifier);
-  }
-
-  /**
-   * Delegates to PRDetector.branchHasPullRequest.
-   * @see PRDetector#branchHasPullRequest
-   */
-  private async branchHasPullRequest(branch: string): Promise<boolean> {
-    return this.prDetector.branchHasPullRequest(branch);
   }
 
   /**

--- a/packages/orchestrator/src/server/routes/chat-proxy.ts
+++ b/packages/orchestrator/src/server/routes/chat-proxy.ts
@@ -19,6 +19,7 @@ type SSEEvent =
   | { type: 'text'; text: string }
   | { type: 'thinking'; text: string }
   | { type: 'tool_use'; tool: string; args?: string }
+  | { type: 'tool_args_delta'; text: string }
   | { type: 'tool_result'; content: string; isError?: boolean }
   | { type: 'status'; text: string }
   | { type: 'error'; error: string };
@@ -180,7 +181,7 @@ function buildArgs(
 
 /** Map a content block from an assistant message to SSE events. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mapContentBlock(block: any): SSEEvent | null {
+export function mapContentBlock(block: any): SSEEvent | null {
   if (block.type === 'thinking' && block.thinking) {
     return { type: 'thinking', text: block.thinking };
   }
@@ -226,13 +227,32 @@ function mapUserBlock(block: any): SSEEvent | null {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function extractMessageBlocks(event: any): SSEEvent[] | null {
   if (!Array.isArray(event.message?.content)) return null;
-  const mapper = event.type === 'assistant' ? mapContentBlock : mapUserBlock;
-  return event.message.content.map(mapper).filter(Boolean) as SSEEvent[];
+
+  // Assistant blocks are fully streamed via content_block_start and content_block_delta.
+  // Re-extracting here causes duplicated text in the UI (e.g. "text" + "text").
+  if (event.type === 'assistant') {
+    return null;
+  }
+
+  return event.message.content.map(mapUserBlock).filter(Boolean) as SSEEvent[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function extractDelta(event: any): SSEEvent[] | null {
   if (event.delta?.text) return [{ type: 'text', text: event.delta.text }];
+  if (event.delta?.partial_json)
+    return [{ type: 'tool_args_delta', text: event.delta.partial_json }];
+  if (event.delta?.thinking) return [{ type: 'thinking', text: event.delta.thinking }];
+  return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractContentBlockStart(event: any): SSEEvent[] | null {
+  if (event.content_block?.type === 'tool_use' && event.content_block.name) {
+    const result: SSEEvent = { type: 'tool_use', tool: event.content_block.name };
+    if (event.content_block.input) result.args = JSON.stringify(event.content_block.input);
+    return [result];
+  }
   return null;
 }
 
@@ -256,6 +276,7 @@ function extractResultText(event: any): SSEEvent[] | null {
 const chunkExtractors: Record<string, (event: any) => SSEEvent[] | null> = {
   assistant: extractMessageBlocks,
   user: extractMessageBlocks,
+  content_block_start: extractContentBlockStart,
   content_block_delta: extractDelta,
   system: extractSystemStatus,
   result: extractResultText,

--- a/packages/orchestrator/src/server/routes/chat-proxy.ts
+++ b/packages/orchestrator/src/server/routes/chat-proxy.ts
@@ -224,18 +224,52 @@ function mapUserBlock(block: any): SSEEvent | null {
 
 // --- Chunk extraction handlers (one per event type) ---
 
+// ── Claude CLI stream-json real-time events ─────────────────────────
+// The CLI emits `text`, `progress`, and `call` events as content streams
+// in real-time. These are the primary source for rich block rendering.
+
+/** Real-time text output from the CLI. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function extractMessageBlocks(event: any): SSEEvent[] | null {
-  if (!Array.isArray(event.message?.content)) return null;
+function extractTextEvent(event: any): SSEEvent[] | null {
+  const text = event.content ?? event.text;
+  if (typeof text === 'string' && text) return [{ type: 'text', text }];
+  return null;
+}
 
-  // Assistant blocks are fully streamed via content_block_start and content_block_delta.
-  // Re-extracting here causes duplicated text in the UI (e.g. "text" + "text").
-  if (event.type === 'assistant') {
-    return null;
+/** Real-time thinking/progress output from the CLI. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractProgressEvent(event: any): SSEEvent[] | null {
+  const text = event.content;
+  if (typeof text === 'string' && text) return [{ type: 'thinking', text }];
+  return null;
+}
+
+/** Real-time tool invocation from the CLI. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractCallEvent(event: any): SSEEvent[] | null {
+  if (!event.tool) return null;
+  const result: SSEEvent = { type: 'tool_use', tool: event.tool };
+  if (event.args != null) {
+    result.args = typeof event.args === 'string' ? event.args : JSON.stringify(event.args);
   }
+  return [result];
+}
 
+// ── Full message events ─────────────────────────────────────────────
+// `assistant` messages contain complete content blocks. Skipped when
+// real-time events (`text`, `progress`, `call`) already provided the
+// content — re-extracting would duplicate every block.
+// `user` messages contain tool_result blocks that attach to prior tool_use.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractUserBlocks(event: any): SSEEvent[] | null {
+  if (!Array.isArray(event.message?.content)) return null;
   return event.message.content.map(mapUserBlock).filter(Boolean) as SSEEvent[];
 }
+
+// ── Anthropic API streaming format (fallback) ───────────────────────
+// Some CLI versions may emit raw API-level events. These handlers serve
+// as fallbacks and do not conflict with the CLI-specific handlers above.
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function extractDelta(event: any): SSEEvent[] | null {
@@ -256,6 +290,8 @@ function extractContentBlockStart(event: any): SSEEvent[] | null {
   return null;
 }
 
+// ── System / status events ──────────────────────────────────────────
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function extractSystemStatus(event: any): SSEEvent[] | null {
   if (event.subtype === 'task_progress' && event.description) {
@@ -271,16 +307,35 @@ function extractResultText(event: any): SSEEvent[] | null {
   return null;
 }
 
-/** Map event type to its chunk extractor. */
+/**
+ * Map event type to its chunk extractor.
+ *
+ * Claude CLI stream-json emits these event types:
+ *   text, progress, call   — real-time streaming (primary)
+ *   assistant, user        — full message batches
+ *   system                 — task progress status
+ *   result, turn_complete  — turn completion
+ *
+ * Anthropic API streaming types (content_block_*) are kept as fallbacks.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const chunkExtractors: Record<string, (event: any) => SSEEvent[] | null> = {
-  assistant: extractMessageBlocks,
-  user: extractMessageBlocks,
+  // CLI real-time streaming events
+  text: extractTextEvent,
+  progress: extractProgressEvent,
+  call: extractCallEvent,
+  // Full message events (assistant skipped — streaming events cover it)
+  assistant: () => null,
+  user: extractUserBlocks,
+  // Anthropic API format fallbacks
   content_block_start: extractContentBlockStart,
   content_block_delta: extractDelta,
+  // Status and completion
   system: extractSystemStatus,
   result: extractResultText,
   turn_complete: extractResultText,
+  // Ignored (no renderable content)
+  message: () => null,
 };
 
 /** Extract SSE events from a Claude Code stream-json line. */

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -221,6 +221,10 @@ export class WorkspaceManager {
         // HEAD on freshly-created worktrees and are never agent-pushed branches.
         const short = refName.startsWith(PREFIX) ? refName.slice(PREFIX.length) : refName;
         if (short === 'HEAD' || short === 'main' || short === 'master') continue;
+        // Agent-pushed branches always use a prefix with a slash (e.g. feat/..., fix/...).
+        // Reject anything without a slash to catch symbolic refs or other non-agent branches
+        // that slip past the skip-list above.
+        if (!short.includes('/')) continue;
         if (sha === head) {
           return short;
         }
@@ -230,6 +234,93 @@ export class WorkspaceManager {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Checks whether a branch exists on the remote by querying `git ls-remote`.
+   * Returns false if the branch is not found or the command fails.
+   */
+  public async branchExistsOnRemote(branch: string): Promise<boolean> {
+    try {
+      const repoRoot = await this.getRepoRoot();
+      const result = await this.git(['ls-remote', '--heads', 'origin', branch], repoRoot);
+      return result.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Deletes remote branches whose PRs are merged and that are older than
+   * `maxAgeDays`. Only considers branches matching agent naming conventions
+   * (feat/*, fix/*). Returns the list of deleted branch names.
+   *
+   * Requires a `checkPR` callback so this class doesn't depend on PRDetector
+   * directly. The orchestrator wires this up at call time.
+   */
+  public async sweepStaleBranches(opts: {
+    maxAgeDays: number;
+    checkPR: (branch: string) => Promise<{ found: boolean; error?: string }>;
+  }): Promise<string[]> {
+    const deleted: string[] = [];
+    try {
+      const repoRoot = await this.getRepoRoot();
+      const refs = (
+        await this.git(
+          [
+            'for-each-ref',
+            '--format=%(refname) %(committerdate:unix)',
+            'refs/remotes/origin/feat/',
+            'refs/remotes/origin/fix/',
+          ],
+          repoRoot
+        )
+      ).trim();
+
+      if (!refs) return deleted;
+
+      const PREFIX = 'refs/remotes/origin/';
+      const cutoffUnix = Date.now() / 1000 - opts.maxAgeDays * 86400;
+      const candidates: Array<{ short: string; age: number }> = [];
+
+      for (const line of refs.split('\n')) {
+        const spaceIdx = line.lastIndexOf(' ');
+        if (spaceIdx < 0) continue;
+        const refName = line.slice(0, spaceIdx);
+        const unixStr = line.slice(spaceIdx + 1);
+        const unix = parseInt(unixStr, 10);
+        if (isNaN(unix) || unix > cutoffUnix) continue;
+        const short = refName.startsWith(PREFIX) ? refName.slice(PREFIX.length) : refName;
+        candidates.push({ short, age: unix });
+      }
+
+      // Throttle to 3 concurrent gh CLI calls
+      const concurrency = 3;
+      for (let i = 0; i < candidates.length; i += concurrency) {
+        const batch = candidates.slice(i, i + concurrency);
+        const results = await Promise.allSettled(
+          batch.map(async ({ short }) => {
+            const pr = await opts.checkPR(short);
+            return { short, pr };
+          })
+        );
+        for (const result of results) {
+          if (result.status !== 'fulfilled') continue;
+          const { short, pr } = result.value;
+          if (!pr.found || pr.error) continue;
+          // PR exists and was found without error — safe to delete the remote branch
+          try {
+            await this.git(['push', 'origin', '--delete', short], repoRoot);
+            deleted.push(short);
+          } catch {
+            // Deletion failed (permissions, already deleted, etc.) — skip
+          }
+        }
+      }
+    } catch {
+      // Sweep is best-effort; don't fail the tick
+    }
+    return deleted;
   }
 
   /**

--- a/packages/orchestrator/tests/integration/orchestrator.test.ts
+++ b/packages/orchestrator/tests/integration/orchestrator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Orchestrator } from '../../src/orchestrator';
 import { WorkflowConfig, Issue, Ok } from '@harness-engineering/types';
 import { MockBackend } from '../../src/agent/backends/mock';
+import { WorkspaceManager } from '../../src/workspace/manager';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs';
@@ -73,6 +74,19 @@ describe('Orchestrator Integration', () => {
     // Ensure workspace root exists so WorkspaceManager can run git commands in it
     fs.mkdirSync(path.join(tmpDir, '.harness', 'workspaces'), { recursive: true });
 
+    // Mock WorkspaceManager methods that shell out to git for worktree operations.
+    // These fail on Windows CI due to path and file-locking differences. The
+    // orchestrator integration test validates dispatch logic, not git worktree
+    // management — the workspace manager has its own unit tests.
+    const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'h-1');
+    vi.spyOn(WorkspaceManager.prototype, 'ensureWorkspace').mockImplementation(async () => {
+      fs.mkdirSync(workspacePath, { recursive: true });
+      return Ok(workspacePath);
+    });
+    vi.spyOn(WorkspaceManager.prototype, 'removeWorkspace').mockResolvedValue(Ok(undefined));
+    vi.spyOn(WorkspaceManager.prototype, 'sweepStaleBranches').mockResolvedValue([]);
+    vi.spyOn(WorkspaceManager.prototype, 'findPushedBranch').mockResolvedValue(null);
+
     // Track assignee state so claimAndVerify sees the correct assignee after claimIssue
     let lastClaimedAssignee: string | null = null;
     mockTracker = {
@@ -104,6 +118,7 @@ describe('Orchestrator Integration', () => {
 
   afterEach(async () => {
     if (orchestrator) await orchestrator.stop();
+    vi.restoreAllMocks();
     // On Windows, git worktree processes may hold file locks briefly after stop.
     for (let i = 0; i < 3; i++) {
       try {

--- a/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
+++ b/packages/orchestrator/tests/orchestrator-pr-guard.test.ts
@@ -152,6 +152,73 @@ describe('hasOpenPRForIdentifier', () => {
   });
 });
 
+describe('branchHasPullRequest', () => {
+  let detector: PRDetector;
+  let mockExecFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+    detector = new PRDetector({
+      logger: makeMockLogger(),
+      execFileFn: execFile,
+      projectRoot: '/tmp',
+    });
+  });
+
+  it('returns { found: true } when a PR exists (any state)', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: '1\n', stderr: '' });
+      }
+    );
+
+    const result = await detector.branchHasPullRequest('feat/my-feature');
+    expect(result).toEqual({ found: true });
+  });
+
+  it('passes --state all to find merged PRs', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: '1\n', stderr: '' });
+      }
+    );
+
+    await detector.branchHasPullRequest('feat/merged-branch');
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['--state', 'all']),
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  it('returns { found: false } when no PR exists', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(null, { stdout: '0\n', stderr: '' });
+      }
+    );
+
+    const result = await detector.branchHasPullRequest('feat/no-pr');
+    expect(result).toEqual({ found: false });
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns { found: false, error } when gh command fails', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        cb(new Error('network timeout'), { stdout: '', stderr: '' });
+      }
+    );
+
+    const result = await detector.branchHasPullRequest('feat/broken');
+    expect(result.found).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain('network timeout');
+  });
+});
+
 describe('hasOpenPRForExternalId', () => {
   let detector: PRDetector;
   let mockExecFile: ReturnType<typeof vi.fn>;

--- a/packages/orchestrator/tests/server/routes/chat-proxy.test.ts
+++ b/packages/orchestrator/tests/server/routes/chat-proxy.test.ts
@@ -96,15 +96,8 @@ describe('chat proxy route (Claude Code session mode)', () => {
 
   it('streams SSE responses with session ID', async () => {
     const child = createMockChild([
-      {
-        type: 'assistant',
-        message: {
-          content: [
-            { type: 'thinking', thinking: 'Let me think...' },
-            { type: 'text', text: 'Hello world' },
-          ],
-        },
-      },
+      { type: 'content_block_delta', delta: { thinking: 'Let me think...' } },
+      { type: 'content_block_delta', delta: { text: 'Hello world' } },
     ]);
     mockSpawn.mockReturnValue(child as unknown as child_process.ChildProcess);
 
@@ -168,10 +161,8 @@ describe('chat proxy route (Claude Code session mode)', () => {
   it('emits tool_use and tool_result events', async () => {
     const child = createMockChild([
       {
-        type: 'assistant',
-        message: {
-          content: [{ type: 'tool_use', name: 'Read', input: { file_path: '/foo.ts' } }],
-        },
+        type: 'content_block_start',
+        content_block: { type: 'tool_use', name: 'Read', input: { file_path: '/foo.ts' } },
       },
       {
         type: 'user',

--- a/packages/orchestrator/tests/workspace/manager.test.ts
+++ b/packages/orchestrator/tests/workspace/manager.test.ts
@@ -359,5 +359,172 @@ describe('WorkspaceManager', () => {
       const branch = await manager.findPushedBranch('test-issue');
       expect(branch).toBeNull();
     });
+
+    it('skips branch names without a slash (positive-pattern validation)', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc123\n';
+        if (args[0] === 'for-each-ref') {
+          // A branch name without a slash — e.g. a symbolic ref that slipped past skip-list
+          return 'refs/remotes/origin/develop abc123\nrefs/remotes/origin/staging abc123\n';
+        }
+        return '';
+      });
+
+      const branch = await manager.findPushedBranch('test-issue');
+      expect(branch).toBeNull();
+    });
+
+    it('accepts branch names with a slash like feat/ or fix/', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc123\n';
+        if (args[0] === 'for-each-ref') {
+          return 'refs/remotes/origin/develop abc999\nrefs/remotes/origin/fix/my-bugfix abc123\n';
+        }
+        return '';
+      });
+
+      const branch = await manager.findPushedBranch('test-issue');
+      expect(branch).toBe('fix/my-bugfix');
+    });
+  });
+
+  describe('branchExistsOnRemote', () => {
+    it('returns true when ls-remote finds the branch', async () => {
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'ls-remote') {
+          return 'abc123\trefs/heads/feat/my-feature\n';
+        }
+        return '';
+      });
+
+      const exists = await manager.branchExistsOnRemote('feat/my-feature');
+      expect(exists).toBe(true);
+    });
+
+    it('returns false when ls-remote returns empty', async () => {
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'ls-remote') return '\n';
+        return '';
+      });
+
+      const exists = await manager.branchExistsOnRemote('feat/nonexistent');
+      expect(exists).toBe(false);
+    });
+
+    it('returns false when git command fails', async () => {
+      manager.setGitImpl((args) => {
+        if (args[0] === 'ls-remote') throw new Error('network error');
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        return '';
+      });
+
+      const exists = await manager.branchExistsOnRemote('feat/broken');
+      expect(exists).toBe(false);
+    });
+  });
+
+  describe('sweepStaleBranches', () => {
+    it('deletes old branches with merged PRs', async () => {
+      const deletedBranches: string[] = [];
+      const oldUnix = Math.floor(Date.now() / 1000) - 10 * 86400; // 10 days ago
+
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'for-each-ref') {
+          return `refs/remotes/origin/feat/old-feature ${oldUnix}\n`;
+        }
+        if (args[0] === 'push' && args[1] === 'origin' && args[2] === '--delete') {
+          deletedBranches.push(args[3]!);
+          return '';
+        }
+        return '';
+      });
+
+      const result = await manager.sweepStaleBranches({
+        maxAgeDays: 7,
+        checkPR: async () => ({ found: true }),
+      });
+
+      expect(result).toEqual(['feat/old-feature']);
+      expect(deletedBranches).toEqual(['feat/old-feature']);
+    });
+
+    it('preserves recent branches even with merged PRs', async () => {
+      const recentUnix = Math.floor(Date.now() / 1000) - 2 * 86400; // 2 days ago
+
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'for-each-ref') {
+          return `refs/remotes/origin/feat/recent-feature ${recentUnix}\n`;
+        }
+        return '';
+      });
+
+      const result = await manager.sweepStaleBranches({
+        maxAgeDays: 7,
+        checkPR: async () => ({ found: true }),
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('preserves old branches without merged PRs', async () => {
+      const oldUnix = Math.floor(Date.now() / 1000) - 10 * 86400;
+
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'for-each-ref') {
+          return `refs/remotes/origin/feat/no-pr-branch ${oldUnix}\n`;
+        }
+        return '';
+      });
+
+      const result = await manager.sweepStaleBranches({
+        maxAgeDays: 7,
+        checkPR: async () => ({ found: false }),
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('preserves branches when PR check errors', async () => {
+      const oldUnix = Math.floor(Date.now() / 1000) - 10 * 86400;
+
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'for-each-ref') {
+          return `refs/remotes/origin/feat/error-check ${oldUnix}\n`;
+        }
+        return '';
+      });
+
+      const result = await manager.sweepStaleBranches({
+        maxAgeDays: 7,
+        checkPR: async () => ({ found: false, error: 'network timeout' }),
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no remote branches exist', async () => {
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'for-each-ref') return '';
+        return '';
+      });
+
+      const result = await manager.sweepStaleBranches({
+        maxAgeDays: 7,
+        checkPR: async () => ({ found: true }),
+      });
+
+      expect(result).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Implements Phase 2 of the Business Knowledge System (ADR-001): four pluggable code signal extractors that mine business-relevant signals from source code across 6 languages (TypeScript, JavaScript, Python, Go, Rust, Java).

**Extractors:**
- **TestDescriptionExtractor** — extracts business rules from test descriptions (`describe`/`it`/`test`, `def test_*`, `func Test*`, `#[test]`, `@Test`/`@DisplayName`)
- **EnumConstantExtractor** — extracts domain vocabulary from enums, `as const`, `StrEnum`, `iota`, Rust/Java enums
- **ValidationRuleExtractor** — extracts business constraints from Zod, Pydantic, Go struct tags, Rust `#[validate]`, Java Bean Validation
- **ApiPathExtractor** — extracts API surface from Express, FastAPI, Gin, Actix, Spring route definitions

**Infrastructure:**
- `ExtractionRunner` orchestrates file walking, language detection, JSONL output to `.harness/knowledge/extracted/`, graph node persistence, and stable-ID-based stale detection
- Creates provisional graph nodes (`business_rule`, `business_term`, `business_process`) with `metadata.source='code-extractor'`
- Integrated into CLI (`harness ingest --source business-signals`) and MCP (`ingest_source` tool) including `--all` flows
- Deterministic IDs survive re-extraction; removed signals marked stale, not deleted

**Test coverage:** 49 new tests across 7 test files (types, 4 extractors, runner, E2E integration). All 586 graph package tests pass with zero regressions.

## Test plan
- [x] All 4 extractors produce valid JSONL for each of the 6 supported languages
- [x] Graph nodes created with correct types and `metadata.source === 'code-extractor'`
- [x] Stable IDs: re-running extraction produces identical output, no duplicate nodes
- [x] Stale detection: removing signals from source marks nodes as stale
- [x] CLI integration: `business-signals` source added to `harness ingest`
- [x] MCP integration: `business-signals` added to `ingest_source` tool enum
- [x] No regression: all 586 existing graph package tests pass
- [x] TypeScript strict mode, ESLint, and `harness validate` all pass