### PR TITLE
fix(eslint-plugin): use project root as path-normalization anchor in monorepos

### DIFF
--- a/.changeset/eslint-plugin-monorepo-path-anchor.md
+++ b/.changeset/eslint-plugin-monorepo-path-anchor.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/eslint-plugin': patch
+---
+
+Use the project root (the directory of `harness.config.json`) as the
+path-normalization anchor for `no-forbidden-imports` and
+`no-layer-violation`. Previously, both rules anchored to `/src/`, which
+collapsed `<monorepo>/packages/<x>/src/foo.ts` to `src/foo.ts` and destroyed
+the package prefix — making layer-based rules with `from: "packages/<x>/**"`
+patterns unable to match files inside `<package>/src/**`.
+
+`normalizePath` and `resolveImportPath` now accept an optional `projectRoot`
+parameter. When provided and the file lives under the root, the
+project-root-relative path is returned (preserving package identity).
+Otherwise the existing `/src/` heuristic is used unchanged, so
+single-package projects and any direct callers of the utilities are
+unaffected. A new `getConfigRoot(filePath)` helper in `config-loader`
+resolves the anchor from the nearest ancestor `harness.config.json`.

--- a/packages/eslint-plugin/src/rules/no-forbidden-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-forbidden-imports.ts
@@ -1,6 +1,6 @@
 // src/rules/no-forbidden-imports.ts
 import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
