### PR TITLE
fix(cli/update): self-upgrade no-op when `npm list -g` doesn't see the install (closes #317)

### DIFF
--- a/.changeset/issue-317-update-self-upgrade.md
+++ b/.changeset/issue-317-update-self-upgrade.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli/update): detect outdated CLI even when `npm list -g` does not see it (closes #317)
+
+`harness update` was reporting "All packages are up to date" while a separate
+banner inside the same transcript advertised "Update available: vX -> vY", and
+never actually performed the self-upgrade. Repeated runs were a no-op.
+
+Root cause: the foreground check in `runUpdateAction` discovered installed
+packages by parsing `npm list -g --json`. When harness was installed via
+Homebrew, bun, asdf, or under a different nvm prefix than the shell's current
+`npm`, `npm list -g` returned no `@harness-engineering/*` entries. `packages`
+came out empty, `checkAllPackages` had nothing to compare, and the code fell
+straight into the "up to date" exit path — printing the success line, refreshing
+hooks, and shelling out to a child `harness generate`. That child process is
+where the contradictory "Update available" banner came from: its own
+`printUpdateNotification` reads the cached state populated by the background
+`npm view` check (which doesn't depend on `npm list` and so works correctly),
+and its stderr inherits to the parent terminal.
+
+Fix: trust `CLI_VERSION` (loaded from the running CLI's `package.json`) as the
+authoritative current version for `@harness-engineering/cli`, exactly as the
+background check already does. `getInstalledPackages` always includes the CLI;
+`getInstalledVersions` falls back to `CLI_VERSION` when `npm list -g` doesn't
+report it; `getInstalledVersion` does the same. The foreground check now
+correctly identifies the outdated CLI and reaches the install path on the
+user's first `harness update` invocation.

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -10,8 +10,11 @@ import { ExitCode } from '../utils/errors';
 import { initHooks } from './hooks/init';
 import type { HookProfile } from '../hooks/profiles';
 import { ensureTelemetryConfigured } from './telemetry-wizard';
+import { CLI_VERSION } from '../version';
 
 type PackageManager = 'npm' | 'pnpm' | 'yarn';
+
+const CLI_PACKAGE = '@harness-engineering/cli';
 
 export function detectPackageManager(): PackageManager {
   try {
@@ -56,15 +59,15 @@ export async function getLatestVersionAsync(pkg: string): Promise<string> {
 
 export function getInstalledVersion(pm: PackageManager): string | null {
   try {
-    const output = execFileSync(pm, ['list', '-g', '@harness-engineering/cli', '--json'], {
+    const output = execFileSync(pm, ['list', '-g', CLI_PACKAGE, '--json'], {
       encoding: 'utf-8',
       timeout: 15000,
     });
     const data = JSON.parse(output);
     const deps = data.dependencies ?? {};
-    return deps['@harness-engineering/cli']?.version ?? null;
+    return deps[CLI_PACKAGE]?.version ?? CLI_VERSION;
   } catch {
-    return null;
+    return CLI_VERSION;
   }
 }
 
@@ -88,6 +91,14 @@ export function getInstalledVersions(
       versions[pkg] = null;
     }
   }
+  // The running CLI is, by definition, installed. When `npm list -g` doesn't
+  // see it (Homebrew / bun / asdf install, or a multi-prefix nvm setup), the
+  // running package.json's CLI_VERSION is the authoritative current version.
+  // Without this fallback, the foreground update check produces a false
+  // "All packages are up to date" — see issue #317.
+  if (packages.includes(CLI_PACKAGE) && versions[CLI_PACKAGE] === null) {
+    versions[CLI_PACKAGE] = CLI_VERSION;
+  }
   return versions;
 }
 
@@ -102,10 +113,16 @@ export function getInstalledPackages(pm: PackageManager): string[] {
     // npm: { dependencies: { "pkg": {...} } }
     // pnpm: { dependencies: { "pkg": {...} } } (similar structure)
     const deps = data.dependencies ?? {};
-    return Object.keys(deps).filter((name) => name.startsWith('@harness-engineering/'));
+    const found = Object.keys(deps).filter((name) => name.startsWith('@harness-engineering/'));
+    // The CLI we are running is always installed, even if `npm list -g` was
+    // run against a different prefix and didn't see it (issue #317).
+    if (!found.includes(CLI_PACKAGE)) {
+      found.unshift(CLI_PACKAGE);
+    }
+    return found;
   } catch {
     // Fallback: assume the core packages are installed
-    return ['@harness-engineering/cli', '@harness-engineering/core'];
+    return [CLI_PACKAGE, '@harness-engineering/core'];
   }
 }
 

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -9,6 +9,7 @@ import {
   getLatestVersionAsync,
   createUpdateCommand,
 } from '../../src/commands/update';
+import { CLI_VERSION } from '../../src/version';
 
 // Mock node:child_process partially
 vi.mock('node:child_process', async (importOriginal) => {
@@ -160,16 +161,19 @@ describe('update command', () => {
       expect(getInstalledVersion('npm')).toBe('1.2.2');
     });
 
-    it('returns null when CLI is not in output', () => {
+    it('falls back to CLI_VERSION when npm list does not include the CLI (#317)', () => {
+      // Reproduces issue #317: harness installed via Homebrew/bun/asdf or
+      // under a different nvm prefix — `npm list -g` returns no harness deps,
+      // but the CLI is actually running at CLI_VERSION.
       mockedExecFileSync.mockReturnValue(JSON.stringify({ dependencies: {} }));
-      expect(getInstalledVersion('npm')).toBeNull();
+      expect(getInstalledVersion('npm')).toBe(CLI_VERSION);
     });
 
-    it('returns null when execFileSync throws', () => {
+    it('falls back to CLI_VERSION when execFileSync throws (#317)', () => {
       mockedExecFileSync.mockImplementation(() => {
         throw new Error('command failed');
       });
-      expect(getInstalledVersion('npm')).toBeNull();
+      expect(getInstalledVersion('npm')).toBe(CLI_VERSION);
     });
   });
 
@@ -209,7 +213,7 @@ describe('update command', () => {
       expect(versions['@harness-engineering/core']).toBeNull();
     });
 
-    it('returns all nulls when execFileSync throws', () => {
+    it('returns CLI_VERSION for cli and null for other pkgs when execFileSync throws (#317)', () => {
       mockedExecFileSync.mockImplementation(() => {
         throw new Error('command failed');
       });
@@ -217,8 +221,25 @@ describe('update command', () => {
         '@harness-engineering/cli',
         '@harness-engineering/core',
       ]);
-      expect(versions['@harness-engineering/cli']).toBeNull();
+      // CLI is always present (we are running it), so the fallback uses
+      // CLI_VERSION rather than null.
+      expect(versions['@harness-engineering/cli']).toBe(CLI_VERSION);
       expect(versions['@harness-engineering/core']).toBeNull();
+    });
+
+    it('falls back to CLI_VERSION when npm list -g returns no harness packages (#317)', () => {
+      // Reproduces issue #317: `npm list -g --json` returns only npm/corepack
+      // because harness was installed against a different prefix.
+      mockedExecFileSync.mockReturnValue(
+        JSON.stringify({
+          dependencies: {
+            corepack: { version: '0.34.6' },
+            npm: { version: '11.12.1' },
+          },
+        })
+      );
+      const versions = getInstalledVersions('npm', ['@harness-engineering/cli']);
+      expect(versions['@harness-engineering/cli']).toBe(CLI_VERSION);
     });
   });
 
@@ -243,7 +264,9 @@ describe('update command', () => {
       expect(packages).not.toContain('typescript');
     });
 
-    it('returns empty array when no harness packages are installed', () => {
+    it('always includes the running CLI even when npm list -g does not (#317)', () => {
+      // Reproduces issue #317: harness installed via Homebrew / bun / asdf
+      // or a different nvm prefix — `npm list -g` doesn't see it.
       mockedExecFileSync.mockReturnValue(
         JSON.stringify({
           dependencies: {
@@ -251,12 +274,14 @@ describe('update command', () => {
           },
         })
       );
-      expect(getInstalledPackages('npm')).toEqual([]);
+      const packages = getInstalledPackages('npm');
+      expect(packages).toContain('@harness-engineering/cli');
+      expect(packages).not.toContain('typescript');
     });
 
-    it('handles missing dependencies key', () => {
+    it('handles missing dependencies key and still includes the CLI (#317)', () => {
       mockedExecFileSync.mockReturnValue(JSON.stringify({}));
-      expect(getInstalledPackages('npm')).toEqual([]);
+      expect(getInstalledPackages('npm')).toEqual(['@harness-engineering/cli']);
     });
 
     it('falls back to default packages when execFileSync throws', () => {
@@ -526,6 +551,58 @@ describe('update command', () => {
       const args = installCall![1] as string[];
       expect(args.some((a) => a === '@harness-engineering/cli@1.5.0')).toBe(true);
       expect(args.some((a) => a === '@harness-engineering/core@latest')).toBe(true);
+    });
+
+    it('detects outdated CLI even when npm list -g does not include it (#317)', async () => {
+      // Reproduces issue #317. Before the fix: `getInstalledPackages` returns
+      // an empty array because `npm list -g` doesn't see the Homebrew/bun/
+      // multi-prefix-nvm install, `checkAllPackages` has nothing to compare,
+      // and the user is told "All packages are up to date" even though the
+      // registry has a newer version.
+
+      // getInstalledPackages: `npm list -g --json` lists only npm + corepack
+      mockedExecFileSync.mockReturnValueOnce(
+        JSON.stringify({
+          dependencies: {
+            corepack: { version: '0.34.6' },
+            npm: { version: '11.12.1' },
+          },
+        })
+      );
+      // getInstalledVersions: same shape — cli not present in npm list output
+      mockedExecFileSync.mockReturnValueOnce(
+        JSON.stringify({
+          dependencies: {
+            corepack: { version: '0.34.6' },
+            npm: { version: '11.12.1' },
+          },
+        })
+      );
+      // install -g succeeds
+      mockedExecFileSync.mockReturnValueOnce(undefined as any);
+
+      // npm view reports a version newer than CLI_VERSION
+      const newerVersion = `${parseInt(CLI_VERSION.split('.')[0]!, 10) + 1}.0.0`;
+      mockedExecFile.mockImplementation(((
+        _cmd: unknown,
+        _args: unknown,
+        _opts: unknown,
+        cb?: Function
+      ) => {
+        if (cb) cb(null, { stdout: `${newerVersion}\n`, stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      }) as typeof execFile);
+
+      const program = createProgram();
+      await expect(program.parseAsync(['node', 'test', 'update'])).rejects.toThrow('process.exit');
+
+      // The fix means we reach the install path instead of the false
+      // "up to date" branch.
+      const installCall = mockedExecFileSync.mock.calls.find(
+        (c) => c[1] && Array.isArray(c[1]) && c[1].includes('install')
+      );
+      expect(installCall).toBeDefined();
+      expect(mockExit).toHaveBeenCalledWith(0);
     });
 
     it('uses verbose mode to log extra info', async () => {


### PR DESCRIPTION
## Summary

- Closes #317. `harness update` was reporting "All packages are up to date" while the same transcript also printed "Update available: vX -> vY", and never actually performed the self-upgrade — repeated runs were a no-op.
- Root cause: the foreground check in `runUpdateAction` discovered installed packages by parsing `npm list -g --json`. When harness was installed under a different npm prefix than the shell's current `npm` (Homebrew, bun, asdf, multi-prefix nvm), that listed no `@harness-engineering/*` entries, `checkAllPackages` had nothing to compare, and the code fell straight to the "up to date" exit branch. The "Update available" banner in the transcript came from the child `harness generate` that `offerRegeneration()` spawns with `stdio: 'inherit'` — the child reads the cached background-check state (which uses `npm view`, independent of `npm list`) and inherits its stderr to the parent terminal.
- Fix: trust `CLI_VERSION` (loaded from the running CLI's `package.json`) as the authoritative current version for `@harness-engineering/cli`, exactly as the background check already does. `getInstalledPackages` always includes the CLI; `getInstalledVersions` / `getInstalledVersion` fall back to `CLI_VERSION` when `npm list -g` doesn't see it.

## Scope note

When the running install lives under a different prefix than PATH's `npm`, this PR correctly *detects* the outdated CLI, but the subsequent `npm install -g` still runs against PATH's `npm` and could install a parallel copy under a different prefix. Tightening `detectPackageManager` (or printing the correct upgrade command per install method — Homebrew/bun/asdf) is a separate cleanup, out of scope here. The user-visible bug — false "up to date" + perpetual "Update available" banner — is fixed for all install methods.

## Test plan

- [x] `pnpm --filter @harness-engineering/cli test tests/commands/update.test.ts` — 37 pass (4 new unit + 1 new end-to-end regression test for #317; 2 existing tests updated for the new fallback semantics).
- [x] Revert-and-fail verified: with the source fix stashed, 7 tests fail (the new regressions + the three updated-behavior tests). Restoring the fix returns to 37 pass.
- [x] `pnpm --filter @harness-engineering/cli typecheck` — clean.
- [x] `pnpm --filter @harness-engineering/cli lint` — clean.
- [ ] Manual smoke: run `harness update` from a Homebrew install on stale CLI and confirm it now reaches the `npm install -g` path instead of the "All packages are up to date" branch.