### PR TITLE
fix(hooks): block-no-verify matches argv tokens, not substrings

### DIFF
--- a/.changeset/block-no-verify-substring-fix.md
+++ b/.changeset/block-no-verify-substring-fix.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(hooks): block-no-verify only matches argv-token flags, not substrings (#285)
+
+The block-no-verify PreToolUse hook previously did a naive substring test for
+`--no-verify` against the entire Bash command, so it blocked commits whose
+message body, heredoc, or shell comment merely _mentioned_ the flag. The
+detector now strips quoted strings, heredoc bodies, and shell comments before
+testing, and matches `--no-verify` and `git commit -n` only when they appear
+as standalone argv tokens.

--- a/.harness/hooks/block-no-verify.js
+++ b/.harness/hooks/block-no-verify.js
@@ -33,7 +33,7 @@ function main() {
       process.exit(0);
     }
 
-    if (/--no-verify/.test(command) || /\bgit\b.*\bcommit\b.*\s-n\b/.test(command)) {
+    if (containsHookBypass(command)) {
       process.stderr.write(
         'BLOCKED: --no-verify flag detected. Hooks must not be bypassed.\n'
       );
@@ -45,6 +45,24 @@ function main() {
     // Unexpected error — fail open
     process.exit(0);
   }
+}
+
+// Strip heredoc bodies, quoted strings, and shell comments so flag detection
+// runs against argv tokens only — not text the user is just talking about.
+function stripStringsAndComments(cmd) {
+  let s = cmd;
+  s = s.replace(/<<-?\s*['"]?(\w+)['"]?[\s\S]*?\n\s*\1\b/g, ' ');
+  s = s.replace(/'[^']*'/g, ' ');
+  s = s.replace(/"(?:[^"\\]|\\.)*"/g, ' ');
+  s = s.replace(/(^|[\s;&|`(])#[^\n]*/g, '$1');
+  return s;
+}
+
+function containsHookBypass(command) {
+  const stripped = stripStringsAndComments(command);
+  if (/(?:^|\s)--no-verify(?=\s|$)/.test(stripped)) return true;
+  if (/\bgit\s+(?:[\w-]+\s+)*?commit\b[^\n]*?(?:^|\s)-n(?=\s|$)/.test(stripped)) return true;
+  return false;
 }
 
 main();

--- a/.harness/security/timeline.json
+++ b/.harness/security/timeline.json
@@ -9150,6 +9150,271 @@
         "3af164a5ea1e2558",
         "cc9e373508ae7415"
       ]
+    },
+    {
+      "capturedAt": "2026-05-07T16:25:06.412Z",
+      "commitHash": "0367e5e19c8b5825727f7c876695849201800821",
+      "securityScore": 83,
+      "totalFindings": 17,
+      "bySeverity": {
+        "error": 0,
+        "warning": 17,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 15,
+          "errorCount": 0,
+          "warningCount": 15,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-07T17:19:47.766Z",
+      "commitHash": "8a5571b2762010c787eb14490df4fa026220af64",
+      "securityScore": 83,
+      "totalFindings": 17,
+      "bySeverity": {
+        "error": 0,
+        "warning": 17,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 15,
+          "errorCount": 0,
+          "warningCount": 15,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-07T18:04:11.274Z",
+      "commitHash": "638bf711916caf55c08d5dd7e02d8c13cb38d2af",
+      "securityScore": 83,
+      "totalFindings": 17,
+      "bySeverity": {
+        "error": 0,
+        "warning": 17,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 15,
+          "errorCount": 0,
+          "warningCount": 15,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-07T18:09:39.887Z",
+      "commitHash": "8e31509a547fb4bdd74045d4cb1da99a276e3360",
+      "securityScore": 83,
+      "totalFindings": 17,
+      "bySeverity": {
+        "error": 0,
+        "warning": 17,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 15,
+          "errorCount": 0,
+          "warningCount": 15,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-07T19:56:59.197Z",
+      "commitHash": "11a59123fb1f3fbb01716637dbaa1ff31ec7f434",
+      "securityScore": 83,
+      "totalFindings": 17,
+      "bySeverity": {
+        "error": 0,
+        "warning": 17,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 15,
+          "errorCount": 0,
+          "warningCount": 15,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
     }
   ],
   "findingLifecycles": [
@@ -9161,8 +9426,8 @@
       "file": "packages/cli/src/skill/dispatch-session.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "9668b4e5b641e73a",
@@ -9205,8 +9470,8 @@
       "file": "packages/dashboard/src/server/routes/actions.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "b894b966346b4eae",
@@ -9227,8 +9492,8 @@
       "file": "packages/orchestrator/src/server/routes/analyze.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "fa0b4a56096d5dca",
@@ -9238,8 +9503,8 @@
       "file": "packages/orchestrator/src/server/routes/chat-proxy.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "527f092fa35ba319",
@@ -9249,8 +9514,8 @@
       "file": "packages/orchestrator/src/server/routes/dispatch-actions.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "5163f59ff7f104ff",
@@ -9260,8 +9525,8 @@
       "file": "packages/orchestrator/src/server/routes/interactions.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "d50dea5b4630e7aa",
@@ -9271,8 +9536,8 @@
       "file": "packages/orchestrator/src/server/routes/maintenance.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "7c9a0d532429a8b0",
@@ -9282,8 +9547,8 @@
       "file": "packages/orchestrator/src/server/routes/plans.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "c8e88de14a12f41a",
@@ -9293,8 +9558,8 @@
       "file": "packages/orchestrator/src/server/routes/roadmap-actions.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "3dd2e2a0c45ffab6",
@@ -9304,8 +9569,8 @@
       "file": "packages/orchestrator/src/server/routes/sessions.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "8383a56fc4f65c3a",
@@ -9315,8 +9580,8 @@
       "file": "packages/orchestrator/src/server/routes/sessions.ts",
       "firstSeenAt": "2026-04-19T21:01:02.937Z",
       "firstSeenCommit": "67082ed9f609ad6ed2fea875feeae6063912b7fc",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "40d8f9e6b93f5093",
@@ -9656,8 +9921,8 @@
       "file": "packages/dashboard/src/client/components/threads/AnalysisThreadView.tsx",
       "firstSeenAt": "2026-04-29T16:06:01.247Z",
       "firstSeenCommit": "2a3a75c06fe35a4b636b09ea31ed64e776edf53e",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "0c5272c9b13bd0b8",
@@ -9667,8 +9932,8 @@
       "file": "packages/dashboard/src/client/hooks/useOrchestratorSocket.ts",
       "firstSeenAt": "2026-04-29T16:06:01.247Z",
       "firstSeenCommit": "2a3a75c06fe35a4b636b09ea31ed64e776edf53e",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "2c599c8e2a76faac",
@@ -9678,8 +9943,8 @@
       "file": "packages/dashboard/src/client/pages/Analyze.tsx",
       "firstSeenAt": "2026-04-29T16:06:01.247Z",
       "firstSeenCommit": "2a3a75c06fe35a4b636b09ea31ed64e776edf53e",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "a649809c30e02bf5",
@@ -9689,8 +9954,8 @@
       "file": "packages/dashboard/src/client/utils/chat-stream.ts",
       "firstSeenAt": "2026-04-29T16:06:01.247Z",
       "firstSeenCommit": "2a3a75c06fe35a4b636b09ea31ed64e776edf53e",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "efed2c050377490a",
@@ -9700,8 +9965,8 @@
       "file": "packages/orchestrator/src/maintenance/reporter.ts",
       "firstSeenAt": "2026-04-29T16:06:01.247Z",
       "firstSeenCommit": "2a3a75c06fe35a4b636b09ea31ed64e776edf53e",
-      "resolvedAt": null,
-      "resolvedCommit": null
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
     },
     {
       "findingId": "310044840c54dfbe",
@@ -9722,6 +9987,193 @@
       "file": "packages/dashboard/src/client/hooks/useLocalModelStatuses.ts",
       "firstSeenAt": "2026-05-07T00:04:59.319Z",
       "firstSeenCommit": "6b87a94361dac5a1e8919de7eadd3c78eea90858",
+      "resolvedAt": "2026-05-07T16:25:06.344Z",
+      "resolvedCommit": "0367e5e19c8b5825727f7c876695849201800821"
+    },
+    {
+      "findingId": "c215c611cd48392c",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/analyze.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "7dc050e1898aac85",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/chat-proxy.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "d105b04f640dfeab",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/dispatch-actions.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "dff00c8326714ff9",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/interactions.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "70c53ff454c3c7d9",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/maintenance.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "62f5bd670137601a",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/plans.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "6dde4d866b3a3edc",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/roadmap-actions.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "f48ff7c4fd33d504",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/sessions.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "86c26e8d696e5beb",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/server/routes/sessions.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "9d5f6135305e92de",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/orchestrator/src/maintenance/reporter.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "38fe6be103e0c955",
+      "ruleId": "SEC-PTH-001",
+      "category": "path-traversal",
+      "severity": "warning",
+      "file": "packages/dashboard/src/server/routes/actions.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "d30bed7ccdc1fe6f",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/dashboard/src/client/utils/chat-stream.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "c4212a5500286c51",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/dashboard/src/client/pages/Analyze.tsx",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "b7c71c01a2847efb",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/dashboard/src/client/hooks/useLocalModelStatuses.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "db73539d16d377f8",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/dashboard/src/client/hooks/useOrchestratorSocket.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "e66ff96d15a5d527",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/dashboard/src/client/components/threads/AnalysisThreadView.tsx",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "53b3cf3e586f168a",
+      "ruleId": "SEC-PTH-001",
+      "category": "path-traversal",
+      "severity": "warning",
+      "file": "packages/cli/src/skill/dispatch-session.ts",
+      "firstSeenAt": "2026-05-07T16:25:06.344Z",
+      "firstSeenCommit": "0367e5e19c8b5825727f7c876695849201800821",
       "resolvedAt": null,
       "resolvedCommit": null
     }

--- a/packages/cli/.harness/arch/baselines.json
+++ b/packages/cli/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-06T20:49:31.038Z",
-  "updatedFrom": "4d0a9cee",
+  "updatedAt": "2026-05-07T18:11:26.302Z",
+  "updatedFrom": "11a59123",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,13 +12,11 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 24,
+      "value": 27,
       "violationIds": [
-        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
-        "6889f8a985ab68a0d10805c0b5cd65ef6c39584be8dc329c18f489844423c8f2",
-        "190066af53f99bfb3a2967bc6b4d4d5731ea34aabcdde6b93dc92e067753eb65",
-        "f49a6dcc0c4256c0b3eabb889a752504b9ce77afa318fe76c9b9ad7857beb691",
         "39915d8638d04f396cc5aad6b0de87b6d8fe53c7a6ea37cf4cd165fe3c033608",
+        "52bfeb39e14e6c6cc4e71132817da11d4c406641d2db4e56a8a50dd57ec77b8d",
+        "38f9135fa977864a843de9dd46a92199de2b25d0ca95e674df4587e7df23b74a",
         "daccba080577cbea98ed500338f51cac6d4e2ed01f40359d69d6a045a647df75",
         "caa8d8292a6e690030cc17edbd92411055b0b6b935c7e371219559d943daf92e",
         "5dc9d9d6e342782195ee53ead7573c75cd552dfafb578cd226ed7cc16230842d",
@@ -28,7 +26,11 @@
         "e20a7b701cbdcfea91f173daa47745e8948c168f752f557ce845a89f91fa45e2",
         "7628647b41d1bc901f32746285caf5b53a1d0599c1d0a89b8895d2b8c61c437b",
         "f920a83a428335ceb3a09122377409a091d3161a8b2763920bd7f4157f5a78b7",
-        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879",
+        "618d90067d89f950ff8e2052445bb88d8a072adfc0ac33656e53527ebe8baed2",
+        "39e8004af4f9abbff2d010731dc511fa5528c38d9d7c0b6baa5d4ecfcfb030a8",
+        "6889f8a985ab68a0d10805c0b5cd65ef6c39584be8dc329c18f489844423c8f2",
+        "190066af53f99bfb3a2967bc6b4d4d5731ea34aabcdde6b93dc92e067753eb65",
+        "f49a6dcc0c4256c0b3eabb889a752504b9ce77afa318fe76c9b9ad7857beb691",
         "2d25259b95052df3e5b92729f6baba686cb3b671d34a4fb5f226bf7d6a788333",
         "173b32d29a880fcb000e74e0b10055ca846eefbc418a947f1ba99c8db1b7a043",
         "4fe3004ac88bda30d223759fa43f8290ed6703b59492da7460a523bb0af91851",
@@ -36,7 +38,8 @@
         "fdf9464474e0f5cb7d03d1de4357c6ebf7b64f1f4e85a8bf8e7d70ef6c20cc25",
         "b82ff3a5a6d1e6a3bbf4b99bced656e44880a0fcb8f0ae3a896c9c778214c1a7",
         "a6f668cd4e884a7bbc7aadc3f454dcadf05f69236453c43bc35fe4f3eda04e3c",
-        "6d56e4633f54b4d0f8b3e6d801e743baa12719835026c35c8638f2a26639aa2e"
+        "6d56e4633f54b4d0f8b3e6d801e743baa12719835026c35c8638f2a26639aa2e",
+        "482d0366444a7392a74e3971fd51c7e6e58895e42aaf96c3278cafb49815a879"
       ]
     },
     "coupling": {
@@ -48,7 +51,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 29718,
+      "value": 29937,
       "violationIds": []
     },
     "dependency-depth": {

--- a/packages/cli/src/hooks/block-no-verify.js
+++ b/packages/cli/src/hooks/block-no-verify.js
@@ -33,7 +33,7 @@ function main() {
       process.exit(0);
     }
 
-    if (/--no-verify/.test(command) || /\bgit\b.*\bcommit\b.*\s-n\b/.test(command)) {
+    if (containsHookBypass(command)) {
       process.stderr.write(
         'BLOCKED: --no-verify flag detected. Hooks must not be bypassed.\n'
       );
@@ -45,6 +45,24 @@ function main() {
     // Unexpected error — fail open
     process.exit(0);
   }
+}
+
+// Strip heredoc bodies, quoted strings, and shell comments so flag detection
+// runs against argv tokens only — not text the user is just talking about.
+function stripStringsAndComments(cmd) {
+  let s = cmd;
+  s = s.replace(/<<-?\s*['"]?(\w+)['"]?[\s\S]*?\n\s*\1\b/g, ' ');
+  s = s.replace(/'[^']*'/g, ' ');
+  s = s.replace(/"(?:[^"\\]|\\.)*"/g, ' ');
+  s = s.replace(/(^|[\s;&|`(])#[^\n]*/g, '$1');
+  return s;
+}
+
+function containsHookBypass(command) {
+  const stripped = stripStringsAndComments(command);
+  if (/(?:^|\s)--no-verify(?=\s|$)/.test(stripped)) return true;
+  if (/\bgit\s+(?:[\w-]+\s+)*?commit\b[^\n]*?(?:^|\s)-n(?=\s|$)/.test(stripped)) return true;
+  return false;
 }
 
 main();

--- a/packages/cli/tests/hooks/block-no-verify.test.ts
+++ b/packages/cli/tests/hooks/block-no-verify.test.ts
@@ -95,4 +95,59 @@ describe('block-no-verify', () => {
     const { exitCode } = runHook('');
     expect(exitCode).toBe(0);
   });
+
+  describe('argv-token boundary (issue #285)', () => {
+    it('allows commit message that mentions --no-verify in single quotes', () => {
+      const input = JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: "git commit -m 'docs: --no-verify is bad'" },
+      });
+      const { exitCode } = runHook(input);
+      expect(exitCode).toBe(0);
+    });
+
+    it('allows commit message that mentions --no-verify in double quotes', () => {
+      const input = JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'git commit -m "blocks --no-verify"' },
+      });
+      const { exitCode } = runHook(input);
+      expect(exitCode).toBe(0);
+    });
+
+    it('allows heredoc body that mentions --no-verify', () => {
+      const command = [
+        `git commit -m "$(cat <<'HEREDOC'`,
+        `fix(harness): block-no-verify hook`,
+        ``,
+        `- blocks attempts to use --no-verify`,
+        `HEREDOC`,
+        `)"`,
+      ].join('\n');
+      const input = JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      const { exitCode } = runHook(input);
+      expect(exitCode).toBe(0);
+    });
+
+    it('allows shell comment mentioning --no-verify', () => {
+      const input = JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'git status # --no-verify is bad' },
+      });
+      const { exitCode } = runHook(input);
+      expect(exitCode).toBe(0);
+    });
+
+    it('still blocks --no-verify when it appears as a real argv token at end', () => {
+      const input = JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'git commit -m "msg" --no-verify' },
+      });
+      const { exitCode } = runHook(input);
+      expect(exitCode).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
Closes #285

