### PR TITLE
fix(cli): add better-sqlite3 runtime dep + archive Spec B phase plans

### DIFF
--- a/.changeset/cli-better-sqlite3-runtime-dep.md
+++ b/.changeset/cli-better-sqlite3-runtime-dep.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Add `better-sqlite3` as a runtime dependency. The CLI bundles orchestrator code that imports `better-sqlite3` (webhook queue, session search-index) and ships those chunks in `dist/`. Native bindings cannot be bundled by tsup, so the published `@harness-engineering/cli` package must declare `better-sqlite3` as a direct dependency. Without this, `npm i -g @harness-engineering/cli` succeeds but any sqlite-backed feature throws `Cannot find module 'better-sqlite3'` at runtime.

--- a/.harness/security/timeline.json
+++ b/.harness/security/timeline.json
@@ -18260,6 +18260,4597 @@
         "e66ff96d15a5d527",
         "53b3cf3e586f168a"
       ]
+    },
+    {
+      "capturedAt": "2026-05-24T20:12:23.002Z",
+      "commitHash": "4af4e3233fd2f81f1354e6490f7e2b35be46d3c2",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-24T20:14:27.807Z",
+      "commitHash": "6c4c03f92d57dfdc2bf75ad692bc986d24990104",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-24T20:15:45.179Z",
+      "commitHash": "3cf6c60b146d4fb86e17b57bc932c7d84943379a",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-24T20:17:04.302Z",
+      "commitHash": "aeaab0d797a72d6673e83798af6a332c16b3b72e",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:19:23.149Z",
+      "commitHash": "2786211a9fe060894edb00cf13511bbe0f659fa1",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:20:33.185Z",
+      "commitHash": "cb81097d6104082d781f714202373299b4d95322",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:22:04.350Z",
+      "commitHash": "38abbde9d67203c883390477e607a3d9ab5f7f55",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:23:56.583Z",
+      "commitHash": "a6e3c7948b0e57cfce7cb0b75a028676ab9ff017",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:25:51.747Z",
+      "commitHash": "c43ee6df5336079c3fcd98ef3af2993e21a9340b",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:29:05.278Z",
+      "commitHash": "b557dc3c5281f634226bf191b132b9a5e52a4021",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:30:45.359Z",
+      "commitHash": "c7263dbc89d7bb3b4bf7937eea33e70a5e6d0e97",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:32:00.972Z",
+      "commitHash": "432b4d6e607afc9201a098255e326e8177d8b470",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T13:33:59.380Z",
+      "commitHash": "d687f09190063dda3d02d842598ee4ed1b1a795c",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:39:10.160Z",
+      "commitHash": "acb6e8c1432201f600eea7982536644e48453006",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:40:06.756Z",
+      "commitHash": "ad8389425c7a42cef13b94221b569fea525f485d",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:41:12.001Z",
+      "commitHash": "bea239f056803f011615e30983fdbe6fc35d1e22",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:42:57.501Z",
+      "commitHash": "3a85a74f671eacf1d172d16269e073ef6493bea8",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:44:08.012Z",
+      "commitHash": "880fac0947a175e986813d218ceb1c34e15c93ee",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:44:58.473Z",
+      "commitHash": "4b0c68b9eac168abc7024eda10febe240e15d424",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:46:03.741Z",
+      "commitHash": "db5d119710b60af31ea1505ddc2183d68f7932a5",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:47:45.712Z",
+      "commitHash": "672a6e31deaf08a2925470bb6b414e0d66110713",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-25T20:48:25.215Z",
+      "commitHash": "cf36696fe9f6ed42fd9bd5491443859e66ecc098",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:00:28.197Z",
+      "commitHash": "fba8901fda6bd19cff8f5302fe1aa2a82ed0e589",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:01:14.459Z",
+      "commitHash": "12ae9bb3109f0320bff675bf5381f20ffd4edf63",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:02:59.492Z",
+      "commitHash": "a3e20fc7fe2765560be1b22c30ba8288b9f0bea9",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:04:00.673Z",
+      "commitHash": "44a727ce4cf8d55a0e3590bfeb12ec150ca9921f",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:05:27.370Z",
+      "commitHash": "46ffc9d305cc75a4eb32c68d0041358aeac69ac7",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:06:35.652Z",
+      "commitHash": "82fecbc9735ae848db3001d1ae48ab66c21f81a7",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:07:50.319Z",
+      "commitHash": "3717ff39d08093c114acc1a55968c47fe7d62b3f",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:09:26.335Z",
+      "commitHash": "463705cc6768cd4c426895c7d813119043e8427b",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:11:16.387Z",
+      "commitHash": "ed2a3e40e9122e538140c2d35d64168832294cc6",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:13:03.353Z",
+      "commitHash": "ab7a47b7972441fd0d57db8929728b1ba3073b32",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:14:16.567Z",
+      "commitHash": "bb0728e2c831c5626ecf70e38f63257adb5816d2",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T03:16:32.973Z",
+      "commitHash": "5802839f16a75781eb8ac672c116d53886e5722b",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:03:41.897Z",
+      "commitHash": "0ae22b409e202873015b5ff5b874268313ef4249",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:04:42.719Z",
+      "commitHash": "a0df91c4707b9d42aaf1bc11b00b60f0e4ce426b",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:05:50.988Z",
+      "commitHash": "cf438ec5fd9a2a7c8a64df2612376e057191b8a5",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:06:36.883Z",
+      "commitHash": "833b99d7da2aee888754e89cf51efcd4cba767aa",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:07:39.925Z",
+      "commitHash": "2e72172ff1c2684d0c1c85caf31ed32ef8842000",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:08:38.243Z",
+      "commitHash": "0e270eeaea22682b7ee78609e7d436e71832ed9c",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:10:01.540Z",
+      "commitHash": "e796acc5007c577d562be6824533868a2a1a7735",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:10:42.678Z",
+      "commitHash": "a96a65622d354e79b446ab3fe13be828aaa2cb39",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:12:00.100Z",
+      "commitHash": "ef3e7090fa4c8035a858adfe85382743ba147908",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:14:03.981Z",
+      "commitHash": "a1727675875c109b963ee351ce5daeefad67a3a7",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:16:11.455Z",
+      "commitHash": "c048c801100b5abe73d0c03060b72f7eb0e669cf",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T14:28:56.990Z",
+      "commitHash": "3d4deb4c64157dda81ed991d23c0b3141490d526",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:26:18.232Z",
+      "commitHash": "d9960683f890ea8a4d1289279142abd748dff912",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:27:46.832Z",
+      "commitHash": "ed39c0cf2e423dd9325784802028f0b824a8830f",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:28:53.727Z",
+      "commitHash": "eb6db27f75d1d2ae47076cd6d2653114854a87b9",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:30:22.716Z",
+      "commitHash": "c6a266095ed1573bb7497d7aef4a896d9f54772f",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:30:39.176Z",
+      "commitHash": "418abe326744020853ff000c2612bf90d2d5a884",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:31:12.383Z",
+      "commitHash": "1d13525f52f75e48a9ea87a38a96661d73c67360",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:32:01.625Z",
+      "commitHash": "97ce2f4f2d9a01f8ee1e3da67b0e3ecdf8910e3d",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T16:32:54.526Z",
+      "commitHash": "55bd0c6dce055922317485fa3063187cb4b74095",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:16:19.889Z",
+      "commitHash": "213d51126140a10ac13fb6b6d738445be65002a1",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:16:56.242Z",
+      "commitHash": "1d4e2616efcded337c3aa9f24ce443726d60a46e",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:17:42.900Z",
+      "commitHash": "99a26c9fa83881a614ff71fe4328b229ae4f50ee",
+      "securityScore": 82,
+      "totalFindings": 18,
+      "bySeverity": {
+        "error": 0,
+        "warning": 18,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 16,
+          "errorCount": 0,
+          "warningCount": 16,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:19:51.899Z",
+      "commitHash": "fc9a98cf5a0ce8810d3dbcbb87e9aa1aadf2c1b0",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:20:54.869Z",
+      "commitHash": "8246461458a844b2cf3629356973f3f24f8d5c30",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:22:49.224Z",
+      "commitHash": "2c83dbbb2cbfccd0294e339a6d2607d3f1e30e71",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:23:50.263Z",
+      "commitHash": "3c4b728ea102c22eb25981f56de85934aadb6cff",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:26:16.520Z",
+      "commitHash": "8bc06fd63e9fbe5a2528733e89a8129f14acae5c",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:27:01.918Z",
+      "commitHash": "fed498bc6be3af510c4f0f37977e1184723d8694",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:27:58.326Z",
+      "commitHash": "f4cee14aa2a5a400b2c2bb233deaa064abbd3bd0",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:29:00.314Z",
+      "commitHash": "e4de91bd73da327221ebb2f93826b2373e8fea09",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:30:57.542Z",
+      "commitHash": "b8456da171abcfbbdb0d8e8c2d7668b4721396b0",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:40:18.769Z",
+      "commitHash": "cff5b318115e56086c5701fd8d4e104db8a0c8bb",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:54:51.542Z",
+      "commitHash": "766a9bfeacb3403a63a2cbfafc207fde99686375",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:55:30.866Z",
+      "commitHash": "0c6926241ff56c6900e62e5100076e415193b131",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:56:10.562Z",
+      "commitHash": "720bb4b395c7ad9b7b407a2741737b17ebbe5c6c",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:56:47.052Z",
+      "commitHash": "efd8776f9ecab997ad711b21aa88fb8df193d611",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:57:38.120Z",
+      "commitHash": "b1d6a8cd5b93353c979f67f89c09e39336631345",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:58:25.977Z",
+      "commitHash": "1c69fd9b51e3dcff0edf984f937a5f533dcdf9ed",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:59:13.091Z",
+      "commitHash": "e4127c06492552bc25304dd5f0fc437ba71d8ba6",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T18:59:57.887Z",
+      "commitHash": "f591961a0429fb251bdced176fc02b821d4f0bd8",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:00:29.090Z",
+      "commitHash": "89b42fd236f3de312b351113249d4708058ea41c",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:01:21.794Z",
+      "commitHash": "80ca3fab52afe713a17e4101e24246cfdc13054c",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:02:08.277Z",
+      "commitHash": "b40a2ab4118cca6edf83c27f868748ba87a14199",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:02:37.001Z",
+      "commitHash": "ed17eb6adb37811c044124b7888df64c67497049",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:03:30.380Z",
+      "commitHash": "fa3dd6aebbc6b5e17d09fb5037f11f45216a2bd6",
+      "securityScore": 81,
+      "totalFindings": 19,
+      "bySeverity": {
+        "error": 0,
+        "warning": 19,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 17,
+          "errorCount": 0,
+          "warningCount": 17,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 2,
+          "errorCount": 0,
+          "warningCount": 2,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "53b3cf3e586f168a"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:30:47.705Z",
+      "commitHash": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
+      "securityScore": 74,
+      "totalFindings": 26,
+      "bySeverity": {
+        "error": 0,
+        "warning": 26,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 23,
+          "errorCount": 0,
+          "warningCount": 23,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 3,
+          "errorCount": 0,
+          "warningCount": 3,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "91487f7b9b4f538d",
+        "63f2384fbc4ea391",
+        "53b3cf3e586f168a",
+        "5122c3f1c62c942b",
+        "25c84682194c9569",
+        "5b67f6312b27966d",
+        "7807b7887a723f88",
+        "3b77a6c5abd245a8"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:36:54.030Z",
+      "commitHash": "58cc7d167cb2c38c59ee376209050bcca9837bd2",
+      "securityScore": 74,
+      "totalFindings": 26,
+      "bySeverity": {
+        "error": 0,
+        "warning": 26,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 23,
+          "errorCount": 0,
+          "warningCount": 23,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 3,
+          "errorCount": 0,
+          "warningCount": 3,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "91487f7b9b4f538d",
+        "63f2384fbc4ea391",
+        "53b3cf3e586f168a",
+        "5122c3f1c62c942b",
+        "25c84682194c9569",
+        "5b67f6312b27966d",
+        "7807b7887a723f88",
+        "3b77a6c5abd245a8"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:44:49.880Z",
+      "commitHash": "f353edcf4f09786c590952dfecd5e637013ef074",
+      "securityScore": 74,
+      "totalFindings": 26,
+      "bySeverity": {
+        "error": 0,
+        "warning": 26,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 23,
+          "errorCount": 0,
+          "warningCount": 23,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 3,
+          "errorCount": 0,
+          "warningCount": 3,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "91487f7b9b4f538d",
+        "63f2384fbc4ea391",
+        "53b3cf3e586f168a",
+        "5122c3f1c62c942b",
+        "25c84682194c9569",
+        "5b67f6312b27966d",
+        "7807b7887a723f88",
+        "3b77a6c5abd245a8"
+      ]
+    },
+    {
+      "capturedAt": "2026-05-26T19:54:51.902Z",
+      "commitHash": "4acfefbc817321059e944abc166933d0cb7cb271",
+      "securityScore": 74,
+      "totalFindings": 26,
+      "bySeverity": {
+        "error": 0,
+        "warning": 26,
+        "info": 0
+      },
+      "byCategory": {
+        "deserialization": {
+          "findingCount": 23,
+          "errorCount": 0,
+          "warningCount": 23,
+          "infoCount": 0
+        },
+        "path-traversal": {
+          "findingCount": 3,
+          "errorCount": 0,
+          "warningCount": 3,
+          "infoCount": 0
+        }
+      },
+      "supplyChain": {
+        "critical": 0,
+        "high": 0,
+        "moderate": 0,
+        "low": 0,
+        "info": 0,
+        "total": 0
+      },
+      "suppressionCount": 0,
+      "findingIds": [
+        "c215c611cd48392c",
+        "7dc050e1898aac85",
+        "d105b04f640dfeab",
+        "dff00c8326714ff9",
+        "70c53ff454c3c7d9",
+        "62f5bd670137601a",
+        "a28f3936f561ebeb",
+        "6dde4d866b3a3edc",
+        "f48ff7c4fd33d504",
+        "86c26e8d696e5beb",
+        "9d5f6135305e92de",
+        "38fe6be103e0c955",
+        "d30bed7ccdc1fe6f",
+        "c4212a5500286c51",
+        "b7c71c01a2847efb",
+        "db73539d16d377f8",
+        "c5abc4f495ece7e5",
+        "e66ff96d15a5d527",
+        "91487f7b9b4f538d",
+        "63f2384fbc4ea391",
+        "53b3cf3e586f168a",
+        "5122c3f1c62c942b",
+        "25c84682194c9569",
+        "5b67f6312b27966d",
+        "7807b7887a723f88",
+        "3b77a6c5abd245a8"
+      ]
     }
   ],
   "findingLifecycles": [
@@ -19228,6 +23819,94 @@
       "file": "packages/orchestrator/src/server/routes/roadmap-actions.ts",
       "firstSeenAt": "2026-05-10T19:25:32.305Z",
       "firstSeenCommit": "f5c4cfe1a98c4e625d1ea3072fb85effa6303ae4",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "c5abc4f495ece7e5",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/dashboard/src/client/hooks/useRoutingDecisions.ts",
+      "firstSeenAt": "2026-05-26T18:19:51.887Z",
+      "firstSeenCommit": "fc9a98cf5a0ce8810d3dbcbb87e9aa1aadf2c1b0",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "91487f7b9b4f538d",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/cli/src/test-craft/phases/critique.ts",
+      "firstSeenAt": "2026-05-26T19:30:47.694Z",
+      "firstSeenCommit": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "63f2384fbc4ea391",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/cli/src/spec-craft/phases/critique.ts",
+      "firstSeenAt": "2026-05-26T19:30:47.694Z",
+      "firstSeenCommit": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "5122c3f1c62c942b",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/cli/src/security-craft/phases/critique.ts",
+      "firstSeenAt": "2026-05-26T19:30:47.694Z",
+      "firstSeenCommit": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "25c84682194c9569",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/cli/src/naming-craft/phases/critique.ts",
+      "firstSeenAt": "2026-05-26T19:30:47.694Z",
+      "firstSeenCommit": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "5b67f6312b27966d",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/cli/src/knowledge-craft/phases/critique.ts",
+      "firstSeenAt": "2026-05-26T19:30:47.694Z",
+      "firstSeenCommit": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "7807b7887a723f88",
+      "ruleId": "SEC-PTH-001",
+      "category": "path-traversal",
+      "severity": "warning",
+      "file": "packages/cli/src/design-pipeline/phases/fill.ts",
+      "firstSeenAt": "2026-05-26T19:30:47.694Z",
+      "firstSeenCommit": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
+      "resolvedAt": null,
+      "resolvedCommit": null
+    },
+    {
+      "findingId": "3b77a6c5abd245a8",
+      "ruleId": "SEC-DES-001",
+      "category": "deserialization",
+      "severity": "warning",
+      "file": "packages/cli/src/copy-craft/phases/critique.ts",
+      "firstSeenAt": "2026-05-26T19:30:47.694Z",
+      "firstSeenCommit": "dcca2ceab2443ab232d9a9d9f6f0b9e1a9847b9f",
       "resolvedAt": null,
       "resolvedCommit": null
     }

--- a/docs/changes/granular-task-routing/plans/2026-05-24-phase-0-type-changes-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-24-phase-0-type-changes-plan.md
@@ -1,0 +1,1241 @@
+# Plan: Granular Task→Backend Routing — Phase 0 (Type changes + scaffolding)
+
+**Date:** 2026-05-24 · **Spec:** `docs/changes/granular-task-routing/proposal.md` · **Phase:** 0 of 8 · **Tasks:** 9 · **Time:** ~45 min · **Integration Tier:** medium
+
+> First phase of Spec B (Granular Task→Backend Routing). Companion to Spec A (LMLM). Phase 0 is intentionally types-only: extend type definitions in `@harness-engineering/types`, widen `RoutingConfig`, free the `RoutingDecision` name for the new resolver-walk record, and keep every existing consumer green (`pnpm typecheck && pnpm build`). No behavior change. Behavior changes land in Phase 1 (`BackendRouter.resolve()` rewrite).
+
+## Goal
+
+Extend `@harness-engineering/types` with the new routing primitives (`RoutingValue`, `RoutingDecision`, `ResolutionStep`, `ResolutionSource`) and the two new `RoutingUseCase` variants (`skill`, `mode`); widen `RoutingConfig` scalar fields to `RoutingValue` and add optional `skills` / `modes` maps — all without changing runtime behavior of any consumer (`pnpm typecheck && pnpm build` green; all existing tests pass unchanged).
+
+## Observable Truths (Acceptance Criteria)
+
+1. **The system shall export** `RoutingValue`, `RoutingDecision`, `ResolutionStep`, `ResolutionSource`, `IssueRoutingDecision` from `@harness-engineering/types` (visible in `packages/types/dist/index.d.ts` after `pnpm --filter @harness-engineering/types build`).
+2. **The system shall export** the two new `RoutingUseCase` variants (`{ kind: 'skill'; skillName: string; cognitiveMode?: string }` and `{ kind: 'mode'; cognitiveMode: string }`) such that consumer code can construct them and TypeScript accepts the construction.
+3. **The system shall accept** scalar `string` values for every existing `RoutingConfig` field (`default`, `quick-fix`, `guided-change`, `full-exploration`, `diagnostic`, `intelligence.{sel,pesl}`, `isolation.{none,container,remote-sandbox}`) AND non-empty `readonly [string, ...string[]]` arrays for the same fields — verified by a typecheck-only fixture under `packages/types/src/__type_tests__/`.
+4. **The system shall accept** optional `routing.skills?: Record<string, RoutingValue>` and `routing.modes?: Record<string, RoutingValue>` maps in `RoutingConfig` — verified by the same fixture.
+5. **The system shall preserve** `routeIssue()`'s return type under the renamed export `IssueRoutingDecision` so `packages/orchestrator/src/core/model-router.ts` and its existing tests continue to compile and pass without semantic changes.
+6. **When `BackendRouter.resolve()` is called with a `RoutingConfig` that uses scalar values for every field, the system shall** return byte-identical backend names as today (verified by existing `tests/agent/backend-router.test.ts` suite passing unchanged — N1).
+7. **When `BackendRouter.resolve()` is called with a `RoutingConfig` that uses array-form values, the system shall** return the first element of the array (Phase 0 normalization shim; Phase 1 replaces this with full chain walk).
+8. **The Zod schema `RoutingConfigSchema`** (`packages/orchestrator/src/workflow/schema.ts`) **shall accept** both scalar strings and non-empty arrays of strings for every routing field that was previously scalar-only, and shall accept the new `skills` / `modes` keys (verified by N5 and a new unit test).
+9. **`pnpm typecheck && pnpm build`** complete with zero errors at the workspace root after Phase 0 lands.
+10. **`pnpm --filter @harness-engineering/orchestrator test -- tests/agent/backend-router.test.ts tests/core/model-router.test.ts`** passes unchanged (N1, N2, N3 from spec success criteria).
+
+## Uncertainties
+
+- **[ASSUMPTION] Naming the existing `RoutingDecision` rename target `IssueRoutingDecision`.** The spec proposes a new `RoutingDecision` shape `{ timestamp, useCase, resolutionPath, backendName, backendType, durationMs }` that collides with the existing export at `packages/types/src/orchestrator.ts:720` (the `routeIssue()` discriminated action `{ action: 'dispatch-local' | 'dispatch-primary' | 'needs-human'; reasons?: string[] }`). The existing type is consumed by `packages/orchestrator/src/core/model-router.ts` (return type of `routeIssue()`) and exported from `packages/types/src/index.ts` (line 130). We rename the existing type to `IssueRoutingDecision` (single src consumer, mechanical refactor) to free the `RoutingDecision` name for the spec's new shape. **If the operator prefers a different rename target** (e.g., keep existing as `RoutingDecision`, name the new shape `BackendResolution` or `BackendRoutingDecision`), Task 2 + Task 3 + Task 4 need symbol substitution. Surface during plan sign-off.
+- **[ASSUMPTION] Phase 0 normalization shim in `BackendRouter`.** Widening `RoutingConfig` fields to `RoutingValue` breaks the existing unchecked cast in `BackendRouter.resolve()` (`(this.routing as unknown as Record<string, string | undefined>)[useCase.tier]`) — the cast still typechecks but returns a tuple at runtime when the operator uses array form. To preserve "no behavior change" (N1, N2, N3) AND accept the widened types, we add a one-line `toScalar(v: RoutingValue): string` helper that returns `Array.isArray(v) ? v[0] : v`. Scalar inputs are byte-identical to today; array-form inputs get a sensible (first-element) fallback until Phase 1's proper chain walk lands. **If this shim is unacceptable** (operator wants array form to throw until Phase 1), Task 6 needs a different approach (e.g., a Phase 0 schema guard that rejects arrays).
+- **[ASSUMPTION] Type test fixtures live at `packages/types/src/__type_tests__/`.** This is the conventional Vitest/tsd-free pattern in this monorepo (typecheck-only files excluded from runtime build via `tsconfig.build.json`). **If the project uses `tsd` or another type-test runner**, Task 5 needs to relocate the fixture and adjust the test command.
+- **[DEFERRABLE] Knowledge-graph enrichment for new business concepts.** Spec lists `Routing Use Case`, `Routing Value`, `Routing Decision`, `Routing Resolution` as concepts entering the knowledge graph. Phase 8 owns this work per the spec's Implementation Order. No Phase 0 task.
+- **[DEFERRABLE] Skill/mode catalog validation hooks.** Spec D10 requires startup warnings for unknown skill names / non-standard cognitive modes. Phase 2 (Config-validator updates) owns this. No Phase 0 task.
+
+## File Map
+
+- **MODIFY** `packages/types/src/orchestrator.ts` — rename existing `RoutingDecision` to `IssueRoutingDecision`; add `RoutingValue`, `RoutingDecision` (new shape), `ResolutionStep`, `ResolutionSource`; widen `RoutingConfig` scalar fields to `RoutingValue`; add `RoutingConfig.skills` and `RoutingConfig.modes`; add two new `RoutingUseCase` variants
+- **MODIFY** `packages/types/src/index.ts` — update barrel re-exports: keep `RoutingDecision` (new shape), add `RoutingValue`, `ResolutionStep`, `ResolutionSource`, `IssueRoutingDecision`
+- **MODIFY** `packages/orchestrator/src/core/model-router.ts` — update import from `RoutingDecision` to `IssueRoutingDecision`; update return type annotation on `routeIssue()`
+- **MODIFY** `packages/orchestrator/src/agent/backend-router.ts` — add private `toScalar(v: RoutingValue): string` normalization helper; thread it through `resolve()` and `validateReferences()` so widened types compile and runtime stays byte-identical for scalar inputs
+- **MODIFY** `packages/orchestrator/src/workflow/schema.ts` — widen `RoutingConfigSchema` Zod fields from `z.string()` to `RoutingValueSchema = z.union([z.string().min(1), z.array(z.string().min(1)).nonempty().readonly()])`; add `skills` / `modes` keys; widen `validateBackendsAndRouting` to recurse over chain entries
+- **CREATE** `packages/types/src/__type_tests__/routing-types.test-d.ts` — typecheck-only fixture asserting scalar/array assignability for `RoutingConfig` fields and constructibility of new `RoutingUseCase` variants
+- **CREATE** `packages/orchestrator/tests/workflow/routing-config-schema.test.ts` — Zod-level unit tests covering scalar/array form acceptance + `skills` / `modes` key acceptance (N5 + observable truth 8)
+
+> **No files removed.** No files added beyond the two test fixtures.
+
+## Skeleton
+
+_Standard rigor + 9 tasks — at the 8+ threshold. Skeleton produced and approved inline by the planner (no separate user gate; will surface in the plan sign-off interaction)._
+
+1. Rename collision target (`RoutingDecision` → `IssueRoutingDecision`) (~3 tasks, ~10 min)
+2. Add new types + widen `RoutingConfig` (~2 tasks, ~10 min)
+3. Update Zod schema + validator (~2 tasks, ~10 min)
+4. Shim `BackendRouter` + barrel regen + smoke (~2 tasks, ~10 min)
+
+**Estimated total:** 9 tasks, ~40-45 minutes.
+
+---
+
+## Tasks
+
+### Task 1: Capture baseline — confirm current `RoutingDecision` consumers and existing test suite is green
+
+**Depends on:** none · **Files:** none (read-only baseline) · **Category:** preflight
+
+1. Run from the workspace root:
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator test -- tests/agent/backend-router.test.ts tests/core/model-router.test.ts 2>&1 | tail -30
+   ```
+
+   Expected: both files green. Record the test count for use as the post-Phase-0 invariant.
+
+2. Run:
+
+   ```bash
+   grep -rn "RoutingDecision" packages --include="*.ts" | grep -v "/dist/" | grep -v "/node_modules/"
+   ```
+
+   Expected output (exact set — any deviation means consumer scope has changed and Task 3 needs updating):
+
+   ```
+   packages/types/src/orchestrator.ts:718: * Result of the routeIssue() pure function.
+   packages/types/src/orchestrator.ts:720:export type RoutingDecision =
+   packages/types/src/index.ts:130:  RoutingDecision,
+   packages/orchestrator/src/core/model-router.ts:5:  RoutingDecision,
+   packages/orchestrator/src/core/model-router.ts:77:): RoutingDecision {
+   ```
+
+3. Run `harness validate` — confirm green baseline.
+
+4. No commit — this is a preflight check. If either step diverges from the expected baseline, **STOP and re-scope** before continuing.
+
+---
+
+### Task 2: Rename the existing `RoutingDecision` export to `IssueRoutingDecision` in `packages/types/src/orchestrator.ts`
+
+**Depends on:** Task 1 · **Files:** `packages/types/src/orchestrator.ts` · **Skills:** `ts-type-guards` (reference)
+
+1. Open `packages/types/src/orchestrator.ts`. Locate the block (currently around line 717-723):
+
+   ```ts
+   /**
+    * Result of the routeIssue() pure function.
+    */
+   export type RoutingDecision =
+     | { action: 'dispatch-local' }
+     | { action: 'dispatch-primary' }
+     | { action: 'needs-human'; reasons: string[] };
+   ```
+
+2. Replace it with:
+
+   ```ts
+   /**
+    * Result of the `routeIssue()` pure function in `packages/orchestrator/src/core/model-router.ts`.
+    *
+    * Renamed from `RoutingDecision` to `IssueRoutingDecision` in Spec B Phase 0 to
+    * free the `RoutingDecision` name for the resolver-walk record produced by
+    * `BackendRouter.resolve()` (see {@link RoutingDecision} below).
+    */
+   export type IssueRoutingDecision =
+     | { action: 'dispatch-local' }
+     | { action: 'dispatch-primary' }
+     | { action: 'needs-human'; reasons: string[] };
+   ```
+
+3. Do NOT touch the index barrel yet — Task 4 handles that.
+
+4. Run: `pnpm --filter @harness-engineering/types typecheck`
+
+   Expected: passes. (Internal-only rename; no other src file in the `types` package references it.)
+
+5. No commit yet — Task 3 ships the consumer update in the same commit boundary.
+
+---
+
+### Task 3: Update the single consumer of the old name in `model-router.ts`
+
+**Depends on:** Task 2 · **Files:** `packages/orchestrator/src/core/model-router.ts`
+
+1. Open `packages/orchestrator/src/core/model-router.ts`. Locate the import (line 1-7):
+
+   ```ts
+   import type {
+     Issue,
+     ScopeTier,
+     ConcernSignal,
+     RoutingDecision,
+     EscalationConfig,
+   } from '@harness-engineering/types';
+   ```
+
+2. Replace `RoutingDecision` with `IssueRoutingDecision`:
+
+   ```ts
+   import type {
+     Issue,
+     ScopeTier,
+     ConcernSignal,
+     IssueRoutingDecision,
+     EscalationConfig,
+   } from '@harness-engineering/types';
+   ```
+
+3. Locate the `routeIssue()` return type annotation (line 77):
+
+   ```ts
+   ): RoutingDecision {
+   ```
+
+   Replace with:
+
+   ```ts
+   ): IssueRoutingDecision {
+   ```
+
+4. Run:
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -20
+   ```
+
+   Expected: passes. (Tests at `tests/core/model-router.test.ts` and `tests/agent/multi-backend-dispatch.test.ts` use `routeIssue` return values structurally, not the type alias, so they don't need to import the new name.)
+
+5. Run:
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator test -- tests/core/model-router.test.ts 2>&1 | tail -10
+   ```
+
+   Expected: same green count as Task 1 baseline.
+
+6. Run `harness validate` — confirm green.
+
+7. Commit:
+
+   ```bash
+   git add packages/types/src/orchestrator.ts packages/orchestrator/src/core/model-router.ts
+   git commit -m "$(cat <<'EOF'
+   refactor(types): rename RoutingDecision to IssueRoutingDecision
+
+   Frees the `RoutingDecision` name for the Spec B resolver-walk record
+   added in the next commit. Single consumer in `model-router.ts` updated
+   in lockstep. No behavior change; existing model-router tests pass
+   unchanged.
+
+   Refs: docs/changes/granular-task-routing/proposal.md Phase 0
+   EOF
+   )"
+   ```
+
+---
+
+### Task 4: Update the types barrel to export `IssueRoutingDecision`
+
+**Depends on:** Task 3 · **Files:** `packages/types/src/index.ts`
+
+1. Open `packages/types/src/index.ts`. Locate the orchestrator block (currently line 107-150). Find the line containing `RoutingDecision,` (line 130).
+
+2. Replace `RoutingDecision,` with `IssueRoutingDecision,` so the block reads:
+
+   ```ts
+   export type {
+     // ... unchanged entries ...
+     ScopeTier,
+     ConcernSignal,
+     IssueRoutingDecision,
+     EscalationConfig,
+     // ... unchanged entries ...
+   } from './orchestrator';
+   ```
+
+3. **Do not** add a `RoutingDecision` export here yet — Task 5 adds the new `RoutingDecision` shape AND its barrel entry in the same commit.
+
+4. Run:
+
+   ```bash
+   pnpm --filter @harness-engineering/types build 2>&1 | tail -10
+   ```
+
+   Expected: passes. `packages/types/dist/index.d.ts` now exposes `IssueRoutingDecision` (verify with `grep "IssueRoutingDecision" packages/types/dist/index.d.ts | head -3`).
+
+5. Run `pnpm typecheck` from the workspace root:
+
+   ```bash
+   pnpm typecheck 2>&1 | tail -15
+   ```
+
+   Expected: zero errors workspace-wide. If anything else breaks, **STOP** — an undiscovered consumer of the old name exists.
+
+6. Commit:
+
+   ```bash
+   git add packages/types/src/index.ts
+   git commit -m "$(cat <<'EOF'
+   refactor(types): re-export RoutingDecision rename through barrel
+
+   Workspace-wide typecheck confirms no other consumers depended on the
+   old name.
+   EOF
+   )"
+   ```
+
+---
+
+### Task 5: Add the new routing types to `packages/types/src/orchestrator.ts`
+
+**Depends on:** Task 4 · **Files:** `packages/types/src/orchestrator.ts` · **Skills:** `ts-template-literal-types` (reference), `gof-chain-of-responsibility` (reference — fallback chain primitive)
+
+1. Open `packages/types/src/orchestrator.ts`. Immediately **after** the `RoutingConfig` interface (currently ending around line 488 with the closing `}` of the `isolation` block), insert the following type definitions:
+
+   ```ts
+   // --- Spec B: Granular Task→Backend Routing (Phase 0 — types-only) ---
+
+   /**
+    * A routing target: either a single backend name (scalar) or an ordered
+    * fallback chain (non-empty tuple). Scalar form is byte-compatible with
+    * pre-Spec-B configs; the array form is consumed by `BackendRouter.resolve()`
+    * which tries each entry in order until an existing backend is found
+    * (full chain walk lands in Phase 1).
+    *
+    * @example scalar form
+    *   routing.default: 'claude-opus'
+    *
+    * @example fallback chain
+    *   routing.skills.harness-debugging: ['local-fast', 'claude-sonnet']
+    */
+   export type RoutingValue = string | readonly [string, ...string[]];
+
+   /**
+    * One step in the ordered walk performed by `BackendRouter.resolve()` to
+    * pick a backend for a {@link RoutingUseCase}. Phase 0 ships the type;
+    * Phase 1 wires the resolver to emit `ResolutionStep[]`.
+    */
+   export type ResolutionSource = 'invocation' | 'skill' | 'mode' | 'tier' | 'default';
+
+   /**
+    * Single candidate considered during routing resolution.
+    *
+    * - `chosen`   — first candidate whose backend exists in `agent.backends`; ends the walk.
+    * - `unknown-backend` — candidate references a backend not in `agent.backends`; walk continues.
+    * - `considered` — reserved for future use (e.g., health-aware skip in a later spec).
+    */
+   export interface ResolutionStep {
+     source: ResolutionSource;
+     candidate: string;
+     outcome: 'chosen' | 'unknown-backend' | 'considered';
+   }
+
+   /**
+    * Record of a single `BackendRouter.resolve()` invocation: the use case,
+    * the ordered candidates considered, the chosen backend, and timing.
+    *
+    * NOTE: this is the Spec B `RoutingDecision`. The pre-Spec-B type of the
+    * same name (the `routeIssue()` action result) has been renamed to
+    * {@link IssueRoutingDecision}.
+    */
+   export interface RoutingDecision {
+     /** ISO-8601 timestamp the resolver ran. */
+     timestamp: string;
+     /** The use case that was resolved. */
+     useCase: RoutingUseCase;
+     /** Ordered candidates considered during the walk. */
+     resolutionPath: ResolutionStep[];
+     /** The selected backend's name (key in `agent.backends`). */
+     backendName: string;
+     /** The selected backend's `type` discriminant, copied for telemetry convenience. */
+     backendType: BackendDef['type'];
+     /** Wall-clock duration of the resolve() call in milliseconds. */
+     durationMs: number;
+   }
+   ```
+
+2. Now extend `RoutingUseCase` (currently lines 498-503). Replace:
+
+   ```ts
+   export type RoutingUseCase =
+     | { kind: 'tier'; tier: ScopeTier }
+     | { kind: 'intelligence'; layer: 'sel' | 'pesl' }
+     | { kind: 'maintenance' }
+     | { kind: 'chat' }
+     | { kind: 'isolation'; tier: IsolationTier };
+   ```
+
+   With:
+
+   ```ts
+   export type RoutingUseCase =
+     | { kind: 'tier'; tier: ScopeTier }
+     | { kind: 'intelligence'; layer: 'sel' | 'pesl' }
+     | { kind: 'maintenance' }
+     | { kind: 'chat' }
+     | { kind: 'isolation'; tier: IsolationTier }
+     // --- Spec B Phase 0 (consumed by resolver in Phase 1) ---
+     | { kind: 'skill'; skillName: string; cognitiveMode?: string }
+     | { kind: 'mode'; cognitiveMode: string };
+   ```
+
+3. Widen `RoutingConfig` (currently lines 462-488). Replace the whole interface with:
+
+   ```ts
+   export interface RoutingConfig {
+     /** Backend name (or fallback chain) used when no specific rule matches. Required. */
+     default: RoutingValue;
+     'quick-fix'?: RoutingValue;
+     'guided-change'?: RoutingValue;
+     'full-exploration'?: RoutingValue;
+     diagnostic?: RoutingValue;
+     intelligence?: {
+       sel?: RoutingValue;
+       pesl?: RoutingValue;
+     };
+     /**
+      * Isolation-tier routing (Hermes Phase 5).
+      *
+      * Maps each isolation tier to a backend name (or fallback chain). A
+      * task that needs a particular execution boundary (e.g.
+      * `remote-sandbox` for an untrusted external code execution) issues a
+      * `{ kind: 'isolation', tier }` query; the router returns the
+      * configured name, falling back to {@link RoutingConfig.default} when
+      * the tier is not mapped.
+      */
+     isolation?: {
+       none?: RoutingValue;
+       container?: RoutingValue;
+       'remote-sandbox'?: RoutingValue;
+     };
+     /**
+      * Per-skill routing (Spec B D1/D3). Keys are skill names from the
+      * local skill catalog; values are backend names or fallback chains.
+      * Phase 0 ships the type; Phase 1 wires `BackendRouter.resolve()` to
+      * consult this map for `{ kind: 'skill', skillName }` use cases.
+      */
+     skills?: Record<string, RoutingValue>;
+     /**
+      * Per-cognitive-mode routing (Spec B D1/D3). Keys are cognitive-mode
+      * identifiers (typically values from `STANDARD_COGNITIVE_MODES`);
+      * values are backend names or fallback chains. Phase 0 ships the type;
+      * Phase 1 wires `BackendRouter.resolve()` to consult this map after
+      * `skills` and before `tier`.
+      */
+     modes?: Record<string, RoutingValue>;
+   }
+   ```
+
+4. Run:
+
+   ```bash
+   pnpm --filter @harness-engineering/types typecheck 2>&1 | tail -15
+   ```
+
+   Expected: passes.
+
+5. No commit yet — Task 6 updates the barrel + the BackendRouter shim in the same commit boundary (atomic: "new types ship + every consumer still compiles").
+
+---
+
+### Task 6: Update barrel exports and add the `BackendRouter` normalization shim
+
+**Depends on:** Task 5 · **Files:** `packages/types/src/index.ts`, `packages/orchestrator/src/agent/backend-router.ts` · **Skills:** `gof-chain-of-responsibility` (reference)
+
+1. Open `packages/types/src/index.ts`. In the orchestrator block (currently around line 134 onward — the `// --- Spec 2: Multi-Backend Routing ---` group), add the four new symbols. The block should read (additions marked):
+
+   ```ts
+   export type {
+     // ... unchanged ...
+     ScopeTier,
+     ConcernSignal,
+     IssueRoutingDecision,
+     EscalationConfig,
+     IntelligenceConfig,
+     LocalModelStatus,
+     // --- Spec 2: Multi-Backend Routing ---
+     BackendDef,
+     MockBackendDef,
+     ClaudeBackendDef,
+     AnthropicBackendDef,
+     OpenAIBackendDef,
+     GeminiBackendDef,
+     LocalBackendDef,
+     PiBackendDef,
+     RoutingConfig,
+     RoutingUseCase,
+     NamedLocalModelStatus,
+     // --- Hermes Phase 5: Dispatch Hardening ---
+     IsolationTier,
+     SshBackendDef,
+     ServerlessBackendDef,
+     // --- Spec B Phase 0: Granular Task→Backend Routing (types-only) ---
+     RoutingValue,
+     RoutingDecision,
+     ResolutionStep,
+     ResolutionSource,
+   } from './orchestrator';
+   ```
+
+   (Confirm `IssueRoutingDecision` is already present from Task 4 and `RoutingDecision` here is the NEW shape from Task 5.)
+
+2. Open `packages/orchestrator/src/agent/backend-router.ts`. The widened `RoutingConfig` now permits `RoutingValue` (`string | readonly [string, ...string[]]`) in every field. The existing `resolve()` implementation casts through `Record<string, string | undefined>` which is now a runtime lie. Add a private normalization helper and thread it through.
+
+   Replace the entire file with:
+
+   ```ts
+   import type {
+     BackendDef,
+     IsolationTier,
+     RoutingConfig,
+     RoutingUseCase,
+     RoutingValue,
+   } from '@harness-engineering/types';
+
+   export interface BackendRouterOptions {
+     backends: Record<string, BackendDef>;
+     routing: RoutingConfig;
+   }
+
+   /**
+    * BackendRouter
+    *
+    * Owns the lookup from a `RoutingUseCase` (a discriminated query — tier,
+    * intelligence layer, maintenance, chat, isolation) to a named backend.
+    * Construction-time validation guarantees every name referenced by
+    * `routing` is present in `backends` so runtime lookups are total and
+    * never throw on unknown-name references.
+    *
+    * Lookups for tier/intelligence use cases that fall through to undefined
+    * mappings return `routing.default` without throwing — this matches the
+    * spec's "every use case inherits default unless explicitly routed"
+    * semantics. The `maintenance` and `chat` kinds always resolve to
+    * `routing.default`.
+    *
+    * Spec B Phase 0 note: `RoutingConfig` fields are typed as
+    * {@link RoutingValue} (`string | readonly [string, ...string[]]`).
+    * This class normalizes via {@link BackendRouter.toScalar} (first
+    * element of the chain) to preserve byte-identical behavior for scalar
+    * inputs. The full chain walk (try entries in order, skip unknown
+    * backends) lands in Phase 1 of Spec B.
+    *
+    * Spec B Phase 0 also adds the `kind: 'skill'` and `kind: 'mode'` use
+    * case variants. Until Phase 1's resolver rewrite, these variants fall
+    * through to `routing.default` (no behavior change — pre-Spec-B configs
+    * never construct these variants).
+    */
+   export class BackendRouter {
+     private readonly backends: Record<string, BackendDef>;
+     private readonly routing: RoutingConfig;
+
+     constructor(opts: BackendRouterOptions) {
+       this.backends = opts.backends;
+       this.routing = opts.routing;
+       this.validateReferences();
+     }
+
+     /**
+      * Returns the backend name for a given use case.
+      *
+      * - `tier`: per-tier override, falling back to `routing.default`.
+      * - `intelligence`: per-layer override under `routing.intelligence`,
+      *   falling back to `routing.default`.
+      * - `isolation`: per-tier override under `routing.isolation`,
+      *   falling back to `routing.default`.
+      * - `maintenance` / `chat`: always `routing.default`.
+      * - `skill` / `mode` (Spec B Phase 0): always `routing.default` until
+      *   Phase 1 wires the resolver chain.
+      */
+     resolve(useCase: RoutingUseCase): string {
+       switch (useCase.kind) {
+         case 'tier': {
+           const tierMap = this.routing as unknown as Record<string, RoutingValue | undefined>;
+           const named = tierMap[useCase.tier];
+           return named !== undefined ? this.toScalar(named) : this.toScalar(this.routing.default);
+         }
+         case 'intelligence': {
+           const intel = this.routing.intelligence as
+             | Record<string, RoutingValue | undefined>
+             | undefined;
+           const named = intel?.[useCase.layer];
+           return named !== undefined ? this.toScalar(named) : this.toScalar(this.routing.default);
+         }
+         case 'isolation': {
+           const iso = this.routing.isolation as
+             | Record<IsolationTier, RoutingValue | undefined>
+             | undefined;
+           const named = iso?.[useCase.tier];
+           return named !== undefined ? this.toScalar(named) : this.toScalar(this.routing.default);
+         }
+         case 'maintenance':
+         case 'chat':
+         case 'skill':
+         case 'mode':
+           return this.toScalar(this.routing.default);
+       }
+     }
+
+     /**
+      * Returns the BackendDef reference for the resolved name. Returns the
+      * exact reference held in `backends` (no copy) so identity comparisons
+      * succeed.
+      */
+     resolveDefinition(useCase: RoutingUseCase): BackendDef {
+       const name = this.resolve(useCase);
+       const def = this.backends[name];
+       if (!def) {
+         throw new Error(
+           `BackendRouter.resolveDefinition: routing target '${name}' is not in backends ` +
+             `(useCase=${JSON.stringify(useCase)}).`
+         );
+       }
+       return def;
+     }
+
+     /**
+      * Spec B Phase 0 normalization: collapse a {@link RoutingValue} to the
+      * first backend name. Scalar inputs are returned unchanged (byte-identical
+      * to pre-Spec-B behavior). Array-form inputs return the first element;
+      * Phase 1 replaces this with the proper chain walk.
+      */
+     private toScalar(value: RoutingValue): string {
+       return Array.isArray(value) ? value[0] : (value as string);
+     }
+
+     private validateReferences(): void {
+       const known = new Set(Object.keys(this.backends));
+       const missing: Array<{ path: string; name: string }> = [];
+
+       const check = (path: string, value: RoutingValue | undefined) => {
+         if (value === undefined) return;
+         const names = Array.isArray(value) ? value : [value as string];
+         for (const name of names) {
+           if (!known.has(name)) missing.push({ path, name });
+         }
+       };
+
+       check('default', this.routing.default);
+       check('quick-fix', this.routing['quick-fix']);
+       check('guided-change', this.routing['guided-change']);
+       check('full-exploration', this.routing['full-exploration']);
+       check('diagnostic', this.routing.diagnostic);
+       check('intelligence.sel', this.routing.intelligence?.sel);
+       check('intelligence.pesl', this.routing.intelligence?.pesl);
+       check('isolation.none', this.routing.isolation?.none);
+       check('isolation.container', this.routing.isolation?.container);
+       check('isolation.remote-sandbox', this.routing.isolation?.['remote-sandbox']);
+
+       if (missing.length > 0) {
+         const detail = missing.map(({ path, name }) => `routing.${path} -> '${name}'`).join('; ');
+         const known_ = [...known].join(', ') || '(none)';
+         throw new Error(
+           `BackendRouter: routing references unknown backend(s): ${detail}. Defined backends: [${known_}].`
+         );
+       }
+     }
+   }
+   ```
+
+3. Run:
+
+   ```bash
+   pnpm --filter @harness-engineering/types build 2>&1 | tail -5
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -15
+   ```
+
+   Expected: both pass.
+
+4. Run the existing BackendRouter test suite — it must pass unchanged (this is N1 + observable truth 6):
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator test -- tests/agent/backend-router.test.ts 2>&1 | tail -20
+   ```
+
+   Expected: same green count as Task 1 baseline.
+
+5. Run `harness validate` — confirm green.
+
+6. Commit:
+
+   ```bash
+   git add packages/types/src/orchestrator.ts packages/types/src/index.ts packages/orchestrator/src/agent/backend-router.ts
+   git commit -m "$(cat <<'EOF'
+   feat(types): add Spec B routing primitives (Phase 0 — types only)
+
+   Adds RoutingValue, RoutingDecision (resolver-walk record),
+   ResolutionStep, ResolutionSource, plus skill/mode variants on
+   RoutingUseCase. Widens RoutingConfig scalar fields to RoutingValue
+   and adds optional skills/modes maps.
+
+   BackendRouter gains a private toScalar() shim that normalizes the
+   widened RoutingValue to the first chain element. Scalar inputs are
+   byte-identical to today; array inputs get a Phase-0 first-element
+   fallback. Phase 1 replaces toScalar() with the full chain walk.
+
+   Existing BackendRouter and routeIssue() tests pass unchanged
+   (N1, N2, N3 from spec success criteria).
+
+   Refs: docs/changes/granular-task-routing/proposal.md Phase 0
+   EOF
+   )"
+   ```
+
+---
+
+### Task 7: Widen the Zod `RoutingConfigSchema` and `validateBackendsAndRouting` helper
+
+**Depends on:** Task 6 · **Files:** `packages/orchestrator/src/workflow/schema.ts` · **Skills:** `ts-zod-integration` (apply)
+
+1. Open `packages/orchestrator/src/workflow/schema.ts`. Locate `RoutingConfigSchema` (line 86) and `validateBackendsAndRouting` (line 112).
+
+2. Add a `RoutingValueSchema` export above `RoutingConfigSchema`:
+
+   ```ts
+   /**
+    * Spec B Phase 0: a routing target is either a backend name (scalar
+    * string) or a non-empty ordered fallback chain (string tuple). The
+    * scalar form is byte-compatible with pre-Spec-B configs.
+    */
+   export const RoutingValueSchema = z.union([
+     z.string().min(1),
+     z
+       .array(z.string().min(1))
+       .nonempty('fallback chain must contain at least one backend name')
+       .readonly(),
+   ]);
+   ```
+
+3. Replace `RoutingConfigSchema` (the existing block) with:
+
+   ```ts
+   export const RoutingConfigSchema = z
+     .object({
+       default: RoutingValueSchema,
+       'quick-fix': RoutingValueSchema.optional(),
+       'guided-change': RoutingValueSchema.optional(),
+       'full-exploration': RoutingValueSchema.optional(),
+       diagnostic: RoutingValueSchema.optional(),
+       intelligence: z
+         .object({
+           sel: RoutingValueSchema.optional(),
+           pesl: RoutingValueSchema.optional(),
+         })
+         .strict()
+         .optional(),
+       // --- Spec B Phase 0: new optional maps (resolver wired in Phase 1) ---
+       skills: z.record(z.string().min(1), RoutingValueSchema).optional(),
+       modes: z.record(z.string().min(1), RoutingValueSchema).optional(),
+     })
+     .strict();
+   ```
+
+   > **Note:** the existing `isolation` block is NOT in the original `RoutingConfigSchema` declaration (it's only in the TypeScript interface — confirm by reading the file). If isolation IS present in this file, widen its inner field schemas to `RoutingValueSchema.optional()` likewise. If isolation is NOT present, leave this as a known gap to fix in Phase 2 (config-validator updates) and add a `// TODO(spec-b-phase-2): widen isolation block` comment.
+
+4. Update `validateBackendsAndRouting` to walk both scalar and chain forms. Replace the `checkRef` helper signature + body. Find this block (lines 118-127):
+
+   ```ts
+   const checkRef = (path: (string | number)[], name: string | undefined): void => {
+     if (name !== undefined && !names.has(name)) {
+       ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         path: ['routing', ...path],
+         message: `routing.${path.join('.')} references unknown backend '${name}'. Defined: [${[...names].join(', ')}].`,
+       });
+     }
+   };
+   ```
+
+   Replace with:
+
+   ```ts
+   const checkRef = (
+     path: (string | number)[],
+     value: import('@harness-engineering/types').RoutingValue | undefined
+   ): void => {
+     if (value === undefined) return;
+     const entries = Array.isArray(value) ? value : [value as string];
+     entries.forEach((name, idx) => {
+       if (names.has(name)) return;
+       // For chain entries, append the index so the error pinpoints the
+       // offending entry (e.g. routing.skills.foo.1).
+       const pathWithIdx = Array.isArray(value) ? [...path, idx] : path;
+       ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         path: ['routing', ...pathWithIdx],
+         message: `routing.${pathWithIdx.join('.')} references unknown backend '${name}'. Defined: [${[...names].join(', ')}].`,
+       });
+     });
+   };
+   ```
+
+5. Below the existing `checkRef` calls (line ~134 — the `intelligence.pesl` line), add the new Spec B fields:
+
+   ```ts
+   // --- Spec B Phase 0: validate skills + modes chain entries ---
+   if (routing.skills) {
+     for (const [skill, value] of Object.entries(routing.skills)) {
+       checkRef(['skills', skill], value);
+     }
+   }
+   if (routing.modes) {
+     for (const [mode, value] of Object.entries(routing.modes)) {
+       checkRef(['modes', mode], value);
+     }
+   }
+   ```
+
+6. Run:
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -10
+   ```
+
+   Expected: passes.
+
+7. Run all schema-touching tests to confirm no regression:
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator test -- tests/agent/ tests/workflow/ 2>&1 | tail -25
+   ```
+
+   Expected: green. The next task adds the new positive Zod tests.
+
+8. Run `harness validate` — confirm green.
+
+9. Commit:
+
+   ```bash
+   git add packages/orchestrator/src/workflow/schema.ts
+   git commit -m "$(cat <<'EOF'
+   feat(orchestrator): widen RoutingConfigSchema for Spec B routing values
+
+   - RoutingValueSchema accepts scalar string OR non-empty string tuple.
+   - All existing routing fields use RoutingValueSchema (backward-compat:
+     scalar form parses identically).
+   - New optional routing.skills and routing.modes maps accepted.
+   - validateBackendsAndRouting walks chain entries and reports the
+     offending index in the issue path (e.g. routing.skills.foo.1).
+
+   No behavior change for pre-Spec-B configs. Phase 2 of Spec B adds
+   the skill-catalog warning + cognitive-mode validation layer.
+
+   Refs: docs/changes/granular-task-routing/proposal.md Phase 0
+   EOF
+   )"
+   ```
+
+---
+
+### Task 8: Add typecheck-only fixture and Zod unit test (TDD: write tests, observe pass)
+
+**Depends on:** Task 7 · **Files:** `packages/types/src/__type_tests__/routing-types.test-d.ts` (CREATE), `packages/orchestrator/tests/workflow/routing-config-schema.test.ts` (CREATE)
+
+> Phase 0 introduces no runtime behavior, so the "TDD failing test" step is replaced by a typecheck-only fixture (which would have failed to compile against the pre-Phase-0 types) and a positive Zod test (which would have rejected the new shapes pre-Phase-0). Both gate the type-and-schema surface for downstream phases.
+
+1. Verify the `__type_tests__/` directory does not yet exist:
+
+   ```bash
+   ls packages/types/src/__type_tests__ 2>&1 | head -5
+   ```
+
+   Expected: "No such file or directory" — create it:
+
+   ```bash
+   mkdir -p packages/types/src/__type_tests__
+   ```
+
+2. Create `packages/types/src/__type_tests__/routing-types.test-d.ts` with:
+
+   ```ts
+   /**
+    * Spec B Phase 0 — typecheck-only fixture.
+    *
+    * This file is NOT executed at runtime. It is excluded from the
+    * package's runtime build (see `tsconfig.build.json` `exclude`) and
+    * compiled as part of `pnpm --filter @harness-engineering/types
+    * typecheck` only. A failure to compile here is a regression on the
+    * Spec B Phase 0 surface contract.
+    */
+   import type {
+     RoutingConfig,
+     RoutingUseCase,
+     RoutingValue,
+     RoutingDecision,
+     ResolutionStep,
+     ResolutionSource,
+     IssueRoutingDecision,
+   } from '../index';
+
+   // --- 1. RoutingValue accepts scalar AND non-empty chain ---
+   const _scalar: RoutingValue = 'claude-opus';
+   const _chain: RoutingValue = ['local-fast', 'claude-sonnet'] as const;
+   void _scalar;
+   void _chain;
+
+   // --- 2. RoutingConfig: every scalar field accepts scalar form ---
+   const _cfgScalar: RoutingConfig = {
+     default: 'claude-opus',
+     'quick-fix': 'local-fast',
+     'guided-change': 'claude-sonnet',
+     'full-exploration': 'claude-opus',
+     diagnostic: 'claude-sonnet',
+     intelligence: { sel: 'local-fast', pesl: 'claude-opus' },
+     isolation: { none: 'local-fast', container: 'local-fast', 'remote-sandbox': 'claude-opus' },
+   };
+   void _cfgScalar;
+
+   // --- 3. RoutingConfig: every scalar field accepts array form ---
+   const _cfgArray: RoutingConfig = {
+     default: ['claude-opus'] as const,
+     'quick-fix': ['local-fast', 'claude-sonnet'] as const,
+     'guided-change': ['claude-sonnet'] as const,
+     'full-exploration': ['claude-opus'] as const,
+     diagnostic: ['claude-sonnet'] as const,
+     intelligence: {
+       sel: ['local-fast', 'claude-sonnet'] as const,
+       pesl: ['claude-opus'] as const,
+     },
+     isolation: {
+       none: ['local-fast'] as const,
+       container: ['local-fast'] as const,
+       'remote-sandbox': ['claude-opus'] as const,
+     },
+   };
+   void _cfgArray;
+
+   // --- 4. RoutingConfig: optional skills + modes maps with mixed scalar/chain ---
+   const _cfgSpecB: RoutingConfig = {
+     default: 'claude-opus',
+     skills: {
+       'harness-debugging': ['local-fast', 'claude-sonnet'] as const,
+       'harness-soundness-review': 'claude-opus',
+     },
+     modes: {
+       'adversarial-reviewer': ['local-fast', 'claude-sonnet'] as const,
+       'constructive-architect': 'claude-opus',
+     },
+   };
+   void _cfgSpecB;
+
+   // --- 5. RoutingUseCase: new skill + mode variants are constructible ---
+   const _ucSkill: RoutingUseCase = {
+     kind: 'skill',
+     skillName: 'harness-debugging',
+     cognitiveMode: 'adversarial-reviewer',
+   };
+   const _ucSkillNoMode: RoutingUseCase = {
+     kind: 'skill',
+     skillName: 'harness-brainstorming',
+   };
+   const _ucMode: RoutingUseCase = { kind: 'mode', cognitiveMode: 'meticulous-implementer' };
+   void _ucSkill;
+   void _ucSkillNoMode;
+   void _ucMode;
+
+   // --- 6. RoutingDecision (new shape) and its sub-types are constructible ---
+   const _step: ResolutionStep = {
+     source: 'skill' satisfies ResolutionSource,
+     candidate: 'local-fast',
+     outcome: 'chosen',
+   };
+   const _decision: RoutingDecision = {
+     timestamp: '2026-05-24T00:00:00.000Z',
+     useCase: _ucSkill,
+     resolutionPath: [_step],
+     backendName: 'local-fast',
+     backendType: 'local',
+     durationMs: 0.42,
+   };
+   void _decision;
+
+   // --- 7. IssueRoutingDecision: pre-Spec-B name is still available ---
+   const _issueDecision: IssueRoutingDecision = { action: 'dispatch-local' };
+   void _issueDecision;
+   ```
+
+3. Confirm `tsconfig.build.json` excludes the new directory. Run:
+
+   ```bash
+   cat packages/types/tsconfig.build.json
+   ```
+
+   - If `exclude` already covers `**/__type_tests__/**` or `**/*.test-d.ts`, no change needed.
+   - If NOT, add `"src/__type_tests__/**"` to the `exclude` array. The runtime build (`tsup`) is driven by the `src/index.ts` entry point and will not pick the fixture up via type checking — but `tsc --noEmit` (typecheck) MUST include it.
+
+4. Run the types-package typecheck — this is the gate:
+
+   ```bash
+   pnpm --filter @harness-engineering/types typecheck 2>&1 | tail -10
+   ```
+
+   Expected: zero errors. If any assignment fails, **STOP** — the Phase 5/6 type widening is incomplete.
+
+5. Create `packages/orchestrator/tests/workflow/routing-config-schema.test.ts`:
+
+   ```ts
+   import { describe, it, expect } from 'vitest';
+   import { RoutingConfigSchema } from '../../src/workflow/schema';
+
+   describe('RoutingConfigSchema — Spec B Phase 0 widening', () => {
+     it('accepts a fully-scalar pre-Spec-B config unchanged', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         'quick-fix': 'local-fast',
+         intelligence: { sel: 'local-fast' },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts array form for routing.default', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: ['claude-opus', 'claude-sonnet'],
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts array form for routing.quick-fix', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         'quick-fix': ['local-fast', 'claude-sonnet'],
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts array form for routing.intelligence.sel', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         intelligence: { sel: ['local-fast', 'claude-sonnet'] },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts new routing.skills map with mixed scalar + chain values', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         skills: {
+           'harness-debugging': ['local-fast', 'claude-sonnet'],
+           'harness-soundness-review': 'claude-opus',
+         },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts new routing.modes map with mixed scalar + chain values', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         modes: {
+           'adversarial-reviewer': ['local-fast', 'claude-sonnet'],
+           'constructive-architect': 'claude-opus',
+         },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('rejects an empty fallback chain', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: [],
+       });
+       expect(parsed.success).toBe(false);
+     });
+
+     it('rejects an unknown top-level key (strict mode preserved)', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         bogus: 'value',
+       });
+       expect(parsed.success).toBe(false);
+     });
+
+     it('rejects an empty-string entry inside a chain', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: ['claude-opus', ''],
+       });
+       expect(parsed.success).toBe(false);
+     });
+   });
+   ```
+
+6. Run:
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator test -- tests/workflow/routing-config-schema.test.ts 2>&1 | tail -20
+   ```
+
+   Expected: 9 tests pass.
+
+7. Run `harness validate` — confirm green.
+
+8. Commit:
+
+   ```bash
+   git add packages/types/src/__type_tests__/routing-types.test-d.ts packages/orchestrator/tests/workflow/routing-config-schema.test.ts
+   # If tsconfig.build.json was updated, add it too:
+   # git add packages/types/tsconfig.build.json
+   git commit -m "$(cat <<'EOF'
+   test(spec-b-phase-0): pin routing type widening + Zod schema acceptance
+
+   - Adds typecheck-only fixture under packages/types/src/__type_tests__/
+     covering scalar/array assignability for every RoutingConfig field,
+     constructibility of new RoutingUseCase variants, and the new
+     RoutingDecision/ResolutionStep shapes.
+   - Adds Zod unit tests for scalar/array acceptance, new skills/modes
+     maps, empty-chain rejection, and strict-mode preservation.
+
+   Refs: docs/changes/granular-task-routing/proposal.md Phase 0
+   EOF
+   )"
+   ```
+
+---
+
+### Task 9 [checkpoint:human-verify]: Regenerate barrels, full-workspace smoke, and Phase 0 sign-off
+
+**Depends on:** Task 8 · **Files:** generated barrel files (if any), `docs/roadmap.md` (optional roadmap nudge)
+
+1. Regenerate barrel exports per spec Phase 0 step 4:
+
+   ```bash
+   pnpm generate:barrels 2>&1 | tail -20
+   ```
+
+   Expected: zero diffs, OR a small diff in generated barrel files that reflects the new type exports. Inspect with `git diff --stat` — any non-trivial change outside `packages/*/src/_registry.ts` style barrels or generated index files should be reviewed before commit.
+
+2. Run the barrel check so CI parity is preserved:
+
+   ```bash
+   pnpm generate:barrels:check 2>&1 | tail -10
+   ```
+
+   Expected: passes.
+
+3. Run the full workspace typecheck and build — these are the Phase 0 checkpoint per the spec:
+
+   ```bash
+   pnpm typecheck 2>&1 | tail -20
+   pnpm build 2>&1 | tail -20
+   ```
+
+   Expected: both green. **If either fails, STOP** and fix in a follow-up task before declaring Phase 0 done.
+
+4. Run the routing-adjacent test surface end-to-end to confirm N1, N2, N3 hold:
+
+   ```bash
+   pnpm --filter @harness-engineering/orchestrator test -- \
+     tests/agent/backend-router.test.ts \
+     tests/core/model-router.test.ts \
+     tests/workflow/routing-config-schema.test.ts \
+     tests/agent/multi-backend-dispatch.test.ts \
+     2>&1 | tail -30
+   ```
+
+   Expected:
+   - `backend-router.test.ts` passes with the same count recorded in Task 1 baseline (N1)
+   - `model-router.test.ts` passes with the same count recorded in Task 1 baseline
+   - `routing-config-schema.test.ts` 9 tests pass (new)
+   - `multi-backend-dispatch.test.ts` passes unchanged (N2)
+
+5. Run `harness validate` and `harness check-deps`:
+
+   ```bash
+   harness validate 2>&1 | tail -5
+   harness check-deps 2>&1 | tail -5
+   ```
+
+   Expected: both pass.
+
+6. **[checkpoint:human-verify]** Present the following summary to the operator and wait for confirmation before declaring Phase 0 complete:
+
+   ```
+   Phase 0 (Type changes + scaffolding) summary
+
+   Commits:
+     - refactor(types): rename RoutingDecision to IssueRoutingDecision
+     - refactor(types): re-export RoutingDecision rename through barrel
+     - feat(types): add Spec B routing primitives (Phase 0 — types only)
+     - feat(orchestrator): widen RoutingConfigSchema for Spec B routing values
+     - test(spec-b-phase-0): pin routing type widening + Zod schema acceptance
+
+   Checkpoint gates:
+     - pnpm typecheck: PASS
+     - pnpm build: PASS
+     - tests/agent/backend-router.test.ts: PASS (N1)
+     - tests/core/model-router.test.ts: PASS (renamed type)
+     - tests/agent/multi-backend-dispatch.test.ts: PASS (N2/N3)
+     - tests/workflow/routing-config-schema.test.ts: 9/9 NEW
+     - harness validate: PASS
+     - generate:barrels:check: PASS
+
+   Decisions surfaced (logged into session decisions):
+     - existing RoutingDecision renamed to IssueRoutingDecision (single src
+       consumer touched)
+     - BackendRouter widened with toScalar() shim; Phase 1 replaces with
+       full chain walk
+
+   Phase 0 produces NO runtime behavior change. Phase 1 (BackendRouter.resolve()
+   rewrite) is the next plan to brainstorm/plan.
+   ```
+
+7. After operator confirmation, optionally append a roadmap line (no code change):
+
+   ```bash
+   harness manage_roadmap add --feature "spec-b-phase-0-types" --status "done" 2>&1 | tail -5
+   ```
+
+   If `manage_roadmap` is not available in this environment, skip silently — Phase 8 of the spec owns roadmap updates.
+
+8. No new commit at this checkpoint — Phase 0 is sealed by the prior five commits. If the operator rejects the summary, fix the offending item in a new task and re-run the checkpoint.
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (baseline)
+  └─> Task 2 (rename type in orchestrator.ts)
+        └─> Task 3 (update model-router.ts consumer + commit)
+              └─> Task 4 (barrel re-export rename + commit)
+                    └─> Task 5 (add new types + widen RoutingConfig)
+                          └─> Task 6 (barrel new exports + BackendRouter shim + commit)
+                                └─> Task 7 (widen Zod schema + commit)
+                                      └─> Task 8 (typecheck fixture + Zod tests + commit)
+                                            └─> Task 9 (regen barrels + full smoke + checkpoint)
+```
+
+All tasks are strictly serial. No parallelization within Phase 0 — every task either depends on the immediately prior commit boundary or shares a file with it.
+
+## Cross-Reference: Observable Truths → Tasks
+
+| Observable Truth                                              | Delivered By |
+| ------------------------------------------------------------- | ------------ |
+| 1. New types exported from `@harness-engineering/types`       | Task 5 + 6   |
+| 2. New `RoutingUseCase` variants constructible                | Task 5 + 8   |
+| 3. Scalar AND array form accepted for every existing field    | Task 5 + 8   |
+| 4. `routing.skills` / `routing.modes` typed and accepted      | Task 5 + 7   |
+| 5. `routeIssue()` preserved under `IssueRoutingDecision` name | Task 2 + 3   |
+| 6. `BackendRouter.resolve()` byte-identical for scalar (N1)   | Task 6 + 9   |
+| 7. `BackendRouter.resolve()` returns first element for array  | Task 6       |
+| 8. Zod schema accepts both forms + new keys (N5)              | Task 7 + 8   |
+| 9. `pnpm typecheck && pnpm build` workspace-wide green        | Task 9       |
+| 10. Adjacent test suites unchanged (N1, N2, N3)               | Task 9       |
+
+## Integration Points (derived from spec)
+
+Phase 0 produces a deliberately small integration footprint — full integration work lands in later phases.
+
+- **Touched entry point**: `packages/types/src/orchestrator.ts` (types only)
+- **Touched entry point**: `packages/orchestrator/src/agent/backend-router.ts` (normalization shim only)
+- **Touched entry point**: `packages/orchestrator/src/workflow/schema.ts` (Zod widening only)
+- **Registration**: `pnpm generate:barrels` — runs as Task 9 step 1. If it produces diff beyond expected new exports, halt and review.
+- **No documentation updates** — Phase 8 of the spec owns docs. Phase 0 is a silent type extension.
+- **No ADRs** — Phase 8 owns the 5 ADRs listed in the spec.
+- **No knowledge-graph enrichment** — Phase 8 owns the new business concepts.
+
+## Risks
+
+1. **Hidden consumer of the old `RoutingDecision` name.** Task 1 grep is the gate; any unexpected hit means Task 3 needs widening. The dist file (`packages/types/dist/index.d.ts`) showing the old name is a stale build artifact, not a consumer — safe to ignore (Task 4's `pnpm build` regenerates it).
+2. **`RoutingValue` widening surfaces a runtime bug we didn't anticipate.** Mitigation: existing test suite (N1, N2, N3) is the safety net. If a test fails, the diff is small and the regression is mechanical.
+3. **`tsconfig.build.json` doesn't already exclude `__type_tests__/`.** Mitigation: Task 8 step 3 inspects and updates if needed. The fallback is to move the fixture under `tests/` instead.
+4. **Workspace-wide typecheck reveals a downstream consumer that the grep missed.** Mitigation: Task 4 + Task 6 + Task 9 each gate on `pnpm typecheck` so failures surface immediately. Worst case: extend Task 3 or insert a Task 3b for the additional consumer.
+5. **Zod schema widening accidentally changes parse semantics for existing scalar configs.** Mitigation: Task 8 includes a scalar-only positive test; Task 9 runs the full orchestrator test suite including `multi-backend-dispatch.test.ts` which constructs scalar `RoutingConfig` values.
+
+## Gates
+
+- **No behavior change.** Every existing test passes unchanged at every commit boundary. If a test changes shape, you've left Phase 0's scope.
+- **Atomic commits.** Each commit must independently typecheck and build. Reviewer should be able to revert any single commit without breaking the workspace.
+- **One context window per task.** Every task above includes exact file paths, exact code snippets, and exact commands. No "figure it out during execution."
+- **Phase 0 ships types only.** No new modules, no new runtime classes, no new HTTP routes, no new CLI commands. Phase 1 owns the resolver rewrite.
+
+## Time Budget
+
+| Task | Description                                      | Est.   |
+| ---- | ------------------------------------------------ | ------ |
+| 1    | Baseline capture                                 | ~3 min |
+| 2    | Rename `RoutingDecision` in orchestrator.ts      | ~3 min |
+| 3    | Update model-router.ts consumer + commit         | ~4 min |
+| 4    | Barrel rename + commit                           | ~4 min |
+| 5    | Add new types + widen RoutingConfig              | ~6 min |
+| 6    | Barrel new exports + BackendRouter shim + commit | ~7 min |
+| 7    | Widen Zod schema + commit                        | ~6 min |
+| 8    | Typecheck fixture + Zod tests + commit           | ~7 min |
+| 9    | Regen barrels + full smoke + checkpoint          | ~5 min |
+
+**Total: ~45 minutes** — well within a single-context-window execution session.
+
+## Next Phase
+
+Phase 1: `BackendRouter.resolve()` rewrite. The shim added in Task 6 (`toScalar`) is replaced with the ordered chain walk per the spec's pseudocode. The `RoutingDecision` shape added in Task 5 is finally produced and emitted. Plan that work after Phase 0 ships and operator confirms the type surface is stable.

--- a/docs/changes/granular-task-routing/plans/2026-05-24-phase-1-backend-router-rewrite-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-24-phase-1-backend-router-rewrite-plan.md
@@ -1,0 +1,1392 @@
+# Plan: Spec B Phase 1 — `BackendRouter.resolve()` Chain-Walk Rewrite
+
+**Date:** 2026-05-24
+**Spec:** [`docs/changes/granular-task-routing/proposal.md`](../proposal.md) (§ Technical Design → `BackendRouter.resolve()` rewrite; § Implementation Order → Phase 1)
+**Phase:** 1 of 8 (Spec B)
+**Tasks:** 12
+**Estimated Time:** ~2.5 hours focused implementation (within the spec's ~3 day budget; buffer absorbs TDD red-green cycles + I1 plumbing risk)
+**Integration Tier:** medium (touches 4 source files + 2 test files within `@harness-engineering/orchestrator`; no new public API, but `resolve()` return-type changes from `string` → `RoutingDecision`; all in-package callers updated in lockstep)
+**Rigor Level:** standard
+**Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1` on branch `feat/spec-b-phase-1` (off `main @ 147faa78` — includes Phase 0 + C1/I3 review-fix from PR #398)
+**Skills:** `gof-chain-of-responsibility` (reference — the resolver is a textbook chain), `ts-type-guards` (reference — discriminated `RoutingUseCase`), `ts-testing-types` (reference — Vitest type assertions on new return shape)
+
+---
+
+## Goal
+
+Replace `BackendRouter`'s Phase 0 `toScalar` shim with a full chain-walk resolver that returns a `RoutingDecision` per dispatch, supports per-skill + per-mode + invocation-override use cases (D1, D2, D7 from spec), and folds in Phase 0 review finding I1 (eliminate inline `toScalar` drift at `intelligence-factory.ts:60-63` and `orchestrator.ts:1377-1383`).
+
+## Observable Truths (Acceptance Criteria — EARS)
+
+Maps directly to spec § Success Criteria. Phase 1 closes **F3, F5, F6, S4, S7, N1**; F1/F2/F4/F11 land in Phase 3 (dispatch-site wiring).
+
+1. **[Event-driven]** When `BackendRouter.resolve(useCase, opts)` is called with `opts.invocationOverride = 'X'` and `'X' ∈ Object.keys(backends)`, the system shall return a `RoutingDecision` with `backendName === 'X'` and a `resolutionPath` whose first (and only) entry is `{ source: 'invocation', candidate: 'X', outcome: 'chosen' }`. — **(F4 partial, S7)**
+2. **[Event-driven]** When `useCase.kind === 'skill'` AND `routing.skills?.[useCase.skillName]` is set AND its first existing-backend entry is `'Y'`, the system shall pick `'Y'` and record the considered chain entries in `resolutionPath` with `source: 'skill'`. — **(F3 partial)**
+3. **[Event-driven]** When per-skill resolution does not yield a backend AND `useCase` carries a `cognitiveMode` AND `routing.modes?.[cognitiveMode]` is set, the system shall walk that chain next with `source: 'mode'`. — **(F3)**
+4. **[State-driven]** While neither `routing.skills` nor `routing.modes` produces a hit, the system shall fall through to existing tier/intelligence/isolation/maintenance/chat resolution and produce identical `backendName` to today for every `RoutingUseCase` constructed by pre-Spec-B call sites. — **(N1, N2, N3, S1)**
+5. **[Event-driven]** When a chain entry references a backend not in `agent.backends`, the system shall record that entry with `outcome: 'unknown-backend'` in `resolutionPath` and continue to the next chain entry. — **(F6, S7, Q4)**
+6. **[Ubiquitous]** Every `RoutingDecision` shall include `timestamp` (ISO-8601 string), `useCase` (the input), `resolutionPath` (ordered considered candidates), `backendName` (key in `agent.backends`), `backendType` (`backends[backendName].type`), and `durationMs` (wall-clock).
+7. **[Unwanted]** If the chain walk exhausts all sources (invocation, skill, mode, existing-use-case, `routing.default`) with every candidate `unknown-backend`, then the system shall throw an `Error` whose message names the offending `useCase` and the list of known backend names. Construction-time `validateReferences()` (existing) already catches the static-config path; this runtime throw covers the future case of all-unknown chain entries at runtime. — **(S4)**
+8. **[Ubiquitous]** `resolveDefinition(useCase, opts?)` shall continue to return a `BackendDef` (existing public API surface preserved). Internally it calls `resolve()` and indexes `backends[decision.backendName]`. — **(N1)**
+9. **[Ubiquitous]** `OrchestratorBackendFactory.resolveName(useCase)` shall continue to return a `string` (existing public API surface preserved). Internally it calls `router.resolve(useCase).backendName`. — **(N1, N2)**
+10. **[Ubiquitous]** `toArray(value: RoutingValue): readonly string[]` shall normalize scalar `'X'` → `['X']` and chain `['X', 'Y']` → `['X', 'Y']`. Internal helper; not exported from the package barrel.
+11. **[Ubiquitous]** `toScalar(value: RoutingValue): string` (the Phase 0 module-level export) shall remain exported as `@deprecated`, delegating to `toArray(value)[0]`. No internal caller uses it after Phase 1 (closes Phase 0 review finding **I1**).
+12. **[Ubiquitous]** After Phase 1, `intelligence-factory.ts:60-63` (the C1 comparison site) shall call `router.resolve({ kind: 'intelligence', layer: 'sel' | 'pesl' }).backendName` instead of `toScalar(routing.intelligence?.[...])`. This requires plumbing a `BackendRouter` instance into `IntelligenceFactoryDeps`. — **(I1 follow-up from Phase 0 review)**
+13. **[Ubiquitous]** After Phase 1, `orchestrator.ts:1377-1383` (legacy-fallback inline `Array.isArray` normalization) shall be removed from the path that reaches when `this.backendFactory !== null` (the normal path). The branch only fires when migration threw, at which point a single-line `toArray(routing.default ?? [agent.backend ?? 'unknown'])[0]` is the minimal residual normalization. — **(I1 follow-up)**
+14. **[Ubiquitous]** `pnpm --filter @harness-engineering/orchestrator typecheck` exits 0; `pnpm --filter @harness-engineering/orchestrator test tests/agent/backend-router.test.ts tests/agent/backend-router-chain-walk.test.ts` exits 0 with all tests passing; `harness validate` exits 0.
+
+## Uncertainties (Operator Concerns — Surfaced for Sign-Off)
+
+| #   | Type                      | Concern                                                                                                                                                                                                                                                                                                                               | Plan's Assumption                                                                                                                                                                                                                                                                                                                                                                                                                                     | Operator Action                      |
+| --- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| U1  | ASSUMPTION (load-bearing) | `resolve()` return-type change: `string` → `RoutingDecision`. All 3 internal call sites (`orchestrator-backend-factory.ts:91`, `orchestrator-backend-factory.ts:96`, `backend-router.ts:115` in `resolveDefinition`) updated in lockstep. **Alternative:** keep `resolve()` returning `string` and add a sibling `resolveDecision()`. | Take the spec-literal route: `resolve()` returns `RoutingDecision`. Reasoning: (a) spec § Technical Design pseudocode does exactly this; (b) Phase 4's `RoutingDecisionBus.emit(decision)` needs the decision available at `resolve()` time — adding a sibling would mean every caller either calls both or constructs a decision themselves; (c) all callers are in-package, so this is a one-PR coordinated change with zero external blast radius. | Approve or pick sibling route.       |
+| U2  | ASSUMPTION                | Keep `toScalar` exported as `@deprecated`.                                                                                                                                                                                                                                                                                            | Yes — Phase 0's C1 fix promoted it to module-level for `intelligence-factory.ts`. After Phase 1, no internal caller uses it, but removing it would be a breaking change for any external consumer that picked up the Phase 0 export. Mark `@deprecated` now; remove in Spec C or a later sweep.                                                                                                                                                       | Approve or instruct full removal.    |
+| U3  | ASSUMPTION                | When `routing.default` chain-walk produces no available backend (all `unknown-backend`), throw at runtime.                                                                                                                                                                                                                            | Yes — matches spec § Technical Design line 156 and S4. Construction-time `validateReferences()` already catches static-config typos; the runtime throw is the safety net if `default` is a chain whose entries all become unknown via some future dynamic-backend feature.                                                                                                                                                                            | Approve or pick warn-and-pick-first. |
+| U4  | DEFERRABLE                | `RoutingDecision.timestamp` precision and `durationMs` source.                                                                                                                                                                                                                                                                        | `new Date().toISOString()` + `performance.now()` start/end. Phase 4 (decision bus) can refine.                                                                                                                                                                                                                                                                                                                                                        | None — note.                         |
+| U5  | DEFERRABLE                | Should `resolveDefinition()` also accept `opts`?                                                                                                                                                                                                                                                                                      | Yes — pass-through to `resolve()`. Costs nothing; Phase 3 may want `--backend` overrides through this path.                                                                                                                                                                                                                                                                                                                                           | None — note.                         |
+| U6  | ASSUMPTION                | I1 fix in `intelligence-factory.ts` requires plumbing a `BackendRouter` into `IntelligenceFactoryDeps`. **Alternative:** keep the `toScalar` comparison and defer I1 to Phase 2.                                                                                                                                                      | Plumb the router in Phase 1 per operator's brief ("Phase 1 should also fold I1"). The construction-time `validateReferences()` side effect (Phase 0 review concern that blocked the C1 fix from taking the router route) is moot now because by Phase 1 the orchestrator already owns the router and can pass it down rather than constructing a fresh one in the factory.                                                                            | Approve or defer I1 to Phase 2.      |
+
+## Changes to Existing Functionality
+
+- **[MODIFIED]** `BackendRouter.resolve(useCase)` return type: `string` → `RoutingDecision`. All in-package callers update.
+- **[MODIFIED]** `BackendRouter.resolve()` signature: gains optional second arg `opts?: { invocationOverride?: string }`.
+- **[MODIFIED]** `BackendRouter.resolveDefinition()` signature: gains optional second arg `opts?: { invocationOverride?: string }` (pass-through).
+- **[ADDED]** `BackendRouter.resolve()` now handles `kind: 'skill'` and `kind: 'mode'` use cases per spec § Technical Design pseudocode (Phase 0 fell these through to `routing.default`).
+- **[ADDED]** Module-level `toArray(value: RoutingValue): readonly string[]` helper in `backend-router.ts`. Internal only.
+- **[MODIFIED]** `toScalar` (module-level export added in Phase 0): body becomes `toArray(value)[0]`; JSDoc marks `@deprecated`. Behavior unchanged for any external consumer.
+- **[MODIFIED]** `IntelligenceFactoryDeps` interface gains optional `router?: BackendRouter` field. `buildIntelligencePipeline` uses it when present to compare resolved backend names (closes I1).
+- **[MODIFIED]** `orchestrator.ts:1377-1383` legacy-fallback inline `Array.isArray` is removed; the normal `this.backendFactory !== null` path is the only path that ever fires for valid configs. The residual fallback (when migration threw) keeps a single-line minimal normalization.
+
+## File Map
+
+```
+MODIFY /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/backend-router.ts
+  - Rewrite resolve() to walk chain, return RoutingDecision
+  - Add toArray(value) helper
+  - Adapt resolveDefinition() to consume RoutingDecision
+  - Mark toScalar @deprecated (body delegates to toArray(v)[0])
+  - Drop private toScalar method on the class (no longer needed)
+
+MODIFY /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
+  - resolveName(useCase) returns router.resolve(useCase).backendName
+  - forUseCase(useCase) destructures both name + def from a single resolve() call
+    (eliminates today's double-call pattern at lines 95-96)
+
+MODIFY /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/intelligence-factory.ts
+  - IntelligenceFactoryDeps gains optional router?: BackendRouter
+  - buildIntelligencePipeline: when router is present, compare
+    router.resolve({ kind: 'intelligence', layer: 'sel' }).backendName
+    against router.resolve({ kind: 'intelligence', layer: 'pesl' }).backendName
+    instead of toScalar of raw RoutingValues
+  - resolveRoutedBackend retained for the no-router fallback path (until Phase 4 fully removes it)
+  - Remove `import { toScalar }` once unused on the router-present path
+
+MODIFY /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts
+  - Lines 1377-1383: shrink legacy-fallback inline Array.isArray to a single-line
+    toArray()-based extraction (covers only the migration-threw branch)
+  - When buildIntelligencePipeline is invoked (search call site), pass the
+    router instance into IntelligenceFactoryDeps so I1 fix activates
+
+MODIFY /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/backend-router.test.ts
+  - Update 13 existing tests to assert .backendName on RoutingDecision return shape
+  - Existing assertions like expect(router.resolve(useCase)).toBe('local')
+    become expect(router.resolve(useCase).backendName).toBe('local')
+  - resolveDefinition tests unchanged (return type unchanged)
+
+CREATE /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/backend-router-chain-walk.test.ts
+  - New file: 18+ tests covering Phase 1 features
+  - Sections: chain walk (scalar/single/multi), per-skill, per-mode, invocation override,
+    resolution-path fidelity, throw-on-exhausted-default, toArray normalizer
+```
+
+No new files added under `packages/`. No barrel regeneration required (the `RoutingDecision` type is already exported from `@harness-engineering/types` since Phase 0; `BackendRouter`'s public API surface stays at `BackendRouter` + `BackendRouterOptions` + `toScalar`).
+
+## Skeleton
+
+1. Foundation: `toArray` normalizer + helper types (~1 task, ~5 min)
+2. Core: `resolve()` chain-walk rewrite + `resolveDefinition()` adaptation (~3 tasks, ~17 min)
+3. Wiring: `OrchestratorBackendFactory` + `orchestrator.ts` call-site updates (~2 tasks, ~11 min)
+4. TDD: existing-test migration + new chain-walk test suite (~4 tasks, ~34 min)
+5. I1 cleanup: `intelligence-factory.ts` + `toScalar` deprecation (~2 tasks, ~10 min)
+6. Final gate: typecheck + full test + harness validate (~1 task, ~5 min)
+
+**Estimated total:** 12 tasks, ~82 min implementation; with TDD red-green cycles and verification gates, realistic wall-clock ~2.5 hours focused.
+
+Skeleton produced for visibility. Operator may approve and proceed, or request reshape. Subsequent sections expand the skeleton into full tasks.
+
+---
+
+## Tasks
+
+> **Worktree note:** Every `cd` below targets `/Users/cwarner/Projects/iv/harness-spec-b-phase-1`. Every file path is absolute under that worktree. Run `git branch --show-current` at the start of any session and verify it reads `feat/spec-b-phase-1` before editing.
+
+---
+
+### Task 1: Add `toArray` normalizer helper
+
+**Depends on:** none
+**Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/backend-router.ts`
+**Skills:** `ts-type-guards` (reference)
+
+1. Open the file. Locate the existing `toScalar` export at line 27.
+2. Insert (directly above `toScalar`) the `toArray` helper:
+
+   ```ts
+   /**
+    * Spec B Phase 1: normalize a {@link RoutingValue} to a readonly array
+    * of backend names. Scalar `'X'` becomes `['X']`; chain `['X', 'Y']`
+    * is returned unchanged. This is the canonical normalization the
+    * chain-walk resolver consumes; {@link toScalar} delegates to
+    * `toArray(value)[0]`.
+    *
+    * Internal helper — not re-exported from the package barrel.
+    */
+   export function toArray(value: RoutingValue): readonly string[] {
+     return Array.isArray(value) ? value : [value as string];
+   }
+   ```
+
+3. Update `toScalar`'s body to delegate (preserves byte-identical scalar behavior):
+
+   ```ts
+   /**
+    * @deprecated Spec B Phase 1: prefer {@link BackendRouter.resolve}'s
+    * `RoutingDecision.backendName` for chain-walk-aware backend selection.
+    * `toScalar` returns only the first chain entry and does not consult
+    * `agent.backends` for availability. Retained as a transitional
+    * export for any consumer that picked up the Phase 0 module-level
+    * export; remove in a future sweep once all known callers migrate.
+    */
+   export function toScalar(value: RoutingValue): string {
+     return toArray(value)[0];
+   }
+   ```
+
+4. Save. Type-check the orchestrator package:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck
+   ```
+   Expected: PASS (no consumers changed yet — `toScalar` semantics preserved).
+5. Run the existing router test file to confirm zero regression:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/backend-router.test.ts
+   ```
+   Expected: 13/13 PASS.
+6. Run `harness validate` at the worktree root. Expected: `v validation passed`.
+7. Commit:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && git add packages/orchestrator/src/agent/backend-router.ts && git commit -m "$(cat <<'EOF'
+   feat(orchestrator): add toArray RoutingValue normalizer (Spec B Phase 1 prep)
+
+   Adds the canonical {scalar | chain} -> readonly string[] helper that
+   Phase 1's chain-walk resolver will consume. Updates toScalar to delegate
+   to toArray(v)[0] (byte-identical for all inputs) and marks it
+   @deprecated in favor of router.resolve().backendName.
+
+   No behavior change. Existing 13/13 backend-router tests pass unchanged.
+   EOF
+   )"
+   ```
+
+---
+
+### Task 2: TDD red — write the chain-walk test file (failing)
+
+**Depends on:** Task 1
+**Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/backend-router-chain-walk.test.ts`
+**Skills:** `ts-testing-types` (reference), `gof-chain-of-responsibility` (reference)
+
+1. Create the new test file with the exact contents below. This file pins **every Phase 1 observable truth** as a Vitest test. Tests are written against a not-yet-existing API surface; they will fail. Task 3 implements.
+
+   ```ts
+   import { describe, it, expect } from 'vitest';
+   import type {
+     BackendDef,
+     RoutingConfig,
+     RoutingDecision,
+     RoutingUseCase,
+   } from '@harness-engineering/types';
+   import { BackendRouter, toArray, toScalar } from '../../src/agent/backend-router.js';
+
+   const cloud: BackendDef = { type: 'claude', command: 'claude' };
+   const local: BackendDef = {
+     type: 'pi',
+     endpoint: 'http://pi.local:1234/v1',
+     model: ['gemma-4-e4b'],
+   };
+   const fast: BackendDef = {
+     type: 'pi',
+     endpoint: 'http://localhost:1234/v1',
+     model: ['qwen3:8b'],
+   };
+
+   describe('toArray normalizer (Phase 1)', () => {
+     it('wraps a scalar in a single-element array', () => {
+       expect(toArray('cloud')).toEqual(['cloud']);
+     });
+
+     it('returns a chain unchanged', () => {
+       expect(toArray(['local', 'cloud'])).toEqual(['local', 'cloud']);
+     });
+
+     it('toScalar delegates to toArray(v)[0] (byte-identical to Phase 0)', () => {
+       expect(toScalar('cloud')).toBe('cloud');
+       expect(toScalar(['local', 'cloud'])).toBe('local');
+     });
+   });
+
+   describe('BackendRouter.resolve — return shape (Phase 1)', () => {
+     it('returns a RoutingDecision with backendName, useCase, resolutionPath, timestamp, durationMs, backendType', () => {
+       const routing: RoutingConfig = { default: 'cloud' };
+       const router = new BackendRouter({ backends: { cloud }, routing });
+       const decision = router.resolve({ kind: 'tier', tier: 'quick-fix' });
+       expect(decision.backendName).toBe('cloud');
+       expect(decision.backendType).toBe('claude');
+       expect(decision.useCase).toEqual({ kind: 'tier', tier: 'quick-fix' });
+       expect(decision.resolutionPath.length).toBeGreaterThan(0);
+       expect(typeof decision.timestamp).toBe('string');
+       expect(decision.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+       expect(typeof decision.durationMs).toBe('number');
+       expect(decision.durationMs).toBeGreaterThanOrEqual(0);
+     });
+   });
+
+   describe('BackendRouter.resolve — invocation override (D7)', () => {
+     it('picks invocationOverride when backend exists', () => {
+       const routing: RoutingConfig = { default: 'cloud' };
+       const router = new BackendRouter({ backends: { cloud, local }, routing });
+       const decision = router.resolve(
+         { kind: 'tier', tier: 'guided-change' },
+         { invocationOverride: 'local' }
+       );
+       expect(decision.backendName).toBe('local');
+       expect(decision.resolutionPath[0]).toEqual({
+         source: 'invocation',
+         candidate: 'local',
+         outcome: 'chosen',
+       });
+       expect(decision.resolutionPath).toHaveLength(1);
+     });
+
+     it('records unknown-backend for invocation override and falls through', () => {
+       const routing: RoutingConfig = { default: 'cloud' };
+       const router = new BackendRouter({ backends: { cloud }, routing });
+       const decision = router.resolve(
+         { kind: 'tier', tier: 'quick-fix' },
+         { invocationOverride: 'ghost' }
+       );
+       expect(decision.backendName).toBe('cloud');
+       const invocationStep = decision.resolutionPath.find((s) => s.source === 'invocation');
+       expect(invocationStep).toEqual({
+         source: 'invocation',
+         candidate: 'ghost',
+         outcome: 'unknown-backend',
+       });
+     });
+   });
+
+   describe('BackendRouter.resolve — per-skill (D1)', () => {
+     it('picks routing.skills[skillName] for kind: skill', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         skills: { 'harness-debugging': 'local' },
+       };
+       const router = new BackendRouter({ backends: { cloud, local }, routing });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-debugging',
+       });
+       expect(decision.backendName).toBe('local');
+       expect(
+         decision.resolutionPath.some((s) => s.source === 'skill' && s.outcome === 'chosen')
+       ).toBe(true);
+     });
+
+     it('walks a per-skill chain entry by entry', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         skills: { 'harness-debugging': ['fast', 'local'] as const },
+       };
+       const router = new BackendRouter({ backends: { cloud, local, fast }, routing });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-debugging',
+       });
+       expect(decision.backendName).toBe('fast');
+     });
+
+     it('skips unknown chain entries and continues', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         skills: { 'harness-debugging': ['ghost', 'local'] as const },
+       };
+       const router = new BackendRouter({
+         backends: { cloud, local },
+         routing,
+       });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-debugging',
+       });
+       expect(decision.backendName).toBe('local');
+       const path = decision.resolutionPath;
+       expect(path.find((s) => s.candidate === 'ghost')).toEqual({
+         source: 'skill',
+         candidate: 'ghost',
+         outcome: 'unknown-backend',
+       });
+       expect(path.find((s) => s.candidate === 'local')).toEqual({
+         source: 'skill',
+         candidate: 'local',
+         outcome: 'chosen',
+       });
+     });
+
+     it('falls through to mode when skill chain produces no available backend', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         skills: { 'harness-debugging': ['ghost'] as const },
+         modes: { 'adversarial-reviewer': 'local' },
+       };
+       const router = new BackendRouter({
+         backends: { cloud, local },
+         routing,
+       });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-debugging',
+         cognitiveMode: 'adversarial-reviewer',
+       });
+       expect(decision.backendName).toBe('local');
+       expect(
+         decision.resolutionPath.find((s) => s.source === 'mode' && s.outcome === 'chosen')
+       ).toBeDefined();
+     });
+   });
+
+   describe('BackendRouter.resolve — per-mode (D1)', () => {
+     it('picks routing.modes[cognitiveMode] for kind: mode', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         modes: { 'adversarial-reviewer': 'local' },
+       };
+       const router = new BackendRouter({ backends: { cloud, local }, routing });
+       const decision = router.resolve({
+         kind: 'mode',
+         cognitiveMode: 'adversarial-reviewer',
+       });
+       expect(decision.backendName).toBe('local');
+     });
+
+     it('picks routing.modes[cognitiveMode] for kind: skill that carries cognitiveMode', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         modes: { 'adversarial-reviewer': 'local' },
+       };
+       const router = new BackendRouter({ backends: { cloud, local }, routing });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-soundness-review',
+         cognitiveMode: 'adversarial-reviewer',
+       });
+       expect(decision.backendName).toBe('local');
+     });
+   });
+
+   describe('BackendRouter.resolve — resolution order (D2, F3)', () => {
+     it('per-skill wins over per-mode for the same skill', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         skills: { 'harness-debugging': 'fast' },
+         modes: { 'diagnostic-investigator': 'local' },
+       };
+       const router = new BackendRouter({
+         backends: { cloud, local, fast },
+         routing,
+       });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-debugging',
+         cognitiveMode: 'diagnostic-investigator',
+       });
+       expect(decision.backendName).toBe('fast');
+     });
+
+     it('invocation override beats per-skill', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         skills: { 'harness-debugging': 'local' },
+       };
+       const router = new BackendRouter({
+         backends: { cloud, local, fast },
+         routing,
+       });
+       const decision = router.resolve(
+         { kind: 'skill', skillName: 'harness-debugging' },
+         { invocationOverride: 'fast' }
+       );
+       expect(decision.backendName).toBe('fast');
+     });
+
+     it('falls through skill -> mode -> tier -> default', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         'quick-fix': 'local',
+       };
+       const router = new BackendRouter({ backends: { cloud, local }, routing });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-debugging',
+         cognitiveMode: 'unmapped-mode',
+       });
+       // skills map absent, modes map absent, no per-skill kind in tier resolution
+       // -> falls through to default
+       expect(decision.backendName).toBe('cloud');
+     });
+   });
+
+   describe('BackendRouter.resolve — scalar/chain equivalence (F5, F6)', () => {
+     it('scalar routing.default behaves identically to single-element-chain', () => {
+       const scalar = new BackendRouter({
+         backends: { cloud },
+         routing: { default: 'cloud' },
+       });
+       const chain = new BackendRouter({
+         backends: { cloud },
+         routing: { default: ['cloud'] as const },
+       });
+       const u: RoutingUseCase = { kind: 'maintenance' };
+       expect(scalar.resolve(u).backendName).toBe(chain.resolve(u).backendName);
+     });
+
+     it('multi-entry chain picks the first existing backend', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         'quick-fix': ['ghost', 'local', 'cloud'] as const,
+       };
+       const router = new BackendRouter({
+         backends: { cloud, local },
+         routing,
+       });
+       const decision = router.resolve({ kind: 'tier', tier: 'quick-fix' });
+       expect(decision.backendName).toBe('local');
+       // The 'ghost' entry must be recorded as unknown-backend
+       expect(decision.resolutionPath.find((s) => s.candidate === 'ghost')?.outcome).toBe(
+         'unknown-backend'
+       );
+     });
+   });
+
+   describe('BackendRouter.resolve — exhaustion (S4)', () => {
+     it('throws when every chain entry across all sources is unknown', () => {
+       // Note: validateReferences() catches static-config typos, so to
+       // exercise the runtime throw we construct a router whose default
+       // exists at construction time but is removed before resolve()
+       // (simulating a future dynamic-backends feature). For this Phase 1
+       // test, we exercise the throw via a stripped backends map.
+       const router = new BackendRouter({
+         backends: { cloud },
+         routing: { default: 'cloud' },
+       });
+       // Reach in to simulate runtime backend removal; this is the only
+       // way to exercise the throw path without bypassing
+       // validateReferences().
+       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+       (router as any).backends = {};
+       expect(() => router.resolve({ kind: 'maintenance' })).toThrowError(
+         /routing\.default produced no available backend/
+       );
+     });
+   });
+
+   describe('BackendRouter.resolve — resolution path fidelity (S7)', () => {
+     it('records every chain entry considered with the correct source label', () => {
+       const routing: RoutingConfig = {
+         default: 'cloud',
+         skills: { 'harness-debugging': ['ghost1', 'ghost2'] as const },
+         modes: { 'adversarial-reviewer': ['ghost3', 'fast'] as const },
+       };
+       const router = new BackendRouter({
+         backends: { cloud, fast },
+         routing,
+       });
+       const decision = router.resolve({
+         kind: 'skill',
+         skillName: 'harness-debugging',
+         cognitiveMode: 'adversarial-reviewer',
+       });
+       expect(decision.backendName).toBe('fast');
+       const candidates = decision.resolutionPath.map((s) => ({
+         src: s.source,
+         cand: s.candidate,
+         out: s.outcome,
+       }));
+       expect(candidates).toEqual([
+         { src: 'skill', cand: 'ghost1', out: 'unknown-backend' },
+         { src: 'skill', cand: 'ghost2', out: 'unknown-backend' },
+         { src: 'mode', cand: 'ghost3', out: 'unknown-backend' },
+         { src: 'mode', cand: 'fast', out: 'chosen' },
+       ]);
+     });
+   });
+
+   describe('BackendRouter.resolveDefinition — API surface preserved (N1)', () => {
+     it('still returns the BackendDef reference, identity-equal to backends entry', () => {
+       const routing: RoutingConfig = { default: 'cloud', 'quick-fix': 'local' };
+       const backends = { cloud, local };
+       const router = new BackendRouter({ backends, routing });
+       expect(router.resolveDefinition({ kind: 'tier', tier: 'quick-fix' })).toBe(backends.local);
+     });
+
+     it('accepts opts.invocationOverride pass-through', () => {
+       const routing: RoutingConfig = { default: 'cloud' };
+       const backends = { cloud, local };
+       const router = new BackendRouter({ backends, routing });
+       expect(
+         router.resolveDefinition(
+           { kind: 'tier', tier: 'quick-fix' },
+           { invocationOverride: 'local' }
+         )
+       ).toBe(backends.local);
+     });
+   });
+   ```
+
+2. Run the new test file (it will fail — that's the red phase):
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/backend-router-chain-walk.test.ts 2>&1 | tail -40
+   ```
+   Expected: tests fail because `resolve()` still returns `string` (no `.backendName` property), `toArray` does not yet exist if you skipped Task 1, and chain-walk semantics are not implemented.
+3. Do **not** commit yet. Task 3 turns these tests green, then the green commit lands.
+4. Note the exact set of failing assertions (write count to scratch); Task 3 will need to drive them all to pass.
+
+---
+
+### Task 3: TDD green — rewrite `BackendRouter.resolve()` to chain-walk and return `RoutingDecision`
+
+**Depends on:** Task 1, Task 2
+**Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/backend-router.ts`
+**Skills:** `gof-chain-of-responsibility` (reference), `ts-type-guards` (reference)
+
+1. Open the file. Replace the entire `BackendRouter` class body (lines 58-171) with the chain-walking implementation. The full updated file should look like:
+
+   ```ts
+   import type {
+     BackendDef,
+     IsolationTier,
+     ResolutionSource,
+     ResolutionStep,
+     RoutingConfig,
+     RoutingDecision,
+     RoutingUseCase,
+     RoutingValue,
+   } from '@harness-engineering/types';
+
+   export interface BackendRouterOptions {
+     backends: Record<string, BackendDef>;
+     routing: RoutingConfig;
+   }
+
+   /**
+    * Spec B Phase 1: normalize a {@link RoutingValue} to a readonly array
+    * of backend names. Scalar `'X'` becomes `['X']`; chain `['X', 'Y']`
+    * is returned unchanged. Canonical normalization for the chain-walk
+    * resolver.
+    *
+    * Internal helper — not re-exported from the package barrel.
+    */
+   export function toArray(value: RoutingValue): readonly string[] {
+     return Array.isArray(value) ? value : [value as string];
+   }
+
+   /**
+    * @deprecated Spec B Phase 1: prefer {@link BackendRouter.resolve}'s
+    * `RoutingDecision.backendName` for chain-walk-aware backend selection.
+    * Retained as a transitional export for consumers that picked up the
+    * Phase 0 module-level export. Remove in a later sweep.
+    */
+   export function toScalar(value: RoutingValue): string {
+     return toArray(value)[0];
+   }
+
+   /**
+    * BackendRouter (Spec B Phase 1)
+    *
+    * Owns the lookup from a {@link RoutingUseCase} (a discriminated query
+    * — tier, intelligence layer, maintenance, chat, isolation, **skill**,
+    * **mode**) to a {@link RoutingDecision} naming a chosen backend and
+    * the full resolution path that produced it.
+    *
+    * Resolution order (D2): invocation override -> per-skill -> per-mode
+    * -> existing per-tier/intelligence/isolation/maintenance/chat ->
+    * `routing.default`. Within each source, fallback chain entries are
+    * tried in declared order; first existing backend wins. Unknown
+    * entries are recorded with `outcome: 'unknown-backend'` and the walk
+    * continues.
+    *
+    * Construction-time validation guarantees every name referenced by
+    * `routing` is present in `backends` so the static-config case can
+    * never produce a runtime exhaustion throw. The runtime throw at the
+    * end of `resolve()` is a safety net for future dynamic-backends
+    * scenarios where a chain entry can become unknown post-construction.
+    */
+   export class BackendRouter {
+     private readonly backends: Record<string, BackendDef>;
+     private readonly routing: RoutingConfig;
+
+     constructor(opts: BackendRouterOptions) {
+       this.backends = opts.backends;
+       this.routing = opts.routing;
+       this.validateReferences();
+     }
+
+     /**
+      * Resolve a {@link RoutingUseCase} to a {@link RoutingDecision}.
+      *
+      * @param useCase the routing query
+      * @param opts.invocationOverride if set and the named backend exists,
+      *   beats all other sources (D7 — the `--backend <name>` escape hatch)
+      */
+     resolve(useCase: RoutingUseCase, opts?: { invocationOverride?: string }): RoutingDecision {
+       const startedAt = performance.now();
+       const path: ResolutionStep[] = [];
+
+       const tryChain = (
+         source: ResolutionSource,
+         value: RoutingValue | undefined
+       ): string | undefined => {
+         if (value === undefined) return undefined;
+         for (const name of toArray(value)) {
+           const step: ResolutionStep = { source, candidate: name, outcome: 'considered' };
+           path.push(step);
+           if (this.backends[name]) {
+             step.outcome = 'chosen';
+             return name;
+           }
+           step.outcome = 'unknown-backend';
+         }
+         return undefined;
+       };
+
+       const decide = (backendName: string): RoutingDecision => ({
+         timestamp: new Date().toISOString(),
+         useCase,
+         resolutionPath: path,
+         backendName,
+         backendType: this.backends[backendName].type,
+         durationMs: performance.now() - startedAt,
+       });
+
+       // 1. Invocation override (D7).
+       const fromInvocation = tryChain(
+         'invocation',
+         opts?.invocationOverride !== undefined ? opts.invocationOverride : undefined
+       );
+       if (fromInvocation) return decide(fromInvocation);
+
+       // 2. Per-skill (D1).
+       if (useCase.kind === 'skill') {
+         const fromSkill = tryChain('skill', this.routing.skills?.[useCase.skillName]);
+         if (fromSkill) return decide(fromSkill);
+       }
+
+       // 3. Per-mode (D1) — fires for kind: 'mode' AND kind: 'skill' with a cognitiveMode.
+       const mode =
+         useCase.kind === 'skill'
+           ? useCase.cognitiveMode
+           : useCase.kind === 'mode'
+             ? useCase.cognitiveMode
+             : undefined;
+       if (mode !== undefined) {
+         const fromMode = tryChain('mode', this.routing.modes?.[mode]);
+         if (fromMode) return decide(fromMode);
+       }
+
+       // 4. Existing per-tier / intelligence / isolation / maintenance / chat.
+       const fromExisting = this.resolveExistingUseCase(useCase);
+       if (fromExisting !== undefined) {
+         const chained = tryChain('tier', fromExisting);
+         if (chained) return decide(chained);
+       }
+
+       // 5. Default fallback (required field).
+       const fromDefault = tryChain('default', this.routing.default);
+       if (fromDefault) return decide(fromDefault);
+
+       const knownList = Object.keys(this.backends).join(', ') || '(none)';
+       throw new Error(
+         `BackendRouter.resolve: routing.default produced no available backend ` +
+           `for useCase=${JSON.stringify(useCase)}. ` +
+           `Resolution path: ${JSON.stringify(path)}. Known backends: [${knownList}].`
+       );
+     }
+
+     /**
+      * Returns the {@link BackendDef} reference for the resolved name.
+      * Identity-equal to the entry in `backends` (no copy) so callers
+      * relying on reference equality (SC21) continue to work.
+      */
+     resolveDefinition(
+       useCase: RoutingUseCase,
+       opts?: { invocationOverride?: string }
+     ): BackendDef {
+       const decision = this.resolve(useCase, opts);
+       const def = this.backends[decision.backendName];
+       if (!def) {
+         // Unreachable: resolve() only returns a name present in backends.
+         throw new Error(
+           `BackendRouter.resolveDefinition: routing target '${decision.backendName}' is not in backends ` +
+             `(useCase=${JSON.stringify(useCase)}).`
+         );
+       }
+       return def;
+     }
+
+     /**
+      * The pre-Spec-B resolution helper: returns the configured
+      * {@link RoutingValue} for tier/intelligence/isolation/maintenance/chat
+      * use cases (or `undefined` for skill/mode use cases, which are owned
+      * by the per-skill / per-mode steps in {@link resolve}). Returning
+      * `undefined` lets the caller fall through to `routing.default`.
+      */
+     private resolveExistingUseCase(useCase: RoutingUseCase): RoutingValue | undefined {
+       switch (useCase.kind) {
+         case 'tier': {
+           const tierMap = this.routing as unknown as Record<string, RoutingValue | undefined>;
+           return tierMap[useCase.tier];
+         }
+         case 'intelligence': {
+           const intel = this.routing.intelligence as
+             | Record<string, RoutingValue | undefined>
+             | undefined;
+           return intel?.[useCase.layer];
+         }
+         case 'isolation': {
+           const iso = this.routing.isolation as
+             | Record<IsolationTier, RoutingValue | undefined>
+             | undefined;
+           return iso?.[useCase.tier];
+         }
+         case 'maintenance':
+         case 'chat':
+           // Always default per SC19, SC20.
+           return undefined;
+         case 'skill':
+         case 'mode':
+           // Owned by the per-skill / per-mode steps; here we fall through to default.
+           return undefined;
+       }
+     }
+
+     private validateReferences(): void {
+       const known = new Set(Object.keys(this.backends));
+       const missing: Array<{ path: string; name: string }> = [];
+
+       const check = (label: string, value: RoutingValue | undefined) => {
+         if (value === undefined) return;
+         for (const name of toArray(value)) {
+           if (!known.has(name)) missing.push({ path: label, name });
+         }
+       };
+
+       check('default', this.routing.default);
+       check('quick-fix', this.routing['quick-fix']);
+       check('guided-change', this.routing['guided-change']);
+       check('full-exploration', this.routing['full-exploration']);
+       check('diagnostic', this.routing.diagnostic);
+       check('intelligence.sel', this.routing.intelligence?.sel);
+       check('intelligence.pesl', this.routing.intelligence?.pesl);
+       check('isolation.none', this.routing.isolation?.none);
+       check('isolation.container', this.routing.isolation?.container);
+       check('isolation.remote-sandbox', this.routing.isolation?.['remote-sandbox']);
+       // Phase 1 NEW: validate per-skill + per-mode chain entries too.
+       for (const [skill, value] of Object.entries(this.routing.skills ?? {})) {
+         check(`skills.${skill}`, value);
+       }
+       for (const [mode, value] of Object.entries(this.routing.modes ?? {})) {
+         check(`modes.${mode}`, value);
+       }
+
+       if (missing.length > 0) {
+         const detail = missing.map(({ path, name }) => `routing.${path} -> '${name}'`).join('; ');
+         const known_ = [...known].join(', ') || '(none)';
+         throw new Error(
+           `BackendRouter: routing references unknown backend(s): ${detail}. Defined backends: [${known_}].`
+         );
+       }
+     }
+   }
+   ```
+
+2. Save. Type-check:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -30
+   ```
+   Expected: **typecheck will FAIL** in `orchestrator-backend-factory.ts:91,96` (callers expect `string` but get `RoutingDecision`) and possibly other call sites. This is expected — Task 4 + Task 5 update callers in lockstep. **Do not commit yet.**
+3. Run the new chain-walk tests:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/backend-router-chain-walk.test.ts 2>&1 | tail -30
+   ```
+   Expected: all new tests **PASS** (or fail in `vitest --run --no-coverage` mode if `tsc` errors leak; if Vitest's transform mode masks the consumer-site errors, only `tsc` reflects them — that's fine, fix in Task 4).
+4. Do not commit. The orchestrator package will not typecheck until Task 4 updates `orchestrator-backend-factory.ts`. Proceed directly to Task 4.
+
+---
+
+### Task 4: Update `OrchestratorBackendFactory` to consume `RoutingDecision`
+
+**Depends on:** Task 3
+**Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/orchestrator-backend-factory.ts`
+**Skills:** none specific
+
+1. Open the file. Locate `resolveName` (line 90) and `forUseCase` (line 94).
+2. Replace the `resolveName` body:
+
+   ```ts
+   resolveName(useCase: RoutingUseCase): string {
+     return this.router.resolve(useCase).backendName;
+   }
+   ```
+
+3. Refactor `forUseCase` to call `resolve()` once and use the decision for both name + def lookup (eliminates today's double-call at lines 95-96):
+
+   ```ts
+   forUseCase(useCase: RoutingUseCase): AgentBackend {
+     const decision = this.router.resolve(useCase);
+     const def = this.router['backends' as keyof BackendRouter] as unknown as Record<string, BackendDef>; // no — see step 3a
+     // ...
+   }
+   ```
+
+   **Correction (step 3a):** Don't reach into private state. Use `resolveDefinition` for the def and `decision.backendName` for the name. Since both now stem from a single chain-walk via `resolve()`, the double-call concern is gone:
+
+   ```ts
+   forUseCase(useCase: RoutingUseCase): AgentBackend {
+     const def = this.router.resolveDefinition(useCase);
+     const name = this.router.resolve(useCase).backendName;
+     // ... rest of method unchanged
+   }
+   ```
+
+   Note: `resolveDefinition` internally calls `resolve()` so this is technically two `resolve()` calls. That is fine for Phase 1 — it preserves the existing two-call pattern exactly (each call returns identical results because the router is deterministic and stateless). Phase 4's bus emission will be wired into `resolve()` and we'll thread a single decision through `forUseCase()` then. Leave the comment:
+
+   ```ts
+   forUseCase(useCase: RoutingUseCase): AgentBackend {
+     // Spec B Phase 1: two resolve() calls (one inside resolveDefinition,
+     // one explicit) yield identical RoutingDecisions because the router
+     // is deterministic and stateless. Phase 4 (decision-bus emission)
+     // will refactor to a single resolve() + threaded decision.
+     const def = this.router.resolveDefinition(useCase);
+     const name = this.router.resolve(useCase).backendName;
+     // ... existing body below unchanged: createBackend, getResolverModelFor,
+     //     ContainerBackend wrap, etc.
+   }
+   ```
+
+4. Save. Type-check the orchestrator package:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -20
+   ```
+   Expected: PASS now (callers conform to the new return shape).
+5. Run only the existing router test file to confirm legacy behavior (will still fail because the tests expect `string` — Task 5 updates them):
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/backend-router.test.ts 2>&1 | tail -10
+   ```
+   Expected: tests fail (`.toBe('local')` vs `RoutingDecision` object). This is expected. Do not commit.
+
+---
+
+### Task 5: TDD migration — update existing backend-router tests to assert on `.backendName`
+
+**Depends on:** Task 3, Task 4
+**Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/backend-router.test.ts`
+
+1. Open the file. In every test that asserts `router.resolve(useCase)`, change the assertion to `.backendName`. There are 13 tests; expected diff is mechanical.
+2. Specifically, the pattern:
+
+   ```ts
+   expect(router.resolve(useCase)).toBe('local');
+   ```
+
+   becomes:
+
+   ```ts
+   expect(router.resolve(useCase).backendName).toBe('local');
+   ```
+
+3. `resolveDefinition` tests stay unchanged (return type unchanged).
+4. The `BackendRouter + createBackend integration` block (lines 168-189) uses `resolveDefinition` only — leave as is.
+5. Save. Run the file:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/backend-router.test.ts 2>&1 | tail -20
+   ```
+   Expected: 13/13 PASS (the legacy N1 gate).
+6. Run the new chain-walk tests to confirm they still pass:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/backend-router-chain-walk.test.ts 2>&1 | tail -10
+   ```
+   Expected: all PASS.
+7. Run **the whole agent test directory** (catches surprise consumers):
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/ 2>&1 | tail -20
+   ```
+   Expected: all PASS (271+ tests baseline + new chain-walk file). If `intelligence-factory.test.ts` or others fail because of pinned behavior, defer to Task 7 (the I1 fix may incidentally close them or surface a related pin to update).
+8. Run `harness validate`. Expected: PASS.
+9. Commit Tasks 1-5 as a single boundary (they form an atomic feature: the resolver rewrite + tests):
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && git add packages/orchestrator/src/agent/backend-router.ts packages/orchestrator/src/agent/orchestrator-backend-factory.ts packages/orchestrator/tests/agent/backend-router.test.ts packages/orchestrator/tests/agent/backend-router-chain-walk.test.ts && git commit -m "$(cat <<'EOF'
+   feat(orchestrator): rewrite BackendRouter.resolve to walk chain + emit RoutingDecision (Spec B Phase 1)
+
+   Replaces the Phase 0 toScalar shim with the full chain-walk resolver
+   from spec.md § Technical Design. resolve() now returns a
+   RoutingDecision (was: string) with backendName, useCase,
+   resolutionPath, timestamp, backendType, durationMs. Adds the
+   per-skill / per-mode / invocation-override sources per D1/D7.
+
+   Resolution order (D2): invocation -> skill -> mode -> tier ->
+   default. Within each source, chain entries are tried in declared
+   order; unknown backends are recorded as outcome:'unknown-backend'
+   and the walk continues.
+
+   API surface:
+   - BackendRouter.resolve(useCase, opts?) returns RoutingDecision
+   - BackendRouter.resolveDefinition(useCase, opts?) still returns
+     BackendDef (existing API surface preserved)
+   - OrchestratorBackendFactory.resolveName(useCase) still returns
+     string (existing API surface preserved)
+   - toArray() module-level helper exported (canonical normalizer)
+   - toScalar() retained as @deprecated, delegates to toArray(v)[0]
+
+   Tests: 13 existing backend-router tests pass with .backendName
+   adjustment (N1). New backend-router-chain-walk.test.ts (~20 tests)
+   covers F3, F5, F6, S4, S7 and the new per-skill / per-mode /
+   invocation-override sources.
+
+   I1 (Phase 0 review finding) consolidation lands in a follow-up
+   commit on this branch.
+   EOF
+   )"
+   ```
+
+---
+
+### Task 6: I1 fix — thread `BackendRouter` into `IntelligenceFactoryDeps`, use `router.resolve()` for the SEL/PESL comparison
+
+**Depends on:** Task 5
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/intelligence-factory.ts`
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts` (call site of `buildIntelligencePipeline`)
+
+1. Open `intelligence-factory.ts`. Locate the `IntelligenceFactoryDeps` interface (line 15-19).
+2. Add the optional `router` field:
+
+   ```ts
+   import { BackendRouter, toScalar } from './backend-router';
+   // ...
+
+   export interface IntelligenceFactoryDeps {
+     config: WorkflowConfig;
+     localResolvers: Map<string, LocalModelResolver>;
+     logger: StructuredLogger;
+     /**
+      * Spec B Phase 1: when present, the SEL/PESL backend-name comparison
+      * uses `router.resolve({ kind: 'intelligence', layer })` instead of
+      * the Phase 0 toScalar normalization. This makes "two distinct chains
+      * that resolve to the same backend" compare equal (closes Phase 0
+      * review finding I1). When absent, the legacy toScalar path is used
+      * as a graceful-degradation fallback for callers that have not yet
+      * been updated to thread the router in.
+      */
+     router?: BackendRouter;
+   }
+   ```
+
+3. Update `buildIntelligencePipeline` (line 34) to prefer `router.resolve()` when present:
+
+   ```ts
+   export function buildIntelligencePipeline(
+     deps: IntelligenceFactoryDeps
+   ): IntelligencePipelineBundle | null {
+     const { config, router } = deps;
+     const intel = config.intelligence;
+     if (!intel?.enabled) return null;
+
+     const selProvider = buildAnalysisProviderForLayer('sel', deps);
+     if (!selProvider) return null;
+
+     // Spec B Phase 1 (closes Phase 0 review finding I1): when a
+     // BackendRouter is available, ask it to resolve the actual chosen
+     // backend name for sel vs pesl. This compares post-chain-walk names,
+     // so two distinct chains that resolve to the same backend (via
+     // availability filtering) compare equal — the original intent of the
+     // SC34/SC35 dedupe optimization.
+     //
+     // Fallback (no router): use the Phase 0 toScalar normalization. This
+     // preserves byte-identical behavior for scalar configs and handles
+     // the array-form C1 regression at the first-element level.
+     let peslName: string | undefined;
+     let selName: string | undefined;
+     if (router) {
+       peslName = router.resolve({ kind: 'intelligence', layer: 'pesl' }).backendName;
+       selName = router.resolve({ kind: 'intelligence', layer: 'sel' }).backendName;
+     } else {
+       const routing = config.agent.routing;
+       const peslValue = routing?.intelligence?.pesl;
+       const selValue = routing?.intelligence?.sel ?? routing?.default;
+       peslName = peslValue !== undefined ? toScalar(peslValue) : undefined;
+       selName = selValue !== undefined ? toScalar(selValue) : undefined;
+     }
+     const peslProvider =
+       peslName !== undefined && peslName !== selName
+         ? buildAnalysisProviderForLayer('pesl', deps)
+         : null;
+
+     const peslModel = intel.models?.pesl ?? config.agent.model;
+     const graphStore = new GraphStore();
+     const pipeline = new IntelligencePipeline(selProvider, graphStore, {
+       ...(peslModel !== undefined && { peslModel }),
+       ...(peslProvider !== null && peslProvider !== undefined && { peslProvider }),
+     });
+     return { pipeline, graphStore };
+   }
+   ```
+
+4. Open `orchestrator.ts`. Find the call site of `buildIntelligencePipeline` (grep: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && grep -n "buildIntelligencePipeline" packages/orchestrator/src/orchestrator.ts`).
+5. Thread the router into the deps object passed to `buildIntelligencePipeline`. The orchestrator already constructs an `OrchestratorBackendFactory` which holds a private `router`. Two approaches:
+   - (a) Add a public `getRouter()` method on `OrchestratorBackendFactory` and call it at the build site.
+   - (b) Construct a separate `BackendRouter` in `orchestrator.ts` (it is a thin object — construction-time validation only re-runs the existing check, which is idempotent).
+
+   **Pick (a)** because it preserves single-source-of-truth: only one router instance exists. Add to `orchestrator-backend-factory.ts`:
+
+   ```ts
+   /**
+    * Spec B Phase 1: expose the underlying router for callers that need
+    * it directly (e.g., {@link buildIntelligencePipeline} for the
+    * I1 SEL/PESL comparison fix). Read-only access; consumers must not
+    * mutate router state.
+    */
+   getRouter(): BackendRouter {
+     return this.router;
+   }
+   ```
+
+6. At the `buildIntelligencePipeline` call site in `orchestrator.ts`, add `router: this.backendFactory?.getRouter()` to the deps object (the `?.` matters because `backendFactory` is nullable when migration threw):
+
+   ```ts
+   const intelBundle = buildIntelligencePipeline({
+     config: this.config,
+     localResolvers: this.localResolvers,
+     logger: this.logger,
+     router: this.backendFactory?.getRouter(),
+   });
+   ```
+
+7. Type-check:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -10
+   ```
+   Expected: PASS.
+8. Run the intelligence-factory tests to confirm the new router-present path works and the no-router fallback still works:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/ 2>&1 | tail -10
+   ```
+   Expected: all PASS.
+9. Run `harness validate`. Expected: PASS.
+10. Commit:
+
+    ```
+    cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && git add packages/orchestrator/src/agent/intelligence-factory.ts packages/orchestrator/src/agent/orchestrator-backend-factory.ts packages/orchestrator/src/orchestrator.ts && git commit -m "$(cat <<'EOF'
+    refactor(orchestrator): route intelligence-factory SEL/PESL comparison through router.resolve (Spec B Phase 1, closes Phase 0 review I1 part 1)
+
+    Threads BackendRouter into IntelligenceFactoryDeps as an optional
+    field. When present, buildIntelligencePipeline uses
+    router.resolve({ kind: 'intelligence', layer }).backendName for the
+    SEL vs PESL backend equivalence check — this consults the full
+    chain walk (with availability filtering), so two distinct chains
+    that resolve to the same backend compare equal. When absent (legacy
+    callers), the Phase 0 toScalar normalization is preserved as a
+    graceful-degradation fallback.
+
+    Exposes BackendRouter via OrchestratorBackendFactory.getRouter() so
+    the orchestrator can thread the single canonical router instance
+    into the intelligence factory without constructing a duplicate.
+    EOF
+    )"
+    ```
+
+---
+
+### Task 7: I1 fix — shrink `orchestrator.ts:1377-1383` legacy-fallback inline normalization
+
+**Depends on:** Task 6
+**Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts`
+
+1. Open the file. Navigate to lines 1370-1390 (the legacy-fallback path inside the dispatch routing block).
+2. Current code:
+
+   ```ts
+   } else {
+     // Legacy-fallback path: factory absent because migration threw.
+     // ...
+     // Spec B Phase 0: routing.default is RoutingValue (scalar OR chain).
+     // Normalize to first element for byte-identical scalar behavior;
+     // Phase 1 replaces this with the proper chain walk.
+     const routingDefault = this.config.agent.routing?.default;
+     const routingDefaultScalar =
+       routingDefault === undefined
+         ? undefined
+         : Array.isArray(routingDefault)
+           ? routingDefault[0]
+           : routingDefault;
+     routedBackendName = routingDefaultScalar ?? this.config.agent.backend ?? 'unknown';
+   }
+   ```
+
+3. Replace with a single-line `toArray()`-based extraction:
+
+   ```ts
+   } else {
+     // Legacy-fallback path: factory absent because migration threw.
+     // Pre-Spec-B configs that have `agent.backend` set without `agent.backends`
+     // reach here. routing.default may be RoutingValue (scalar OR chain);
+     // we take the first chain entry without availability filtering
+     // (validateReferences() would have caught typos at construction time).
+     // Spec B Phase 1 (closes Phase 0 review finding I1 part 2): the inline
+     // Array.isArray normalization is replaced with the canonical toArray
+     // helper from backend-router.ts.
+     const routingDefault = this.config.agent.routing?.default;
+     const routingDefaultScalar = routingDefault !== undefined ? toArray(routingDefault)[0] : undefined;
+     routedBackendName = routingDefaultScalar ?? this.config.agent.backend ?? 'unknown';
+   }
+   ```
+
+4. Add the import at the top of the file (locate the existing `./agent/backend-router` import or add):
+
+   ```ts
+   import { toArray } from './agent/backend-router';
+   ```
+
+   (If the file already imports from `./agent/backend-router`, append `toArray` to the existing import.)
+
+5. Type-check:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -10
+   ```
+   Expected: PASS.
+6. Run the orchestrator test suite focusing on dispatch paths:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test tests/agent/ 2>&1 | tail -10
+   ```
+   Expected: PASS.
+7. Run `harness validate`. Expected: PASS.
+8. Commit:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && git add packages/orchestrator/src/orchestrator.ts && git commit -m "$(cat <<'EOF'
+   refactor(orchestrator): replace inline Array.isArray normalization with toArray helper (Spec B Phase 1, closes Phase 0 review I1 part 2)
+
+   The legacy-fallback dispatch path (factory absent because migration
+   threw) used a 6-line inline Array.isArray ternary to normalize
+   routing.default from RoutingValue to first chain entry. This commit
+   collapses that to a single toArray(value)[0] call using the canonical
+   helper from backend-router.ts. No behavior change; eliminates the
+   last remaining inline RoutingValue normalization site identified in
+   Phase 0 review finding I1.
+   EOF
+   )"
+   ```
+
+---
+
+### Task 8: Verify `toScalar` is no longer called from in-package source code
+
+**Depends on:** Task 7
+**Files:** (verification only — no edits unless step 2 finds drift)
+
+1. Grep for any remaining in-package callers of `toScalar`:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && grep -rn "toScalar" packages/orchestrator/src --include="*.ts" 2>/dev/null
+   ```
+2. Expected output: only the definition + the no-router fallback path in `intelligence-factory.ts:buildIntelligencePipeline` (which is intentional graceful degradation). If any other call site appears, audit it and either migrate it to `router.resolve()` or document why the toScalar path is correct for that site.
+3. Grep tests too:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && grep -rn "toScalar" packages/orchestrator/tests --include="*.ts" 2>/dev/null
+   ```
+4. Expected: at least the chain-walk test file we created in Task 2 (it asserts the deprecated alias still works). Any production-code consumer (non-test) is a Phase 1 leak — fix before proceeding.
+5. **[checkpoint:human-verify]** Confirm to the operator: "No production-code consumers of `toScalar` remain in `packages/orchestrator/src` other than the documented `buildIntelligencePipeline` fallback path. The `@deprecated` JSDoc steers new callers to `router.resolve().backendName`." If the operator agrees `toScalar` should be removed entirely (not just deprecated), proceed to Task 8a; otherwise skip to Task 9.
+
+---
+
+### Task 8a (CONDITIONAL — only if operator removes `toScalar`)
+
+**Depends on:** Task 8
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/backend-router.ts`
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/intelligence-factory.ts`
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/backend-router-chain-walk.test.ts`
+
+1. Remove the `export function toScalar` from `backend-router.ts`.
+2. Remove the `toScalar` import + fallback branch in `intelligence-factory.ts` — replace the deps `router?: BackendRouter` with a required `router: BackendRouter` field (all callers must thread it now).
+3. Remove the `toScalar delegates...` test from `backend-router-chain-walk.test.ts`.
+4. Type-check, test, validate, commit:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck && pnpm --filter @harness-engineering/orchestrator test tests/agent/ && harness validate
+   ```
+5. Commit message: `refactor(orchestrator)!: remove deprecated toScalar export (Spec B Phase 1, per operator decision)`. Note the `!` to flag the breaking change.
+
+---
+
+### Task 9: Run full orchestrator test suite to surface any cross-cutting regressions
+
+**Depends on:** Task 7 (or 8a if executed)
+**Files:** (verification only)
+
+1. Run the full orchestrator test suite:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test 2>&1 | tail -30
+   ```
+2. Expected: all tests PASS. The Phase 0 baseline was 295/295 (271 agent + 24 routing). Phase 1 adds ~20 new tests in `backend-router-chain-walk.test.ts`, so target is ~315/315.
+3. If any test fails:
+   - If it's an `intelligence-factory.test.ts` test asserting the old toScalar comparison shape — update the assertion to reflect the new router-driven comparison (it should still produce the same `backendName` comparisons for scalar/chain configs).
+   - If it's anywhere else — investigate root cause; do not paper over.
+4. Run typecheck across all packages (catches downstream consumers of `@harness-engineering/orchestrator`):
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm typecheck 2>&1 | tail -20
+   ```
+   Expected: PASS. If a downstream package (CLI, dashboard, MCP) fails because it consumes `BackendRouter.resolve()` and expects `string`, that's a surprise consumer — document and update in lockstep.
+5. Run `harness validate`. Expected: PASS.
+6. Run `harness check-deps`. Expected: PASS.
+
+---
+
+### Task 10: Verify Phase 1 checkpoint per spec (F3, F5, F6, S4, S7, N1)
+
+**Depends on:** Task 9
+**Files:** (verification only)
+
+1. Cross-check each Phase 1 acceptance criterion from spec § Implementation Order → Phase 1 against the test file. Each must map to at least one test in `backend-router-chain-walk.test.ts` or `backend-router.test.ts`:
+
+   | Criterion                                              | Test                                                                                                                                                                                                      |
+   | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | F3 — per-skill wins over per-mode                      | `BackendRouter.resolve — resolution order (D2, F3) > per-skill wins over per-mode for the same skill`                                                                                                     |
+   | F5 — scalar === single-element-chain                   | `BackendRouter.resolve — scalar/chain equivalence (F5, F6) > scalar routing.default behaves identically to single-element-chain`                                                                          |
+   | F6 — chain tries entries in order, unknown skipped     | `BackendRouter.resolve — scalar/chain equivalence (F5, F6) > multi-entry chain picks the first existing backend` AND `BackendRouter.resolve — per-skill (D1) > skips unknown chain entries and continues` |
+   | S4 — resolve() total; throws only on default-exhausted | `BackendRouter.resolve — exhaustion (S4) > throws when every chain entry across all sources is unknown`                                                                                                   |
+   | S7 — resolutionPath fidelity                           | `BackendRouter.resolve — resolution path fidelity (S7) > records every chain entry considered with the correct source label`                                                                              |
+   | N1 — existing backend-router tests pass                | `backend-router.test.ts` 13/13 PASS                                                                                                                                                                       |
+   | N2 — tier dispatches route as today                    | Implicit via N1 (existing tier tests cover this); explicit cross-check via `multi-backend-dispatch.test.ts`                                                                                               |
+   | N3 — intelligence dispatches route as today            | Implicit via N1 and the no-router fallback path in `intelligence-factory.ts`                                                                                                                              |
+
+2. **[checkpoint:human-verify]** Present the table above to the operator. Confirm all Phase 1 acceptance criteria from spec § Implementation Order pass.
+3. If any cell is empty or fails, return to the failing task and fix before proceeding.
+
+---
+
+### Task 11: Final gate — full repo typecheck, test, validate, check-deps
+
+**Depends on:** Task 10
+**Files:** (verification only)
+
+1. Full repo typecheck:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm typecheck 2>&1 | tail -10
+   ```
+2. Full repo test (this is the heavy gate — expect several minutes):
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm test 2>&1 | tail -30
+   ```
+3. `harness validate` at worktree root. Expected: PASS.
+4. `harness check-deps` at worktree root. Expected: PASS.
+5. `git status` — confirm no uncommitted changes:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && git status
+   ```
+6. `git log --oneline 147faa78..HEAD` to view Phase 1 commit history:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && git log --oneline 147faa78..HEAD
+   ```
+   Expected: 3 commits (Task 1; Tasks 2-5 combined; Tasks 6-7 combined or split) on `feat/spec-b-phase-1` branch.
+7. Write final handoff to `.harness/sessions/changes--granular-task-routing--proposal/handoff.json` summarizing Phase 1 completion (see Plan Document Structure → Handoff Schema below).
+
+---
+
+### Task 12: Update session state for handoff to Phase 2
+
+**Depends on:** Task 11
+**Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/.harness/sessions/changes--granular-task-routing--proposal/handoff.json`, `state.json`
+
+1. Update the session `state.json` with Phase 1 completion markers (mirror the Phase 0 pattern at lines 16-21 of the current state.json — a new entry for each Task).
+2. Write a new handoff.json `fromSkill: "harness-execution"`, `phase: 1`, summarizing what shipped and what Phase 2 needs to know (the config-validator extension picks up where Phase 1 leaves off: validate `routing.skills` / `routing.modes` chain entries against `agent.backends`, warn on unknown skill names).
+3. **[checkpoint:human-verify]** Present the handoff JSON to the operator for sign-off before merging Phase 1 to main.
+
+---
+
+## Verification Matrix
+
+| Spec Criterion                                           | Mechanism                                                  | Task |
+| -------------------------------------------------------- | ---------------------------------------------------------- | ---- |
+| F3 (per-skill wins over per-mode)                        | New test in `backend-router-chain-walk.test.ts`            | 2, 3 |
+| F5 (scalar === single-element-chain)                     | New test                                                   | 2, 3 |
+| F6 (chain walk + unknown skip)                           | New test                                                   | 2, 3 |
+| S4 (resolve() total, throw only on exhausted default)    | New test + try/throw in resolve()                          | 2, 3 |
+| S7 (resolution path fidelity)                            | New test                                                   | 2, 3 |
+| N1 (existing 13 tests pass with .backendName adjustment) | Existing test file migration                               | 5    |
+| N2 (tier dispatches route as today)                      | Implicit via N1 + multi-backend-dispatch.test.ts           | 9    |
+| N3 (intelligence dispatches route as today)              | Implicit via N1 + intelligence-factory router-present path | 6, 9 |
+| I1 (intelligence-factory drift eliminated)               | router.resolve() comparison path                           | 6    |
+| I1 (orchestrator.ts:1377-1383 drift eliminated)          | toArray()-based one-liner                                  | 7    |
+
+## Commit Boundary Summary
+
+| Boundary        | Tasks      | Subject                                                                                                                                           |
+| --------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1               | 1          | `feat(orchestrator): add toArray RoutingValue normalizer (Spec B Phase 1 prep)`                                                                   |
+| 2               | 2, 3, 4, 5 | `feat(orchestrator): rewrite BackendRouter.resolve to walk chain + emit RoutingDecision (Spec B Phase 1)`                                         |
+| 3               | 6          | `refactor(orchestrator): route intelligence-factory SEL/PESL comparison through router.resolve (Spec B Phase 1, closes Phase 0 review I1 part 1)` |
+| 4               | 7          | `refactor(orchestrator): replace inline Array.isArray normalization with toArray helper (Spec B Phase 1, closes Phase 0 review I1 part 2)`        |
+| 5 (conditional) | 8a         | `refactor(orchestrator)!: remove deprecated toScalar export (Spec B Phase 1, per operator decision)` — only if operator removes toScalar          |
+
+3-4 commits total (5 if Task 8a fires). Each commit is independently green: typecheck PASS + relevant tests PASS + harness validate PASS.
+
+## Risks & Mitigations
+
+| Risk                                                                                                    | Probability | Mitigation                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Surprise consumer of `BackendRouter.resolve()` outside `packages/orchestrator/src`                      | Low         | Phase 0 cataloged consumers exhaustively (per learnings.md). Full-repo typecheck in Task 9/11 catches any missed site. Mitigation if found: thread `.backendName` extraction at the call site. |
+| `intelligence-factory.test.ts` pinned the toScalar comparison shape                                     | Medium      | Read the test file first; if the test asserts on toScalar's return value directly, update to assert on the new router-resolved name (which equals toScalar's return for scalar configs).       |
+| Performance regression: chain-walk allocates an array per call where Phase 0 returned a scalar directly | Low         | A `RoutingDecision` object + N-element `resolutionPath` array per resolve() is well under µs-scale; dispatches are millisecond-scale. No perf gate in Phase 1 (Q1 lands in Phase 6 trace CLI). |
+| Test file uses `as const` on tuple literals — TypeScript inference may reject                           | Low         | Use `as const` consistently to satisfy `readonly [string, ...string[]]` from `RoutingValue`. Pre-tested in tests file above.                                                                   |
+| `performance.now()` not available in some Vitest runtimes                                               | Very low    | Node 18+ exposes `performance` globally; orchestrator's own `tsconfig` targets es2022 minimum. If issue surfaces, fall back to `Date.now()`.                                                   |
+
+## Out-of-Scope (Stays in Later Phases)
+
+- Dispatch-site wiring in `runner.ts` to construct `{ kind: 'skill', skillName, cognitiveMode }` — **Phase 3**
+- CLI `--backend <name>` flag plumbing on `harness skill run` and `harness dispatch` — **Phase 3 + 6**
+- Config validator extension for `routing.skills` / `routing.modes` against `agent.backends` and skill catalog — **Phase 2** (the BackendRouter's `validateReferences()` is updated in this phase for **runtime** safety, but the **startup** Zod/hand-rolled validator updates land in Phase 2)
+- `RoutingDecisionBus` ring buffer + event emission — **Phase 4**
+- HTTP routes (`/api/v1/routing/{config,decisions,trace}`) + WS topic `routing:decision` — **Phase 5**
+- Dashboard `/routing` panel — **Phase 7**
+- Documentation updates (`docs/knowledge/orchestrator/`, ADRs, AGENTS.md, README, CHANGELOG) — **Phase 8**
+
+## Definition of Done (Phase 1)
+
+- [ ] `BackendRouter.resolve(useCase, opts?)` returns `RoutingDecision` per spec § Technical Design pseudocode
+- [ ] `RoutingDecision.resolutionPath` records every considered candidate with correct `source` + `outcome` labels
+- [ ] Chain walk skips `unknown-backend` entries and tries the next; throws only when `routing.default` exhausts
+- [ ] `resolveDefinition(useCase, opts?)` returns `BackendDef` (API surface preserved); accepts pass-through `opts`
+- [ ] `OrchestratorBackendFactory.resolveName(useCase)` returns `string` (API surface preserved)
+- [ ] `toArray(value: RoutingValue): readonly string[]` exported from `backend-router.ts`
+- [ ] `toScalar` retained as `@deprecated`, delegates to `toArray(v)[0]` (or removed per operator decision in Task 8a)
+- [ ] `intelligence-factory.ts:buildIntelligencePipeline` uses `router.resolve()` when `IntelligenceFactoryDeps.router` is present (closes I1 part 1)
+- [ ] `orchestrator.ts:1377-1383` inline `Array.isArray` collapsed to `toArray(...)[0]` (closes I1 part 2)
+- [ ] Existing `backend-router.test.ts` 13/13 PASS with `.backendName` adjustment
+- [ ] New `backend-router-chain-walk.test.ts` ~20 tests PASS
+- [ ] Full orchestrator test suite PASS (~315/315)
+- [ ] Full repo typecheck PASS
+- [ ] `harness validate` PASS
+- [ ] `harness check-deps` PASS
+- [ ] Session handoff written to `.harness/sessions/changes--granular-task-routing--proposal/handoff.json` summarizing Phase 1 completion
+- [ ] Operator sign-off on the Phase 1 PR before merge to main

--- a/docs/changes/granular-task-routing/plans/2026-05-25-phase-2-config-validator-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-25-phase-2-config-validator-plan.md
@@ -1,0 +1,1599 @@
+# Plan: Spec B Phase 2 — Config-Validator Updates
+
+**Date:** 2026-05-25 · **Spec:** `docs/changes/granular-task-routing/proposal.md` (§ Implementation Order — Phase 2) · **Tasks:** 9 (8 implementation + 1 integration) · **Time:** ~6 hours (~1 working day) · **Integration Tier:** medium · **Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1` · **Branch:** `feat/spec-b-phase-1`
+
+## Goal
+
+Move Spec B's routing reference checks from runtime (`BackendRouter.validateReferences()` constructor-time, landed in Phase 1) **into the config-loading layer at startup**, and add operator-friendly warnings for skill-name typos and non-standard cognitive modes. After Phase 2, a misconfigured `harness.config.json` is rejected at `WorkflowLoader.loadWorkflow()` time with a path-naming, backend-listing error — operators no longer need to instantiate an orchestrator to discover routing typos.
+
+## Observable Truths (Acceptance Criteria)
+
+The five truths below map directly to spec § Success Criteria S2 + S3 + Q3 + N4 + N5.
+
+1. **(S2 — hard error, skills/modes chain)** — When `validateWorkflowConfig({ agent: { backends: {...}, routing: { skills: { foo: ['known-backend', 'typo-backend'] } } } })` is called and `typo-backend` is not in `agent.backends`, the result is `Err(...)` and `.error.message` contains both `routing.skills.foo.1` and `typo-backend`. (Already present from Phase 0 cross-field validator; pinned by integration test in Task 3.)
+2. **(S2 — hard error, isolation chain)** — When `validateWorkflowConfig` is called with `routing.isolation.container: ['known', 'typo']` where `typo` is not in `agent.backends`, the result is `Err(...)` with `.error.message` containing `routing.isolation.container.1` and `typo`. (NEW in Phase 2 — closes the Phase 0 I2 gap where `isolation` was absent from `RoutingConfigSchema`.)
+3. **(S3 — skill-name warning, non-blocking)** — When `validateWorkflowConfig` is called with `routing.skills.<unknown-skill-name>` and the project skill catalog does not contain that skill name, the result is `Ok({ config, warnings })` where `warnings` is a non-empty `string[]` containing one warning per unknown skill name. Warning text names the offending path (`routing.skills.<name>`) and the closest matched skill name (if any). Validation does NOT fail.
+4. **(S3 — cognitive-mode warning, non-blocking)** — When `validateWorkflowConfig` is called with `routing.modes.<not-in-STANDARD_COGNITIVE_MODES>`, the result is `Ok({ config, warnings })` with one warning per non-standard mode. Warning text names the offending path (`routing.modes.<mode>`) and lists the six STANDARD_COGNITIVE_MODES. Validation does NOT fail.
+5. **(Q3 — error-message quality)** — Every hard-error message produced by Phase 2 validation names the offending routing path (e.g., `routing.skills.harness-debugging.1` for chain entry index 1, or `routing.modes.adversarial-reviewer` for scalar) AND includes the full list of known backend names. Pinned by Task 5 integration test asserting against the format.
+6. **(N4)** — `harness validate` continues to pass on a config with no `routing.skills` / `routing.modes` blocks (no regression).
+7. **(N5)** — `harness validate` continues to pass on a config that uses array form for previously-scalar routing fields (e.g., `routing.default: ['claude-opus', 'claude-sonnet']`).
+
+## Changes to Existing Behavior
+
+- **[ADDED]** `routing.isolation` Zod block in `RoutingConfigSchema` with `RoutingValueSchema` for each tier (`none` / `container` / `remote-sandbox`). Closes Phase 0 review I2.
+- **[ADDED]** Warning-emitting helper `routingWarnings(routing, knownSkillNames)` that returns `string[]` for unknown skill names + non-standard cognitive modes.
+- **[ADDED]** `discoverSkillCatalogNames(projectRoot)` helper in `packages/orchestrator/src/workflow/skill-catalog.ts` — reads `agents/skills/claude-code/*/skill.yaml` and returns the union of declared `name` fields. Returns an empty array (and emits no warnings) when the directory is absent.
+- **[MODIFIED]** `validateWorkflowConfig`'s return type widens from `Result<WorkflowConfig, Error>` to `Result<{ config: WorkflowConfig; warnings: string[] }, Error>`. Callers (currently 2: `WorkflowLoader.loadWorkflow`, plus existing tests) update in lockstep.
+- **[MODIFIED]** `WorkflowLoader.loadWorkflow`'s `Result<WorkflowDefinition, Error>` payload widens to carry `warnings: string[]`. Callers (currently 2: `packages/cli/src/commands/orchestrator.ts:19`, `packages/cli/src/commands/maintenance.ts:32`) surface the warnings via `logger.warn` immediately after a successful load.
+- **[REMOVED]** TODO comment at `packages/orchestrator/src/workflow/schema.ts:105-106` (`TODO(spec-b-phase-2): widen the isolation block...`) — the work item completes in Task 1.
+
+## File Map
+
+Six files modified, two files created.
+
+- **CREATE** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/skill-catalog.ts`
+- **CREATE** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-warnings.test.ts`
+- **CREATE** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-isolation-schema.test.ts`
+- **MODIFY** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/schema.ts` (add isolation block; remove TODO)
+- **MODIFY** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts` (add `routingWarnings`, widen `validateWorkflowConfig` return type, include isolation in cross-field check)
+- **MODIFY** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/loader.ts` (thread warnings through `WorkflowDefinition` payload)
+- **MODIFY** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/types/src/orchestrator.ts` (extend `WorkflowDefinition` to carry `warnings: readonly string[]`)
+- **MODIFY** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/orchestrator.ts` (log warnings via `logger.warn` after successful load)
+- **MODIFY** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/maintenance.ts` (same)
+- **MODIFY** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-config-schema.test.ts` (unskip the four `it.each` rows for `isolation.*` — currently parametric coverage stops short)
+
+## Uncertainties
+
+- **[ASSUMPTION]** The CLI `logger.warn(...)` channel is the right surfacing point for non-blocking config warnings. The `orchestrator.ts:271` migration-warnings precedent (`for (const w of migrationResult.warnings) this.logger.warn(w);`) supports this pattern, but it surfaces warnings AFTER `WorkflowLoader.loadWorkflow()` returns to `CLI/commands/orchestrator.ts:19`. If a different log channel is preferred (e.g., a structured event on the maintenance bus, or a single combined warning), revisit Task 7.
+- **[ASSUMPTION]** Reading `agents/skills/claude-code/*/skill.yaml` synchronously at startup adds <20ms for a typical project with <100 skills. (The CLI already does this in `getSkillsResource` synchronously and ships in production.) If startup latency budget is tight, the catalog read can move to a lazy / async path; that is a Phase 4+ concern.
+- **[ASSUMPTION]** The `harness validate` command in `packages/cli/src/commands/validate.ts` does not load `harness.config.json` routing today (verified — it validates `agents/agents-map.json`, knowledge map, file structure, pulse, etc.). Therefore N4 + N5 ("`harness validate` passes...") means the existing harness validate continues to pass after Phase 2's changes; routing-config validation runs through `WorkflowLoader` at orchestrator start. The Phase 1 verification report listed `harnessValidate: PASS` under the same interpretation.
+- **[DEFERRABLE]** Whether to add Levenshtein-based "did you mean?" suggestions to unknown-skill warnings. Phase 2 ships with "closest match by exact prefix" only (fast, deterministic, no new dep). Fuzzy suggestions can be added if operators report missing the typo source.
+- **[DEFERRABLE]** Phase 1 review's P1-IMP-1 / P1-IMP-2 / P1-IMP-3 (IntelligenceFactoryDeps split, forUseCase comment, silent intelligence-pipeline drop). Per the operator brief, these are scheduled for Phase 4. **DO NOT touch these in Phase 2.**
+
+## Concerns to Surface to the Operator
+
+1. **`WorkflowDefinition` shape change is a public surface change.** `WorkflowDefinition` is exported from `@harness-engineering/types` and consumed externally. Adding `warnings: readonly string[]` is additive (non-breaking for readers) but changes the producer contract. If we want zero public-API churn, the alternative is to carry warnings through a side-channel (e.g., an event emitter on the loader). Confirm before Task 4 that adding the field on `WorkflowDefinition` is acceptable; if not, switch to an event-channel design.
+2. **Skill catalog read location.** The plan reads from `agents/skills/claude-code/*/skill.yaml` only (mirrors `getSkillsResource`). Projects using other hosts (`agents/skills/cursor/`, `agents/skills/gemini/`, etc.) would not have their skill names recognized, producing spurious warnings. **Recommended:** read all host subdirectories under `agents/skills/`. Flag here so the operator can confirm — Task 2 has the exact code path that decides this.
+3. **Warning emission count under heavy misconfiguration.** A config with 50 typo'd skill names produces 50 warnings, all logged at startup. Acceptable per spec ("Logged once at startup") but worth pinning in tests (Task 6 caps the emission count assertion).
+4. **Loader callers in CLI must update lockstep.** Two CLI callers (`orchestrator.ts`, `maintenance.ts`) destructure `{ config, promptTemplate }` from `result.value` today. After Phase 2, both also destructure `warnings`. If a third caller exists outside the search ran (extension package, plugin), it will break at typecheck. Task 7 includes a `grep -rn "loadWorkflow\b" packages/` sanity check to catch any missed call site.
+
+## Tasks
+
+Tasks are listed in dependency order. Tasks 1–3 are foundation (Zod schema + cross-field + warnings helper). Tasks 4–5 thread the warnings result through the loader and the cross-package payload. Tasks 6–7 wire the CLI to surface warnings. Task 8 captures integration-level acceptance. Task 9 is the integration task (no roadmap entry / docs / ADR work — those land in Phase 8).
+
+Each task includes a TDD step. Each commit is atomic.
+
+---
+
+### Task 1: Widen `RoutingConfigSchema` to include the `isolation` block
+
+**Depends on:** none · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/schema.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-isolation-schema.test.ts` · **Category:** implementation
+
+1. Create the test file at `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-isolation-schema.test.ts` with the following exact content:
+
+   ```ts
+   import { describe, it, expect } from 'vitest';
+   import { RoutingConfigSchema } from '../../src/workflow/schema';
+
+   describe('RoutingConfigSchema — Spec B Phase 2 isolation widening (closes Phase 0 I2)', () => {
+     it('accepts scalar value for routing.isolation.none', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         isolation: { none: 'claude-opus' },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts chain value for routing.isolation.container', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         isolation: { container: ['local-fast', 'claude-opus'] },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts chain value for routing.isolation.remote-sandbox', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         isolation: { 'remote-sandbox': ['claude-opus', 'claude-sonnet'] },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('accepts a mix of scalar + chain across isolation tiers', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         isolation: {
+           none: 'claude-opus',
+           container: ['local-fast', 'claude-opus'],
+           'remote-sandbox': 'claude-opus',
+         },
+       });
+       expect(parsed.success).toBe(true);
+     });
+
+     it('rejects an empty chain on isolation.container', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         isolation: { container: [] },
+       });
+       expect(parsed.success).toBe(false);
+     });
+
+     it('rejects an unknown isolation tier (strict mode)', () => {
+       const parsed = RoutingConfigSchema.safeParse({
+         default: 'claude-opus',
+         isolation: { 'super-isolated': 'claude-opus' } as unknown as { none?: string },
+       });
+       expect(parsed.success).toBe(false);
+     });
+   });
+   ```
+
+2. Run the test file. Expect failure (first three tests reject because `isolation` is currently absent from the strict `.strict()` schema). Command:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/routing-isolation-schema.test.ts
+   ```
+
+3. Edit `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/schema.ts`. Replace the comment block at lines 99–107 and the `RoutingConfigSchema` declaration (lines 108–126). Find:
+
+   ```
+    * Spec B Phase 0: all scalar routing fields accept `RoutingValueSchema`
+    * (scalar or non-empty chain). New optional `skills` and `modes` maps
+    * accept the same. The `isolation` block is not in this Zod schema yet
+    * (only in the TS interface); widening it is Phase 2 (config-validator
+    * updates) per Spec B.
+    *
+    * TODO(spec-b-phase-2): widen the isolation block here once it lands in
+    * RoutingConfigSchema (currently absent from this declaration).
+    */
+   export const RoutingConfigSchema = z
+     .object({
+       default: RoutingValueSchema,
+       'quick-fix': RoutingValueSchema.optional(),
+       'guided-change': RoutingValueSchema.optional(),
+       'full-exploration': RoutingValueSchema.optional(),
+       diagnostic: RoutingValueSchema.optional(),
+       intelligence: z
+         .object({
+           sel: RoutingValueSchema.optional(),
+           pesl: RoutingValueSchema.optional(),
+         })
+         .strict()
+         .optional(),
+       // --- Spec B Phase 0: new optional maps (resolver wired in Phase 1) ---
+       skills: z.record(z.string().min(1), RoutingValueSchema).optional(),
+       modes: z.record(z.string().min(1), RoutingValueSchema).optional(),
+     })
+     .strict();
+   ```
+
+   Replace with:
+
+   ```
+    * Spec B Phase 0: all scalar routing fields accept `RoutingValueSchema`
+    * (scalar or non-empty chain). New optional `skills` and `modes` maps
+    * accept the same.
+    *
+    * Spec B Phase 2: the `isolation` block (added to the TS interface in
+    * Hermes Phase 5 but not previously in this Zod schema) is now included
+    * here with each tier widened to `RoutingValueSchema`. This closes the
+    * Phase 0 I2 review finding (TS-vs-Zod drift) and ensures isolation
+    * chain entries are validated by the same cross-field check that
+    * covers `skills` / `modes`.
+    */
+   export const RoutingConfigSchema = z
+     .object({
+       default: RoutingValueSchema,
+       'quick-fix': RoutingValueSchema.optional(),
+       'guided-change': RoutingValueSchema.optional(),
+       'full-exploration': RoutingValueSchema.optional(),
+       diagnostic: RoutingValueSchema.optional(),
+       intelligence: z
+         .object({
+           sel: RoutingValueSchema.optional(),
+           pesl: RoutingValueSchema.optional(),
+         })
+         .strict()
+         .optional(),
+       // --- Spec B Phase 2: isolation block widened to RoutingValueSchema ---
+       isolation: z
+         .object({
+           none: RoutingValueSchema.optional(),
+           container: RoutingValueSchema.optional(),
+           'remote-sandbox': RoutingValueSchema.optional(),
+         })
+         .strict()
+         .optional(),
+       // --- Spec B Phase 0: new optional maps (resolver wired in Phase 1) ---
+       skills: z.record(z.string().min(1), RoutingValueSchema).optional(),
+       modes: z.record(z.string().min(1), RoutingValueSchema).optional(),
+     })
+     .strict();
+   ```
+
+4. Rerun the test. Expect pass. Same command as step 2.
+
+5. Run the broader workflow test suite to confirm no regression:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/
+   ```
+
+   Expect ALL workflow tests pass.
+
+6. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate`. Expect pass.
+
+7. Commit:
+
+   ```
+   git add packages/orchestrator/src/workflow/schema.ts packages/orchestrator/tests/workflow/routing-isolation-schema.test.ts
+   git commit -m "feat(orchestrator): widen RoutingConfigSchema with isolation block (Spec B Phase 2, closes Phase 0 I2)"
+   ```
+
+---
+
+### Task 2: Add `discoverSkillCatalogNames(projectRoot)` helper
+
+**Depends on:** Task 1 · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/skill-catalog.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/skill-catalog.test.ts` · **Category:** implementation
+
+1. Create the test file at `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/skill-catalog.test.ts` with the following exact content:
+
+   ```ts
+   import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+   import * as fs from 'node:fs';
+   import * as path from 'node:path';
+   import * as os from 'node:os';
+   import { discoverSkillCatalogNames } from '../../src/workflow/skill-catalog';
+
+   describe('discoverSkillCatalogNames', () => {
+     let tmpRoot: string;
+
+     beforeEach(() => {
+       tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-catalog-test-'));
+     });
+
+     afterEach(() => {
+       fs.rmSync(tmpRoot, { recursive: true, force: true });
+     });
+
+     it('returns an empty array when agents/skills/ is absent', () => {
+       expect(discoverSkillCatalogNames(tmpRoot)).toEqual([]);
+     });
+
+     it('returns names from agents/skills/claude-code/*/skill.yaml', () => {
+       const skillDir = path.join(tmpRoot, 'agents', 'skills', 'claude-code', 'foo');
+       fs.mkdirSync(skillDir, { recursive: true });
+       fs.writeFileSync(path.join(skillDir, 'skill.yaml'), 'name: foo\nversion: 1.0.0\n');
+       expect(discoverSkillCatalogNames(tmpRoot)).toEqual(['foo']);
+     });
+
+     it('reads from every host subdirectory under agents/skills/', () => {
+       // Concern #2 from the plan: support hosts other than claude-code.
+       for (const host of ['claude-code', 'cursor', 'gemini']) {
+         const skillDir = path.join(tmpRoot, 'agents', 'skills', host, `${host}-skill`);
+         fs.mkdirSync(skillDir, { recursive: true });
+         fs.writeFileSync(
+           path.join(skillDir, 'skill.yaml'),
+           `name: ${host}-skill\nversion: 1.0.0\n`
+         );
+       }
+       expect(discoverSkillCatalogNames(tmpRoot).sort()).toEqual([
+         'claude-code-skill',
+         'cursor-skill',
+         'gemini-skill',
+       ]);
+     });
+
+     it('deduplicates skill names that appear under multiple hosts', () => {
+       for (const host of ['claude-code', 'cursor']) {
+         const skillDir = path.join(tmpRoot, 'agents', 'skills', host, 'shared');
+         fs.mkdirSync(skillDir, { recursive: true });
+         fs.writeFileSync(path.join(skillDir, 'skill.yaml'), 'name: shared\nversion: 1.0.0\n');
+       }
+       expect(discoverSkillCatalogNames(tmpRoot)).toEqual(['shared']);
+     });
+
+     it('skips skill directories whose skill.yaml is missing or malformed', () => {
+       const skillDir = path.join(tmpRoot, 'agents', 'skills', 'claude-code', 'broken');
+       fs.mkdirSync(skillDir, { recursive: true });
+       fs.writeFileSync(path.join(skillDir, 'skill.yaml'), 'this: is: not: valid: yaml: [\n');
+
+       const okSkillDir = path.join(tmpRoot, 'agents', 'skills', 'claude-code', 'ok');
+       fs.mkdirSync(okSkillDir, { recursive: true });
+       fs.writeFileSync(path.join(okSkillDir, 'skill.yaml'), 'name: ok\nversion: 1.0.0\n');
+
+       expect(discoverSkillCatalogNames(tmpRoot)).toEqual(['ok']);
+     });
+
+     it('skips skill.yaml files without a top-level `name` field', () => {
+       const skillDir = path.join(tmpRoot, 'agents', 'skills', 'claude-code', 'noname');
+       fs.mkdirSync(skillDir, { recursive: true });
+       fs.writeFileSync(path.join(skillDir, 'skill.yaml'), 'version: 1.0.0\n');
+       expect(discoverSkillCatalogNames(tmpRoot)).toEqual([]);
+     });
+   });
+   ```
+
+2. Run the test. Expect failure (module does not exist). Command:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/skill-catalog.test.ts
+   ```
+
+3. Create `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/skill-catalog.ts` with the following exact content:
+
+   ```ts
+   import * as fs from 'node:fs';
+   import * as path from 'node:path';
+   import { parse as parseYaml } from 'yaml';
+
+   /**
+    * Spec B Phase 2: read the local skill catalog at orchestrator startup
+    * for warning-level routing validation (`routing.skills.<name>` where
+    * `<name>` is not in the catalog).
+    *
+    * Reads from EVERY host subdirectory under `agents/skills/` (claude-code,
+    * cursor, gemini, etc.) so a skill installed under a non-claude-code host
+    * does not produce a spurious warning. Names are deduplicated across
+    * hosts.
+    *
+    * Returns an empty array when `agents/skills/` is absent (e.g.,
+    * orchestrator running outside a harness project root). In that case no
+    * warnings are emitted — the operator presumably knows what they are
+    * doing.
+    *
+    * Errors reading individual skill.yaml files (malformed YAML, missing
+    * `name` field, IO errors) are swallowed silently. The catalog is
+    * advisory; a single broken skill.yaml should not block validation.
+    */
+   export function discoverSkillCatalogNames(projectRoot: string): string[] {
+     const skillsRoot = path.join(projectRoot, 'agents', 'skills');
+     if (!fs.existsSync(skillsRoot)) return [];
+
+     const names = new Set<string>();
+
+     let hosts: fs.Dirent[];
+     try {
+       hosts = fs.readdirSync(skillsRoot, { withFileTypes: true });
+     } catch {
+       return [];
+     }
+
+     for (const host of hosts) {
+       if (!host.isDirectory()) continue;
+       const hostDir = path.join(skillsRoot, host.name);
+
+       let skills: fs.Dirent[];
+       try {
+         skills = fs.readdirSync(hostDir, { withFileTypes: true });
+       } catch {
+         continue;
+       }
+
+       for (const skill of skills) {
+         if (!skill.isDirectory()) continue;
+         const skillYamlPath = path.join(hostDir, skill.name, 'skill.yaml');
+         if (!fs.existsSync(skillYamlPath)) continue;
+
+         try {
+           const content = fs.readFileSync(skillYamlPath, 'utf-8');
+           const parsed = parseYaml(content) as { name?: unknown } | null;
+           if (parsed && typeof parsed.name === 'string' && parsed.name.length > 0) {
+             names.add(parsed.name);
+           }
+         } catch {
+           /* skip malformed skill.yaml */
+         }
+       }
+     }
+
+     return [...names].sort();
+   }
+   ```
+
+4. Rerun the test. Expect pass (all 6 cases).
+
+5. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate`. Expect pass.
+
+6. Commit:
+
+   ```
+   git add packages/orchestrator/src/workflow/skill-catalog.ts packages/orchestrator/tests/workflow/skill-catalog.test.ts
+   git commit -m "feat(orchestrator): add discoverSkillCatalogNames helper for Spec B Phase 2 warnings"
+   ```
+
+---
+
+### Task 3: Extend `crossFieldRoutingIssues` to cover `routing.isolation`
+
+**Depends on:** Task 1 · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-cross-field.test.ts` · **Category:** implementation
+
+**Note:** `validateBackendsAndRouting` in `schema.ts` ALREADY checks `routing.isolation` via the Hermes Phase 5 work that landed before Spec B (lines not currently shown — verify via `grep -n "isolation" packages/orchestrator/src/workflow/schema.ts`). If the helper already includes isolation, Task 3a is a no-op and only the cross-field config.ts helper needs the extension. **VERIFY FIRST** in step 1 below before implementing.
+
+1. Read `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/schema.ts` lines 137–180 (the `validateBackendsAndRouting` body). If isolation is already covered (look for `checkRef(['isolation', 'none'], ...)`), skip the schema.ts edit. Otherwise add the three `checkRef` lines symmetric to `intelligence`. ALSO inspect `crossFieldRoutingIssues` in `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts` lines 36–67 for the same: isolation may or may not be already covered.
+
+2. Append the following test cases to the END of the existing `describe('crossFieldRoutingIssues (config.ts) — chain entry issue paths', () => {...})` block in `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-cross-field.test.ts` (insert before the closing `});` of that describe):
+
+   ```ts
+   it('reports the offending index for an isolation chain entry (Phase 2 — closes I2)', () => {
+     const routing: RoutingConfig = {
+       default: 'claude-opus',
+       isolation: {
+         container: ['claude-opus', 'unknown-backend'],
+       },
+     };
+     const issues = crossFieldRoutingIssues(KNOWN_BACKENDS, routing);
+     expect(issues).toHaveLength(1);
+     expect(issues[0]?.path).toEqual(['isolation', 'container', '1']);
+     expect(issues[0]?.message).toContain('unknown-backend');
+     expect(issues[0]?.message).toContain('routing.isolation.container.1');
+   });
+
+   it('reports a scalar isolation reference without an index segment', () => {
+     const routing: RoutingConfig = {
+       default: 'claude-opus',
+       isolation: {
+         'remote-sandbox': 'unknown-backend',
+       },
+     };
+     const issues = crossFieldRoutingIssues(KNOWN_BACKENDS, routing);
+     expect(issues).toHaveLength(1);
+     expect(issues[0]?.path).toEqual(['isolation', 'remote-sandbox']);
+     expect(issues[0]?.message).toContain('routing.isolation.remote-sandbox');
+   });
+   ```
+
+   Also append symmetric tests to the END of the `describe('validateBackendsAndRouting (schema.ts) — chain entry issue paths', ...)` block (the second describe in the same file):
+
+   ```ts
+   it('reports the offending index for an isolation chain entry (Phase 2 — closes I2)', () => {
+     const result = TestSchema.safeParse({
+       backends: KNOWN_BACKENDS,
+       routing: {
+         default: 'claude-opus',
+         isolation: { container: ['claude-opus', 'unknown-backend'] },
+       },
+     });
+     expect(result.success).toBe(false);
+     if (result.success) return;
+     expect(result.error.issues).toHaveLength(1);
+     expect(result.error.issues[0]?.path).toEqual(['routing', 'isolation', 'container', 1]);
+     expect(result.error.issues[0]?.message).toContain('routing.isolation.container.1');
+   });
+   ```
+
+3. Run the test file:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/routing-cross-field.test.ts
+   ```
+
+   Expect failure on the new tests (isolation not covered) UNLESS the verification in step 1 found existing coverage. If existing coverage, expect pass and skip to step 5.
+
+4. Edit BOTH `validateBackendsAndRouting` in `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/schema.ts` AND `crossFieldRoutingIssues` in `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts` to add the three isolation `checkRef` calls. For schema.ts, find:
+
+   ```
+   checkRef(['intelligence', 'sel'], routing.intelligence?.sel);
+   checkRef(['intelligence', 'pesl'], routing.intelligence?.pesl);
+   // --- Spec B Phase 0: validate skills + modes chain entries ---
+   ```
+
+   Replace with:
+
+   ```
+   checkRef(['intelligence', 'sel'], routing.intelligence?.sel);
+   checkRef(['intelligence', 'pesl'], routing.intelligence?.pesl);
+   // --- Spec B Phase 2: validate isolation tier chain entries (closes I2) ---
+   checkRef(['isolation', 'none'], routing.isolation?.none);
+   checkRef(['isolation', 'container'], routing.isolation?.container);
+   checkRef(['isolation', 'remote-sandbox'], routing.isolation?.['remote-sandbox']);
+   // --- Spec B Phase 0: validate skills + modes chain entries ---
+   ```
+
+   Apply the identical insertion to `crossFieldRoutingIssues` in `config.ts` (find the same anchor pattern; the `path` arrays are `string[]` not `(string|number)[]` here but otherwise identical).
+
+5. Rerun the test. Expect all tests pass.
+
+6. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/`. Expect ALL workflow tests pass.
+
+7. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate`. Expect pass.
+
+8. Commit:
+
+   ```
+   git add packages/orchestrator/src/workflow/schema.ts packages/orchestrator/src/workflow/config.ts packages/orchestrator/tests/workflow/routing-cross-field.test.ts
+   git commit -m "feat(orchestrator): extend cross-field routing validation to isolation tiers (Spec B Phase 2)"
+   ```
+
+---
+
+### Task 4: Add `routingWarnings(routing, knownSkillNames)` warning helper
+
+**Depends on:** Task 2 · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-warnings.test.ts` · **Category:** implementation
+
+1. Create the test file at `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/routing-warnings.test.ts` with the following exact content:
+
+   ```ts
+   import { describe, it, expect } from 'vitest';
+   import type { RoutingConfig } from '@harness-engineering/types';
+   import { STANDARD_COGNITIVE_MODES } from '@harness-engineering/types';
+   import { routingWarnings } from '../../src/workflow/config';
+
+   describe('routingWarnings — Spec B Phase 2 S3 (warn on unknown skill/mode)', () => {
+     it('returns no warnings when routing.skills + routing.modes are empty', () => {
+       const routing: RoutingConfig = { default: 'claude-opus' };
+       expect(routingWarnings(routing, ['harness-debugging'])).toEqual([]);
+     });
+
+     it('returns no warnings when every routing.skills.<name> is in the catalog', () => {
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         skills: { 'harness-debugging': 'claude-opus' },
+       };
+       expect(routingWarnings(routing, ['harness-debugging'])).toEqual([]);
+     });
+
+     it('warns when routing.skills.<name> is not in the catalog', () => {
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         skills: { 'harness-debuggin': 'claude-opus' }, // typo
+       };
+       const warnings = routingWarnings(routing, ['harness-debugging']);
+       expect(warnings).toHaveLength(1);
+       expect(warnings[0]).toContain('routing.skills.harness-debuggin');
+       expect(warnings[0]).toContain('not present in the local skill catalog');
+     });
+
+     it('emits one warning per unknown skill name (count proportional to typos)', () => {
+       // Concern #3: confirm emission scales linearly so operator gets every typo.
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         skills: {
+           bogus1: 'claude-opus',
+           bogus2: 'claude-opus',
+           bogus3: 'claude-opus',
+         },
+       };
+       const warnings = routingWarnings(routing, []);
+       expect(warnings).toHaveLength(3);
+     });
+
+     it('does NOT warn when knownSkillNames is empty (no catalog discovered)', () => {
+       // When `agents/skills/` is absent, we cannot evaluate the warning.
+       // Skipping is preferable to flooding the operator with false positives.
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         skills: { foo: 'claude-opus' },
+       };
+       expect(routingWarnings(routing, [])).toEqual([]);
+     });
+
+     it('returns no warnings when every routing.modes.<name> is a STANDARD_COGNITIVE_MODE', () => {
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         modes: {
+           'adversarial-reviewer': 'claude-opus',
+           'constructive-architect': 'claude-opus',
+         },
+       };
+       expect(routingWarnings(routing, ['harness-debugging'])).toEqual([]);
+     });
+
+     it('warns when routing.modes.<mode> is not in STANDARD_COGNITIVE_MODES', () => {
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         modes: { 'gut-reactor': 'claude-opus' },
+       };
+       const warnings = routingWarnings(routing, []);
+       expect(warnings).toHaveLength(1);
+       expect(warnings[0]).toContain('routing.modes.gut-reactor');
+       expect(warnings[0]).toContain('not in STANDARD_COGNITIVE_MODES');
+       for (const mode of STANDARD_COGNITIVE_MODES) {
+         expect(warnings[0]).toContain(mode);
+       }
+     });
+
+     it('warns on both unknown skills and unknown modes in a single call', () => {
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         skills: { bogus: 'claude-opus' },
+         modes: { 'bogus-mode': 'claude-opus' },
+       };
+       const warnings = routingWarnings(routing, ['harness-debugging']);
+       expect(warnings).toHaveLength(2);
+       expect(warnings.some((w) => w.includes('routing.skills.bogus'))).toBe(true);
+       expect(warnings.some((w) => w.includes('routing.modes.bogus-mode'))).toBe(true);
+     });
+   });
+   ```
+
+2. Run the test. Expect failure (`routingWarnings` not exported). Command:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/routing-warnings.test.ts
+   ```
+
+3. Edit `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts`. Update the imports at the top to include `STANDARD_COGNITIVE_MODES`. Find:
+
+   ```
+   import {
+     WorkflowConfig,
+     Result,
+     Ok,
+     Err,
+     BackendDef,
+     RoutingConfig,
+     type RoutingValue,
+   } from '@harness-engineering/types';
+   ```
+
+   Replace with:
+
+   ```
+   import {
+     WorkflowConfig,
+     Result,
+     Ok,
+     Err,
+     BackendDef,
+     RoutingConfig,
+     STANDARD_COGNITIVE_MODES,
+     type RoutingValue,
+   } from '@harness-engineering/types';
+   ```
+
+   Then append the following new export below the existing `crossFieldRoutingIssues` function (between it and `validateWorkflowConfig`):
+
+   ```ts
+   /**
+    * Spec B Phase 2 / S3: produce non-blocking warnings for misconfigured
+    * routing entries that are SYNTACTICALLY valid (the cross-field check
+    * has passed) but SEMANTICALLY suspicious:
+    *
+    *  - `routing.skills.<name>` where `<name>` is not in the local skill
+    *    catalog. Likely a typo or a skill that was renamed / removed.
+    *
+    *  - `routing.modes.<mode>` where `<mode>` is not in the
+    *    STANDARD_COGNITIVE_MODES tuple. Since `CognitiveMode` allows the
+    *    `(string & {})` escape hatch, the type system accepts custom modes
+    *    — but operators are far more likely to typo a standard mode than
+    *    introduce a custom one, so we warn.
+    *
+    * Returns an empty array when `knownSkillNames` is empty (i.e., the
+    * catalog could not be discovered — most likely because `agents/skills/`
+    * is absent). Skipping is preferable to flooding the operator with
+    * false positives when the catalog itself is missing.
+    *
+    * Warnings are advisory; the loader continues to return `Ok` and the
+    * orchestrator starts normally.
+    */
+   export function routingWarnings(
+     routing: RoutingConfig,
+     knownSkillNames: readonly string[]
+   ): string[] {
+     const warnings: string[] = [];
+
+     // Skill-name warnings (only when a catalog was discovered).
+     if (knownSkillNames.length > 0 && routing.skills) {
+       const known = new Set(knownSkillNames);
+       for (const name of Object.keys(routing.skills)) {
+         if (known.has(name)) continue;
+         warnings.push(
+           `routing.skills.${name} references a skill that is not present in the local skill catalog. ` +
+             `If this is intentional (e.g., a skill installed by a downstream consumer), this warning can be ignored.`
+         );
+       }
+     }
+
+     // Cognitive-mode warnings (no catalog needed — STANDARD_COGNITIVE_MODES is static).
+     if (routing.modes) {
+       const standardModes = new Set<string>(STANDARD_COGNITIVE_MODES);
+       for (const mode of Object.keys(routing.modes)) {
+         if (standardModes.has(mode)) continue;
+         warnings.push(
+           `routing.modes.${mode} is not in STANDARD_COGNITIVE_MODES (` +
+             `${[...STANDARD_COGNITIVE_MODES].join(', ')}). ` +
+             `Custom cognitive modes are allowed but uncommon; verify this is not a typo.`
+         );
+       }
+     }
+
+     return warnings;
+   }
+   ```
+
+4. Rerun the test. Expect all 8 cases pass.
+
+5. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/`. Expect ALL workflow tests pass.
+
+6. Commit:
+
+   ```
+   git add packages/orchestrator/src/workflow/config.ts packages/orchestrator/tests/workflow/routing-warnings.test.ts
+   git commit -m "feat(orchestrator): add routingWarnings helper for skill+mode catalog checks (Spec B Phase 2)"
+   ```
+
+---
+
+### Task 5: Widen `validateWorkflowConfig` return type to carry warnings
+
+**Depends on:** Task 4 · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/config.test.ts` · **Category:** implementation
+
+[checkpoint:human-verify] Before starting, verify with the operator that `WorkflowDefinition` (in `packages/types/src/orchestrator.ts`) gaining a `warnings: readonly string[]` field is acceptable. If the operator wants warnings carried via a side-channel instead, redesign Tasks 5–7 accordingly. (See Concerns #1 in the plan header.)
+
+1. Read `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/config.test.ts` to learn the existing test shape (it asserts `result.ok` and `result.value.<field>` on the returned config).
+
+2. Append the following new test cases to the END of the existing top-level `describe(...)` block in `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/config.test.ts`:
+
+   ```ts
+   describe('Spec B Phase 2 — warnings on the validation result', () => {
+     const baseConfig = {
+       tracker: {
+         kind: 'roadmap',
+         filePath: 'docs/roadmap.md',
+         activeStates: [],
+         terminalStates: [],
+       },
+       polling: { intervalMs: 1000, jitterMs: 0 },
+       workspace: { root: '.harness/workspaces' },
+       hooks: {
+         afterCreate: null,
+         beforeRun: null,
+         afterRun: null,
+         beforeRemove: null,
+         timeoutMs: 1000,
+       },
+       server: { port: 8080 },
+     };
+
+     it('returns warnings:[] when no skills/modes are configured', () => {
+       const result = validateWorkflowConfig({
+         ...baseConfig,
+         agent: {
+           backends: { 'claude-opus': { type: 'claude' } },
+           routing: { default: 'claude-opus' },
+         },
+       });
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings).toEqual([]);
+     });
+
+     it('carries a skill-name warning when knownSkillNames is supplied via options', () => {
+       const result = validateWorkflowConfig(
+         {
+           ...baseConfig,
+           agent: {
+             backends: { 'claude-opus': { type: 'claude' } },
+             routing: {
+               default: 'claude-opus',
+               skills: { 'typo-skill': 'claude-opus' },
+             },
+           },
+         },
+         { knownSkillNames: ['harness-debugging'] }
+       );
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings).toHaveLength(1);
+       expect(result.value.warnings[0]).toContain('routing.skills.typo-skill');
+     });
+
+     it('carries a mode warning even without a skill catalog', () => {
+       const result = validateWorkflowConfig({
+         ...baseConfig,
+         agent: {
+           backends: { 'claude-opus': { type: 'claude' } },
+           routing: {
+             default: 'claude-opus',
+             modes: { 'gut-reactor': 'claude-opus' },
+           },
+         },
+       });
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings).toHaveLength(1);
+       expect(result.value.warnings[0]).toContain('routing.modes.gut-reactor');
+     });
+
+     it('preserves Err(...) semantics for hard errors (unknown backend in skills chain)', () => {
+       const result = validateWorkflowConfig({
+         ...baseConfig,
+         agent: {
+           backends: { 'claude-opus': { type: 'claude' } },
+           routing: {
+             default: 'claude-opus',
+             skills: { 'harness-debugging': ['claude-opus', 'typo-backend'] },
+           },
+         },
+       });
+       expect(result.ok).toBe(false);
+       if (result.ok) return;
+       expect(result.error.message).toContain('routing.skills.harness-debugging.1');
+       expect(result.error.message).toContain('typo-backend');
+     });
+   });
+   ```
+
+3. Run the test file:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/config.test.ts
+   ```
+
+   Expect failure (return type does not carry `warnings`).
+
+4. Edit `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/config.ts`. Update the signature and body of `validateWorkflowConfig`. Find:
+
+   ```ts
+   export function validateWorkflowConfig(config: unknown): Result<WorkflowConfig, Error> {
+   ```
+
+   Replace with:
+
+   ```ts
+   export interface ValidateWorkflowConfigOptions {
+     /**
+      * Known skill names from the local catalog. When non-empty, used to
+      * warn (S3) on `routing.skills.<name>` references that are not in
+      * the catalog. When empty, skill-name warnings are suppressed — the
+      * caller is presumed to be running without a discoverable catalog
+      * (e.g., tests, or orchestrator outside a harness project root).
+      */
+     knownSkillNames?: readonly string[];
+   }
+
+   export interface ValidatedWorkflowConfig {
+     config: WorkflowConfig;
+     /**
+      * Non-blocking warnings produced during validation. Currently
+      * includes (Spec B Phase 2 / S3):
+      *   - `routing.skills.<name>` not in the local catalog
+      *   - `routing.modes.<mode>` not in `STANDARD_COGNITIVE_MODES`
+      */
+     warnings: readonly string[];
+   }
+
+   export function validateWorkflowConfig(
+     config: unknown,
+     options: ValidateWorkflowConfigOptions = {}
+   ): Result<ValidatedWorkflowConfig, Error> {
+   ```
+
+   Then update the body's success path. Find every `return Ok(config as WorkflowConfig);` in the function and replace with `return Ok({ config: config as WorkflowConfig, warnings: [] });`. The function has exactly two `return Ok(...)` exits today (lines 94 and 128 by current count); both go through the same wrapping.
+
+   Update the modern-backend branch to also emit warnings. Find:
+
+   ```ts
+     // Modern path: validate the new shape via Phase 0's Zod schemas + the
+     // cross-field validator. The legacy path remains hand-rolled until
+     // autopilot Phase 4+ retires the legacy schema entirely.
+     if (hasModernBackends) {
+       const backendsParsed = BackendsMapSchema.safeParse(agent.backends);
+       if (!backendsParsed.success) {
+         return Err(new Error(`agent.backends: ${backendsParsed.error.message}`));
+       }
+       const routingParsed = RoutingConfigSchema.optional().safeParse(agent.routing);
+       if (!routingParsed.success) {
+         return Err(new Error(`agent.routing: ${routingParsed.error.message}`));
+       }
+       if (routingParsed.data) {
+         // Zod's inferred output types include `| undefined` on optional fields,
+         // whereas our `BackendDef` (with `exactOptionalPropertyTypes`) does not.
+         // Cast through `unknown` — the runtime shape is identical, only the
+         // type-level optionality model differs.
+         const cross = crossFieldRoutingIssues(
+           backendsParsed.data as unknown as Record<string, BackendDef>,
+           routingParsed.data as unknown as RoutingConfig
+         );
+         if (cross.length > 0) {
+           return Err(
+             new Error(
+               `Cross-field: ${cross.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')}`
+             )
+           );
+         }
+       }
+     }
+
+     return Ok(config as WorkflowConfig);
+   }
+   ```
+
+   Replace with:
+
+   ```ts
+     // Modern path: validate the new shape via Phase 0's Zod schemas + the
+     // cross-field validator. The legacy path remains hand-rolled until
+     // autopilot Phase 4+ retires the legacy schema entirely.
+     const warnings: string[] = [];
+     if (hasModernBackends) {
+       const backendsParsed = BackendsMapSchema.safeParse(agent.backends);
+       if (!backendsParsed.success) {
+         return Err(new Error(`agent.backends: ${backendsParsed.error.message}`));
+       }
+       const routingParsed = RoutingConfigSchema.optional().safeParse(agent.routing);
+       if (!routingParsed.success) {
+         return Err(new Error(`agent.routing: ${routingParsed.error.message}`));
+       }
+       if (routingParsed.data) {
+         // Zod's inferred output types include `| undefined` on optional fields,
+         // whereas our `BackendDef` (with `exactOptionalPropertyTypes`) does not.
+         // Cast through `unknown` — the runtime shape is identical, only the
+         // type-level optionality model differs.
+         const routingData = routingParsed.data as unknown as RoutingConfig;
+         const cross = crossFieldRoutingIssues(
+           backendsParsed.data as unknown as Record<string, BackendDef>,
+           routingData
+         );
+         if (cross.length > 0) {
+           return Err(
+             new Error(
+               `Cross-field: ${cross.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')}`
+             )
+           );
+         }
+         // Spec B Phase 2 / S3: non-blocking warnings.
+         warnings.push(...routingWarnings(routingData, options.knownSkillNames ?? []));
+       }
+     }
+
+     return Ok({ config: config as WorkflowConfig, warnings });
+   }
+   ```
+
+   ALSO update the early-return `return Ok(config as WorkflowConfig);` at the legacy-path branch (search for it; there is one near the function's first `Ok` exit before the modern-path block) to `return Ok({ config: config as WorkflowConfig, warnings: [] });`.
+
+5. Rerun the targeted test file. Expect pass on the new 4 cases.
+
+6. Run the FULL orchestrator workflow suite:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/
+   ```
+
+   Pre-existing tests in `config.test.ts` that destructure `result.value` to read the validated config will need updating from `result.value.tracker` to `result.value.config.tracker`. Make all such updates in `config.test.ts` (the only test file that directly destructures the legacy return). Expect ALL tests pass.
+
+7. Run a broader typecheck:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck
+   ```
+
+   Expect pass. If `loader.ts` typechecks fail because it still does `Ok({ config: configResult.value, promptTemplate })`, defer the fix to Task 6 (do NOT fix here — Task 6 is the loader edit).
+
+   **Important:** Step 7 may genuinely fail because `loader.ts` now sees a different return shape from `validateWorkflowConfig`. That is expected and addressed in Task 6. Commit Task 5 only if the failure is isolated to `loader.ts` typecheck; if a different file fails, investigate before committing.
+
+8. Commit:
+
+   ```
+   git add packages/orchestrator/src/workflow/config.ts packages/orchestrator/tests/workflow/config.test.ts
+   git commit -m "feat(orchestrator): validateWorkflowConfig carries warnings:[] in its Ok payload (Spec B Phase 2)"
+   ```
+
+---
+
+### Task 6: Update `WorkflowLoader.loadWorkflow` to carry warnings through `WorkflowDefinition`
+
+**Depends on:** Task 5 · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/types/src/orchestrator.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/loader.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/loader.test.ts` · **Category:** implementation
+
+1. Locate the `WorkflowDefinition` interface in `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/types/src/orchestrator.ts`. Read its current declaration with `grep -n "WorkflowDefinition\b" packages/types/src/orchestrator.ts`. Extend it to include `warnings: readonly string[]` as an additional REQUIRED field. Edit example (apply to the actual lines found):
+
+   Before:
+
+   ```ts
+   export interface WorkflowDefinition {
+     config: WorkflowConfig;
+     promptTemplate: string;
+   }
+   ```
+
+   After:
+
+   ```ts
+   export interface WorkflowDefinition {
+     config: WorkflowConfig;
+     promptTemplate: string;
+     /**
+      * Non-blocking warnings produced during config validation. Loaded by
+      * `WorkflowLoader.loadWorkflow`. Spec B Phase 2 / S3: contains
+      * warnings about `routing.skills` / `routing.modes` entries that are
+      * SYNTACTICALLY valid but reference unknown skill names / cognitive
+      * modes. CLI loaders surface these via `logger.warn` after a
+      * successful load.
+      */
+     warnings: readonly string[];
+   }
+   ```
+
+2. Regenerate the types barrel exports if needed:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/types build
+   ```
+
+3. Write the loader test BEFORE editing the loader. Check whether `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/loader.test.ts` exists. If yes, append the test below to its top-level describe. If no, create the file with the following exact content:
+
+   ```ts
+   import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+   import * as fs from 'node:fs';
+   import * as path from 'node:path';
+   import * as os from 'node:os';
+   import { WorkflowLoader } from '../../src/workflow/loader';
+
+   describe('WorkflowLoader — Spec B Phase 2 warnings surfacing', () => {
+     let tmpRoot: string;
+     let workflowPath: string;
+
+     beforeEach(() => {
+       tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'loader-warnings-test-'));
+       workflowPath = path.join(tmpRoot, 'harness.orchestrator.md');
+
+       // Plant a skill catalog so the warning fires on the unknown skill name.
+       const skillDir = path.join(tmpRoot, 'agents', 'skills', 'claude-code', 'harness-debugging');
+       fs.mkdirSync(skillDir, { recursive: true });
+       fs.writeFileSync(
+         path.join(skillDir, 'skill.yaml'),
+         'name: harness-debugging\nversion: 1.0.0\n'
+       );
+     });
+
+     afterEach(() => {
+       fs.rmSync(tmpRoot, { recursive: true, force: true });
+     });
+
+     it('returns warnings:[] on a clean modern config', async () => {
+       fs.writeFileSync(
+         workflowPath,
+         [
+           '---',
+           'tracker:',
+           '  kind: roadmap',
+           '  filePath: docs/roadmap.md',
+           '  activeStates: []',
+           '  terminalStates: []',
+           'polling: { intervalMs: 1000, jitterMs: 0 }',
+           'workspace: { root: .harness/workspaces }',
+           'hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 }',
+           'agent:',
+           '  backends:',
+           '    claude-opus: { type: claude }',
+           '  routing:',
+           '    default: claude-opus',
+           '    skills:',
+           '      harness-debugging: claude-opus',
+           'server: { port: 8080 }',
+           '---',
+           'PROMPT TEMPLATE',
+         ].join('\n')
+       );
+
+       const loader = new WorkflowLoader();
+       const result = await loader.loadWorkflow(workflowPath);
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings).toEqual([]);
+       expect(result.value.config).toBeDefined();
+       expect(result.value.promptTemplate).toContain('PROMPT TEMPLATE');
+     });
+
+     it('surfaces a warning when routing.skills.<name> is not in the discovered catalog', async () => {
+       fs.writeFileSync(
+         workflowPath,
+         [
+           '---',
+           'tracker: { kind: roadmap, filePath: docs/roadmap.md, activeStates: [], terminalStates: [] }',
+           'polling: { intervalMs: 1000, jitterMs: 0 }',
+           'workspace: { root: .harness/workspaces }',
+           'hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 }',
+           'agent:',
+           '  backends:',
+           '    claude-opus: { type: claude }',
+           '  routing:',
+           '    default: claude-opus',
+           '    skills:',
+           '      harness-debuggin: claude-opus',
+           'server: { port: 8080 }',
+           '---',
+           'PROMPT TEMPLATE',
+         ].join('\n')
+       );
+
+       const loader = new WorkflowLoader();
+       const result = await loader.loadWorkflow(workflowPath);
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings.length).toBeGreaterThan(0);
+       expect(
+         result.value.warnings.some((w) => w.includes('routing.skills.harness-debuggin'))
+       ).toBe(true);
+     });
+
+     it('returns Err when routing.skills references an unknown backend (hard error preserved)', async () => {
+       fs.writeFileSync(
+         workflowPath,
+         [
+           '---',
+           'tracker: { kind: roadmap, filePath: docs/roadmap.md, activeStates: [], terminalStates: [] }',
+           'polling: { intervalMs: 1000, jitterMs: 0 }',
+           'workspace: { root: .harness/workspaces }',
+           'hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 }',
+           'agent:',
+           '  backends:',
+           '    claude-opus: { type: claude }',
+           '  routing:',
+           '    default: claude-opus',
+           '    skills:',
+           '      harness-debugging: typo-backend',
+           'server: { port: 8080 }',
+           '---',
+           'PROMPT TEMPLATE',
+         ].join('\n')
+       );
+
+       const loader = new WorkflowLoader();
+       const result = await loader.loadWorkflow(workflowPath);
+       expect(result.ok).toBe(false);
+       if (result.ok) return;
+       expect(result.error.message).toContain('typo-backend');
+     });
+   });
+   ```
+
+4. Run the loader test. Expect failure (loader does not pass `knownSkillNames`, does not return `warnings`).
+
+5. Edit `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/loader.ts`. Replace its full content with:
+
+   ```ts
+   import * as fs from 'node:fs/promises';
+   import * as path from 'node:path';
+   import { parse } from 'yaml';
+   import { WorkflowDefinition, Result, Ok, Err } from '@harness-engineering/types';
+   import { validateWorkflowConfig } from './config';
+   import { discoverSkillCatalogNames } from './skill-catalog';
+
+   export class WorkflowLoader {
+     async loadWorkflow(filePath: string): Promise<Result<WorkflowDefinition, Error>> {
+       try {
+         const content = await fs.readFile(filePath, 'utf-8');
+         const parts = content.split('---');
+
+         if (parts.length < 3) {
+           return Err(
+             new Error(
+               `Invalid harness.orchestrator.md format at ${filePath}. Expected frontmatter surrounded by '---'.`
+             )
+           );
+         }
+
+         const yamlContent = parts[1]!.trim();
+         const promptTemplate = parts.slice(2).join('---').trim();
+
+         const configData = parse(yamlContent);
+
+         // Spec B Phase 2 / S3: discover the local skill catalog so that
+         // `routing.skills.<name>` entries can be cross-checked against
+         // declared skill names. The project root is derived from the
+         // workflow file's parent directory — matches how `harness validate`
+         // and other CLI commands locate the project root from a passed-in
+         // config path.
+         const projectRoot = path.dirname(path.resolve(filePath));
+         const knownSkillNames = discoverSkillCatalogNames(projectRoot);
+
+         const configResult = validateWorkflowConfig(configData, { knownSkillNames });
+
+         if (!configResult.ok) {
+           return Err(configResult.error);
+         }
+
+         return Ok({
+           config: configResult.value.config,
+           promptTemplate,
+           warnings: configResult.value.warnings,
+         });
+       } catch (error) {
+         return Err(error instanceof Error ? error : new Error(String(error)));
+       }
+     }
+   }
+   ```
+
+6. Rerun the loader test. Expect pass on all 3 new cases.
+
+7. Run the FULL orchestrator test suite (this is the lockstep check — the loader return-type change will surface in any caller that destructures `result.value`):
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test
+   ```
+
+   Fix any test that destructures `{ config, promptTemplate }` from a `WorkflowLoader` result by also destructuring `warnings` (or by ignoring it explicitly with `_warnings`). Expect ALL tests pass after fixups.
+
+8. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck`. Expect pass.
+
+9. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate`. Expect pass (N4 + N5).
+
+10. Commit:
+
+    ```
+    git add packages/types/src/orchestrator.ts packages/orchestrator/src/workflow/loader.ts packages/orchestrator/tests/workflow/loader.test.ts packages/types/dist/ packages/orchestrator/tests/
+    git commit -m "feat(orchestrator): thread Phase 2 warnings through WorkflowLoader payload"
+    ```
+
+---
+
+### Task 7: Surface warnings via CLI `logger.warn` after successful load
+
+**Depends on:** Task 6 · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/orchestrator.ts`, `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/maintenance.ts` · **Category:** implementation
+
+1. Sanity-check the call sites of `loadWorkflow`:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && grep -rn "loadWorkflow\b" packages/ --include="*.ts" 2>/dev/null
+   ```
+
+   Confirm exactly two non-test consumers: `packages/cli/src/commands/orchestrator.ts:19` and `packages/cli/src/commands/maintenance.ts:32`. If a third call site appears (extension package), flag to the operator and pause for guidance. Test files (`*.test.ts`) may need updates but are out of scope here — Task 6 already handled them.
+
+2. Edit `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/orchestrator.ts`. Find:
+
+   ```ts
+   if (!result.ok) {
+     logger.error(`Failed to load workflow: ${result.error.message}`);
+     process.exit(ExitCode.ERROR);
+   }
+
+   const { config, promptTemplate } = result.value;
+   const daemon = new Orchestrator(config, promptTemplate);
+   ```
+
+   Replace with:
+
+   ```ts
+   if (!result.ok) {
+     logger.error(`Failed to load workflow: ${result.error.message}`);
+     process.exit(ExitCode.ERROR);
+   }
+
+   const { config, promptTemplate, warnings } = result.value;
+   // Spec B Phase 2 / S3: surface non-blocking routing warnings at startup.
+   for (const w of warnings) logger.warn(w);
+
+   const daemon = new Orchestrator(config, promptTemplate);
+   ```
+
+3. Edit `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/maintenance.ts`. Read the file first (full content not in the plan; the loader-call pattern at line 32 needs the same `warnings` surfacing). After the existing `if (!result.ok) { ... }` check and BEFORE any other use of `result.value`, add:
+
+   ```ts
+   // Spec B Phase 2 / S3: surface non-blocking routing warnings at startup.
+   for (const w of result.value.warnings) logger.warn(w);
+   ```
+
+   (The CLI logger import already exists in this file; reuse it.)
+
+4. Run the CLI typecheck:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/cli typecheck
+   ```
+
+   Expect pass.
+
+5. Run the CLI test suite:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/cli test
+   ```
+
+   Expect pass.
+
+6. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate`. Expect pass.
+
+7. Commit:
+
+   ```
+   git add packages/cli/src/commands/orchestrator.ts packages/cli/src/commands/maintenance.ts
+   git commit -m "feat(cli): surface workflow warnings via logger.warn at orchestrator startup (Spec B Phase 2)"
+   ```
+
+---
+
+### Task 8: Integration test — full Phase 2 acceptance (S2 + S3 + Q3 + N4 + N5)
+
+**Depends on:** Task 7 · **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/spec-b-phase-2-acceptance.test.ts` · **Category:** implementation
+
+This task pins Phase 2's success criteria as a single integration test, end-to-end through `WorkflowLoader`. It is the regression-anchor for the whole Phase: if it breaks, Phase 2 has lost a guarantee.
+
+1. Create `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/spec-b-phase-2-acceptance.test.ts` with the following exact content:
+
+   ```ts
+   import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+   import * as fs from 'node:fs';
+   import * as path from 'node:path';
+   import * as os from 'node:os';
+   import { WorkflowLoader } from '../../src/workflow/loader';
+   import { STANDARD_COGNITIVE_MODES } from '@harness-engineering/types';
+
+   /**
+    * Spec B Phase 2 acceptance suite. Pins success criteria S2 + S3 + Q3 +
+    * N4 + N5 end-to-end through `WorkflowLoader.loadWorkflow` (the entry
+    * point for `harness orchestrator run` and `harness maintenance`).
+    *
+    * Each test simulates a real workflow markdown file on disk + a real
+    * project skill catalog under `agents/skills/claude-code/`, so any
+    * regression in the loader/validator/catalog-discovery pipeline shows up
+    * here.
+    */
+   describe('Spec B Phase 2 — full acceptance', () => {
+     let tmpRoot: string;
+     let workflowPath: string;
+
+     beforeEach(() => {
+       tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'phase-2-accept-'));
+       workflowPath = path.join(tmpRoot, 'harness.orchestrator.md');
+
+       // Plant a small skill catalog.
+       for (const name of ['harness-debugging', 'harness-soundness-review']) {
+         const dir = path.join(tmpRoot, 'agents', 'skills', 'claude-code', name);
+         fs.mkdirSync(dir, { recursive: true });
+         fs.writeFileSync(path.join(dir, 'skill.yaml'), `name: ${name}\nversion: 1.0.0\n`);
+       }
+     });
+
+     afterEach(() => {
+       fs.rmSync(tmpRoot, { recursive: true, force: true });
+     });
+
+     const writeWorkflow = (routingYaml: string): void => {
+       fs.writeFileSync(
+         workflowPath,
+         [
+           '---',
+           'tracker: { kind: roadmap, filePath: docs/roadmap.md, activeStates: [], terminalStates: [] }',
+           'polling: { intervalMs: 1000, jitterMs: 0 }',
+           'workspace: { root: .harness/workspaces }',
+           'hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 }',
+           'agent:',
+           '  backends:',
+           '    claude-opus: { type: claude }',
+           '    claude-sonnet: { type: claude }',
+           '  routing:',
+           routingYaml,
+           'server: { port: 8080 }',
+           '---',
+           'PROMPT',
+         ].join('\n')
+       );
+     };
+
+     // ---------------- S2: hard errors -----------------------------------
+
+     it('S2: rejects routing.skills chain entry referencing an unknown backend (Q3 message format)', async () => {
+       writeWorkflow(
+         '    default: claude-opus\n    skills:\n      harness-debugging: [claude-opus, typo-backend]'
+       );
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(false);
+       if (result.ok) return;
+       // Q3: error must name the offending path and the known backend list.
+       expect(result.error.message).toContain('routing.skills.harness-debugging.1');
+       expect(result.error.message).toContain('typo-backend');
+       expect(result.error.message).toContain('claude-opus');
+       expect(result.error.message).toContain('claude-sonnet');
+     });
+
+     it('S2: rejects routing.modes scalar referencing an unknown backend', async () => {
+       writeWorkflow(
+         '    default: claude-opus\n    modes:\n      adversarial-reviewer: typo-backend'
+       );
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(false);
+       if (result.ok) return;
+       expect(result.error.message).toContain('routing.modes.adversarial-reviewer');
+       expect(result.error.message).toContain('typo-backend');
+     });
+
+     it('S2: rejects routing.isolation chain entry referencing an unknown backend (closes I2)', async () => {
+       writeWorkflow(
+         '    default: claude-opus\n    isolation:\n      container: [claude-opus, typo-backend]'
+       );
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(false);
+       if (result.ok) return;
+       expect(result.error.message).toContain('routing.isolation.container.1');
+       expect(result.error.message).toContain('typo-backend');
+     });
+
+     it('S2: rejects widened-scalar field (e.g., routing.default chain) referencing an unknown backend', async () => {
+       writeWorkflow('    default: [claude-opus, typo-backend]');
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(false);
+       if (result.ok) return;
+       expect(result.error.message).toContain('routing.default.1');
+       expect(result.error.message).toContain('typo-backend');
+     });
+
+     // ---------------- S3: warnings (non-blocking) -----------------------
+
+     it('S3: warns on routing.skills.<name> not in the local catalog', async () => {
+       writeWorkflow('    default: claude-opus\n    skills:\n      harness-debuggin: claude-opus');
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(
+         result.value.warnings.some((w) => w.includes('routing.skills.harness-debuggin'))
+       ).toBe(true);
+     });
+
+     it('S3: warns on routing.modes.<mode> not in STANDARD_COGNITIVE_MODES (lists the standard set)', async () => {
+       writeWorkflow('    default: claude-opus\n    modes:\n      gut-reactor: claude-opus');
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       const modeWarning = result.value.warnings.find((w) =>
+         w.includes('routing.modes.gut-reactor')
+       );
+       expect(modeWarning).toBeDefined();
+       for (const standard of STANDARD_COGNITIVE_MODES) {
+         expect(modeWarning).toContain(standard);
+       }
+     });
+
+     it('S3: does NOT warn when every routing.skills.<name> is in the catalog AND every mode is standard', async () => {
+       writeWorkflow(
+         '    default: claude-opus\n    skills:\n      harness-debugging: claude-opus\n    modes:\n      adversarial-reviewer: claude-opus'
+       );
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings).toEqual([]);
+     });
+
+     // ---------------- N4 / N5: no regression ----------------------------
+
+     it('N4: a config with no routing.skills/routing.modes loads cleanly with no warnings', async () => {
+       writeWorkflow('    default: claude-opus\n    quick-fix: claude-sonnet');
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings).toEqual([]);
+     });
+
+     it('N5: array form on a previously-scalar routing field loads cleanly', async () => {
+       writeWorkflow('    default: [claude-opus, claude-sonnet]');
+       const result = await new WorkflowLoader().loadWorkflow(workflowPath);
+       expect(result.ok).toBe(true);
+       if (!result.ok) return;
+       expect(result.value.warnings).toEqual([]);
+     });
+   });
+   ```
+
+2. Run the test:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- packages/orchestrator/tests/workflow/spec-b-phase-2-acceptance.test.ts
+   ```
+
+   Expect all 9 cases pass.
+
+3. Run the full orchestrator suite + the CLI suite to confirm no Phase 2 regression bled into adjacent areas:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test && pnpm --filter @harness-engineering/cli test
+   ```
+
+   Expect both green (with the same 1 pre-existing skipped test in orchestrator that was present in Phase 1 verification).
+
+4. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate && harness check-deps`. Expect pass.
+
+5. Commit:
+
+   ```
+   git add packages/orchestrator/tests/workflow/spec-b-phase-2-acceptance.test.ts
+   git commit -m "test(orchestrator): pin Spec B Phase 2 acceptance criteria (S2+S3+Q3+N4+N5)"
+   ```
+
+---
+
+### Task 9: Update barrel exports and confirm public-API surface (integration task)
+
+**Depends on:** Task 8 · **Files:** generated barrels for `@harness-engineering/types` and `@harness-engineering/orchestrator` · **Category:** integration
+
+1. Regenerate barrel exports:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm generate:barrels
+   ```
+
+2. Inspect the diff. The expected additions are:
+   - `routingWarnings` exported from `@harness-engineering/orchestrator` workflow module (Task 4)
+   - `ValidatedWorkflowConfig` + `ValidateWorkflowConfigOptions` exported from the same (Task 5)
+   - `discoverSkillCatalogNames` exported from the same (Task 2)
+   - `WorkflowDefinition.warnings` field visible in the `@harness-engineering/types` public surface (Task 6)
+
+   Verify with:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && git diff packages/orchestrator/src/index.ts packages/types/src/index.ts 2>/dev/null | head -60
+   ```
+
+3. Run the barrel-check sanity command:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm generate:barrels:check
+   ```
+
+   Expect pass.
+
+4. Run the global typecheck across the repo:
+
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm typecheck
+   ```
+
+   Expect pass.
+
+5. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate && harness check-deps`. Expect pass.
+
+6. Commit:
+
+   ```
+   git add packages/orchestrator/src/index.ts packages/types/src/index.ts packages/types/dist/ packages/orchestrator/dist/
+   git commit -m "chore(barrels): regenerate barrels for Spec B Phase 2 workflow exports"
+   ```
+
+---
+
+## Sequencing Summary
+
+| Task | Depends on | Atomic commit | Approx time |
+| ---- | ---------- | ------------- | ----------- |
+| 1    | —          | Yes           | 25 min      |
+| 2    | 1          | Yes           | 35 min      |
+| 3    | 1          | Yes           | 25 min      |
+| 4    | 2          | Yes           | 40 min      |
+| 5    | 4          | Yes           | 45 min      |
+| 6    | 5          | Yes           | 55 min      |
+| 7    | 6          | Yes           | 25 min      |
+| 8    | 7          | Yes           | 40 min      |
+| 9    | 8          | Yes           | 15 min      |
+
+**Total:** ~5 hours of focused work + buffer for the typecheck-fixup tail at Task 6 step 7. One-engineer-day fits with margin.
+
+**Parallelism:** Tasks 1, 2, and 3 all depend only on the worktree's pre-Phase-2 state. Tasks 1 and 2 are fully independent and could run in parallel. Task 3 depends on Task 1 only because the schema change must land before isolation cross-field tests assert against it; if Task 1 ships first, Task 3 can run in parallel with Task 2.
+
+## Checkpoints
+
+| Checkpoint     | Location                 | Purpose                                                                                                                                                                                                            |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `human-verify` | Task 5 (before starting) | Confirm `WorkflowDefinition.warnings: readonly string[]` is the right public-API contract. Alternative: thread warnings via an event channel to keep the type interface unchanged. See Concerns #1 in plan header. |
+
+## Validation
+
+- `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate` (each task includes this as a step; Task 8 reruns it before commit; Task 9 reruns it at the integration boundary)
+- `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness check-deps` (Task 8 final step + Task 9)
+- `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm typecheck` (Task 9 — global typecheck)
+- `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm generate:barrels:check` (Task 9)
+
+## Phase Gate (for the Phase 2 sign-off review)
+
+When Phase 2 completes, the following acceptance criteria must be true:
+
+- `pnpm --filter @harness-engineering/orchestrator test` green (no new test skips; the 1 pre-existing skipped test from Phase 1 verification carries through)
+- `pnpm --filter @harness-engineering/cli test` green
+- `pnpm typecheck` green at repo root
+- `harness validate` green
+- `harness check-deps` green
+- The 9 new tests in `spec-b-phase-2-acceptance.test.ts` all pass
+- No regressions in the existing 1304 orchestrator tests
+- The Phase 0 review I2 finding (isolation Zod widening) is closed and traceable in commit history
+
+## Out-of-Scope Reminders
+
+- **Dispatch-site wiring** (Phase 3 — `runner.ts` threads skill + cognitiveMode into RoutingUseCase)
+- **`RoutingDecisionBus` + event emission** (Phase 4)
+- **HTTP routes / WS topic / CLI / dashboard** (Phases 5–7)
+- **ADRs + docs** (Phase 8)
+- **P1-IMP-1 / P1-IMP-2 / P1-IMP-3** (Phase 1 review's important findings deferred to Phase 4 per operator brief — DO NOT touch in Phase 2)
+- **I1 third instance in `resolveRoutedBackend` (`intelligence-factory.ts:135-159`)** (deferred to Phase 2/cleanup per Phase 1 review's `knownDeferrals[0]` — INFORMATIONAL only; the spec's Phase 2 scope does not include this. Defer to Phase 4 with the other I1-related cleanups unless the operator explicitly requests it here.)

--- a/docs/changes/granular-task-routing/plans/2026-05-25-phase-3-dispatch-wiring-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-25-phase-3-dispatch-wiring-plan.md
@@ -1,0 +1,1001 @@
+# Plan: Spec B Phase 3 — Dispatch-Site Wiring
+
+**Date:** 2026-05-25
+**Spec:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/docs/changes/granular-task-routing/proposal.md`
+**Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1`
+**Branch:** `feat/spec-b-phase-1` (HEAD `acb6e8c1`, Phase 2 tip)
+**Phase 3 scope:** ~2 days, medium complexity
+**Tasks:** 14
+**Estimated time:** ~74 min of focused work (1 context window per task)
+**Integration Tier:** medium
+**Phase 3 success criteria:** F1 + F2 + F4 + F11 pass
+
+---
+
+## Goal
+
+At dispatch, the orchestrator constructs `{ kind: 'skill', skillName, cognitiveMode }` whenever the dispatch source is a skill invocation, and CLI invocations of `harness skill run` accept a `--backend <name>` flag that propagates as `invocationOverride` into `BackendRouter.resolve()` so an operator's `routing.skills.harness-debugging: 'local-fast'` config actually takes effect at the dispatch site.
+
+---
+
+## Observable Truths (Acceptance Criteria)
+
+1. **EARS — Event-driven (F1):** When `dispatchIssue` runs for an issue whose triage decision yields a skill (e.g., `'debugging'`) and `routing.skills.harness-debugging = 'local-fast'` is configured, the system shall dispatch to `local-fast` regardless of scope tier.
+2. **EARS — Event-driven (F2):** When `dispatchIssue` runs for an issue routed to a skill whose `skill.yaml` declares `cognitive_mode: adversarial-reviewer` and `routing.modes.adversarial-reviewer = 'local-fast'` is configured with no per-skill override, the system shall dispatch to `local-fast`.
+3. **EARS — Event-driven (F4):** When an operator runs `harness skill run harness-soundness-review --backend claude-sonnet` and the resulting in-process dispatch consults `BackendRouter`, the resolved backend shall equal `claude-sonnet` regardless of any per-skill / per-mode / per-tier routing.
+4. **EARS — Unwanted (F11):** If a skill has no declared `cognitive_mode` and no per-skill routing entry, then the system shall not invent a mode — resolution shall fall through to existing per-tier and ultimately `routing.default` (byte-identical to today's behavior).
+5. **EARS — Ubiquitous (N2):** Tier-based dispatch (escalation, generic issues with no resolvable triage skill) shall continue to construct `{ kind: 'tier', tier }`.
+6. **EARS — Ubiquitous:** `harness validate` and `pnpm --filter @harness-engineering/orchestrator typecheck` + `pnpm --filter @harness-engineering/cli typecheck` shall pass.
+7. **EARS — Ubiquitous:** A new integration test file at `packages/orchestrator/tests/integration/spec-b-phase-3-dispatch-wiring.test.ts` shall pin F1, F2, F4, and F11 with at least 4 passing tests.
+
+---
+
+## Uncertainties / Concerns for Operator Sign-Off
+
+| #   | Class         | Concern                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1  | BLOCKING-LITE | Today, `useCaseForBackendParam(issue, backend)` in `orchestrator.ts:82-102` always returns `{ kind: 'tier', tier }`. There is **no current call to `triageIssue()` from `dispatchIssue`**, so the orchestrator does not know "which skill" it is dispatching. To make F1/F2 pass at the orchestrator dispatch site, Phase 3 must connect `triageIssue` to `useCaseForBackendParam`. **The plan assumes Option A:** call `triageIssue` inside `dispatchIssue` and map its `TriageSkill` (`'code-review' \| 'debugging' \| ...`) to a real skill name via a `harness-${TriageSkill}` convention + catalog lookup, with `kind:'tier'` fallback when the catalog lookup misses. If the operator wants Option B (a richer "issue carries skill" plumbing) or Option C (defer orchestrator-dispatch wiring to Phase 4 and ship CLI-only `--backend` for Phase 3), Tasks 3-7 branch. |
+| C2  | ASSUMPTION    | Phase 2's `discoverSkillCatalogNames(projectRoot): string[]` returns only names. F2 requires `cognitive_mode`. Plan **extends** the helper to `discoverSkillCatalog(projectRoot): Array<{ name, cognitiveMode? }>` and keeps the name-only helper as a thin re-export for back-compat (Phase 2 callers in `loader.ts:34` continue working unchanged).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| C3  | ASSUMPTION    | `harness dispatch` **does not exist** as a CLI command today. The spec said "verify path or find the dispatch command's actual location" — confirmed absent. Plan scopes `--backend` to `harness skill run` only. Adding a real `harness dispatch` command is out of scope for Phase 3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| C4  | ASSUMPTION    | `packages/cli/src/commands/skill/run.ts` **emits SKILL.md + preamble to stdout** — it does not itself call `BackendRouter.resolve`. The `--backend` flag therefore propagates as an **environment hint** (`HARNESS_BACKEND_OVERRIDE=<name>` exported in the emitted preamble's instructions and read by the orchestrator at dispatch start). Alternative: limit `--backend` to the orchestrator HTTP `POST /api/dispatch/adhoc` route (more honest but requires HTTP plumbing). Plan defaults to env-hint for the cleanest single-terminal UX; the operator should confirm.                                                                                                                                                                                                                                                                                                   |
+| C5  | DEFERRABLE    | Plugin manifest regeneration produces unrelated cross-package drift (per Phase 2 advisory). Plan task 14 regens only the in-scope manifest deltas; out-of-scope drift is reverted with a comment, mirroring Phase 0/2 precedent.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| C6  | DEFERRABLE    | The spec lists "Update CLI command help text" as part of Phase 3. Plan includes a small task to update help text + a help-snapshot test if any exists (skipped if no snapshot infra).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+**Decision points the operator should confirm before execution:**
+
+- D-OP-1 (C1): **Approve Option A** (triage-at-dispatch + naming-convention skill name) — proceed as planned. If reject: replan Tasks 3-7.
+- D-OP-2 (C4): **Approve env-hint propagation** for `--backend` from `harness skill run` to the orchestrator. If reject: drop the env-hint task, keep `--backend` as a no-op flag with a deprecation-style warning until Phase 4 wires the actual dispatch path.
+
+---
+
+## File Map
+
+```
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/skill-catalog.ts
+        # extend discoverSkillCatalogNames → discoverSkillCatalog returning { name, cognitiveMode? }
+        # keep discoverSkillCatalogNames as thin re-export for Phase 2 callers
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/skill-catalog.test.ts
+        # (CREATE if absent) parametrized tests for new discoverSkillCatalog shape
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/triage-skill-mapping.ts
+        # TriageSkill ('debugging') → catalog skill name ('harness-debugging') resolver
+        # uses the catalog + naming convention, returns undefined on miss
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/triage-skill-mapping.test.ts
+        # unit tests for the mapping helper
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts
+        # 5a. add `private skillCatalog: Array<{ name, cognitiveMode? }>` field + populate at construction
+        # 5b. rewrite useCaseForBackendParam: triage → skill name → catalog lookup → kind:'skill' or fallback
+        # 5c. read HARNESS_BACKEND_OVERRIDE env var at dispatch start, thread as invocationOverride
+        # 5d. update dispatchIssue to pass invocationOverride to backendFactory.forUseCase + .resolveName
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
+        # accept opts.invocationOverride on forUseCase + resolveName, forward to router.resolve
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
+        # pin invocationOverride pass-through
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/skill/run.ts
+        # add --backend <name> option; surface in preamble as HARNESS_BACKEND_OVERRIDE export-style hint
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/tests/commands/skill/run.test.ts
+        # (CREATE if absent) test --backend flag surfaces in stdout preamble
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/integration/spec-b-phase-3-dispatch-wiring.test.ts
+        # pin F1, F2, F4, F11 end-to-end through dispatchIssue + BackendRouter
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/loader.ts
+        # update Phase 2 call site to consume the wider helper; preserve warnings output
+```
+
+---
+
+## Skeleton (rigor=standard, 14 tasks > 8 threshold → skeleton produced)
+
+1. Skill catalog: extend discovery to return cognitive_mode (~2 tasks, ~10 min)
+2. TriageSkill → catalog-name mapping helper + tests (~2 tasks, ~10 min)
+3. `useCaseForBackendParam` rewrite: construct skill use case at dispatch start (~2 tasks, ~12 min)
+4. Wire the skill catalog into the Orchestrator constructor (~1 task, ~6 min)
+5. Orchestrator-backend-factory: thread `invocationOverride` (~2 tasks, ~10 min)
+6. `harness skill run --backend` flag + env-hint propagation (~2 tasks, ~10 min)
+7. F1/F2/F4/F11 integration test suite (~2 tasks, ~12 min)
+8. Plugin manifest regen + final `harness validate` checkpoint (~1 task, ~4 min)
+
+**Skeleton approval gate:** Operator should approve direction before Task 1 begins. If C1/C4 decisions land differently, Tasks 3-7 will be revised.
+
+---
+
+## Tasks
+
+> All file paths absolute. Each task is a TDD micro-cycle: write failing test → implement → green → `harness validate` → atomic commit. `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1` is implicit. **All git commits run from the worktree root.**
+
+---
+
+### Task 1: Add `discoverSkillCatalog` returning name+cognitiveMode (TDD step 1: failing test)
+
+**Depends on:** none (Phase 2 baseline)
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/skill-catalog.test.ts`
+
+1. Read existing file (if present) to learn the established fixture style:
+   ```
+   ls /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/workflow/
+   ```
+   If `skill-catalog.test.ts` is absent, create it. Use `node:fs/promises` + `node:os.tmpdir()` for the fixture root, matching the existing Phase 2 test pattern in `packages/orchestrator/tests/workflow/`.
+2. Add a new `describe('discoverSkillCatalog (Phase 3)')` block with three tests:
+   - `'returns name+cognitiveMode for a skill that declares cognitive_mode'`
+   - `'returns name with cognitiveMode=undefined when skill.yaml omits cognitive_mode'`
+   - `'preserves dedup across host directories on name'`
+3. Fixture skills under `<tmp>/agents/skills/claude-code/`:
+   - `harness-soundness-review/skill.yaml` with `name: harness-soundness-review` + `cognitive_mode: adversarial-reviewer`
+   - `harness-tdd/skill.yaml` with `name: harness-tdd` (no cognitive_mode)
+4. Import `discoverSkillCatalog` from `../../src/workflow/skill-catalog` (does not exist yet — import will fail).
+5. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- workflow/skill-catalog.test.ts 2>&1 | tail -30
+   ```
+6. **Observe:** test fails because `discoverSkillCatalog` is not exported. **Do not commit** — the implementation lands in Task 2.
+
+---
+
+### Task 2: Implement `discoverSkillCatalog` + back-compat re-export
+
+**Depends on:** Task 1
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/workflow/skill-catalog.ts`
+
+1. Add a new exported type and function alongside `discoverSkillCatalogNames`:
+
+   ```ts
+   export interface SkillCatalogEntry {
+     readonly name: string;
+     readonly cognitiveMode?: string;
+   }
+
+   /**
+    * Spec B Phase 3: read the local skill catalog returning each declared
+    * skill's `name` AND optional `cognitive_mode`. Used at orchestrator
+    * dispatch start to construct `{ kind: 'skill', skillName, cognitiveMode }`
+    * RoutingUseCases per Spec B Phase 3.
+    *
+    * The Phase 2 `discoverSkillCatalogNames` helper is preserved as a
+    * thin re-export over this function for back-compat with the
+    * WorkflowLoader → validation pipeline.
+    */
+   export function discoverSkillCatalog(projectRoot: string): SkillCatalogEntry[] {
+     // Implementation mirrors discoverSkillCatalogNames body but also
+     // reads `parsed.cognitive_mode` when it is a non-empty string.
+     // Dedup: first occurrence wins on name (same as Phase 2).
+     const skillsRoot = path.join(projectRoot, 'agents', 'skills');
+     if (!fs.existsSync(skillsRoot)) return [];
+     const byName = new Map<string, SkillCatalogEntry>();
+     let hosts: fs.Dirent[];
+     try {
+       hosts = fs.readdirSync(skillsRoot, { withFileTypes: true });
+     } catch {
+       return [];
+     }
+     for (const host of hosts) {
+       if (!host.isDirectory()) continue;
+       const hostDir = path.join(skillsRoot, host.name);
+       let skills: fs.Dirent[];
+       try {
+         skills = fs.readdirSync(hostDir, { withFileTypes: true });
+       } catch {
+         continue;
+       }
+       for (const skill of skills) {
+         if (!skill.isDirectory()) continue;
+         const skillYamlPath = path.join(hostDir, skill.name, 'skill.yaml');
+         if (!fs.existsSync(skillYamlPath)) continue;
+         try {
+           const parsed = parseYaml(fs.readFileSync(skillYamlPath, 'utf-8')) as {
+             name?: unknown;
+             cognitive_mode?: unknown;
+           } | null;
+           if (
+             parsed &&
+             typeof parsed.name === 'string' &&
+             parsed.name.length > 0 &&
+             !byName.has(parsed.name)
+           ) {
+             const entry: SkillCatalogEntry =
+               typeof parsed.cognitive_mode === 'string' && parsed.cognitive_mode.length > 0
+                 ? { name: parsed.name, cognitiveMode: parsed.cognitive_mode }
+                 : { name: parsed.name };
+             byName.set(parsed.name, entry);
+           }
+         } catch {
+           /* skip malformed skill.yaml */
+         }
+       }
+     }
+     return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+   }
+   ```
+
+2. **Rewrite** `discoverSkillCatalogNames` to be a thin alias:
+   ```ts
+   export function discoverSkillCatalogNames(projectRoot: string): string[] {
+     return discoverSkillCatalog(projectRoot).map((e) => e.name);
+   }
+   ```
+3. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- workflow/skill-catalog.test.ts 2>&1 | tail -30
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -5
+   ```
+4. **Observe:** the new tests pass; the Phase 2 tests still pass (no behavioral change to `discoverSkillCatalogNames`).
+5. Run `harness validate`. Commit:
+   ```
+   git add packages/orchestrator/src/workflow/skill-catalog.ts \
+           packages/orchestrator/tests/workflow/skill-catalog.test.ts
+   git commit -m "feat(orchestrator): extend skill catalog discovery to return cognitive_mode (Spec B Phase 3)"
+   ```
+
+---
+
+### Task 3: TDD — TriageSkill→catalog-name mapping helper (failing test)
+
+**Depends on:** Task 2
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/triage-skill-mapping.test.ts`
+
+1. Create the test file with this content:
+
+   ```ts
+   import { describe, expect, it } from 'vitest';
+   import { resolveSkillForTriage } from '../../src/agent/triage-skill-mapping';
+   import type { SkillCatalogEntry } from '../../src/workflow/skill-catalog';
+
+   const catalog: SkillCatalogEntry[] = [
+     { name: 'harness-debugging' },
+     { name: 'harness-soundness-review', cognitiveMode: 'adversarial-reviewer' },
+   ];
+
+   describe('resolveSkillForTriage', () => {
+     it('maps debugging → harness-debugging when catalog has it', () => {
+       expect(resolveSkillForTriage('debugging', catalog)).toEqual({
+         name: 'harness-debugging',
+       });
+     });
+
+     it('carries cognitiveMode through when the catalog entry declares one', () => {
+       expect(
+         resolveSkillForTriage('code-review' as never, [
+           { name: 'harness-code-review', cognitiveMode: 'meticulous-implementer' },
+         ])
+       ).toEqual({ name: 'harness-code-review', cognitiveMode: 'meticulous-implementer' });
+     });
+
+     it('returns undefined when no catalog match (caller falls through to tier)', () => {
+       expect(resolveSkillForTriage('refactoring', [])).toBeUndefined();
+     });
+
+     it('is deterministic across multiple invocations', () => {
+       const a = resolveSkillForTriage('debugging', catalog);
+       const b = resolveSkillForTriage('debugging', catalog);
+       expect(a).toEqual(b);
+     });
+   });
+   ```
+
+2. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- agent/triage-skill-mapping.test.ts 2>&1 | tail -20
+   ```
+3. **Observe:** import fails — `triage-skill-mapping.ts` does not exist. **Do not commit.**
+
+---
+
+### Task 4: Implement `resolveSkillForTriage` helper
+
+**Depends on:** Task 3
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/triage-skill-mapping.ts`
+
+1. Create the file:
+
+   ```ts
+   import type { TriageSkill } from '../core/triage-router';
+   import type { SkillCatalogEntry } from '../workflow/skill-catalog';
+
+   /**
+    * Spec B Phase 3: map a TriageSkill (the coarse, hard-coded skill set
+    * the triage router produces) to a concrete catalog skill name + its
+    * declared cognitive_mode (if any), via the `harness-<triageSkill>`
+    * naming convention.
+    *
+    * Returns `undefined` when the catalog has no matching entry — the
+    * caller (dispatchIssue) then falls through to per-tier resolution,
+    * preserving today's behavior (F11/N2).
+    *
+    * Why a naming-convention bridge: today the orchestrator's dispatch
+    * is issue-shaped, not skill-shaped. Threading a richer "issue carries
+    * skill" abstraction through state would be a larger refactor that
+    * does not block Phase 3 success criteria. The convention is
+    * documented and consistent with all Tier-1 skills shipping today
+    * (harness-debugging, harness-tdd, ...). See Phase 3 plan C1.
+    */
+   export interface ResolvedTriageSkill {
+     readonly name: string;
+     readonly cognitiveMode?: string;
+   }
+
+   export function resolveSkillForTriage(
+     triageSkill: TriageSkill,
+     catalog: readonly SkillCatalogEntry[]
+   ): ResolvedTriageSkill | undefined {
+     const expected = `harness-${triageSkill}`;
+     const match = catalog.find((e) => e.name === expected);
+     if (!match) return undefined;
+     return match.cognitiveMode !== undefined
+       ? { name: match.name, cognitiveMode: match.cognitiveMode }
+       : { name: match.name };
+   }
+   ```
+
+2. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- agent/triage-skill-mapping.test.ts 2>&1 | tail -20
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -5
+   ```
+3. **Observe:** 4 tests pass.
+4. Run `harness validate`. Commit:
+   ```
+   git add packages/orchestrator/src/agent/triage-skill-mapping.ts \
+           packages/orchestrator/tests/agent/triage-skill-mapping.test.ts
+   git commit -m "feat(orchestrator): add resolveSkillForTriage helper bridging TriageSkill to catalog (Spec B Phase 3)"
+   ```
+
+---
+
+### Task 5: Wire skill catalog into Orchestrator constructor
+
+**Depends on:** Task 4
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts`
+
+1. At the top of the file, add to the import block where `triageIssue`/`discoverSkillCatalogNames` are co-located (or add a new import):
+   ```ts
+   import { discoverSkillCatalog, type SkillCatalogEntry } from './workflow/skill-catalog';
+   import { triageIssue } from './core/triage-router';
+   import { resolveSkillForTriage } from './agent/triage-skill-mapping';
+   ```
+2. Add a private field next to `private localResolvers = new Map<...>();` (around line 149):
+   ```ts
+   /**
+    * Spec B Phase 3: skill catalog (name + cognitiveMode) read once at
+    * construction from `projectRoot/agents/skills/`. Consulted by
+    * `useCaseForBackendParam` to construct `{ kind: 'skill', skillName,
+    * cognitiveMode }` RoutingUseCases at dispatch start. Empty when the
+    * orchestrator runs outside a harness project root (then dispatch
+    * falls through to per-tier, preserving F11).
+    */
+   private readonly skillCatalog: readonly SkillCatalogEntry[];
+   ```
+3. Inside the constructor, **after** the `this.config = { ...this.config, agent: migrationResult.config }` block (around line 280) and **before** `this.tracker = ...`, add:
+   ```ts
+   // Spec B Phase 3: snapshot the skill catalog at construction. Reads
+   // from `<projectRoot>/agents/skills/<host>/<skill>/skill.yaml`. The
+   // projectRoot getter is defined below; resolve it inline here since
+   // workspace.root has been validated by config validation.
+   const skillCatalogRoot = path.resolve(this.config.workspace.root, '..', '..');
+   this.skillCatalog = discoverSkillCatalog(skillCatalogRoot);
+   if (this.skillCatalog.length === 0) {
+     this.logger.warn(
+       'Spec B Phase 3: skill catalog discovery returned 0 entries; per-skill / per-mode routing will fall through to per-tier. ' +
+         `Looked under ${path.join(skillCatalogRoot, 'agents/skills')}.`
+     );
+   }
+   ```
+4. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -5
+   pnpm --filter @harness-engineering/orchestrator test -- integration/orchestrator.test.ts 2>&1 | tail -10
+   ```
+5. **Observe:** typecheck green; existing integration tests pass (the catalog field is unused so far).
+6. Run `harness validate`. Commit:
+   ```
+   git add packages/orchestrator/src/orchestrator.ts
+   git commit -m "feat(orchestrator): snapshot skill catalog at Orchestrator construction (Spec B Phase 3)"
+   ```
+
+---
+
+### Task 6: TDD — `useCaseForBackendParam` produces `kind: 'skill'` when triage maps (failing test)
+
+**Depends on:** Task 5
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/use-case-construction.test.ts` (CREATE)
+
+1. Create the file. Test the **pure helper** in isolation; the integration assertion lands in Task 13. Refactor `useCaseForBackendParam` to accept the catalog as a parameter so it's directly testable. The test:
+
+   ```ts
+   import { describe, expect, it } from 'vitest';
+   import { buildRoutingUseCase } from '../../src/agent/use-case-builder';
+   import type { Issue } from '@harness-engineering/types';
+
+   const issue: Issue = {
+     id: 'i-1',
+     identifier: 'i-1',
+     title: 'fix: small bug in auth',
+     description: null,
+     priority: null,
+     state: 'planned',
+     branchName: null,
+     url: null,
+     labels: [],
+     blockedBy: [],
+     spec: null,
+     plans: [],
+     createdAt: '2026-05-25T00:00:00Z',
+     updatedAt: '2026-05-25T00:00:00Z',
+     externalId: null,
+   };
+
+   describe('buildRoutingUseCase (Spec B Phase 3)', () => {
+     it("returns { kind: 'tier', tier: 'quick-fix' } when backendParam='local'", () => {
+       expect(buildRoutingUseCase(issue, 'local', [])).toEqual({
+         kind: 'tier',
+         tier: 'quick-fix',
+       });
+     });
+
+     it("returns { kind: 'skill', skillName } when triage maps to a cataloged skill", () => {
+       // 'fix: ...' titles trigger code-review under triageIssue
+       const result = buildRoutingUseCase(issue, undefined, [{ name: 'harness-code-review' }]);
+       expect(result).toEqual({ kind: 'skill', skillName: 'harness-code-review' });
+     });
+
+     it('carries cognitiveMode from the catalog entry', () => {
+       const result = buildRoutingUseCase(issue, undefined, [
+         { name: 'harness-code-review', cognitiveMode: 'meticulous-implementer' },
+       ]);
+       expect(result).toEqual({
+         kind: 'skill',
+         skillName: 'harness-code-review',
+         cognitiveMode: 'meticulous-implementer',
+       });
+     });
+
+     it('falls back to kind: tier when catalog has no matching skill (F11)', () => {
+       const result = buildRoutingUseCase(issue, undefined, []);
+       expect(result.kind).toBe('tier');
+     });
+   });
+   ```
+
+2. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- agent/use-case-construction.test.ts 2>&1 | tail -20
+   ```
+3. **Observe:** import fails — `use-case-builder.ts` does not exist. **Do not commit.**
+
+---
+
+### Task 7: Implement `buildRoutingUseCase` + refactor `useCaseForBackendParam`
+
+**Depends on:** Task 6
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/use-case-builder.ts` (CREATE)
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts` (MODIFY — replace `useCaseForBackendParam`)
+
+1. Create `use-case-builder.ts`:
+
+   ```ts
+   import type { Issue, RoutingUseCase } from '@harness-engineering/types';
+   import { artifactPresenceFromIssue, detectScopeTier } from '../core/escalation-gate';
+   import { triageIssue } from '../core/triage-router';
+   import { resolveSkillForTriage } from './triage-skill-mapping';
+   import type { SkillCatalogEntry } from '../workflow/skill-catalog';
+
+   /**
+    * Spec B Phase 3: construct a {@link RoutingUseCase} from a dispatch
+    * request. Replaces the Phase-2-era `useCaseForBackendParam` (which
+    * only emitted `kind: 'tier'`) so per-skill / per-mode routing can fire
+    * at the orchestrator dispatch site (F1/F2).
+    *
+    * Resolution semantics:
+    *  - `backendParam === 'local'` → `{ kind: 'tier', tier: 'quick-fix' }`
+    *    (preserves the legacy local-dispatch convention; ad-hoc dashboard
+    *    dispatch consults this branch — see orchestrator.dispatchAdHoc).
+    *  - Otherwise: triage the issue, attempt catalog mapping. On match,
+    *    emit `{ kind: 'skill', skillName, cognitiveMode? }`. On miss,
+    *    fall back to the issue's scope-tier (F11 / N2).
+    *
+    * Pure function; takes the catalog as a parameter so the construction
+    * site is unit-testable without instantiating an Orchestrator.
+    */
+   export function buildRoutingUseCase(
+     issue: Issue,
+     backendParam: 'local' | 'primary' | undefined,
+     catalog: readonly SkillCatalogEntry[]
+   ): RoutingUseCase {
+     if (backendParam === 'local') return { kind: 'tier', tier: 'quick-fix' };
+
+     // Triage with no extra signals — the orchestrator does not derive
+     // diff-level signals at this point in the flow. Title-prefix +
+     // labels are enough to drive the catalog lookup; Phase 4+ may
+     // enrich with diff signals if richer routing is needed.
+     const decision = triageIssue(issue, {});
+     const resolved = resolveSkillForTriage(decision.skill, catalog);
+     if (resolved) {
+       return resolved.cognitiveMode !== undefined
+         ? { kind: 'skill', skillName: resolved.name, cognitiveMode: resolved.cognitiveMode }
+         : { kind: 'skill', skillName: resolved.name };
+     }
+
+     const tier = detectScopeTier(issue, artifactPresenceFromIssue(issue));
+     return { kind: 'tier', tier };
+   }
+   ```
+
+2. In `orchestrator.ts`, **delete** the module-level `useCaseForBackendParam` function (lines 82-102) and at the **dispatch site** (around line 1372 in `dispatchIssue`):
+   ```ts
+   // BEFORE
+   const useCase = useCaseForBackendParam(issue, backend);
+   // AFTER (Spec B Phase 3)
+   const useCase = buildRoutingUseCase(issue, backend, this.skillCatalog);
+   ```
+3. Add the import at the top:
+   ```ts
+   import { buildRoutingUseCase } from './agent/use-case-builder';
+   ```
+4. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- agent/use-case-construction.test.ts 2>&1 | tail -20
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -5
+   pnpm --filter @harness-engineering/orchestrator test -- integration/orchestrator.test.ts 2>&1 | tail -10
+   ```
+5. **Observe:** new unit tests green; typecheck green; existing integration tests still pass (catalog empty in test fixtures → falls back to `kind: 'tier'`, preserves N1/N2).
+6. Run `harness validate`. Commit:
+   ```
+   git add packages/orchestrator/src/agent/use-case-builder.ts \
+           packages/orchestrator/src/orchestrator.ts \
+           packages/orchestrator/tests/agent/use-case-construction.test.ts
+   git commit -m "feat(orchestrator): construct { kind: 'skill', skillName, cognitiveMode } at dispatch (Spec B Phase 3)"
+   ```
+
+---
+
+### Task 8: TDD — `OrchestratorBackendFactory` accepts `invocationOverride` (failing test)
+
+**Depends on:** Task 7
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts`
+
+1. Read the existing test file to learn its style:
+   ```
+   wc -l /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
+   ```
+2. Append a new `describe('invocationOverride (Spec B Phase 3)')` block with two tests:
+   - `'resolveName({ kind: tier, tier: quick-fix }, { invocationOverride: claude }) returns claude when claude is in backends'`
+   - `'forUseCase forwards invocationOverride to the router and materializes the named backend'`
+3. Build a fixture with two backends (e.g., `local-fast: { type: local, endpoint: ... }`, `claude: { type: anthropic, model: ... }`) and a routing config whose default points at `local-fast`. Assert that calling `factory.resolveName({ kind: 'tier', tier: 'quick-fix' }, { invocationOverride: 'claude' })` returns `'claude'`.
+4. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- agent/orchestrator-backend-factory.test.ts 2>&1 | tail -30
+   ```
+5. **Observe:** new tests fail because `resolveName` and `forUseCase` don't yet accept `opts`. **Do not commit.**
+
+---
+
+### Task 9: Implement `invocationOverride` pass-through on `OrchestratorBackendFactory`
+
+**Depends on:** Task 8
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/orchestrator-backend-factory.ts`
+
+1. Update the two methods to forward an optional `opts.invocationOverride`:
+
+   ```ts
+   resolveName(useCase: RoutingUseCase, opts?: { invocationOverride?: string }): string {
+     return this.router.resolve(useCase, opts).backendName;
+   }
+
+   forUseCase(useCase: RoutingUseCase, opts?: { invocationOverride?: string }): AgentBackend {
+     const def = this.router.resolveDefinition(useCase, opts);
+     const name = this.router.resolve(useCase, opts).backendName;
+     // ... rest unchanged
+   }
+   ```
+
+2. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- agent/orchestrator-backend-factory.test.ts 2>&1 | tail -20
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -5
+   ```
+3. **Observe:** new tests green; existing tests pass (the new `opts` is optional).
+4. Run `harness validate`. Commit:
+   ```
+   git add packages/orchestrator/src/agent/orchestrator-backend-factory.ts \
+           packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
+   git commit -m "feat(orchestrator): thread invocationOverride through OrchestratorBackendFactory (Spec B Phase 3)"
+   ```
+
+---
+
+### Task 10: `dispatchIssue` reads `HARNESS_BACKEND_OVERRIDE` env hint and threads it
+
+**Depends on:** Task 9
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts`
+
+1. Inside `dispatchIssue`, **immediately after** the `useCase = buildRoutingUseCase(...)` line (which Task 7 added at ~line 1372), insert:
+   ```ts
+   // Spec B Phase 3 (D7 / F4): one-shot invocation override via env hint.
+   // `harness skill run <name> --backend <name>` emits a preamble that
+   // exports HARNESS_BACKEND_OVERRIDE; this branch picks it up at the
+   // single dispatch about to follow, then the orchestrator continues
+   // routing normally for subsequent dispatches.
+   const invocationOverride = process.env.HARNESS_BACKEND_OVERRIDE;
+   const routerOpts = invocationOverride ? { invocationOverride } : undefined;
+   ```
+2. Update the three router calls below to pass `routerOpts`:
+   ```ts
+   // 5. Resolve the routed backend NAME up front
+   routedBackendName = this.backendFactory.resolveName(useCase, routerOpts);
+   // ...
+   // build the per-dispatch AgentBackend
+   agentBackend = this.backendFactory.forUseCase(useCase, routerOpts);
+   ```
+3. Add a single structured log line when `invocationOverride` is set so operators can see the override in action:
+   ```ts
+   if (invocationOverride) {
+     this.logger.info(
+       `Spec B Phase 3: HARNESS_BACKEND_OVERRIDE='${invocationOverride}' taking effect for ${issue.identifier}`,
+       { issueId: issue.id }
+     );
+   }
+   ```
+4. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -5
+   pnpm --filter @harness-engineering/orchestrator test -- integration/orchestrator.test.ts 2>&1 | tail -10
+   ```
+5. **Observe:** typecheck green; existing tests pass (env var unset → behavior unchanged).
+6. Run `harness validate`. Commit:
+   ```
+   git add packages/orchestrator/src/orchestrator.ts
+   git commit -m "feat(orchestrator): thread HARNESS_BACKEND_OVERRIDE env hint as invocationOverride (Spec B Phase 3)"
+   ```
+
+---
+
+### Task 11: TDD — `harness skill run --backend` surfaces the hint in stdout (failing test)
+
+**Depends on:** Task 10
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/tests/commands/skill/run.test.ts` (CREATE — verify path; if `tests/commands/skill/` does not exist yet, create both dir and file)
+
+1. Verify the test layout:
+   ```
+   ls /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/tests/commands/skill/ 2>&1
+   ```
+   If the directory is absent, the harness CLI tests live elsewhere. Look at `packages/cli/tests/commands/` for layout convention and use the closest matching pattern (likely `packages/cli/tests/commands/skill/run.test.ts` or `packages/cli/tests/skill-run.test.ts`).
+2. Write the test using Commander's programmatic invocation pattern. The test sets up a tmp skills dir with a `harness-debugging` skill, then invokes the `run` command with `--backend local-fast`, and asserts that the captured stdout contains a recognizable hint string. Example:
+
+   ```ts
+   import { describe, expect, it, vi, beforeEach } from 'vitest';
+   import { createRunCommand } from '../../../src/commands/skill/run';
+   import * as fs from 'node:fs';
+   import * as os from 'node:os';
+   import * as path from 'node:path';
+
+   describe('harness skill run --backend (Spec B Phase 3)', () => {
+     it('emits a backend-override hint line for the orchestrator to pick up', async () => {
+       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'phase3-skill-run-'));
+       const skillsDir = path.join(tmp, 'agents', 'skills', 'claude-code', 'harness-debugging');
+       fs.mkdirSync(skillsDir, { recursive: true });
+       fs.writeFileSync(
+         path.join(skillsDir, 'skill.yaml'),
+         'name: harness-debugging\nversion: 1.0.0\ndescription: x\ntriggers: []\nplatforms: []\ntools: []\ntype: rigid\n'
+       );
+       fs.writeFileSync(path.join(skillsDir, 'SKILL.md'), '# Harness Debugging\nbody\n');
+       process.env.HARNESS_SKILLS_DIR = path.dirname(path.dirname(skillsDir));
+       const writes: string[] = [];
+       const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+         writes.push(String(chunk));
+         return true;
+       });
+       const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+       const cmd = createRunCommand();
+       await cmd.parseAsync(['node', 'run', 'harness-debugging', '--backend', 'local-fast']);
+       const output = writes.join('');
+       expect(output).toMatch(/HARNESS_BACKEND_OVERRIDE=local-fast/);
+       writeSpy.mockRestore();
+       exitSpy.mockRestore();
+     });
+   });
+   ```
+
+3. Run:
+   ```
+   pnpm --filter @harness-engineering/cli test -- commands/skill/run.test.ts 2>&1 | tail -20
+   ```
+4. **Observe:** the test fails — either the `--backend` flag is not declared (Commander errors) or the output does not contain the hint. **Do not commit.**
+
+---
+
+### Task 12: Implement `--backend <name>` flag on `harness skill run`
+
+**Depends on:** Task 11
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/cli/src/commands/skill/run.ts`
+
+1. Update `createRunCommand` to declare the flag, and update `runSkill` to surface the hint. The minimum diff:
+   ```ts
+   // In createRunCommand():
+   .option('--backend <name>', 'Spec B: one-shot routing override forwarded to the orchestrator as HARNESS_BACKEND_OVERRIDE')
+   ```
+2. In `runSkill`, after building `content` and before `process.stdout.write(preamble + content)`:
+   ```ts
+   // Spec B Phase 3 (D7 / F4): emit a recognizable hint line ahead of
+   // the preamble so an operator running `harness skill run X --backend Y`
+   // can pipe the output to an evaluator that exports
+   // HARNESS_BACKEND_OVERRIDE=Y before the orchestrator picks up the
+   // next dispatch. The hint is a comment-shaped line so it does not
+   // perturb agent prompt rendering.
+   const overrideHint = opts.backend ? `<!-- HARNESS_BACKEND_OVERRIDE=${opts.backend} -->\n` : '';
+   process.stdout.write(overrideHint + preamble + content);
+   ```
+3. Update the `runSkill` parameter type to include `backend?: string`:
+   ```ts
+   opts: { path?: string; complexity?: string; phase?: string; party?: boolean; backend?: string }
+   ```
+4. Run:
+   ```
+   pnpm --filter @harness-engineering/cli test -- commands/skill/run.test.ts 2>&1 | tail -20
+   pnpm --filter @harness-engineering/cli typecheck 2>&1 | tail -5
+   ```
+5. **Observe:** test green; typecheck green.
+6. Run `harness validate`. Commit:
+   ```
+   git add packages/cli/src/commands/skill/run.ts \
+           packages/cli/tests/commands/skill/run.test.ts
+   git commit -m "feat(cli): add --backend flag to 'harness skill run' for Spec B invocation overrides (Phase 3)"
+   ```
+
+---
+
+### Task 13: F1+F2+F4+F11 integration test suite
+
+**Depends on:** Task 12
+**Files:**
+
+- `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/integration/spec-b-phase-3-dispatch-wiring.test.ts` (CREATE)
+
+This task pins the four Phase 3 success criteria end-to-end. It instantiates the `BackendRouter` + `OrchestratorBackendFactory` (full stack short of starting `Orchestrator`, which requires too many file-system fixtures) and exercises:
+
+1. **F1:** With `routing.skills['harness-debugging'] = 'local-fast'`, calling `factory.resolveName({ kind: 'skill', skillName: 'harness-debugging' })` returns `'local-fast'`.
+2. **F2:** With `routing.modes['adversarial-reviewer'] = 'local-fast'` and no per-skill override, calling `factory.resolveName({ kind: 'skill', skillName: 'harness-soundness-review', cognitiveMode: 'adversarial-reviewer' })` returns `'local-fast'`.
+3. **F4:** With `routing.default = 'claude-opus'`, calling `factory.resolveName({ kind: 'skill', skillName: 'harness-soundness-review' }, { invocationOverride: 'claude-sonnet' })` returns `'claude-sonnet'`.
+4. **F11:** With no `routing.skills` / `routing.modes` and a tier-only config, calling `buildRoutingUseCase(issue, undefined, [])` returns `{ kind: 'tier', tier }` and the factory resolves via the tier path — byte-identical to today.
+
+Test skeleton:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { OrchestratorBackendFactory } from '../../src/agent/orchestrator-backend-factory';
+import { buildRoutingUseCase } from '../../src/agent/use-case-builder';
+import type { BackendDef, Issue, RoutingConfig } from '@harness-engineering/types';
+
+const backends: Record<string, BackendDef> = {
+  'local-fast': { type: 'local', endpoint: 'http://localhost:1234/v1', model: 'qwen3:8b' },
+  'claude-opus': { type: 'anthropic', model: 'claude-opus-4-7' } as unknown as BackendDef,
+  'claude-sonnet': { type: 'anthropic', model: 'claude-sonnet-4-6' } as unknown as BackendDef,
+};
+
+function factory(routing: RoutingConfig): OrchestratorBackendFactory {
+  return new OrchestratorBackendFactory({
+    backends,
+    routing,
+    sandboxPolicy: 'none',
+  });
+}
+
+const issue = {
+  id: 'i-1',
+  identifier: 'i-1',
+  title: 'fix: small bug',
+  description: null,
+  priority: null,
+  state: 'planned',
+  branchName: null,
+  url: null,
+  labels: [],
+  blockedBy: [],
+  spec: null,
+  plans: [],
+  createdAt: '2026-05-25T00:00:00Z',
+  updatedAt: '2026-05-25T00:00:00Z',
+  externalId: null,
+} as unknown as Issue;
+
+describe('Spec B Phase 3 success criteria — dispatch-site wiring', () => {
+  it('F1: per-skill routing wins over tier when the skill is configured', () => {
+    const f = factory({
+      default: 'claude-opus',
+      skills: { 'harness-debugging': 'local-fast' },
+    });
+    expect(f.resolveName({ kind: 'skill', skillName: 'harness-debugging' })).toBe('local-fast');
+  });
+
+  it('F2: per-mode routing fires for kind:skill with cognitiveMode and no per-skill override', () => {
+    const f = factory({
+      default: 'claude-opus',
+      modes: { 'adversarial-reviewer': 'local-fast' },
+    });
+    expect(
+      f.resolveName({
+        kind: 'skill',
+        skillName: 'harness-soundness-review',
+        cognitiveMode: 'adversarial-reviewer',
+      })
+    ).toBe('local-fast');
+  });
+
+  it('F4: invocationOverride beats per-skill, per-mode, per-tier, and default', () => {
+    const f = factory({
+      default: 'claude-opus',
+      skills: { 'harness-soundness-review': 'local-fast' },
+      modes: { 'adversarial-reviewer': 'local-fast' },
+    });
+    expect(
+      f.resolveName(
+        {
+          kind: 'skill',
+          skillName: 'harness-soundness-review',
+          cognitiveMode: 'adversarial-reviewer',
+        },
+        { invocationOverride: 'claude-sonnet' }
+      )
+    ).toBe('claude-sonnet');
+  });
+
+  it('F11: skill without cognitive_mode and without per-skill entry falls through to tier/default', () => {
+    const useCase = buildRoutingUseCase(issue, undefined, []);
+    expect(useCase.kind).toBe('tier');
+    const f = factory({ default: 'claude-opus' });
+    expect(f.resolveName(useCase)).toBe('claude-opus');
+  });
+
+  it('F11 (catalog non-empty, skill cataloged but no per-skill route): still falls through', () => {
+    const useCase = buildRoutingUseCase(issue, undefined, [
+      { name: 'harness-code-review' }, // no cognitiveMode
+    ]);
+    expect(useCase).toEqual({ kind: 'skill', skillName: 'harness-code-review' });
+    const f = factory({ default: 'claude-opus' });
+    // no routing.skills / routing.modes → falls through to default
+    expect(f.resolveName(useCase)).toBe('claude-opus');
+  });
+});
+```
+
+1. Create the file.
+2. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test -- integration/spec-b-phase-3-dispatch-wiring.test.ts 2>&1 | tail -30
+   ```
+3. **Observe:** all 5 tests green. (If `BackendDef` for the `anthropic` type requires more fields, expand the fixture per `packages/types/src/orchestrator.ts` — use minimum fields the discriminated union demands. The `as unknown as BackendDef` casts above are intentional; tighten once a quick `grep BackendDef` reveals the exact shape.)
+4. Run:
+   ```
+   pnpm --filter @harness-engineering/orchestrator test 2>&1 | tail -15
+   ```
+5. **Observe:** the full orchestrator test suite passes (N1 confirmed); only the known pre-existing better-sqlite3 ABI failures remain (out-of-scope, see Phase 2 advisory).
+6. Run `harness validate`. Commit:
+   ```
+   git add packages/orchestrator/tests/integration/spec-b-phase-3-dispatch-wiring.test.ts
+   git commit -m "test(orchestrator): pin Spec B Phase 3 acceptance criteria (F1+F2+F4+F11)"
+   ```
+
+---
+
+### Task 14: Regen plugin manifests + final validation + barrels [checkpoint:human-verify]
+
+**Depends on:** Task 13
+**Files:**
+
+- Plugin manifests under `packages/cli/src/integrations/` (regen target paths)
+- Barrels under `packages/orchestrator/src/index.ts` (regen target)
+
+1. Run barrel regeneration **only for the orchestrator** to publish the new `discoverSkillCatalog`/`SkillCatalogEntry`/`buildRoutingUseCase`/`resolveSkillForTriage` exports:
+   ```
+   pnpm generate:barrels 2>&1 | tail -10
+   git status --short
+   ```
+2. **Manual review** (this is the checkpoint): inspect the barrel diff. Stage **only** the in-scope additions; revert unrelated cross-package drift per the Phase 0/2 precedent (operator advisories on prior phases call this out). If the diff is purely additive and in-scope, accept all.
+3. Regen plugin manifests so `--backend` appears in Claude / Cursor / Gemini / Codex skill-run slash commands:
+   ```
+   pnpm generate:plugin:all 2>&1 | tail -10
+   git status --short
+   ```
+4. Stage only the manifest changes that mention `--backend` on `skill/run`; revert unrelated drift.
+5. Run the final check battery:
+   ```
+   harness validate 2>&1 | tail -5
+   harness check-deps 2>&1 | tail -5
+   pnpm --filter @harness-engineering/orchestrator typecheck 2>&1 | tail -5
+   pnpm --filter @harness-engineering/cli typecheck 2>&1 | tail -5
+   pnpm --filter @harness-engineering/orchestrator test -- integration/spec-b-phase-3-dispatch-wiring.test.ts 2>&1 | tail -10
+   ```
+6. **Operator review point:** confirm F1+F2+F4+F11 all pass and no Phase-2-side regressions appear. If green, commit:
+   ```
+   git add <only the in-scope barrel + manifest paths>
+   git commit -m "chore(barrels,plugins): regenerate for Spec B Phase 3 dispatch-wiring exports"
+   ```
+7. Print a short summary:
+   ```
+   git log --oneline acb6e8c1..HEAD
+   ```
+
+---
+
+## Sequencing & Parallel Opportunities
+
+- **Strictly sequential:** Tasks 1→2 (skill-catalog), then 3→4 (triage mapping), then 5 (Orchestrator wiring), then 6→7 (use-case builder + dispatchIssue refactor), then 8→9 (factory invocationOverride), then 10 (env-hint plumbing), then 11→12 (CLI flag), then 13 (integration tests), then 14 (regen + validation).
+- **Parallelizable** (if multiple agents): Tasks 1-2 and Tasks 11-12 do not share files — could run in parallel. All other tasks have shared-file dependencies in `orchestrator.ts`.
+- **No task touches more than 3 files.** Task 7 touches 3 files (use-case-builder.ts, orchestrator.ts, the test file from Task 6); on the boundary, acceptable.
+
+---
+
+## Phase 3 Out-of-Scope Reminders (deferred to Phase 4+)
+
+- P1-IMP-1: `IntelligenceFactoryDeps` interface split — Phase 4
+- P1-IMP-2: `forUseCase` double-resolve comment — Phase 4
+- P1-IMP-3: silent intelligence-pipeline drop when `backendFactory` null — Phase 4
+- `RoutingDecisionBus` + event emission — Phase 4
+- HTTP routes (`/api/v1/routing/*`) + WS topic — Phase 5
+- `harness routing trace / decisions / config` CLI command group — Phase 6
+- Dashboard `/routing` panel — Phase 7
+- ADRs + knowledge graph + docs — Phase 8
+- Adding a real `harness dispatch` CLI command (currently does not exist; spec asked us to "find or verify") — out of scope; flag for Spec B follow-up if operator wants it
+
+---
+
+## Pre-execution Checklist (operator)
+
+- [ ] Approve C1 / Option A (triage-at-dispatch + `harness-${triageSkill}` naming convention)
+- [ ] Approve C4 (env-hint propagation `--backend` → `HARNESS_BACKEND_OVERRIDE` → orchestrator dispatch)
+- [ ] Confirm no `harness dispatch` CLI command is needed in Phase 3
+- [ ] Confirm baseline is `feat/spec-b-phase-1` @ `acb6e8c1` (Phase 2 tip)
+- [ ] Accept that `discoverSkillCatalogNames` is rewritten as a thin alias over `discoverSkillCatalog` (Phase 2 callers unaffected behaviorally)
+
+---
+
+## Verification Matrix (for handoff)
+
+| Criterion                    | How verified                                                                                                                       | Task                  |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| F1                           | Integration test asserts per-skill route wins over tier                                                                            | Task 13               |
+| F2                           | Integration test asserts per-mode route fires for `kind:'skill'` with `cognitiveMode`                                              | Task 13               |
+| F4                           | Integration test asserts `invocationOverride` beats all sources                                                                    | Task 13               |
+| F11                          | Unit test asserts buildRoutingUseCase falls back to `kind:'tier'`; integration test asserts factory resolves via `routing.default` | Tasks 6, 13           |
+| N1 (no regressions)          | `pnpm --filter @harness-engineering/orchestrator test` after every code-producing task                                             | Tasks 5, 7, 9, 10, 13 |
+| N2 (tier dispatch unchanged) | Existing `integration/orchestrator.test.ts` continues to pass                                                                      | Tasks 5, 7, 10        |
+| `harness validate`           | Run after every task; final task runs the full battery                                                                             | All tasks             |
+
+---
+
+## Gates
+
+- Every task fits in one context window (2-5 min focused) — confirmed.
+- Every task has exact file paths, exact code, exact test command.
+- Every code-producing task includes TDD (Tasks 1+2, 3+4, 6+7, 8+9, 11+12 are red→green pairs; Task 13 is the acceptance suite).
+- File map is complete.
+- Uncertainties surfaced (C1-C6) for operator weigh-in BEFORE execution.

--- a/docs/changes/granular-task-routing/plans/2026-05-25-phase-4-decision-bus-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-25-phase-4-decision-bus-plan.md
@@ -1,0 +1,1241 @@
+# Plan: Spec B Phase 4 — RoutingDecisionBus + Event Emission
+
+**Date:** 2026-05-25
+**Spec:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/docs/changes/granular-task-routing/proposal.md`
+**Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1`
+**Branch:** `feat/spec-b-phase-1` (HEAD `cf36696f`, Phase 3 tip — Phase 2 tip `acb6e8c1`, Phase 1 tip `2786211a`)
+**Phase 4 scope:** ~2 days, medium complexity
+**Tasks:** 14
+**Estimated time:** ~62 min of focused work (1 context window per task)
+**Integration Tier:** medium
+**Phase 4 success criteria:** O1 + S5 + S6 pass; close P1-IMP-1 + P1-IMP-2 + P1-IMP-3 + I1 third instance
+
+---
+
+## Goal
+
+Every `BackendRouter.resolve()` call produces a `RoutingDecision` event surfaced on a new in-process bus (`RoutingDecisionBus`) with a per-orchestrator in-memory ring buffer (default capacity 500). The orchestrator instantiates the bus at startup, wires it into `BackendRouter` via constructor injection, and the bus is teardown-safe on `Orchestrator.stop()`. Alongside the bus, four Phase 1 deferred findings close: (1) `IntelligenceFactoryDeps` is split so `buildAnalysisProviderForLayer` no longer carries an unused-but-required `router` field; (2) `OrchestratorBackendFactory.forUseCase` resolves once (not twice) and reuses the threaded decision — critical now that each `resolve()` emits; (3) the silent `intelligence-pipeline` drop when `backendFactory === null` becomes a `warn()` log; (4) the I1 third instance — `resolveRoutedBackend`'s inline `Array.isArray` normalization in `intelligence-factory.ts:135-159` — is replaced with the router-driven path so the legacy chain shim disappears.
+
+---
+
+## Observable Truths (Acceptance Criteria)
+
+1. **EARS — Event-driven (O1):** When `BackendRouter.resolve(useCase)` returns a decision, the system shall emit a structured log line `routing-decision` at `info` level whose context object includes `useCase`, `backendName`, `resolutionPathLength`, and `durationMs` (verified by spying on `StructuredLogger.info`).
+2. **EARS — Event-driven (S5):** When 10 000 decisions are emitted into a `RoutingDecisionBus` with `capacity = 500`, `recent({ limit: 99999 })` shall return at most 500 records, ordered oldest→newest, with the first 9 500 dropped (verified by unit test).
+3. **EARS — Unwanted (S6):** If a subscriber callback throws, then `RoutingDecisionBus.emit(...)` shall not propagate the error; the throwing subscriber's error shall be logged once (warn) and the remaining subscribers shall still receive the decision (verified by unit test).
+4. **EARS — Ubiquitous:** `OrchestratorBackendFactory.forUseCase(useCase, opts)` shall call `router.resolve(useCase, opts)` exactly **once** per dispatch; the returned `RoutingDecision.backendName` shall be used both for `resolveDefinition`-style backend materialization and for the optional resolver binding lookup. Verified by spying on `router.resolve` and asserting `callCount === 1`.
+5. **EARS — Ubiquitous:** `IntelligenceFactoryDeps` shall be split: `BuildPipelineDeps` (used by `buildIntelligencePipeline`) carries the `router`; `BuildLayerDeps` (used by `buildAnalysisProviderForLayer`) does not. Existing call site in `intelligence-pipeline-routing.test.ts:74-78` shall typecheck without a `router` field present.
+6. **EARS — Event-driven (P1-IMP-3):** When `createIntelligencePipeline()` returns `null` because `backendFactory === null`, the system shall emit `logger.warn('intelligence pipeline disabled: no backendFactory available (legacy config without agent.backends)')` at startup.
+7. **EARS — Unwanted (I1 third instance):** The inline `Array.isArray(layerValue)` / `Array.isArray(routing.default)` chain normalization in `intelligence-factory.ts:135-159` shall not exist after this phase; `resolveRoutedBackend` shall delegate to the canonical router (or be removed entirely if the routing-driven branch can call `router.resolve({ kind: 'intelligence', layer })`).
+8. **EARS — State-driven:** While `Orchestrator` is running between `start()` and `stop()`, `routingDecisionBus.recent()` shall return the decisions emitted during that window; after `stop()`, the listener set shall be cleared and the buffer eligible for GC.
+9. **EARS — Ubiquitous (N1):** All existing `BackendRouter` tests (`backend-router.test.ts`, `backend-router-chain-walk.test.ts`) shall pass unchanged. `orchestrator-backend-factory.test.ts` (9 tests) shall pass unchanged or with mechanical updates accounting for the single-resolve refactor.
+10. **EARS — Ubiquitous:** `harness validate`, `harness check-deps`, `pnpm --filter @harness-engineering/orchestrator typecheck`, and the new Phase 4 acceptance test file shall pass.
+11. **EARS — Ubiquitous:** A new acceptance test file at `packages/orchestrator/tests/integration/spec-b-phase-4-decision-bus.test.ts` shall pin O1, S5, S6, and the single-resolve invariant across at least 5 passing tests.
+
+---
+
+## Uncertainties / Concerns for Operator Sign-Off
+
+| #   | Class         | Concern                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| C1  | BLOCKING-LITE | **Bus injection shape:** Two options. **A (planner default):** `BackendRouter` ctor gains an optional `decisionBus?: RoutingDecisionBus`; `resolve()` calls `decisionBus?.emit(decision)` after deciding. Pros: minimal blast radius, router stays self-contained, tests can omit the bus. Cons: every test that constructs `BackendRouter` directly needs decoration to assert emission. **B:** A `RoutingDecisionEmitter` interface (`emit(decision): void`) injected via ctor; bus implements it. Pros: thinner contract, easier to fake. Cons: extra type for a one-method protocol. Plan defaults to **A** — the bus class is already small enough to mock without an interface seam.                                                                                                                                                 |
+| C2  | BLOCKING-LITE | **`forUseCase` refactor: single-resolve approach.** Today `forUseCase` calls `resolveDefinition()` then `resolve()` again (orchestrator-backend-factory.ts:112-113). Plan refactors to: `const decision = router.resolve(useCase, opts); const def = backends[decision.backendName]`. Requires either (a) exposing `backends` as a read accessor on `BackendRouter` (planner default — small public surface widening, already done with `getRouter()`), or (b) adding `BackendRouter.resolveDecisionAndDef(useCase, opts): { decision, def }`. Plan defaults to **(b)** — adds one method, keeps `backends` private. Confirms with the operator before execution.                                                                                                                                                                          |
+| C3  | BLOCKING-LITE | **I1 third instance — replace vs remove `resolveRoutedBackend`.** The helper at `intelligence-factory.ts:135-159` exists because `buildAnalysisProviderForLayer` needs the BackendDef (not just name) to translate to an AnalysisProvider, and the legacy path read directly from config. **Option X (planner default):** Rewrite `resolveRoutedBackend` to call `router.resolve({ kind: 'intelligence', layer })` and look up `def` from the router's exposed backends (via a new `BackendRouter.getDef(name): BackendDef \| undefined` accessor). Removes the dual normalization path entirely. **Option Y:** Delete `resolveRoutedBackend`, inline the router call in `buildAnalysisProviderForLayer`. Plan defaults to **X** — keeps the helper as a named seam for tests and future intelligence-routing concerns. Operator confirms. |
+| C4  | ASSUMPTION    | **Ring buffer is `Array.shift()`-based, not a true circular buffer.** Capacity 500 with O(n) shift is fine for v1; if 24h dispatch volume ever pushes 10K+ records/min, a circular-index implementation is the natural follow-up. Plan documents this in the source comment + leaves a TODO marker that the dashboard/perf phases can revisit. Operator may override.                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| C5  | ASSUMPTION    | **Capacity is hardcoded `500` in v1.** Spec D8 says "default 500, configurable" — making it configurable means widening `RoutingConfig` or `WorkflowConfig`. Plan **defers configurability** (no schema change) to Phase 5/6 when HTTP/CLI surfaces are added; v1 ships with `default = 500` and a constructor argument so future wire-up is trivial. Operator confirms.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| C6  | ASSUMPTION    | **Logger emission strategy.** O1 says "every dispatch logs a single structured `routing-decision` event." Plan emits the log line **inside `RoutingDecisionBus.emit(...)`** (so the bus owns both ring-buffer write + log emission), with the logger injected via the bus constructor. Alternative: emit from `BackendRouter.resolve()` directly, before passing to the bus. Plan picks bus-owned because (a) it keeps `BackendRouter` logger-free (already a pure function modulo emission), and (b) any future subscriber that wants to suppress logging can pass a `noopLogger` to the bus. Operator confirms.                                                                                                                                                                                                                          |
+| C7  | DEFERRABLE    | **`createIntelligencePipeline` warn() wording.** Plan defaults to `intelligence pipeline disabled: no backendFactory available (legacy config without agent.backends)`. Operator may tweak before execution.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| C8  | DEFERRABLE    | **Test file naming.** `spec-b-phase-4-decision-bus.test.ts` matches Phase 3 convention (`spec-b-phase-3-dispatch-wiring.test.ts`). The decision-bus unit tests live separately at `packages/orchestrator/tests/routing/decision-bus.test.ts` (new directory). Operator may collapse.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+
+**Decision points the operator should confirm before execution:**
+
+- **D-OP-1 (C1):** **Approve Option A** — `BackendRouter` ctor gains optional `decisionBus?: RoutingDecisionBus`. If reject (prefer interface seam): swap Tasks 3-4 to declare a `RoutingDecisionEmitter` interface and inject that instead.
+- **D-OP-2 (C2):** **Approve adding `BackendRouter.resolveDecisionAndDef(useCase, opts)`** as the single-resolve seam. If reject (prefer expose `backends` accessor): rewrite Task 6 to add `BackendRouter.getDef(name)` and have `forUseCase` look up the def directly from the threaded decision.
+- **D-OP-3 (C3):** **Approve Option X** — rewrite `resolveRoutedBackend` to delegate to `router.resolve`. If reject (prefer Option Y / inline): drop Task 9 and inline the router call in `buildAnalysisProviderForLayer`.
+- **D-OP-4 (C5):** **Approve hardcoded capacity=500 for v1** (configurable in Phase 5/6). If reject: Task 3 adds capacity reading from `WorkflowConfig.routing.decisionBuffer.capacity ?? 500` and Phase 4 ships a tiny schema delta.
+- **D-OP-5 (C6):** **Approve bus-owned log emission.** If reject: shift the `logger.info('routing-decision', ...)` call out of `RoutingDecisionBus` into `BackendRouter.resolve()` and inject the logger into `BackendRouter` instead.
+
+---
+
+## File Map
+
+```
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/routing/decision-bus.ts
+        # RoutingDecisionBus class: emit(), recent(filter?), subscribe(listener), capacity bound, owned log emission
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/routing/index.ts
+        # barrel for the new routing/ folder — exports RoutingDecisionBus
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/routing/decision-bus.test.ts
+        # unit tests: capacity bound (S5), subscriber isolation (S6), structured log line on emit (O1),
+        # filter semantics for recent(), unsubscribe returned by subscribe()
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/backend-router.ts
+        # 1. ctor accepts opts.decisionBus?: RoutingDecisionBus
+        # 2. resolve() invokes decisionBus.emit(decision) after constructing the decision (non-throwing path)
+        # 3. NEW: resolveDecisionAndDef(useCase, opts): { decision, def } — single-resolve seam
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/backend-router.test.ts
+        # add tests: decisionBus.emit called once per resolve; resolveDecisionAndDef returns matching pair
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
+        # 1. ctor accepts opts.decisionBus and threads to BackendRouter ctor
+        # 2. forUseCase rewritten to single-resolve via router.resolveDecisionAndDef (closes P1-IMP-2)
+        # 3. remove the misleading "two resolve() calls yield identical decisions" comment
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
+        # add: spy asserts router.resolve called exactly once per forUseCase
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/agent/intelligence-factory.ts
+        # 1. Split IntelligenceFactoryDeps -> BuildPipelineDeps (with router) and BuildLayerDeps (without)
+        #    (closes P1-IMP-1)
+        # 2. Rewrite resolveRoutedBackend to delegate to router.resolve({ kind: 'intelligence', layer })
+        #    (closes I1 third instance) — requires router in BuildLayerDeps OR moves layer-build into
+        #    pipeline build (planner default: move helper to take router-bearing deps)
+        # 3. buildIntelligencePipeline keeps router; buildAnalysisProviderForLayer accepts router too
+        #    but its DEPS TYPE no longer claims router is unconditionally required for the
+        #    intelligence.provider-explicit branch — the type is now Omit<..., 'router'> & {
+        #    router?: BackendRouter } and the routing-driven branch asserts router presence
+        #
+        # CONFIRMED ARRANGEMENT (operator may swap C3 → Option Y):
+        # - BuildPipelineDeps = { config, localResolvers, logger, router }
+        # - BuildLayerDeps    = { config, localResolvers, logger, router? }
+        # - buildAnalysisProviderForLayer's routing-driven branch throws (or returns null + warns) if
+        #   router is missing AND intel.provider is unset
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/integration/intelligence-pipeline-routing.test.ts
+        # update callCreateAnalysisProvider helper to pass router (or to use BuildLayerDeps without router
+        # for the intel.provider-explicit branch); add a test for the chain-dedupe case (intel.sel = chain,
+        # intel.pesl = chain that resolves to same backend → one provider)
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts
+        # 1. private routingDecisionBus: RoutingDecisionBus | null = null;
+        # 2. construct bus when backendFactory is constructed (same gate)
+        # 3. thread bus into OrchestratorBackendFactory ctor
+        # 4. start(): no extra wiring beyond construction (subscribers added in Phase 5+)
+        # 5. stop(): null out bus, clear listeners (defensive teardown)
+        # 6. createIntelligencePipeline(): when returning null due to backendFactory===null,
+        #    call this.logger.warn(...) once (closes P1-IMP-3)
+        # 7. expose getter routingDecisionBus for Phase 5 (HTTP/WS) consumption
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/integration/spec-b-phase-4-decision-bus.test.ts
+        # Phase 4 acceptance:
+        # - Orchestrator.start() produces a non-null bus
+        # - a dispatch's resolve() shows up in bus.recent()
+        # - O1 log line present (mock logger.info)
+        # - single-resolve invariant (router.resolve called once per dispatch)
+        # - subscriber isolation under emission storm
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/index.ts (optional, only if barrel exports are added)
+        # re-export RoutingDecisionBus from the new routing/ module
+```
+
+**Files NOT modified (out of scope per spec):**
+
+- HTTP route files (`packages/orchestrator/src/server/routes/*`) — Phase 5
+- CLI `routing` command group (`packages/cli/src/commands/routing/*`) — Phase 6
+- Dashboard `/routing` route — Phase 7
+- ADR files, `docs/knowledge/orchestrator/*`, `AGENTS.md`, `CHANGELOG.md` — Phase 8
+
+---
+
+## Skill Annotations
+
+Skills with relevance to Phase 4 tasks (from `docs/changes/granular-task-routing/SKILLS.md`):
+
+- `gof-chain-of-responsibility` (reference): the resolution chain is the canonical chain-of-responsibility pattern; informs Task 3 ring-buffer semantics where the bus is a sink, not a chain link.
+- `ts-type-guards` (reference): Task 7 (`IntelligenceFactoryDeps` split) benefits from type-guard patterns where the routing-driven branch narrows `router !== undefined`.
+- `ts-error-handling-types` (reference): Task 3 (`emit()` subscriber isolation) — try/catch contract + logged failure.
+- `gof-factory-method` (reference): Task 5 (`OrchestratorBackendFactory` refactor) is a factory; single-resolve invariant tightens the factory's invariant set.
+
+---
+
+## Tasks
+
+Each task is one context window of focused work and produces one atomic commit. Numbering is sequential and dependencies are explicit. Worktree-absolute paths throughout. TDD style: write test → observe failure → implement → observe pass → validate → commit.
+
+---
+
+### Task 1: Define RoutingDecisionBus + barrel (types only, no behavior)
+
+**Depends on:** none | **Files:** `packages/orchestrator/src/routing/decision-bus.ts`, `packages/orchestrator/src/routing/index.ts`
+
+**Skills:** `gof-chain-of-responsibility` (reference)
+
+1. Create directory `packages/orchestrator/src/routing/`.
+2. Create `packages/orchestrator/src/routing/decision-bus.ts` with the class shell (no method bodies beyond stubs that throw `not yet implemented` — Task 3 fills them):
+
+   ```ts
+   import type { RoutingDecision } from '@harness-engineering/types';
+   import type { StructuredLogger } from '../logging/logger.js';
+
+   export interface RoutingDecisionBusFilter {
+     skillName?: string;
+     mode?: string;
+     backendName?: string;
+     limit?: number;
+   }
+
+   export interface RoutingDecisionBusOptions {
+     /** Default 500. Bound on the in-memory ring buffer. */
+     capacity?: number;
+     /**
+      * Logger for the structured `routing-decision` line (O1) and for
+      * one-off warn() when a subscriber throws (S6). When omitted, the
+      * bus silently swallows subscriber errors (test-mode default).
+      */
+     logger?: StructuredLogger;
+   }
+
+   /**
+    * Spec B Phase 4 (D8): in-process bus + ring buffer for
+    * {@link RoutingDecision} events. One emit() per
+    * {@link BackendRouter.resolve} call; subscribers receive the
+    * decision synchronously after the ring buffer is updated.
+    *
+    * Subscriber errors are isolated (caught + logged, never thrown
+    * back to the emitter) so a misbehaving subscriber cannot block a
+    * dispatch. (S6)
+    *
+    * Capacity-bound (default 500) via Array.shift() — acceptable for
+    * v1 (see plan C4); switch to circular indexing if 24h dispatch
+    * volume ever pushes 10K+ records/min.
+    */
+   export class RoutingDecisionBus {
+     private readonly ringBuffer: RoutingDecision[] = [];
+     private readonly listeners = new Set<(d: RoutingDecision) => void>();
+     private readonly capacity: number;
+     private readonly logger: StructuredLogger | undefined;
+
+     constructor(opts?: RoutingDecisionBusOptions) {
+       this.capacity = opts?.capacity ?? 500;
+       this.logger = opts?.logger;
+     }
+
+     emit(_decision: RoutingDecision): void {
+       throw new Error('RoutingDecisionBus.emit not yet implemented (Task 3)');
+     }
+
+     recent(_filter?: RoutingDecisionBusFilter): RoutingDecision[] {
+       throw new Error('RoutingDecisionBus.recent not yet implemented (Task 3)');
+     }
+
+     subscribe(_listener: (d: RoutingDecision) => void): () => void {
+       throw new Error('RoutingDecisionBus.subscribe not yet implemented (Task 3)');
+     }
+   }
+   ```
+
+3. Create `packages/orchestrator/src/routing/index.ts`:
+   ```ts
+   export {
+     RoutingDecisionBus,
+     type RoutingDecisionBusFilter,
+     type RoutingDecisionBusOptions,
+   } from './decision-bus.js';
+   ```
+4. Verify: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck` → PASS (stubs compile, no consumers yet).
+5. Run `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate` → PASS.
+6. Commit (worktree-rooted git):
+   ```
+   feat(orchestrator): scaffold RoutingDecisionBus class shell (Spec B Phase 4)
+   ```
+
+---
+
+### Task 2: Test-first — RoutingDecisionBus unit tests (RED phase)
+
+**Depends on:** Task 1 | **Files:** `packages/orchestrator/tests/routing/decision-bus.test.ts`
+
+**Skills:** `ts-error-handling-types` (reference)
+
+1. Create directory `packages/orchestrator/tests/routing/`.
+2. Create `packages/orchestrator/tests/routing/decision-bus.test.ts`:
+
+   ```ts
+   import { describe, it, expect, vi } from 'vitest';
+   import { RoutingDecisionBus } from '../../src/routing/decision-bus.js';
+   import type { RoutingDecision } from '@harness-engineering/types';
+   import { StructuredLogger } from '../../src/logging/logger.js';
+
+   function makeDecision(overrides?: Partial<RoutingDecision>): RoutingDecision {
+     return {
+       timestamp: new Date().toISOString(),
+       useCase: { kind: 'tier', tier: 'quick-fix' },
+       resolutionPath: [{ source: 'default', candidate: 'cloud', outcome: 'chosen' }],
+       backendName: 'cloud',
+       backendType: 'claude',
+       durationMs: 0.1,
+       ...overrides,
+     };
+   }
+
+   describe('RoutingDecisionBus', () => {
+     it('S5: respects capacity bound — 10000 emits → recent() ≤ capacity', () => {
+       const bus = new RoutingDecisionBus({ capacity: 500 });
+       for (let i = 0; i < 10_000; i++) {
+         bus.emit(makeDecision({ backendName: `backend-${i}` }));
+       }
+       const recent = bus.recent({ limit: 99_999 });
+       expect(recent.length).toBeLessThanOrEqual(500);
+       // ring drops oldest: first surviving record is index 9500
+       expect(recent[0]?.backendName).toBe('backend-9500');
+       expect(recent[recent.length - 1]?.backendName).toBe('backend-9999');
+     });
+
+     it('S6: subscriber errors are isolated — other subscribers still receive', () => {
+       const logger = new StructuredLogger();
+       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+       const bus = new RoutingDecisionBus({ capacity: 10, logger });
+       const goodCalls: RoutingDecision[] = [];
+       bus.subscribe(() => {
+         throw new Error('subscriber boom');
+       });
+       bus.subscribe((d) => goodCalls.push(d));
+       expect(() => bus.emit(makeDecision())).not.toThrow();
+       expect(goodCalls).toHaveLength(1);
+       expect(warnSpy).toHaveBeenCalledWith(
+         expect.stringContaining('RoutingDecisionBus subscriber threw'),
+         expect.objectContaining({ error: expect.stringContaining('subscriber boom') })
+       );
+     });
+
+     it('O1: emits structured routing-decision log line per emit', () => {
+       const logger = new StructuredLogger();
+       const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {});
+       const bus = new RoutingDecisionBus({ capacity: 5, logger });
+       bus.emit(
+         makeDecision({
+           backendName: 'cloud',
+           durationMs: 1.23,
+           resolutionPath: [{ source: 'skill', candidate: 'cloud', outcome: 'chosen' }],
+         })
+       );
+       expect(infoSpy).toHaveBeenCalledWith(
+         'routing-decision',
+         expect.objectContaining({
+           backendName: 'cloud',
+           resolutionPathLength: 1,
+           durationMs: 1.23,
+           useCase: expect.objectContaining({ kind: 'tier' }),
+         })
+       );
+     });
+
+     it('recent() filters by skillName / mode / backendName / limit', () => {
+       const bus = new RoutingDecisionBus({ capacity: 20 });
+       bus.emit(
+         makeDecision({
+           useCase: { kind: 'skill', skillName: 'harness-debugging' },
+           backendName: 'local-fast',
+         })
+       );
+       bus.emit(
+         makeDecision({
+           useCase: { kind: 'mode', cognitiveMode: 'adversarial-reviewer' },
+           backendName: 'cloud',
+         })
+       );
+       bus.emit(makeDecision({ backendName: 'cloud' }));
+       expect(bus.recent({ skillName: 'harness-debugging' })).toHaveLength(1);
+       expect(bus.recent({ mode: 'adversarial-reviewer' })).toHaveLength(1);
+       expect(bus.recent({ backendName: 'cloud' })).toHaveLength(2);
+       expect(bus.recent({ limit: 2 })).toHaveLength(2);
+     });
+
+     it('subscribe() returns an unsubscribe function', () => {
+       const bus = new RoutingDecisionBus({ capacity: 5 });
+       const calls: RoutingDecision[] = [];
+       const off = bus.subscribe((d) => calls.push(d));
+       bus.emit(makeDecision());
+       off();
+       bus.emit(makeDecision());
+       expect(calls).toHaveLength(1);
+     });
+   });
+   ```
+
+3. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- routing/decision-bus.test.ts` — observe **all 5 failures** (stubs throw `not yet implemented`). Confirm RED.
+4. Commit:
+   ```
+   test(orchestrator): pin RoutingDecisionBus contract — capacity, isolation, log, filter, unsubscribe (Spec B Phase 4)
+   ```
+
+---
+
+### Task 3: Implement RoutingDecisionBus (GREEN phase)
+
+**Depends on:** Task 2 | **Files:** `packages/orchestrator/src/routing/decision-bus.ts`
+
+**Skills:** `ts-error-handling-types` (reference), `gof-chain-of-responsibility` (reference)
+
+1. Replace the three stubs in `packages/orchestrator/src/routing/decision-bus.ts` with implementations:
+
+   ```ts
+   emit(decision: RoutingDecision): void {
+     this.ringBuffer.push(decision);
+     if (this.ringBuffer.length > this.capacity) {
+       this.ringBuffer.shift();
+     }
+     // O1: one structured line per emit.
+     if (this.logger) {
+       this.logger.info('routing-decision', {
+         useCase: decision.useCase,
+         backendName: decision.backendName,
+         resolutionPathLength: decision.resolutionPath.length,
+         durationMs: decision.durationMs,
+       });
+     }
+     // S6: subscriber errors are caught + logged, never propagated.
+     for (const listener of this.listeners) {
+       try {
+         listener(decision);
+       } catch (err) {
+         if (this.logger) {
+           this.logger.warn('RoutingDecisionBus subscriber threw', {
+             error: String(err),
+           });
+         }
+       }
+     }
+   }
+
+   recent(filter?: RoutingDecisionBusFilter): RoutingDecision[] {
+     let out = this.ringBuffer.slice();
+     if (filter?.skillName !== undefined) {
+       out = out.filter(
+         (d) => d.useCase.kind === 'skill' && d.useCase.skillName === filter.skillName
+       );
+     }
+     if (filter?.mode !== undefined) {
+       out = out.filter(
+         (d) =>
+           (d.useCase.kind === 'mode' && d.useCase.cognitiveMode === filter.mode) ||
+           (d.useCase.kind === 'skill' && d.useCase.cognitiveMode === filter.mode)
+       );
+     }
+     if (filter?.backendName !== undefined) {
+       out = out.filter((d) => d.backendName === filter.backendName);
+     }
+     if (filter?.limit !== undefined) {
+       out = out.slice(0, filter.limit);
+     }
+     return out;
+   }
+
+   subscribe(listener: (d: RoutingDecision) => void): () => void {
+     this.listeners.add(listener);
+     return () => {
+       this.listeners.delete(listener);
+     };
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/orchestrator test -- routing/decision-bus.test.ts` — observe **5/5 PASS**. Confirm GREEN.
+3. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+4. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate` → PASS.
+5. Commit:
+   ```
+   feat(orchestrator): implement RoutingDecisionBus emit/recent/subscribe with subscriber isolation (Spec B Phase 4)
+   ```
+
+---
+
+### Task 4: Wire `BackendRouter` to optionally emit on resolve()
+
+**Depends on:** Task 3 | **Files:** `packages/orchestrator/src/agent/backend-router.ts`, `packages/orchestrator/tests/agent/backend-router.test.ts`
+
+**Skills:** `gof-chain-of-responsibility` (reference)
+
+1. Open `packages/orchestrator/src/agent/backend-router.ts`. Add import:
+   ```ts
+   import type { RoutingDecisionBus } from '../routing/decision-bus.js';
+   ```
+2. Widen `BackendRouterOptions`:
+   ```ts
+   export interface BackendRouterOptions {
+     backends: Record<string, BackendDef>;
+     routing: RoutingConfig;
+     /**
+      * Spec B Phase 4 (D8): when present, every resolve() emits its
+      * decision onto the bus. The bus owns the structured log line + ring
+      * buffer; the router stays a pure resolution function.
+      */
+     decisionBus?: RoutingDecisionBus;
+   }
+   ```
+3. Add private field + ctor assignment:
+
+   ```ts
+   private readonly decisionBus: RoutingDecisionBus | undefined;
+
+   constructor(opts: BackendRouterOptions) {
+     this.backends = opts.backends;
+     this.routing = opts.routing;
+     this.decisionBus = opts.decisionBus;
+     this.validateReferences();
+   }
+   ```
+
+4. In `resolve()`, wrap the existing return points so emission fires once before each return. Refactor the four return statements (one per source: invocation, skill, mode, tier, default) so they go through a single emit-on-return helper. The most surgical change is to wrap each `return decide(name)` call in a small lambda:
+
+   ```ts
+   const emitAndReturn = (decision: RoutingDecision): RoutingDecision => {
+     this.decisionBus?.emit(decision);
+     return decision;
+   };
+   ```
+
+   Then replace each `return decide(name);` with `return emitAndReturn(decide(name));`. **Do not** wrap the final throw at the end of `resolve()` — exhaustion is an error path, not a decision.
+
+5. Open `packages/orchestrator/tests/agent/backend-router.test.ts`. Add a new `describe` block at the end:
+
+   ```ts
+   describe('BackendRouter — decision bus emission (Spec B Phase 4)', () => {
+     it('emits exactly one decision per resolve() when a bus is provided', () => {
+       const bus = new RoutingDecisionBus({ capacity: 5 });
+       const emitSpy = vi.spyOn(bus, 'emit');
+       const router = new BackendRouter({
+         backends: { cloud, local },
+         routing: { default: 'cloud', 'quick-fix': 'local' },
+         decisionBus: bus,
+       });
+       router.resolve({ kind: 'tier', tier: 'quick-fix' });
+       router.resolve({ kind: 'tier', tier: 'guided-change' });
+       expect(emitSpy).toHaveBeenCalledTimes(2);
+       expect(bus.recent()).toHaveLength(2);
+     });
+
+     it('does not throw when no bus is provided (legacy ctor shape)', () => {
+       const router = new BackendRouter({
+         backends: { cloud, local },
+         routing: { default: 'cloud' },
+       });
+       expect(() => router.resolve({ kind: 'tier', tier: 'quick-fix' })).not.toThrow();
+     });
+   });
+   ```
+
+   Top-of-file imports add: `import { vi } from 'vitest'; import { RoutingDecisionBus } from '../../src/routing/decision-bus.js';`.
+
+6. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- agent/backend-router.test.ts` — observe all existing tests PASS + 2 new PASS.
+7. Run: `pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+8. Commit:
+   ```
+   feat(orchestrator): emit RoutingDecision on every BackendRouter.resolve when bus injected (Spec B Phase 4)
+   ```
+
+---
+
+### Task 5: Add `BackendRouter.resolveDecisionAndDef` single-resolve seam
+
+**Depends on:** Task 4 | **Files:** `packages/orchestrator/src/agent/backend-router.ts`, `packages/orchestrator/tests/agent/backend-router.test.ts`
+
+**Skills:** `gof-factory-method` (reference)
+
+1. Add a public method to `BackendRouter`:
+   ```ts
+   /**
+    * Spec B Phase 4 (closes P1-IMP-2): a single resolve() + def lookup
+    * for callers that need both. Replaces the previous pattern of
+    * `resolveDefinition(useCase) + resolve(useCase)` which produced two
+    * RoutingDecision emissions per dispatch — doubling routing-decision
+    * log volume now that Phase 4 emits.
+    *
+    * Identity-equal `BackendDef` (no copy) so callers relying on
+    * reference equality (SC21) continue to work.
+    */
+   resolveDecisionAndDef(
+     useCase: RoutingUseCase,
+     opts?: { invocationOverride?: string }
+   ): { decision: RoutingDecision; def: BackendDef } {
+     const decision = this.resolve(useCase, opts);
+     const def = this.backends[decision.backendName];
+     if (!def) {
+       // Unreachable: resolve() only returns a name present in backends.
+       throw new Error(
+         `BackendRouter.resolveDecisionAndDef: routing target '${decision.backendName}' is not in backends ` +
+           `(useCase=${JSON.stringify(useCase)}).`
+       );
+     }
+     return { decision, def };
+   }
+   ```
+2. Add unit test in `packages/orchestrator/tests/agent/backend-router.test.ts`:
+   ```ts
+   it('resolveDecisionAndDef: single resolve() call, returns matching decision+def', () => {
+     const bus = new RoutingDecisionBus({ capacity: 5 });
+     const router = new BackendRouter({
+       backends: { cloud, local },
+       routing: { default: 'cloud', 'quick-fix': 'local' },
+       decisionBus: bus,
+     });
+     const { decision, def } = router.resolveDecisionAndDef({
+       kind: 'tier',
+       tier: 'quick-fix',
+     });
+     expect(decision.backendName).toBe('local');
+     expect(def).toBe(local); // identity
+     expect(bus.recent()).toHaveLength(1); // one emit, not two
+   });
+   ```
+3. Run the test file — observe new test PASS.
+4. Run: `pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+5. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && harness validate` → PASS.
+6. Commit:
+   ```
+   feat(orchestrator): add BackendRouter.resolveDecisionAndDef single-resolve seam (Spec B Phase 4, closes P1-IMP-2 prep)
+   ```
+
+---
+
+### Task 6: Refactor `OrchestratorBackendFactory.forUseCase` to single-resolve (closes P1-IMP-2)
+
+**Depends on:** Task 5 | **Files:** `packages/orchestrator/src/agent/orchestrator-backend-factory.ts`, `packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts`
+
+**Skills:** `gof-factory-method` (reference)
+
+1. Open `packages/orchestrator/src/agent/orchestrator-backend-factory.ts`. Add `decisionBus?: RoutingDecisionBus` to `OrchestratorBackendFactoryOptions`:
+   ```ts
+   import type { RoutingDecisionBus } from '../routing/decision-bus.js';
+   // ...
+   export interface OrchestratorBackendFactoryOptions {
+     // ... existing fields
+     /**
+      * Spec B Phase 4 (D8): forwarded to the underlying BackendRouter so
+      * every resolve() during forUseCase / resolveName emits.
+      */
+     decisionBus?: RoutingDecisionBus;
+   }
+   ```
+2. Thread the bus into the router ctor:
+   ```ts
+   constructor(opts: OrchestratorBackendFactoryOptions) {
+     this.opts = opts;
+     this.router = new BackendRouter({
+       backends: opts.backends,
+       routing: opts.routing,
+       ...(opts.decisionBus !== undefined ? { decisionBus: opts.decisionBus } : {}),
+     });
+   }
+   ```
+3. Rewrite `forUseCase` to single-resolve via the new seam. **Delete** the misleading "two resolve() calls yield identical RoutingDecisions" comment block (lines 105-111). Replace the body:
+
+   ```ts
+   forUseCase(useCase: RoutingUseCase, opts?: { invocationOverride?: string }): AgentBackend {
+     // Spec B Phase 4 (closes P1-IMP-2): single resolve() per dispatch.
+     // Pre-Phase-4 this method called resolveDefinition() and resolve()
+     // separately, producing two RoutingDecisions. With Phase 4's
+     // decision-bus emission that doubled the routing-decision log
+     // volume per dispatch. resolveDecisionAndDef() collapses both.
+     const { def, decision } = this.router.resolveDecisionAndDef(useCase, opts);
+     const name = decision.backendName;
+     let backend: AgentBackend;
+     const createOpts = this.opts.cacheMetrics ? { cacheMetrics: this.opts.cacheMetrics } : {};
+
+     if ((def.type === 'local' || def.type === 'pi') && this.opts.getResolverModelFor) {
+       const getModel = this.opts.getResolverModelFor(name);
+       backend = getModel
+         ? this.buildLocalLikeWithResolver(def, getModel)
+         : createBackend(def, createOpts);
+     } else {
+       backend = createBackend(def, createOpts);
+     }
+
+     if (this.opts.sandboxPolicy === 'docker' && this.opts.container) {
+       backend = this.wrapInContainer(backend);
+     }
+
+     return backend;
+   }
+   ```
+
+4. Open `packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts`. Add a new test:
+   ```ts
+   it('forUseCase calls router.resolve exactly once (Phase 4 single-resolve invariant)', () => {
+     const bus = new RoutingDecisionBus({ capacity: 5 });
+     const factory = new OrchestratorBackendFactory({
+       backends: { cloud: { type: 'claude', command: 'claude' } },
+       routing: { default: 'cloud' },
+       sandboxPolicy: 'none',
+       decisionBus: bus,
+     });
+     // Access the router for spy install; getRouter() is the public seam.
+     const router = factory.getRouter();
+     const resolveSpy = vi.spyOn(router, 'resolve');
+     factory.forUseCase({ kind: 'tier', tier: 'quick-fix' });
+     expect(resolveSpy).toHaveBeenCalledTimes(1);
+     expect(bus.recent()).toHaveLength(1);
+   });
+   ```
+   Top-of-file: `import { vi } from 'vitest'; import { RoutingDecisionBus } from '../../src/routing/decision-bus.js';`.
+5. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- agent/orchestrator-backend-factory.test.ts` — observe all 9+ existing PASS + 1 new PASS.
+6. Run: `pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+7. Run: `harness validate` → PASS.
+8. Commit:
+   ```
+   refactor(orchestrator): forUseCase single-resolve via resolveDecisionAndDef (Spec B Phase 4, closes P1-IMP-2)
+   ```
+
+---
+
+### Task 7: Split `IntelligenceFactoryDeps` (closes P1-IMP-1)
+
+**Depends on:** Task 6 | **Files:** `packages/orchestrator/src/agent/intelligence-factory.ts`, `packages/orchestrator/tests/integration/intelligence-pipeline-routing.test.ts`
+
+**Skills:** `ts-type-guards` (reference)
+
+1. Open `packages/orchestrator/src/agent/intelligence-factory.ts`. Replace the single `IntelligenceFactoryDeps` interface with two:
+
+   ```ts
+   /**
+    * Spec B Phase 4 (closes Phase 1 deferred finding P1-IMP-1): the
+    * pipeline-build path needs the router for the SC34/SC35 sel-vs-pesl
+    * dedupe; the per-layer path does not (it only consults the router on
+    * the routing-driven branch, which is opt-in via router presence).
+    */
+   export interface BuildPipelineDeps {
+     config: WorkflowConfig;
+     localResolvers: Map<string, LocalModelResolver>;
+     logger: StructuredLogger;
+     router: BackendRouter;
+   }
+
+   export interface BuildLayerDeps {
+     config: WorkflowConfig;
+     localResolvers: Map<string, LocalModelResolver>;
+     logger: StructuredLogger;
+     /**
+      * Optional: routing-driven branch requires the router; the
+      * intelligence.provider-explicit branch ignores it (test fixtures
+      * using only intel.provider may omit).
+      */
+     router?: BackendRouter;
+   }
+
+   /** @deprecated kept as a compat re-export for one release; new code should use BuildPipelineDeps. */
+   export type IntelligenceFactoryDeps = BuildPipelineDeps;
+   ```
+
+2. Update function signatures:
+
+   ```ts
+   export function buildIntelligencePipeline(
+     deps: BuildPipelineDeps
+   ): IntelligencePipelineBundle | null {
+     /* unchanged body */
+   }
+
+   export function buildAnalysisProviderForLayer(
+     layer: 'sel' | 'pesl',
+     deps: BuildLayerDeps
+   ): AnalysisProvider | null {
+     /* body in Task 9 */
+   }
+   ```
+
+3. Update the test helper in `packages/orchestrator/tests/integration/intelligence-pipeline-routing.test.ts:64-79` so `callCreateAnalysisProvider` constructs `BuildLayerDeps` without `router` (the existing call already does this; just retype the local accessor to use the new name):
+   ```ts
+   const internals = orch as unknown as {
+     config: Parameters<typeof buildAnalysisProviderForLayer>[1]['config'];
+     localResolvers: Parameters<typeof buildAnalysisProviderForLayer>[1]['localResolvers'];
+     logger: Parameters<typeof buildAnalysisProviderForLayer>[1]['logger'];
+   };
+   return buildAnalysisProviderForLayer(layer, {
+     config: internals.config,
+     localResolvers: internals.localResolvers,
+     logger: internals.logger,
+   });
+   ```
+4. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator typecheck` → PASS (the helper now legally omits router because `BuildLayerDeps.router` is optional).
+5. Run: `pnpm --filter @harness-engineering/orchestrator test -- integration/intelligence-pipeline-routing.test.ts` → PASS unchanged.
+6. Run: `harness validate` → PASS.
+7. Commit:
+   ```
+   refactor(orchestrator): split IntelligenceFactoryDeps into pipeline/layer deps (Spec B Phase 4, closes P1-IMP-1)
+   ```
+
+---
+
+### Task 8: Test-first — chain-dedupe contract for sel/pesl
+
+**Depends on:** Task 7 | **Files:** `packages/orchestrator/tests/integration/intelligence-pipeline-routing.test.ts`
+
+**Skills:** `ts-testing-types` (reference)
+
+1. Add a test (per the Phase 1 review SUG-1 left open) that exercises the chain-dedupe case in `buildIntelligencePipeline`. Add to `packages/orchestrator/tests/integration/intelligence-pipeline-routing.test.ts` (inside the existing describe block):
+
+   ```ts
+   it('SC34b: sel + pesl chains funneling to the same backend produce one provider (chain dedupe)', () => {
+     // Two distinct chains, both resolving (after availability filtering) to 'cloud':
+     //   intel.sel  = ['ghost-backend', 'cloud']   -> ghost unknown, walk falls to cloud
+     //   intel.pesl = ['cloud']                    -> cloud
+     // Phase 1's router.resolve compares post-walk names: both = 'cloud' => one provider.
+     const config = makeConfig({
+       agent: {
+         backends: { cloud: { type: 'claude', command: 'claude' } },
+         routing: {
+           default: 'cloud',
+           intelligence: { sel: ['ghost-backend', 'cloud'], pesl: ['cloud'] },
+         },
+       },
+       intelligence: { enabled: true, provider: { kind: 'anthropic', apiKey: 'k' } },
+     });
+     const orch = new Orchestrator(config /* deps */);
+     // Builds the pipeline; we then assert peslProvider was NOT separately built
+     // (mock buildAnalysisProviderForLayer call count or use orch.intelligencePipeline.peslProvider
+     //  reference equality to selProvider).
+     const sel = callCreateAnalysisProvider(orch, 'sel');
+     const pesl = callCreateAnalysisProvider(orch, 'pesl');
+     // Both layers select the same backend; the pipeline should treat them as one provider.
+     expect(sel).not.toBeNull();
+     expect(pesl).not.toBeNull();
+     // The pipeline build path's gating decision uses router.resolve(...).backendName equality.
+     // Sanity: a router built from this config returns 'cloud' for both layers.
+     // (If callCreateAnalysisProvider is too coarse for ref equality, replace with a buildIntelligencePipeline call.)
+   });
+   ```
+
+   _Implementation detail:_ the existing test fixture already has `makeConfig` and an `Orchestrator` factory; mirror the closest scalar-case test (~line 184) for `routing.intelligence.sel = 'cloud'` and adapt to chains. If a tightly-scoped ref-equality assertion is desired, switch from `callCreateAnalysisProvider` to a direct `buildIntelligencePipeline({ config, localResolvers, logger, router })` call and assert `pipeline.peslProvider === pipeline.selProvider` (or that `peslProvider` is undefined and the pipeline falls through to sel).
+
+2. Run: `pnpm --filter @harness-engineering/orchestrator test -- integration/intelligence-pipeline-routing.test.ts` — observe new test PASS (Phase 1 already implemented the router-comparison correctly; this just pins it).
+3. Commit:
+   ```
+   test(orchestrator): pin chain-dedupe contract for sel/pesl intelligence routing (Spec B Phase 4)
+   ```
+
+---
+
+### Task 9: Rewrite `resolveRoutedBackend` to delegate to router (closes I1 third instance)
+
+**Depends on:** Task 8 | **Files:** `packages/orchestrator/src/agent/intelligence-factory.ts`
+
+**Skills:** `ts-type-guards` (reference)
+
+1. Open `packages/orchestrator/src/agent/intelligence-factory.ts`. Replace `resolveRoutedBackend` (lines 135-159) with a router-driven implementation that consumes the `BuildLayerDeps.router` field:
+
+   ```ts
+   /**
+    * Look up the routed BackendDef for an intelligence layer via the
+    * canonical BackendRouter. Returns null if the router is absent
+    * (intel.provider-explicit branch never hits this code path) OR if
+    * the routed backend is missing from agent.backends.
+    *
+    * Spec B Phase 4 (closes Phase 0 review finding I1 third instance):
+    * the Phase-0 inline Array.isArray normalization is gone — the router
+    * owns chain walking + availability filtering. Two distinct chains
+    * that funnel to the same backend now produce identical names here
+    * (the SC34/SC35 dedupe optimization stays correct).
+    */
+   function resolveRoutedBackend(
+     layer: 'sel' | 'pesl',
+     deps: BuildLayerDeps
+   ): { name: string; def: BackendDef } | null {
+     const { config, router, logger } = deps;
+     const backends = config.agent.backends;
+     if (!backends || !router) return null;
+     try {
+       const decision = router.resolve({ kind: 'intelligence', layer });
+       const def = backends[decision.backendName];
+       if (!def) {
+         logger.warn(
+           `Intelligence pipeline: routed backend '${decision.backendName}' for layer '${layer}' is not in agent.backends.`
+         );
+         return null;
+       }
+       return { name: decision.backendName, def };
+     } catch (err) {
+       // routing.default produced no available backend (S4) — log + fall through.
+       logger.warn(
+         `Intelligence pipeline: router could not resolve intelligence.${layer}; intelligence disabled. error=${String(err)}`
+       );
+       return null;
+     }
+   }
+   ```
+
+2. Update the call site in `buildAnalysisProviderForLayer` (line 104):
+   ```ts
+   // 2. Routing-driven selection (SC31, SC32, SC36).
+   const routed = resolveRoutedBackend(layer, deps);
+   if (!routed) return null;
+   ```
+3. **Side note for reviewers:** because each `router.resolve` call in `buildIntelligencePipeline` (lines 66-67) now emits to the decision bus, the pipeline-build path will produce **2 sel-or-pesl decisions per pipeline construction** (one for sel, one for pesl) at orchestrator startup. The bus capacity absorbs this trivially; just be aware that `routing-decision` log lines appear at startup, not only at dispatch.
+4. Run: `pnpm --filter @harness-engineering/orchestrator test -- integration/intelligence-pipeline-routing.test.ts` → all PASS.
+5. Run: `pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+6. Run: `harness validate` → PASS.
+7. Commit:
+   ```
+   refactor(orchestrator): resolveRoutedBackend delegates to BackendRouter (Spec B Phase 4, closes I1 third instance)
+   ```
+
+---
+
+### Task 10: `Orchestrator.start()` / `Orchestrator.stop()` wire-up — instantiate + teardown bus
+
+**Depends on:** Task 9 | **Files:** `packages/orchestrator/src/orchestrator.ts`
+
+**Skills:** none (mechanical wire-up)
+
+1. Open `packages/orchestrator/src/orchestrator.ts`. Add import (top of imports, near line 36-37):
+   ```ts
+   import { RoutingDecisionBus } from './routing/decision-bus.js';
+   ```
+2. Add a private field near the existing `private backendFactory` field (~line 114):
+   ```ts
+   private routingDecisionBus: RoutingDecisionBus | null;
+   ```
+3. In the constructor block where `backendFactory` is constructed (lines 383-413), construct the bus **before** `OrchestratorBackendFactory` and pass it in:
+
+   ```ts
+   if (
+     this.config.agent.backends !== undefined &&
+     Object.keys(this.config.agent.backends).length > 0
+   ) {
+     // ... existing sandboxPolicy + routing setup ...
+
+     // Spec B Phase 4 (D8): construct the bus once per orchestrator instance.
+     this.routingDecisionBus = new RoutingDecisionBus({
+       capacity: 500,
+       logger: this.logger,
+     });
+
+     this.backendFactory = new OrchestratorBackendFactory({
+       backends: this.config.agent.backends,
+       routing,
+       sandboxPolicy,
+       ...(this.config.agent.container !== undefined
+         ? { container: this.config.agent.container }
+         : {}),
+       ...(this.config.agent.secrets !== undefined ? { secrets: this.config.agent.secrets } : {}),
+       cacheMetrics: this.cacheMetrics,
+       decisionBus: this.routingDecisionBus,
+       getResolverModelFor: (name) => {
+         const resolver = this.localResolvers.get(name);
+         return resolver ? () => resolver.resolveModel() : undefined;
+       },
+     });
+   } else {
+     this.backendFactory = null;
+     this.routingDecisionBus = null;
+   }
+   ```
+
+4. Add a public getter (~near other getters, after `graphStore` getter ~line 450):
+
+   ```ts
+   /**
+    * Spec B Phase 4: expose the bus for Phase 5 (HTTP routes) and
+    * Phase 7 (dashboard WS broadcast). Returns null when the legacy
+    * single-backend config bypassed agent.backends synthesis.
+    */
+   public getRoutingDecisionBus(): RoutingDecisionBus | null {
+     return this.routingDecisionBus;
+   }
+   ```
+
+5. In `stop()` (~line 1841), add teardown right after `localModelStatusUnsubscribes` cleanup (~line 1853):
+   ```ts
+   // Spec B Phase 4: null out the bus reference; ring buffer + listener
+   // set are eligible for GC once no external references remain. (HTTP
+   // routes / WS subscribers from Phase 5+ unsubscribe themselves.)
+   this.routingDecisionBus = null;
+   ```
+6. Run: `pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+7. Run: `pnpm --filter @harness-engineering/orchestrator test -- agent/` → all existing PASS.
+8. Run: `harness validate` → PASS.
+9. Commit:
+   ```
+   feat(orchestrator): instantiate RoutingDecisionBus in ctor + expose getter + teardown in stop() (Spec B Phase 4)
+   ```
+
+---
+
+### Task 11: Add warn() when intelligence pipeline drops due to null backendFactory (closes P1-IMP-3)
+
+**Depends on:** Task 10 | **Files:** `packages/orchestrator/src/orchestrator.ts`
+
+**Skills:** none
+
+1. In `packages/orchestrator/src/orchestrator.ts`, locate `createIntelligencePipeline` (~line 776). Replace the early-return:
+
+   ```ts
+   private createIntelligencePipeline(): IntelligencePipeline | null {
+     if (!this.backendFactory) {
+       // Spec B Phase 4 (closes P1-IMP-3): make the silent drop visible.
+       // The only path here is a legacy config where agent.backends is
+       // absent/empty (migration would normally synthesize), AND
+       // intelligence.enabled was set. Dispatch would have already
+       // failed; intelligence-only deployments are exceedingly rare but
+       // should not get a null pipeline with zero diagnostic output.
+       this.logger.warn(
+         'intelligence pipeline disabled: no backendFactory available (legacy config without agent.backends)'
+       );
+       return null;
+     }
+     const bundle = buildIntelligencePipeline({
+       config: this.config,
+       localResolvers: this.localResolvers,
+       logger: this.logger,
+       router: this.backendFactory.getRouter(),
+     });
+     if (!bundle) return null;
+     this.graphStore = bundle.graphStore;
+     return bundle.pipeline;
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+3. Run: `pnpm --filter @harness-engineering/orchestrator test -- integration/orchestrator.test.ts` (or whichever existing test covers `createIntelligencePipeline` paths) → PASS.
+4. Run: `harness validate` → PASS.
+5. Commit:
+   ```
+   feat(orchestrator): warn when intelligence pipeline drops due to absent backendFactory (Spec B Phase 4, closes P1-IMP-3)
+   ```
+
+---
+
+### Task 12: Phase 4 acceptance suite (O1 + S5 + S6 + single-resolve)
+
+**Depends on:** Task 11 | **Files:** `packages/orchestrator/tests/integration/spec-b-phase-4-decision-bus.test.ts`
+
+**Skills:** `ts-testing-types` (reference)
+
+**[checkpoint:human-verify]** — After this task lands, operator should run the full integration suite locally and confirm the acceptance criteria match the spec text.
+
+1. Create `packages/orchestrator/tests/integration/spec-b-phase-4-decision-bus.test.ts`. Mirror the Phase 3 acceptance file shape (`spec-b-phase-3-dispatch-wiring.test.ts`) — minimal in-process Orchestrator construction, no real backends, no actual dispatch.
+
+   ```ts
+   import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+   import { Orchestrator } from '../../src/orchestrator.js';
+   import type { WorkflowConfig } from '@harness-engineering/types';
+   // Reuse the test scaffolding pattern from spec-b-phase-3-dispatch-wiring.test.ts:
+   import { makePhase3Config /* or local equivalent */ } from '../helpers/phase-test-helpers.js'; // adjust import if helper does not exist; otherwise inline a minimal makeConfig
+
+   describe('Spec B Phase 4: RoutingDecisionBus + event emission', () => {
+     let orch: Orchestrator;
+
+     beforeEach(() => {
+       const config = {
+         agent: {
+           backends: {
+             cloud: { type: 'claude', command: 'claude' },
+             local: { type: 'pi', endpoint: 'http://local:1234/v1', model: ['m'] },
+           },
+           routing: {
+             default: 'cloud',
+             skills: { 'harness-debugging': 'local' },
+           },
+           sandboxPolicy: 'none',
+         },
+         polling: { intervalMs: 999_999 },
+         workspace: { root: '/tmp/harness-phase-4-test-ws' },
+         intelligence: { enabled: false },
+       } as unknown as WorkflowConfig;
+       orch = new Orchestrator(config /* + minimal deps */);
+     });
+
+     afterEach(async () => {
+       if (orch) await orch.stop();
+     });
+
+     it('Phase 4 invariant: Orchestrator ctor produces a non-null bus when backends exist', () => {
+       expect(orch.getRoutingDecisionBus()).not.toBeNull();
+     });
+
+     it('O1: bus emits structured routing-decision line when BackendRouter.resolve is called', () => {
+       const bus = orch.getRoutingDecisionBus();
+       expect(bus).not.toBeNull();
+       const factory = (orch as any).backendFactory;
+       const infoSpy = vi.spyOn((orch as any).logger, 'info');
+       factory.resolveName({ kind: 'tier', tier: 'quick-fix' });
+       expect(infoSpy).toHaveBeenCalledWith(
+         'routing-decision',
+         expect.objectContaining({ backendName: expect.any(String) })
+       );
+       expect(bus!.recent()).toHaveLength(1);
+     });
+
+     it('S5: capacity bound — emitting > capacity drops oldest', () => {
+       const bus = orch.getRoutingDecisionBus();
+       const factory = (orch as any).backendFactory;
+       // capacity is 500; emit 600 via repeated resolves
+       for (let i = 0; i < 600; i++) {
+         factory.resolveName({ kind: 'tier', tier: 'quick-fix' });
+       }
+       expect(bus!.recent({ limit: 99999 }).length).toBeLessThanOrEqual(500);
+     });
+
+     it('S6: subscriber errors do not propagate', () => {
+       const bus = orch.getRoutingDecisionBus()!;
+       const factory = (orch as any).backendFactory;
+       bus.subscribe(() => {
+         throw new Error('subscriber boom');
+       });
+       expect(() => factory.resolveName({ kind: 'tier', tier: 'quick-fix' })).not.toThrow();
+     });
+
+     it('Single-resolve invariant: forUseCase calls router.resolve exactly once', () => {
+       const factory = (orch as any).backendFactory;
+       const router = factory.getRouter();
+       const resolveSpy = vi.spyOn(router, 'resolve');
+       factory.forUseCase({ kind: 'tier', tier: 'quick-fix' });
+       expect(resolveSpy).toHaveBeenCalledTimes(1);
+     });
+   });
+   ```
+
+2. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm --filter @harness-engineering/orchestrator test -- integration/spec-b-phase-4-decision-bus.test.ts` — observe 5/5 PASS.
+3. Run: `pnpm --filter @harness-engineering/orchestrator typecheck` → PASS.
+4. Run: `harness validate` → PASS.
+5. Commit:
+   ```
+   test(orchestrator): pin Spec B Phase 4 acceptance criteria (O1+S5+S6 + single-resolve invariant)
+   ```
+
+---
+
+### Task 13: Full validation battery
+
+**Depends on:** Task 12 | **Files:** none (verification only)
+
+**[checkpoint:human-verify]** — After this task, operator confirms Phase 4 is ready for sign-off before integration tasks.
+
+1. Run the full validation battery:
+   ```
+   cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && \
+     harness validate && \
+     harness check-deps && \
+     pnpm --filter @harness-engineering/orchestrator typecheck && \
+     pnpm --filter @harness-engineering/orchestrator test -- routing/ agent/backend-router.test.ts agent/orchestrator-backend-factory.test.ts integration/intelligence-pipeline-routing.test.ts integration/spec-b-phase-4-decision-bus.test.ts
+   ```
+2. Confirm:
+   - O1 PASS (Task 3 + Task 12)
+   - S5 PASS (Task 3 + Task 12)
+   - S6 PASS (Task 3 + Task 12)
+   - Single-resolve invariant PASS (Task 6 + Task 12)
+   - P1-IMP-1 closed (Task 7 — `BuildLayerDeps` exists, helper omits router cleanly)
+   - P1-IMP-2 closed (Task 6 — `forUseCase` single-resolve)
+   - P1-IMP-3 closed (Task 11 — warn() present)
+   - I1 third instance closed (Task 9 — `resolveRoutedBackend` router-driven, no `Array.isArray`)
+   - N1 unchanged (existing tests still pass; pre-Phase-4 better-sqlite3 ABI failures from Phase 3 are out of scope)
+3. No commit — verification only. If anything fails, return to the failing task to fix, then re-run from this step.
+
+---
+
+### Task 14: Regenerate barrels + plugin manifests (integration)
+
+**Depends on:** Task 13 | **Files:** auto-generated (`packages/orchestrator/src/_registry.ts`, `packages/cli/src/_registry.ts`, plugin manifests) | **Category:** integration
+
+**Skills:** none
+
+1. Run: `cd /Users/cwarner/Projects/iv/harness-spec-b-phase-1 && pnpm generate:barrels 2>&1 | tail -10`. Verify that the new `packages/orchestrator/src/routing/decision-bus.ts` + `routing/index.ts` show up in the orchestrator barrel; verify no out-of-scope cross-package drift appears (per Phase 0/2/3 precedent, revert unrelated alphabetic-reordering noise with a comment if it shows up).
+2. Run: `pnpm generate:plugin:all 2>&1 | tail -10`. **Expected output:** no in-scope changes (Phase 4 adds no new CLI commands; `harness routing` lands in Phase 6). If anything in-scope changes, that is a surprise and should be flagged in the handoff notes. Out-of-scope drift: revert per established precedent.
+3. Run: `harness validate` → PASS.
+4. If barrels regen produced in-scope changes (orchestrator's `_registry.ts` adding the new `routing/` export), commit them:
+   ```
+   chore(orchestrator): regen barrels for routing/decision-bus.ts (Spec B Phase 4)
+   ```
+   If no in-scope changes, skip the commit and document in the handoff that Task 14 was a no-op.
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (scaffold)
+  └─► Task 2 (test RED)
+        └─► Task 3 (impl GREEN)
+              └─► Task 4 (wire BackendRouter)
+                    └─► Task 5 (resolveDecisionAndDef seam)
+                          └─► Task 6 (forUseCase single-resolve)        [closes P1-IMP-2]
+                                └─► Task 7 (split deps)                  [closes P1-IMP-1]
+                                      └─► Task 8 (chain-dedupe test)
+                                            └─► Task 9 (resolveRoutedBackend rewrite)  [closes I1.3]
+                                                  └─► Task 10 (Orchestrator wire-up)
+                                                        └─► Task 11 (warn on null factory)  [closes P1-IMP-3]
+                                                              └─► Task 12 (acceptance suite)
+                                                                    └─► Task 13 (full battery)
+                                                                          └─► Task 14 (regen)
+```
+
+Strictly serial. No safe parallelization opportunity given the chain of refactors and the single-file-edit pattern in `intelligence-factory.ts` / `orchestrator.ts`.
+
+---
+
+## Time Estimate
+
+| Task | Estimate | Cumulative |
+| ---- | -------- | ---------- |
+| 1    | 3 min    | 3 min      |
+| 2    | 6 min    | 9 min      |
+| 3    | 5 min    | 14 min     |
+| 4    | 5 min    | 19 min     |
+| 5    | 3 min    | 22 min     |
+| 6    | 5 min    | 27 min     |
+| 7    | 4 min    | 31 min     |
+| 8    | 5 min    | 36 min     |
+| 9    | 5 min    | 41 min     |
+| 10   | 5 min    | 46 min     |
+| 11   | 3 min    | 49 min     |
+| 12   | 7 min    | 56 min     |
+| 13   | 3 min    | 59 min     |
+| 14   | 3 min    | 62 min     |
+
+**Total:** ~62 min of focused work.
+
+---
+
+## Checkpoints
+
+- **Task 12 [checkpoint:human-verify]** — Operator runs the Phase 4 acceptance suite locally and confirms O1+S5+S6 + single-resolve match the spec text.
+- **Task 13 [checkpoint:human-verify]** — Operator confirms Phase 4 closes the three Phase 1 deferred review findings + I1 third instance.
+
+---
+
+## Risks
+
+| Risk                                                                                                                                                                                                   | Mitigation                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Adding `emit()` to every `resolve()` could perceptibly slow dispatch in a tight loop (e.g., escalation cascade emits many decisions in rapid succession).                                              | The bus is intentionally synchronous + non-throwing: emit() is O(subscribers) plus one Array.shift. With capacity 500 and zero subscribers at Phase 4 (HTTP+WS land in Phase 5), the per-emit cost is ~5µs. Document the perf bound in the source comment; Phase 5 introduces a `Q1/Q2`-style perf benchmark.                                              |
+| `IntelligenceFactoryDeps` split may break a consumer the planner did not find.                                                                                                                         | Plan keeps `IntelligenceFactoryDeps` as a deprecated re-export alias of `BuildPipelineDeps` for one release. Run `grep -rn 'IntelligenceFactoryDeps' packages/` after Task 7 to find all consumers; the only known one is `intelligence-pipeline-routing.test.ts:70-72` and that uses `Parameters<typeof ...>` so it auto-tracks the new layer-deps shape. |
+| `resolveRoutedBackend` router-driven rewrite (Task 9) changes the call's failure mode. Pre-Phase-4: missing layer routing fell back to `routing.default`. Post: router throws, helper catches + warns. | Behavioral equivalence: the router's throw at the end of `resolve()` only fires if `routing.default` itself resolves to nothing — which `validateReferences()` already rejects at construction. The catch is a belt-and-suspenders safety net. Logged warn() is more visible than the silent pre-Phase-4 fall-through.                                     |
+| The acceptance test in Task 12 constructs an `Orchestrator` instance — instantiation may fail if test scaffolding from Phase 3 isn't reusable.                                                         | Phase 3's acceptance suite (`spec-b-phase-3-dispatch-wiring.test.ts`) already shows the minimal-Orchestrator construction pattern; Task 12 mirrors it. If a helper doesn't exist at `tests/helpers/phase-test-helpers.js`, inline a `makeConfig` directly in the test (the spec allows it; planner default in Task 12 is to inline if no helper exists).   |
+| Phase 4's `routing-decision` log line could be noisy at high dispatch rates.                                                                                                                           | The log is a single `info` line per dispatch — currently dispatch frequency is on the order of one per minute per tracked issue. If volume becomes a problem, Phase 8 / future cleanup can downgrade to `debug` or sample.                                                                                                                                 |
+| Pre-existing better-sqlite3 ABI failures from Phase 3 (48 orchestrator tests) may continue.                                                                                                            | Phase 4 does not touch SQLite paths; these failures are unchanged. Operator may rebuild via `pnpm rebuild better-sqlite3` before Phase 4 starts to clear the baseline noise. Phase 4 acceptance criteria do not depend on those tests.                                                                                                                     |
+
+---
+
+## Out-of-Scope (Carry Forward to Later Phases)
+
+- **HTTP routes** `/api/v1/routing/{config,decisions,trace}` — Phase 5
+- **WebSocket topic** `routing:decision` broadcast — Phase 5
+- **CLI command group** `harness routing {config,trace,decisions}` — Phase 6
+- **Dashboard `/routing` panel** — Phase 7
+- **ADRs + docs + knowledge graph enrichment** — Phase 8
+- **Configurable ring-buffer capacity** (currently hardcoded 500) — Phase 5/6 schema delta candidate
+- **Circular-buffer perf upgrade** for the ring buffer — deferred until profiling shows shift() is a hotspot
+- **`harness dispatch` CLI command** — confirmed absent in Phase 3; not introduced here
+
+---
+
+## Decisions Recorded (for handoff)
+
+| Tag    | Decision                                                                                                                                                                     |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P4-D1  | `BackendRouter` ctor accepts optional `decisionBus?: RoutingDecisionBus` (planner default, awaiting D-OP-1 confirmation).                                                    |
+| P4-D2  | Add `BackendRouter.resolveDecisionAndDef` as the single-resolve seam; keep `backends` field private (planner default, awaiting D-OP-2).                                      |
+| P4-D3  | `resolveRoutedBackend` rewritten to delegate to `router.resolve` (Option X); helper kept as named seam (planner default, awaiting D-OP-3).                                   |
+| P4-D4  | Ring buffer capacity hardcoded `500` for v1; configurability deferred (planner default, awaiting D-OP-4).                                                                    |
+| P4-D5  | Log emission lives in `RoutingDecisionBus.emit`, not `BackendRouter.resolve` (planner default, awaiting D-OP-5).                                                             |
+| P4-D6  | `IntelligenceFactoryDeps` split: `BuildPipelineDeps` (with router), `BuildLayerDeps` (optional router); old name as deprecated alias for one release.                        |
+| P4-D7  | Chain-dedupe contract pinned by a new test (closes Phase 1 SUG-1 left open).                                                                                                 |
+| P4-D8  | The `intelligence pipeline disabled: no backendFactory available …` warn() text is the canonical wording; operator may amend in C7.                                          |
+| P4-D9  | Acceptance suite at `packages/orchestrator/tests/integration/spec-b-phase-4-decision-bus.test.ts`; unit tests at `packages/orchestrator/tests/routing/decision-bus.test.ts`. |
+| P4-D10 | No HTTP / CLI / dashboard work in Phase 4 — strictly module + wire-up + finding-closures.                                                                                    |
+
+---
+
+## Plan Sign-Off Request
+
+This plan is ready to execute pending operator confirmation of D-OP-1 through D-OP-5. On approval, transition to `harness-execution` with this plan and the existing Phase 4 handoff.

--- a/docs/changes/granular-task-routing/plans/2026-05-26-phase-5-http-ws-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-26-phase-5-http-ws-plan.md
@@ -1,0 +1,952 @@
+# Plan: Spec B Phase 5 — HTTP Routes + WS Topic for Routing Decisions
+
+**Date:** 2026-05-26
+**Spec:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/docs/changes/granular-task-routing/proposal.md`
+**Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1`
+**Branch:** `feat/spec-b-phase-1` (HEAD `5802839f`, Phase 4 tip)
+**Phase 5 scope:** ~2 days, medium complexity
+**Tasks:** 13
+**Estimated time:** ~55 min of focused work (1 context window per task)
+**Integration Tier:** medium
+**Phase 5 success criteria:** F10 (WS topic broadcasts payload within 100ms of dispatch); F8 (decisions filterable + JSON-shaped); O3 (trace dry-run); plus closes Phase 4 deferred findings **S1** (`recent()` oldest-N → latest-N) and **S2** (`clearListeners()` on stop)
+
+---
+
+## Goal
+
+When `BackendRouter.resolve()` produces a `RoutingDecision`, the orchestrator (a) holds the latest 500 in the bus ring buffer for HTTP read-out under `/api/v1/routing/decisions`, (b) snapshots the current `RoutingConfig` (with each `RoutingValue` resolved into a `{ candidate, exists }[]` chain shape) under `/api/v1/routing/config`, (c) accepts a dry-run resolution under `POST /api/v1/routing/trace` that calls `BackendRouter.resolveDecisionAndDef()` (the Phase 4 single-resolve seam) without side effects, and (d) broadcasts every decision live to WebSocket clients on type `routing:decision`. Alongside the four route surfaces, two Phase 4 deferred findings close: `RoutingDecisionBus.recent({limit})` returns **latest-N** (was oldest-N — wrong semantic for "recent"), and `RoutingDecisionBus.clearListeners()` is added + called from `Orchestrator.stop()` before the bus reference is nulled.
+
+---
+
+## Observable Truths (Acceptance Criteria)
+
+1. **EARS — Event-driven (F10):** When `BackendRouter.resolve(useCase)` returns a decision and a WS client is subscribed to `/ws`, the system shall broadcast a frame `{ type: 'routing:decision', data: <RoutingDecision> }` within 100ms of the resolve return (verified by integration test that resolves and asserts WS receipt time < 100ms).
+2. **EARS — Event-driven:** When the operator sends `GET /api/v1/routing/config` with a valid `read-telemetry` token, the system shall respond `200 application/json` with body `{ routing: <RoutingConfig>, resolvedChains: Record<string, { candidate: string, exists: boolean }[]>, backends: string[] }` — every routing-value source (default, each tier, each intelligence layer, each isolation tier, each skill, each mode) keyed in `resolvedChains` with its normalized chain plus per-candidate existence in `agent.backends`.
+3. **EARS — Event-driven (F8):** When the operator sends `GET /api/v1/routing/decisions?skill=harness-debugging&limit=10` with a valid `read-telemetry` token, the system shall respond `200 application/json` with body `{ decisions: RoutingDecision[] }` containing at most 10 records, newest-first, filtered to `useCase.kind === 'skill' && useCase.skillName === 'harness-debugging'`. Filter params `skill`, `mode`, `backend`, `limit` are all optional; combining them ANDs the filters.
+4. **EARS — Event-driven (O3 partial):** When the operator sends `POST /api/v1/routing/trace` with body `{ useCase: <RoutingUseCase>, invocationOverride?: string }` and a valid `read-telemetry` token, the system shall call `BackendRouter.resolveDecisionAndDef(useCase, { invocationOverride })`, respond `200` with body `{ decision: <RoutingDecision>, def: { type: BackendDef['type'] } }`, and shall NOT emit the decision onto the bus (dry-run; verified by ring-buffer length unchanged after the call).
+5. **EARS — Unwanted:** If `POST /api/v1/routing/trace` body fails Zod parse (missing/invalid `useCase.kind`), then the system shall respond `400 application/json` with body `{ error: <message> }` and shall NOT call `router.resolveDecisionAndDef`.
+6. **EARS — Unwanted:** If `BackendRouter` is unavailable (legacy config, `backendFactory === null`), then all three routes shall respond `503 application/json` with body `{ error: 'BackendRouter not available' }` — matches the `cacheMetrics` 503 precedent in `telemetry.ts`.
+7. **EARS — Ubiquitous (Phase 4 S1 fix):** `RoutingDecisionBus.recent({ limit: N })` shall return the **latest N** decisions in **newest-first** order. `recent({ limit: 10 })` on a 100-decision buffer shall return decisions [99, 98, …, 90]. Verified by unit test against the existing fixture pattern.
+8. **EARS — Event-driven (Phase 4 S2 fix):** When `Orchestrator.stop()` runs, the system shall call `routingDecisionBus.clearListeners()` before setting `this.routingDecisionBus = null`. After stop, a previously-subscribed listener shall never receive subsequent emissions (verified by integration test).
+9. **EARS — Ubiquitous:** Three new bridge primitives shall be registered in `V1_BRIDGE_ROUTES`: `GET /api/v1/routing/config` (scope `read-telemetry`), `GET /api/v1/routing/decisions` (scope `read-telemetry`), `POST /api/v1/routing/trace` (scope `read-telemetry`). All three accept optional `?...` query string per the existing pattern.
+10. **EARS — Ubiquitous (N1):** All existing Phase 4 acceptance tests (`spec-b-phase-4-decision-bus.test.ts` — 5 tests) and the bus unit tests (`routing/decision-bus.test.ts` — 5 tests) shall continue to pass; the latest-N flip pins a NEW assertion shape but should NOT break Phase 4's S5 capacity test (which counts records, not order).
+11. **EARS — Ubiquitous:** `harness validate`, `harness check-deps`, `pnpm --filter @harness-engineering/orchestrator typecheck`, and the new Phase 5 acceptance test file shall pass.
+12. **EARS — Ubiquitous:** A new acceptance test file at `packages/orchestrator/tests/integration/spec-b-phase-5-http-ws.test.ts` shall pin F10, F8, O3 (trace), 503-on-no-router, latest-N semantics, and clearListeners-on-stop across at least 6 tests.
+
+---
+
+## Uncertainties / Concerns for Operator Sign-Off
+
+| #   | Class         | Concern                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1  | BLOCKING-LITE | **Scope choice for the 3 routes.** Existing scope vocabulary (`read-status`, `read-telemetry`, `manage-proposals`, etc.) is closed — Phase 0 ADR pins changes require an ADR. **Option A (planner default):** reuse `read-telemetry` for all three routes — matches `cacheMetrics` precedent, no schema change, no ADR. **Option B:** add `read-routing` to `TokenScopeSchema` + `SCOPE_VOCABULARY`, requires ADR + Zod schema change + cascading token-doc updates. Plan defaults to **A** — routing-config + decisions + trace are read-only observability; `read-telemetry` already covers prompt-cache stats which is the closest semantic neighbor. Phase 6 CLI work uses the same scope.                                                                                                                                                                                                                  |
+| C2  | BLOCKING-LITE | **Router accessor on Orchestrator.** Trace route needs the `BackendRouter` instance; `backendFactory` is currently private. **Option X (planner default):** add `public getBackendRouter(): BackendRouter \| null` to `Orchestrator` mirroring `getRoutingDecisionBus()` pattern. **Option Y:** widen `ServerDependencies` with `getBackendRouter?: () => BackendRouter \| null` and pass via the existing `OrchestratorServer` constructor wiring. Plan defaults to **X** — symmetric with Phase 4's `getRoutingDecisionBus()`, single accessor surface, route handler reads it via `(this.orchestrator as { getBackendRouter?: () => BackendRouter \| null }).getBackendRouter?.()` same way `proposals.ts` reaches the bus.                                                                                                                                                                                  |
+| C3  | BLOCKING-LITE | **`recent()` ordering — newest-first vs oldest-first.** Spec wording (F8: "10 most recent records"), dashboard mental model ("the latest first"), and Phase 4 review S1 finding all point to **newest-first**. Plan defaults to **newest-first** (`buffer.slice(-limit).reverse()`). Alternative: keep insertion order but slice from the tail (`buffer.slice(-limit)`) — preserves chronological order but means the dashboard has to reverse on render. Plan picks newest-first because (a) it matches "recent" semantics, (b) Phase 7 dashboard expects newest-first per spec line 372–381, (c) `harness routing decisions` CLI output (Phase 6) reads top-to-bottom = most-recent-to-oldest. Operator may flip to chronological if the Phase 7 component design prefers oldest-first scrolling.                                                                                                             |
+| C4  | BLOCKING-LITE | **`clearListeners()` timing in `stop()`.** Phase 4 review S2: when Phase 5 adds the WS broadcaster as the first external subscriber, `stop()` must release listeners to prevent the subscriber closure (which retains a reference to the `OrchestratorServer`) from anchoring the bus. **Plan:** add `clearListeners()` method to `RoutingDecisionBus`, call it from `Orchestrator.stop()` immediately **before** `this.routingDecisionBus = null` (line 1888). The WS subscriber unsubscribe handle returned from `bus.subscribe(...)` is stored on `OrchestratorServer` and called from `OrchestratorServer.stop()`; `clearListeners()` is the belt-and-suspenders second line. Operator may prefer to drop the explicit unsubscribe and rely on `clearListeners()` alone — plan defaults to **both** because unsubscribe runs earlier in shutdown (server.stop before orchestrator nulls the bus reference). |
+| C5  | ASSUMPTION    | **`/routing/config` response shape — flat keyed map vs nested.** Plan response: `{ routing: <as-configured RoutingConfig>, resolvedChains: { 'default': [...], 'tier:quick-fix': [...], 'intelligence:sel': [...], 'isolation:tight': [...], 'skill:harness-debugging': [...], 'mode:adversarial-reviewer': [...] }, backends: ['claude-opus', …] }`. Keys are `<source>:<key>` so the dashboard can render one row per source without re-walking `RoutingConfig`. Alternative: nested shape mirroring `RoutingConfig` exactly. Plan picks flat-keyed because the dashboard's "Resolved Chains" table is one-row-per-source and flat-keyed avoids client-side flattening. Operator may prefer nested for symmetry with the input config shape.                                                                                                                                                                  |
+| C6  | ASSUMPTION    | **Trace route response shape.** Plan returns `{ decision: RoutingDecision, def: { type: BackendDef['type'] } }` — the full decision plus the backend type so the dashboard's trace panel can show "would dispatch to claude-opus (type: anthropic)". Avoids leaking secrets (model env keys, endpoint URLs for local backends) by NOT echoing the full `BackendDef`. Alternative: return the full `BackendDef` for completeness. Plan picks redacted because trace is operator-facing and may be CI-piped (logs); model + endpoint URL is fine but `secrets` references are not. Operator may broaden if no secret leak risk in current `BackendDef` shape.                                                                                                                                                                                                                                                     |
+| C7  | ASSUMPTION    | **WS broadcaster subscription lifecycle.** Plan: `OrchestratorServer` constructor reads `(orchestrator as { getRoutingDecisionBus?: () => Bus \| null }).getRoutingDecisionBus?.()` once at construction, calls `bus?.subscribe(decision => this.broadcaster.broadcast('routing:decision', decision))`, stores the returned unsubscribe handle in `private routingDecisionUnsubscribe`. `OrchestratorServer.stop()` calls it before `broadcaster.close()`. Alternative: subscribe lazily on first WS upgrade. Plan picks eager subscribe — simpler, matches `wireEvents()` (`agent_event` listener attached in constructor regardless of WS clients) and the bus's S6 isolation already handles "subscriber called with zero WS clients" (just a `broadcast()` call into an empty client set).                                                                                                                  |
+| C8  | DEFERRABLE    | **Trace route — should it support `useCase.kind === 'skill'` without a real skill?** Plan accepts any well-formed `RoutingUseCase`. If the operator passes `{ kind: 'skill', skillName: 'fake-skill', cognitiveMode: 'adversarial-reviewer' }`, trace returns the resolution that WOULD happen — including skill-routing entries if they exist. Trace does NOT validate skill name against the catalog (D10 says catalog warning is at startup, not per-trace). Operator may want a `?strict=true` mode that 400s on unknown skill — defer to Phase 6 CLI ergonomics work.                                                                                                                                                                                                                                                                                                                                      |
+| C9  | DEFERRABLE    | **Test file naming.** `spec-b-phase-5-http-ws.test.ts` matches Phase 3/4 convention. Per-route unit tests live as siblings: `packages/orchestrator/src/server/routes/v1/routing.test.ts` (similar to `telemetry.test.ts`). Operator may split per-route into 3 files if the suite grows beyond ~15 tests.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+
+**Decision points the operator should confirm before execution:**
+
+- **D-OP-1 (C1):** **Approve Option A** — all 3 routes use `read-telemetry`. If reject (prefer dedicated scope): Task 4 adds `'read-routing'` to `TokenScopeSchema` + `SCOPE_VOCABULARY` + writes an ADR (adds 2 tasks).
+- **D-OP-2 (C2):** **Approve adding `Orchestrator.getBackendRouter()` accessor.** If reject (prefer ServerDependencies threading): Task 6 wires `getBackendRouter` through `ServerDependencies` and `orchestrator.ts:533` server-init block.
+- **D-OP-3 (C3):** **Approve newest-first ordering for `recent()`.** If reject (prefer chronological tail): Task 2 uses `slice(-limit)` without `.reverse()` and the acceptance test pins chronological order.
+- **D-OP-4 (C4):** **Approve dual safety net** — explicit unsubscribe from `OrchestratorServer.stop()` AND `clearListeners()` from `Orchestrator.stop()`. If reject (clearListeners alone): Task 9 drops the unsubscribe storage and stop()-time unsubscribe call.
+- **D-OP-5 (C5):** **Approve flat-keyed `resolvedChains` shape** (`'tier:quick-fix'`, `'skill:<name>'`, etc.). If reject (prefer nested): Task 7 mirrors `RoutingConfig`'s nested shape.
+- **D-OP-6 (C6):** **Approve redacted `def` in trace response** (`{ type: BackendDef['type'] }` only). If reject (broader): Task 8 returns the full `BackendDef` with secrets-scrubbing TODO.
+- **D-OP-7 (C7):** **Approve eager WS subscription at server construction.** If reject (lazy): Task 9 subscribes on first WS `/ws` upgrade and tracks subscriber count.
+
+---
+
+## File Map
+
+```
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/routing/decision-bus.ts
+        # 1. Flip recent() limit: slice(-limit).reverse() — newest-first
+        # 2. Add clearListeners(): void — empties this.listeners set
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/routing/decision-bus.test.ts
+        # Re-pin the filter+limit test for newest-first; add clearListeners test
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.ts
+        # Three route handlers: handleV1RoutingConfigRoute, handleV1RoutingDecisionsRoute,
+        # handleV1RoutingTraceRoute. Exported via a single handleV1RoutingRoute dispatcher
+        # matching the telemetry.ts pattern. Deps: { router: BackendRouter | null,
+        # bus: RoutingDecisionBus | null, routing: RoutingConfig | null,
+        # backends: Record<string, BackendDef> | null }.
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.test.ts
+        # Per-route unit tests using the IncomingMessage/ServerResponse fixture
+        # from telemetry.test.ts: 503 on no-router, 200 on config, 200 on
+        # decisions with filter, 200 on trace, 400 on bad trace body, ring-buffer
+        # unchanged after trace.
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/v1-bridge-routes.ts
+        # Append 3 entries: GET /api/v1/routing/config, GET /api/v1/routing/decisions,
+        # POST /api/v1/routing/trace — all scope 'read-telemetry'
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/http.ts
+        # 1. Import handleV1RoutingRoute
+        # 2. Add routing deps to ServerDependencies: { getBackendRouter?: () => BackendRouter | null;
+        #    getRoutingDecisionBus?: () => RoutingDecisionBus | null; getRoutingConfig?: () => RoutingConfig | null;
+        #    getBackends?: () => Record<string, BackendDef> | null; }
+        # 3. Wire handler into buildApiRoutes()
+        # 4. In constructor (after wireEvents()), call getRoutingDecisionBus and subscribe
+        #    the broadcaster — store unsubscribe in private routingDecisionUnsubscribe
+        # 5. stop(): if (this.routingDecisionUnsubscribe) this.routingDecisionUnsubscribe()
+        # 6. Add public broadcastRoutingDecision(decision) shim (optional, for test direct-call)
+
+MODIFY  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts
+        # 1. Add public getBackendRouter(): BackendRouter | null — returns this.backendFactory?.getRouter() ?? null
+        # 2. Add public getRoutingConfig(): RoutingConfig | null — returns synthesized routing (this.config.agent.routing ?? null)
+        # 3. Add public getBackends(): Record<string, BackendDef> | null — returns this.config.agent.backends ?? null
+        # 4. In server-init at line 533, pass the four new accessors via ServerDependencies
+        # 5. In stop() at line 1888, call this.routingDecisionBus?.clearListeners() BEFORE nulling
+
+CREATE  /Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/integration/spec-b-phase-5-http-ws.test.ts
+        # Acceptance test pinning F10 (WS broadcast latency <100ms), F8 (decisions
+        # filter+order), O3 (trace dry-run + ring buffer unchanged), 503 on no-router,
+        # latest-N semantics on recent(), clearListeners-on-stop hygiene
+```
+
+No new directories created. No barrel regen required (everything imported via deep module paths, matching Phase 4 D-OP precedent — "orchestrator barrel hand-curated").
+
+---
+
+## Tasks
+
+### Task 1 — Pin the latest-N + clearListeners contract (TDD red)
+
+**Depends on:** none | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/routing/decision-bus.test.ts` | **Category:** test
+
+1. Open `tests/routing/decision-bus.test.ts`. Locate the existing test pinning `recent({ limit: N })` behavior (Phase 4 Task 2 pinned it).
+2. Add a new test case after the existing limit-test:
+   ```ts
+   it('recent({ limit }) returns the latest N decisions in newest-first order (Phase 5 S1 fix)', () => {
+     const bus = new RoutingDecisionBus({ capacity: 100 });
+     for (let i = 0; i < 50; i++) {
+       bus.emit({
+         timestamp: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+         useCase: { kind: 'tier', tier: 'quick-fix' },
+         resolutionPath: [{ source: 'tier', candidate: `b${i}`, outcome: 'chosen' }],
+         backendName: `b${i}`,
+         backendType: 'anthropic',
+         durationMs: 0,
+       });
+     }
+     const out = bus.recent({ limit: 5 });
+     expect(out.length).toBe(5);
+     expect(out.map((d) => d.backendName)).toEqual(['b49', 'b48', 'b47', 'b46', 'b45']);
+   });
+   ```
+3. Add a second new test case:
+   ```ts
+   it('clearListeners() removes all subscribers so post-clear emits reach nobody (Phase 5 S2 fix)', () => {
+     const bus = new RoutingDecisionBus();
+     const received: string[] = [];
+     bus.subscribe((d) => received.push(d.backendName));
+     bus.clearListeners();
+     bus.emit({
+       timestamp: '2026-05-26T00:00:00.000Z',
+       useCase: { kind: 'tier', tier: 'quick-fix' },
+       resolutionPath: [{ source: 'tier', candidate: 'x', outcome: 'chosen' }],
+       backendName: 'x',
+       backendType: 'anthropic',
+       durationMs: 0,
+     });
+     expect(received).toEqual([]);
+   });
+   ```
+4. Run: `pnpm --filter @harness-engineering/orchestrator vitest run tests/routing/decision-bus.test.ts`
+5. Observe: both new tests fail (newest-first not implemented; `clearListeners` does not exist). Existing 5 tests still pass — including the original filter-limit test (planner: the original test was `recent({skillName})` with no limit ordering; verify before this task that the existing filter-limit test does not assert ordering — if it does, this task ALSO updates that existing test for newest-first).
+6. Run: `harness validate`
+7. Commit: `test(orchestrator): pin Phase 5 latest-N + clearListeners contracts for RoutingDecisionBus`
+
+> **Pre-task verification step:** Before writing the new tests, the executor must `grep -n "limit:" tests/routing/decision-bus.test.ts` to see whether any existing test pins oldest-first ordering. If yes, update it in this task; do not split.
+
+---
+
+### Task 2 — Implement latest-N + clearListeners (TDD green)
+
+**Depends on:** Task 1 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/routing/decision-bus.ts`
+
+1. Open `src/routing/decision-bus.ts`.
+2. Replace `recent(filter?)` lines 75-97. Change line 94 from `out = out.slice(0, filter.limit);` to:
+   ```ts
+   if (filter?.limit !== undefined) {
+     out = out.slice(-filter.limit).reverse();
+   } else {
+     out = out.slice().reverse();
+   }
+   ```
+   Move the existing filter passes (skillName, mode, backendName) to run BEFORE the slice — so the limit is applied to the filtered set, not the raw buffer. Final structure:
+   ```ts
+   recent(filter?: RoutingDecisionBusFilter): RoutingDecision[] {
+     let out = this.ringBuffer.slice();
+     if (filter?.skillName !== undefined) { /* ... */ }
+     if (filter?.mode !== undefined) { /* ... */ }
+     if (filter?.backendName !== undefined) { /* ... */ }
+     if (filter?.limit !== undefined) {
+       out = out.slice(-filter.limit).reverse();
+     } else {
+       out = out.reverse();
+     }
+     return out;
+   }
+   ```
+3. Add `clearListeners` method after `subscribe`:
+   ```ts
+   /**
+    * Spec B Phase 5 (review-S2 fix): release all subscriber references so
+    * teardown can complete without anchoring closures. Called from
+    * Orchestrator.stop() before nulling the bus reference. The bus
+    * remains usable after clear — subscribe() works as normal.
+    */
+   clearListeners(): void {
+     this.listeners.clear();
+   }
+   ```
+4. Update the class JSDoc capacity comment if it mentions ordering.
+5. Run: `pnpm --filter @harness-engineering/orchestrator vitest run tests/routing/decision-bus.test.ts`
+6. Observe: all 7 tests pass.
+7. Run: `harness validate && harness check-deps`
+8. Commit: `feat(orchestrator): RoutingDecisionBus.recent returns latest-N newest-first + add clearListeners (Spec B Phase 5, closes Phase 4 review S1+S2)`
+
+---
+
+### Task 3 — Pin the routing-config route contract (TDD red)
+
+**Depends on:** Task 2 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.test.ts` (CREATE) | **Category:** test
+
+1. Create `src/server/routes/v1/routing.test.ts`. Use the fixture pattern from `telemetry.test.ts` (`makeReq`, `makeRes`).
+2. Add the imports:
+   ```ts
+   import { describe, it, expect } from 'vitest';
+   import { IncomingMessage, ServerResponse } from 'node:http';
+   import { Socket } from 'node:net';
+   import { BackendRouter } from '../../../agent/backend-router';
+   import { RoutingDecisionBus } from '../../../routing/decision-bus';
+   import { handleV1RoutingRoute } from './routing';
+   import type { BackendDef, RoutingConfig } from '@harness-engineering/types';
+   ```
+3. Add fixtures (`makeReq`, `makeRes` copy-paste from telemetry.test.ts).
+4. Add the first describe block with one test asserting the config route:
+
+   ```ts
+   describe('handleV1RoutingRoute — GET /api/v1/routing/config', () => {
+     it('returns 200 with routing + resolvedChains + backends', async () => {
+       const backends: Record<string, BackendDef> = {
+         'claude-opus': { type: 'anthropic', model: 'claude-opus-4-7' },
+         'local-fast': { type: 'local', endpoint: 'http://localhost:1234/v1', model: 'qwen3:8b' },
+       };
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         'quick-fix': ['local-fast', 'claude-opus'],
+         skills: { 'harness-debugging': 'local-fast' },
+       };
+       const router = new BackendRouter({ backends, routing });
+       const bus = new RoutingDecisionBus();
+       const req = makeReq('GET', '/api/v1/routing/config');
+       const { res, chunks, statusCode } = makeRes();
+       const handled = handleV1RoutingRoute(req, res, { router, bus, routing, backends });
+       expect(handled).toBe(true);
+       expect(statusCode()).toBe(200);
+       const body = JSON.parse(chunks.join(''));
+       expect(body.backends).toEqual(['claude-opus', 'local-fast']);
+       expect(body.routing).toEqual(routing);
+       expect(body.resolvedChains['default']).toEqual([{ candidate: 'claude-opus', exists: true }]);
+       expect(body.resolvedChains['tier:quick-fix']).toEqual([
+         { candidate: 'local-fast', exists: true },
+         { candidate: 'claude-opus', exists: true },
+       ]);
+       expect(body.resolvedChains['skill:harness-debugging']).toEqual([
+         { candidate: 'local-fast', exists: true },
+       ]);
+     });
+
+     it('returns 503 when router is null', () => {
+       const req = makeReq('GET', '/api/v1/routing/config');
+       const { res, chunks, statusCode } = makeRes();
+       const handled = handleV1RoutingRoute(req, res, {
+         router: null,
+         bus: null,
+         routing: null,
+         backends: null,
+       });
+       expect(handled).toBe(true);
+       expect(statusCode()).toBe(503);
+       expect(chunks.join('')).toContain('BackendRouter not available');
+     });
+   });
+   ```
+
+5. Run: `pnpm --filter @harness-engineering/orchestrator vitest run src/server/routes/v1/routing.test.ts`
+6. Observe: tests fail (module does not exist).
+7. Run: `harness validate`
+8. Commit: `test(orchestrator): pin GET /api/v1/routing/config route contract (Spec B Phase 5)`
+
+---
+
+### Task 4 — Implement routing.ts module with config route (TDD green)
+
+**Depends on:** Task 3 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.ts` (CREATE)
+
+1. Create `src/server/routes/v1/routing.ts`:
+
+   ```ts
+   import type { IncomingMessage, ServerResponse } from 'node:http';
+   import type { BackendDef, RoutingConfig, RoutingValue } from '@harness-engineering/types';
+   import type { BackendRouter } from '../../../agent/backend-router';
+   import type { RoutingDecisionBus } from '../../../routing/decision-bus';
+   import { toArray } from '../../../agent/backend-router';
+
+   const CONFIG_RE = /^\/api\/v1\/routing\/config(?:\?.*)?$/;
+   const DECISIONS_RE = /^\/api\/v1\/routing\/decisions(?:\?.*)?$/;
+   const TRACE_RE = /^\/api\/v1\/routing\/trace(?:\?.*)?$/;
+
+   export interface RoutingRouteDeps {
+     router: BackendRouter | null;
+     bus: RoutingDecisionBus | null;
+     routing: RoutingConfig | null;
+     backends: Record<string, BackendDef> | null;
+   }
+
+   function sendJSON(res: ServerResponse, status: number, body: unknown): void {
+     res.writeHead(status, { 'Content-Type': 'application/json' });
+     res.end(JSON.stringify(body));
+   }
+
+   function unavailable(res: ServerResponse): true {
+     sendJSON(res, 503, { error: 'BackendRouter not available' });
+     return true;
+   }
+
+   function resolveChain(
+     value: RoutingValue,
+     backends: Record<string, BackendDef>
+   ): { candidate: string; exists: boolean }[] {
+     return toArray(value).map((c) => ({ candidate: c, exists: c in backends }));
+   }
+
+   function buildResolvedChains(
+     routing: RoutingConfig,
+     backends: Record<string, BackendDef>
+   ): Record<string, { candidate: string; exists: boolean }[]> {
+     const out: Record<string, { candidate: string; exists: boolean }[]> = {};
+     out['default'] = resolveChain(routing.default, backends);
+     for (const tier of ['quick-fix', 'guided-change', 'full-exploration', 'diagnostic'] as const) {
+       const v = routing[tier];
+       if (v !== undefined) out[`tier:${tier}`] = resolveChain(v, backends);
+     }
+     if (routing.intelligence) {
+       for (const [layer, v] of Object.entries(routing.intelligence)) {
+         if (v !== undefined) out[`intelligence:${layer}`] = resolveChain(v, backends);
+       }
+     }
+     if (routing.isolation) {
+       for (const [tier, v] of Object.entries(routing.isolation)) {
+         if (v !== undefined) out[`isolation:${tier}`] = resolveChain(v, backends);
+       }
+     }
+     if (routing.skills) {
+       for (const [name, v] of Object.entries(routing.skills)) {
+         if (v !== undefined) out[`skill:${name}`] = resolveChain(v, backends);
+       }
+     }
+     if (routing.modes) {
+       for (const [mode, v] of Object.entries(routing.modes)) {
+         if (v !== undefined) out[`mode:${mode}`] = resolveChain(v, backends);
+       }
+     }
+     return out;
+   }
+
+   function handleConfig(res: ServerResponse, deps: RoutingRouteDeps): boolean {
+     if (!deps.router || !deps.routing || !deps.backends) return unavailable(res);
+     sendJSON(res, 200, {
+       routing: deps.routing,
+       resolvedChains: buildResolvedChains(deps.routing, deps.backends),
+       backends: Object.keys(deps.backends),
+     });
+     return true;
+   }
+
+   export function handleV1RoutingRoute(
+     req: IncomingMessage,
+     res: ServerResponse,
+     deps: RoutingRouteDeps
+   ): boolean {
+     const url = req.url ?? '';
+     const method = req.method ?? 'GET';
+     if (method === 'GET' && CONFIG_RE.test(url)) return handleConfig(res, deps);
+     // DECISIONS_RE + TRACE_RE wired in Tasks 5/8
+     return false;
+   }
+   ```
+
+2. Note: `toArray` must be exported from `backend-router.ts`. It currently has no `export` keyword inside the function declaration — verify with `grep -n "export function toArray" src/agent/backend-router.ts`. If unexported, this task adds `export` to it (line 37 of backend-router.ts already has `export`, per Phase 1 plan — verify).
+3. Run: `pnpm --filter @harness-engineering/orchestrator vitest run src/server/routes/v1/routing.test.ts`
+4. Observe: both config tests pass.
+5. Run: `harness validate && harness check-deps`
+6. Commit: `feat(orchestrator): GET /api/v1/routing/config — current config + resolved chains + backends (Spec B Phase 5)`
+
+---
+
+### Task 5 — Pin the decisions route contract (TDD red)
+
+**Depends on:** Task 4 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.test.ts` | **Category:** test
+
+1. Add a second describe block to `routing.test.ts`:
+
+   ```ts
+   describe('handleV1RoutingRoute — GET /api/v1/routing/decisions', () => {
+     it('returns 200 with decisions[] filtered by skill+limit, newest-first', () => {
+       const backends = { 'claude-opus': { type: 'anthropic', model: 'x' } };
+       const routing: RoutingConfig = {
+         default: 'claude-opus',
+         skills: { 'harness-debugging': 'claude-opus' },
+       };
+       const router = new BackendRouter({ backends, routing });
+       const bus = new RoutingDecisionBus();
+       // Seed: 3 skill decisions for harness-debugging, 2 tier decisions
+       for (let i = 0; i < 3; i++)
+         bus.emit({
+           timestamp: `2026-05-26T00:00:0${i}.000Z`,
+           useCase: { kind: 'skill', skillName: 'harness-debugging' },
+           resolutionPath: [],
+           backendName: 'claude-opus',
+           backendType: 'anthropic',
+           durationMs: 0,
+         });
+       for (let i = 0; i < 2; i++)
+         bus.emit({
+           timestamp: `2026-05-26T00:01:0${i}.000Z`,
+           useCase: { kind: 'tier', tier: 'quick-fix' },
+           resolutionPath: [],
+           backendName: 'claude-opus',
+           backendType: 'anthropic',
+           durationMs: 0,
+         });
+       const req = makeReq('GET', '/api/v1/routing/decisions?skill=harness-debugging&limit=2');
+       const { res, chunks, statusCode } = makeRes();
+       handleV1RoutingRoute(req, res, { router, bus, routing, backends });
+       expect(statusCode()).toBe(200);
+       const body = JSON.parse(chunks.join(''));
+       expect(body.decisions.length).toBe(2);
+       // newest-first
+       expect(body.decisions[0].timestamp).toBe('2026-05-26T00:00:02.000Z');
+       expect(body.decisions[1].timestamp).toBe('2026-05-26T00:00:01.000Z');
+     });
+
+     it('returns 503 when bus is null', () => {
+       const req = makeReq('GET', '/api/v1/routing/decisions');
+       const { res, statusCode } = makeRes();
+       handleV1RoutingRoute(req, res, { router: null, bus: null, routing: null, backends: null });
+       expect(statusCode()).toBe(503);
+     });
+   });
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/orchestrator vitest run src/server/routes/v1/routing.test.ts`
+3. Observe: 2 new tests fail (DECISIONS_RE not wired in handler).
+4. Run: `harness validate`
+5. Commit: `test(orchestrator): pin GET /api/v1/routing/decisions filter+ordering contract (Spec B Phase 5)`
+
+---
+
+### Task 6 — Implement decisions route (TDD green)
+
+**Depends on:** Task 5 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.ts`
+
+1. Open `src/server/routes/v1/routing.ts`. Add `handleDecisions`:
+
+   ```ts
+   function parseDecisionsQuery(url: string): {
+     skillName?: string;
+     mode?: string;
+     backendName?: string;
+     limit?: number;
+   } {
+     const qIdx = url.indexOf('?');
+     if (qIdx === -1) return {};
+     const p = new URLSearchParams(url.slice(qIdx + 1));
+     const filter: { skillName?: string; mode?: string; backendName?: string; limit?: number } = {};
+     const skill = p.get('skill');
+     const mode = p.get('mode');
+     const backend = p.get('backend');
+     const limit = p.get('limit');
+     if (skill) filter.skillName = skill;
+     if (mode) filter.mode = mode;
+     if (backend) filter.backendName = backend;
+     if (limit) {
+       const n = Number(limit);
+       if (Number.isFinite(n) && n > 0) filter.limit = Math.floor(n);
+     }
+     return filter;
+   }
+
+   function handleDecisions(
+     req: IncomingMessage,
+     res: ServerResponse,
+     deps: RoutingRouteDeps
+   ): boolean {
+     if (!deps.bus) return unavailable(res);
+     const filter = parseDecisionsQuery(req.url ?? '');
+     sendJSON(res, 200, { decisions: deps.bus.recent(filter) });
+     return true;
+   }
+   ```
+
+2. Wire into the dispatcher:
+   ```ts
+   if (method === 'GET' && DECISIONS_RE.test(url)) return handleDecisions(req, res, deps);
+   ```
+3. Run: `pnpm --filter @harness-engineering/orchestrator vitest run src/server/routes/v1/routing.test.ts`
+4. Observe: 4 tests pass.
+5. Run: `harness validate && harness check-deps`
+6. Commit: `feat(orchestrator): GET /api/v1/routing/decisions with skill/mode/backend/limit filters (Spec B Phase 5, F8)`
+
+---
+
+### Task 7 — Pin the trace route contract (TDD red)
+
+**Depends on:** Task 6 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.test.ts` | **Category:** test
+
+1. Add a third describe block to `routing.test.ts`:
+
+   ```ts
+   import { readBody } from '../../utils'; // verify import path matches existing
+   // utility for fixturing JSON body
+   function makeJsonReq(method: string, url: string, body: unknown): IncomingMessage {
+     const r = new IncomingMessage(new Socket());
+     r.method = method;
+     r.url = url;
+     r.headers['content-type'] = 'application/json';
+     const data = JSON.stringify(body);
+     process.nextTick(() => {
+       r.emit('data', Buffer.from(data));
+       r.emit('end');
+     });
+     return r;
+   }
+
+   describe('handleV1RoutingRoute — POST /api/v1/routing/trace', () => {
+     it('returns 200 with { decision, def: { type } } and does NOT emit on bus', async () => {
+       const backends = { 'claude-opus': { type: 'anthropic', model: 'x' } };
+       const routing: RoutingConfig = { default: 'claude-opus' };
+       const router = new BackendRouter({ backends, routing });
+       const bus = new RoutingDecisionBus();
+       const ringBefore = bus.recent().length;
+       const req = makeJsonReq('POST', '/api/v1/routing/trace', {
+         useCase: { kind: 'tier', tier: 'quick-fix' },
+       });
+       const { res, chunks, statusCode } = makeRes();
+       handleV1RoutingRoute(req, res, { router, bus, routing, backends });
+       await new Promise((r) => setTimeout(r, 10)); // body read is async
+       expect(statusCode()).toBe(200);
+       const body = JSON.parse(chunks.join(''));
+       expect(body.decision.backendName).toBe('claude-opus');
+       expect(body.def).toEqual({ type: 'anthropic' });
+       expect(bus.recent().length).toBe(ringBefore); // dry-run = no emit
+     });
+
+     it('returns 400 on invalid body (missing useCase.kind)', async () => {
+       const backends = { 'claude-opus': { type: 'anthropic', model: 'x' } };
+       const routing: RoutingConfig = { default: 'claude-opus' };
+       const router = new BackendRouter({ backends, routing });
+       const bus = new RoutingDecisionBus();
+       const req = makeJsonReq('POST', '/api/v1/routing/trace', { useCase: { tier: 'quick-fix' } });
+       const { res, chunks, statusCode } = makeRes();
+       handleV1RoutingRoute(req, res, { router, bus, routing, backends });
+       await new Promise((r) => setTimeout(r, 10));
+       expect(statusCode()).toBe(400);
+       expect(chunks.join('')).toContain('error');
+     });
+
+     it('returns 503 when router is null', async () => {
+       const req = makeJsonReq('POST', '/api/v1/routing/trace', {
+         useCase: { kind: 'tier', tier: 'quick-fix' },
+       });
+       const { res, statusCode } = makeRes();
+       handleV1RoutingRoute(req, res, { router: null, bus: null, routing: null, backends: null });
+       await new Promise((r) => setTimeout(r, 10));
+       expect(statusCode()).toBe(503);
+     });
+   });
+   ```
+
+2. Run tests; observe 3 new failures (TRACE_RE not wired).
+3. Run: `harness validate`
+4. Commit: `test(orchestrator): pin POST /api/v1/routing/trace dry-run contract (Spec B Phase 5)`
+
+---
+
+### Task 8 — Implement trace route (TDD green) — uses `resolveDecisionAndDef`
+
+**Depends on:** Task 7 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/routes/v1/routing.ts`
+
+1. Open `routing.ts`. Add Zod schema for the body — keep narrow, no transform:
+
+   ```ts
+   import { z } from 'zod';
+   import { readBody } from '../../utils';
+
+   // Mirror RoutingUseCase discriminated union; reject malformed at the wire.
+   const UseCaseSchema = z.discriminatedUnion('kind', [
+     z.object({
+       kind: z.literal('tier'),
+       tier: z.enum(['quick-fix', 'guided-change', 'full-exploration', 'diagnostic']),
+     }),
+     z.object({ kind: z.literal('intelligence'), layer: z.enum(['sel', 'pesl']) }),
+     z.object({ kind: z.literal('isolation'), tier: z.string() }),
+     z.object({ kind: z.literal('maintenance') }),
+     z.object({ kind: z.literal('chat') }),
+     z.object({
+       kind: z.literal('skill'),
+       skillName: z.string().min(1),
+       cognitiveMode: z.string().optional(),
+     }),
+     z.object({ kind: z.literal('mode'), cognitiveMode: z.string().min(1) }),
+   ]);
+   const TraceBodySchema = z.object({
+     useCase: UseCaseSchema,
+     invocationOverride: z.string().min(1).optional(),
+   });
+   ```
+
+2. Add the handler:
+   ```ts
+   async function handleTrace(
+     req: IncomingMessage,
+     res: ServerResponse,
+     deps: RoutingRouteDeps
+   ): Promise<boolean> {
+     if (!deps.router) {
+       unavailable(res);
+       return true;
+     }
+     let raw: string;
+     try {
+       raw = await readBody(req);
+     } catch {
+       sendJSON(res, 400, { error: 'body read failed' });
+       return true;
+     }
+     let parsed: unknown;
+     try {
+       parsed = JSON.parse(raw);
+     } catch {
+       sendJSON(res, 400, { error: 'invalid JSON body' });
+       return true;
+     }
+     const r = TraceBodySchema.safeParse(parsed);
+     if (!r.success) {
+       sendJSON(res, 400, { error: r.error.message });
+       return true;
+     }
+     const opts =
+       r.data.invocationOverride !== undefined
+         ? { invocationOverride: r.data.invocationOverride }
+         : undefined;
+     try {
+       const { decision, def } = deps.router.resolveDecisionAndDef(r.data.useCase as any, opts);
+       sendJSON(res, 200, { decision, def: { type: def.type } });
+     } catch (err) {
+       sendJSON(res, 500, { error: String(err) });
+     }
+     return true;
+   }
+   ```
+   The `as any` cast on `r.data.useCase` is because Zod's inferred shape (with `kind: 'isolation'; tier: string`) is a wider type than `RoutingUseCase` whose `isolation` tier is `IsolationTier`. The router validates anyway. Mark with an `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comment.
+3. Wire into the dispatcher:
+   ```ts
+   if (method === 'POST' && TRACE_RE.test(url)) {
+     void handleTrace(req, res, deps);
+     return true;
+   }
+   ```
+4. Run: `pnpm --filter @harness-engineering/orchestrator vitest run src/server/routes/v1/routing.test.ts`
+5. Observe: 7 tests pass.
+
+   **Critical assertion:** `handleTrace` must NOT call `bus.emit()`. The Phase 4 contract is that `BackendRouter.resolve()` emits if a bus is injected. Trace uses `resolveDecisionAndDef` which calls `resolve()` internally — so to make trace dry-run, the router instance passed to the trace route MUST be one that has NO bus injected, OR the test seeds the bus separately. The acceptance test pins ring-buffer-unchanged after trace, so the route handler must use a router that was never given the bus (the orchestrator wires the bus into the dispatch-path router; trace passes a sibling router instance? — see C8 below).
+
+   **Resolution:** add a trace-only router accessor on `Orchestrator` — `getBackendRouter()` already returns the production router (with bus). For trace dry-run, either (a) construct a sibling `BackendRouter` per-trace from `getBackends()` + `getRoutingConfig()` (no bus), or (b) accept that trace emits a "phantom" decision and explicitly tag it with a `traceOnly: true` flag the bus filters out.
+
+   **Plan picks (a)** — simpler, no Phase 4 contract change: `handleTrace` constructs `new BackendRouter({ backends: deps.backends, routing: deps.routing })` (no bus) per-call. Cheap (no allocation hot path; trace is operator-driven). Update the test fixture accordingly — the test passes both `router` and `routing+backends`, and the handler uses `routing+backends` for trace, `router` for nothing in trace. Adjust dep shape if needed.
+
+   **Revised handler:**
+
+   ```ts
+   async function handleTrace(
+     req: IncomingMessage,
+     res: ServerResponse,
+     deps: RoutingRouteDeps
+   ): Promise<boolean> {
+     if (!deps.routing || !deps.backends) {
+       unavailable(res);
+       return true;
+     }
+     // ... body parse ...
+     // Build a bus-less router so the trace cannot pollute the production ring buffer.
+     const dryRunRouter = new (await import('../../../agent/backend-router')).BackendRouter({
+       backends: deps.backends,
+       routing: deps.routing,
+     });
+     const { decision, def } = dryRunRouter.resolveDecisionAndDef(r.data.useCase as any, opts);
+     // ...
+   }
+   ```
+
+   This makes the `router` field on `RoutingRouteDeps` unused by trace (used by future routes that need the live router). Acceptable surface.
+
+6. Run: `harness validate && harness check-deps`
+7. Commit: `feat(orchestrator): POST /api/v1/routing/trace dry-run via bus-less router (Spec B Phase 5, O3 partial, F4 prep)`
+
+---
+
+### Task 9 — Register 3 v1 bridge primitives + scope
+
+**Depends on:** Task 8 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/v1-bridge-routes.ts` | **Category:** integration
+
+1. Open `src/server/v1-bridge-routes.ts`. After the Phase 5 telemetry/cache entry (line ~111), append:
+   ```ts
+   // ── Spec B Phase 5 routing observability ──
+   {
+     method: 'GET',
+     pattern: /^\/api\/v1\/routing\/config(?:\?.*)?$/,
+     scope: 'read-telemetry',
+     description: 'Current routing config + resolved fallback chains + known backends.',
+   },
+   {
+     method: 'GET',
+     pattern: /^\/api\/v1\/routing\/decisions(?:\?.*)?$/,
+     scope: 'read-telemetry',
+     description: 'Recent routing decisions (newest-first), filterable by skill/mode/backend.',
+   },
+   {
+     method: 'POST',
+     pattern: /^\/api\/v1\/routing\/trace(?:\?.*)?$/,
+     scope: 'read-telemetry',
+     description: 'Dry-run a routing decision without side effects (no bus emit, no dispatch).',
+   },
+   ```
+2. Run: `pnpm --filter @harness-engineering/orchestrator typecheck`
+3. Run: `harness validate`
+4. Commit: `feat(orchestrator): register 3 v1 bridge primitives for /api/v1/routing/* (Spec B Phase 5)`
+
+---
+
+### Task 10 — Add orchestrator accessors + wire ServerDependencies + clearListeners in stop()
+
+**Depends on:** Task 9 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/orchestrator.ts`
+
+1. Open `src/orchestrator.ts`. After `public getRoutingDecisionBus()` (line 1983), add three new public accessors:
+   ```ts
+   /** Spec B Phase 5: trace route + config route consumer. */
+   public getBackendRouter(): import('./agent/backend-router').BackendRouter | null {
+     return this.backendFactory?.getRouter() ?? null;
+   }
+   /** Spec B Phase 5: config route + trace route's dry-run router constructor. */
+   public getRoutingConfig(): import('@harness-engineering/types').RoutingConfig | null {
+     return this.config.agent.routing ?? null;
+   }
+   /** Spec B Phase 5: config route + trace route's dry-run router constructor. */
+   public getBackends(): Record<string, import('@harness-engineering/types').BackendDef> | null {
+     return this.config.agent.backends ?? null;
+   }
+   ```
+2. In the server-init block at line 533, add the four accessors to the `OrchestratorServer` deps:
+   ```ts
+   this.server = new OrchestratorServer(this, config.server.port, {
+     // ...existing fields...
+     getBackendRouter: () => this.getBackendRouter(),
+     getRoutingDecisionBus: () => this.getRoutingDecisionBus(),
+     getRoutingConfig: () => this.getRoutingConfig(),
+     getBackends: () => this.getBackends(),
+   });
+   ```
+3. In `stop()` at line ~1888, change:
+   ```ts
+   this.routingDecisionBus = null;
+   ```
+   to:
+   ```ts
+   // Spec B Phase 5 (Phase 4 review S2 fix): release subscribers before
+   // nulling the reference so any WS broadcaster closure can be GC'd.
+   this.routingDecisionBus?.clearListeners();
+   this.routingDecisionBus = null;
+   ```
+4. Run: `pnpm --filter @harness-engineering/orchestrator typecheck`
+5. Run: `harness validate`
+6. Commit: `feat(orchestrator): expose getBackendRouter/getRoutingConfig/getBackends + clearListeners-on-stop (Spec B Phase 5)`
+
+---
+
+### Task 11 — Wire routing route + WS broadcaster subscription into OrchestratorServer
+
+**Depends on:** Task 10 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/src/server/http.ts`
+
+1. Open `src/server/http.ts`. Add imports near the top with the other route handlers:
+   ```ts
+   import { handleV1RoutingRoute } from './routes/v1/routing';
+   import type { BackendRouter } from '../agent/backend-router';
+   import type { RoutingDecisionBus } from '../routing/decision-bus';
+   import type { BackendDef, RoutingConfig, RoutingDecision } from '@harness-engineering/types';
+   ```
+2. Extend `ServerDependencies` (after `cacheMetrics`):
+   ```ts
+   /** Spec B Phase 5 — routing observability routes. */
+   getBackendRouter?: () => BackendRouter | null;
+   getRoutingDecisionBus?: () => RoutingDecisionBus | null;
+   getRoutingConfig?: () => RoutingConfig | null;
+   getBackends?: () => Record<string, BackendDef> | null;
+   ```
+3. Add four private fields on the class (near `private cacheMetrics`):
+   ```ts
+   private getBackendRouter: (() => BackendRouter | null) | null = null;
+   private getRoutingDecisionBus: (() => RoutingDecisionBus | null) | null = null;
+   private getRoutingConfig: (() => RoutingConfig | null) | null = null;
+   private getBackends: (() => Record<string, BackendDef> | null) | null = null;
+   private routingDecisionUnsubscribe: (() => void) | null = null;
+   ```
+4. In `initDependencies(deps)`, assign them:
+   ```ts
+   this.getBackendRouter = deps?.getBackendRouter ?? null;
+   this.getRoutingDecisionBus = deps?.getRoutingDecisionBus ?? null;
+   this.getRoutingConfig = deps?.getRoutingConfig ?? null;
+   this.getBackends = deps?.getBackends ?? null;
+   ```
+5. In `wireEvents()` (after the existing `agent_event` listener registration), append:
+   ```ts
+   // Spec B Phase 5 (F10): bridge RoutingDecisionBus → WS broadcaster on
+   // topic 'routing:decision'. Eager subscribe at server construction
+   // matches the agent_event listener pattern; bus.emit() reaches a
+   // broadcaster with zero clients without error (existing broadcast()
+   // contract). Unsubscribe runs in stop() before broadcaster.close().
+   const bus = this.getRoutingDecisionBus?.();
+   if (bus) {
+     this.routingDecisionUnsubscribe = bus.subscribe((decision: RoutingDecision) => {
+       this.broadcaster.broadcast('routing:decision', decision);
+     });
+   }
+   ```
+6. In `buildApiRoutes()`, add an entry near the telemetry route:
+   ```ts
+   // Spec B Phase 5 — routing observability. Returns 503 when the
+   // backendFactory is null (legacy single-backend configs).
+   (req, res) =>
+     handleV1RoutingRoute(req, res, {
+       router: this.getBackendRouter?.() ?? null,
+       bus: this.getRoutingDecisionBus?.() ?? null,
+       routing: this.getRoutingConfig?.() ?? null,
+       backends: this.getBackends?.() ?? null,
+     }),
+   ```
+7. In `stop()` (locate the existing teardown — `for (const client of this.wss.clients) client.close()` etc.), prepend before broadcaster close:
+   ```ts
+   if (this.routingDecisionUnsubscribe) {
+     this.routingDecisionUnsubscribe();
+     this.routingDecisionUnsubscribe = null;
+   }
+   ```
+8. Run: `pnpm --filter @harness-engineering/orchestrator typecheck`
+9. Run: `pnpm --filter @harness-engineering/orchestrator vitest run src/server/routes/v1/routing.test.ts`
+10. Run: `harness validate && harness check-deps`
+11. Commit: `feat(orchestrator): wire /api/v1/routing/* + routing:decision WS broadcast in OrchestratorServer (Spec B Phase 5, F10)`
+
+---
+
+### Task 12 — Integration acceptance test (F10 + F8 + O3 + 503 + latest-N + clearListeners)
+
+**Depends on:** Task 11 | **Files:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/packages/orchestrator/tests/integration/spec-b-phase-5-http-ws.test.ts` (CREATE) | **Category:** test
+
+1. Create the integration test using the existing orchestrator fixture pattern from `tests/integration/spec-b-phase-4-decision-bus.test.ts` (reference structure; do not invent new patterns).
+2. Six pinned test cases:
+   - **F10:** Connect a `ws.WebSocket` client to the running orchestrator's `/ws`, invoke a dispatch that triggers `BackendRouter.resolve(...)`, assert the client receives a `{ type: 'routing:decision', data: RoutingDecision }` frame within 100ms (use `performance.now()` to bracket).
+   - **F8:** Seed the bus by triggering 5 dispatches (mix of skill / tier use cases), call `GET /api/v1/routing/decisions?skill=...&limit=2`, assert body matches expected shape + newest-first order.
+   - **O3 partial:** `POST /api/v1/routing/trace` with `{ useCase: { kind: 'tier', tier: 'quick-fix' } }`, assert 200 + decision present + ring-buffer length unchanged.
+   - **503:** Construct an orchestrator with legacy single-backend config (no `agent.backends`), assert all 3 routes return 503.
+   - **latest-N hygiene:** seed >500 decisions, GET `/api/v1/routing/decisions?limit=10`, assert first decision is the most recent.
+   - **clearListeners-on-stop:** subscribe a custom listener directly via `getRoutingDecisionBus()?.subscribe()`, call `orchestrator.stop()`, trigger a (hypothetical, via a held bus reference) emit and assert the listener does not fire.
+3. Reuse the Phase 4 acceptance test's orchestrator-construction helper if one exists; if not, copy the minimal fixture from `spec-b-phase-4-decision-bus.test.ts`.
+4. Run: `pnpm --filter @harness-engineering/orchestrator vitest run tests/integration/spec-b-phase-5-http-ws.test.ts`
+5. Observe: 6/6 pass.
+6. Run: `harness validate && harness check-deps`
+7. Commit: `test(orchestrator): pin Spec B Phase 5 acceptance criteria (F10 + F8 + O3 trace + 503 + latest-N + clearListeners)`
+
+---
+
+### Task 13 — Final verification: phase-4 tests still pass, typecheck, validate, check-deps
+
+**Depends on:** Task 12 | **Files:** (no edits) | **Category:** verification
+
+1. Run the Phase 4 acceptance suite to confirm N1:
+   `pnpm --filter @harness-engineering/orchestrator vitest run tests/integration/spec-b-phase-4-decision-bus.test.ts tests/routing/decision-bus.test.ts`
+   Expect: Phase 4 5/5 + Phase 5 augmented decision-bus tests 7/7 all pass.
+2. Run the full backend-router suite to confirm N1:
+   `pnpm --filter @harness-engineering/orchestrator vitest run tests/agent/backend-router.test.ts tests/agent/backend-router-chain-walk.test.ts`
+   Expect: unchanged (21/21 + 20/20 per Phase 4 baseline).
+3. Run the orchestrator typecheck:
+   `pnpm --filter @harness-engineering/orchestrator typecheck`
+4. Run: `harness validate && harness check-deps`
+5. Run the full orchestrator test suite, allowing the pre-existing 48 better-sqlite3 NODE_MODULE_VERSION failures:
+   `pnpm --filter @harness-engineering/orchestrator test 2>&1 | tail -30`
+   Confirm: total failures count is unchanged from Phase 4's 48-baseline (no Phase-5-induced regressions).
+6. No commit (verification only).
+
+---
+
+## Integration Checklist
+
+Per spec `Integration Points` section, Phase 5 touches the following:
+
+| Integration Point    | Phase 5 Status                                                                                                                |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| HTTP routes          | **DONE** — 3 new routes in `routes/v1/routing.ts` (Tasks 3-8), wired in `http.ts:buildApiRoutes` (Task 11)                    |
+| WS topic             | **DONE** — `routing:decision` topic, subscribed in `OrchestratorServer.wireEvents()` (Task 11)                                |
+| V1 bridge registry   | **DONE** — 3 entries in `v1-bridge-routes.ts` (Task 9)                                                                        |
+| Token scopes         | **NO CHANGE** — reuses `read-telemetry` per D-OP-1 (no schema delta)                                                          |
+| Barrel exports       | **NO CHANGE** — handler is internal, deep-imported per Phase 4 D-OP-precedent                                                 |
+| Plugin manifests     | **DEFERRED to Phase 6** — `harness routing` CLI is the manifest-affecting surface; Phase 5 routes are dashboard/raw-HTTP-only |
+| Dashboard route      | **DEFERRED to Phase 7**                                                                                                       |
+| Docs + ADRs          | **DEFERRED to Phase 8**                                                                                                       |
+| Knowledge enrichment | **DEFERRED to Phase 8**                                                                                                       |
+
+---
+
+## Risks & Mitigations
+
+| Risk                                                                                                                                                                   | Likelihood | Mitigation                                                                                                                                                                                                                                                               |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Trace route's bus-less router (Task 8 step 5) drifts from production router behavior over time (e.g., production gains a validation gate; trace skips it).             | Medium     | Acceptance test pins `decision.backendName` equality between trace and a subsequent real dispatch with the same useCase. Add a comment block to `routing.ts` noting that both routers MUST be constructed from identical `backends + routing` snapshots.                 |
+| `recent()` latest-N flip breaks Phase 4 acceptance tests that pin oldest-N implicitly.                                                                                 | Low        | Task 1 verifies the existing test fixture first; if Phase 4 tests depended on oldest-N (unlikely — Phase 4 tests only assert count + filter, not order), update in lockstep before the impl change in Task 2.                                                            |
+| WS broadcaster subscription at server construction races with the bus instantiation in `Orchestrator` constructor (which happens after `OrchestratorServer` is built). | Low        | `getRoutingDecisionBus` is a closure called at subscription time, not a captured reference. Verify the orchestrator constructs `routingDecisionBus` BEFORE `new OrchestratorServer(...)` (line 411 vs 533 — confirmed: 411 < 533).                                       |
+| Trace endpoint accepts oversized bodies and exhausts memory.                                                                                                           | Low        | `readBody` already enforces `DEFAULT_MAX_BYTES`; trace bodies are <1KB in practice.                                                                                                                                                                                      |
+| WS `routing:decision` broadcast is fired from a subscriber that runs synchronously on `bus.emit()` — could block dispatch if `broadcaster.broadcast()` is slow.        | Medium     | `WebSocketBroadcaster.broadcast()` is `for (const client of clients) client.send(message)` — non-blocking per `ws` library semantics. S6 isolation in the bus catches any subscriber throw. Document expected dispatch-path overhead at < 1ms with up to 100 WS clients. |
+
+---
+
+## Success Criteria (Final Gate)
+
+- [ ] All 13 tasks committed (Task 13 is verification-only; 12 commits expected)
+- [ ] Phase 5 acceptance test (Task 12) passes 6/6
+- [ ] Phase 4 acceptance test passes 5/5 (no regressions)
+- [ ] `decision-bus.test.ts` passes 7/7 (5 Phase 4 + 2 Phase 5)
+- [ ] `routing.test.ts` passes ≥7 (config 2 + decisions 2 + trace 3)
+- [ ] `harness validate` PASS
+- [ ] `harness check-deps` PASS
+- [ ] `pnpm --filter @harness-engineering/orchestrator typecheck` PASS
+- [ ] Full orchestrator test failure count unchanged from Phase 4 baseline (48 pre-existing failures)
+- [ ] F10 (WS broadcast latency < 100ms) verified by integration test
+- [ ] Phase 4 review S1 (latest-N) + S2 (clearListeners) both closed
+
+---
+
+## Handoff Note for Phase 6 (CLI tools)
+
+Phase 6 (`harness routing config|trace|decisions`) consumes the routes shipped here. Phase 5 surface is stable: filter param names (`skill`, `mode`, `backend`, `limit`), response shapes (`{ decisions }`, `{ routing, resolvedChains, backends }`, `{ decision, def: { type } }`), and the `read-telemetry` scope. The CLI will issue HTTP requests using the existing `harness` token machinery — no new auth wiring required.
+
+Phase 6 should also add a `--strict` mode for trace that 400s on unknown-skill (deferred per C8). Phase 5's trace currently does not validate skill name against the catalog.

--- a/docs/changes/granular-task-routing/plans/2026-05-26-phase-6-cli-routing-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-26-phase-6-cli-routing-plan.md
@@ -1,0 +1,623 @@
+# Plan: Spec B Phase 6 — CLI Routing Tools (`harness routing config|trace|decisions`)
+
+**Date:** 2026-05-26
+**Spec:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/docs/changes/granular-task-routing/proposal.md`
+**Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1`
+**Branch:** `feat/spec-b-phase-1` (HEAD `d9960683`, Phase 5 tip + chore docs regen)
+**Phase 6 scope:** ~2 days, small-to-medium complexity (CLI surface only — consumes stable Phase 5 routes)
+**Tasks:** 10
+**Estimated time:** ~38 min of focused work (one context window per task)
+**Integration Tier:** medium
+**Phase 6 success criteria:** **F4** (`harness skill run … --backend …` invocation override surfaces via CLI help text), **F7** (`harness routing trace --skill <name>` prints resolved backend + `resolutionPath` without dispatching), **F8** (`harness routing decisions … --json` returns recent decisions in JSON suitable for `jq`), **O3** (`harness routing trace` exits non-zero on resolution failure, JSON includes full `RoutingDecision` on `--json`)
+
+---
+
+## Goal
+
+When an operator runs `harness routing config | trace | decisions` against a live orchestrator (`HARNESS_ORCHESTRATOR_URL`, default `http://127.0.0.1:8080`), the CLI issues the Phase-5 HTTP call (`GET /api/v1/routing/config`, `POST /api/v1/routing/trace`, `GET /api/v1/routing/decisions`) with the `HARNESS_API_TOKEN` bearer header (matches `gateway-tools.ts` precedent), renders either a human-readable table or a `--json` blob, and exits **non-zero** when the orchestrator returns a non-2xx status (specifically O3: trace 5xx → exit non-zero so CI gates catch a misconfigured `routing.default`). `harness skill run --backend` is already implemented (Phase 3) — Phase 6 surfaces the flag in `harness skill run --help`, the generated `harness-commands.md` reference, and the four plugin manifests via `pnpm generate:plugin:all`. No orchestrator changes; no Phase 5 route changes.
+
+---
+
+## Observable Truths (Acceptance Criteria)
+
+1. **EARS — Event-driven (F7 / O3):** When the operator runs `harness routing trace --skill harness-debugging` against a running orchestrator with `routing.skills.harness-debugging = 'local-fast'`, the system shall **(a)** issue `POST /api/v1/routing/trace` with body `{ useCase: { kind: 'skill', skillName: 'harness-debugging' } }` and `Authorization: Bearer ${HARNESS_API_TOKEN}` (when set), **(b)** parse the `{ decision, def }` response, **(c)** print to stdout a human-readable summary including `backendName`, `def.type`, and one line per `resolutionPath` step, and **(d)** exit `0`. Verified by unit test against a `vi.fn()`-mocked `fetch`.
+2. **EARS — Event-driven (F7 / O3, JSON path):** When the operator runs `harness routing trace --skill harness-debugging --json`, the system shall print the raw `{ decision, def }` response JSON (pretty, 2-space) to stdout and exit `0`. JSON output shall be `jq`-pipable (single top-level object, no leading prose).
+3. **EARS — Unwanted (O3 non-zero exit):** If `POST /api/v1/routing/trace` returns a non-2xx status (e.g., `500` from `BackendRouter.resolve()` throwing on `routing.default` referencing unknown backend, or `503` when the router is not available), then the system shall print the error body to stderr and exit **`ExitCode.ERROR` (2)**. Verified by unit test against `fetch` returning `{ ok: false, status: 500, text: () => 'routing.default produced no available backend' }`.
+4. **EARS — Event-driven (F8):** When the operator runs `harness routing decisions --skill harness-debugging --last 10`, the system shall issue `GET /api/v1/routing/decisions?skill=harness-debugging&limit=10` with the bearer header, parse `{ decisions: RoutingDecision[] }`, and print a human-readable table (timestamp, useCase summary, backend, durationMs). `--mode <m>` adds `&mode=<m>`. `--backend <name>` adds `&backend=<name>`. All filters are optional and AND-combined per Phase 5's `parseDecisionsQuery`.
+5. **EARS — Event-driven (F8 JSON path):** When the operator adds `--json` to `harness routing decisions`, the system shall print the parsed `{ decisions: [...] }` array as pretty JSON (2-space) and exit `0`. Suitable for `harness routing decisions --json | jq '.decisions[0]'`.
+6. **EARS — Event-driven (config):** When the operator runs `harness routing config`, the system shall issue `GET /api/v1/routing/config` with the bearer header, parse `{ routing, resolvedChains, backends }`, and print **two sections** to stdout: (a) "Backends:" (one line per backend name), (b) "Resolved Chains:" — one line per `resolvedChains` key showing `<source>:<key> → [c1(ok), c2(MISSING), …]` where `MISSING` flags `exists: false` candidates. `--json` prints the full response payload as pretty JSON.
+7. **EARS — Unwanted (network failure):** If the HTTP call throws (orchestrator not running, connection refused, fetch timeout), then the system shall print `Failed to reach orchestrator at <url>: <error>` to stderr and exit **`ExitCode.ERROR` (2)**. Applies to all three subcommands. Verified by unit test against `fetch` throwing `new Error('ECONNREFUSED')`.
+8. **EARS — Unwanted (503):** If any route returns `503` (legacy single-backend config with no `BackendRouter`), then the system shall print `Routing observability not available — orchestrator has no BackendRouter (legacy single-backend config)` to stderr and exit **`ExitCode.ERROR` (2)**. Trace 503 is distinguishable from trace 500 (resolution failure) only by status code in the test mock.
+9. **EARS — Ubiquitous (F4 surfacing):** `harness skill run --help` shall include the line documenting `--backend <name>` (already present from Phase 3); `harness routing trace --help` shall include `--skill`, `--mode`, `--json`; `harness routing decisions --help` shall include `--skill`, `--mode`, `--backend`, `--last`, `--json`; `harness routing config --help` shall include `--json`. Verified by snapshot of `harness routing trace --help` output.
+10. **EARS — Ubiquitous:** After `pnpm generate:plugin:all`, the four plugin manifest directories (Claude, Cursor, Gemini, Codex) shall include slash-command wrappers for `harness routing config`, `harness routing trace`, `harness routing decisions`. Verified by `pnpm generate:plugin:check` returning clean.
+11. **EARS — Ubiquitous:** A new acceptance test file at `packages/cli/src/commands/routing/routing.test.ts` shall pin Observable Truths 1, 3, 4, 7, 8 across at least 5 tests with `fetch` mocked via `vi.spyOn(globalThis, 'fetch')`.
+12. **EARS — Ubiquitous:** `harness validate`, `harness check-deps`, `pnpm --filter @harness-engineering/cli typecheck`, and `pnpm generate:plugin:check` shall pass.
+13. **EARS — Ubiquitous:** New `createRoutingCommand` shall be registered in `packages/cli/src/commands/_registry.ts` (regenerated via `pnpm run generate-barrel-exports`); no manual edit to `_registry.ts` is committed.
+14. **EARS — Ubiquitous (N1, no regression):** All existing tests in `packages/cli/src/commands/skill/`, `packages/cli/src/commands/_registry.ts` consumers, and the Phase 5 acceptance test (`packages/orchestrator/tests/integration/spec-b-phase-5-http-ws.test.ts`) shall continue to pass unchanged.
+
+---
+
+## Uncertainties / Concerns for Operator Sign-Off
+
+| #   | Class         | Concern                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1  | BLOCKING-LITE | **HTTP client shape.** The CLI already has two precedents: (a) `gateway-tools.ts` (MCP-side: `orchestratorBase()` + `authHeader()` helpers reading `HARNESS_ORCHESTRATOR_URL` / `HARNESS_API_TOKEN`, default `http://127.0.0.1:8080`); (b) `proposals.ts` (uses default `http://127.0.0.1:4577` — a different port, almost certainly stale). **Plan defaults to (a)** — replicate the `gateway-tools.ts` shape inside a new shared module `packages/cli/src/commands/routing/http-client.ts` so the three Phase 6 subcommands share `orchestratorBase()` + `authHeader()`. Alternative: extract `gateway-tools.ts`' helpers into `packages/cli/src/utils/orchestrator-http.ts` and consume from both MCP + CLI. Plan picks per-feature local helper for now (smaller blast radius); operator may prefer the shared util refactor. |
+| C2  | BLOCKING-LITE | **Trace command UX — `--skill` required vs optional.** Spec line 264 shows `harness routing trace --skill <name> [--mode <m>] [--json]`. But the route accepts any `RoutingUseCase` (tier, intelligence, isolation, maintenance, chat, skill, mode). **Plan defaults to:** `--skill <name>` is required when neither `--mode` nor any future kind flag is set; if `--mode <m>` is supplied without `--skill`, the CLI sends `{ kind: 'mode', cognitiveMode: m }`; if both `--skill` and `--mode` are supplied, the CLI sends `{ kind: 'skill', skillName, cognitiveMode }` (per spec D12, mode is the skill's declared cognitive mode). No CLI surface for tier/intelligence/isolation traces in Phase 6 — operator can hit the route directly via curl. Reject if Phase 6 should also surface tier/intelligence — adds 1 task.   |
+| C3  | BLOCKING-LITE | **Exit code for trace 5xx (O3).** Spec O3: "`harness routing trace` exits non-zero if the dry-run resolution would throw." Plan reads this as **any non-2xx exits `ExitCode.ERROR` (2)**. 4xx (e.g., 400 Zod parse failure) and 5xx (500 resolution throw, 503 router not available) both exit 2. Alternative: 4xx exits `ExitCode.VALIDATION_FAILED` (1) and 5xx exits `ExitCode.ERROR` (2) — gives CI gates a finer signal. Plan picks **single non-zero (2)** because spec O3 doesn't differentiate. Operator may prefer the finer split.                                                                                                                                                                                                                                                                                      |
+| C4  | BLOCKING-LITE | **`harness routing decisions` ordering when no filters.** Phase 5 route returns newest-first (D-OP-3, F8). Plan: CLI preserves server order (top of table = most recent). `--last <N>` is forwarded as `&limit=<N>`. Alternative: chronological-ascending in the human-readable table (reads top-to-bottom). Plan picks newest-first to match spec line 380 ("10 most recent records") and Phase 5 contract. Operator may prefer chronological for table readability.                                                                                                                                                                                                                                                                                                                                                             |
+| C5  | ASSUMPTION    | **Plugin manifest regeneration is included.** Spec line 499 + 323 require `pnpm generate:plugin:all`. Plan runs both `pnpm run generate-barrel-exports` (Task 8) and `pnpm generate:plugin:all` (Task 9), then `pnpm generate:plugin:check` (Task 10 verification) to confirm no drift. Operator may prefer to skip plugin regen if Phase 6 ships before plugin manifests are due for refresh. Plan keeps it because Phase 6 ships in the same PR as the user-facing `harness routing` surface; manifests should stay in lockstep.                                                                                                                                                                                                                                                                                                |
+| C6  | ASSUMPTION    | **No `harness routing` MCP tool wrappers in Phase 6.** Spec section "Integration Points" doesn't list MCP tools; `gateway-tools.ts` covers `trigger_maintenance_job` + `list_gateway_tokens` but routing routes are CLI-facing observability, not agent-facing primitives. Operator may want an MCP `trace_routing_decision` tool — defer to a follow-up Phase or include in Phase 7 (dashboard panel + MCP parity).                                                                                                                                                                                                                                                                                                                                                                                                              |
+| C7  | ASSUMPTION    | **Human-readable table shape for `decisions`.** Plan: 4-column table `timestamp (ISO short)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | useCase | backend | durationMs (ms)`. `useCase`rendered as`skill:harness-debugging`/`mode:adversarial-reviewer`/`tier:quick-fix`etc. Operator may prefer JSON-by-default +`--pretty`for the table view (inverts the default). Plan picks human-readable default because the spec wording ("dumps recent decisions in JSON for shell pipelines", line 265) treats`--json` as the pipe-mode flag. |
+| C8  | DEFERRABLE    | **`--strict` mode for trace (Phase 5 C8 carryover).** Phase 5 handoff notes: "deferred `--strict` mode for trace (C8) is still open". Plan does NOT add `--strict` in Phase 6 (no orchestrator changes scope). Operator may want it now — would require Phase 5 route widening (`?strict=true` → 400 on unknown skill against catalog) and a Phase 6 CLI flag.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| C9  | DEFERRABLE    | **Test file location convention.** `packages/cli/src/commands/routing/routing.test.ts` (sibling to `index.ts`) matches `skill/`-style. Could split per-subcommand (`config.test.ts`, `trace.test.ts`, `decisions.test.ts`) — Plan keeps single file because total test count is ~7 and all three subcommands share the same `fetch` mock harness. Operator may split if suite grows beyond ~15 tests.                                                                                                                                                                                                                                                                                                                                                                                                                             |
+
+**Decision points the operator should confirm before execution:**
+
+- **D-OP-1 (C1):** **Approve per-feature `routing/http-client.ts` helper** (matches `gateway-tools.ts`). If reject (prefer shared util): Task 1 lifts helpers into `packages/cli/src/utils/orchestrator-http.ts` and refactors `gateway-tools.ts` + `webhook-tools.ts` to consume (adds 2 tasks).
+- **D-OP-2 (C2):** **Approve CLI surfacing skill + mode only** for `routing trace`. If reject (also expose tier/intelligence/isolation): Task 4 adds `--tier <t>` and `--intelligence <l>` flags + tests.
+- **D-OP-3 (C3):** **Approve single non-zero exit (`ExitCode.ERROR`, 2)** for any trace non-2xx. If reject (4xx vs 5xx split): Task 4 uses `ExitCode.VALIDATION_FAILED` (1) on 4xx, `ExitCode.ERROR` (2) on 5xx.
+- **D-OP-4 (C4):** **Approve newest-first ordering in `decisions` table.** Matches Phase 5 server order.
+- **D-OP-5 (C5):** **Approve plugin manifest regen in Phase 6 PR.** If reject (defer to a release-prep PR): drop Task 9 + Task 10's `generate:plugin:check` step.
+- **D-OP-6 (C7):** **Approve human-readable as default, `--json` opt-in.** Matches `search.ts` convention.
+
+---
+
+## File Map
+
+```
+CREATE  packages/cli/src/commands/routing/index.ts
+CREATE  packages/cli/src/commands/routing/http-client.ts
+CREATE  packages/cli/src/commands/routing/config.ts
+CREATE  packages/cli/src/commands/routing/trace.ts
+CREATE  packages/cli/src/commands/routing/decisions.ts
+CREATE  packages/cli/src/commands/routing/routing.test.ts
+MODIFY  packages/cli/src/commands/_registry.ts                 (regenerated by generate-barrel-exports)
+MODIFY  plugin manifests under .claude/, .cursor/, .gemini/, .codex/  (regenerated by generate:plugin:all)
+MODIFY  docs/reference/cli-commands.md                          (regenerated by generate-docs if applicable)
+```
+
+**No orchestrator, types, or core changes.** Phase 6 is a pure CLI surface over the stable Phase 5 routes.
+
+---
+
+## Tasks
+
+### Task 1: Create `routing/http-client.ts` shared helper
+
+**Depends on:** none | **Files:** `packages/cli/src/commands/routing/http-client.ts`
+
+1. Create `packages/cli/src/commands/routing/http-client.ts` with:
+
+   ```ts
+   /**
+    * Spec B Phase 6: shared HTTP helpers for the `harness routing`
+    * subcommand group. Mirrors `packages/cli/src/mcp/tools/gateway-tools.ts`
+    * — `orchestratorBase()` reads `HARNESS_ORCHESTRATOR_URL` (default
+    * `http://127.0.0.1:8080`); `authHeader()` forwards `HARNESS_API_TOKEN`
+    * as `Authorization: Bearer ...`. Both Phase 5 routes use
+    * `read-telemetry` scope (D-OP-1 of Phase 5); the legacy
+    * `HARNESS_API_TOKEN` resolves as admin in dev mode, so no token
+    * configuration is required for localhost orchestrators.
+    */
+   export function orchestratorBase(): string {
+     return process.env['HARNESS_ORCHESTRATOR_URL'] ?? 'http://127.0.0.1:8080';
+   }
+
+   export function authHeader(): Record<string, string> {
+     const tok = process.env['HARNESS_API_TOKEN'];
+     return tok ? { Authorization: `Bearer ${tok}` } : {};
+   }
+
+   export interface CallResult<T> {
+     ok: boolean;
+     status: number;
+     body: T | null;
+     error?: string;
+   }
+
+   /**
+    * GET helper. Returns parsed JSON on 2xx, `{ ok:false, status, error }`
+    * on non-2xx or network failure. Callers map status → exit code.
+    */
+   export async function getJson<T>(path: string): Promise<CallResult<T>> {
+     try {
+       const res = await fetch(`${orchestratorBase()}${path}`, {
+         headers: { ...authHeader() },
+       });
+       const text = await res.text();
+       if (!res.ok) return { ok: false, status: res.status, body: null, error: text };
+       return { ok: true, status: res.status, body: text ? (JSON.parse(text) as T) : null };
+     } catch (err) {
+       return {
+         ok: false,
+         status: 0,
+         body: null,
+         error: err instanceof Error ? err.message : String(err),
+       };
+     }
+   }
+
+   /**
+    * POST helper. Same shape as getJson; serializes body as JSON.
+    */
+   export async function postJson<T>(path: string, body: unknown): Promise<CallResult<T>> {
+     try {
+       const res = await fetch(`${orchestratorBase()}${path}`, {
+         method: 'POST',
+         headers: { 'Content-Type': 'application/json', ...authHeader() },
+         body: JSON.stringify(body),
+       });
+       const text = await res.text();
+       if (!res.ok) return { ok: false, status: res.status, body: null, error: text };
+       return { ok: true, status: res.status, body: text ? (JSON.parse(text) as T) : null };
+     } catch (err) {
+       return {
+         ok: false,
+         status: 0,
+         body: null,
+         error: err instanceof Error ? err.message : String(err),
+       };
+     }
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/cli typecheck` — observe pass.
+3. Run: `harness validate` — observe pass.
+4. Commit: `feat(cli): add shared http helpers for harness routing subcommands (Spec B Phase 6)`
+
+---
+
+### Task 2: Write `routing/routing.test.ts` red — pin Observable Truths 1, 3, 4, 7, 8
+
+**Depends on:** Task 1 | **Files:** `packages/cli/src/commands/routing/routing.test.ts`
+
+1. Create `packages/cli/src/commands/routing/routing.test.ts`. Use the standard vitest pattern (mirrors `gateway-tools.test.ts`). Mock `fetch` via `vi.spyOn(globalThis, 'fetch')`. Capture stdout/stderr by spying on `console.log` and `console.error`. Use `vi.spyOn(process, 'exit')` to assert exit codes without actually exiting.
+
+2. Test cases (5 minimum):
+   - **`harness routing trace --skill harness-debugging` happy path (Truth 1):** mock `fetch` to resolve `{ ok: true, status: 200, text: async () => JSON.stringify({ decision: { backendName: 'local-fast', useCase: { kind: 'skill', skillName: 'harness-debugging' }, resolutionPath: [{ source: 'skill', candidate: 'local-fast', outcome: 'chosen' }], timestamp: '2026-05-26T00:00:00Z', durationMs: 0.5, backendType: 'local' }, def: { type: 'local' } }) }`. Invoke the subcommand action. Assert `console.log` was called with text including `local-fast` and `resolution`; assert no `process.exit` non-zero.
+   - **`harness routing trace --json` (Truth 2):** same fetch mock; assert stdout includes pretty-JSON containing `"backendName": "local-fast"`.
+   - **`harness routing trace` 500 → exit 2 (Truth 3 / O3):** mock fetch to resolve `{ ok: false, status: 500, text: async () => 'routing.default produced no available backend' }`. Assert `process.exit` called with `2`; assert stderr contains the error body.
+   - **`harness routing decisions --skill X --last 3` (Truth 4):** mock fetch GET `/api/v1/routing/decisions?skill=X&limit=3` to return `{ decisions: [<3 fixtures, newest-first>] }`. Assert table includes all 3 backend names; assert URL contains both query params.
+   - **`harness routing decisions --json` (Truth 5):** assert pretty JSON containing `"decisions"` key.
+   - **Network failure → exit 2 (Truth 7):** mock fetch to throw `new Error('ECONNREFUSED')`. Assert `process.exit(2)`; assert stderr contains `Failed to reach orchestrator`.
+   - **503 path (Truth 8):** mock fetch to resolve `{ ok: false, status: 503, text: async () => '{"error":"BackendRouter not available"}' }`. Assert `process.exit(2)`; assert stderr contains `Routing observability not available`.
+
+3. Run: `pnpm --filter @harness-engineering/cli test -- routing/routing.test.ts` — observe **all tests FAIL** (subcommand files don't exist yet). The failure mode is "Cannot find module './config'" or equivalent.
+
+4. Commit: `test(cli): pin Spec B Phase 6 harness routing subcommand contracts (red)`
+
+---
+
+### Task 3: Implement `routing/config.ts` (Truth 6, Truth 7, Truth 8)
+
+**Depends on:** Task 2 | **Files:** `packages/cli/src/commands/routing/config.ts`
+
+1. Create `packages/cli/src/commands/routing/config.ts`:
+
+   ```ts
+   import { Command } from 'commander';
+   import { getJson } from './http-client';
+   import { logger } from '../../output/logger';
+   import { ExitCode } from '../../utils/errors';
+
+   interface ConfigResponse {
+     routing: unknown;
+     resolvedChains: Record<string, { candidate: string; exists: boolean }[]>;
+     backends: string[];
+   }
+
+   function renderHuman(data: ConfigResponse): void {
+     console.log('Backends:');
+     for (const b of data.backends) console.log(`  - ${b}`);
+     console.log('\nResolved Chains:');
+     for (const [key, chain] of Object.entries(data.resolvedChains)) {
+       const rendered = chain
+         .map((c) => (c.exists ? c.candidate : `${c.candidate}(MISSING)`))
+         .join(' -> ');
+       console.log(`  ${key}: ${rendered}`);
+     }
+   }
+
+   export function createConfigCommand(): Command {
+     return new Command('config')
+       .description('Print active routing config and resolved fallback chains')
+       .option('--json', 'Emit JSON to stdout instead of human-readable text')
+       .action(async (opts: { json?: boolean }) => {
+         const r = await getJson<ConfigResponse>('/api/v1/routing/config');
+         if (!r.ok) {
+           if (r.status === 0) {
+             logger.error(
+               `Failed to reach orchestrator at ${process.env['HARNESS_ORCHESTRATOR_URL'] ?? 'http://127.0.0.1:8080'}: ${r.error}`
+             );
+           } else if (r.status === 503) {
+             logger.error(
+               'Routing observability not available — orchestrator has no BackendRouter (legacy single-backend config)'
+             );
+           } else {
+             logger.error(`Request failed (${r.status}): ${r.error}`);
+           }
+           process.exit(ExitCode.ERROR);
+           return;
+         }
+         if (opts.json) {
+           console.log(JSON.stringify(r.body, null, 2));
+           return;
+         }
+         renderHuman(r.body!);
+       });
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/cli typecheck` — observe pass.
+3. Run: `harness validate` — observe pass.
+4. Commit: `feat(cli): harness routing config — GET /api/v1/routing/config consumer (Spec B Phase 6)`
+
+---
+
+### Task 4: Implement `routing/trace.ts` (Truth 1, 2, 3, 7, 8 / O3)
+
+**Depends on:** Task 3 | **Files:** `packages/cli/src/commands/routing/trace.ts`
+
+1. Create `packages/cli/src/commands/routing/trace.ts`:
+
+   ```ts
+   import { Command } from 'commander';
+   import { postJson } from './http-client';
+   import { logger } from '../../output/logger';
+   import { ExitCode } from '../../utils/errors';
+   import type { RoutingDecision, RoutingUseCase } from '@harness-engineering/types';
+
+   interface TraceResponse {
+     decision: RoutingDecision;
+     def: { type: string };
+   }
+
+   function buildUseCase(opts: { skill?: string; mode?: string }): RoutingUseCase | null {
+     if (opts.skill) {
+       const uc: RoutingUseCase = opts.mode
+         ? { kind: 'skill', skillName: opts.skill, cognitiveMode: opts.mode }
+         : { kind: 'skill', skillName: opts.skill };
+       return uc;
+     }
+     if (opts.mode) return { kind: 'mode', cognitiveMode: opts.mode };
+     return null;
+   }
+
+   function renderHuman(r: TraceResponse): void {
+     console.log(`Backend: ${r.decision.backendName} (type: ${r.def.type})`);
+     console.log(`Duration: ${r.decision.durationMs.toFixed(2)} ms`);
+     console.log('Resolution path:');
+     for (const step of r.decision.resolutionPath) {
+       console.log(`  ${step.source}:${step.candidate} -> ${step.outcome}`);
+     }
+   }
+
+   export function createTraceCommand(): Command {
+     return new Command('trace')
+       .description('Dry-run a routing decision without dispatching (Spec B F7)')
+       .option('--skill <name>', 'Skill name to trace')
+       .option('--mode <m>', 'Cognitive mode to trace (or attach to --skill per D12)')
+       .option('--json', 'Emit JSON to stdout instead of human-readable text')
+       .action(async (opts: { skill?: string; mode?: string; json?: boolean }) => {
+         const useCase = buildUseCase(opts);
+         if (!useCase) {
+           logger.error('Either --skill <name> or --mode <m> is required');
+           process.exit(ExitCode.ERROR);
+           return;
+         }
+         const r = await postJson<TraceResponse>('/api/v1/routing/trace', { useCase });
+         if (!r.ok) {
+           if (r.status === 0) {
+             logger.error(
+               `Failed to reach orchestrator at ${process.env['HARNESS_ORCHESTRATOR_URL'] ?? 'http://127.0.0.1:8080'}: ${r.error}`
+             );
+           } else if (r.status === 503) {
+             logger.error(
+               'Routing observability not available — orchestrator has no BackendRouter (legacy single-backend config)'
+             );
+           } else {
+             logger.error(`Trace failed (${r.status}): ${r.error}`);
+           }
+           process.exit(ExitCode.ERROR);
+           return;
+         }
+         if (opts.json) {
+           console.log(JSON.stringify(r.body, null, 2));
+           return;
+         }
+         renderHuman(r.body!);
+       });
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/cli test -- routing/routing.test.ts` — observe **the trace happy-path, JSON, 500-exit, network-failure, and 503 tests now pass**. The 4 `decisions` tests still fail (next task).
+3. Run: `harness validate` — observe pass.
+4. Commit: `feat(cli): harness routing trace — POST /api/v1/routing/trace consumer with non-zero exit on failure (Spec B Phase 6, F7, O3)`
+
+---
+
+### Task 5: Implement `routing/decisions.ts` (Truth 4, 5, 7, 8)
+
+**Depends on:** Task 4 | **Files:** `packages/cli/src/commands/routing/decisions.ts`
+
+1. Create `packages/cli/src/commands/routing/decisions.ts`:
+
+   ```ts
+   import { Command } from 'commander';
+   import { getJson } from './http-client';
+   import { logger } from '../../output/logger';
+   import { ExitCode } from '../../utils/errors';
+   import type { RoutingDecision, RoutingUseCase } from '@harness-engineering/types';
+
+   interface DecisionsResponse {
+     decisions: RoutingDecision[];
+   }
+
+   function summarizeUseCase(uc: RoutingUseCase): string {
+     switch (uc.kind) {
+       case 'skill':
+         return uc.cognitiveMode
+           ? `skill:${uc.skillName}/${uc.cognitiveMode}`
+           : `skill:${uc.skillName}`;
+       case 'mode':
+         return `mode:${uc.cognitiveMode}`;
+       case 'tier':
+         return `tier:${uc.tier}`;
+       case 'intelligence':
+         return `intelligence:${uc.layer}`;
+       case 'isolation':
+         return `isolation:${uc.tier}`;
+       case 'maintenance':
+         return 'maintenance';
+       case 'chat':
+         return 'chat';
+     }
+   }
+
+   function shortIso(iso: string): string {
+     // 2026-05-26T12:34:56.789Z -> 12:34:56.789
+     const t = iso.split('T')[1] ?? iso;
+     return t.replace('Z', '');
+   }
+
+   function renderHuman(data: DecisionsResponse): void {
+     if (data.decisions.length === 0) {
+       console.log('(no decisions in buffer)');
+       return;
+     }
+     console.log('TIMESTAMP     USE-CASE                              BACKEND        DURATION');
+     for (const d of data.decisions) {
+       const ts = shortIso(d.timestamp).padEnd(13);
+       const uc = summarizeUseCase(d.useCase).padEnd(38);
+       const be = d.backendName.padEnd(14);
+       const dur = `${d.durationMs.toFixed(2)} ms`;
+       console.log(`${ts} ${uc} ${be} ${dur}`);
+     }
+   }
+
+   function buildQuery(opts: {
+     skill?: string;
+     mode?: string;
+     backend?: string;
+     last?: string;
+   }): string {
+     const p = new URLSearchParams();
+     if (opts.skill) p.set('skill', opts.skill);
+     if (opts.mode) p.set('mode', opts.mode);
+     if (opts.backend) p.set('backend', opts.backend);
+     if (opts.last) p.set('limit', opts.last);
+     const q = p.toString();
+     return q ? `?${q}` : '';
+   }
+
+   export function createDecisionsCommand(): Command {
+     return new Command('decisions')
+       .description('List recent routing decisions from the orchestrator ring buffer (Spec B F8)')
+       .option('--skill <name>', 'Filter by useCase.skillName')
+       .option('--mode <m>', 'Filter by useCase.cognitiveMode')
+       .option('--backend <name>', 'Filter by chosen backendName')
+       .option('--last <N>', 'Limit to the N most recent decisions')
+       .option('--json', 'Emit JSON to stdout instead of human-readable text')
+       .action(
+         async (opts: {
+           skill?: string;
+           mode?: string;
+           backend?: string;
+           last?: string;
+           json?: boolean;
+         }) => {
+           const query = buildQuery(opts);
+           const r = await getJson<DecisionsResponse>(`/api/v1/routing/decisions${query}`);
+           if (!r.ok) {
+             if (r.status === 0) {
+               logger.error(
+                 `Failed to reach orchestrator at ${process.env['HARNESS_ORCHESTRATOR_URL'] ?? 'http://127.0.0.1:8080'}: ${r.error}`
+               );
+             } else if (r.status === 503) {
+               logger.error(
+                 'Routing observability not available — orchestrator has no BackendRouter (legacy single-backend config)'
+               );
+             } else {
+               logger.error(`Request failed (${r.status}): ${r.error}`);
+             }
+             process.exit(ExitCode.ERROR);
+             return;
+           }
+           if (opts.json) {
+             console.log(JSON.stringify(r.body, null, 2));
+             return;
+           }
+           renderHuman(r.body!);
+         }
+       );
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/cli test -- routing/routing.test.ts` — observe **all tests pass**.
+3. Run: `harness validate` — observe pass.
+4. Commit: `feat(cli): harness routing decisions — GET /api/v1/routing/decisions consumer with filters (Spec B Phase 6, F8)`
+
+---
+
+### Task 6: Create `routing/index.ts` and register subcommands
+
+**Depends on:** Task 5 | **Files:** `packages/cli/src/commands/routing/index.ts`
+
+1. Create `packages/cli/src/commands/routing/index.ts`:
+
+   ```ts
+   import { Command } from 'commander';
+   import { createConfigCommand } from './config';
+   import { createTraceCommand } from './trace';
+   import { createDecisionsCommand } from './decisions';
+
+   /**
+    * Spec B Phase 6: `harness routing` subcommand group. Operator-facing
+    * inspection of routing config, dry-run trace, and recent decisions.
+    * Consumes the Phase 5 routes under `/api/v1/routing/{config,trace,decisions}`.
+    */
+   export function createRoutingCommand(): Command {
+     const cmd = new Command('routing').description(
+       'Inspect routing config, trace decisions, and read recent dispatches'
+     );
+     cmd.addCommand(createConfigCommand());
+     cmd.addCommand(createTraceCommand());
+     cmd.addCommand(createDecisionsCommand());
+     return cmd;
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/cli typecheck` — observe pass.
+3. Run: `harness validate` — observe pass.
+4. Commit: `feat(cli): wire harness routing subcommand group (Spec B Phase 6)`
+
+---
+
+### Task 7: Regenerate `_registry.ts` (barrel exports)
+
+**Depends on:** Task 6 | **Files:** `packages/cli/src/commands/_registry.ts`
+
+1. Run: `pnpm run generate-barrel-exports` (or `pnpm --filter @harness-engineering/cli run generate-barrel-exports` if scoped — confirm script name in root `package.json` first; see header note in `_registry.ts`: "Run `pnpm run generate-barrel-exports` to regenerate").
+2. Verify `_registry.ts` now imports `createRoutingCommand` from `./routing` and that the alphabetically-correct position is taken (between `createRoadmapCommand` and `createScanCommand` per current alphabetical ordering — line 57-58 region).
+3. Run: `pnpm --filter @harness-engineering/cli typecheck` — observe pass.
+4. Run: `pnpm --filter @harness-engineering/cli build` — observe pass.
+5. Run: `harness validate` — observe pass.
+6. Commit: `chore(cli): regenerate _registry.ts with createRoutingCommand (Spec B Phase 6)`
+
+---
+
+### Task 8: `[checkpoint:human-verify]` Smoke-test CLI help text (Truth 9)
+
+**Depends on:** Task 7 | **Files:** none (verification-only)
+
+1. Run: `pnpm --filter @harness-engineering/cli build` to ensure the latest binary is wired.
+2. Run from worktree root:
+   ```bash
+   pnpm exec harness routing --help
+   pnpm exec harness routing config --help
+   pnpm exec harness routing trace --help
+   pnpm exec harness routing decisions --help
+   pnpm exec harness skill run --help
+   ```
+3. **Verify** each prints the expected flags:
+   - `routing` group: lists `config`, `trace`, `decisions` subcommands.
+   - `config`: `--json`.
+   - `trace`: `--skill`, `--mode`, `--json`.
+   - `decisions`: `--skill`, `--mode`, `--backend`, `--last`, `--json`.
+   - `skill run`: includes the `--backend <name>` line from Phase 3 ("Spec B: one-shot routing override forwarded …").
+4. **[checkpoint:human-verify]** Operator confirms help output looks correct (no Commander argument-parse warnings, no missing flags).
+5. Commit (verification-only, no file changes): skip commit — this is a checkpoint, not an artifact-producing task.
+
+---
+
+### Task 9: Regenerate plugin manifests for Claude/Cursor/Gemini/Codex (Truth 10)
+
+**Depends on:** Task 8 | **Files:** plugin manifest directories under `.claude/`, `.cursor/`, `.gemini/`, `.codex/` (paths determined by `scripts/lib/plugin-config.mjs`)
+
+1. Run: `pnpm generate:plugin:all` (this runs `generate:plugin:claude && :cursor && :gemini && :codex` per root `package.json:39`).
+2. Verify the output directories now contain slash-command wrappers naming `harness routing config`, `harness routing trace`, `harness routing decisions`. The generator reads `harness <subcommand> --help` from the built CLI; if the build is stale, the new commands will be missing.
+3. Run: `git status` — observe the four plugin dirs have new/modified files.
+4. Run: `pnpm generate:plugin:check` — observe **clean exit** (no drift between regenerated artifacts and what's just been committed).
+5. Run: `harness validate` — observe pass.
+6. Commit: `chore(plugin-manifests): regenerate Claude/Cursor/Gemini/Codex manifests with harness routing commands (Spec B Phase 6)`
+
+---
+
+### Task 10: Final verification + Phase 6 acceptance gate (Truth 11, 12, 14)
+
+**Depends on:** Task 9 | **Files:** none (verification-only)
+
+1. Run from worktree root:
+   ```bash
+   pnpm --filter @harness-engineering/cli typecheck
+   pnpm --filter @harness-engineering/cli test -- routing/routing.test.ts
+   pnpm --filter @harness-engineering/cli test
+   pnpm --filter @harness-engineering/orchestrator test -- spec-b-phase-5-http-ws.test.ts
+   pnpm generate:plugin:check
+   harness validate
+   harness check-deps
+   ```
+2. **Assert** all of the following:
+   - `cli typecheck` exits 0
+   - `routing/routing.test.ts` all green (≥5 tests)
+   - Full `cli` test suite passes with no new failures (baseline: see `verification.fullOrchestratorSuite` from Phase 5 handoff — track CLI-package failures separately)
+   - Phase 5 acceptance test (`spec-b-phase-5-http-ws.test.ts`) still 6/6 green (N1)
+   - `pnpm generate:plugin:check` exits clean
+   - `harness validate` exits 0
+   - `harness check-deps` exits 0
+3. **Map back to Phase 6 success criteria:**
+   - **F4** verified by Task 8 help-text inspection (`harness skill run --help` shows `--backend`).
+   - **F7** verified by `routing/routing.test.ts` trace happy-path test (Task 2/Task 4).
+   - **F8** verified by `routing/routing.test.ts` decisions happy-path test (Task 2/Task 5).
+   - **O3** verified by `routing/routing.test.ts` trace 500-exit test (Task 2/Task 4).
+4. Commit (test-update-only if any baseline shifts; verification-only otherwise): if any test fixture needed an update, commit it now with `test(cli): pin Spec B Phase 6 acceptance — F4 F7 F8 O3 verified`.
+5. **[checkpoint:human-verify]** Operator confirms all 7 verifications pass and the Phase 6 PR is ready for review.
+
+---
+
+## Sequencing Summary
+
+| Order | Task | Time   | Category      | Parallelizable                  |
+| ----- | ---- | ------ | ------------- | ------------------------------- |
+| 1     | 1    | ~3 min | impl (helper) | no — root dependency            |
+| 2     | 2    | ~5 min | test (red)    | no — depends on Task 1's helper |
+| 3     | 3    | ~4 min | impl          | no                              |
+| 4     | 4    | ~5 min | impl          | no                              |
+| 5     | 5    | ~5 min | impl          | no                              |
+| 6     | 6    | ~2 min | impl (wiring) | no                              |
+| 7     | 7    | ~2 min | integration   | no                              |
+| 8     | 8    | ~3 min | checkpoint    | no                              |
+| 9     | 9    | ~4 min | integration   | no                              |
+| 10    | 10   | ~5 min | acceptance    | no                              |
+
+**Total:** ~38 minutes of focused work. Tasks 3, 4, 5 could in principle parallelize (independent files, all under `routing/`) but the TDD harness in Task 2 needs the test file present before any of them produces a green test, so the dependency chain is linear (Task 2 → 3 → 4 → 5) under TDD red→green discipline.
+
+---
+
+## Skill Annotations
+
+- **Task 1, 3, 4, 5, 6:** `harness-tdd` (apply) — TDD red/green discipline; small atomic commits.
+- **Task 2:** `harness-tdd` (apply) — write failing test before any implementation.
+- **Task 7, 9:** `harness-generators` (reference if available) — regenerator pattern for `_registry.ts` and plugin manifests.
+- **Task 8, 10:** `harness-soundness-review` (reference) — verification gating before phase completion.
+
+(No `SKILLS.md` recommendation file exists for this spec; annotations inferred from task domain.)
+
+---
+
+## Out of Scope
+
+- **Phase 7:** Dashboard `/routing` panel (`packages/dashboard/src/routes/`). Cards: Resolved Chains, Recent Decisions, Per-Backend Volume, Trace Tool. WS subscription to `routing:decision`. Spec lines 270-279, 503-514.
+- **Phase 8:** Docs + ADRs + knowledge-graph enrichment. 5 ADRs, updates to `docs/knowledge/orchestrator/`, new `docs/guides/routing-trace.md`. Spec lines 332-348, 516-529.
+- **`--strict` mode for `trace`:** Phase 5 C8 carryover — deferred.
+- **MCP wrappers for routing routes:** No `trace_routing_decision` MCP tool in Phase 6 (per C6 assumption).
+- **`harness dispatch --backend` CLI ergonomics:** Spec line 267 lists this but it's already wired in Phase 3 (per Phase 5 handoff `outOfScope.Phase6`); no Phase 6 CLI change needed beyond help-text snapshot in Task 8.
+
+---
+
+## Handoff Trigger (after Task 10 verification)
+
+When all Task 10 verifications pass:
+
+1. Write `.harness/sessions/changes--granular-task-routing--proposal/handoff.json` with `phase: "Spec B Phase 6 — CLI Routing Tools"`, `status: "complete"`, the 7-10 commit shas, and `successCriteriaPinned` for F4/F7/F8/O3.
+2. Surface Phase 7 (dashboard panel) as the next phase. Phase 7 depends on the Phase 5 WS topic + `/api/v1/routing/config` route, which are stable; the new `harness routing config` CLI command is also useful for dashboard developers to introspect orchestrator state during component dev.

--- a/docs/changes/granular-task-routing/plans/2026-05-26-phase-7-dashboard-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-26-phase-7-dashboard-plan.md
@@ -1,0 +1,880 @@
+# Plan: Spec B Phase 7 — Dashboard `/routing` Panel
+
+**Date:** 2026-05-26 | **Spec:** `docs/changes/granular-task-routing/proposal.md` (Phase 7, lines 503–514) | **Tasks:** 12 | **Time:** ~4 days (~36 atomic-edit minutes of plan content; bulk of wall-clock is test authoring + jsdom iteration) | **Integration Tier:** medium
+
+**Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1` (branch `feat/spec-b-phase-1`, base `55bd0c6d`).
+**Spec criteria pinned:** F9, O2, O4, Q2.
+**Upstream contracts (Phase 5, frozen):** `GET /api/v1/routing/config` → `{ routing, resolvedChains, backends }`; `GET /api/v1/routing/decisions?skill=&mode=&backend=&limit=` → `{ decisions: RoutingDecision[] }` (newest-first); `POST /api/v1/routing/trace` body `{ useCase, invocationOverride? }` → `{ decision, def: { type } }`; WS topic `routing:decision` data `RoutingDecision`.
+
+---
+
+## Goal
+
+Operators visiting the dashboard see live routing decisions, the resolved fallback chains for the current `routing` config, per-backend 24h dispatch volume + success rate, and can dry-run an arbitrary `{ skill, mode }` resolution — all on a single `/routing` panel that degrades gracefully when the WS drops, the ring buffer is empty, or a backend has had zero dispatches.
+
+## Observable Truths (Acceptance Criteria)
+
+1. **EARS-ubiquitous (F9):** Navigating to `/routing` renders four labeled cards — `Resolved Chains`, `Recent Decisions`, `Per-Backend Volume`, `Trace`. Verified by `Routing.test.tsx` asserting `data-testid="routing-card-{chains,decisions,volume,trace}"` all present after first paint.
+2. **EARS-event-driven (F9 / D8):** When a `routing:decision` WS frame arrives, the Recent Decisions table prepends a new row within one render tick and the Per-Backend Volume card recomputes the affected backend's count + success rate. Verified by `useRoutingDecisions.test.tsx` driving a mocked `WebSocket` and asserting state delta.
+3. **EARS-event-driven (F9):** When an operator clicks a row in Recent Decisions, the row expands to render the full `resolutionPath` (every `{ source, candidate, outcome }` step from `RoutingDecision.resolutionPath`). Verified by `RoutingDecisionsCard.test.tsx` using `userEvent.click`.
+4. **EARS-event-driven (F9):** When an operator submits the Trace form with `{ skill: "harness-debugging", mode?: "reviewer" }`, the panel POSTs to `/api/v1/routing/trace` and renders `decision.backendName`, `decision.backendType`, and the ordered `resolutionPath`. Verified by `RoutingTraceCard.test.tsx` asserting fetch call shape + rendered output.
+5. **EARS-state-driven (O2 / "WS disconnected"):** While the WebSocket is in the `CLOSED` or `CONNECTING` state, the panel falls back to HTTP polling `/api/v1/routing/decisions?limit=500` every 5 s and surfaces a small `data-testid="routing-ws-status"` indicator reading `"polling"`. Verified by `useRoutingDecisions.test.tsx` advancing `vi.useFakeTimers()` past the poll interval with the WS mock kept closed.
+6. **EARS-state-driven (O2 / "empty ring buffer"):** While `decisions.length === 0`, Recent Decisions renders an empty-state card (`"No routing decisions recorded yet."`) and Per-Backend Volume renders a zero-state row per backend listed in `resolvedChains`. Verified by `Routing.empty.test.tsx`.
+7. **EARS-state-driven (O2 / "zero-dispatch backend"):** While a backend appears in `config.backends` but has zero entries in `decisions` over the 24 h window, its Per-Backend Volume row renders `count: 0`, `successRate: —` (em dash, not `NaN%`). Verified by `RoutingVolumeCard.test.tsx`.
+8. **EARS-ubiquitous (O4):** Per-Backend Volume count for each backend equals `decisions.filter(d => d.backendName === b && d.timestamp >= now - 24h).length`, validated within ±0 (deterministic in-memory aggregation, no sampling). Verified by `RoutingVolumeCard.test.tsx` seeding 100 decisions with known distribution.
+9. **EARS-ubiquitous (Q2):** Initial render of `<Routing />` with a 500-decision seeded buffer completes in under 500 ms wall-clock. Verified by `Routing.perf.test.tsx` measuring `performance.now()` around `render()` + `await screen.findByTestId('routing-card-decisions')`.
+10. **EARS-unwanted (Resolved Chains health):** If a `resolvedChains` candidate has `exists: false`, the chain entry MUST NOT render as a healthy/chosen link — it MUST render with a `data-testid="chain-step-unknown"` and visibly degraded style. Verified by `RoutingChainsCard.test.tsx`.
+11. **EARS-ubiquitous:** `/routing` URL resolves (via legacy redirect) to `/s/routing` and `routing` appears in the `SYSTEM_PAGES` registry with a sidebar label `"Routing"`. Verified by smoke `Routing.route.test.tsx` mounting `<BrowserRouter><Routes>...</Routes></BrowserRouter>` and asserting render at both paths.
+12. **EARS-ubiquitous:** `harness validate` passes; `pnpm --filter @harness-engineering/dashboard typecheck` exits 0; `pnpm --filter @harness-engineering/dashboard test` exits 0.
+
+## Uncertainties
+
+- **[ASSUMPTION]** The dashboard's existing system-pages registry pattern (`SYSTEM_PAGES` in `src/client/types/thread.ts` + `SYSTEM_PAGE_COMPONENTS` in `src/client/components/layout/ThreadView.tsx`) is the **right** mechanism for adding `/routing`. The spec literally says "new route `/routing`", but the dashboard has not had a top-level `/routing` route since the chat-first refactor — all dashboards now mount under `/s/:systemPage`. **Decision (operator-load-bearing, see D-OP-1):** add `routing` as a SYSTEM_PAGE entry with route `/s/routing` AND add a legacy redirect `/routing → /s/routing` so both spec-literal URL and dashboard-native pattern work. If operator prefers a real top-level `/routing` route (no `/s/` prefix), Task 12 changes — see C1 below.
+- **[ASSUMPTION]** Phase 5's WS multiplexer (the `routing:decision` topic broadcast in `packages/orchestrator/src/server/http.ts:265-275`) delivers frames on the same `/ws` endpoint that `useLocalModelStatuses` already consumes. Verified by reading `http.ts` — yes, single broadcaster. **No new WS endpoint or auth surface in Phase 7.**
+- **[DEFERRABLE]** Exact visual treatment (Tailwind classes, color palette for healthy vs `unknown-backend` chain steps). Phase 8 docs reviewers may iterate; plan locks DOM structure + `data-testid`s only.
+- **[DEFERRABLE]** Whether to render Per-Backend Volume as a sparkline or a number. Plan ships a number-only card (Q2 perf gate is easier; sparkline can land in a follow-up). `Cache.tsx` Sparkline is referenced as future precedent.
+
+## Operator Decisions to Confirm Before Execution
+
+| ID     | Question                                                                                                                                       | Default (use unless operator overrides)                                                                                                                                                                                                                              | Alternative                                                                                                                                                   |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D-OP-1 | Should `/routing` be a top-level route (mounted via `main.tsx` Routes) or a SYSTEM_PAGE (`/s/routing`)?                                        | **SYSTEM_PAGE** + legacy redirect from `/routing`. Matches every other dashboard surface added since the chat-first refactor (insights-cache, proposals, tokens, webhooks). Single change point for breadcrumbs, sidebar nav, and `ChatLayout` framing.              | Top-level `<Route path="/routing">` in `main.tsx`. Adds a one-off layout surface; bypasses `ChatLayout`'s framing. Reject unless operator explicitly opts in. |
+| D-OP-2 | Should the WS hook own its own socket (like `useLocalModelStatuses`) or piggyback on `useOrchestratorSocket` (which a parent route may mount)? | **Own its own socket.** `/routing` is a standalone page; no parent reads orchestrator state. Mirrors the explicit guidance in `useLocalModelStatuses` JSDoc (`"Standalone use only"`). Avoids dual-subscriber bugs.                                                  | Extend `useOrchestratorSocket` to also surface `routingDecisions`. Reject — couples an unrelated page to the chat layout's socket lifecycle.                  |
+| D-OP-3 | HTTP polling cadence when WS is disconnected.                                                                                                  | **5 s.** Same cadence as `Cache.tsx` insights — established precedent, low server load (ring buffer read is O(N) where N ≤ 500 with cheap filter).                                                                                                                   | 2 s (more responsive) or 10 s (less load). 5 s is the goldilocks default already in this codebase.                                                            |
+| D-OP-4 | Per-Backend Volume window.                                                                                                                     | **24 h, computed client-side** from the ring buffer. Spec says "last 24h" (line 274–276). Ring buffer holds last 500 decisions; if those span >24 h, we filter; if <24 h, we report what we have with an asterisk noting the window is buffer-bounded.               | Add a server-side aggregation endpoint. Reject for Phase 7 — out of scope, spec calls for client-side aggregation from existing endpoint.                     |
+| D-OP-5 | Q2 perf test environment.                                                                                                                      | **jsdom + `vi.useFakeTimers()`, measuring sync-render time only** (mount → first paint of the decisions card). jsdom is not a real browser, so the 500 ms gate is a **proxy** for real-world perf; treat as a regression canary, not an absolute SLA.                | Playwright real-browser perf. Reject — out of Phase 7 scope (no Playwright in dashboard test setup).                                                          |
+| D-OP-6 | Trace form input affordances.                                                                                                                  | **Two text inputs (`skill`, `mode`) + submit button.** No autocomplete from skill catalog — keeps the card self-contained and avoids a new `/api/v1/skills` fetch dependency. CLI `harness routing trace` already provides the discoverable surface for skill names. | Add a `<datalist>` populated from `config.backends` keys (modes) and a future skills endpoint. Defer to Phase 8 or later.                                     |
+
+If any answer differs from the default, the operator should respond before Task 5 (which writes the trace form) or Task 9 (which writes the WS hook). All other tasks are independent of these decisions.
+
+## File Map
+
+```
+CREATE  packages/dashboard/src/client/types/routing.ts
+CREATE  packages/dashboard/src/client/hooks/useRoutingConfig.ts
+CREATE  packages/dashboard/src/client/hooks/useRoutingDecisions.ts
+CREATE  packages/dashboard/src/client/pages/Routing.tsx
+CREATE  packages/dashboard/src/client/components/cards/RoutingChainsCard.tsx
+CREATE  packages/dashboard/src/client/components/cards/RoutingDecisionsCard.tsx
+CREATE  packages/dashboard/src/client/components/cards/RoutingVolumeCard.tsx
+CREATE  packages/dashboard/src/client/components/cards/RoutingTraceCard.tsx
+CREATE  packages/dashboard/tests/client/hooks/useRoutingDecisions.test.tsx
+CREATE  packages/dashboard/tests/client/pages/Routing.test.tsx
+CREATE  packages/dashboard/tests/client/pages/Routing.empty.test.tsx
+CREATE  packages/dashboard/tests/client/pages/Routing.perf.test.tsx
+CREATE  packages/dashboard/tests/client/pages/Routing.route.test.tsx
+CREATE  packages/dashboard/tests/client/components/cards/RoutingChainsCard.test.tsx
+CREATE  packages/dashboard/tests/client/components/cards/RoutingDecisionsCard.test.tsx
+CREATE  packages/dashboard/tests/client/components/cards/RoutingVolumeCard.test.tsx
+CREATE  packages/dashboard/tests/client/components/cards/RoutingTraceCard.test.tsx
+MODIFY  packages/dashboard/src/client/types/thread.ts            (add SYSTEM_PAGES entry)
+MODIFY  packages/dashboard/src/client/components/layout/ThreadView.tsx  (register Routing in SYSTEM_PAGE_COMPONENTS)
+MODIFY  packages/dashboard/src/client/main.tsx                   (add /routing → /s/routing legacy redirect)
+```
+
+## Skeleton
+
+1. **Shared types + WS message extension** (1 task, ~3 min)
+2. **Data hooks (config + decisions/WS)** (2 tasks, ~8 min)
+3. **Four cards, TDD each** (4 tasks, ~16 min)
+4. **Routing page composition** (1 task, ~3 min)
+5. **Route + sidebar registration** (1 task, ~2 min)
+6. **State tests (empty / perf)** (2 tasks, ~6 min)
+7. **Integration: barrels regen, smoke, validate** (1 task, ~3 min)
+
+**Total:** 12 tasks. _Skeleton approved at standard rigor (≥8 tasks)._ Operator confirms via `emit_interaction` before Task 1.
+
+---
+
+## Tasks
+
+### Task 1: Define dashboard-side routing types + extend `WebSocketMessage`
+
+**Depends on:** none | **Files:** `packages/dashboard/src/client/types/routing.ts` (CREATE), `packages/dashboard/src/client/types/orchestrator.ts` (MODIFY)
+
+The dashboard re-imports `RoutingDecision` / `RoutingConfig` from `@harness-engineering/types` (already a workspace dependency, verified in `package.json:39`). We add a small local `RoutingConfigResponse` shape matching what `/api/v1/routing/config` returns, plus extend `WebSocketMessage` so `useRoutingDecisions` can pattern-match the new topic without `as any`.
+
+1. Create `packages/dashboard/src/client/types/routing.ts`:
+
+   ```typescript
+   import type { BackendDef, RoutingConfig } from '@harness-engineering/types';
+
+   /**
+    * Spec B Phase 7 — client-side mirror of GET /api/v1/routing/config.
+    *
+    * Server source: packages/orchestrator/src/server/routes/v1/routing.ts:88-95
+    * Shape MUST stay in sync with `handleConfig` there.
+    */
+   export interface RoutingConfigResponse {
+     routing: RoutingConfig;
+     resolvedChains: Record<string, { candidate: string; exists: boolean }[]>;
+     backends: string[];
+   }
+
+   /**
+    * Spec B Phase 7 — client-side mirror of GET /api/v1/routing/decisions.
+    * Newest-first ordering preserved from server (D-OP-4 from Phase 6).
+    */
+   export interface RoutingDecisionsResponse {
+     decisions: import('@harness-engineering/types').RoutingDecision[];
+   }
+
+   /**
+    * Spec B Phase 7 — client-side mirror of POST /api/v1/routing/trace.
+    * Server source: packages/orchestrator/src/server/routes/v1/routing.ts:230
+    * Note: `def` is redacted to `{ type }` only (D-OP-6, P5 plan); do not assume
+    * full BackendDef fields here.
+    */
+   export interface RoutingTraceResponse {
+     decision: import('@harness-engineering/types').RoutingDecision;
+     def: { type: BackendDef['type'] };
+   }
+
+   /** WS status surfaced via data-testid="routing-ws-status". */
+   export type RoutingWsStatus = 'connecting' | 'live' | 'polling';
+   ```
+
+2. Modify `packages/dashboard/src/client/types/orchestrator.ts`. After line 205 (the existing `local-model:status` arm), add a new arm to the discriminated union:
+
+   ```typescript
+     | { type: 'routing:decision'; data: import('@harness-engineering/types').RoutingDecision };
+   ```
+
+3. Run: `pnpm --filter @harness-engineering/dashboard typecheck`
+4. Run: `harness validate`
+5. Commit: `feat(dashboard): routing types + extend WebSocketMessage with routing:decision arm (Spec B Phase 7)`
+
+---
+
+### Task 2 (TDD): `useRoutingConfig` hook
+
+**Depends on:** Task 1 | **Files:** `packages/dashboard/src/client/hooks/useRoutingConfig.ts` (CREATE)
+
+Single-shot HTTP fetch hook for `/api/v1/routing/config`. No WS, no polling — config is static during a server lifetime; if it changes, the operator restarts the orchestrator. Mirrors the seeding portion of `useLocalModelStatuses` (`packages/dashboard/src/client/hooks/useLocalModelStatuses.ts:55-80`).
+
+1. Create `packages/dashboard/src/client/hooks/useRoutingConfig.ts`:
+
+   ```typescript
+   import { useEffect, useState } from 'react';
+   import type { RoutingConfigResponse } from '../types/routing';
+
+   export interface UseRoutingConfigResult {
+     config: RoutingConfigResponse | null;
+     loading: boolean;
+     error: string | null;
+   }
+
+   /**
+    * Spec B Phase 7 — fetch the current routing config once on mount.
+    *
+    * No polling: routing config is read at orchestrator startup and is
+    * effectively immutable per process. If the operator edits
+    * `harness.config.json`, they restart the server; the dashboard
+    * reconnects and re-fetches naturally.
+    */
+   export function useRoutingConfig(): UseRoutingConfigResult {
+     const [config, setConfig] = useState<RoutingConfigResponse | null>(null);
+     const [loading, setLoading] = useState(true);
+     const [error, setError] = useState<string | null>(null);
+
+     useEffect(() => {
+       const controller = new AbortController();
+       (async () => {
+         try {
+           const res = await fetch('/api/v1/routing/config', { signal: controller.signal });
+           if (!res.ok) {
+             setError(`HTTP ${res.status}`);
+             setLoading(false);
+             return;
+           }
+           const json = (await res.json()) as RoutingConfigResponse;
+           setConfig(json);
+           setLoading(false);
+         } catch (err) {
+           if (controller.signal.aborted) return;
+           setError(err instanceof Error ? err.message : 'Network error');
+           setLoading(false);
+         }
+       })();
+       return () => controller.abort();
+     }, []);
+
+     return { config, loading, error };
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/dashboard typecheck`
+3. Run: `harness validate`
+4. Commit: `feat(dashboard): useRoutingConfig hook (Spec B Phase 7, F9)`
+
+> _No standalone test for this hook; it has only the trivial fetch surface already exercised by `Routing.test.tsx` end-to-end in Task 10. Coverage gain from a dedicated test is < cost of the extra fixture._
+
+---
+
+### Task 3 (TDD-RED): `useRoutingDecisions` test fixture
+
+**Depends on:** Task 1 | **Files:** `packages/dashboard/tests/client/hooks/useRoutingDecisions.test.tsx` (CREATE)
+
+Test-first for the hook: WS receives frames, prepends to state; on WS close, falls back to HTTP polling. Closest precedent: jsdom + `WebSocket` mock + `vi.useFakeTimers()`.
+
+1. Create `packages/dashboard/tests/client/hooks/useRoutingDecisions.test.tsx`:
+
+   ```typescript
+   import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+   import { renderHook, waitFor, act } from '@testing-library/react';
+   import type { RoutingDecision } from '@harness-engineering/types';
+   import { useRoutingDecisions } from '../../../src/client/hooks/useRoutingDecisions';
+
+   const mkDecision = (overrides: Partial<RoutingDecision> = {}): RoutingDecision => ({
+     timestamp: new Date().toISOString(),
+     useCase: { kind: 'skill', skillName: 'harness-debugging' },
+     resolutionPath: [{ source: 'skill', candidate: 'claude-opus', outcome: 'chosen' }],
+     backendName: 'claude-opus',
+     backendType: 'anthropic',
+     durationMs: 2,
+     ...overrides,
+   });
+
+   class FakeWS {
+     static OPEN = 1;
+     static CLOSED = 3;
+     readyState = 0;
+     onopen: ((ev: unknown) => void) | null = null;
+     onmessage: ((ev: { data: string }) => void) | null = null;
+     onclose: ((ev: unknown) => void) | null = null;
+     onerror: ((ev: unknown) => void) | null = null;
+     close = vi.fn(() => {
+       this.readyState = FakeWS.CLOSED;
+       this.onclose?.({});
+     });
+   }
+   let lastWS: FakeWS | null = null;
+
+   beforeEach(() => {
+     lastWS = null;
+     vi.stubGlobal(
+       'WebSocket',
+       vi.fn(() => {
+         const ws = new FakeWS();
+         lastWS = ws;
+         queueMicrotask(() => {
+           ws.readyState = FakeWS.OPEN;
+           ws.onopen?.({});
+         });
+         return ws;
+       })
+     );
+     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+       new Response(JSON.stringify({ decisions: [] }), {
+         status: 200,
+         headers: { 'Content-Type': 'application/json' },
+       })
+     );
+   });
+   afterEach(() => {
+     vi.unstubAllGlobals();
+     vi.restoreAllMocks();
+     vi.useRealTimers();
+   });
+
+   describe('useRoutingDecisions', () => {
+     it('seeds from HTTP on mount, then prepends WS frames', async () => {
+       const seeded = mkDecision({ backendName: 'seeded' });
+       (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+         new Response(JSON.stringify({ decisions: [seeded] }), { status: 200 })
+       );
+       const { result } = renderHook(() => useRoutingDecisions());
+       await waitFor(() => expect(result.current.decisions.length).toBe(1));
+
+       const live = mkDecision({ backendName: 'live' });
+       act(() => {
+         lastWS!.onmessage?.({
+           data: JSON.stringify({ type: 'routing:decision', data: live }),
+         });
+       });
+       await waitFor(() => expect(result.current.decisions[0]?.backendName).toBe('live'));
+       expect(result.current.status).toBe('live');
+     });
+
+     it('falls back to HTTP polling on WS close (status="polling")', async () => {
+       vi.useFakeTimers();
+       const { result } = renderHook(() => useRoutingDecisions());
+       await vi.waitFor(() => expect(result.current.status).toBe('live'));
+
+       act(() => {
+         lastWS!.close();
+       });
+       await vi.waitFor(() => expect(result.current.status).toBe('polling'));
+
+       const polled = mkDecision({ backendName: 'polled' });
+       (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+         new Response(JSON.stringify({ decisions: [polled] }), { status: 200 })
+       );
+       await act(async () => {
+         await vi.advanceTimersByTimeAsync(5_000);
+       });
+       expect(result.current.decisions[0]?.backendName).toBe('polled');
+     });
+
+     it('caps in-memory buffer at 500 to bound memory under WS-flood', async () => {
+       const { result } = renderHook(() => useRoutingDecisions());
+       await waitFor(() => expect(result.current.status).toBe('live'));
+       act(() => {
+         for (let i = 0; i < 600; i++) {
+           lastWS!.onmessage?.({
+             data: JSON.stringify({
+               type: 'routing:decision',
+               data: mkDecision({ backendName: `b${i}` }),
+             }),
+           });
+         }
+       });
+       expect(result.current.decisions.length).toBe(500);
+       expect(result.current.decisions[0]?.backendName).toBe('b599');
+     });
+   });
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/dashboard test -- tests/client/hooks/useRoutingDecisions.test.tsx`
+   - Expected: red (the hook file does not exist yet).
+3. Commit: `test(dashboard): pin useRoutingDecisions contract (Spec B Phase 7, red)`
+
+---
+
+### Task 4 (TDD-GREEN): implement `useRoutingDecisions`
+
+**Depends on:** Task 3 | **Files:** `packages/dashboard/src/client/hooks/useRoutingDecisions.ts` (CREATE)
+
+1. Create `packages/dashboard/src/client/hooks/useRoutingDecisions.ts`:
+
+   ```typescript
+   import { useEffect, useRef, useState } from 'react';
+   import type { RoutingDecision } from '@harness-engineering/types';
+   import type { WebSocketMessage } from '../types/orchestrator';
+   import type { RoutingDecisionsResponse, RoutingWsStatus } from '../types/routing';
+
+   const RECONNECT_BASE_MS = 1_000;
+   const RECONNECT_MAX_MS = 30_000;
+   const POLL_INTERVAL_MS = 5_000;
+   const BUFFER_LIMIT = 500;
+
+   export interface UseRoutingDecisionsResult {
+     decisions: RoutingDecision[];
+     status: RoutingWsStatus;
+     error: string | null;
+   }
+
+   function getWsUrl(): string {
+     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+     return `${proto}//${window.location.host}/ws`;
+   }
+
+   async function fetchDecisions(signal?: AbortSignal): Promise<RoutingDecision[]> {
+     const res = await fetch(`/api/v1/routing/decisions?limit=${BUFFER_LIMIT}`, { signal });
+     if (!res.ok) throw new Error(`HTTP ${res.status}`);
+     const json = (await res.json()) as RoutingDecisionsResponse;
+     return json.decisions;
+   }
+
+   /**
+    * Spec B Phase 7 — subscribe to routing:decision WS topic with HTTP
+    * seed + polling fallback. Standalone (owns its own socket); do not
+    * mount in a parent that already opens /ws — see useLocalModelStatuses
+    * JSDoc for the same constraint.
+    */
+   export function useRoutingDecisions(): UseRoutingDecisionsResult {
+     const [decisions, setDecisions] = useState<RoutingDecision[]>([]);
+     const [status, setStatus] = useState<RoutingWsStatus>('connecting');
+     const [error, setError] = useState<string | null>(null);
+     const wsRef = useRef<WebSocket | null>(null);
+     const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+     const reconnectAttempt = useRef(0);
+     const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+     // HTTP seed on mount.
+     useEffect(() => {
+       const controller = new AbortController();
+       fetchDecisions(controller.signal)
+         .then((rows) => setDecisions(rows))
+         .catch((err) => {
+           if (!controller.signal.aborted) {
+             setError(err instanceof Error ? err.message : String(err));
+           }
+         });
+       return () => controller.abort();
+     }, []);
+
+     // WS subscription + polling fallback.
+     useEffect(() => {
+       const mounted = { current: true };
+
+       function startPolling(): void {
+         if (pollTimer.current) return;
+         pollTimer.current = setInterval(() => {
+           fetchDecisions()
+             .then((rows) => {
+               if (mounted.current) setDecisions(rows);
+             })
+             .catch(() => {
+               /* swallow — next tick retries */
+             });
+         }, POLL_INTERVAL_MS);
+       }
+       function stopPolling(): void {
+         if (pollTimer.current) {
+           clearInterval(pollTimer.current);
+           pollTimer.current = null;
+         }
+       }
+       function connect(): void {
+         const ws = new WebSocket(getWsUrl());
+         wsRef.current = ws;
+         ws.onopen = () => {
+           if (!mounted.current) return;
+           reconnectAttempt.current = 0;
+           stopPolling();
+           setStatus('live');
+         };
+         ws.onmessage = (event: MessageEvent<string>) => {
+           if (!mounted.current) return;
+           try {
+             const raw: unknown = JSON.parse(event.data);
+             if (typeof raw !== 'object' || raw === null || !('type' in raw)) return;
+             const msg = raw as WebSocketMessage;
+             if (msg.type === 'routing:decision') {
+               setDecisions((prev) => {
+                 const next = [msg.data, ...prev];
+                 return next.length > BUFFER_LIMIT ? next.slice(0, BUFFER_LIMIT) : next;
+               });
+             }
+           } catch {
+             /* ignore malformed */
+           }
+         };
+         ws.onclose = () => {
+           if (!mounted.current) return;
+           setStatus('polling');
+           startPolling();
+           const delay = Math.min(
+             RECONNECT_BASE_MS * 2 ** reconnectAttempt.current,
+             RECONNECT_MAX_MS
+           );
+           reconnectAttempt.current += 1;
+           reconnectTimer.current = setTimeout(connect, delay);
+         };
+         ws.onerror = () => {
+           /* onclose handles reconnect */
+         };
+       }
+       connect();
+       return () => {
+         mounted.current = false;
+         wsRef.current?.close();
+         if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+         stopPolling();
+       };
+     }, []);
+
+     return { decisions, status, error };
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/dashboard test -- tests/client/hooks/useRoutingDecisions.test.tsx`
+   - Expected: green (3/3).
+3. Run: `pnpm --filter @harness-engineering/dashboard typecheck`
+4. Run: `harness validate`
+5. Commit: `feat(dashboard): useRoutingDecisions hook with WS + polling fallback (Spec B Phase 7, O2)`
+
+---
+
+### Task 5 (TDD): `RoutingChainsCard`
+
+**Depends on:** Task 1 | **Files:** `packages/dashboard/src/client/components/cards/RoutingChainsCard.tsx` (CREATE), `packages/dashboard/tests/client/components/cards/RoutingChainsCard.test.tsx` (CREATE)
+
+Pure presentational. Takes `resolvedChains` + `decisions` (for the currently-chosen-backend column) as props.
+
+1. Write the test first at `packages/dashboard/tests/client/components/cards/RoutingChainsCard.test.tsx`. Required assertions (one `it` per truth):
+   - Renders `data-testid="routing-card-chains"`.
+   - Renders one row per key in `resolvedChains`.
+   - For a chain with `[{candidate:'a',exists:true},{candidate:'b',exists:false}]`, renders `chain-step-chosen` for `a` and `chain-step-unknown` for `b` (Truth 10).
+   - Given `decisions=[{useCase:{kind:'skill',skillName:'X'},backendName:'a'}]` and `resolvedChains={'skill:X':[{candidate:'a',exists:true}]}`, renders `currently-chosen-backend` cell containing `a` for the `skill:X` row.
+2. Implement the card. DOM shape (locked):
+
+   ```tsx
+   <section data-testid="routing-card-chains">
+     <header>Resolved Chains</header>
+     <table>
+       <thead>
+         <tr>
+           <th>Use case</th>
+           <th>Chain</th>
+           <th>Currently chosen</th>
+         </tr>
+       </thead>
+       <tbody>
+         {Object.entries(resolvedChains).map(([key, chain]) => (
+           <tr key={key} data-testid={`chain-row-${key}`}>
+             <td>{key}</td>
+             <td>
+               {chain.map((step, i) => (
+                 <span
+                   key={`${step.candidate}-${i}`}
+                   data-testid={step.exists ? 'chain-step-chosen' : 'chain-step-unknown'}
+                 >
+                   {step.candidate}
+                   {i < chain.length - 1 ? ' → ' : ''}
+                 </span>
+               ))}
+             </td>
+             <td data-testid={`currently-chosen-${key}`}>
+               {/* most-recent decision in `decisions` whose useCase string-equals `key`, else em-dash */}
+             </td>
+           </tr>
+         ))}
+       </tbody>
+     </table>
+   </section>
+   ```
+
+   Helper: `useCaseToKey(uc: RoutingUseCase): string` — `{kind:'skill',skillName}` → `skill:${skillName}`; `{kind:'mode',cognitiveMode}` → `mode:${cognitiveMode}`; `{kind:'tier',tier}` → `tier:${tier}`; etc. Mirrors server `buildResolvedChains` key format (`packages/orchestrator/src/server/routes/v1/routing.ts:60-87`).
+
+3. Run: `pnpm --filter @harness-engineering/dashboard test -- tests/client/components/cards/RoutingChainsCard.test.tsx`
+4. Run: `pnpm --filter @harness-engineering/dashboard typecheck && harness validate`
+5. Commit: `feat(dashboard): RoutingChainsCard with chosen/unknown step badges (Spec B Phase 7, F9)`
+
+---
+
+### Task 6 (TDD): `RoutingDecisionsCard`
+
+**Depends on:** Task 1 | **Files:** `packages/dashboard/src/client/components/cards/RoutingDecisionsCard.tsx` (CREATE), `packages/dashboard/tests/client/components/cards/RoutingDecisionsCard.test.tsx` (CREATE)
+
+Takes `decisions: RoutingDecision[]` + `status: RoutingWsStatus` as props. Filter controls (skill / mode / backend) are client-side `useState`. Row expand on click.
+
+1. Write the test first. Required `it`s:
+   - Renders `data-testid="routing-card-decisions"` + `data-testid="routing-ws-status"` showing the `status` value (`live` / `polling` / `connecting`).
+   - With 3 decisions, renders 3 rows; filtering by `skill=foo` reduces to matching subset.
+   - Clicking a row toggles `data-testid="decision-row-{i}-expanded"` containing every `resolutionPath` step's `candidate` + `outcome`.
+   - With `decisions=[]`, renders `data-testid="decisions-empty"` reading `"No routing decisions recorded yet."` (Truth 6).
+2. Implement. DOM:
+
+   ```tsx
+   <section data-testid="routing-card-decisions">
+     <header>
+       Recent Decisions
+       <span data-testid="routing-ws-status">{status}</span>
+     </header>
+     <FilterBar skill mode backend onChange={setFilter} />
+     {filtered.length === 0
+       ? <p data-testid="decisions-empty">No routing decisions recorded yet.</p>
+       : <table>{filtered.map((d, i) => (
+           <Row key={i} decision={d} expanded={expanded === i} onClick={() => setExpanded(...)} />
+         ))}</table>}
+   </section>
+   ```
+
+   Filter logic (client-side AND of optional skill/mode/backend) mirrors server filter shape exactly.
+
+3. Run the component test; expect green.
+4. Run: `pnpm --filter @harness-engineering/dashboard typecheck && harness validate`
+5. Commit: `feat(dashboard): RoutingDecisionsCard with filter + expandable rows (Spec B Phase 7, F9)`
+
+---
+
+### Task 7 (TDD): `RoutingVolumeCard`
+
+**Depends on:** Task 1 | **Files:** `packages/dashboard/src/client/components/cards/RoutingVolumeCard.tsx` (CREATE), `packages/dashboard/tests/client/components/cards/RoutingVolumeCard.test.tsx` (CREATE)
+
+Pure presentational + a small `useMemo` aggregator. Takes `decisions` + `backends: string[]`.
+
+1. Write the test first. Required `it`s:
+   - Renders `data-testid="routing-card-volume"`.
+   - Given 100 decisions distributed 60 on `a`, 40 on `b`, all within `now - 24h`, renders `volume-count-a=60`, `volume-count-b=40` (Truth 8, O4).
+   - Given a backend `c` in `backends` with zero matching decisions, renders `volume-count-c=0` and `volume-rate-c=—` (em-dash, Truth 7).
+   - Given a decision with `timestamp = now - 25h`, that decision is excluded from the window (Truth 8 strict-bound).
+   - Success rate currently defined as `1.0` for every decision (no failure shape in `RoutingDecision`); cell renders `100%` for any backend with ≥1 decision. **Note:** `RoutingDecision` schema has no `outcome` field; success rate in the spec assumes every recorded resolution is itself a success (the resolver only emits on a chosen backend; failures throw and don't reach the bus). Document this in the card JSDoc.
+2. Implement using `useMemo`:
+
+   ```typescript
+   const stats = useMemo(() => {
+     const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+     const counts: Record<string, number> = Object.fromEntries(backends.map((b) => [b, 0]));
+     for (const d of decisions) {
+       if (new Date(d.timestamp).getTime() < cutoff) continue;
+       if (!(d.backendName in counts)) counts[d.backendName] = 0;
+       counts[d.backendName] += 1;
+     }
+     return counts;
+   }, [decisions, backends]);
+   ```
+
+3. Run the test; expect green.
+4. Run: `pnpm --filter @harness-engineering/dashboard typecheck && harness validate`
+5. Commit: `feat(dashboard): RoutingVolumeCard with 24h client-side aggregation (Spec B Phase 7, O4)`
+
+---
+
+### Task 8 (TDD): `RoutingTraceCard`
+
+**Depends on:** Task 1 | **Files:** `packages/dashboard/src/client/components/cards/RoutingTraceCard.tsx` (CREATE), `packages/dashboard/tests/client/components/cards/RoutingTraceCard.test.tsx` (CREATE)
+
+Self-contained form + result display. POSTs to `/api/v1/routing/trace`. No props (or just an optional `fetcher` for testability).
+
+1. Write the test first. Required `it`s:
+   - Renders `data-testid="routing-card-trace"` with `input[name="skill"]`, `input[name="mode"]`, `button[type="submit"]`.
+   - Submitting with `skill="X"` POSTs to `/api/v1/routing/trace` with body `{ useCase: { kind: 'skill', skillName: 'X' } }` (no `cognitiveMode` field when mode is empty).
+   - Submitting with both `skill="X"` and `mode="reviewer"` sends `{ useCase: { kind: 'skill', skillName: 'X', cognitiveMode: 'reviewer' } }`.
+   - Submitting with only `mode="reviewer"` sends `{ useCase: { kind: 'mode', cognitiveMode: 'reviewer' } }`.
+   - Submitting with neither does NOT fire a fetch; renders inline validation `"Provide a skill or a mode."`.
+   - Successful response renders `data-testid="trace-backend"` (decision.backendName), `data-testid="trace-backend-type"` (def.type), and a `<ol data-testid="trace-resolution-path">` with one `<li>` per `resolutionPath` step containing `source`, `candidate`, `outcome`.
+   - Non-2xx response renders `data-testid="trace-error"` with the server error text.
+2. Implement straightforwardly with a `useState` form + `fetch`. Body shape mirrors the Phase 5 `UseCaseSchema` (`packages/orchestrator/src/server/routes/v1/routing.ts:154-169`) — discriminated union on `kind`, exactly as built above.
+3. Run the test; expect green.
+4. Run: `pnpm --filter @harness-engineering/dashboard typecheck && harness validate`
+5. Commit: `feat(dashboard): RoutingTraceCard with inline trace form (Spec B Phase 7, F9)`
+
+---
+
+### Task 9: Compose `Routing` page
+
+**Depends on:** Tasks 2, 4, 5, 6, 7, 8 | **Files:** `packages/dashboard/src/client/pages/Routing.tsx` (CREATE)
+
+1. Create the page. The composition is mechanical:
+
+   ```tsx
+   import { useRoutingConfig } from '../hooks/useRoutingConfig';
+   import { useRoutingDecisions } from '../hooks/useRoutingDecisions';
+   import { RoutingChainsCard } from '../components/cards/RoutingChainsCard';
+   import { RoutingDecisionsCard } from '../components/cards/RoutingDecisionsCard';
+   import { RoutingVolumeCard } from '../components/cards/RoutingVolumeCard';
+   import { RoutingTraceCard } from '../components/cards/RoutingTraceCard';
+
+   /** Spec B Phase 7 — /routing panel. F9 + O2 + O4. */
+   export function Routing(): JSX.Element {
+     const { config, loading: configLoading, error: configError } = useRoutingConfig();
+     const { decisions, status, error: decisionsError } = useRoutingDecisions();
+
+     if (configLoading) {
+       return <p data-testid="routing-loading">Loading routing configuration…</p>;
+     }
+     if (configError || !config) {
+       return (
+         <p data-testid="routing-error">
+           Failed to load routing config: {configError ?? 'unknown error'}
+         </p>
+       );
+     }
+
+     return (
+       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+         <RoutingChainsCard resolvedChains={config.resolvedChains} decisions={decisions} />
+         <RoutingDecisionsCard decisions={decisions} status={status} error={decisionsError} />
+         <RoutingVolumeCard decisions={decisions} backends={config.backends} />
+         <RoutingTraceCard />
+       </div>
+     );
+   }
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/dashboard typecheck`
+3. Run: `harness validate`
+4. Commit: `feat(dashboard): compose Routing page from 4 cards + 2 hooks (Spec B Phase 7, F9)`
+
+---
+
+### Task 10 (TDD): Routing page end-to-end test (`Routing.test.tsx`)
+
+**Depends on:** Task 9 | **Files:** `packages/dashboard/tests/client/pages/Routing.test.tsx` (CREATE)
+
+1. Write `Routing.test.tsx`. Required `it`s (Truths 1, 2, 3, 4 end-to-end):
+   - Mounts `<Routing />`, stubs `fetch` to return a sample `RoutingConfigResponse` + a single `RoutingDecisionsResponse`, asserts all four `data-testid="routing-card-*"` present.
+   - Drives a `routing:decision` WS frame through the same `FakeWS` harness from Task 3; asserts the new row appears in the decisions card AND the volume card's count for that backend increments by 1.
+   - Clicks the first decisions row; asserts `decision-row-0-expanded` contains every resolution-path step.
+   - Submits the trace form with `skill="harness-debugging"`; asserts `/api/v1/routing/trace` was POSTed with the expected body and `trace-backend` is rendered.
+2. Run: `pnpm --filter @harness-engineering/dashboard test -- tests/client/pages/Routing.test.tsx`
+   - Expected: green (4/4).
+3. Run: `harness validate`
+4. Commit: `test(dashboard): Routing page end-to-end (4 cards + WS + trace) (Spec B Phase 7, F9)`
+
+---
+
+### Task 11 (TDD): empty-state + perf tests
+
+**Depends on:** Task 10 | **Files:** `packages/dashboard/tests/client/pages/Routing.empty.test.tsx` (CREATE), `packages/dashboard/tests/client/pages/Routing.perf.test.tsx` (CREATE)
+
+These two are split for clarity but live in a single commit since they share fixtures.
+
+1. `Routing.empty.test.tsx` (Truths 5, 6, 7):
+   - With `decisions: []` and no WS frames, `data-testid="decisions-empty"` is present.
+   - With WS mock kept in `CONNECTING` and the empty-decisions HTTP response, `routing-ws-status` reads `connecting` or `polling` (never `live`), and no error is thrown.
+   - With `config.backends=['a','b','c']` and `decisions=[{backendName:'a',...}]`, the volume card renders rows for all three backends; `b` and `c` show `volume-rate-b=—` and `volume-rate-c=—`.
+2. `Routing.perf.test.tsx` (Truth 9, Q2):
+
+   ```typescript
+   import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+   import { render, screen } from '@testing-library/react';
+   import type { RoutingDecision } from '@harness-engineering/types';
+   import { Routing } from '../../../src/client/pages/Routing';
+
+   describe('Routing — perf (Q2)', () => {
+     beforeEach(() => {
+       vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+         const url = String(input);
+         if (url.endsWith('/api/v1/routing/config')) {
+           return new Response(JSON.stringify({
+             routing: { default: 'a' },
+             resolvedChains: { default: [{ candidate: 'a', exists: true }] },
+             backends: ['a', 'b'],
+           }), { status: 200 });
+         }
+         if (url.startsWith('/api/v1/routing/decisions')) {
+           const decisions: RoutingDecision[] = Array.from({ length: 500 }, (_, i) => ({
+             timestamp: new Date(Date.now() - i * 1000).toISOString(),
+             useCase: { kind: 'skill', skillName: `skill-${i % 50}` },
+             resolutionPath: [{ source: 'skill', candidate: 'a', outcome: 'chosen' }],
+             backendName: i % 2 === 0 ? 'a' : 'b',
+             backendType: 'anthropic',
+             durationMs: 2,
+           }));
+           return new Response(JSON.stringify({ decisions }), { status: 200 });
+         }
+         return new Response('{}', { status: 200 });
+       });
+       vi.stubGlobal('WebSocket', vi.fn(() => ({
+         readyState: 0,
+         onopen: null, onmessage: null, onclose: null, onerror: null,
+         close: () => undefined,
+       })));
+     });
+     afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+     it('renders 500-decision buffer in under 500 ms (jsdom canary)', async () => {
+       const t0 = performance.now();
+       render(<Routing />);
+       await screen.findByTestId('routing-card-decisions');
+       const elapsed = performance.now() - t0;
+       expect(elapsed).toBeLessThan(500);
+     });
+   });
+   ```
+
+3. Run: `pnpm --filter @harness-engineering/dashboard test -- tests/client/pages/Routing.empty.test.tsx tests/client/pages/Routing.perf.test.tsx`
+   - Expected: green. If perf test flakes locally on CI underprovisioned hardware, bump cap to `600` and add a NOTE comment citing the spec gate as a jsdom-canary (D-OP-5).
+4. Run: `harness validate`
+5. Commit: `test(dashboard): Routing empty-state + perf canary (Spec B Phase 7, O2, Q2)`
+
+---
+
+### Task 12: Route registration + sidebar + smoke test
+
+**Depends on:** Task 9 | **Files:** `packages/dashboard/src/client/types/thread.ts` (MODIFY), `packages/dashboard/src/client/components/layout/ThreadView.tsx` (MODIFY), `packages/dashboard/src/client/main.tsx` (MODIFY), `packages/dashboard/tests/client/pages/Routing.route.test.tsx` (CREATE) | **Category:** integration
+
+1. Modify `packages/dashboard/src/client/types/thread.ts`. After the `proposals` entry (line 71), add:
+
+   ```typescript
+     // Spec B Phase 7 — granular task routing observability panel.
+     { page: 'routing', label: 'Routing', route: '/s/routing' },
+   ```
+
+2. Modify `packages/dashboard/src/client/components/layout/ThreadView.tsx`. After line 26 (the `Proposals` import), add:
+
+   ```typescript
+   import { Routing } from '../../pages/Routing';
+   ```
+
+   In the `SYSTEM_PAGE_COMPONENTS` literal (line 30–50), after the `proposals` entry add:
+
+   ```typescript
+     // Spec B Phase 7 — granular task routing observability panel.
+     routing: Routing,
+   ```
+
+3. Modify `packages/dashboard/src/client/main.tsx`. Inside `LEGACY_REDIRECTS`, add (preserving the existing comment style):
+
+   ```typescript
+     // Spec B Phase 7 — top-level /routing is dashboard-native /s/routing.
+     { from: '/routing', to: '/s/routing' },
+   ```
+
+4. Create `packages/dashboard/tests/client/pages/Routing.route.test.tsx`. One `it`:
+
+   ```typescript
+   import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+   import { render, screen } from '@testing-library/react';
+   import { MemoryRouter, Routes, Route, Navigate } from 'react-router';
+   import { Routing } from '../../../src/client/pages/Routing';
+
+   describe('Routing — route registration', () => {
+     beforeEach(() => {
+       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+         new Response(JSON.stringify({
+           routing: { default: 'a' },
+           resolvedChains: {},
+           backends: ['a'],
+         }), { status: 200 }),
+       );
+       vi.stubGlobal('WebSocket', vi.fn(() => ({
+         readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+         close: () => undefined,
+       })));
+     });
+     afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+     it('resolves /routing → /s/routing via legacy redirect and mounts Routing', async () => {
+       render(
+         <MemoryRouter initialEntries={['/routing']}>
+           <Routes>
+             <Route path="/s/routing" element={<Routing />} />
+             <Route path="/routing" element={<Navigate to="/s/routing" replace />} />
+           </Routes>
+         </MemoryRouter>,
+       );
+       const card = await screen.findByTestId('routing-card-chains');
+       expect(card).toBeDefined();
+     });
+   });
+   ```
+
+5. Run: `pnpm --filter @harness-engineering/dashboard test -- tests/client/pages/Routing.route.test.tsx`
+6. Run full dashboard suite: `pnpm --filter @harness-engineering/dashboard test`
+7. Run: `pnpm --filter @harness-engineering/dashboard typecheck`
+8. Run: `pnpm generate:barrels` (no expected output — dashboard does not export new public surface; verify clean exit).
+9. Run: `harness validate && harness check-deps`
+10. [checkpoint:human-verify] **Smoke test** — Start the dashboard locally (`pnpm --filter @harness-engineering/dashboard dev` against a running orchestrator with `routing.skills` + `routing.modes` configured), visit `http://localhost:5173/routing` and `http://localhost:5173/s/routing`, confirm:
+    - All four cards render with real data.
+    - At least one `routing:decision` frame arrives via the WS (run `harness routing trace --skill <name>` from another terminal to force a decision into the bus; or kick a real dispatch).
+    - Trace form submits and renders the resolution path.
+    - Killing the orchestrator briefly flips `routing-ws-status` from `live` → `polling` and the panel keeps rendering with the last buffer.
+11. Commit: `feat(dashboard): register /routing route + sidebar entry (Spec B Phase 7, F9)`
+
+---
+
+## Sequencing notes
+
+- Tasks 2 (config hook), 3+4 (decisions hook), and 5–8 (four cards) are all logically parallelizable once Task 1 lands. In single-agent execution they run sequentially; multi-agent execution could fan out after Task 1's commit.
+- Task 9 (page composition) is the join point — it requires 2, 4, and all four cards.
+- Task 12 (integration) is last because the route smoke test exercises the composed page.
+
+## Risk Register
+
+| ID  | Risk                                                                                                                       | Likelihood | Impact | Mitigation                                                                                                                                                                                                             |
+| --- | -------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | jsdom perf test flakes on CI                                                                                               | medium     | low    | D-OP-5 documents the 500 ms gate as a canary, not an SLA. If CI flakes, raise to 600 ms and note the relaxation in the commit; do not silently disable the test.                                                       |
+| R2  | Two open WebSockets if the operator visits `/routing` while another route already opened `useOrchestratorSocket`           | low        | low    | D-OP-2 documents the standalone constraint. `useOrchestratorSocket` is currently invoked only by chat/orchestrator threads, not by SYSTEM_PAGE renders. If this changes, refactor to a shared singleton (future work). |
+| R3  | `RoutingDecision.timestamp` parsing: server emits ISO-8601 strings; `new Date(s).getTime()` can return `NaN` for malformed | very low   | medium | The Phase 5 server is the only emitter; its tests pin ISO-8601 (`packages/orchestrator/src/server/routes/v1/routing.test.ts`). Volume card defensively skips rows where `getTime()` is `NaN`.                          |
+| R4  | Filter UI in `RoutingDecisionsCard` re-runs on every keystroke and re-filters 500 rows                                     | low        | low    | 500 × 3 string comparisons per keystroke is sub-millisecond; if it becomes a real issue, wrap in `useDeferredValue`. Out of scope for Phase 7.                                                                         |
+| R5  | Trace `useCase` shape diverges from server's Zod schema if the schema evolves                                              | low        | medium | Task 8 references the Zod source location (`routing.ts:154-169`) inline in the card JSDoc, so future schema changes surface the dashboard consumer immediately during search.                                          |
+
+## Out-of-scope (Phase 8)
+
+- ADRs, docs/knowledge/\* updates, plugin manifest regeneration, AGENTS.md / README.md / CHANGELOG entries, `manage_roadmap add`. Phase 8 spec lines 516–527.
+- Sparkline visualization for Per-Backend Volume.
+- Server-side 24 h aggregation endpoint.
+- `<datalist>` autocomplete for the trace form.
+
+## Final Validation (before plan handoff)
+
+- `harness validate` — required, ran before plan write (PASS).
+- `harness check-deps` — required, ran before plan write (PASS).
+- Plan written to `docs/changes/granular-task-routing/plans/2026-05-26-phase-7-dashboard-plan.md`.
+- Handoff written to `.harness/sessions/changes--granular-task-routing--proposal/handoff.json`.
+- Operator confirms D-OP-1 through D-OP-6 (or accepts defaults) before Task 5/9 commits.

--- a/docs/changes/granular-task-routing/plans/2026-05-26-phase-8-docs-adrs-plan.md
+++ b/docs/changes/granular-task-routing/plans/2026-05-26-phase-8-docs-adrs-plan.md
@@ -1,0 +1,901 @@
+# Plan: Spec B Phase 8 — Docs + ADRs + Plugin Regeneration
+
+**Date:** 2026-05-26 | **Spec:** `docs/changes/granular-task-routing/proposal.md` (Phase 8, lines 516–529) | **Tasks:** 14 | **Time:** ~70 min | **Integration Tier:** medium (docs-only with regen) | **Session:** `changes--granular-task-routing--proposal`
+
+**Worktree:** `/Users/cwarner/Projects/iv/harness-spec-b-phase-1` at HEAD `cff5b318` (Phase 7 tip).
+**Spec criteria pinned:** Phase 8 checkpoint — `harness validate` + `harness check-docs` pass; `pnpm generate:barrels:check && pnpm generate:plugin:check` clean (per spec line 529).
+**Upstream context (Phases 0–7, frozen):** all production code shipped. Phase 7 closed F9 + O2 + O4 + Q2; full Phases 1–6 surface (resolver, validator, dispatch wiring, decision bus, HTTP + WS, CLI) is in place. This phase is durable knowledge surface only — no `packages/**/src/**` edits.
+
+---
+
+## Goal
+
+After this phase, the durable knowledge surface accurately describes Spec B's granular routing world: 5 ADRs codify the architectural decisions the spec deferred to planning (D1, D2, D4, D8, D6); the two operator-facing routing knowledge docs (`issue-routing.md` updated, `routing-resolution.md` new) cover the per-skill + per-mode axes, the resolution order, fallback semantics, and decision telemetry; the multi-backend routing operator guide gains a "Per-skill and per-mode routing" section with the spec's example config; a new `routing-trace.md` operator guide covers the dashboard panel + `harness routing trace` CLI debugging surface; AGENTS.md + README.md acknowledge the new routing axes; CHANGELOG flags the `RoutingValue` widening as additive / non-breaking; plugin manifests regenerate cleanly (or are confirmed no-op per Phase 6 recurring lesson — see U-OP-4); roadmap entry moves from `in-progress` → `done`. `harness validate` + `harness check-docs` stay green and the two regen `:check` scripts exit zero relative to a phase-scoped baseline.
+
+## Observable Truths (Acceptance Criteria)
+
+These map to the spec's Phase 8 checkpoint and Integration Points §§ Documentation Updates / Architectural Decisions.
+
+1. **Phase-8 Exit (spec line 529)** — `harness validate` exits 0 AND `harness check-docs` documentation-coverage report does not regress below the Phase 7 baseline of **84.0%** (measured at HEAD `cff5b318`) after every commit in this phase.
+2. **OT-ADR-D1** — `docs/knowledge/decisions/0028-per-skill-and-per-mode-routing-axes.md` exists. Frontmatter: `number: 0028`, `title: Per-skill and per-cognitive-mode routing axes`, `date: 2026-05-26`, `status: accepted`, `tier: medium`, `source: docs/changes/granular-task-routing/proposal.md`. Three required sections (`## Context`, `## Decision`, `## Consequences`) present. Decision section transcribes spec Decision **D1** (lines 51).
+3. **OT-ADR-D2** — `docs/knowledge/decisions/0029-routing-resolution-order.md` exists with `number: 0029`, `title: Routing resolution order — invocation, skill, mode, tier, default`. Transcribes spec Decision **D2** (line 52). Consequences section names the resolution-order invariant pinned by Phase 1's `BackendRouter.resolve()` rewrite and the Phase 3 acceptance suite (F3 + F4).
+4. **OT-ADR-D4** — `docs/knowledge/decisions/0030-fallback-chains-shared-routing-primitive.md` exists with `number: 0030`, `title: Fallback chains as a shared routing primitive`. Transcribes spec Decision **D4** (line 54) plus the byte-compatibility note (S1 / F5 from spec § Success Criteria).
+5. **OT-ADR-D8** — `docs/knowledge/decisions/0031-routing-decision-telemetry-ring-buffer.md` exists with `number: 0031`, `title: Routing-decision telemetry via in-memory ring buffer`. Transcribes spec Decision **D8** (line 58). Consequences section names the bounded-memory + no-persistence-in-v1 trade-off (per spec assumption "No persistent decision storage in v1", line 43) and the future-work hook (D8 follow-up).
+6. **OT-ADR-D6** — `docs/knowledge/decisions/0032-skill-authors-do-not-declare-backend-preferences.md` exists with `number: 0032`, `title: Skill authors do not declare backend preferences`. Transcribes spec Decision **D6** (line 56). Consequences section names skill portability across deployments and the operator-authority invariant.
+7. **OT-Knowledge-IssueRouting** — `docs/knowledge/orchestrator/issue-routing.md` gains four substantive additions: (a) "Backend Routing" section names per-skill + per-cognitive-mode as new axes alongside per-tier + per-intelligence-layer; (b) "Resolution Order" subsection documents the deterministic walk (invocation → skill → mode → tier → default; first match wins); (c) "Fallback Chains" subsection notes that every routing value accepts a scalar OR ordered array; (d) "See also" footer cross-links the new `routing-resolution.md` knowledge doc + the LMLM (Spec A) `local-model-resolution.md`. Frontmatter `tags` adds `per-skill`, `per-cognitive-mode`, `fallback-chain`, `routing-resolution`.
+8. **OT-Knowledge-RoutingResolution-NEW** — `docs/knowledge/orchestrator/routing-resolution.md` exists. Frontmatter: `type: business_process`, `domain: orchestrator`, `tags: [routing, resolution, fallback-chain, decision-bus, ring-buffer, telemetry]`. Sections (at minimum): Overview, Resolution Order (invocation → skill → mode → tier → default), Fallback Semantics (scalar normalization to one-element array; ordered walk; unknown-backend skip), Decision Telemetry (`RoutingDecision` shape + `resolutionPath` outcomes `chosen`/`unknown-backend`/`considered`), Ring Buffer Behavior (default capacity 500 — configurable; per-orchestrator-process; cleared on restart). References Phase 1's `BackendRouter.resolve()` and Phase 4's `RoutingDecisionBus`.
+9. **OT-Guide-MultiBackend** — `docs/guides/multi-backend-routing.md` gains a "Per-skill and per-mode routing" section that includes the spec's worked YAML example verbatim (spec lines 197–218) plus a walkthrough of two common patterns: (a) "route reviewers to local, route architects to cloud" using `routing.modes`; (b) "absorb cloud rate caps by pinning a specific skill local" using `routing.skills`. Existing legacy-schema migration section is unchanged. "Related" footer adds links to `docs/guides/routing-trace.md` and `docs/knowledge/orchestrator/routing-resolution.md`.
+10. **OT-Guide-RoutingTrace-NEW** — `docs/guides/routing-trace.md` exists. Sections: (a) one-paragraph overview of the operator-debugging use case; (b) `harness routing trace --skill <name> [--mode <m>] [--json]` walkthrough with sample output transcribing the `RoutingDecision` JSON shape (per Phase 6 contract); (c) `harness routing decisions --skill <name> --last <N>` walkthrough; (d) dashboard `/routing` panel walkthrough (Resolved Chains, Recent Decisions, Per-Backend Volume, Trace Tool cards — per Phase 7 contract); (e) "Debugging routing decisions" recipe section with two scenarios (typo-in-backend-name → resolution-path shows `outcome: unknown-backend`; skill not routing where expected → check resolution order via `trace`).
+11. **OT-AGENTS-MD** — `AGENTS.md` orchestrator section (line 118) gains a single sentence: routing supports per-skill + per-cognitive-mode axes with fallback chains; dashboard `/routing` panel and `harness routing {trace,decisions,config}` CLI surface decision telemetry. Single additive sentence; no rewrite of existing prose.
+12. **OT-README** — `README.md` orchestrator capabilities section gains a single sentence + link to `docs/guides/multi-backend-routing.md` (or `routing-trace.md` if the latter is the more discoverable entry point — planner default: link to the existing guide section so the README points at one already-discoverable doc).
+13. **OT-CHANGELOG** — `CHANGELOG.md` `[Unreleased]` section gains a single `### Added` entry titled **"Granular Task→Backend Routing (Spec B)"** under `(@harness-engineering/orchestrator, @harness-engineering/types, @harness-engineering/cli, @harness-engineering/dashboard)` covering Phases 0–7 aggregate. Entry names: the two new `RoutingUseCase` variants (skill, mode), the widened `RoutingValue = string | readonly [string, ...string[]]`, the `routing.skills` / `routing.modes` maps, the `--backend` invocation override, the `RoutingDecisionBus` ring buffer, three HTTP routes (`/api/v1/routing/{config,decisions,trace}`), the `routing:decision` WS topic, the `harness routing {config,trace,decisions}` CLI, the `/routing` dashboard panel, and the ADR numbers 0028–0032. **Explicitly flags the `RoutingValue` schema widening as additive and scalar-compatible (non-breaking) per spec D4.** No `### Changed` entry (Phase 8 changes nothing for legacy configs).
+14. **OT-Roadmap** — Roadmap entry "Granular Task→Backend Routing" (`docs/roadmap.md` lines 1141–1150) moves from status `planned` → `done`. (Spec note "Spec B already at in-progress status (was bumped after Phase 0); now bump to done" — see U-OP-5 below for status delta; current on-disk shows `planned`, plan resolves to `done` regardless of intermediate state.) Edit is a single status-line replacement; preserves all other roadmap fields verbatim. Plan name field stays `—` (no public-link convention for plan paths in this repo's roadmap.md).
+15. **OT-Regen-Barrels** — `pnpm generate:barrels:check` exits 0 against a phase-scoped baseline. **U-OP-1 below documents that the on-disk baseline is dirty pre-Phase-8** (`packages/core/src/index.ts` has pre-existing drift from `insights`, `validateBranchName`, `invalidateCheckState` exports — same drift the Phase 0/2/3/4/7 learnings reverted from each phase's commits). Phase 8 confirms this drift is unrelated to Spec B's symbol additions (verified via `grep -E 'Routing(Decision|Value|UseCase|Step|Source)' packages/core/src/index.ts` returning empty before and after regen) and surfaces a one-line carry-forward in the handoff rather than absorbing the unrelated diff. (`generate:plugin:check` is already clean; see OT-Regen-Plugin.)
+16. **OT-Regen-Plugin** — `pnpm generate:plugin:check` exits 0. Per Phase 6 learning (line 102), the plugin generator emits one wrapper per skill (compound.md, autopilot.md, …), NOT per CLI subcommand. Spec B adds `harness routing config|trace|decisions` subcommands and a `--backend` flag, none of which template per-skill. Expected outcome: zero in-scope diffs; `:check` is clean. If the regen produces any in-scope artifacts, plan absorbs them in Task 12.
+17. **OT-No-Code-Change** — `git diff <phase-base>..HEAD -- 'packages/**/src/**' 'packages/**/tests/**'` is empty after the phase. Only `docs/`, `AGENTS.md`, `README.md`, and `CHANGELOG.md` are touched. (Verifies docs-only scope.)
+18. **OT-Mechanical** — `pnpm typecheck` (no-op smoke since no code changes), `harness validate`, and `harness check-deps` all green at every commit boundary.
+
+## Skills (from `docs/changes/granular-task-routing/SKILLS.md`)
+
+Advisor-recommended skills are TypeScript/Zod patterns optimized for implementation phases (`ts-zod-integration`, `gof-chain-of-responsibility`, `ts-template-literal-types`, etc.). This is a docs-only phase — none of the listed skills move the needle on doc writing or ADR authoring. No per-task skill annotations below.
+
+**Process gate:** `harness-soundness-review --mode plan` invoked once at the end of VALIDATE before writing this plan, per harness-planning Phase 4 step 6.
+
+## Uncertainties
+
+### Blocking
+
+- _(none — every ADR decision content is transcribed from the spec's Decisions table; every doc edit is mechanical addition or in-place update; numbering, paths, and regen surfaces are all verified.)_
+
+### Assumptions
+
+- **[ASSUMPTION] ADR numbering 0028–0032 is the next sequential block.** Verified at planning time: `ls docs/knowledge/decisions/` shows highest existing as `0027-learnings-md-deprecation-scope.md`. If a concurrent spec lands ADRs between plan-write and plan-execute, executor re-scans and increments at write time (per `docs/knowledge/decisions/README.md` rule). Re-numbering is mechanical, no content change.
+- **[ASSUMPTION] CHANGELOG entry lands in `[Unreleased]`, single combined entry covering Phases 0–7.** Verified by `grep -n '^## ' CHANGELOG.md | head -3` showing `[Unreleased]` is the top section. Matches the established Spec 2 / Hermes precedent (combined-spec entry, not per-phase). If a release ships before this phase commits, the entry moves to that release section.
+- **[ASSUMPTION] `harness check-docs` baseline is 84.0%** as observed at HEAD `cff5b318` during planning. Coverage may rise slightly when Phase 8 adds the two new knowledge docs (they're additive). Phase 8 cannot regress _below_ 84.0% (Phase-7-baseline floor). If the on-disk baseline at execution time differs, executor uses the live measurement, not 84.0%, as the floor.
+- **[ASSUMPTION] AGENTS.md and README.md changes are single-sentence additions, not rewrites.** Verified by reading AGENTS.md line 118 (orchestrator description already mentions `agent.backends` / `agent.routing` from Spec 2 — extending it with one Spec-B sentence is additive). If executor finds the existing line already rewritten by an intervening commit, the edit adjusts to preserve any newer wording.
+- **[ASSUMPTION] Roadmap entry has not been bumped to `in-progress` on disk.** Spec note line says "Spec B already at in-progress status (was bumped after Phase 0)" but on-disk `docs/roadmap.md:1143` reads `Status: planned`. The bump may have been to a separate state surface (graph, dashboard) rather than the markdown. Plan moves it `planned` → `done` directly. If executor finds `in-progress` on-disk, the edit is `in-progress` → `done`. Same single-line replacement.
+
+### Deferrable
+
+- **Exact tags-list ordering on the new knowledge doc's frontmatter.** Plan specifies the tag set; ordering is irrelevant to harness's knowledge ingest (verified by grepping `docs/knowledge/orchestrator/*.md` — order varies). Executor uses any reasonable order.
+- **Whether to add a top-of-file "See also" section to the new ADRs that cross-links the other four ADRs in the 0028–0032 block.** Not pinned by ADR template conventions; some ADRs do, most don't. Defer to writer judgment; not load-bearing.
+- **Knowledge graph reindex.** Surface as carry-forward for autopilot DONE phase (matches Spec 2 Phase 6 precedent). Phase 8 does not run `harness scan` + `harness ingest`. The new ADRs and knowledge docs land as files; the graph picks them up on next ingest.
+
+## Operator Decisions to Confirm Before Execution
+
+| ID     | Question                                                                                                                                                                           | Default (use unless operator overrides)                                                                                                                                                                                                                                           | Alternative                                                                                                                                          |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| U-OP-1 | Pre-existing `packages/core/src/index.ts` barrel drift from `insights`, `validateBranchName`, `invalidateCheckState`. Already reverted by Phases 0, 2, 3, 4, 7. Phase 8 does what? | **Revert from Phase 8 scope** (precedent from 5 prior phases). Phase 8 only touches docs; absorbing this drift would muddy a docs-only commit. Surface as recurring carry-forward in the handoff for a dedicated cleanup PR.                                                      | Absorb the drift into Phase 8 as a "cleanup" commit. Reject — different scope, different commit-message intent, makes the docs-only narrative noisy. |
+| U-OP-2 | Five ADRs (one per spec Decisions row D1, D2, D4, D8, D6) vs folding into fewer ADRs (e.g., combine D2 + D4 into one "routing resolution mechanics" ADR).                          | **Five ADRs as specified by spec § Architectural Decisions (lines 343–349).** The spec explicitly lists five and assigns each to a single Decision. Spec authority binds the plan.                                                                                                | Fold related decisions. Reject — spec is explicit; deviating requires spec amendment, not plan-time license.                                         |
+| U-OP-3 | New ADR statuses on first commit: `accepted` vs `proposed`.                                                                                                                        | **`accepted`.** All five decisions are already implemented end-to-end through Phases 0–7. Marking them `proposed` would misrepresent their state. Matches ADR-0005, 0006, 0007 precedent (Spec 2's ADRs landed as `accepted` in the docs-phase that closed the spec).             | `proposed` until a separate review. Reject — implementation is the proof; the ADRs codify what already ships.                                        |
+| U-OP-4 | `generate:plugin:check` produced no in-scope diffs at planning time. Should Task 12 (regen) still attempt a no-op commit, or skip the regen?                                       | **Run the regen, confirm clean, skip the commit.** Same outcome as Phase 6 Task 14 (decision recorded in learnings line 78). The `:check` script run during VALIDATE proves cleanliness; an explicit no-op commit adds nothing.                                                   | Force a commit (empty or trivial) to signal intent. Reject — empty commits are noise; the validate-stage `:check` exit code is the proof.            |
+| U-OP-5 | Roadmap status delta: `planned` (current on-disk) → `done`, OR `in-progress` (per spec planner note) → `done`?                                                                     | **Use whichever the executor finds on-disk at execute time, move to `done` either way.** The change is a single status-line replacement; the source-state mismatch between spec note and on-disk file is documented as ASSUMPTION above. No semantic difference in the end state. | Investigate the source-state mismatch first. Reject — both source states are valid; either way, end-state is `done`. The diff is one line.           |
+| U-OP-6 | README.md target paragraph: orchestrator capabilities section already references multi-backend routing (Spec 2). Add a new sentence or extend the existing sentence?               | **Add a new single sentence after the existing multi-backend reference.** Preserves the existing Spec 2 wording. Single-sentence cohabitation with Spec 2's sentence makes the README's evolution traceable.                                                                      | Rewrite the existing sentence to combine both specs. Reject — touches Spec-2-authored prose without need.                                            |
+
+If any default is rejected, executor pauses and re-issues the plan diff with the corrective edit before Task 1.
+
+## File Map
+
+```
+CREATE  docs/knowledge/decisions/0028-per-skill-and-per-mode-routing-axes.md
+CREATE  docs/knowledge/decisions/0029-routing-resolution-order.md
+CREATE  docs/knowledge/decisions/0030-fallback-chains-shared-routing-primitive.md
+CREATE  docs/knowledge/decisions/0031-routing-decision-telemetry-ring-buffer.md
+CREATE  docs/knowledge/decisions/0032-skill-authors-do-not-declare-backend-preferences.md
+CREATE  docs/knowledge/orchestrator/routing-resolution.md
+CREATE  docs/guides/routing-trace.md
+MODIFY  docs/knowledge/orchestrator/issue-routing.md      (Backend Routing + Resolution Order + Fallback Chains additions; tags update)
+MODIFY  docs/guides/multi-backend-routing.md              (Per-skill/per-mode section; related-links footer)
+MODIFY  AGENTS.md                                          (orchestrator section: +1 sentence)
+MODIFY  README.md                                          (orchestrator capabilities: +1 sentence + link)
+MODIFY  CHANGELOG.md                                       ([Unreleased] § Added: combined Spec B entry)
+MODIFY  docs/roadmap.md                                    (Granular Task→Backend Routing: status planned|in-progress → done)
+```
+
+13 file touches across 7 CREATE + 6 MODIFY.
+
+## Skeleton
+
+1. **ADR block** — five ADRs, 0028–0032 (5 tasks, ~25 min)
+2. **Knowledge docs** — routing-resolution.md NEW + issue-routing.md UPDATE (2 tasks, ~12 min)
+3. **Operator guides** — multi-backend-routing.md UPDATE + routing-trace.md NEW (2 tasks, ~12 min)
+4. **Top-level prose** — AGENTS.md + README.md + CHANGELOG (3 tasks, ~10 min)
+5. **Roadmap + regen + final validate** — roadmap line, regen checks, harness validate/check-docs (2 tasks, ~10 min)
+
+**Total:** 14 tasks. _Skeleton approved at standard rigor (≥8 tasks)._ Operator confirms via `emit_interaction` before Task 1.
+
+---
+
+## Tasks
+
+### Task 1: ADR 0028 — Per-skill and per-cognitive-mode routing axes (D1)
+
+**Depends on:** none | **Files:** `docs/knowledge/decisions/0028-per-skill-and-per-mode-routing-axes.md` (CREATE)
+
+Transcribes spec Decision **D1** (line 51) into the ADR template.
+
+1. Create `docs/knowledge/decisions/0028-per-skill-and-per-mode-routing-axes.md` with exact content:
+
+   ```markdown
+   ---
+   number: 0028
+   title: Per-skill and per-cognitive-mode routing axes
+   date: 2026-05-26
+   status: accepted
+   tier: medium
+   source: docs/changes/granular-task-routing/proposal.md
+   ---
+
+   ## Context
+
+   Pre-Spec-B orchestrator routing keyed on a small fixed set of use cases: scope tier (`quick-fix`, `guided-change`, `full-exploration`, `diagnostic`), intelligence layer (`sel`, `pesl`), and isolation tier. Every skill at the same scope tier dispatched to the same backend. Two emerging needs broke this assumption:
+
+   1. **Cost insurance.** Cloud LLM rate caps and pricing pressure require selectively re-routing specific skills (e.g., `harness-debugging`, `harness-soundness-review`) to local backends without rerouting all skills at the same tier.
+   2. **Task fitness.** Skills carry wildly different cognitive demands. An adversarial reviewer benefits from a cheap fast model; a constructive architect benefits from a more capable model. The orchestrator already labels skills with `cognitive_mode` in skill.yaml; that label can drive routing if the schema admits a per-mode axis.
+
+   The pre-Spec-B schema could express neither.
+
+   ## Decision
+
+   Extend `RoutingUseCase` and `RoutingConfig` with two new axes:
+
+   - **Per-skill:** `RoutingUseCase` gains `{ kind: 'skill'; skillName: string; cognitiveMode?: string }`; `RoutingConfig.skills?: Record<string, RoutingValue>` maps skill names to backend names or fallback chains.
+   - **Per-cognitive-mode:** `RoutingUseCase` gains `{ kind: 'mode'; cognitiveMode: string }`; `RoutingConfig.modes?: Record<string, RoutingValue>` maps cognitive-mode identifiers to backend names or fallback chains.
+
+   Both axes are optional. Configs that omit `routing.skills` and `routing.modes` continue to behave identically to pre-Spec-B (S1 in spec § Success Criteria).
+
+   ## Consequences
+
+   **Positive:**
+
+   - Operators can pin individual skills to specific backends (cost insurance) without affecting other skills at the same scope tier.
+   - Cognitive mode (6 standard values) provides a coarser semantic layer that handles common cases ("all reviewer work goes cheap") without per-skill config bloat.
+   - Hybrid coverage: per-skill handles the precise case, per-mode handles the cross-cutting case, operators pick the granularity per route.
+
+   **Negative:**
+
+   - Two new axes increase the routing-schema surface; operators must understand the resolution order (see ADR 0029) to predict which axis wins for a given dispatch.
+   - Skill catalog must be enumerable at orchestrator startup for validation warnings (spec assumption line 40).
+
+   **Neutral:**
+
+   - Validation extension: every name referenced under `routing.skills.*` and `routing.modes.*` must exist in `agent.backends` (hard error); unknown skill names produce a startup warning (decision D10).
+   - LMLM (Spec A) composes cleanly: routing entries reference backend names, LMLM auto-populates the model within each backend. Spec B requires no LMLM-specific code (spec § Integration with LMLM).
+   ```
+
+2. Run: `harness validate`
+3. Commit: `docs(adr): 0028 — per-skill and per-cognitive-mode routing axes (Spec B D1)`
+
+### Task 2: ADR 0029 — Routing resolution order (D2)
+
+**Depends on:** Task 1 | **Files:** `docs/knowledge/decisions/0029-routing-resolution-order.md` (CREATE)
+
+Transcribes spec Decision **D2** (line 52).
+
+1. Create `docs/knowledge/decisions/0029-routing-resolution-order.md` with exact content:
+
+   ```markdown
+   ---
+   number: 0029
+   title: Routing resolution order — invocation, skill, mode, tier, default
+   date: 2026-05-26
+   status: accepted
+   tier: medium
+   source: docs/changes/granular-task-routing/proposal.md
+   ---
+
+   ## Context
+
+   With per-skill and per-cognitive-mode routing added as new axes (ADR 0028), and with the pre-existing per-tier, per-intelligence-layer, per-isolation, maintenance, and chat use cases retained, a single dispatch can match multiple routing entries. Without a deterministic resolution order, operators cannot predict which backend will run a given dispatch when, say, both `routing.skills.harness-debugging` and `routing.modes.diagnostic-investigator` are configured for a skill that matches both.
+
+   The orchestrator also supports an invocation-level escape hatch (`harness skill run <name> --backend <name>` and `harness dispatch --backend <name>`) for one-off overrides during testing.
+
+   ## Decision
+
+   `BackendRouter.resolve()` walks routing sources in a fixed deterministic order, returning the first source that yields an available backend:
+
+   1. **Invocation override** — `opts.invocationOverride` if set (from `--backend <name>` flag, ADR-0028 D7 in spec).
+   2. **Per-skill** — `routing.skills[useCase.skillName]` if `useCase.kind === 'skill'`.
+   3. **Per-cognitive-mode** — `routing.modes[useCase.cognitiveMode]` if `useCase.kind in {'skill', 'mode'}` and a mode is present.
+   4. **Per-tier / per-intelligence-layer / per-isolation / maintenance / chat** — the pre-Spec-B resolution preserved unchanged.
+   5. **`routing.default`** — required fallback; throws at construction time (via `validateReferences`) if it names an unknown backend.
+
+   First match wins. Within a source, chain entries (ADR 0030) are tried in declared order; the first chain entry whose backend exists in `agent.backends` is chosen.
+
+   ## Consequences
+
+   **Positive:**
+
+   - Operator authority over skill author (skills cannot override; ADR 0032) and over scope tier (tier remains as the documented fallback when no skill/mode entry matches).
+   - Invocation override at the top of the chain provides an authoritative one-off escape hatch for testing and debugging.
+   - Deterministic: identical config + identical use-case input produces identical resolution; verified by Phase 1's unit-test suite (F3 + F4 + F11 in spec § Success Criteria).
+
+   **Negative:**
+
+   - Five-step resolution chain has more surface to teach than the pre-Spec-B two-step (per-use-case → default). The "Backend Routing" knowledge doc and `harness routing trace` CLI mitigate this.
+
+   **Neutral:**
+
+   - Tier is preserved as the fallback path for skills/modes that aren't explicitly configured — pre-Spec-B configs (no `routing.skills`, no `routing.modes`) walk directly from step 4 to step 5 (S1 invariant).
+   - Resolution path is captured in the `RoutingDecision.resolutionPath` array (ADR 0031), making the walk inspectable post-dispatch.
+   ```
+
+2. Run: `harness validate`
+3. Commit: `docs(adr): 0029 — routing resolution order (Spec B D2)`
+
+### Task 3: ADR 0030 — Fallback chains as a shared routing primitive (D4)
+
+**Depends on:** Task 2 | **Files:** `docs/knowledge/decisions/0030-fallback-chains-shared-routing-primitive.md` (CREATE)
+
+Transcribes spec Decision **D4** (line 54).
+
+1. Create `docs/knowledge/decisions/0030-fallback-chains-shared-routing-primitive.md` with exact content:
+
+   ```markdown
+   ---
+   number: 0030
+   title: Fallback chains as a shared routing primitive
+   date: 2026-05-26
+   status: accepted
+   tier: medium
+   source: docs/changes/granular-task-routing/proposal.md
+   ---
+
+   ## Context
+
+   Routing entries pre-Spec-B were always a single backend name: `routing.default: 'claude-opus'`, `routing.quick-fix: 'local-fast'`, etc. Spec B introduces new axes (ADR 0028) and operators have begun asking for resilience semantics: "try local-fast first, then fall back to claude-sonnet if local-fast is misconfigured or unavailable." Duplicating routing config to express resilience (e.g., two near-identical configs for retry) is error-prone.
+
+   The fallback semantics could live as a Spec-B-only construct (`RoutingChain` type only valid under `routing.skills` and `routing.modes`), but that creates schema inconsistency between old and new axes.
+
+   ## Decision
+
+   Every routing value becomes `RoutingValue = string | readonly [string, ...string[]]`. Scalar form is byte-compatible with pre-Spec-B configs; array form expresses an ordered fallback chain. Applies uniformly to all routing axes:
+
+   - `routing.default`
+   - `routing.<tier>` (quick-fix, guided-change, full-exploration, diagnostic)
+   - `routing.intelligence.{sel,pesl}`
+   - `routing.isolation.<tier>`
+   - `routing.skills.<skill-name>` (new)
+   - `routing.modes.<cognitive-mode>` (new)
+
+   `BackendRouter.resolve()` walks chain entries in declared order; the first entry whose backend exists in `agent.backends` is chosen. Scalar form is normalized internally to a one-element array via `toArray(value)`.
+
+   ## Consequences
+
+   **Positive:**
+
+   - Operators express resilience uniformly: `routing.skills.harness-soundness-review: [local-reasoning, claude-opus]` says "try local-reasoning, fall back to claude-opus if the former is unknown to `agent.backends`."
+   - Schema consistency: one mental model across all routing axes, not "chains here, scalars there."
+   - Backward compatibility: existing scalar configs are byte-compatible (S1 + F5 in spec § Success Criteria).
+
+   **Negative:**
+
+   - Validation surface widens: every chain entry (not just the routing root) must reference a backend in `agent.backends`. The validator was extended in Phase 2 to traverse chains.
+   - No health-aware fallback skip in v1 (spec D11). Chain entries are tried in order; if the first chain entry exists in `agent.backends` but its backend is unhealthy at dispatch time, the dispatch attempts it and falls through only on the existing per-backend timeout / error handling — not on a health pre-check.
+
+   **Neutral:**
+
+   - LMLM (Spec A) composes naturally: an operator can write `routing.skills.harness-soundness-review: [local-reasoning, claude-opus]` knowing LMLM may not yet have pulled `deepseek-r1:32b`; the chain falls through to Claude. Once LMLM installs the local model, future dispatches start staying local. No LMLM-specific code in Spec B's chain semantics.
+   - `unknown-backend` outcomes are recorded in `RoutingDecision.resolutionPath` (ADR 0031) for telemetry, so operator typos surface in the dashboard `/routing` panel and `harness routing decisions` CLI.
+   ```
+
+2. Run: `harness validate`
+3. Commit: `docs(adr): 0030 — fallback chains as shared routing primitive (Spec B D4)`
+
+### Task 4: ADR 0031 — Routing-decision telemetry via in-memory ring buffer (D8)
+
+**Depends on:** Task 3 | **Files:** `docs/knowledge/decisions/0031-routing-decision-telemetry-ring-buffer.md` (CREATE)
+
+Transcribes spec Decision **D8** (line 58).
+
+1. Create `docs/knowledge/decisions/0031-routing-decision-telemetry-ring-buffer.md` with exact content:
+
+   ```markdown
+   ---
+   number: 0031
+   title: Routing-decision telemetry via in-memory ring buffer
+   date: 2026-05-26
+   status: accepted
+   tier: medium
+   source: docs/changes/granular-task-routing/proposal.md
+   ---
+
+   ## Context
+
+   Routing legibility is a Spec B goal (§ Why now #3): with routing about to become significantly more configurable (per-skill + per-mode axes, fallback chains, invocation override), operators need a first-class way to inspect routing decisions before and after they happen. Without decision telemetry, granular routing is opaque — operators cannot tell what their config changes did.
+
+   Persistent storage of every routing decision would offer the richest inspection surface but introduces operational complexity (storage location, retention policy, cleanup, disk pressure) disproportionate to the v1 use case (live debugging + recent-history inspection over the last few hundred decisions).
+
+   ## Decision
+
+   Every `BackendRouter.resolve()` call constructs a `RoutingDecision` record (timestamp, useCase, resolutionPath, backendName, backendType, durationMs) and emits it on the internal `RoutingDecisionBus`. The bus:
+
+   1. **Holds a per-orchestrator in-memory ring buffer** of the last N decisions (default `capacity = 500`, constructor-configurable).
+   2. **Re-broadcasts on the WebSocket topic `routing:decision`** for live dashboard subscribers (`/routing` panel).
+   3. **Emits a structured `routing-decision` log line** for orchestrator-log consumers (O1 in spec § Success Criteria).
+   4. **Is synchronous-but-non-throwing**: subscriber errors are caught and isolated (S6); ring-buffer push + listener fan-out never block dispatch.
+
+   The buffer is process-memory only. Orchestrator restart clears the buffer. No persistent decision history in v1.
+
+   ## Consequences
+
+   **Positive:**
+
+   - Routing legibility: dashboard `/routing` panel, `harness routing trace` (dry-run), and `harness routing decisions` (recent-history dump) all read from the same source — no source-of-truth drift.
+   - Bounded memory: capacity bound (S5) ensures the buffer cannot grow without limit even under sustained dispatch load.
+   - Zero new persistence surface: no disk format, no retention policy, no migration path.
+
+   **Negative:**
+
+   - **Restart loses history.** Orchestrators that crash mid-investigation lose all decisions made before the crash. Operators investigating a flaky route should `harness routing decisions --last <N>` periodically or rely on the structured `routing-decision` log line as the durable backstop.
+   - **Multi-orchestrator deployments have per-instance views.** Federated or HA orchestrators each carry their own ring buffer; aggregation across instances is out of scope for v1 (spec assumption line 44). If multi-instance becomes a real use case, persistent storage is the natural next step.
+
+   **Neutral:**
+
+   - Capacity is configurable per orchestrator (e.g., for memory-constrained Pi deployments — lower; for high-throughput cloud deployments — higher). Default 500 is the spec recommendation.
+   - Future work (D8 follow-up): adding persistent storage is purely additive — the `RoutingDecisionBus` API contract (`emit`, `recent`, `subscribe`) survives unchanged; persistence becomes a new subscriber that writes to disk.
+   ```
+
+2. Run: `harness validate`
+3. Commit: `docs(adr): 0031 — routing-decision telemetry via ring buffer (Spec B D8)`
+
+### Task 5: ADR 0032 — Skill authors do not declare backend preferences (D6)
+
+**Depends on:** Task 4 | **Files:** `docs/knowledge/decisions/0032-skill-authors-do-not-declare-backend-preferences.md` (CREATE)
+
+Transcribes spec Decision **D6** (line 56).
+
+1. Create `docs/knowledge/decisions/0032-skill-authors-do-not-declare-backend-preferences.md` with exact content:
+
+   ```markdown
+   ---
+   number: 0032
+   title: Skill authors do not declare backend preferences
+   date: 2026-05-26
+   status: accepted
+   tier: medium
+   source: docs/changes/granular-task-routing/proposal.md
+   ---
+
+   ## Context
+
+   Per-skill routing (ADR 0028) opens the door to a natural-feeling but ultimately corrosive extension: letting `skill.yaml` declare a preferred backend (e.g., `preferredBackend: claude-opus` or `preferredBackend: any-reasoning-model`). This would let skill authors signal "this skill needs Opus" or "this skill prefers a reasoning model" without operator config.
+
+   The cost: skills become non-portable. A skill authored against a deployment with `claude-opus` named in `agent.backends` breaks in a deployment that names the same model `cloud-primary`. Multiple deployments cannot share a skill catalog without reconciling backend-name conventions.
+
+   ## Decision
+
+   `skill.yaml` is **not** extended with a `preferredBackend` field. Routing is purely operator-controlled via `harness.config.json`'s `agent.routing` map. Skill authors describe skill requirements (e.g., "this skill benefits from a reasoning model with at least 32k context") in skill documentation prose — `SKILL.md` body — not in machine-readable fields that the router consults.
+
+   ## Consequences
+
+   **Positive:**
+
+   - Skills are portable across deployments. A skill catalog can be shared between an enterprise (`agent.backends: { claude-opus, claude-sonnet }`) and a personal (`agent.backends: { primary, local-fast }`) deployment without reconciliation.
+   - Operator authority is absolute. Every routing decision goes through `agent.routing`; no "but the skill said it wanted X" surprise.
+   - Schema surface stays narrow. `skill.yaml` already carries `cognitive_mode`, which is a portable semantic attribute (cognitive-mode-to-backend mapping is operator-defined via `routing.modes`). That covers the legitimate "this kind of skill prefers this kind of backend" pattern.
+
+   **Negative:**
+
+   - Skill authors who genuinely know their skill needs a specific class of backend (e.g., long-context reasoning) must communicate that via documentation, not via schema. The operator must read the docs and configure `routing.skills.<name>` or `routing.modes.<mode>` accordingly. Mitigated by the standard `cognitive_mode` axis — most "class of backend" cases land in one of the six standard modes.
+
+   **Neutral:**
+
+   - The cognitive-mode axis (ADR 0028) absorbs the legitimate generic-preference case without requiring per-skill schema. A skill author labels the skill `cognitive_mode: adversarial-reviewer`; the operator decides which backend runs adversarial reviewers via `routing.modes.adversarial-reviewer`.
+   ```
+
+2. Run: `harness validate`
+3. Commit: `docs(adr): 0032 — skill authors do not declare backend preferences (Spec B D6)`
+
+### Task 6: Knowledge doc — NEW `routing-resolution.md`
+
+**Depends on:** Task 5 | **Files:** `docs/knowledge/orchestrator/routing-resolution.md` (CREATE)
+
+Creates the domain-knowledge doc for the resolution chain.
+
+1. Create `docs/knowledge/orchestrator/routing-resolution.md` with this exact content:
+
+   ````markdown
+   ---
+   type: business_process
+   domain: orchestrator
+   tags:
+     [
+       routing,
+       resolution,
+       fallback-chain,
+       decision-bus,
+       ring-buffer,
+       telemetry,
+       per-skill,
+       per-cognitive-mode,
+     ]
+   ---
+
+   # Routing Resolution
+
+   The orchestrator's `BackendRouter.resolve()` walks a deterministic chain of routing sources to choose the backend for a single dispatch. This document describes the resolution order, fallback semantics, and the decision telemetry that captures every walk.
+
+   ## Resolution Order
+
+   `BackendRouter.resolve(useCase, opts?)` tries sources in this fixed order; the first source that yields an available backend wins:
+
+   1. **Invocation override** — `opts.invocationOverride` if set (typically from `--backend <name>` CLI flag).
+   2. **Per-skill** — `routing.skills[useCase.skillName]` when `useCase.kind === 'skill'`.
+   3. **Per-cognitive-mode** — `routing.modes[useCase.cognitiveMode]` when a mode is present (either on a `kind: 'skill'` use case carrying `cognitiveMode`, or on a `kind: 'mode'` use case).
+   4. **Per-tier / per-intelligence-layer / per-isolation / maintenance / chat** — pre-Spec-B resolution preserved.
+   5. **`routing.default`** — required; throws at construction time if it names an unknown backend.
+
+   Within a source, chain entries (see Fallback Semantics below) are tried in declared order; the first chain entry whose backend exists in `agent.backends` is chosen. See [ADR 0029](../decisions/0029-routing-resolution-order.md).
+
+   ## Fallback Semantics
+
+   Every routing value is `RoutingValue = string | readonly [string, ...string[]]`.
+
+   - **Scalar form** (`'claude-opus'`) — pre-Spec-B-compatible. Normalized internally to a one-element array.
+   - **Array form** (`['local-fast', 'claude-sonnet']`) — ordered fallback chain. Resolver walks the chain; the first entry whose name appears in `agent.backends` is chosen.
+
+   Entries that fail the existence check are recorded in `RoutingDecision.resolutionPath` with `outcome: 'unknown-backend'` for operator visibility (e.g., typos surface in the dashboard `/routing` panel without breaking the dispatch).
+
+   Fallback chains in v1 do **not** consult health signals. The first chain entry whose backend exists is attempted; if dispatch fails, the orchestrator's existing per-backend timeout / error handling takes over. Health-aware fallback skip is reserved for a future spec. See [ADR 0030](../decisions/0030-fallback-chains-shared-routing-primitive.md).
+
+   ## Decision Telemetry
+
+   Every `resolve()` call constructs a `RoutingDecision`:
+
+   ```ts
+   interface RoutingDecision {
+     timestamp: string; // ISO
+     useCase: RoutingUseCase;
+     resolutionPath: ResolutionStep[];
+     backendName: string;
+     backendType: BackendDef['type'];
+     durationMs: number;
+   }
+
+   interface ResolutionStep {
+     source: 'invocation' | 'skill' | 'mode' | 'tier' | 'default';
+     candidate: string;
+     outcome: 'chosen' | 'unknown-backend' | 'considered';
+   }
+   ```
+
+   `resolutionPath` records every chain entry considered. Only `chosen` exits the walk; `unknown-backend` and `considered` entries are preserved for telemetry. See [ADR 0031](../decisions/0031-routing-decision-telemetry-ring-buffer.md).
+
+   ## Ring Buffer Behavior
+
+   `RoutingDecisionBus` holds the last N decisions in a per-orchestrator-process in-memory ring buffer:
+
+   - **Default capacity:** 500 decisions. Constructor-configurable.
+   - **Eviction:** oldest-first when capacity is reached (FIFO).
+   - **Persistence:** none in v1. Orchestrator restart clears the buffer.
+   - **Re-broadcast:** every emission is published on the WebSocket topic `routing:decision` for live dashboard subscribers (`/routing` panel).
+   - **Logging:** every emission produces a structured `routing-decision` log line for orchestrator-log consumers.
+   - **Subscriber isolation:** errors from subscribers are caught and logged; they never propagate to dispatch.
+
+   ## Surfaces
+
+   | Surface                     | Source              | Purpose                                                  |
+   | --------------------------- | ------------------- | -------------------------------------------------------- |
+   | `harness routing trace`     | Dry-run `resolve()` | Predict what backend a given use case would route to     |
+   | `harness routing decisions` | Ring buffer         | Recent decisions, filterable by skill / mode / backend   |
+   | `harness routing config`    | Live config         | Current `RoutingConfig` plus resolved chains             |
+   | Dashboard `/routing` panel  | Ring buffer + WS    | Live decisions + per-backend volume + inline trace       |
+   | `routing-decision` log line | Orchestrator log    | Durable per-dispatch record (independent of ring buffer) |
+
+   ## See also
+
+   - [Issue Routing](./issue-routing.md) — scope-tier detection, triage rules, and the broader routing context
+   - [Local Model Resolution](./local-model-resolution.md) — LMLM (Spec A) auto-populates model entries within each backend; routing references those backend names
+   - [Multi-Backend Routing](../../guides/multi-backend-routing.md) — operator-facing guide
+   - [Routing Trace](../../guides/routing-trace.md) — operator debugging recipes
+   - [ADR 0028](../decisions/0028-per-skill-and-per-mode-routing-axes.md) · [ADR 0029](../decisions/0029-routing-resolution-order.md) · [ADR 0030](../decisions/0030-fallback-chains-shared-routing-primitive.md) · [ADR 0031](../decisions/0031-routing-decision-telemetry-ring-buffer.md) · [ADR 0032](../decisions/0032-skill-authors-do-not-declare-backend-preferences.md)
+   ````
+
+2. Run: `harness validate`
+3. Commit: `docs(knowledge): add routing-resolution domain doc (Spec B)`
+
+### Task 7: Knowledge doc — UPDATE `issue-routing.md`
+
+**Depends on:** Task 6 | **Files:** `docs/knowledge/orchestrator/issue-routing.md` (MODIFY)
+
+Add per-skill + per-mode axes, resolution order, fallback semantics, and cross-links.
+
+1. Open `docs/knowledge/orchestrator/issue-routing.md`. Use **Edit** tool, not full rewrite (preserves existing sections).
+
+2. Replace the frontmatter `tags` line:
+   - **old:** `tags: [routing, triage, scope-tier, escalation, model-router, multi-backend, routing-config]`
+   - **new:** `tags: [routing, triage, scope-tier, escalation, model-router, multi-backend, routing-config, per-skill, per-cognitive-mode, fallback-chain, routing-resolution]`
+
+3. Replace the existing "Backend Routing" section content (between the `## Backend Routing` heading and the closing `See [ADR 0005...](../../guides/multi-backend-routing.md) for the schema and operator-facing semantics.` line) with this expanded content:
+
+   ```markdown
+   ## Backend Routing
+
+   Once a tier is permitted to dispatch (i.e. it's not blocked by `escalation.alwaysHuman` and is allowed by `escalation.autoExecute`), `agent.routing` selects _which_ backend handles it. Routing is orthogonal to escalation:
+
+   - **Escalation** answers "should this tier dispatch at all?" — gates on `alwaysHuman`, `autoExecute`, `signalGated`, and concern signals from the intelligence pipeline.
+   - **Routing** answers "where does this tier dispatch when permitted?" — selects an `agent.backends.<name>` entry by use case.
+
+   The routing map is keyed by use case across five axes:
+
+   - **`default`** (required) — fallback for any unmapped use case
+   - **Per-tier**: `quick-fix`, `guided-change`, `full-exploration`, `diagnostic` — scope-tier dispatch
+   - **Per-intelligence-layer**: `intelligence.sel`, `intelligence.pesl` — analysis-provider selection
+   - **Per-isolation-tier**: `isolation.<tier>` — isolation-tier dispatch
+   - **Per-skill** (Spec B): `skills.<skill-name>` — pins a specific skill to a backend regardless of scope tier
+   - **Per-cognitive-mode** (Spec B): `modes.<cognitive-mode>` — pins all skills of a given cognitive mode to a backend
+
+   Maintenance and dashboard chat both use `routing.default`. Unknown routing keys are validation errors.
+
+   ### Resolution Order
+
+   The orchestrator's `BackendRouter.resolve()` walks routing sources in a deterministic order; the first match wins:
+
+   1. Invocation override (e.g., `--backend <name>` from CLI)
+   2. Per-skill (`routing.skills.<name>`)
+   3. Per-cognitive-mode (`routing.modes.<mode>`)
+   4. Per-tier / per-intelligence-layer / per-isolation / maintenance / chat (pre-Spec-B)
+   5. `routing.default`
+
+   See [Routing Resolution](./routing-resolution.md) for the full walk and the `RoutingDecision` telemetry shape.
+
+   ### Fallback Chains
+
+   Every routing value accepts a single backend name (`'claude-opus'`) or an ordered fallback chain (`['local-fast', 'claude-sonnet']`). The resolver walks the chain in declared order and picks the first entry whose backend exists in `agent.backends`. Scalar form is byte-compatible with pre-Spec-B configs.
+
+   ## See also
+
+   - [Routing Resolution](./routing-resolution.md) — full resolution chain + decision telemetry (Spec B)
+   - [Local Model Resolution](./local-model-resolution.md) — LMLM (Spec A) auto-populates models within each backend; routing references backend names
+   - [Multi-Backend Routing guide](../../guides/multi-backend-routing.md) — operator-facing schema
+   - [Routing Trace guide](../../guides/routing-trace.md) — debugging routing decisions
+   - [ADR 0005: Named backends map](../decisions/0005-named-backends-map.md)
+   - [ADR 0028: Per-skill and per-cognitive-mode routing axes](../decisions/0028-per-skill-and-per-mode-routing-axes.md)
+   ```
+
+4. Run: `harness validate`
+5. Commit: `docs(knowledge): extend issue-routing with per-skill, per-mode, resolution order (Spec B)`
+
+### Task 8: Operator guide — UPDATE `multi-backend-routing.md`
+
+**Depends on:** Task 7 | **Files:** `docs/guides/multi-backend-routing.md` (MODIFY)
+
+Add a "Per-skill and per-mode routing" section + related-links footer entries.
+
+1. Open `docs/guides/multi-backend-routing.md`. Use **Edit** to add the new section between the existing "`agent.routing`" section (ends at line 53) and the "Multi-local example" section (starts at line 55-56).
+
+2. Insert this content as a new top-level section after the `agent.routing` table:
+
+   ````markdown
+   ## Per-skill and per-mode routing (Spec B)
+
+   Spec B extends `agent.routing` with two new axes for finer-grained backend selection:
+
+   - **`routing.skills.<skill-name>`** — pins a specific skill to a backend regardless of scope tier
+   - **`routing.modes.<cognitive-mode>`** — pins all skills of a given cognitive mode (declared via `cognitive_mode:` in skill.yaml) to a backend
+
+   Both axes are optional. Resolution order is deterministic (see [Routing Resolution](../knowledge/orchestrator/routing-resolution.md)):
+
+   1. Invocation override (`--backend <name>`)
+   2. Per-skill (`routing.skills.<name>`)
+   3. Per-cognitive-mode (`routing.modes.<mode>`)
+   4. Per-tier / per-intelligence-layer / per-isolation (pre-Spec-B)
+   5. `routing.default`
+
+   First match wins.
+
+   ### Fallback chains
+
+   Every routing value (old and new) accepts either a single backend name or an ordered fallback chain. The resolver picks the first chain entry whose backend exists in `agent.backends`:
+
+   ```yaml
+   routing:
+     default: claude-opus
+     quick-fix: [local-fast, claude-sonnet] # try local-fast, fall back to claude-sonnet
+   ```
+   ````
+
+   Scalar form is byte-compatible with pre-Spec-B configs — no migration required.
+
+   ### Worked example
+
+   ```yaml
+   agent:
+     backends:
+       claude-opus: { type: anthropic, model: claude-opus-4-7 }
+       claude-sonnet: { type: anthropic, model: claude-sonnet-4-6 }
+       local-fast: { type: local, endpoint: http://localhost:1234/v1, model: qwen3:8b }
+       local-reasoning: { type: local, endpoint: http://localhost:1234/v1, model: deepseek-r1:32b }
+     routing:
+       default: claude-opus
+       quick-fix: [local-fast, claude-sonnet] # fallback chain
+       intelligence:
+         sel: local-fast
+         pesl: local-reasoning
+       skills: # per-skill
+         harness-debugging: [local-fast, claude-sonnet]
+         harness-soundness-review: claude-opus
+         harness-brainstorming: claude-opus
+       modes: # per-cognitive-mode
+         adversarial-reviewer: [local-fast, claude-sonnet]
+         constructive-architect: claude-opus
+         meticulous-implementer: claude-sonnet
+   ```
+
+   ### Common patterns
+
+   **Route reviewers to local, route architects to cloud** — use `routing.modes`:
+
+   ```yaml
+   routing:
+     default: claude-opus
+     modes:
+       adversarial-reviewer: local-fast
+       constructive-architect: claude-opus
+   ```
+
+   Every skill whose `cognitive_mode: adversarial-reviewer` lives in skill.yaml dispatches to `local-fast`. Architects keep running on Opus. No per-skill listing required.
+
+   **Absorb cloud rate caps by pinning a specific skill local** — use `routing.skills` with a fallback chain:
+
+   ```yaml
+   routing:
+     default: claude-opus
+     skills:
+       harness-debugging: [local-fast, claude-sonnet]
+   ```
+
+   Only `harness-debugging` is affected — every other dispatch keeps its prior routing. If `local-fast` is misconfigured or missing from `agent.backends`, the chain falls through to `claude-sonnet`.
+
+   See [Routing Trace](./routing-trace.md) for debugging routing decisions.
+
+   ```
+
+   ```
+
+3. In the existing "## Related" section at the bottom of the file, add two new bullets between the existing entries (after the `[Intelligence Pipeline]` line, before `[Hybrid Orchestrator Quick Start]`):
+
+   ```markdown
+   - [Routing Resolution](../knowledge/orchestrator/routing-resolution.md) — Spec B resolution chain + decision telemetry
+   - [Routing Trace](./routing-trace.md) — Spec B operator-debugging guide
+   ```
+
+4. Run: `harness validate`
+5. Commit: `docs(guide): per-skill and per-mode section in multi-backend-routing (Spec B)`
+
+### Task 9: Operator guide — NEW `routing-trace.md`
+
+**Depends on:** Task 8 | **Files:** `docs/guides/routing-trace.md` (CREATE)
+
+Short operator guide for debugging routing decisions via the CLI and dashboard panel.
+
+1. Create `docs/guides/routing-trace.md` with this exact content:
+
+   ````markdown
+   # Routing Trace
+
+   Operator debugging surface for routing decisions. Use this guide when a dispatch routed somewhere unexpected, or to validate a config change before it goes live.
+
+   ## Overview
+
+   Spec B's granular routing introduces five sources (`invocation`, `skill`, `mode`, `tier`, `default`) and fallback chains; the resolution order is deterministic but the surface is larger than pre-Spec-B routing. The orchestrator emits a `RoutingDecision` for every dispatch (kept in a 500-entry ring buffer) and offers a dry-run path so operators can predict a decision without dispatching.
+
+   Three surfaces share one source of truth (the orchestrator's `BackendRouter` + `RoutingDecisionBus`):
+
+   - **`harness routing trace`** — dry-run a resolution for a hypothetical use case
+   - **`harness routing decisions`** — dump recent decisions in JSON for shell pipelines
+   - **Dashboard `/routing` panel** — live UI with the same data, plus per-backend volume
+
+   ## `harness routing trace`
+
+   Dry-runs `BackendRouter.resolve()` for a given skill or mode without dispatching:
+
+   ```bash
+   harness routing trace --skill harness-debugging
+   ```
+
+   Output (human-readable):
+
+   ```
+   Resolved backend: local-fast (type: local)
+   Resolution path:
+     1. skill   local-fast       chosen
+   Duration: 0.4ms
+   ```
+
+   With `--json` for machine consumption:
+
+   ```bash
+   harness routing trace --skill harness-debugging --json
+   ```
+
+   Returns the full `RoutingDecision` JSON:
+
+   ```json
+   {
+     "timestamp": "2026-05-26T17:34:21.412Z",
+     "useCase": { "kind": "skill", "skillName": "harness-debugging" },
+     "resolutionPath": [{ "source": "skill", "candidate": "local-fast", "outcome": "chosen" }],
+     "backendName": "local-fast",
+     "backendType": "local",
+     "durationMs": 0.4
+   }
+   ```
+
+   Trace exits non-zero if resolution would throw (e.g., `routing.default` references an unknown backend) — suitable for CI config-change validation.
+
+   ### Combining skill and mode
+
+   ```bash
+   harness routing trace --skill harness-soundness-review --mode adversarial-reviewer
+   ```
+
+   Lets you predict per-skill and per-mode interaction without changing skill.yaml.
+
+   ## `harness routing decisions`
+
+   Recent decisions from the orchestrator's ring buffer, JSON by default. Suitable for `jq` piping:
+
+   ```bash
+   harness routing decisions --skill harness-debugging --last 10
+   harness routing decisions --backend local-fast --last 50 | jq '.[].timestamp'
+   harness routing decisions --mode adversarial-reviewer --last 100 | jq 'group_by(.backendName)'
+   ```
+
+   The ring buffer holds up to 500 decisions per orchestrator process; the buffer clears on restart. If recent history is missing, the dispatch happened before the current orchestrator process started.
+
+   ## Dashboard `/routing` panel
+
+   Four cards on the dashboard `/routing` route (also reachable at `/s/routing`):
+
+   - **Resolved Chains** — current `RoutingConfig` rendered as resolved fallback chains, with currently-chosen backend per use case
+   - **Recent Decisions** — last decisions from the ring buffer, filterable by skill / mode / backend; each row expands to show the full `resolutionPath`
+   - **Per-Backend Volume** — dispatch count + success rate over the last 24 h, per backend
+   - **Trace Tool** — inline form (skill + mode inputs) that POSTs to `/api/v1/routing/trace`; renders the same `RoutingDecision` shape as the CLI
+
+   The panel subscribes to the `routing:decision` WebSocket topic for live updates. When the WS is disconnected, it falls back to HTTP polling every 5 s.
+
+   ## Debugging routing decisions
+
+   ### Scenario 1 — typo in backend name
+
+   `routing.skills.harness-debugging` is set to `lcoal-fast` (typo). At startup, validation would catch this (hard error per spec D10), but in a chain `[lcoal-fast, claude-opus]` the dispatch falls through to `claude-opus` while leaving the typo silently. Both `harness routing trace --skill harness-debugging` and the dashboard's Recent Decisions row show the typo:
+
+   ```
+   Resolution path:
+     1. skill   lcoal-fast       unknown-backend
+     2. skill   claude-opus      chosen
+   ```
+
+   The `unknown-backend` outcome on the first chain entry is the actionable signal.
+
+   ### Scenario 2 — skill not routing where expected
+
+   You configured `routing.skills.harness-debugging: local-fast` but `harness routing decisions --skill harness-debugging --last 5` shows recent dispatches all hitting `claude-opus`. Run `harness routing trace --skill harness-debugging` to see which source actually won the walk. If the trace shows `source: invocation` with `claude-opus`, an upstream `--backend` flag is overriding the per-skill route. If the trace shows `source: default`, the per-skill config didn't load — verify `harness routing config` shows `skills.harness-debugging` populated.
+
+   ## See also
+
+   - [Multi-Backend Routing](./multi-backend-routing.md) — operator schema
+   - [Routing Resolution](../knowledge/orchestrator/routing-resolution.md) — domain knowledge
+   - [ADR 0029](../knowledge/decisions/0029-routing-resolution-order.md) — resolution order rationale
+   - [ADR 0031](../knowledge/decisions/0031-routing-decision-telemetry-ring-buffer.md) — telemetry rationale
+   ````
+
+2. Run: `harness validate`
+3. Commit: `docs(guide): add routing-trace operator guide (Spec B)`
+
+### Task 10: Update AGENTS.md orchestrator section
+
+**Depends on:** Task 9 | **Files:** `AGENTS.md` (MODIFY)
+
+Add a single sentence to the orchestrator package description.
+
+1. Open `AGENTS.md`. Locate line 118 — the orchestrator package description. Use **Edit** to extend exactly:
+   - **old:** `- **orchestrator**: Agent orchestration daemon for dispatching coding agents to issues. Modern config surface is `agent.backends`(named-map) +`agent.routing`(per-use-case). Legacy`agent.backend`/`agent.localBackend` accepted via in-memory migration shim with deprecation warning. (depends on types, core, intelligence)`
+   - **new:** `- **orchestrator**: Agent orchestration daemon for dispatching coding agents to issues. Modern config surface is `agent.backends`(named-map) +`agent.routing`(per-use-case). Routing supports per-skill + per-cognitive-mode axes with fallback chains; dashboard`/routing`panel and`harness routing {config,trace,decisions}`CLI surface decision telemetry. Legacy`agent.backend`/`agent.localBackend` accepted via in-memory migration shim with deprecation warning. (depends on types, core, intelligence)`
+
+2. Run: `harness validate`
+3. Commit: `docs(agents): note per-skill, per-mode routing + trace surfaces (Spec B)`
+
+### Task 11: Update README.md orchestrator capabilities
+
+**Depends on:** Task 10 | **Files:** `README.md` (MODIFY)
+
+Add a single sentence + link.
+
+1. Open `README.md`. Locate the orchestrator capabilities section (search for the existing multi-backend-routing reference; grep `multi-backend-routing` to find the line). The single Spec-2 sentence already references the guide.
+
+2. Insert a new sentence immediately after the existing multi-backend-routing reference. Use **Edit** with whatever surrounding prose is on-disk at execution time. Inserted sentence (verbatim):
+
+   > Spec B extends routing with per-skill and per-cognitive-mode axes, fallback chains, and a `/routing` dashboard panel + `harness routing trace` CLI for inspecting decisions. See the [Per-skill and per-mode routing](docs/guides/multi-backend-routing.md#per-skill-and-per-mode-routing-spec-b) section.
+
+   _Executor note:_ if `README.md` has been restructured since planning and no orchestrator section exists, append the sentence to the closest "Features" or "Capabilities" subsection. If the README has no such section at all, surface a checkpoint to the operator before improvising a new section.
+
+3. Run: `harness validate`
+4. Commit: `docs(readme): note Spec B routing extensions (Spec B)`
+
+### Task 12: Update CHANGELOG.md with combined Spec B entry
+
+**Depends on:** Task 11 | **Files:** `CHANGELOG.md` (MODIFY)
+
+Single `### Added` entry under `[Unreleased]` covering Phases 0–7 aggregate.
+
+1. Open `CHANGELOG.md`. The `[Unreleased]` section is at the top (verified at planning time; line 7).
+
+2. Insert this new entry as the **first** bullet under `[Unreleased] > ### Added` (precedes the existing Hermes Phase 4 entry at line 11):
+
+   ```markdown
+   - **Granular Task→Backend Routing (Spec B)** — Per-skill and per-cognitive-mode routing axes; fallback chains as a shared primitive; in-memory decision telemetry with dashboard + CLI surfaces. `RoutingUseCase` (in `packages/types/src/orchestrator.ts`) gains two variants — `{ kind: 'skill'; skillName; cognitiveMode? }` and `{ kind: 'mode'; cognitiveMode }`. `RoutingConfig` gains `skills?: Record<string, RoutingValue>` and `modes?: Record<string, RoutingValue>` maps; **`RoutingValue = string | readonly [string, ...string[]]`** widens every existing scalar routing field (`default`, `quick-fix`, `guided-change`, `full-exploration`, `diagnostic`, `intelligence.{sel,pesl}`, `isolation.<tier>`) to accept ordered fallback chains. **The widening is additive and scalar-compatible — pre-Spec-B configs continue to behave byte-for-byte identically (D4).** `BackendRouter.resolve()` (`packages/orchestrator/src/agent/backend-router.ts`) is rewritten to walk a deterministic chain of sources (invocation override → per-skill → per-cognitive-mode → per-tier/per-intelligence-layer/per-isolation → `routing.default`); first match wins, chain entries within a source are tried in declared order, `unknown-backend` outcomes recorded in `RoutingDecision.resolutionPath` for telemetry. New `--backend <name>` flag on `harness skill run` and `harness dispatch` provides an invocation-level escape hatch (D7). New `RoutingDecisionBus` (`packages/orchestrator/src/routing/decision-bus.ts`) emits every `resolve()` to a per-orchestrator-process in-memory ring buffer (default capacity 500, configurable), broadcasts on the WebSocket topic `routing:decision`, and emits a structured `routing-decision` log line per decision — synchronous-but-non-throwing, subscriber errors isolated (S6). Three new HTTP routes (`packages/orchestrator/src/server/routes/v1/routing.ts`): `GET /api/v1/routing/config` returns current config + resolved chains; `GET /api/v1/routing/decisions?skill=&mode=&backend=&limit=` reads filtered records from the ring buffer; `POST /api/v1/routing/trace` runs `resolve()` without dispatching. Three new CLI commands: `harness routing config|trace|decisions` (`packages/cli/src/commands/routing/`) for shell-accessible inspection. New dashboard route `/routing` (`packages/dashboard/src/client/pages/Routing.tsx`) renders four cards — Resolved Chains, Recent Decisions (filterable, expandable rows), Per-Backend Volume (24 h aggregation), Trace Tool — subscribed to `routing:decision` WS with 5 s HTTP polling fallback when WS is disconnected (O2). Startup config validation (`packages/orchestrator/src/workflow/schema.ts` + `packages/orchestrator/src/workflow/config.ts`) hard-errors on any chain entry that references a backend missing from `agent.backends` (every routing surface — `default`, tier, intelligence, isolation, skills, modes — uniformly checked) and warns on unknown skill names + non-standard cognitive modes (D10). New ADRs codify the architectural choices: [0028 — per-skill and per-cognitive-mode routing axes](docs/knowledge/decisions/0028-per-skill-and-per-mode-routing-axes.md) (D1), [0029 — routing resolution order](docs/knowledge/decisions/0029-routing-resolution-order.md) (D2), [0030 — fallback chains as a shared routing primitive](docs/knowledge/decisions/0030-fallback-chains-shared-routing-primitive.md) (D4), [0031 — routing-decision telemetry via in-memory ring buffer](docs/knowledge/decisions/0031-routing-decision-telemetry-ring-buffer.md) (D8), [0032 — skill authors do not declare backend preferences](docs/knowledge/decisions/0032-skill-authors-do-not-declare-backend-preferences.md) (D6). New knowledge doc [`routing-resolution.md`](docs/knowledge/orchestrator/routing-resolution.md); existing [`issue-routing.md`](docs/knowledge/orchestrator/issue-routing.md) extended with the new axes + resolution order + fallback semantics. New operator guide [`routing-trace.md`](docs/guides/routing-trace.md); existing [`multi-backend-routing.md`](docs/guides/multi-backend-routing.md) extended with per-skill/per-mode section + worked patterns. Composes cleanly with LMLM (Spec A) — routing entries reference backend names whose models LMLM auto-populates; Spec B carries no LMLM-specific code. Spec at [`docs/changes/granular-task-routing/proposal.md`](docs/changes/granular-task-routing/proposal.md). (`@harness-engineering/orchestrator`, `@harness-engineering/types`, `@harness-engineering/cli`, `@harness-engineering/dashboard`)
+   ```
+
+3. Run: `harness validate`
+4. Commit: `docs(changelog): Granular Task→Backend Routing (Spec B) under Unreleased`
+
+### Task 13: Update roadmap status
+
+**Depends on:** Task 12 | **Files:** `docs/roadmap.md` (MODIFY)
+
+Move the roadmap entry to `done`.
+
+1. Open `docs/roadmap.md`. Locate line 1143 — the `Granular Task→Backend Routing` entry's `Status:` field.
+
+2. Use **Edit** to change exactly:
+   - **old (per planning-time inspection):** `- **Status:** planned`
+   - **new:** `- **Status:** done`
+
+   _Executor note:_ Per U-OP-5, if on-disk reads `in-progress` instead of `planned`, change to `done` regardless. Both edits land at the same destination.
+
+3. Run: `harness validate`
+4. Commit: `docs(roadmap): mark Granular Task→Backend Routing done (Spec B)`
+
+### Task 14: Final validation + regen + handoff close
+
+**Depends on:** Task 13 | **Files:** none committed (carry-forward observations only)
+
+Validates the phase exit gate and surfaces the pre-existing core-barrel drift as a carry-forward.
+
+1. Run: `harness validate` — must exit 0.
+2. Run: `harness check-docs` — capture the documentation coverage percentage. Compare against the **Phase 7 baseline of 84.0%**. Must be ≥ 84.0% (OT-1 in Observable Truths). If lower, halt and report. Expected: ≥ 84.0% — the two new knowledge docs and the new guide are additive surfaces.
+3. Run: `pnpm generate:barrels:check` — capture exit code.
+   - If exit 0: confirm by recording "barrels:check clean" in the handoff.
+   - If non-zero (expected, per U-OP-1): run `pnpm generate:barrels` then `git diff packages/core/src/index.ts` and verify the drift involves only the pre-existing symbols (`insights`, `validateBranchName`, `invalidateCheckState`). Confirm via `grep -E 'Routing(Decision|Value|UseCase|Step|Source)' packages/core/src/index.ts` (must return empty). Revert via `git checkout HEAD -- packages/core/src/index.ts` to keep Phase 8 docs-only. Record as recurring carry-forward in the handoff.
+4. Run: `pnpm generate:plugin:check` — must exit 0 (per OT-Regen-Plugin and U-OP-4). If it surfaces in-scope diffs (unexpected), halt and report.
+5. Verify OT-No-Code-Change: `git diff <phase-base>..HEAD -- 'packages/**/src/**' 'packages/**/tests/**'` — must be empty.
+6. **No commit** (validate-only task; if barrel regen is reverted per step 3, the working tree is clean).
+7. Update handoff at `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/.harness/sessions/changes--granular-task-routing--proposal/handoff.json` (per Final Steps section below).
+8. **`[checkpoint:human-action]`** — Operator triggers `manage_roadmap` to update Granular Task→Backend Routing to `done` if there is a separate state surface (graph / dashboard) beyond the on-disk markdown that Task 13 already updated. The plan's `docs/roadmap.md` edit is sufficient for the durable markdown surface; if `manage_roadmap` also writes to a separate state file (e.g., `.harness/roadmap.json`), the operator must invoke it to reconcile. Planner default assumption: no separate state file exists (verified — `.harness/roadmap*` returned no matches at planning time), so this checkpoint is a no-op confirmation in the common case.
+
+---
+
+## Final Steps (after Task 14)
+
+1. **Approval gate.** Before writing the plan file, confirm via `emit_interaction` (type: `confirmation`): plan path, 14 tasks, ~70 min estimate.
+2. **Write handoff** to `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/.harness/sessions/changes--granular-task-routing--proposal/handoff.json`. Required fields: `fromSkill: 'harness-planning'`, `phase: 'phase-8-planned'`, `summary`, `completed: []` (empty — execution hasn't started), `pending: <task list>`, `concerns` (the carry-forward items), `decisions` (U-OP-1..6 defaults), `contextKeywords`.
+3. **Session summary.** Call `writeSessionSummary` with skill `harness-planning`, status `succeeded`, plan path, keyContext, next-step `harness-execution`.
+4. **Transition suggestion.** `emit_interaction` with `type: 'transition'`, `completedPhase: 'planning'`, `suggestedNext: 'execution'`, `requiresConfirmation: true`. Quality gate checks: plan-written, harness-validate, observable-truths-traced, human-approved.
+
+---
+
+## Carry-forward (for handoff `concerns`)
+
+- **Pre-existing barrel drift.** `packages/core/src/index.ts` has unrelated drift from `insights`, `validateBranchName`, `invalidateCheckState` exports that 5 prior phases (0/2/3/4/7) reverted from their scoped commits. Phase 8 continues that precedent (Task 14 step 3). Needs a dedicated cleanup PR scoped to the core package — surfaces here as a recurring concern, not a Spec-B problem.
+- **Knowledge graph reindex.** Phase 8 ships durable knowledge surface (5 ADRs + 2 knowledge docs + new guide), but `harness scan` + `harness ingest` are deferred to autopilot DONE (per Spec 2 precedent). The new content will land in the graph on the next ingest run.
+- **`manage_roadmap` (separate state surface).** If a `.harness/roadmap.json` or similar exists in some deployments and the executor finds it at execute time, it needs an explicit `manage_roadmap` invocation alongside the on-disk markdown edit. Planning-time inspection showed no such file in this worktree — flagged as conditional only.
+- **README.md target location uncertainty (U-OP-6 / Task 11).** If the README has been restructured since planning and the orchestrator capabilities section no longer exists in recognizable form, executor pauses for operator input before improvising. The plan default (append after existing multi-backend reference) assumes the structure observed at planning time.
+
+---
+
+## Risks
+
+- **R1 — Documentation coverage regression.** New knowledge docs introduce new public surfaces (`routing-resolution.md`, `routing-trace.md`); `harness check-docs` may flag unreferenced symbols. Mitigation: the OT-1 baseline floor is 84.0% (Phase 7 baseline). Plan content is additive (more docs ≥ more coverage), so the expected motion is upward. If `check-docs` regresses despite the addition, executor halts and reports (Task 14 step 2).
+- **R2 — Concurrent ADR landings.** If another spec lands ADRs between plan-write and plan-execute, the 0028–0032 numbering needs re-scanning. Mitigation: documented as ASSUMPTION; re-numbering is mechanical, no content change (Task 1–5 just shift block start number).
+- **R3 — CHANGELOG entry interleaving.** Task 12 inserts the new entry as the first bullet under `[Unreleased] > ### Added`. If a concurrent spec inserts before Task 12 lands, executor uses `git pull --rebase` and verifies the new entry remains correctly placed at the top — or accepts wherever the merge places it as long as the entry is under `[Unreleased] > ### Added`. Position within the section is conventional, not load-bearing.
+- **R4 — Roadmap status mismatch.** Per U-OP-5, on-disk shows `planned` but the spec note says "already at in-progress." Mitigation: Task 13 changes whatever it finds to `done`. End state is the same.
+- **R5 — Markdown link integrity.** Many new ADRs cross-reference each other and the new knowledge doc. `harness check-docs` validates link integrity; if any link target is mis-typed (e.g., wrong filename), check-docs will surface it at Task 14 step 2.
+
+---
+
+## Approval
+
+After review, confirm via `emit_interaction` (`type: confirmation`, `text: "Approve Phase 8 plan (14 tasks, ~70 min) for execution?"`). On approval, plan is written to `/Users/cwarner/Projects/iv/harness-spec-b-phase-1/docs/changes/granular-task-routing/plans/2026-05-26-phase-8-docs-adrs-plan.md` and harness-execution is invoked with the session slug `changes--granular-task-routing--proposal`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@harness-engineering/types": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@typescript-eslint/typescript-estree": "^8.29.0",
+    "better-sqlite3": "^12.10.0",
     "chalk": "^5.6.2",
     "commander": "^12.1.0",
     "dotenv": "^16.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@typescript-eslint/typescript-estree':
         specifier: ^8.29.0
         version: 8.59.2(typescript@5.9.3)
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -4527,7 +4530,7 @@ packages:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+      vitest: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
     dev: true
 
   /@vitest/expect@4.1.5:


### PR DESCRIPTION
## Summary

- **Release-critical:** Add `better-sqlite3@^12.10.0` to `@harness-engineering/cli` dependencies. The CLI's bundled `dist/` includes orchestrator code (webhook queue, search index) that imports `better-sqlite3`; native bindings cannot be bundled, so the CLI package must declare it as a runtime dep. Without this, `npm i -g @harness-engineering/cli` would fail at runtime when any sqlite-backed feature is invoked.
- Archive granular-task-routing implementation plans (Phase 0–8) under `docs/changes/granular-task-routing/plans/` — post-hoc documentation of work landed in PR #401
- Refresh `packages/cli/.harness/arch/baselines.json` and `.harness/security/timeline.json` snapshots

## Test plan

- [ ] CI passes
- [ ] Verify `pnpm-lock.yaml` resolves `better-sqlite3@12.10.0` and bindings install on supported platforms