### PR TITLE
refactor(core): clear all 9 Tier 2 perf violations on main

### DIFF
--- a/.changeset/core-tier2-perf-refactors.md
+++ b/.changeset/core-tier2-perf-refactors.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': patch
+---
+
+Clear all 9 Tier 2 structural perf violations (`harness check-perf --structural`) in `packages/core`. Behavior-preserving refactors of `validateBranchName`, `isSanitizedResult`, `gatherDecayBlock`, `attributesToOTLP`, `OTLPExporter` constructor, `spansToOTLPJSON`, `metaToPatch`, `formatDiff`, and `metaFromFeatureFields`. Each function drops below its threshold (cyclomatic ≤ 10, nesting ≤ 4) via extract-method or destructuring-defaults; no API or wire-format changes; 2864/2864 core tests pass.

--- a/packages/core/src/insights/aggregator.ts
+++ b/packages/core/src/insights/aggregator.ts
@@ -81,15 +81,25 @@ async function gatherDecayBlock(projectPath: string): Promise<InsightsDecayBlock
     recentSnapshots?: unknown[];
     topAffected?: Array<{ id?: string; name?: string }>;
   };
-  const recentBumps = arrayLen(trends.recentSnapshots);
-  const affected = Array.isArray(trends.topAffected) ? trends.topAffected : [];
-  const topAffected: string[] = [];
+  return {
+    recentBumps: arrayLen(trends.recentSnapshots),
+    topAffected: collectTopAffectedLabels(trends.topAffected),
+  };
+}
+
+const MAX_TOP_AFFECTED = 5;
+
+function collectTopAffectedLabels(
+  affected: Array<{ id?: string; name?: string }> | undefined
+): string[] {
+  if (!Array.isArray(affected)) return [];
+  const out: string[] = [];
   for (const node of affected) {
     const label = node.id ?? node.name;
-    if (typeof label === 'string' && label.length > 0) topAffected.push(label);
-    if (topAffected.length >= 5) break;
+    if (typeof label === 'string' && label.length > 0) out.push(label);
+    if (out.length >= MAX_TOP_AFFECTED) break;
   }
-  return { recentBumps, topAffected };
+  return out;
 }
 
 /** Gather the attention block — count active vs stale session directories. */

--- a/packages/core/src/pulse/sanitize.ts
+++ b/packages/core/src/pulse/sanitize.ts
@@ -41,15 +41,24 @@ export const PII_LINE_RE = new RegExp(`\\b(?:${PII_TOKENS.join('|')})\\b`, 'i');
 
 const ALLOWED_SET: ReadonlySet<string> = new Set(ALLOWED_FIELD_KEYS);
 
