### PR TITLE
ci: guard against missing-changeset and post-publish import drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Fail PRs that change a publishable package without a corresponding
+  # .changeset entry. Skipped on release PRs opened by the changesets bot
+  # (those delete changesets and bump versions, which is the opposite signal).
+  changeset-check:
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Fetch enough history that origin/main is a usable diff base.
+          fetch-depth: 0
+
+      - name: Verify every changed package has a changeset
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: node scripts/check-changesets.mjs
+
   build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -5,6 +5,14 @@ on:
     types: [completed]
     branches: [main]
 
+# Why this exists: the previous smoke test only ran `harness --version`,
+# which exits via commander before loading orchestrator. Incident #332
+# slipped past it — orchestrator's dist imported symbols from a stale
+# published types build, but `--version` never triggered that code path.
+# This workflow now imports every published @harness-engineering/*
+# package directly and exercises a CLI command that walks the
+# orchestrator dep chain, so a module-load mismatch fails the release.
+
 jobs:
   smoke:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -13,16 +21,64 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+
       - name: Wait for npm CDN propagation
         run: sleep 30
+
       - name: Install published CLI
         run: npm install -g @harness-engineering/cli
-      - name: Verify CLI runs
+
+      - name: Verify CLI version command
         run: harness --version
-      - name: Verify core exports
+
+      - name: Verify CLI help loads every subcommand module
+        # Commander lazily registers subcommands but `--help` traverses them
+        # all to print the listing. A bad import in any subcommand surfaces
+        # here even when `--version` would short-circuit.
+        run: harness --help
+
+      - name: Verify every published @harness-engineering/* package imports cleanly
         run: |
           mkdir /tmp/smoke && cd /tmp/smoke
-          npm init -y
-          npm install @harness-engineering/core @harness-engineering/types
-          node -e "const c = require('@harness-engineering/core'); console.log('core OK:', typeof c.validateConfig)"
-          node -e "const t = require('@harness-engineering/types'); console.log('types OK:', Object.keys(t).length > 0)"
+          npm init -y >/dev/null
+          # Pin nothing: install whatever the registry now resolves for each
+          # public package. If any pair is incompatible (incident #332-style),
+          # the dynamic import below blows up.
+          npm install \
+            @harness-engineering/cli \
+            @harness-engineering/core \
+            @harness-engineering/types \
+            @harness-engineering/orchestrator \
+            @harness-engineering/intelligence \
+            @harness-engineering/graph \
+            @harness-engineering/dashboard \
+            @harness-engineering/linter-gen
+          node --input-type=module -e "
+            const pkgs = [
+              '@harness-engineering/cli',
+              '@harness-engineering/core',
+              '@harness-engineering/types',
+              '@harness-engineering/orchestrator',
+              '@harness-engineering/intelligence',
+              '@harness-engineering/graph',
+              '@harness-engineering/dashboard',
+              '@harness-engineering/linter-gen',
+            ];
+            const failures = [];
+            for (const pkg of pkgs) {
+              try {
+                const mod = await import(pkg);
+                const exportCount = Object.keys(mod).length;
+                console.log(\`ok  \${pkg}  (\${exportCount} exports)\`);
+              } catch (err) {
+                failures.push({ pkg, message: err?.message ?? String(err) });
+                console.error(\`fail \${pkg}: \${err?.message ?? err}\`);
+              }
+            }
+            if (failures.length > 0) {
+              console.error('');
+              console.error(\`\${failures.length} package(s) failed to import. Most likely a\`);
+              console.error('cross-package version mismatch — see incident #332 for the pattern.');
+              process.exit(1);
+            }
+          "

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Fail if a PR changes a publishable package without a matching changeset.
+ *
+ * Driven by the incident in PR #332: schemas were added to
+ * `packages/types/src/` across four commits but no `.changeset/` entry
+ * bumped the types package. The release pipeline bumped downstream
+ * packages (which had their own changesets) and shipped dists that
+ * imported the new symbols — but the types package on npm stayed at
+ * 0.11.0 without them. Every fresh `npm install -g @harness-engineering/cli`
+ * crashed at module load.
+ *
+ * Heuristic: a publishable change is anything under `packages/<pkg>/src/`
+ * or a modification to `packages/<pkg>/package.json` (deps moves are
+ * publishable). Tests, .harness state, docs, and changelogs are not
+ * publishable and never require a changeset.
+ *
+ * Escape hatch: an empty changeset (no packages listed in the
+ * frontmatter, produced by `pnpm changeset --empty`) is accepted as
+ * acknowledgement that this PR intentionally doesn't release anything.
+ *
+ * Usage: BASE_REF=origin/main node scripts/check-changesets.mjs
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+
+const BASE_REF = process.env.BASE_REF || 'origin/main';
+
+/** Files under packages/<pkg>/ that should require a changeset when modified. */
+const PUBLISHABLE_FILE = /^packages\/([^/]+)\/(src\/.+|package\.json)$/;
+
+/**
+ * Paths that are publishable-source-like but never require a release —
+ * e.g. test fixtures co-located under src, or auto-managed harness state.
+ */
+const SKIP_FILE = [
+  /\.test\.[cm]?[tj]sx?$/,
+  /\.spec\.[cm]?[tj]sx?$/,
+  /\/tests?\//,
+  /\/__tests__\//,
+  /\/__fixtures__\//,
+  /\/\.harness\//,
+];
+
+function gitFiles({ extraArgs = '', pathspec = '' } = {}) {
+  // Argument order matters: `git diff [opts] <ref> -- <paths>`. Putting `--`
+  // before the ref makes git treat the ref as a path and the diff comes back
+  // empty.
+  const cmd =
+    `git diff --name-only ${extraArgs} ${BASE_REF}...HEAD` + (pathspec ? ` -- ${pathspec}` : '');
+  return execSync(cmd, { encoding: 'utf-8' }).split('\n').filter(Boolean);
+}
+
+function packageNameFor(dirName) {
+  const path = `packages/${dirName}/package.json`;
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')).name ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const changedFiles = gitFiles();
+const changedPackages = new Set();
+for (const f of changedFiles) {
+  if (SKIP_FILE.some((re) => re.test(f))) continue;
+  const m = f.match(PUBLISHABLE_FILE);
+  if (!m) continue;
+  const name = packageNameFor(m[1]);
+  if (name) changedPackages.add(name);
+}
+
+if (changedPackages.size === 0) {
+  console.log('No publishable package changes detected.');
+  process.exit(0);
+}
+
+// Look at every changeset file (added OR modified) in this PR. The standard
+// case is added, but reviewers sometimes amend an existing changeset to add a
+// missing package — both should count.
+const changesetFiles = gitFiles({
+  extraArgs: '--diff-filter=AM',
+  pathspec: '.changeset/',
+}).filter((f) => f.endsWith('.md') && !f.endsWith('README.md'));
+
+const mentionedPackages = new Set();
+let hasEmptyChangeset = false;
+
+for (const f of changesetFiles) {
+  let raw;
+  try {
+    raw = readFileSync(f, 'utf-8');
+  } catch {
+    continue;
+  }
+  const frontmatter = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatter) continue;
+  const body = frontmatter[1].trim();
+  if (body === '') {
+    hasEmptyChangeset = true;
+    continue;
+  }
+  for (const line of body.split(/\r?\n/)) {
+    // Match `'@scope/pkg': patch|minor|major` or with double quotes.
+    const m = line.match(/^["']([^"']+)["']\s*:\s*(patch|minor|major)\s*$/);
+    if (m) mentionedPackages.add(m[1]);
+  }
+}
+
+if (hasEmptyChangeset) {
+  console.log(
+    `Empty changeset present — accepting source changes without per-package changesets.`
+  );
+  console.log(`Changed packages: ${[...changedPackages].sort().join(', ')}`);
+  process.exit(0);
+}
+
+const missing = [...changedPackages].filter((p) => !mentionedPackages.has(p)).sort();
+if (missing.length === 0) {
+  console.log(`Changeset check OK. Covered: ${[...changedPackages].sort().join(', ')}`);
+  process.exit(0);
+}
+
+console.error('');
+console.error('Missing changeset for the following changed package(s):');
+for (const p of missing) console.error(`  - ${p}`);
+console.error('');
+console.error('Every PR that changes a publishable package must add a `.changeset/*.md`');
+console.error('file that lists that package and the bump level (patch | minor | major).');
+console.error('');
+console.error('Run `pnpm changeset` to create one interactively.');
+console.error('');
+console.error('If this change should NOT release, run `pnpm changeset --empty` to add an');
+console.error('explicit no-release marker.');
+console.error('');
+console.error(
+  `Context: incident ${'#'}332 — a missing changeset shipped an orchestrator dist that imported`
+);
+console.error('symbols from an unreleased types build, breaking every fresh CLI install.');
+process.exit(1);


