### PR TITLE
fix(graph/ingest): materialize general docs as document nodes (#302)

### DIFF
--- a/.changeset/issue-302-ingest-general-docs.md
+++ b/.changeset/issue-302-ingest-general-docs.md
@@ -1,0 +1,34 @@
+---
+'@harness-engineering/graph': minor
+'@harness-engineering/core': patch
+'@harness-engineering/cli': patch
+---
+
+fix(graph/ingest): materialize general Markdown as `document` nodes (#302); consolidate skip-dir usage across walkers and glob excludes
+
+**`@harness-engineering/graph`:**
+
+- Issue #302 — `KnowledgeIngestor.ingestAll()` only ran `ingestADRs`, `ingestLearnings`, and `ingestFailures`. Top-level `README.md`/`AGENTS.md` and `docs/**/*.md` (non-ADR) were silently skipped, so no `document` nodes existed and no `documents` edges were created for general docs. The `detect-doc-drift` skill's graph-enhanced traversal was a no-op on any project without a `docs/adr/` directory.
+- New `KnowledgeIngestor.ingestGeneralDocs(projectPath)` materializes `document` nodes for top-level `*.md` (non-recursive) and `docs/**/*.md` (recursive), skipping subdirs owned by sibling ingestors (`docs/adr` → `ingestADRs`, `docs/knowledge` → `BusinessKnowledgeIngestor`, `docs/changes` → `RequirementIngestor`, `docs/solutions` → solutions pipeline). Node id format: `doc:<rel-path>`. Title parsed from the first H1, falling back to the filename. Runs `linkToCode(content, nodeId, 'documents')` so mentioned code symbols get `documents` edges automatically. Wired into `ingestAll()`, so both the MCP `ingest_source` (knowledge|all) handler and the CLI `harness ingest --source knowledge` path benefit without further changes.
+- New `skipDirGlobs(skipDirs?)` helper exported from `@harness-engineering/graph`. Converts a skip-dirs set (default: `DEFAULT_SKIP_DIRS`) into minimatch glob patterns of the form `**/<name>/**`. Use this for tools that exclude via globs (security scan, doc coverage, entropy snapshot) instead of by reading directory names during traversal — the previously hand-maintained `['**/node_modules/**', '**/dist/**']` mini-lists across packages now derive from the canonical 60+ entry set automatically.
+- Consolidated all hand-rolled skip-dir lists inside the graph package around `DEFAULT_SKIP_DIRS`: `KnowledgeIngestor.findMarkdownFiles`, `BusinessKnowledgeIngestor.findMarkdownFiles` (the byte-identical twin of the #302 bug), `DiagramParser.findDiagramFiles`, `ExtractionRunner.walkSources`. Each picks up the full coverage from #274 (Python `__pycache__`/`.venv`, JS framework caches `.next`/`.turbo`/`.vite`, AI agent sandboxes `.claude`/`.cursor`/`.codex`, etc.) for free, and any future addition to `DEFAULT_SKIP_DIRS` propagates everywhere.
+
+**`@harness-engineering/core`:**
+
+- `architecture/collectors/module-size.ts` and `architecture/collectors/dep-depth.ts`: `isSkippedEntry` now combines `name.startsWith('.')` with `DEFAULT_SKIP_DIRS.has(name)`. Preserves the existing broad dotfile heuristic and adds curated non-dotfile names (`vendor`, `out`, `target`, `build`, `coverage`, etc.).
+- `entropy/detectors/size-budget.ts:dirSize`: skip-set widened from `{node_modules, .git}` to the full `DEFAULT_SKIP_DIRS`. Size budgets now exclude `dist`, `build`, `.turbo`, etc., matching intent.
+- `performance/critical-path.ts`: source-file walker uses `DEFAULT_SKIP_DIRS`.
+- `security/types.ts:DEFAULT_SECURITY_CONFIG.exclude` and `security/config.ts:SecurityConfigSchema.exclude`: default exclude list is now `[...skipDirGlobs(), '**/*.test.ts', '**/fixtures/**']` — file-type/fixture filters preserved, dir-skip portion derives from the canonical set.
+- `ci/check-orchestrator.ts`: same treatment for the two `excludePatterns` defaults (doc-coverage fallback and security-scan ignore fallback).
+- `entropy/snapshot.ts`: `excludePatterns` fallback now derives from `skipDirGlobs()`. Also corrects a latent bug — the previous `'node_modules/**'` (no leading `**/`) only matched top-level `node_modules`, missing nested ones in monorepos.
+
+**`@harness-engineering/cli`:**
+
+- `commands/migrate.ts:walk`: skip-set uses `DEFAULT_SKIP_DIRS`.
+- `commands/install.ts`: skill-scan walker combines `startsWith('.')` with `DEFAULT_SKIP_DIRS.has(name)`.
+- `config/schema.ts:EntropyConfigSchema.excludePatterns`: default is now `[...skipDirGlobs(), '**/*.test.ts']`.
+
+**Tests:**
+
+- New `general docs ingestion (issue #302)` block in `packages/graph/tests/ingest/KnowledgeIngestor.test.ts`: 5 cases covering top-level README/AGENTS creation, `documents`-edge linking to mentioned code symbols, ADR non-duplication, ownership-aware subdir skipping (`docs/{adr,knowledge,changes,solutions}`), and `.harness/*.md` exclusion. Revert-and-fail check confirms 3 of the 5 fail without the fix; the remaining 2 guard against future over-ingestion.
+- Updated `packages/cli/tests/commands/install.test.ts` `child_process` mock to use `importOriginal()` partial pattern so transitively-loaded code from `@harness-engineering/graph` resolves correctly.

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -23,6 +23,7 @@ import {
 import { getBundledSkillNames } from '../registry/bundled-skills';
 import { resolveGlobalSkillsDir, resolveGlobalCommunityBaseDir } from '../utils/paths';
 import { logger } from '../output/logger';
+import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph';
 
 export interface InstallOptions {
   version?: string;
@@ -146,7 +147,7 @@ function discoverSkillDirs(rootDir: string): string[] {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+      if (entry.name.startsWith('.') || DEFAULT_SKIP_DIRS.has(entry.name)) continue;
       scan(path.join(dir, entry.name), depth + 1);
     }
   }

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -6,6 +6,7 @@ import { execFileSync } from 'child_process';
 import chalk from 'chalk';
 import type { Result } from '@harness-engineering/core';
 import { Ok, Err } from '@harness-engineering/core';
+import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph';
 import { logger } from '../output/logger';
 import { CLIError, ExitCode } from '../utils/errors';
 import { resolveConfig } from '../config/loader';
@@ -89,7 +90,7 @@ function walk(dir: string, predicate: (p: string) => boolean): string[] {
   if (!fs.existsSync(dir)) return [];
   const out: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist') continue;
+    if (DEFAULT_SKIP_DIRS.has(entry.name)) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) out.push(...walk(full, predicate));
     else if (predicate(full)) out.push(full);

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { ArchConfigSchema } from '@harness-engineering/core';
+import { skipDirGlobs } from '@harness-engineering/graph';
 import { IngestConfigSchema } from './ingest-schema.js';
 
 export { IngestConfigSchema } from './ingest-schema.js';
@@ -56,7 +57,7 @@ export const EntropyConfigSchema = z.object({
   /** Explicit entry points for reachability analysis (overrides auto-detection) */
   entryPoints: z.array(z.string()).optional(),
   /** Patterns to exclude from entropy analysis */
-  excludePatterns: z.array(z.string()).default(['**/node_modules/**', '**/*.test.ts']),
+  excludePatterns: z.array(z.string()).default([...skipDirGlobs(), '**/*.test.ts']),
   /** Whether to automatically attempt to fix simple entropy issues */
   autoFix: z.boolean().default(false),
 });

--- a/packages/cli/tests/commands/install.test.ts
+++ b/packages/cli/tests/commands/install.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createInstallCommand, runInstall, runBulkInstall } from '../../src/commands/install';
 
-vi.mock('child_process', () => ({
-  execFileSync: vi.fn(() => {
-    throw new Error('git not available in test environment');
-  }),
-}));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => {
+      throw new Error('git not available in test environment');
+    }),
+  };
+});
 
 // Mock all registry modules
 vi.mock('../../src/registry/npm-client', () => ({

--- a/packages/core/src/architecture/collectors/dep-depth.ts
+++ b/packages/core/src/architecture/collectors/dep-depth.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
+import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph';
 import type { Collector, ArchConfig, MetricResult, Violation, ConstraintRule } from '../types';
 import { violationId, constraintRuleId } from './hash';
 import { relativePosix } from '../../shared/fs-utils';
@@ -29,7 +30,7 @@ function extractImportSources(content: string, filePath: string): string[] {
 }
 
 function isSkippedEntry(name: string): boolean {
-  return name.startsWith('.') || name === 'node_modules' || name === 'dist';
+  return name.startsWith('.') || DEFAULT_SKIP_DIRS.has(name);
 }
 
 function isTsSourceFile(name: string): boolean {

--- a/packages/core/src/architecture/collectors/module-size.ts
+++ b/packages/core/src/architecture/collectors/module-size.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph';
 import type { Collector, ArchConfig, MetricResult, Violation, ConstraintRule } from '../types';
 import { violationId, constraintRuleId } from './hash';
 import { relativePosix } from '../../shared/fs-utils';
@@ -12,7 +13,7 @@ interface ModuleStats {
 }
 
 function isSkippedEntry(name: string): boolean {
-  return name.startsWith('.') || name === 'node_modules' || name === 'dist';
+  return name.startsWith('.') || DEFAULT_SKIP_DIRS.has(name);
 }
 
 function isTsSourceFile(name: string): boolean {

--- a/packages/core/src/ci/check-orchestrator.ts
+++ b/packages/core/src/ci/check-orchestrator.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { skipDirGlobs } from '@harness-engineering/graph';
 import { ArchBaselineManager } from '../architecture/baseline-manager';
 import { diff } from '../architecture/diff';
 import type {
@@ -116,8 +117,7 @@ async function runDocsCheck(
     docsDir,
     sourceDir: projectRoot,
     excludePatterns: (entropyConfig.excludePatterns as string[]) || [
-      '**/node_modules/**',
-      '**/dist/**',
+      ...skipDirGlobs(),
       '**/*.test.ts',
       '**/fixtures/**',
     ],
@@ -195,12 +195,7 @@ async function runSecurityCheck(
   const { glob: globFn } = await import('glob');
   const sourceFiles = await globFn('**/*.{ts,tsx,js,jsx,go,py}', {
     cwd: projectRoot,
-    ignore: securityConfig.exclude ?? [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/*.test.ts',
-      '**/fixtures/**',
-    ],
+    ignore: securityConfig.exclude ?? [...skipDirGlobs(), '**/*.test.ts', '**/fixtures/**'],
     absolute: true,
   });
 

--- a/packages/core/src/entropy/detectors/size-budget.ts
+++ b/packages/core/src/entropy/detectors/size-budget.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types';
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph';
 
 /**
  * Parse a human-readable size string into bytes.
@@ -32,7 +33,7 @@ export function parseSize(size: string): number {
 
 /**
  * Recursively compute directory size in bytes.
- * Skips node_modules and .git.
+ * Skips dirs listed in DEFAULT_SKIP_DIRS (node_modules, .git, build outputs, caches, etc.).
  */
 function dirSize(dirPath: string): number {
   let total = 0;
@@ -43,7 +44,7 @@ function dirSize(dirPath: string): number {
     return 0;
   }
   for (const entry of entries) {
-    if (entry === 'node_modules' || entry === '.git') continue;
+    if (DEFAULT_SKIP_DIRS.has(entry)) continue;
     const fullPath = join(dirPath, entry);
     try {
       const stat = statSync(fullPath);

--- a/packages/core/src/entropy/snapshot.ts
+++ b/packages/core/src/entropy/snapshot.ts
@@ -15,6 +15,7 @@ import type {
 } from './types';
 import type { AST, Export, LanguageParser } from '../shared/parsers';
 import { getDefaultRegistry } from '../shared/parsers';
+import { skipDirGlobs } from '@harness-engineering/graph';
 import { createEntropyError } from '../shared/errors';
 import { readFileContent, findFiles, relativePosix } from '../shared/fs-utils';
 import { buildDependencyGraph } from '../constraints/dependencies';
@@ -292,12 +293,7 @@ export async function buildSnapshot(
 
   // Find source files
   const includePatterns = config.include || DEFAULT_INCLUDE_PATTERNS;
-  const excludePatterns = config.exclude || [
-    'node_modules/**',
-    'dist/**',
-    '**/*.test.ts',
-    '**/*.spec.ts',
-  ];
+  const excludePatterns = config.exclude || [...skipDirGlobs(), '**/*.test.ts', '**/*.spec.ts'];
 
   let sourceFilePaths: string[] = [];
   for (const pattern of includePatterns) {

--- a/packages/core/src/performance/critical-path.ts
+++ b/packages/core/src/performance/critical-path.ts
@@ -1,12 +1,12 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { DEFAULT_SKIP_DIRS } from '@harness-engineering/graph';
 import type { CriticalPathEntry, CriticalPathSet } from './types';
 
 export interface GraphCriticalPathData {
   highFanInFunctions: Array<{ file: string; function: string; fanIn: number }>;
 }
 
-const SKIP_DIRS = new Set(['node_modules', 'dist', '.git']);
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
 
 const FUNCTION_DECL_RE = /(?:export\s+)?(?:async\s+)?function\s+(\w+)/;
@@ -98,7 +98,7 @@ export class CriticalPathResolver {
 
     for (const item of items) {
       if (item.isDirectory()) {
-        if (SKIP_DIRS.has(item.name)) continue;
+        if (DEFAULT_SKIP_DIRS.has(item.name)) continue;
         this.walkDir(path.join(dir, item.name), entries);
       } else if (item.isFile() && SOURCE_EXTENSIONS.has(path.extname(item.name))) {
         this.scanFile(path.join(dir, item.name), entries);

--- a/packages/core/src/security/config.ts
+++ b/packages/core/src/security/config.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { skipDirGlobs } from '@harness-engineering/graph';
 import type { SecurityConfig, SecuritySeverity, RuleOverride } from './types';
 import { DEFAULT_SECURITY_CONFIG } from './types';
 
@@ -11,7 +12,7 @@ export const SecurityConfigSchema = z.object({
   exclude: z
     .array(z.string())
     .optional()
-    .default(['**/node_modules/**', '**/dist/**', '**/*.test.ts', '**/fixtures/**']),
+    .default([...skipDirGlobs(), '**/*.test.ts', '**/fixtures/**']),
   external: z
     .object({
       semgrep: z

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -1,3 +1,5 @@
+import { skipDirGlobs } from '@harness-engineering/graph';
+
 export type SecurityCategory =
   | 'secrets'
   | 'injection'
@@ -76,5 +78,5 @@ export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
   enabled: true,
   strict: false,
   rules: {},
-  exclude: ['**/node_modules/**', '**/dist/**', '**/*.test.ts', '**/fixtures/**'],
+  exclude: [...skipDirGlobs(), '**/*.test.ts', '**/fixtures/**'],
 };

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -6,6 +6,10 @@ export default defineConfig({
     environment: 'node',
     testTimeout: 15_000,
     setupFiles: ['./tests/setup.ts'],
+    // Restrict discovery to source/test trees. Without this, vitest 4's
+    // default include picks up compiled `dist/**/*.test.js` artifacts whose
+    // sibling data files (e.g. `template.md`) are not copied during build.
+    include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -43,7 +43,7 @@ export type { ImpactGroups, NodeCategory } from './query/groupImpact.js';
 // Ingest
 export { CodeIngestor } from './ingest/CodeIngestor.js';
 export type { CodeIngestorOptions } from './ingest/CodeIngestor.js';
-export { DEFAULT_SKIP_DIRS, resolveSkipDirs } from './ingest/skip-dirs.js';
+export { DEFAULT_SKIP_DIRS, resolveSkipDirs, skipDirGlobs } from './ingest/skip-dirs.js';
 export { GitIngestor } from './ingest/GitIngestor.js';
 export type { GitRunner } from './ingest/GitIngestor.js';
 export { TopologicalLinker } from './ingest/TopologicalLinker.js';

--- a/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+++ b/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import type { GraphStore } from '../store/GraphStore.js';
 import type { GraphNode, IngestResult, NodeType, EdgeType } from '../types.js';
 import { emptyResult } from './ingestUtils.js';
+import { DEFAULT_SKIP_DIRS } from './skip-dirs.js';
 
 // Local schema mirror of @harness-engineering/core's SolutionDocFrontmatterSchema.
 // Inlined because the graph layer cannot depend on core (layer rule:
@@ -294,23 +295,7 @@ export class BusinessKnowledgeIngestor {
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
-      if (
-        entry.isDirectory() &&
-        entry.name !== 'node_modules' &&
-        entry.name !== 'dist' &&
-        entry.name !== 'target' &&
-        entry.name !== 'build' &&
-        entry.name !== '.git' &&
-        entry.name !== '.gradle' &&
-        entry.name !== '.harness' &&
-        entry.name !== 'vendor' &&
-        entry.name !== 'bin' &&
-        entry.name !== 'obj' &&
-        entry.name !== 'venv' &&
-        entry.name !== '_build' &&
-        entry.name !== 'deps' &&
-        entry.name !== 'coverage'
-      ) {
+      if (entry.isDirectory() && !DEFAULT_SKIP_DIRS.has(entry.name)) {
         results.push(...(await this.findMarkdownFiles(fullPath)));
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
         results.push(fullPath);

--- a/packages/graph/src/ingest/DiagramParser.ts
+++ b/packages/graph/src/ingest/DiagramParser.ts
@@ -13,6 +13,7 @@ import * as path from 'node:path';
 import type { GraphStore } from '../store/GraphStore.js';
 import type { IngestResult } from '../types.js';
 import { hash } from './ingestUtils.js';
+import { DEFAULT_SKIP_DIRS } from './skip-dirs.js';
 
 // Re-export types and parsers so existing imports remain valid
 export type {
@@ -30,7 +31,6 @@ import { MermaidParser, D2Parser, PlantUmlParser } from './parsers/index.js';
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const DIAGRAM_EXTENSIONS = new Set(['.mmd', '.mermaid', '.d2', '.puml', '.plantuml']);
-const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.harness']);
 
 // ─── DiagramParser Orchestrator ─────────────────────────────────────────────
 
@@ -148,7 +148,7 @@ export class DiagramParser {
 
       for (const entry of entries) {
         if (entry.isDirectory()) {
-          if (!SKIP_DIRS.has(entry.name)) {
+          if (!DEFAULT_SKIP_DIRS.has(entry.name)) {
             await walk(path.join(currentDir, entry.name));
           }
         } else if (entry.isFile()) {

--- a/packages/graph/src/ingest/KnowledgeIngestor.ts
+++ b/packages/graph/src/ingest/KnowledgeIngestor.ts
@@ -3,8 +3,14 @@ import * as path from 'node:path';
 import type { GraphStore } from '../store/GraphStore.js';
 import type { GraphNode, IngestResult, EdgeType } from '../types.js';
 import { hash, mergeResults, emptyResult } from './ingestUtils.js';
+import { DEFAULT_SKIP_DIRS } from './skip-dirs.js';
 
 const CODE_NODE_TYPES = ['file', 'function', 'class', 'method', 'interface', 'variable'] as const;
+
+// Subdirectories of docs/ owned by other ingestors. Skipping these avoids
+// duplicating ADRs (ingestADRs), business knowledge (BusinessKnowledgeIngestor),
+// requirements (RequirementIngestor), and solutions docs.
+const DOCS_OWNED_BY_OTHER_INGESTORS = new Set(['adr', 'knowledge', 'changes', 'solutions']);
 
 export class KnowledgeIngestor {
   constructor(private readonly store: GraphStore) {}
@@ -90,15 +96,60 @@ export class KnowledgeIngestor {
     return buildResult(nodesAdded, edgesAdded, [], start);
   }
 
+  async ingestGeneralDocs(projectPath: string): Promise<IngestResult> {
+    const start = Date.now();
+    const errors: string[] = [];
+    let nodesAdded = 0;
+    let edgesAdded = 0;
+
+    const files = new Set<string>();
+
+    try {
+      const entries = await fs.readdir(projectPath, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.endsWith('.md')) {
+          files.add(path.join(projectPath, entry.name));
+        }
+      }
+    } catch {
+      return emptyResult(Date.now() - start);
+    }
+
+    const docsRoot = path.join(projectPath, 'docs');
+    try {
+      const scanned = await this.scanDocsDir(docsRoot);
+      for (const f of scanned) files.add(f);
+    } catch {
+      // docs/ absent or unreadable — fine
+    }
+
+    for (const filePath of files) {
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const relPath = path.relative(projectPath, filePath).replaceAll('\\', '/');
+        const nodeId = `doc:${relPath}`;
+        if (this.store.getNode(nodeId)) continue;
+        this.store.addNode(parseDocumentNode(nodeId, filePath, relPath, content));
+        nodesAdded++;
+        edgesAdded += this.linkToCode(content, nodeId, 'documents');
+      } catch (err) {
+        errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return buildResult(nodesAdded, edgesAdded, errors, start);
+  }
+
   async ingestAll(projectPath: string, opts?: { adrDir?: string }): Promise<IngestResult> {
     const start = Date.now();
     const adrDir = opts?.adrDir ?? path.join(projectPath, 'docs', 'adr');
-    const [adrResult, learningsResult, failuresResult] = await Promise.all([
+    const [adrResult, learningsResult, failuresResult, docsResult] = await Promise.all([
       this.ingestADRs(adrDir),
       this.ingestLearnings(projectPath),
       this.ingestFailures(projectPath),
+      this.ingestGeneralDocs(projectPath),
     ]);
-    const merged = mergeResults(adrResult, learningsResult, failuresResult);
+    const merged = mergeResults(adrResult, learningsResult, failuresResult, docsResult);
     return { ...merged, durationMs: Date.now() - start };
   }
 
@@ -141,23 +192,23 @@ export class KnowledgeIngestor {
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
-      if (
-        entry.isDirectory() &&
-        entry.name !== 'node_modules' &&
-        entry.name !== 'dist' &&
-        entry.name !== 'target' &&
-        entry.name !== 'build' &&
-        entry.name !== '.git' &&
-        entry.name !== '.gradle' &&
-        entry.name !== '.harness' &&
-        entry.name !== 'vendor' &&
-        entry.name !== 'bin' &&
-        entry.name !== 'obj' &&
-        entry.name !== 'venv' &&
-        entry.name !== '_build' &&
-        entry.name !== 'deps' &&
-        entry.name !== 'coverage'
-      ) {
+      if (entry.isDirectory() && !DEFAULT_SKIP_DIRS.has(entry.name)) {
+        results.push(...(await this.findMarkdownFiles(fullPath)));
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        results.push(fullPath);
+      }
+    }
+    return results;
+  }
+
+  private async scanDocsDir(docsRoot: string): Promise<string[]> {
+    const results: string[] = [];
+    const rootEntries = await fs.readdir(docsRoot, { withFileTypes: true });
+    for (const entry of rootEntries) {
+      const fullPath = path.join(docsRoot, entry.name);
+      if (entry.isDirectory()) {
+        if (DEFAULT_SKIP_DIRS.has(entry.name)) continue;
+        if (DOCS_OWNED_BY_OTHER_INGESTORS.has(entry.name)) continue;
         results.push(...(await this.findMarkdownFiles(fullPath)));
       } else if (entry.isFile() && entry.name.endsWith('.md')) {
         results.push(fullPath);
@@ -190,6 +241,23 @@ function buildResult(
     edgesUpdated: 0,
     errors,
     durationMs: Date.now() - start,
+  };
+}
+
+function parseDocumentNode(
+  nodeId: string,
+  filePath: string,
+  relPath: string,
+  content: string
+): GraphNode {
+  const titleMatch = content.match(/^#\s+(.+)$/m);
+  const title = titleMatch ? titleMatch[1]!.trim() : path.basename(filePath, '.md');
+  return {
+    id: nodeId,
+    type: 'document',
+    name: title,
+    path: filePath,
+    metadata: { relPath },
   };
 }
 

--- a/packages/graph/src/ingest/extractors/ExtractionRunner.ts
+++ b/packages/graph/src/ingest/extractors/ExtractionRunner.ts
@@ -3,34 +3,8 @@ import * as path from 'node:path';
 import type { GraphStore } from '../../store/GraphStore.js';
 import type { IngestResult, GraphNode, GraphEdge, EdgeType } from '../../types.js';
 import { hash } from '../ingestUtils.js';
+import { DEFAULT_SKIP_DIRS } from '../skip-dirs.js';
 import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
-
-/** Directories to skip during file walking (matches CodeIngestor). */
-const SKIP_DIRS = new Set([
-  'node_modules',
-  'dist',
-  'target',
-  'build',
-  '.git',
-  '__pycache__',
-  '.venv',
-  '.turbo',
-  '.harness',
-  '.next',
-  '.vscode',
-  '.idea',
-  'vendor',
-  'out',
-  '.gradle',
-  '.gradle-home',
-  'bin',
-  'obj',
-  'venv',
-  '_build',
-  'deps',
-  'coverage',
-  '.nyc_output',
-]);
 
 /** Map file extensions to Language. */
 const EXT_TO_LANGUAGE: Record<string, Language> = {
@@ -264,7 +238,7 @@ export class ExtractionRunner {
     }
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+      if (entry.isDirectory() && !DEFAULT_SKIP_DIRS.has(entry.name)) {
         results.push(...(await this.findSourceFiles(fullPath)));
       } else if (entry.isFile() && detectLanguage(fullPath) !== undefined) {
         results.push(fullPath);

--- a/packages/graph/src/ingest/skip-dirs.ts
+++ b/packages/graph/src/ingest/skip-dirs.ts
@@ -110,3 +110,16 @@ export function resolveSkipDirs(options?: {
   }
   return base;
 }
+
+/**
+ * Convert a skip-dirs set into minimatch glob patterns of the form
+ * `**\/<name>/\**`. Use for tools that exclude via globs (security scan, doc
+ * coverage, entropy analysis) rather than by reading directory names during
+ * traversal. Defaults to {@link DEFAULT_SKIP_DIRS}.
+ *
+ * Returns a fresh array each call so callers may freely mutate/append
+ * domain-specific patterns (e.g. test/fixture file globs).
+ */
+export function skipDirGlobs(skipDirs: ReadonlySet<string> = DEFAULT_SKIP_DIRS): string[] {
+  return Array.from(skipDirs, (name) => `**/${name}/**`);
+}

--- a/packages/graph/tests/ingest/KnowledgeIngestor.test.ts
+++ b/packages/graph/tests/ingest/KnowledgeIngestor.test.ts
@@ -244,4 +244,114 @@ describe('KnowledgeIngestor', () => {
       expect(nodes[0]!.metadata.outcome).toBeUndefined();
     });
   });
+
+  // Regression coverage for issue #302 — ingestAll must materialize README,
+  // AGENTS.md, and docs/**/*.md (non-ADR) as `document` nodes so that the
+  // detect-doc-drift skill's graph-enhanced path has `documents` edges to
+  // traverse on projects without a docs/adr/ directory.
+  describe('general docs ingestion (issue #302)', () => {
+    let tmpDir: string;
+    let isolatedStore: GraphStore;
+    let isolatedIngestor: KnowledgeIngestor;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'general-docs-'));
+      // Seed a tiny source tree so linkToCode has something to match against.
+      await fs.mkdir(path.join(tmpDir, 'src'), { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, 'src', 'thing.ts'),
+        'export function doStuff(): void {\n  return;\n}\n'
+      );
+      isolatedStore = new GraphStore();
+      const codeIngestor = new CodeIngestor(isolatedStore);
+      await codeIngestor.ingest(tmpDir);
+      isolatedIngestor = new KnowledgeIngestor(isolatedStore);
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('creates document nodes for top-level README.md and AGENTS.md', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nUses `doStuff` to do stuff.\n'
+      );
+      await fs.writeFile(
+        path.join(tmpDir, 'AGENTS.md'),
+        '# Agents\n\nSee src/thing.ts for details.\n'
+      );
+
+      const result = await isolatedIngestor.ingestAll(tmpDir);
+
+      const docs = isolatedStore.findNodes({ type: 'document' });
+      expect(docs.length).toBeGreaterThanOrEqual(2);
+      expect(docs.find((d) => d.path?.endsWith('README.md'))).toBeDefined();
+      expect(docs.find((d) => d.path?.endsWith('AGENTS.md'))).toBeDefined();
+      expect(result.nodesAdded).toBeGreaterThanOrEqual(2);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('creates documents edges from docs/*.md to mentioned code symbols', async () => {
+      await fs.mkdir(path.join(tmpDir, 'docs'), { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, 'docs', 'guide.md'),
+        '# Guide\n\nCall doStuff() to perform the operation.\n'
+      );
+
+      await isolatedIngestor.ingestAll(tmpDir);
+
+      const docs = isolatedStore.findNodes({ type: 'document' });
+      const guideDoc = docs.find((d) => d.path?.endsWith('guide.md'));
+      expect(guideDoc).toBeDefined();
+
+      const edges = isolatedStore.getEdges({ from: guideDoc!.id, type: 'documents' });
+      expect(edges.length).toBeGreaterThanOrEqual(1);
+      const doStuffFn = isolatedStore.findNodes({ type: 'function', name: 'doStuff' });
+      expect(doStuffFn.length).toBe(1);
+      expect(edges.map((e) => e.to)).toContain(doStuffFn[0]!.id);
+    });
+
+    it('does not duplicate ADRs as document nodes (docs/adr is owned by ingestADRs)', async () => {
+      await fs.mkdir(path.join(tmpDir, 'docs', 'adr'), { recursive: true });
+      await fs.writeFile(
+        path.join(tmpDir, 'docs', 'adr', 'ADR-100.md'),
+        '# ADR-100: Test decision\n\n**Date:** 2026-05-13\n**Status:** Accepted\n'
+      );
+
+      await isolatedIngestor.ingestAll(tmpDir);
+
+      expect(isolatedStore.findNodes({ type: 'adr' })).toHaveLength(1);
+      const docs = isolatedStore.findNodes({ type: 'document' });
+      expect(docs.find((d) => d.path?.includes('ADR-100.md'))).toBeUndefined();
+    });
+
+    it('skips docs/{knowledge,changes,solutions} (owned by other ingestors)', async () => {
+      await fs.mkdir(path.join(tmpDir, 'docs', 'knowledge'), { recursive: true });
+      await fs.mkdir(path.join(tmpDir, 'docs', 'changes'), { recursive: true });
+      await fs.mkdir(path.join(tmpDir, 'docs', 'solutions'), { recursive: true });
+      await fs.writeFile(path.join(tmpDir, 'docs', 'knowledge', 'k.md'), '# k\n');
+      await fs.writeFile(path.join(tmpDir, 'docs', 'changes', 'c.md'), '# c\n');
+      await fs.writeFile(path.join(tmpDir, 'docs', 'solutions', 's.md'), '# s\n');
+      await fs.writeFile(path.join(tmpDir, 'docs', 'visible.md'), '# visible\n');
+
+      await isolatedIngestor.ingestAll(tmpDir);
+
+      const docs = isolatedStore.findNodes({ type: 'document' });
+      expect(docs.find((d) => d.path?.includes('knowledge'))).toBeUndefined();
+      expect(docs.find((d) => d.path?.includes('changes'))).toBeUndefined();
+      expect(docs.find((d) => d.path?.includes('solutions'))).toBeUndefined();
+      expect(docs.find((d) => d.path?.endsWith('visible.md'))).toBeDefined();
+    });
+
+    it('does not ingest .harness/*.md as document nodes', async () => {
+      await fs.mkdir(path.join(tmpDir, '.harness'), { recursive: true });
+      await fs.writeFile(path.join(tmpDir, '.harness', 'notes.md'), '# notes\n');
+
+      await isolatedIngestor.ingestAll(tmpDir);
+
+      const docs = isolatedStore.findNodes({ type: 'document' });
+      expect(docs.find((d) => d.path?.includes('.harness'))).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Closes #302. `KnowledgeIngestor.ingestAll()` now materializes top-level `README.md`/`AGENTS.md` and `docs/**/*.md` (non-ADR) as `document` nodes with `documents` edges to mentioned code, so `detect-doc-drift`'s graph path works on repos without `docs/adr/`.
- Drive-by consolidation: 9 hand-rolled skip-dir lists and 5 hand-rolled glob exclude lists across `@harness-engineering/{graph,core,cli}` now derive from the canonical `DEFAULT_SKIP_DIRS` (and the new `skipDirGlobs()` helper).
- Small chore: `packages/core/vitest.config.mts` `test.include` set explicitly so vitest 4 stops picking up compiled `dist/**/*.test.js` artifacts (pre-existing failure that blocked `test:coverage`).

## Issue context

Reporter (bstevenski) ran `ingest_source({source: 'all'})` on a Python repo with `README.md`, `AGENTS.md`, and `docs/{FORK_POLICY,SECURITY_LEDGER,roadmap,ORACLE_STATE}.md` (no `docs/adr/`). Result: 182 nodes added across `file`/`class`/`method`/`function`/`module`/`commit`/`business_rule` — **zero `document` nodes, zero `documents` edges**. The `detect-doc-drift` SKILL.md explicitly relies on `documents` edges for its graph-enhanced path; that path was a silent no-op on every project without ADRs.

Root cause: `KnowledgeIngestor.ingestAll()` ran only `ingestADRs`, `ingestLearnings`, `ingestFailures`. The `documents` edge type was emitted only by ADRs.

## What changed

### `@harness-engineering/graph`

- New `KnowledgeIngestor.ingestGeneralDocs(projectPath)`. Scans top-level `*.md` (non-recursive) plus `docs/**/*.md` (recursive). Skips subdirs owned by sibling ingestors (`adr`/`knowledge`/`changes`/`solutions`). Emits `document` nodes (id `doc:<rel-path>`) and runs `linkToCode(content, nodeId, 'documents')`. Wired into `ingestAll()`.
- New `skipDirGlobs(skipDirs?)` helper. Converts a skip-dirs set into minimatch glob patterns of the form `**/<name>/**`. Exported from the package barrel.
- Consolidated `KnowledgeIngestor.findMarkdownFiles`, `BusinessKnowledgeIngestor.findMarkdownFiles` (byte-identical twin of the #302 bug), `DiagramParser.findDiagramFiles`, `ExtractionRunner.walkSources` around `DEFAULT_SKIP_DIRS`.

### `@harness-engineering/core`

- `architecture/collectors/{module-size,dep-depth}.ts`, `entropy/detectors/size-budget.ts`, `performance/critical-path.ts` use `DEFAULT_SKIP_DIRS`.
- `security/{types,config}.ts`, `ci/check-orchestrator.ts` (×2), `entropy/snapshot.ts` use `skipDirGlobs()` for their default exclude lists. File-type/fixture filters (e.g. `**/*.test.ts`, `**/fixtures/**`) preserved — different concern. Fixes a latent bug in `entropy/snapshot.ts` where `'node_modules/**'` (no `**/` prefix) only matched the top-level dir.

### `@harness-engineering/cli`

- `commands/migrate.ts:walk`, `commands/install.ts` skill-scan walker, `config/schema.ts:EntropyConfigSchema.excludePatterns` use the canonical sources.
- `tests/commands/install.test.ts`: `child_process` mock now uses `importOriginal()` partial pattern so transitively-loaded code from `@harness-engineering/graph` resolves correctly.

### Vitest config (drive-by)

- `packages/core/vitest.config.mts`: explicit `test.include: ['src/**/*.test.ts', 'tests/**/*.test.ts']`. Pre-existing issue (`dist/pulse/run/report.test.js` reads a non-copied template file) blocked `test:coverage` in pre-push.

## Verification

- 866 graph + 2792 core + 3104 cli tests pass.
- `KnowledgeIngestor.test.ts` gains a new `general docs ingestion (issue #302)` block (5 tests). Revert-and-fail check confirms 3 of the 5 fail without the fix; the other 2 guard against over-ingestion (ADR duplication, owned-subdir leakage).
- End-to-end smoke against a temp fixture (README + AGENTS + `docs/guide.md` + `src/widget.ts`) produces 3 `document` nodes and 5 `documents` edges to both file and function nodes.
- `harness validate` + `harness check-deps` pass.

## Test plan

- [ ] `pnpm -w build` succeeds
- [ ] `pnpm -w test:ci` passes on CI
- [ ] On a Python project without `docs/adr/`, `mcp__harness__ingest_source({source: 'all'})` produces nonzero `document` nodes and at least one `documents` edge to a code symbol
- [ ] `detect-doc-drift` skill's graph-enhanced path now traverses `documents` edges instead of silently falling back to file-based scanning