### PR TITLE
feat(setup): integrate OpenCode in harness setup

### DIFF
--- a/.changeset/harness-setup-opencode.md
+++ b/.changeset/harness-setup-opencode.md
@@ -1,0 +1,65 @@
+---
+'@harness-engineering/cli': minor
+---
+
+feat: integrate OpenCode in `harness setup` (PR-E in the marketplace stack)
+
+Adds OpenCode as the fifth supported AI client in `harness setup`. Unlike
+the four marketplace plugins (PR-A through PR-D), OpenCode joins via the
+existing `harness setup` flow rather than its own marketplace manifest —
+OpenCode plugins are JS/TS code, not declarative manifests, and OpenCode
+auto-discovers `.claude/skills/` so it shares Claude's skill tree without
+any plugin-side wiring.
+
+**What ships:**
+
+- **`harness setup` detects `~/.config/opencode/`** as a new client marker
+  and writes the harness MCP server to `./opencode.json` in the project
+  root. Skipped (with a friendly warning) when neither the global config
+  dir nor a project-local `opencode.json` is present.
+- **`harness setup-mcp --client opencode`** wires up the MCP server
+  standalone for users who want fine-grained control.
+- **Tier-0 MCP integrations parity** — context7, sequential-thinking, and
+  playwright are written to `opencode.json` alongside `.mcp.json` and
+  `.gemini/settings.json`, mirroring the existing Gemini parity block.
+
+**OpenCode's MCP shape differs from the others:**
+
+OpenCode uses `mcp` (not `mcpServers`) at the top level, and each entry
+uses `type: "local"`, a single combined `command` array (executable +
+args), `enabled`, and `environment`. The new `writeOpencodeMcpEntry`
+helper translates the standard `{command, args?, env?}` shape into
+OpenCode's wire format.
+
+**Test coverage:**
+
+- 6 new tests in `setup-mcp.test.ts` covering the OpenCode branch
+  (configure, skip-if-configured, all-clients, key preservation).
+- 6 new tests in `integrations/config.test.ts` covering the
+  `writeOpencodeMcpEntry` translation (mcp field, command array,
+  environment translation, top-level field preservation, mcp entry
+  preservation).
+- 3 new tests in `setup.test.ts` covering Tier-0 OpenCode parity
+  (project-local marker, global marker, neither-present negative).
+
+**Stack complete:**
+
+| Tool         | Integration                                  | Status         |
+| ------------ | -------------------------------------------- | -------------- |
+| Claude Code  | `harness-claude` marketplace plugin          | shipped (#284) |
+| Cursor       | `harness-cursor` marketplace plugin          | shipped (#288) |
+| Gemini CLI   | `harness-gemini` marketplace extension       | shipped (#290) |
+| Codex CLI    | `harness-codex` marketplace plugin           | shipped (#291) |
+| **OpenCode** | **via `harness setup` (no plugin manifest)** | **this PR**    |
+
+**README updates:**
+
+- Quick Start now lists Gemini CLI and Codex CLI marketplace plugins as
+  shipped (they were "coming" before PR-C/PR-D landed) and adds an
+  OpenCode bullet pointing to the npm path.
+- Plugin-vs-npm parity table replaces the outdated "Gemini CLI / Codex /
+  OpenCode integration ❌ (sibling plugins coming)" row with two rows
+  reflecting current state — Gemini/Codex shipped via plugins, OpenCode
+  via `harness setup`.
+- MCP config table gains an OpenCode row showing the project-local
+  `opencode.json` path.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Pick the install path that matches how you use harness:
 
 - **Claude Code users** → install the `harness-claude` marketplace plugin (recommended). Skills, slash commands, persona subagents, lifecycle hooks, and MCP are wired up automatically — no `harness setup` step.
 - **Cursor users** → install the `harness-cursor` marketplace plugin (recommended). Same component surface as Claude, plus 4 curated project rules.
-- **Gemini CLI / Codex users** → sibling marketplace plugins are coming (`harness-gemini`, `harness-codex`). Until they ship, use the npm path below.
+- **Gemini CLI users** → install the `harness-gemini` marketplace extension. Slash commands + GEMINI.md context + MCP. (Gemini extensions don't define a subagents or hooks field, so those surfaces live in GEMINI.md.)
+- **Codex CLI users** → install the `harness-codex` marketplace plugin. Skills + MCP (Codex's plugin spec defines no slash-command or agents surface).
+- **OpenCode users** → install the npm package and run `harness setup`. OpenCode auto-discovers `.claude/skills/` and shares Claude's skill tree, so the only setup work is wiring the harness MCP server into `opencode.json`, which `harness setup` does automatically once it detects `~/.config/opencode/` or a project-local `opencode.json`.
 - **Plain CLI / CI users (or any tool not yet covered by a plugin)** → install the npm package. `harness setup` detects every supported AI client (Claude Code, Gemini CLI, Cursor, Codex CLI, OpenCode) and lays down skills, slash commands, agent personas, MCP, and hooks.
 
 ### 1a. Install via the Claude Code plugin marketplace (recommended for Claude Code sessions)
@@ -67,22 +69,23 @@ This installs the CLI and runs interactive setup: generates global slash command
 
 The marketplace plugins are the **agent-session interface**. The npm package is what you need for shell-level workflows. Pick based on where you actually use harness:
 
-| Surface                                                                                                | `harness-claude` / `harness-cursor` plugin (after `/harness:initialize-project` runs once per repo) | `npm install -g @harness-engineering/cli` (after `harness setup`) |
-| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Inside a Claude Code or Cursor session — skills, `/harness:*`, subagents, hooks, MCP tools             | ✅ full parity                                                                                      | ✅ same                                                           |
-| Cursor project rules (validate-before-commit, respect-architecture, use-harness-skills, respect-hooks) | ✅ shipped with `harness-cursor`                                                                    | ❌ Cursor-only feature                                            |
-| Adoption tracking + anonymous telemetry (hooks fire, defaults enabled)                                 | ✅ works                                                                                            | ✅ works                                                          |
-| Project bootstrap (`harness.config.json`, `.harness/` scaffolding)                                     | ✅ via `/harness:initialize-project` (Phase 2)                                                      | ✅ via `harness init` / `harness setup`                           |
-| Knowledge graph (`.harness/graph/`)                                                                    | ✅ via `/harness:initialize-project` (Phase 5 step 1)                                               | ✅ initial scan during `harness setup`                            |
-| Architecture / performance baselines                                                                   | ✅ via `/harness:initialize-project` (Phase 5 steps 2–3)                                            | ✅ auto-refreshed on main via CI                                  |
-| Telemetry **identity** tagging (project / team / alias)                                                | ✅ via `/harness:initialize-project` (Phase 5 step 4)                                               | ✅ via interactive telemetry wizard                               |
-| Legacy layout migration warnings (`docs/plans/`, `.harness/architecture/`)                             | ✅ via `/harness:initialize-project` (Phase 5 step 5)                                               | ✅ surfaced during `harness setup`                                |
-| Tier-0 MCP integrations (context7, sequential-thinking, playwright) added to project `.mcp.json`       | ✅ via `/harness:initialize-project` (Phase 5 step 6)                                               | ✅ wired during interactive setup                                 |
-| Tier-1 API-key integrations (Linear, Slack, Perplexity, …)                                             | ⚠️ surfaced by `harness integrations list`; user wires via `npx … add <name>`                       | ⚠️ same — API keys required either way                            |
-| Gemini CLI / Codex / OpenCode integration                                                              | ❌ (sibling plugins coming)                                                                         | ✅ `harness setup` configures all detected clients                |
-| Terminal use — `harness validate`, `harness init`, `harness check-arch`                                | ⚠️ only via `npx @harness-engineering/cli <cmd>`                                                    | ✅ binary in PATH                                                 |
-| CI workflows (GitHub Actions, etc.)                                                                    | ⚠️ workable via `npx` (cold-start cost per job)                                                     | ✅ `npm install -g` once, fast thereafter                         |
-| Git pre-commit hooks (`harness validate` on commit)                                                    | ⚠️ npx-based, slow                                                                                  | ✅ direct binary, fast                                            |
+| Surface                                                                                                | `harness-claude` / `harness-cursor` plugin (after `/harness:initialize-project` runs once per repo) | `npm install -g @harness-engineering/cli` (after `harness setup`)                                                                                                        |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Inside a Claude Code or Cursor session — skills, `/harness:*`, subagents, hooks, MCP tools             | ✅ full parity                                                                                      | ✅ same                                                                                                                                                                  |
+| Cursor project rules (validate-before-commit, respect-architecture, use-harness-skills, respect-hooks) | ✅ shipped with `harness-cursor`                                                                    | ❌ Cursor-only feature                                                                                                                                                   |
+| Adoption tracking + anonymous telemetry (hooks fire, defaults enabled)                                 | ✅ works                                                                                            | ✅ works                                                                                                                                                                 |
+| Project bootstrap (`harness.config.json`, `.harness/` scaffolding)                                     | ✅ via `/harness:initialize-project` (Phase 2)                                                      | ✅ via `harness init` / `harness setup`                                                                                                                                  |
+| Knowledge graph (`.harness/graph/`)                                                                    | ✅ via `/harness:initialize-project` (Phase 5 step 1)                                               | ✅ initial scan during `harness setup`                                                                                                                                   |
+| Architecture / performance baselines                                                                   | ✅ via `/harness:initialize-project` (Phase 5 steps 2–3)                                            | ✅ auto-refreshed on main via CI                                                                                                                                         |
+| Telemetry **identity** tagging (project / team / alias)                                                | ✅ via `/harness:initialize-project` (Phase 5 step 4)                                               | ✅ via interactive telemetry wizard                                                                                                                                      |
+| Legacy layout migration warnings (`docs/plans/`, `.harness/architecture/`)                             | ✅ via `/harness:initialize-project` (Phase 5 step 5)                                               | ✅ surfaced during `harness setup`                                                                                                                                       |
+| Tier-0 MCP integrations (context7, sequential-thinking, playwright) added to project `.mcp.json`       | ✅ via `/harness:initialize-project` (Phase 5 step 6)                                               | ✅ wired during interactive setup                                                                                                                                        |
+| Tier-1 API-key integrations (Linear, Slack, Perplexity, …)                                             | ⚠️ surfaced by `harness integrations list`; user wires via `npx … add <name>`                       | ⚠️ same — API keys required either way                                                                                                                                   |
+| Gemini CLI / Codex integration                                                                         | ✅ via sibling marketplace plugins (`harness-gemini`, `harness-codex`)                              | ✅ `harness setup` configures all detected clients                                                                                                                       |
+| OpenCode integration                                                                                   | ⚠️ no OpenCode-native plugin manifest (OpenCode uses code-based plugins, not marketplace JSON)      | ✅ `harness setup` writes `opencode.json` with the harness MCP server (and Tier-0 integrations) when `~/.config/opencode/` or a project-local `opencode.json` is present |
+| Terminal use — `harness validate`, `harness init`, `harness check-arch`                                | ⚠️ only via `npx @harness-engineering/cli <cmd>`                                                    | ✅ binary in PATH                                                                                                                                                        |
+| CI workflows (GitHub Actions, etc.)                                                                    | ⚠️ workable via `npx` (cold-start cost per job)                                                     | ✅ `npm install -g` once, fast thereafter                                                                                                                                |
+| Git pre-commit hooks (`harness validate` on commit)                                                    | ⚠️ npx-based, slow                                                                                  | ✅ direct binary, fast                                                                                                                                                   |
 
 **TL;DR**: run `/harness:initialize-project` once per repo and the plugin covers ~95% of what `harness setup` does — the skill's Phase 5 (INSTRUMENT) closes the bootstrap gap. The remaining ~5% (multi-tool MCP wiring, fast CI/terminal access without npx cold-start) is what `npm install -g` fills. They coexist cleanly.
 
@@ -306,16 +309,32 @@ args = ["mcp"]
 enabled = true
 ```
 
+**OpenCode** — add to `opencode.json` in your project root:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "harness": {
+      "type": "local",
+      "command": ["harness", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
 > **Note:** `harness-mcp` is installed alongside the CLI by `npm install -g @harness-engineering/cli`. Using the installed binary instead of `npx @harness-engineering/mcp-server` avoids stale npx cache issues and ensures the MCP server uses the same package versions as the CLI.
 
 </details>
 
-| Client      | MCP Config Location     | Additional Setup                               |
-| ----------- | ----------------------- | ---------------------------------------------- |
-| Claude Code | `.mcp.json`             | None                                           |
-| Gemini CLI  | `.gemini/settings.json` | Add project to `~/.gemini/trustedFolders.json` |
-| Cursor      | `.cursor/mcp.json`      | None                                           |
-| Codex CLI   | `.codex/config.toml`    | None                                           |
+| Client      | MCP Config Location     | Additional Setup                                     |
+| ----------- | ----------------------- | ---------------------------------------------------- |
+| Claude Code | `.mcp.json`             | None                                                 |
+| Gemini CLI  | `.gemini/settings.json` | Add project to `~/.gemini/trustedFolders.json`       |
+| Cursor      | `.cursor/mcp.json`      | None                                                 |
+| Codex CLI   | `.codex/config.toml`    | None                                                 |
+| OpenCode    | `opencode.json`         | None — skills auto-discovered from `.claude/skills/` |
 
 ## What's Included
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -351,7 +351,7 @@ Configure MCP server for AI agent integration
 
 **Options:**
 
-- `--client` — Client to configure (claude, gemini, codex, cursor, all) (default: "all")
+- `--client` — Client to configure (claude, gemini, codex, cursor, opencode, all) (default: "all")
 - `--pick` — Launch interactive tool picker (Cursor only)
 - `--yes` — Bypass interactive picker and use curated 25-tool set (Cursor only)
 

--- a/packages/cli/src/commands/setup-mcp.ts
+++ b/packages/cli/src/commands/setup-mcp.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import * as clack from '@clack/prompts';
 import { logger } from '../output/logger';
 import { ExitCode } from '../utils/errors';
-import { writeMcpEntry } from '../integrations/config';
+import { writeMcpEntry, writeOpencodeMcpEntry } from '../integrations/config';
 import { writeTomlMcpEntry } from '../integrations/toml';
 
 interface McpConfig {
@@ -260,6 +260,17 @@ export function setupMcp(
     }
   }
 
+  if (client === 'all' || client === 'opencode') {
+    const configPath = path.join(cwd, 'opencode.json');
+    const existing = readJsonFile<{ mcp?: Record<string, unknown> }>(configPath);
+    if (existing?.mcp?.['harness']) {
+      skipped.push('OpenCode');
+    } else {
+      writeOpencodeMcpEntry(configPath, 'harness', { command: 'harness', args: ['mcp'] });
+      configured.push('OpenCode');
+    }
+  }
+
   return { configured, skipped, trustedFolder };
 }
 
@@ -317,7 +328,11 @@ function printMcpResult(configured: string[], skipped: string[], trustedFolder: 
 export function createSetupMcpCommand(): Command {
   return new Command('setup-mcp')
     .description('Configure MCP server for AI agent integration')
-    .option('--client <client>', 'Client to configure (claude, gemini, codex, cursor, all)', 'all')
+    .option(
+      '--client <client>',
+      'Client to configure (claude, gemini, codex, cursor, opencode, all)',
+      'all'
+    )
     .option('--pick', 'Launch interactive tool picker (Cursor only)')
     .option('--yes', 'Bypass interactive picker and use curated 25-tool set (Cursor only)')
     .action(async (opts, cmd) => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -8,7 +8,7 @@ import { setupMcp } from './setup-mcp';
 import { markSetupComplete } from '../utils/first-run';
 import { checkNodeVersion as checkNode } from '../utils/node-version';
 import { ExitCode } from '../utils/errors';
-import { readMcpConfig, writeMcpEntry } from '../integrations/config';
+import { readMcpConfig, writeMcpEntry, writeOpencodeMcpEntry } from '../integrations/config';
 import { INTEGRATION_REGISTRY } from '../integrations/registry';
 import { initHooks } from './hooks/init';
 import type { HookProfile } from '../hooks/profiles';
@@ -61,6 +61,12 @@ async function runMcpSetup(cwd: string): Promise<StepResult[]> {
     },
     { name: 'Codex CLI', dir: '.codex', client: 'codex', configTarget: '.codex/config.toml' },
     { name: 'Cursor', dir: '.cursor', client: 'cursor', configTarget: '.cursor/mcp.json' },
+    {
+      name: 'OpenCode',
+      dir: path.join('.config', 'opencode'),
+      client: 'opencode',
+      configTarget: 'opencode.json',
+    },
   ];
 
   for (const { name, dir, client, configTarget } of clients) {
@@ -118,6 +124,20 @@ export function configureTier0Integrations(cwd: string): StepResult {
         if (!geminiConfig.mcpServers![integration.name]) {
           writeMcpEntry(geminiPath, integration.name, integration.mcpConfig);
         }
+      }
+    }
+
+    // OpenCode parity: write Tier 0 integrations to ./opencode.json. Detect
+    // OpenCode by an existing project-local opencode.json or a global
+    // ~/.config/opencode/ presence — we only write parity if at least one
+    // marker is there, so users without OpenCode don't get a stray file.
+    // writeOpencodeMcpEntry is idempotent per key, so re-running setup
+    // overwrites with identical content rather than duplicating entries.
+    const opencodePath = path.join(cwd, 'opencode.json');
+    const opencodeGlobalDir = path.join(os.homedir(), '.config', 'opencode');
+    if (fs.existsSync(opencodePath) || fs.existsSync(opencodeGlobalDir)) {
+      for (const integration of tier0) {
+        writeOpencodeMcpEntry(opencodePath, integration.name, integration.mcpConfig);
       }
     }
 

--- a/packages/cli/src/integrations/config.ts
+++ b/packages/cli/src/integrations/config.ts
@@ -53,6 +53,52 @@ export function writeMcpEntry(
 }
 
 /**
+ * OpenCode config shape. Differs from Claude/Cursor/Gemini:
+ *   - Top-level field is `mcp`, not `mcpServers`
+ *   - Server entry uses `type: "local"`, a single `command` array
+ *     (executable + args combined), `enabled`, and `environment`
+ */
+export interface OpencodeConfig {
+  mcp?: Record<
+    string,
+    {
+      type: 'local';
+      command: string[];
+      enabled?: boolean;
+      environment?: Record<string, string>;
+    }
+  >;
+  [key: string]: unknown;
+}
+
+function readOpencodeConfig(filePath: string): OpencodeConfig {
+  const config = readJsonSafe<OpencodeConfig>(filePath);
+  if (!config) return { mcp: {} };
+  if (!config.mcp) config.mcp = {};
+  return config;
+}
+
+/**
+ * Write an MCP server entry to an OpenCode config file (`opencode.json`).
+ * Translates the standard `{command, args?, env?}` shape into OpenCode's
+ * `{type, command[], enabled, environment}` shape.
+ */
+export function writeOpencodeMcpEntry(
+  filePath: string,
+  name: string,
+  entry: { command: string; args?: string[]; env?: Record<string, string> }
+): void {
+  const config = readOpencodeConfig(filePath);
+  config.mcp![name] = {
+    type: 'local',
+    command: [entry.command, ...(entry.args ?? [])],
+    enabled: true,
+    ...(entry.env ? { environment: entry.env } : {}),
+  };
+  writeJson(filePath, config);
+}
+
+/**
  * Remove an MCP server entry from an MCP config file.
  * Preserves all other entries. No-op if the file or entry doesn't exist.
  */

--- a/packages/cli/tests/commands/setup-mcp.test.ts
+++ b/packages/cli/tests/commands/setup-mcp.test.ts
@@ -175,6 +175,57 @@ describe('setup-mcp command', () => {
       const result = setupMcp(tempDir, 'codex');
       expect(result.trustedFolder).toBe(false);
     });
+
+    it('configures OpenCode MCP server', () => {
+      const result = setupMcp(tempDir, 'opencode');
+      expect(result.configured).toContain('OpenCode');
+      expect(result.skipped).not.toContain('OpenCode');
+
+      const configPath = path.join(tempDir, 'opencode.json');
+      expect(fs.existsSync(configPath)).toBe(true);
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      // OpenCode uses `mcp` (not `mcpServers`) and a combined `command` array.
+      expect(config.mcp.harness).toBeDefined();
+      expect(config.mcp.harness.type).toBe('local');
+      expect(config.mcp.harness.command).toEqual(['harness', 'mcp']);
+      expect(config.mcp.harness.enabled).toBe(true);
+    });
+
+    it('skips OpenCode if already configured', () => {
+      setupMcp(tempDir, 'opencode');
+      const result = setupMcp(tempDir, 'opencode');
+      expect(result.skipped).toContain('OpenCode');
+      expect(result.configured).not.toContain('OpenCode');
+    });
+
+    it('configures all five clients when client is all', () => {
+      const result = setupMcp(tempDir, 'all');
+      expect(result.configured).toContain('Claude Code');
+      expect(result.configured).toContain('Gemini CLI');
+      expect(result.configured).toContain('Codex CLI');
+      expect(result.configured).toContain('Cursor');
+      expect(result.configured).toContain('OpenCode');
+    });
+
+    it('preserves existing OpenCode config keys when adding harness', () => {
+      const configPath = path.join(tempDir, 'opencode.json');
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          $schema: 'https://opencode.ai/config.json',
+          model: 'anthropic/claude-sonnet-4-5',
+          mcp: { other: { type: 'local', command: ['foo'], enabled: true } },
+        })
+      );
+
+      setupMcp(tempDir, 'opencode');
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.$schema).toBe('https://opencode.ai/config.json');
+      expect(config.model).toBe('anthropic/claude-sonnet-4-5');
+      expect(config.mcp.other).toBeDefined();
+      expect(config.mcp.harness).toBeDefined();
+    });
   });
 
   describe('--pick flag stub', () => {

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -53,6 +53,7 @@ vi.mock('../../src/integrations/config', () => ({
     mcpServers: { ...(mockMcpConfig.mcpServers as Record<string, unknown>) },
   })),
   writeMcpEntry: vi.fn(),
+  writeOpencodeMcpEntry: vi.fn(),
 }));
 
 vi.mock('../../src/commands/telemetry-wizard', () => ({
@@ -76,7 +77,7 @@ import { runSetup, configureTier0Integrations } from '../../src/commands/setup';
 import { generateSlashCommands } from '../../src/commands/generate-slash-commands';
 import { setupMcp } from '../../src/commands/setup-mcp';
 import { markSetupComplete } from '../../src/utils/first-run';
-import { readMcpConfig, writeMcpEntry } from '../../src/integrations/config';
+import { readMcpConfig, writeMcpEntry, writeOpencodeMcpEntry } from '../../src/integrations/config';
 
 const mockExistsSync = vi.mocked(fs.existsSync);
 
@@ -87,6 +88,7 @@ function mockAllClientsExist() {
     if (s === path.join(os.homedir(), '.gemini')) return true;
     if (s === path.join(os.homedir(), '.codex')) return true;
     if (s === path.join(os.homedir(), '.cursor')) return true;
+    if (s === path.join(os.homedir(), '.config', 'opencode')) return true;
     return false;
   });
 }
@@ -106,7 +108,7 @@ describe('runSetup', () => {
     const { steps, success } = await runSetup('/tmp/test');
 
     expect(success).toBe(true);
-    expect(steps).toHaveLength(11);
+    expect(steps).toHaveLength(12);
     expect(steps[0].status).toBe('pass');
     expect(steps[0].message).toContain('Node.js');
     expect(steps[1].status).toBe('pass');
@@ -118,9 +120,10 @@ describe('runSetup', () => {
         yes: true,
       })
     );
-    expect(setupMcp).toHaveBeenCalledTimes(4);
-    expect(steps[6].status).toBe('pass');
-    expect(steps[6].message).toContain('MCP integrations');
+    // setupMcp now runs for all five clients (claude, gemini, codex, cursor, opencode).
+    expect(setupMcp).toHaveBeenCalledTimes(5);
+    expect(steps[7].status).toBe('pass');
+    expect(steps[7].message).toContain('MCP integrations');
     expect(markSetupComplete).toHaveBeenCalled();
   });
 
@@ -149,7 +152,7 @@ describe('runSetup', () => {
     const { steps, success } = await runSetup('/tmp/test');
 
     expect(success).toBe(true);
-    expect(steps).toHaveLength(11);
+    expect(steps).toHaveLength(12);
     const geminiStep = steps[3];
     expect(geminiStep.status).toBe('warn');
     expect(geminiStep.message).toContain('Gemini CLI not detected');
@@ -159,6 +162,9 @@ describe('runSetup', () => {
     const cursorStep = steps[5];
     expect(cursorStep.status).toBe('warn');
     expect(cursorStep.message).toContain('Cursor not detected');
+    const opencodeStep = steps[6];
+    expect(opencodeStep.status).toBe('warn');
+    expect(opencodeStep.message).toContain('OpenCode not detected');
     expect(setupMcp).toHaveBeenCalledTimes(1);
     expect(setupMcp).toHaveBeenCalledWith('/tmp/test', 'claude');
     expect(markSetupComplete).toHaveBeenCalled();
@@ -173,7 +179,7 @@ describe('runSetup', () => {
     expect(success).toBe(true);
     expect(setupMcp).not.toHaveBeenCalled();
     const mcpSteps = steps.filter((s) => s.message.includes('not detected'));
-    expect(mcpSteps).toHaveLength(4);
+    expect(mcpSteps).toHaveLength(5);
     expect(markSetupComplete).toHaveBeenCalled();
   });
 
@@ -290,6 +296,42 @@ describe('configureTier0Integrations', () => {
       String(call[0]).includes('.gemini')
     );
     expect(geminiCalls.length).toBe(0);
+  });
+
+  it('writes Tier 0 to opencode.json when project-local opencode.json exists', () => {
+    const mockWriteOpencode = vi.mocked(writeOpencodeMcpEntry);
+    mockExistsSync.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      // Project-local opencode.json present
+      if (s === path.join('/tmp/test', 'opencode.json')) return true;
+      return false;
+    });
+
+    configureTier0Integrations('/tmp/test');
+
+    expect(mockWriteOpencode).toHaveBeenCalledTimes(3); // All 3 Tier 0 integrations
+  });
+
+  it('writes Tier 0 to opencode.json when global ~/.config/opencode exists', () => {
+    const mockWriteOpencode = vi.mocked(writeOpencodeMcpEntry);
+    mockExistsSync.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      if (s === path.join(os.homedir(), '.config', 'opencode')) return true;
+      return false;
+    });
+
+    configureTier0Integrations('/tmp/test');
+
+    expect(mockWriteOpencode).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not write to opencode.json when neither project nor global marker exists', () => {
+    const mockWriteOpencode = vi.mocked(writeOpencodeMcpEntry);
+    mockExistsSync.mockReturnValue(false);
+
+    configureTier0Integrations('/tmp/test');
+
+    expect(mockWriteOpencode).not.toHaveBeenCalled();
   });
 
   it('does not add Tier 1 integrations', () => {

--- a/packages/cli/tests/integrations/config.test.ts
+++ b/packages/cli/tests/integrations/config.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import {
   readMcpConfig,
   writeMcpEntry,
+  writeOpencodeMcpEntry,
   removeMcpEntry,
   readIntegrationsConfig,
   writeIntegrationsConfig,
@@ -71,6 +72,88 @@ describe('integrations config', () => {
       const config = JSON.parse(fs.readFileSync(mcpPath, 'utf-8'));
       expect(config.mcpServers.harness).toBeDefined();
       expect(config.mcpServers.perplexity).toBeDefined();
+    });
+  });
+
+  describe('writeOpencodeMcpEntry', () => {
+    it('writes harness entry in OpenCode format (mcp field, command array)', () => {
+      const configPath = path.join(tempDir, 'opencode.json');
+      writeOpencodeMcpEntry(configPath, 'harness', { command: 'harness', args: ['mcp'] });
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.mcp).toBeDefined();
+      expect(config.mcp.harness).toEqual({
+        type: 'local',
+        command: ['harness', 'mcp'],
+        enabled: true,
+      });
+    });
+
+    it('combines command and args into a single command array', () => {
+      const configPath = path.join(tempDir, 'opencode.json');
+      writeOpencodeMcpEntry(configPath, 'context7', {
+        command: 'npx',
+        args: ['-y', '@upstash/context7-mcp'],
+      });
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.mcp.context7.command).toEqual(['npx', '-y', '@upstash/context7-mcp']);
+    });
+
+    it('translates env to environment field', () => {
+      const configPath = path.join(tempDir, 'opencode.json');
+      writeOpencodeMcpEntry(configPath, 'perplexity', {
+        command: 'npx',
+        args: ['-y', 'perplexity-mcp'],
+        env: { PERPLEXITY_API_KEY: '${PERPLEXITY_API_KEY}' },
+      });
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.mcp.perplexity.environment).toEqual({
+        PERPLEXITY_API_KEY: '${PERPLEXITY_API_KEY}',
+      });
+    });
+
+    it('omits environment when no env is provided', () => {
+      const configPath = path.join(tempDir, 'opencode.json');
+      writeOpencodeMcpEntry(configPath, 'harness', { command: 'harness', args: ['mcp'] });
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.mcp.harness).not.toHaveProperty('environment');
+    });
+
+    it('preserves existing top-level fields like $schema and model', () => {
+      const configPath = path.join(tempDir, 'opencode.json');
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          $schema: 'https://opencode.ai/config.json',
+          model: 'anthropic/claude-sonnet-4-5',
+        })
+      );
+
+      writeOpencodeMcpEntry(configPath, 'harness', { command: 'harness', args: ['mcp'] });
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.$schema).toBe('https://opencode.ai/config.json');
+      expect(config.model).toBe('anthropic/claude-sonnet-4-5');
+      expect(config.mcp.harness).toBeDefined();
+    });
+
+    it('preserves existing mcp entries when adding harness', () => {
+      const configPath = path.join(tempDir, 'opencode.json');
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          mcp: { other: { type: 'local', command: ['foo'], enabled: true } },
+        })
+      );
+
+      writeOpencodeMcpEntry(configPath, 'harness', { command: 'harness', args: ['mcp'] });
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.mcp.other).toBeDefined();
+      expect(config.mcp.harness).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Final piece of the marketplace stack: OpenCode joins as the fifth supported
AI client. Unlike PR-A through PR-D which shipped marketplace plugins,
OpenCode integrates via the existing \`harness setup\` flow — OpenCode's
plugin system is JS/TS code rather than declarative manifests, and OpenCode
auto-discovers \`.claude/skills/\`, so it shares Claude's skill tree without
plugin-side wiring. The remaining work is just MCP server registration.

## What ships

- **\`harness setup\`** detects \`~/.config/opencode/\` as a new client
  marker. When found, writes the harness MCP server to \`./opencode.json\`
  in the project root. Skipped (with a friendly warning) when the marker
  is absent.
- **\`harness setup-mcp --client opencode\`** wires the MCP server
  standalone for fine-grained control.
- **Tier-0 MCP integrations parity** — context7, sequential-thinking, and
  playwright are written to \`opencode.json\` alongside \`.mcp.json\` and
  \`.gemini/settings.json\`, mirroring the existing Gemini parity block.

## OpenCode's MCP shape

OpenCode's config differs from Claude/Cursor/Gemini:

- Top-level field is \`mcp\` (not \`mcpServers\`)
- Each entry uses \`type: "local"\`, a single combined \`command\` array
  (executable + args), \`enabled\`, and \`environment\`
- Config path: \`opencode.json\` in project root (or
  \`~/.config/opencode/opencode.json\` global)

The new \`writeOpencodeMcpEntry\` helper in \`integrations/config.ts\`
translates the standard \`{command, args?, env?}\` shape into OpenCode's
wire format.

## Test coverage

15 new tests:

- 6 in \`setup-mcp.test.ts\` covering the OpenCode branch (configure,
  skip-if-configured, all-clients, key preservation)
- 6 in \`integrations/config.test.ts\` covering the
  \`writeOpencodeMcpEntry\` translation (mcp field, command array,
  environment translation, top-level field preservation, mcp entry
  preservation)
- 3 in \`setup.test.ts\` covering Tier-0 OpenCode parity (project-local
  marker, global marker, neither-present negative)

## Stack complete

| Tool         | Integration                                  | Status         |
| ------------ | -------------------------------------------- | -------------- |
| Claude Code  | \`harness-claude\` marketplace plugin        | shipped (#284) |
| Cursor       | \`harness-cursor\` marketplace plugin        | shipped (#288) |
| Gemini CLI   | \`harness-gemini\` marketplace extension     | shipped (#290) |
| Codex CLI    | \`harness-codex\` marketplace plugin         | shipped (#291) |
| **OpenCode** | **via \`harness setup\` (no plugin manifest)** | **this PR**  |

## README updates

- Quick Start now lists Gemini CLI and Codex CLI marketplace plugins as
  shipped (they were "coming" before PR-C/PR-D landed) and adds an
  OpenCode bullet pointing to the npm path
- Plugin-vs-npm parity table replaces the outdated "Gemini CLI / Codex /
  OpenCode integration ❌ (sibling plugins coming)" row with current state
- MCP config table gains an OpenCode row

## Test plan

- [x] \`pnpm run format:check\` clean
- [x] \`pnpm run typecheck\` clean
- [x] \`pnpm run test:ci\` green (70 setup-related tests pass)
- [x] Coverage ratchet passes
- [x] \`pnpm run generate-docs --check\` clean (docs/reference/cli-commands.md
      updated to reflect the new \`--client opencode\` option)
- [x] \`pnpm generate:plugin:check\` clean for all four targets (no plugin
      changes in this PR, but verified the drift guard still passes)
- [ ] Smoke test: install OpenCode, run \`harness setup\`, verify
      \`opencode.json\` is created with the harness MCP entry
- [ ] Smoke test: confirm OpenCode picks up \`.claude/skills/\` automatically
      and \`/harness:*\` invocations route through the MCP server