### PR TITLE
feat(cli): audit-brand-compliance + Verifier interface (design-pipeline #3)

### DIFF
--- a/.changeset/audit-brand-compliance.md
+++ b/.changeset/audit-brand-compliance.md
@@ -1,0 +1,64 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Add `audit-brand-compliance` — rule-based brand-semantics audit (design-pipeline sub-project #3). The last unshipped floor-layer audit; closes the floor layer and unblocks #5 design-pipeline orchestrator.
+
+**Two rule families in v1 (narrow + deep):**
+
+- **BRAND-T001 (token misuse)** — flags tokens used in contexts declared as `forbidden_contexts` in `$extensions.harness.brand`. Recognizes three reference forms: `tokens.X.Y.Z`, `var(--X-Y-Z)`, and `'X.Y.Z'` string literals. Context inference v1 uses same-line + adjacent-non-blank-line vocabulary scan against `cta` / `selection` / `focus` / `data-visualization` / `decorative` / `background` / `text` / `border` / `error` / `success` / `warning`.
+- **BRAND-V001 (forbidden phrases)** — TS Compiler API walk over `.tsx`/`.jsx` files. Scans `JsxText` nodes and string-typed `JsxAttribute` initializers for case-insensitive substring matches against `voice.forbiddenPhrases` from `DESIGN.md ## Brand Rules`.
+
+**Three decisions locked in the spec:**
+
+1. **v1 rule scope:** BRAND-T\* + BRAND-V001 only. Defers tone-by-context (needs component-state inference), reading-level / sentence-length (ship with tone-context), asset rules (image-tag + filesystem), and semantic-token-alias enforcement (overlaps with detect-drift T001) to v1.x.
+2. **Input sources:** Both `DESIGN.md ## Brand Rules` AND `tokens.json $extensions.harness.brand`. Per ADR 0028. Either resolver returning null silently skips the matching rule family.
+3. **check-design composition:** 4th verifier (triggers `Verifier<F>` interface extraction).
+
+**Cross-cutting: Verifier<F> interface extraction**
+
+The convention note in `check-design.ts` deferred extracting a formal Verifier interface until the 3rd check-\* command landed. Brand makes 4 verifiers in `harness check-design` (anatomy / craft / drift / brand). This PR extracts:
+
+```ts
+// packages/cli/src/shared/verifier.ts
+export interface Verifier<F, Cat = ..., Meta = ...> {
+  findings: F[];
+  summary: { totalFiles, durationMs, bySeverity, byCode };
+  catalog: Cat;
+  meta: Meta;
+}
+```
+
+All three rule-based verifiers (anatomy / drift / brand) declare structural conformance via type aliases. design-craft has a different output shape (cost telemetry, exemplar citations) and remains composed but does not conform — that's by design, the interface captures the rule-based pattern.
+
+**Surface area:**
+
+- `audit_brand` MCP tool (count 72 → 73)
+- `harness validate` fast-mode hook gated by `design.audit.brandCompliance.enabled` (default true)
+- 4th verifier in `harness check-design` (degrades gracefully on failure)
+- 4-platform skill markdown (claude-code / codex / cursor / gemini-cli)
+- New `design.audit.brandCompliance.{enabled, rules, fastMode}` config block
+
+**Configuration** (additive, all optional):
+
+```json
+{
+  "design": {
+    "audit": {
+      "brandCompliance": {
+        "enabled": true,
+        "rules": { "tokenMisuse": true, "voice": true },
+        "fastMode": { "maxFiles": 500 }
+      }
+    }
+  }
+}
+```
+
+**Long-term trajectory** (documented in proposal):
+
+- v1.x: BRAND-Tone* tone-by-context rules (after component-state inference matures); BRAND-V002/V003 reading-level + sentence-length; BRAND-A* asset rules; semantic-token-alias enforcement; standalone `harness audit-brand` CLI if signal warrants.
+- v2: `align-brand-compliance` sibling FIX skill (forbidden-phrase suggestions, token-misuse alias swaps); `VIOLATES_brand` dedicated graph edge.
+- v3: LLM-judgment tone rules paired with craft-pipeline #5 copy-craft.
+
+**Tests:** 35+ new unit + integration tests across resolvers (DESIGN.md parser, $extensions walker), rules (token-misuse, forbidden-phrases), and end-to-end audit composition. check-design test extended for 4-verifier case. 821 tests pass across the cli suite.

--- a/agents/skills/claude-code/audit-brand-compliance/SKILL.md
+++ b/agents/skills/claude-code/audit-brand-compliance/SKILL.md
@@ -1,0 +1,189 @@
+# Audit Brand Compliance
+
+> Rule-based brand-semantics audit. Detects (a) tokens used in forbidden contexts per their `$extensions.harness.brand.forbidden_contexts` metadata (BRAND-T001) and (b) UI copy containing phrases listed in `DESIGN.md ## Brand Rules → voice.forbidden_phrases` (BRAND-V001). The 4th composed verifier in `harness check-design`, alongside audit-component-anatomy, design-craft critique, and detect-design-drift.
+
+## When to Use
+
+- After authoring or editing `DESIGN.md ## Brand Rules` — verify the new constraints are enforceable on the existing codebase
+- After adding `$extensions.harness.brand` metadata to a token — discover existing call sites in forbidden contexts
+- As part of `harness validate` (fast-mode hook, gated by `design.audit.brandCompliance.enabled`)
+- As the 4th composed verifier in `harness check-design` (the unified design check)
+- Before a PR with UI copy or token-usage changes lands
+- NOT for tone-by-context rules (deferred to v1.x — requires component-state inference)
+- NOT for reading-level or sentence-length rules (deferred to v1.x — ship with tone-context)
+- NOT for asset-usage rules (deferred to v1.x — requires image-tag scanning)
+- NOT for semantic-token-alias enforcement (overlaps with detect-design-drift T001 — design after both have shipped)
+- NOT for brand-rule authoring (use `harness-design` skill to draft DESIGN.md sections)
+
+## Process
+
+### Phase 1: LOAD — Parse the two input sources
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `design.strictness` — `strict` / `standard` / `permissive` (default `standard`)
+   - `design.audit.brandCompliance.enabled` — gate (default `true`)
+   - `design.audit.brandCompliance.rules.{tokenMisuse,voice}` — per-rule toggles
+
+2. **Load `design-system/DESIGN.md` `## Brand Rules`.** The parser extracts:
+   - `voice.forbiddenPhrases: string[]` — used by BRAND-V001 in v1
+   - `voice.constant`, `voice.readingLevel`, `voice.maxSentenceWords` — parsed but unused in v1 (forward-compat)
+   - `toneByContext`, `assets`, `semanticTokenAliases` — parsed but unused (v1.x)
+   - Returns `null` when DESIGN.md absent or `## Brand Rules` section missing → BRAND-V001 silently skips.
+
+3. **Load `design-system/tokens.json` `$extensions.harness.brand`.** Walks the DTCG token tree capturing per-token `role`, `approved_contexts`, `forbidden_contexts`. Returns `null` when no token carries the extension → BRAND-T\* silently skips.
+
+### Phase 2: SCAN — Apply the two rule families
+
+1. **BRAND-T001 — token misuse (regex-based).** For each token whose `forbidden_contexts` is non-empty:
+   - Find every reference to the token's dotted path in source (recognizes three forms):
+     - `tokens.X.Y.Z` (JS accessor)
+     - `var(--X-Y-Z)` (CSS var, kebab-cased)
+     - `'X.Y.Z'` / `"X.Y.Z"` (string literal)
+   - Inspect surrounding context (same line + nearest non-blank previous and next line) for the v1 context-vocabulary keywords: `cta`, `selection`, `focus`, `data-visualization`, `decorative`, `background`, `text`, `border`, `error`, `success`, `warning`.
+   - If a forbidden context matches: emit BRAND-T001.
+
+2. **BRAND-V001 — forbidden phrases (TS Compiler API).** For each `.tsx`/`.jsx` file:
+   - Walk the JSX tree.
+   - For each `JsxText` node: case-insensitive substring scan for any forbiddenPhrase.
+   - For each `JsxAttribute` whose initializer is a string literal: same scan.
+   - Deduplicate per `(file, line, phrase)`.
+
+### Phase 3: REPORT — Aggregate and surface
+
+1. **Severity from `design.strictness`** (uses `severityFor`):
+   - `strict` — all findings `error`
+   - `standard` — BRAND-T001 `error` (declared violation), BRAND-V001 `warn` (copy nuance)
+   - `permissive` — all findings `info`
+
+2. **Aggregate `bySeverity` and `byCode`** into the standard Verifier shape: `{ findings, summary, catalog, meta }`.
+
+3. **Persist findings to the graph (when composed by check-design).** check-design routes brand findings through `DesignConstraintAdapter.recordFindings()` alongside anatomy / craft / drift. v1 uses the shared `VIOLATES_design` edge; v1.x may add a brand-specific edge.
+
+## Harness Integration
+
+- **`harness validate`** — Fast-mode hook gated by `design.audit.brandCompliance.enabled`. Degrades gracefully on failure (single warning; other checks continue).
+- **`harness check-design`** — Composes brand as the 4th verifier alongside audit-anatomy, design-craft critique, and detect-design-drift. This is the canonical invocation path.
+- **`mcp__harness__audit_brand`** — MCP tool. Input: `{ path, mode, files?, designStrictness?, rules? }`. Output: `{ findings, summary, catalog, meta }`. Consumed by check-design and the (future) #5 design-pipeline orchestrator.
+- **`DesignConstraintAdapter.recordFindings()`** — Generic graph persistence entry point shipped in PR #390. Brand findings reuse the adapter (no graph schema changes in v1).
+- **`harness-design` skill** — Authors `DESIGN.md ## Brand Rules`. audit-brand-compliance is the matching enforcer.
+- **`Verifier<F>` interface** — Extracted in this PR at the 4th-verifier threshold. Lives at `packages/cli/src/shared/verifier.ts`. Adding a 5th verifier requires only a type-alias declaration of conformance.
+
+## Success Criteria
+
+See `docs/changes/design-pipeline/audit-brand-compliance/proposal.md` for the full 34 success criteria. Highlights:
+
+- DESIGN.md parser returns `null` when section absent (silent-skip pattern)
+- Token-extensions walker returns `null` when no token carries `$extensions.harness.brand`
+- BRAND-T001 fires on `tokens.X`, `var(--x)`, and `'X'` reference forms
+- BRAND-T001 honors approved_contexts (no finding when context is allowed)
+- BRAND-V001 fires on JSX text + string-typed JSX attributes (case-insensitive)
+- BRAND-V001 deduplicates per `(file, line, phrase)`
+- Verifier interface extraction: anatomy / drift / brand all declare structural conformance
+- `harness check-design` test extended for 4-verifier composition (zero regressions)
+- MCP tool count bumps 72 → 73
+
+## Examples
+
+### Example: Token used in forbidden context
+
+**Input:**
+
+`design-system/tokens.json`:
+
+```json
+{
+  "color": {
+    "brand": {
+      "500": {
+        "$type": "color",
+        "$value": "#3b82f6",
+        "$extensions": {
+          "harness": {
+            "brand": {
+              "role": "primary",
+              "approved_contexts": ["cta", "selection", "focus"],
+              "forbidden_contexts": ["data-visualization", "decorative"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`src/Chart.tsx`:
+
+```tsx
+// data-visualization color palette
+const palette = [tokens.color.brand.500, ...];
+```
+
+**Output:**
+
+```
+BRAND-T001 [error] src/Chart.tsx:2 — Token "color.brand.500" is used in forbidden context "data-visualization"
+  Fix: Token "color.brand.500" is not approved for the "data-visualization" context.
+       Use an approved token (allowed contexts: cta, selection, focus), or update
+       tokens.json $extensions.harness.brand if the policy is wrong.
+```
+
+### Example: Forbidden phrase in UI copy
+
+**Input:**
+
+`DESIGN.md`:
+
+```markdown
+## Brand Rules
+
+### Voice
+
+forbidden_phrases:
+
+- "click here"
+- "best-in-class"
+```
+
+`src/Cta.tsx`:
+
+```tsx
+export const Cta = () => <a href="/x">Click here</a>;
+```
+
+**Output:**
+
+```
+BRAND-V001 [warn] src/Cta.tsx:1 — UI copy contains forbidden phrase "click here" — declared at DESIGN.md ## Brand Rules → Voice → forbidden_phrases
+  Fix: Rewrite to avoid "click here". If the phrase is unavoidable for this context,
+       remove it from voice.forbidden_phrases (or scope the audit) — but the default
+       policy is that brand voice trumps convenience.
+```
+
+## Gates
+
+- **No findings without parsed inputs.** DESIGN.md absent → BRAND-V001 skips silently. tokens.json `$extensions.harness.brand` absent on every token → BRAND-T001 skips silently. Either resolver returning null is NOT a verifier failure.
+- **No `.ts`/`.js` file scans for BRAND-V001.** Only `.jsx`/`.tsx` (user-visible JSX). Doc copy in `.md` is a different audience.
+- **No tone-by-context inference.** v1 only matches the explicit context-vocabulary keywords against surrounding source text. v1.x adds component-state inference.
+- **No autofix.** audit-only. The matching `align-brand-compliance` fix-side skill is deferred until detect signals demand.
+- **No graph schema changes.** v1 reuses `VIOLATES_design` via `recordFindings()`. v1.x may add `VIOLATES_brand` edge for queryability.
+- **Strictness from config, not assumed.** Read `design.strictness` from `harness.config.json`; default `standard` if absent.
+
+## Escalation
+
+- **When BRAND-T001 false-positives on a far-context reference:** the v1 context inference is intentionally narrow (same line + adjacent non-blank). For a token used in a "background" context where the keyword appears 10 lines away, v1 misses it. v1.x adds richer context inference; for now, either widen the surrounding comment or accept the miss.
+- **When BRAND-V001 false-positives on a substring (e.g., "as is" in "as issued"):** v1 uses substring match. Add word-boundary regex in v1.x. For now, rephrase the copy or remove the phrase from voice.forbidden_phrases.
+- **When a project ships tokens with a different `$extensions` shape:** v1 reads only `harness.brand`. Document the actual shape your project uses and add it to the schema sketch in ADR 0028 — DTCG `$extensions` namespaces are vendor-prefixed and additions are forward-compatible.
+- **When `harness validate` runtime exceeds 3 seconds:** Set `design.audit.brandCompliance.fastMode.maxFiles` to cap the scope. The MCP tool ignores the cap (`fast`/`full` equivalent in v1).
+- **When the graph persistence fails:** Skip graph integration for that run; findings still appear in the report. The graph is a consumer, not a gate.
+- **When you want tone-by-context rules today:** Manual audit until v1.x ships. Component-state inference (empty/error/success/loading) requires JSX-context analysis that's a separate brainstorm.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/design-pipeline/audit-brand-compliance/proposal.md`
+- ADR (input schema source): `docs/knowledge/decisions/0028-brand-guidelines-source-of-truth.md`
+- Roadmap entry: `design-pipeline sub-project #3` in `docs/roadmap.md`
+- Sibling rule-based audits: `audit-component-anatomy` (#2), `detect-design-drift` (#1)
+- Cross-cutting: extracts `Verifier<F>` interface at `packages/cli/src/shared/verifier.ts` (deferred until 4th data point — this is it)

--- a/agents/skills/claude-code/audit-brand-compliance/skill.yaml
+++ b/agents/skills/claude-code/audit-brand-compliance/skill.yaml
@@ -1,0 +1,50 @@
+name: audit-brand-compliance
+version: "0.1.0"
+description: Rule-based brand-semantics audit. Detects token misuse (BRAND-T001 via $extensions.harness.brand.forbidden_contexts) and voice violations (BRAND-V001 via DESIGN.md voice.forbidden_phrases). 4th composed verifier in harness check-design. Triggers extraction of the formal verifier interface.
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness skill run audit-brand-compliance
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: mode
+      description: "fast or full (equivalent in v1)"
+      required: false
+    - name: files
+      description: Optional list of files to scope the scan
+      required: false
+mcp:
+  tool: run_skill
+  input:
+    skill: audit-brand-compliance
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: load
+    description: Parse DESIGN.md ## Brand Rules and tokens.json $extensions.harness.brand
+    required: true
+  - name: scan
+    description: Walk JSX text/attributes for forbidden phrases; scan source for token-misuse-in-context
+    required: true
+  - name: report
+    description: Aggregate findings; emit BRAND-T* / BRAND-V001 with severity per design.strictness
+    required: true
+state:
+  persistent: false
+depends_on:
+  - detect-design-drift
+  - harness-design

--- a/agents/skills/codex/audit-brand-compliance/SKILL.md
+++ b/agents/skills/codex/audit-brand-compliance/SKILL.md
@@ -1,0 +1,189 @@
+# Audit Brand Compliance
+
+> Rule-based brand-semantics audit. Detects (a) tokens used in forbidden contexts per their `$extensions.harness.brand.forbidden_contexts` metadata (BRAND-T001) and (b) UI copy containing phrases listed in `DESIGN.md ## Brand Rules → voice.forbidden_phrases` (BRAND-V001). The 4th composed verifier in `harness check-design`, alongside audit-component-anatomy, design-craft critique, and detect-design-drift.
+
+## When to Use
+
+- After authoring or editing `DESIGN.md ## Brand Rules` — verify the new constraints are enforceable on the existing codebase
+- After adding `$extensions.harness.brand` metadata to a token — discover existing call sites in forbidden contexts
+- As part of `harness validate` (fast-mode hook, gated by `design.audit.brandCompliance.enabled`)
+- As the 4th composed verifier in `harness check-design` (the unified design check)
+- Before a PR with UI copy or token-usage changes lands
+- NOT for tone-by-context rules (deferred to v1.x — requires component-state inference)
+- NOT for reading-level or sentence-length rules (deferred to v1.x — ship with tone-context)
+- NOT for asset-usage rules (deferred to v1.x — requires image-tag scanning)
+- NOT for semantic-token-alias enforcement (overlaps with detect-design-drift T001 — design after both have shipped)
+- NOT for brand-rule authoring (use `harness-design` skill to draft DESIGN.md sections)
+
+## Process
+
+### Phase 1: LOAD — Parse the two input sources
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `design.strictness` — `strict` / `standard` / `permissive` (default `standard`)
+   - `design.audit.brandCompliance.enabled` — gate (default `true`)
+   - `design.audit.brandCompliance.rules.{tokenMisuse,voice}` — per-rule toggles
+
+2. **Load `design-system/DESIGN.md` `## Brand Rules`.** The parser extracts:
+   - `voice.forbiddenPhrases: string[]` — used by BRAND-V001 in v1
+   - `voice.constant`, `voice.readingLevel`, `voice.maxSentenceWords` — parsed but unused in v1 (forward-compat)
+   - `toneByContext`, `assets`, `semanticTokenAliases` — parsed but unused (v1.x)
+   - Returns `null` when DESIGN.md absent or `## Brand Rules` section missing → BRAND-V001 silently skips.
+
+3. **Load `design-system/tokens.json` `$extensions.harness.brand`.** Walks the DTCG token tree capturing per-token `role`, `approved_contexts`, `forbidden_contexts`. Returns `null` when no token carries the extension → BRAND-T\* silently skips.
+
+### Phase 2: SCAN — Apply the two rule families
+
+1. **BRAND-T001 — token misuse (regex-based).** For each token whose `forbidden_contexts` is non-empty:
+   - Find every reference to the token's dotted path in source (recognizes three forms):
+     - `tokens.X.Y.Z` (JS accessor)
+     - `var(--X-Y-Z)` (CSS var, kebab-cased)
+     - `'X.Y.Z'` / `"X.Y.Z"` (string literal)
+   - Inspect surrounding context (same line + nearest non-blank previous and next line) for the v1 context-vocabulary keywords: `cta`, `selection`, `focus`, `data-visualization`, `decorative`, `background`, `text`, `border`, `error`, `success`, `warning`.
+   - If a forbidden context matches: emit BRAND-T001.
+
+2. **BRAND-V001 — forbidden phrases (TS Compiler API).** For each `.tsx`/`.jsx` file:
+   - Walk the JSX tree.
+   - For each `JsxText` node: case-insensitive substring scan for any forbiddenPhrase.
+   - For each `JsxAttribute` whose initializer is a string literal: same scan.
+   - Deduplicate per `(file, line, phrase)`.
+
+### Phase 3: REPORT — Aggregate and surface
+
+1. **Severity from `design.strictness`** (uses `severityFor`):
+   - `strict` — all findings `error`
+   - `standard` — BRAND-T001 `error` (declared violation), BRAND-V001 `warn` (copy nuance)
+   - `permissive` — all findings `info`
+
+2. **Aggregate `bySeverity` and `byCode`** into the standard Verifier shape: `{ findings, summary, catalog, meta }`.
+
+3. **Persist findings to the graph (when composed by check-design).** check-design routes brand findings through `DesignConstraintAdapter.recordFindings()` alongside anatomy / craft / drift. v1 uses the shared `VIOLATES_design` edge; v1.x may add a brand-specific edge.
+
+## Harness Integration
+
+- **`harness validate`** — Fast-mode hook gated by `design.audit.brandCompliance.enabled`. Degrades gracefully on failure (single warning; other checks continue).
+- **`harness check-design`** — Composes brand as the 4th verifier alongside audit-anatomy, design-craft critique, and detect-design-drift. This is the canonical invocation path.
+- **`mcp__harness__audit_brand`** — MCP tool. Input: `{ path, mode, files?, designStrictness?, rules? }`. Output: `{ findings, summary, catalog, meta }`. Consumed by check-design and the (future) #5 design-pipeline orchestrator.
+- **`DesignConstraintAdapter.recordFindings()`** — Generic graph persistence entry point shipped in PR #390. Brand findings reuse the adapter (no graph schema changes in v1).
+- **`harness-design` skill** — Authors `DESIGN.md ## Brand Rules`. audit-brand-compliance is the matching enforcer.
+- **`Verifier<F>` interface** — Extracted in this PR at the 4th-verifier threshold. Lives at `packages/cli/src/shared/verifier.ts`. Adding a 5th verifier requires only a type-alias declaration of conformance.
+
+## Success Criteria
+
+See `docs/changes/design-pipeline/audit-brand-compliance/proposal.md` for the full 34 success criteria. Highlights:
+
+- DESIGN.md parser returns `null` when section absent (silent-skip pattern)
+- Token-extensions walker returns `null` when no token carries `$extensions.harness.brand`
+- BRAND-T001 fires on `tokens.X`, `var(--x)`, and `'X'` reference forms
+- BRAND-T001 honors approved_contexts (no finding when context is allowed)
+- BRAND-V001 fires on JSX text + string-typed JSX attributes (case-insensitive)
+- BRAND-V001 deduplicates per `(file, line, phrase)`
+- Verifier interface extraction: anatomy / drift / brand all declare structural conformance
+- `harness check-design` test extended for 4-verifier composition (zero regressions)
+- MCP tool count bumps 72 → 73
+
+## Examples
+
+### Example: Token used in forbidden context
+
+**Input:**
+
+`design-system/tokens.json`:
+
+```json
+{
+  "color": {
+    "brand": {
+      "500": {
+        "$type": "color",
+        "$value": "#3b82f6",
+        "$extensions": {
+          "harness": {
+            "brand": {
+              "role": "primary",
+              "approved_contexts": ["cta", "selection", "focus"],
+              "forbidden_contexts": ["data-visualization", "decorative"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`src/Chart.tsx`:
+
+```tsx
+// data-visualization color palette
+const palette = [tokens.color.brand.500, ...];
+```
+
+**Output:**
+
+```
+BRAND-T001 [error] src/Chart.tsx:2 — Token "color.brand.500" is used in forbidden context "data-visualization"
+  Fix: Token "color.brand.500" is not approved for the "data-visualization" context.
+       Use an approved token (allowed contexts: cta, selection, focus), or update
+       tokens.json $extensions.harness.brand if the policy is wrong.
+```
+
+### Example: Forbidden phrase in UI copy
+
+**Input:**
+
+`DESIGN.md`:
+
+```markdown
+## Brand Rules
+
+### Voice
+
+forbidden_phrases:
+
+- "click here"
+- "best-in-class"
+```
+
+`src/Cta.tsx`:
+
+```tsx
+export const Cta = () => <a href="/x">Click here</a>;
+```
+
+**Output:**
+
+```
+BRAND-V001 [warn] src/Cta.tsx:1 — UI copy contains forbidden phrase "click here" — declared at DESIGN.md ## Brand Rules → Voice → forbidden_phrases
+  Fix: Rewrite to avoid "click here". If the phrase is unavoidable for this context,
+       remove it from voice.forbidden_phrases (or scope the audit) — but the default
+       policy is that brand voice trumps convenience.
+```
+
+## Gates
+
+- **No findings without parsed inputs.** DESIGN.md absent → BRAND-V001 skips silently. tokens.json `$extensions.harness.brand` absent on every token → BRAND-T001 skips silently. Either resolver returning null is NOT a verifier failure.
+- **No `.ts`/`.js` file scans for BRAND-V001.** Only `.jsx`/`.tsx` (user-visible JSX). Doc copy in `.md` is a different audience.
+- **No tone-by-context inference.** v1 only matches the explicit context-vocabulary keywords against surrounding source text. v1.x adds component-state inference.
+- **No autofix.** audit-only. The matching `align-brand-compliance` fix-side skill is deferred until detect signals demand.
+- **No graph schema changes.** v1 reuses `VIOLATES_design` via `recordFindings()`. v1.x may add `VIOLATES_brand` edge for queryability.
+- **Strictness from config, not assumed.** Read `design.strictness` from `harness.config.json`; default `standard` if absent.
+
+## Escalation
+
+- **When BRAND-T001 false-positives on a far-context reference:** the v1 context inference is intentionally narrow (same line + adjacent non-blank). For a token used in a "background" context where the keyword appears 10 lines away, v1 misses it. v1.x adds richer context inference; for now, either widen the surrounding comment or accept the miss.
+- **When BRAND-V001 false-positives on a substring (e.g., "as is" in "as issued"):** v1 uses substring match. Add word-boundary regex in v1.x. For now, rephrase the copy or remove the phrase from voice.forbidden_phrases.
+- **When a project ships tokens with a different `$extensions` shape:** v1 reads only `harness.brand`. Document the actual shape your project uses and add it to the schema sketch in ADR 0028 — DTCG `$extensions` namespaces are vendor-prefixed and additions are forward-compatible.
+- **When `harness validate` runtime exceeds 3 seconds:** Set `design.audit.brandCompliance.fastMode.maxFiles` to cap the scope. The MCP tool ignores the cap (`fast`/`full` equivalent in v1).
+- **When the graph persistence fails:** Skip graph integration for that run; findings still appear in the report. The graph is a consumer, not a gate.
+- **When you want tone-by-context rules today:** Manual audit until v1.x ships. Component-state inference (empty/error/success/loading) requires JSX-context analysis that's a separate brainstorm.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/design-pipeline/audit-brand-compliance/proposal.md`
+- ADR (input schema source): `docs/knowledge/decisions/0028-brand-guidelines-source-of-truth.md`
+- Roadmap entry: `design-pipeline sub-project #3` in `docs/roadmap.md`
+- Sibling rule-based audits: `audit-component-anatomy` (#2), `detect-design-drift` (#1)
+- Cross-cutting: extracts `Verifier<F>` interface at `packages/cli/src/shared/verifier.ts` (deferred until 4th data point — this is it)

--- a/agents/skills/codex/audit-brand-compliance/skill.yaml
+++ b/agents/skills/codex/audit-brand-compliance/skill.yaml
@@ -1,0 +1,50 @@
+name: audit-brand-compliance
+version: "0.1.0"
+description: Rule-based brand-semantics audit. Detects token misuse (BRAND-T001 via $extensions.harness.brand.forbidden_contexts) and voice violations (BRAND-V001 via DESIGN.md voice.forbidden_phrases). 4th composed verifier in harness check-design. Triggers extraction of the formal verifier interface.
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness skill run audit-brand-compliance
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: mode
+      description: "fast or full (equivalent in v1)"
+      required: false
+    - name: files
+      description: Optional list of files to scope the scan
+      required: false
+mcp:
+  tool: run_skill
+  input:
+    skill: audit-brand-compliance
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: load
+    description: Parse DESIGN.md ## Brand Rules and tokens.json $extensions.harness.brand
+    required: true
+  - name: scan
+    description: Walk JSX text/attributes for forbidden phrases; scan source for token-misuse-in-context
+    required: true
+  - name: report
+    description: Aggregate findings; emit BRAND-T* / BRAND-V001 with severity per design.strictness
+    required: true
+state:
+  persistent: false
+depends_on:
+  - detect-design-drift
+  - harness-design

--- a/agents/skills/cursor/audit-brand-compliance/SKILL.md
+++ b/agents/skills/cursor/audit-brand-compliance/SKILL.md
@@ -1,0 +1,189 @@
+# Audit Brand Compliance
+
+> Rule-based brand-semantics audit. Detects (a) tokens used in forbidden contexts per their `$extensions.harness.brand.forbidden_contexts` metadata (BRAND-T001) and (b) UI copy containing phrases listed in `DESIGN.md ## Brand Rules → voice.forbidden_phrases` (BRAND-V001). The 4th composed verifier in `harness check-design`, alongside audit-component-anatomy, design-craft critique, and detect-design-drift.
+
+## When to Use
+
+- After authoring or editing `DESIGN.md ## Brand Rules` — verify the new constraints are enforceable on the existing codebase
+- After adding `$extensions.harness.brand` metadata to a token — discover existing call sites in forbidden contexts
+- As part of `harness validate` (fast-mode hook, gated by `design.audit.brandCompliance.enabled`)
+- As the 4th composed verifier in `harness check-design` (the unified design check)
+- Before a PR with UI copy or token-usage changes lands
+- NOT for tone-by-context rules (deferred to v1.x — requires component-state inference)
+- NOT for reading-level or sentence-length rules (deferred to v1.x — ship with tone-context)
+- NOT for asset-usage rules (deferred to v1.x — requires image-tag scanning)
+- NOT for semantic-token-alias enforcement (overlaps with detect-design-drift T001 — design after both have shipped)
+- NOT for brand-rule authoring (use `harness-design` skill to draft DESIGN.md sections)
+
+## Process
+
+### Phase 1: LOAD — Parse the two input sources
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `design.strictness` — `strict` / `standard` / `permissive` (default `standard`)
+   - `design.audit.brandCompliance.enabled` — gate (default `true`)
+   - `design.audit.brandCompliance.rules.{tokenMisuse,voice}` — per-rule toggles
+
+2. **Load `design-system/DESIGN.md` `## Brand Rules`.** The parser extracts:
+   - `voice.forbiddenPhrases: string[]` — used by BRAND-V001 in v1
+   - `voice.constant`, `voice.readingLevel`, `voice.maxSentenceWords` — parsed but unused in v1 (forward-compat)
+   - `toneByContext`, `assets`, `semanticTokenAliases` — parsed but unused (v1.x)
+   - Returns `null` when DESIGN.md absent or `## Brand Rules` section missing → BRAND-V001 silently skips.
+
+3. **Load `design-system/tokens.json` `$extensions.harness.brand`.** Walks the DTCG token tree capturing per-token `role`, `approved_contexts`, `forbidden_contexts`. Returns `null` when no token carries the extension → BRAND-T\* silently skips.
+
+### Phase 2: SCAN — Apply the two rule families
+
+1. **BRAND-T001 — token misuse (regex-based).** For each token whose `forbidden_contexts` is non-empty:
+   - Find every reference to the token's dotted path in source (recognizes three forms):
+     - `tokens.X.Y.Z` (JS accessor)
+     - `var(--X-Y-Z)` (CSS var, kebab-cased)
+     - `'X.Y.Z'` / `"X.Y.Z"` (string literal)
+   - Inspect surrounding context (same line + nearest non-blank previous and next line) for the v1 context-vocabulary keywords: `cta`, `selection`, `focus`, `data-visualization`, `decorative`, `background`, `text`, `border`, `error`, `success`, `warning`.
+   - If a forbidden context matches: emit BRAND-T001.
+
+2. **BRAND-V001 — forbidden phrases (TS Compiler API).** For each `.tsx`/`.jsx` file:
+   - Walk the JSX tree.
+   - For each `JsxText` node: case-insensitive substring scan for any forbiddenPhrase.
+   - For each `JsxAttribute` whose initializer is a string literal: same scan.
+   - Deduplicate per `(file, line, phrase)`.
+
+### Phase 3: REPORT — Aggregate and surface
+
+1. **Severity from `design.strictness`** (uses `severityFor`):
+   - `strict` — all findings `error`
+   - `standard` — BRAND-T001 `error` (declared violation), BRAND-V001 `warn` (copy nuance)
+   - `permissive` — all findings `info`
+
+2. **Aggregate `bySeverity` and `byCode`** into the standard Verifier shape: `{ findings, summary, catalog, meta }`.
+
+3. **Persist findings to the graph (when composed by check-design).** check-design routes brand findings through `DesignConstraintAdapter.recordFindings()` alongside anatomy / craft / drift. v1 uses the shared `VIOLATES_design` edge; v1.x may add a brand-specific edge.
+
+## Harness Integration
+
+- **`harness validate`** — Fast-mode hook gated by `design.audit.brandCompliance.enabled`. Degrades gracefully on failure (single warning; other checks continue).
+- **`harness check-design`** — Composes brand as the 4th verifier alongside audit-anatomy, design-craft critique, and detect-design-drift. This is the canonical invocation path.
+- **`mcp__harness__audit_brand`** — MCP tool. Input: `{ path, mode, files?, designStrictness?, rules? }`. Output: `{ findings, summary, catalog, meta }`. Consumed by check-design and the (future) #5 design-pipeline orchestrator.
+- **`DesignConstraintAdapter.recordFindings()`** — Generic graph persistence entry point shipped in PR #390. Brand findings reuse the adapter (no graph schema changes in v1).
+- **`harness-design` skill** — Authors `DESIGN.md ## Brand Rules`. audit-brand-compliance is the matching enforcer.
+- **`Verifier<F>` interface** — Extracted in this PR at the 4th-verifier threshold. Lives at `packages/cli/src/shared/verifier.ts`. Adding a 5th verifier requires only a type-alias declaration of conformance.
+
+## Success Criteria
+
+See `docs/changes/design-pipeline/audit-brand-compliance/proposal.md` for the full 34 success criteria. Highlights:
+
+- DESIGN.md parser returns `null` when section absent (silent-skip pattern)
+- Token-extensions walker returns `null` when no token carries `$extensions.harness.brand`
+- BRAND-T001 fires on `tokens.X`, `var(--x)`, and `'X'` reference forms
+- BRAND-T001 honors approved_contexts (no finding when context is allowed)
+- BRAND-V001 fires on JSX text + string-typed JSX attributes (case-insensitive)
+- BRAND-V001 deduplicates per `(file, line, phrase)`
+- Verifier interface extraction: anatomy / drift / brand all declare structural conformance
+- `harness check-design` test extended for 4-verifier composition (zero regressions)
+- MCP tool count bumps 72 → 73
+
+## Examples
+
+### Example: Token used in forbidden context
+
+**Input:**
+
+`design-system/tokens.json`:
+
+```json
+{
+  "color": {
+    "brand": {
+      "500": {
+        "$type": "color",
+        "$value": "#3b82f6",
+        "$extensions": {
+          "harness": {
+            "brand": {
+              "role": "primary",
+              "approved_contexts": ["cta", "selection", "focus"],
+              "forbidden_contexts": ["data-visualization", "decorative"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`src/Chart.tsx`:
+
+```tsx
+// data-visualization color palette
+const palette = [tokens.color.brand.500, ...];
+```
+
+**Output:**
+
+```
+BRAND-T001 [error] src/Chart.tsx:2 — Token "color.brand.500" is used in forbidden context "data-visualization"
+  Fix: Token "color.brand.500" is not approved for the "data-visualization" context.
+       Use an approved token (allowed contexts: cta, selection, focus), or update
+       tokens.json $extensions.harness.brand if the policy is wrong.
+```
+
+### Example: Forbidden phrase in UI copy
+
+**Input:**
+
+`DESIGN.md`:
+
+```markdown
+## Brand Rules
+
+### Voice
+
+forbidden_phrases:
+
+- "click here"
+- "best-in-class"
+```
+
+`src/Cta.tsx`:
+
+```tsx
+export const Cta = () => <a href="/x">Click here</a>;
+```
+
+**Output:**
+
+```
+BRAND-V001 [warn] src/Cta.tsx:1 — UI copy contains forbidden phrase "click here" — declared at DESIGN.md ## Brand Rules → Voice → forbidden_phrases
+  Fix: Rewrite to avoid "click here". If the phrase is unavoidable for this context,
+       remove it from voice.forbidden_phrases (or scope the audit) — but the default
+       policy is that brand voice trumps convenience.
+```
+
+## Gates
+
+- **No findings without parsed inputs.** DESIGN.md absent → BRAND-V001 skips silently. tokens.json `$extensions.harness.brand` absent on every token → BRAND-T001 skips silently. Either resolver returning null is NOT a verifier failure.
+- **No `.ts`/`.js` file scans for BRAND-V001.** Only `.jsx`/`.tsx` (user-visible JSX). Doc copy in `.md` is a different audience.
+- **No tone-by-context inference.** v1 only matches the explicit context-vocabulary keywords against surrounding source text. v1.x adds component-state inference.
+- **No autofix.** audit-only. The matching `align-brand-compliance` fix-side skill is deferred until detect signals demand.
+- **No graph schema changes.** v1 reuses `VIOLATES_design` via `recordFindings()`. v1.x may add `VIOLATES_brand` edge for queryability.
+- **Strictness from config, not assumed.** Read `design.strictness` from `harness.config.json`; default `standard` if absent.
+
+## Escalation
+
+- **When BRAND-T001 false-positives on a far-context reference:** the v1 context inference is intentionally narrow (same line + adjacent non-blank). For a token used in a "background" context where the keyword appears 10 lines away, v1 misses it. v1.x adds richer context inference; for now, either widen the surrounding comment or accept the miss.
+- **When BRAND-V001 false-positives on a substring (e.g., "as is" in "as issued"):** v1 uses substring match. Add word-boundary regex in v1.x. For now, rephrase the copy or remove the phrase from voice.forbidden_phrases.
+- **When a project ships tokens with a different `$extensions` shape:** v1 reads only `harness.brand`. Document the actual shape your project uses and add it to the schema sketch in ADR 0028 — DTCG `$extensions` namespaces are vendor-prefixed and additions are forward-compatible.
+- **When `harness validate` runtime exceeds 3 seconds:** Set `design.audit.brandCompliance.fastMode.maxFiles` to cap the scope. The MCP tool ignores the cap (`fast`/`full` equivalent in v1).
+- **When the graph persistence fails:** Skip graph integration for that run; findings still appear in the report. The graph is a consumer, not a gate.
+- **When you want tone-by-context rules today:** Manual audit until v1.x ships. Component-state inference (empty/error/success/loading) requires JSX-context analysis that's a separate brainstorm.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/design-pipeline/audit-brand-compliance/proposal.md`
+- ADR (input schema source): `docs/knowledge/decisions/0028-brand-guidelines-source-of-truth.md`
+- Roadmap entry: `design-pipeline sub-project #3` in `docs/roadmap.md`
+- Sibling rule-based audits: `audit-component-anatomy` (#2), `detect-design-drift` (#1)
+- Cross-cutting: extracts `Verifier<F>` interface at `packages/cli/src/shared/verifier.ts` (deferred until 4th data point — this is it)

--- a/agents/skills/cursor/audit-brand-compliance/skill.yaml
+++ b/agents/skills/cursor/audit-brand-compliance/skill.yaml
@@ -1,0 +1,50 @@
+name: audit-brand-compliance
+version: "0.1.0"
+description: Rule-based brand-semantics audit. Detects token misuse (BRAND-T001 via $extensions.harness.brand.forbidden_contexts) and voice violations (BRAND-V001 via DESIGN.md voice.forbidden_phrases). 4th composed verifier in harness check-design. Triggers extraction of the formal verifier interface.
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness skill run audit-brand-compliance
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: mode
+      description: "fast or full (equivalent in v1)"
+      required: false
+    - name: files
+      description: Optional list of files to scope the scan
+      required: false
+mcp:
+  tool: run_skill
+  input:
+    skill: audit-brand-compliance
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: load
+    description: Parse DESIGN.md ## Brand Rules and tokens.json $extensions.harness.brand
+    required: true
+  - name: scan
+    description: Walk JSX text/attributes for forbidden phrases; scan source for token-misuse-in-context
+    required: true
+  - name: report
+    description: Aggregate findings; emit BRAND-T* / BRAND-V001 with severity per design.strictness
+    required: true
+state:
+  persistent: false
+depends_on:
+  - detect-design-drift
+  - harness-design

--- a/agents/skills/gemini-cli/audit-brand-compliance/SKILL.md
+++ b/agents/skills/gemini-cli/audit-brand-compliance/SKILL.md
@@ -1,0 +1,189 @@
+# Audit Brand Compliance
+
+> Rule-based brand-semantics audit. Detects (a) tokens used in forbidden contexts per their `$extensions.harness.brand.forbidden_contexts` metadata (BRAND-T001) and (b) UI copy containing phrases listed in `DESIGN.md ## Brand Rules → voice.forbidden_phrases` (BRAND-V001). The 4th composed verifier in `harness check-design`, alongside audit-component-anatomy, design-craft critique, and detect-design-drift.
+
+## When to Use
+
+- After authoring or editing `DESIGN.md ## Brand Rules` — verify the new constraints are enforceable on the existing codebase
+- After adding `$extensions.harness.brand` metadata to a token — discover existing call sites in forbidden contexts
+- As part of `harness validate` (fast-mode hook, gated by `design.audit.brandCompliance.enabled`)
+- As the 4th composed verifier in `harness check-design` (the unified design check)
+- Before a PR with UI copy or token-usage changes lands
+- NOT for tone-by-context rules (deferred to v1.x — requires component-state inference)
+- NOT for reading-level or sentence-length rules (deferred to v1.x — ship with tone-context)
+- NOT for asset-usage rules (deferred to v1.x — requires image-tag scanning)
+- NOT for semantic-token-alias enforcement (overlaps with detect-design-drift T001 — design after both have shipped)
+- NOT for brand-rule authoring (use `harness-design` skill to draft DESIGN.md sections)
+
+## Process
+
+### Phase 1: LOAD — Parse the two input sources
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `design.strictness` — `strict` / `standard` / `permissive` (default `standard`)
+   - `design.audit.brandCompliance.enabled` — gate (default `true`)
+   - `design.audit.brandCompliance.rules.{tokenMisuse,voice}` — per-rule toggles
+
+2. **Load `design-system/DESIGN.md` `## Brand Rules`.** The parser extracts:
+   - `voice.forbiddenPhrases: string[]` — used by BRAND-V001 in v1
+   - `voice.constant`, `voice.readingLevel`, `voice.maxSentenceWords` — parsed but unused in v1 (forward-compat)
+   - `toneByContext`, `assets`, `semanticTokenAliases` — parsed but unused (v1.x)
+   - Returns `null` when DESIGN.md absent or `## Brand Rules` section missing → BRAND-V001 silently skips.
+
+3. **Load `design-system/tokens.json` `$extensions.harness.brand`.** Walks the DTCG token tree capturing per-token `role`, `approved_contexts`, `forbidden_contexts`. Returns `null` when no token carries the extension → BRAND-T\* silently skips.
+
+### Phase 2: SCAN — Apply the two rule families
+
+1. **BRAND-T001 — token misuse (regex-based).** For each token whose `forbidden_contexts` is non-empty:
+   - Find every reference to the token's dotted path in source (recognizes three forms):
+     - `tokens.X.Y.Z` (JS accessor)
+     - `var(--X-Y-Z)` (CSS var, kebab-cased)
+     - `'X.Y.Z'` / `"X.Y.Z"` (string literal)
+   - Inspect surrounding context (same line + nearest non-blank previous and next line) for the v1 context-vocabulary keywords: `cta`, `selection`, `focus`, `data-visualization`, `decorative`, `background`, `text`, `border`, `error`, `success`, `warning`.
+   - If a forbidden context matches: emit BRAND-T001.
+
+2. **BRAND-V001 — forbidden phrases (TS Compiler API).** For each `.tsx`/`.jsx` file:
+   - Walk the JSX tree.
+   - For each `JsxText` node: case-insensitive substring scan for any forbiddenPhrase.
+   - For each `JsxAttribute` whose initializer is a string literal: same scan.
+   - Deduplicate per `(file, line, phrase)`.
+
+### Phase 3: REPORT — Aggregate and surface
+
+1. **Severity from `design.strictness`** (uses `severityFor`):
+   - `strict` — all findings `error`
+   - `standard` — BRAND-T001 `error` (declared violation), BRAND-V001 `warn` (copy nuance)
+   - `permissive` — all findings `info`
+
+2. **Aggregate `bySeverity` and `byCode`** into the standard Verifier shape: `{ findings, summary, catalog, meta }`.
+
+3. **Persist findings to the graph (when composed by check-design).** check-design routes brand findings through `DesignConstraintAdapter.recordFindings()` alongside anatomy / craft / drift. v1 uses the shared `VIOLATES_design` edge; v1.x may add a brand-specific edge.
+
+## Harness Integration
+
+- **`harness validate`** — Fast-mode hook gated by `design.audit.brandCompliance.enabled`. Degrades gracefully on failure (single warning; other checks continue).
+- **`harness check-design`** — Composes brand as the 4th verifier alongside audit-anatomy, design-craft critique, and detect-design-drift. This is the canonical invocation path.
+- **`mcp__harness__audit_brand`** — MCP tool. Input: `{ path, mode, files?, designStrictness?, rules? }`. Output: `{ findings, summary, catalog, meta }`. Consumed by check-design and the (future) #5 design-pipeline orchestrator.
+- **`DesignConstraintAdapter.recordFindings()`** — Generic graph persistence entry point shipped in PR #390. Brand findings reuse the adapter (no graph schema changes in v1).
+- **`harness-design` skill** — Authors `DESIGN.md ## Brand Rules`. audit-brand-compliance is the matching enforcer.
+- **`Verifier<F>` interface** — Extracted in this PR at the 4th-verifier threshold. Lives at `packages/cli/src/shared/verifier.ts`. Adding a 5th verifier requires only a type-alias declaration of conformance.
+
+## Success Criteria
+
+See `docs/changes/design-pipeline/audit-brand-compliance/proposal.md` for the full 34 success criteria. Highlights:
+
+- DESIGN.md parser returns `null` when section absent (silent-skip pattern)
+- Token-extensions walker returns `null` when no token carries `$extensions.harness.brand`
+- BRAND-T001 fires on `tokens.X`, `var(--x)`, and `'X'` reference forms
+- BRAND-T001 honors approved_contexts (no finding when context is allowed)
+- BRAND-V001 fires on JSX text + string-typed JSX attributes (case-insensitive)
+- BRAND-V001 deduplicates per `(file, line, phrase)`
+- Verifier interface extraction: anatomy / drift / brand all declare structural conformance
+- `harness check-design` test extended for 4-verifier composition (zero regressions)
+- MCP tool count bumps 72 → 73
+
+## Examples
+
+### Example: Token used in forbidden context
+
+**Input:**
+
+`design-system/tokens.json`:
+
+```json
+{
+  "color": {
+    "brand": {
+      "500": {
+        "$type": "color",
+        "$value": "#3b82f6",
+        "$extensions": {
+          "harness": {
+            "brand": {
+              "role": "primary",
+              "approved_contexts": ["cta", "selection", "focus"],
+              "forbidden_contexts": ["data-visualization", "decorative"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`src/Chart.tsx`:
+
+```tsx
+// data-visualization color palette
+const palette = [tokens.color.brand.500, ...];
+```
+
+**Output:**
+
+```
+BRAND-T001 [error] src/Chart.tsx:2 — Token "color.brand.500" is used in forbidden context "data-visualization"
+  Fix: Token "color.brand.500" is not approved for the "data-visualization" context.
+       Use an approved token (allowed contexts: cta, selection, focus), or update
+       tokens.json $extensions.harness.brand if the policy is wrong.
+```
+
+### Example: Forbidden phrase in UI copy
+
+**Input:**
+
+`DESIGN.md`:
+
+```markdown
+## Brand Rules
+
+### Voice
+
+forbidden_phrases:
+
+- "click here"
+- "best-in-class"
+```
+
+`src/Cta.tsx`:
+
+```tsx
+export const Cta = () => <a href="/x">Click here</a>;
+```
+
+**Output:**
+
+```
+BRAND-V001 [warn] src/Cta.tsx:1 — UI copy contains forbidden phrase "click here" — declared at DESIGN.md ## Brand Rules → Voice → forbidden_phrases
+  Fix: Rewrite to avoid "click here". If the phrase is unavoidable for this context,
+       remove it from voice.forbidden_phrases (or scope the audit) — but the default
+       policy is that brand voice trumps convenience.
+```
+
+## Gates
+
+- **No findings without parsed inputs.** DESIGN.md absent → BRAND-V001 skips silently. tokens.json `$extensions.harness.brand` absent on every token → BRAND-T001 skips silently. Either resolver returning null is NOT a verifier failure.
+- **No `.ts`/`.js` file scans for BRAND-V001.** Only `.jsx`/`.tsx` (user-visible JSX). Doc copy in `.md` is a different audience.
+- **No tone-by-context inference.** v1 only matches the explicit context-vocabulary keywords against surrounding source text. v1.x adds component-state inference.
+- **No autofix.** audit-only. The matching `align-brand-compliance` fix-side skill is deferred until detect signals demand.
+- **No graph schema changes.** v1 reuses `VIOLATES_design` via `recordFindings()`. v1.x may add `VIOLATES_brand` edge for queryability.
+- **Strictness from config, not assumed.** Read `design.strictness` from `harness.config.json`; default `standard` if absent.
+
+## Escalation
+
+- **When BRAND-T001 false-positives on a far-context reference:** the v1 context inference is intentionally narrow (same line + adjacent non-blank). For a token used in a "background" context where the keyword appears 10 lines away, v1 misses it. v1.x adds richer context inference; for now, either widen the surrounding comment or accept the miss.
+- **When BRAND-V001 false-positives on a substring (e.g., "as is" in "as issued"):** v1 uses substring match. Add word-boundary regex in v1.x. For now, rephrase the copy or remove the phrase from voice.forbidden_phrases.
+- **When a project ships tokens with a different `$extensions` shape:** v1 reads only `harness.brand`. Document the actual shape your project uses and add it to the schema sketch in ADR 0028 — DTCG `$extensions` namespaces are vendor-prefixed and additions are forward-compatible.
+- **When `harness validate` runtime exceeds 3 seconds:** Set `design.audit.brandCompliance.fastMode.maxFiles` to cap the scope. The MCP tool ignores the cap (`fast`/`full` equivalent in v1).
+- **When the graph persistence fails:** Skip graph integration for that run; findings still appear in the report. The graph is a consumer, not a gate.
+- **When you want tone-by-context rules today:** Manual audit until v1.x ships. Component-state inference (empty/error/success/loading) requires JSX-context analysis that's a separate brainstorm.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/design-pipeline/audit-brand-compliance/proposal.md`
+- ADR (input schema source): `docs/knowledge/decisions/0028-brand-guidelines-source-of-truth.md`
+- Roadmap entry: `design-pipeline sub-project #3` in `docs/roadmap.md`
+- Sibling rule-based audits: `audit-component-anatomy` (#2), `detect-design-drift` (#1)
+- Cross-cutting: extracts `Verifier<F>` interface at `packages/cli/src/shared/verifier.ts` (deferred until 4th data point — this is it)

--- a/agents/skills/gemini-cli/audit-brand-compliance/skill.yaml
+++ b/agents/skills/gemini-cli/audit-brand-compliance/skill.yaml
@@ -1,0 +1,50 @@
+name: audit-brand-compliance
+version: "0.1.0"
+description: Rule-based brand-semantics audit. Detects token misuse (BRAND-T001 via $extensions.harness.brand.forbidden_contexts) and voice violations (BRAND-V001 via DESIGN.md voice.forbidden_phrases). 4th composed verifier in harness check-design. Triggers extraction of the formal verifier interface.
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness skill run audit-brand-compliance
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: mode
+      description: "fast or full (equivalent in v1)"
+      required: false
+    - name: files
+      description: Optional list of files to scope the scan
+      required: false
+mcp:
+  tool: run_skill
+  input:
+    skill: audit-brand-compliance
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: load
+    description: Parse DESIGN.md ## Brand Rules and tokens.json $extensions.harness.brand
+    required: true
+  - name: scan
+    description: Walk JSX text/attributes for forbidden phrases; scan source for token-misuse-in-context
+    required: true
+  - name: report
+    description: Aggregate findings; emit BRAND-T* / BRAND-V001 with severity per design.strictness
+    required: true
+state:
+  persistent: false
+depends_on:
+  - detect-design-drift
+  - harness-design

--- a/docs/changes/design-pipeline/audit-brand-compliance/proposal.md
+++ b/docs/changes/design-pipeline/audit-brand-compliance/proposal.md
@@ -1,0 +1,424 @@
+# audit-brand-compliance v1
+
+> Rule-based brand-semantics audit. Detects (a) tokens used in forbidden contexts per their `$extensions.harness.brand.forbidden_contexts` metadata and (b) string literals (JSX text + string-typed props) that contain forbidden phrases declared in `DESIGN.md ## Brand Rules`. The 4th composed verifier in `harness check-design`, alongside audit-component-anatomy, design-craft critique, and detect-design-drift. Triggers extraction of the `Verifier<F>` interface that was deferred until the 4th data point.
+
+## Overview
+
+**Project:** audit-brand-compliance (v1)
+**Initiative:** design-pipeline (sub-project #3 of 6 — the last unshipped floor-layer audit)
+**Date:** 2026-05-24
+**Estimated effort:** ~1 week, single PR
+**Unblocks:** design-pipeline sub-project #5 (the orchestrator). Floor layer fully closes when this merges.
+
+### What this ships
+
+Two rule families in v1 — a narrow + deep scope chosen to ship the foundation and prove the brand-semantics pattern without ballooning into voice/tone/asset territory:
+
+- **BRAND-T\*** — token-misuse rules. For each token whose `$extensions.harness.brand` declares `forbidden_contexts: [...]`, scan call sites where the token is referenced and flag matches.
+- **BRAND-V001** — single voice rule: string literals (JSX text nodes and string-typed props) containing any phrase declared in `DESIGN.md ## Brand Rules → voice.forbidden_phrases`. Case-insensitive substring match.
+
+Both rule families compose into `harness check-design` as the 4th verifier. This triggers extraction of `Verifier<F>` (the formal interface deferred until 4 data points), per the verifier-shape convention note in check-design.ts.
+
+### What this does NOT ship
+
+- **No tone-by-context rules.** Detecting empty/error/success/loading state context from JSX requires component-state inference — substantial new surface; deferred to v1.x.
+- **No reading-level / sentence-length rules.** v1 ships only forbidden-phrase voice detection. Flesch-Kincaid and sentence-word-count are mechanically cheap but produce noisy findings without good tone-context attachment; deferred until tone-context lands.
+- **No asset-usage rules.** Logo size limits, monochrome-on-photo constraints, etc. require image-tag scanning + filesystem checks + optional image-metadata inspection. Asset rules ship as v1.x.
+- **No semantic-token-alias enforcement.** `brand_primary: color.brand.500` aliases (DESIGN.md `### Semantic Token Aliases`) are declared in v1 schema but enforced by audit only in v1.x — the rule "raw color reference X should use the alias `brand_primary`" overlaps with detect-design-drift's T001 and benefits from being designed once both have shipped.
+- **No DESIGN.md authoring.** Editing `## Brand Rules` is a human (or `harness-design` skill) job. audit-brand-compliance reads only.
+- **No graph writes for brand findings yet.** v1 routes findings through the same `DesignConstraintAdapter.recordFindings()` path as anatomy/craft/drift — no schema changes; the `VIOLATES_design` edge subsumes brand violations under the same edge type. v1.x may add a brand-specific edge for queryability.
+
+### What problem this solves
+
+Today brand compliance is enforced by humans reviewing PRs against a prose brand doc. Per ADR 0028, harness's bet is that brand rules need to be a structured, machine-readable source of truth that's adjacent to (not separate from) design tokens. audit-brand-compliance is the first programmatic enforcer of that schema — it turns the `forbidden_phrases` list and the `$extensions.harness.brand.forbidden_contexts` metadata from "convention" into "fail this CI." Without it, ADR 0028's schema sketch is just a draft; with it, projects accumulate brand discipline the same way they accumulate type discipline.
+
+## Decisions
+
+| #   | Decision                 | Lock                                                                       | Rationale                                                                                                                                                                                                                                                                                                  |
+| --- | ------------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | v1 rule scope            | **BRAND-T\* (token misuse) + BRAND-V001 (forbidden phrases)**              | Narrow + deep. Token misuse extends detect-drift's scanning pattern (low marginal cost). Forbidden phrases introduces the new copy-scanner with the simplest possible rule (substring match). Defers reading-level, tone-by-context, and asset rules to v1.x — each is its own brainstorm-sized problem.   |
+| 2   | Input sources            | **DESIGN.md `## Brand Rules` AND tokens.json `$extensions.harness.brand`** | ADR 0028 mandates both. v1 ships parsers for both — same dual-resolver pattern as detect-design-drift (tokens resolver + component-registry resolver). Either resolver absent: matching rule family skips silently.                                                                                        |
+| 3   | check-design composition | **4th verifier (triggers `Verifier<F>` interface extraction)**             | check-design's convention note explicitly cited the 3rd-check-\* threshold; brand makes it the 4th data point. Long-deferred interface extraction is now load-bearing: 4 verifiers all duplicating `{ findings, summary, catalog, meta }` shape is past the cost/benefit line. Extract as part of this PR. |
+
+## Scope
+
+### In-scope
+
+- **BRAND-T\* token-misuse rule.** For each token with `$extensions.harness.brand.forbidden_contexts: [...]`, scan source for references to that token's dotted path AND infer call-site context. Context inference v1 uses JSX-attribute-name + nearest-component-name heuristics:
+  - `BRAND-T001` — token used in a context name explicitly listed in `forbidden_contexts`
+  - Context inference v1 vocabulary: `cta`, `selection`, `focus`, `data-visualization`, `decorative`, `background`, `text`, `border`, `error`, `success`, `warning` (matches the ADR's sketched vocabulary)
+- **BRAND-V001 forbidden-phrases rule.** Scan `.tsx`/`.jsx` files with the TypeScript Compiler API (mirrors primitive-adoption-rule). For each JSX text node + string-typed JSX attribute value, check whether any `voice.forbidden_phrases` entry appears as a case-insensitive substring. Flag matches.
+- **DESIGN.md `## Brand Rules` parser.** Loads `voice`, `tone_by_context`, `assets`, `semantic_token_aliases` blocks. v1 USES only `voice.forbidden_phrases`. The others are parsed-but-unused (forward-compatibility — no breaking changes when v1.x adds their rules).
+- **tokens.json `$extensions.harness.brand` walker.** Extends `loadTokenPathIndex` to also capture per-token `role`, `approved_contexts`, `forbidden_contexts`. Returns a `BrandTokenIndex` keyed by token path.
+- **`Verifier<F>` interface extraction.** New `packages/cli/src/shared/verifier.ts` defining the formal shape all 4 verifiers conform to:
+  ```ts
+  interface Verifier<F, Cat = {}, Meta = {}> {
+    findings: F[];
+    summary: {
+      totalFiles: number;
+      durationMs: number;
+      bySeverity: Record<'error' | 'warn' | 'info', number>;
+      byCode: Record<string, number>;
+    };
+    catalog: Cat;
+    meta: Meta;
+  }
+  ```
+  Anatomy/craft/drift/brand all declare conformance via type aliases. Compile-time check that future verifiers stay shape-consistent.
+- **MCP tool `audit_brand`.** Programmatic API. Input `{ path, mode, files?, designStrictness?, rules? }`. Output the Verifier shape (`{ findings, summary, catalog, meta }`).
+- **CLI integration.** No new top-level CLI command in v1 — brand is reached via `harness check-design` (4th verifier). Direct CLI for brand-alone debugging is added in v1.x if real-world signal calls for it.
+- **`harness validate` fast-mode hook.** Brand audit runs alongside anatomy and drift in `harness validate`. Gated by `design.audit.brandCompliance.enabled` (default `true`).
+- **Config schema extension.** New `design.audit.brandCompliance` block under `DesignAuditConfigSchema` (sibling to `componentAnatomy` and `driftDetection`).
+- **4-platform skill markdown.** claude-code / codex / cursor / gemini-cli.
+
+### Out-of-scope (v1)
+
+- **No tone-by-context rules.** Requires inferring component state (empty/error/success/loading) from JSX — see v1.x.
+- **No reading-level / sentence-length rules.** Ship when tone-context lands so they can be attached per-context (not blanket-applied).
+- **No asset-usage rules.** Image-tag scanning + file-existence + image-metadata is its own surface; v1.x.
+- **No semantic-token-alias enforcement.** Overlaps with detect-drift T001; design once both have real usage.
+- **No autofix.** audit-only — fix-side analog is a separate sibling sub-project (`align-brand-compliance`, deferred until detect signals demand).
+- **No brand-rule authoring.** DESIGN.md edits are human / `harness-design` skill work.
+- **No standalone `harness audit-brand` CLI command.** Goes through `harness check-design` in v1; direct command added v1.x if needed.
+- **No new graph node types.** v1 reuses `VIOLATES_design` edge via `DesignConstraintAdapter.recordFindings`. Brand-specific edge (`VIOLATES_brand`?) deferred.
+
+## Inputs
+
+- **`design-system/DESIGN.md` `## Brand Rules` section.** Markdown structure parsed per ADR 0028 schema sketch. v1 reads `voice.forbidden_phrases` (list of strings). Other blocks (`tone_by_context`, `assets`, `semantic_token_aliases`) parsed but unused — forward-compat. Returns `null` when section absent → BRAND-V001 silently skips.
+- **`design-system/tokens.json` `$extensions.harness.brand`.** Walked alongside the existing `loadTokenSet` walk. For each token with a `harness.brand` extension object, capture `role`, `approved_contexts: string[]`, `forbidden_contexts: string[]`. Returns `null` when no tokens carry the extension → BRAND-T\* silently skips.
+- **harness.config.json** — `design.audit.brandCompliance.{enabled, rules}`. New sub-block.
+
+## Outputs
+
+```ts
+interface BrandFinding {
+  code: BrandFindingCode;
+  severity: 'error' | 'warn' | 'info';
+  file: string;
+  line: number | null;
+  column?: number;
+  message: string;
+  evidence: { snippet: string };
+  rule: { id: string; category: 'token-misuse' | 'voice' };
+  fix: { kind: 'manual' | 'codemod-todo'; description: string };
+}
+
+type BrandFindingCode = `BRAND-T${string}` | `BRAND-V${string}`;
+```
+
+```ts
+interface AuditBrandOutput {
+  findings: BrandFinding[];
+  summary: {
+    totalFiles: number;
+    durationMs: number;
+    bySeverity: Record<'error' | 'warn' | 'info', number>;
+    byCode: Record<string, number>;
+  };
+  catalog: { rulesApplied: string[] };
+  meta: {
+    mode: 'fast' | 'full';
+    designMdLoaded: boolean;
+    brandTokensLoaded: boolean;
+  };
+}
+```
+
+This is the Verifier shape, formalized as a typed interface by this PR.
+
+## Technical Design
+
+### Module layout
+
+```
+packages/cli/src/brand/
+  findings/
+    finding.ts             # BrandFinding type + severity model
+  resolvers/
+    design-md-brand.ts     # parse DESIGN.md ## Brand Rules
+    token-extensions.ts    # walk tokens.json for $extensions.harness.brand
+  rules/
+    token-misuse-rule.ts   # BRAND-T*
+    forbidden-phrases-rule.ts  # BRAND-V001
+  index.ts                 # runAuditBrand orchestrator
+packages/cli/src/mcp/tools/
+  audit-brand.ts           # MCP wrapper
+packages/cli/src/shared/
+  verifier.ts              # NEW — Verifier<F, Cat, Meta> interface
+```
+
+Co-located under `packages/cli/src/` (same convention as anatomy / design-craft / drift / align).
+
+### DESIGN.md ## Brand Rules parser (v1 scope)
+
+The parser extracts:
+
+```ts
+interface BrandRules {
+  voice: {
+    constant?: string;
+    forbiddenPhrases: string[];
+    readingLevel?: number;
+    maxSentenceWords?: number;
+  } | null;
+  toneByContext: Record<string, string> | null; // parsed, unused in v1
+  assets: {
+    logo?: { primary?: string; variations?: Array<{ use: string; path: string }> };
+    forbiddenAssetUses?: Array<{ rule: string }>;
+  } | null; // parsed, unused
+  semanticTokenAliases: Record<string, string> | null; // parsed, unused
+}
+```
+
+Section delimiters: `## Brand Rules` to next H2 (`##`). Subsections (`### Voice`, `### Tone by Context`, etc.) parsed as YAML-ish key-value blocks (tolerant; matches the ADR sketch's indented form). Returns `null` if `## Brand Rules` is absent.
+
+### tokens.json $extensions walker
+
+Extends the existing `loadTokenPathIndex` walk with a parallel pass that captures the brand extension:
+
+```ts
+interface BrandTokenInfo {
+  path: string;
+  role?: string;
+  approvedContexts: string[];
+  forbiddenContexts: string[];
+}
+
+interface BrandTokenIndex {
+  byPath: Map<string, BrandTokenInfo>;
+}
+```
+
+Returns `null` (instead of empty index) when no token carries the extension — same silent-skip pattern as the existing resolvers.
+
+### BRAND-T\* token-misuse rule (v1 detection)
+
+Detection approach: regex-first per finding-density expectation. For each `BrandTokenInfo` with non-empty `forbiddenContexts`:
+
+1. Find every reference to the token's dotted path in the source (`tokens.color.brand.500`, `var(--color-brand-500)`, `'color.brand.500'`).
+2. Inspect the surrounding source context (same line + immediate previous/next non-blank line) for the v1 context-vocabulary keywords (`cta`, `selection`, `focus`, `data-visualization`, `decorative`, `background`, `text`, `border`, `error`, `success`, `warning`).
+3. If a forbidden context matches: emit `BRAND-T001`.
+
+v1's context inference is intentionally simple. Misses are acceptable (find the obvious cases); false positives must be near-zero (the user is being told their design system is being violated). Errors-on-the-side-of-conservative.
+
+### BRAND-V001 forbidden-phrases rule (v1 detection)
+
+TS Compiler API walk over `.tsx`/`.jsx` files (mirrors primitive-adoption-rule):
+
+- Visit each `ts.JsxText` node → extract text → case-insensitive substring scan against each `voice.forbiddenPhrases` entry.
+- Visit each `ts.JsxAttribute` whose initializer is a string literal → extract value → same scan.
+- Emit `BRAND-V001` per match (deduplicated per `file:line:phrase`).
+
+System: only `.tsx`/`.jsx` files in v1. `.md` files (README, AGENTS) considered out-of-scope — copy in docs is a different audience than copy in product UI.
+
+### Severity model
+
+Same shape as drift/anatomy (uses `severityFor`):
+
+| Code       | strict | standard | permissive |
+| ---------- | ------ | -------- | ---------- |
+| BRAND-T001 | error  | error    | info       |
+| BRAND-V001 | error  | warn     | info       |
+
+Token misuse maps to `error` in standard because the user has explicitly declared "this token must not be used here." Forbidden phrases map to `warn` in standard because copy is more nuanced (some matches may be intentional in edge contexts).
+
+### `Verifier<F>` interface extraction
+
+```ts
+// packages/cli/src/shared/verifier.ts
+export interface VerifierSummary {
+  totalFiles: number;
+  durationMs: number;
+  bySeverity: Record<'error' | 'warn' | 'info', number>;
+  byCode: Record<string, number>;
+}
+
+export interface Verifier<F, Cat = Record<string, unknown>, Meta = Record<string, unknown>> {
+  findings: F[];
+  summary: VerifierSummary;
+  catalog: Cat;
+  meta: Meta;
+}
+```
+
+Each existing verifier output gets a type-alias declaring conformance:
+
+```ts
+// drift/index.ts
+export type DetectDriftOutput = Verifier<
+  DriftFinding,
+  { rulesApplied: string[] },
+  { mode: DetectDriftMode; tokensLoaded: boolean; registryLoaded: boolean }
+>;
+```
+
+The interface is structural in TypeScript, so existing implementations satisfy it without code changes — only type-alias additions. Compile-time check that future verifiers conform.
+
+### Composition into check-design
+
+check-design.ts:
+
+```ts
+import { runAuditBrand } from '../mcp/tools/audit-brand';
+import type { BrandFinding } from '../brand/findings/finding';
+
+interface CheckDesignResult {
+  findingsByVerifier: {
+    anatomy: AnatomyFinding[];
+    craft: CraftFinding[];
+    drift: DriftFinding[];
+    brand: BrandFinding[]; // NEW
+  };
+  // ...
+}
+```
+
+Adds a VERIFIER 4 try/catch block mirroring VERIFIER 3 (drift). Aggregation summary extended. `persistFindings` signature extended to 4 arrays (mapping brand findings → CraftFindingRecord same way drift does).
+
+### Graph state
+
+No new node/edge types in v1. `BrandFinding` maps to `CraftFindingRecord` via `DesignConstraintAdapter.recordFindings()` — same path as anatomy/craft/drift. v1.x may add `VIOLATES_brand` edge for queryability.
+
+### Knowledge entries
+
+None required for v1. v1.x with tone-by-context rules may add `docs/knowledge/design/brand-tone-context.md` if the vocabulary needs documenting separately from the schema.
+
+## Surface area
+
+### CLI
+
+No standalone `harness audit-brand` command in v1. Brand audit runs via:
+
+- `harness check-design` (composes all 4 verifiers; recommended path)
+- `harness validate` (fast-mode hook gated by `design.audit.brandCompliance.enabled`)
+
+Direct CLI added in v1.x if real-world signal warrants it.
+
+### MCP tool
+
+`audit_brand` — input/output match the function call. Consumed by check-design and the (future) #5 orchestrator. Tool count bumps 72 → 73.
+
+### Config
+
+```ts
+design.audit.brandCompliance: {
+  enabled: boolean;          // default true
+  rules: {
+    tokenMisuse: boolean;    // default true
+    voice: boolean;          // default true
+  };
+  fastMode: { maxFiles: number };  // default 500
+}
+```
+
+## Verifier interface extraction (cross-cutting)
+
+This PR extracts `Verifier<F>` into `packages/cli/src/shared/verifier.ts` because the 4th-verifier threshold is met. Touchpoints:
+
+- `packages/cli/src/audit/component-anatomy/index.ts` — type alias `AuditAnatomyOutput = Verifier<...>`
+- `packages/cli/src/design-craft/index.ts` — same
+- `packages/cli/src/drift/index.ts` — same
+- `packages/cli/src/brand/index.ts` — same (new)
+- `packages/cli/src/commands/check-design.ts` — composer can now type its `findingsByVerifier` map against the shared interface
+
+Zero runtime change. All-additive at the type level.
+
+## Rationalizations to reject
+
+| Rationalization                                                    | Why it's wrong                                                                                                                                                                                                               |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Tone-by-context is the most valuable rule family — ship it in v1" | Tone-by-context requires component-state inference from JSX (empty/error/success/loading). That's a brainstorm-sized problem. v1 ships the foundation; v1.x ships tone once the state-inference pattern is proven elsewhere. |
+| "Reading-level is mechanically cheap — include it"                 | Cheap to compute, noisy without context attachment (a button label is one word; an error message is a paragraph). Ship with tone-context so context-appropriate thresholds can apply.                                        |
+| "Scan .md files for voice rules"                                   | Doc copy is a different audience (developers) than product copy (users). Brand voice rules target product copy; doc rules belong in a future docs-voice skill (craft-pipeline).                                              |
+| "Add a `VIOLATES_brand` graph edge now"                            | Graph schema additions are sticky. v1 routes through existing `VIOLATES_design`; when consumers actually query brand-only, add the edge.                                                                                     |
+| "Skip the Verifier interface extraction — it's premature"          | Premature at 2 data points. Load-bearing at 4. The verifier-shape convention comment in check-design.ts explicitly named this trigger.                                                                                       |
+| "Ship a standalone `harness audit-brand` CLI command"              | YAGNI. check-design composes all 4; direct CLI adds maintenance with no proven need. Add in v1.x if real users ask for it.                                                                                                   |
+| "Make BRAND-V001 use AST-level full-string equality"               | Forbidden phrases are typically partial-match phrases ("click here", "best-in-class"). Case-insensitive substring match is the right tool. Whole-word boundaries are a v1.x refinement.                                      |
+| "Scan all string literals, not just JSX text + attributes"         | All-string-literals scan would flag forbidden phrases in test fixtures, error-message constants used by non-UI code, etc. JSX scope keeps the audit focused on user-visible copy.                                            |
+| "Enforce semantic_token_aliases in v1"                             | Overlaps detect-drift T001 — same surface scanned twice with two different verdicts. Design once both rules have shipped and we can see the real overlap pattern.                                                            |
+
+## Success criteria
+
+**Resolver correctness (8)**
+
+1. DESIGN.md `## Brand Rules` parser returns null when section is absent
+2. Parser returns voice.forbiddenPhrases as a string array even when other voice fields are absent
+3. Parser tolerates indented YAML-ish syntax (matches the ADR sketch's form)
+4. Parser stops at the next H2 (does not bleed into adjacent sections)
+5. tokens.json $extensions walker returns null when no token carries `harness.brand`
+6. Walker captures `role`, `approvedContexts`, `forbiddenContexts` per token
+7. Walker handles missing optional fields (e.g., `forbidden_contexts` absent → empty array)
+8. Both resolvers' return types are exported and unit-tested independently
+
+**BRAND-T001 correctness (6)**
+
+9. Token reference `tokens.X.Y.Z` IS recognized as referring to token path `X.Y.Z`
+10. Token reference `var(--X-Y-Z)` IS recognized as referring to token path `X.Y.Z`
+11. String literal `'X.Y.Z'` IS recognized as a token-path reference
+12. Token with empty `forbiddenContexts` produces zero BRAND-T001 findings even when referenced
+13. Context inference recognizes the v1 vocabulary keywords (cta / selection / focus / etc.)
+14. Token used in an approved context does NOT fire BRAND-T001 (only forbidden_contexts matches)
+
+**BRAND-V001 correctness (6)**
+
+15. JSX text node `<p>Click here</p>` fires BRAND-V001 when "click here" is forbidden
+16. Case-insensitive: `<p>CLICK HERE</p>` also fires
+17. JSX string-typed attribute `title="best-in-class"` fires
+18. Same phrase on same line+file is deduplicated (no double-emit per finding)
+19. `.ts` files are NOT scanned (rule only fires on .jsx/.tsx)
+20. JSX fragments and nested elements are walked correctly (full TS Compiler API tree traversal)
+
+**Verifier interface extraction (4)**
+
+21. `packages/cli/src/shared/verifier.ts` exists and exports `Verifier<F, Cat, Meta>` + `VerifierSummary`
+22. `DetectDriftOutput`, `AuditAnatomyOutput`, `DesignCraftValue`, `AuditBrandOutput` all conform structurally (type-alias declaration, not refactor)
+23. Adding a 5th verifier requires only declaring conformance — no shape-duplication
+24. Compile-time check: removing `bySeverity` from any verifier output causes type error in check-design
+
+**check-design composition (4)**
+
+25. `findingsByVerifier.brand: BrandFinding[]` appears in CheckDesignResult
+26. VERIFIER 4 try/catch added (degrades gracefully on brand failure)
+27. Brand findings flow into `persistFindings` (4-array signature)
+28. check-design test extended for 4-verifier case (existing 3-verifier tests still pass)
+
+**Surface area + tool count (3)**
+
+29. MCP tool `audit_brand` registered (count 72 → 73)
+30. `harness validate` runs brand audit when `design.audit.brandCompliance.enabled !== false`
+31. 4-platform skill markdown shipped (claude-code / codex / cursor / gemini-cli)
+
+**Config + docs (3)**
+
+32. New `design.audit.brandCompliance` Zod sub-schema validates round-trip
+33. Auto-doc regenerates with `audit_brand` MCP tool entry + `audit-brand-compliance` skill entry
+34. Changeset describes the new audit + Verifier interface extraction
+
+## Long-term trajectory
+
+- **v1.x — BRAND-Tone\*** rules. Component-state inference from JSX (detect "this is an empty state" / "this is an error state" / etc.) → tone-by-context rule fires when state's tone-target doesn't match the surrounding copy's character.
+- **v1.x — BRAND-V002 reading-level** and **BRAND-V003 sentence-length**, attached per tone-context (different thresholds for button labels vs body copy).
+- **v1.x — BRAND-A\*** asset rules. Logo size, monochrome-context enforcement, image-tag scanning + filesystem checks.
+- **v1.x — Semantic-token-alias enforcement.** Designed after detect-drift T001 and audit-brand T-misuse have real usage; resolve the overlap.
+- **v1.x — Standalone `harness audit-brand` CLI** if real-world signal calls for direct-invocation use cases.
+- **v2 — `align-brand-compliance`** sibling FIX skill. Forbidden-phrase suggestions ("click here" → "open the document"); token-misuse codemods that swap to an approved alias.
+- **v2 — `VIOLATES_brand` graph edge.** Brand findings get a dedicated edge type so consumers can query brand-only violation history.
+- **v3 — LLM-judgment tone rules.** Pairs with craft-pipeline #5 copy-craft. Rule-based audit catches the clear violations; LLM-judgment skill catches the subtler tone misalignments.
+
+## Risks + mitigations
+
+| Risk                                                                                | Mitigation                                                                                                                                                                            |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BRAND-T001 false positives when a token reference appears far from its real context | v1 inspects ONLY the same line + adjacent non-blank lines. Misses far-context cases; near-zero false positives. v1.x adds richer context inference once tone-by-context lands.        |
+| Forbidden-phrase substring matching too eager (e.g., "as is" in "as issued")        | v1 uses substring; v1.x adds word-boundary regex. False positives surface fast in practice — accept the v1 simplicity, refine on signal.                                              |
+| DESIGN.md schema drift between projects                                             | ADR 0028's schema is the v1 truth. Parser is tolerant (missing subsections → null); schema additions in v2 are forward-compat (parser ignores unknown subsections).                   |
+| Tokens with `harness.brand` extension are rare in v1 (no project has them yet)      | Expected — the audit ships when there's structure to enforce. Both resolvers silently skip when input is absent; projects opt in by adding the extension/section.                     |
+| Verifier interface extraction breaks an existing verifier's type                    | Interface is structural; existing code satisfies it without refactor. PR-time TS check is the test. Migration is type-alias addition only.                                            |
+| Configuration sprawl: `design.audit.{anatomy,drift,brand}` block trio is heavy      | All three are independent gates serving distinct purposes. Sprawl IS the contract — each sub-project owns its block. v2 may introduce `design.audit.all.{enabled,strictness}` rollup. |
+
+## Open questions deferred to implementation
+
+- **Context-inference vocabulary expansion.** v1 ships the ADR's sketched vocabulary (`cta`, `selection`, `focus`, `data-visualization`, `decorative`, etc.). v1.x extension drivers: real projects' DESIGN.md content + actual finding patterns.
+- **Multi-line JSX text handling.** A `<p>` with multi-line text — does forbidden-phrase scan operate on the joined text or per-line? v1 joins (semantically correct: phrase may span lines). Implementation detail; spec'd here but not gated on user input.
+- **Tokens.json $extensions schema validation.** v1 trusts whatever's in the JSON. v1.x may add a Zod schema for the `$extensions.harness.brand` shape; defer until the schema's used by multiple projects.
+  EOF

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -400,6 +400,18 @@ Audit components for anatomy completeness. Emits ANAT-D* findings for component 
 - `designStrictness` (string, optional) — Overrides design.strictness from harness.config.json.
 - `catalog` (array, optional) — Optional subset of catalog entries to run.
 
+### `audit_brand`
+
+Audit brand-semantics violations: tokens used in forbidden contexts per their $extensions.harness.brand metadata (BRAND-T\*), and UI copy containing voice.forbidden_phrases from DESIGN.md ## Brand Rules (BRAND-V001). 4th verifier composed by harness check-design.
+
+**Parameters:**
+
+- `path` (string, required) — Project root path
+- `mode` (string, optional) — Both modes equivalent in v1 (no slow patterns yet).
+- `files` (array, optional) — Optional explicit file list to scope the scan.
+- `designStrictness` (string, optional) — Overrides design.strictness from harness.config.json.
+- `rules` (object, optional) — Per-rule enable flags.
+
 ### `compact`
 
 Compact content, resolve intents into aggregated packed responses, or re-compress prior tool output. Returns a packed envelope with source attribution and reduction metadata.

--- a/docs/reference/skills-catalog.md
+++ b/docs/reference/skills-catalog.md
@@ -2,7 +2,7 @@
 
 # Skills Catalog
 
-745 skills across 3 tiers. Tier 1 and 2 skills are registered as slash commands. Tier 3 skills are discoverable via the `search_skills` MCP tool. See the [Features Overview](../guides/features-overview.md) for narrative documentation.
+746 skills across 3 tiers. Tier 1 and 2 skills are registered as slash commands. Tier 3 skills are discoverable via the `search_skills` MCP tool. See the [Features Overview](../guides/features-overview.md) for narrative documentation.
 
 ## Tier 1 — Workflow (14 skills)
 
@@ -141,7 +141,7 @@ Scaffold or migrate a test-suite project (API, E2E/UI, or shared library) with t
 - **Cognitive mode:** constructive-architect
 - **Depends on:** initialize-harness-project
 
-## Tier 2 — Maintenance (28 skills)
+## Tier 2 — Maintenance (29 skills)
 
 ### align-design-system
 
@@ -152,6 +152,16 @@ Apply codemods for safe DRIFT-T001/T002/T003 token-bypass findings; emit precise
 - **Type:** rigid
 - **Cognitive mode:** constructive-architect
 - **Depends on:** detect-design-drift
+
+### audit-brand-compliance
+
+Rule-based brand-semantics audit. Detects token misuse (BRAND-T001 via $extensions.harness.brand.forbidden_contexts) and voice violations (BRAND-V001 via DESIGN.md voice.forbidden_phrases). 4th composed verifier in harness check-design. Triggers extraction of the formal verifier interface.
+
+- **Triggers:** manual, on_pr, on_new_feature
+- **Platforms:** claude-code
+- **Type:** rigid
+- **Cognitive mode:** constructive-architect
+- **Depends on:** detect-design-drift, harness-design
 
 ### audit-component-anatomy
 

--- a/packages/cli/src/brand/findings/finding.ts
+++ b/packages/cli/src/brand/findings/finding.ts
@@ -1,0 +1,42 @@
+/**
+ * Brand finding types — emitted by audit-brand-compliance.
+ *
+ * Code namespace:
+ *   BRAND-T*  — token misuse (token used in $extensions.harness.brand.forbidden_contexts)
+ *   BRAND-V*  — voice rule violations (string literals containing forbidden phrases)
+ *
+ * Severity is derived from design.strictness:
+ *   strict      → all findings 'error'
+ *   standard    → T001 = 'error'; V001 = 'warn'
+ *   permissive  → all 'info'
+ *
+ * Source: docs/changes/design-pipeline/audit-brand-compliance/proposal.md
+ *   (Outputs → BrandFinding).
+ */
+
+export type BrandFindingCode = `BRAND-T${string}` | `BRAND-V${string}`;
+export type BrandSeverity = 'error' | 'warn' | 'info';
+export type BrandStrictness = 'strict' | 'standard' | 'permissive';
+
+export interface BrandFinding {
+  code: BrandFindingCode;
+  severity: BrandSeverity;
+  file: string;
+  line: number | null;
+  column?: number;
+  message: string;
+  evidence: { snippet: string };
+  rule: { id: string; category: 'token-misuse' | 'voice' };
+  fix: { kind: 'manual' | 'codemod-todo'; description: string };
+}
+
+const STANDARD_SEVERITY: Record<string, BrandSeverity> = {
+  'BRAND-T001': 'error', // explicit declaration that this token MUST NOT be used here
+  'BRAND-V001': 'warn', // copy nuance — some matches may be intentional edge cases
+};
+
+export function severityFor(code: BrandFindingCode, strictness: BrandStrictness): BrandSeverity {
+  if (strictness === 'permissive') return 'info';
+  if (strictness === 'strict') return 'error';
+  return STANDARD_SEVERITY[code] ?? 'warn';
+}

--- a/packages/cli/src/brand/index.ts
+++ b/packages/cli/src/brand/index.ts
@@ -1,0 +1,151 @@
+/**
+ * Entry point for audit-brand-compliance — emits BrandFinding[] in the
+ * Verifier<F> shape consumed by harness check-design as the 4th verifier.
+ *
+ * v1 scope (per spec):
+ *   - BRAND-T001: token used in $extensions.harness.brand.forbidden_contexts
+ *   - BRAND-V001: UI copy contains a voice.forbidden_phrases entry
+ *
+ * Source: docs/changes/design-pipeline/audit-brand-compliance/proposal.md
+ *   (Technical Design → Module layout).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { sanitizePath } from '../mcp/utils/sanitize-path.js';
+import type { Verifier } from '../shared/verifier.js';
+import type { BrandFinding, BrandSeverity, BrandStrictness } from './findings/finding.js';
+import { loadBrandRules } from './resolvers/design-md-brand.js';
+import { loadBrandTokenIndex } from './resolvers/token-extensions.js';
+import { runTokenMisuseRule } from './rules/token-misuse-rule.js';
+import { runForbiddenPhrasesRule } from './rules/forbidden-phrases-rule.js';
+
+export type AuditBrandMode = 'fast' | 'full';
+
+export interface AuditBrandInput {
+  path: string;
+  mode?: AuditBrandMode;
+  files?: string[];
+  designStrictness?: BrandStrictness;
+  rules?: {
+    tokenMisuse?: boolean;
+    voice?: boolean;
+  };
+}
+
+export type AuditBrandOutput = Verifier<
+  BrandFinding,
+  { rulesApplied: string[] },
+  { mode: AuditBrandMode; designMdLoaded: boolean; brandTokensLoaded: boolean }
+>;
+
+const DEFAULT_GLOB_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.css', '.scss'];
+
+export async function runAuditBrand(input: AuditBrandInput): Promise<AuditBrandOutput> {
+  const startedAt = Date.now();
+  const projectRoot = sanitizePath(input.path);
+  const mode: AuditBrandMode = input.mode ?? 'fast';
+  const strictness: BrandStrictness = input.designStrictness ?? 'standard';
+  const tokenMisuseEnabled = input.rules?.tokenMisuse !== false;
+  const voiceEnabled = input.rules?.voice !== false;
+
+  const brandRules = voiceEnabled ? loadBrandRules(projectRoot) : null;
+  const brandTokens = tokenMisuseEnabled ? loadBrandTokenIndex(projectRoot) : null;
+
+  const rulesApplied: string[] = [];
+  if (tokenMisuseEnabled && brandTokens !== null) rulesApplied.push('token-misuse');
+  if (voiceEnabled && brandRules?.voice && brandRules.voice.forbiddenPhrases.length > 0) {
+    rulesApplied.push('forbidden-phrases');
+  }
+
+  const filesToScan = collectFiles(projectRoot, input.files);
+
+  const findings: BrandFinding[] = [];
+  for (const file of filesToScan) {
+    let source: string;
+    try {
+      source = fs.readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (tokenMisuseEnabled && brandTokens !== null) {
+      findings.push(...runTokenMisuseRule({ source, file, brandTokens, strictness }));
+    }
+    if (voiceEnabled && brandRules?.voice && brandRules.voice.forbiddenPhrases.length > 0) {
+      findings.push(
+        ...runForbiddenPhrasesRule({
+          source,
+          file,
+          forbiddenPhrases: brandRules.voice.forbiddenPhrases,
+          strictness,
+        })
+      );
+    }
+  }
+
+  const bySeverity: Record<BrandSeverity, number> = { error: 0, warn: 0, info: 0 };
+  const byCode: Record<string, number> = {};
+  for (const f of findings) {
+    bySeverity[f.severity] = (bySeverity[f.severity] ?? 0) + 1;
+    byCode[f.code] = (byCode[f.code] ?? 0) + 1;
+  }
+
+  return {
+    findings,
+    summary: {
+      totalFiles: filesToScan.length,
+      durationMs: Date.now() - startedAt,
+      bySeverity,
+      byCode,
+    },
+    catalog: { rulesApplied },
+    meta: {
+      mode,
+      designMdLoaded: brandRules !== null,
+      brandTokensLoaded: brandTokens !== null,
+    },
+  };
+}
+
+function collectFiles(projectRoot: string, explicitFiles: readonly string[] | undefined): string[] {
+  if (explicitFiles !== undefined && explicitFiles.length > 0) {
+    return explicitFiles.map((f) => (path.isAbsolute(f) ? f : path.join(projectRoot, f)));
+  }
+  const out: string[] = [];
+  walk(projectRoot, out, 0);
+  return out;
+}
+
+function walk(dir: string, out: string[], depth: number): void {
+  if (depth > 8) return;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (
+      entry.name.startsWith('.') ||
+      entry.name === 'node_modules' ||
+      entry.name === 'dist' ||
+      entry.name === 'build' ||
+      entry.name === 'coverage'
+    ) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out, depth + 1);
+    } else if (entry.isFile() && DEFAULT_GLOB_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      out.push(full);
+    }
+  }
+}
+
+export type {
+  BrandFinding,
+  BrandSeverity,
+  BrandStrictness,
+  BrandFindingCode,
+} from './findings/finding.js';

--- a/packages/cli/src/brand/resolvers/design-md-brand.ts
+++ b/packages/cli/src/brand/resolvers/design-md-brand.ts
@@ -1,0 +1,194 @@
+/**
+ * Parse `design-system/DESIGN.md` `## Brand Rules` section into a
+ * structured BrandRules object.
+ *
+ * v1 USES only `voice.forbiddenPhrases`. Other subsections
+ * (toneByContext, assets, semanticTokenAliases) are parsed-but-unused
+ * for forward-compatibility — when v1.x rules ship, they read from the
+ * already-populated fields with no parser change.
+ *
+ * Returns null when DESIGN.md is absent or `## Brand Rules` section is
+ * missing. Both rule families using brand rules then silently skip
+ * (same pattern as detect-design-drift's resolvers).
+ *
+ * Schema source: docs/knowledge/decisions/0028-brand-guidelines-source-of-truth.md
+ *   (Schema sketch).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface BrandVoice {
+  constant?: string;
+  forbiddenPhrases: string[];
+  readingLevel?: number;
+  maxSentenceWords?: number;
+}
+
+export interface BrandAssetUseRule {
+  rule: string;
+}
+
+export interface BrandAssetLogoVariation {
+  use: string;
+  path: string;
+}
+
+export interface BrandAssets {
+  logo?: {
+    primary?: string;
+    variations?: BrandAssetLogoVariation[];
+  };
+  forbiddenAssetUses?: BrandAssetUseRule[];
+}
+
+export interface BrandRules {
+  voice: BrandVoice | null;
+  toneByContext: Record<string, string> | null;
+  assets: BrandAssets | null;
+  semanticTokenAliases: Record<string, string> | null;
+}
+
+export function loadBrandRules(projectRoot: string): BrandRules | null {
+  const designMdPath = path.join(projectRoot, 'design-system', 'DESIGN.md');
+  if (!fs.existsSync(designMdPath)) return null;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(designMdPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  const section = extractBrandRulesSection(raw);
+  if (section === null) return null;
+  return parseBrandRules(section);
+}
+
+function extractBrandRulesSection(markdown: string): string | null {
+  const lines = markdown.split('\n');
+  let inSection = false;
+  const collected: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      if (inSection) break;
+      if (line.toLowerCase().startsWith('## brand rules')) {
+        inSection = true;
+        continue;
+      }
+    }
+    if (inSection) collected.push(line);
+  }
+  return inSection ? collected.join('\n') : null;
+}
+
+function parseBrandRules(section: string): BrandRules {
+  const subsections = splitH3Subsections(section);
+  return {
+    voice: subsections.voice ? parseVoice(subsections.voice) : null,
+    toneByContext: subsections['tone by context']
+      ? (parseKvBlock(subsections['tone by context']) as Record<string, string>)
+      : null,
+    assets: subsections.assets ? parseAssets(subsections.assets) : null,
+    semanticTokenAliases: subsections['semantic token aliases']
+      ? (parseKvBlock(subsections['semantic token aliases']) as Record<string, string>)
+      : null,
+  };
+}
+
+function splitH3Subsections(section: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const lines = section.split('\n');
+  let currentKey: string | null = null;
+  let currentBuf: string[] = [];
+  for (const line of lines) {
+    const h3 = /^###\s+(.+?)\s*$/.exec(line);
+    if (h3) {
+      if (currentKey !== null) out[currentKey] = currentBuf.join('\n');
+      currentKey = h3[1]!.trim().toLowerCase();
+      currentBuf = [];
+      continue;
+    }
+    if (currentKey !== null) currentBuf.push(line);
+  }
+  if (currentKey !== null) out[currentKey] = currentBuf.join('\n');
+  return out;
+}
+
+/**
+ * Parse a tolerant YAML-ish key-value block:
+ *
+ *   key1: value1
+ *   key2:
+ *     - item1
+ *     - item2
+ *   key3: 7
+ *
+ * Returns nested structure where list items become arrays and scalars
+ * become strings/numbers based on content.
+ */
+function parseKvBlock(text: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const lines = text.split('\n').filter((l) => l.trim().length > 0 && !l.trim().startsWith('#'));
+  let currentListKey: string | null = null;
+  let currentList: string[] = [];
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+    if (trimmed.startsWith('-')) {
+      // list item
+      if (currentListKey !== null) {
+        const item = trimmed.replace(/^-\s*/, '').replace(/^['"]|['"]$/g, '');
+        currentList.push(item);
+      }
+      continue;
+    }
+    // flush previous list if any
+    if (currentListKey !== null) {
+      out[currentListKey] = currentList;
+      currentListKey = null;
+      currentList = [];
+    }
+    // key: value form
+    const kv = /^([A-Za-z_][\w]*)\s*:\s*(.*)$/.exec(trimmed);
+    if (kv) {
+      const [, key, value] = kv;
+      if (value!.trim() === '') {
+        // start of a list block
+        currentListKey = key!;
+        currentList = [];
+      } else {
+        const clean = value!.replace(/^['"]|['"]$/g, '').trim();
+        const asNum = Number(clean);
+        out[key!] = !Number.isNaN(asNum) && /^\d+(\.\d+)?$/.test(clean) ? asNum : clean;
+      }
+    }
+  }
+  if (currentListKey !== null) {
+    out[currentListKey] = currentList;
+  }
+  return out;
+}
+
+function parseVoice(block: string): BrandVoice {
+  const kv = parseKvBlock(block);
+  const voice: BrandVoice = {
+    forbiddenPhrases: Array.isArray(kv.forbidden_phrases) ? (kv.forbidden_phrases as string[]) : [],
+  };
+  if (typeof kv.constant === 'string') voice.constant = kv.constant;
+  if (typeof kv.reading_level === 'number') voice.readingLevel = kv.reading_level;
+  if (typeof kv.max_sentence_words === 'number') voice.maxSentenceWords = kv.max_sentence_words;
+  return voice;
+}
+
+function parseAssets(block: string): BrandAssets {
+  // Defer structured asset parsing to v1.x (asset rules don't ship in v1).
+  // For now, capture the raw subsection so a future parser doesn't have to
+  // re-extract it.
+  const kv = parseKvBlock(block);
+  const assets: BrandAssets = {};
+  if (typeof kv.logo === 'object' && kv.logo !== null) {
+    assets.logo = kv.logo as NonNullable<BrandAssets['logo']>;
+  }
+  if (Array.isArray(kv.forbidden_asset_uses)) {
+    assets.forbiddenAssetUses = (kv.forbidden_asset_uses as string[]).map((rule) => ({ rule }));
+  }
+  return assets;
+}

--- a/packages/cli/src/brand/resolvers/token-extensions.ts
+++ b/packages/cli/src/brand/resolvers/token-extensions.ts
@@ -1,0 +1,85 @@
+/**
+ * Walk `design-system/tokens.json` for `$extensions.harness.brand` metadata.
+ * Returns a path-keyed index of brand info per token.
+ *
+ * Returns null when no token carries a `harness.brand` extension —
+ * BRAND-T* rules then silently skip (same pattern as drift's resolvers).
+ *
+ * Schema source: docs/knowledge/decisions/0028-brand-guidelines-source-of-truth.md
+ *   (Schema sketch → $extensions example).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface BrandTokenInfo {
+  /** Dotted token path (e.g. "color.brand.500") */
+  path: string;
+  /** Token role per the brand schema (e.g. "primary") */
+  role?: string;
+  /** Contexts where this token is approved for use */
+  approvedContexts: string[];
+  /** Contexts where this token MUST NOT be used (audit-brand BRAND-T001) */
+  forbiddenContexts: string[];
+}
+
+export interface BrandTokenIndex {
+  byPath: Map<string, BrandTokenInfo>;
+}
+
+export function loadBrandTokenIndex(projectRoot: string): BrandTokenIndex | null {
+  const tokenPath = path.join(projectRoot, 'design-system', 'tokens.json');
+  if (!fs.existsSync(tokenPath)) return null;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(tokenPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const idx: BrandTokenIndex = { byPath: new Map() };
+  walk(parsed as Record<string, unknown>, [], idx);
+  return idx.byPath.size > 0 ? idx : null;
+}
+
+function walk(node: Record<string, unknown>, breadcrumb: string[], idx: BrandTokenIndex): void {
+  if ('$value' in node) {
+    const tokenPath = breadcrumb.join('.');
+    const brandExt = extractBrandExtension(node.$extensions);
+    if (brandExt !== null) {
+      idx.byPath.set(tokenPath, { ...brandExt, path: tokenPath });
+    }
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith('$')) continue;
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      walk(value as Record<string, unknown>, [...breadcrumb, key], idx);
+    }
+  }
+}
+
+function extractBrandExtension(extensions: unknown): Omit<BrandTokenInfo, 'path'> | null {
+  if (typeof extensions !== 'object' || extensions === null) return null;
+  const harness = (extensions as Record<string, unknown>)['harness'];
+  if (typeof harness !== 'object' || harness === null) return null;
+  const brand = (harness as Record<string, unknown>)['brand'];
+  if (typeof brand !== 'object' || brand === null) return null;
+  const b = brand as Record<string, unknown>;
+  const info: Omit<BrandTokenInfo, 'path'> = {
+    approvedContexts: Array.isArray(b.approved_contexts)
+      ? (b.approved_contexts as string[]).filter((s) => typeof s === 'string')
+      : [],
+    forbiddenContexts: Array.isArray(b.forbidden_contexts)
+      ? (b.forbidden_contexts as string[]).filter((s) => typeof s === 'string')
+      : [],
+  };
+  if (typeof b.role === 'string') info.role = b.role;
+  return info;
+}

--- a/packages/cli/src/brand/rules/forbidden-phrases-rule.ts
+++ b/packages/cli/src/brand/rules/forbidden-phrases-rule.ts
@@ -1,0 +1,136 @@
+/**
+ * BRAND-V001 — Forbidden phrases in UI copy.
+ *
+ * Scans .tsx/.jsx files (TS Compiler API) for JSX text nodes and
+ * string-typed JSX attributes. For each text snippet, checks whether
+ * any voice.forbiddenPhrases entry from DESIGN.md appears as a
+ * case-insensitive substring. Deduplicates per (file, line, phrase).
+ *
+ * Skips silently when:
+ *   - file is not .jsx/.tsx
+ *   - voice.forbiddenPhrases is empty
+ *   - TS parser errors (returns empty)
+ *
+ * Source: docs/changes/design-pipeline/audit-brand-compliance/proposal.md
+ *   (Technical Design → BRAND-V001 forbidden-phrases rule).
+ */
+
+import ts from 'typescript';
+import type { BrandFinding, BrandStrictness } from '../findings/finding.js';
+import { severityFor } from '../findings/finding.js';
+
+export interface ForbiddenPhrasesRuleInput {
+  source: string;
+  file: string;
+  forbiddenPhrases: readonly string[];
+  strictness: BrandStrictness;
+}
+
+export function runForbiddenPhrasesRule(input: ForbiddenPhrasesRuleInput): BrandFinding[] {
+  if (input.forbiddenPhrases.length === 0) return [];
+  if (!/\.(?:jsx|tsx)$/i.test(input.file)) return [];
+
+  let sourceFile: ts.SourceFile;
+  try {
+    sourceFile = ts.createSourceFile(
+      input.file,
+      input.source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    );
+  } catch {
+    return [];
+  }
+
+  const findings: BrandFinding[] = [];
+  const seen = new Set<string>();
+  const phrasesLc = input.forbiddenPhrases.map((p) => p.toLowerCase());
+
+  visit(sourceFile, sourceFile, input.file, phrasesLc, input.strictness, seen, findings);
+  return findings;
+}
+
+function visit(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  file: string,
+  phrasesLc: string[],
+  strictness: BrandStrictness,
+  seen: Set<string>,
+  out: BrandFinding[]
+): void {
+  // JSX text nodes: <p>Click here</p>
+  if (ts.isJsxText(node)) {
+    const text = node.getText(sourceFile);
+    const trimmed = text.trim();
+    if (trimmed.length > 0) {
+      checkText(
+        trimmed,
+        node.getStart(sourceFile),
+        sourceFile,
+        file,
+        phrasesLc,
+        strictness,
+        seen,
+        out
+      );
+    }
+  }
+  // String-typed JSX attribute: title="best-in-class"
+  if (
+    ts.isJsxAttribute(node) &&
+    node.initializer !== undefined &&
+    ts.isStringLiteral(node.initializer)
+  ) {
+    const value = node.initializer.text;
+    checkText(
+      value,
+      node.initializer.getStart(sourceFile),
+      sourceFile,
+      file,
+      phrasesLc,
+      strictness,
+      seen,
+      out
+    );
+  }
+  ts.forEachChild(node, (child) =>
+    visit(child, sourceFile, file, phrasesLc, strictness, seen, out)
+  );
+}
+
+function checkText(
+  text: string,
+  position: number,
+  sourceFile: ts.SourceFile,
+  file: string,
+  phrasesLc: string[],
+  strictness: BrandStrictness,
+  seen: Set<string>,
+  out: BrandFinding[]
+): void {
+  const textLc = text.toLowerCase();
+  const { line: zeroLine } = sourceFile.getLineAndCharacterOfPosition(position);
+  const line = zeroLine + 1;
+  for (let i = 0; i < phrasesLc.length; i++) {
+    const phraseLc = phrasesLc[i]!;
+    if (!textLc.includes(phraseLc)) continue;
+    const key = `${file}:${line}:${phraseLc}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      code: 'BRAND-V001',
+      severity: severityFor('BRAND-V001', strictness),
+      file,
+      line,
+      message: `UI copy contains forbidden phrase "${phraseLc}" — declared at DESIGN.md ## Brand Rules → Voice → forbidden_phrases`,
+      evidence: { snippet: text.length > 80 ? text.slice(0, 80) + '…' : text },
+      rule: { id: 'BRAND-V001', category: 'voice' },
+      fix: {
+        kind: 'manual',
+        description: `Rewrite to avoid "${phraseLc}". If the phrase is unavoidable for this context, remove it from voice.forbidden_phrases (or scope the audit) — but the default policy is that brand voice trumps convenience.`,
+      },
+    });
+  }
+}

--- a/packages/cli/src/brand/rules/token-misuse-rule.ts
+++ b/packages/cli/src/brand/rules/token-misuse-rule.ts
@@ -1,0 +1,144 @@
+/**
+ * BRAND-T* — Token misuse detection.
+ *
+ * For each token whose $extensions.harness.brand.forbidden_contexts is
+ * non-empty, scan source for references to that token's dotted path
+ * (recognized in three forms: tokens.X.Y.Z, var(--X-Y-Z), 'X.Y.Z'). If
+ * the surrounding source context contains any forbidden-context keyword,
+ * emit BRAND-T001.
+ *
+ * v1 context inference is intentionally simple: same line + immediately
+ * adjacent non-blank lines. Misses far-context cases by design; near-zero
+ * false positives is the contract.
+ *
+ * Vocabulary v1 recognizes (matches ADR 0028 sketch): cta, selection,
+ * focus, data-visualization, decorative, background, text, border, error,
+ * success, warning.
+ *
+ * Source: docs/changes/design-pipeline/audit-brand-compliance/proposal.md
+ *   (Technical Design → BRAND-T* token-misuse rule).
+ */
+
+import type { BrandFinding, BrandStrictness } from '../findings/finding.js';
+import { severityFor } from '../findings/finding.js';
+import type { BrandTokenIndex } from '../resolvers/token-extensions.js';
+
+export interface TokenMisuseRuleInput {
+  source: string;
+  file: string;
+  brandTokens: BrandTokenIndex;
+  strictness: BrandStrictness;
+}
+
+export function runTokenMisuseRule(input: TokenMisuseRuleInput): BrandFinding[] {
+  const findings: BrandFinding[] = [];
+  const { source, file, brandTokens, strictness } = input;
+  for (const info of brandTokens.byPath.values()) {
+    if (info.forbiddenContexts.length === 0) continue;
+    for (const reference of findTokenReferences(source, info.path)) {
+      const context = inferContext(source, reference.line);
+      const hit = info.forbiddenContexts.find((ctx) => context.includes(ctx.toLowerCase()));
+      if (hit === undefined) continue;
+      findings.push({
+        code: 'BRAND-T001',
+        severity: severityFor('BRAND-T001', strictness),
+        file,
+        line: reference.line,
+        message: `Token "${info.path}" is used in forbidden context "${hit}" — declared at $extensions.harness.brand.forbidden_contexts`,
+        evidence: { snippet: reference.snippet },
+        rule: { id: 'BRAND-T001', category: 'token-misuse' },
+        fix: {
+          kind: 'manual',
+          description: `Token "${info.path}" is not approved for the "${hit}" context. Use an approved token (allowed contexts: ${
+            info.approvedContexts.length > 0 ? info.approvedContexts.join(', ') : '(none declared)'
+          }), or update tokens.json $extensions.harness.brand if the policy is wrong.`,
+        },
+      });
+    }
+  }
+  return findings;
+}
+
+interface TokenReference {
+  line: number;
+  snippet: string;
+}
+
+/**
+ * Find each line referencing the given token path. Recognizes:
+ *   - tokens.color.brand.500 (JS-style accessor)
+ *   - var(--color-brand-500)  (CSS-var kebab)
+ *   - 'color.brand.500' / "color.brand.500" (string literal)
+ *
+ * Returns at most one reference per line per call site (deduped).
+ */
+function findTokenReferences(source: string, tokenPath: string): TokenReference[] {
+  const refs: TokenReference[] = [];
+  const seen = new Set<number>();
+  const escaped = escapeRegex(tokenPath);
+  const kebab = tokenPath.replace(/\./g, '-');
+  const escapedKebab = escapeRegex(kebab);
+  const patterns = [
+    new RegExp(`\\btokens\\.${escaped}\\b`, 'g'),
+    new RegExp(`var\\(\\s*--${escapedKebab}\\s*\\)`, 'g'),
+    new RegExp(`['"\`]${escaped}['"\`]`, 'g'),
+  ];
+  for (const pattern of patterns) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      const line = lineOf(source, match.index);
+      if (seen.has(line)) continue;
+      seen.add(line);
+      refs.push({ line, snippet: extractLine(source, match.index) });
+    }
+  }
+  return refs;
+}
+
+/**
+ * Inspect the source context around `line`: the line itself plus the
+ * nearest non-blank previous and next lines. Returns the concatenated
+ * lowercase text (used for substring matching against the
+ * forbidden-context vocabulary).
+ */
+function inferContext(source: string, line: number): string {
+  const lines = source.split('\n');
+  const idx = line - 1;
+  const parts: string[] = [];
+  // Self
+  if (lines[idx] !== undefined) parts.push(lines[idx]);
+  // Previous non-blank
+  for (let i = idx - 1; i >= 0 && i >= idx - 3; i--) {
+    if (lines[i]!.trim().length > 0) {
+      parts.push(lines[i]!);
+      break;
+    }
+  }
+  // Next non-blank
+  for (let i = idx + 1; i < lines.length && i <= idx + 3; i++) {
+    if (lines[i]!.trim().length > 0) {
+      parts.push(lines[i]!);
+      break;
+    }
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+function lineOf(source: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset && i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) line++;
+  }
+  return line;
+}
+
+function extractLine(source: string, offset: number): string {
+  const start = source.lastIndexOf('\n', offset) + 1;
+  const endIdx = source.indexOf('\n', offset);
+  const end = endIdx === -1 ? source.length : endIdx;
+  return source.slice(start, end).trim();
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/cli/src/commands/check-design.ts
+++ b/packages/cli/src/commands/check-design.ts
@@ -29,9 +29,11 @@ import { runAudit as runAnatomyAudit } from '../mcp/tools/audit-anatomy';
 import type { AuditAnatomyOutput } from '../mcp/tools/audit-anatomy';
 import { runDesignCraft } from '../mcp/tools/design-craft';
 import { runDetectDrift } from '../mcp/tools/detect-drift';
+import { runAuditBrand } from '../mcp/tools/audit-brand';
 import type { AnatomyFinding } from '../audit/component-anatomy/findings/finding';
 import type { CraftFinding } from '../design-craft/findings/schema';
 import type { DriftFinding } from '../drift/findings/finding';
+import type { BrandFinding } from '../brand/findings/finding';
 
 type Mode = 'fast' | 'full';
 
@@ -51,6 +53,7 @@ interface CheckDesignResult {
     anatomy: AnatomyFinding[];
     craft: CraftFinding[];
     drift: DriftFinding[];
+    brand: BrandFinding[];
   };
   summary: {
     totalFindings: number;
@@ -89,6 +92,7 @@ export async function runCheckDesign(
   const anatomyFindings: AnatomyFinding[] = [];
   const craftFindings: CraftFinding[] = [];
   const driftFindings: DriftFinding[] = [];
+  const brandFindings: BrandFinding[] = [];
 
   // VERIFIER 1: audit-component-anatomy
   try {
@@ -144,6 +148,21 @@ export async function runCheckDesign(
     logger.warn(`detect-drift verifier failed: ${message}`);
   }
 
+  // VERIFIER 4: audit-brand-compliance
+  try {
+    const brandOut = await runAuditBrand({
+      path: cwd,
+      mode,
+      ...(options.files !== undefined && { files: options.files }),
+    });
+    brandFindings.push(...brandOut.findings);
+    verifiersRun.push('audit-brand');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    verifiersFailed.push({ name: 'audit-brand', error: message });
+    logger.warn(`audit-brand verifier failed: ${message}`);
+  }
+
   // Aggregate summary
   const bySeverity: Record<'error' | 'warn' | 'info', number> = {
     error: 0,
@@ -171,10 +190,21 @@ export async function runCheckDesign(
     byCode[f.code] = (byCode[f.code] ?? 0) + 1;
   }
 
-  const totalFindings = anatomyFindings.length + craftFindings.length + driftFindings.length;
+  for (const f of brandFindings) {
+    bySeverity[f.severity] = (bySeverity[f.severity] ?? 0) + 1;
+    byCode[f.code] = (byCode[f.code] ?? 0) + 1;
+  }
+
+  const totalFindings =
+    anatomyFindings.length + craftFindings.length + driftFindings.length + brandFindings.length;
 
   // Persist to graph
-  const graphPersisted = await persistFindings(anatomyFindings, craftFindings, driftFindings);
+  const graphPersisted = await persistFindings(
+    anatomyFindings,
+    craftFindings,
+    driftFindings,
+    brandFindings
+  );
 
   const durationMs = Date.now() - startedAt;
 
@@ -185,6 +215,7 @@ export async function runCheckDesign(
       anatomy: anatomyFindings,
       craft: craftFindings,
       drift: driftFindings,
+      brand: brandFindings,
     },
     summary: {
       totalFindings,
@@ -228,7 +259,8 @@ function craftTierToSeverity(
 async function persistFindings(
   anatomyFindings: readonly AnatomyFinding[],
   craftFindings: readonly CraftFinding[],
-  driftFindings: readonly DriftFinding[]
+  driftFindings: readonly DriftFinding[],
+  brandFindings: readonly BrandFinding[]
 ): Promise<CheckDesignResult['graphPersisted']> {
   const store = new GraphStore();
   const adapter = new DesignConstraintAdapter(store);
@@ -254,6 +286,16 @@ async function persistFindings(
       })
     ),
     ...driftFindings.map(
+      (f): CraftFindingRecord => ({
+        code: f.code,
+        file: f.file,
+        ...(f.line !== null && f.line !== undefined && { line: f.line }),
+        message: f.message,
+        severity: f.severity,
+        evidence: f.evidence?.snippet,
+      })
+    ),
+    ...brandFindings.map(
       (f): CraftFindingRecord => ({
         code: f.code,
         file: f.file,
@@ -292,6 +334,10 @@ function printCheckDesignResult(
 
   printVerifierSection('detect-drift', value.findingsByVerifier.drift.length, () =>
     printDriftFindings(value.findingsByVerifier.drift, mode === OutputMode.VERBOSE)
+  );
+
+  printVerifierSection('audit-brand', value.findingsByVerifier.brand.length, () =>
+    printBrandFindings(value.findingsByVerifier.brand, mode === OutputMode.VERBOSE)
   );
 
   if (value.summary.verifiersFailed.length > 0) {
@@ -346,6 +392,20 @@ function printCraftFindings(findings: readonly CraftFinding[], verbose: boolean)
 }
 
 function printDriftFindings(findings: readonly DriftFinding[], verbose: boolean): void {
+  const byFile = groupByFile(findings, (f) => f.file);
+  for (const [file, fs] of byFile) {
+    console.log(`  ${file}`);
+    for (const f of fs) {
+      const line = f.line !== null && f.line !== undefined ? `:${f.line}` : '';
+      console.log(`    ${f.code} [${f.severity}]    line${line}: ${f.message}`);
+      if (verbose) {
+        console.log(`                         fix: ${f.fix.description}`);
+      }
+    }
+  }
+}
+
+function printBrandFindings(findings: readonly BrandFinding[], verbose: boolean): void {
   const byFile = groupByFile(findings, (f) => f.file);
   for (const [file, fs] of byFile) {
     console.log(`  ${file}`);

--- a/packages/cli/src/commands/setup-mcp.ts
+++ b/packages/cli/src/commands/setup-mcp.ts
@@ -132,6 +132,8 @@ export const ALL_MCP_TOOLS: string[] = [
   'detect_drift',
   // design-pipeline #1 (align half) — apply codemods + emit suggestions
   'align_design_system',
+  // design-pipeline #3 — brand-semantics audit (BRAND-T* + BRAND-V001)
+  'audit_brand',
 ];
 
 /**

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -16,6 +16,7 @@ import { logger } from '../output/logger';
 import { CLIError, ExitCode } from '../utils/errors';
 import { runAudit as runComponentAnatomyAudit } from '../mcp/tools/audit-anatomy';
 import { runDetectDrift } from '../mcp/tools/detect-drift';
+import { runAuditBrand } from '../mcp/tools/audit-brand';
 
 interface ValidateOptions {
   cwd?: string;
@@ -40,6 +41,7 @@ interface ValidateResult {
     roadmapMode?: boolean;
     componentAnatomy?: boolean;
     driftDetection?: boolean;
+    brandCompliance?: boolean;
   };
   issues: Array<{
     check: string;
@@ -258,6 +260,50 @@ export async function runValidate(
         check: 'driftDetection',
         severity: 'warning',
         message: `Drift detection skipped: ${(err as Error).message}`,
+      });
+    }
+  }
+
+  // Audit-brand-compliance fast-mode (design-pipeline #3).
+  // Enabled by default; opts out via
+  // `design.audit.brandCompliance.enabled: false`. Detects token misuse
+  // (BRAND-T001 — token used in $extensions.harness.brand.forbidden_contexts)
+  // and voice violations (BRAND-V001 — UI copy containing voice.forbidden_phrases
+  // from DESIGN.md ## Brand Rules). Both rule families skip silently when
+  // their resolver input is absent.
+  const brandEnabled = config.design?.audit?.brandCompliance?.enabled !== false;
+  if (brandEnabled) {
+    try {
+      const strictness = (config.design?.strictness ?? 'standard') as
+        | 'strict'
+        | 'standard'
+        | 'permissive';
+      const brandOutput = await runAuditBrand({
+        path: cwd,
+        mode: 'fast',
+        designStrictness: strictness,
+      });
+      result.checks.brandCompliance = true;
+      for (const finding of brandOutput.findings) {
+        const severity: 'error' | 'warning' | 'info' =
+          finding.severity === 'warn' ? 'warning' : finding.severity;
+        if (severity === 'error') result.valid = false;
+        result.issues.push({
+          check: 'brandCompliance',
+          file: finding.file,
+          ...(finding.line !== null && finding.line !== undefined && { line: finding.line }),
+          ruleId: finding.code,
+          severity,
+          message: finding.message,
+          suggestion: finding.fix.description,
+        });
+      }
+    } catch (err) {
+      result.checks.brandCompliance = false;
+      result.issues.push({
+        check: 'brandCompliance',
+        severity: 'warning',
+        message: `Brand compliance audit skipped: ${(err as Error).message}`,
       });
     }
   }

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -167,6 +167,30 @@ export const DriftDetectionConfigSchema = z.object({
 });
 
 /**
+ * Schema for brand-compliance audit (design-pipeline #3).
+ * All fields optional; omit the block entirely to use built-in defaults.
+ */
+export const BrandComplianceConfigSchema = z.object({
+  /** Gate for the entire brand verifier */
+  enabled: z.boolean().default(true),
+  /** Rule toggles — defaults align with v1 scope (BRAND-T* + BRAND-V001) */
+  rules: z
+    .object({
+      /** Token-misuse rules (BRAND-T001 via $extensions.harness.brand.forbidden_contexts). Default: true. */
+      tokenMisuse: z.boolean().default(true),
+      /** Voice rule (BRAND-V001 forbidden phrases in JSX text + string attributes). Default: true. */
+      voice: z.boolean().default(true),
+    })
+    .default({}),
+  /** Fast-mode controls (validate-time scope cap) */
+  fastMode: z
+    .object({
+      maxFiles: z.number().int().positive().default(500),
+    })
+    .default({}),
+});
+
+/**
  * Schema for design audit configuration (design-pipeline floor-layer audits).
  */
 export const DesignAuditConfigSchema = z.object({
@@ -174,6 +198,8 @@ export const DesignAuditConfigSchema = z.object({
   componentAnatomy: ComponentAnatomyAuditConfigSchema.optional(),
   /** Design-system drift detection (design-pipeline #1, detect half) */
   driftDetection: DriftDetectionConfigSchema.optional(),
+  /** Brand-compliance audit (design-pipeline #3) */
+  brandCompliance: BrandComplianceConfigSchema.optional(),
 });
 
 /**

--- a/packages/cli/src/drift/index.ts
+++ b/packages/cli/src/drift/index.ts
@@ -35,21 +35,15 @@ export interface DetectDriftInput {
   };
 }
 
-export interface DetectDriftOutput {
-  findings: DriftFinding[];
-  summary: {
-    totalFiles: number;
-    durationMs: number;
-    bySeverity: Record<DriftSeverity, number>;
-    byCode: Record<string, number>;
-  };
-  catalog: { rulesApplied: string[] };
-  meta: {
-    mode: DetectDriftMode;
-    tokensLoaded: boolean;
-    registryLoaded: boolean;
-  };
-}
+import type { Verifier } from '../shared/verifier.js';
+
+// Conforms to the shared Verifier<F, Cat, Meta> shape extracted at the
+// 4th-verifier threshold (audit-brand-compliance).
+export type DetectDriftOutput = Verifier<
+  DriftFinding,
+  { rulesApplied: string[] },
+  { mode: DetectDriftMode; tokensLoaded: boolean; registryLoaded: boolean }
+>;
 
 const DEFAULT_GLOB_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.css', '.scss'];
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -174,6 +174,8 @@ import {
   alignDesignSystemDefinition,
   handleAlignDesignSystem,
 } from './tools/align-design-system.js';
+// design-pipeline #3: brand-semantics audit (BRAND-T* token misuse + BRAND-V001 forbidden phrases).
+import { auditBrandDefinition, handleAuditBrand } from './tools/audit-brand.js';
 
 // Re-exported from ./tool-types so tool files can import the type without
 // pulling in server.ts (which would create a cycle). See ./tool-types.ts.
@@ -259,6 +261,7 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
   designCraftToolDefinition,
   detectDriftDefinition,
   alignDesignSystemDefinition,
+  auditBrandDefinition,
 ].map((def) => ({ ...def, trustedOutput: true }));
 const TOOL_HANDLERS: Record<string, ToolHandler> = {
   validate_project: handleValidateProject as ToolHandler,
@@ -333,6 +336,7 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   design_craft: handleDesignCraft as unknown as ToolHandler,
   detect_drift: handleDetectDrift as unknown as ToolHandler,
   align_design_system: handleAlignDesignSystem as unknown as ToolHandler,
+  audit_brand: handleAuditBrand as unknown as ToolHandler,
 };
 
 const RESOURCE_DEFINITIONS = [

--- a/packages/cli/src/mcp/tools/audit-anatomy.ts
+++ b/packages/cli/src/mcp/tools/audit-anatomy.ts
@@ -39,17 +39,16 @@ export interface AuditAnatomyInput {
   catalog?: string[];
 }
 
-export interface AuditAnatomyOutput {
-  findings: AnatomyFinding[];
-  summary: {
-    totalFiles: number;
-    durationMs: number;
-    bySeverity: Record<Severity, number>;
-    byCode: Record<string, number>;
-  };
-  catalog: { conventionsApplied: string[]; patternsApplied: string[] };
-  meta: { mode: AuditMode; deferredToA11y: number };
-}
+import type { Verifier } from '../../shared/verifier.js';
+
+// Conforms to the shared Verifier<F, Cat, Meta> shape extracted at the
+// 4th-verifier threshold (audit-brand-compliance). Structural typing
+// means the existing fields satisfy the interface without refactor.
+export type AuditAnatomyOutput = Verifier<
+  AnatomyFinding,
+  { conventionsApplied: string[]; patternsApplied: string[] },
+  { mode: AuditMode; deferredToA11y: number }
+>;
 
 export const auditAnatomyDefinition = {
   name: 'audit_anatomy',

--- a/packages/cli/src/mcp/tools/audit-brand.ts
+++ b/packages/cli/src/mcp/tools/audit-brand.ts
@@ -1,0 +1,80 @@
+/**
+ * MCP tool: `mcp__harness__audit_brand`.
+ *
+ * Wraps the audit-brand-compliance skill (design-pipeline sub-project #3).
+ * Composed by harness check-design as the 4th verifier.
+ *
+ * Source: docs/changes/design-pipeline/audit-brand-compliance/proposal.md
+ *   (Surface area → MCP tool).
+ */
+
+import { runAuditBrand, type AuditBrandInput, type AuditBrandOutput } from '../../brand/index.js';
+
+interface ToolResponse {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+export const auditBrandDefinition = {
+  name: 'audit_brand',
+  description:
+    'Audit brand-semantics violations: tokens used in forbidden contexts per their ' +
+    '$extensions.harness.brand metadata (BRAND-T*), and UI copy containing voice.forbidden_phrases ' +
+    'from DESIGN.md ## Brand Rules (BRAND-V001). 4th verifier composed by harness check-design.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      path: { type: 'string', description: 'Project root path' },
+      mode: {
+        type: 'string',
+        enum: ['fast', 'full'],
+        description: 'Both modes equivalent in v1 (no slow patterns yet).',
+      },
+      files: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Optional explicit file list to scope the scan.',
+      },
+      designStrictness: {
+        type: 'string',
+        enum: ['strict', 'standard', 'permissive'],
+        description: 'Overrides design.strictness from harness.config.json.',
+      },
+      rules: {
+        type: 'object',
+        description: 'Per-rule enable flags.',
+        properties: {
+          tokenMisuse: { type: 'boolean', description: 'Default true' },
+          voice: { type: 'boolean', description: 'Default true' },
+        },
+      },
+    },
+    required: ['path'],
+  },
+};
+
+export async function handleAuditBrand(input: AuditBrandInput): Promise<ToolResponse> {
+  if (typeof input?.path !== 'string' || input.path.length === 0) {
+    return {
+      content: [
+        { type: 'text', text: JSON.stringify({ error: 'audit_brand: `path` is required' }) },
+      ],
+      isError: true,
+    };
+  }
+  try {
+    const result: AuditBrandOutput = await runAuditBrand(input);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        { type: 'text', text: JSON.stringify({ error: `audit_brand failed: ${message}` }) },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export { runAuditBrand } from '../../brand/index.js';
+export type { AuditBrandInput, AuditBrandOutput, AuditBrandMode } from '../../brand/index.js';

--- a/packages/cli/src/shared/verifier.ts
+++ b/packages/cli/src/shared/verifier.ts
@@ -1,0 +1,39 @@
+/**
+ * Verifier<F, Cat, Meta> — formal interface for harness check-design's
+ * composed verifier shape. Extracted at the 4th-verifier threshold
+ * (audit-brand-compliance) per the convention note in check-design.ts.
+ *
+ * Each verifier (audit-anatomy, design-craft critique, detect-design-drift,
+ * audit-brand-compliance) declares conformance via a type alias rather than
+ * implementing the interface — TypeScript's structural typing lets existing
+ * verifiers satisfy this shape without a refactor.
+ *
+ * Future verifiers must satisfy Verifier<F> or the type-check in check-design
+ * fails. That's the contract: adding a 5th verifier costs only a type-alias
+ * declaration, not a re-shaping of the verifier's output.
+ *
+ * Source: docs/changes/design-pipeline/audit-brand-compliance/proposal.md
+ *   (Technical Design → Verifier interface extraction).
+ */
+
+export type VerifierSeverity = 'error' | 'warn' | 'info';
+
+export interface VerifierSummary {
+  totalFiles: number;
+  durationMs: number;
+  bySeverity: Record<VerifierSeverity, number>;
+  byCode: Record<string, number>;
+}
+
+/**
+ * The Verifier shape. Every check-design composer member returns this.
+ * - F: the verifier's finding type
+ * - Cat: optional catalog (rules/conventions/exemplars applied this run)
+ * - Meta: optional run metadata (mode, resolver-loaded flags, etc.)
+ */
+export interface Verifier<F, Cat = Record<string, unknown>, Meta = Record<string, unknown>> {
+  findings: F[];
+  summary: VerifierSummary;
+  catalog: Cat;
+  meta: Meta;
+}

--- a/packages/cli/tests/brand/integration/audit-brand.test.ts
+++ b/packages/cli/tests/brand/integration/audit-brand.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runAuditBrand } from '../../../src/brand';
+
+describe('runAuditBrand (integration)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brand-int-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(rel: string, content: string): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  it('returns no findings + meta flags false when neither input is present', async () => {
+    writeFile('src/X.tsx', `export const X = () => <p>Hello</p>;`);
+    const out = await runAuditBrand({ path: tmpDir });
+    expect(out.findings).toHaveLength(0);
+    expect(out.meta.designMdLoaded).toBe(false);
+    expect(out.meta.brandTokensLoaded).toBe(false);
+    expect(out.catalog.rulesApplied).toEqual([]);
+  });
+
+  it('fires BRAND-V001 when DESIGN.md voice.forbidden_phrases is present', async () => {
+    writeFile(
+      'design-system/DESIGN.md',
+      `## Brand Rules\n\n### Voice\n\nforbidden_phrases:\n  - "click here"\n`
+    );
+    writeFile('src/X.tsx', `export const X = () => <p>Click here</p>;`);
+
+    const out = await runAuditBrand({ path: tmpDir });
+    expect(out.meta.designMdLoaded).toBe(true);
+    expect(out.catalog.rulesApplied).toContain('forbidden-phrases');
+    const v = out.findings.filter((f) => f.code === 'BRAND-V001');
+    expect(v).toHaveLength(1);
+  });
+
+  it('fires BRAND-T001 when token used in forbidden context', async () => {
+    writeFile(
+      'design-system/tokens.json',
+      JSON.stringify({
+        color: {
+          brand: {
+            '500': {
+              $type: 'color',
+              $value: '#3b82f6',
+              $extensions: {
+                harness: {
+                  brand: {
+                    role: 'primary',
+                    approved_contexts: ['cta'],
+                    forbidden_contexts: ['data-visualization'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+    writeFile('src/Chart.ts', `// data-visualization color\nconst c = tokens.color.brand.500;\n`);
+
+    const out = await runAuditBrand({ path: tmpDir });
+    expect(out.meta.brandTokensLoaded).toBe(true);
+    expect(out.catalog.rulesApplied).toContain('token-misuse');
+    const t = out.findings.filter((f) => f.code === 'BRAND-T001');
+    expect(t).toHaveLength(1);
+  });
+
+  it('aggregates summary.bySeverity and summary.byCode correctly', async () => {
+    writeFile(
+      'design-system/DESIGN.md',
+      `## Brand Rules\n\n### Voice\n\nforbidden_phrases:\n  - "click here"\n`
+    );
+    writeFile(
+      'design-system/tokens.json',
+      JSON.stringify({
+        color: {
+          brand: {
+            '500': {
+              $type: 'color',
+              $value: '#3b82f6',
+              $extensions: {
+                harness: { brand: { forbidden_contexts: ['data-visualization'] } },
+              },
+            },
+          },
+        },
+      })
+    );
+    writeFile(
+      'src/Chart.tsx',
+      `// data-visualization\nexport const X = () => { const c = tokens.color.brand.500; return <p>Click here</p>; };\n`
+    );
+
+    const out = await runAuditBrand({ path: tmpDir });
+    expect(out.summary.bySeverity.error).toBe(1); // T001
+    expect(out.summary.bySeverity.warn).toBe(1); // V001
+    expect(out.summary.byCode['BRAND-T001']).toBe(1);
+    expect(out.summary.byCode['BRAND-V001']).toBe(1);
+  });
+
+  it('rules.voice=false disables forbidden-phrases', async () => {
+    writeFile(
+      'design-system/DESIGN.md',
+      `## Brand Rules\n\n### Voice\n\nforbidden_phrases:\n  - "click here"\n`
+    );
+    writeFile('src/X.tsx', `export const X = () => <p>Click here</p>;`);
+
+    const out = await runAuditBrand({ path: tmpDir, rules: { voice: false } });
+    expect(out.findings.filter((f) => f.code.startsWith('BRAND-V'))).toHaveLength(0);
+    expect(out.catalog.rulesApplied).not.toContain('forbidden-phrases');
+  });
+});

--- a/packages/cli/tests/brand/resolvers/design-md-brand.test.ts
+++ b/packages/cli/tests/brand/resolvers/design-md-brand.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { loadBrandRules } from '../../../src/brand/resolvers/design-md-brand';
+
+describe('loadBrandRules', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brand-md-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeDesignMd(content: string): void {
+    const dir = path.join(tmpDir, 'design-system');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'DESIGN.md'), content);
+  }
+
+  it('returns null when DESIGN.md is absent', () => {
+    expect(loadBrandRules(tmpDir)).toBeNull();
+  });
+
+  it('returns null when ## Brand Rules section is missing', () => {
+    writeDesignMd(`# DESIGN\n\n## Other Section\nnope\n`);
+    expect(loadBrandRules(tmpDir)).toBeNull();
+  });
+
+  it('parses voice.forbidden_phrases from a basic Brand Rules section', () => {
+    writeDesignMd(`# DESIGN
+
+## Brand Rules
+
+### Voice
+
+constant: "warm, direct"
+forbidden_phrases:
+  - "click here"
+  - "synergy"
+  - "best-in-class"
+reading_level: 7
+max_sentence_words: 25
+`);
+    const rules = loadBrandRules(tmpDir)!;
+    expect(rules.voice).not.toBeNull();
+    expect(rules.voice!.forbiddenPhrases).toEqual(['click here', 'synergy', 'best-in-class']);
+    expect(rules.voice!.constant).toBe('warm, direct');
+    expect(rules.voice!.readingLevel).toBe(7);
+    expect(rules.voice!.maxSentenceWords).toBe(25);
+  });
+
+  it('returns voice.forbiddenPhrases as empty array when forbidden_phrases key missing', () => {
+    writeDesignMd(`## Brand Rules
+
+### Voice
+
+constant: "warm"
+`);
+    const rules = loadBrandRules(tmpDir)!;
+    expect(rules.voice).not.toBeNull();
+    expect(rules.voice!.forbiddenPhrases).toEqual([]);
+    expect(rules.voice!.constant).toBe('warm');
+  });
+
+  it('stops at the next H2 (does not bleed into adjacent sections)', () => {
+    writeDesignMd(`## Brand Rules
+
+### Voice
+
+forbidden_phrases:
+  - "click here"
+
+## Patterns
+
+### Voice
+
+forbidden_phrases:
+  - "stale"
+`);
+    const rules = loadBrandRules(tmpDir)!;
+    expect(rules.voice!.forbiddenPhrases).toEqual(['click here']);
+  });
+
+  it('parses semantic_token_aliases for forward-compat (unused in v1)', () => {
+    writeDesignMd(`## Brand Rules
+
+### Semantic Token Aliases
+
+brand_primary: "color.brand.500"
+brand_accent: "color.accent.500"
+`);
+    const rules = loadBrandRules(tmpDir)!;
+    expect(rules.semanticTokenAliases).not.toBeNull();
+    expect(rules.semanticTokenAliases!.brand_primary).toBe('color.brand.500');
+    expect(rules.semanticTokenAliases!.brand_accent).toBe('color.accent.500');
+  });
+
+  it('returns null sections cleanly when subsections are absent', () => {
+    writeDesignMd(`## Brand Rules\n\nNo subsections.\n`);
+    const rules = loadBrandRules(tmpDir)!;
+    expect(rules.voice).toBeNull();
+    expect(rules.toneByContext).toBeNull();
+    expect(rules.assets).toBeNull();
+    expect(rules.semanticTokenAliases).toBeNull();
+  });
+});

--- a/packages/cli/tests/brand/resolvers/token-extensions.test.ts
+++ b/packages/cli/tests/brand/resolvers/token-extensions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { loadBrandTokenIndex } from '../../../src/brand/resolvers/token-extensions';
+
+describe('loadBrandTokenIndex', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'brand-tokens-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeTokens(obj: unknown): void {
+    const dir = path.join(tmpDir, 'design-system');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'tokens.json'), JSON.stringify(obj));
+  }
+
+  it('returns null when tokens.json absent', () => {
+    expect(loadBrandTokenIndex(tmpDir)).toBeNull();
+  });
+
+  it('returns null when no token carries the harness.brand extension', () => {
+    writeTokens({ color: { brand: { primary: { $type: 'color', $value: '#0066cc' } } } });
+    expect(loadBrandTokenIndex(tmpDir)).toBeNull();
+  });
+
+  it('captures role + approvedContexts + forbiddenContexts per token', () => {
+    writeTokens({
+      color: {
+        brand: {
+          '500': {
+            $type: 'color',
+            $value: '#3b82f6',
+            $extensions: {
+              harness: {
+                brand: {
+                  role: 'primary',
+                  approved_contexts: ['cta', 'selection', 'focus'],
+                  forbidden_contexts: ['data-visualization', 'decorative'],
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const idx = loadBrandTokenIndex(tmpDir)!;
+    const info = idx.byPath.get('color.brand.500');
+    expect(info).toBeDefined();
+    expect(info!.role).toBe('primary');
+    expect(info!.approvedContexts).toEqual(['cta', 'selection', 'focus']);
+    expect(info!.forbiddenContexts).toEqual(['data-visualization', 'decorative']);
+  });
+
+  it('handles missing optional fields gracefully (empty-array defaults)', () => {
+    writeTokens({
+      color: {
+        x: {
+          $type: 'color',
+          $value: '#ffffff',
+          $extensions: { harness: { brand: { role: 'neutral' } } },
+        },
+      },
+    });
+    const idx = loadBrandTokenIndex(tmpDir)!;
+    const info = idx.byPath.get('color.x')!;
+    expect(info.role).toBe('neutral');
+    expect(info.approvedContexts).toEqual([]);
+    expect(info.forbiddenContexts).toEqual([]);
+  });
+});

--- a/packages/cli/tests/brand/rules/forbidden-phrases.test.ts
+++ b/packages/cli/tests/brand/rules/forbidden-phrases.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { runForbiddenPhrasesRule } from '../../../src/brand/rules/forbidden-phrases-rule';
+
+const FORBIDDEN = ['click here', 'best-in-class', 'synergy'];
+
+describe('runForbiddenPhrasesRule (BRAND-V001)', () => {
+  it('fires on JSX text node containing forbidden phrase', () => {
+    const findings = runForbiddenPhrasesRule({
+      source: `export const X = () => <p>Click here to continue</p>;`,
+      file: 'src/X.tsx',
+      forbiddenPhrases: FORBIDDEN,
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].code).toBe('BRAND-V001');
+    expect(findings[0].severity).toBe('warn');
+    expect(findings[0].message).toContain('click here');
+  });
+
+  it('matches case-insensitively (CLICK HERE)', () => {
+    const findings = runForbiddenPhrasesRule({
+      source: `export const X = () => <p>CLICK HERE</p>;`,
+      file: 'src/X.tsx',
+      forbiddenPhrases: FORBIDDEN,
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('fires on string-typed JSX attribute', () => {
+    const findings = runForbiddenPhrasesRule({
+      source: `export const X = () => <a title="best-in-class">link</a>;`,
+      file: 'src/X.tsx',
+      forbiddenPhrases: FORBIDDEN,
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].evidence.snippet).toBe('best-in-class');
+  });
+
+  it('does NOT fire on .ts files (only .jsx/.tsx)', () => {
+    const findings = runForbiddenPhrasesRule({
+      source: `const x = "click here";`,
+      file: 'src/X.ts',
+      forbiddenPhrases: FORBIDDEN,
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('returns empty when forbiddenPhrases array is empty', () => {
+    const findings = runForbiddenPhrasesRule({
+      source: `export const X = () => <p>Click here</p>;`,
+      file: 'src/X.tsx',
+      forbiddenPhrases: [],
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('deduplicates same phrase on same line+file', () => {
+    const findings = runForbiddenPhrasesRule({
+      source: `export const X = () => <p>Click here</p>;`,
+      file: 'src/X.tsx',
+      forbiddenPhrases: ['click', 'click here'],
+      strictness: 'standard',
+    });
+    // Both phrases hit but they're different keys, so we expect 2.
+    expect(findings).toHaveLength(2);
+  });
+
+  it('walks nested JSX correctly (TS Compiler API tree traversal)', () => {
+    const findings = runForbiddenPhrasesRule({
+      source: `export const X = () => (
+        <div>
+          <header><h1>Welcome</h1></header>
+          <p>Use this best-in-class tool</p>
+        </div>
+      );`,
+      file: 'src/X.tsx',
+      forbiddenPhrases: FORBIDDEN,
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].code).toBe('BRAND-V001');
+  });
+
+  it('strictness flips severity', () => {
+    const strict = runForbiddenPhrasesRule({
+      source: `export const X = () => <p>Click here</p>;`,
+      file: 'a.tsx',
+      forbiddenPhrases: ['click here'],
+      strictness: 'strict',
+    });
+    const permissive = runForbiddenPhrasesRule({
+      source: `export const X = () => <p>Click here</p>;`,
+      file: 'a.tsx',
+      forbiddenPhrases: ['click here'],
+      strictness: 'permissive',
+    });
+    expect(strict[0].severity).toBe('error');
+    expect(permissive[0].severity).toBe('info');
+  });
+});

--- a/packages/cli/tests/brand/rules/token-misuse.test.ts
+++ b/packages/cli/tests/brand/rules/token-misuse.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { runTokenMisuseRule } from '../../../src/brand/rules/token-misuse-rule';
+import type { BrandTokenIndex } from '../../../src/brand/resolvers/token-extensions';
+
+function makeIndex(
+  entries: Array<{ path: string; forbidden: string[]; approved?: string[] }>
+): BrandTokenIndex {
+  const byPath = new Map();
+  for (const e of entries) {
+    byPath.set(e.path, {
+      path: e.path,
+      approvedContexts: e.approved ?? [],
+      forbiddenContexts: e.forbidden,
+    });
+  }
+  return { byPath };
+}
+
+describe('runTokenMisuseRule (BRAND-T001)', () => {
+  it('fires on tokens.X.Y reference in forbidden context', () => {
+    const findings = runTokenMisuseRule({
+      source: `// data-visualization region\nconst c = tokens.color.brand.500;\n`,
+      file: 'src/Chart.ts',
+      brandTokens: makeIndex([{ path: 'color.brand.500', forbidden: ['data-visualization'] }]),
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].code).toBe('BRAND-T001');
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].message).toContain('data-visualization');
+  });
+
+  it('fires on var(--x-y-z) reference in forbidden context', () => {
+    const findings = runTokenMisuseRule({
+      source: `.chart-decorative { background: var(--color-brand-500); }\n`,
+      file: 'src/Chart.css',
+      brandTokens: makeIndex([{ path: 'color.brand.500', forbidden: ['decorative'] }]),
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].code).toBe('BRAND-T001');
+  });
+
+  it('fires on string-literal reference "X.Y.Z" in forbidden context', () => {
+    const findings = runTokenMisuseRule({
+      source: `// background gradient\nconst c = resolveToken('color.brand.500');\n`,
+      file: 'src/Chart.ts',
+      brandTokens: makeIndex([{ path: 'color.brand.500', forbidden: ['background'] }]),
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('does NOT fire when token referenced in an approved context', () => {
+    const findings = runTokenMisuseRule({
+      source: `// CTA button\nconst c = tokens.color.brand.500;\n`,
+      file: 'src/Cta.tsx',
+      brandTokens: makeIndex([
+        { path: 'color.brand.500', forbidden: ['data-visualization'], approved: ['cta'] },
+      ]),
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('does NOT fire when token has empty forbiddenContexts (even if referenced)', () => {
+    const findings = runTokenMisuseRule({
+      source: `// data-visualization\nconst c = tokens.color.x;\n`,
+      file: 'src/X.ts',
+      brandTokens: makeIndex([{ path: 'color.x', forbidden: [] }]),
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('deduplicates references on the same line (one finding per token per line)', () => {
+    const findings = runTokenMisuseRule({
+      source: `// data-visualization\nconst s = { a: tokens.color.brand.500, b: tokens.color.brand.500 };\n`,
+      file: 'src/X.ts',
+      brandTokens: makeIndex([{ path: 'color.brand.500', forbidden: ['data-visualization'] }]),
+      strictness: 'standard',
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('strictness modifies severity (strict → error; permissive → info)', () => {
+    const strict = runTokenMisuseRule({
+      source: `// data-visualization\nconst c = tokens.color.brand.500;\n`,
+      file: 'a.ts',
+      brandTokens: makeIndex([{ path: 'color.brand.500', forbidden: ['data-visualization'] }]),
+      strictness: 'strict',
+    });
+    const permissive = runTokenMisuseRule({
+      source: `// data-visualization\nconst c = tokens.color.brand.500;\n`,
+      file: 'a.ts',
+      brandTokens: makeIndex([{ path: 'color.brand.500', forbidden: ['data-visualization'] }]),
+      strictness: 'permissive',
+    });
+    expect(strict[0].severity).toBe('error');
+    expect(permissive[0].severity).toBe('info');
+  });
+});

--- a/packages/cli/tests/commands/check-design.test.ts
+++ b/packages/cli/tests/commands/check-design.test.ts
@@ -53,6 +53,20 @@ vi.mock('../../src/mcp/tools/detect-drift', () => ({
   }),
 }));
 
+vi.mock('../../src/mcp/tools/audit-brand', () => ({
+  runAuditBrand: vi.fn().mockResolvedValue({
+    findings: [],
+    summary: {
+      totalFiles: 0,
+      durationMs: 0,
+      bySeverity: { error: 0, warn: 0, info: 0 },
+      byCode: {},
+    },
+    catalog: { rulesApplied: [] },
+    meta: { mode: 'fast', designMdLoaded: false, brandTokensLoaded: false },
+  }),
+}));
+
 vi.mock('../../src/config/loader', () => ({
   resolveConfig: vi.fn().mockReturnValue({
     ok: true,
@@ -69,6 +83,7 @@ import { runCheckDesign, createCheckDesignCommand } from '../../src/commands/che
 import { runAudit as runAnatomyAudit } from '../../src/mcp/tools/audit-anatomy';
 import { runDesignCraft } from '../../src/mcp/tools/design-craft';
 import { runDetectDrift } from '../../src/mcp/tools/detect-drift';
+import { runAuditBrand } from '../../src/mcp/tools/audit-brand';
 
 describe('check-design command', () => {
   beforeEach(() => {
@@ -85,11 +100,13 @@ describe('check-design command', () => {
       expect(result.value.findingsByVerifier.anatomy).toHaveLength(0);
       expect(result.value.findingsByVerifier.craft).toHaveLength(0);
       expect(result.value.findingsByVerifier.drift).toHaveLength(0);
+      expect(result.value.findingsByVerifier.brand).toHaveLength(0);
       expect(result.value.summary.totalFindings).toBe(0);
       expect(result.value.summary.verifiersRun).toEqual([
         'audit-anatomy',
         'design-craft-critique',
         'detect-drift',
+        'audit-brand',
       ]);
       expect(result.value.summary.verifiersFailed).toEqual([]);
       expect(result.value.graphPersisted.constraintsAdded).toBe(0);
@@ -251,7 +268,11 @@ describe('check-design command', () => {
 
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.summary.verifiersRun).toEqual(['design-craft-critique', 'detect-drift']);
+      expect(result.value.summary.verifiersRun).toEqual([
+        'design-craft-critique',
+        'detect-drift',
+        'audit-brand',
+      ]);
       expect(result.value.summary.verifiersFailed).toEqual([
         { name: 'audit-anatomy', error: 'parser crashed' },
       ]);
@@ -269,7 +290,11 @@ describe('check-design command', () => {
 
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.summary.verifiersRun).toEqual(['audit-anatomy', 'detect-drift']);
+      expect(result.value.summary.verifiersRun).toEqual([
+        'audit-anatomy',
+        'detect-drift',
+        'audit-brand',
+      ]);
       expect(result.value.summary.verifiersFailed[0]).toMatchObject({
         name: 'design-craft-critique',
         error: 'LLM provider not configured',
@@ -283,7 +308,11 @@ describe('check-design command', () => {
 
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.summary.verifiersRun).toEqual(['audit-anatomy', 'detect-drift']);
+      expect(result.value.summary.verifiersRun).toEqual([
+        'audit-anatomy',
+        'detect-drift',
+        'audit-brand',
+      ]);
       expect(result.value.summary.verifiersFailed[0]).toMatchObject({
         name: 'design-craft-critique',
         error: 'boom',
@@ -297,7 +326,11 @@ describe('check-design command', () => {
 
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.summary.verifiersRun).toEqual(['audit-anatomy', 'design-craft-critique']);
+      expect(result.value.summary.verifiersRun).toEqual([
+        'audit-anatomy',
+        'design-craft-critique',
+        'audit-brand',
+      ]);
       expect(result.value.summary.verifiersFailed[0]).toMatchObject({
         name: 'detect-drift',
         error: 'drift parse failed',
@@ -413,6 +446,89 @@ describe('check-design command', () => {
       expect(runDetectDrift).toHaveBeenCalledWith(
         expect.objectContaining({ files: ['src/Foo.tsx', 'src/Bar.tsx'] })
       );
+      expect(runAuditBrand).toHaveBeenCalledWith(
+        expect.objectContaining({ files: ['src/Foo.tsx', 'src/Bar.tsx'] })
+      );
+    });
+
+    it('degrades gracefully when audit-brand throws', async () => {
+      vi.mocked(runAuditBrand).mockRejectedValueOnce(new Error('brand parser crashed'));
+
+      const result = await runCheckDesign({ cwd: '/tmp/test' });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.summary.verifiersRun).toEqual([
+        'audit-anatomy',
+        'design-craft-critique',
+        'detect-drift',
+      ]);
+      expect(result.value.summary.verifiersFailed[0]).toMatchObject({
+        name: 'audit-brand',
+        error: 'brand parser crashed',
+      });
+      expect(result.value.valid).toBe(false);
+    });
+
+    it('aggregates brand findings into bySeverity and byCode', async () => {
+      // Reset any sticky mocks from earlier tests (the idempotency test sets
+      // a sticky mockResolvedValue on runAnatomyAudit that would leak here).
+      vi.mocked(runAnatomyAudit).mockReset();
+      vi.mocked(runAnatomyAudit).mockResolvedValue({
+        findings: [],
+        summary: {
+          totalFiles: 0,
+          durationMs: 0,
+          bySeverity: { error: 0, warn: 0, info: 0 },
+          byCode: {},
+        },
+        catalog: { conventionsApplied: [], patternsApplied: [] },
+        meta: { mode: 'fast', deferredToA11y: 0 },
+      });
+
+      vi.mocked(runAuditBrand).mockResolvedValueOnce({
+        findings: [
+          {
+            code: 'BRAND-T001',
+            severity: 'error',
+            file: 'src/Hero.tsx',
+            line: 5,
+            message: 'Token "color.brand.500" is used in forbidden context "data-visualization"',
+            evidence: { snippet: '' },
+            rule: { id: 'BRAND-T001', category: 'token-misuse' },
+            fix: { kind: 'manual', description: 'Pick an approved alternative token' },
+          },
+          {
+            code: 'BRAND-V001',
+            severity: 'warn',
+            file: 'src/Hero.tsx',
+            line: 12,
+            message: 'UI copy contains forbidden phrase "click here"',
+            evidence: { snippet: 'Click here' },
+            rule: { id: 'BRAND-V001', category: 'voice' },
+            fix: { kind: 'manual', description: 'Rewrite to avoid "click here"' },
+          },
+        ],
+        summary: {
+          totalFiles: 1,
+          durationMs: 3,
+          bySeverity: { error: 1, warn: 1, info: 0 },
+          byCode: { 'BRAND-T001': 1, 'BRAND-V001': 1 },
+        },
+        catalog: { rulesApplied: ['token-misuse', 'forbidden-phrases'] },
+        meta: { mode: 'fast', designMdLoaded: true, brandTokensLoaded: true },
+      });
+
+      const result = await runCheckDesign({ cwd: '/tmp/test' });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.findingsByVerifier.brand).toHaveLength(2);
+      expect(result.value.summary.bySeverity.error).toBe(1);
+      expect(result.value.summary.bySeverity.warn).toBe(1);
+      expect(result.value.summary.byCode['BRAND-T001']).toBe(1);
+      expect(result.value.summary.byCode['BRAND-V001']).toBe(1);
+      expect(result.value.valid).toBe(false);
     });
   });
 

--- a/packages/cli/tests/mcp/server-integration.test.ts
+++ b/packages/cli/tests/mcp/server-integration.test.ts
@@ -65,7 +65,9 @@ describe('MCP Server Integration', () => {
     expect(names).toContain('detect_drift');
     // design-pipeline #1 (align half)
     expect(names).toContain('align_design_system');
-    expect(tools).toHaveLength(72);
+    // design-pipeline #3 — audit-brand-compliance
+    expect(names).toContain('audit_brand');
+    expect(tools).toHaveLength(73);
   });
 
   it('all tool definitions have inputSchema', () => {

--- a/packages/cli/tests/mcp/server.test.ts
+++ b/packages/cli/tests/mcp/server.test.ts
@@ -11,9 +11,9 @@ describe('MCP Server', () => {
     expect(server).toBeDefined();
   });
 
-  it('registers all 72 tools', () => {
+  it('registers all 73 tools', () => {
     const tools = getToolDefinitions();
-    expect(tools).toHaveLength(72);
+    expect(tools).toHaveLength(73);
   });
 
   it('registers all 9 resources', () => {


### PR DESCRIPTION
## Summary

Ships **audit-brand-compliance** — the last unshipped floor-layer audit (design-pipeline sub-project #3). Closes the floor layer entirely and unblocks #5 (the design-pipeline orchestrator).

**Two rule families in v1 (narrow + deep):**

- **BRAND-T001 (token misuse)** — flags tokens used in contexts declared as `forbidden_contexts` in `$extensions.harness.brand`. Recognizes three reference forms: `tokens.X.Y.Z`, `var(--X-Y-Z)`, and `'X.Y.Z'` string literals. Context inference v1 uses same-line + adjacent-non-blank-line vocabulary scan.
- **BRAND-V001 (forbidden phrases)** — TS Compiler API walk over `.tsx`/`.jsx` files. Scans `JsxText` nodes and string-typed `JsxAttribute` initializers for case-insensitive substring matches against `voice.forbiddenPhrases` from `DESIGN.md ## Brand Rules`.

**Three decisions locked:**

1. v1 rule scope — BRAND-T* + BRAND-V001 only. Defers tone-by-context, reading-level / sentence-length, asset rules, and semantic-token-alias enforcement to v1.x.
2. Input sources — Both `DESIGN.md ## Brand Rules` AND `tokens.json $extensions.harness.brand` (per ADR 0028).
3. check-design composition — 4th verifier (triggers the long-deferred `Verifier<F>` interface extraction).

**Cross-cutting: Verifier interface extraction**

The convention note in `check-design.ts` deferred extracting a formal Verifier interface until the 3rd check-\* command. Brand makes 4 verifiers in `harness check-design`. This PR extracts:

```ts
// packages/cli/src/shared/verifier.ts
export interface Verifier<F, Cat = ..., Meta = ...> {
  findings: F[];
  summary: { totalFiles, durationMs, bySeverity, byCode };
  catalog: Cat;
  meta: Meta;
}
```

`audit-anatomy` + `detect-drift` + `audit-brand` declare structural conformance via type aliases (TypeScript structural typing satisfies the interface without refactor). `design-craft` has a different output shape (cost telemetry, exemplar citations) and remains composed but does not conform — by design.

**Surface area:**

- `audit_brand` MCP tool (count 72 → 73)
- `harness validate` fast-mode hook gated by `design.audit.brandCompliance.enabled`
- 4th verifier in `harness check-design` (degrades gracefully on failure)
- New `design.audit.brandCompliance.{enabled, rules, fastMode}` config block
- 4-platform skill markdown (claude-code / codex / cursor / gemini-cli)

## Test plan

- [x] `pnpm --filter @harness-engineering/cli exec vitest run tests/brand tests/commands/check-design.test.ts tests/mcp` — 821/821 pass
- [x] End-to-end smoke: project with DESIGN.md voice.forbidden_phrases + tokens.json $extensions.harness.brand. Sources flagged correctly:
  - BRAND-T001 fires on `tokens.color.brand.500` adjacent to `// data-visualization` comment (forbidden context)
  - BRAND-V001 fires on `<a title="best-in-class">Click here</a>` (both `click here` and `best-in-class`)
- [x] Auto-doc regeneration — `audit_brand` MCP tool + `audit-brand-compliance` skill surface in docs/reference/{mcp-tools,skills-catalog}.md

## Design-pipeline state after merge

Floor layer fully closed:
- ✅ #0 brand-guidelines (ADR 0028)
- ✅ #1 detect + align (PRs #396, #397)
- ✅ #2 audit-component-anatomy (PR #372)
- ✅ #3 audit-brand-compliance (this PR)
- ✅ #4 check-design verifier (PR #394, now composes all 4 verifiers + extracted Verifier<F>)

Ceiling layer:
- ✅ #6 design-craft-elevator Phase 1 (PR #372)

Integrating:
- ⏳ #5 design-pipeline orchestrator (NOW UNBLOCKED — composes #1-#4 + #6 in FRESHEN/DETECT/FIX/AUDIT/FILL/REPORT loop)