-export function isSanitizedResult(value: unknown): value is SanitizedResult {
-  if (!value || typeof value !== 'object') return false;
-  const v = value as { fields?: unknown; distributions?: unknown };
-  if (!v.fields || typeof v.fields !== 'object') return false;
-  for (const k of Object.keys(v.fields)) {
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function hasAllowedFieldKeys(fields: Record<string, unknown>): boolean {
+  for (const k of Object.keys(fields)) {
     if (!ALLOWED_SET.has(k)) return false;
     if (PII_FIELD_DENYLIST.test(k)) return false;
   }
-  if (!v.distributions || typeof v.distributions !== 'object') return false;
+  return true;
+}
+
+export function isSanitizedResult(value: unknown): value is SanitizedResult {
+  if (!isObject(value)) return false;
+  const { fields, distributions } = value as { fields?: unknown; distributions?: unknown };
+  if (!isObject(fields)) return false;
+  if (!hasAllowedFieldKeys(fields)) return false;
+  if (!isObject(distributions)) return false;
   return true;
 }
 

--- a/packages/core/src/roadmap/migrate/plan-builder.ts
+++ b/packages/core/src/roadmap/migrate/plan-builder.ts
@@ -168,22 +168,30 @@ function assignIfPresent<K extends keyof FeaturePatch>(
 }
 
 function formatDiff(actual: BodyMeta, expected: BodyMeta): string {
-  const keys = new Set<string>();
-  const collect = (m: BodyMeta) => {
-    for (const k of Object.keys(m)) {
-      const v = (m as Record<string, unknown>)[k];
-      if (v !== undefined && v !== null && !(Array.isArray(v) && v.length === 0)) keys.add(k);
-    }
-  };
-  collect(actual);
-  collect(expected);
+  const keys = collectPresentKeys(actual, expected);
   const changed: string[] = [];
-  for (const key of [...keys].sort()) {
+  for (const key of keys) {
     const a = (actual as Record<string, unknown>)[key];
     const e = (expected as Record<string, unknown>)[key];
     if (JSON.stringify(a ?? null) !== JSON.stringify(e ?? null)) changed.push(key);
   }
   return changed.join(',');
+}
+
+function hasMeaningfulValue(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (Array.isArray(value) && value.length === 0) return false;
+  return true;
+}
+
+function collectPresentKeys(...metas: BodyMeta[]): string[] {
+  const keys = new Set<string>();
+  for (const m of metas) {
+    for (const [k, v] of Object.entries(m)) {
+      if (hasMeaningfulValue(v)) keys.add(k);
+    }
+  }
+  return [...keys].sort();
 }
 
 function mapAction(action: 'assigned' | 'completed' | 'unassigned'): HistoryEventType {

--- a/packages/core/src/roadmap/migrate/plan-builder.ts
+++ b/packages/core/src/roadmap/migrate/plan-builder.ts
@@ -161,10 +161,10 @@ function assignIfPresent<K extends keyof FeaturePatch>(
   patch: FeaturePatch,
   key: K,
   value: FeaturePatch[K] | null | undefined,
-  fallback: NonNullable<FeaturePatch[K]>
+  fallback: FeaturePatch[K]
 ): void {
   if (value === undefined) return;
-  patch[key] = (value ?? fallback) as FeaturePatch[K];
+  patch[key] = value ?? fallback;
 }
 
 function formatDiff(actual: BodyMeta, expected: BodyMeta): string {

--- a/packages/core/src/roadmap/migrate/plan-builder.ts
+++ b/packages/core/src/roadmap/migrate/plan-builder.ts
@@ -148,14 +148,23 @@ function featureToNewInput(feature: RoadmapFeature, milestone: RoadmapMilestone)
 }
 
 function metaToPatch(feature: RoadmapFeature, expected: BodyMeta): FeaturePatch {
-  const patch: FeaturePatch = {};
-  patch.summary = feature.summary;
-  if (expected.spec !== undefined) patch.spec = expected.spec ?? null;
-  if (expected.plan !== undefined && expected.plan != null) patch.plans = [expected.plan];
-  if (expected.blocked_by !== undefined) patch.blockedBy = expected.blocked_by ?? [];
-  if (expected.priority !== undefined) patch.priority = expected.priority ?? null;
-  if (expected.milestone !== undefined) patch.milestone = expected.milestone ?? null;
+  const patch: FeaturePatch = { summary: feature.summary };
+  assignIfPresent(patch, 'spec', expected.spec, null);
+  if (expected.plan != null) patch.plans = [expected.plan];
+  assignIfPresent(patch, 'blockedBy', expected.blocked_by, []);
+  assignIfPresent(patch, 'priority', expected.priority, null);
+  assignIfPresent(patch, 'milestone', expected.milestone, null);
   return patch;
+}
+
+function assignIfPresent<K extends keyof FeaturePatch>(
+  patch: FeaturePatch,
+  key: K,
+  value: FeaturePatch[K] | null | undefined,
+  fallback: NonNullable<FeaturePatch[K]>
+): void {
+  if (value === undefined) return;
+  patch[key] = (value ?? fallback) as FeaturePatch[K];
 }
 
 function formatDiff(actual: BodyMeta, expected: BodyMeta): string {

--- a/packages/core/src/roadmap/tracker/adapters/github-issues.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-issues.ts
@@ -55,12 +55,25 @@ interface MetaSource {
 /** Extracts a populated BodyMeta from a feature-like source, dropping null/empty fields. */
 function metaFromFeatureFields(src: MetaSource): BodyMeta {
   const meta: BodyMeta = {};
-  if (src.spec !== undefined && src.spec !== null) meta.spec = src.spec;
-  if (src.plans && src.plans.length > 0) meta.plan = src.plans[0]!;
-  if (src.blockedBy && src.blockedBy.length > 0) meta.blocked_by = src.blockedBy;
-  if (src.priority !== undefined && src.priority !== null) meta.priority = src.priority;
-  if (src.milestone !== undefined && src.milestone !== null) meta.milestone = src.milestone;
+  assignNonNullish(meta, 'spec', src.spec);
+  if (hasItems(src.plans)) meta.plan = src.plans[0]!;
+  if (hasItems(src.blockedBy)) meta.blocked_by = src.blockedBy;
+  assignNonNullish(meta, 'priority', src.priority);
+  assignNonNullish(meta, 'milestone', src.milestone);
   return meta;
+}
+
+function assignNonNullish<K extends keyof BodyMeta>(
+  meta: BodyMeta,
+  key: K,
+  value: BodyMeta[K] | null | undefined
+): void {
+  if (value === undefined || value === null) return;
+  meta[key] = value;
+}
+
+function hasItems<T>(arr: T[] | undefined): arr is T[] {
+  return Array.isArray(arr) && arr.length > 0;
 }
 
 /** Convenience wrapper for create's NewFeatureInput shape. */

--- a/packages/core/src/telemetry/exporter/otlp-http.ts
+++ b/packages/core/src/telemetry/exporter/otlp-http.ts
@@ -66,20 +66,20 @@ function toUnixNanoString(ns: bigint): string {
  * String values → stringValue. Booleans → boolValue. Integers (safe
  * range) → intValue (stringified). Non-integer numbers → doubleValue.
  */
+function encodeAttributeValue(value: unknown): Record<string, unknown> | null {
+  if (typeof value === 'string') return { stringValue: value };
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value };
+  }
+  return null;
+}
+
 function attributesToOTLP(attrs: TraceSpan['attributes']): unknown[] {
   const out: unknown[] = [];
   for (const [key, value] of Object.entries(attrs)) {
-    if (typeof value === 'string') {
-      out.push({ key, value: { stringValue: value } });
-    } else if (typeof value === 'boolean') {
-      out.push({ key, value: { boolValue: value } });
-    } else if (typeof value === 'number') {
-      if (Number.isInteger(value)) {
-        out.push({ key, value: { intValue: String(value) } });
-      } else {
-        out.push({ key, value: { doubleValue: value } });
-      }
-    }
+    const encoded = encodeAttributeValue(value);
+    if (encoded) out.push({ key, value: encoded });
   }
   return out;
 }

--- a/packages/core/src/telemetry/exporter/otlp-http.ts
+++ b/packages/core/src/telemetry/exporter/otlp-http.ts
@@ -235,33 +235,31 @@ export class OTLPExporter {
    * tests; not part of the supported API surface.
    */
   spansToOTLPJSON(spans: TraceSpan[]): unknown {
-    return {
-      resourceSpans: [
-        {
-          resource: {
-            attributes: [{ key: 'service.name', value: { stringValue: 'harness' } }],
-          },
-          scopeSpans: [
-            {
-              scope: { name: 'harness' },
-              spans: spans.map((s) => {
-                const span: Record<string, unknown> = {
-                  traceId: s.traceId,
-                  spanId: s.spanId,
-                  name: s.name,
-                  kind: s.kind,
-                  startTimeUnixNano: toUnixNanoString(s.startTimeNs),
-                  endTimeUnixNano: toUnixNanoString(s.endTimeNs),
-                  attributes: attributesToOTLP(s.attributes),
-                };
-                if (s.parentSpanId !== undefined) span['parentSpanId'] = s.parentSpanId;
-                if (s.statusCode !== undefined) span['status'] = { code: s.statusCode };
-                return span;
-              }),
-            },
-          ],
-        },
-      ],
+    const scopeSpan = {
+      scope: { name: 'harness' },
+      spans: spans.map(spanToOTLP),
     };
+    const resourceSpan = {
+      resource: { attributes: SERVICE_NAME_ATTR },
+      scopeSpans: [scopeSpan],
+    };
+    return { resourceSpans: [resourceSpan] };
   }
+}
+
+const SERVICE_NAME_ATTR = [{ key: 'service.name', value: { stringValue: 'harness' } }];
+
+function spanToOTLP(s: TraceSpan): Record<string, unknown> {
+  const span: Record<string, unknown> = {
+    traceId: s.traceId,
+    spanId: s.spanId,
+    name: s.name,
+    kind: s.kind,
+    startTimeUnixNano: toUnixNanoString(s.startTimeNs),
+    endTimeUnixNano: toUnixNanoString(s.endTimeNs),
+    attributes: attributesToOTLP(s.attributes),
+  };
+  if (s.parentSpanId !== undefined) span['parentSpanId'] = s.parentSpanId;
+  if (s.statusCode !== undefined) span['status'] = { code: s.statusCode };
+  return span;
 }

--- a/packages/core/src/telemetry/exporter/otlp-http.ts
+++ b/packages/core/src/telemetry/exporter/otlp-http.ts
@@ -75,6 +75,43 @@ function encodeAttributeValue(value: unknown): Record<string, unknown> | null {
   return null;
 }
 
+interface ResolvedOTLPOptions {
+  endpoint: string;
+  enabled: boolean;
+  headers: Record<string, string>;
+  flushIntervalMs: number;
+  batchSize: number;
+  fetchImpl: typeof fetch;
+  warn: (...args: unknown[]) => void;
+}
+
+const DEFAULT_FLUSH_INTERVAL_MS = 2000;
+const DEFAULT_BATCH_SIZE = 64;
+
+const defaultFetch: typeof fetch = (...args) => globalThis.fetch(...args);
+const defaultWarn = (...args: unknown[]): void => console.warn(...args);
+
+function resolveOTLPOptions(opts: OTLPExporterOptions): ResolvedOTLPOptions {
+  const {
+    endpoint,
+    enabled = true,
+    headers = {},
+    flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS,
+    batchSize = DEFAULT_BATCH_SIZE,
+    fetchImpl = defaultFetch,
+    warn = defaultWarn,
+  } = opts;
+  return {
+    endpoint,
+    enabled,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    flushIntervalMs,
+    batchSize,
+    fetchImpl,
+    warn,
+  };
+}
+
 function attributesToOTLP(attrs: TraceSpan['attributes']): unknown[] {
   const out: unknown[] = [];
   for (const [key, value] of Object.entries(attrs)) {
@@ -98,13 +135,14 @@ export class OTLPExporter {
   private readonly inFlightFlushes = new Set<Promise<void>>();
 
   constructor(opts: OTLPExporterOptions) {
-    this.endpoint = opts.endpoint;
-    this.enabled = opts.enabled !== false;
-    this.headers = { 'Content-Type': 'application/json', ...(opts.headers ?? {}) };
-    this.flushIntervalMs = opts.flushIntervalMs ?? 2000;
-    this.batchSize = opts.batchSize ?? 64;
-    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
-    this.warn = opts.warn ?? ((...a: unknown[]) => console.warn(...a));
+    const resolved = resolveOTLPOptions(opts);
+    this.endpoint = resolved.endpoint;
+    this.enabled = resolved.enabled;
+    this.headers = resolved.headers;
+    this.flushIntervalMs = resolved.flushIntervalMs;
+    this.batchSize = resolved.batchSize;
+    this.fetchImpl = resolved.fetchImpl;
+    this.warn = resolved.warn;
   }
 
   /**

--- a/packages/core/src/validation/branch.ts
+++ b/packages/core/src/validation/branch.ts
@@ -83,25 +83,8 @@ export function validateBranchName(
 
   if (config.enforceKebabCase) {
     for (const part of slug.split('/')) {
-      const ticketMatch = part.match(TICKET_ID);
-      if (ticketMatch) {
-        const rest = ticketMatch[2];
-        if (rest && !KEBAB_CASE.test(rest)) {
-          return {
-            valid: false,
-            branchName,
-            message: `Branch slug part "${part}" does not follow kebab-case after the ticket ID.`,
-            suggestion: `Ensure the description after "${ticketMatch[1]}" uses kebab-case (lowercase, single hyphens, no leading/trailing hyphen).`,
-          };
-        }
-      } else if (!KEBAB_CASE.test(part)) {
-        return {
-          valid: false,
-          branchName,
-          message: `Branch slug part "${part}" must be in kebab-case (lowercase, single hyphens, no leading/trailing hyphen).`,
-          suggestion: `Change "${part}" to match the convention.`,
-        };
-      }
+      const kebabFailure = validateKebabSlugPart(part, branchName);
+      if (kebabFailure) return kebabFailure;
     }
   }
 
@@ -119,4 +102,25 @@ export function validateBranchName(
   }
 
   return { valid: true, branchName };
+}
+
+function validateKebabSlugPart(part: string, branchName: string): BranchValidationResult | null {
+  const ticketMatch = part.match(TICKET_ID);
+  if (ticketMatch) {
+    const rest = ticketMatch[2];
+    if (!rest || KEBAB_CASE.test(rest)) return null;
+    return {
+      valid: false,
+      branchName,
+      message: `Branch slug part "${part}" does not follow kebab-case after the ticket ID.`,
+      suggestion: `Ensure the description after "${ticketMatch[1]}" uses kebab-case (lowercase, single hyphens, no leading/trailing hyphen).`,
+    };
+  }
+  if (KEBAB_CASE.test(part)) return null;
+  return {
+    valid: false,
+    branchName,
+    message: `Branch slug part "${part}" must be in kebab-case (lowercase, single hyphens, no leading/trailing hyphen).`,
+    suggestion: `Change "${part}" to match the convention.`,
+  };
 }


### PR DESCRIPTION
## Summary

- Refactors the 9 functions reported as Tier 2 violations by `harness check-perf --structural` (cyclomatic > 10 or nesting > 4). Result: `harness --json check-perf --structural` from `packages/core` reports **0 Tier 2 hits** (down from 9).
- All refactors preserve behavior — same observable inputs/outputs, same boundary semantics, no API or wire-format changes.
- One commit per function (per the convention) so each refactor is reviewable in isolation.

## Why now

These violations were surfaced while running `/harness:perf` in PR #418 (Codex skills). They long pre-existed that branch — `git blame` on each function shows the complexity grew organically over the past months. They're inherited Tier-2 work on main; addressing them on their own branch keeps PR #418's diff focused on Codex.

## Commits (in order)

| Commit | Function | Before | After (technique) |
|---|---|---|---|
| `f3b29f53` | `validateBranchName` kebab-case loop | nesting 5 | extract `validateKebabSlugPart` |
| `e53ad77e` | `isSanitizedResult` | cyclomatic 12 | split `isObject` + `hasAllowedFieldKeys` predicates |
| `62997e5b` | `gatherDecayBlock` | cyclomatic 12 | extract `collectTopAffectedLabels` |
| `00a9af66` | `attributesToOTLP` | nesting 5 | extract `encodeAttributeValue` per-type encoder |
| `77205452` | `OTLPExporter` constructor | cyclomatic 11 | move to `resolveOTLPOptions` with destructuring defaults |
| `e18153c0` | `spansToOTLPJSON` | nesting 5 | hoist `spanToOTLP`, name envelope locals, lift constant attrs |
| `8ac8559b` | `metaToPatch` | cyclomatic 15 | extract `assignIfPresent<K>` table-driven helper |
| `0356d967` | `formatDiff` | cyclomatic 12 | split `collectPresentKeys` + `hasMeaningfulValue` |
| `9095216b` | `metaFromFeatureFields` | cyclomatic 11 | extract `assignNonNullish` + `hasItems` |
| `ed6a2310` | (fixup) | — | widen `assignIfPresent` fallback type to allow null |
| `f5dbaec7` | (infra) | — | husky pre-push PATH order (cherry-picked from #418) |

## Tests

- [x] `pnpm --filter @harness-engineering/core test` — 2864/2864 pass (1 pre-existing skip)
- [x] `npx tsc --noEmit` from `packages/core` — clean (caught the original assignIfPresent type bug before push)
- [x] `harness --json check-perf --structural` from `packages/core` — Tier 2 count drops from 9 to 0
- [x] `pnpm run test:ci` — all 19 workspaces green
- [x] `node scripts/coverage-ratchet.mjs` — no regression

## Out of scope

- **`harness check-perf` from repo root throws "Could not resolve entry points"** — the entry-point resolver in `packages/core/src/entropy/entry-points.ts:364` ignores the `performance.entryPoints` list in `harness.config.json`. Worked around by running from `packages/core` for verification. Worth its own bug fix.
- **96 Tier 3 file-length warnings** — pre-existing, info-only, no gate. Many are coherent single-concern files where the 300-line threshold is the wrong gate; should be addressed via module decomposition only where it improves cohesion, not as a blanket sweep.
- **`packages/core/.harness/` transient scan state** — auto-generated when `harness scan` runs; not in `.prettierignore`. Removed manually before push. Worth adding `**/.harness/security/` to `.prettierignore` on its own commit.

## Dependencies

- `f5dbaec7` (husky PATH fix) is cherry-picked from PR #418 because this branch was forked from main before #418 merged. When #418 lands, this becomes a no-op merge.

## Note on the rebased order

`ed6a2310` is a fixup that wires up cleanly between T2-7 and T2-9. I kept it as a separate honest commit rather than rewriting history with interactive rebase. Reviewers can squash on merge if preferred.