### PR TITLE
fix(graph): round-trip metadata.source through knowledge doc materializer/ingestor

### DIFF
--- a/.changeset/knowledge-source-roundtrip.md
+++ b/.changeset/knowledge-source-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/graph': patch
+---
+
+Round-trip `metadata.source` through `KnowledgeDocMaterializer` ↔ `BusinessKnowledgeIngestor` so materialized knowledge docs no longer appear as a second "unknown" source contradicting their original extractor. Closes #265.

--- a/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+++ b/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
@@ -26,6 +26,7 @@ const MEASURABLE_TYPES = new Set<string>(['business_process', 'business_concept'
 interface Frontmatter {
   type: string;
   domain: string;
+  source?: string;
   tags?: string[];
   related?: string[];
 }
@@ -106,6 +107,7 @@ export class BusinessKnowledgeIngestor {
       content: body.trim(),
       metadata: {
         domain,
+        ...(frontmatter.source && { source: frontmatter.source }),
         ...(frontmatter.tags && { tags: frontmatter.tags }),
         ...(frontmatter.related && { related: frontmatter.related }),
       },

--- a/packages/graph/src/ingest/KnowledgeDocMaterializer.ts
+++ b/packages/graph/src/ingest/KnowledgeDocMaterializer.ts
@@ -193,6 +193,13 @@ export class KnowledgeDocMaterializer {
     const sanitize = (s: string) => s.replace(/[\n\r]/g, ' ').replace(/:/g, '-');
     const lines: string[] = ['---', `type: ${sanitize(mappedType)}`, `domain: ${sanitize(domain)}`];
 
+    // Source — preserve provenance so a re-ingest of the materialized doc
+    // doesn't appear as a second "unknown" source contradicting the original.
+    const source = node.metadata?.source;
+    if (typeof source === 'string' && source.length > 0) {
+      lines.push(`source: ${sanitize(source)}`);
+    }
+
     // Tags — sanitize each element to prevent YAML injection
     const tags = node.metadata?.tags;
     if (Array.isArray(tags) && tags.length > 0) {

--- a/packages/graph/tests/ingest/BusinessKnowledgeIngestor.test.ts
+++ b/packages/graph/tests/ingest/BusinessKnowledgeIngestor.test.ts
@@ -56,6 +56,53 @@ The monorepo enforces strict layer boundaries.
       expect(node!.metadata.tags).toEqual(['layers', 'imports']);
     });
 
+    it('should preserve source field from frontmatter into node metadata', async () => {
+      await writeKnowledgeFile(
+        'payments',
+        'refund-window.md',
+        `---
+type: business_rule
+domain: payments
+source: code-extractor
+---
+
+# Refund Window
+
+Refunds are accepted within 30 days of purchase.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+      expect(result.nodesAdded).toBe(1);
+
+      const node = store.getNode('bk:payments:refund-window');
+      expect(node).not.toBeNull();
+      expect(node!.metadata.source).toBe('code-extractor');
+    });
+
+    it('should omit source from metadata when frontmatter has no source field', async () => {
+      await writeKnowledgeFile(
+        'payments',
+        'no-source.md',
+        `---
+type: business_rule
+domain: payments
+---
+
+# No Source
+
+Frontmatter without a source field.
+`
+      );
+
+      const result = await ingestor.ingest(tmpDir);
+      expect(result.nodesAdded).toBe(1);
+
+      const node = store.getNode('bk:payments:no-source');
+      expect(node).not.toBeNull();
+      expect(node!.metadata.source).toBeUndefined();
+    });
+
     it('should create nodes for multiple knowledge types', async () => {
       await writeKnowledgeFile(
         'ops',

--- a/packages/graph/tests/ingest/KnowledgeDocMaterializer.test.ts
+++ b/packages/graph/tests/ingest/KnowledgeDocMaterializer.test.ts
@@ -58,7 +58,7 @@ describe('KnowledgeDocMaterializer', () => {
     expect(result.created[0]!.domain).toBe('payments');
 
     const content = await fs.readFile(path.join(tmpDir, result.created[0]!.filePath), 'utf-8');
-    expect(content).toContain('---\ntype: business_rule\ndomain: payments\n---');
+    expect(content).toContain('---\ntype: business_rule\ndomain: payments\nsource: extractor\n---');
     expect(content).toContain('# Refund Rules');
     expect(content).toContain('Customers may request a refund within 30 days of purchase.');
   });
@@ -256,11 +256,31 @@ describe('KnowledgeDocMaterializer', () => {
 
     expect(parsed.type).toBe('business_rule');
     expect(parsed.domain).toBe('payments');
+    expect(parsed.source).toBe('extractor');
     expect(parsed.tags).toEqual(['billing', 'refund']);
 
     // Body should contain the heading and content
     expect(body).toContain('# Round Trip Test');
     expect(body).toContain('This content should survive the round trip');
+  });
+
+  it('omits source from frontmatter when node has no metadata.source', async () => {
+    store.addNode(
+      makeNode({
+        id: 'no-source',
+        name: 'No Source',
+        metadata: { domain: 'payments' },
+        content: 'Content without an explicit provenance source.',
+      })
+    );
+
+    const result = await materializer.materialize(
+      [makeGap({ nodeId: 'no-source', name: 'No Source' })],
+      { projectDir: tmpDir, dryRun: false }
+    );
+
+    const raw = await fs.readFile(path.join(tmpDir, result.created[0]!.filePath), 'utf-8');
+    expect(raw).not.toContain('source:');
   });
 
   it('respects maxDocs cap', async () => {


### PR DESCRIPTION
Closes #265.

## Problem

`harness knowledge-pipeline --fix` materializes business-knowledge docs whose ingested form has `metadata.source = "unknown"`, while the same finding from the extractor has `metadata.source = "code-extractor"`. The contradiction detector then flags every materialized doc as conflicting with its own source. A clean `--fix` run produces N new docs and N matching `status_divergence` contradictions, leaving the verdict permanently `FAIL` with no project-side workaround.

The two halves of the round-trip were out of sync:

- `KnowledgeDocMaterializer.formatDoc` wrote only `type`, `domain`, `tags`, `related` — never `source`, even when the source node had `metadata.source` set.
- `BusinessKnowledgeIngestor.parseAndAddNode` only copied `tags` and `related` from frontmatter — so even hand-authored `source:` fields were silently dropped.

The `DecisionIngestor` already does this correctly for ADR-style decision docs; this PR brings the business-knowledge path in line.

## Changes

1. `KnowledgeDocMaterializer.formatDoc`: write `source: <value>` when `node.metadata.source` is a non-empty string. Field is sanitized through the same helper used for `type`/`domain`.
2. `BusinessKnowledgeIngestor`: add optional `source` to the `Frontmatter` interface and copy it into node metadata when present.

## Tests

- Extends the existing `round-trip: materialized doc is parseable by BusinessKnowledgeIngestor frontmatter regex` test to assert `parsed.source === 'extractor'` (the test fixture already set this on the input node — the assertion was just missing).
- Adds `omits source from frontmatter when node has no metadata.source` to the materializer suite.
- Adds two ingestor tests: one verifying `source` is copied from frontmatter, one verifying it stays `undefined` when absent.
- Updates one frontmatter-shape assertion in the materializer's first test to include the new field (the `makeNode` helper sets `source: 'extractor'`, so the rendered doc now correctly includes it).

All 834 graph-package tests pass. Typecheck passes. Changeset added (`@harness-engineering/graph: patch`).

## Verifying the fix end-to-end

In a fresh project that previously hit this:

```bash
# pre-fix: 18 contradictions, verdict FAIL
harness knowledge-pipeline --fix
harness knowledge-pipeline --check-contradictions

# post-fix (with rebuilt CLI): contradictions clear, verdict WARN/PASS
```
