### PR TITLE
docs(roadmap): mark Hermes Phase 5 done — sync stale entry

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ version: 1
 created: 2026-03-21
 updated: 2026-04-24
 last_synced: 2026-05-15T18:43:18.077Z
-last_manual_edit: 2026-05-16T13:50:11.526Z
+last_manual_edit: 2026-05-17T19:30:00.000Z
 ---
 
 # Roadmap
@@ -1208,12 +1208,12 @@ last_manual_edit: 2026-05-16T13:50:11.526Z
 
 ### Hermes Phase 5: Dispatch Hardening
 
-- **Status:** planned
-- **Spec:** docs/changes/hermes-adoption/proposal.md
+- **Status:** done
+- **Spec:** docs/changes/hermes-phase-5-dispatch-hardening/proposal.md
 - **Summary:** SSH agent dispatch backend, serverless backend interface (Modal-style not Modal-coupled), isolation tier as fourth axis on BackendRouter (local/container/remote-sandbox), per-task cost ceiling with abort-on-exceed. Cost ceiling requires Phase 0 telemetry. From Hermes adoption meta-spec.
-- **Blockers:** Hermes Phase 0: Gateway API + Telemetry
-- **Plan:** —
-- **Assignee:** —
+- **Blockers:** —
+- **Plan:** docs/changes/hermes-phase-5-dispatch-hardening/plans/2026-05-16-main-plan.md
+- **Assignee:** @cwarner
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#315
 


### PR DESCRIPTION
## Summary

Phase 5 (Dispatch Hardening) shipped via PR #344 (commit `26025304`) but the roadmap entry for #315 remained `Status: planned`, causing roadmap-pilot to redispatch the issue into workspace `hermes-phase-5-dispa-060b636e`. This PR syncs the stale roadmap entry to match reality.

**No code change** — the implementation, tests, ADRs, and knowledge docs already live on `main`:

- ✅ `packages/orchestrator/src/agent/backends/ssh.ts` + tests
- ✅ `packages/orchestrator/src/agent/backends/serverless.ts` + tests
- ✅ `packages/orchestrator/src/cost/cost-ceiling-monitor.ts` + tests
- ✅ `isolation` axis on `BackendRouter` + factory
- ✅ ADR 0013 (dispatch isolation tier), ADR 0014 (cost ceiling policy)
- ✅ Knowledge docs: dispatch-isolation, cost-ceiling, backends-ssh, backends-serverless
- ✅ 47 Phase 5 tests passing

## Roadmap entry changes

| Field | Before | After |
|-------|--------|-------|
| Status | `planned` | `done` |
| Spec | `docs/changes/hermes-adoption/proposal.md` (parent meta-spec) | `docs/changes/hermes-phase-5-dispatch-hardening/proposal.md` (sub-spec) |
| Plan | — | `docs/changes/hermes-phase-5-dispatch-hardening/plans/2026-05-16-main-plan.md` |
| Blockers | Hermes Phase 0: Gateway API + Telemetry | — (Phase 0 shipped) |
| Assignee | — | @cwarner |

Closes #315.

## Test plan

- [x] \`harness validate\` green
- [x] No code files touched (verified via \`git diff --stat\`)
- [x] Roadmap renders correctly (single-section diff, frontmatter \`last_manual_edit\` bumped)