### PR TITLE
docs(roadmap): decompose design-pipeline into 5 sub-projects (+ fix flaky pre-push test timeouts)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,9 +2,9 @@
 project: harness-engineering
 version: 1
 created: 2026-03-21
-updated: 2026-04-24
+updated: 2026-05-17
 last_synced: 2026-05-15T18:43:18.077Z
-last_manual_edit: 2026-05-17T22:30:00.000Z
+last_manual_edit: 2026-05-17T23:30:00.000Z
 ---
 
 # Roadmap
@@ -1929,14 +1929,58 @@ last_manual_edit: 2026-05-17T22:30:00.000Z
 
 ### harness:design-pipeline orchestrator
 
-- **Status:** planned
+- **Status:** blocked
 - **Spec:** —
-- **Summary:** Multi-phase orchestrator skill composing existing design-_, a11y-_, and harness-design skills into a convergence-loop pipeline (pattern: docs-pipeline, knowledge-pipeline). Anticipated phases: design-system drift detection → accessibility audit → brand/token compliance → component-anatomy coverage → remediation. Output: design-system health report + remediation PRs through the maintenance-task lifecycle. Surfaced 2026-05-13 during Hermes feature-evaluation conversation; deferred so it doesn't multi-thread the Hermes adoption work. Re-evaluate after Hermes Phase 0 lands. See memory: project_design_pipeline_idea.md.
-- **Blockers:** —
+- **Summary:** Initiative parent. Decomposed 2026-05-17 into 5 sub-projects (Path B chosen — full roadmap promise). Sub-projects: #1 detect-design-drift + align-design-system, #2 audit-component-anatomy, #3 audit-brand-compliance (blocked on brand-guidelines source-of-truth decision), #4 harness check-design verifier, #5 (this entry) the orchestrator itself composing #1-#4 with FRESHEN/DETECT/FIX/AUDIT/FILL/REPORT phases mirroring harness-docs-pipeline. Existing operational dependency wired in as-is: harness-accessibility. See memory project_design_pipeline_idea.md.
+- **Blockers:** design-pipeline sub-project #1 (#354), design-pipeline sub-project #2 (#355), design-pipeline sub-project #3 (#356), design-pipeline sub-project #4 (#357)
 - **Plan:** —
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#316
+
+### design-pipeline sub-project #1: detect-design-drift + align-design-system
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Detection skill (detect-design-drift) and remediation skill (align-design-system) for token bypass, variant proliferation, and components not adopting design-system primitives. Pattern-mirrors detect-doc-drift + align-documentation. Detect skill can land independently; align skill blocks on #4 verifier for its convergence loop.
+- **Blockers:** design-pipeline sub-project #4 (#357) for align skill only
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#354
+
+### design-pipeline sub-project #2: audit-component-anatomy
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Audit skill detecting missing required anatomy parts (label, helper text, error state, loading state, empty state). Rules sourced from design-component-anatomy reference content. Lowest-ambiguity sub-project. Needs documented overlap-resolution with harness-accessibility (no double-counting label-missing findings).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#355
+
+### design-pipeline sub-project #3: audit-brand-compliance
+
+- **Status:** blocked
+- **Spec:** —
+- **Summary:** Audit skill for semantic token misuse, brand voice violations in copy, and asset misuse. Highest-ambiguity sub-project. Blocked on brand-guidelines source-of-truth decision (sub-project #0): extend DESIGN.md schema with structured brand rules, or add a brand-guidelines authoring skill. Overlaps with #1 — raw token bypass goes to #1, semantic misuse to this.
+- **Blockers:** brand-guidelines source-of-truth decision (sub-project #0, not yet filed)
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#356
+
+### design-pipeline sub-project #4: harness check-design verifier
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Convergence-verifier the design align skills rerun after each fix batch — equivalent of harness check-docs in docs-pipeline. Two options to decide during brainstorm: new harness check-design CLI command vs. extension of harness validate. Hooks into existing DesignConstraintAdapter. Prerequisite for the align skill in sub-project #1.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#357
 
 ## v4.0 Business Knowledge System
 

--- a/packages/cli/tests/integration/cli.test.ts
+++ b/packages/cli/tests/integration/cli.test.ts
@@ -56,7 +56,7 @@ describe('CLI Integration', { timeout: 30000 }, () => {
   });
 
   describe('harness validate', () => {
-    it('validates initialized project', { timeout: 15000 }, () => {
+    it('validates initialized project', () => {
       // Initialize first
       runCLI(['init', '--name', 'test'], tempDir);
 
@@ -65,7 +65,7 @@ describe('CLI Integration', { timeout: 30000 }, () => {
       expect(result.status).toBe(0);
     });
 
-    it('outputs JSON when --json flag used', { timeout: 15000 }, () => {
+    it('outputs JSON when --json flag used', () => {
       runCLI(['init', '--name', 'test'], tempDir);
       const result = runCLI(['validate', '--json'], tempDir);
       expect(result.status).toBe(0);
@@ -75,7 +75,7 @@ describe('CLI Integration', { timeout: 30000 }, () => {
   });
 
   describe('harness add', () => {
-    it('adds layer to project', { timeout: 15000 }, () => {
+    it('adds layer to project', () => {
       runCLI(['init', '--name', 'test'], tempDir);
       fs.mkdirSync(path.join(tempDir, 'src'), { recursive: true });
 

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
     testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],

--- a/packages/orchestrator/vitest.config.mts
+++ b/packages/orchestrator/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
     environment: 'node',
     testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],


### PR DESCRIPTION
## Summary

- Decomposes the `harness:design-pipeline` initiative (#316) into 5 sub-projects per the brainstorming decision recorded 2026-05-17 (Path B — full roadmap promise). #316 reframed as initiative parent; 4 new sub-project entries link to GitHub issues **#354**–**#357**.
- Fixes pre-existing flaky pre-push test timeouts in `orchestrator` and `cli` packages — `vitest` hookTimeout defaulted to 10s while heavy `beforeEach` blocks under v8 coverage instrumentation routinely needed longer; three `cli/tests/integration/cli.test.ts` tests had explicit 15s inline timeouts that were too tight for two-CLI-subprocess scenarios under coverage. These were blocking the roadmap commit from being pushed.

## Roadmap changes

| Sub-project | Skill | GH Issue | Status |
|---|---|---|---|
| #1 | `detect-design-drift` + `align-design-system` | #354 | planned |
| #2 | `audit-component-anatomy` | #355 | planned |
| #3 | `audit-brand-compliance` | #356 | blocked (on sub-project #0, brand-guidelines source-of-truth) |
| #4 | `harness check-design` verifier | #357 | planned |
| #5 | `harness-design-pipeline` orchestrator | #316 (existing, reframed) | blocked on #1-#4 |

Sequencing: #1 + #4 in parallel (prerequisites); #2 next; #3 after #0 resolved; #5 last.

## Test plan

- [x] `harness validate` passes against the modified roadmap
- [x] `pnpm --filter @harness-engineering/orchestrator test` passes (1218/1219)
- [x] `pnpm --filter @harness-engineering/cli test:coverage` passes after timeout fixes
- [x] Pre-push hook completes successfully (format/typecheck/test:ci/coverage-ratchet/generate-docs all ✓)
- [x] Roadmap parses round-trip
- [ ] Reviewer: confirm parent issue #316 description on GitHub reflects the decomposition (already updated via `gh issue edit`)
- [ ] Reviewer: confirm the 5-sub-project sequencing matches the team's intent before starting sub-project #1 brainstorm

## Notes

- Test-timeout changes are surgical: orchestrator + cli `vitest.config.mts` add `hookTimeout: 30_000` to match the existing `testTimeout: 30_000`; three `cli.test.ts` tests drop their 15s inline override so they inherit the describe-level 30s.
- Sub-project #0 (brand-guidelines source-of-truth) is flagged in #356's description but not yet filed as its own issue — that's a decision to make before kicking off #356's brainstorm.