-import { getConfig } from '../utils/config-loader';
+import { getConfig, getConfigRoot } from '../utils/config-loader';
 import { matchesPattern, resolveImportPath, normalizePath } from '../utils/path-utils';
 
 const createRule = ESLintUtils.RuleCreator(
@@ -50,6 +50,7 @@ function checkImportDeclaration(
   node: TSESTree.ImportDeclaration,
   applicableRules: ForbiddenImportRule[],
   filename: string,
+  projectRoot: string | null,
   report: (opts: {
     node: TSESTree.Node;
     messageId: MessageIds;
@@ -57,7 +58,7 @@ function checkImportDeclaration(
   }) => void
 ): void {
   const importPath = node.source.value;
-  const resolvedImport = resolveImportPath(importPath, filename);
+  const resolvedImport = resolveImportPath(importPath, filename, projectRoot ?? undefined);
   const violatedRule = findViolatedRule(applicableRules, importPath, resolvedImport);
   if (violatedRule) {
     report({
@@ -87,7 +88,8 @@ export default createRule<[], MessageIds>({
       return {}; // No-op if no config
     }
 
-    const filePath = normalizePath(context.filename);
+    const projectRoot = getConfigRoot(context.filename);
+    const filePath = normalizePath(context.filename, projectRoot ?? undefined);
     const applicableRules = config.forbiddenImports.filter((rule) =>
       matchesPattern(filePath, rule.from)
     );
@@ -104,7 +106,7 @@ export default createRule<[], MessageIds>({
 
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
-        checkImportDeclaration(node, applicableRules, context.filename, report);
+        checkImportDeclaration(node, applicableRules, context.filename, projectRoot, report);
       },
     };
   },

--- a/packages/eslint-plugin/src/rules/no-layer-violation.ts
+++ b/packages/eslint-plugin/src/rules/no-layer-violation.ts
@@ -1,6 +1,6 @@
 // src/rules/no-layer-violation.ts
 import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
-import { getConfig } from '../utils/config-loader';
+import { getConfig, getConfigRoot } from '../utils/config-loader';
 import {
   resolveImportPath,
   getLayerForFile,
@@ -31,10 +31,11 @@ function isLayerViolation(
 function resolveImportLayer(
   importPath: string,
   filename: string,
-  layers: LayerDef[]
+  layers: LayerDef[],
+  projectRoot: string | null
 ): string | null {
   if (!importPath.startsWith('.')) return null;
-  const resolvedImport = resolveImportPath(importPath, filename);
+  const resolvedImport = resolveImportPath(importPath, filename, projectRoot ?? undefined);
   return getLayerForFile(resolvedImport, layers) ?? null;
 }
 
@@ -45,9 +46,10 @@ function checkLayerImport(
   context: RuleContext,
   currentLayer: string,
   currentLayerDef: LayerDef,
-  layers: LayerDef[]
+  layers: LayerDef[],
+  projectRoot: string | null
 ): void {
-  const importLayer = resolveImportLayer(node.source.value, context.filename, layers);
+  const importLayer = resolveImportLayer(node.source.value, context.filename, layers, projectRoot);
   if (!importLayer) return;
   if (isLayerViolation(importLayer, currentLayer, currentLayerDef)) {
     context.report({
@@ -77,7 +79,8 @@ export default createRule<[], MessageIds>({
       return {}; // No-op if no layers configured
     }
 
-    const filePath = normalizePath(context.filename);
+    const projectRoot = getConfigRoot(context.filename);
+    const filePath = normalizePath(context.filename, projectRoot ?? undefined);
     const currentLayer = getLayerForFile(filePath, config.layers);
 
     if (!currentLayer) {
@@ -92,7 +95,7 @@ export default createRule<[], MessageIds>({
     const layers = config.layers;
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
-        checkLayerImport(node, context, currentLayer, currentLayerDef, layers);
+        checkLayerImport(node, context, currentLayer, currentLayerDef, layers, projectRoot);
       },
     };
   },

--- a/packages/eslint-plugin/src/utils/config-loader.ts
+++ b/packages/eslint-plugin/src/utils/config-loader.ts
@@ -54,6 +54,16 @@ export function getConfig(filePath: string): HarnessConfig | null {
 }
 
 /**
+ * Resolve the project root directory for a given file by locating the
+ * nearest ancestor `harness.config.json`. Returns the directory containing
+ * the config, or null if none is found.
+ */
+export function getConfigRoot(filePath: string): string | null {
+  const configPath = findConfigFile(path.dirname(filePath));
+  return configPath ? path.dirname(configPath) : null;
+}
+
+/**
  * Clear the config cache (for testing)
  */
 export function clearConfigCache(): void {

--- a/packages/eslint-plugin/src/utils/path-utils.ts
+++ b/packages/eslint-plugin/src/utils/path-utils.ts
@@ -5,9 +5,18 @@ import type { Layer } from './schema';
 
 /**
  * Resolve an import path relative to the importing file
- * Returns path relative to project root (assumes /project/ prefix)
+ * Returns path relative to project root.
+ *
+ * When `projectRoot` is provided and the resolved file lives under it, the
+ * project-root-relative path is returned (preserves package identity in
+ * monorepos). Otherwise falls back to the `/src/` heuristic for
+ * single-package projects.
  */
-export function resolveImportPath(importPath: string, importingFile: string): string {
+export function resolveImportPath(
+  importPath: string,
+  importingFile: string,
+  projectRoot?: string
+): string {
   // External/absolute imports stay as-is
   if (!importPath.startsWith('.')) {
     return importPath;
@@ -16,10 +25,18 @@ export function resolveImportPath(importPath: string, importingFile: string): st
   // Resolve relative to importing file's directory
   const importingDir = path.dirname(importingFile);
   const resolved = path.resolve(importingDir, importPath);
-
-  // Extract path relative to project root
-  // Assumes paths like /project/src/... or /path/to/project/src/...
   const normalized = resolved.replace(/\\/g, '/');
+
+  // Preferred: anchor to project root (monorepo-safe)
+  if (projectRoot) {
+    const root = projectRoot.replace(/\\/g, '/').replace(/\/$/, '');
+    if (normalized.startsWith(root + '/')) {
+      return normalized.slice(root.length + 1);
+    }
+  }
+
+  // Legacy fallback: /src/ heuristic for single-package projects and any
+  // caller not threading a project root through.
   const srcIndex = normalized.indexOf('/src/'); // eslint-disable-line @harness-engineering/no-hardcoded-path-separator -- platform-safe
   if (srcIndex !== -1) {
     return normalized.slice(srcIndex + 1); // Remove leading /
@@ -60,11 +77,22 @@ export function getLayerByName(name: string, layers: Layer[]): Layer | undefined
 }
 
 /**
- * Normalize a file path to project-relative format
- * Extracts path from /any/path/src/... to src/...
+ * Normalize a file path to project-relative format.
+ *
+ * When `projectRoot` is provided and the file lives under it, returns the
+ * project-relative path (preserves package prefix in monorepos). Otherwise
+ * falls back to the `/src/` heuristic for single-package projects.
  */
-export function normalizePath(filePath: string): string {
+export function normalizePath(filePath: string, projectRoot?: string): string {
   const normalized = filePath.replace(/\\/g, '/');
+
+  if (projectRoot) {
+    const root = projectRoot.replace(/\\/g, '/').replace(/\/$/, '');
+    if (normalized.startsWith(root + '/')) {
+      return normalized.slice(root.length + 1);
+    }
+  }
+
   const srcIndex = normalized.indexOf('/src/'); // eslint-disable-line @harness-engineering/no-hardcoded-path-separator -- platform-safe
   if (srcIndex !== -1) {
     return normalized.slice(srcIndex + 1);

--- a/packages/eslint-plugin/tests/fixtures/monorepo/harness.config.json
+++ b/packages/eslint-plugin/tests/fixtures/monorepo/harness.config.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "layers": [
+    {
+      "name": "package-a",
+      "pattern": "packages/a/**",
+      "allowedDependencies": []
+    },
+    {
+      "name": "package-b",
+      "pattern": "packages/b/**",
+      "allowedDependencies": []
+    }
+  ],
+  "forbiddenImports": [
+    {
+      "from": "packages/a/**",
+      "disallow": ["react", "packages/b/**"],
+      "message": "package-a may not import from package-b or react"
+    }
+  ]
+}

--- a/packages/eslint-plugin/tests/integration/monorepo-path-anchor.test.ts
+++ b/packages/eslint-plugin/tests/integration/monorepo-path-anchor.test.ts
@@ -1,0 +1,51 @@
+// tests/integration/monorepo-path-anchor.test.ts
+//
+// Regression: in monorepos, layer-based rules must use the directory of
+// harness.config.json as the path-normalization anchor — not the /src/
+// heuristic, which collapses packages/<x>/src/... to src/... and destroys
+// package identity. Without the fix, the invalid case below produces zero
+// errors because `from: "packages/a/**"` never matches the normalized path.
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll, beforeEach } from 'vitest';
+import * as path from 'path';
+import forbiddenImports from '../../src/rules/no-forbidden-imports';
+import { clearConfigCache } from '../../src/utils/config-loader';
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+const monorepoDir = path.join(__dirname, '../fixtures/monorepo');
+
+beforeEach(() => {
+  clearConfigCache();
+});
+
+ruleTester.run('no-forbidden-imports (monorepo path anchor)', forbiddenImports, {
+  valid: [
+    // package-a importing from itself — not forbidden.
+    {
+      code: `import { local } from './helper';`,
+      filename: path.join(monorepoDir, 'packages/a/src/index.ts'),
+    },
+    // package-b is unconstrained.
+    {
+      code: `import * as anything from 'react';`,
+      filename: path.join(monorepoDir, 'packages/b/src/index.ts'),
+    },
+  ],
+  invalid: [
+    // The regression case: a file at packages/a/src/index.ts importing
+    // 'react'. The forbiddenImports rule has `from: "packages/a/**"`.
+    // Pre-fix: normalizePath drops 'packages/a' and yields 'src/index.ts',
+    // so the rule doesn't fire. Post-fix: project-root anchoring yields
+    // 'packages/a/src/index.ts' and the rule fires.
+    {
+      code: `import React from 'react';`,
+      filename: path.join(monorepoDir, 'packages/a/src/index.ts'),
+      errors: [{ messageId: 'forbiddenImport' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/utils/config-loader.test.ts
+++ b/packages/eslint-plugin/tests/utils/config-loader.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { getConfig, clearConfigCache } from '../../src/utils/config-loader';
+import { getConfig, getConfigRoot, clearConfigCache } from '../../src/utils/config-loader';
 
 describe('config-loader', () => {
   const fixturesDir = path.join(__dirname, '../fixtures');
@@ -66,5 +66,23 @@ describe('config-loader', () => {
     const config1 = getConfig(path.join(tempDir, 'file1.ts'));
     const config2 = getConfig(path.join(tempDir, 'file2.ts'));
     expect(config1).toBe(config2); // Same object reference
+  });
+
+  describe('getConfigRoot', () => {
+    it('returns the directory containing harness.config.json', () => {
+      fs.copyFileSync(
+        path.join(fixturesDir, 'harness.config.json'),
+        path.join(tempDir, 'harness.config.json')
+      );
+      const nestedDir = path.join(tempDir, 'src', 'deep');
+      fs.mkdirSync(nestedDir, { recursive: true });
+
+      expect(getConfigRoot(path.join(nestedDir, 'file.ts'))).toBe(tempDir);
+    });
+
+    it('returns null when no harness.config.json is found', () => {
+      // tempDir has no config and no ancestor config — guarantees null branch.
+      expect(getConfigRoot(path.join(tempDir, 'no-config', 'file.ts'))).toBeNull();
+    });
   });
 });

--- a/packages/eslint-plugin/tests/utils/path-utils.test.ts
+++ b/packages/eslint-plugin/tests/utils/path-utils.test.ts
@@ -32,6 +32,12 @@ describe('path-utils', () => {
       // uses the same .replace(/\\/g, '/') + indexOf('/src/') pattern.
       expect(normalizePath('C:\\project\\src\\domain\\helper')).toBe('src/domain/helper');
     });
+
+    it('returns original importPath when resolved path has no /src/ and no projectRoot', () => {
+      // Final fallback path: relative import resolves to a location outside
+      // any /src/ boundary, no projectRoot anchor — return import unchanged.
+      expect(resolveImportPath('../sibling', '/lib/pkg/foo.ts')).toBe('../sibling');
+    });
   });
 
   describe('matchesPattern', () => {

--- a/packages/eslint-plugin/tests/utils/path-utils.test.ts
+++ b/packages/eslint-plugin/tests/utils/path-utils.test.ts
@@ -140,21 +140,32 @@ describe('path-utils', () => {
   });
 
   describe('resolveImportPath with projectRoot (monorepo)', () => {
-    it('returns project-root-relative path preserving package identity', () => {
-      // packages/types/src/foo.ts importing '../api' resolves to
-      // packages/types/api which the legacy /src/ heuristic would mangle.
-      expect(resolveImportPath('../api', '/abs/repo/packages/types/src/foo.ts', '/abs/repo')).toBe(
-        'packages/types/api'
-      );
-    });
+    // These cases exercise `path.resolve`, which on Windows prepends a drive
+    // letter to Unix-style absolute paths (e.g. '/abs/repo/...' becomes
+    // 'D:/abs/repo/...'). That breaks the synthetic Unix path setup but
+    // cannot happen in real Windows ESLint usage, where both
+    // `context.filename` and the `getConfigRoot` result share a drive
+    // prefix. The integration test exercises real cross-platform paths.
+    const skipOnWindows = process.platform === 'win32';
 
-    it('resolves intra-package imports under projectRoot', () => {
+    it.skipIf(skipOnWindows)(
+      'returns project-root-relative path preserving package identity',
+      () => {
+        // packages/types/src/foo.ts importing '../api' resolves to
+        // packages/types/api which the legacy /src/ heuristic would mangle.
+        expect(
+          resolveImportPath('../api', '/abs/repo/packages/types/src/foo.ts', '/abs/repo')
+        ).toBe('packages/types/api');
+      }
+    );
+
+    it.skipIf(skipOnWindows)('resolves intra-package imports under projectRoot', () => {
       expect(
         resolveImportPath('./helper', '/abs/repo/packages/types/src/foo.ts', '/abs/repo')
       ).toBe('packages/types/src/helper');
     });
 
-    it('handles trailing-slash projectRoot', () => {
+    it.skipIf(skipOnWindows)('handles trailing-slash projectRoot', () => {
       expect(
         resolveImportPath('./helper', '/abs/repo/packages/types/src/foo.ts', '/abs/repo/')
       ).toBe('packages/types/src/helper');

--- a/packages/eslint-plugin/tests/utils/path-utils.test.ts
+++ b/packages/eslint-plugin/tests/utils/path-utils.test.ts
@@ -100,5 +100,71 @@ describe('path-utils', () => {
         'src/api/handler.ts'
       );
     });
+
+    describe('with projectRoot (monorepo)', () => {
+      it('preserves package prefix when file is under projectRoot', () => {
+        expect(normalizePath('/abs/repo/packages/types/src/foo.ts', '/abs/repo')).toBe(
+          'packages/types/src/foo.ts'
+        );
+      });
+
+      it('handles files without /src/ when projectRoot supplied', () => {
+        // No /src/ in path — the project-root anchor must win over the fallback,
+        // not fall back to returning the absolute path.
+        expect(normalizePath('/abs/repo/apps/web/app/foo.tsx', '/abs/repo')).toBe(
+          'apps/web/app/foo.tsx'
+        );
+      });
+
+      it('falls back to /src/ heuristic when file is outside projectRoot', () => {
+        expect(normalizePath('/elsewhere/pkg/src/foo.ts', '/abs/repo')).toBe('src/foo.ts');
+      });
+
+      it('treats trailing-slash projectRoot the same as no trailing slash', () => {
+        expect(normalizePath('/abs/repo/packages/types/src/foo.ts', '/abs/repo/')).toBe(
+          'packages/types/src/foo.ts'
+        );
+      });
+
+      it('preserves legacy behavior when projectRoot is omitted', () => {
+        // Existing single-package projects must keep working.
+        expect(normalizePath('/abs/repo/packages/types/src/foo.ts')).toBe('src/foo.ts');
+      });
+    });
+  });
+
+  describe('resolveImportPath with projectRoot (monorepo)', () => {
+    it('returns project-root-relative path preserving package identity', () => {
+      // packages/types/src/foo.ts importing '../api' resolves to
+      // packages/types/api which the legacy /src/ heuristic would mangle.
+      expect(resolveImportPath('../api', '/abs/repo/packages/types/src/foo.ts', '/abs/repo')).toBe(
+        'packages/types/api'
+      );
+    });
+
+    it('resolves intra-package imports under projectRoot', () => {
+      expect(
+        resolveImportPath('./helper', '/abs/repo/packages/types/src/foo.ts', '/abs/repo')
+      ).toBe('packages/types/src/helper');
+    });
+
+    it('handles trailing-slash projectRoot', () => {
+      expect(
+        resolveImportPath('./helper', '/abs/repo/packages/types/src/foo.ts', '/abs/repo/')
+      ).toBe('packages/types/src/helper');
+    });
+
+    it('falls back to legacy /src/ heuristic when projectRoot is omitted', () => {
+      // Existing test parity: no projectRoot threaded through.
+      expect(resolveImportPath('../types/user', '/project/src/domain/service.ts')).toBe(
+        'src/types/user'
+      );
+    });
+
+    it('keeps absolute imports unchanged even with projectRoot', () => {
+      expect(resolveImportPath('lodash', '/abs/repo/packages/types/src/foo.ts', '/abs/repo')).toBe(
+        'lodash'
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- In monorepos, `<package>/src/**` files normalized to `src/<...>`, destroying the package prefix and making layer-based rules with `from: "packages/<x>/**"` patterns unable to match files inside `<package>/src/**`.
- Add an optional `projectRoot` parameter to `normalizePath` / `resolveImportPath` in `packages/eslint-plugin/src/utils/path-utils.ts`. Rules resolve the anchor via a new `getConfigRoot(filePath)` helper that walks up to `harness.config.json` (wraps the existing `findConfigFile`).
- When `projectRoot` is provided and the file lives under it, return the project-root-relative path (preserves package identity). Otherwise fall back to the legacy `/src/` heuristic — byte-identical to current behavior.

## Backward compatibility

- Every existing test passes unmodified. They don't thread a `projectRoot` and hit the legacy fallback path.
- No schema changes. `projectRoot` is implicit (derived from config file location), not a config field.

## Repro & consumer impact

Before this fix, in a monorepo:

```ts
normalizePath('/abs/repo/packages/types/src/foo.ts') === 'src/foo.ts'
```

so a `forbiddenImports` rule with `from: "packages/types/**"` never matched. After this fix, the same call with a `projectRoot` of `/abs/repo` returns `'packages/types/src/foo.ts'`, and layer-internal rules for `packages/<x>/src/**` start firing as intended.

## Out of scope

- The `importMatchesDisallowed` matcher is unchanged — workspace-package specifier matching is a separate config-side concern.
- No schema additions.

## Test plan

- [x] New unit tests in `tests/utils/path-utils.test.ts` for `with projectRoot (monorepo)` covering: anchoring, files without `/src/`, outside-root fallback, trailing-slash equivalence, legacy preservation.
- [x] New unit tests in `tests/utils/config-loader.test.ts` for `getConfigRoot` (resolved directory + null branch).
- [x] New integration test `tests/integration/monorepo-path-anchor.test.ts` with a `tests/fixtures/monorepo/harness.config.json` fixture: `forbiddenImports` rule with `from: "packages/a/**"` fires on a file at `packages/a/src/index.ts` (it does not on `main`).
- [x] Revert-verified: stashing the four source files produces 7 test failures; restoring the fix → 180/180 pass.
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean in `packages/eslint-plugin`.
- [x] Repo-wide `pnpm -w lint` and `pnpm test:ci` clean.