### PR TITLE
fix(intelligence): read structured_output from Claude CLI envelope

### DIFF
--- a/packages/intelligence/src/analysis-provider/claude-cli.ts
+++ b/packages/intelligence/src/analysis-provider/claude-cli.ts
@@ -105,17 +105,26 @@ export class ClaudeCliAnalysisProvider implements AnalysisProvider {
 
         try {
           const parsed = JSON.parse(stdout);
-          // Claude --output-format json returns { result, usage, model, ... }
-          const content = parsed.result ?? parsed;
+          // Claude Code CLI 2.1.x with --output-format json --json-schema returns
+          // { type: 'result', result: '<natural-language summary string>',
+          //   structured_output: { ...schema-conforming object... }, usage, model, ... }.
+          // Older CLI versions put the schema-conforming response in `result`
+          // (sometimes JSON-encoded as a string). Prefer structured_output, then
+          // fall back to result, then to the raw envelope.
+          const content = parsed.structured_output ?? parsed.result ?? parsed;
           resolve({
             content: typeof content === 'string' ? JSON.parse(content) : content,
             usage: parsed.usage,
             model: parsed.model,
           });
         } catch (err) {
+          const stdoutSnippet = stdout.slice(0, 500);
+          const stderrSnippet = stderr.slice(0, 500);
           reject(
             new Error(
-              `Failed to parse Claude CLI output: ${err instanceof Error ? err.message : String(err)}`
+              `Failed to parse Claude CLI output: ${err instanceof Error ? err.message : String(err)}. ` +
+                `stdout (first 500 chars): ${JSON.stringify(stdoutSnippet)}. ` +
+                `stderr (first 500 chars): ${JSON.stringify(stderrSnippet)}`
             )
           );
         }

--- a/packages/intelligence/tests/analysis-provider/claude-cli.test.ts
+++ b/packages/intelligence/tests/analysis-provider/claude-cli.test.ts
@@ -103,6 +103,29 @@ describe('ClaudeCliAnalysisProvider', () => {
       expect(response.result).toEqual({ summary: 'Bare object', score: 0.5 });
     });
 
+    it('prefers structured_output over result (Claude Code CLI 2.1.x envelope)', async () => {
+      // Claude Code CLI 2.1.x with --output-format json --json-schema puts the
+      // schema-conforming object in `structured_output` and a natural-language
+      // summary string in `result`. The older shape (schema-conforming JSON in
+      // `result`) was the previous behavior the parser was written against.
+      const cliOutput = JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'Analyzed the work item and returned structured output. Key takeaway: ...',
+        structured_output: { summary: 'From structured_output', score: 0.42 },
+        usage: { input_tokens: 100, output_tokens: 50 },
+        model: 'claude-opus-4-7',
+      });
+      setupChild(cliOutput, 0);
+
+      const response = await provider.analyze({
+        prompt: 'test',
+        responseSchema: testSchema,
+      });
+
+      expect(response.result).toEqual({ summary: 'From structured_output', score: 0.42 });
+    });
+
     it('handles missing usage gracefully (defaults to 0)', async () => {
       const cliOutput = JSON.stringify({
         result: { summary: 'ok', score: 1 },
@@ -294,6 +317,20 @@ describe('ClaudeCliAnalysisProvider', () => {
       await expect(
         provider.analyze({ prompt: 'test', responseSchema: testSchema })
       ).rejects.toThrow('Failed to parse Claude CLI output');
+    });
+
+    it('includes stdout and stderr snippets in parse-failure error', async () => {
+      // Truncated leading words from `result` (e.g. "Analyzed t...", "Returned s...")
+      // were what the previous error reported, with no surrounding context.
+      // Including the first 500 chars of both streams makes the next
+      // diagnosis a one-log-line affair instead of requiring instrumentation.
+      setupChild('Analyzed the work item and returned plain prose, not JSON.', 0, 'auth warning');
+
+      await expect(
+        provider.analyze({ prompt: 'test', responseSchema: testSchema })
+      ).rejects.toThrow(
+        /stdout \(first 500 chars\): "Analyzed the work item.*stderr \(first 500 chars\): "auth warning"/s
+      );
     });
 
     it('throws ZodError when response does not match schema', async () => {


### PR DESCRIPTION
## Summary

The intelligence pipeline's Claude CLI provider currently fails 100% of the time against Claude Code CLI 2.1.x. Every analyzed work item produces:

```
Error: Failed to parse Claude CLI output: Unexpected token 'A', "Analyzed t"... is not valid JSON
```

(or `'R', "Returned s"`, `'C', "Captured t"`, `'S', "Structured"` — the truncated leading word from Claude's natural-language summary).

**Root cause:** Claude Code CLI 2.1.x with `--output-format json --json-schema {...}` returns:

```json
{
  "type": "result",
  "result": "Analyzed the work item and returned structured output. ...",
  "structured_output": { /* ← schema-conforming object lives here */ },
  "usage": { ... },
  "model": "claude-opus-4-7"
}
```

The parser was reading `parsed.result` (a natural-language summary string) and calling `JSON.parse()` on it. The schema-conforming response is in `parsed.structured_output`.

## Changes

- `packages/intelligence/src/analysis-provider/claude-cli.ts`
  - **Read `parsed.structured_output` first**, fall back to `parsed.result` (older CLIs / `--output-format text`), then to the raw envelope. Single-line change.
  - **Surface stdout/stderr in parse-failure errors** (first 500 chars each). The previous error truncated at ~10 chars and dropped stderr entirely, which made this bug invisible without instrumenting the CLI with a `tee` wrapper.
- `packages/intelligence/tests/analysis-provider/claude-cli.test.ts`
  - New test: `prefers structured_output over result (Claude Code CLI 2.1.x envelope)` — uses a realistic CLI envelope with both fields populated, asserts `structured_output` wins.
  - New test: `includes stdout and stderr snippets in parse-failure error` — guards the diagnostic improvement.

## Evidence

Reproduced and verified locally with a `tee` wrapper around `claude` (Claude Code 2.1.132). Five failing runs all matched the same pattern: `parsed.result` was a natural-language summary, `parsed.structured_output` contained exactly the schema fields the SEL prompt requested (`affectedSystems`, `ambiguities`, `apiChanges`, etc.). After patching to read `structured_output`, the same three previously-failing issues completed cleanly with no parse errors.

## Testing

- [x] `pnpm build` passes
- [x] `pnpm test` passes (220/220, 24 files, includes 2 new tests)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes

## Related Issues

Refs #287 — root cause documented at https://github.com/Intense-Visions/harness-engineering/issues/287#issuecomment-4398803483.

## Notes

- The fallback chain is intentional (`structured_output ?? result ?? parsed`) — anyone running an older Claude CLI or text-mode response will keep working.
- The diagnostic stderr/stdout snippet length (500 chars) is conservative; happy to dial up/down based on review.
- The unrelated dashboard 502 finding from the same issue thread (port `10080` is on the WHATWG bad-ports list) is not in this PR; it's a one-line config / docs fix that I can split into a separate PR if you'd like.
