### PR TITLE
fix(dashboard): preserve chat sessions across navigation and reload

### DIFF
--- a/packages/dashboard/src/client/components/layout/ChatLayout.tsx
+++ b/packages/dashboard/src/client/components/layout/ChatLayout.tsx
@@ -3,6 +3,7 @@ import { createContext, useEffect, useState, type ReactNode } from 'react';
 import { useLocation } from 'react-router';
 import { useAgentSync } from '../../hooks/useAgentSync';
 import { useAttentionSync } from '../../hooks/useAttentionSync';
+import { useChatSessionsSync } from '../../hooks/useChatSessionsSync';
 import { useOrchestratorSocket } from '../../hooks/useOrchestratorSocket';
 import { useThreadStore } from '../../stores/threadStore';
 import type { ContentBlock } from '../../types/chat';
@@ -28,6 +29,7 @@ export function ChatLayout({ children }: Props) {
   const socket = useOrchestratorSocket();
   useAttentionSync(socket);
   useAgentSync(socket);
+  useChatSessionsSync();
 
   // Panel state — null for system routes, read from ThreadStore for threads
   const storedPanelState = useThreadStore((s) =>

--- a/packages/dashboard/src/client/components/layout/EmptyState.tsx
+++ b/packages/dashboard/src/client/components/layout/EmptyState.tsx
@@ -1,7 +1,7 @@
 import { Plus, FlaskConical, Terminal } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import { motion } from 'framer-motion';
-import { useThreadStore } from '../../stores/threadStore';
+import { getOrCreateDraftChatThread, useThreadStore } from '../../stores/threadStore';
 import { NeuralOrganism } from '../chat/NeuralOrganism';
 import { CommandPalette } from '../chat/CommandPalette';
 import type { SkillEntry } from '../../types/skills';
@@ -9,9 +9,8 @@ import type { SkillEntry } from '../../types/skills';
 export function EmptyState() {
   const navigate = useNavigate();
   const handleNewChat = () => {
-    const store = useThreadStore.getState();
-    const thread = store.createThread('chat', { sessionId: crypto.randomUUID(), command: null });
-    store.setActiveThread(thread.id);
+    const thread = getOrCreateDraftChatThread();
+    useThreadStore.getState().setActiveThread(thread.id);
     navigate(`/t/${thread.id}`);
   };
 

--- a/packages/dashboard/src/client/components/layout/ThreadSidebar.tsx
+++ b/packages/dashboard/src/client/components/layout/ThreadSidebar.tsx
@@ -1,7 +1,11 @@
 import { FlaskConical, Plus } from 'lucide-react';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
-import { selectSidebarSections, useThreadStore } from '../../stores/threadStore';
+import {
+  getOrCreateDraftChatThread,
+  selectSidebarSections,
+  useThreadStore,
+} from '../../stores/threadStore';
 import { SYSTEM_PAGES } from '../../types/thread';
 import { Sigil } from '../NeonAI/Sigil';
 import { SidebarSection } from '../sidebar/SidebarSection';
@@ -16,9 +20,8 @@ export function ThreadSidebar() {
     [threads]
   );
   const handleNewChat = () => {
-    const store = useThreadStore.getState();
-    const thread = store.createThread('chat', { sessionId: crypto.randomUUID(), command: null });
-    store.setActiveThread(thread.id);
+    const thread = getOrCreateDraftChatThread();
+    useThreadStore.getState().setActiveThread(thread.id);
     navigate(`/t/${thread.id}`);
   };
 

--- a/packages/dashboard/src/client/components/threads/ChatThreadView.tsx
+++ b/packages/dashboard/src/client/components/threads/ChatThreadView.tsx
@@ -59,12 +59,18 @@ export function ChatThreadView({ thread }: Props) {
   const autoExecutedRef = useRef(new Set<string>());
   const pendingCommandArgsRef = useRef<string | null>(null);
 
-  // Load existing session messages on mount
+  // Load existing session messages on cold-mount only.
+  // If the store already has messages for this thread (e.g. user navigated away
+  // within the SPA and came back), skip the fetch — the in-memory state is
+  // newer than the server snapshot, which lags behind streaming replies.
   useEffect(() => {
+    const existing = storeApi.getState().messages.get(thread.id);
+    if (existing && existing.length > 0) return;
+
     fetch(`/api/sessions/${meta.sessionId}`)
       .then((res) => (res.ok ? res.json() : null))
       .then((session: ChatSession | null) => {
-        if (session) {
+        if (session && Array.isArray(session.messages)) {
           storeApi.getState().setMessages(thread.id, session.messages);
           if (session.orchestratorSessionId) {
             setOrchestratorSessionId(session.orchestratorSessionId);
@@ -74,7 +80,7 @@ export function ChatThreadView({ thread }: Props) {
       .catch(() => {
         // Session doesn't exist on server yet — that's fine for new threads
       });
-  }, [meta.sessionId, thread.id]);
+  }, [meta.sessionId, thread.id, storeApi]);
 
   // If thread was created with a command, resolve the skill
   useEffect(() => {

--- a/packages/dashboard/src/client/hooks/useChatSessionsSync.ts
+++ b/packages/dashboard/src/client/hooks/useChatSessionsSync.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { useThreadStore } from '../stores/threadStore';
+import type { ChatSession } from '../types/chat-session';
+
+/**
+ * Hydrates the thread store with chat sessions persisted on the server
+ * (`.harness/sessions/<id>/session.json`).
+ *
+ * Without this, chat threads only exist in zustand's in-memory map, so any full
+ * reload (refresh / tab reopen) loses every prior chat — even though the
+ * messages are still on disk.
+ */
+export function useChatSessionsSync() {
+  const initialFetchDone = useRef(false);
+
+  useEffect(() => {
+    if (initialFetchDone.current) return;
+    initialFetchDone.current = true;
+
+    fetch('/api/sessions')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((sessions: ChatSession[]) => {
+        if (!Array.isArray(sessions)) return;
+        const store = useThreadStore.getState();
+        for (const session of sessions) {
+          if (!session?.sessionId) continue;
+          if (store.threads.has(`chat:${session.sessionId}`)) continue;
+          const thread = store.createThread('chat', {
+            sessionId: session.sessionId,
+            command: session.command ?? null,
+          });
+          if (session.label && session.label !== 'New Chat') {
+            store.updateThread(thread.id, { title: session.label });
+          }
+          if (Array.isArray(session.messages) && session.messages.length > 0) {
+            store.setMessages(thread.id, session.messages);
+          }
+        }
+      })
+      .catch(() => {})
+      .finally(() => useThreadStore.getState().markSourceHydrated());
+  }, []);
+}

--- a/packages/dashboard/src/client/stores/threadStore.ts
+++ b/packages/dashboard/src/client/stores/threadStore.ts
@@ -16,7 +16,7 @@ import type { PanelState } from '../components/layout/ContextPanel';
 const LAST_THREAD_KEY = 'harness-last-thread-id';
 
 /** Number of async sources that must call markSourceHydrated() before the store is considered ready. */
-let _hydrationPending = 2; // agents + attention
+let _hydrationPending = 3; // agents + attention + chat sessions
 
 function readLastThreadId(): string | null {
   try {
@@ -163,6 +163,23 @@ export interface ThreadStore {
 /** Derive sidebar sections from the current thread map. */
 export function selectSidebarSections(state: ThreadStore): SidebarSections {
   return deriveSidebarSections(state.threads);
+}
+
+/**
+ * Return an existing draft chat thread (no command, zero messages) if one is
+ * already in the store; otherwise create a fresh one. Used by the "New Chat"
+ * button so navigating away and clicking New Chat to come back doesn't strand
+ * the user on a brand-new thread when an empty draft is already available.
+ */
+export function getOrCreateDraftChatThread(): Thread {
+  const state = useThreadStore.getState();
+  for (const thread of state.threads.values()) {
+    if (thread.type !== 'chat') continue;
+    if ((thread.meta as ChatMeta).command) continue;
+    const msgs = state.messages.get(thread.id);
+    if (!msgs || msgs.length === 0) return thread;
+  }
+  return state.createThread('chat', { sessionId: crypto.randomUUID(), command: null });
 }
 
 export const useThreadStore = create<ThreadStore>((set, get) => ({

--- a/packages/dashboard/tests/client/stores/threadStore.test.ts
+++ b/packages/dashboard/tests/client/stores/threadStore.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useThreadStore, selectSidebarSections } from '../../../src/client/stores/threadStore';
+import {
+  useThreadStore,
+  selectSidebarSections,
+  getOrCreateDraftChatThread,
+} from '../../../src/client/stores/threadStore';
 
 describe('threadStore', () => {
   beforeEach(() => {
@@ -7,6 +11,7 @@ describe('threadStore', () => {
       threads: new Map(),
       activeThreadId: null,
       lastThreadId: null,
+      messages: new Map(),
     });
   });
 
@@ -187,6 +192,38 @@ describe('threadStore', () => {
       const sections = selectSidebarSections(useThreadStore.getState());
       expect(sections.attention).toHaveLength(0);
       expect(sections.recent).toHaveLength(1);
+    });
+  });
+
+  describe('getOrCreateDraftChatThread', () => {
+    it('creates a fresh thread when no draft exists', () => {
+      const thread = getOrCreateDraftChatThread();
+      expect(thread.type).toBe('chat');
+      expect(useThreadStore.getState().threads.size).toBe(1);
+    });
+
+    it('reuses an existing empty chat thread instead of creating a new one', () => {
+      const first = getOrCreateDraftChatThread();
+      const second = getOrCreateDraftChatThread();
+      expect(second.id).toBe(first.id);
+      expect(useThreadStore.getState().threads.size).toBe(1);
+    });
+
+    it('creates a new thread when the existing chat has messages', () => {
+      const first = getOrCreateDraftChatThread();
+      useThreadStore.getState().setMessages(first.id, [{ role: 'user', content: 'hi' }]);
+      const second = getOrCreateDraftChatThread();
+      expect(second.id).not.toBe(first.id);
+      expect(useThreadStore.getState().threads.size).toBe(2);
+    });
+
+    it('skips chat threads seeded with a command (skill drafts)', () => {
+      const seeded = useThreadStore
+        .getState()
+        .createThread('chat', { sessionId: 'skill-seed', command: 'harness:tdd' });
+      const draft = getOrCreateDraftChatThread();
+      expect(draft.id).not.toBe(seeded.id);
+      expect(useThreadStore.getState().threads.size).toBe(2);
     });
   });
 });

--- a/packages/orchestrator/src/server/routes/sessions.ts
+++ b/packages/orchestrator/src/server/routes/sessions.ts
@@ -57,6 +57,24 @@ async function handleList(res: ServerResponse, sessionsDir: string): Promise<voi
   }
 }
 
+async function handleGet(res: ServerResponse, id: string, sessionsDir: string): Promise<void> {
+  if (!isSafeId(id)) {
+    jsonResponse(res, 400, { error: 'Invalid sessionId' });
+    return;
+  }
+  try {
+    // harness-ignore SEC-DES-001: reading self-written session.json from disk — trusted internal source
+    const content = await fs.readFile(path.join(sessionsDir, id, 'session.json'), 'utf-8');
+    jsonResponse(res, 200, JSON.parse(content));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      jsonResponse(res, 404, { error: 'Session not found' });
+      return;
+    }
+    jsonResponse(res, 500, { error: 'Failed to read session' });
+  }
+}
+
 async function handleCreate(
   req: IncomingMessage,
   res: ServerResponse,
@@ -134,9 +152,12 @@ export function handleSessionsRoute(
   if (!url?.startsWith(API_PREFIX)) return false;
 
   switch (method) {
-    case 'GET':
-      void handleList(res, sessionsDir);
+    case 'GET': {
+      const id = extractSessionId(url);
+      if (id) void handleGet(res, id, sessionsDir);
+      else void handleList(res, sessionsDir);
       return true;
+    }
     case 'POST':
       void handleCreate(req, res, sessionsDir);
       return true;

--- a/packages/orchestrator/tests/server/routes/sessions.test.ts
+++ b/packages/orchestrator/tests/server/routes/sessions.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { handleSessionsRoute } from '../../../src/server/routes/sessions';
+
+function createServer(sessionsDir: string): http.Server {
+  return http.createServer((req, res) => {
+    if (!handleSessionsRoute(req, res, sessionsDir)) {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+}
+
+function request(
+  server: http.Server,
+  port: number,
+  method: string,
+  urlPath: string,
+  body?: unknown
+): Promise<{ statusCode: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const payload = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: urlPath,
+        method,
+        headers: payload
+          ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) }
+          : {},
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = data;
+          }
+          resolve({ statusCode: res.statusCode ?? 500, body: parsed });
+        });
+      }
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+const SESSION_A = {
+  sessionId: 'aaaaaaaa-1111-2222-3333-444444444444',
+  command: null,
+  interactionId: null,
+  label: 'Session A',
+  createdAt: '2026-04-29T00:00:00.000Z',
+  lastActiveAt: '2026-04-29T00:05:00.000Z',
+  artifacts: [],
+  status: 'active',
+  messages: [
+    { role: 'user', content: 'hello' },
+    { role: 'assistant', blocks: [{ kind: 'text', text: 'hi there' }] },
+  ],
+  input: '',
+};
+
+const SESSION_B = {
+  sessionId: 'bbbbbbbb-1111-2222-3333-444444444444',
+  command: null,
+  interactionId: null,
+  label: 'Session B',
+  createdAt: '2026-04-30T00:00:00.000Z',
+  lastActiveAt: '2026-04-30T00:01:00.000Z',
+  artifacts: [],
+  status: 'active',
+  messages: [],
+  input: '',
+};
+
+describe('sessions routes', () => {
+  let server: http.Server;
+  let port: number;
+  let sessionsDir: string;
+
+  beforeEach(async () => {
+    sessionsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sessions-test-'));
+    port = Math.floor(Math.random() * 10000) + 40000;
+    server = createServer(sessionsDir);
+    await new Promise<void>((r) => server.listen(port, '127.0.0.1', r));
+  });
+
+  afterEach(async () => {
+    if (server) await new Promise<void>((r) => server.close(() => r()));
+    await fs.rm(sessionsDir, { recursive: true, force: true });
+  });
+
+  async function seed(session: typeof SESSION_A): Promise<void> {
+    const dir = path.join(sessionsDir, session.sessionId);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'session.json'), JSON.stringify(session));
+  }
+
+  it('GET /api/sessions returns array sorted by lastActiveAt desc', async () => {
+    await seed(SESSION_A);
+    await seed(SESSION_B);
+    const res = await request(server, port, 'GET', '/api/sessions');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    const sessions = res.body as Array<{ sessionId: string }>;
+    expect(sessions.map((s) => s.sessionId)).toEqual([SESSION_B.sessionId, SESSION_A.sessionId]);
+  });
+
+  it('GET /api/sessions/<id> returns the single session, not an array', async () => {
+    await seed(SESSION_A);
+    await seed(SESSION_B);
+    const res = await request(server, port, 'GET', `/api/sessions/${SESSION_A.sessionId}`);
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(false);
+    expect(res.body).toMatchObject({
+      sessionId: SESSION_A.sessionId,
+      messages: SESSION_A.messages,
+    });
+  });
+
+  it('GET /api/sessions/<id> returns 404 when the session does not exist', async () => {
+    const res = await request(
+      server,
+      port,
+      'GET',
+      '/api/sessions/cccccccc-1111-2222-3333-444444444444'
+    );
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('GET /api/sessions/<id> rejects unsafe ids', async () => {
+    const res = await request(server, port, 'GET', '/api/sessions/..%2Fescape');
+    expect([400, 404]).toContain(res.statusCode);
+    expect(Array.isArray(res.body)).toBe(false);
+  });
+
+  it('POST /api/sessions writes session.json and round-trips via GET /<id>', async () => {
+    const post = await request(server, port, 'POST', '/api/sessions', SESSION_A);
+    expect(post.statusCode).toBe(200);
+    const get = await request(server, port, 'GET', `/api/sessions/${SESSION_A.sessionId}`);
+    expect(get.statusCode).toBe(200);
+    expect(get.body).toMatchObject({ sessionId: SESSION_A.sessionId });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `GET /api/sessions/<id>` returning the full list (caused `ChatThreadView` to wipe the in-memory store on every remount triggered by `AnimatePresence`'s pathname-keyed children).
- Hydrate the threadStore from `/api/sessions` on app boot via new `useChatSessionsSync` hook so refresh / reopen restores prior chats.
- "New Chat" buttons now reuse an existing empty draft chat thread (`getOrCreateDraftChatThread`) instead of always minting a fresh `sessionId`.

## Test plan
- [ ] Start a chat, send a message, click a sidebar System page (e.g. Health), click the chat in the Active sidebar section — messages persist.
- [ ] Start a chat, send a message, refresh the page — chat appears in sidebar; clicking it restores the conversation.
- [ ] Click "New Chat" twice without typing — only one empty draft exists.
- [ ] Click "New Chat" while a non-empty chat is active — a new empty thread is created; the existing chat is unchanged.
- [ ] \`pnpm --filter @harness-engineering/orchestrator test tests/server/routes/sessions.test.ts\` — 5/5 pass.
- [ ] \`pnpm --filter @harness-engineering/dashboard test tests/client/stores/threadStore.test.ts\` — 17/17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)