### PR TITLE
feat(cli): naming-craft (craft-pipeline #1)

### DIFF
--- a/.changeset/naming-craft.md
+++ b/.changeset/naming-craft.md
@@ -1,0 +1,46 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Add **naming-craft** — first member of the craft-pipeline initiative (sub-project #1 of 10). LLM-judgment skill that critiques identifier names (variables, functions, types, files) against a curated rubric catalog seeded from Martin / Beck / Karlton.
+
+**Three decisions locked in the spec:**
+
+1. **v1 identifier kinds: variables + functions + types + files.** Covers ~80% of naming value in TS codebases. Modules / branches / commit subjects deferred to v1.x (different infrastructure; commit subjects belong to copy-craft #5).
+2. **Convention source: catalog-only + derived-from-code.** No project input required. Universal rubrics ship in the default catalog; case convention (camelCase / snake_case / PascalCase) is sampled from the project's existing identifiers via majority-rule (>50% threshold). Below threshold → silent skip of convention-conformance rubric.
+3. **Living catalog H (ADR 0020).** Mirrors design-craft's catalog pattern. Seed rubrics with `contribution` / `signal` / `version` fields reserved for future growth mechanism.
+
+**6 seed rubrics** (one file per rubric, matches design-craft layout):
+
+- `NAME-R001` predictive power (Martin)
+- `NAME-R002` concreteness (Martin / Beck)
+- `NAME-R003` verb/noun honesty (Beck)
+- `NAME-R004` convention conformance (Karlton)
+- `NAME-R005` scope match (Beck)
+- `NAME-R006` encoded measure / unit (Pragmatic Programmer)
+
+**Honors ADRs 0018-0021:**
+
+- ADR 0018 (LLM-judgment skill pattern): confidence is first-class on every finding; LlmProvider records cost telemetry.
+- ADR 0019 (3-axis output): tier × impact × confidence emitted on every finding, never collapsed to single severity.
+- ADR 0020 (living catalog H): every finding carries `cite.rubricId` for catalog usage signal; rubric `signal`/`contribution`/`version` fields ship reserved.
+
+**Cross-cutting:** other craft skills (docs-craft / test-craft / code-craft) will call `critiqueNamesInFile(file, opts)` — exported entry point that operates on a single file without project re-walk. Pre-computed convention can be passed through to avoid re-sampling per consumer.
+
+**Reuses design-craft infrastructure:** imports `LlmProvider` + `MockLlmProvider` + `derivePriority` directly. Extraction to `packages/cli/src/shared/llm/` deferred until a second non-design craft skill needs differences (v2 decision).
+
+**Surface area:**
+
+- `harness naming-craft` CLI command (`--files` / `--kinds` / `--max-files` / `--max-identifiers-per-file` / `--json` / `--verbose`)
+- `naming_craft` MCP tool (count 73 → 74)
+- 4-platform skill markdown (claude-code / codex / cursor / gemini-cli)
+- New `craft.naming.{enabled, maxFiles, maxIdentifiersPerFile}` config block under a new top-level `craft.*` namespace
+- Cross-cutting API: `runNamingCraft(input)` + `critiqueNamesInFile(file, opts)`
+
+**Tests:** 22 new unit + integration tests across extractor, convention sampler, classifier, critique phase, and end-to-end pipeline (with mock LLM provider). 801 tests pass across the cli suite. Smoke-tested end-to-end on a fixture file: 23 findings emitted from 6 rubrics × ~5 identifiers; convention sampler correctly derives `camelCase` for variables/functions and `null` for types (single type sample insufficient for majority).
+
+**Long-term trajectory:**
+
+- v1.x: module / branch / commit-subject naming; POLISH phase; per-project rubric overrides; per-language (Python / Go / Rust) idiom catalogs; `align-naming` sibling FIX skill once safe-rename heuristics mature.
+- v2: extract shared craft infrastructure (`LlmProvider` + 3-axis types + `derivePriority`) to `packages/cli/src/shared/craft/` when a second non-design craft skill lands; cross-craft convergence inside the (future) craft-pipeline orchestrator with shared `pipeline.namingFindings` field.
+- v3: aesthetic-intent-aware naming — when project has declared `harness-design` aesthetic intent, naming critique matches identifier verbosity to that aesthetic (terse for minimalist, descriptive for verbose).

--- a/agents/skills/claude-code/naming-craft/SKILL.md
+++ b/agents/skills/claude-code/naming-craft/SKILL.md
@@ -1,0 +1,172 @@
+# Naming Craft
+
+> LLM-judgment skill that critiques identifier names — variables, functions, types, and files — for clarity, concreteness, weight, and predictive power. First member of the craft-pipeline initiative (sub-project #1 of 10). Uses a curated rubric catalog seeded from Martin / Beck / Karlton. Emits 3-axis findings (tier × impact × confidence per ADR 0019).
+
+## When to Use
+
+- During PR review on code that adds or renames identifiers
+- When onboarding a new contributor (audit names they introduced)
+- When refactoring a module (verify renamed names earn their letters)
+- As the cross-cutting naming critic for other craft skills (docs-craft, test-craft, code-craft will call into this)
+- NOT for code-convention enforcement (use ESLint rules — this is ceiling, those are floor)
+- NOT for autofix / rename codemod (this is judgment-only; the v2 sibling `align-naming` ships the fix path)
+- NOT for module / branch / commit-subject naming (v1.x — different infrastructure)
+- NOT for languages beyond TS/JS in v1 (Python/Go/Rust idiom catalogs are v1.x)
+
+## Process
+
+### Phase 1: EXTRACT — Identifier walk
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `craft.naming.enabled` — gate (default `true`)
+   - `craft.naming.maxFiles` — file count cap (default 100)
+   - `craft.naming.maxIdentifiersPerFile` — per-file sampling cap (default 15)
+
+2. **Walk project files** (.ts / .tsx / .js / .jsx). Skip `node_modules`, `dist`, `build`, `coverage`, dotdirs.
+
+3. **Extract identifiers per file** via TS Compiler API:
+   - **variable** — `const x =`, `let x =`, destructuring binders
+   - **function** — `function x()`, `const x = () =>`, class methods, arrow functions assigned to a name
+   - **type** — `type X`, `interface X`, `class X`
+   - For each: capture file, line, exported status, scope size (`short` = body ≤10 lines; `long` = otherwise), and ±2 context lines for LLM prompt construction.
+
+### Phase 2: SAMPLE — Convention inference
+
+For each identifier kind, sample up to N=500 identifiers across the project and infer the dominant convention via majority-rule:
+
+- **variables / functions** — camelCase / snake_case / PascalCase
+- **types** — PascalCase / camelCase
+- **files** — kebab-case / camelCase / PascalCase (basenames sans extension)
+
+`>50%` majority threshold per kind. Below threshold → `null` (no dominant convention) and the convention-conformance rubric silently skips.
+
+### Phase 3: CRITIQUE — Per-rubric LLM loop
+
+For each file:
+
+1. **Sample identifiers** weighted by importance:
+   - Exported identifiers first
+   - Then long-scope (file-level, methods on long classes)
+   - Then short-scope random fill
+   - Cap at `maxIdentifiersPerFile` per file (default 15).
+
+2. **For each (identifier, rubric)** in the cross-product:
+   - Build a prompt with rubric description + identifier + context lines + project convention.
+   - LLM returns fenced JSON: either `null` (rubric doesn't apply / name is fine) or `{ tier, impact, confidence, message }`.
+   - On non-null: emit a `NamingFinding` with `cite.rubricId` populated for ADR 0020 traceability.
+
+3. **v1 rubric catalog (6 seed rubrics):**
+   - `NAME-R001` **predictive power** (Martin) — does the name predict the contract?
+   - `NAME-R002` **concreteness** (Martin / Beck) — concrete > vague
+   - `NAME-R003` **verb/noun honesty** (Beck) — verb for functions; noun for types; questions for booleans
+   - `NAME-R004` **convention conformance** (Karlton) — matches project convention
+   - `NAME-R005` **scope match** (Beck) — length proportional to scope
+   - `NAME-R006` **encoded measure** (Pragmatic Programmer) — silent units cause real bugs
+
+### Phase 4: REPORT — Aggregate + cost telemetry
+
+Emit `NamingCraftOutput`:
+
+```ts
+{
+  findings: NamingFinding[];
+  summary: {
+    phaseRun: ['critique'];
+    durationMs: number;
+    llmCalls: { provider, model, count, costUsd };
+    catalog: { rubricsApplied: string[] };
+    convention: { variables, functions, types, files };
+    runId: string;
+  }
+}
+```
+
+## Harness Integration
+
+- **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
+- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
+- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+
+## Success Criteria
+
+See `docs/changes/craft-pipeline/naming-craft/proposal.md` for the full 34 success criteria. Highlights:
+
+- 6 seed rubrics ship in `catalog/rubrics/<id>.ts` (file-per-rubric matches design-craft pattern)
+- 3-axis output preserved (tier × impact × confidence, never collapsed) per ADR 0019
+- `cite.rubricId` populated on every finding per ADR 0020
+- Convention sampler returns `null` when no dominant convention (>50% threshold)
+- Cross-cutting `critiqueNamesInFile` API exported for future craft skills
+- LlmProvider / MockLlmProvider IMPORTED from design-craft (no duplication)
+- MCP tool count bumps (running total maintained by parallel PRs)
+
+## Examples
+
+### Example: Vague function name
+
+**Input:** `src/orders/processor.ts`:
+
+```ts
+export function processData(orders: Order[]) { ... }
+```
+
+**Output (mock LLM):**
+
+```
+NAME-R002 [polish/medium/low] function processData:14
+  "processData" is a vague verb-pair where the operation and subject
+  are both unstated. Consider `applyDiscountsToOrders` or
+  `convertOrdersToInvoices` depending on the actual transform.
+NAME-R001 [polish/medium/medium] function processData:14
+  The name predicts neither the input shape (orders) nor the operation.
+```
+
+(Real LLM responses vary; mock provider returns deterministic low-confidence findings for test determinism.)
+
+### Example: Silent unit
+
+**Input:**
+
+```ts
+const timeout = 5000;
+```
+
+**Output:**
+
+```
+NAME-R006 [foundational/medium/high] variable timeout:1
+  "timeout" implies a time measure but the unit is silent. Use
+  `timeoutMs` so the call site can't be misread as seconds.
+```
+
+### Example: Mixed-convention project — convention sampler returns null
+
+**Input:** A project with 60% camelCase, 30% snake_case, 10% PascalCase variables. No >50% camelCase majority (60% IS >50%, so convention=camelCase). But with 45/40/15 split: no convention.
+
+**Output:** convention-conformance rubric (NAME-R004) silently skips for the variables kind. Other rubrics still run.
+
+## Gates
+
+- **No autofix.** This is ceiling-judgment. v2's `align-naming` may add safe-rename codemods.
+- **No NAMING.md authoring.** v1 derives convention from sampling.
+- **No language support beyond TS/JS.** v1.x.
+- **No modules / branches / commit subjects.** v1.x (and commit subjects go to copy-craft #5).
+- **No graph persistence.** Phase 1 MVP posture (matches design-craft).
+- **No deep/vision mode.** Naming is text-only.
+
+## Escalation
+
+- **When LLM cost is too high on a large project:** drop `maxIdentifiersPerFile` to 10 or `maxFiles` to 50. Cost = files × identifiers × rubrics × per-call cost.
+- **When a rubric produces high false-positive rate:** v1 has no per-rubric disable; v1.x adds `craft.naming.disabledRubrics: ['NAME-R005']`. Until then: filter findings by `cite.rubricId` in your consumer.
+- **When the convention sampler misidentifies a mid-migration project:** below 50% threshold returns null and convention rubric skips. Better silent skip than wrong findings. Wait until migration completes; until then disable NAME-R004 in v1.x or filter findings.
+- **When you want naming critique for a single file (e.g. in CI on changed files):** use `--files <glob>` or call `critiqueNamesInFile()` via the cross-cutting API.
+- **When you want module / branch / commit-subject naming today:** manual review. v1.x adds these surfaces.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/craft-pipeline/naming-craft/proposal.md`
+- Roadmap entry: `craft-pipeline sub-project #1` (the first member)
+- Sibling: `harness-design-craft` (design-pipeline #6 — the LLM-judgment template this follows)
+- Future cross-cutters: docs-craft (#2), test-craft (#3), code-craft (#4) will call into naming-craft's `critiqueNamesInFile()` for their domain-specific naming critique.

--- a/agents/skills/claude-code/naming-craft/skill.yaml
+++ b/agents/skills/claude-code/naming-craft/skill.yaml
@@ -1,0 +1,51 @@
+name: naming-craft
+version: "0.1.0"
+description: LLM-judgment skill that critiques identifier names (variables, functions, types, files) against a curated rubric catalog seeded from Martin / Beck / Karlton. First craft-pipeline ceiling skill; cross-cutting (other craft skills call into it for domain-specific naming).
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness naming-craft
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: files
+      description: Optional file/glob scope
+      required: false
+    - name: kinds
+      description: Restrict to variable / function / type / file
+      required: false
+mcp:
+  tool: naming_craft
+  input:
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: extract
+    description: TS Compiler API walk; gather identifiers + scope metadata + context lines
+    required: true
+  - name: sample
+    description: Derive project naming convention via majority-rule sampling
+    required: true
+  - name: critique
+    description: LLM-rubric loop per (identifier, rubric) pair; emit 3-axis findings
+    required: true
+  - name: report
+    description: Aggregate findings + LLM cost + convention summary
+    required: true
+state:
+  persistent: false
+depends_on:
+  - harness-design-craft

--- a/agents/skills/codex/naming-craft/SKILL.md
+++ b/agents/skills/codex/naming-craft/SKILL.md
@@ -1,0 +1,172 @@
+# Naming Craft
+
+> LLM-judgment skill that critiques identifier names — variables, functions, types, and files — for clarity, concreteness, weight, and predictive power. First member of the craft-pipeline initiative (sub-project #1 of 10). Uses a curated rubric catalog seeded from Martin / Beck / Karlton. Emits 3-axis findings (tier × impact × confidence per ADR 0019).
+
+## When to Use
+
+- During PR review on code that adds or renames identifiers
+- When onboarding a new contributor (audit names they introduced)
+- When refactoring a module (verify renamed names earn their letters)
+- As the cross-cutting naming critic for other craft skills (docs-craft, test-craft, code-craft will call into this)
+- NOT for code-convention enforcement (use ESLint rules — this is ceiling, those are floor)
+- NOT for autofix / rename codemod (this is judgment-only; the v2 sibling `align-naming` ships the fix path)
+- NOT for module / branch / commit-subject naming (v1.x — different infrastructure)
+- NOT for languages beyond TS/JS in v1 (Python/Go/Rust idiom catalogs are v1.x)
+
+## Process
+
+### Phase 1: EXTRACT — Identifier walk
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `craft.naming.enabled` — gate (default `true`)
+   - `craft.naming.maxFiles` — file count cap (default 100)
+   - `craft.naming.maxIdentifiersPerFile` — per-file sampling cap (default 15)
+
+2. **Walk project files** (.ts / .tsx / .js / .jsx). Skip `node_modules`, `dist`, `build`, `coverage`, dotdirs.
+
+3. **Extract identifiers per file** via TS Compiler API:
+   - **variable** — `const x =`, `let x =`, destructuring binders
+   - **function** — `function x()`, `const x = () =>`, class methods, arrow functions assigned to a name
+   - **type** — `type X`, `interface X`, `class X`
+   - For each: capture file, line, exported status, scope size (`short` = body ≤10 lines; `long` = otherwise), and ±2 context lines for LLM prompt construction.
+
+### Phase 2: SAMPLE — Convention inference
+
+For each identifier kind, sample up to N=500 identifiers across the project and infer the dominant convention via majority-rule:
+
+- **variables / functions** — camelCase / snake_case / PascalCase
+- **types** — PascalCase / camelCase
+- **files** — kebab-case / camelCase / PascalCase (basenames sans extension)
+
+`>50%` majority threshold per kind. Below threshold → `null` (no dominant convention) and the convention-conformance rubric silently skips.
+
+### Phase 3: CRITIQUE — Per-rubric LLM loop
+
+For each file:
+
+1. **Sample identifiers** weighted by importance:
+   - Exported identifiers first
+   - Then long-scope (file-level, methods on long classes)
+   - Then short-scope random fill
+   - Cap at `maxIdentifiersPerFile` per file (default 15).
+
+2. **For each (identifier, rubric)** in the cross-product:
+   - Build a prompt with rubric description + identifier + context lines + project convention.
+   - LLM returns fenced JSON: either `null` (rubric doesn't apply / name is fine) or `{ tier, impact, confidence, message }`.
+   - On non-null: emit a `NamingFinding` with `cite.rubricId` populated for ADR 0020 traceability.
+
+3. **v1 rubric catalog (6 seed rubrics):**
+   - `NAME-R001` **predictive power** (Martin) — does the name predict the contract?
+   - `NAME-R002` **concreteness** (Martin / Beck) — concrete > vague
+   - `NAME-R003` **verb/noun honesty** (Beck) — verb for functions; noun for types; questions for booleans
+   - `NAME-R004` **convention conformance** (Karlton) — matches project convention
+   - `NAME-R005` **scope match** (Beck) — length proportional to scope
+   - `NAME-R006` **encoded measure** (Pragmatic Programmer) — silent units cause real bugs
+
+### Phase 4: REPORT — Aggregate + cost telemetry
+
+Emit `NamingCraftOutput`:
+
+```ts
+{
+  findings: NamingFinding[];
+  summary: {
+    phaseRun: ['critique'];
+    durationMs: number;
+    llmCalls: { provider, model, count, costUsd };
+    catalog: { rubricsApplied: string[] };
+    convention: { variables, functions, types, files };
+    runId: string;
+  }
+}
+```
+
+## Harness Integration
+
+- **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
+- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
+- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+
+## Success Criteria
+
+See `docs/changes/craft-pipeline/naming-craft/proposal.md` for the full 34 success criteria. Highlights:
+
+- 6 seed rubrics ship in `catalog/rubrics/<id>.ts` (file-per-rubric matches design-craft pattern)
+- 3-axis output preserved (tier × impact × confidence, never collapsed) per ADR 0019
+- `cite.rubricId` populated on every finding per ADR 0020
+- Convention sampler returns `null` when no dominant convention (>50% threshold)
+- Cross-cutting `critiqueNamesInFile` API exported for future craft skills
+- LlmProvider / MockLlmProvider IMPORTED from design-craft (no duplication)
+- MCP tool count bumps (running total maintained by parallel PRs)
+
+## Examples
+
+### Example: Vague function name
+
+**Input:** `src/orders/processor.ts`:
+
+```ts
+export function processData(orders: Order[]) { ... }
+```
+
+**Output (mock LLM):**
+
+```
+NAME-R002 [polish/medium/low] function processData:14
+  "processData" is a vague verb-pair where the operation and subject
+  are both unstated. Consider `applyDiscountsToOrders` or
+  `convertOrdersToInvoices` depending on the actual transform.
+NAME-R001 [polish/medium/medium] function processData:14
+  The name predicts neither the input shape (orders) nor the operation.
+```
+
+(Real LLM responses vary; mock provider returns deterministic low-confidence findings for test determinism.)
+
+### Example: Silent unit
+
+**Input:**
+
+```ts
+const timeout = 5000;
+```
+
+**Output:**
+
+```
+NAME-R006 [foundational/medium/high] variable timeout:1
+  "timeout" implies a time measure but the unit is silent. Use
+  `timeoutMs` so the call site can't be misread as seconds.
+```
+
+### Example: Mixed-convention project — convention sampler returns null
+
+**Input:** A project with 60% camelCase, 30% snake_case, 10% PascalCase variables. No >50% camelCase majority (60% IS >50%, so convention=camelCase). But with 45/40/15 split: no convention.
+
+**Output:** convention-conformance rubric (NAME-R004) silently skips for the variables kind. Other rubrics still run.
+
+## Gates
+
+- **No autofix.** This is ceiling-judgment. v2's `align-naming` may add safe-rename codemods.
+- **No NAMING.md authoring.** v1 derives convention from sampling.
+- **No language support beyond TS/JS.** v1.x.
+- **No modules / branches / commit subjects.** v1.x (and commit subjects go to copy-craft #5).
+- **No graph persistence.** Phase 1 MVP posture (matches design-craft).
+- **No deep/vision mode.** Naming is text-only.
+
+## Escalation
+
+- **When LLM cost is too high on a large project:** drop `maxIdentifiersPerFile` to 10 or `maxFiles` to 50. Cost = files × identifiers × rubrics × per-call cost.
+- **When a rubric produces high false-positive rate:** v1 has no per-rubric disable; v1.x adds `craft.naming.disabledRubrics: ['NAME-R005']`. Until then: filter findings by `cite.rubricId` in your consumer.
+- **When the convention sampler misidentifies a mid-migration project:** below 50% threshold returns null and convention rubric skips. Better silent skip than wrong findings. Wait until migration completes; until then disable NAME-R004 in v1.x or filter findings.
+- **When you want naming critique for a single file (e.g. in CI on changed files):** use `--files <glob>` or call `critiqueNamesInFile()` via the cross-cutting API.
+- **When you want module / branch / commit-subject naming today:** manual review. v1.x adds these surfaces.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/craft-pipeline/naming-craft/proposal.md`
+- Roadmap entry: `craft-pipeline sub-project #1` (the first member)
+- Sibling: `harness-design-craft` (design-pipeline #6 — the LLM-judgment template this follows)
+- Future cross-cutters: docs-craft (#2), test-craft (#3), code-craft (#4) will call into naming-craft's `critiqueNamesInFile()` for their domain-specific naming critique.

--- a/agents/skills/codex/naming-craft/skill.yaml
+++ b/agents/skills/codex/naming-craft/skill.yaml
@@ -1,0 +1,51 @@
+name: naming-craft
+version: "0.1.0"
+description: LLM-judgment skill that critiques identifier names (variables, functions, types, files) against a curated rubric catalog seeded from Martin / Beck / Karlton. First craft-pipeline ceiling skill; cross-cutting (other craft skills call into it for domain-specific naming).
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness naming-craft
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: files
+      description: Optional file/glob scope
+      required: false
+    - name: kinds
+      description: Restrict to variable / function / type / file
+      required: false
+mcp:
+  tool: naming_craft
+  input:
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: extract
+    description: TS Compiler API walk; gather identifiers + scope metadata + context lines
+    required: true
+  - name: sample
+    description: Derive project naming convention via majority-rule sampling
+    required: true
+  - name: critique
+    description: LLM-rubric loop per (identifier, rubric) pair; emit 3-axis findings
+    required: true
+  - name: report
+    description: Aggregate findings + LLM cost + convention summary
+    required: true
+state:
+  persistent: false
+depends_on:
+  - harness-design-craft

--- a/agents/skills/cursor/naming-craft/SKILL.md
+++ b/agents/skills/cursor/naming-craft/SKILL.md
@@ -1,0 +1,172 @@
+# Naming Craft
+
+> LLM-judgment skill that critiques identifier names — variables, functions, types, and files — for clarity, concreteness, weight, and predictive power. First member of the craft-pipeline initiative (sub-project #1 of 10). Uses a curated rubric catalog seeded from Martin / Beck / Karlton. Emits 3-axis findings (tier × impact × confidence per ADR 0019).
+
+## When to Use
+
+- During PR review on code that adds or renames identifiers
+- When onboarding a new contributor (audit names they introduced)
+- When refactoring a module (verify renamed names earn their letters)
+- As the cross-cutting naming critic for other craft skills (docs-craft, test-craft, code-craft will call into this)
+- NOT for code-convention enforcement (use ESLint rules — this is ceiling, those are floor)
+- NOT for autofix / rename codemod (this is judgment-only; the v2 sibling `align-naming` ships the fix path)
+- NOT for module / branch / commit-subject naming (v1.x — different infrastructure)
+- NOT for languages beyond TS/JS in v1 (Python/Go/Rust idiom catalogs are v1.x)
+
+## Process
+
+### Phase 1: EXTRACT — Identifier walk
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `craft.naming.enabled` — gate (default `true`)
+   - `craft.naming.maxFiles` — file count cap (default 100)
+   - `craft.naming.maxIdentifiersPerFile` — per-file sampling cap (default 15)
+
+2. **Walk project files** (.ts / .tsx / .js / .jsx). Skip `node_modules`, `dist`, `build`, `coverage`, dotdirs.
+
+3. **Extract identifiers per file** via TS Compiler API:
+   - **variable** — `const x =`, `let x =`, destructuring binders
+   - **function** — `function x()`, `const x = () =>`, class methods, arrow functions assigned to a name
+   - **type** — `type X`, `interface X`, `class X`
+   - For each: capture file, line, exported status, scope size (`short` = body ≤10 lines; `long` = otherwise), and ±2 context lines for LLM prompt construction.
+
+### Phase 2: SAMPLE — Convention inference
+
+For each identifier kind, sample up to N=500 identifiers across the project and infer the dominant convention via majority-rule:
+
+- **variables / functions** — camelCase / snake_case / PascalCase
+- **types** — PascalCase / camelCase
+- **files** — kebab-case / camelCase / PascalCase (basenames sans extension)
+
+`>50%` majority threshold per kind. Below threshold → `null` (no dominant convention) and the convention-conformance rubric silently skips.
+
+### Phase 3: CRITIQUE — Per-rubric LLM loop
+
+For each file:
+
+1. **Sample identifiers** weighted by importance:
+   - Exported identifiers first
+   - Then long-scope (file-level, methods on long classes)
+   - Then short-scope random fill
+   - Cap at `maxIdentifiersPerFile` per file (default 15).
+
+2. **For each (identifier, rubric)** in the cross-product:
+   - Build a prompt with rubric description + identifier + context lines + project convention.
+   - LLM returns fenced JSON: either `null` (rubric doesn't apply / name is fine) or `{ tier, impact, confidence, message }`.
+   - On non-null: emit a `NamingFinding` with `cite.rubricId` populated for ADR 0020 traceability.
+
+3. **v1 rubric catalog (6 seed rubrics):**
+   - `NAME-R001` **predictive power** (Martin) — does the name predict the contract?
+   - `NAME-R002` **concreteness** (Martin / Beck) — concrete > vague
+   - `NAME-R003` **verb/noun honesty** (Beck) — verb for functions; noun for types; questions for booleans
+   - `NAME-R004` **convention conformance** (Karlton) — matches project convention
+   - `NAME-R005` **scope match** (Beck) — length proportional to scope
+   - `NAME-R006` **encoded measure** (Pragmatic Programmer) — silent units cause real bugs
+
+### Phase 4: REPORT — Aggregate + cost telemetry
+
+Emit `NamingCraftOutput`:
+
+```ts
+{
+  findings: NamingFinding[];
+  summary: {
+    phaseRun: ['critique'];
+    durationMs: number;
+    llmCalls: { provider, model, count, costUsd };
+    catalog: { rubricsApplied: string[] };
+    convention: { variables, functions, types, files };
+    runId: string;
+  }
+}
+```
+
+## Harness Integration
+
+- **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
+- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
+- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+
+## Success Criteria
+
+See `docs/changes/craft-pipeline/naming-craft/proposal.md` for the full 34 success criteria. Highlights:
+
+- 6 seed rubrics ship in `catalog/rubrics/<id>.ts` (file-per-rubric matches design-craft pattern)
+- 3-axis output preserved (tier × impact × confidence, never collapsed) per ADR 0019
+- `cite.rubricId` populated on every finding per ADR 0020
+- Convention sampler returns `null` when no dominant convention (>50% threshold)
+- Cross-cutting `critiqueNamesInFile` API exported for future craft skills
+- LlmProvider / MockLlmProvider IMPORTED from design-craft (no duplication)
+- MCP tool count bumps (running total maintained by parallel PRs)
+
+## Examples
+
+### Example: Vague function name
+
+**Input:** `src/orders/processor.ts`:
+
+```ts
+export function processData(orders: Order[]) { ... }
+```
+
+**Output (mock LLM):**
+
+```
+NAME-R002 [polish/medium/low] function processData:14
+  "processData" is a vague verb-pair where the operation and subject
+  are both unstated. Consider `applyDiscountsToOrders` or
+  `convertOrdersToInvoices` depending on the actual transform.
+NAME-R001 [polish/medium/medium] function processData:14
+  The name predicts neither the input shape (orders) nor the operation.
+```
+
+(Real LLM responses vary; mock provider returns deterministic low-confidence findings for test determinism.)
+
+### Example: Silent unit
+
+**Input:**
+
+```ts
+const timeout = 5000;
+```
+
+**Output:**
+
+```
+NAME-R006 [foundational/medium/high] variable timeout:1
+  "timeout" implies a time measure but the unit is silent. Use
+  `timeoutMs` so the call site can't be misread as seconds.
+```
+
+### Example: Mixed-convention project — convention sampler returns null
+
+**Input:** A project with 60% camelCase, 30% snake_case, 10% PascalCase variables. No >50% camelCase majority (60% IS >50%, so convention=camelCase). But with 45/40/15 split: no convention.
+
+**Output:** convention-conformance rubric (NAME-R004) silently skips for the variables kind. Other rubrics still run.
+
+## Gates
+
+- **No autofix.** This is ceiling-judgment. v2's `align-naming` may add safe-rename codemods.
+- **No NAMING.md authoring.** v1 derives convention from sampling.
+- **No language support beyond TS/JS.** v1.x.
+- **No modules / branches / commit subjects.** v1.x (and commit subjects go to copy-craft #5).
+- **No graph persistence.** Phase 1 MVP posture (matches design-craft).
+- **No deep/vision mode.** Naming is text-only.
+
+## Escalation
+
+- **When LLM cost is too high on a large project:** drop `maxIdentifiersPerFile` to 10 or `maxFiles` to 50. Cost = files × identifiers × rubrics × per-call cost.
+- **When a rubric produces high false-positive rate:** v1 has no per-rubric disable; v1.x adds `craft.naming.disabledRubrics: ['NAME-R005']`. Until then: filter findings by `cite.rubricId` in your consumer.
+- **When the convention sampler misidentifies a mid-migration project:** below 50% threshold returns null and convention rubric skips. Better silent skip than wrong findings. Wait until migration completes; until then disable NAME-R004 in v1.x or filter findings.
+- **When you want naming critique for a single file (e.g. in CI on changed files):** use `--files <glob>` or call `critiqueNamesInFile()` via the cross-cutting API.
+- **When you want module / branch / commit-subject naming today:** manual review. v1.x adds these surfaces.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/craft-pipeline/naming-craft/proposal.md`
+- Roadmap entry: `craft-pipeline sub-project #1` (the first member)
+- Sibling: `harness-design-craft` (design-pipeline #6 — the LLM-judgment template this follows)
+- Future cross-cutters: docs-craft (#2), test-craft (#3), code-craft (#4) will call into naming-craft's `critiqueNamesInFile()` for their domain-specific naming critique.

--- a/agents/skills/cursor/naming-craft/skill.yaml
+++ b/agents/skills/cursor/naming-craft/skill.yaml
@@ -1,0 +1,51 @@
+name: naming-craft
+version: "0.1.0"
+description: LLM-judgment skill that critiques identifier names (variables, functions, types, files) against a curated rubric catalog seeded from Martin / Beck / Karlton. First craft-pipeline ceiling skill; cross-cutting (other craft skills call into it for domain-specific naming).
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness naming-craft
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: files
+      description: Optional file/glob scope
+      required: false
+    - name: kinds
+      description: Restrict to variable / function / type / file
+      required: false
+mcp:
+  tool: naming_craft
+  input:
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: extract
+    description: TS Compiler API walk; gather identifiers + scope metadata + context lines
+    required: true
+  - name: sample
+    description: Derive project naming convention via majority-rule sampling
+    required: true
+  - name: critique
+    description: LLM-rubric loop per (identifier, rubric) pair; emit 3-axis findings
+    required: true
+  - name: report
+    description: Aggregate findings + LLM cost + convention summary
+    required: true
+state:
+  persistent: false
+depends_on:
+  - harness-design-craft

--- a/agents/skills/gemini-cli/naming-craft/SKILL.md
+++ b/agents/skills/gemini-cli/naming-craft/SKILL.md
@@ -1,0 +1,172 @@
+# Naming Craft
+
+> LLM-judgment skill that critiques identifier names — variables, functions, types, and files — for clarity, concreteness, weight, and predictive power. First member of the craft-pipeline initiative (sub-project #1 of 10). Uses a curated rubric catalog seeded from Martin / Beck / Karlton. Emits 3-axis findings (tier × impact × confidence per ADR 0019).
+
+## When to Use
+
+- During PR review on code that adds or renames identifiers
+- When onboarding a new contributor (audit names they introduced)
+- When refactoring a module (verify renamed names earn their letters)
+- As the cross-cutting naming critic for other craft skills (docs-craft, test-craft, code-craft will call into this)
+- NOT for code-convention enforcement (use ESLint rules — this is ceiling, those are floor)
+- NOT for autofix / rename codemod (this is judgment-only; the v2 sibling `align-naming` ships the fix path)
+- NOT for module / branch / commit-subject naming (v1.x — different infrastructure)
+- NOT for languages beyond TS/JS in v1 (Python/Go/Rust idiom catalogs are v1.x)
+
+## Process
+
+### Phase 1: EXTRACT — Identifier walk
+
+1. **Read project configuration.** Check `harness.config.json` for:
+   - `craft.naming.enabled` — gate (default `true`)
+   - `craft.naming.maxFiles` — file count cap (default 100)
+   - `craft.naming.maxIdentifiersPerFile` — per-file sampling cap (default 15)
+
+2. **Walk project files** (.ts / .tsx / .js / .jsx). Skip `node_modules`, `dist`, `build`, `coverage`, dotdirs.
+
+3. **Extract identifiers per file** via TS Compiler API:
+   - **variable** — `const x =`, `let x =`, destructuring binders
+   - **function** — `function x()`, `const x = () =>`, class methods, arrow functions assigned to a name
+   - **type** — `type X`, `interface X`, `class X`
+   - For each: capture file, line, exported status, scope size (`short` = body ≤10 lines; `long` = otherwise), and ±2 context lines for LLM prompt construction.
+
+### Phase 2: SAMPLE — Convention inference
+
+For each identifier kind, sample up to N=500 identifiers across the project and infer the dominant convention via majority-rule:
+
+- **variables / functions** — camelCase / snake_case / PascalCase
+- **types** — PascalCase / camelCase
+- **files** — kebab-case / camelCase / PascalCase (basenames sans extension)
+
+`>50%` majority threshold per kind. Below threshold → `null` (no dominant convention) and the convention-conformance rubric silently skips.
+
+### Phase 3: CRITIQUE — Per-rubric LLM loop
+
+For each file:
+
+1. **Sample identifiers** weighted by importance:
+   - Exported identifiers first
+   - Then long-scope (file-level, methods on long classes)
+   - Then short-scope random fill
+   - Cap at `maxIdentifiersPerFile` per file (default 15).
+
+2. **For each (identifier, rubric)** in the cross-product:
+   - Build a prompt with rubric description + identifier + context lines + project convention.
+   - LLM returns fenced JSON: either `null` (rubric doesn't apply / name is fine) or `{ tier, impact, confidence, message }`.
+   - On non-null: emit a `NamingFinding` with `cite.rubricId` populated for ADR 0020 traceability.
+
+3. **v1 rubric catalog (6 seed rubrics):**
+   - `NAME-R001` **predictive power** (Martin) — does the name predict the contract?
+   - `NAME-R002` **concreteness** (Martin / Beck) — concrete > vague
+   - `NAME-R003` **verb/noun honesty** (Beck) — verb for functions; noun for types; questions for booleans
+   - `NAME-R004` **convention conformance** (Karlton) — matches project convention
+   - `NAME-R005` **scope match** (Beck) — length proportional to scope
+   - `NAME-R006` **encoded measure** (Pragmatic Programmer) — silent units cause real bugs
+
+### Phase 4: REPORT — Aggregate + cost telemetry
+
+Emit `NamingCraftOutput`:
+
+```ts
+{
+  findings: NamingFinding[];
+  summary: {
+    phaseRun: ['critique'];
+    durationMs: number;
+    llmCalls: { provider, model, count, costUsd };
+    catalog: { rubricsApplied: string[] };
+    convention: { variables, functions, types, files };
+    runId: string;
+  }
+}
+```
+
+## Harness Integration
+
+- **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
+- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
+- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+
+## Success Criteria
+
+See `docs/changes/craft-pipeline/naming-craft/proposal.md` for the full 34 success criteria. Highlights:
+
+- 6 seed rubrics ship in `catalog/rubrics/<id>.ts` (file-per-rubric matches design-craft pattern)
+- 3-axis output preserved (tier × impact × confidence, never collapsed) per ADR 0019
+- `cite.rubricId` populated on every finding per ADR 0020
+- Convention sampler returns `null` when no dominant convention (>50% threshold)
+- Cross-cutting `critiqueNamesInFile` API exported for future craft skills
+- LlmProvider / MockLlmProvider IMPORTED from design-craft (no duplication)
+- MCP tool count bumps (running total maintained by parallel PRs)
+
+## Examples
+
+### Example: Vague function name
+
+**Input:** `src/orders/processor.ts`:
+
+```ts
+export function processData(orders: Order[]) { ... }
+```
+
+**Output (mock LLM):**
+
+```
+NAME-R002 [polish/medium/low] function processData:14
+  "processData" is a vague verb-pair where the operation and subject
+  are both unstated. Consider `applyDiscountsToOrders` or
+  `convertOrdersToInvoices` depending on the actual transform.
+NAME-R001 [polish/medium/medium] function processData:14
+  The name predicts neither the input shape (orders) nor the operation.
+```
+
+(Real LLM responses vary; mock provider returns deterministic low-confidence findings for test determinism.)
+
+### Example: Silent unit
+
+**Input:**
+
+```ts
+const timeout = 5000;
+```
+
+**Output:**
+
+```
+NAME-R006 [foundational/medium/high] variable timeout:1
+  "timeout" implies a time measure but the unit is silent. Use
+  `timeoutMs` so the call site can't be misread as seconds.
+```
+
+### Example: Mixed-convention project — convention sampler returns null
+
+**Input:** A project with 60% camelCase, 30% snake_case, 10% PascalCase variables. No >50% camelCase majority (60% IS >50%, so convention=camelCase). But with 45/40/15 split: no convention.
+
+**Output:** convention-conformance rubric (NAME-R004) silently skips for the variables kind. Other rubrics still run.
+
+## Gates
+
+- **No autofix.** This is ceiling-judgment. v2's `align-naming` may add safe-rename codemods.
+- **No NAMING.md authoring.** v1 derives convention from sampling.
+- **No language support beyond TS/JS.** v1.x.
+- **No modules / branches / commit subjects.** v1.x (and commit subjects go to copy-craft #5).
+- **No graph persistence.** Phase 1 MVP posture (matches design-craft).
+- **No deep/vision mode.** Naming is text-only.
+
+## Escalation
+
+- **When LLM cost is too high on a large project:** drop `maxIdentifiersPerFile` to 10 or `maxFiles` to 50. Cost = files × identifiers × rubrics × per-call cost.
+- **When a rubric produces high false-positive rate:** v1 has no per-rubric disable; v1.x adds `craft.naming.disabledRubrics: ['NAME-R005']`. Until then: filter findings by `cite.rubricId` in your consumer.
+- **When the convention sampler misidentifies a mid-migration project:** below 50% threshold returns null and convention rubric skips. Better silent skip than wrong findings. Wait until migration completes; until then disable NAME-R004 in v1.x or filter findings.
+- **When you want naming critique for a single file (e.g. in CI on changed files):** use `--files <glob>` or call `critiqueNamesInFile()` via the cross-cutting API.
+- **When you want module / branch / commit-subject naming today:** manual review. v1.x adds these surfaces.
+
+## Status
+
+**v1 — in implementation.** See:
+
+- Spec: `docs/changes/craft-pipeline/naming-craft/proposal.md`
+- Roadmap entry: `craft-pipeline sub-project #1` (the first member)
+- Sibling: `harness-design-craft` (design-pipeline #6 — the LLM-judgment template this follows)
+- Future cross-cutters: docs-craft (#2), test-craft (#3), code-craft (#4) will call into naming-craft's `critiqueNamesInFile()` for their domain-specific naming critique.

--- a/agents/skills/gemini-cli/naming-craft/skill.yaml
+++ b/agents/skills/gemini-cli/naming-craft/skill.yaml
@@ -1,0 +1,51 @@
+name: naming-craft
+version: "0.1.0"
+description: LLM-judgment skill that critiques identifier names (variables, functions, types, files) against a curated rubric catalog seeded from Martin / Beck / Karlton. First craft-pipeline ceiling skill; cross-cutting (other craft skills call into it for domain-specific naming).
+stability: draft
+cognitive_mode: constructive-architect
+triggers:
+  - manual
+  - on_pr
+  - on_new_feature
+platforms:
+  - claude-code
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+cli:
+  command: harness naming-craft
+  args:
+    - name: path
+      description: Project root path
+      required: false
+    - name: files
+      description: Optional file/glob scope
+      required: false
+    - name: kinds
+      description: Restrict to variable / function / type / file
+      required: false
+mcp:
+  tool: naming_craft
+  input:
+    path: string
+type: rigid
+tier: 2
+phases:
+  - name: extract
+    description: TS Compiler API walk; gather identifiers + scope metadata + context lines
+    required: true
+  - name: sample
+    description: Derive project naming convention via majority-rule sampling
+    required: true
+  - name: critique
+    description: LLM-rubric loop per (identifier, rubric) pair; emit 3-axis findings
+    required: true
+  - name: report
+    description: Aggregate findings + LLM cost + convention summary
+    required: true
+state:
+  persistent: false
+depends_on:
+  - harness-design-craft

--- a/docs/changes/craft-pipeline/naming-craft/proposal.md
+++ b/docs/changes/craft-pipeline/naming-craft/proposal.md
@@ -1,0 +1,418 @@
+# naming-craft v1
+
+> First member of the craft-pipeline initiative (sub-project #1 of 10). LLM-judgment skill that critiques identifier names — variables, functions, types, and files — for clarity, concreteness, weight, and predictive power. Follows ADRs 0018-0021 (LLM-judgment skill pattern + 3-axis output + living-catalog H + B' detect-and-offer). Cross-cutting: other craft skills (docs-craft, test-craft, code-craft) call into naming-craft for their domain-specific naming dimensions. The first non-design ceiling skill.
+
+## Overview
+
+**Project:** naming-craft (v1)
+**Initiative:** craft-pipeline (sub-project #1 of 10 — the first member)
+**Date:** 2026-05-24
+**Estimated effort:** ~1 week, single PR
+**Establishes:** the craft-pipeline pattern for non-design domains. design-craft-elevator (design-pipeline #6) proved the LLM-judgment pattern works; naming-craft is the next instance and the cross-cutting one other craft skills depend on.
+
+### What this ships
+
+A new skill + CLI command + MCP tool that:
+
+1. Walks the project's `.ts`/`.tsx`/`.js`/`.jsx` files (and the project's filenames themselves).
+2. Extracts identifiers via TS Compiler API: variables (const/let), functions (declarations + expressions), types (interface/type aliases), file names.
+3. Samples a few hundred identifiers and derives the project's naming convention via majority-rule (camelCase vs snake_case vs PascalCase per identifier kind).
+4. Invokes an LLM with a curated rubric catalog (seeded from Martin/Karlton/Beck) to critique a representative sample of identifiers per file.
+5. Emits 3-axis `NamingFinding`s (tier × impact × confidence per ADR 0019) — never collapsed to single severity.
+6. Records catalog usage signal per ADR 0020 so the rubric set grows from real-world friction.
+
+### What this does NOT ship
+
+- **No module/branch/commit-subject naming.** Modules are a TS concept that overlaps with file naming (defer to v1.x). Branches and commit subjects need git infrastructure (defer to v1.x); commit subjects are also explicitly in copy-craft's (#5) territory.
+- **No NAMING.md authoring or B' detect-and-offer.** v1 uses majority-rule sampling for convention derivation. B' is design-craft's premier infrastructure; copying it here without design-craft's B' having landed yet is premature.
+- **No autofix / rename codemod.** This is a ceiling-judgment skill, not a fix-applier. v2 may add an `align-naming` sibling once we have signal on what's safe to auto-rename.
+- **No per-project config gates beyond `craft.naming.enabled`.** Catalog scoping (which rubrics to apply) is v1.x.
+- **No graph writes for naming findings yet.** Same path as design-craft Phase 1: findings flow through the existing reporter; graph integration is a separate concern.
+- **No vision-LLM use.** Naming is a code-only critique by nature. No `mode: deep`.
+- **No cross-craft invocation contract yet.** v1 ships the naming-craft API; other craft skills will import + invoke it when THEY ship (docs-craft, test-craft, code-craft). The cross-cutting role is in the API design, not new infrastructure.
+- **No standalone language support beyond TypeScript/JavaScript.** Python/Go/Rust naming is real but each language has different idioms — adding language-specific rubrics is v1.x.
+
+### What problem this solves
+
+Naming is universally judgment-bound and universally bad. Rule-based linters catch case-convention violations but say nothing about whether `processData()` is a name worth keeping. Reviewers say "name this better" without a vocabulary for WHY a name falls short. naming-craft gives projects a programmatic critic that pulls from the canonical naming canon (Martin's _Clean Code_ chapter, Karlton's "two hard things", Beck's _Smalltalk Best Practices_) and surfaces specific findings: "this name predicts the data shape but not the operation"; "this name is a noun where the function is the verb"; "this name uses a metric/measure suffix the rest of the file doesn't establish". It's the first cross-cutting craft skill — once it ships, every other craft skill in the family can call into it for domain-specific naming critique.
+
+## Decisions
+
+| #   | Decision            | Lock                                      | Rationale                                                                                                                                                                                                                                   |
+| --- | ------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | v1 identifier kinds | **variables + functions + types + files** | Covers ~80% of naming value in TS codebases. Single PR scope. Modules / branches / commit subjects need different infrastructure (TS module graph + git log scan) and deferred to v1.x. Commit subjects are also in copy-craft's territory. |
+| 2   | Convention source   | **catalog-only + derived-from-code**      | No project input required. Universal rubrics ship in the default catalog; case convention is sampled from project's existing identifiers (majority rule per kind). v1.x adds per-project override + B' bootstrap if signal demands.         |
+| 3   | Catalog pattern     | **Living catalog H (ADR 0020)**           | Mirrors design-craft H decision. Seed + contribution + signal + measurement + versioning. Catalog evolves from real-world friction; cross-craft skills benefit from a single growing rubric corpus.                                         |
+
+## Scope
+
+### In-scope
+
+- **Identifier extraction (TS Compiler API).** Walks every `.ts`/`.tsx`/`.js`/`.jsx` file and extracts:
+  - Variables: `const x =` / `let x =` / destructuring binders.
+  - Functions: `function x()` / `const x = () =>` / `class.method()` / arrow-function expressions assigned to a name.
+  - Types: `type X` / `interface X` / `class X`.
+  - File names (basenames, sans extension).
+- **Convention sampling.** Walks up to N=500 identifiers per kind across the project and infers the dominant convention:
+  - Variables/functions → camelCase / snake_case / PascalCase counts.
+  - Types → PascalCase / camelCase counts.
+  - Files → kebab-case / camelCase / PascalCase counts.
+    Returns the modal convention per kind. (>50% majority threshold; below threshold = "no dominant convention" and case-convention findings skip.)
+- **Critique phase.** For each file:
+  - Sample up to M=15 identifiers per file (weighted toward exports + long-lived names).
+  - Build a prompt with: project convention, identifier kind, the name, surrounding context (declaration line + ±2 lines).
+  - Apply each enabled rubric from the catalog (default: 6 v1 rubrics, see below).
+  - LLM returns 3-axis judgment per (identifier, rubric) pair OR `null` if the rubric doesn't apply.
+- **6 v1 rubrics (default catalog):**
+  - `NAME-R001` **predictive power** — does the name predict the thing's behavior/contract from a stranger's reading?
+  - `NAME-R002` **concreteness** — concrete > vague (`buildInvoice` > `processData`).
+  - `NAME-R003` **verb/noun honesty** — functions verb (or noun-phrase-with-implied-verb); types/data noun; booleans should read as questions (`isReady` not `ready`).
+  - `NAME-R004` **convention conformance** — does the name match the project's sampled convention for its kind?
+  - `NAME-R005` **scope match** — long-lived/exported names earn more characters; short-scoped names can be terse (`i` is fine in a 3-line loop, terrible as an exported const).
+  - `NAME-R006` **encoded measure / unit** — when a name implies a unit/measure (`timeout`, `delay`, `size`), is the unit visible (`timeoutMs`, `sizeBytes`)? Punish silent units.
+- **3-axis NamingFinding** matching the CraftFinding shape (tier × impact × confidence). Reuses `packages/cli/src/design-craft/findings/schema.ts`'s structure via a thin wrapper.
+- **LlmProvider reuse.** Imports design-craft's `LlmProvider` interface + `MockLlmProvider` directly. v1.x extracts to `packages/cli/src/shared/llm/` if a second craft skill needs minor differences.
+- **Catalog scaffolding (H).** Catalog stored at `packages/cli/src/naming-craft/catalog/rubrics/<rubric-id>.ts` (one file per rubric, matches design-craft's layout). Future contribution mechanism deferred to v1.x but the directory structure supports it.
+- **Cross-cutting API export.** `runNamingCraft(input)` + `critiqueNamesInFile(file, opts)` exported so future craft skills can call into per-file naming critique without re-walking the project.
+- **CLI command:** `harness naming-craft`.
+- **MCP tool:** `naming_craft` (count 74 → 75).
+- **4-platform skill markdown:** claude-code / codex / cursor / gemini-cli.
+
+### Out-of-scope (v1)
+
+- **No module / branch / commit-subject naming.** Each needs different infrastructure; v1.x.
+- **No autofix or rename codemod.** Ceiling-judgment ships; fix-side is a separate sibling skill (deferred until signal warrants).
+- **No NAMING.md or per-project config beyond `craft.naming.enabled`.** Convention is derived from sampling.
+- **No deep/vision mode.** Naming is text-only.
+- **No language support beyond TS/JS.** Per-language idiom catalogs are v1.x.
+- **No graph persistence for findings.** Same as design-craft Phase 1.
+- **No per-craft-skill catalog merge yet.** Other craft skills will hold their own catalogs; cross-cutting consolidation is a craft-pipeline orchestrator concern (the future #10-equivalent orchestrator entry).
+
+## Inputs
+
+- **Project root path** (CLI / MCP arg).
+- **harness.config.json** — `craft.naming.{enabled, maxFiles, maxIdentifiersPerFile}` (new sub-block under a new top-level `craft.*` section that future craft skills will share).
+- **TS Compiler API** for identifier extraction.
+- **LLM provider** (`MockLlmProvider` in v1 — same posture as design-craft Phase 1).
+
+No DESIGN.md, no NAMING.md, no graph required.
+
+## Outputs
+
+```ts
+interface NamingFinding {
+  /** Stable code in the NAME-R\d{3} namespace. */
+  code: string;
+
+  /** Always 'critique' in v1 — no POLISH phase yet. */
+  phase: 'critique';
+
+  /** 3-axis (ADR 0019) — never collapsed. */
+  tier: 'foundational' | 'polish' | 'aspirational';
+  impact: 'small' | 'medium' | 'large';
+  confidence: 'high' | 'medium' | 'low';
+
+  /** Target identifier. */
+  target: {
+    file: string;
+    line?: number;
+    identifier: string;
+    kind: 'variable' | 'function' | 'type' | 'file';
+  };
+
+  /** Free-form critique with a suggested alternative when possible. */
+  message: string;
+
+  /** Citation of which rubric produced this finding (ADR 0020). */
+  cite: { rubricId: string; source: string };
+
+  /** Derived priority — computed via design-craft's derived.ts logic. */
+  derived: { priority: number };
+}
+
+interface NamingCraftOutput {
+  findings: NamingFinding[];
+  summary: {
+    phaseRun: ['critique'];
+    mode: 'fast';
+    durationMs: number;
+    llmCalls: { provider: string; model: string; count: number; costUsd: number };
+    catalog: { rubricsApplied: string[] };
+    convention: {
+      variables: 'camelCase' | 'snake_case' | 'PascalCase' | null;
+      functions: 'camelCase' | 'snake_case' | 'PascalCase' | null;
+      types: 'PascalCase' | 'camelCase' | null;
+      files: 'kebab-case' | 'camelCase' | 'PascalCase' | null;
+    };
+    runId: string;
+  };
+}
+```
+
+## Technical Design
+
+### Module layout
+
+```
+packages/cli/src/naming-craft/
+  findings/
+    schema.ts           # NamingFinding + NamingCraftOutput
+    derived.ts          # priority computation (re-exports from design-craft/findings/derived)
+  catalog/
+    rubrics/
+      predictive-power.ts        # NAME-R001
+      concreteness.ts            # NAME-R002
+      verb-noun-honesty.ts       # NAME-R003
+      convention-conformance.ts  # NAME-R004
+      scope-match.ts             # NAME-R005
+      encoded-measure.ts         # NAME-R006
+    index.ts            # rubric registry
+  extract/
+    identifiers.ts      # TS Compiler API walk
+    convention.ts       # majority-rule sampler
+  phases/
+    critique.ts         # LLM critique loop
+  llm/
+    provider.ts         # re-export design-craft's LlmProvider + MockLlmProvider
+  index.ts              # runNamingCraft + critiqueNamesInFile
+packages/cli/src/mcp/tools/
+  naming-craft.ts       # MCP tool wrapper
+packages/cli/src/commands/
+  naming-craft.ts       # CLI command
+agents/skills/{4 platforms}/naming-craft/
+  SKILL.md
+  skill.yaml
+```
+
+### Identifier extraction
+
+Single TS Compiler API walk per file. Collects:
+
+```ts
+interface Identifier {
+  name: string;
+  kind: 'variable' | 'function' | 'type'; // file is per-file, not per-AST-node
+  file: string;
+  line: number;
+  exported: boolean; // weight in sampling
+  scopeSize: 'short' | 'long'; // for NAME-R005
+  contextLines: string[]; // ±2 lines for LLM context
+}
+```
+
+`scopeSize: 'short'` = local within a function body of ≤10 lines. `'long'` = everything else (file-scope, method, function parameter on a function >10 lines).
+
+### Convention sampling
+
+```ts
+function sampleConvention(
+  identifiers: Identifier[],
+  kind: Identifier['kind']
+): 'camelCase' | 'snake_case' | 'PascalCase' | null {
+  const samples = identifiers.filter((i) => i.kind === kind).slice(0, 500);
+  const counts = { camelCase: 0, snake_case: 0, PascalCase: 0 };
+  for (const id of samples) {
+    if (/^[a-z][a-zA-Z0-9]*$/.test(id.name)) counts.camelCase++;
+    else if (/^[a-z][a-z0-9_]*$/.test(id.name)) counts.snake_case++;
+    else if (/^[A-Z][a-zA-Z0-9]*$/.test(id.name)) counts.PascalCase++;
+  }
+  // Majority threshold: >50% to count as a convention
+  const total = counts.camelCase + counts.snake_case + counts.PascalCase;
+  if (total === 0) return null;
+  const max = Math.max(counts.camelCase, counts.snake_case, counts.PascalCase);
+  if (max / total < 0.5) return null;
+  // Return the modal convention
+  if (counts.camelCase === max) return 'camelCase';
+  if (counts.snake_case === max) return 'snake_case';
+  return 'PascalCase';
+}
+```
+
+File-naming convention sampled the same way over project file basenames (sans extension).
+
+### Critique phase
+
+For each file:
+
+1. Extract identifiers.
+2. Sample up to M=15 (weighted: all exports first, then long-scope, then random fill).
+3. For each (identifier, rubric) in `sample × catalog`:
+   - Build prompt with rubric description + identifier + context.
+   - LLM returns JSON `{ tier, impact, confidence, message, suggestedName? }` or `null` if rubric doesn't apply.
+   - On non-null: emit NamingFinding with `cite.rubricId` set.
+4. Aggregate findings; compute derived priority via design-craft's `derived.ts`.
+
+### Living catalog H
+
+Each rubric is a file at `packages/cli/src/naming-craft/catalog/rubrics/<id>.ts`:
+
+```ts
+export const predictivePowerRubric: NamingRubric = {
+  id: 'NAME-R001',
+  title: 'Predictive power',
+  description: '...',
+  source: 'Martin, Clean Code, ch. 2',
+  // Catalog growth fields (deferred but reserved):
+  contribution: { addedAt: '2026-05-24', addedBy: 'seed' },
+  signal: { invocations: 0, suppressedAt: [] },
+  version: 1,
+};
+```
+
+The `signal` / `contribution` / `version` fields are present in v1 (per ADR 0020) but the growth mechanism (proposal pipeline, signal aggregation) ships in a later vertical slice — matches design-craft's posture.
+
+### Reusing design-craft infrastructure
+
+- `packages/cli/src/design-craft/llm/provider.ts` — imported directly (`LlmProvider`, `MockLlmProvider`, `getProvider`).
+- `packages/cli/src/design-craft/findings/derived.ts` — `computePriority` re-exported.
+- `packages/cli/src/design-craft/findings/schema.ts` — `Tier`, `Impact`, `Confidence` types re-exported.
+
+Not extracting to `packages/cli/src/shared/craft/` yet — premature with only one consumer. When test-craft (#3) or code-craft (#4) lands as the second non-design consumer, extract.
+
+### Cross-cutting export
+
+```ts
+// packages/cli/src/naming-craft/index.ts
+export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCraftOutput>;
+export async function critiqueNamesInFile(
+  file: string,
+  opts: { identifierKinds?: Array<'variable' | 'function' | 'type'>; convention?: NamingConvention }
+): Promise<NamingFinding[]>;
+```
+
+`critiqueNamesInFile` is the cross-cutting entry point — when docs-craft / test-craft / code-craft want naming critique for their domain, they call this without re-walking the whole project.
+
+## Surface area
+
+### CLI
+
+```
+harness naming-craft [options]
+  --files <files...>             Optional file/glob scope
+  --kinds <kinds...>             Restrict to variable / function / type / file (default: all)
+  --max-files <n>                Cap file count for cost control (default: 100)
+  --max-identifiers-per-file <n> Cap per-file identifier sampling (default: 15)
+  --json                         Machine-readable output
+  --verbose / --quiet            Standard
+```
+
+Exit codes:
+
+- `0` — no error-tier findings
+- `1` — at least one error-tier finding (tier=foundational maps to error per ADR 0019)
+- `2` — verifier crashed
+
+### MCP tool
+
+`naming_craft` — input `{ path, files?, kinds?, maxFiles?, maxIdentifiersPerFile? }`. Output the full `NamingCraftOutput`. Count bumps 74 → 75.
+
+### Config
+
+```ts
+craft.naming: {
+  enabled: boolean;     // default true
+  maxFiles: number;     // default 100
+  maxIdentifiersPerFile: number;  // default 15
+}
+```
+
+New top-level `craft.*` config namespace. Future craft skills will sibling under it.
+
+## Rationalizations to reject
+
+| Rationalization                                                             | Why it's wrong                                                                                                                                                             |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Add commit-subject naming in v1 — it's a high-value naming surface"        | Different infrastructure (git log scan). Copy-craft (#5) explicitly owns commit subjects per its roadmap entry. Don't poach.                                               |
+| "Skip the convention sampling — just hard-code camelCase"                   | Real projects use snake_case (Python interop), PascalCase (some TS projects), or are mixed. Hardcoding camelCase emits noise findings in non-camelCase projects.           |
+| "Add module naming in v1 — same TS infrastructure"                          | TS modules are files in v1. Module-as-distinct-concept needs a TS module-graph walk + per-project module-naming convention (path vs identifier). v1.x.                     |
+| "Use a single CRAFT-N\d{3} code namespace, share with copy/test/code"       | Code namespace per skill keeps debugging local. design-craft uses CRAFT-C\d{3}, naming-craft uses NAME-R\d{3}. Convergence on a shared prefix scheme is v2 if it pays off. |
+| "Don't extract identifiers from .jsx/.tsx — JSX has different naming rules" | JSX components ARE identifiers (PascalCase by convention). The convention sampler picks this up; rubrics apply uniformly.                                                  |
+| "Ship a NAMING.md spec for projects to declare custom conventions"          | YAGNI. 95% of projects use one convention per kind consistently. v1.x adds the override only if signal warrants.                                                           |
+| "Use AST-level full name+kind tuple as the dedup key (not just file+line)"  | Findings already cite identifier name in `target.identifier` + rubric in `cite.rubricId` — natural dedup. AST-tuple dedup is over-engineered for v1.                       |
+| "Critique every identifier in the file, not a sample"                       | LLM cost balloons in large files. M=15 weighted sample captures exported + long-lived names; misses only short-scope local fine-tuning, which is the lowest-value naming.  |
+| "Cap sample to N=100 instead of M=15"                                       | Per-file cost is the constraint. 15 × 6 rubrics × 100 files = 9000 LLM calls per project run. M=15 is the ceiling; M=10 may be the right default after signal.             |
+| "Don't reuse design-craft's LlmProvider — write a fresh one"                | Duplication = drift. Reuse until a SECOND craft skill needs differences, then extract to shared/. v1.x decision.                                                           |
+
+## Success criteria
+
+**Extractor correctness (8)**
+
+1. `extractIdentifiers(file)` returns all `const`/`let` binders as kind='variable'
+2. ...all `function` declarations + `const fn = () =>` as kind='function'
+3. ...all `interface`/`type`/`class` declarations as kind='type'
+4. Destructuring binders (`const { x } = ...`) extracted as kind='variable' with name='x'
+5. JSX components (PascalCase function returning JSX) extracted as kind='function' (same as plain functions; convention is project-derived)
+6. `exported: true` set for `export const/function/type X = ...`
+7. `scopeSize: 'short'` set for vars/functions declared inside a function body ≤10 lines
+8. `contextLines` includes the declaration line ±2 (clamped at file bounds)
+
+**Convention sampler (6)**
+
+9. Returns `'camelCase'` when >50% of sampled variables match camelCase regex
+10. Returns `null` when no convention has >50% majority
+11. Samples up to 500 identifiers per kind (test with synthetic corpus of 1000)
+12. Variables-only convention is independent of type-only convention (per-kind sampling)
+13. File-naming convention sampled from basenames (sans extension)
+14. Empty project returns `null` for all kinds (no findings emitted from convention-based rubric)
+
+**Catalog + critique (10)**
+
+15. 6 seed rubrics ship at `catalog/rubrics/<id>.ts` matching the file-per-rubric pattern
+16. `runNamingCraft({ path })` walks the project and produces a NamingCraftOutput
+17. Mock LLM provider's deterministic response produces a valid NamingFinding (validates the parse path)
+18. Each finding includes `cite.rubricId` (ADR 0020 traceability)
+19. `tier` × `impact` × `confidence` axes present on every finding (ADR 0019 preserved)
+20. `derived.priority` computed via design-craft's logic
+21. Per-file identifier sample is capped at maxIdentifiersPerFile (default 15)
+22. Per-project file count capped at maxFiles (default 100)
+23. LLM `null` response (rubric-not-applicable) does NOT emit a finding
+24. Cost telemetry recorded: `summary.llmCalls.{count, costUsd}` populated
+
+**Cross-cutting API (3)**
+
+25. `critiqueNamesInFile(file, opts)` exported and invocable independently of full pipeline
+26. `critiqueNamesInFile` accepts `kinds` filter (e.g. only critique functions)
+27. `critiqueNamesInFile` accepts pre-computed convention (so callers avoid re-sampling)
+
+**Surface area + integration (5)**
+
+28. New MCP tool `naming_craft` registered (count 74 → 75)
+29. New CLI command `harness naming-craft` registered
+30. 4-platform skill markdown shipped
+31. New config block `craft.naming.*` validates round-trip
+32. Auto-doc regenerates with `naming_craft` MCP entry + `naming-craft` skill entry
+
+**Config + reuse (2)**
+
+33. `LlmProvider`/`MockLlmProvider` IMPORTED from design-craft (no duplication)
+34. `computePriority` IMPORTED from design-craft's derived.ts (no duplication)
+
+## Long-term trajectory
+
+- **v1.x — module + branch + commit-subject naming.** Module naming needs TS module-graph walk. Branch + commit subjects need git infrastructure (and commit subjects sub-divide with copy-craft #5).
+- **v1.x — POLISH phase.** Pattern-driven elevation suggestions ("the `processData` rename to `extractInvoiceFromOrder` would honor NAME-R002 + R003 simultaneously"). Same shape as design-craft POLISH.
+- **v1.x — per-project rubric override config.** Skill catalog override + per-rubric enable/disable.
+- **v1.x — language support: Python, Go, Rust.** Per-language convention vocabularies + idiom catalogs.
+- **v1.x — `align-naming` sibling FIX skill.** Once safe-to-rename heuristics mature.
+- **v2 — extract shared craft infrastructure.** When a second non-design craft skill lands (test-craft or code-craft), pull `LlmProvider` + `Tier`/`Impact`/`Confidence` + `computePriority` to `packages/cli/src/shared/craft/`.
+- **v2 — cross-craft convergence in craft-pipeline orchestrator.** When the craft-pipeline orchestrator ships, naming-craft is invoked once per file, results dispatched to consumer craft skills via shared `pipeline.namingFindings` field.
+- **v3 — LLM-judgment via project's `harness-design` aesthetic intent.** When the project has declared aesthetic intent (e.g. "minimal, geometric, restrained"), naming-craft can match identifier naming to that aesthetic (terse vs descriptive). Cross-pipeline polish.
+
+## Risks + mitigations
+
+| Risk                                                                               | Mitigation                                                                                                                                                                        |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LLM cost balloons on large projects                                                | Per-file caps (maxIdentifiersPerFile=15) and per-project cap (maxFiles=100). User can scope further via `--files`. cost reported in `summary.llmCalls.costUsd` for transparency.  |
+| False positives on intentional convention violations (project-specific exceptions) | v1 has no opt-out per-identifier. v1.x adds JSDoc `@allow-naming-violation` annotation. Until then: lower-confidence findings are visually de-emphasized in reporting (ADR 0019). |
+| Convention sampler misidentifies a project mid-migration (camelCase → snake_case)  | Threshold is >50%. Below threshold returns `null` and convention-conformance rubric skips silently. Better silent skip than wrong findings.                                       |
+| Cross-cutting `critiqueNamesInFile` API gets called repeatedly by future skills    | API supports pre-computed convention pass-through (no re-sample). v2 orchestrator caches across consumers.                                                                        |
+| LlmProvider reuse breaks if design-craft changes the interface                     | Imports are typed; TypeScript will flag drift at compile time. When the interface evolves both consumers update together. v2 shared-craft extraction makes this explicit.         |
+| Rubric set drift over time (someone adds a 7th rubric, breaks tests)               | Rubric registry is the source of truth; tests assert exactly 6 seed rubrics by default (additions explicit). Catalog growth is a code-change event, not a runtime event in v1.    |
+| Identifier extraction over-counts (same identifier across hot-reload modules etc.) | File + line is the dedup key. JSX components that are imported many times still extract once per declaration.                                                                     |
+
+## Open questions deferred to implementation
+
+- **Exact M cap default.** Spec says 15. Real-world signal may show 10 is sufficient or 20 is needed. Implementation chooses 15; tunable per-config.
+- **Rubric prompt format.** Mirrors design-craft's fenced-JSON contract. Specific JSON shape finalized in `phases/critique.ts`.
+- **Cost-per-rubric metering.** v1 records aggregate `summary.llmCalls.{count, costUsd}`. Per-rubric cost split is v1.x telemetry.
+  EOF

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -322,6 +322,17 @@ Migrate legacy harness artifact locations to current layout
 - `--orphan-strategy` — How to handle orphan plans (ask|skip|bucket) (default: "ask")
 - `--orphan-topic` — Stub topic name when --orphan-strategy=bucket
 
+### `harness naming-craft`
+
+LLM-judgment critique of identifier names (variables, functions, types, files). First craft-pipeline ceiling skill; uses curated rubric catalog from Martin/Beck/Karlton.
+
+**Options:**
+
+- `-f, --files` — Optional file/glob scope
+- `-k, --kinds` — Restrict to variable / function / type / file (default: all)
+- `--max-files` — Cap file count (default: 100)
+- `--max-identifiers-per-file` — Cap per-file identifier sampling (default: 15)
+
 ### `harness predict`
 
 Predict which architectural constraints will break and when

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -507,6 +507,18 @@ Composite report combining health, entropy, decay, attention, and impact (Hermes
 - `path` (string, required) — Path to project root
 - `skip` (array, optional) — Top-level keys to skip.
 
+### `naming_craft`
+
+LLM-judgment critique of identifier names (variables, functions, types, files). First craft-pipeline ceiling skill; uses a curated rubric catalog seeded from Martin / Beck / Karlton. Emits 3-axis findings (tier x impact x confidence per ADR 0019).
+
+**Parameters:**
+
+- `path` (string, required) — Project root path
+- `files` (array, optional) — Optional file/glob scope
+- `kinds` (array, optional) — Restrict to specific identifier kinds (default: all)
+- `maxFiles` (number, optional) — Cap file count (default: 100)
+- `maxIdentifiersPerFile` (number, optional) — Cap per-file identifier sampling (default: 15)
+
 ### `recommend_skills`
 
 Recommend skills based on codebase health. Returns sequenced workflow with urgency markers.

--- a/docs/reference/skills-catalog.md
+++ b/docs/reference/skills-catalog.md
@@ -2,7 +2,7 @@
 
 # Skills Catalog
 
-746 skills across 3 tiers. Tier 1 and 2 skills are registered as slash commands. Tier 3 skills are discoverable via the `search_skills` MCP tool. See the [Features Overview](../guides/features-overview.md) for narrative documentation.
+747 skills across 3 tiers. Tier 1 and 2 skills are registered as slash commands. Tier 3 skills are discoverable via the `search_skills` MCP tool. See the [Features Overview](../guides/features-overview.md) for narrative documentation.
 
 ## Tier 1 — Workflow (14 skills)
 
@@ -141,7 +141,7 @@ Scaffold or migrate a test-suite project (API, E2E/UI, or shared library) with t
 - **Cognitive mode:** constructive-architect
 - **Depends on:** initialize-harness-project
 
-## Tier 2 — Maintenance (29 skills)
+## Tier 2 — Maintenance (30 skills)
 
 ### align-design-system
 
@@ -415,6 +415,16 @@ Binary pass/fail quick gate — runs test, lint, typecheck commands and returns 
 - **Platforms:** claude-code, gemini-cli, cursor, codex
 - **Type:** rigid
 - **Cognitive mode:** meticulous-verifier
+
+### naming-craft
+
+LLM-judgment skill that critiques identifier names (variables, functions, types, files) against a curated rubric catalog seeded from Martin / Beck / Karlton. First craft-pipeline ceiling skill; cross-cutting (other craft skills call into it for domain-specific naming).
+
+- **Triggers:** manual, on_pr, on_new_feature
+- **Platforms:** claude-code
+- **Type:** rigid
+- **Cognitive mode:** constructive-architect
+- **Depends on:** harness-design-craft
 
 ## Tier 3 — Domain (703 skills)
 

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -10,6 +10,7 @@ import { createAuditProtectedCommand } from './audit-protected';
 import { createBackfillSkillProvenanceCommand } from './backfill-skill-provenance';
 import { createBlueprintCommand } from './blueprint';
 import { createAlignDesignSystemCommand } from './align-design-system';
+import { createNamingCraftCommand } from './naming-craft';
 import { createCheckArchCommand } from './check-arch';
 import { createCheckDepsCommand } from './check-deps';
 import { createCheckDesignCommand } from './check-design';
@@ -90,6 +91,7 @@ export const commandCreators: Array<() => Command> = [
   createBackfillSkillProvenanceCommand,
   createBlueprintCommand,
   createAlignDesignSystemCommand,
+  createNamingCraftCommand,
   createCheckArchCommand,
   createCheckDepsCommand,
   createCheckDesignCommand,

--- a/packages/cli/src/commands/naming-craft.ts
+++ b/packages/cli/src/commands/naming-craft.ts
@@ -1,0 +1,120 @@
+/**
+ * `harness naming-craft` — CLI entry for naming-craft (craft-pipeline #1).
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Surface area → CLI).
+ */
+
+import { Command } from 'commander';
+import { OutputFormatter, OutputMode } from '../output/formatter';
+import type { OutputModeType } from '../output/formatter';
+import { resolveOutputMode } from '../utils/output';
+import { logger } from '../output/logger';
+import { ExitCode } from '../utils/errors';
+import {
+  runNamingCraft,
+  type NamingCraftInput,
+  type NamingCraftOutput,
+  type IdentifierKind,
+} from '../naming-craft/index.js';
+
+interface NamingCraftCliOptions {
+  files?: string[];
+  kinds?: string[];
+  maxFiles?: string;
+  maxIdentifiersPerFile?: string;
+}
+
+export function createNamingCraftCommand(): Command {
+  return new Command('naming-craft')
+    .description(
+      'LLM-judgment critique of identifier names (variables, functions, types, files). ' +
+        'First craft-pipeline ceiling skill; uses curated rubric catalog from Martin/Beck/Karlton.'
+    )
+    .option('-f, --files <files...>', 'Optional file/glob scope')
+    .option(
+      '-k, --kinds <kinds...>',
+      'Restrict to variable / function / type / file (default: all)'
+    )
+    .option('--max-files <n>', 'Cap file count (default: 100)')
+    .option('--max-identifiers-per-file <n>', 'Cap per-file identifier sampling (default: 15)')
+    .action(async (opts: NamingCraftCliOptions, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const outputMode = resolveOutputMode(globalOpts);
+      const formatter = new OutputFormatter(outputMode);
+      const cwd = (globalOpts.cwd as string | undefined) ?? process.cwd();
+
+      const input: NamingCraftInput = { path: cwd };
+      if (opts.files !== undefined) input.files = opts.files;
+      if (opts.kinds !== undefined) input.kinds = opts.kinds as IdentifierKind[];
+      if (opts.maxFiles !== undefined) input.maxFiles = parseInt(opts.maxFiles, 10);
+      if (opts.maxIdentifiersPerFile !== undefined)
+        input.maxIdentifiersPerFile = parseInt(opts.maxIdentifiersPerFile, 10);
+
+      let result: NamingCraftOutput;
+      try {
+        result = await runNamingCraft(input);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (outputMode === OutputMode.JSON) {
+          console.log(JSON.stringify({ error: message }));
+        } else {
+          logger.error(`naming-craft failed: ${message}`);
+        }
+        process.exit(ExitCode.ERROR);
+        return;
+      }
+
+      if (outputMode === OutputMode.JSON) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        printResult(result, outputMode, formatter);
+      }
+
+      const hasError = result.findings.some((f) => f.tier === 'foundational');
+      process.exit(hasError ? ExitCode.VALIDATION_FAILED : ExitCode.SUCCESS);
+    });
+}
+
+function printResult(
+  result: NamingCraftOutput,
+  mode: OutputModeType,
+  _formatter: OutputFormatter
+): void {
+  const verbose = mode === OutputMode.VERBOSE;
+  const { findings, summary } = result;
+
+  if (findings.length === 0) {
+    console.log('No naming findings.');
+  } else {
+    const byFile = new Map<string, typeof findings>();
+    for (const f of findings) {
+      const list = byFile.get(f.target.file) ?? [];
+      list.push(f);
+      byFile.set(f.target.file, list);
+    }
+    for (const [file, fs] of byFile) {
+      console.log(`\n${file}`);
+      for (const f of fs) {
+        const line = f.target.line !== undefined ? `:${f.target.line}` : '';
+        console.log(
+          `  ${f.code} [${f.tier}/${f.impact}/${f.confidence}] ${f.target.kind} ${f.target.identifier}${line}`
+        );
+        console.log(`    ${f.message}`);
+        if (verbose) console.log(`    source: ${f.cite.source}`);
+      }
+    }
+  }
+
+  console.log('');
+  console.log(
+    `Summary: ${findings.length} findings ` +
+      `(rubrics: ${summary.catalog.rubricsApplied.length}, ` +
+      `LLM calls: ${summary.llmCalls.count}, cost: $${summary.llmCalls.costUsd.toFixed(4)}, ` +
+      `${summary.durationMs}ms)`
+  );
+  console.log(
+    `Convention: vars=${summary.convention.variables ?? '?'}, funcs=${summary.convention.functions ?? '?'}, ` +
+      `types=${summary.convention.types ?? '?'}, files=${summary.convention.files ?? '?'}`
+  );
+}

--- a/packages/cli/src/commands/setup-mcp.ts
+++ b/packages/cli/src/commands/setup-mcp.ts
@@ -134,6 +134,8 @@ export const ALL_MCP_TOOLS: string[] = [
   'align_design_system',
   // design-pipeline #3 — brand-semantics audit (BRAND-T* + BRAND-V001)
   'audit_brand',
+  // craft-pipeline #1 — naming-craft LLM-judgment ceiling skill
+  'naming_craft',
 ];
 
 /**

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -176,6 +176,8 @@ import {
 } from './tools/align-design-system.js';
 // design-pipeline #3: brand-semantics audit (BRAND-T* token misuse + BRAND-V001 forbidden phrases).
 import { auditBrandDefinition, handleAuditBrand } from './tools/audit-brand.js';
+// craft-pipeline #1: naming-craft LLM-judgment skill (variables / functions / types / files).
+import { namingCraftDefinition, handleNamingCraft } from './tools/naming-craft.js';
 
 // Re-exported from ./tool-types so tool files can import the type without
 // pulling in server.ts (which would create a cycle). See ./tool-types.ts.
@@ -262,6 +264,7 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
   detectDriftDefinition,
   alignDesignSystemDefinition,
   auditBrandDefinition,
+  namingCraftDefinition,
 ].map((def) => ({ ...def, trustedOutput: true }));
 const TOOL_HANDLERS: Record<string, ToolHandler> = {
   validate_project: handleValidateProject as ToolHandler,
@@ -337,6 +340,7 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   detect_drift: handleDetectDrift as unknown as ToolHandler,
   align_design_system: handleAlignDesignSystem as unknown as ToolHandler,
   audit_brand: handleAuditBrand as unknown as ToolHandler,
+  naming_craft: handleNamingCraft as unknown as ToolHandler,
 };
 
 const RESOURCE_DEFINITIONS = [

--- a/packages/cli/src/mcp/tools/naming-craft.ts
+++ b/packages/cli/src/mcp/tools/naming-craft.ts
@@ -1,0 +1,75 @@
+/**
+ * MCP tool: `mcp__harness__naming_craft`.
+ *
+ * Wraps naming-craft (craft-pipeline #1).
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Surface area → MCP tool).
+ */
+
+import {
+  runNamingCraft,
+  type NamingCraftInput,
+  type NamingCraftOutput,
+} from '../../naming-craft/index.js';
+
+interface ToolResponse {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+export const namingCraftDefinition = {
+  name: 'naming_craft',
+  description:
+    'LLM-judgment critique of identifier names (variables, functions, types, files). ' +
+    'First craft-pipeline ceiling skill; uses a curated rubric catalog seeded from ' +
+    'Martin / Beck / Karlton. Emits 3-axis findings (tier x impact x confidence per ADR 0019).',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      path: { type: 'string', description: 'Project root path' },
+      files: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Optional file/glob scope',
+      },
+      kinds: {
+        type: 'array',
+        items: { type: 'string', enum: ['variable', 'function', 'type', 'file'] },
+        description: 'Restrict to specific identifier kinds (default: all)',
+      },
+      maxFiles: { type: 'number', description: 'Cap file count (default: 100)' },
+      maxIdentifiersPerFile: {
+        type: 'number',
+        description: 'Cap per-file identifier sampling (default: 15)',
+      },
+    },
+    required: ['path'],
+  },
+};
+
+export async function handleNamingCraft(input: NamingCraftInput): Promise<ToolResponse> {
+  if (typeof input?.path !== 'string' || input.path.length === 0) {
+    return {
+      content: [
+        { type: 'text', text: JSON.stringify({ error: 'naming_craft: `path` is required' }) },
+      ],
+      isError: true,
+    };
+  }
+  try {
+    const result: NamingCraftOutput = await runNamingCraft(input);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        { type: 'text', text: JSON.stringify({ error: `naming_craft failed: ${message}` }) },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export { runNamingCraft } from '../../naming-craft/index.js';
+export type { NamingCraftInput, NamingCraftOutput } from '../../naming-craft/index.js';

--- a/packages/cli/src/naming-craft/catalog/rubrics/concreteness.ts
+++ b/packages/cli/src/naming-craft/catalog/rubrics/concreteness.ts
@@ -1,0 +1,16 @@
+import type { NamingRubric } from './index.js';
+
+export const concretenessRubric: NamingRubric = {
+  id: 'NAME-R002',
+  title: 'Concreteness',
+  description:
+    'Concrete names beat vague ones. `buildInvoice` is concrete; `processData` is vague. ' +
+    'The vague version asks the reader to scan the body to learn what the function does; ' +
+    'the concrete version states it. Generic words to suspect: handle, process, manage, ' +
+    'do, run, exec, perform, util, helper, data, info, value, item, thing.',
+  source: 'Martin, Clean Code + Beck, Smalltalk Best Practice Patterns',
+  appliesTo: ['variable', 'function', 'type'],
+  contribution: { addedAt: '2026-05-24', addedBy: 'seed' },
+  signal: { invocations: 0, suppressedAt: [] },
+  version: 1,
+};

--- a/packages/cli/src/naming-craft/catalog/rubrics/convention-conformance.ts
+++ b/packages/cli/src/naming-craft/catalog/rubrics/convention-conformance.ts
@@ -1,0 +1,16 @@
+import type { NamingRubric } from './index.js';
+
+export const conventionConformanceRubric: NamingRubric = {
+  id: 'NAME-R004',
+  title: 'Convention conformance',
+  description:
+    "Does the name match the project's dominant convention for its identifier kind " +
+    '(camelCase / snake_case / PascalCase)? Mixing conventions adds cognitive load and ' +
+    'often signals copy-paste from a different ecosystem. Skip the rubric when the ' +
+    'project has no dominant convention (<50% majority).',
+  source: 'Karlton, "two hard things" — naming consistency at the project level',
+  appliesTo: ['variable', 'function', 'type', 'file'],
+  contribution: { addedAt: '2026-05-24', addedBy: 'seed' },
+  signal: { invocations: 0, suppressedAt: [] },
+  version: 1,
+};

--- a/packages/cli/src/naming-craft/catalog/rubrics/encoded-measure.ts
+++ b/packages/cli/src/naming-craft/catalog/rubrics/encoded-measure.ts
@@ -1,0 +1,16 @@
+import type { NamingRubric } from './index.js';
+
+export const encodedMeasureRubric: NamingRubric = {
+  id: 'NAME-R006',
+  title: 'Encoded measure / unit',
+  description:
+    'When a name implies a unit or measure (timeout, delay, size, distance, weight, latency), ' +
+    'the unit should be visible in the name (`timeoutMs` not `timeout`; `sizeBytes` not `size`; ' +
+    '`distanceKm` not `distance`). Silent units cause real production bugs (the Mars Climate ' +
+    'Orbiter loss is the canonical example). Punish silent units; reward explicit ones.',
+  source: 'Hunt + Thomas, Pragmatic Programmer — name your units',
+  appliesTo: ['variable', 'function'],
+  contribution: { addedAt: '2026-05-24', addedBy: 'seed' },
+  signal: { invocations: 0, suppressedAt: [] },
+  version: 1,
+};

--- a/packages/cli/src/naming-craft/catalog/rubrics/index.ts
+++ b/packages/cli/src/naming-craft/catalog/rubrics/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Living catalog (ADR 0020) — seed rubrics for naming-craft v1.
+ * Each rubric is a separate file under ./rubrics/. The registry below
+ * gates which rubrics are available at runtime; future contribution
+ * mechanism (proposal → review → version bump) will land at v1.x.
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Technical Design → Living catalog H).
+ */
+
+export interface NamingRubric {
+  id: string;
+  title: string;
+  /** Concise rubric description used as part of the LLM prompt. */
+  description: string;
+  /** Authoritative citation for the rubric (Martin, Beck, etc.). */
+  source: string;
+  /** Identifier kinds this rubric applies to. */
+  appliesTo: ReadonlyArray<'variable' | 'function' | 'type' | 'file'>;
+  /** ADR 0020 — catalog growth metadata (reserved, not consumed in v1). */
+  contribution: { addedAt: string; addedBy: string };
+  signal: { invocations: number; suppressedAt: string[] };
+  version: number;
+}
+
+import { predictivePowerRubric } from './predictive-power.js';
+import { concretenessRubric } from './concreteness.js';
+import { verbNounHonestyRubric } from './verb-noun-honesty.js';
+import { conventionConformanceRubric } from './convention-conformance.js';
+import { scopeMatchRubric } from './scope-match.js';
+import { encodedMeasureRubric } from './encoded-measure.js';
+
+/**
+ * The v1 default rubric set — 6 seed entries from Martin, Beck, Karlton,
+ * and the wider naming canon. Order is intentional: rubrics earlier in
+ * the list run first in the critique loop so cost-capped runs still see
+ * the highest-value findings.
+ */
+export const SEED_RUBRICS: ReadonlyArray<NamingRubric> = [
+  predictivePowerRubric,
+  concretenessRubric,
+  verbNounHonestyRubric,
+  conventionConformanceRubric,
+  scopeMatchRubric,
+  encodedMeasureRubric,
+];

--- a/packages/cli/src/naming-craft/catalog/rubrics/predictive-power.ts
+++ b/packages/cli/src/naming-craft/catalog/rubrics/predictive-power.ts
@@ -1,0 +1,15 @@
+import type { NamingRubric } from './index.js';
+
+export const predictivePowerRubric: NamingRubric = {
+  id: 'NAME-R001',
+  title: 'Predictive power',
+  description:
+    "Does the name predict the thing's behavior or contract from a stranger's reading? " +
+    'Names like `processData()` or `handle()` predict nothing. Names like `parseCsvRow()` ' +
+    'or `userInvitationEmailSubject` predict both the operation and the artifact.',
+  source: 'Martin, Clean Code, ch. 2 (Meaningful Names)',
+  appliesTo: ['variable', 'function', 'type', 'file'],
+  contribution: { addedAt: '2026-05-24', addedBy: 'seed' },
+  signal: { invocations: 0, suppressedAt: [] },
+  version: 1,
+};

--- a/packages/cli/src/naming-craft/catalog/rubrics/scope-match.ts
+++ b/packages/cli/src/naming-craft/catalog/rubrics/scope-match.ts
@@ -1,0 +1,16 @@
+import type { NamingRubric } from './index.js';
+
+export const scopeMatchRubric: NamingRubric = {
+  id: 'NAME-R005',
+  title: 'Scope match',
+  description:
+    'Long-lived or exported names earn more characters; short-scoped names can be terse. ' +
+    '`i` is fine in a 3-line loop, terrible as an exported const. `userInvitationAcceptanceToken` ' +
+    'is justified at module scope, overkill as a loop variable. Punish exported single-letter ' +
+    'and reward terseness in short scopes.',
+  source: 'Beck, Smalltalk Best Practice Patterns — name length proportional to scope',
+  appliesTo: ['variable', 'function', 'type'],
+  contribution: { addedAt: '2026-05-24', addedBy: 'seed' },
+  signal: { invocations: 0, suppressedAt: [] },
+  version: 1,
+};

--- a/packages/cli/src/naming-craft/catalog/rubrics/verb-noun-honesty.ts
+++ b/packages/cli/src/naming-craft/catalog/rubrics/verb-noun-honesty.ts
@@ -1,0 +1,16 @@
+import type { NamingRubric } from './index.js';
+
+export const verbNounHonestyRubric: NamingRubric = {
+  id: 'NAME-R003',
+  title: 'Verb / noun honesty',
+  description:
+    'Functions should read as verbs (or verb-phrases); types and data should read as nouns; ' +
+    'booleans should read as questions (`isReady`, `hasPermission`, `canEdit`, not `ready` ' +
+    "or `permission`). A function named `userEmail()` looks like a getter for the user's " +
+    'email; a boolean named `enabled` could be a flag setter, getter, or state value.',
+  source: 'Beck, Implementation Patterns + general OOP idiom',
+  appliesTo: ['variable', 'function', 'type'],
+  contribution: { addedAt: '2026-05-24', addedBy: 'seed' },
+  signal: { invocations: 0, suppressedAt: [] },
+  version: 1,
+};

--- a/packages/cli/src/naming-craft/extract/convention.ts
+++ b/packages/cli/src/naming-craft/extract/convention.ts
@@ -1,0 +1,82 @@
+/**
+ * Convention sampler — derives the project's dominant naming convention
+ * per identifier kind via majority-rule over a sample of up to 500
+ * identifiers. Returns null when no convention has >50% majority; the
+ * convention-conformance rubric silently skips in that case.
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Technical Design → Convention sampling).
+ */
+
+import type { NamingConvention, ProjectConvention } from '../findings/schema.js';
+import type { ExtractedIdentifier } from './identifiers.js';
+
+const SAMPLE_CAP = 500;
+const MAJORITY_THRESHOLD = 0.5;
+
+export function sampleConventions(
+  identifiers: readonly ExtractedIdentifier[],
+  files: readonly string[]
+): ProjectConvention {
+  return {
+    variables: sampleForKind(identifiers, 'variable', ['camelCase', 'snake_case', 'PascalCase']),
+    functions: sampleForKind(identifiers, 'function', ['camelCase', 'snake_case', 'PascalCase']),
+    types: sampleForKind(identifiers, 'type', ['PascalCase', 'camelCase']),
+    files: sampleFiles(files),
+  };
+}
+
+function sampleForKind(
+  identifiers: readonly ExtractedIdentifier[],
+  kind: ExtractedIdentifier['kind'],
+  candidates: readonly NamingConvention[]
+): NamingConvention | null {
+  const samples = identifiers.filter((i) => i.kind === kind).slice(0, SAMPLE_CAP);
+  return mode(
+    samples.map((i) => i.name),
+    candidates
+  );
+}
+
+function sampleFiles(files: readonly string[]): NamingConvention | null {
+  const basenames = files.slice(0, SAMPLE_CAP).map((f) => {
+    const last = f.split(/[\\/]/).pop() ?? f;
+    return last.replace(/\.(?:ts|tsx|js|jsx|css|scss|md|json)$/i, '');
+  });
+  return mode(basenames, ['kebab-case', 'camelCase', 'PascalCase']);
+}
+
+function mode(
+  names: readonly string[],
+  candidates: readonly NamingConvention[]
+): NamingConvention | null {
+  if (names.length === 0) return null;
+  const counts = new Map<NamingConvention, number>();
+  for (const c of candidates) counts.set(c, 0);
+  for (const name of names) {
+    const conv = classify(name);
+    if (conv !== null && counts.has(conv)) {
+      counts.set(conv, (counts.get(conv) ?? 0) + 1);
+    }
+  }
+  const total = [...counts.values()].reduce((a, b) => a + b, 0);
+  if (total === 0) return null;
+  let maxCount = 0;
+  let maxConv: NamingConvention | null = null;
+  for (const [conv, count] of counts) {
+    if (count > maxCount) {
+      maxCount = count;
+      maxConv = conv;
+    }
+  }
+  if (maxCount / total < MAJORITY_THRESHOLD) return null;
+  return maxConv;
+}
+
+export function classify(name: string): NamingConvention | null {
+  if (/^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$/.test(name)) return 'kebab-case';
+  if (/^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$/.test(name)) return 'snake_case';
+  if (/^[A-Z][a-zA-Z0-9]*$/.test(name)) return 'PascalCase';
+  if (/^[a-z][a-zA-Z0-9]*$/.test(name)) return 'camelCase';
+  return null;
+}

--- a/packages/cli/src/naming-craft/extract/identifiers.ts
+++ b/packages/cli/src/naming-craft/extract/identifiers.ts
@@ -1,0 +1,151 @@
+/**
+ * Identifier extraction via TS Compiler API. Walks a source file and
+ * collects every variable / function / type identifier along with
+ * declaration line, export status, scope size, and surrounding context
+ * lines for LLM prompt construction.
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Technical Design → Identifier extraction).
+ */
+
+import ts from 'typescript';
+import type { IdentifierKind } from '../findings/schema.js';
+
+export interface ExtractedIdentifier {
+  name: string;
+  kind: Exclude<IdentifierKind, 'file'>;
+  file: string;
+  line: number;
+  exported: boolean;
+  scopeSize: 'short' | 'long';
+  contextLines: string[];
+}
+
+const SHORT_SCOPE_BODY_LINE_THRESHOLD = 10;
+
+export function extractIdentifiers(file: string, source: string): ExtractedIdentifier[] {
+  let sourceFile: ts.SourceFile;
+  try {
+    sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  } catch {
+    return [];
+  }
+
+  const out: ExtractedIdentifier[] = [];
+  const sourceLines = source.split('\n');
+
+  function visit(node: ts.Node, parentBodyLineSize: number | null): void {
+    // function declarations
+    if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
+      pushIdentifier(
+        node.name.text,
+        'function',
+        node,
+        sourceFile,
+        sourceLines,
+        out,
+        parentBodyLineSize
+      );
+    }
+    // interface / type alias / class declarations
+    if (
+      (ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isClassDeclaration(node)) &&
+      node.name !== undefined
+    ) {
+      pushIdentifier(
+        node.name.text,
+        'type',
+        node,
+        sourceFile,
+        sourceLines,
+        out,
+        parentBodyLineSize
+      );
+    }
+    // const / let variable declarations (also handles destructuring binders)
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        for (const binding of collectBindingNames(decl.name)) {
+          // Detect if the init is a function expression → kind=function
+          const kind: 'variable' | 'function' =
+            decl.initializer !== undefined &&
+            (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer))
+              ? 'function'
+              : 'variable';
+          pushIdentifier(binding, kind, decl, sourceFile, sourceLines, out, parentBodyLineSize);
+        }
+      }
+    }
+
+    // recurse — compute body line size if entering a function body
+    let nextParentBodyLineSize = parentBodyLineSize;
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node)) &&
+      node.body !== undefined
+    ) {
+      const start = sourceFile.getLineAndCharacterOfPosition(node.body.getStart(sourceFile)).line;
+      const end = sourceFile.getLineAndCharacterOfPosition(node.body.getEnd()).line;
+      nextParentBodyLineSize = end - start + 1;
+    }
+
+    ts.forEachChild(node, (child) => visit(child, nextParentBodyLineSize));
+  }
+
+  visit(sourceFile, null);
+  return out;
+}
+
+function pushIdentifier(
+  name: string,
+  kind: 'variable' | 'function' | 'type',
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  sourceLines: string[],
+  out: ExtractedIdentifier[],
+  parentBodyLineSize: number | null
+): void {
+  const { line: zeroLine } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  const line = zeroLine + 1;
+  out.push({
+    name,
+    kind,
+    file: sourceFile.fileName,
+    line,
+    exported: hasExportModifier(node),
+    scopeSize:
+      parentBodyLineSize !== null && parentBodyLineSize <= SHORT_SCOPE_BODY_LINE_THRESHOLD
+        ? 'short'
+        : 'long',
+    contextLines: extractContextLines(sourceLines, zeroLine, 2),
+  });
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  const mods = (node as unknown as { modifiers?: readonly ts.ModifierLike[] }).modifiers;
+  if (mods === undefined) return false;
+  return mods.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+function collectBindingNames(binding: ts.BindingName): string[] {
+  if (ts.isIdentifier(binding)) return [binding.text];
+  const names: string[] = [];
+  if (ts.isObjectBindingPattern(binding) || ts.isArrayBindingPattern(binding)) {
+    for (const element of binding.elements) {
+      if (ts.isBindingElement(element)) {
+        for (const n of collectBindingNames(element.name)) names.push(n);
+      }
+    }
+  }
+  return names;
+}
+
+function extractContextLines(lines: string[], zeroLine: number, radius: number): string[] {
+  const start = Math.max(0, zeroLine - radius);
+  const end = Math.min(lines.length, zeroLine + radius + 1);
+  return lines.slice(start, end);
+}

--- a/packages/cli/src/naming-craft/findings/derived.ts
+++ b/packages/cli/src/naming-craft/findings/derived.ts
@@ -1,0 +1,8 @@
+/**
+ * Re-export design-craft's derived priority computation. Avoids
+ * duplication and keeps the craft-family priority semantics consistent
+ * across skills. When test-craft or code-craft lands, extract to
+ * `packages/cli/src/shared/craft/derived.ts` (v2).
+ */
+
+export { derivePriority } from '../../design-craft/findings/derived.js';

--- a/packages/cli/src/naming-craft/findings/schema.ts
+++ b/packages/cli/src/naming-craft/findings/schema.ts
@@ -1,0 +1,58 @@
+/**
+ * NamingFinding schema — 3-axis (ADR 0019) finding emitted by naming-craft's
+ * critique phase. Reuses design-craft's Tier/Impact/Confidence types so the
+ * craft family shares the axes; cross-craft consumers can introspect findings
+ * without per-skill type-narrowing.
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Outputs → NamingFinding).
+ */
+
+import type { Tier, Impact, Confidence } from '../../design-craft/findings/schema.js';
+
+export type { Tier, Impact, Confidence };
+
+export type IdentifierKind = 'variable' | 'function' | 'type' | 'file';
+
+export type NamingConvention = 'camelCase' | 'snake_case' | 'PascalCase' | 'kebab-case';
+
+export interface NamingFinding {
+  /** Stable code in the NAME-R\d{3} namespace. */
+  code: string;
+  /** Always 'critique' in v1 (no POLISH phase yet). */
+  phase: 'critique';
+  tier: Tier;
+  impact: Impact;
+  confidence: Confidence;
+  target: {
+    file: string;
+    line?: number;
+    identifier: string;
+    kind: IdentifierKind;
+  };
+  message: string;
+  cite: { rubricId: string; source: string };
+  derived: { priority: number };
+}
+
+export interface NamingCraftSummary {
+  phaseRun: ['critique'];
+  mode: 'fast';
+  durationMs: number;
+  llmCalls: { provider: string; model: string; count: number; costUsd: number };
+  catalog: { rubricsApplied: string[] };
+  convention: ProjectConvention;
+  runId: string;
+}
+
+export interface ProjectConvention {
+  variables: NamingConvention | null;
+  functions: NamingConvention | null;
+  types: NamingConvention | null;
+  files: NamingConvention | null;
+}
+
+export interface NamingCraftOutput {
+  findings: NamingFinding[];
+  summary: NamingCraftSummary;
+}

--- a/packages/cli/src/naming-craft/index.ts
+++ b/packages/cli/src/naming-craft/index.ts
@@ -1,0 +1,228 @@
+/**
+ * naming-craft orchestrator — first member of the craft-pipeline
+ * initiative (#1 of 10). LLM-judgment skill that critiques identifier
+ * names against a curated rubric catalog.
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { sanitizePath } from '../mcp/utils/sanitize-path.js';
+import { getProvider, type LlmProvider } from './llm/provider.js';
+import { extractIdentifiers, type ExtractedIdentifier } from './extract/identifiers.js';
+import { sampleConventions } from './extract/convention.js';
+import { SEED_RUBRICS, type NamingRubric } from './catalog/rubrics/index.js';
+import { critiqueOne } from './phases/critique.js';
+import type {
+  NamingCraftOutput,
+  NamingFinding,
+  ProjectConvention,
+  IdentifierKind,
+} from './findings/schema.js';
+
+export interface NamingCraftInput {
+  path: string;
+  files?: string[];
+  kinds?: Array<IdentifierKind>;
+  maxFiles?: number;
+  maxIdentifiersPerFile?: number;
+  /** Optional provider override for testing. */
+  __testProvider?: LlmProvider;
+}
+
+const DEFAULT_MAX_FILES = 100;
+const DEFAULT_MAX_IDENTIFIERS_PER_FILE = 15;
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+
+export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCraftOutput> {
+  const startedAt = Date.now();
+  const projectRoot = sanitizePath(input.path);
+  const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
+  const maxIdentifiersPerFile = input.maxIdentifiersPerFile ?? DEFAULT_MAX_IDENTIFIERS_PER_FILE;
+  const provider = input.__testProvider ?? getProvider();
+
+  const files = collectFiles(projectRoot, input.files).slice(0, maxFiles);
+
+  // First pass: extract all identifiers across files (for convention sampling).
+  const allIdentifiers: ExtractedIdentifier[] = [];
+  const perFile: Map<string, ExtractedIdentifier[]> = new Map();
+  for (const file of files) {
+    let source: string;
+    try {
+      source = fs.readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    const ids = extractIdentifiers(file, source);
+    perFile.set(file, ids);
+    allIdentifiers.push(...ids);
+  }
+
+  const convention = sampleConventions(allIdentifiers, files);
+  const rubrics = SEED_RUBRICS;
+  const findings: NamingFinding[] = [];
+
+  for (const [, identifiers] of perFile) {
+    const sample = sampleIdentifiers(identifiers, maxIdentifiersPerFile, input.kinds);
+    for (const identifier of sample) {
+      for (const rubric of rubrics) {
+        if (!rubric.appliesTo.includes(identifier.kind)) continue;
+        try {
+          const finding = await critiqueOne({ identifier, rubric, convention, provider });
+          if (finding !== null) findings.push(finding);
+        } catch {
+          // Swallow per-(identifier, rubric) errors — one bad LLM call
+          // shouldn't sink the whole run.
+        }
+      }
+    }
+  }
+
+  const totalCost = sumCosts(provider);
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: Date.now() - startedAt,
+      llmCalls: {
+        provider: provider.providerId,
+        model: provider.model,
+        count: totalCost.count,
+        costUsd: totalCost.costUsd,
+      },
+      catalog: { rubricsApplied: rubrics.map((r) => r.id) },
+      convention,
+      runId: randomUUID(),
+    },
+  };
+}
+
+/**
+ * Cross-cutting entry: critique names in a single file without the
+ * project walk. Used by future craft skills (docs-craft, test-craft,
+ * code-craft) that already have file context.
+ */
+export async function critiqueNamesInFile(
+  file: string,
+  opts: {
+    source?: string;
+    kinds?: Array<IdentifierKind>;
+    convention?: ProjectConvention;
+    provider?: LlmProvider;
+    rubrics?: ReadonlyArray<NamingRubric>;
+    maxIdentifiers?: number;
+  } = {}
+): Promise<NamingFinding[]> {
+  const source = opts.source ?? fs.readFileSync(file, 'utf-8');
+  const identifiers = extractIdentifiers(file, source);
+  const convention = opts.convention ?? sampleConventions(identifiers, [file]);
+  const rubrics = opts.rubrics ?? SEED_RUBRICS;
+  const provider = opts.provider ?? getProvider();
+  const sample = sampleIdentifiers(
+    identifiers,
+    opts.maxIdentifiers ?? DEFAULT_MAX_IDENTIFIERS_PER_FILE,
+    opts.kinds
+  );
+  const findings: NamingFinding[] = [];
+  for (const identifier of sample) {
+    for (const rubric of rubrics) {
+      if (!rubric.appliesTo.includes(identifier.kind)) continue;
+      try {
+        const finding = await critiqueOne({ identifier, rubric, convention, provider });
+        if (finding !== null) findings.push(finding);
+      } catch {
+        /* swallow per-call */
+      }
+    }
+  }
+  return findings;
+}
+
+function collectFiles(projectRoot: string, explicitFiles: readonly string[] | undefined): string[] {
+  if (explicitFiles !== undefined && explicitFiles.length > 0) {
+    return explicitFiles.map((f) => (path.isAbsolute(f) ? f : path.join(projectRoot, f)));
+  }
+  const out: string[] = [];
+  walk(projectRoot, out, 0);
+  return out;
+}
+
+function walk(dir: string, out: string[], depth: number): void {
+  if (depth > 8) return;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (
+      entry.name.startsWith('.') ||
+      entry.name === 'node_modules' ||
+      entry.name === 'dist' ||
+      entry.name === 'build' ||
+      entry.name === 'coverage'
+    ) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out, depth + 1);
+    else if (entry.isFile() && EXTENSIONS.some((ext) => entry.name.endsWith(ext))) out.push(full);
+  }
+}
+
+/**
+ * Weighted sample: exported first, then long-scope, then random fill.
+ */
+function sampleIdentifiers(
+  identifiers: readonly ExtractedIdentifier[],
+  max: number,
+  kindsFilter: ReadonlyArray<IdentifierKind> | undefined
+): ExtractedIdentifier[] {
+  const candidates = identifiers.filter((i) => {
+    if (kindsFilter !== undefined && !kindsFilter.includes(i.kind)) return false;
+    return true;
+  });
+  const exported = candidates.filter((i) => i.exported);
+  const longScope = candidates.filter((i) => !i.exported && i.scopeSize === 'long');
+  const shortScope = candidates.filter((i) => !i.exported && i.scopeSize === 'short');
+  const out: ExtractedIdentifier[] = [];
+  const dedup = new Set<string>();
+  for (const list of [exported, longScope, shortScope]) {
+    for (const id of list) {
+      const key = `${id.kind}:${id.name}:${id.line}`;
+      if (dedup.has(key)) continue;
+      dedup.add(key);
+      out.push(id);
+      if (out.length >= max) return out;
+    }
+  }
+  return out;
+}
+
+interface CostSummary {
+  count: number;
+  costUsd: number;
+}
+
+function sumCosts(provider: LlmProvider): CostSummary {
+  // MockLlmProvider exposes getCosts(); production providers may not.
+  const maybeGetCosts = (provider as unknown as { getCosts?: () => readonly { costUsd: number }[] })
+    .getCosts;
+  if (typeof maybeGetCosts !== 'function') return { count: 0, costUsd: 0 };
+  const costs = maybeGetCosts.call(provider);
+  return {
+    count: costs.length,
+    costUsd: costs.reduce((sum, c) => sum + c.costUsd, 0),
+  };
+}
+
+export type {
+  NamingFinding,
+  NamingCraftOutput,
+  IdentifierKind,
+  ProjectConvention,
+} from './findings/schema.js';

--- a/packages/cli/src/naming-craft/llm/provider.ts
+++ b/packages/cli/src/naming-craft/llm/provider.ts
@@ -1,0 +1,16 @@
+/**
+ * Re-export design-craft's LLM provider infrastructure. Cross-craft
+ * sharing happens through plain re-export until a second non-design
+ * craft skill needs differences; at that point the shared interface
+ * extracts to `packages/cli/src/shared/llm/` (v2).
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Technical Design → Reusing design-craft infrastructure).
+ */
+
+export {
+  type LlmProvider,
+  type LlmCallCost,
+  MockLlmProvider,
+  getProvider,
+} from '../../design-craft/llm/provider.js';

--- a/packages/cli/src/naming-craft/phases/critique.ts
+++ b/packages/cli/src/naming-craft/phases/critique.ts
@@ -1,0 +1,132 @@
+/**
+ * CRITIQUE phase — invokes the LLM provider per (identifier, rubric)
+ * pair and parses 3-axis findings from the response. Matches design-
+ * craft's fenced-JSON parser contract.
+ *
+ * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
+ *   (Technical Design → Critique phase).
+ */
+
+import type { LlmProvider } from '../llm/provider.js';
+import type { NamingRubric } from '../catalog/rubrics/index.js';
+import type {
+  NamingFinding,
+  ProjectConvention,
+  Tier,
+  Impact,
+  Confidence,
+} from '../findings/schema.js';
+import type { ExtractedIdentifier } from '../extract/identifiers.js';
+import { derivePriority } from '../findings/derived.js';
+
+export interface CritiqueInput {
+  identifier: ExtractedIdentifier;
+  rubric: NamingRubric;
+  convention: ProjectConvention;
+  provider: LlmProvider;
+}
+
+export async function critiqueOne(input: CritiqueInput): Promise<NamingFinding | null> {
+  const { identifier, rubric, provider } = input;
+  const prompt = buildPrompt(input);
+  const raw = await provider.callText(prompt, {
+    systemPrompt:
+      'You are a senior engineer critiquing identifier names against a single naming rubric. ' +
+      'Respond ONLY with a fenced JSON block. If the rubric does not apply or the name is fine, ' +
+      'return `null` (literally the word null inside the JSON block).',
+  });
+  const parsed = parseFencedJson(raw);
+  if (parsed === null) return null;
+  if (typeof parsed !== 'object') return null;
+
+  const tier = parsed.tier as Tier;
+  const impact = parsed.impact as Impact;
+  const confidence = parsed.confidence as Confidence;
+  if (!isTier(tier) || !isImpact(impact) || !isConfidence(confidence)) return null;
+  if (typeof parsed.message !== 'string' || parsed.message.length === 0) return null;
+
+  const finding: NamingFinding = {
+    code: rubric.id,
+    phase: 'critique',
+    tier,
+    impact,
+    confidence,
+    target: {
+      file: identifier.file,
+      line: identifier.line,
+      identifier: identifier.name,
+      kind: identifier.kind,
+    },
+    message: parsed.message,
+    cite: { rubricId: rubric.id, source: rubric.source },
+    derived: { priority: derivePriority(tier, impact, confidence) },
+  };
+  return finding;
+}
+
+function buildPrompt(input: CritiqueInput): string {
+  const { identifier, rubric, convention } = input;
+  const conventionLine = describeConvention(identifier.kind, convention);
+  return [
+    `Rubric: ${rubric.title} (${rubric.id})`,
+    `Source: ${rubric.source}`,
+    `Description: ${rubric.description}`,
+    '',
+    `Identifier: "${identifier.name}"`,
+    `Kind: ${identifier.kind}`,
+    `Exported: ${identifier.exported}`,
+    `Scope size: ${identifier.scopeSize}`,
+    conventionLine,
+    '',
+    'Context:',
+    '```',
+    identifier.contextLines.join('\n'),
+    '```',
+    '',
+    'Respond with a fenced JSON block. Either:',
+    '- `null` (literal) if the rubric does not apply OR the name is fine, OR',
+    '- `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "<critique with suggested rename when possible>" }`',
+  ].join('\n');
+}
+
+function describeConvention(
+  kind: ExtractedIdentifier['kind'],
+  convention: ProjectConvention
+): string {
+  const conv = convention[kindToConventionKey(kind)];
+  if (conv === null)
+    return 'Project convention: (no dominant convention detected — skip convention-conformance rubric)';
+  return `Project convention for ${kind}: ${conv}`;
+}
+
+function kindToConventionKey(
+  kind: ExtractedIdentifier['kind']
+): 'variables' | 'functions' | 'types' {
+  if (kind === 'variable') return 'variables';
+  if (kind === 'function') return 'functions';
+  return 'types';
+}
+
+function parseFencedJson(raw: string): Record<string, unknown> | null {
+  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
+  const body = match !== null ? match[1]! : raw;
+  if (body.trim() === 'null') return null;
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed === null) return null;
+    if (typeof parsed !== 'object') return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function isTier(v: unknown): v is Tier {
+  return v === 'foundational' || v === 'polish' || v === 'aspirational';
+}
+function isImpact(v: unknown): v is Impact {
+  return v === 'small' || v === 'medium' || v === 'large';
+}
+function isConfidence(v: unknown): v is Confidence {
+  return v === 'high' || v === 'medium' || v === 'low';
+}

--- a/packages/cli/tests/mcp/server-integration.test.ts
+++ b/packages/cli/tests/mcp/server-integration.test.ts
@@ -67,7 +67,9 @@ describe('MCP Server Integration', () => {
     expect(names).toContain('align_design_system');
     // design-pipeline #3 — audit-brand-compliance
     expect(names).toContain('audit_brand');
-    expect(tools).toHaveLength(73);
+    // craft-pipeline #1 — naming-craft
+    expect(names).toContain('naming_craft');
+    expect(tools).toHaveLength(74);
   });
 
   it('all tool definitions have inputSchema', () => {

--- a/packages/cli/tests/mcp/server.test.ts
+++ b/packages/cli/tests/mcp/server.test.ts
@@ -11,9 +11,9 @@ describe('MCP Server', () => {
     expect(server).toBeDefined();
   });
 
-  it('registers all 73 tools', () => {
+  it('registers all 74 tools', () => {
     const tools = getToolDefinitions();
-    expect(tools).toHaveLength(73);
+    expect(tools).toHaveLength(74);
   });
 
   it('registers all 9 resources', () => {

--- a/packages/cli/tests/naming-craft/critique.test.ts
+++ b/packages/cli/tests/naming-craft/critique.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { critiqueOne } from '../../src/naming-craft/phases/critique';
+import { MockLlmProvider } from '../../src/naming-craft/llm/provider';
+import { predictivePowerRubric } from '../../src/naming-craft/catalog/rubrics/predictive-power';
+import { sampleConventions } from '../../src/naming-craft/extract/convention';
+import type { ExtractedIdentifier } from '../../src/naming-craft/extract/identifiers';
+
+const identifier: ExtractedIdentifier = {
+  name: 'processData',
+  kind: 'function',
+  file: 'a.ts',
+  line: 10,
+  exported: true,
+  scopeSize: 'long',
+  contextLines: ['function processData(input) {', '  return input;', '}'],
+};
+
+describe('critiqueOne', () => {
+  it('parses a fenced-JSON finding and emits a NamingFinding', async () => {
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'processData',
+        response:
+          '```json\n{"tier":"polish","impact":"medium","confidence":"high","message":"vague verb"}\n```',
+      },
+    ]);
+    const convention = sampleConventions([], []);
+    const finding = await critiqueOne({
+      identifier,
+      rubric: predictivePowerRubric,
+      convention,
+      provider,
+    });
+    expect(finding).not.toBeNull();
+    expect(finding!.code).toBe('NAME-R001');
+    expect(finding!.tier).toBe('polish');
+    expect(finding!.impact).toBe('medium');
+    expect(finding!.confidence).toBe('high');
+    expect(finding!.message).toBe('vague verb');
+    expect(finding!.target.identifier).toBe('processData');
+    expect(finding!.cite.rubricId).toBe('NAME-R001');
+    expect(finding!.derived.priority).toBeGreaterThan(0);
+  });
+
+  it('returns null when LLM responds with `null`', async () => {
+    const provider = new MockLlmProvider([
+      { promptIncludes: 'processData', response: '```json\nnull\n```' },
+    ]);
+    const convention = sampleConventions([], []);
+    const finding = await critiqueOne({
+      identifier,
+      rubric: predictivePowerRubric,
+      convention,
+      provider,
+    });
+    expect(finding).toBeNull();
+  });
+
+  it('returns null when LLM response is malformed', async () => {
+    const provider = new MockLlmProvider([
+      { promptIncludes: 'processData', response: 'not a JSON block' },
+    ]);
+    const convention = sampleConventions([], []);
+    const finding = await critiqueOne({
+      identifier,
+      rubric: predictivePowerRubric,
+      convention,
+      provider,
+    });
+    expect(finding).toBeNull();
+  });
+
+  it('returns null when 3-axis fields are missing or invalid', async () => {
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'processData',
+        response:
+          '```json\n{"tier":"polish","impact":"medium","confidence":"super-high","message":"bad"}\n```',
+      },
+    ]);
+    const convention = sampleConventions([], []);
+    const finding = await critiqueOne({
+      identifier,
+      rubric: predictivePowerRubric,
+      convention,
+      provider,
+    });
+    expect(finding).toBeNull();
+  });
+});

--- a/packages/cli/tests/naming-craft/extract.test.ts
+++ b/packages/cli/tests/naming-craft/extract.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { extractIdentifiers } from '../../src/naming-craft/extract/identifiers';
+import { classify, sampleConventions } from '../../src/naming-craft/extract/convention';
+
+describe('extractIdentifiers', () => {
+  it('extracts const + let variables', () => {
+    const ids = extractIdentifiers('a.ts', `const userName = "x";\nlet retryCount = 0;\n`);
+    expect(ids.map((i) => i.name)).toEqual(['userName', 'retryCount']);
+    expect(ids.every((i) => i.kind === 'variable')).toBe(true);
+  });
+
+  it('extracts function declarations + arrow-function consts', () => {
+    const ids = extractIdentifiers('a.ts', `function fetchUser() {}\nconst saveUser = () => {};\n`);
+    expect(ids.find((i) => i.name === 'fetchUser')?.kind).toBe('function');
+    expect(ids.find((i) => i.name === 'saveUser')?.kind).toBe('function');
+  });
+
+  it('extracts interface + type + class as kind=type', () => {
+    const ids = extractIdentifiers('a.ts', `interface Foo {}\ntype Bar = string;\nclass Baz {}\n`);
+    const kinds = new Map(ids.map((i) => [i.name, i.kind]));
+    expect(kinds.get('Foo')).toBe('type');
+    expect(kinds.get('Bar')).toBe('type');
+    expect(kinds.get('Baz')).toBe('type');
+  });
+
+  it('marks `export` keyword as exported=true', () => {
+    const ids = extractIdentifiers(
+      'a.ts',
+      `export function publicFn() {}\nfunction privateFn() {}\n`
+    );
+    expect(ids.find((i) => i.name === 'publicFn')?.exported).toBe(true);
+    expect(ids.find((i) => i.name === 'privateFn')?.exported).toBe(false);
+  });
+
+  it('extracts destructuring binders as variables', () => {
+    const ids = extractIdentifiers('a.ts', `const { name, age } = user;\n`);
+    expect(ids.map((i) => i.name).sort()).toEqual(['age', 'name']);
+  });
+
+  it('records line numbers', () => {
+    const ids = extractIdentifiers('a.ts', `// line 1 comment\nconst x = 1;\nfunction y() {}\n`);
+    expect(ids.find((i) => i.name === 'x')?.line).toBe(2);
+    expect(ids.find((i) => i.name === 'y')?.line).toBe(3);
+  });
+
+  it('marks scope=short for vars inside a short function body', () => {
+    const ids = extractIdentifiers('a.ts', `function quick() {\n  const inner = 1;\n}\n`);
+    expect(ids.find((i) => i.name === 'inner')?.scopeSize).toBe('short');
+  });
+});
+
+describe('classify (convention)', () => {
+  it.each([
+    ['userName', 'camelCase'],
+    ['user_name', 'snake_case'],
+    ['UserName', 'PascalCase'],
+    ['user-name', 'kebab-case'],
+    ['user', 'camelCase'], // single lowercase word
+    ['USER', 'PascalCase'], // ALL_CAPS fits PascalCase regex in v1 (refine in v1.x)
+    ['', null],
+  ])('classify(%j) → %j', (name, expected) => {
+    expect(classify(name)).toBe(expected);
+  });
+});
+
+describe('sampleConventions', () => {
+  it('returns camelCase when >50% of variables are camelCase', () => {
+    const ids = [
+      {
+        name: 'userName',
+        kind: 'variable' as const,
+        file: 'a.ts',
+        line: 1,
+        exported: false,
+        scopeSize: 'long' as const,
+        contextLines: [],
+      },
+      {
+        name: 'fooBar',
+        kind: 'variable' as const,
+        file: 'a.ts',
+        line: 2,
+        exported: false,
+        scopeSize: 'long' as const,
+        contextLines: [],
+      },
+      {
+        name: 'snake_x',
+        kind: 'variable' as const,
+        file: 'a.ts',
+        line: 3,
+        exported: false,
+        scopeSize: 'long' as const,
+        contextLines: [],
+      },
+    ];
+    const conv = sampleConventions(ids, []);
+    expect(conv.variables).toBe('camelCase');
+  });
+
+  it('returns null when no convention has >50% majority', () => {
+    const ids = [
+      {
+        name: 'userName',
+        kind: 'variable' as const,
+        file: 'a.ts',
+        line: 1,
+        exported: false,
+        scopeSize: 'long' as const,
+        contextLines: [],
+      },
+      {
+        name: 'snake_x',
+        kind: 'variable' as const,
+        file: 'a.ts',
+        line: 2,
+        exported: false,
+        scopeSize: 'long' as const,
+        contextLines: [],
+      },
+      {
+        name: 'PascalY',
+        kind: 'variable' as const,
+        file: 'a.ts',
+        line: 3,
+        exported: false,
+        scopeSize: 'long' as const,
+        contextLines: [],
+      },
+    ];
+    const conv = sampleConventions(ids, []);
+    expect(conv.variables).toBe(null);
+  });
+
+  it('files convention sampled from basenames sans extension', () => {
+    const conv = sampleConventions([], ['my-file.ts', 'other-file.tsx', 'thirdFile.ts']);
+    expect(conv.files).toBe('kebab-case');
+  });
+});

--- a/packages/cli/tests/naming-craft/integration.test.ts
+++ b/packages/cli/tests/naming-craft/integration.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runNamingCraft, critiqueNamesInFile } from '../../src/naming-craft';
+import { MockLlmProvider } from '../../src/naming-craft/llm/provider';
+
+describe('runNamingCraft (integration)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-craft-int-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(rel: string, content: string): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  it('walks empty project and emits zero findings', async () => {
+    const out = await runNamingCraft({ path: tmpDir });
+    expect(out.findings).toEqual([]);
+    expect(out.summary.catalog.rubricsApplied).toHaveLength(6);
+  });
+
+  it('walks a real file and aggregates findings via mock provider', async () => {
+    writeFile('src/orders.ts', `export function processData(orders) { return orders; }\n`);
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'processData',
+        response:
+          '```json\n{"tier":"polish","impact":"medium","confidence":"medium","message":"vague verb"}\n```',
+      },
+    ]);
+    const out = await runNamingCraft({ path: tmpDir, __testProvider: provider });
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.findings[0].target.identifier).toBe('processData');
+    expect(out.summary.llmCalls.count).toBeGreaterThan(0);
+    expect(out.summary.runId).toBeTruthy();
+  });
+
+  it('honors maxFiles cap', async () => {
+    for (let i = 0; i < 5; i++) {
+      writeFile(`src/file${i}.ts`, `const x${i} = ${i};\n`);
+    }
+    const out = await runNamingCraft({ path: tmpDir, maxFiles: 2 });
+    // 5 files written, cap to 2: convention sampling still works but only
+    // 2 files are scanned for findings. Verify by summary metadata path.
+    expect(out.summary.llmCalls.count).toBeLessThanOrEqual(2 * 6 * 15);
+  });
+
+  it('derives camelCase convention from a uniformly camelCase project', async () => {
+    writeFile('src/a.ts', `const userName = 1;\nconst retryCount = 2;\nconst maxBuffer = 3;\n`);
+    const out = await runNamingCraft({ path: tmpDir });
+    expect(out.summary.convention.variables).toBe('camelCase');
+  });
+
+  it('cross-cutting critiqueNamesInFile works on a single file without project walk', async () => {
+    writeFile('src/x.ts', `export function fetchData() {}\n`);
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'fetchData',
+        response:
+          '```json\n{"tier":"polish","impact":"small","confidence":"medium","message":"hi"}\n```',
+      },
+    ]);
+    const findings = await critiqueNamesInFile(path.join(tmpDir, 'src/x.ts'), { provider });
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('emits NamingFinding with all 3 axes present (ADR 0019)', async () => {
+    writeFile('src/a.ts', `export const userName = 1;\n`);
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'userName',
+        response:
+          '```json\n{"tier":"foundational","impact":"large","confidence":"low","message":"x"}\n```',
+      },
+    ]);
+    const out = await runNamingCraft({ path: tmpDir, __testProvider: provider });
+    const f = out.findings.find((finding) => finding.target.identifier === 'userName');
+    expect(f).toBeDefined();
+    expect(f!.tier).toBe('foundational');
+    expect(f!.impact).toBe('large');
+    expect(f!.confidence).toBe('low');
+    expect(f!.cite.rubricId).toMatch(/^NAME-R/);
+  });
+});


### PR DESCRIPTION
## Summary

Ships **naming-craft** — first member of the craft-pipeline initiative (sub-project #1 of 10). LLM-judgment skill that critiques identifier names (variables, functions, types, files) against a curated rubric catalog seeded from Martin / Beck / Karlton.

**Three decisions locked:**

1. **v1 identifier kinds: variables + functions + types + files.** Covers ~80% of naming value in TS codebases. Modules / branches / commit subjects deferred to v1.x.
2. **Convention source: catalog-only + derived-from-code.** Universal rubrics ship in the default catalog; case convention is sampled from project's existing identifiers via majority-rule (>50% threshold). No project input required.
3. **Living catalog H (ADR 0020).** Mirrors design-craft. Seed rubrics with `contribution` / `signal` / `version` fields reserved for future growth mechanism.

**6 seed rubrics** (one file per rubric, matches design-craft layout):

- `NAME-R001` predictive power (Martin)
- `NAME-R002` concreteness (Martin / Beck)
- `NAME-R003` verb/noun honesty (Beck)
- `NAME-R004` convention conformance (Karlton)
- `NAME-R005` scope match (Beck)
- `NAME-R006` encoded measure / unit (Pragmatic Programmer)

**Honors ADRs 0018-0021:** confidence first-class, 3-axis preserved (tier × impact × confidence, never collapsed), `cite.rubricId` on every finding for catalog usage signal.

**Cross-cutting:** `critiqueNamesInFile(file, opts)` exported so future craft skills (docs-craft / test-craft / code-craft) can invoke naming critique on a file they're already processing without re-walking the project.

**Reuses design-craft infrastructure:** imports `LlmProvider` + `MockLlmProvider` + `derivePriority` directly. Extraction to `packages/cli/src/shared/llm/` deferred until a second non-design craft skill needs differences (v2).

**Surface area:**

- `harness naming-craft` CLI command (`--files` / `--kinds` / `--max-files` / `--max-identifiers-per-file` / `--json` / `--verbose`)
- `naming_craft` MCP tool (count 73 → 74)
- 4-platform skill markdown (claude-code / codex / cursor / gemini-cli)
- New `craft.naming.{enabled, maxFiles, maxIdentifiersPerFile}` config block under new top-level `craft.*` namespace

## Test plan

- [x] `pnpm --filter @harness-engineering/cli exec vitest run tests/naming-craft tests/mcp` — 801/801 pass
- [x] 22 new unit + integration tests across extractor, convention sampler, classifier, critique phase, end-to-end pipeline
- [x] End-to-end smoke: fixture file with `processData()` / `timeout` / `userName` / `foo_bar` interface. 23 findings emitted (6 rubrics × ~5 identifiers); convention sampler derived `camelCase` for variables/functions/files; mock provider's deterministic low-confidence response surfaces (ADR 0019 honesty preserved).
- [x] Auto-doc regenerated: `naming_craft` MCP tool + `naming-craft` skill surface in docs/reference/{mcp-tools,skills-catalog}.md

## Note on tool count

This PR bumps tool count 73 → 74. PR #400 (design-pipeline orchestrator) also bumps 73 → 74 from main. Whichever merges first, the second will need a small rebase to bump 74 → 75 and add the missing assertion.

## Long-term trajectory

- v1.x — module / branch / commit-subject naming; POLISH phase; per-project rubric overrides; per-language (Python / Go / Rust) idiom catalogs; `align-naming` sibling FIX skill.
- v2 — extract shared craft infrastructure to `packages/cli/src/shared/craft/` when a second non-design craft skill lands; cross-craft convergence inside the (future) craft-pipeline orchestrator.
- v3 — aesthetic-intent-aware naming (terse for minimalist, descriptive for verbose).