### PR TITLE
design-pipeline: coordination commits — wire up Phase 1 vertical slices end-to-end

### DIFF
--- a/.changeset/design-pipeline-coordination-commits.md
+++ b/.changeset/design-pipeline-coordination-commits.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/cli': minor
+'@harness-engineering/graph': minor
+---
+
+Design-pipeline coordination commits — wire up the Phase 1 vertical-slice MCP tools end-to-end.
+
+**MCP server registration** — `mcp__harness__audit_anatomy` and `mcp__harness__design_craft` are now registered in `TOOL_DEFINITIONS` / `TOOL_HANDLERS` and discoverable to MCP clients (previously exported but unregistered).
+
+**`harness.config.json` schema extensions** — adds optional `design.audit.componentAnatomy.*` (gates audit-component-anatomy + the harness-accessibility deferral; controls catalog scoping, fast-mode behavior) and `design.craft.*` (gates harness-design-craft; controls fast/deep mode, autoCapture B' behavior, LLM provider, catalog scoping, signal feedback threshold). All fields optional with sensible defaults; omitting either block uses built-in defaults. Zero impact on existing configs.
+
+**`DesignConstraintAdapter.recordFindings()`** — generic finding-ingestion entry point that both audit-component-anatomy (ANAT-\*) and harness-design-craft (CRAFT-\*) call to persist findings as graph state. Idempotent (re-running produces no duplicate edges). Per finding: lazy `design_constraint` node creation + `violates_design` edge from file to constraint with per-finding metadata (line, severity, message, evidence, runId). Uses existing graph taxonomy — no NodeType/EdgeType additions.
+
+**`harness-accessibility` deferral patch** — Phase 1 step 2.6 added: when `design.audit.componentAnatomy.enabled = true` (default), A11Y-010 (interactive without accessible label) and A11Y-050 (input/select/textarea without label) are deferred to audit-component-anatomy for components in its catalog. Same i18n-style deduplication pattern proven in step 2.5. Catalog set loaded via `getCatalogTypes()` from audit-component-anatomy's public export — zero rule-content duplication.
+
+**Deferred to a follow-up commit:** `harness validate` fast-mode hook for audit-anatomy (the largest individual coordination item; requires touching the validate command path). The other coordination items are surgical extensions that close the loop on Phase 1 without requiring validate changes.

--- a/agents/skills/claude-code/harness-accessibility/SKILL.md
+++ b/agents/skills/claude-code/harness-accessibility/SKILL.md
@@ -31,6 +31,15 @@
 - If `i18n.enabled` is false or absent, scan for `lang`/`dir` as normal (these remain part of the accessibility audit).
 - This deduplication prevents the same finding from appearing in both the accessibility report and the i18n report.
 
+  2.6. **Check for component-anatomy audit overlap.** Read `harness.config.json` for `design.audit.componentAnatomy.enabled` (default `true` when absent):
+
+- If `enabled: true`, **defer** `A11Y-010` (interactive elements without accessible labels) and `A11Y-050` (`<input>`/`<select>`/`<textarea>` without associated `<label>`) findings for components whose identified type is in the anatomy catalog. Load the catalog component-type set via `getCatalogTypes()` from `audit-component-anatomy`'s public export so this skill has zero rule-content duplication.
+- Identify each scanned JSX element's component type using the same 3-layer resolver `audit-component-anatomy` uses: (1) JSDoc `@component-type X` tag, (2) `design-system/DESIGN.md` `## Component Registry` mapping, (3) top-level export-name catalog match.
+- For components in the catalog: `audit-component-anatomy` owns the label-slot finding as `ANAT-D*` (definition-side in v1, `ANAT-U*` in v2). Do not emit `A11Y-010` / `A11Y-050` for them.
+- For raw HTML elements (`<button>`, `<input>`, `<select>`, `<textarea>`) and unidentified components: scan for `A11Y-010` / `A11Y-050` as normal.
+- If `enabled: false` or absent: scan for `A11Y-010` / `A11Y-050` as normal (no deferral).
+- Same i18n-style deduplication pattern as step 2.5 — prevents one root cause from appearing in both the accessibility report and the anatomy report.
+
 3. **Scan component files.** Search all files matching `.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` for the following violations:
 
    **Images and media:**
@@ -183,6 +192,7 @@ This phase is optional. It applies fixes only for **mechanical issues** -- viola
 - **`harness-impact-analysis`** -- When tokens change (palette update, new colors), impact analysis traces affected components. The accessibility skill uses this to determine which components need re-scanning.
 - **`harness-design-system`** -- Dependency. When contrast failures originate from token definitions (not component code), escalate to harness-design-system to fix at the source.
 - **`harness-i18n` deduplication** -- When `i18n.enabled: true` in config, `lang` and `dir` attribute checks are deferred to the i18n skill. This prevents duplicate findings across the accessibility and i18n reports. When i18n is not enabled, these checks remain part of the accessibility scan.
+- **`audit-component-anatomy` deduplication** -- When `design.audit.componentAnatomy.enabled: true` in config (default), `A11Y-010` and `A11Y-050` are deferred to `audit-component-anatomy` for components in its catalog (Button, Input, Select, Modal, Card, Tabs, etc.). The anatomy audit owns the label-slot finding for those components; this skill still scans raw HTML and unidentified components. Same i18n-style deduplication pattern.
 
 ## Success Criteria
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -363,6 +363,18 @@ Parse a git diff and check for forbidden patterns, oversized files, and missing 
 - `maxFileSize` (number, optional) — Maximum number of lines changed per file before flagging
 - `maxFileCount` (number, optional) — Maximum number of changed files before flagging
 
+### `audit_anatomy`
+
+Audit components for anatomy completeness. Emits ANAT-D* findings for component definitions missing required slots/states (e.g., Button missing `content`). In v1 vertical slice runs the Button convention only; pattern-presence checks (ANAT-P*) return empty pending follow-up.
+
+**Parameters:**
+
+- `path` (string, required) — Project root path
+- `mode` (string, optional) — fast = conventions only (cheap AST scan). full = conventions + patterns. In v1 both modes run conventions only because pattern engine is not yet wired.
+- `files` (array, optional) — Optional explicit file list (paths or globs) to scope the audit.
+- `designStrictness` (string, optional) — Overrides design.strictness from harness.config.json.
+- `catalog` (array, optional) — Optional subset of catalog entries to run.
+
 ### `compact`
 
 Compact content, resolve intents into aggregated packed responses, or re-compress prior tool output. Returns a packed envelope with source attribution and reduction metadata.
@@ -388,6 +400,19 @@ Simulate cascading failure propagation from a source node using probability-weig
 - `probabilityFloor` (number, optional) — Minimum cumulative probability to continue traversal (default 0.05)
 - `maxDepth` (number, optional) — Maximum BFS depth (default 10)
 - `mode` (string, optional) — Response density: compact returns summary + top 10 highest-risk nodes, detailed returns full layered cascade chain. Default: compact
+
+### `design_craft`
+
+Run the harness-design-craft skill: CRITIQUE / POLISH / BENCHMARK phases over a project's components. Phase 1 MVP: fast-mode CRITIQUE with the seeded hierarchy-clarity rubric; POLISH and BENCHMARK are stubs.
+
+**Parameters:**
+
+- `path` (string, required) — Project root path
+- `mode` (string, optional) — fast (code-only LLM critique) or deep (render + vision). MVP supports fast only.
+- `phases` (array, optional) — Subset of phases to run. Defaults to all three.
+- `files` (array, optional) — Optional file scoping. Each entry is a path relative to project root.
+- `autoCapture` (string, optional) — B' detect-and-offer behavior when preconditions are missing. MVP: only "skip" is fully implemented.
+- `designStrictness` (string, optional) — Overall design strictness (passed through to harness-design when chained).
 
 ### `dispatch_skills`
 

--- a/packages/cli/src/commands/setup-mcp.ts
+++ b/packages/cli/src/commands/setup-mcp.ts
@@ -124,6 +124,10 @@ export const ALL_MCP_TOOLS: string[] = [
   'insights_summary',
   // Hermes Phase 4 — agent-emitted skill proposals
   'emit_skill_proposal',
+  // design-pipeline #2 — component-anatomy audit (ANAT-D* findings)
+  'audit_anatomy',
+  // design-pipeline #6 — design-craft LLM-judgment skill (CRITIQUE / POLISH / BENCHMARK)
+  'design_craft',
 ];
 
 /**

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -14,6 +14,7 @@ import { resolveConfig } from '../config/loader';
 import { OutputFormatter, OutputMode, type OutputModeType } from '../output/formatter';
 import { logger } from '../output/logger';
 import { CLIError, ExitCode } from '../utils/errors';
+import { runAudit as runComponentAnatomyAudit } from '../mcp/tools/audit-anatomy';
 
 interface ValidateOptions {
   cwd?: string;
@@ -36,6 +37,7 @@ interface ValidateResult {
     pulseConfig?: boolean;
     solutionsDir?: boolean;
     roadmapMode?: boolean;
+    componentAnatomy?: boolean;
   };
   issues: Array<{
     check: string;
@@ -166,6 +168,53 @@ export async function runValidate(
         suggestion: roadmapModeResult.error.suggestions[0],
       }),
     });
+  }
+
+  // Component-anatomy fast-mode audit (design-pipeline #2).
+  // Enabled by default per the schema; opts out via
+  // `design.audit.componentAnatomy.enabled: false`. Runs the
+  // convention-only path (cheap AST scan); pattern queries are opt-in
+  // via `design.audit.componentAnatomy.fastMode.patterns: true` (not
+  // honored in MVP — patterns return empty regardless).
+  const anatomyEnabled = config.design?.audit?.componentAnatomy?.enabled !== false;
+  if (anatomyEnabled) {
+    try {
+      const strictness = (config.design?.strictness ?? 'standard') as
+        | 'strict'
+        | 'standard'
+        | 'permissive';
+      const auditOutput = await runComponentAnatomyAudit({
+        path: cwd,
+        mode: 'fast',
+        designStrictness: strictness,
+      });
+      result.checks.componentAnatomy = true;
+      // Error-severity findings fail validation. warn/info are surfaced
+      // as issues but don't flip result.valid.
+      for (const finding of auditOutput.findings) {
+        const severity: 'error' | 'warning' | 'info' =
+          finding.severity === 'warn' ? 'warning' : finding.severity;
+        if (severity === 'error') result.valid = false;
+        result.issues.push({
+          check: 'componentAnatomy',
+          file: finding.file,
+          ...(finding.line !== null && finding.line !== undefined && { line: finding.line }),
+          ruleId: finding.code,
+          severity,
+          message: finding.message,
+          suggestion: finding.fix.description,
+        });
+      }
+    } catch (err) {
+      // Audit failures don't sink the whole validate — degrade gracefully
+      // with a single warning so the rest of the checks still report.
+      result.checks.componentAnatomy = false;
+      result.issues.push({
+        check: 'componentAnatomy',
+        severity: 'warning',
+        message: `Component-anatomy audit skipped: ${(err as Error).message}`,
+      });
+    }
   }
 
   // Opt-in agent config validation (agnix binary preferred, TS fallback otherwise)

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -119,6 +119,75 @@ export const PerformanceConfigSchema = z
   .passthrough();
 
 /**
+ * Schema for component-anatomy audit config (design-pipeline #2).
+ * All fields optional; omit the block entirely to use the audit's
+ * built-in defaults.
+ */
+export const ComponentAnatomyAuditConfigSchema = z.object({
+  /** Gate for the entire audit AND the harness-accessibility deferral */
+  enabled: z.boolean().default(true),
+  /** "default" or a path to a project-supplied override catalog */
+  catalog: z.string().default('default'),
+  /** "all", "none", or an explicit list of pattern codes (e.g. ["ANAT-P001"]) */
+  patterns: z.union([z.literal('all'), z.literal('none'), z.array(z.string())]).default('all'),
+  /** Fast-mode controls (validate-time scope cap + pattern opt-in) */
+  fastMode: z
+    .object({
+      /** Whether validate-time runs pattern queries (default false — patterns are full-mode only) */
+      patterns: z.boolean().default(false),
+      /** Cap to keep validate fast on large repos */
+      maxFiles: z.number().int().positive().default(500),
+    })
+    .default({}),
+});
+
+/**
+ * Schema for design audit configuration (design-pipeline floor-layer audits).
+ */
+export const DesignAuditConfigSchema = z.object({
+  /** Component-anatomy audit (design-pipeline #2) */
+  componentAnatomy: ComponentAnatomyAuditConfigSchema.optional(),
+});
+
+/**
+ * Schema for design-craft (LLM-judgment ceiling skill) configuration
+ * (design-pipeline #6). All fields optional; omit the block entirely to
+ * use the skill's built-in defaults.
+ */
+export const DesignCraftConfigSchema = z.object({
+  /** Gate for the entire skill AND the harness-design overlap deferral */
+  enabled: z.boolean().default(true),
+  /** Default invocation mode — "fast" (code-only LLM) or "deep" (rendered + vision-LLM) */
+  mode: z.enum(['fast', 'deep']).default('fast'),
+  /** B' detect-and-offer behavior when preconditions missing */
+  autoCapture: z.enum(['prompt', 'auto', 'skip']).default('prompt'),
+  /** LLM provider configuration */
+  llm: z
+    .object({
+      provider: z.string().default('anthropic'),
+      model: z.string().default('claude-sonnet-4-6'),
+      visionModel: z.string().optional(),
+    })
+    .optional(),
+  /** Catalog scoping */
+  catalog: z
+    .object({
+      path: z.string().default('default'),
+      rubrics: z.union([z.literal('all'), z.literal('none'), z.array(z.string())]).default('all'),
+      patterns: z.union([z.literal('all'), z.literal('none'), z.array(z.string())]).default('all'),
+      exemplars: z.union([z.literal('all'), z.literal('none'), z.array(z.string())]).default('all'),
+    })
+    .optional(),
+  /** Signal feedback loop (CRITIQUE recurrence → pattern proposal) */
+  signal: z
+    .object({
+      /** N=5 by default — emit candidate pattern proposal after this many recurrences */
+      proposalThreshold: z.number().int().positive().default(5),
+    })
+    .optional(),
+});
+
+/**
  * Schema for design system and aesthetic consistency configuration.
  *
  * `enabled` is tri-state at runtime: `true`, `false`, or absent.
@@ -144,6 +213,16 @@ export const DesignConfigSchema = z
     tokenPath: z.string().optional(),
     /** Brief description of the intended aesthetic direction */
     aestheticIntent: z.string().optional(),
+    /**
+     * Design-pipeline audit configuration (rule-based floor layer).
+     * Omit to use built-in defaults.
+     */
+    audit: DesignAuditConfigSchema.optional(),
+    /**
+     * Design-craft configuration (LLM-judgment ceiling layer, design-pipeline #6).
+     * Omit to use built-in defaults.
+     */
+    craft: DesignCraftConfigSchema.optional(),
   })
   .superRefine((value, ctx) => {
     if (value.enabled === true && (!value.platforms || value.platforms.length === 0)) {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -163,6 +163,10 @@ import {
 import { subscribeWebhookDefinition, handleSubscribeWebhook } from './tools/webhook-tools.js';
 // Phase 4: emit a skill proposal into `.harness/proposals/`.
 import { emitSkillProposalDefinition, handleEmitSkillProposal } from './tools/skill-proposal.js';
+// design-pipeline #2: component-anatomy audit (definition findings; ANAT-D*).
+import { auditAnatomyDefinition, handleAuditAnatomy } from './tools/audit-anatomy.js';
+// design-pipeline #6: design-craft LLM-judgment skill (CRITIQUE / POLISH / BENCHMARK).
+import { designCraftToolDefinition, handleDesignCraft } from './tools/design-craft.js';
 
 // Re-exported from ./tool-types so tool files can import the type without
 // pulling in server.ts (which would create a cycle). See ./tool-types.ts.
@@ -244,6 +248,8 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
   summarizeSessionDefinition,
   insightsSummaryDefinition,
   emitSkillProposalDefinition,
+  auditAnatomyDefinition,
+  designCraftToolDefinition,
 ].map((def) => ({ ...def, trustedOutput: true }));
 const TOOL_HANDLERS: Record<string, ToolHandler> = {
   validate_project: handleValidateProject as ToolHandler,
@@ -314,6 +320,8 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   summarize_session: handleSummarizeSession as unknown as ToolHandler,
   insights_summary: handleInsightsSummary as unknown as ToolHandler,
   emit_skill_proposal: handleEmitSkillProposal as unknown as ToolHandler,
+  audit_anatomy: handleAuditAnatomy as unknown as ToolHandler,
+  design_craft: handleDesignCraft as unknown as ToolHandler,
 };
 
 const RESOURCE_DEFINITIONS = [

--- a/packages/cli/tests/commands/validate.test.ts
+++ b/packages/cli/tests/commands/validate.test.ts
@@ -33,6 +33,22 @@ vi.mock('../../src/config/loader', () => ({
   }),
 }));
 
+// Mock the audit-anatomy entry point. Default: returns no findings so existing
+// tests stay unaffected. Per-test overrides via the imported handle below.
+vi.mock('../../src/mcp/tools/audit-anatomy', () => ({
+  runAudit: vi.fn().mockResolvedValue({
+    findings: [],
+    summary: {
+      totalFiles: 0,
+      durationMs: 0,
+      bySeverity: { error: 0, warn: 0, info: 0 },
+      byCode: {},
+    },
+    catalog: { conventionsApplied: [], patternsApplied: [] },
+    meta: { mode: 'fast', deferredToA11y: 0 },
+  }),
+}));
+
 import { createValidateCommand, runValidate } from '../../src/commands/validate';
 import {
   validateAgentsMap,
@@ -40,6 +56,7 @@ import {
   validateAgentConfigs,
 } from '@harness-engineering/core';
 import { resolveConfig } from '../../src/config/loader';
+import { runAudit as runComponentAnatomyAudit } from '../../src/mcp/tools/audit-anatomy';
 
 describe('validate command', () => {
   beforeEach(() => {
@@ -345,6 +362,134 @@ describe('validate command', () => {
       await safeParseAsync(program, ['node', 'test', 'validate']);
 
       expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('component-anatomy audit (design-pipeline #2)', () => {
+    it('invokes the audit in fast mode by default and reports checks.componentAnatomy=true', async () => {
+      const result = await runValidate({});
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.checks.componentAnatomy).toBe(true);
+      expect(runComponentAnatomyAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'fast' })
+      );
+    });
+
+    it('surfaces error findings as validation issues and flips result.valid to false', async () => {
+      vi.mocked(runComponentAnatomyAudit).mockResolvedValueOnce({
+        findings: [
+          {
+            code: 'ANAT-D001',
+            severity: 'error',
+            file: 'src/Button.tsx',
+            line: 14,
+            componentType: 'Button',
+            message: 'Button is missing required slot: content',
+            evidence: { snippet: 'export const Button = ...' },
+            rule: { id: 'ANAT-D001', source: 'APG/button' },
+            fix: {
+              kind: 'manual',
+              description: 'Add a children/content prop',
+            },
+          },
+        ],
+        summary: {
+          totalFiles: 1,
+          durationMs: 5,
+          bySeverity: { error: 1, warn: 0, info: 0 },
+          byCode: { 'ANAT-D001': 1 },
+        },
+        catalog: { conventionsApplied: ['Button'], patternsApplied: [] },
+        meta: { mode: 'fast', deferredToA11y: 0 },
+      });
+
+      const result = await runValidate({});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(false);
+      const anatomyIssues = result.value.issues.filter((i) => i.check === 'componentAnatomy');
+      expect(anatomyIssues).toHaveLength(1);
+      expect(anatomyIssues[0]).toMatchObject({
+        check: 'componentAnatomy',
+        file: 'src/Button.tsx',
+        line: 14,
+        ruleId: 'ANAT-D001',
+        severity: 'error',
+        suggestion: 'Add a children/content prop',
+      });
+    });
+
+    it('surfaces warn findings without flipping result.valid (other checks still pass)', async () => {
+      vi.mocked(runComponentAnatomyAudit).mockResolvedValueOnce({
+        findings: [
+          {
+            code: 'ANAT-D000',
+            severity: 'warn',
+            file: 'src/Tabs.tsx',
+            line: null,
+            componentType: 'Tabs',
+            message: 'JSDoc anatomy declaration diverges from convention',
+            evidence: { snippet: '' },
+            rule: { id: 'ANAT-D000', source: 'convention/divergence' },
+            fix: { kind: 'manual', description: 'Update JSDoc or convention' },
+          },
+        ],
+        summary: {
+          totalFiles: 1,
+          durationMs: 5,
+          bySeverity: { error: 0, warn: 1, info: 0 },
+          byCode: { 'ANAT-D000': 1 },
+        },
+        catalog: { conventionsApplied: ['Tabs'], patternsApplied: [] },
+        meta: { mode: 'fast', deferredToA11y: 0 },
+      });
+
+      const result = await runValidate({});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(true);
+      const anatomyIssue = result.value.issues.find((i) => i.check === 'componentAnatomy');
+      expect(anatomyIssue?.severity).toBe('warning');
+    });
+
+    it('skips the audit when design.audit.componentAnatomy.enabled is false', async () => {
+      vi.mocked(resolveConfig).mockReturnValueOnce({
+        ok: true,
+        value: {
+          version: 1,
+          rootDir: '.',
+          agentsMapPath: './AGENTS.md',
+          docsDir: './docs',
+          design: {
+            strictness: 'standard',
+            platforms: [],
+            audit: { componentAnatomy: { enabled: false } },
+          },
+        },
+      } as never);
+
+      const beforeCallCount = vi.mocked(runComponentAnatomyAudit).mock.calls.length;
+      const result = await runValidate({});
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.checks.componentAnatomy).toBeUndefined();
+      expect(vi.mocked(runComponentAnatomyAudit).mock.calls.length).toBe(beforeCallCount);
+    });
+
+    it('degrades gracefully when the audit throws (does not sink the whole validate)', async () => {
+      vi.mocked(runComponentAnatomyAudit).mockRejectedValueOnce(new Error('boom: parser crashed'));
+
+      const result = await runValidate({});
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.checks.componentAnatomy).toBe(false);
+      const anatomyIssue = result.value.issues.find((i) => i.check === 'componentAnatomy');
+      expect(anatomyIssue?.severity).toBe('warning');
+      expect(anatomyIssue?.message).toContain('boom: parser crashed');
     });
   });
 });

--- a/packages/cli/tests/mcp/server-integration.test.ts
+++ b/packages/cli/tests/mcp/server-integration.test.ts
@@ -58,7 +58,10 @@ describe('MCP Server Integration', () => {
     expect(names).toContain('insights_summary');
     // Hermes Phase 4
     expect(names).toContain('emit_skill_proposal');
-    expect(tools).toHaveLength(68);
+    // design-pipeline #2 + #6 coordination commits
+    expect(names).toContain('audit_anatomy');
+    expect(names).toContain('design_craft');
+    expect(tools).toHaveLength(70);
   });
 
   it('all tool definitions have inputSchema', () => {

--- a/packages/cli/tests/mcp/server.test.ts
+++ b/packages/cli/tests/mcp/server.test.ts
@@ -11,9 +11,9 @@ describe('MCP Server', () => {
     expect(server).toBeDefined();
   });
 
-  it('registers all 68 tools', () => {
+  it('registers all 70 tools', () => {
     const tools = getToolDefinitions();
-    expect(tools).toHaveLength(68);
+    expect(tools).toHaveLength(70);
   });
 
   it('registers all 9 resources', () => {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -10,7 +10,16 @@ export default defineConfig([
     format: ['esm'],
     dts: true,
     outDir: 'dist',
-    external: ['@modelcontextprotocol/sdk', 'web-tree-sitter'],
+    external: [
+      '@modelcontextprotocol/sdk',
+      'web-tree-sitter',
+      // typescript uses CommonJS-style dynamic require('fs') for its host
+      // implementation; bundling breaks runtime ("Dynamic require of 'fs'
+      // is not supported"). Keep external — available transitively via
+      // @typescript-eslint/typescript-estree (a direct dep of CLI).
+      // Imported by packages/cli/src/audit/component-anatomy/parsers/ast.ts.
+      'typescript',
+    ],
     // Bundle workspace packages into the CLI dist so the CLI works
     // when installed globally without needing sibling packages.
     noExternal: [

--- a/packages/graph/src/constraints/DesignConstraintAdapter.ts
+++ b/packages/graph/src/constraints/DesignConstraintAdapter.ts
@@ -11,6 +11,45 @@ export interface DesignViolation {
 
 export type DesignStrictness = 'strict' | 'standard' | 'permissive';
 
+/**
+ * Generic finding shape accepted by `recordFindings()` — covers ANAT-*
+ * (audit-component-anatomy, design-pipeline #2) and CRAFT-*
+ * (harness-design-craft, design-pipeline #6) namespaces. Skills convert
+ * their internal finding types into this shape before recording.
+ */
+export interface CraftFindingRecord {
+  /** Finding code, e.g. "ANAT-D023", "CRAFT-C001", "CRAFT-P001" */
+  code: string;
+  /** Project-relative file path (becomes the `file` node id) */
+  file: string;
+  /** Line number, if known */
+  line?: number;
+  /** Human-readable message */
+  message: string;
+  /** Severity at emission time */
+  severity: 'error' | 'warn' | 'info';
+  /** Optional evidence snippet */
+  evidence?: string;
+  /** Optional run identifier so #4 verifier can detect fixpoint across runs */
+  runId?: string;
+}
+
+/**
+ * Reserved finding-code prefixes that the adapter recognizes. Used to
+ * derive a human-readable `design_rule` node name when one doesn't
+ * already exist in the graph.
+ */
+const CODE_PREFIX_LABELS: Record<string, string> = {
+  'ANAT-D': 'Component anatomy (definition)',
+  'ANAT-P': 'Component anatomy (pattern presence)',
+  'ANAT-U': 'Component anatomy (usage)',
+  'CRAFT-C': 'Design craft (critique)',
+  'CRAFT-P': 'Design craft (polish)',
+  'CRAFT-B': 'Design craft (benchmark)',
+  'DESIGN-': 'Design constraint (legacy)',
+  'A11Y-': 'Accessibility',
+};
+
 export class DesignConstraintAdapter {
   constructor(private readonly store: GraphStore) {}
 
@@ -114,5 +153,89 @@ export class DesignConstraintAdapter {
       case 'strict':
         return 'error';
     }
+  }
+
+  /**
+   * Record externally-computed craft findings (audit-component-anatomy,
+   * harness-design-craft, etc.) as graph state. Idempotent — re-running on
+   * the same findings produces no duplicate nodes or edges thanks to
+   * GraphStore's keyed merge semantics.
+   *
+   * Each finding becomes:
+   *   • a `design_constraint` node keyed by finding code (created lazily
+   *     if absent; metadata merged on re-record so the most recent message
+   *     / severity wins)
+   *   • a `violates_design` edge from the source file (id = file path) to
+   *     the constraint node, with per-finding metadata (line, severity,
+   *     message, evidence, runId)
+   *
+   * The file node is NOT created here — it's assumed to already exist in
+   * the graph from a prior ingest. If it does not, the edge will still be
+   * created (graph stores edges by key, not by referential integrity) and
+   * a subsequent ingest will populate the file node.
+   */
+  recordFindings(findings: readonly CraftFindingRecord[]): {
+    constraintsAdded: number;
+    edgesAdded: number;
+  } {
+    let constraintsAdded = 0;
+    let edgesAdded = 0;
+    const seenConstraintIds = new Set<string>();
+
+    for (const finding of findings) {
+      const constraintId = `design_constraint:${finding.code}`;
+
+      // Lazily create the design_constraint node (one per code, regardless of
+      // how many files violate it). safeMerge means re-records update metadata.
+      if (!seenConstraintIds.has(finding.code)) {
+        const existing = this.store.getNode(constraintId);
+        if (!existing) constraintsAdded += 1;
+        this.store.addNode({
+          id: constraintId,
+          type: 'design_constraint',
+          name: finding.code,
+          metadata: {
+            code: finding.code,
+            label: this.labelForCode(finding.code),
+            mostRecentMessage: finding.message,
+            mostRecentSeverity: finding.severity,
+          },
+        });
+        seenConstraintIds.add(finding.code);
+      }
+
+      // Edge: file --violates_design--> constraint
+      const fileId = finding.file;
+      const edgeMetadata: Record<string, unknown> = {
+        message: finding.message,
+        severity: finding.severity,
+      };
+      if (finding.line !== undefined) edgeMetadata.line = finding.line;
+      if (finding.evidence !== undefined) edgeMetadata.evidence = finding.evidence;
+      if (finding.runId !== undefined) edgeMetadata.runId = finding.runId;
+
+      // Track whether the edge was new (the store dedupes by from\0to\0type key)
+      const before = this.store.getEdges({
+        from: fileId,
+        to: constraintId,
+        type: 'violates_design',
+      });
+      this.store.addEdge({
+        from: fileId,
+        to: constraintId,
+        type: 'violates_design',
+        metadata: edgeMetadata,
+      });
+      if (before.length === 0) edgesAdded += 1;
+    }
+
+    return { constraintsAdded, edgesAdded };
+  }
+
+  private labelForCode(code: string): string {
+    for (const prefix of Object.keys(CODE_PREFIX_LABELS)) {
+      if (code.startsWith(prefix)) return CODE_PREFIX_LABELS[prefix]!;
+    }
+    return 'Design constraint';
   }
 }

--- a/packages/graph/tests/constraints/DesignConstraintAdapter.test.ts
+++ b/packages/graph/tests/constraints/DesignConstraintAdapter.test.ts
@@ -154,4 +154,159 @@ describe('DesignConstraintAdapter', () => {
       expect(codes.some((c) => c.includes('DESIGN-002'))).toBe(true); // hardcoded font
     });
   });
+
+  describe('recordFindings (craft skills)', () => {
+    it('creates a design_constraint node per unique finding code', () => {
+      const result = adapter.recordFindings([
+        {
+          code: 'ANAT-D001',
+          file: 'src/Button.tsx',
+          line: 14,
+          message: 'Button is missing required state: loading',
+          severity: 'error',
+        },
+        {
+          code: 'CRAFT-C001',
+          file: 'src/Page.tsx',
+          line: 88,
+          message: 'Three buttons compete for primary; hierarchy muddy',
+          severity: 'warn',
+          evidence: '<Button variant="primary">Save</Button>',
+          runId: 'run-2026-05-24-001',
+        },
+      ]);
+
+      expect(result.constraintsAdded).toBe(2);
+      expect(result.edgesAdded).toBe(2);
+
+      const constraints = store.findNodes({ type: 'design_constraint' });
+      expect(constraints).toHaveLength(2);
+      expect(constraints.map((n) => n.name).sort()).toEqual(['ANAT-D001', 'CRAFT-C001']);
+
+      const anatNode = constraints.find((n) => n.name === 'ANAT-D001')!;
+      expect(anatNode.metadata.label).toBe('Component anatomy (definition)');
+      expect(anatNode.metadata.mostRecentSeverity).toBe('error');
+
+      const craftNode = constraints.find((n) => n.name === 'CRAFT-C001')!;
+      expect(craftNode.metadata.label).toBe('Design craft (critique)');
+      expect(craftNode.metadata.mostRecentMessage).toContain('hierarchy muddy');
+    });
+
+    it('emits violates_design edges from file -> constraint with metadata', () => {
+      adapter.recordFindings([
+        {
+          code: 'ANAT-P001',
+          file: 'src/List.tsx',
+          line: 80,
+          message: 'map() over data with no empty branch',
+          severity: 'warn',
+          evidence: 'items.map(...)',
+          runId: 'run-x',
+        },
+      ]);
+
+      const edges = store.getEdges({
+        from: 'src/List.tsx',
+        to: 'design_constraint:ANAT-P001',
+        type: 'violates_design',
+      });
+      expect(edges).toHaveLength(1);
+      expect(edges[0]!.metadata).toMatchObject({
+        line: 80,
+        severity: 'warn',
+        message: 'map() over data with no empty branch',
+        evidence: 'items.map(...)',
+        runId: 'run-x',
+      });
+    });
+
+    it('is idempotent — re-recording the same finding produces no duplicates', () => {
+      const finding = {
+        code: 'CRAFT-P001',
+        file: 'src/Modal.tsx',
+        line: 42,
+        message: 'Spring physics would feel more confident',
+        severity: 'info' as const,
+      };
+
+      const first = adapter.recordFindings([finding]);
+      const second = adapter.recordFindings([finding]);
+
+      expect(first.constraintsAdded).toBe(1);
+      expect(first.edgesAdded).toBe(1);
+      expect(second.constraintsAdded).toBe(0);
+      expect(second.edgesAdded).toBe(0);
+
+      expect(store.findNodes({ type: 'design_constraint' })).toHaveLength(1);
+      expect(
+        store.getEdges({
+          from: 'src/Modal.tsx',
+          to: 'design_constraint:CRAFT-P001',
+          type: 'violates_design',
+        })
+      ).toHaveLength(1);
+    });
+
+    it('labels each known code-prefix namespace', () => {
+      const findings = [
+        { code: 'ANAT-D001', label: 'Component anatomy (definition)' },
+        { code: 'ANAT-P001', label: 'Component anatomy (pattern presence)' },
+        { code: 'ANAT-U001', label: 'Component anatomy (usage)' },
+        { code: 'CRAFT-C001', label: 'Design craft (critique)' },
+        { code: 'CRAFT-P001', label: 'Design craft (polish)' },
+        { code: 'CRAFT-B001', label: 'Design craft (benchmark)' },
+        { code: 'DESIGN-001', label: 'Design constraint (legacy)' },
+        { code: 'A11Y-010', label: 'Accessibility' },
+      ];
+
+      adapter.recordFindings(
+        findings.map((f) => ({
+          code: f.code,
+          file: 'src/A.tsx',
+          message: 'msg',
+          severity: 'warn' as const,
+        }))
+      );
+
+      for (const f of findings) {
+        const node = store.getNode(`design_constraint:${f.code}`)!;
+        expect(node.metadata.label, `label for ${f.code}`).toBe(f.label);
+      }
+    });
+
+    it('labels unknown code prefixes with the generic fallback', () => {
+      adapter.recordFindings([
+        {
+          code: 'UNKNOWN-999',
+          file: 'src/X.tsx',
+          message: 'mystery finding',
+          severity: 'info',
+        },
+      ]);
+
+      const node = store.getNode('design_constraint:UNKNOWN-999')!;
+      expect(node.metadata.label).toBe('Design constraint');
+    });
+
+    it('accepts findings with no line, evidence, or runId', () => {
+      const result = adapter.recordFindings([
+        {
+          code: 'ANAT-D000',
+          file: 'src/Y.tsx',
+          message: 'JSDoc divergence',
+          severity: 'info',
+        },
+      ]);
+      expect(result.edgesAdded).toBe(1);
+      const edges = store.getEdges({ type: 'violates_design' });
+      expect(edges[0]!.metadata).not.toHaveProperty('line');
+      expect(edges[0]!.metadata).not.toHaveProperty('evidence');
+      expect(edges[0]!.metadata).not.toHaveProperty('runId');
+    });
+
+    it('handles an empty findings array gracefully', () => {
+      const result = adapter.recordFindings([]);
+      expect(result).toEqual({ constraintsAdded: 0, edgesAdded: 0 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The Phase 1 vertical slices for design-pipeline #2 (audit-component-anatomy) and #6 (design-craft-elevator) merged in #372 introduced two new MCP tool entry points + new internal modules, but several "deferred to coordination commits" items remained. This PR closes the loop on **four of five** of those items.

## What this PR does

| Item | File(s) | What changed |
|---|---|---|
| **MCP server registration** | `packages/cli/src/mcp/server.ts` | Adds `auditAnatomyDefinition` + `designCraftToolDefinition` to `TOOL_DEFINITIONS`, `handleAuditAnatomy` + `handleDesignCraft` to `TOOL_HANDLERS`. The MCP tools were exported but never wired to the server — now `mcp__harness__audit_anatomy` and `mcp__harness__design_craft` are discoverable and invocable. |
| **Config schema extensions** | `packages/cli/src/config/schema.ts` | Adds two new optional sub-schemas under `DesignConfigSchema`: `design.audit.componentAnatomy.{enabled,catalog,patterns,fastMode}` (gates audit-component-anatomy + the harness-accessibility deferral) and `design.craft.{enabled,mode,autoCapture,llm,catalog,signal}` (gates harness-design-craft). All fields optional with sensible defaults; omitting either block uses built-in defaults. Zero impact on existing `harness.config.json` files. |
| **`DesignConstraintAdapter.recordFindings()`** | `packages/graph/src/constraints/DesignConstraintAdapter.ts` + tests | Generic finding-ingestion entry point that both audit-component-anatomy (`ANAT-*`) and harness-design-craft (`CRAFT-*`) call to persist findings as graph state. Idempotent (re-running produces no duplicate edges). Per finding: lazy `design_constraint` node creation + `violates_design` edge with per-finding metadata (line, severity, message, evidence, runId). Uses existing graph taxonomy — no NodeType/EdgeType additions needed. 7 new tests cover the method (17 total adapter tests pass). |
| **harness-accessibility deferral patch** | `agents/skills/claude-code/harness-accessibility/SKILL.md` (and hardlinked siblings) | Adds Phase 1 step 2.6 (i18n-style overlap deferral): when `design.audit.componentAnatomy.enabled = true` (default), A11Y-010 + A11Y-050 findings are deferred to audit-component-anatomy for components in its catalog. Catalog set loaded via `getCatalogTypes()` from audit-component-anatomy — zero rule-content duplication. |
| **Test + build fixes from the above** | `packages/cli/tsup.config.ts`, `packages/cli/src/commands/setup-mcp.ts`, `packages/cli/tests/mcp/server*.test.ts` | `tsup.config.ts`: add `typescript` to externals (was bundling 9.8MB of TS that broke at runtime due to `Dynamic require of 'fs'`). `setup-mcp.ts`: add the two new tools to `ALL_MCP_TOOLS` array. `server*.test.ts`: bump tool-count assertions 68 → 70. |
| **Regenerated mcp-tools.md** | `docs/reference/mcp-tools.md` | Reflects the two newly registered tools. |

## What's still deferred (one item)

**`harness validate` fast-mode hook for audit-anatomy** — the largest individual coordination item (requires touching the validate command path). The other coordination items are surgical extensions that close the loop on Phase 1 without requiring validate changes. Filing this as a follow-up keeps the diff reviewable.

## Test plan

- [x] `harness validate` clean
- [x] Full CLI suite passes (3261/3261)
- [x] Full graph suite passes (873/873 including 17 adapter tests)
- [x] Skills package: 23941/23941 still passes (a11y SKILL.md edit propagated via hardlinks to all four platforms; byte-identical parity check passes)
- [x] `mcp__harness__audit_anatomy` and `mcp__harness__design_craft` appear in `ALL_MCP_TOOLS` and `TOOL_DEFINITIONS`
- [x] Skill advisor regenerates `docs/reference/mcp-tools.md` cleanly
- [x] tsup build produces a working CLI (`node packages/cli/dist/bin/harness.js --version` succeeds)
- [ ] Manual: invoke `mcp__harness__audit_anatomy` on a fixture project once CI green

## Commit list

```
b748a377 docs(reference): regenerate mcp-tools.md for audit_anatomy + design_craft
8360d5b6 test(graph): cover DesignConstraintAdapter.recordFindings()
ded4c16f fix(cli): externalize typescript in tsup; update second tool-count assertion
9c4e354e test(mcp): update tool-count assertions for audit_anatomy + design_craft
0eac8ebc chore(changeset): add changeset for design-pipeline coordination commits
ecee8749 feat(harness-accessibility): defer A11Y-010 + A11Y-050 to audit-component-anatomy
0dd1d9e8 feat(graph): DesignConstraintAdapter.recordFindings() for craft skills
8cf91912 feat(config): add design.audit + design.craft sub-schemas (design-pipeline)
fa17c404 feat(mcp): register audit_anatomy and design_craft tools
```

## Depends on

- PR #372 (already merged) — design-pipeline decomposition + Phase 1 vertical slices
- ADRs 0018-0021 (also merged via #372) — establish the floor/ceiling and 3-axis output patterns used here