### PR TITLE
docs(hermes): add gateway tunnel guide (Phase 0.2)

### DIFF
--- a/docs/changes/hermes-phase-0-2-gateway-tunnel-guide/plans/2026-05-16-gateway-tunnel-guide-plan.md
+++ b/docs/changes/hermes-phase-0-2-gateway-tunnel-guide/plans/2026-05-16-gateway-tunnel-guide-plan.md
@@ -1,0 +1,139 @@
+# Plan: Hermes Phase 0.2 — Gateway Tunnel Guide
+
+**Date:** 2026-05-16
+**Spec:** `docs/changes/hermes-phase-0-2-gateway-tunnel-guide/proposal.md`
+**Parent phase spec:** `docs/changes/hermes-phase-0-gateway-api/proposal.md` (§D5, §547)
+**Roadmap item:** `Hermes Phase 0.2: Gateway Tunnel Guide` (`github:Intense-Visions/harness-engineering#328`)
+**Tasks:** 6
+**Checkpoints:** 1 (`human-verify` after Task 3 — guide reads naturally end-to-end)
+**Estimated time:** ~45 minutes implementation
+**Integration Tier:** low (docs-only; no code, no graph nodes, no new CLI surface)
+
+## Goal
+
+Write `docs/guides/gateway-tunnel.md` covering Cloudflare Tunnel, Tailscale, and ngrok as the three canonical bridge-exposure patterns, with `examples/slack-echo-bridge/` as the worked end-to-end example. Wire the guide into the docs index and the slack-bridge README; flip the roadmap entry to `done`. No orchestrator code changes.
+
+## Observable Truths (Acceptance Criteria)
+
+1. **The repository shall contain `docs/guides/gateway-tunnel.md`** with sections for each of Cloudflare Tunnel, Tailscale, and ngrok in that order, each presenting install/auth, start-the-bridge, bring-up-the-tunnel, register-the-subscription, trigger-and-verify, teardown steps.
+2. **The guide shall cite orchestrator URL-validation constraints** by file path + line range (`packages/orchestrator/src/server/routes/v1/webhooks.ts` and `packages/orchestrator/src/server/utils/url-guard.ts`); the citations shall resolve to the correct code at write time.
+3. **The guide shall NOT inline the HMAC verification snippet** — it shall link to `examples/slack-echo-bridge/src/signer.ts` as the canonical source.
+4. **`docs/guides/index.md` shall list the new guide** in the same shape as existing entries (title link + one-line summary + "Best for:" line) and shall be inserted after the Docker Deployment entry to keep operational-deployment guides adjacent.
+5. **`examples/slack-echo-bridge/README.md` shall no longer carry the `_Note: docs/guides/gateway-tunnel.md is a forthcoming Hermes Phase 0.2 deliverable…_` disclaimer paragraph.** The pointer line above it (currently line 89) shall remain as-is.
+6. **`docs/roadmap.md`'s Phase 0.2 entry shall report `Status: done`** and shall reference this plan in its `Plan:` field; the `External-ID` shall remain `github:Intense-Visions/harness-engineering#328`.
+7. **`harness validate` shall pass on the working tree** after all changes are applied.
+8. **All cross-references shall resolve.** No broken relative links from the guide → bridge, guide → orchestrator code, bridge → guide, index → guide.
+
+## Uncertainties
+
+- **[ASSUMPTION] The orchestrator's URL guard is the authoritative constraint set.** Verified at `packages/orchestrator/src/server/routes/v1/webhooks.ts:143-150` (https check + `isPrivateHost` rejection) and `packages/orchestrator/src/server/utils/url-guard.ts:1-12` (full regex set). The guide cites these by line range. If future PRs renumber, `harness check-docs` will catch it.
+- **[ASSUMPTION] The slack-echo-bridge listens on port 3000 by default.** Verified at `examples/slack-echo-bridge/README.md:34` and line 68 (PORT default = 3000). The guide uses port 3000 in the worked example.
+- **[ASSUMPTION] The guides index is naturally appended-to, not auto-generated.** Verified by reading `docs/guides/index.md` — entries are hand-authored. Insertion is a normal Edit.
+- **[DEFERRED] Re-validation cadence for vendor commands.** Cloudflare/Tailscale/ngrok CLI surfaces evolve. Cadence and ownership of "re-run the three recipes" is **not** in scope for this plan; the guide carries a "vendor commands re-validated YYYY-MM-DD" footer instead.
+
+## Tasks
+
+### Task 1 — Write the guide
+
+**Files:**
+
+- `docs/guides/gateway-tunnel.md` (NEW)
+
+**What:** Create the guide following the structure laid out in the proposal's "Guide structure" section. Use `examples/slack-echo-bridge/README.md`'s style and vocabulary (HMAC, subscribe-webhook scope, `X-Harness-Signature`, etc.) as the prose register. Order: Cloudflare Tunnel → Tailscale → ngrok. Each pattern documents both topology variants (bridge-local + orchestrator-remote, and bridge-remote + orchestrator-local). Include the comparison table, code-cited constraints section, troubleshooting table, security notes, next steps.
+
+**Verify:**
+
+- File exists at the path the bridge README references.
+- Markdown renders without warnings under `markdownlint` (already in repo's lint chain via `harness validate`).
+- Both topology variants are described for every pattern.
+
+### Task 2 — Update the guides index
+
+**Files:**
+
+- `docs/guides/index.md`
+
+**What:** Insert a "### Gateway Tunnel Guide" section after the existing "Docker Deployment" section. One-paragraph summary, "Best for:" line. Use the existing entries' formatting verbatim.
+
+**Verify:**
+
+- The new entry sits between Docker Deployment and the next existing entry (or in the spot dictated by the file's natural ordering).
+- The link `./gateway-tunnel.md` resolves.
+
+### Task 3 — Wire the slack-echo-bridge README
+
+**Files:**
+
+- `examples/slack-echo-bridge/README.md`
+
+**What:** Delete the blockquote `_Note: docs/guides/gateway-tunnel.md is a forthcoming Hermes Phase 0.2 deliverable …_` paragraph at line 91. Do NOT touch line 89's link — the cross-reference is now live and works as written.
+
+**Verify:**
+
+- `grep -n "forthcoming" examples/slack-echo-bridge/README.md` returns no matches.
+- Line 89's pointer is unchanged.
+
+**Checkpoint:** `[checkpoint:human-verify]` — at this point a human-skimmable read of bridge README → tunnel guide → bridge README loop should feel continuous, not circular.
+
+### Task 4 — Roadmap state flip
+
+**Files:**
+
+- `docs/roadmap.md` (entry at line 1154)
+
+**What:** Update the Phase 0.2 entry: `Status: planned` → `done`; `Plan: —` → `Plan: docs/changes/hermes-phase-0-2-gateway-tunnel-guide/plans/2026-05-16-gateway-tunnel-guide-plan.md`. Preserve `External-ID` and `Summary`. Do NOT use `manage_roadmap` for the GitHub-side close in the execution step — that happens in integration.
+
+**Verify:**
+
+- `grep -A 9 "Hermes Phase 0\.2: Gateway Tunnel Guide" docs/roadmap.md` shows `Status: done` and the populated `Plan:` line.
+
+### Task 5 — Verify cross-references and validate
+
+**Files:** (verification only)
+
+**What:**
+
+1. `harness validate` — passes.
+2. `grep -r "gateway-tunnel.md" docs examples` — every reference resolves (every `docs/guides/gateway-tunnel.md` mentioned in code/docs now points at a real file).
+3. `grep -n "isPrivateHost\|startsWith('https" packages/orchestrator/src/server/routes/v1/webhooks.ts packages/orchestrator/src/server/utils/url-guard.ts` — confirm the line numbers cited in the guide still match.
+4. Markdown lint passes on the new guide.
+
+**Verify:**
+
+- All four checks green. Any drift in cited line numbers is fixed in Task 1 immediately, not deferred.
+
+### Task 6 — Final read-through
+
+**Files:** (review only)
+
+**What:** Read the guide top-to-bottom as if you were a new operator. Confirm:
+
+- The Quick Comparison table sets up the recommendation order.
+- Every code block is copy-pasteable (no `<placeholders-that-look-like-commands>`).
+- The Slack bridge worked example is the same shape across all three patterns.
+- The troubleshooting table covers the four failure modes named in the proposal's risk register.
+
+**Verify:**
+
+- The doc reads coherently end-to-end in under 15 minutes for a first-time reader.
+
+## Integration Tasks (derived from spec's Integration Points)
+
+These are tracked separately and run during `/harness:integration` step, NOT during execution:
+
+- **I1.** Update roadmap GitHub issue (#328) via `manage_roadmap` — flips the issue state and adds a comment with the PR URL. Source: spec Integration Point §3.
+- **I2.** Confirm no edit needed to `docs/knowledge/decisions/0011-orchestrator-gateway-api-contract.md` (spec Integration Point §7). The ADR's "deferred" language reads correctly post-ship.
+- **I3.** Confirm no edit needed to top-level `README.md` (spec Integration Point §4). The Gateway API bullet stays single-link to the Slack bridge; the bridge is the entry point that surfaces the tunnel guide.
+- **I4.** Run `harness check-docs` and confirm zero new drift on the touched files.
+
+## Rollback
+
+Single-commit revert. The guide adds one file and edits three existing files; reverting the commit restores the prior state with no orphaned references (the bridge README's "forthcoming" disclaimer regains accuracy on revert).
+
+## Out of scope (explicit)
+
+- New orchestrator code, env vars, validators
+- Knowledge graph node additions
+- A second worked example beyond the Slack bridge
+- Docker / production deployment refinements
+- Updates to plugin marketplace listings (the Gateway API listing is unchanged; tunnels are an operator concern)

--- a/docs/changes/hermes-phase-0-2-gateway-tunnel-guide/proposal.md
+++ b/docs/changes/hermes-phase-0-2-gateway-tunnel-guide/proposal.md
@@ -1,0 +1,189 @@
+# Hermes Phase 0.2 — Gateway Tunnel Guide
+
+**Keywords:** hermes, gateway-api, tunnel, tailscale, cloudflare-tunnel, ngrok, documentation, slack-bridge
+
+**Parent meta-spec:** `docs/changes/hermes-adoption/proposal.md`
+**Parent phase spec:** `docs/changes/hermes-phase-0-gateway-api/proposal.md` (§D5, §547)
+**Roadmap item:** `Hermes Phase 0.2: Gateway Tunnel Guide` (external-id `github:Intense-Visions/harness-engineering#328`)
+
+## Overview
+
+Phase 0 of the Orchestrator Gateway API shipped with a deliberate decision (`§D5`) that the orchestrator binds `127.0.0.1` by default and that public exposure of bridge endpoints is a **documentation problem, not a code problem** — operators reach for an existing tunnel tool (Tailscale, Cloudflare Tunnel, or ngrok) rather than building a public-binding code path into harness. Phase 0 deferred the actual guide that explains how to do this; Phase 0.1 then shipped the canonical reference consumer (`examples/slack-echo-bridge/`) which references the missing guide by path with an inline "forthcoming" note (`examples/slack-echo-bridge/README.md:91`).
+
+Phase 0.2 closes that loop by writing `docs/guides/gateway-tunnel.md`: the canonical, copy-pasteable, end-to-end procedure for exposing a webhook-receiving bridge to a live harness orchestrator using each of the three supported tunnel patterns, with the reference Slack bridge as the worked example.
+
+### Problem
+
+Three concrete frictions exist today:
+
+1. **The bridge README points at a non-existent file.** `examples/slack-echo-bridge/README.md` references `docs/guides/gateway-tunnel.md` as the canonical setup; the link is dead until this phase ships.
+2. **The orchestrator's network constraints are documented only in code.** A bridge author hitting `POST /api/v1/webhooks` with `http://localhost:3000/...` gets a 422 (`URL must use https` or `URL must not target private or loopback addresses`) with no obvious next step. The fix is "use a tunnel" — but nothing in the docs tree names the supported tunnel patterns.
+3. **Three tunnel tools have meaningfully different operational profiles.** Tailscale (private mesh, signed-in peers), Cloudflare Tunnel (anonymous public HTTPS, free, persistent), and ngrok (ephemeral, easiest for one-shot demos) each suit a different deployment shape. Without comparison the operator must read three sets of vendor docs, run three abandoned setups, and stitch together which step is harness-specific.
+
+### Goals
+
+1. **Reproducible end-to-end procedure** for each of Tailscale, Cloudflare Tunnel, and ngrok — fresh developer machine → tunnel up → live orchestrator → Slack message received, in one read.
+2. **Explicit citation of orchestrator constraints** so the guide stays correct even if the orchestrator's URL validator changes: `https://` only, `isPrivateHost()` rejects loopback / RFC-1918 / link-local / `*.local`, body cap 1 MiB.
+3. **Trade-off matrix** so the operator can pick a tool by deployment shape (private mesh vs. anonymous public vs. one-shot demo), not by alphabetical order.
+4. **Cross-link from the bridge README and docs index** so anyone arriving from the Phase 0.1 reference consumer or the guides landing page finds it.
+
+### Non-goals
+
+- **Tunnel tool comparison beyond the three named patterns.** SSH reverse tunnels, Wireguard hand-rolled, frp, localtunnel — out of scope; the spec named the canonical three.
+- **Production deployment guidance.** This guide targets a developer machine + a deployed orchestrator OR a deployed bridge + a developer-laptop orchestrator. Multi-tenant SaaS deployment, autoscaling, HA tunneling — out of scope.
+- **A second worked example.** The Slack bridge IS the worked example (proposal §547: "includes a sample Slack-bot bridge as the end-to-end example"). Discord/GitHub-app/custom examples are deferred.
+- **Codifying the tunnel as a harness-managed primitive.** Proposal §D5 explicitly rejected `HARNESS_LISTEN_MODE=public` and a harness-owned tunnel. Nothing in this phase adds code to the orchestrator or CLI.
+
+### Scope
+
+**In-scope:**
+
+- `docs/guides/gateway-tunnel.md` (NEW)
+- `docs/guides/index.md` — add entry pointing at the new guide
+- `examples/slack-echo-bridge/README.md` — remove the inline "forthcoming" `_Note:_` block (the dead-link disclaimer at lines 91); the link itself is preserved
+- `docs/roadmap.md` — flip the Phase 0.2 item status from `planned` to `done` and link the plan
+
+**Out-of-scope:**
+
+- Orchestrator code changes (no new env vars, no new validators, no public-binding code path)
+- New examples directory or new reference consumer
+- Knowledge graph node additions (no `business_concept` / `business_process` / `business_rule` nodes — this is operator documentation, not a knowledge primitive)
+
+## Decisions
+
+| #   | Decision                                                                                                                                                                                                                | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Three tunnel patterns covered in fixed order: Cloudflare Tunnel → Tailscale → ngrok                                                                                                                                     | Cloudflare Tunnel is the "production-shaped" default (free, persistent hostname, anonymous public HTTPS, no peer-install on the orchestrator side); Tailscale is the right answer when both sides are owned by the same operator and want a private mesh; ngrok is the right answer for a 5-minute demo or CI smoke run. Ordering signals the recommended-first choice. **Rejected:** alphabetical (Cloudflare/Tailscale/ngrok would not survive a rename and obscures the recommendation). |
+| 2   | The Slack bridge is the only worked example                                                                                                                                                                             | Proposal §547 explicitly names it as the end-to-end example. A second example would double maintenance burden without changing the tunnel shape. **Rejected:** generic curl-receiver example (no Slack proof, easier to write incorrectly), Discord adapter (no reference consumer exists yet).                                                                                                                                       |
+| 3   | Each pattern documents two topology variants: **bridge-local + orchestrator-remote** and **bridge-remote + orchestrator-local**                                                                                         | These are the two real shapes a developer faces. Bridge-local + orchestrator-remote is the deployed-orchestrator-on-a-VPS case; bridge-remote + orchestrator-local is the developer-laptop-running-the-orchestrator case. Skipping either leaves a 50% reader stranded. **Rejected:** single bidirectional topology (overspecifies, doesn't match either real shape).                                                                  |
+| 4   | The HMAC verification snippet from `examples/slack-echo-bridge/src/signer.ts` is NOT duplicated into the guide — only linked                                                                                             | Duplicated code rots. The bridge owns the canonical 5-line snippet; the guide links to it. **Rejected:** inline the snippet (rot risk; proposal §792 already places the snippet in the bridge, not in this guide).                                                                                                                                                                                                                    |
+| 5   | The guide cites orchestrator constraints by file path + line range (`packages/orchestrator/src/server/routes/v1/webhooks.ts:143-150`, `packages/orchestrator/src/server/utils/url-guard.ts`) rather than restating them | Restated constraints drift; cited constraints stay correct or fail loudly under `harness check-docs`. **Rejected:** restate inline (drift risk).                                                                                                                                                                                                                                                                                      |
+| 6   | A "Troubleshooting" table mirrors the Slack-bridge README shape                                                                                                                                                         | Operators land on the troubleshooting table 80% of the time after the happy-path fails. Bridge README already established the table shape (`README.md:117-126`); the guide reuses the convention. **Rejected:** free-form troubleshooting prose (less scannable).                                                                                                                                                                     |
+| 7   | No code, no tests, no harness CLI surface added                                                                                                                                                                         | The whole point of §D5 was to keep this out of code. Phase 0.2 IS the documentation deliverable.                                                                                                                                                                                                                                                                                                                                      |
+
+## Technical Design
+
+### File layout
+
+**New:**
+
+```
+docs/guides/gateway-tunnel.md
+docs/changes/hermes-phase-0-2-gateway-tunnel-guide/proposal.md   -- this file
+docs/changes/hermes-phase-0-2-gateway-tunnel-guide/plans/<dated>-gateway-tunnel-guide-plan.md
+```
+
+**Modified:**
+
+- `docs/guides/index.md` — add "Gateway Tunnel Guide" entry under the existing alphabetical-ish guide list (between "Docker Deployment" and "Features Overview" by natural ordering).
+- `examples/slack-echo-bridge/README.md` — delete the "forthcoming" disclaimer paragraph at line 91. The pointer at line 89 stays exactly as-is and now resolves.
+- `docs/roadmap.md` — Phase 0.2 entry: `Status: planned` → `done`, `Plan:` set to the plan path.
+
+### Guide structure (`docs/guides/gateway-tunnel.md`)
+
+```
+# Gateway Tunnel Guide
+
+## Why this guide exists
+   - Orchestrator binds 127.0.0.1 by default
+   - Bridges must register `https://` URLs that resolve to non-private hosts
+   - Tunnel is the operator-side solution; harness does not own one
+
+## What you need before starting
+   - A running harness orchestrator with a token that has `subscribe-webhook` scope
+   - The Slack echo bridge (examples/slack-echo-bridge/) built and runnable locally
+   - Slack workspace + bot token + channel id
+
+## Pick a tunnel
+   - Quick comparison table (anonymity, persistence, install footprint, recommended for)
+   - Pattern 1: Cloudflare Tunnel (recommended for production-shaped use)
+   - Pattern 2: Tailscale (recommended for private mesh)
+   - Pattern 3: ngrok (recommended for demos / one-shot tests)
+
+## Per-pattern recipe (×3)
+   Each pattern includes:
+     - Install + auth one-time setup
+     - Start the bridge on 127.0.0.1:3000
+     - Bring up the tunnel
+     - Capture the public https URL
+     - POST /api/v1/webhooks with the public URL
+     - Trigger maintenance.completed, watch Slack
+     - Teardown
+   Each pattern documents BOTH topology variants:
+     (a) bridge-local, orchestrator-remote
+     (b) bridge-remote, orchestrator-local
+
+## Verifying it worked
+   - Bridge logs: webhook.received → webhook.delivered
+   - Orchestrator dashboard: webhook delivery status row
+   - Slack: message visible in channel
+
+## Constraints (cited from code)
+   - https only (routes/v1/webhooks.ts:143)
+   - non-private host (utils/url-guard.ts)
+   - 1 MiB body cap
+
+## Troubleshooting
+   - URL must use https → tunnel not started or http url copied
+   - URL must not target private or loopback addresses → public hostname mismatch
+   - 401 webhook.signature.mismatch → secret swap missed
+   - Tunnel reset / 502 from public endpoint → bridge not listening or port mismatch
+
+## Security notes
+   - Tunnel public URL = world-readable; HMAC signature is your authn
+   - Tailscale: peers are signed-in; the bridge still validates HMAC
+   - Cloudflare Tunnel: optional Cloudflare Access in front for IP allowlisting
+   - ngrok free plan rotates URLs; recreate the subscription on each restart
+
+## Next steps
+   - Build a non-Slack bridge: link bridge README signer snippet
+   - Production deployment: link Docker guide, mention HOST=0.0.0.0 for container orchestrators
+```
+
+### Integration Points
+
+This is the section the workflow explicitly requires. Documents how the new guide wires into the surrounding system.
+
+1. **Bridge README (`examples/slack-echo-bridge/README.md`)** — already links to `docs/guides/gateway-tunnel.md` at line 89. The "forthcoming" disclaimer at line 91 gets removed; the link goes live. No other text changes.
+
+2. **Guides index (`docs/guides/index.md`)** — gains a new "### Gateway Tunnel Guide" section in the same shape as the existing entries (one-line summary, "Best for:" line). Placement: just after "Docker Deployment" since they're both operational-deployment guides.
+
+3. **Roadmap (`docs/roadmap.md`)** — Phase 0.2 entry flips to `done`, the `Plan:` line points at the dated plan file, and the GitHub external-id is preserved. The `manage_roadmap` MCP tool handles the GitHub-side close as part of integration.
+
+4. **Top-level README (`README.md`)** — line 30's Orchestrator Gateway API bullet currently links to the Slack bridge but not to the tunnel guide. NOT modified in this phase: the guide is downstream of the bridge in the natural reading order (bridge README is the entry point; the guide is the bridge's deeper-dive). Cross-linking from the top-level README adds a fourth link to an already-dense bullet without a navigation win.
+
+5. **Knowledge pipeline** — no new nodes. The guide is operator-facing, not knowledge-graph material. The phase ships zero updates to `docs/knowledge/`.
+
+6. **Code citations** — the guide cites `packages/orchestrator/src/server/routes/v1/webhooks.ts:143-150` (https + private-host check) and `packages/orchestrator/src/server/utils/url-guard.ts:1-12` (full `isPrivateHost` regex). `harness check-docs` (drift detector) will surface line-number drift on future edits; the integration step verifies the citations resolve at write-time.
+
+7. **ADR linkage** — `docs/knowledge/decisions/0011-orchestrator-gateway-api-contract.md` lines 82-83 already note that the gateway-tunnel guide is the deferred Phase 0.2 deliverable. The ADR text remains correct after this phase (still "the deferred deliverable" — done is also a kind of resolution; the ADR's "deferred" reads as "carved out", not "still pending"). No ADR edit required, but the integration step double-checks by grep.
+
+## Success Criteria
+
+### Level 1 — Functional
+
+- [ ] `docs/guides/gateway-tunnel.md` exists at the path the bridge README points to
+- [ ] The guide includes a section for each of Cloudflare Tunnel, Tailscale, and ngrok
+- [ ] Each pattern includes copy-pasteable commands ending in a `curl POST /api/v1/webhooks` step
+- [ ] The HMAC verification reference points at `examples/slack-echo-bridge/src/signer.ts`, not an inline copy
+- [ ] The orchestrator-constraint citations resolve to the correct line ranges at write time
+- [ ] `docs/guides/index.md` lists the new guide
+- [ ] `examples/slack-echo-bridge/README.md` no longer carries the "forthcoming" disclaimer
+- [ ] `docs/roadmap.md` Phase 0.2 entry status is `done`
+
+### Level 2 — Reproducibility (manual)
+
+- [ ] A fresh developer machine + Cloudflare Tunnel + a remote orchestrator URL completes the worked example end-to-end (proposal §675's reproducibility criterion, scoped to the Cloudflare path as the recommended default)
+
+### Level 3 — Integration
+
+- [ ] `harness validate` passes after the changes
+- [ ] `harness check-docs` reports zero new drift on the touched files
+- [ ] The roadmap GitHub issue is closed via `manage_roadmap` (handled at integration step)
+
+## Risk register
+
+- **Vendor-doc rot.** Tunnel CLIs evolve. The guide leans on copy-pasteable commands for `cloudflared tunnel`, `tailscale serve`, `ngrok http`. **Mitigation:** include the canonical vendor-docs URL inline for each pattern + a maintenance note that the harness team re-validates the recipes when re-running Phase 0.2 reproducibility.
+- **Tunnel security misimplication.** A reader might assume "tunnel = secure" and skip HMAC verification. **Mitigation:** the Security notes section is explicit that the HMAC signature is the authn boundary, NOT the tunnel.
+- **ngrok-URL rotation under free plan.** ngrok free re-rotates the URL on restart, invalidating the orchestrator's stored subscription. **Mitigation:** explicit teardown step + retry recipe in the ngrok pattern.
+- **The Slack bridge worked example references a future-tense doc that this guide now realizes.** A reader following the bridge README → guide → bridge README loop should not feel like they hit a circular reference. **Mitigation:** the guide's "What you need" section states "the Slack echo bridge … built and runnable locally" and links forward; the loop terminates at the curl POST step.

--- a/docs/guides/gateway-tunnel.md
+++ b/docs/guides/gateway-tunnel.md
@@ -1,0 +1,321 @@
+# Gateway Tunnel Guide
+
+How to expose a harness Gateway API bridge to a remote orchestrator (or a remote bridge to a local orchestrator) using Cloudflare Tunnel, Tailscale, or ngrok.
+
+This guide is the canonical operator-side answer to "the orchestrator binds 127.0.0.1 and only delivers to https URLs — how do I actually wire up a webhook bridge?". The harness orchestrator deliberately does **not** ship a public-binding mode or a built-in tunnel; routing public traffic to a webhook receiver is a deployment concern that an off-the-shelf tunnel solves better than harness ever could (see [ADR 0011](../knowledge/decisions/0011-orchestrator-gateway-api-contract.md) for the rationale).
+
+The end-to-end example throughout this guide is the [`examples/slack-echo-bridge/`](../../examples/slack-echo-bridge/) reference consumer: a standalone Node service that subscribes to `maintenance.completed` webhooks, verifies the `X-Harness-Signature: sha256=<hex>` HMAC SHA-256 signature, and posts a message to a Slack channel.
+
+> _Vendor commands re-validated 2026-05-16 against `cloudflared` 2025.x, `tailscale` 1.x, `ngrok` 3.x. If you hit a command surface drift, file an issue at `github:Intense-Visions/harness-engineering` with the offending pattern._
+
+## Why this guide exists
+
+Three constraints on the harness side force the tunnel:
+
+1. **The orchestrator binds `127.0.0.1` by default** ([`packages/orchestrator/src/server/http.ts:97-99`](../../packages/orchestrator/src/server/http.ts)). Override only with `HOST=0.0.0.0` and only when you genuinely need off-host inbound traffic — bare-binding to a public interface without an authn proxy in front is an explicit anti-pattern.
+2. **Webhook subscription URLs must be `https://`** ([`packages/orchestrator/src/server/routes/v1/webhooks.ts:143-146`](../../packages/orchestrator/src/server/routes/v1/webhooks.ts)). The orchestrator returns `422 { error: "URL must use https" }` on `http://`.
+3. **Webhook subscription URLs must not resolve to private or loopback addresses** ([`packages/orchestrator/src/server/utils/url-guard.ts`](../../packages/orchestrator/src/server/utils/url-guard.ts)). The orchestrator returns `422 { error: "URL must not target private or loopback addresses" }` for `localhost`, `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `*.local`, and IPv6 loopback equivalents.
+
+The tunnel solves all three at once: it gives you a real public `https://<random>.<vendor-domain>/` URL that resolves to a vendor edge, terminates TLS for you, and forwards traffic back to your `127.0.0.1` listener over an outbound-initiated connection.
+
+**The HMAC signature is your authentication boundary.** The public tunnel URL is world-reachable; nothing stops a stranger from POSTing to it. The bridge verifies `X-Harness-Signature: sha256=<hex>` against a shared secret on every request, and unsigned/malformed/wrong-secret requests get rejected with 401. Treat the tunnel URL as public and the HMAC verifier as the gate. See the [Security notes](#security-notes) section.
+
+## What you need before starting
+
+- A running harness orchestrator (locally or on a deployed host) reachable to **you** at some address (`http://localhost:8080` for a local one, or whatever your operator wired up).
+- A Gateway API token with the `subscribe-webhook` scope. Create one with:
+
+  ```bash
+  harness gateway token create --name slack-bridge --scopes subscribe-webhook
+  # → prints { id: "tok_…", secret: "<one-time-secret>" } once. Save the secret.
+  ```
+
+- The Slack echo bridge built and runnable locally:
+
+  ```bash
+  cd examples/slack-echo-bridge
+  npm install
+  cp .env.example .env
+  # edit .env — SLACK_BOT_TOKEN, SLACK_CHANNEL. HARNESS_WEBHOOK_SECRET is filled in
+  # after you create the subscription further below.
+  npm run build
+  ```
+
+- A Slack workspace, a bot user with `chat:write`, and a target channel **ID** (`C…` — not the channel name).
+
+## Pick a tunnel
+
+| Tunnel                              | Public URL persistence       | Anonymous to peers?        | Install footprint                 | Recommended for                                  |
+| ----------------------------------- | ---------------------------- | -------------------------- | --------------------------------- | ------------------------------------------------ |
+| [Cloudflare Tunnel](#1-cloudflare-tunnel) | Persistent named hostname    | Yes (anonymous public HTTPS) | `cloudflared` daemon, Cloudflare account, one DNS record | Production-shaped deployments; long-lived bridges |
+| [Tailscale](#2-tailscale)           | Stable while peers signed in | No (peers are signed-in)   | `tailscale` daemon on both ends   | Private mesh; you own both ends                  |
+| [ngrok](#3-ngrok)                   | Ephemeral (free) or reserved (paid) | Yes (anonymous public HTTPS) | `ngrok` binary, ngrok account  | Demos, CI smoke runs, 5-minute experiments       |
+
+The order in this guide is the recommended order to reach for. Read the comparison row that matches your situation, then jump to that section.
+
+---
+
+## 1. Cloudflare Tunnel
+
+Cloudflare Tunnel runs an outbound-only daemon (`cloudflared`) that connects to the Cloudflare edge and accepts public HTTPS traffic on a hostname you control (via Cloudflare DNS). The bridge stays on `127.0.0.1`; no inbound port is opened on its host.
+
+### 1a. Bridge-local, orchestrator-remote (Slack bridge on your laptop, orchestrator on a deployed host)
+
+This is the "I'm developing a bridge against a hosted harness" case.
+
+**One-time setup:**
+
+```bash
+# Install
+brew install cloudflared           # macOS
+# or: see https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+
+# Authenticate (opens a browser; pick the zone you'll use)
+cloudflared tunnel login
+
+# Create a named tunnel
+cloudflared tunnel create harness-slack-bridge
+# → prints a tunnel UUID and writes credentials to ~/.cloudflared/<uuid>.json
+
+# Route a DNS hostname at the tunnel (replace bridge.example.com with a hostname under
+# a Cloudflare-managed zone you own):
+cloudflared tunnel route dns harness-slack-bridge bridge.example.com
+```
+
+**Per-session:**
+
+```bash
+# In one terminal: start the bridge on 127.0.0.1:3000
+cd examples/slack-echo-bridge
+npm start                          # listens on 127.0.0.1:3000 by default
+
+# In another terminal: bring up the tunnel pointing at the bridge
+cloudflared tunnel --url http://127.0.0.1:3000 run harness-slack-bridge
+```
+
+`cloudflared` is now forwarding `https://bridge.example.com/*` → `http://127.0.0.1:3000/*`.
+
+**Register the subscription with the orchestrator:**
+
+```bash
+curl -X POST https://<orchestrator-host>/api/v1/webhooks \
+  -H "authorization: Bearer <tok_…>" \
+  -H "content-type: application/json" \
+  -d '{
+    "url": "https://bridge.example.com/webhooks/maintenance-completed",
+    "events": ["maintenance.completed"]
+  }'
+# → { id: "whk_…", secret: "<base64url-secret>", … }
+```
+
+Copy the `secret` into `HARNESS_WEBHOOK_SECRET` in `examples/slack-echo-bridge/.env`, then restart `npm start`. Trigger a maintenance job on the orchestrator and watch:
+
+- Bridge logs: `webhook.received` → `webhook.verified` → `slack.postMessage.ok`
+- Slack channel: the formatted maintenance message lands
+
+**Teardown:**
+
+```bash
+# Stop the bridge and cloudflared. The named tunnel + DNS record persist;
+# the next session reuses both. To remove entirely:
+cloudflared tunnel delete harness-slack-bridge
+```
+
+### 1b. Bridge-remote, orchestrator-local (orchestrator on your laptop, bridge on a deployed host)
+
+This is the "I'm developing the orchestrator and want a real bridge calling it" case. Same `cloudflared` mechanics; tunnel target flips.
+
+**Run on the bridge's host** (e.g. a Fly.io VM, EC2, or anywhere you've placed the bridge):
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:3000 run harness-slack-bridge
+```
+
+**Register the subscription with the orchestrator** — but the orchestrator is on your laptop binding `127.0.0.1`. The bridge can't reach `https://localhost`, so flip the perspective: register the bridge's tunnel URL with the local orchestrator and let the orchestrator's **outbound** delivery dial out to `https://bridge.example.com`:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/webhooks \
+  -H "authorization: Bearer <tok_…>" \
+  -H "content-type: application/json" \
+  -d '{
+    "url": "https://bridge.example.com/webhooks/maintenance-completed",
+    "events": ["maintenance.completed"]
+  }'
+```
+
+Outbound from the orchestrator goes to the public DNS name → Cloudflare edge → `cloudflared` on the bridge host → `127.0.0.1:3000`. No tunnel required on the orchestrator side.
+
+---
+
+## 2. Tailscale
+
+Tailscale builds a WireGuard mesh where every host is identifiable by a magicDNS name (`<machine>.<tailnet>.ts.net`) on a private network. Unlike Cloudflare Tunnel and ngrok, Tailscale peers are **signed-in** — only members of your tailnet can resolve and reach the hostname. Pick Tailscale when you own both the orchestrator host and the bridge host and want a private link with no public surface at all.
+
+The harness orchestrator's URL guard rejects `localhost`, RFC-1918, and `*.local`, but Tailscale's `ts.net` magicDNS names resolve to CGNAT `100.x.y.z` addresses outside those ranges, so the orchestrator accepts them.
+
+### 2a. Bridge-local, orchestrator-remote (both on your tailnet)
+
+**One-time setup:**
+
+```bash
+# Install on the bridge host
+brew install tailscale             # macOS, or follow https://tailscale.com/download
+sudo tailscale up                  # opens a browser to authenticate
+tailscale status                   # confirm your machine is listed
+```
+
+Repeat on the orchestrator host. Both must share a tailnet.
+
+**Per-session:**
+
+```bash
+# On the bridge host, start the bridge listening on the Tailscale interface OR
+# on 127.0.0.1 fronted by `tailscale serve`. The `tailscale serve` route is
+# cleaner because it terminates TLS at the Tailscale daemon — no certs to
+# manage and you get a real https:// URL.
+cd examples/slack-echo-bridge
+npm start                          # listens on 127.0.0.1:3000
+
+# In a second terminal on the same host:
+tailscale serve --bg --https=443 http://127.0.0.1:3000
+# → prints https://<machine>.<tailnet>.ts.net/ as the public-on-tailnet URL
+```
+
+**Register the subscription** from the orchestrator host:
+
+```bash
+curl -X POST https://<orchestrator-host>/api/v1/webhooks \
+  -H "authorization: Bearer <tok_…>" \
+  -H "content-type: application/json" \
+  -d '{
+    "url": "https://<machine>.<tailnet>.ts.net/webhooks/maintenance-completed",
+    "events": ["maintenance.completed"]
+  }'
+```
+
+The orchestrator's outbound delivery dials the magicDNS name; resolution succeeds **only because the orchestrator host is on the same tailnet**. A non-tailnet caller cannot resolve the hostname.
+
+**Teardown:**
+
+```bash
+tailscale serve reset              # tears down the serve mapping
+# tailscale daemon keeps running; leave as-is for the next session
+```
+
+### 2b. Bridge-remote, orchestrator-local (Tailscale mirror)
+
+Symmetric to §1b. Run `tailscale serve` on the bridge host; from your laptop orchestrator (also on the tailnet) register the bridge's `https://<machine>.<tailnet>.ts.net/...` URL. The orchestrator's outbound delivery dials magicDNS over WireGuard.
+
+---
+
+## 3. ngrok
+
+ngrok is the fastest-to-set-up option and the right choice for a 5-minute demo or a one-shot integration smoke. The free plan gives an ephemeral public hostname that rotates on every restart — fine for demos, painful for anything long-lived (you re-create the webhook subscription each rotation). The paid plan reserves a stable hostname.
+
+### 3a. Bridge-local, orchestrator-remote
+
+**One-time setup:**
+
+```bash
+brew install ngrok                 # macOS, or download from https://ngrok.com/download
+ngrok config add-authtoken <your-ngrok-authtoken>
+```
+
+**Per-session:**
+
+```bash
+# Terminal 1: start the bridge
+cd examples/slack-echo-bridge
+npm start                          # 127.0.0.1:3000
+
+# Terminal 2: bring up the tunnel
+ngrok http 3000
+# → prints a Forwarding line like:
+#   Forwarding   https://abc123-xyz.ngrok-free.app -> http://localhost:3000
+```
+
+**Register the subscription:**
+
+```bash
+curl -X POST https://<orchestrator-host>/api/v1/webhooks \
+  -H "authorization: Bearer <tok_…>" \
+  -H "content-type: application/json" \
+  -d '{
+    "url": "https://abc123-xyz.ngrok-free.app/webhooks/maintenance-completed",
+    "events": ["maintenance.completed"]
+  }'
+```
+
+Trigger a maintenance job. Watch the ngrok inspector at `http://127.0.0.1:4040` to see each delivery's request/response pair — invaluable for debugging signature mismatches.
+
+**Teardown:**
+
+```bash
+# Ctrl-C the ngrok process. The hostname is gone; if you restart ngrok you'll
+# get a new hostname and the orchestrator's stored subscription will start
+# failing on every delivery. Delete and re-create the subscription:
+curl -X DELETE https://<orchestrator-host>/api/v1/webhooks/whk_… \
+  -H "authorization: Bearer <tok_…>"
+```
+
+### 3b. Bridge-remote, orchestrator-local
+
+Same pattern; run `ngrok http 3000` on the bridge host, register the resulting `https://*.ngrok-free.app/...` URL with the laptop-local orchestrator.
+
+---
+
+## Verifying it worked
+
+End-to-end, a successful `maintenance.completed` delivery looks like this:
+
+1. **Orchestrator side** (`harness gateway deliveries list` or the dashboard's webhook page): the latest delivery row shows `status: delivered`, `attempts: 1`, `responseCode: 200`.
+2. **Bridge logs:**
+   ```
+   webhook.received   { deliveryId: "dlv_…", eventType: "maintenance.completed" }
+   webhook.verified   { deliveryId: "dlv_…" }
+   slack.postMessage.ok { channel: "C…", ts: "1730000000.001" }
+   ```
+3. **Slack:** the formatted maintenance-completed message appears in the configured channel.
+
+If any of those three is missing, jump to [Troubleshooting](#troubleshooting).
+
+## HMAC verification
+
+The bridge verifies `X-Harness-Signature: sha256=<lowercase-hex>` on every delivery against `HMAC-SHA256(HARNESS_WEBHOOK_SECRET, rawBody)` using constant-time compare. The canonical 5-line snippet lives in [`examples/slack-echo-bridge/src/signer.ts`](../../examples/slack-echo-bridge/src/signer.ts) — read that file rather than copy-pasting from this guide, since the bridge owns the canonical implementation and this guide does not.
+
+If you build a non-Slack bridge in another language, the wire contract is:
+
+- Header: `X-Harness-Signature: sha256=<lowercase-hex-digest>`
+- Body: the raw request body (do **not** reparse before computing the digest)
+- Secret: the `secret` field returned **once** from `POST /api/v1/webhooks`
+- Comparison: constant-time / `timingSafeEqual`-style; reject pairs of unequal byte length before comparing
+
+The orchestrator also includes `X-Harness-Delivery-Id` ([`packages/orchestrator/src/gateway/webhooks/delivery.ts:147`](../../packages/orchestrator/src/gateway/webhooks/delivery.ts)) — stable across retries of the same delivery — that you can use as a dedup key if your bridge needs exactly-once semantics.
+
+## Troubleshooting
+
+| Symptom                                                                              | Likely cause                                                                                                              | Fix                                                                                                                                                                                                                  |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/v1/webhooks` returns `422 { error: "URL must use https" }`                | The URL you sent starts with `http://` (e.g. you copied the bridge's local URL instead of the tunnel URL).                | Re-read the tunnel-forwarder output; use the `https://` URL it printed.                                                                                                                                              |
+| `POST /api/v1/webhooks` returns `422 { error: "URL must not target private…" }`      | The URL hostname matches `localhost`, `127.x.x.x`, `10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`, `169.254.x.x`, or `*.local`. | The tunnel isn't pointing at a public hostname. For ngrok, look for the `Forwarding` line and copy the `*.ngrok-free.app` URL. For Tailscale, use the `*.ts.net` magicDNS name, not `100.x.y.z` directly.            |
+| Bridge logs `webhook.signature.mismatch` (HTTP 401) on every delivery               | `HARNESS_WEBHOOK_SECRET` in `.env` doesn't match what the orchestrator generated for this subscription.                   | Re-read the **one-time** `secret` field from the `POST /api/v1/webhooks` response (you can't fetch it again). If you've lost it, `DELETE /api/v1/webhooks/<id>` and re-create the subscription, then update `.env`. |
+| Orchestrator dashboard shows `status: failed, responseCode: 502` for every delivery  | The tunnel is up but the bridge isn't listening on the upstream port the tunnel forwards to (typo on the port).            | Confirm `npm start` is running. Check the tunnel's upstream: `cloudflared tunnel --url http://127.0.0.1:3000` ⇄ bridge `PORT=3000` (or whatever you set).                                                            |
+| Delivery succeeds but you don't see a Slack message                                  | Bridge returned 200 but Slack rejected the post (bad channel ID, missing `chat:write`).                                   | Read the bridge log line `slack.postMessage.failed`. Common: `channel_not_found` → use the channel **ID** (`C…`), not the name. `not_authed` / `invalid_auth` → rotate `SLACK_BOT_TOKEN`.                            |
+| ngrok URL rotated overnight; deliveries 502 ever since                               | Free-plan ngrok rotates URLs on restart. The orchestrator still has the old `*.ngrok-free.app` URL in its subscription.   | `DELETE /api/v1/webhooks/<id>` then re-register with the current ngrok URL, copy the fresh `secret` into `.env`, restart the bridge. Or use Cloudflare Tunnel / paid-ngrok for a stable hostname.                    |
+| Cloudflare Tunnel: `cloudflared` exits with `error connecting to origin`             | The bridge isn't on `127.0.0.1:3000` (different port, not running, or bound to `0.0.0.0` and firewalled).                 | Run `curl -i http://127.0.0.1:3000/healthz` (or whatever the bridge exposes) directly from the tunnel host — it must succeed locally before `cloudflared` can forward.                                              |
+| Tailscale: orchestrator on the same tailnet still gets `URL must not target private` | The orchestrator's `isPrivateHost` check rejected the address you used.                                                   | Use the magicDNS name (`<machine>.<tailnet>.ts.net`), not the `100.x.y.z` Tailscale IP and not `<machine>.local`.                                                                                                    |
+| Delivery payload returns 413                                                         | Bridge body cap (default 1 MiB) exceeded.                                                                                 | Default cap is 1,048,576 bytes ([`packages/orchestrator/src/server/utils.ts:3`](../../packages/orchestrator/src/server/utils.ts)). Bump the bridge's `maxBodyBytes` if you genuinely need larger payloads.           |
+
+## Security notes
+
+- **The HMAC signature is the authentication boundary, not the tunnel.** Public tunnels (Cloudflare, ngrok) expose the bridge's URL to the internet. Anyone who guesses or learns the URL can POST to it. The bridge's only defense is rejecting requests whose `X-Harness-Signature` doesn't validate against the shared secret. **Do not skip signature verification under "but my URL is secret."** URL secrecy is broken (Phase 0 §156 explicitly rejected the URL-secrecy model).
+- **Tailscale gives you peer authentication too, layered on top of HMAC.** Only signed-in tailnet members can resolve the magicDNS name, so an internet stranger cannot reach the bridge at all. HMAC verification is still required (and the bridge still enforces it) as defense-in-depth.
+- **Cloudflare Tunnel optionally chains Cloudflare Access in front of the public hostname** for IP allowlisting / SSO before traffic reaches `cloudflared`. Useful when the bridge's audience is internal even though the URL is technically public.
+- **Never commit `HARNESS_WEBHOOK_SECRET` or the tunnel-vendor auth tokens to git.** The bridge's `.env` is gitignored by default; keep it that way. If you leak a webhook secret, `DELETE /api/v1/webhooks/<id>` immediately and re-create the subscription — there is no rotation endpoint (Phase 0 §154).
+- **Audit-log shape.** Every delivery attempt writes one row to the orchestrator's `webhook-queue.sqlite`. Failed deliveries persist the response body to the `lastError` column. If your bridge surfaces verbose error strings that embed bearer tokens (e.g. `@slack/web-api` does this in rare transport failures — see [the slack-bridge README "Verbatim Slack errors" note](../../examples/slack-echo-bridge/README.md)), those strings land on disk. Production bridges in regulated environments should redact `Bearer …` / `xoxb-…` substrings from their 502 response bodies.
+
+## Next steps
+
+- **Building a non-Slack bridge?** Re-use the wire contract: read [`examples/slack-echo-bridge/src/signer.ts`](../../examples/slack-echo-bridge/src/signer.ts) for HMAC, [`examples/slack-echo-bridge/src/webhook-handler.ts`](../../examples/slack-echo-bridge/src/webhook-handler.ts) for the HTTP shape, and the OpenAPI artifact at [`docs/api/openapi.yaml`](../api/openapi.yaml) for the orchestrator's full surface.
+- **Production deployment?** If you're running the orchestrator in Docker behind a real reverse proxy (Caddy, nginx, Traefik), the tunnel pattern is unnecessary — that proxy gives you `https://` on a real hostname, and you set `HOST=0.0.0.0` so the orchestrator listens on the container's network namespace. See [Docker Deployment](docker.md) for the container setup. The tunnel patterns here are explicitly for the developer-machine + remote-counterpart case.
+- **Operator runbook for the harness Gateway API?** See [ADR 0011](../knowledge/decisions/0011-orchestrator-gateway-api-contract.md) for the Gateway API design rationale and the long-form decision log.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -67,6 +67,17 @@ Run and deploy harness via Docker containers:
 
 **Best for:** Teams deploying harness as containerized services or running without local Node.js
 
+### [Gateway Tunnel Guide](./gateway-tunnel.md)
+
+Expose a Gateway API bridge to a remote orchestrator (or a remote bridge to a local orchestrator) using a tunnel, since the orchestrator binds `127.0.0.1` by default and only delivers to public `https://` URLs:
+
+- Cloudflare Tunnel, Tailscale, and ngrok as the three canonical patterns
+- Per-pattern recipe: install, start, register subscription, verify, teardown
+- Both topology variants: bridge-local + orchestrator-remote, and bridge-remote + orchestrator-local
+- Troubleshooting table, security notes (HMAC is the authn boundary, not the tunnel), and pointers to the reference Slack bridge
+
+**Best for:** Anyone wiring an external webhook bridge to a running harness orchestrator across hosts
+
 ### [Templates and Framework Overlays](./templates-and-overlays.md)
 
 How project scaffolding works -- the template system behind `harness init`:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1153,12 +1153,12 @@ last_manual_edit: 2026-05-16T13:50:11.526Z
 
 ### Hermes Phase 0.2: Gateway Tunnel Guide
 
-- **Status:** planned
-- **Spec:** docs/changes/hermes-phase-0-gateway-api/proposal.md
-- **Summary:** `docs/guides/gateway-tunnel.md` covering Tailscale, Cloudflare Tunnel, and ngrok as canonical bridge-exposure patterns. Required to complete the spec §D5 "localhost-by-default + tunnel-pattern guide" decision. Deferred from Phase 0.
+- **Status:** done
+- **Spec:** docs/changes/hermes-phase-0-2-gateway-tunnel-guide/proposal.md
+- **Summary:** `docs/guides/gateway-tunnel.md` covering Cloudflare Tunnel, Tailscale, and ngrok as canonical bridge-exposure patterns. Completes the parent spec §D5 "localhost-by-default + tunnel-pattern guide" decision (parent: docs/changes/hermes-phase-0-gateway-api/proposal.md). Slack echo bridge is the worked end-to-end example.
 - **Blockers:** —
-- **Plan:** —
-- **Assignee:** —
+- **Plan:** docs/changes/hermes-phase-0-2-gateway-tunnel-guide/plans/2026-05-16-gateway-tunnel-guide-plan.md
+- **Assignee:** @cwarner
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#328
 

--- a/examples/slack-echo-bridge/README.md
+++ b/examples/slack-echo-bridge/README.md
@@ -86,9 +86,7 @@ See `src/signer.ts` for the full implementation with the length-mismatch guard (
 
 ## Exposing the bridge to the internet
 
-The orchestrator runs on `127.0.0.1` by default and will only deliver to `https://` URLs. To accept deliveries from a live orchestrator on a developer machine, expose the bridge via a tunnel. See `docs/guides/gateway-tunnel.md` for the canonical setups (Tailscale, Cloudflare Tunnel, ngrok).
-
-> _Note: `docs/guides/gateway-tunnel.md` is a forthcoming Hermes Phase 0.2 deliverable and has not been written yet. Until then, use Tailscale, Cloudflare Tunnel, or ngrok directly per their own docs — point the tunnel at `http://127.0.0.1:3000` (or whatever `PORT` you chose) and use the resulting public HTTPS URL as the `url` field when calling `POST /api/v1/webhooks`._
+The orchestrator runs on `127.0.0.1` by default and will only deliver to `https://` URLs. To accept deliveries from a live orchestrator on a developer machine, expose the bridge via a tunnel. See [`docs/guides/gateway-tunnel.md`](../../docs/guides/gateway-tunnel.md) for the canonical setups (Cloudflare Tunnel, Tailscale, ngrok) with this bridge as the end-to-end worked example.
 
 ## Known properties (intentional)
 


### PR DESCRIPTION
## Summary

- Ships `docs/guides/gateway-tunnel.md`, the canonical bridge-exposure guide called for by the Phase 0 Orchestrator Gateway API spec §D5. Covers **Cloudflare Tunnel**, **Tailscale**, and **ngrok** with copy-pasteable recipes for both topology variants (bridge-local + orchestrator-remote, and bridge-remote + orchestrator-local). The Slack echo bridge (`examples/slack-echo-bridge/`) is the worked end-to-end example.
- Removes the "forthcoming" disclaimer in `examples/slack-echo-bridge/README.md`; the cross-reference now resolves.
- Flips `docs/roadmap.md` "Hermes Phase 0.2: Gateway Tunnel Guide" (#328) from `planned` to `done`.
- No orchestrator code changes, no knowledge-graph nodes, no new CLI surface — the whole point of §D5 was to keep this out of code.

Spec: `docs/changes/hermes-phase-0-2-gateway-tunnel-guide/proposal.md`
Plan: `docs/changes/hermes-phase-0-2-gateway-tunnel-guide/plans/2026-05-16-gateway-tunnel-guide-plan.md`
Parent: `docs/changes/hermes-phase-0-gateway-api/proposal.md` (§D5, §547)
Closes #328

## Guide contents

- Why the tunnel exists (cites \`getBindHost\`, \`webhooks.ts:143-150\`, \`url-guard.ts\` so future drift surfaces in \`harness check-docs\`)
- Pick-a-tunnel comparison table (persistence / anonymity / install footprint / recommended-for)
- Per-pattern recipe (×3): install + auth, start bridge, bring up tunnel, register \`POST /api/v1/webhooks\`, trigger and verify, teardown
- HMAC verification — link-only to \`examples/slack-echo-bridge/src/signer.ts\` (no inline copy; bridge owns the canonical snippet per spec §792)
- Troubleshooting table (https mismatch, private-host rejection, signature mismatch, 502, ngrok URL rotation, 413 body cap…)
- Security notes: HMAC is the authn boundary, **not** the tunnel
- Next steps: non-Slack bridge wiring, production Docker hand-off

## Test plan

- [x] \`harness validate\` passes
- [x] \`harness check-docs\` reports 90.0% coverage (no new drift)
- [x] All file-path citations resolve
- [x] No remaining "forthcoming" blockquote in \`examples/slack-echo-bridge/README.md\`
- [x] \`docs/guides/index.md\` lists the new guide between Docker Deployment and Templates
- [x] Roadmap entry flipped to \`done\` with the Plan pointer populated
- [ ] **Manual end-to-end reproducibility** (proposal §675; recommended Cloudflare path) — deferred to integration; tracked as Phase 0.2 success criterion Level 2