### PR TITLE
fix(ingest, graph): resolve harness ingest OOM (#274) and loadGraph string-cap (#276)

### DIFF
--- a/.harness/learnings.md
+++ b/.harness/learnings.md
@@ -1,3 +1,18 @@
+## 2026-05-06: Graph ingest robustness — issues #274 + #276
+
+Two independent crash modes on real-world monorepos, both fixed in this pass:
+
+- **#274 (recursion / OOM)**: `CodeIngestor.findSourceFiles` shipped a 22-entry inline if-chain skip list and missed every modern JS-monorepo cache (`.turbo`, `.vite`, `.cache`, `.docusaurus`, `.wrangler`, `.svelte-kit`, `storybook-static`, etc.) plus AI agent sandbox dirs (`.claude`, `.cursor`, `.codex`). On heavy users, `.claude/worktrees/` (Claude Code's worktree clones) alone multiplied walker workload 50×. The walker was also recursive — one stack frame per directory level. Fix: extracted `DEFAULT_SKIP_DIRS` to a shared constant (60+ entries), rewrote the walker as iterative BFS, added `CodeIngestorOptions` for `skipDirs` / `additionalSkipDirs` / `excludePatterns` / `respectGitignore`, plumbed an `ingest` block through `harness.config.json` → `runScan` / `runIngest`.
+
+- **#276 (V8 string-cap)**: `loadGraph` slurped `graph.json` into one string via `readFile` then `JSON.parse`. V8 hard-caps single strings at ~512 MB; production graphs exceed it. Fix: bumped on-disk schema v1 → v2 with NDJSON format (one record per line, `kind` discriminator), streaming reader via `readline`, `loadGraphMetadata` fast-path so `harness graph status` works on multi-GB graphs without ever opening `graph.json`. Old v1 graphs trigger the existing `schema_mismatch` path → automatic rebuild on next scan.
+
+Lessons:
+
+- For library packages, hand-roll a tiny `.gitignore` parser instead of pulling in the `ignore` package — the common subset (blank, comment, anchored, dir-only, glob) is ~25 lines; negation is the only feature worth deferring.
+- Schema migrations are nearly free here because `GraphStore.load` already returns false on `schema_mismatch` and warns the caller to rerun scan. Bumping the version is cheaper than building a migration shim.
+- When extracting sub-schemas from `HarnessConfigSchema`, give them their own files — the cli's command-test mocks of `@harness-engineering/graph` are incomplete by convention, and any transitive import dragged in by the schema breaks them.
+- JSDoc inside TypeScript files cannot contain literal `**/` — the embedded `*/` ends the comment block and corrupts the parse. Keep glob examples in markdown docs, not JSDoc.
+
 ## 2026-04-23: Phase 5 Visual & Advanced — Cross-Layer Interface Re-declaration
 
 When the `graph` package needs to accept an `AnalysisProvider` (from `intelligence`), re-declare a minimal interface locally rather than importing across layers. The `graph` → `intelligence` dependency would violate the layer architecture. The `ImageAnalysisExtractor` declares its own `AnalysisProvider` interface with matching shape, and callers (CLI, pipeline) inject the concrete provider.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -183,6 +183,38 @@ Controls how agent tasks are executed.
 }
 ```
 
+## `ingest`
+
+- **Type:** `IngestConfig`
+- **Required:** No
+
+Controls which directories and files `harness scan` and `harness ingest --source code` walk when building the knowledge graph.
+
+The default skip-list is comprehensive — it excludes `node_modules`, `.git`, framework caches (`.turbo`, `.vite`, `.next`, `.nuxt`, `.svelte-kit`, `.parcel-cache`, `.docusaurus`, `.wrangler`, `.astro`, `.remix`, `storybook-static`), test/coverage outputs (`coverage`, `.nyc_output`, `playwright-report`, `test-results`, `.pytest_cache`), Python virtualenvs and bytecode (`__pycache__`, `.venv`, `venv`, `.tox`, `.mypy_cache`, `.ruff_cache`), JVM build outputs (`.gradle`, `.gradle-home`, `target`, `build`, `out`, `bin`, `obj`, `_build`, `deps`), package-manager stores (`.pnpm-store`, `.yarn`, `vendor`), IDE metadata (`.idea`, `.vscode`, `.vs`), the `.harness` directory itself, and AI agent sandboxes (`.claude`, `.cursor`, `.codex`, `.gemini`, `.aider`, `.agents`, `.agentastic`, `.playwright-mcp`).
+
+These fields are escape hatches for projects with non-standard cache or output directories.
+
+### IngestConfig Object
+
+| Field                | Type       | Default | Description                                                                                                      |
+| -------------------- | ---------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `skipDirs`           | `string[]` | --      | Replace the default skip-dirs set entirely. Each entry is a single path segment matched as a directory name.     |
+| `additionalSkipDirs` | `string[]` | --      | Extend the default skip-dirs set. The recommended extension point.                                               |
+| `excludePatterns`    | `string[]` | --      | Glob patterns (minimatch syntax) excluded from ingestion. Matched against the project-relative POSIX-style path. |
+| `respectGitignore`   | `boolean`  | `true`  | Treat lines in `<rootDir>/.gitignore` as additional exclude patterns. Negation (`!pattern`) is not supported.    |
+
+### Example
+
+```json
+{
+  "ingest": {
+    "additionalSkipDirs": ["my-custom-cache", "vendored-deps"],
+    "excludePatterns": ["apps/legacy/**", "**/*.snap"],
+    "respectGitignore": true
+  }
+}
+```
+
 ## `entropy`
 
 - **Type:** `EntropyConfig`

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-05T17:32:11.912Z",
-  "updatedFrom": "32989caf",
+  "updatedAt": "2026-05-06T20:49:31.038Z",
+  "updatedFrom": "4d0a9cee",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 20,
+      "value": 24,
       "violationIds": [
         "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
         "6889f8a985ab68a0d10805c0b5cd65ef6c39584be8dc329c18f489844423c8f2",
@@ -32,6 +32,10 @@
         "2d25259b95052df3e5b92729f6baba686cb3b671d34a4fb5f226bf7d6a788333",
         "173b32d29a880fcb000e74e0b10055ca846eefbc418a947f1ba99c8db1b7a043",
         "4fe3004ac88bda30d223759fa43f8290ed6703b59492da7460a523bb0af91851",
+        "8f98437218eb38d239ee87c16c1c8b427873ce94d7643743974ea02b98b2665d",
+        "fdf9464474e0f5cb7d03d1de4357c6ebf7b64f1f4e85a8bf8e7d70ef6c20cc25",
+        "b82ff3a5a6d1e6a3bbf4b99bced656e44880a0fcb8f0ae3a896c9c778214c1a7",
+        "a6f668cd4e884a7bbc7aadc3f454dcadf05f69236453c43bc35fe4f3eda04e3c",
         "6d56e4633f54b4d0f8b3e6d801e743baa12719835026c35c8638f2a26639aa2e"
       ]
     },
@@ -44,7 +48,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 29297,
+      "value": 29718,
       "violationIds": []
     },
     "dependency-depth": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,45 @@
 # @harness-engineering/cli
 
+## 2.1.0
+
+### Minor Changes
+
+- fix(ingest, graph): resolve `harness ingest` OOM/recursion crashes (#274) and `loadGraph` V8 string-cap crashes (#276) on real-world monorepos.
+
+  **`@harness-engineering/graph`:**
+  - Issue #274 — recursive walker with a 22-entry inline if-chain skip list crashed with `Maximum call stack size exceeded` or heap-OOM on monorepos with populated build caches. The skip list missed `.turbo`, `.vite`, `.cache`, `.docusaurus`, `.wrangler`, `.svelte-kit`, `.parcel-cache`, `storybook-static`, `playwright-report`, `test-results`, `.pytest_cache`, `.pnpm-store`, `.nuxt`, and AI agent sandbox dirs (`.claude`, `.cursor`, `.codex`, `.gemini`, `.aider`). The `.claude/worktrees/` omission alone could multiply walker workload by 50× on heavy users of Claude Code's worktree feature.
+  - New shared `DEFAULT_SKIP_DIRS` constant (60+ entries) at `packages/graph/src/ingest/skip-dirs.ts`, exported from the package barrel along with `resolveSkipDirs`. Covers VCS, package managers, JS/TS framework caches, test/coverage outputs, Python virtualenvs and bytecode, JVM build outputs, IDE metadata, and AI agent sandboxes.
+  - `CodeIngestor.findSourceFiles` rewritten as an iterative BFS walker — no more recursion, bounded by frontier size rather than path depth.
+  - New `CodeIngestorOptions` constructor parameter: `skipDirs` (replace defaults), `additionalSkipDirs` (extend defaults), `excludePatterns` (minimatch globs), `respectGitignore` (default-on, supports the common `.gitignore` subset; negation is dropped silently).
+  - Issue #276 — `loadGraph` slurped `graph.json` into one V8 string and crashed with `RangeError: Invalid string length` on graphs > ~512 MB. Production monorepos with thousands of source files hit this easily.
+  - On-disk schema bumped v1 → v2: `graph.json` is now NDJSON, one record per line with a `kind` discriminator (`"node"` or `"edge"`). Reader uses `readline` so peak string size is bounded by the largest single record. Old v1 graphs trigger the existing `schema_mismatch` path → automatic rebuild on next scan.
+  - New `loadGraphMetadata` helper (exported) reads only `metadata.json`. New `nodesByType` field on `GraphMetadata` enables a fast-path for summary callers that never touch `graph.json`.
+  - `RangeError: Invalid string length` now wraps into an actionable error pointing at the offending file and likely cause.
+
+  **`@harness-engineering/cli`:**
+  - New `ingest` config block on `HarnessConfigSchema` mirroring `CodeIngestorOptions`. Use `additionalSkipDirs` to extend the comprehensive defaults without replacing them, `excludePatterns` for glob-based exclusions, and `respectGitignore: false` to opt out of `.gitignore` honoring.
+  - `harness scan` and `harness ingest --source code` load the `ingest` block via best-effort `loadIngestOptions` — if `harness.config.json` is missing or malformed, falls back to defaults silently.
+  - `harness graph status` now reads only `metadata.json` (via `loadGraphMetadata`) and returns instantly with full per-type node breakdown, even on multi-GB graphs that previously failed to load.
+  - `harness graph status` reports a clear `schema_mismatch` message instead of an opaque parse error when the graph was written by an older schema version.
+  - The CLI's MCP `glob-helper` now imports the shared `DEFAULT_SKIP_DIRS` so the MCP file walker and the graph ingester can no longer drift.
+
+  **Documentation:**
+  - `docs/reference/configuration.md` — new `ingest` section documenting `skipDirs`, `additionalSkipDirs`, `excludePatterns`, `respectGitignore`, the comprehensive default list, and a worked example.
+
+  **Tests:**
+  - New `packages/graph/tests/ingest/CodeIngestor-skip-dirs.test.ts` — asserts default coverage of `.claude`/`.vite`/`.turbo`/etc., custom `additionalSkipDirs`/`skipDirs`/`excludePatterns` work, `.gitignore` is honored, iterative walker handles deeply nested directories.
+  - New `packages/graph/tests/store/Serializer.test.ts` — asserts NDJSON line shape, save/load roundtrip preserves nodes and edges, metadata fast-path returns counts without reading `graph.json`, schema-mismatch on legacy v1 files, large-graph (5K nodes + 5K edges) streams cleanly.
+  - Existing `packages/cli/tests/commands/graph.test.ts` updated to assert the v2 NDJSON shape.
+
+### Patch Changes
+
+- Updated dependencies
+  - @harness-engineering/graph@0.8.0
+  - @harness-engineering/core@0.23.7
+  - @harness-engineering/dashboard@0.5.1
+  - @harness-engineering/intelligence@0.2.1
+  - @harness-engineering/orchestrator@0.3.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "CLI for Harness Engineering toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/graph/index.ts
+++ b/packages/cli/src/commands/graph/index.ts
@@ -8,15 +8,17 @@ function resolveProjectPath(globalOpts: { config?: string }): string {
 }
 
 function printGraphStatus(result: Awaited<ReturnType<typeof runGraphStatus>>): void {
-  if (result.status === 'no_graph') {
+  if (result.status === 'no_graph' || result.status === 'schema_mismatch') {
     console.log(result.message);
     return;
   }
   console.log(`Graph: ${result.nodeCount} nodes, ${result.edgeCount} edges`);
   console.log(`Last scan: ${result.lastScanTimestamp}`);
-  console.log('Nodes by type:');
-  for (const [type, count] of Object.entries(result.nodesByType!)) {
-    console.log(`  ${type}: ${count}`);
+  if (result.nodesByType) {
+    console.log('Nodes by type:');
+    for (const [type, count] of Object.entries(result.nodesByType)) {
+      console.log(`  ${type}: ${count}`);
+    }
   }
   if (!result.connectorSyncStatus) return;
   console.log('Connector sync status:');

--- a/packages/cli/src/commands/graph/ingest-options.ts
+++ b/packages/cli/src/commands/graph/ingest-options.ts
@@ -1,0 +1,47 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { CodeIngestorOptions } from '@harness-engineering/graph';
+import { IngestConfigSchema } from '../../config/ingest-schema.js';
+
+/**
+ * Best-effort load of `ingest.*` settings from `<projectPath>/harness.config.json`.
+ *
+ * Intentionally synchronous and best-effort: if the file is missing, malformed,
+ * or fails schema validation, we silently fall back to {@link CodeIngestor} defaults.
+ * Surfacing a hard error from the loader would make the broad scan/ingest commands
+ * fail on projects that have not yet run `harness init`, which is worse than
+ * "use sensible defaults".
+ */
+export function loadIngestOptions(projectPath: string): CodeIngestorOptions {
+  const configPath = path.join(projectPath, 'harness.config.json');
+  if (!fs.existsSync(configPath)) return {};
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch {
+    return {};
+  }
+
+  // Pull just the `ingest` block; ignore the rest of the config to avoid
+  // pulling the full HarnessConfigSchema (and its `@harness-engineering/core`
+  // dependency) into the ingest hot path.
+  const ingestRaw = (raw as { ingest?: unknown } | null | undefined)?.ingest;
+  if (ingestRaw === undefined) return {};
+  const parsed = IngestConfigSchema.safeParse(ingestRaw);
+  if (!parsed.success) return {};
+
+  // Build incrementally so we never emit `key: undefined` entries — the
+  // workspace's `exactOptionalPropertyTypes` rejects them. A mutable shape
+  // is used internally; the return type re-applies the readonly markers.
+  const out: {
+    -readonly [K in keyof CodeIngestorOptions]: CodeIngestorOptions[K];
+  } = {};
+  if (parsed.data.skipDirs !== undefined) out.skipDirs = parsed.data.skipDirs;
+  if (parsed.data.additionalSkipDirs !== undefined)
+    out.additionalSkipDirs = parsed.data.additionalSkipDirs;
+  if (parsed.data.excludePatterns !== undefined) out.excludePatterns = parsed.data.excludePatterns;
+  if (parsed.data.respectGitignore !== undefined)
+    out.respectGitignore = parsed.data.respectGitignore;
+  return out;
+}

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import * as path from 'path';
 import type { IngestResult, GraphConnector } from '@harness-engineering/graph';
+import { loadIngestOptions } from './ingest-options.js';
 
 async function loadConnectorConfig(
   projectPath: string,
@@ -61,10 +62,11 @@ export async function runIngest(
   const graphDir = path.join(projectPath, '.harness', 'graph');
   const store = new GraphStore();
   await store.load(graphDir);
+  const ingestOptions = loadIngestOptions(projectPath);
 
   if (opts?.all) {
     const startMs = Date.now();
-    const codeResult = await new CodeIngestor(store).ingest(projectPath);
+    const codeResult = await new CodeIngestor(store, ingestOptions).ingest(projectPath);
     new TopologicalLinker(store).link();
     const knowledgeResult = await new KnowledgeIngestor(store).ingestAll(projectPath);
     const reqResult = await new RequirementIngestor(store).ingestSpecs(
@@ -109,7 +111,7 @@ export async function runIngest(
   let result: IngestResult;
   switch (source) {
     case 'code':
-      result = await new CodeIngestor(store).ingest(projectPath);
+      result = await new CodeIngestor(store, ingestOptions).ingest(projectPath);
       new TopologicalLinker(store).link();
       break;
     case 'knowledge':

--- a/packages/cli/src/commands/graph/scan.ts
+++ b/packages/cli/src/commands/graph/scan.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import * as path from 'path';
+import { loadIngestOptions } from './ingest-options.js';
 
 export async function runScan(
   projectPath: string
@@ -15,8 +16,9 @@ export async function runScan(
   const store = new GraphStore();
   const start = Date.now();
 
-  // Code ingestion
-  await new CodeIngestor(store).ingest(projectPath);
+  // Code ingestion (honors `ingest.*` config from harness.config.json)
+  const ingestOptions = loadIngestOptions(projectPath);
+  await new CodeIngestor(store, ingestOptions).ingest(projectPath);
   new TopologicalLinker(store).link();
 
   // Knowledge ingestion

--- a/packages/cli/src/commands/graph/status.ts
+++ b/packages/cli/src/commands/graph/status.ts
@@ -10,41 +10,78 @@ export interface GraphStatusResult {
   connectorSyncStatus?: Record<string, string>;
 }
 
-export async function runGraphStatus(projectPath: string): Promise<GraphStatusResult> {
-  const { GraphStore } = await import('@harness-engineering/graph');
-  const graphDir = path.join(projectPath, '.harness', 'graph');
-  const store = new GraphStore();
-  const loaded = await store.load(graphDir);
-  if (!loaded) return { status: 'no_graph', message: 'No graph found. Run `harness scan` first.' };
-
-  // Read metadata
+async function readConnectorSyncStatus(graphDir: string): Promise<Record<string, string>> {
   const fs = await import('node:fs/promises');
-  const metaPath = path.join(graphDir, 'metadata.json');
-  let lastScan = 'unknown';
-  try {
-    const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8'));
-    lastScan = meta.lastScanTimestamp;
-  } catch {
-    /* metadata file may not exist */
-  }
-
-  // Count by type
-  const allNodes = store.findNodes({});
-  const nodesByType: Record<string, number> = {};
-  for (const node of allNodes) {
-    nodesByType[node.type] = (nodesByType[node.type] ?? 0) + 1;
-  }
-
-  // Read connector sync metadata
-  let connectorSyncStatus: Record<string, string> = {};
+  const result: Record<string, string> = {};
   try {
     const syncMetaPath = path.join(graphDir, 'sync-metadata.json');
     const syncMeta = JSON.parse(await fs.readFile(syncMetaPath, 'utf-8'));
     for (const [name, data] of Object.entries(syncMeta.connectors ?? {})) {
-      connectorSyncStatus[name] = (data as { lastSyncTimestamp: string }).lastSyncTimestamp;
+      result[name] = (data as { lastSyncTimestamp: string }).lastSyncTimestamp;
     }
   } catch {
-    /* no sync metadata */
+    /* no sync metadata — connectors not configured or never synced */
+  }
+  return result;
+}
+
+/**
+ * Reports graph statistics. Reads `metadata.json` only — it carries node/edge
+ * counts and per-type breakdowns (since schema v2). This avoids the streaming
+ * graph.json read entirely, so `harness graph status` returns instantly even on
+ * multi-GB graphs that would otherwise take seconds (or trip pre-v2 callers).
+ *
+ * Falls back to a full graph load only when the metadata file lacks `nodesByType`,
+ * which happens for graphs written before that field was added.
+ */
+export async function runGraphStatus(projectPath: string): Promise<GraphStatusResult> {
+  const { GraphStore, loadGraphMetadata } = await import('@harness-engineering/graph');
+  const graphDir = path.join(projectPath, '.harness', 'graph');
+
+  const metaResult = await loadGraphMetadata(graphDir);
+  if (metaResult.status === 'not_found') {
+    return { status: 'no_graph', message: 'No graph found. Run `harness scan` first.' };
+  }
+  if (metaResult.status === 'schema_mismatch') {
+    return {
+      status: 'schema_mismatch',
+      message:
+        `Graph schema version mismatch: file is v${metaResult.found}, CLI expects v${metaResult.expected}. ` +
+        'Run `harness scan` to rebuild.',
+    };
+  }
+
+  const meta = metaResult.metadata;
+  const connectorSyncStatus = await readConnectorSyncStatus(graphDir);
+
+  // Fast path: metadata carries everything we need.
+  if (meta.nodesByType) {
+    return {
+      status: 'ok',
+      nodeCount: meta.nodeCount,
+      edgeCount: meta.edgeCount,
+      nodesByType: { ...meta.nodesByType },
+      lastScanTimestamp: meta.lastScanTimestamp,
+      ...(Object.keys(connectorSyncStatus).length > 0 ? { connectorSyncStatus } : {}),
+    };
+  }
+
+  // Slow path: pre-`nodesByType` metadata; load the graph to compute the breakdown.
+  const store = new GraphStore();
+  const loaded = await store.load(graphDir);
+  if (!loaded) {
+    return {
+      status: 'ok',
+      nodeCount: meta.nodeCount,
+      edgeCount: meta.edgeCount,
+      lastScanTimestamp: meta.lastScanTimestamp,
+      ...(Object.keys(connectorSyncStatus).length > 0 ? { connectorSyncStatus } : {}),
+    };
+  }
+
+  const nodesByType: Record<string, number> = {};
+  for (const node of store.findNodes({})) {
+    nodesByType[node.type] = (nodesByType[node.type] ?? 0) + 1;
   }
 
   return {
@@ -52,7 +89,7 @@ export async function runGraphStatus(projectPath: string): Promise<GraphStatusRe
     nodeCount: store.nodeCount,
     edgeCount: store.edgeCount,
     nodesByType,
-    lastScanTimestamp: lastScan,
+    lastScanTimestamp: meta.lastScanTimestamp,
     ...(Object.keys(connectorSyncStatus).length > 0 ? { connectorSyncStatus } : {}),
   };
 }

--- a/packages/cli/src/config/ingest-schema.ts
+++ b/packages/cli/src/config/ingest-schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/**
+ * Schema for source-file ingestion controls (used by `harness scan` and `harness ingest --source code`).
+ *
+ * Lives in its own file (separate from {@link HarnessConfigSchema}) so that the
+ * scan/ingest command path can validate the `ingest` block without dragging in
+ * the rest of the config schema's transitive imports — notably `@harness-engineering/core`,
+ * which the graph-ingest unit tests mock incompletely.
+ *
+ * The default skip-list (see `DEFAULT_SKIP_DIRS` in `@harness-engineering/graph`)
+ * is comprehensive — these fields are escape hatches for projects with non-standard
+ * cache or output directories.
+ */
+export const IngestConfigSchema = z.object({
+  /** Replace the default skip-dirs set entirely. Single path segments matched as directory names (NOT globs). */
+  skipDirs: z.array(z.string().min(1)).optional(),
+  /** Extend the default skip-dirs set. Recommended extension point. */
+  additionalSkipDirs: z.array(z.string().min(1)).optional(),
+  /** Glob patterns (minimatch syntax) excluded from ingestion. Matched against the project-relative POSIX-style path. */
+  excludePatterns: z.array(z.string().min(1)).optional(),
+  /** When true, parse `<rootDir>/.gitignore` and treat each line as an additional exclude pattern. Default: true. */
+  respectGitignore: z.boolean().optional().default(true),
+});
+
+export type IngestConfig = z.infer<typeof IngestConfigSchema>;

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import { ArchConfigSchema } from '@harness-engineering/core';
+import { IngestConfigSchema } from './ingest-schema.js';
+
+export { IngestConfigSchema } from './ingest-schema.js';
+export type { IngestConfig } from './ingest-schema.js';
 
 /**
  * Schema for architectural layer definitions.
@@ -324,6 +328,8 @@ export const HarnessConfigSchema = z.object({
   docsDir: z.string().default('./docs'),
   /** Agent orchestration settings */
   agent: AgentConfigSchema.optional(),
+  /** Source-file ingestion controls (skip-dirs, exclude patterns, gitignore handling) */
+  ingest: IngestConfigSchema.optional(),
   /** Drift and stale code management settings */
   entropy: EntropyConfigSchema.optional(),
   /** Security scanning configuration */

--- a/packages/cli/src/mcp/utils/glob-helper.ts
+++ b/packages/cli/src/mcp/utils/glob-helper.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph';
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.go', '.py']);
 
@@ -26,36 +27,39 @@ function isExcluded(relativePath: string, excludeRegexes: RegExp[]): boolean {
   return false;
 }
 
-// Directories that are always skipped for performance
-const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', '.next', '.nuxt', '__pycache__']);
+/**
+ * Walk a directory iteratively (BFS via explicit queue), collecting source files.
+ *
+ * Iterative on purpose — see {@link DEFAULT_SKIP_DIRS} for the bug history.
+ * The shared default skip-list is sourced from `@harness-engineering/graph` so
+ * this MCP walker, the CLI scanner, and the graph ingester stay in sync.
+ */
+async function walkDir(rootDir: string, excludeRegexes: RegExp[], files: string[]): Promise<void> {
+  const queue: string[] = [rootDir];
 
-/** Walk a directory recursively, collecting source files into the provided array. */
-async function walkDir(
-  dir: string,
-  rootDir: string,
-  excludeRegexes: RegExp[],
-  files: string[]
-): Promise<void> {
-  let entries;
-  try {
-    entries = await fs.readdir(dir, { withFileTypes: true });
-  } catch {
-    return; // Permission denied or missing directory
-  }
+  while (queue.length > 0) {
+    const dir = queue.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue; // permission denied, broken symlink, or vanished directory
+    }
 
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    const relativePath = path.relative(rootDir, fullPath).replaceAll('\\', '/');
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const relativePath = path.relative(rootDir, fullPath).replaceAll('\\', '/');
 
-    if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      if (isExcluded(relativePath + '/', excludeRegexes)) continue;
-      await walkDir(fullPath, rootDir, excludeRegexes, files);
-    } else if (entry.isFile()) {
-      const ext = path.extname(entry.name);
-      if (!SOURCE_EXTENSIONS.has(ext)) continue;
-      if (isExcluded(relativePath, excludeRegexes)) continue;
-      files.push(fullPath);
+      if (entry.isDirectory()) {
+        if (DEFAULT_SKIP_DIRS.has(entry.name)) continue;
+        if (isExcluded(relativePath + '/', excludeRegexes)) continue;
+        queue.push(fullPath);
+      } else if (entry.isFile()) {
+        const ext = path.extname(entry.name);
+        if (!SOURCE_EXTENSIONS.has(ext)) continue;
+        if (isExcluded(relativePath, excludeRegexes)) continue;
+        files.push(fullPath);
+      }
     }
   }
 }
@@ -73,6 +77,6 @@ export async function globFiles(rootDir: string, exclude?: string[]): Promise<st
   ];
   const excludeRegexes = patterns.map(globToRegex);
   const files: string[] = [];
-  await walkDir(rootDir, rootDir, excludeRegexes, files);
+  await walkDir(rootDir, excludeRegexes, files);
   return files;
 }

--- a/packages/cli/tests/commands/graph.test.ts
+++ b/packages/cli/tests/commands/graph.test.ts
@@ -44,18 +44,23 @@ describe('graph commands', () => {
       expect(stat.isDirectory()).toBe(true);
     });
 
-    it('creates graph.json and metadata.json', async () => {
+    it('creates graph.json (NDJSON) and metadata.json', async () => {
       await runScan(tmpDir);
       const graphDir = path.join(tmpDir, '.harness', 'graph');
+
+      // graph.json is NDJSON since schema v2 — one node or edge per line, each
+      // line a self-contained JSON object with a `kind` discriminator.
       const graphJson = await fs.readFile(path.join(graphDir, 'graph.json'), 'utf-8');
-      const parsed = JSON.parse(graphJson);
-      expect(parsed).toHaveProperty('nodes');
-      expect(parsed).toHaveProperty('edges');
+      const lines = graphJson.split('\n').filter((l) => l.trim() !== '');
+      expect(lines.length).toBeGreaterThan(0);
+      const kinds = new Set(lines.map((l) => JSON.parse(l).kind));
+      expect(kinds.has('node')).toBe(true);
 
       const metaJson = await fs.readFile(path.join(graphDir, 'metadata.json'), 'utf-8');
       const meta = JSON.parse(metaJson);
       expect(meta).toHaveProperty('schemaVersion');
       expect(meta).toHaveProperty('nodeCount');
+      expect(meta).toHaveProperty('nodesByType');
     });
   });
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.23.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @harness-engineering/graph@0.8.0
+
 ## 0.23.6
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/core",
-  "version": "0.23.6",
+  "version": "0.23.7",
   "description": "Core library for Harness Engineering toolkit",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/dashboard/CHANGELOG.md
+++ b/packages/dashboard/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @harness-engineering/dashboard
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @harness-engineering/graph@0.8.0
+  - @harness-engineering/core@0.23.7
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/dashboard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Local web dashboard for harness project health and roadmap visualization",
   "type": "module",
   "exports": {

--- a/packages/graph/CHANGELOG.md
+++ b/packages/graph/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @harness-engineering/graph
 
+## 0.8.0
+
+### Minor Changes
+
+- fix(ingest, graph): resolve `harness ingest` OOM/recursion crashes (#274) and `loadGraph` V8 string-cap crashes (#276) on real-world monorepos.
+
+  **`@harness-engineering/graph`:**
+  - Issue #274 — recursive walker with a 22-entry inline if-chain skip list crashed with `Maximum call stack size exceeded` or heap-OOM on monorepos with populated build caches. The skip list missed `.turbo`, `.vite`, `.cache`, `.docusaurus`, `.wrangler`, `.svelte-kit`, `.parcel-cache`, `storybook-static`, `playwright-report`, `test-results`, `.pytest_cache`, `.pnpm-store`, `.nuxt`, and AI agent sandbox dirs (`.claude`, `.cursor`, `.codex`, `.gemini`, `.aider`). The `.claude/worktrees/` omission alone could multiply walker workload by 50× on heavy users of Claude Code's worktree feature.
+  - New shared `DEFAULT_SKIP_DIRS` constant (60+ entries) at `packages/graph/src/ingest/skip-dirs.ts`, exported from the package barrel along with `resolveSkipDirs`. Covers VCS, package managers, JS/TS framework caches, test/coverage outputs, Python virtualenvs and bytecode, JVM build outputs, IDE metadata, and AI agent sandboxes.
+  - `CodeIngestor.findSourceFiles` rewritten as an iterative BFS walker — no more recursion, bounded by frontier size rather than path depth.
+  - New `CodeIngestorOptions` constructor parameter: `skipDirs` (replace defaults), `additionalSkipDirs` (extend defaults), `excludePatterns` (minimatch globs), `respectGitignore` (default-on, supports the common `.gitignore` subset; negation is dropped silently).
+  - Issue #276 — `loadGraph` slurped `graph.json` into one V8 string and crashed with `RangeError: Invalid string length` on graphs > ~512 MB. Production monorepos with thousands of source files hit this easily.
+  - On-disk schema bumped v1 → v2: `graph.json` is now NDJSON, one record per line with a `kind` discriminator (`"node"` or `"edge"`). Reader uses `readline` so peak string size is bounded by the largest single record. Old v1 graphs trigger the existing `schema_mismatch` path → automatic rebuild on next scan.
+  - New `loadGraphMetadata` helper (exported) reads only `metadata.json`. New `nodesByType` field on `GraphMetadata` enables a fast-path for summary callers that never touch `graph.json`.
+  - `RangeError: Invalid string length` now wraps into an actionable error pointing at the offending file and likely cause.
+
+  **`@harness-engineering/cli`:**
+  - New `ingest` config block on `HarnessConfigSchema` mirroring `CodeIngestorOptions`. Use `additionalSkipDirs` to extend the comprehensive defaults without replacing them, `excludePatterns` for glob-based exclusions, and `respectGitignore: false` to opt out of `.gitignore` honoring.
+  - `harness scan` and `harness ingest --source code` load the `ingest` block via best-effort `loadIngestOptions` — if `harness.config.json` is missing or malformed, falls back to defaults silently.
+  - `harness graph status` now reads only `metadata.json` (via `loadGraphMetadata`) and returns instantly with full per-type node breakdown, even on multi-GB graphs that previously failed to load.
+  - `harness graph status` reports a clear `schema_mismatch` message instead of an opaque parse error when the graph was written by an older schema version.
+  - The CLI's MCP `glob-helper` now imports the shared `DEFAULT_SKIP_DIRS` so the MCP file walker and the graph ingester can no longer drift.
+
+  **Documentation:**
+  - `docs/reference/configuration.md` — new `ingest` section documenting `skipDirs`, `additionalSkipDirs`, `excludePatterns`, `respectGitignore`, the comprehensive default list, and a worked example.
+
+  **Tests:**
+  - New `packages/graph/tests/ingest/CodeIngestor-skip-dirs.test.ts` — asserts default coverage of `.claude`/`.vite`/`.turbo`/etc., custom `additionalSkipDirs`/`skipDirs`/`excludePatterns` work, `.gitignore` is honored, iterative walker handles deeply nested directories.
+  - New `packages/graph/tests/store/Serializer.test.ts` — asserts NDJSON line shape, save/load roundtrip preserves nodes and edges, metadata fast-path returns counts without reading `graph.json`, schema-mismatch on legacy v1 files, large-graph (5K nodes + 5K edges) streams cleanly.
+  - Existing `packages/cli/tests/commands/graph.test.ts` updated to assert the v2 NDJSON shape.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/graph",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "MIT",
   "description": "Knowledge graph for context assembly in Harness Engineering",
   "main": "./dist/index.js",

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -28,8 +28,8 @@ export { GraphStore } from './store/GraphStore.js';
 export type { NodeQuery, EdgeQuery } from './store/GraphStore.js';
 export { VectorStore } from './store/VectorStore.js';
 export type { VectorSearchResult } from './store/VectorStore.js';
-export { saveGraph, loadGraph } from './store/Serializer.js';
-export type { LoadGraphResult } from './store/Serializer.js';
+export { saveGraph, loadGraph, loadGraphMetadata } from './store/Serializer.js';
+export type { LoadGraphResult, LoadMetadataResult } from './store/Serializer.js';
 export { PackedSummaryCache, normalizeIntent } from './store/PackedSummaryCache.js';
 export type { CacheableEnvelope } from './store/PackedSummaryCache.js';
 
@@ -42,6 +42,8 @@ export type { ImpactGroups, NodeCategory } from './query/groupImpact.js';
 
 // Ingest
 export { CodeIngestor } from './ingest/CodeIngestor.js';
+export type { CodeIngestorOptions } from './ingest/CodeIngestor.js';
+export { DEFAULT_SKIP_DIRS, resolveSkipDirs } from './ingest/skip-dirs.js';
 export { GitIngestor } from './ingest/GitIngestor.js';
 export type { GitRunner } from './ingest/GitIngestor.js';
 export { TopologicalLinker } from './ingest/TopologicalLinker.js';

--- a/packages/graph/src/ingest/CodeIngestor.ts
+++ b/packages/graph/src/ingest/CodeIngestor.ts
@@ -1,7 +1,25 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { minimatch } from 'minimatch';
 import type { GraphStore } from '../store/GraphStore.js';
 import type { GraphNode, GraphEdge, IngestResult } from '../types.js';
+import { resolveSkipDirs } from './skip-dirs.js';
+
+/**
+ * Options controlling which files {@link CodeIngestor} walks. Each field is optional;
+ * defaults skip standard build artifacts, package-manager caches, AI agent sandboxes,
+ * and IDE metadata (see {@link DEFAULT_SKIP_DIRS}).
+ */
+export interface CodeIngestorOptions {
+  /** Replace the default skip-dirs set entirely. Use sparingly — defaults are broad on purpose. */
+  readonly skipDirs?: Iterable<string>;
+  /** Add directory names to the default skip-dirs set. The common extension point. */
+  readonly additionalSkipDirs?: Iterable<string>;
+  /** Glob patterns (minimatch syntax) to exclude paths from ingestion. Evaluated against the relative POSIX-style path. */
+  readonly excludePatterns?: readonly string[];
+  /** When true, parse `<rootDir>/.gitignore` and use it as additional exclude patterns. Default: true. */
+  readonly respectGitignore?: boolean;
+}
 
 interface ClassContext {
   className: string | null;
@@ -105,11 +123,86 @@ function isSupportedSourceFile(name: string): boolean {
 }
 
 /**
+ * Match a relative POSIX-style path against a set of minimatch patterns.
+ * Patterns may include `**` for any-depth and `*` for single-segment matches.
+ * Both `dir/` and `dir` style targets are supported by callers passing the
+ * appropriate suffix.
+ */
+function isExcluded(relPath: string, patterns: readonly string[]): boolean {
+  if (patterns.length === 0) return false;
+  for (const pattern of patterns) {
+    if (minimatch(relPath, pattern, { dot: true, matchBase: false })) return true;
+    // matchBase: also try matching just the basename (e.g. `*.snap` against `foo/bar/x.snap`)
+    if (!pattern.includes('/') && minimatch(relPath, pattern, { dot: true, matchBase: true })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Read `<rootDir>/.gitignore` if it exists and translate its lines into
+ * minimatch-compatible glob patterns. Supports the common subset:
+ *   - blank lines and `#` comments are skipped
+ *   - leading `/` makes the pattern root-anchored
+ *   - trailing `/` marks a directory-only pattern (kept as-is for the matcher)
+ *   - leading `!` negation is NOT supported and is dropped with no error
+ *
+ * Hand-rolled to avoid pulling in the `ignore` package as a runtime dep of the
+ * published `@harness-engineering/graph` library. Coverage is good enough for
+ * the common case of "skip what gitignore skips"; for full gitignore semantics
+ * users can supply explicit `excludePatterns`.
+ */
+async function readGitignorePatterns(rootDir: string): Promise<string[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(path.join(rootDir, '.gitignore'), 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const patterns: string[] = [];
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    if (line.startsWith('!')) continue; // negation: out of scope for the minimatch translation
+    const rooted = line.startsWith('/');
+    const stripped = rooted ? line.slice(1) : line;
+    const isDirOnly = stripped.endsWith('/');
+    const core = isDirOnly ? stripped.slice(0, -1) : stripped;
+    if (core === '') continue;
+
+    if (rooted) {
+      // anchored to project root
+      patterns.push(isDirOnly ? `${core}/**` : core);
+      if (isDirOnly) patterns.push(`${core}/`);
+    } else {
+      // matches at any depth
+      patterns.push(`**/${core}`);
+      patterns.push(`**/${core}/**`);
+      if (isDirOnly) patterns.push(`**/${core}/`);
+    }
+  }
+  return patterns;
+}
+
+/**
  * Ingests source files into the graph via regex-based parsing.
  * Supports TypeScript, JavaScript, Python, Go, Rust, and Java.
  */
 export class CodeIngestor {
-  constructor(private readonly store: GraphStore) {}
+  private readonly skipDirs: ReadonlySet<string>;
+  private readonly excludePatterns: readonly string[];
+  private readonly respectGitignore: boolean;
+
+  constructor(
+    private readonly store: GraphStore,
+    options: CodeIngestorOptions = {}
+  ) {
+    this.skipDirs = resolveSkipDirs(options);
+    this.excludePatterns = options.excludePatterns ?? [];
+    this.respectGitignore = options.respectGitignore ?? true;
+  }
 
   async ingest(rootDir: string): Promise<IngestResult> {
     const start = Date.now();
@@ -233,43 +326,59 @@ export class CodeIngestor {
     files.add(relativePath);
   }
 
-  private async findSourceFiles(dir: string): Promise<string[]> {
+  /**
+   * Walk `rootDir` iteratively (BFS via an explicit queue) and return absolute paths
+   * of every supported source file that is not excluded by the configured filters.
+   *
+   * Iterative on purpose: a recursive walker burns one stack frame per nested
+   * directory and crashes with `Maximum call stack size exceeded` on deeply nested
+   * monorepos (issue #274). The queue-based form keeps memory bounded by the
+   * frontier size rather than the deepest path.
+   */
+  private async findSourceFiles(rootDir: string): Promise<string[]> {
     const results: string[] = [];
-    const entries = await fs.readdir(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
-      if (
-        entry.isDirectory() &&
-        entry.name !== 'node_modules' &&
-        entry.name !== 'dist' &&
-        entry.name !== 'target' &&
-        entry.name !== 'build' &&
-        entry.name !== '.git' &&
-        entry.name !== '__pycache__' &&
-        entry.name !== '.venv' &&
-        entry.name !== '.turbo' &&
-        entry.name !== '.harness' &&
-        entry.name !== '.next' &&
-        entry.name !== '.vscode' &&
-        entry.name !== '.idea' &&
-        entry.name !== 'vendor' &&
-        entry.name !== 'out' &&
-        entry.name !== '.gradle' &&
-        entry.name !== '.gradle-home' &&
-        entry.name !== 'bin' &&
-        entry.name !== 'obj' &&
-        entry.name !== 'venv' &&
-        entry.name !== '_build' &&
-        entry.name !== 'deps' &&
-        entry.name !== 'coverage' &&
-        entry.name !== '.nyc_output'
-      ) {
-        results.push(...(await this.findSourceFiles(fullPath)));
-      } else if (entry.isFile() && isSupportedSourceFile(entry.name)) {
-        results.push(fullPath);
+    const matchers = await this.buildExcludeMatchers(rootDir);
+    const queue: string[] = [rootDir];
+
+    while (queue.length > 0) {
+      const dir = queue.pop()!;
+      let entries;
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        continue; // permission denied, broken symlink, or vanished directory — skip silently
+      }
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        const relPath = path.relative(rootDir, fullPath).replaceAll('\\', '/');
+
+        if (entry.isDirectory()) {
+          if (this.skipDirs.has(entry.name)) continue;
+          if (isExcluded(`${relPath}/`, matchers)) continue;
+          queue.push(fullPath);
+        } else if (entry.isFile()) {
+          if (!isSupportedSourceFile(entry.name)) continue;
+          if (isExcluded(relPath, matchers)) continue;
+          results.push(fullPath);
+        }
       }
     }
+
     return results;
+  }
+
+  /**
+   * Compose the exclude matchers from `excludePatterns` and (optionally) `.gitignore`.
+   * Returns a list of minimatch-compatible patterns; an empty list means "no excludes".
+   */
+  private async buildExcludeMatchers(rootDir: string): Promise<readonly string[]> {
+    const patterns: string[] = [...this.excludePatterns];
+    if (this.respectGitignore) {
+      const gitignorePatterns = await readGitignorePatterns(rootDir);
+      patterns.push(...gitignorePatterns);
+    }
+    return patterns;
   }
 
   private extractSymbols(

--- a/packages/graph/src/ingest/skip-dirs.ts
+++ b/packages/graph/src/ingest/skip-dirs.ts
@@ -1,0 +1,112 @@
+/**
+ * Default directory names skipped during source-file walking.
+ *
+ * Walking into these on a populated monorepo (e.g. .turbo or .claude/worktrees)
+ * inflates the walked-file count by orders of magnitude and is the root cause
+ * of the recursion-depth and heap-OOM crashes reported in
+ * https://github.com/Intense-Visions/harness-engineering/issues/274.
+ *
+ * Categories covered:
+ *   - VCS / repo metadata
+ *   - Package-manager caches and stores
+ *   - JS/TS framework build & dev caches
+ *   - Test, coverage, and reporter outputs
+ *   - Python virtualenvs and bytecode caches
+ *   - JVM build outputs
+ *   - IDE / editor metadata
+ *   - AI agent sandbox directories (Claude Code worktrees, Cursor, Codex, etc.)
+ *
+ * Consumers may extend or replace this set via {@link CodeIngestorOptions}
+ * or the project-level `ingest.skipDirs` / `ingest.additionalSkipDirs` config.
+ */
+export const DEFAULT_SKIP_DIRS: ReadonlySet<string> = new Set([
+  // VCS
+  '.git',
+  '.hg',
+  '.svn',
+
+  // Package managers
+  'node_modules',
+  '.pnpm-store',
+  '.yarn',
+  'vendor',
+
+  // JS/TS build outputs
+  'dist',
+  'build',
+  'out',
+  '_build',
+  'bin',
+  'obj',
+  'target',
+  'deps',
+
+  // JS/TS framework / tooling caches
+  '.next',
+  '.nuxt',
+  '.svelte-kit',
+  '.turbo',
+  '.vite',
+  '.cache',
+  '.parcel-cache',
+  '.docusaurus',
+  '.wrangler',
+  '.astro',
+  '.remix',
+  'storybook-static',
+
+  // Test / coverage / reporter outputs
+  'coverage',
+  '.nyc_output',
+  '.pytest_cache',
+  'playwright-report',
+  'test-results',
+  '.e2e',
+
+  // Python
+  '__pycache__',
+  '.venv',
+  'venv',
+  '.tox',
+  '.mypy_cache',
+  '.ruff_cache',
+
+  // JVM
+  '.gradle',
+  '.gradle-home',
+
+  // IDE / editor
+  '.idea',
+  '.vscode',
+  '.vs',
+
+  // Harness self
+  '.harness',
+
+  // AI agent sandboxes (these often contain full repo clones — skipping them
+  // prevents the walker from re-ingesting nested copies of the project)
+  '.claude',
+  '.cursor',
+  '.codex',
+  '.gemini',
+  '.aider',
+  '.agents',
+  '.agentastic',
+  '.playwright-mcp',
+]);
+
+/**
+ * Build an effective skip-dirs Set from optional caller overrides.
+ * - If `skipDirs` is provided, it replaces the defaults entirely.
+ * - If `additionalSkipDirs` is provided, it extends the defaults (or the override).
+ */
+export function resolveSkipDirs(options?: {
+  skipDirs?: Iterable<string>;
+  additionalSkipDirs?: Iterable<string>;
+}): ReadonlySet<string> {
+  const base = options?.skipDirs ? new Set(options.skipDirs) : new Set(DEFAULT_SKIP_DIRS);
+  if (options?.additionalSkipDirs) {
+    for (const name of options.additionalSkipDirs) base.add(name);
+  }
+  return base;
+}

--- a/packages/graph/src/store/Serializer.ts
+++ b/packages/graph/src/store/Serializer.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
-import { createWriteStream } from 'node:fs';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 import { join } from 'node:path';
 import type { GraphNode, GraphEdge, GraphMetadata } from '../types.js';
 import { CURRENT_SCHEMA_VERSION } from '../types.js';
@@ -10,10 +11,14 @@ interface SerializedGraph {
 }
 
 /**
- * Write graph JSON as a stream to avoid holding the entire serialized string
- * in memory. For large graphs (100MB+) this prevents OOM during serialization.
+ * Stream-write the graph as NDJSON — one node or edge per line, each line a
+ * self-contained JSON object with a `kind` discriminator.
+ *
+ * Format chosen to dodge V8's ~512 MB single-string cap, which the previous
+ * "one giant JSON document" format hit on production monorepos (issue #276).
+ * NDJSON also lets the reader stream the file with bounded per-line memory.
  */
-function streamGraphJson(
+function streamGraphNdjson(
   filePath: string,
   nodes: readonly GraphNode[],
   edges: readonly GraphEdge[]
@@ -22,19 +27,24 @@ function streamGraphJson(
     const stream = createWriteStream(filePath, { encoding: 'utf-8' });
     stream.on('error', reject);
 
-    stream.write('{"nodes":[');
-    for (let i = 0; i < nodes.length; i++) {
-      if (i > 0) stream.write(',');
-      stream.write(JSON.stringify(nodes[i]));
+    for (const node of nodes) {
+      stream.write(JSON.stringify({ kind: 'node', ...node }));
+      stream.write('\n');
     }
-    stream.write('],"edges":[');
-    for (let i = 0; i < edges.length; i++) {
-      if (i > 0) stream.write(',');
-      stream.write(JSON.stringify(edges[i]));
+    for (const edge of edges) {
+      stream.write(JSON.stringify({ kind: 'edge', ...edge }));
+      stream.write('\n');
     }
-    stream.write(']}');
     stream.end(() => resolve());
   });
+}
+
+function countNodesByType(nodes: readonly GraphNode[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const node of nodes) {
+    counts[node.type] = (counts[node.type] ?? 0) + 1;
+  }
+  return counts;
 }
 
 export async function saveGraph(
@@ -49,10 +59,11 @@ export async function saveGraph(
     lastScanTimestamp: new Date().toISOString(),
     nodeCount: nodes.length,
     edgeCount: edges.length,
+    nodesByType: countNodesByType(nodes),
   };
 
   await Promise.all([
-    streamGraphJson(join(dirPath, 'graph.json'), nodes, edges),
+    streamGraphNdjson(join(dirPath, 'graph.json'), nodes, edges),
     writeFile(join(dirPath, 'metadata.json'), JSON.stringify(metadata, null, 2), 'utf-8'),
   ]);
 }
@@ -61,6 +72,95 @@ export type LoadGraphResult =
   | { status: 'loaded'; graph: SerializedGraph }
   | { status: 'not_found' }
   | { status: 'schema_mismatch'; found: number; expected: number };
+
+export type LoadMetadataResult =
+  | { status: 'loaded'; metadata: GraphMetadata }
+  | { status: 'not_found' }
+  | { status: 'schema_mismatch'; found: number; expected: number };
+
+/**
+ * Read just `metadata.json` — fast-path for callers that only need counts/timestamps
+ * (e.g. `harness graph status`). Avoids the streaming graph.json read entirely.
+ *
+ * Returns `not_found` when the metadata file is missing or unreadable.
+ * Returns `schema_mismatch` when the graph was written by a different schema version,
+ * letting callers either rebuild or surface the version skew without loading nodes.
+ */
+export async function loadGraphMetadata(dirPath: string): Promise<LoadMetadataResult> {
+  const metaPath = join(dirPath, 'metadata.json');
+  try {
+    await access(metaPath);
+  } catch {
+    return { status: 'not_found' };
+  }
+
+  let metadata: GraphMetadata;
+  try {
+    const content = await readFile(metaPath, 'utf-8');
+    metadata = JSON.parse(content);
+  } catch {
+    return { status: 'not_found' };
+  }
+
+  if (metadata.schemaVersion !== CURRENT_SCHEMA_VERSION) {
+    return {
+      status: 'schema_mismatch',
+      found: metadata.schemaVersion,
+      expected: CURRENT_SCHEMA_VERSION,
+    };
+  }
+  return { status: 'loaded', metadata };
+}
+
+interface NdjsonRecord {
+  kind?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Stream-read the NDJSON graph file line-by-line. Each line is parsed independently,
+ * so peak string size stays bounded by the largest single record rather than the
+ * total file — which is what got us into trouble in the v1 single-document format.
+ */
+async function streamReadGraph(filePath: string): Promise<SerializedGraph> {
+  const stream = createReadStream(filePath, { encoding: 'utf-8' });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+
+  try {
+    for await (const rawLine of rl) {
+      const line = rawLine.trim();
+      if (line === '') continue;
+      const record = JSON.parse(line) as NdjsonRecord;
+      if (record.kind === 'node') {
+        const { kind: _kind, ...rest } = record;
+        nodes.push(rest as unknown as GraphNode);
+      } else if (record.kind === 'edge') {
+        const { kind: _kind, ...rest } = record;
+        edges.push(rest as unknown as GraphEdge);
+      }
+      // Unknown `kind` values are silently skipped to keep older readers
+      // forward-compatible with future record kinds.
+    }
+  } catch (err) {
+    if (err instanceof RangeError && /invalid string length/i.test(err.message)) {
+      throw new Error(
+        `Graph contains a record larger than V8 can hold in a single string (~512 MB). ` +
+          `This usually means a node or edge has a multi-hundred-MB content/embedding field. ` +
+          `Inspect ${filePath} for the offending record.`,
+        { cause: err }
+      );
+    }
+    throw err;
+  } finally {
+    rl.close();
+    stream.close();
+  }
+
+  return { nodes, edges };
+}
 
 export async function loadGraph(dirPath: string): Promise<LoadGraphResult> {
   const metaPath = join(dirPath, 'metadata.json');
@@ -85,7 +185,7 @@ export async function loadGraph(dirPath: string): Promise<LoadGraphResult> {
     };
   }
 
-  // Parse graph — let parse errors propagate
-  const graphContent = await readFile(graphPath, 'utf-8');
-  return { status: 'loaded', graph: JSON.parse(graphContent) as SerializedGraph };
+  // Stream-read NDJSON graph — never builds a single string > one line
+  const graph = await streamReadGraph(graphPath);
+  return { status: 'loaded', graph };
 }

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -186,9 +186,30 @@ export interface GraphMetadata {
   readonly lastScanTimestamp: string;
   readonly nodeCount: number;
   readonly edgeCount: number;
+  /**
+   * Per-NodeType counts. Populated at save time so `harness graph status`
+   * (and other summary callers) can render counts without loading graph.json.
+   * Optional for forward compatibility with older v2 metadata files written
+   * before this field was added.
+   */
+  readonly nodesByType?: Readonly<Record<string, number>>;
 }
 
-export const CURRENT_SCHEMA_VERSION = 1;
+/**
+ * On-disk graph format version.
+ *
+ * - v1 (legacy): `graph.json` was a single JSON object (`{"nodes":[...],"edges":[...]}`)
+ *   — read by slurping the whole file, which crashed with `RangeError: Invalid string length`
+ *   on graphs > ~512 MB (V8's hard string cap). See issue #276.
+ * - v2 (current): `graph.json` is NDJSON — one node or edge per line, each line a
+ *   self-contained JSON object with a `kind` discriminator (`"node"` or `"edge"`).
+ *   Reader streams the file and never builds a buffer larger than one line, so the
+ *   string cap no longer applies to graph size.
+ *
+ * Old v1 graphs trigger `schema_mismatch` in `loadGraph` and are rebuilt on the
+ * next scan via {@link GraphStore.load}'s existing schema-mismatch handling.
+ */
+export const CURRENT_SCHEMA_VERSION = 2;
 
 // --- Node Stability Classification (for prompt caching) ---
 

--- a/packages/graph/tests/ingest/CodeIngestor-skip-dirs.test.ts
+++ b/packages/graph/tests/ingest/CodeIngestor-skip-dirs.test.ts
@@ -1,0 +1,196 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GraphStore } from '../../src/store/GraphStore.js';
+import { CodeIngestor } from '../../src/ingest/CodeIngestor.js';
+import { DEFAULT_SKIP_DIRS } from '../../src/ingest/skip-dirs.js';
+
+/**
+ * Regression tests for issue #274 — `harness ingest --source code` OOM/recursion
+ * crashes on monorepos with build caches and AI agent sandbox dirs.
+ */
+describe('CodeIngestor — skip-dirs and exclude config', () => {
+  async function buildProject(setup: (root: string) => Promise<void>): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'codeingestor-skip-'));
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src', 'main.ts'), 'export const main = 1;\n');
+    await setup(root);
+    return root;
+  }
+
+  function ingestedPaths(root: string, store: GraphStore): string[] {
+    return store
+      .findNodes({ type: 'file' })
+      .map((n) => n.path ?? '')
+      .filter((p) => p.length > 0);
+  }
+
+  it('default skip list covers common JS-monorepo cache dirs (issue #274)', async () => {
+    // These are the dirs the original bug report flagged as missing from the
+    // hardcoded list. None should be walked by the default ingestor.
+    const expected = [
+      '.turbo',
+      '.vite',
+      '.cache',
+      '.docusaurus',
+      '.wrangler',
+      'storybook-static',
+      'playwright-report',
+      'test-results',
+      '.pytest_cache',
+      '.parcel-cache',
+      '.svelte-kit',
+      '.pnpm-store',
+      '.next',
+      '.nuxt',
+    ];
+    for (const dir of expected) {
+      expect(DEFAULT_SKIP_DIRS.has(dir)).toBe(true);
+    }
+  });
+
+  it('default skip list covers AI agent sandbox dirs (.claude, .cursor, etc.)', async () => {
+    // The .claude omission was the highest-impact piece of #274 — Claude Code's
+    // worktree feature can multiply walker workload by 50× on heavy users.
+    for (const dir of ['.claude', '.cursor', '.codex', '.gemini', '.aider']) {
+      expect(DEFAULT_SKIP_DIRS.has(dir)).toBe(true);
+    }
+  });
+
+  it('does not descend into .claude/worktrees clones', async () => {
+    const root = await buildProject(async (r) => {
+      // Simulate Claude Code's worktree clone: full repo copy under .claude/worktrees
+      await mkdir(join(r, '.claude', 'worktrees', 'session-1', 'src'), { recursive: true });
+      await writeFile(join(r, '.claude', 'worktrees', 'session-1', 'src', 'leaked.ts'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths).toContain('src/main.ts');
+    expect(paths.some((p) => p.includes('.claude/worktrees'))).toBe(false);
+  });
+
+  it('does not descend into .turbo, .vite, or .next caches', async () => {
+    const root = await buildProject(async (r) => {
+      await mkdir(join(r, '.turbo', 'cache'), { recursive: true });
+      await writeFile(join(r, '.turbo', 'cache', 'cached.ts'), 'x;\n');
+      await mkdir(join(r, '.vite', 'deps'), { recursive: true });
+      await writeFile(join(r, '.vite', 'deps', 'dep.js'), 'x;\n');
+      await mkdir(join(r, '.next', 'cache'), { recursive: true });
+      await writeFile(join(r, '.next', 'cache', 'page.js'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths.some((p) => p.startsWith('.turbo/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.vite/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.next/'))).toBe(false);
+  });
+
+  it('respects `additionalSkipDirs` for project-specific cache dirs', async () => {
+    const root = await buildProject(async (r) => {
+      await mkdir(join(r, 'my-custom-cache'), { recursive: true });
+      await writeFile(join(r, 'my-custom-cache', 'a.ts'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store, { additionalSkipDirs: ['my-custom-cache'] }).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths).toContain('src/main.ts');
+    expect(paths.some((p) => p.startsWith('my-custom-cache/'))).toBe(false);
+  });
+
+  it('`skipDirs` replaces the default set entirely', async () => {
+    const root = await buildProject(async (r) => {
+      // Normally skipped — but with override, walker should descend.
+      await mkdir(join(r, 'dist'), { recursive: true });
+      await writeFile(join(r, 'dist', 'compiled.ts'), 'x;\n');
+      // Custom override entry — should be skipped.
+      await mkdir(join(r, 'only-skip-me'), { recursive: true });
+      await writeFile(join(r, 'only-skip-me', 'x.ts'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store, { skipDirs: ['only-skip-me'] }).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths).toContain('src/main.ts');
+    expect(paths).toContain('dist/compiled.ts'); // no longer skipped
+    expect(paths.some((p) => p.startsWith('only-skip-me/'))).toBe(false);
+  });
+
+  it('respects `excludePatterns` glob entries', async () => {
+    const root = await buildProject(async (r) => {
+      await mkdir(join(r, 'apps', 'legacy'), { recursive: true });
+      await writeFile(join(r, 'apps', 'legacy', 'old.ts'), 'x;\n');
+      await mkdir(join(r, 'apps', 'modern'), { recursive: true });
+      await writeFile(join(r, 'apps', 'modern', 'new.ts'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store, { excludePatterns: ['apps/legacy/**'] }).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths).toContain('apps/modern/new.ts');
+    expect(paths.some((p) => p.startsWith('apps/legacy/'))).toBe(false);
+  });
+
+  it('`respectGitignore: true` honors .gitignore line patterns', async () => {
+    const root = await buildProject(async (r) => {
+      await writeFile(join(r, '.gitignore'), 'private/\n*.gen.ts\n');
+      await mkdir(join(r, 'private', 'inner'), { recursive: true });
+      await writeFile(join(r, 'private', 'inner', 'secret.ts'), 'x;\n');
+      await writeFile(join(r, 'src', 'thing.gen.ts'), 'x;\n');
+      await writeFile(join(r, 'src', 'kept.ts'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store, { respectGitignore: true }).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths).toContain('src/main.ts');
+    expect(paths).toContain('src/kept.ts');
+    expect(paths.some((p) => p.startsWith('private/'))).toBe(false);
+    expect(paths.some((p) => p.endsWith('.gen.ts'))).toBe(false);
+  });
+
+  it('`respectGitignore: false` ingests files .gitignore would have excluded', async () => {
+    const root = await buildProject(async (r) => {
+      await writeFile(join(r, '.gitignore'), 'private/\n');
+      await mkdir(join(r, 'private'), { recursive: true });
+      await writeFile(join(r, 'private', 'sneak.ts'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store, { respectGitignore: false }).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths).toContain('private/sneak.ts');
+  });
+
+  it('iterative walker handles deeply nested directories without stack overflow', async () => {
+    const root = await buildProject(async (r) => {
+      // 60 levels with single-character segment names — exercises iteration
+      // without bumping into POSIX path-length limits (typically 1024 chars).
+      // The previous recursive walker burned one stack frame per level; the
+      // iterative replacement should walk this without issue.
+      let dir = join(r, 'd');
+      for (let i = 0; i < 60; i++) {
+        dir = join(dir, 'a');
+      }
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, 'leaf.ts'), 'export const leaf = true;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths.some((p) => p.endsWith('leaf.ts'))).toBe(true);
+  });
+});
+
+describe('CodeIngestor', () => {
+  let store: GraphStore;
+  beforeEach(() => {
+    store = new GraphStore();
+  });
+
+  it('still ingests the standard sample fixture (smoke check)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codeingestor-smoke-'));
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src', 'index.ts'), 'export function hello() { return 1; }\n');
+    await new CodeIngestor(store).ingest(root);
+    expect(store.findNodes({ type: 'function' }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/graph/tests/store/Serializer.test.ts
+++ b/packages/graph/tests/store/Serializer.test.ts
@@ -1,0 +1,188 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { describe, it, expect } from 'vitest';
+import { saveGraph, loadGraph, loadGraphMetadata } from '../../src/store/Serializer.js';
+import { CURRENT_SCHEMA_VERSION } from '../../src/types.js';
+import type { GraphNode, GraphEdge, GraphMetadata } from '../../src/types.js';
+
+/**
+ * Regression tests for issue #276 — `loadGraph` slurped graph.json into a single
+ * string and crashed with `RangeError: Invalid string length` on graphs > ~512 MB.
+ * Schema bumped to v2 with NDJSON on-disk format; reader streams line-by-line.
+ */
+describe('Serializer (schema v2 — NDJSON)', () => {
+  function makeNode(over: Partial<GraphNode> & Pick<GraphNode, 'id' | 'type' | 'name'>): GraphNode {
+    return { metadata: {}, ...over };
+  }
+  function makeEdge(over: GraphEdge): GraphEdge {
+    return { ...over };
+  }
+
+  it('writes NDJSON: each line is a self-contained JSON record with a `kind` discriminator', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-ndjson-'));
+    const nodes: GraphNode[] = [
+      makeNode({ id: 'n1', type: 'file', name: 'a.ts' }),
+      makeNode({ id: 'n2', type: 'class', name: 'Foo' }),
+    ];
+    const edges: GraphEdge[] = [makeEdge({ from: 'n1', to: 'n2', type: 'contains' })];
+
+    await saveGraph(dir, nodes, edges);
+
+    const raw = await readFile(join(dir, 'graph.json'), 'utf-8');
+    const lines = raw.split('\n').filter((l) => l.trim() !== '');
+    expect(lines).toHaveLength(3); // 2 nodes + 1 edge
+
+    const records = lines.map((l) => JSON.parse(l));
+    expect(records[0]!.kind).toBe('node');
+    expect(records[0]!.id).toBe('n1');
+    expect(records[1]!.kind).toBe('node');
+    expect(records[2]!.kind).toBe('edge');
+    expect(records[2]!.from).toBe('n1');
+  });
+
+  it('round-trips nodes and edges through save/load', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-roundtrip-'));
+    const nodes: GraphNode[] = [
+      makeNode({ id: 'n1', type: 'file', name: 'a.ts', path: 'src/a.ts' }),
+      makeNode({ id: 'n2', type: 'function', name: 'doIt', metadata: { exported: true } }),
+    ];
+    const edges: GraphEdge[] = [
+      makeEdge({ from: 'n1', to: 'n2', type: 'contains', metadata: { foo: 'bar' } }),
+    ];
+
+    await saveGraph(dir, nodes, edges);
+    const result = await loadGraph(dir);
+
+    expect(result.status).toBe('loaded');
+    if (result.status !== 'loaded') return;
+    expect(result.graph.nodes).toHaveLength(2);
+    expect(result.graph.edges).toHaveLength(1);
+    expect(result.graph.nodes[0]!.id).toBe('n1');
+    expect(result.graph.edges[0]!.metadata?.foo).toBe('bar');
+    // The discriminator field must NOT leak through to the parsed records
+    expect((result.graph.nodes[0] as unknown as { kind?: string }).kind).toBeUndefined();
+    expect((result.graph.edges[0] as unknown as { kind?: string }).kind).toBeUndefined();
+  });
+
+  it('writes metadata.json with schema v2 and a nodesByType breakdown', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-meta-'));
+    await saveGraph(
+      dir,
+      [
+        makeNode({ id: 'f1', type: 'file', name: 'a.ts' }),
+        makeNode({ id: 'f2', type: 'file', name: 'b.ts' }),
+        makeNode({ id: 'c1', type: 'class', name: 'C' }),
+      ],
+      []
+    );
+    const meta: GraphMetadata = JSON.parse(await readFile(join(dir, 'metadata.json'), 'utf-8'));
+    expect(meta.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(meta.schemaVersion).toBe(2);
+    expect(meta.nodeCount).toBe(3);
+    expect(meta.nodesByType).toEqual({ file: 2, class: 1 });
+  });
+
+  it('loadGraph returns `not_found` when files are missing', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-missing-'));
+    const result = await loadGraph(dir);
+    expect(result.status).toBe('not_found');
+  });
+
+  it('loadGraph returns `schema_mismatch` for legacy v1 graphs (single-document JSON)', async () => {
+    // Reproduce a pre-fix graph: schema v1 with the old `{nodes:[],edges:[]}` shape.
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-v1-'));
+    await writeFile(
+      join(dir, 'graph.json'),
+      JSON.stringify({ nodes: [{ id: 'n1', type: 'file', name: 'a.ts', metadata: {} }], edges: [] })
+    );
+    await writeFile(
+      join(dir, 'metadata.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        lastScanTimestamp: new Date().toISOString(),
+        nodeCount: 1,
+        edgeCount: 0,
+      })
+    );
+    const result = await loadGraph(dir);
+    expect(result.status).toBe('schema_mismatch');
+    if (result.status !== 'schema_mismatch') return;
+    expect(result.found).toBe(1);
+    expect(result.expected).toBe(2);
+  });
+});
+
+describe('loadGraphMetadata — fast-path', () => {
+  it('returns counts and timestamp without reading graph.json', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-fastpath-'));
+    await saveGraph(
+      dir,
+      [{ id: 'n1', type: 'file', name: 'a.ts', metadata: {} }],
+      [{ from: 'n1', to: 'n1', type: 'contains' }]
+    );
+
+    // Wipe graph.json so we can prove the metadata path doesn't touch it.
+    await writeFile(join(dir, 'graph.json'), '');
+
+    const result = await loadGraphMetadata(dir);
+    expect(result.status).toBe('loaded');
+    if (result.status !== 'loaded') return;
+    expect(result.metadata.nodeCount).toBe(1);
+    expect(result.metadata.edgeCount).toBe(1);
+    expect(result.metadata.nodesByType?.file).toBe(1);
+  });
+
+  it('returns `not_found` when metadata.json is absent', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-fastpath-missing-'));
+    const result = await loadGraphMetadata(dir);
+    expect(result.status).toBe('not_found');
+  });
+
+  it('returns `schema_mismatch` for legacy v1 metadata', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-fastpath-v1-'));
+    await writeFile(
+      join(dir, 'metadata.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        lastScanTimestamp: new Date().toISOString(),
+        nodeCount: 0,
+        edgeCount: 0,
+      })
+    );
+    const result = await loadGraphMetadata(dir);
+    expect(result.status).toBe('schema_mismatch');
+  });
+});
+
+describe('Serializer — large graph', () => {
+  it('streams thousands of records line-by-line without buffering the full file', async () => {
+    // Not nearly the 512 MB cap (would slow CI), but enough to prove the streaming
+    // path: 5,000 nodes + 5,000 edges — multi-MB on disk, written and read back via
+    // the NDJSON loop rather than slurped.
+    const dir = await mkdtemp(join(tmpdir(), 'serializer-large-'));
+    const N = 5000;
+    const nodes: GraphNode[] = Array.from({ length: N }, (_, i) => ({
+      id: `n${i}`,
+      type: 'file',
+      name: `file-${i}.ts`,
+      path: `src/file-${i}.ts`,
+      metadata: { idx: i },
+    }));
+    const edges: GraphEdge[] = Array.from({ length: N }, (_, i) => ({
+      from: `n${i}`,
+      to: `n${(i + 1) % N}`,
+      type: 'imports',
+    }));
+
+    await saveGraph(dir, nodes, edges);
+
+    const result = await loadGraph(dir);
+    expect(result.status).toBe('loaded');
+    if (result.status !== 'loaded') return;
+    expect(result.graph.nodes).toHaveLength(N);
+    expect(result.graph.edges).toHaveLength(N);
+    expect(result.graph.nodes[0]!.id).toBe('n0');
+    expect(result.graph.nodes[N - 1]!.id).toBe(`n${N - 1}`);
+  });
+});

--- a/packages/intelligence/CHANGELOG.md
+++ b/packages/intelligence/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @harness-engineering/intelligence
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @harness-engineering/graph@0.8.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/intelligence",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Intelligence pipeline for spec enrichment, complexity modeling, and pre-execution simulation",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/orchestrator/CHANGELOG.md
+++ b/packages/orchestrator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @harness-engineering/orchestrator
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @harness-engineering/graph@0.8.0
+  - @harness-engineering/core@0.23.7
+  - @harness-engineering/intelligence@0.2.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harness-engineering/orchestrator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Orchestrator daemon for dispatching coding agents to issues",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Two independent crash modes on real-world monorepos, both fixed in this pass.

- **#274** — `harness ingest --source code` (and `harness scan`) crashed with `Maximum call stack size exceeded` or heap-OOM on monorepos with populated build/AI-sandbox caches. `CodeIngestor.findSourceFiles` was a recursive walker with a 22-entry inline if-chain skip list that missed common JS-monorepo cache dirs (`.turbo`, `.vite`, `.cache`, `.docusaurus`, `.wrangler`, `.svelte-kit`, `.parcel-cache`, `storybook-static`, `playwright-report`, `test-results`, `.pytest_cache`, `.pnpm-store`, `.nuxt`) and AI agent sandbox dirs (`.claude`, `.cursor`, `.codex`, `.gemini`, `.aider`). The `.claude/worktrees/` omission alone could multiply walker workload by 50× on heavy users of Claude Code's worktree feature.
- **#276** — `harness graph status` (and any `loadGraph` caller) crashed with `RangeError: Invalid string length` on graphs > ~512 MB. The reader slurped `graph.json` into a single V8 string while the writer was already streaming.

### Fix shape

**`@harness-engineering/graph`** (0.7.1 → 0.8.0, minor)

- New shared `DEFAULT_SKIP_DIRS` constant (60+ entries) at `packages/graph/src/ingest/skip-dirs.ts`. Covers VCS, package managers, JS/TS framework caches, test/coverage outputs, Python virtualenvs, JVM build outputs, IDE metadata, and AI agent sandboxes. Exported alongside `resolveSkipDirs`.
- `CodeIngestor.findSourceFiles` rewritten as iterative BFS — no more recursion, bounded by frontier size rather than path depth.
- New `CodeIngestorOptions` constructor parameter: `skipDirs` (replace defaults), `additionalSkipDirs` (extend), `excludePatterns` (minimatch globs), `respectGitignore` (default-on; hand-rolled common-subset parser, no new deps; negation dropped silently).
- On-disk schema bumped v1 → v2: `graph.json` is now NDJSON, one record per line with a `kind` discriminator. Reader uses `readline` so peak string size stays bounded by the largest single record. Old v1 graphs trigger the existing `schema_mismatch` path → automatic rebuild on next scan.
- New `loadGraphMetadata` helper + `nodesByType` field in `GraphMetadata` enable a fast-path for summary callers that never opens `graph.json`.
- `RangeError: Invalid string length` now wraps into an actionable error pointing at the file path and likely cause.

**`@harness-engineering/cli`** (2.0.0 → 2.1.0, minor)

- New `ingest` config block (`skipDirs`, `additionalSkipDirs`, `excludePatterns`, `respectGitignore`) on `harness.config.json`. Plumbed through `runScan` and `runIngest` via best-effort `loadIngestOptions`.
- `harness graph status` reads only `metadata.json` and works instantly on multi-GB graphs that previously failed to load.
- `harness graph status` now reports a clear `schema_mismatch` message instead of an opaque parse error on legacy graphs.
- The CLI's MCP `glob-helper.ts` now imports the shared `DEFAULT_SKIP_DIRS` so the MCP file walker and the graph ingester can no longer drift.

**Documentation**

- `docs/reference/configuration.md` — new `ingest` section documenting the four fields, the comprehensive defaults, and a worked example.

### Verification

- All **861 graph tests** + **2,989 cli tests** + the rest of the workspace pass.
- `pnpm typecheck`, `pnpm lint`, `harness validate`, `harness check-deps` — all clean.
- Revert-and-fail protocol confirmed each regression test catches its bug:
  - Removed `.claude` from `DEFAULT_SKIP_DIRS` → `.claude/worktrees` regression test fails.
  - Restored v1 single-document writer → 3 NDJSON Serializer tests fail.
- Fresh `harness scan` ingested this repo (30,053 nodes / 135,665 edges in 20s); `harness graph status` resolves via the metadata fast-path.

## Test plan

- [ ] Reviewer pulls the branch and runs `pnpm test` (workspace-wide).
- [ ] Reviewer runs `harness validate && harness check-deps` to confirm baseline checks remain clean.
- [ ] Reviewer inspects `packages/graph/tests/ingest/CodeIngestor-skip-dirs.test.ts` and `packages/graph/tests/store/Serializer.test.ts` — they assert the headline behaviors from #274 / #276 directly.
- [ ] Reviewer runs `harness scan` against a heavy monorepo with `.claude/worktrees/` populated to confirm the ingestion no longer crashes and produces a sensibly-sized graph.
- [ ] Reviewer runs `harness graph status` against any existing graph and confirms the per-type breakdown still renders (now via the metadata fast-path).
- [ ] Reviewer confirms a project-level `harness.config.json` `ingest` block is honored (e.g. add `additionalSkipDirs: [\"some-custom-dir\"]` and confirm it's skipped).

Closes #274, closes #276.