### PR TITLE
fix(security-craft): rewrite signals.ts comments to avoid harness security scanner FPs

### DIFF
--- a/.changeset/security-craft-signals-comments.md
+++ b/.changeset/security-craft-signals-comments.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix harness security scanner false positives on `security-craft/extract/signals.ts`. The scanner is regex-based and matched three comments that described what the AST detector looks for (`new Function(...)`, `Bare identifier calls: eval(...), fetch(...)`, `Raw query: db.query(\`...\${x}...\`)`) as actual sinks. Rewrote the three comments to describe the same logic without the literal patterns the regex scanner triggers on. No behavior change — pure documentation rewrite. `harness ci check --skip arch` now exits 0 (was exit 1 with 3 SEC-INJ-001/SEC-INJ-002 error-severity findings).

--- a/packages/cli/src/security-craft/extract/signals.ts
+++ b/packages/cli/src/security-craft/extract/signals.ts
@@ -167,7 +167,7 @@ function visit(node: ts.Node, sf: ts.SourceFile, out: SecuritySignal[], seen: Se
     detectCallSignals(node, sf, out, seen);
   }
 
-  // new Function(...)
+  // Function constructor expression — detected via NewExpression on identifier 'Function'
   if (
     ts.isNewExpression(node) &&
     ts.isIdentifier(node.expression) &&
@@ -244,7 +244,7 @@ function detectCallSignals(
   const callee = node.expression;
   const line = lineOf(node, sf);
 
-  // Bare identifier calls: eval(...), fetch(...)
+  // Bare identifier call expressions — match against BARE_PRIVILEGED_IDENTIFIERS / BARE_EGRESS_IDENTIFIERS
   if (ts.isIdentifier(callee)) {
     if (BARE_PRIVILEGED_IDENTIFIERS.has(callee.text)) {
       emit(out, seen, 'privileged-op', callee.text, line);
@@ -313,7 +313,7 @@ function detectCallSignals(
       }
     }
 
-    // Raw query: db.query(`...${x}...`) or db.raw(...)
+    // Raw-query method call (query / raw / queryRaw / executeRaw) with a SQL-shaped template-literal argument
     if (
       (method === 'query' ||
         method === 'raw' ||


### PR DESCRIPTION
## Summary

The harness security scanner is regex-based and matched on three comments in `packages/cli/src/security-craft/extract/signals.ts` that described what the AST detector looks for:

- `// new Function(...)` → SEC-INJ-001 (eval/Function constructor)
- `// Bare identifier calls: eval(...), fetch(...)` → SEC-INJ-001
- `// Raw query: db.query(\`...\${x}...\`) or db.raw(...)` → SEC-INJ-002 (template-literal SQL)

These were comments documenting the AST detector's intent, not actual sinks. The scanner does not parse comments AST-aware, so it triggered on documentation text. Rewritten the three comments to describe the same logic without the literal patterns the regex scanner triggers on.

**Root cause of why this landed in main:** I made this fix locally on `feat/security-craft-brainstorm` and pushed it, but PR #410 had already been auto-merged at the prior commit. The fix push created an orphan branch on remote with the fix commit (`f599c42a`); main inherited the broken state. This PR cherry-picks that fix onto a fresh branch off main.

**Verification:** `node packages/cli/dist/bin/harness.js ci check --skip arch` now exits 0 with `All checks passed (4/9)` and zero `[SEC-*]` error-severity findings (previously 3 error-severity findings on signals.ts).

## Test plan

- [x] Local `harness ci check --skip arch` exits 0 (was exit 1)
- [x] Zero `[SEC-INJ-001]` / `[SEC-INJ-002]` error-severity findings on `signals.ts` (was 3)
- [x] No behavior change: pure comment rewrite (3 lines)
- [x] All 48 security-craft tests still pass