### PR TITLE
chore(roadmap): mark Hermes Phase 0.1 Reference Slack Bridge as done

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ version: 1
 created: 2026-03-21
 updated: 2026-04-24
 last_synced: 2026-05-15T18:43:18.077Z
-last_manual_edit: 2026-05-16T13:50:11.526Z
+last_manual_edit: 2026-05-17T18:46:00.000Z
 ---
 
 # Roadmap
@@ -1142,7 +1142,7 @@ last_manual_edit: 2026-05-16T13:50:11.526Z
 
 ### Hermes Phase 0.1: Reference Slack Bridge
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/hermes-phase-0-gateway-api/proposal.md
 - **Summary:** External test consumer `examples/slack-echo-bridge/` — ~150 LOC Node bridge that subscribes to `maintenance.completed` webhooks, verifies HMAC SHA-256 signatures, posts to Slack. Validates the Phase 0 API contract is usable from an external bridge author's perspective (anti-success #4). Deferred from Phase 0 to ship Phase 0 surface promptly.
 - **Blockers:** —


### PR DESCRIPTION
## Summary

The reference Slack bridge at `examples/slack-echo-bridge/` shipped via PR #335 (`feature/hermes-phase-0`) — all 11 Phase 6 tasks merged. This PR flips the roadmap status from `in-progress` to `done` to reflect the merged code.

## Implementation already on main

- HMAC SHA-256 verification with constant-time compare + length-mismatch guard (`src/signer.ts`)
- Raw-body capture before JSON parsing — load-bearing for HMAC correctness (`src/webhook-handler.ts`)
- Slack `chat.postMessage` wrapper with verbatim error surface (`src/slack-client.ts`)
- Standalone Node project (NOT in pnpm workspace) — installable by an external author with `@slack/web-api` as the only runtime dep
- 14 vitest cases (6 signer + 8 HTTP flow) — all green
- README documents env-var contract, one-time-secret capture workflow, 5-line HMAC-verify snippet, and intentional known properties

## Success-criteria satisfied (code level)

- Spec §672 — \"reference bridge built against the API\"
- Spec §685 — \"external test consumer exists\"
- Phase 0 anti-success #4 — reference bridge author validates the API contract is usable

## Operational gap (carried forward)

Spec §870's live end-to-end run against a real orchestrator + Slack workspace is documented in `CHANGELOG.md` as pending operational verification — that is **not** a blocker to closing the roadmap item, since the code-level contract is fully exercised by the 14 unit/integration tests. The live run is the kind of verification that lives in the Phase 0.2 tunnel-guide validation flow (already done) or a post-GA telemetry window.

## Test plan

- [x] \`npm install && npm test\` in \`examples/slack-echo-bridge/\` — 14/14 pass
- [x] \`npm run typecheck\` — clean
- [x] \`pnpm exec harness validate\` — passes