### PR TITLE
feat(compliance): branch naming convention + harness verify (closes #319)

### DIFF
--- a/.changeset/issue-319-branch-naming-convention.md
+++ b/.changeset/issue-319-branch-naming-convention.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/cli': minor
+'@harness-engineering/core': minor
+---
+
+feat(compliance): branch naming convention and `harness verify` command (closes #319)
+
+Adds a project-wide branch naming convention with optional `harness.config.json`
+override under `compliance.branching`, and a `harness verify` command that
+checks the current branch against the convention.
+
+- **Core:** New `validateBranchName` export from `@harness-engineering/core`
+  with `BranchingConfig` type. Enforces prefix list, strict kebab-case slugs
+  (no leading/trailing or doubled hyphens), optional ticket-ID pattern
+  (`feat/PROJ-123-desc`), slug length cap, and ignore globs for long-lived
+  branches.
+- **CLI:** New `harness verify` command. Works without a `harness.config.json`
+  by falling back to schema defaults. Supports `--branch <name>` and reads
+  `HARNESS_BRANCH` / `GITHUB_HEAD_REF` / `CI_COMMIT_REF_NAME` /
+  `BUILDKITE_BRANCH` so CI runners in detached-HEAD state can still verify
+  the PR source branch. `--json` emits a machine-readable result.
+- **Config:** Adds `compliance.branching` to `HarnessConfigSchema` with
+  fields `prefixes`, `enforceKebabCase`, `customRegex`, `ignore`, and
+  `maxLength` (default 60; set to 0 to disable). Defaults declared in the
+  schema are the single source of truth.
+
+Defaults: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`; ignore
+`main`, `release/**`, `dependabot/**`, `harness/**`. `customRegex` is a full
+override -- when set, the prefix, kebab-case, and length checks are bypassed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,14 @@ harness-engineering/
 1. **Create a branch:**
 
    ```bash
-   git checkout -b feature/your-feature-name
+   git checkout -b feat/your-feature-name
    ```
+
+   **Branch Naming Convention:**
+   - Use prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/`.
+   - Use `kebab-case` for the description.
+   - Optional ticket ID: `feat/PROJ-123-description`.
+   - Verify compliance: `harness verify`.
 
 2. **Make your changes**
 

--- a/agents/skills/claude-code/harness-compliance/SKILL.md
+++ b/agents/skills/claude-code/harness-compliance/SKILL.md
@@ -125,10 +125,20 @@
 
 ### Phase 3.5: INTERNAL COMPLIANCE -- Project Conventions
 
-1. **Verify branch naming convention.** Check the current branch name against project rules:
-   - Allowed prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/`
-   - Format: `prefix/kebab-case-description` or `prefix/PROJ-123-description`
-   - Command: `harness verify`
+1. **Verify branch naming convention.** Before creating a branch and again before
+   opening a PR, run `harness verify` (or `harness verify --json` for parsable
+   output) and act on the result -- do not just describe the rule to the user.
+   - Default prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/`
+   - Default slug format: strict `kebab-case` (lowercase, single hyphens, no
+     leading/trailing hyphen), max 60 chars after the prefix
+   - Optional ticket form: `prefix/PROJ-123-short-desc`
+   - Projects may override via `compliance.branching` in `harness.config.json`
+     (`prefixes`, `enforceKebabCase`, `customRegex`, `ignore`, `maxLength`). If
+     `customRegex` is set, it fully replaces the prefix/kebab/length checks --
+     read the project config before suggesting a branch name.
+   - On a non-compliant branch, surface the suggested fix from `harness verify`
+     to the user and offer to rename (`git branch -m <new-name>`) before
+     continuing. Do not push or open a PR from a non-compliant branch.
 
 ---
 

--- a/agents/skills/claude-code/harness-compliance/SKILL.md
+++ b/agents/skills/claude-code/harness-compliance/SKILL.md
@@ -123,6 +123,15 @@
 
 ---
 
+### Phase 3.5: INTERNAL COMPLIANCE -- Project Conventions
+
+1. **Verify branch naming convention.** Check the current branch name against project rules:
+   - Allowed prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/`
+   - Format: `prefix/kebab-case-description` or `prefix/PROJ-123-description`
+   - Command: `harness verify`
+
+---
+
 ### Phase 4: REPORT -- Generate Gap Analysis and Remediation Plan
 
 1. **Score compliance posture per framework.** For each applicable framework:

--- a/docs/changes/branch-naming-convention/proposal.md
+++ b/docs/changes/branch-naming-convention/proposal.md
@@ -16,13 +16,16 @@ Implement a project-wide branch naming convention and a verification mechanism t
 
 ## Decisions
 
-| Decision                 | Rationale                                                                                 |
-| ------------------------ | ----------------------------------------------------------------------------------------- |
-| Standard Prefixes        | `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/` cover 99% of use cases. |
-| Forward Slash Separator  | Standard convention for grouping branches in git clients.                                 |
-| `kebab-case` Slugs       | Improves readability and matches URL-safe patterns.                                       |
-| Optional Ticket IDs      | Support for `prefix/PROJ-123-short-desc` allows integration with issue trackers.          |
-| `harness verify` Command | Provides immediate feedback to developers without requiring a full validation pass.       |
+| Decision                     | Rationale                                                                                                                                                  |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Standard Prefixes            | `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/` cover 99% of use cases.                                                                  |
+| Forward Slash Separator      | Standard convention for grouping branches in git clients.                                                                                                  |
+| Strict `kebab-case` Slugs    | Lowercase alphanumerics joined by single hyphens. No leading/trailing hyphens, no `--` runs. URL-safe and unambiguous.                                     |
+| Slug Length Cap              | Default `maxLength: 60` characters (after the prefix). Set to `0` in config to disable. Keeps names under FS / CI label caps.                              |
+| Optional Ticket IDs          | Support for `prefix/PROJ-123-short-desc` allows integration with issue trackers.                                                                           |
+| `customRegex` Is an Override | When set, fully replaces prefix/kebab/length checks. Only the ignore list and this regex run. For orgs whose convention doesn't fit the prefix/slug model. |
+| `harness verify` Command     | Provides immediate feedback without requiring a full validation pass. Works with or without a `harness.config.json`.                                       |
+| CI-aware Branch Resolution   | Reads `--branch`, then `HARNESS_BRANCH` / `GITHUB_HEAD_REF` / `CI_COMMIT_REF_NAME` / `BUILDKITE_BRANCH`, then `git rev-parse`.                             |
 
 ## Technical Design
 
@@ -37,14 +40,17 @@ A new `validateBranchName` function is added to `@harness-engineering/core`. It 
 
 ### Configuration Schema
 
-The `HarnessConfigSchema` is extended with a `compliance.branching` section:
+The `HarnessConfigSchema` is extended with a `compliance.branching` section.
+Defaults declared in `BranchingConfigSchema` are the single source of truth --
+the CLI does not re-declare fallback values.
 
 ```typescript
 branching: {
-  prefixes: string[]; // default: ['feat', 'fix', 'chore', ...]
-  enforceKebabCase: boolean; // default: true
-  customRegex?: string;
-  ignore: string[]; // default: ['main', 'release/**', ...]
+  prefixes: string[];          // default: ['feat','fix','chore','docs','refactor','test','perf']
+  enforceKebabCase: boolean;   // default: true
+  customRegex?: string;        // when set, fully replaces prefix/kebab/length checks
+  ignore: string[];            // default: ['main','release/**','dependabot/**','harness/**']
+  maxLength: number;           // default: 60 (0 disables)
 }
 ```
 
@@ -52,9 +58,14 @@ branching: {
 
 A new `harness verify` command is implemented in `packages/cli`. It:
 
-1.  Determines the current branch name using `git rev-parse --abbrev-ref HEAD`.
-2.  Resolves configuration (using defaults if none provided).
-3.  Runs validation and outputs success or error messages with suggestions.
+1.  Resolves the branch name from (in order) `--branch`, `HARNESS_BRANCH`,
+    `GITHUB_HEAD_REF`, `CI_COMMIT_REF_NAME`, `BUILDKITE_BRANCH`, then
+    `git rev-parse --abbrev-ref HEAD`. The env-var fallbacks handle CI runners
+    that build PRs in detached-HEAD state where `git rev-parse` returns `HEAD`.
+2.  Resolves configuration if `harness.config.json` exists; otherwise uses
+    schema defaults so the command works on un-onboarded repos.
+3.  Runs validation. Prints a human-readable message + suggestion, or a
+    machine-readable JSON payload when `--json` is passed.
 
 ## Integration Points
 

--- a/docs/changes/branch-naming-convention/proposal.md
+++ b/docs/changes/branch-naming-convention/proposal.md
@@ -1,0 +1,85 @@
+# Branch Naming Convention and Compliance Verification
+
+**Status:** Proposed
+**Keywords:** branching, convention, compliance, verification, git
+
+## Overview
+
+Implement a project-wide branch naming convention and a verification mechanism to ensure consistency and facilitate automation. This includes standardizing on `feat/`, `fix/`, etc., prefixes, enforcing `kebab-case` for branch slugs, and providing a `harness verify` command to check compliance.
+
+## Goals
+
+- Standardize branch names to eliminate drift (e.g., `feature/` vs `feat/`).
+- Enable automation for PR titling, changelogs, and release notes.
+- Reduce contributor friction with clear guidelines and automated feedback.
+- Support project-level overrides for prefixes and ignore lists via `harness.config.json`.
+
+## Decisions
+
+| Decision                 | Rationale                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| Standard Prefixes        | `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/` cover 99% of use cases. |
+| Forward Slash Separator  | Standard convention for grouping branches in git clients.                                 |
+| `kebab-case` Slugs       | Improves readability and matches URL-safe patterns.                                       |
+| Optional Ticket IDs      | Support for `prefix/PROJ-123-short-desc` allows integration with issue trackers.          |
+| `harness verify` Command | Provides immediate feedback to developers without requiring a full validation pass.       |
+
+## Technical Design
+
+### Core Validation Logic
+
+A new `validateBranchName` function is added to `@harness-engineering/core`. It checks:
+
+1.  **Ignore List:** Matches against glob patterns like `main`, `release/**`, `dependabot/**`.
+2.  **Custom Regex:** Optional project-specific naming rule.
+3.  **Prefixes:** Must start with an allowed prefix followed by a slash.
+4.  **Slug Format:** Enforces `kebab-case` while allowing uppercase ticket IDs at the start of segments.
+
+### Configuration Schema
+
+The `HarnessConfigSchema` is extended with a `compliance.branching` section:
+
+```typescript
+branching: {
+  prefixes: string[]; // default: ['feat', 'fix', 'chore', ...]
+  enforceKebabCase: boolean; // default: true
+  customRegex?: string;
+  ignore: string[]; // default: ['main', 'release/**', ...]
+}
+```
+
+### CLI Command
+
+A new `harness verify` command is implemented in `packages/cli`. It:
+
+1.  Determines the current branch name using `git rev-parse --abbrev-ref HEAD`.
+2.  Resolves configuration (using defaults if none provided).
+3.  Runs validation and outputs success or error messages with suggestions.
+
+## Integration Points
+
+### Entry Points
+
+- `harness verify` command.
+- `validateBranchName` exported from `@harness-engineering/core`.
+
+### Documentation Updates
+
+- `CONTRIBUTING.md` updated with branch creation guidelines.
+- `harness-compliance` skill updated to include branch convention checks.
+
+## Success Criteria
+
+1.  `harness verify` correctly identifies compliant and non-compliant branches.
+2.  Branch names like `feat/new-feature` and `fix/PROJ-123-bug` pass validation.
+3.  Branch names like `feature/wrong-prefix` or `feat/Invalid_Case` fail validation.
+4.  Ignored branches like `main` and `release/v1.0.0` pass validation.
+5.  All unit tests for the validation logic pass.
+
+## Implementation Order
+
+1.  **Implement `validateBranchName`** in `@harness-engineering/core`. (COMPLETED)
+2.  **Update Config Schema** in `packages/cli`. (COMPLETED)
+3.  **Implement `harness verify`** in `packages/cli`. (COMPLETED)
+4.  **Update Documentation** (`CONTRIBUTING.md`, `SKILL.md`). (COMPLETED)
+5.  **Add Unit Tests** for validation logic. (COMPLETED)

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -438,6 +438,15 @@ Run all validation checks
 - `--strict` — Treat warnings as errors (applies to --agent-configs)
 - `--agnix-bin` — Override the agnix binary path discovered on PATH
 
+### `harness verify`
+
+Verify project conventions (currently: branch naming). Works with or without a harness.config.json.
+
+**Options:**
+
+- `--branch` — Branch name to verify (defaults to HARNESS_BRANCH/GITHUB_HEAD_REF/current branch)
+- `--json` — Emit machine-readable JSON output
+
 ## Adoption Commands
 
 View skill adoption telemetry

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1121,6 +1121,14 @@ last_manual_edit: 2026-05-09T21:07:20.759Z
 - **Blockers:** —
 - **Plan:** —
 
+### Branch Naming Convention and Compliance Verification
+
+- **Status:** done
+- **Spec:** docs/changes/branch-naming-convention/proposal.md
+- **Summary:** Standardize branch naming prefixes (feat/, fix/, etc.) and kebab-case slugs. Implement harness verify command and @harness-engineering/core validation logic.
+- **Blockers:** —
+- **Plan:** —
+
 ## v3.0 Graph Intelligence
 
 ### Graph Anomaly Detection

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -65,6 +65,7 @@ import { createUninstallConstraintsCommand } from './uninstall-constraints';
 import { createUpdateCommand } from './update';
 import { createUsageCommand } from './usage';
 import { createValidateCommand } from './validate';
+import { createVerifyCommand } from './verify';
 
 /**
  * All discovered command creators, sorted alphabetically.
@@ -134,4 +135,5 @@ export const commandCreators: Array<() => Command> = [
   createUpdateCommand,
   createUsageCommand,
   createValidateCommand,
+  createVerifyCommand,
 ];

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,77 +1,131 @@
 import { Command } from 'commander';
 import { execSync } from 'child_process';
 import { validateBranchName, type BranchingConfig } from '@harness-engineering/core';
-import { resolveConfig } from '../config/loader';
+import { resolveConfig, findConfigFile } from '../config/loader';
+import { BranchingConfigSchema } from '../config/schema';
 import { logger } from '../output/logger';
 import { ExitCode } from '../utils/errors';
 
 interface VerifyOptions {
   configPath?: string;
+  branch?: string;
+  json?: boolean;
 }
 
-export async function runVerify(options: VerifyOptions): Promise<void> {
-  // Load config
-  const configResult = resolveConfig(options.configPath);
-  if (!configResult.ok) {
-    logger.error(configResult.error.message);
-    process.exit(configResult.error.exitCode);
+interface VerifyJsonOutput {
+  valid: boolean;
+  branchName: string;
+  message?: string;
+  suggestion?: string;
+}
+
+/**
+ * Resolve the branching config, defaulting to schema defaults when no
+ * `harness.config.json` is present. Verification of conventions should not
+ * require project onboarding.
+ */
+function loadBranchingConfig(configPath: string | undefined): BranchingConfig {
+  // Only attempt to load a config if the user explicitly pointed at one,
+  // or one is discoverable from cwd. Otherwise fall back to schema defaults
+  // so `harness verify` works on greenfield/external repos.
+  const shouldLoad = configPath !== undefined || findConfigFile().ok;
+  if (!shouldLoad) {
+    return BranchingConfigSchema.parse({});
   }
-  const config = configResult.value;
 
-  const branchingConfig: BranchingConfig = {
-    prefixes: config.compliance?.branching?.prefixes ?? [
-      'feat',
-      'fix',
-      'chore',
-      'docs',
-      'refactor',
-      'test',
-      'perf',
-    ],
-    enforceKebabCase: config.compliance?.branching?.enforceKebabCase ?? true,
-    customRegex: config.compliance?.branching?.customRegex,
-    ignore: config.compliance?.branching?.ignore ?? [
-      'main',
-      'release/**',
-      'dependabot/**',
-      'harness/**',
-    ],
-  };
+  const result = resolveConfig(configPath);
+  if (!result.ok) {
+    // Explicit config path failed -- surface the error.
+    logger.error(result.error.message);
+    process.exit(result.error.exitCode);
+  }
+  const cfg = result.value.compliance?.branching;
+  return cfg ?? BranchingConfigSchema.parse({});
+}
 
-  // Get current branch name
-  let branchName: string;
+/**
+ * Determine the branch name to verify. CI runners typically run in detached
+ * HEAD on PR builds, so `git rev-parse --abbrev-ref HEAD` returns the literal
+ * "HEAD". Honour explicit overrides and common CI env vars first.
+ */
+function resolveBranchName(explicit: string | undefined): string | null {
+  if (explicit && explicit.length > 0) return explicit;
+
+  const envBranch =
+    process.env.HARNESS_BRANCH ||
+    process.env.GITHUB_HEAD_REF ||
+    process.env.CI_COMMIT_REF_NAME ||
+    process.env.BUILDKITE_BRANCH;
+  if (envBranch && envBranch.length > 0) return envBranch;
+
   try {
-    branchName = execSync('git rev-parse --abbrev-ref HEAD', {
+    const out = execSync('git rev-parse --abbrev-ref HEAD', {
       stdio: ['ignore', 'pipe', 'ignore'],
     })
       .toString()
       .trim();
+    if (out && out !== 'HEAD') return out;
   } catch {
-    logger.error('Failed to determine current branch name. Are you in a git repository?');
+    return null;
+  }
+  return null;
+}
+
+export async function runVerify(options: VerifyOptions): Promise<void> {
+  const branchingConfig = loadBranchingConfig(options.configPath);
+
+  const branchName = resolveBranchName(options.branch);
+  if (!branchName) {
+    const msg =
+      'Could not determine the current branch name. Pass --branch <name>, set HARNESS_BRANCH/GITHUB_HEAD_REF, or run inside a git checkout.';
+    if (options.json) {
+      console.log(JSON.stringify({ valid: false, branchName: '', message: msg }));
+    } else {
+      logger.error(msg);
+    }
     process.exit(ExitCode.ERROR);
   }
 
   const result = validateBranchName(branchName, branchingConfig);
 
+  if (options.json) {
+    const payload: VerifyJsonOutput = {
+      valid: result.valid,
+      branchName: result.branchName,
+      ...(result.message !== undefined && { message: result.message }),
+      ...(result.suggestion !== undefined && { suggestion: result.suggestion }),
+    };
+    console.log(JSON.stringify(payload));
+    process.exit(result.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
+  }
+
   if (result.valid) {
     logger.success(`Branch name "${branchName}" is compliant.`);
     process.exit(ExitCode.SUCCESS);
-  } else {
-    logger.error(result.message || `Branch name "${branchName}" is not compliant.`);
-    if (result.suggestion) {
-      logger.info(`Suggestion: ${result.suggestion}`);
-    }
-    process.exit(ExitCode.VALIDATION_FAILED);
   }
+  logger.error(result.message || `Branch name "${branchName}" is not compliant.`);
+  if (result.suggestion) {
+    logger.info(`Suggestion: ${result.suggestion}`);
+  }
+  process.exit(ExitCode.VALIDATION_FAILED);
 }
 
 export function createVerifyCommand(): Command {
   return new Command('verify')
-    .description('Verify project conventions (e.g., branch naming)')
+    .description(
+      'Verify project conventions (currently: branch naming). Works with or without a harness.config.json.'
+    )
+    .option(
+      '--branch <name>',
+      'Branch name to verify (defaults to HARNESS_BRANCH/GITHUB_HEAD_REF/current branch)'
+    )
+    .option('--json', 'Emit machine-readable JSON output')
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       await runVerify({
-        configPath: globalOpts.config,
+        ...(typeof globalOpts.config === 'string' && { configPath: globalOpts.config }),
+        ...(typeof opts.branch === 'string' && { branch: opts.branch }),
+        json: opts.json === true || globalOpts.json === true,
       });
     });
 }

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,0 +1,77 @@
+import { Command } from 'commander';
+import { execSync } from 'child_process';
+import { validateBranchName, type BranchingConfig } from '@harness-engineering/core';
+import { resolveConfig } from '../config/loader';
+import { logger } from '../output/logger';
+import { ExitCode } from '../utils/errors';
+
+interface VerifyOptions {
+  configPath?: string;
+}
+
+export async function runVerify(options: VerifyOptions): Promise<void> {
+  // Load config
+  const configResult = resolveConfig(options.configPath);
+  if (!configResult.ok) {
+    logger.error(configResult.error.message);
+    process.exit(configResult.error.exitCode);
+  }
+  const config = configResult.value;
+
+  const branchingConfig: BranchingConfig = {
+    prefixes: config.compliance?.branching?.prefixes ?? [
+      'feat',
+      'fix',
+      'chore',
+      'docs',
+      'refactor',
+      'test',
+      'perf',
+    ],
+    enforceKebabCase: config.compliance?.branching?.enforceKebabCase ?? true,
+    customRegex: config.compliance?.branching?.customRegex,
+    ignore: config.compliance?.branching?.ignore ?? [
+      'main',
+      'release/**',
+      'dependabot/**',
+      'harness/**',
+    ],
+  };
+
+  // Get current branch name
+  let branchName: string;
+  try {
+    branchName = execSync('git rev-parse --abbrev-ref HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    logger.error('Failed to determine current branch name. Are you in a git repository?');
+    process.exit(ExitCode.ERROR);
+  }
+
+  const result = validateBranchName(branchName, branchingConfig);
+
+  if (result.valid) {
+    logger.success(`Branch name "${branchName}" is compliant.`);
+    process.exit(ExitCode.SUCCESS);
+  } else {
+    logger.error(result.message || `Branch name "${branchName}" is not compliant.`);
+    if (result.suggestion) {
+      logger.info(`Suggestion: ${result.suggestion}`);
+    }
+    process.exit(ExitCode.VALIDATION_FAILED);
+  }
+}
+
+export function createVerifyCommand(): Command {
+  return new Command('verify')
+    .description('Verify project conventions (e.g., branch naming)')
+    .action(async (opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      await runVerify({
+        configPath: globalOpts.config,
+      });
+    });
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -336,6 +336,9 @@ export const KnowledgeConfigSchema = z.object({
 
 /**
  * Schema for branch naming convention configuration.
+ *
+ * Defaults declared here are the single source of truth -- consumers should call
+ * `BranchingConfigSchema.parse({})` rather than re-declaring fallback values.
  */
 export const BranchingConfigSchema = z.object({
   /** Allowed branch name prefixes */
@@ -344,10 +347,16 @@ export const BranchingConfigSchema = z.object({
     .default(['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'perf']),
   /** Whether to enforce kebab-case for the branch slug */
   enforceKebabCase: z.boolean().default(true),
-  /** Optional regex for custom branch naming rules */
+  /**
+   * Optional regex that fully replaces the default prefix and kebab-case checks.
+   * When set, only the ignore list and this regex are evaluated; `prefixes`,
+   * `enforceKebabCase`, and `maxLength` are bypassed.
+   */
   customRegex: z.string().optional(),
   /** List of ignored branch names (exact match or glob) */
   ignore: z.array(z.string()).default(['main', 'release/**', 'dependabot/**', 'harness/**']),
+  /** Maximum slug length (characters after the first `/`). Set to 0 to disable. */
+  maxLength: z.number().int().nonnegative().default(60),
 });
 
 /**

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -334,6 +334,30 @@ export const KnowledgeConfigSchema = z.object({
   domainBlocklist: z.array(z.string().min(1)).optional().default([]),
 });
 
+/**
+ * Schema for branch naming convention configuration.
+ */
+export const BranchingConfigSchema = z.object({
+  /** Allowed branch name prefixes */
+  prefixes: z
+    .array(z.string())
+    .default(['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'perf']),
+  /** Whether to enforce kebab-case for the branch slug */
+  enforceKebabCase: z.boolean().default(true),
+  /** Optional regex for custom branch naming rules */
+  customRegex: z.string().optional(),
+  /** List of ignored branch names (exact match or glob) */
+  ignore: z.array(z.string()).default(['main', 'release/**', 'dependabot/**', 'harness/**']),
+});
+
+/**
+ * Schema for compliance-specific configuration.
+ */
+export const ComplianceConfigSchema = z.object({
+  /** Branch naming convention settings */
+  branching: BranchingConfigSchema.default({}),
+});
+
 export const HarnessConfigSchema = z.object({
   /** Configuration schema version */
   version: z.literal(1),
@@ -434,6 +458,8 @@ export const HarnessConfigSchema = z.object({
       enabled: z.boolean().default(true),
     })
     .optional(),
+  /** Compliance and convention enforcement settings */
+  compliance: ComplianceConfigSchema.optional(),
   /** Central telemetry collection settings */
   telemetry: z
     .object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,12 @@ export { WHATWG_BAD_PORTS, isBadPort, assertPortUsable } from './shared/port';
 export * from './validation';
 
 /**
+ * Branch name validation.
+ */
+export { validateBranchName } from './validation/branch';
+export type { BranchingConfig, BranchValidationResult } from './validation/branch';
+
+/**
  * Context module for managing AI agent context and knowledge maps.
  */
 export * from './context';

--- a/packages/core/src/validation/branch.ts
+++ b/packages/core/src/validation/branch.ts
@@ -5,10 +5,17 @@ export interface BranchingConfig {
   prefixes: string[];
   /** Whether to enforce kebab-case for the branch slug */
   enforceKebabCase: boolean;
-  /** Optional regex for custom branch naming rules */
-  customRegex?: string;
+  /**
+   * Optional regex that fully replaces the default prefix and kebab-case checks.
+   * When set, only the ignore list and this regex are evaluated -- the `prefixes`,
+   * `enforceKebabCase`, and `maxLength` settings are bypassed. Use for projects
+   * whose convention does not fit the prefix/slug model.
+   */
+  customRegex?: string | undefined;
   /** List of ignored branch names (exact match or glob) */
   ignore: string[];
+  /** Maximum slug length (everything after the first `/`). Omit or set 0 to disable. */
+  maxLength?: number | undefined;
 }
 
 export interface BranchValidationResult {
@@ -17,6 +24,11 @@ export interface BranchValidationResult {
   message?: string;
   suggestion?: string;
 }
+
+// Strict kebab-case: lowercase alphanumeric segments separated by single hyphens,
+// no leading/trailing hyphens, no double hyphens.
+const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const TICKET_ID = /^([A-Z0-9]+-[0-9]+)-(.*)$/;
 
 /**
  * Validates a branch name against the provided configuration.
@@ -29,14 +41,12 @@ export function validateBranchName(
   branchName: string,
   config: BranchingConfig
 ): BranchValidationResult {
-  // 1. Check ignored branches
   for (const pattern of config.ignore) {
     if (minimatch(branchName, pattern)) {
       return { valid: true, branchName };
     }
   }
 
-  // 2. Check custom regex if provided
   if (config.customRegex) {
     const regex = new RegExp(config.customRegex);
     if (!regex.test(branchName)) {
@@ -49,7 +59,6 @@ export function validateBranchName(
     return { valid: true, branchName };
   }
 
-  // 3. Check prefixes
   const parts = branchName.split('/');
   if (parts.length < 2) {
     return {
@@ -72,33 +81,41 @@ export function validateBranchName(
     };
   }
 
-  // 4. Check kebab-case
   if (config.enforceKebabCase) {
-    const kebabRegex = /^[a-z0-9-]+$/;
-
-    const slugParts = slug.split('/');
-    for (const part of slugParts) {
-      // Support optional pattern: prefix/PROJ-123-short-desc
-      const ticketMatch = part.match(/^([A-Z0-9]+-[0-9]+)-(.*)$/);
+    for (const part of slug.split('/')) {
+      const ticketMatch = part.match(TICKET_ID);
       if (ticketMatch) {
         const rest = ticketMatch[2];
-        if (rest && !kebabRegex.test(rest)) {
+        if (rest && !KEBAB_CASE.test(rest)) {
           return {
             valid: false,
             branchName,
             message: `Branch slug part "${part}" does not follow kebab-case after the ticket ID.`,
-            suggestion: `Ensure the description after "${ticketMatch[1]}" uses kebab-case (lowercase and hyphens only).`,
+            suggestion: `Ensure the description after "${ticketMatch[1]}" uses kebab-case (lowercase, single hyphens, no leading/trailing hyphen).`,
           };
         }
-      } else if (!kebabRegex.test(part)) {
+      } else if (!KEBAB_CASE.test(part)) {
         return {
           valid: false,
           branchName,
-          message: `Branch slug part "${part}" must be in kebab-case (lowercase and hyphens only).`,
+          message: `Branch slug part "${part}" must be in kebab-case (lowercase, single hyphens, no leading/trailing hyphen).`,
           suggestion: `Change "${part}" to match the convention.`,
         };
       }
     }
+  }
+
+  if (
+    typeof config.maxLength === 'number' &&
+    config.maxLength > 0 &&
+    slug.length > config.maxLength
+  ) {
+    return {
+      valid: false,
+      branchName,
+      message: `Branch slug is ${slug.length} characters; max allowed is ${config.maxLength}.`,
+      suggestion: `Shorten the description after "${prefix}/" to ${config.maxLength} characters or fewer.`,
+    };
   }
 
   return { valid: true, branchName };

--- a/packages/core/src/validation/branch.ts
+++ b/packages/core/src/validation/branch.ts
@@ -1,0 +1,105 @@
+import { minimatch } from 'minimatch';
+
+export interface BranchingConfig {
+  /** Allowed branch name prefixes */
+  prefixes: string[];
+  /** Whether to enforce kebab-case for the branch slug */
+  enforceKebabCase: boolean;
+  /** Optional regex for custom branch naming rules */
+  customRegex?: string;
+  /** List of ignored branch names (exact match or glob) */
+  ignore: string[];
+}
+
+export interface BranchValidationResult {
+  valid: boolean;
+  branchName: string;
+  message?: string;
+  suggestion?: string;
+}
+
+/**
+ * Validates a branch name against the provided configuration.
+ *
+ * @param branchName - The name of the branch to validate.
+ * @param config - The branching configuration.
+ * @returns A BranchValidationResult.
+ */
+export function validateBranchName(
+  branchName: string,
+  config: BranchingConfig
+): BranchValidationResult {
+  // 1. Check ignored branches
+  for (const pattern of config.ignore) {
+    if (minimatch(branchName, pattern)) {
+      return { valid: true, branchName };
+    }
+  }
+
+  // 2. Check custom regex if provided
+  if (config.customRegex) {
+    const regex = new RegExp(config.customRegex);
+    if (!regex.test(branchName)) {
+      return {
+        valid: false,
+        branchName,
+        message: `Branch name "${branchName}" does not match the custom regex: ${config.customRegex}`,
+      };
+    }
+    return { valid: true, branchName };
+  }
+
+  // 3. Check prefixes
+  const parts = branchName.split('/');
+  if (parts.length < 2) {
+    return {
+      valid: false,
+      branchName,
+      message: `Branch name "${branchName}" must have a prefix followed by a slash (e.g., "feat/my-feature").`,
+      suggestion: `Try renaming to "feat/${branchName}" or "fix/${branchName}".`,
+    };
+  }
+
+  const prefix = parts[0]!;
+  const slug = parts.slice(1).join('/');
+
+  if (!config.prefixes.includes(prefix)) {
+    return {
+      valid: false,
+      branchName,
+      message: `Prefix "${prefix}" is not allowed.`,
+      suggestion: `Allowed prefixes: ${config.prefixes.join(', ')}.`,
+    };
+  }
+
+  // 4. Check kebab-case
+  if (config.enforceKebabCase) {
+    const kebabRegex = /^[a-z0-9-]+$/;
+
+    const slugParts = slug.split('/');
+    for (const part of slugParts) {
+      // Support optional pattern: prefix/PROJ-123-short-desc
+      const ticketMatch = part.match(/^([A-Z0-9]+-[0-9]+)-(.*)$/);
+      if (ticketMatch) {
+        const rest = ticketMatch[2];
+        if (rest && !kebabRegex.test(rest)) {
+          return {
+            valid: false,
+            branchName,
+            message: `Branch slug part "${part}" does not follow kebab-case after the ticket ID.`,
+            suggestion: `Ensure the description after "${ticketMatch[1]}" uses kebab-case (lowercase and hyphens only).`,
+          };
+        }
+      } else if (!kebabRegex.test(part)) {
+        return {
+          valid: false,
+          branchName,
+          message: `Branch slug part "${part}" must be in kebab-case (lowercase and hyphens only).`,
+          suggestion: `Change "${part}" to match the convention.`,
+        };
+      }
+    }
+  }
+
+  return { valid: true, branchName };
+}

--- a/packages/core/tests/validation/branch.test.ts
+++ b/packages/core/tests/validation/branch.test.ts
@@ -66,4 +66,24 @@ describe('validateBranchName', () => {
     expect(result.valid).toBe(false);
     expect(result.message).toContain('must be in kebab-case');
   });
+
+  it('rejects double, leading, and trailing hyphens', () => {
+    expect(validateBranchName('feat/foo--bar', defaultConfig).valid).toBe(false);
+    expect(validateBranchName('feat/-foo', defaultConfig).valid).toBe(false);
+    expect(validateBranchName('feat/foo-', defaultConfig).valid).toBe(false);
+  });
+
+  it('enforces maxLength when configured', () => {
+    const cfg: BranchingConfig = { ...defaultConfig, maxLength: 10 };
+    expect(validateBranchName('feat/short', cfg).valid).toBe(true);
+
+    const tooLong = validateBranchName('feat/this-slug-is-too-long', cfg);
+    expect(tooLong.valid).toBe(false);
+    expect(tooLong.message).toContain('max allowed is 10');
+  });
+
+  it('skips length check when maxLength is undefined', () => {
+    const long = 'feat/' + 'a-'.repeat(100) + 'b';
+    expect(validateBranchName(long, defaultConfig).valid).toBe(true);
+  });
 });

--- a/packages/core/tests/validation/branch.test.ts
+++ b/packages/core/tests/validation/branch.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { validateBranchName, type BranchingConfig } from '../../src/validation/branch';
+
+describe('validateBranchName', () => {
+  const defaultConfig: BranchingConfig = {
+    prefixes: ['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'perf'],
+    enforceKebabCase: true,
+    ignore: ['main', 'release/**', 'dependabot/**', 'harness/**'],
+  };
+
+  it('should allow ignored branches', () => {
+    expect(validateBranchName('main', defaultConfig).valid).toBe(true);
+    expect(validateBranchName('release/v1.0.0', defaultConfig).valid).toBe(true);
+    expect(validateBranchName('dependabot/npm/something', defaultConfig).valid).toBe(true);
+  });
+
+  it('should require a prefix and a slash', () => {
+    const result = validateBranchName('my-feature', defaultConfig);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('must have a prefix followed by a slash');
+  });
+
+  it('should validate allowed prefixes', () => {
+    expect(validateBranchName('feat/valid-feature', defaultConfig).valid).toBe(true);
+    expect(validateBranchName('fix/valid-fix', defaultConfig).valid).toBe(true);
+
+    const result = validateBranchName('feature/invalid-prefix', defaultConfig);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('Prefix "feature" is not allowed');
+  });
+
+  it('should enforce kebab-case by default', () => {
+    expect(validateBranchName('feat/valid-kebab-case', defaultConfig).valid).toBe(true);
+
+    const result = validateBranchName('feat/invalid_snake_case', defaultConfig);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('must be in kebab-case');
+
+    const result2 = validateBranchName('feat/InvalidCamelCase', defaultConfig);
+    expect(result2.valid).toBe(false);
+  });
+
+  it('should allow ticket IDs in kebab-case slugs', () => {
+    expect(validateBranchName('feat/PROJ-123-short-desc', defaultConfig).valid).toBe(true);
+    expect(validateBranchName('feat/HNS-456-another-one', defaultConfig).valid).toBe(true);
+
+    const result = validateBranchName('feat/PROJ-123-Invalid_Snake', defaultConfig);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('does not follow kebab-case after the ticket ID');
+  });
+
+  it('should support custom regex', () => {
+    const customConfig: BranchingConfig = {
+      ...defaultConfig,
+      customRegex: '^user/.*$',
+    };
+
+    expect(validateBranchName('user/anything', customConfig).valid).toBe(true);
+    expect(validateBranchName('feat/something', customConfig).valid).toBe(false);
+  });
+
+  it('should allow deep hierarchies if all parts are kebab-case', () => {
+    expect(validateBranchName('feat/ui/button/primary', defaultConfig).valid).toBe(true);
+
+    const result = validateBranchName('feat/ui/Button/Primary', defaultConfig);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('must be in kebab-case');
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the branch naming convention from #319: standard prefixes (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `perf/`), strict kebab-case slugs (no leading/trailing or doubled hyphens), optional ticket-ID form (`feat/PROJ-123-desc`), `maxLength` cap (default 60), and ignore globs for long-lived branches (`main`, `release/**`, `dependabot/**`, `harness/**`).
- Adds `harness verify` CLI command. Works with or without a `harness.config.json` (falls back to schema defaults), supports `--branch <name>` and reads `HARNESS_BRANCH` / `GITHUB_HEAD_REF` / `CI_COMMIT_REF_NAME` / `BUILDKITE_BRANCH` so detached-HEAD CI runners can verify the PR source. `--json` for tooling.
- Adds `compliance.branching` to `HarnessConfigSchema` per the [issue comment](https://github.com/Intense-Visions/harness-engineering/issues/319#issuecomment-4455201244) ("better in the harness.config.json file"). Schema defaults are the single source of truth.
- Exports `validateBranchName` + `BranchingConfig` from `@harness-engineering/core`.
- Updates `CONTRIBUTING.md`, the `harness-compliance` skill (instructs the agent to actually run `harness verify` and refuse to push from non-compliant branches), and the proposal doc.

## Commits

1. `feat(compliance): implement branch naming convention and verify command` — original implementation.
2. `fix(compliance): address review findings on branch naming` — fixes from the in-line code review:
   - **Critical:** `harness verify` no longer fails on un-onboarded repos (was: "No harness.config.json found").
   - **Important:** added missing `maxLength` from the issue; removed duplicated default block; documented `customRegex` as a full override; added CI env-var fallback for detached HEAD.
   - **Suggestion:** tightened kebab-case regex; added `--json`; sharpened command description and skill instructions.
3. `docs(cli): regenerate reference docs for harness verify command` — pre-push hook required.

Changeset attached (minor for both `@harness-engineering/cli` and `@harness-engineering/core`).

## Test plan

- [x] `pnpm typecheck` — green (16/16 tasks)
- [x] `pnpm lint` — green (9/9 tasks)
- [x] `pnpm test` — green (core 2814 pass / 1 pre-existing skip; cli 3106 pass)
- [x] 10 dedicated `validateBranchName` tests (3 new): maxLength, strict kebab (rejects `--`, `-foo`, `foo-`), and skip-when-undefined.
- [x] Smoke tests on `/tmp` empty repo: configless bad prefix, configless good branch, `--json` with `--branch`, `GITHUB_HEAD_REF` env fallback — all behave correctly.
- [x] Branch name `feat/issue-319-branch-naming-convention` passes its own `harness verify` check (dogfood).
- [x] Manual: `harness validate` on this repo still passes (schema change parses cleanly).

Closes #319.