### PR TITLE
fix(types): republish types so downstream dist matches published exports

### DIFF
--- a/.changeset/republish-types-with-auth-and-webhook-schemas.md
+++ b/.changeset/republish-types-with-auth-and-webhook-schemas.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/types': minor
+---
+
+Publish exports that landed in source without a corresponding version bump. `@harness-engineering/types@0.11.0` shipped without these symbols even though commits between 0.11.0 and now (`0db97708`, `40246b06`, `d1493fe6`, `9ba567b6`) added them to `src/index.ts`. Downstream packages (notably `@harness-engineering/orchestrator@0.4.3`) compiled their dist against the new exports and pinned `@harness-engineering/types@0.11.0`, so `npm install -g @harness-engineering/cli` resolves both at incompatible versions and the CLI fails at module load with `SyntaxError: The requested module '@harness-engineering/types' does not provide an export named 'AuthAuditEntrySchema'`.
+
+New exports made available in this release:
+
+- `AuthTokenSchema`, `AuthTokenPublicSchema`, `AuthAuditEntrySchema`, `TokenScopeSchema` and accompanying types (added in `0db97708`)
+- `WebhookSubscriptionSchema`, `WebhookSubscriptionPublicSchema`, `GatewayEventSchema` (added in `40246b06`)
+- `WebhookDeliverySchema`, `WebhookDeliveryStatusSchema` (added in `d1493fe6`)
+- `TrajectoryMetadataSchema`, `PromptCacheStatsSchema`, `OTLPSpanSchema`, `OTLPKeyValueSchema` (added in `9ba567b6`)
+
+Because `updateInternalDependencies` is `patch` in `.changeset/config.json`, every package that depends on `@harness-engineering/types` will receive a patch bump and a fresh dist when this release publishes, repairing the broken installs.


### PR DESCRIPTION
## Why this is urgent

Every fresh `npm install -g @harness-engineering/cli@2.4.1` fails at module load:

```
SyntaxError: The requested module '@harness-engineering/types' does not provide an export named 'AuthAuditEntrySchema'
    at orchestrator/dist/index.mjs:7471
```

The published `@harness-engineering/types@0.11.0` is missing exports that downstream packages (notably `@harness-engineering/orchestrator@0.4.3`) reference at the top of their compiled `dist/index.mjs`. Because the import is a top-level static import, the failure happens before any subcommand runs — including `harness update`. Users are stuck unless they downgrade.

## Root cause

Several commits since the `types@0.11.0` release added exports to `packages/types/src/index.ts` **without a `.changeset/` entry that bumps the types package**:

- `0db97708` — `AuthTokenSchema`, `AuthTokenPublicSchema`, `AuthAuditEntrySchema`, `TokenScopeSchema`
- `40246b06` — `WebhookSubscriptionSchema`, `WebhookSubscriptionPublicSchema`, `GatewayEventSchema`
- `d1493fe6` — `WebhookDeliverySchema`, `WebhookDeliveryStatusSchema`
- `9ba567b6` — `TrajectoryMetadataSchema`, `PromptCacheStatsSchema`, `OTLPSpanSchema`, `OTLPKeyValueSchema`

Downstream packages each had their own changesets and got bumped (orchestrator → 0.4.3, cli → 2.4.1, etc.). Their dist bundles reference the new symbols. But their `package.json` deps still resolve to the last-published `@harness-engineering/types`, which is 0.11.0 and missing the symbols.

## What this PR does

Adds a single minor changeset for `@harness-engineering/types`. Because `.changeset/config.json` sets `updateInternalDependencies: patch`, the release will patch-bump every dependent (orchestrator, core, cli, dashboard, intelligence, graph) and republish their dists against the matching types version. The next `harness update` will then resolve a coherent dep graph.

## Test plan

- [ ] CI green on this PR
- [ ] After merge + release, `npm install -g @harness-engineering/cli@latest` succeeds in a clean shell and `harness --version` works
- [ ] Follow-up issue tracking the prevention work outlined below

## Follow-up (separate PR)

This class of bug should be impossible to land in the first place. The minimum guards I'd add next:

1. **Block PRs that change `packages/*/src/**` without a corresponding changeset** — the existing `@changesets/cli status` command can be wired into CI to fail when a touched package has no pending changeset.
2. **Post-publish smoke test** — after the release workflow publishes, install `@harness-engineering/cli@latest` from npm (not from workspace) in a fresh container and run `harness --version`. Module-load failures like this one would surface immediately.
3. **API surface lint** — diff `packages/types/src/index.ts` exports against the last release tag in CI and require an explicit "expand types" annotation on the changeset when public exports change, so reviewers see it.