### PR TITLE
chore(cli): ignore webhook-queue sqlite and maintenance/ runtime artifacts

### DIFF
--- a/.changeset/ignore-webhook-queue-and-maintenance-runtime.md
+++ b/.changeset/ignore-webhook-queue-and-maintenance-runtime.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Add `webhook-queue.sqlite`, `webhook-queue.sqlite-wal`, `webhook-queue.sqlite-shm`, and `maintenance/` to the canonical `.harness/.gitignore` template written by `ensureHarnessGitignore`.
+
+The Phase 3 webhook delivery queue persists state in `.harness/webhook-queue.sqlite` (plus its WAL and SHM sidecars), and the maintenance runner writes per-tick history to `.harness/maintenance/`. Both are ephemeral runtime artifacts that should never be committed. Before this change they were left untracked but unignored, so `git status` always showed them as new files in any project running the orchestrator and they were easy to commit by accident. They now match the same ignore semantics as the rest of the harness runtime directory.

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,12 @@ temp/
 **/.harness/audit.log
 # Phase 3 webhook runtime artifact — NEVER commit plaintext webhook secrets
 **/.harness/webhooks.json
+# Phase 3 webhook delivery queue — SQLite runtime DB (and WAL/SHM sidecars)
+**/.harness/webhook-queue.sqlite
+**/.harness/webhook-queue.sqlite-wal
+**/.harness/webhook-queue.sqlite-shm
+# Maintenance task run history (regenerated each tick)
+**/.harness/maintenance/
 # Phase 6 reference bridge — NEVER commit Slack tokens or HMAC secret
 examples/slack-echo-bridge/.env
 # Test fixtures: ignore the whole security dir (timeline.json there is test scaffolding)

--- a/.harness/.gitignore
+++ b/.harness/.gitignore
@@ -23,6 +23,13 @@ events.jsonl
 telemetry.json
 .telemetry-notice-shown
 
+# Phase 3 webhook delivery queue — SQLite runtime DB (and WAL/SHM sidecars)
+webhook-queue.sqlite
+webhook-queue.sqlite-wal
+webhook-queue.sqlite-shm
+# Maintenance task run history (regenerated each tick)
+maintenance/
+
 # security/: track timeline.json (trend ledger), ignore everything else
 security/*
 !security/timeline.json

--- a/packages/cli/src/templates/post-write.ts
+++ b/packages/cli/src/templates/post-write.ts
@@ -83,6 +83,13 @@ events.jsonl
 telemetry.json
 .telemetry-notice-shown
 
+# Phase 3 webhook delivery queue — SQLite runtime DB (and WAL/SHM sidecars)
+webhook-queue.sqlite
+webhook-queue.sqlite-wal
+webhook-queue.sqlite-shm
+# Maintenance task run history (regenerated each tick)
+maintenance/
+
 # security/: track timeline.json (trend ledger), ignore everything else
 security/*
 !security/timeline.json

--- a/packages/cli/tests/templates/post-write.test.ts
+++ b/packages/cli/tests/templates/post-write.test.ts
@@ -47,6 +47,10 @@ describe('ensureHarnessGitignore', () => {
     expect(content).toContain('.install-id');
     expect(content).toContain('.telemetry-notice-shown');
     expect(content).toContain('telemetry.json');
+    expect(content).toContain('webhook-queue.sqlite');
+    expect(content).toContain('webhook-queue.sqlite-wal');
+    expect(content).toContain('webhook-queue.sqlite-shm');
+    expect(content).toContain('maintenance/');
   });
 
   // Issue #270: hooks/ are team-policy code and security/timeline.json is a shared


### PR DESCRIPTION
## Summary

- The Phase 3 webhook delivery queue persists state in `.harness/webhook-queue.sqlite` (plus `.sqlite-wal` and `.sqlite-shm` sidecars), and the maintenance task runner writes per-tick history to `.harness/maintenance/`. Both are ephemeral runtime artifacts but were left untracked and unignored — `git status` always surfaced them in any project running the orchestrator, making accidental commits easy.
- Add the patterns to all three sources of truth:
  - `.gitignore` (root) — `**/.harness/webhook-queue.sqlite{,-wal,-shm}`, `**/.harness/maintenance/`
  - `.harness/.gitignore` (this repo's project ignores) — relative-path equivalents
  - `packages/cli/src/templates/post-write.ts` — the template content that `ensureHarnessGitignore` writes into every harness project, so the CLI scaffolds the right ignores for new projects too
- Pin the new template entries in `packages/cli/tests/templates/post-write.test.ts` so future edits can't quietly drop them.

## Notes

While preparing this PR, the running orchestrator overwrote `.harness/.gitignore` from its installed (pre-fix) CLI template — a live demonstration of exactly why the canonical template needs to ship with the CLI release. The pushed commit reflects the correct content; rolling out a CLI release with this patch will make the working-tree write self-consistent.

## Test plan

- [x] `packages/cli/tests/templates/post-write.test.ts` (5 passing) — pins the new ignore entries
- [x] `git check-ignore -v` confirms all four runtime paths now match
- [x] Changeset included (`@harness-engineering/cli` patch)