### PR TITLE
fix(orchestrator): Spec B Phase 0 review fixes (C1 + I3)

### DIFF
--- a/packages/orchestrator/src/agent/backend-router.ts
+++ b/packages/orchestrator/src/agent/backend-router.ts
@@ -12,6 +12,23 @@ export interface BackendRouterOptions {
 }
 
 /**
+ * Spec B Phase 0 normalization: collapse a {@link RoutingValue} to the
+ * first backend name. Scalar inputs are returned unchanged
+ * (byte-identical to pre-Spec-B behavior). Array-form inputs return the
+ * first element.
+ *
+ * Exported as a module-level helper so the small number of "surprise
+ * consumers" of widened {@link RoutingValue} fields (e.g.
+ * `intelligence-factory.ts`) can normalize through a single canonical
+ * implementation. Phase 1 of Spec B replaces the body of this function
+ * with the proper chain-walk resolver; every caller upgrades in
+ * lockstep at that point.
+ */
+export function toScalar(value: RoutingValue): string {
+  return Array.isArray(value) ? value[0] : (value as string);
+}
+
+/**
  * BackendRouter
  *
  * Owns the lookup from a `RoutingUseCase` (a discriminated query — tier,
@@ -110,12 +127,14 @@ export class BackendRouter {
 
   /**
    * Spec B Phase 0 normalization: collapse a {@link RoutingValue} to the
-   * first backend name. Scalar inputs are returned unchanged (byte-identical
-   * to pre-Spec-B behavior). Array-form inputs return the first element;
-   * Phase 1 replaces this with the proper chain walk.
+   * first backend name. Delegates to the module-level {@link toScalar}
+   * helper so external "surprise consumers" of widened RoutingValue
+   * fields (e.g. `intelligence-factory.ts`) and the router itself share
+   * one canonical implementation. Phase 1 replaces the helper body with
+   * the proper chain walk.
    */
   private toScalar(value: RoutingValue): string {
-    return Array.isArray(value) ? value[0] : (value as string);
+    return toScalar(value);
   }
 
   private validateReferences(): void {

--- a/packages/orchestrator/src/agent/intelligence-factory.ts
+++ b/packages/orchestrator/src/agent/intelligence-factory.ts
@@ -9,6 +9,7 @@ import { GraphStore } from '@harness-engineering/graph';
 import type { WorkflowConfig, BackendDef } from '@harness-engineering/types';
 import type { LocalModelResolver } from './local-model-resolver';
 import { buildAnalysisProvider } from './analysis-provider-factory';
+import { toScalar } from './backend-router';
 import type { StructuredLogger } from '../logging/logger';
 
 export interface IntelligenceFactoryDeps {
@@ -44,9 +45,22 @@ export function buildIntelligencePipeline(
   // build a distinct provider for the PESL layer. When they route to
   // the same backend (or pesl is unset), pass undefined so the
   // pipeline falls back to the sel provider (current behavior).
+  //
+  // Spec B Phase 0 (C1 fix): compare the *resolved* backend names rather
+  // than the raw RoutingValue (which can be a fresh array literal —
+  // reference equality would be false for any chain form, building a
+  // redundant duplicate provider). `toScalar` collapses scalar | chain
+  // to the first backend name; this is byte-identical to the
+  // pre-widening behavior for scalar inputs and also makes
+  // scalar-vs-single-element-chain compare equal. Phase 1 will replace
+  // this with a `router.resolve({ kind: 'intelligence', layer: ... })`
+  // call so two distinct chains that resolve to the same backend (via
+  // chain walk + availability filtering) also compare equal.
   const routing = config.agent.routing;
-  const peslName = routing?.intelligence?.pesl;
-  const selName = routing?.intelligence?.sel ?? routing?.default;
+  const peslValue = routing?.intelligence?.pesl;
+  const selValue = routing?.intelligence?.sel ?? routing?.default;
+  const peslName = peslValue !== undefined ? toScalar(peslValue) : undefined;
+  const selName = selValue !== undefined ? toScalar(selValue) : undefined;
   const peslProvider =
     peslName !== undefined && peslName !== selName
       ? buildAnalysisProviderForLayer('pesl', deps)

--- a/packages/orchestrator/src/workflow/config.ts
+++ b/packages/orchestrator/src/workflow/config.ts
@@ -19,8 +19,12 @@ const BackendsMapSchema = z.record(z.string(), BackendDefSchema);
  * `backends`. Mirrors the Phase 1 standalone helper but returns a flat
  * array of issues for synchronous consumption inside
  * `validateWorkflowConfig` (which is hand-rolled, not a Zod parse).
+ *
+ * Exported for unit testing. Production callers should prefer
+ * `validateWorkflowConfig` (which wraps this helper with the surrounding
+ * legacy-vs-modern branching).
  */
-function crossFieldRoutingIssues(
+export function crossFieldRoutingIssues(
   backends: Record<string, BackendDef>,
   routing: RoutingConfig
 ): Array<{ path: string[]; message: string }> {

--- a/packages/orchestrator/tests/workflow/routing-config-schema.test.ts
+++ b/packages/orchestrator/tests/workflow/routing-config-schema.test.ts
@@ -77,4 +77,47 @@ describe('RoutingConfigSchema — Spec B Phase 0 widening', () => {
     });
     expect(parsed.success).toBe(false);
   });
+
+  // --- I3 (Phase 0 review) — coverage gaps -----------------------------------
+  // The original suite covered the headline cases (scalar + array on a few
+  // representative fields). The cases below pin behavior for shapes that
+  // the typecheck fixture already covers but that the Zod schema did not.
+
+  it('accepts a single-element chain on routing.default (parity with scalar form)', () => {
+    const parsed = RoutingConfigSchema.safeParse({
+      default: ['claude-opus'],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts a duplicate-entry chain (pins current behavior — no diagnostic)', () => {
+    // I3: duplicates within a chain may be intentional (operator hedging) or
+    // accidental. Phase 0 accepts both — this test pins the behavior so a
+    // future tightening (e.g., warn-on-duplicate) is an explicit change.
+    const parsed = RoutingConfigSchema.safeParse({
+      default: 'claude-opus',
+      skills: {
+        foo: ['claude-opus', 'claude-opus'],
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  // I3: parametric coverage of array form across the remaining widened
+  // scalar fields. `default`, `quick-fix`, `intelligence.sel`, `skills.*`,
+  // and `modes.*` are exercised by earlier tests; the four below close
+  // the gap. (`isolation.*` is intentionally skipped — not in the Zod
+  // schema yet per `schema.ts:105-106` TODO; Phase 2 follow-up.)
+  it.each([
+    ['guided-change', { 'guided-change': ['claude-opus', 'claude-sonnet'] }],
+    ['full-exploration', { 'full-exploration': ['claude-opus', 'claude-sonnet'] }],
+    ['diagnostic', { diagnostic: ['claude-opus', 'claude-sonnet'] }],
+    ['intelligence.pesl', { intelligence: { pesl: ['claude-opus', 'claude-sonnet'] } }],
+  ])('accepts array form for routing.%s', (_label, extraFields) => {
+    const parsed = RoutingConfigSchema.safeParse({
+      default: 'claude-opus',
+      ...extraFields,
+    });
+    expect(parsed.success).toBe(true);
+  });
 });

--- a/packages/orchestrator/tests/workflow/routing-cross-field.test.ts
+++ b/packages/orchestrator/tests/workflow/routing-cross-field.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { BackendDef, RoutingConfig } from '@harness-engineering/types';
+import { crossFieldRoutingIssues } from '../../src/workflow/config';
+import { validateBackendsAndRouting } from '../../src/workflow/schema';
+
+/**
+ * I3 (Phase 0 review): pin the per-entry issue path produced by
+ * Phase 0's cross-field validators. The path-with-index logic
+ * (schema.ts:152-159, config.ts:35-43) is the only Phase-0 code path
+ * that emits *user-facing error messages* with per-chain-entry
+ * granularity. Without these tests, a refactor that changes
+ * `path.push(idx)` -> `path.push(String(idx))` (or vice versa) would
+ * pass typecheck and the existing schema-acceptance tests, but break
+ * downstream consumers that index into `issue.path` to highlight the
+ * offending entry in a config UI.
+ *
+ * Both validators are tested in parallel because they produce
+ * structurally-equivalent issue paths (one inside Zod's
+ * `superRefine` context, one as a flat array).
+ */
+
+const KNOWN_BACKENDS: Record<string, BackendDef> = {
+  'claude-opus': { type: 'claude' },
+  mock: { type: 'mock' },
+};
+
+describe('crossFieldRoutingIssues (config.ts) — chain entry issue paths', () => {
+  it('reports the offending index when a skills chain entry is unknown', () => {
+    const routing: RoutingConfig = {
+      default: 'claude-opus',
+      skills: {
+        foo: ['claude-opus', 'unknown-backend'],
+      },
+    };
+    const issues = crossFieldRoutingIssues(KNOWN_BACKENDS, routing);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toEqual(['skills', 'foo', '1']);
+    expect(issues[0]?.message).toContain('unknown-backend');
+    expect(issues[0]?.message).toContain('routing.skills.foo.1');
+  });
+
+  it('reports the offending index when a modes chain entry is unknown', () => {
+    const routing: RoutingConfig = {
+      default: 'claude-opus',
+      modes: {
+        'adversarial-reviewer': ['unknown-backend', 'claude-opus'],
+      },
+    };
+    const issues = crossFieldRoutingIssues(KNOWN_BACKENDS, routing);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toEqual(['modes', 'adversarial-reviewer', '0']);
+    expect(issues[0]?.message).toContain('unknown-backend');
+    expect(issues[0]?.message).toContain('routing.modes.adversarial-reviewer.0');
+  });
+
+  it('reports indices for multiple unknown entries in the same chain', () => {
+    const routing: RoutingConfig = {
+      default: 'claude-opus',
+      skills: {
+        foo: ['claude-opus', 'unknown-one', 'mock', 'unknown-two'],
+      },
+    };
+    const issues = crossFieldRoutingIssues(KNOWN_BACKENDS, routing);
+
+    expect(issues).toHaveLength(2);
+    expect(issues[0]?.path).toEqual(['skills', 'foo', '1']);
+    expect(issues[1]?.path).toEqual(['skills', 'foo', '3']);
+  });
+
+  it('omits the index segment for scalar form (1-segment path preserved)', () => {
+    // Pins the asymmetric path shape: scalar entries report
+    // `['skills', 'foo']` (no `.0` suffix), chain entries report
+    // `['skills', 'foo', '<idx>']`. A consumer doing
+    // `path[path.length - 1]` to extract the entry index must be able
+    // to tell scalar from chain — the contract is "path length
+    // increases by 1 when reporting a chain entry".
+    const routing: RoutingConfig = {
+      default: 'claude-opus',
+      skills: {
+        foo: 'unknown-backend',
+      },
+    };
+    const issues = crossFieldRoutingIssues(KNOWN_BACKENDS, routing);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toEqual(['skills', 'foo']);
+  });
+
+  it('reports no issues when every chain entry is a known backend', () => {
+    const routing: RoutingConfig = {
+      default: 'claude-opus',
+      skills: {
+        foo: ['claude-opus', 'mock'],
+      },
+      modes: {
+        bar: ['mock'],
+      },
+    };
+    const issues = crossFieldRoutingIssues(KNOWN_BACKENDS, routing);
+
+    expect(issues).toEqual([]);
+  });
+});
+
+/**
+ * `validateBackendsAndRouting` is the Zod-flavored sibling — it pushes
+ * issues into a `superRefine` context rather than returning an array.
+ * To exercise it in isolation we wrap a minimal Zod schema that
+ * forwards (backends, routing) to the helper.
+ */
+describe('validateBackendsAndRouting (schema.ts) — chain entry issue paths', () => {
+  const TestSchema = z
+    .object({
+      backends: z.record(z.string(), z.any()).optional(),
+      routing: z.any().optional(),
+    })
+    .superRefine((val, ctx) => {
+      validateBackendsAndRouting(
+        val.backends as Record<string, BackendDef> | undefined,
+        val.routing as RoutingConfig | undefined,
+        ctx
+      );
+    });
+
+  it('reports the offending index in the issue path for a skills chain', () => {
+    const result = TestSchema.safeParse({
+      backends: KNOWN_BACKENDS,
+      routing: {
+        default: 'claude-opus',
+        skills: { foo: ['claude-opus', 'unknown-backend'] },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return; // type guard
+    expect(result.error.issues).toHaveLength(1);
+    // `validateBackendsAndRouting` prefixes the path with `routing`;
+    // the index segment is appended as a number (not a string) per
+    // schema.ts:154.
+    expect(result.error.issues[0]?.path).toEqual(['routing', 'skills', 'foo', 1]);
+    expect(result.error.issues[0]?.message).toContain('unknown-backend');
+    expect(result.error.issues[0]?.message).toContain('routing.skills.foo.1');
+  });
+
+  it('reports the offending index in the issue path for a modes chain', () => {
+    const result = TestSchema.safeParse({
+      backends: KNOWN_BACKENDS,
+      routing: {
+        default: 'claude-opus',
+        modes: { bar: ['unknown-backend', 'mock'] },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toHaveLength(1);
+    expect(result.error.issues[0]?.path).toEqual(['routing', 'modes', 'bar', 0]);
+  });
+
+  it('reports the offending index in the issue path for intelligence.pesl chain', () => {
+    const result = TestSchema.safeParse({
+      backends: KNOWN_BACKENDS,
+      routing: {
+        default: 'claude-opus',
+        intelligence: { pesl: ['mock', 'unknown-backend'] },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toHaveLength(1);
+    expect(result.error.issues[0]?.path).toEqual(['routing', 'intelligence', 'pesl', 1]);
+  });
+
+  it('omits the index segment for scalar form (1-segment path under the field key)', () => {
+    const result = TestSchema.safeParse({
+      backends: KNOWN_BACKENDS,
+      routing: {
+        default: 'claude-opus',
+        skills: { foo: 'unknown-backend' },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toHaveLength(1);
+    expect(result.error.issues[0]?.path).toEqual(['routing', 'skills', 'foo']);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses two non-deferred findings from the Spec B Phase 0 code review (`docs/changes/granular-task-routing/`):

- **C1 (critical)** — `intelligence-factory.ts:47-53` used reference equality (`peslName !== selName`) on widened `RoutingValue` types. Two array literals are never `===`, so any array-form sel/pesl config silently built duplicate intelligence providers. Fixed by promoting `BackendRouter.toScalar()` to a module-level export from `backend-router.ts` and normalizing both sides before comparison. JSDoc names Phase 1's `router.resolve()` as the planned upgrade site (for chain-walk equivalence).
- **I3 (important)** — added 6 tests to `routing-config-schema.test.ts` (single-element chain acceptance, duplicate-entry pin, parametric coverage of remaining widened scalar fields) and a new `routing-cross-field.test.ts` (9 tests covering both `crossFieldRoutingIssues` and `validateBackendsAndRouting` issue-path shapes including the chain-index encoding asymmetry).

Deferred per the review: I1 (consolidate inline normalizations — natural fit for Phase 1's resolver rewrite), I2 (widen isolation block in Zod schema — Phase 2's config-validator work), G1–G5 (polish).

## Commits

- `a81ba8bc` — fix(orchestrator): compare resolved backend names in intelligence-factory (C1)
- `8e80ab13` — test(spec-b-phase-0): cover single-element chains, duplicates, cross-field issue paths (I3)

## Test plan

- [x] `pnpm --filter @harness-engineering/orchestrator typecheck` PASS
- [x] `pnpm --filter @harness-engineering/orchestrator test -- tests/agent/ tests/workflow/` — 295/295 PASS
- [x] `harness validate` PASS · `harness check-deps` PASS
- [x] Pre-push hooks passed at push time

## Related

- Spec B Phase 0 originally landed via #393, baselines refreshed in #395
- Spec: `docs/changes/granular-task-routing/proposal.md`
- Prior review findings: `.harness/sessions/changes--granular-task-routing--proposal/phase-0-review.json`
- Follow-up review (this PR): `.harness/sessions/changes--granular-task-routing--proposal/phase-0-review-pass-2.json`