### PR TITLE
ci(release): publish via npm OIDC instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      # OIDC publish requires npm >= 11.5.1; Node 22 ships with npm 10.x.
+      - run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build
@@ -60,7 +63,6 @@ jobs:
         env:
           HUSKY: '0'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Extract CLI version for Docker


### PR DESCRIPTION
## Summary

- Drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the changesets publish step so npm uses the configured Trusted Publisher (OIDC) instead of the legacy token.
- Add `npm install -g npm@latest` before publish — OIDC publish requires npm ≥ 11.5.1 and Node 22 ships with npm 10.x.

## Why

Trusted Publisher is configured on npm (`Intense-Visions/harness-engineering`, workflow `release.yml`, `npm publish` allowed). But the workflow still passed `NODE_AUTH_TOKEN`, which forces the npm CLI down the token-auth path and skips the OIDC exchange. The legacy `NPM_TOKEN` secret (created 2026-03-17, before Trusted Publishers) lacks publish rights to `@harness-engineering/*`, so the last release run 404’d on all three packages:

- `@harness-engineering/graph@0.10.0`
- `@harness-engineering/core@0.28.1`
- `@harness-engineering/cli@2.7.0`

Failing run: https://github.com/Intense-Visions/harness-engineering/actions/runs/26484489668/job/77989472326

`id-token: write` (workflow-level) and `registry-url: https://registry.npmjs.org` are already in place, so this is the minimum change to flip auth over to OIDC.

## Test plan

- [ ] CI gate (`ci-gate` job) passes on this PR
- [ ] After merge, the auto-triggered `release` workflow on `main` re-publishes `cli@2.7.0` / `core@0.28.1` / `graph@0.10.0` to npmjs.org via OIDC (with provenance attestation)
- [ ] Confirm `@harness-engineering/cli@2.7.0` is installable via `npm i -g @harness-engineering/cli@2.7.0`
- [ ] Once verified, the now-unused `NPM_TOKEN` secret can be deleted from repo settings (follow-up)