## Summary

- The `block-no-verify` PreToolUse hook ran a naive substring test against the entire Bash command, so it blocked any commit whose message body, heredoc, or shell comment merely *mentioned* the flag — including this very PR description before the fix was in.
- Strip heredoc bodies, single/double-quoted strings, and `#`-prefixed shell comments before testing, then require the long form to appear as a standalone argv token. Scope the short-form `-n` check to `git ... commit` so unrelated commands like `echo -n` are unaffected.
- Resync the tracked project-installed copy at `.harness/hooks/block-no-verify.js` from the package source.

## Test plan

- [x] Add 5 regression cases in `packages/cli/tests/hooks/block-no-verify.test.ts`: single-quoted body, double-quoted body, heredoc body, shell comment, and a real flag at end-of-command (still blocks).
- [x] Without the fix: 4 of the 5 new tests fail with exit 2.
- [x] With the fix: all 14 tests in the file pass.
- [x] Full hook suite (136 tests across 11 files) passes.
- [x] `npm run lint` and `npx tsc --noEmit` clean for `packages/cli`.
- [x] Validated full 9-case matrix from the issue against the new detector — all pass.

## Notes

- Includes a small `chore(harness): refresh security timeline and cli arch baselines` commit that landed on `main` immediately before this branch — happy to drop or split if reviewers prefer.