### PR TITLE
docs(roadmap): mark Hermes Phase 3 done — sync stale roadmap entry

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ version: 1
 created: 2026-03-21
 updated: 2026-04-24
 last_synced: 2026-05-15T18:43:18.077Z
-last_manual_edit: 2026-05-16T13:50:11.526Z
+last_manual_edit: 2026-05-17T22:00:00.000Z
 ---
 
 # Roadmap
@@ -1186,10 +1186,10 @@ last_manual_edit: 2026-05-16T13:50:11.526Z
 
 ### Hermes Phase 3: Multi-Sink Notifications
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/hermes-phase-3-notifications/proposal.md
 - **Summary:** Generalize CINotifier to NotificationSink interface with Slack-first concrete adapter; wrap_response envelope option for platform-shape delivery formatting; harden harness doctor with live pings, hook validity, baseline freshness, session corruption check. Requires Phase 0 webhook fanout. From Hermes adoption meta-spec.
-- **Blockers:** Hermes Phase 0: Gateway API + Telemetry
+- **Blockers:** —
 - **Plan:** docs/changes/hermes-phase-3-notifications/plans/main.md
 - **Assignee:** @cwarner
 - **Priority:** —


### PR DESCRIPTION
## Summary

Phase 3 (Multi-Sink Notifications + Doctor Hardening) shipped via PR #345 (commit `bd3e6020`) but the roadmap entry remained `Status: in-progress`, causing roadmap-pilot to redispatch issue #313 (workspace `hermes-phase-3-multi-48ae9c4c`). This PR syncs the entry so the roadmap matches reality:

- **Status:** `in-progress` → `done`
- **Blockers:** Hermes Phase 0 (Gateway API + Telemetry) is shipped, so blocker cleared

No code surface change — implementation, tests, ADRs ([0013 notification sink interface](docs/knowledge/decisions/0013-notification-sink-interface.md), [0014 doctor live-state checks](docs/knowledge/decisions/0014-doctor-live-state-checks.md)), and knowledge docs ([notification-sinks.md](docs/knowledge/orchestrator/notification-sinks.md), [doctor-hardening.md](docs/knowledge/cli/doctor-hardening.md)) already live on main.

Mirrors the precedent of #347 (Phase 0.1 sync) and the Phase 5 sync commit 6032717e1.

Closes #313.

## Test plan

- [x] harness validate green
- [x] Roadmap entry diff is the only file change
- [x] Phase 0 prerequisite confirmed done in roadmap