### PR TITLE
ci: fix post-publish smoke test and refresh-baselines auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,14 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     permissions:
+      # `contents: write` for the direct-push path; `pull-requests: write` is
+      # required for the `gh pr create` fallback used when branch protection
+      # blocks direct pushes to main (which is the current configuration —
+      # without this permission gh fails with "Resource not accessible by
+      # integration" and the merge run is marked failed even when the
+      # baseline diff was empty).
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -54,22 +54,31 @@ jobs:
             @harness-engineering/dashboard \
             @harness-engineering/linter-gen
           node --input-type=module -e "
-            const pkgs = [
-              '@harness-engineering/cli',
-              '@harness-engineering/core',
-              '@harness-engineering/types',
-              '@harness-engineering/orchestrator',
-              '@harness-engineering/intelligence',
-              '@harness-engineering/graph',
-              '@harness-engineering/dashboard',
-              '@harness-engineering/linter-gen',
+            // Bare specifier for library packages. The dashboard publishes no
+            // '.' export — it's a runnable server with no library API and a
+            // side-effectful entrypoint — so probe its package.json subpath
+            // instead. That still exercises module resolution (incident #332
+            // would surface as a missing transitive dep at npm install time).
+            const targets = [
+              ['@harness-engineering/cli', '@harness-engineering/cli'],
+              ['@harness-engineering/core', '@harness-engineering/core'],
+              ['@harness-engineering/types', '@harness-engineering/types'],
+              ['@harness-engineering/orchestrator', '@harness-engineering/orchestrator'],
+              ['@harness-engineering/intelligence', '@harness-engineering/intelligence'],
+              ['@harness-engineering/graph', '@harness-engineering/graph'],
+              ['@harness-engineering/dashboard', '@harness-engineering/dashboard/package.json'],
+              ['@harness-engineering/linter-gen', '@harness-engineering/linter-gen'],
             ];
             const failures = [];
-            for (const pkg of pkgs) {
+            for (const [pkg, spec] of targets) {
               try {
-                const mod = await import(pkg);
+                const isJson = spec.endsWith('.json');
+                const mod = isJson
+                  ? await import(spec, { with: { type: 'json' } })
+                  : await import(spec);
                 const exportCount = Object.keys(mod).length;
-                console.log(\`ok  \${pkg}  (\${exportCount} exports)\`);
+                const note = spec === pkg ? '' : \` via \${spec}\`;
+                console.log(\`ok  \${pkg}  (\${exportCount} exports)\${note}\`);
               } catch (err) {
                 failures.push({ pkg, message: err?.message ?? String(err) });
                 console.error(\`fail \${pkg}: \${err?.message ?? err}\`);


### PR DESCRIPTION
Two pre-existing workflow failures, both consistently breaking every merge to main since at least 2026-05-18 (six failed Post-Publish Smoke Test runs in a row, and the refresh-baselines job has failed on the last several main merges including #363 and #365). Neither was introduced by a recent PR — they're workflow bugs.

## Summary

**1. `Post-Publish Smoke Test`** (`.github/workflows/smoke-test.yml`)
- Was importing every published package by bare specifier in a loop. `@harness-engineering/dashboard` publishes only `./server` and `./package.json` subpath exports — it's a runnable server with no library API and a side-effectful entrypoint — so the bare import fails with `No "exports" main defined`.
- Switched dashboard to probe via `@harness-engineering/dashboard/package.json` instead. Other packages keep the bare-specifier import. `npm install` still resolves dashboard's transitive deps, so incident #332-style cross-package drift would still surface there.

**2. `refresh-baselines`** (`.github/workflows/ci.yml`)
- Had `permissions: contents: write` only. Branch protection blocks direct pushes to `main`, so the workflow falls back to `gh pr create` — which fails with `Resource not accessible by integration` because the token lacks `pull-requests: write`. Result: the merge run is marked failed even when the baseline diff was empty.
- Added `pull-requests: write` to the job's permissions. Comment in the workflow explains the contract.

## Test plan

- [x] YAML validity: `python3 -c "import yaml; yaml.safe_load(...)"` parses both files.
- [x] JSON-with-import-attributes syntax (`with: { type: 'json' }`) verified to work on Node 22+ locally (the smoke runner is pinned to Node 22).
- [ ] On merge: confirm Post-Publish Smoke Test passes end-to-end.
- [ ] On merge: confirm refresh-baselines either commits cleanly or successfully opens a baseline-refresh PR.

## Out of scope

- Dashboard's published shape (no `.` export) is intentional; this PR adapts the test, not the package.
- The pre-existing `arch` baseline regressions in `packages/cli` (`handleEmitSkillProposal` complexity, module-size, dependency-depth) are unrelated.