### PR DESCRIPTION
## Why

In PR #332, four commits added schemas to `packages/types/src/index.ts` without a corresponding `.changeset/*.md`. The release pipeline therefore left `@harness-engineering/types` at its previous version, while downstream packages (notably `@harness-engineering/orchestrator`) compiled against the new exports and were published referencing symbols the published types build didn't expose. Every fresh `npm install -g @harness-engineering/cli` then crashed at module load. The existing smoke test (`harness --version`) didn't catch it because commander short-circuits on `--version` before loading orchestrator.

This PR adds two independent guards so the same failure can't ship again.

## What

### 1. Pre-merge: `changeset-check` CI job

`scripts/check-changesets.mjs` + a new job in `.github/workflows/ci.yml`. On every PR to main, it:

- Lists files touched since `origin/main` and maps `packages/<pkg>/src/**` or `packages/<pkg>/package.json` to that package's npm name.
- Reads new/modified `.changeset/*.md` frontmatter to collect mentioned packages.
- Fails if any changed package has no changeset, with a clear message and the exact `pnpm changeset` command to fix it.

Edge cases handled:

- Tests, fixtures, `.harness/` state, and docs don't require changesets (excluded by pattern).
- `pnpm changeset --empty` (no packages in frontmatter) is accepted as an explicit "no release for this PR" marker.
- Release PRs from the changesets bot (`changeset-release/*` branches) are skipped — those delete changesets by design.

Verified locally:

- Source change + matching changeset → exit 0
- Source change without changeset → exit 1, names the package and prints the fix command
- This PR (no `packages/*/src` changes) → exit 0

### 2. Post-publish: smoke test rewritten

`.github/workflows/smoke-test.yml` now does what `harness --version` alone couldn't:

- `harness --help` — forces commander to traverse every subcommand module, so any subcommand with a broken import surfaces here.
- A separate step installs every published `@harness-engineering/*` package into a fresh project and dynamically imports each one. Any incident #332-style mismatch fails the run and (because this workflow is `workflow_run: Release/completed`) alerts immediately after publish, before users hit the broken install.

## Test plan

- [x] Script success path verified locally
- [x] Script failure path verified locally
- [x] This PR's own changes (CI infra only) pass the guard
- [ ] CI green
- [ ] Confirmed on a subsequent PR that touches a package without a changeset (will surface organically)