### PR TITLE
fix(orchestrator): respect existing assignees in file-backed roadmap claims

### DIFF
--- a/.changeset/orchestrator-claim-safety.md
+++ b/.changeset/orchestrator-claim-safety.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Stop the file-backed roadmap orchestrator from claiming roadmap items already
+assigned to another developer or another orchestrator. `selectCandidates`
+now accepts an optional `selfAssignee` and skips items whose `assignee` is a
+third party. `RoadmapTrackerAdapter.claimIssue` no-ops the write when a
+third party currently holds the assignee, so the existing
+`ClaimManager.claimAndVerify` verify step reads back the unchanged file and
+returns `'rejected'` instead of silently overwriting the assignment.

--- a/docs/changes/orchestrator-claim-safety/plans/2026-05-18-claim-safety-plan.md
+++ b/docs/changes/orchestrator-claim-safety/plans/2026-05-18-claim-safety-plan.md
@@ -1,0 +1,250 @@
+# Plan: Orchestrator Claim Safety for File-Backed Roadmap
+
+**Date:** 2026-05-18 | **Spec:** none (bug-fix, derived from debug session
+`.harness/debug/active/2026-05-18-orchestrator-roadmap-sync.md`) | **Tasks:**
+6 | **Time:** ~25 min | **Integration Tier:** small
+
+## Goal
+
+Stop the file-backed roadmap orchestrator from claiming roadmap items that are
+already assigned to another developer (or another orchestrator). Today
+`isEligible` ignores `assignee`, and `RoadmapTrackerAdapter.claimIssue` blindly
+overwrites it. After this change, third-party-assigned items are filtered out
+of dispatch, and a racing claim write becomes a no-op so the existing verify
+step in `ClaimManager.claimAndVerify` reports `'rejected'`.
+
+## Observable Truths (Acceptance Criteria)
+
+1. **When** `selectCandidates` runs over an issue with `assignee` equal to a
+   non-null value that is not `selfAssignee`, **the system shall not** include
+   it in the returned list.
+2. **When** `selectCandidates` runs with `selfAssignee` omitted (back-compat),
+   **the system shall** include items regardless of assignee (today's
+   behavior preserved).
+3. **When** `selectCandidates` runs over an issue with `assignee === null`,
+   **the system shall** include it (assuming all other gates pass).
+4. **When** `selectCandidates` runs over an issue with `assignee ===
+selfAssignee`, **the system shall** include it (mid-session resume).
+5. **When** `RoadmapTrackerAdapter.claimIssue(issueId, selfId)` reads a file
+   whose target feature has `assignee` non-null and not equal to `selfId`,
+   **the system shall not** write to the file, and **shall** return
+   `Ok(undefined)`. The follow-up verify in `ClaimManager.claimAndVerify` then
+   reports `'rejected'`.
+6. **When** `claimIssue` reads a feature with `assignee === null` or
+   `assignee === selfId`, **the system shall** write status and assignee as
+   today.
+7. `pnpm --filter @harness-engineering/orchestrator vitest run` passes.
+8. `harness validate` passes.
+
+## File Map
+
+```
+MODIFY packages/orchestrator/src/core/candidate-selection.ts
+MODIFY packages/orchestrator/tests/core/candidate-selection.test.ts
+MODIFY packages/orchestrator/src/types/events.ts
+MODIFY packages/orchestrator/src/core/state-machine.ts
+MODIFY packages/orchestrator/src/orchestrator.ts
+MODIFY packages/orchestrator/src/tracker/adapters/roadmap.ts
+MODIFY packages/orchestrator/tests/tracker/roadmap.test.ts
+CREATE .changeset/orchestrator-claim-safety.md
+```
+
+## Uncertainties
+
+- [ASSUMPTION] Making the `selfAssignee` parameter optional on
+  `isEligible`/`selectCandidates` is acceptable (preserves existing test
+  call-sites). If a strict signature is preferred, all candidate-selection
+  test call-sites need updating; that is mechanical, not architectural.
+- [ASSUMPTION] Leaving `claimIssue`'s return type as `Result<void, Error>` is
+  acceptable. The third-party-assignee case becomes a no-op write; the
+  existing `claimAndVerify` verify step converts that into a `'rejected'`
+  outcome. No caller behavior changes.
+- [DEFERRABLE] Committing/pushing `docs/roadmap.md` after each tracker write
+  (the H3/H4 sync-drift problem from the debug session) is intentionally out
+  of scope here. Tracked separately.
+- [DEFERRABLE] Adding the same gate to the GitHub-issues issue-tracker
+  adapter. That path already has ETag-based concurrency upstream, so the
+  symmetric write-time guard is lower priority.
+
+## Skeleton
+
+_Not produced — task count (6) below the standard-rigor threshold (8)._
+
+## Tasks
+
+### Task 1: Add failing tests for `isEligible` assignee gate
+
+**Depends on:** none | **Files:** `packages/orchestrator/tests/core/candidate-selection.test.ts`
+
+1. Open `packages/orchestrator/tests/core/candidate-selection.test.ts`.
+2. Add a `describe('assignee gate', ...)` block at the end of the file with
+   four cases, each constructing an `Issue` with the helper already used in
+   the file (or inline shape if no helper exists):
+   - `excludes planned items assigned to another developer when selfAssignee
+is provided` — issue `{ state: 'planned', assignee: '@alice' }`,
+     `isEligible(issue, emptyState, ['planned'], ['done'], 'orchestrator-1')`
+     returns `false`.
+   - `includes planned items with null assignee when selfAssignee is provided`
+     — issue `{ state: 'planned', assignee: null }`, same call returns `true`.
+   - `includes planned items assigned to self when selfAssignee is provided`
+     — issue `{ state: 'planned', assignee: 'orchestrator-1' }`, same call
+     returns `true`.
+   - `ignores assignee when selfAssignee is omitted (back-compat)` — issue
+     `{ state: 'planned', assignee: '@alice' }`,
+     `isEligible(issue, emptyState, ['planned'], ['done'])` returns `true`.
+3. Run:
+   `pnpm --filter @harness-engineering/orchestrator vitest run tests/core/candidate-selection.test.ts`.
+4. Observe: 4 new failures (the new gate does not exist yet).
+5. Commit: `test(orchestrator): assert isEligible filters third-party-assigned items`
+
+### Task 2: Implement assignee gate in `isEligible` and `selectCandidates`
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/src/core/candidate-selection.ts`
+
+1. Open `packages/orchestrator/src/core/candidate-selection.ts`.
+2. Extend `isEligible`'s signature with an optional final parameter:
+   `selfAssignee?: string | null`.
+3. After the existing `state.completed.has(...)` guard and before the Todo
+   blocker rule, add:
+   ```ts
+   if (selfAssignee !== undefined && issue.assignee !== null && issue.assignee !== selfAssignee) {
+     return false;
+   }
+   ```
+4. Extend `selectCandidates`'s signature with the same optional
+   `selfAssignee?: string | null` parameter and pass it through to
+   `isEligible(issue, state, activeStates, terminalStates, selfAssignee)`.
+5. Run:
+   `pnpm --filter @harness-engineering/orchestrator vitest run tests/core/candidate-selection.test.ts`.
+6. Observe: all tests pass (including the 4 new ones).
+7. Run: `harness validate`.
+8. Commit: `feat(orchestrator): skip third-party-assigned roadmap items in selectCandidates`
+
+### Task 3: Thread `selfAssignee` through TickEvent and `handleTick`
+
+**Depends on:** Task 2 | **Files:** `packages/orchestrator/src/types/events.ts`, `packages/orchestrator/src/core/state-machine.ts`
+
+1. Open `packages/orchestrator/src/types/events.ts`. Add an optional field to
+   `TickEvent` after `personaRecommendations?`:
+   ```ts
+   /** Identity of this orchestrator. Items assigned to a different value
+    *  are filtered out of dispatch by `selectCandidates`. */
+   selfAssignee?: string;
+   ```
+2. Open `packages/orchestrator/src/core/state-machine.ts`. In `handleTick`
+   (around line 415), update the `selectCandidates` call to:
+   ```ts
+   const eligible = selectCandidates(
+     candidates,
+     next,
+     config.tracker.activeStates,
+     config.tracker.terminalStates,
+     event.selfAssignee
+   );
+   ```
+3. Run: `pnpm --filter @harness-engineering/orchestrator vitest run`.
+4. Observe: all tests pass. Existing tick events that omit `selfAssignee`
+   preserve today's behavior.
+5. Run: `harness validate`.
+6. Commit: `feat(orchestrator): thread selfAssignee through TickEvent to handleTick`
+
+### Task 4: Populate `selfAssignee` on tick events in the orchestrator
+
+**Depends on:** Task 3 | **Files:** `packages/orchestrator/src/orchestrator.ts`
+
+1. Open `packages/orchestrator/src/orchestrator.ts`. In `asyncTick` around
+   line 838, just before the `tickEvent` object literal, resolve the ID:
+   ```ts
+   const selfAssignee = await this.orchestratorIdPromise;
+   ```
+   (Reuse the same promise; it is already awaited in `ensureClaimManager`
+   earlier in the tick, so this is a cheap re-await of a resolved promise.)
+2. Add `selfAssignee` to the `tickEvent` object literal alongside `nowMs`:
+   ```ts
+   const tickEvent: OrchestratorEvent = {
+     type: 'tick' as const,
+     candidates,
+     runningStates: runningStatesResult.value,
+     nowMs,
+     selfAssignee,
+     ...(concernSignals !== undefined && { concernSignals }),
+     ...
+   };
+   ```
+3. Run: `pnpm --filter @harness-engineering/orchestrator vitest run`.
+4. Observe: all tests pass.
+5. Run: `harness validate`.
+6. Commit: `feat(orchestrator): populate selfAssignee on tick events`
+
+### Task 5: TDD compare-and-set in `RoadmapTrackerAdapter.claimIssue`
+
+**Depends on:** none (parallelizable with Tasks 1-4) | **Files:** `packages/orchestrator/src/tracker/adapters/roadmap.ts`, `packages/orchestrator/tests/tracker/roadmap.test.ts`
+
+1. Open `packages/orchestrator/tests/tracker/roadmap.test.ts`. Add a
+   `describe('claimIssue compare-and-set', ...)` block with three cases:
+   - `does not overwrite a third-party assignee` — write a roadmap fixture
+     with a feature whose `Assignee:` line is `@alice` and `Status: planned`.
+     Call `adapter.claimIssue(id, 'orchestrator-1')`. Read the file back.
+     Assert: `assignee` is still `@alice` and `status` is still `planned`.
+     Result is `Ok(undefined)`.
+   - `writes when assignee is null` — fixture with `Assignee: —`. Call
+     `claimIssue`. Assert file now has `assignee: 'orchestrator-1'` and
+     `status: 'in-progress'`. Result is `Ok(undefined)`.
+   - `is idempotent for same-self in-progress` — fixture with
+     `Status: in-progress` and `Assignee: orchestrator-1`. Call
+     `claimIssue(id, 'orchestrator-1')`. Assert file is unchanged (no
+     `updatedAt` bump), result is `Ok(undefined)`.
+2. Run: `pnpm --filter @harness-engineering/orchestrator vitest run tests/tracker/roadmap.test.ts`.
+3. Observe: the third-party case fails — `claimIssue` currently rewrites the
+   assignee.
+4. Open `packages/orchestrator/src/tracker/adapters/roadmap.ts`. In
+   `claimIssue` after `if (!target) return Ok(undefined);` and before the
+   existing same-self idempotent check, insert:
+   ```ts
+   if (target.assignee !== null && target.assignee !== orchestratorId) {
+     return Ok(undefined);
+   }
+   ```
+5. Re-run vitest. Observe all three new cases pass.
+6. Run: `harness validate`.
+7. Commit: `fix(orchestrator): RoadmapTrackerAdapter.claimIssue no-ops on third-party assignee`
+
+### Task 6: Add changeset entry
+
+**Depends on:** Tasks 2, 4, 5 | **Files:** `.changeset/orchestrator-claim-safety.md` | **Category:** integration
+
+1. Create `.changeset/orchestrator-claim-safety.md`:
+
+   ```markdown
+   ---
+   '@harness-engineering/orchestrator': patch
+   ---
+
+   Stop the file-backed roadmap orchestrator from claiming items already
+   assigned to another developer or orchestrator. `selectCandidates` now
+   skips third-party-assigned items, and `RoadmapTrackerAdapter.claimIssue`
+   no-ops when a third party currently holds the assignee, so the
+   `ClaimManager` verify step reports `'rejected'` instead of silently
+   overwriting.
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/orchestrator vitest run`.
+3. Run: `harness validate`.
+4. Commit: `chore(changeset): add orchestrator claim-safety patch entry`
+
+## Sequencing & Parallelism
+
+- Strict order: Task 1 → Task 2 → Task 3 → Task 4.
+- Task 5 is independent of Tasks 1-4 and can run in parallel.
+- Task 6 runs last after the code lands.
+
+## Notes
+
+The two defensive layers are intentional belt-and-suspenders:
+
+- **Proactive filter** (`selectCandidates`) — the orchestrator never even
+  tries to claim a third-party item, so no spurious write traffic.
+- **Reactive guard** (`claimIssue`) — catches the race where a human assigns
+  between the orchestrator's fetch and its claim write. The guard is a
+  no-op write, which lets the existing `ClaimManager.claimAndVerify` verify
+  step naturally return `'rejected'` without any caller changes.

--- a/packages/orchestrator/src/core/candidate-selection.ts
+++ b/packages/orchestrator/src/core/candidate-selection.ts
@@ -36,7 +36,8 @@ export function isEligible(
   issue: Issue,
   state: OrchestratorState,
   activeStates: string[],
-  terminalStates: string[]
+  terminalStates: string[],
+  selfAssignee?: string | null
 ): boolean {
   // Must have required fields
   if (!issue.id || !issue.identifier || !issue.title || !issue.state) {
@@ -70,6 +71,13 @@ export function isEligible(
     return false;
   }
 
+  // Assignee gate: if the caller provided a self-identity, skip items
+  // assigned to anyone else. When omitted, behavior is unchanged
+  // (preserves existing call-sites that don't yet thread identity).
+  if (selfAssignee !== undefined && issue.assignee != null && issue.assignee !== selfAssignee) {
+    return false;
+  }
+
   // Blocker rule for Todo state: block if any blocker is non-terminal
   if (normalizedState === 'todo' && issue.blockedBy.length > 0) {
     const hasNonTerminalBlocker = issue.blockedBy.some((blocker) => {
@@ -91,8 +99,11 @@ export function selectCandidates(
   issues: readonly Issue[],
   state: OrchestratorState,
   activeStates: string[],
-  terminalStates: string[]
+  terminalStates: string[],
+  selfAssignee?: string | null
 ): Issue[] {
   const sorted = sortCandidates(issues);
-  return sorted.filter((issue) => isEligible(issue, state, activeStates, terminalStates));
+  return sorted.filter((issue) =>
+    isEligible(issue, state, activeStates, terminalStates, selfAssignee)
+  );
 }

--- a/packages/orchestrator/src/core/state-machine.ts
+++ b/packages/orchestrator/src/core/state-machine.ts
@@ -416,7 +416,8 @@ function handleTick(
     candidates,
     next,
     config.tracker.activeStates,
-    config.tracker.terminalStates
+    config.tracker.terminalStates,
+    event.selfAssignee
   );
 
   const escalationConfig = resolveEscalationConfig(config);

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -835,11 +835,13 @@ export class Orchestrator extends EventEmitter {
     } = pipelineResult ?? {};
 
     // 4. Dispatch tick event to state machine
+    const selfAssignee = await this.orchestratorIdPromise;
     const tickEvent: OrchestratorEvent = {
       type: 'tick' as const,
       candidates,
       runningStates: runningStatesResult.value,
       nowMs,
+      selfAssignee,
       ...(concernSignals !== undefined && { concernSignals }),
       ...(enrichedSpecs !== undefined && { enrichedSpecs }),
       ...(complexityScores !== undefined && { complexityScores }),

--- a/packages/orchestrator/src/tracker/adapters/roadmap.ts
+++ b/packages/orchestrator/src/tracker/adapters/roadmap.ts
@@ -131,6 +131,14 @@ export class RoadmapTrackerAdapter implements IssueTrackerClient {
       const target = this.findFeatureById(roadmap.milestones, issueId);
       if (!target) return Ok(undefined);
 
+      // Compare-and-set: never overwrite an assignment held by a third
+      // party (another orchestrator OR a human). The no-op write lets the
+      // post-claim verify in ClaimManager.claimAndVerify read back the
+      // unchanged file and return 'rejected'.
+      if (target.assignee != null && target.assignee !== orchestratorId) {
+        return Ok(undefined);
+      }
+
       // Idempotent: already claimed by same orchestrator
       if (target.status === 'in-progress' && target.assignee === orchestratorId) {
         return Ok(undefined);

--- a/packages/orchestrator/src/types/events.ts
+++ b/packages/orchestrator/src/types/events.ts
@@ -34,6 +34,10 @@ export interface TickEvent {
   simulationResults?: Map<string, SimulationResult>;
   /** Pre-computed persona recommendations from specialization scorer (issueId -> recommendations) */
   personaRecommendations?: Map<string, WeightedRecommendation[]>;
+  /** Identity of this orchestrator. Items assigned to a different value are
+   *  filtered out of dispatch by `selectCandidates`. Omit for back-compat
+   *  (preserves today's permissive behavior). */
+  selfAssignee?: string;
 }
 
 export interface WorkerExitEvent {

--- a/packages/orchestrator/tests/core/candidate-selection.test.ts
+++ b/packages/orchestrator/tests/core/candidate-selection.test.ts
@@ -155,6 +155,28 @@ describe('isEligible', () => {
     });
     expect(isEligible(issue, makeState(), ['todo', 'in progress'], ['done'])).toBe(true);
   });
+
+  describe('assignee gate', () => {
+    it('excludes items assigned to another developer when selfAssignee is provided', () => {
+      const issue = makeIssue({ state: 'planned', assignee: '@alice' });
+      expect(isEligible(issue, makeState(), ['planned'], ['done'], 'orchestrator-1')).toBe(false);
+    });
+
+    it('includes items with null assignee when selfAssignee is provided', () => {
+      const issue = makeIssue({ state: 'planned', assignee: null });
+      expect(isEligible(issue, makeState(), ['planned'], ['done'], 'orchestrator-1')).toBe(true);
+    });
+
+    it('includes items assigned to self when selfAssignee is provided', () => {
+      const issue = makeIssue({ state: 'planned', assignee: 'orchestrator-1' });
+      expect(isEligible(issue, makeState(), ['planned'], ['done'], 'orchestrator-1')).toBe(true);
+    });
+
+    it('ignores assignee when selfAssignee is omitted (back-compat)', () => {
+      const issue = makeIssue({ state: 'planned', assignee: '@alice' });
+      expect(isEligible(issue, makeState(), ['planned'], ['done'])).toBe(true);
+    });
+  });
 });
 
 describe('selectCandidates', () => {

--- a/packages/orchestrator/tests/tracker/roadmap.test.ts
+++ b/packages/orchestrator/tests/tracker/roadmap.test.ts
@@ -256,7 +256,10 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
-    it('overwrites claim when a different orchestrator claims', async () => {
+    it('does not overwrite when another orchestrator currently holds the claim', async () => {
+      // Compare-and-set: skip the write when the on-disk assignee is a
+      // third party. ClaimManager.claimAndVerify then reads back the
+      // unchanged file and returns 'rejected'.
       const claimedByOther = writableRoadmap
         .replace('**Status:** planned', '**Status:** in-progress')
         .replace('- **Plan:** —', '- **Plan:** —\n- **Assignee:** orch-other');
@@ -267,9 +270,22 @@ last_manual_edit: '2026-03-24T00:00:00.000Z'
       const result = await adapter.claimIssue(idFor('Task 1'), 'orch-abc123');
 
       expect(result.ok).toBe(true);
-      expect(fs.writeFile).toHaveBeenCalledTimes(1);
-      const written = vi.mocked(fs.writeFile).mock.calls[0]![1] as string;
-      expect(written).toContain('**Assignee:** orch-abc123');
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('does not overwrite when a human currently holds the assignment', async () => {
+      const claimedByHuman = writableRoadmap.replace(
+        '- **Plan:** —',
+        '- **Plan:** —\n- **Assignee:** @alice'
+      );
+      vi.mocked(fs.readFile).mockResolvedValue(claimedByHuman);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      const adapter = new RoadmapTrackerAdapter(mockConfig);
+      const result = await adapter.claimIssue(idFor('Task 1'), 'orch-abc123');
+
+      expect(result.ok).toBe(true);
+      expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
     it('is a no-op when the feature is not found', async () => {


### PR DESCRIPTION
## Summary

Two defensive patches that stop the file-backed roadmap orchestrator from silently stealing roadmap items already assigned to another developer or another orchestrator.

- **Proactive filter:** `selectCandidates` / `isEligible` accept an optional `selfAssignee` and skip items whose `assignee` is non-null and not us. Threaded through `TickEvent` → `handleTick` and populated in `asyncTick` from the resolved orchestrator id. The parameter is optional, so call-sites that don't supply it keep today's permissive behavior.
- **Reactive guard:** `RoadmapTrackerAdapter.claimIssue` no-ops the write when the on-disk assignee is a third party (human or another orchestrator). The existing `ClaimManager.claimAndVerify` verify step then reads back the unchanged file and returns `'rejected'`, with no caller-side changes required.

## Background

Without these patches, two developers editing `docs/roadmap.md` alongside a running orchestrator produce silent assignment overwrites: today `isEligible` ignores `assignee` entirely, and `claimIssue` does a blind read-modify-write that always writes `orchestratorId` into the assignee slot. The plan and a fuller debug write-up live at `docs/changes/orchestrator-claim-safety/plans/2026-05-18-claim-safety-plan.md`.

This patch addresses the claim-safety hole only. The separate (and larger) markdown-file concurrency problem — concurrent writes with no lockfile, and orchestrator writes that never get committed to git — is intentionally out of scope and tracked separately. Projects that want a stronger guarantee should consider `roadmap.mode: file-less`.

## Test plan

- [x] `pnpm --filter @harness-engineering/orchestrator vitest run tests/core tests/tracker` — 268/268 pass
- [x] Full orchestrator suite — passing count +5 vs `main` (1188 vs 1183), pre-existing failures unchanged
- [x] `pnpm --filter @harness-engineering/orchestrator typecheck` — clean on touched files
- [ ] Reviewer: confirm behavior preservation when `selfAssignee` is omitted (mocks / unit tests that don't yet thread the id)
- [ ] Reviewer: confirm `ClaimManager.claimAndVerify`'s post-write verify correctly converts the no-op write into `'rejected'` (the design assumes a `verifyDelayMs > 0` round trip; default is 2000ms)