### PR TITLE
feat(cli): unify craft LLM provider config + multi-backend + local-model support

### DIFF
--- a/.changeset/fix-entropy-suggestions-stack-overflow.md
+++ b/.changeset/fix-entropy-suggestions-stack-overflow.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/core': patch
+'@harness-engineering/cli': patch
+---
+
+Fix `harness recommend` crashing with `Unexpected token 'E', "Error: Max"... is not valid JSON` on repos with very large drift reports.
+
+Root cause: `generateSuggestions` in `@harness-engineering/core` spread sub-arrays into `Array.push` (`suggestions.push(...subList)`), exceeding V8's argument-count limit (~65k) on a 322k-entry drift report and throwing `RangeError: Maximum call stack size exceeded`. The cli's `parseToolResult` then JSON-parsed the resulting error text and crashed the recommend pipeline.
+
+Core: switched spread-push to `concat` so the suggestion accumulator scales with report size. Cli: made `parseToolResult` honor `isError`, catch parse failures, warn via logger, and fall back to `{}` so a single failing sub-check degrades gracefully instead of taking the whole pipeline down. Both layers gained regression tests with revert-and-fail verified.

--- a/.changeset/orchestrator-craft-provider-exports.md
+++ b/.changeset/orchestrator-craft-provider-exports.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+Re-export workflow Zod schemas (`BackendDefSchema`, `RoutingConfigSchema`, `RoutingValueSchema`) and local-model probe primitives (`defaultFetchModels`, `normalizeLocalModel`, `LocalModelResolver`, `LocalModelResolverOptions`, `ResolverLogger`) so the cli's unified craft LLM provider config and the craft skill family can validate `agent.backends` / `agent.routing` and resolve `/v1/models` against the same source of truth the orchestrator runtime uses. Additive API surface only.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,9 @@
 export PATH="$PATH:/opt/homebrew/bin"
 
+# Mirror CI's changeset-check job so missing changesets fail locally
+# (cheap diff-only script — runs in ~1s before the heavier steps).
+pnpm run check:changesets
+
 # Format check catches files missed by lint-staged (e.g., from merges).
 pnpm run format:check
 pnpm run typecheck

--- a/agents/skills/claude-code/naming-craft/SKILL.md
+++ b/agents/skills/claude-code/naming-craft/SKILL.md
@@ -84,9 +84,81 @@ Emit `NamingCraftOutput`:
 ## Harness Integration
 
 - **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
-- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__naming_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__naming_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
-- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+- **LLM provider:** configured in `harness.config.json`. The shared selector in `packages/cli/src/shared/craft/llm/provider.ts` reads two blocks:
+  - **`agent.backends`** — named backend definitions, shared with the orchestrator. Supported types: `claude`, `anthropic`, `openai`, `local`, `pi`, `mock`. (`local` and `pi` are OpenAI-compatible — point them at Ollama / LM Studio / vLLM / LiteLLM / any compliant server.)
+  - **`craft.llm`** — either `{ "backend": "<name>" }` to route through one of the entries above, or `{ "mode": "in-session" | "mock" }` for the non-backend modes. Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow).
+  - **`HARNESS_CRAFT_LLM`** env var overrides the file. Accepts `in-session`, `mock`, or the name of any entry in `agent.backends`.
+
+### Migration from `harness.orchestrator.md`
+
+If you already declared `agent.backends` in `harness.orchestrator.md`, the craft selector reads from it as a fallback and emits a one-time warning on first run. Run `harness migrate backends` (preview with `--dry-run`) to copy the entries into `harness.config.json` so both files share a single source of truth.
+
+### Example
+
+Example config snippet for routing craft skills to a local Ollama:
+
+```jsonc
+{
+  "agent": {
+    "backends": {
+      "ollama": {
+        "type": "local",
+        "endpoint": "http://localhost:11434/v1",
+        "model": ["deepseek-coder-v2", "qwen3:8b"],
+      },
+    },
+  },
+  "craft": { "llm": { "backend": "ollama" } },
+}
+```
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. Instead it returns a list of prompts for the calling agent to answer with its own model. This is a two-step protocol:
+
+**Step 1 — `mcp__harness__naming_craft({ path, ... })`** returns:
+
+```json
+{
+  "status": "collected",
+  "runId": "<uuid>",
+  "pendingPrompts": [
+    { "promptId": "p1", "systemPrompt": "...", "userPrompt": "..." },
+    ...
+  ],
+  "projection": { "promptCount": N, "budget": 100 }
+}
+```
+
+If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxIdentifiersPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the identifier. The required response shape (per prompt) is:
+
+````
+```json
+null
+```
+````
+
+if the rubric does not apply or the name is fine, OR:
+
+````
+```json
+{
+  "tier": "foundational|polish|aspirational",
+  "impact": "small|medium|large",
+  "confidence": "high|medium|low",
+  "message": "<critique with suggested rename when possible>"
+}
+```
+````
+
+**Step 3 — `mcp__harness__naming_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses, applies the same validation the inline path uses, and returns the standard `NamingCraftOutput`.
+
+If you want the inline behavior (skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider.
 
 ## Success Criteria
 

--- a/agents/skills/codex/naming-craft/SKILL.md
+++ b/agents/skills/codex/naming-craft/SKILL.md
@@ -84,9 +84,81 @@ Emit `NamingCraftOutput`:
 ## Harness Integration
 
 - **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
-- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__naming_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__naming_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
-- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+- **LLM provider:** configured in `harness.config.json`. The shared selector in `packages/cli/src/shared/craft/llm/provider.ts` reads two blocks:
+  - **`agent.backends`** — named backend definitions, shared with the orchestrator. Supported types: `claude`, `anthropic`, `openai`, `local`, `pi`, `mock`. (`local` and `pi` are OpenAI-compatible — point them at Ollama / LM Studio / vLLM / LiteLLM / any compliant server.)
+  - **`craft.llm`** — either `{ "backend": "<name>" }` to route through one of the entries above, or `{ "mode": "in-session" | "mock" }` for the non-backend modes. Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow).
+  - **`HARNESS_CRAFT_LLM`** env var overrides the file. Accepts `in-session`, `mock`, or the name of any entry in `agent.backends`.
+
+### Migration from `harness.orchestrator.md`
+
+If you already declared `agent.backends` in `harness.orchestrator.md`, the craft selector reads from it as a fallback and emits a one-time warning on first run. Run `harness migrate backends` (preview with `--dry-run`) to copy the entries into `harness.config.json` so both files share a single source of truth.
+
+### Example
+
+Example config snippet for routing craft skills to a local Ollama:
+
+```jsonc
+{
+  "agent": {
+    "backends": {
+      "ollama": {
+        "type": "local",
+        "endpoint": "http://localhost:11434/v1",
+        "model": ["deepseek-coder-v2", "qwen3:8b"],
+      },
+    },
+  },
+  "craft": { "llm": { "backend": "ollama" } },
+}
+```
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. Instead it returns a list of prompts for the calling agent to answer with its own model. This is a two-step protocol:
+
+**Step 1 — `mcp__harness__naming_craft({ path, ... })`** returns:
+
+```json
+{
+  "status": "collected",
+  "runId": "<uuid>",
+  "pendingPrompts": [
+    { "promptId": "p1", "systemPrompt": "...", "userPrompt": "..." },
+    ...
+  ],
+  "projection": { "promptCount": N, "budget": 100 }
+}
+```
+
+If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxIdentifiersPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the identifier. The required response shape (per prompt) is:
+
+````
+```json
+null
+```
+````
+
+if the rubric does not apply or the name is fine, OR:
+
+````
+```json
+{
+  "tier": "foundational|polish|aspirational",
+  "impact": "small|medium|large",
+  "confidence": "high|medium|low",
+  "message": "<critique with suggested rename when possible>"
+}
+```
+````
+
+**Step 3 — `mcp__harness__naming_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses, applies the same validation the inline path uses, and returns the standard `NamingCraftOutput`.
+
+If you want the inline behavior (skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider.
 
 ## Success Criteria
 

--- a/agents/skills/cursor/naming-craft/SKILL.md
+++ b/agents/skills/cursor/naming-craft/SKILL.md
@@ -84,9 +84,81 @@ Emit `NamingCraftOutput`:
 ## Harness Integration
 
 - **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
-- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__naming_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__naming_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
-- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+- **LLM provider:** configured in `harness.config.json`. The shared selector in `packages/cli/src/shared/craft/llm/provider.ts` reads two blocks:
+  - **`agent.backends`** — named backend definitions, shared with the orchestrator. Supported types: `claude`, `anthropic`, `openai`, `local`, `pi`, `mock`. (`local` and `pi` are OpenAI-compatible — point them at Ollama / LM Studio / vLLM / LiteLLM / any compliant server.)
+  - **`craft.llm`** — either `{ "backend": "<name>" }` to route through one of the entries above, or `{ "mode": "in-session" | "mock" }` for the non-backend modes. Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow).
+  - **`HARNESS_CRAFT_LLM`** env var overrides the file. Accepts `in-session`, `mock`, or the name of any entry in `agent.backends`.
+
+### Migration from `harness.orchestrator.md`
+
+If you already declared `agent.backends` in `harness.orchestrator.md`, the craft selector reads from it as a fallback and emits a one-time warning on first run. Run `harness migrate backends` (preview with `--dry-run`) to copy the entries into `harness.config.json` so both files share a single source of truth.
+
+### Example
+
+Example config snippet for routing craft skills to a local Ollama:
+
+```jsonc
+{
+  "agent": {
+    "backends": {
+      "ollama": {
+        "type": "local",
+        "endpoint": "http://localhost:11434/v1",
+        "model": ["deepseek-coder-v2", "qwen3:8b"],
+      },
+    },
+  },
+  "craft": { "llm": { "backend": "ollama" } },
+}
+```
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. Instead it returns a list of prompts for the calling agent to answer with its own model. This is a two-step protocol:
+
+**Step 1 — `mcp__harness__naming_craft({ path, ... })`** returns:
+
+```json
+{
+  "status": "collected",
+  "runId": "<uuid>",
+  "pendingPrompts": [
+    { "promptId": "p1", "systemPrompt": "...", "userPrompt": "..." },
+    ...
+  ],
+  "projection": { "promptCount": N, "budget": 100 }
+}
+```
+
+If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxIdentifiersPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the identifier. The required response shape (per prompt) is:
+
+````
+```json
+null
+```
+````
+
+if the rubric does not apply or the name is fine, OR:
+
+````
+```json
+{
+  "tier": "foundational|polish|aspirational",
+  "impact": "small|medium|large",
+  "confidence": "high|medium|low",
+  "message": "<critique with suggested rename when possible>"
+}
+```
+````
+
+**Step 3 — `mcp__harness__naming_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses, applies the same validation the inline path uses, and returns the standard `NamingCraftOutput`.
+
+If you want the inline behavior (skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider.
 
 ## Success Criteria
 

--- a/agents/skills/gemini-cli/naming-craft/SKILL.md
+++ b/agents/skills/gemini-cli/naming-craft/SKILL.md
@@ -84,9 +84,81 @@ Emit `NamingCraftOutput`:
 ## Harness Integration
 
 - **`harness naming-craft`** — CLI entry. `--files <glob>` / `--kinds <variable|function|type|file>` / `--max-files <n>` / `--max-identifiers-per-file <n>` / `--json` / `--verbose`.
-- **`mcp__harness__naming_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__naming_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__naming_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueNamesInFile(file, opts)` exported from `packages/cli/src/naming-craft/index.ts`. Future craft skills (docs-craft, test-craft, code-craft) import and invoke this when they want naming critique on a file they're already processing — no project re-walk needed.
-- **LLM provider reuse:** imports design-craft's `LlmProvider` + `MockLlmProvider` directly. v2 extracts to `packages/cli/src/shared/llm/` when a second non-design craft skill needs differences.
+- **LLM provider:** configured in `harness.config.json`. The shared selector in `packages/cli/src/shared/craft/llm/provider.ts` reads two blocks:
+  - **`agent.backends`** — named backend definitions, shared with the orchestrator. Supported types: `claude`, `anthropic`, `openai`, `local`, `pi`, `mock`. (`local` and `pi` are OpenAI-compatible — point them at Ollama / LM Studio / vLLM / LiteLLM / any compliant server.)
+  - **`craft.llm`** — either `{ "backend": "<name>" }` to route through one of the entries above, or `{ "mode": "in-session" | "mock" }` for the non-backend modes. Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow).
+  - **`HARNESS_CRAFT_LLM`** env var overrides the file. Accepts `in-session`, `mock`, or the name of any entry in `agent.backends`.
+
+### Migration from `harness.orchestrator.md`
+
+If you already declared `agent.backends` in `harness.orchestrator.md`, the craft selector reads from it as a fallback and emits a one-time warning on first run. Run `harness migrate backends` (preview with `--dry-run`) to copy the entries into `harness.config.json` so both files share a single source of truth.
+
+### Example
+
+Example config snippet for routing craft skills to a local Ollama:
+
+```jsonc
+{
+  "agent": {
+    "backends": {
+      "ollama": {
+        "type": "local",
+        "endpoint": "http://localhost:11434/v1",
+        "model": ["deepseek-coder-v2", "qwen3:8b"],
+      },
+    },
+  },
+  "craft": { "llm": { "backend": "ollama" } },
+}
+```
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. Instead it returns a list of prompts for the calling agent to answer with its own model. This is a two-step protocol:
+
+**Step 1 — `mcp__harness__naming_craft({ path, ... })`** returns:
+
+```json
+{
+  "status": "collected",
+  "runId": "<uuid>",
+  "pendingPrompts": [
+    { "promptId": "p1", "systemPrompt": "...", "userPrompt": "..." },
+    ...
+  ],
+  "projection": { "promptCount": N, "budget": 100 }
+}
+```
+
+If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxIdentifiersPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the identifier. The required response shape (per prompt) is:
+
+````
+```json
+null
+```
+````
+
+if the rubric does not apply or the name is fine, OR:
+
+````
+```json
+{
+  "tier": "foundational|polish|aspirational",
+  "impact": "small|medium|large",
+  "confidence": "high|medium|low",
+  "message": "<critique with suggested rename when possible>"
+}
+```
+````
+
+**Step 3 — `mcp__harness__naming_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses, applies the same validation the inline path uses, and returns the standard `NamingCraftOutput`.
+
+If you want the inline behavior (skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider.
 
 ## Success Criteria
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -43,7 +43,7 @@ Report all harness-ignore protected code regions
 
 ### `harness backfill-skill-provenance`
 
-Stamp `provenance: user-authored` on every catalog skill missing the field (Hermes Phase 4 one-shot)
+Stamp `provenance: user-authored` on every catalog skill missing the field (one-shot migration)
 
 **Options:**
 
@@ -130,9 +130,9 @@ Remove stale entries from .harness/. Default: only .harness/sessions/ (no write 
 
 - `--dry-run` — List stale entries without deleting them
 - `--path` — Project root path (default: ".")
-- `--all` — Hermes Phase 2: sweep every registered .harness/ target
-- `--include` — Hermes Phase 2: comma-separated target names (mutually-exclusive with --exclude/--all)
-- `--exclude` — Hermes Phase 2: comma-separated target names to skip
+- `--all` — Sweep every registered .harness/ target
+- `--include` — Comma-separated target names (mutually-exclusive with --exclude/--all)
+- `--exclude` — Comma-separated target names to skip
 
 ### `harness copy-craft`
 
@@ -274,7 +274,7 @@ Initialize a new harness-engineering project
 
 ### `harness insights`
 
-Composite project report — health, entropy, decay, attention, impact (Hermes Phase 1).
+Composite project report — health, entropy, decay, attention, impact.
 
 **Options:**
 
@@ -346,18 +346,6 @@ Start the MCP (Model Context Protocol) server on stdio
 - `--tools` — Only register the specified tools (used by Cursor integration)
 - `--tier` — Load a preset tool tier instead of all tools
 - `--budget-tokens` — Auto-select tier to fit this baseline token budget
-
-### `harness migrate`
-
-Migrate legacy harness artifact locations to current layout
-
-**Options:**
-
-- `--dry-run` — Show the migration plan without moving files
-- `--yes` — Skip confirmation prompt
-- `--skip-references` — Do not update path references in docs/sessions after moves
-- `--orphan-strategy` — How to handle orphan plans (ask|skip|bucket) (default: "ask")
-- `--orphan-topic` — Stub topic name when --orphan-strategy=bucket
 
 ### `harness naming-craft`
 
@@ -431,7 +419,7 @@ Scan CLAUDE.md, AGENTS.md, .gemini/settings.json, and skill.yaml for prompt inje
 
 ### `harness search <query>`
 
-Full-text search over archived + live session content (Hermes Phase 1).
+Full-text search over archived + live session content.
 
 **Arguments:**
 
@@ -823,7 +811,7 @@ Validate harness-linter.yml config
 
 ## Maintenance Commands
 
-Hermes Phase 2 — inspect built-in + custom maintenance tasks and their persisted outputs
+Inspect built-in + custom maintenance tasks and their persisted outputs
 
 ### `harness maintenance list`
 
@@ -861,6 +849,34 @@ Check every MCP/npx package in .mcp.json against OSV.dev advisories
 - `--strict` — Fail closed on network errors (default: fail-open)
 - `--json` — Emit machine-readable JSON
 - `--path` — Project root path (default: ".")
+
+## Migrate Commands
+
+Migrate legacy harness artifact locations to current layout
+
+### `harness migrate backends`
+
+Copy agent.backends (and routing) from harness.orchestrator.md into harness.config.json.
+
+**Options:**
+
+- `--dry-run` — Show what would change without writing
+- `--force` — Overwrite existing agent.backends in harness.config.json
+
+## Models Commands
+
+Inspect and manage local LLM backends. Currently ships `probe`; LMLM phases add status/suggest/pool/proposals.
+
+### `harness models probe`
+
+Probe a local backend's /v1/models endpoint and report which configured model is loaded.
+
+**Options:**
+
+- `--backend` — Name of an entry in agent.backends. Defaults to the first local/pi entry.
+- `--endpoint` — Override the backend endpoint (bypasses harness.config.json).
+- `--api-key` — Override the API key.
+- `--json` — Print machine-readable JSON instead of a human summary.
 
 ## Notifications Commands
 
@@ -932,7 +948,7 @@ List available agent personas
 
 ## Proposals Commands
 
-Skill-proposal review queue (Hermes Phase 4)
+Skill-proposal review queue
 
 ### `harness proposals approve <id>`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -514,7 +514,7 @@ Scaffold a new harness engineering project from a template
 
 ### `insights_summary`
 
-Composite report combining health, entropy, decay, attention, and impact (Hermes Phase 1).
+Composite report combining health, entropy, decay, attention, and impact.
 
 **Parameters:**
 
@@ -534,7 +534,7 @@ LLM-judgment critique of knowledge-entry quality (docs/knowledge/, excluding dec
 
 ### `naming_craft`
 
-LLM-judgment critique of identifier names (variables, functions, types, files). First craft-pipeline ceiling skill; uses a curated rubric catalog seeded from Martin / Beck / Karlton. Emits 3-axis findings (tier x impact x confidence per ADR 0019).
+LLM-judgment critique of identifier names (variables, functions, types, files). First craft-pipeline ceiling skill; uses a curated rubric catalog seeded from Martin / Beck / Karlton. Emits 3-axis findings (tier x impact x confidence per ADR 0019). In-session mode (default in Claude Code) returns prompts for the calling agent to answer; call naming_craft_finalize with the responses to get findings.
 
 **Parameters:**
 
@@ -543,6 +543,18 @@ LLM-judgment critique of identifier names (variables, functions, types, files). 
 - `kinds` (array, optional) — Restrict to specific identifier kinds (default: all)
 - `maxFiles` (number, optional) — Cap file count (default: 100)
 - `maxIdentifiersPerFile` (number, optional) — Cap per-file identifier sampling (default: 15)
+- `mode` (string, optional) — 'in-session' (default): return prompts for the calling agent to answer, then call naming_craft_finalize. 'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).
+- `promptBudget` (number, optional) — Cap prompt count in in-session mode (default: 100)
+
+### `naming_craft_finalize`
+
+Finalize a naming_craft in-session run by submitting the calling agent's responses to the prompts collected by naming_craft. Returns the standard NamingCraftOutput with findings.
+
+**Parameters:**
+
+- `path` (string, required) — Project root path used in the collect call (must match)
+- `runId` (string, required) — runId returned by the naming_craft collect call
+- `responses` (array, required) — Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.
 
 ### `recommend_skills`
 
@@ -602,7 +614,7 @@ Subscribe to outbound webhook fan-out via POST /api/v1/webhooks. Returns the sec
 
 ### `summarize_session`
 
-Generate or regenerate the LLM `llm-summary.md` for an archived session (Hermes Phase 1).
+Generate or regenerate the LLM `llm-summary.md` for an archived session.
 
 **Parameters:**
 
@@ -743,7 +755,7 @@ Query the project knowledge graph using ContextQL. Traverses from root nodes out
 
 ### `search_sessions`
 
-Full-text search over archived + live session content (Hermes Phase 1, FTS5/BM25).
+Full-text search over archived + live session content (FTS5/BM25).
 
 **Parameters:**
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "generate:plugin:all": "pnpm generate:plugin:claude && pnpm generate:plugin:cursor && pnpm generate:plugin:gemini && pnpm generate:plugin:codex",
     "generate:plugin:check": "node scripts/generate-plugin.mjs --target claude --check && node scripts/generate-plugin.mjs --target cursor --check && node scripts/generate-plugin.mjs --target gemini --check && node scripts/generate-plugin.mjs --target codex --check",
     "changeset": "changeset",
+    "check:changesets": "BASE_REF=origin/main node scripts/check-changesets.mjs",
     "version": "changeset version",
     "release": "pnpm build && changeset publish",
     "prepare": "husky"

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -48,6 +48,7 @@ import { createMaintenanceCommand } from './maintenance';
 import { createMcpCommand } from './mcp';
 import { createMcpGuardCommand } from './mcp-guard';
 import { createMigrateCommand } from './migrate';
+import { createModelsCommand } from './models';
 import { createNamingCraftCommand } from './naming-craft';
 import { createNotificationsCommand } from './notifications';
 import { createOrchestratorCommand } from './orchestrator';
@@ -136,6 +137,7 @@ export const commandCreators: Array<() => Command> = [
   createMcpCommand,
   createMcpGuardCommand,
   createMigrateCommand,
+  createModelsCommand,
   createNamingCraftCommand,
   createNotificationsCommand,
   createOrchestratorCommand,

--- a/packages/cli/src/commands/backfill-skill-provenance.ts
+++ b/packages/cli/src/commands/backfill-skill-provenance.ts
@@ -113,7 +113,7 @@ export function runBackfillSkillProvenance(projectRoot: string): BackfillResult 
 export function createBackfillSkillProvenanceCommand(): Command {
   const cmd = new Command('backfill-skill-provenance')
     .description(
-      'Stamp `provenance: user-authored` on every catalog skill missing the field (Hermes Phase 4 one-shot)'
+      'Stamp `provenance: user-authored` on every catalog skill missing the field (one-shot migration)'
     )
     .option('--root <path>', 'Project root containing agents/skills/', process.cwd())
     .action((opts: { root: string }) => {

--- a/packages/cli/src/commands/cleanup-sessions.ts
+++ b/packages/cli/src/commands/cleanup-sessions.ts
@@ -295,12 +295,12 @@ export function createCleanupSessionsCommand(): Command {
     )
     .option('--dry-run', 'List stale entries without deleting them', false)
     .option('--path <path>', 'Project root path', '.')
-    .option('--all', 'Hermes Phase 2: sweep every registered .harness/ target')
+    .option('--all', 'Sweep every registered .harness/ target')
     .option(
       '--include <list>',
-      'Hermes Phase 2: comma-separated target names (mutually-exclusive with --exclude/--all)'
+      'Comma-separated target names (mutually-exclusive with --exclude/--all)'
     )
-    .option('--exclude <list>', 'Hermes Phase 2: comma-separated target names to skip')
+    .option('--exclude <list>', 'Comma-separated target names to skip')
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const cwd = path.resolve(opts.path);

--- a/packages/cli/src/commands/insights.ts
+++ b/packages/cli/src/commands/insights.ts
@@ -56,9 +56,7 @@ function renderPretty(report: InsightsReport): void {
 
 export function createInsightsCommand(): Command {
   return new Command('insights')
-    .description(
-      'Composite project report — health, entropy, decay, attention, impact (Hermes Phase 1).'
-    )
+    .description('Composite project report — health, entropy, decay, attention, impact.')
     .option('--json', 'Emit JSON to stdout instead of pretty text')
     .option('--skip <list>', `Comma-separated keys to skip (${INSIGHTS_KEYS.join(',')})`)
     .action(async (opts: InsightsOptions) => {

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -140,7 +140,7 @@ function printListTable(rows: ListRow[]): void {
 
 export function createMaintenanceCommand(): Command {
   const command = new Command('maintenance').description(
-    'Hermes Phase 2 — inspect built-in + custom maintenance tasks and their persisted outputs'
+    'Inspect built-in + custom maintenance tasks and their persisted outputs'
   );
 
   command

--- a/packages/cli/src/commands/migrate-backends.ts
+++ b/packages/cli/src/commands/migrate-backends.ts
@@ -1,0 +1,195 @@
+// packages/cli/src/commands/migrate-backends.ts
+//
+// One-shot migration: copy `agent.backends` (and `agent.routing` when
+// present) from harness.orchestrator.md into harness.config.json so
+// the craft selector and the orchestrator share a single source of truth.
+//
+// This is the migration path for users who declared backends in
+// harness.orchestrator.md before the shared-config change landed.
+//
+// Safety:
+//   - Refuses to overwrite an existing `agent.backends` in harness.config.json
+//     unless --force is passed.
+//   - --dry-run prints the diff without writing.
+//   - Leaves harness.orchestrator.md untouched.
+
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import chalk from 'chalk';
+import { logger } from '../output/logger';
+import { ExitCode } from '../utils/errors';
+import {
+  findOrchestratorMd,
+  readBackendsFromOrchestratorMd,
+} from '../shared/craft/llm/orchestrator-md';
+import { parse as parseYaml } from 'yaml';
+
+interface MigrateBackendsOptions {
+  dryRun?: boolean;
+  force?: boolean;
+  cwd?: string;
+}
+
+interface MigrateResult {
+  status: 'ok' | 'noop' | 'error';
+  message: string;
+  exitCode: number;
+}
+
+export async function runMigrateBackends(
+  opts: MigrateBackendsOptions = {}
+): Promise<MigrateResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const mdPath = findOrchestratorMd(cwd);
+  if (mdPath === null) {
+    return {
+      status: 'noop',
+      message: 'No harness.orchestrator.md found — nothing to migrate.',
+      exitCode: ExitCode.SUCCESS,
+    };
+  }
+
+  const backends = readBackendsFromOrchestratorMd(cwd);
+  if (backends === null) {
+    return {
+      status: 'noop',
+      message: `Found ${mdPath} but no agent.backends to migrate.`,
+      exitCode: ExitCode.SUCCESS,
+    };
+  }
+  const routing = readRoutingFromOrchestratorMd(mdPath);
+
+  // Locate harness.config.json — start at the same directory as harness.orchestrator.md.
+  const jsonPath = path.join(path.dirname(mdPath), 'harness.config.json');
+  if (!fs.existsSync(jsonPath)) {
+    return {
+      status: 'error',
+      message:
+        `harness.config.json not found at ${jsonPath}. ` +
+        'Run `harness init` first, then re-run this migration.',
+      exitCode: ExitCode.ERROR,
+    };
+  }
+
+  let configRaw: string;
+  try {
+    configRaw = fs.readFileSync(jsonPath, 'utf-8');
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `Failed to read ${jsonPath}: ${err instanceof Error ? err.message : String(err)}`,
+      exitCode: ExitCode.ERROR,
+    };
+  }
+  let configObj: Record<string, unknown>;
+  try {
+    configObj = JSON.parse(configRaw) as Record<string, unknown>;
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `${jsonPath} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      exitCode: ExitCode.ERROR,
+    };
+  }
+
+  const agent = (configObj.agent as Record<string, unknown> | undefined) ?? {};
+  const existingBackends = agent.backends as Record<string, unknown> | undefined;
+  if (existingBackends !== undefined && !opts.force) {
+    return {
+      status: 'error',
+      message:
+        `${jsonPath} already declares agent.backends. ` +
+        'Re-run with --force to overwrite, or merge manually.',
+      exitCode: ExitCode.ERROR,
+    };
+  }
+
+  const nextAgent: Record<string, unknown> = { ...agent, backends };
+  if (routing !== null) nextAgent.routing = routing;
+  const nextConfig = { ...configObj, agent: nextAgent };
+  const nextJson = JSON.stringify(nextConfig, null, 2) + '\n';
+
+  if (opts.dryRun) {
+    logger.info(chalk.bold('--- dry run ---'));
+    logger.info(`Would write ${Object.keys(backends).length} backend(s) to ${jsonPath}:`);
+    for (const name of Object.keys(backends)) {
+      logger.info(`  • ${name}`);
+    }
+    if (routing !== null) {
+      logger.info('Would also copy agent.routing.');
+    }
+    return {
+      status: 'ok',
+      message: '(dry-run) migration plan above — re-run without --dry-run to apply.',
+      exitCode: ExitCode.SUCCESS,
+    };
+  }
+
+  try {
+    fs.writeFileSync(jsonPath, nextJson);
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `Failed to write ${jsonPath}: ${err instanceof Error ? err.message : String(err)}`,
+      exitCode: ExitCode.ERROR,
+    };
+  }
+
+  return {
+    status: 'ok',
+    message:
+      `Migrated ${Object.keys(backends).length} backend(s)${routing !== null ? ' + routing' : ''} ` +
+      `from ${mdPath} to ${jsonPath}. ` +
+      'You can leave the entries in harness.orchestrator.md (orchestrator still reads them) ' +
+      'or remove them once the orchestrator config picks up the JSON source.',
+    exitCode: ExitCode.SUCCESS,
+  };
+}
+
+function readRoutingFromOrchestratorMd(mdPath: string): unknown {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(mdPath, 'utf-8');
+  } catch {
+    return null;
+  }
+  const parts = raw.split('---');
+  if (parts.length < 3) return null;
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(parts[1]!.trim());
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const agent = (parsed as { agent?: unknown }).agent;
+  if (agent === null || typeof agent !== 'object') return null;
+  const routing = (agent as { routing?: unknown }).routing;
+  return routing ?? null;
+}
+
+/**
+ * Subcommand factory — attached to `harness migrate` via `.addCommand()`.
+ * Invocation: `harness migrate backends [--dry-run] [--force]`.
+ */
+export function createBackendsSubcommand(): Command {
+  return new Command('backends')
+    .description(
+      'Copy agent.backends (and routing) from harness.orchestrator.md into harness.config.json.'
+    )
+    .option('--dry-run', 'Show what would change without writing', false)
+    .option('--force', 'Overwrite existing agent.backends in harness.config.json', false)
+    .action(async (options: { dryRun?: boolean; force?: boolean }) => {
+      const result = await runMigrateBackends({
+        dryRun: options.dryRun ?? false,
+        force: options.force ?? false,
+      });
+      if (result.status === 'error') {
+        logger.error(result.message);
+        process.exit(result.exitCode);
+      }
+      logger.info(result.message);
+      process.exit(result.exitCode);
+    });
+}

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { createBackendsSubcommand } from './migrate-backends';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
@@ -556,7 +557,7 @@ export async function runMigrate(opts: MigrateOptions): Promise<Result<Migration
 }
 
 export function createMigrateCommand(): Command {
-  return new Command('migrate')
+  const cmd = new Command('migrate')
     .description('Migrate legacy harness artifact locations to current layout')
     .option('--dry-run', 'Show the migration plan without moving files', false)
     .option('--yes', 'Skip confirmation prompt', false)
@@ -582,4 +583,10 @@ export function createMigrateCommand(): Command {
       }
       process.exit(result.value.movesFailed === 0 ? ExitCode.SUCCESS : ExitCode.ERROR);
     });
+
+  // Subcommands for targeted migrations. Bare `harness migrate` still runs
+  // the docs-layout migration above (no behavior change).
+  cmd.addCommand(createBackendsSubcommand());
+
+  return cmd;
 }

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -1,0 +1,214 @@
+// packages/cli/src/commands/models.ts
+//
+// `harness models` command group. Today ships the `probe` subcommand only —
+// a focused primitive that lets operators (and craft skills via the lazy
+// adapter) check what's loaded at a local backend's `/v1/models` endpoint.
+//
+// Future LMLM phases add `status`, `suggest`, `pool {...}`, `proposals`,
+// `approve`, `reject`, `install`, `evict`, `refresh` under this same group.
+// See docs/changes/local-model-lifecycle-manager/proposal.md.
+
+import { Command } from 'commander';
+import { defaultFetchModels } from '@harness-engineering/orchestrator';
+import { logger } from '../output/logger';
+import { ExitCode } from '../utils/errors';
+import { resolveConfig } from '../config/loader';
+
+interface ProbeOptions {
+  backend?: string;
+  endpoint?: string;
+  apiKey?: string;
+  json?: boolean;
+  configPath?: string;
+}
+
+interface ProbeResult {
+  status: 'ok' | 'no-match' | 'error';
+  backend?: string;
+  endpoint: string;
+  configured: string[];
+  detected: string[];
+  resolved: string | null;
+  error?: string;
+  exitCode: number;
+}
+
+interface ProbeContext {
+  endpoint: string;
+  configured: string[];
+  apiKey: string;
+  backendLabel: string | undefined;
+}
+
+function errorResult(message: string, partial?: Partial<ProbeResult>): ProbeResult {
+  return {
+    status: 'error',
+    endpoint: '',
+    configured: [],
+    detected: [],
+    resolved: null,
+    error: message,
+    exitCode: ExitCode.ERROR,
+    ...partial,
+  };
+}
+
+function pickConfiguredList(model: unknown): string[] {
+  if (typeof model === 'string') return [model];
+  if (Array.isArray(model)) return model.filter((m): m is string => typeof m === 'string');
+  return [];
+}
+
+type BackendDefRecord = Record<string, unknown>;
+
+interface LocatedBackend {
+  name: string;
+  def: BackendDefRecord;
+}
+
+/** Walk harness.config.json → agent.backends and pick the requested entry (or default). */
+function locateBackend(opts: ProbeOptions): LocatedBackend | ProbeResult {
+  const resolved = resolveConfig(opts.configPath);
+  if (!resolved.ok) {
+    return errorResult(`Could not load harness.config.json: ${resolved.error.message}`);
+  }
+  const backends = resolved.value.agent?.backends as Record<string, BackendDefRecord> | undefined;
+  const name = opts.backend ?? defaultLocalBackend(backends);
+  if (name === null) {
+    return errorResult(
+      'No local backend in agent.backends. Declare one with type "local" or "pi", ' +
+        'or pass --endpoint <url>.'
+    );
+  }
+  const def = backends?.[name];
+  if (def === undefined) {
+    return errorResult(`agent.backends["${name}"] not found.`);
+  }
+  return { name, def };
+}
+
+/** Resolve probe inputs from explicit options + harness.config.json. */
+function resolveProbeContext(opts: ProbeOptions): ProbeContext | ProbeResult {
+  if (opts.endpoint !== undefined) {
+    return {
+      endpoint: opts.endpoint,
+      configured: [],
+      apiKey: opts.apiKey ?? 'local',
+      backendLabel: opts.backend,
+    };
+  }
+
+  const located = locateBackend(opts);
+  if ('status' in located) return located;
+
+  const ep = located.def.endpoint;
+  if (typeof ep !== 'string') {
+    return errorResult(`agent.backends["${located.name}"]: missing or invalid 'endpoint'.`);
+  }
+  const explicitKey = typeof located.def.apiKey === 'string' ? located.def.apiKey : undefined;
+  return {
+    endpoint: ep,
+    configured: pickConfiguredList(located.def.model),
+    apiKey: opts.apiKey ?? explicitKey ?? 'local',
+    backendLabel: located.name,
+  };
+}
+
+export async function runModelsProbe(opts: ProbeOptions): Promise<ProbeResult> {
+  const ctx = resolveProbeContext(opts);
+  if ('status' in ctx) return ctx;
+
+  let detected: string[];
+  try {
+    detected = await defaultFetchModels(ctx.endpoint, ctx.apiKey);
+  } catch (err) {
+    return {
+      status: 'error',
+      ...(ctx.backendLabel !== undefined ? { backend: ctx.backendLabel } : {}),
+      endpoint: ctx.endpoint,
+      configured: ctx.configured,
+      detected: [],
+      resolved: null,
+      error: err instanceof Error ? err.message : String(err),
+      exitCode: ExitCode.ERROR,
+    };
+  }
+
+  const match = ctx.configured.find((id) => detected.includes(id)) ?? null;
+  return {
+    status: match !== null ? 'ok' : 'no-match',
+    ...(ctx.backendLabel !== undefined ? { backend: ctx.backendLabel } : {}),
+    endpoint: ctx.endpoint,
+    configured: ctx.configured,
+    detected,
+    resolved: match,
+    exitCode: match !== null ? ExitCode.SUCCESS : ExitCode.ERROR,
+  };
+}
+
+function defaultLocalBackend(
+  backends: Record<string, Record<string, unknown>> | undefined
+): string | null {
+  if (backends === undefined) return null;
+  for (const [name, def] of Object.entries(backends)) {
+    const t = def.type;
+    if (t === 'local' || t === 'pi') return name;
+  }
+  return null;
+}
+
+function formatProbe(result: ProbeResult): string {
+  if (result.status === 'error') {
+    return `error probing ${result.endpoint || '(no endpoint)'}: ${result.error}`;
+  }
+  const lines: string[] = [];
+  lines.push(
+    `endpoint: ${result.endpoint}${result.backend !== undefined ? ` (agent.backends["${result.backend}"])` : ''}`
+  );
+  lines.push(`configured: [${result.configured.join(', ')}]`);
+  lines.push(`detected:   [${result.detected.join(', ')}]`);
+  if (result.resolved !== null) {
+    lines.push(`resolved:   ${result.resolved}`);
+  } else {
+    lines.push('resolved:   (no configured model is loaded)');
+    lines.push(
+      'hint: load one of the configured models or update agent.backends.<name>.model to include a detected id.'
+    );
+  }
+  return lines.join('\n');
+}
+
+export function createModelsCommand(): Command {
+  const cmd = new Command('models').description(
+    'Inspect and manage local LLM backends. Currently ships `probe`; LMLM phases add status/suggest/pool/proposals.'
+  );
+
+  cmd
+    .command('probe')
+    .description(
+      "Probe a local backend's /v1/models endpoint and report which configured model is loaded."
+    )
+    .option(
+      '--backend <name>',
+      'Name of an entry in agent.backends. Defaults to the first local/pi entry.'
+    )
+    .option('--endpoint <url>', 'Override the backend endpoint (bypasses harness.config.json).')
+    .option('--api-key <key>', 'Override the API key.')
+    .option('--json', 'Print machine-readable JSON instead of a human summary.', false)
+    .action(async (options: ProbeOptions) => {
+      const result = await runModelsProbe(options);
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        const text = formatProbe(result);
+        if (result.status === 'error' || result.status === 'no-match') {
+          logger.error(text);
+        } else {
+          logger.info(text);
+        }
+      }
+      process.exit(result.exitCode);
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/proposals.ts
+++ b/packages/cli/src/commands/proposals.ts
@@ -115,7 +115,7 @@ async function actApproveCommand(id: string): Promise<void> {
 }
 
 export function createProposalsCommand(): Command {
-  const cmd = new Command('proposals').description('Skill-proposal review queue (Hermes Phase 4)');
+  const cmd = new Command('proposals').description('Skill-proposal review queue');
 
   cmd
     .command('list')

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -40,7 +40,7 @@ function fmtBytes(n: number): string {
 
 export function createSearchCommand(): Command {
   return new Command('search')
-    .description('Full-text search over archived + live session content (Hermes Phase 1).')
+    .description('Full-text search over archived + live session content.')
     .argument(
       '<query>',
       'FTS5 query (bare words AND-joined; quotes/AND/OR/NOT/column: for advanced syntax)'

--- a/packages/cli/src/commands/setup-mcp.ts
+++ b/packages/cli/src/commands/setup-mcp.ts
@@ -138,6 +138,7 @@ export const ALL_MCP_TOOLS: string[] = [
   'run_design_pipeline',
   // craft-pipeline #1 — naming-craft LLM-judgment ceiling skill
   'naming_craft',
+  'naming_craft_finalize',
   // craft-pipeline #6 — spec-craft LLM-judgment ceiling skill
   'spec_craft',
   // craft-pipeline #5 — copy-craft LLM-judgment ceiling skill (6 surfaces)

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { ArchConfigSchema } from '@harness-engineering/core';
 import { skipDirGlobs } from '@harness-engineering/graph';
+import { BackendDefSchema, RoutingConfigSchema } from '@harness-engineering/orchestrator';
 import { IngestConfigSchema } from './ingest-schema.js';
 
 export { IngestConfigSchema } from './ingest-schema.js';
@@ -48,6 +49,20 @@ export const AgentConfigSchema = z.object({
   timeout: z.number().default(300000),
   /** Optional list of skill IDs pre-authorized for the agent */
   skills: z.array(z.string()).optional(),
+  /**
+   * Named backend definitions (Spec 2 — multi-backend routing).
+   *
+   * Each entry maps a backend name (chosen by the project) to a backend
+   * type plus its connection details (model, endpoint, apiKey, etc.).
+   * Referenced from `craft.llm.backend`, from orchestrator routing rules,
+   * and from any future subsystem that needs a configured LLM backend.
+   *
+   * Schema is re-exported from @harness-engineering/orchestrator so this
+   * file and the orchestrator runtime validate against the same source.
+   */
+  backends: z.record(z.string(), BackendDefSchema).optional(),
+  /** Routing rules for orchestrator agent dispatch. */
+  routing: RoutingConfigSchema.optional(),
 });
 
 /**
@@ -547,6 +562,43 @@ export const ComplianceConfigSchema = z.object({
   branching: BranchingConfigSchema.default({}),
 });
 
+/**
+ * Schema for the shared `craft.*` config block consumed by all
+ * craft-pipeline ceiling skills (naming-craft, design-craft, copy-craft,
+ * spec-craft, test-craft, knowledge-craft, security-craft).
+ *
+ * Backend selection unifies on `agent.backends`: craft.llm.backend names
+ * an entry there. The non-backend modes (`in-session`, `mock`) live in
+ * `craft.llm.mode` because they don't map to a backend definition.
+ *
+ * Resolution precedence at runtime:
+ *   1. Explicit override passed to getProvider({ mode })
+ *   2. HARNESS_CRAFT_LLM env (CI / test isolation escape hatch)
+ *   3. craft.llm.backend  → adapt agent.backends[name]
+ *   4. craft.llm.mode     → in-session | mock
+ *   5. Built-in default   → in-session
+ */
+export const CraftConfigSchema = z.object({
+  llm: z
+    .object({
+      /**
+       * Name of an entry in `agent.backends` to route craft LLM calls
+       * through. Supported backend types: claude, anthropic, openai,
+       * local, pi, mock. (gemini is declared in agent.backends but is
+       * not yet wired through the craft adapter.)
+       */
+      backend: z.string().optional(),
+      /**
+       * Special-case mode that doesn't correspond to a backend def.
+       *   - `in-session` — defer prompts to the calling chat session
+       *     via the two-step MCP flow (collect → finalize).
+       *   - `mock` — deterministic mock provider, for tests / smoke runs.
+       */
+      mode: z.enum(['in-session', 'mock']).optional(),
+    })
+    .optional(),
+});
+
 export const HarnessConfigSchema = z.object({
   /** Configuration schema version */
   version: z.literal(1),
@@ -602,6 +654,8 @@ export const HarnessConfigSchema = z.object({
   phaseGates: PhaseGatesConfigSchema.optional(),
   /** Design system consistency settings */
   design: DesignConfigSchema.optional(),
+  /** Shared configuration for craft-pipeline ceiling skills (LLM-judgment) */
+  craft: CraftConfigSchema.optional(),
   /** Internationalization (i18n) settings */
   i18n: I18nConfigSchema.optional(),
   /** Code review settings */
@@ -661,7 +715,7 @@ export const HarnessConfigSchema = z.object({
     })
     .optional(),
   /**
-   * Hermes Phase 2 — Disk-hygiene rules consumed by `harness cleanup-sessions --all`.
+   * Disk-hygiene rules consumed by `harness cleanup-sessions --all`.
    * Keys correspond to registered target names (sessions, cache, maintenance,
    * dashboard-state, snapshots, analyzer-output); values override the default
    * TTL in hours. Unknown keys are ignored (forward-compatible).
@@ -672,7 +726,7 @@ export const HarnessConfigSchema = z.object({
     })
     .optional(),
   /**
-   * Hermes Phase 2 — Pre-launch OSV malware guard configuration.
+   * Pre-launch OSV malware guard configuration.
    * `enabled: false` disables the guard; `strict: true` reverses the default
    * fail-open posture on OSV.dev network errors.
    */

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -179,7 +179,12 @@ import { auditBrandDefinition, handleAuditBrand } from './tools/audit-brand.js';
 // design-pipeline #5: orchestrator composing all design verifiers (FRESHEN/DETECT/FIX/AUDIT/FILL/REPORT).
 import { designPipelineDefinition, handleDesignPipeline } from './tools/design-pipeline.js';
 // craft-pipeline #1: naming-craft LLM-judgment skill (variables / functions / types / files).
-import { namingCraftDefinition, handleNamingCraft } from './tools/naming-craft.js';
+import {
+  namingCraftDefinition,
+  namingCraftFinalizeDefinition,
+  handleNamingCraft,
+  handleNamingCraftFinalize,
+} from './tools/naming-craft.js';
 // craft-pipeline #6: spec-craft LLM-judgment skill (proposals + ADRs, per-section critique).
 import { specCraftDefinition, handleSpecCraft } from './tools/spec-craft.js';
 // craft-pipeline #5: copy-craft LLM-judgment skill (errors, logs, CLI output, commits, PRs, comments).
@@ -278,6 +283,7 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
   auditBrandDefinition,
   designPipelineDefinition,
   namingCraftDefinition,
+  namingCraftFinalizeDefinition,
   specCraftDefinition,
   copyCraftDefinition,
   testCraftDefinition,
@@ -360,6 +366,7 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   audit_brand: handleAuditBrand as unknown as ToolHandler,
   run_design_pipeline: handleDesignPipeline as unknown as ToolHandler,
   naming_craft: handleNamingCraft as unknown as ToolHandler,
+  naming_craft_finalize: handleNamingCraftFinalize as unknown as ToolHandler,
   spec_craft: handleSpecCraft as unknown as ToolHandler,
   copy_craft: handleCopyCraft as unknown as ToolHandler,
   test_craft: handleTestCraft as unknown as ToolHandler,

--- a/packages/cli/src/mcp/tools/insights-summary.ts
+++ b/packages/cli/src/mcp/tools/insights-summary.ts
@@ -9,8 +9,7 @@ import { sanitizePath } from '../utils/sanitize-path.js';
 
 export const insightsSummaryDefinition = {
   name: 'insights_summary',
-  description:
-    'Composite report combining health, entropy, decay, attention, and impact (Hermes Phase 1).',
+  description: 'Composite report combining health, entropy, decay, attention, and impact.',
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/cli/src/mcp/tools/naming-craft.ts
+++ b/packages/cli/src/mcp/tools/naming-craft.ts
@@ -1,17 +1,31 @@
 /**
- * MCP tool: `mcp__harness__naming_craft`.
+ * MCP tools for naming-craft (craft-pipeline #1):
  *
- * Wraps naming-craft (craft-pipeline #1).
+ *   `naming_craft` — runs the skill. With `mode: 'in-session'` it walks
+ *     the project, builds prompts, persists run-state, and returns the
+ *     prompts to the calling agent without invoking an LLM. With
+ *     `mode: 'inline'` (or unset when HARNESS_CRAFT_LLM != 'in-session')
+ *     it runs end-to-end against whichever provider is configured.
+ *
+ *   `naming_craft_finalize` — completes the in-session flow by consuming
+ *     the calling agent's responses, parsing them into NamingFindings,
+ *     and returning the standard NamingCraftOutput.
  *
  * Source: docs/changes/craft-pipeline/naming-craft/proposal.md
- *   (Surface area → MCP tool).
+ *   (Surface area → MCP tool) + the in-session two-step extension.
  */
 
 import {
   runNamingCraft,
+  collectNamingCraftPrompts,
+  finalizeNamingCraft,
   type NamingCraftInput,
   type NamingCraftOutput,
+  type CollectPromptsOutput,
+  type FinalizeNamingCraftInput,
+  type NamingCraftMode,
 } from '../../naming-craft/index.js';
+import { resolveCraftLlmMode } from '../../shared/craft/llm/provider.js';
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
@@ -23,7 +37,9 @@ export const namingCraftDefinition = {
   description:
     'LLM-judgment critique of identifier names (variables, functions, types, files). ' +
     'First craft-pipeline ceiling skill; uses a curated rubric catalog seeded from ' +
-    'Martin / Beck / Karlton. Emits 3-axis findings (tier x impact x confidence per ADR 0019).',
+    'Martin / Beck / Karlton. Emits 3-axis findings (tier x impact x confidence per ADR 0019). ' +
+    'In-session mode (default in Claude Code) returns prompts for the calling agent to answer; ' +
+    'call naming_craft_finalize with the responses to get findings.',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -43,12 +59,66 @@ export const namingCraftDefinition = {
         type: 'number',
         description: 'Cap per-file identifier sampling (default: 15)',
       },
+      mode: {
+        type: 'string',
+        enum: ['inline', 'in-session'],
+        description:
+          "'in-session' (default): return prompts for the calling agent to answer, " +
+          'then call naming_craft_finalize. ' +
+          "'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).",
+      },
+      promptBudget: {
+        type: 'number',
+        description: 'Cap prompt count in in-session mode (default: 100)',
+      },
     },
     required: ['path'],
   },
 };
 
-export async function handleNamingCraft(input: NamingCraftInput): Promise<ToolResponse> {
+export const namingCraftFinalizeDefinition = {
+  name: 'naming_craft_finalize',
+  description:
+    "Finalize a naming_craft in-session run by submitting the calling agent's " +
+    'responses to the prompts collected by naming_craft. Returns the standard ' +
+    'NamingCraftOutput with findings.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      path: {
+        type: 'string',
+        description: 'Project root path used in the collect call (must match)',
+      },
+      runId: { type: 'string', description: 'runId returned by the naming_craft collect call' },
+      responses: {
+        type: 'array',
+        description:
+          'Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.',
+        items: {
+          type: 'object',
+          properties: {
+            promptId: { type: 'string' },
+            raw: { type: 'string' },
+          },
+          required: ['promptId', 'raw'],
+        },
+      },
+    },
+    required: ['path', 'runId', 'responses'],
+  },
+};
+
+function effectiveMode(input: NamingCraftInput): NamingCraftMode {
+  if (input.mode !== undefined) return input.mode;
+  // Auto: route to in-session when the configured provider is in-session
+  // (the default). Otherwise inline.
+  const envMode = resolveCraftLlmMode();
+  return envMode === 'in-session' ? 'in-session' : 'inline';
+}
+
+export async function handleNamingCraft(
+  input: NamingCraftInput & { promptBudget?: number }
+): Promise<ToolResponse> {
   if (typeof input?.path !== 'string' || input.path.length === 0) {
     return {
       content: [
@@ -57,7 +127,12 @@ export async function handleNamingCraft(input: NamingCraftInput): Promise<ToolRe
       isError: true,
     };
   }
+
   try {
+    if (effectiveMode(input) === 'in-session') {
+      const result: CollectPromptsOutput = await collectNamingCraftPrompts(input);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
     const result: NamingCraftOutput = await runNamingCraft(input);
     return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
   } catch (err) {
@@ -71,5 +146,69 @@ export async function handleNamingCraft(input: NamingCraftInput): Promise<ToolRe
   }
 }
 
-export { runNamingCraft } from '../../naming-craft/index.js';
-export type { NamingCraftInput, NamingCraftOutput } from '../../naming-craft/index.js';
+export async function handleNamingCraftFinalize(
+  input: FinalizeNamingCraftInput
+): Promise<ToolResponse> {
+  if (typeof input?.path !== 'string' || input.path.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ error: 'naming_craft_finalize: `path` is required' }),
+        },
+      ],
+      isError: true,
+    };
+  }
+  if (typeof input?.runId !== 'string' || input.runId.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ error: 'naming_craft_finalize: `runId` is required' }),
+        },
+      ],
+      isError: true,
+    };
+  }
+  if (!Array.isArray(input?.responses)) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: 'naming_craft_finalize: `responses` must be an array',
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+  try {
+    const result = await finalizeNamingCraft(input);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ error: `naming_craft_finalize failed: ${message}` }),
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+export {
+  runNamingCraft,
+  collectNamingCraftPrompts,
+  finalizeNamingCraft,
+} from '../../naming-craft/index.js';
+export type {
+  NamingCraftInput,
+  NamingCraftOutput,
+  CollectPromptsOutput,
+  FinalizeNamingCraftInput,
+} from '../../naming-craft/index.js';

--- a/packages/cli/src/mcp/tools/search-sessions.ts
+++ b/packages/cli/src/mcp/tools/search-sessions.ts
@@ -10,7 +10,7 @@ import { sanitizePath } from '../utils/sanitize-path.js';
 
 export const searchSessionsDefinition = {
   name: 'search_sessions',
-  description: 'Full-text search over archived + live session content (Hermes Phase 1, FTS5/BM25).',
+  description: 'Full-text search over archived + live session content (FTS5/BM25).',
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/cli/src/mcp/tools/summarize-session.ts
+++ b/packages/cli/src/mcp/tools/summarize-session.ts
@@ -11,8 +11,7 @@ import { sanitizePath } from '../utils/sanitize-path.js';
 
 export const summarizeSessionDefinition = {
   name: 'summarize_session',
-  description:
-    'Generate or regenerate the LLM `llm-summary.md` for an archived session (Hermes Phase 1).',
+  description: 'Generate or regenerate the LLM `llm-summary.md` for an archived session.',
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/cli/src/naming-craft/index.ts
+++ b/packages/cli/src/naming-craft/index.ts
@@ -10,11 +10,22 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { sanitizePath } from '../mcp/utils/sanitize-path.js';
-import { getProvider, type LlmProvider } from './llm/provider.js';
+import { getProvider, type LlmProvider, InSessionLlmProvider } from './llm/provider.js';
 import { extractIdentifiers, type ExtractedIdentifier } from './extract/identifiers.js';
 import { sampleConventions } from './extract/convention.js';
 import { SEED_RUBRICS, type NamingRubric } from './catalog/rubrics/index.js';
-import { critiqueOne } from './phases/critique.js';
+import {
+  critiqueOne,
+  buildPrompt,
+  parseFindingFromRaw,
+  CRITIQUE_SYSTEM_PROMPT,
+} from './phases/critique.js';
+import {
+  saveRunState,
+  loadRunState,
+  deleteRunState,
+  pruneOldRuns,
+} from '../shared/craft/runs/store.js';
 import type {
   NamingCraftOutput,
   NamingFinding,
@@ -22,30 +33,73 @@ import type {
   IdentifierKind,
 } from './findings/schema.js';
 
+export type NamingCraftMode = 'inline' | 'in-session';
+
 export interface NamingCraftInput {
   path: string;
   files?: string[];
   kinds?: Array<IdentifierKind>;
   maxFiles?: number;
   maxIdentifiersPerFile?: number;
+  /** Two-step flow toggle. Defaults follow provider: in-session if env says so, else inline. */
+  mode?: NamingCraftMode;
   /** Optional provider override for testing. */
   __testProvider?: LlmProvider;
+}
+
+/** Projected-cost guard: max prompts collected before bailing. */
+const DEFAULT_PROMPT_BUDGET = 100;
+
+export interface CollectPromptsOutput {
+  status: 'collected' | 'budget-exceeded';
+  runId: string;
+  pendingPrompts: Array<{
+    promptId: string;
+    systemPrompt: string;
+    userPrompt: string;
+  }>;
+  projection: { promptCount: number; budget: number };
+  /** Populated when status='budget-exceeded'. */
+  hint?: string;
+  /** Persisted to disk under .harness/craft/runs/<runId>.json. */
+  runFile?: string;
+}
+
+export interface FinalizeNamingCraftInput {
+  path: string;
+  runId: string;
+  responses: Array<{ promptId: string; raw: string }>;
 }
 
 const DEFAULT_MAX_FILES = 100;
 const DEFAULT_MAX_IDENTIFIERS_PER_FILE = 15;
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
 
-export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCraftOutput> {
-  const startedAt = Date.now();
+/** Skill-specific run-state metadata persisted between collect and finalize. */
+interface NamingRunMeta {
+  projectRoot: string;
+  startedAt: number;
+  convention: ProjectConvention;
+  rubricsApplied: string[];
+  /** Pairs every queued prompt to the data needed to build a finding. */
+  prompts: Array<{
+    promptId: string;
+    identifier: ExtractedIdentifier;
+    rubricId: string;
+  }>;
+}
+
+interface ProjectContext {
+  projectRoot: string;
+  files: string[];
+  perFile: Map<string, ExtractedIdentifier[]>;
+  convention: ProjectConvention;
+}
+
+function gatherProjectContext(input: NamingCraftInput): ProjectContext {
   const projectRoot = sanitizePath(input.path);
   const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
-  const maxIdentifiersPerFile = input.maxIdentifiersPerFile ?? DEFAULT_MAX_IDENTIFIERS_PER_FILE;
-  const provider = input.__testProvider ?? getProvider();
-
   const files = collectFiles(projectRoot, input.files).slice(0, maxFiles);
-
-  // First pass: extract all identifiers across files (for convention sampling).
   const allIdentifiers: ExtractedIdentifier[] = [];
   const perFile: Map<string, ExtractedIdentifier[]> = new Map();
   for (const file of files) {
@@ -59,8 +113,24 @@ export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCra
     perFile.set(file, ids);
     allIdentifiers.push(...ids);
   }
-
   const convention = sampleConventions(allIdentifiers, files);
+  return { projectRoot, files, perFile, convention };
+}
+
+export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCraftOutput> {
+  const startedAt = Date.now();
+  const maxIdentifiersPerFile = input.maxIdentifiersPerFile ?? DEFAULT_MAX_IDENTIFIERS_PER_FILE;
+  const provider = input.__testProvider ?? getProvider();
+
+  if (provider instanceof InSessionLlmProvider) {
+    throw new Error(
+      'runNamingCraft is the inline entry point; the in-session provider ' +
+        'requires the two-step flow. Call collectNamingCraftPrompts(...) and ' +
+        'then finalizeNamingCraft(...), or set HARNESS_CRAFT_LLM=mock for tests.'
+    );
+  }
+
+  const { perFile, convention } = gatherProjectContext(input);
   const rubrics = SEED_RUBRICS;
   const findings: NamingFinding[] = [];
 
@@ -96,6 +166,136 @@ export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCra
       catalog: { rubricsApplied: rubrics.map((r) => r.id) },
       convention,
       runId: randomUUID(),
+    },
+  };
+}
+
+/**
+ * Step 1 of the two-step in-session flow. Walks the project, builds one
+ * prompt per (identifier, rubric) pair, persists run-state to disk, and
+ * returns the prompts for the calling agent to answer. No LLM is called.
+ */
+export async function collectNamingCraftPrompts(
+  input: NamingCraftInput & { promptBudget?: number }
+): Promise<CollectPromptsOutput> {
+  const maxIdentifiersPerFile = input.maxIdentifiersPerFile ?? DEFAULT_MAX_IDENTIFIERS_PER_FILE;
+  const budget = input.promptBudget ?? DEFAULT_PROMPT_BUDGET;
+  const { projectRoot, perFile, convention } = gatherProjectContext(input);
+  const rubrics = SEED_RUBRICS;
+  const runId = randomUUID();
+
+  const promptRecords: NamingRunMeta['prompts'] = [];
+  const pending: CollectPromptsOutput['pendingPrompts'] = [];
+
+  outer: for (const [, identifiers] of perFile) {
+    const sample = sampleIdentifiers(identifiers, maxIdentifiersPerFile, input.kinds);
+    for (const identifier of sample) {
+      for (const rubric of rubrics) {
+        if (!rubric.appliesTo.includes(identifier.kind)) continue;
+        // Use the InSession provider only to gain a stable promptId per pair.
+        const promptId = `p${promptRecords.length + 1}`;
+        const userPrompt = buildPrompt({ identifier, rubric, convention });
+        promptRecords.push({ promptId, identifier, rubricId: rubric.id });
+        pending.push({ promptId, systemPrompt: CRITIQUE_SYSTEM_PROMPT, userPrompt });
+        if (pending.length > budget) break outer;
+      }
+    }
+  }
+
+  if (pending.length > budget) {
+    return {
+      status: 'budget-exceeded',
+      runId,
+      pendingPrompts: [],
+      projection: { promptCount: pending.length, budget },
+      hint:
+        `Projected at least ${pending.length} LLM prompts (budget: ${budget}). ` +
+        'Re-invoke with smaller maxFiles / maxIdentifiersPerFile, or pass promptBudget to raise the ceiling.',
+    };
+  }
+
+  const meta: NamingRunMeta = {
+    projectRoot,
+    startedAt: Date.now(),
+    convention,
+    rubricsApplied: rubrics.map((r) => r.id),
+    prompts: promptRecords,
+  };
+  pruneOldRuns(projectRoot);
+  const { runFile } = saveRunState<NamingRunMeta>(projectRoot, {
+    v: 1,
+    runId,
+    skill: 'naming-craft',
+    createdAt: Date.now(),
+    meta,
+  });
+
+  return {
+    status: 'collected',
+    runId,
+    pendingPrompts: pending,
+    projection: { promptCount: pending.length, budget },
+    runFile,
+  };
+}
+
+/**
+ * Step 2 of the two-step in-session flow. Loads run-state, applies the
+ * supplied responses through the same parser the inline path uses, and
+ * returns the final NamingCraftOutput. Deletes the run-state file on
+ * successful completion.
+ */
+export async function finalizeNamingCraft(
+  input: FinalizeNamingCraftInput
+): Promise<NamingCraftOutput> {
+  const startedAt = Date.now();
+  const projectRoot = sanitizePath(input.path);
+  const state = loadRunState<NamingRunMeta>(projectRoot, input.runId);
+  if (state === null) {
+    throw new Error(
+      `naming-craft: no persisted run found for runId=${input.runId} under ${projectRoot}. ` +
+        'Run collectNamingCraftPrompts first, or ensure the path matches the project root used at collection time.'
+    );
+  }
+  if (state.skill !== 'naming-craft') {
+    throw new Error(
+      `naming-craft: runId=${input.runId} belongs to skill ${state.skill}, not naming-craft.`
+    );
+  }
+
+  const rubricById = new Map(SEED_RUBRICS.map((r) => [r.id, r]));
+  const promptById = new Map(state.meta.prompts.map((p) => [p.promptId, p]));
+  const findings: NamingFinding[] = [];
+
+  for (const response of input.responses) {
+    const promptRecord = promptById.get(response.promptId);
+    if (promptRecord === undefined) continue;
+    const rubric = rubricById.get(promptRecord.rubricId);
+    if (rubric === undefined) continue;
+    const finding = parseFindingFromRaw(response.raw, {
+      identifier: promptRecord.identifier,
+      rubric,
+    });
+    if (finding !== null) findings.push(finding);
+  }
+
+  deleteRunState(projectRoot, input.runId);
+
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: Date.now() - startedAt,
+      llmCalls: {
+        provider: 'in-session',
+        model: 'host-chat',
+        count: input.responses.length,
+        costUsd: 0,
+      },
+      catalog: { rubricsApplied: state.meta.rubricsApplied },
+      convention: state.meta.convention,
+      runId: input.runId,
     },
   };
 }

--- a/packages/cli/src/naming-craft/llm/provider.ts
+++ b/packages/cli/src/naming-craft/llm/provider.ts
@@ -12,5 +12,10 @@ export {
   type LlmProvider,
   type LlmCallCost,
   MockLlmProvider,
+  InSessionLlmProvider,
+  PromptDeferredError,
+  type DeferredPrompt,
   getProvider,
+  resolveCraftLlmMode,
+  type CraftLlmMode,
 } from '../../shared/craft/llm/provider.js';

--- a/packages/cli/src/naming-craft/phases/critique.ts
+++ b/packages/cli/src/naming-craft/phases/critique.ts
@@ -26,15 +26,26 @@ export interface CritiqueInput {
   provider: LlmProvider;
 }
 
+export const CRITIQUE_SYSTEM_PROMPT =
+  'You are a senior engineer critiquing identifier names against a single naming rubric. ' +
+  'Respond ONLY with a fenced JSON block. If the rubric does not apply or the name is fine, ' +
+  'return `null` (literally the word null inside the JSON block).';
+
 export async function critiqueOne(input: CritiqueInput): Promise<NamingFinding | null> {
   const { identifier, rubric, provider } = input;
   const prompt = buildPrompt(input);
-  const raw = await provider.callText(prompt, {
-    systemPrompt:
-      'You are a senior engineer critiquing identifier names against a single naming rubric. ' +
-      'Respond ONLY with a fenced JSON block. If the rubric does not apply or the name is fine, ' +
-      'return `null` (literally the word null inside the JSON block).',
-  });
+  const raw = await provider.callText(prompt, { systemPrompt: CRITIQUE_SYSTEM_PROMPT });
+  return parseFindingFromRaw(raw, { identifier, rubric });
+}
+
+/**
+ * Parse a raw LLM response (fenced JSON) into a NamingFinding. Returns
+ * null if the response says null / fails validation. Pure — no LLM call.
+ */
+export function parseFindingFromRaw(
+  raw: string,
+  ctx: { identifier: ExtractedIdentifier; rubric: NamingRubric }
+): NamingFinding | null {
   const parsed = parseFencedJson(raw);
   if (parsed === null) return null;
   if (typeof parsed !== 'object') return null;
@@ -45,26 +56,31 @@ export async function critiqueOne(input: CritiqueInput): Promise<NamingFinding |
   if (!isTier(tier) || !isImpact(impact) || !isConfidence(confidence)) return null;
   if (typeof parsed.message !== 'string' || parsed.message.length === 0) return null;
 
-  const finding: NamingFinding = {
-    code: rubric.id,
+  return {
+    code: ctx.rubric.id,
     phase: 'critique',
     tier,
     impact,
     confidence,
     target: {
-      file: identifier.file,
-      line: identifier.line,
-      identifier: identifier.name,
-      kind: identifier.kind,
+      file: ctx.identifier.file,
+      line: ctx.identifier.line,
+      identifier: ctx.identifier.name,
+      kind: ctx.identifier.kind,
     },
     message: parsed.message,
-    cite: { rubricId: rubric.id, source: rubric.source },
+    cite: { rubricId: ctx.rubric.id, source: ctx.rubric.source },
     derived: { priority: derivePriority(tier, impact, confidence) },
   };
-  return finding;
 }
 
-function buildPrompt(input: CritiqueInput): string {
+export interface BuildPromptInput {
+  identifier: ExtractedIdentifier;
+  rubric: NamingRubric;
+  convention: ProjectConvention;
+}
+
+export function buildPrompt(input: BuildPromptInput): string {
   const { identifier, rubric, convention } = input;
   const conventionLine = describeConvention(identifier.kind, convention);
   return [

--- a/packages/cli/src/shared/craft/llm/adapters.ts
+++ b/packages/cli/src/shared/craft/llm/adapters.ts
@@ -1,0 +1,122 @@
+// packages/cli/src/shared/craft/llm/adapters.ts
+//
+// Adapters that wrap the intelligence-package AnalysisProvider surface
+// (AnthropicAnalysisProvider, ClaudeCliAnalysisProvider) into the
+// LlmProvider.callText contract used by craft phases.
+//
+// The mismatch addressed here:
+//   - AnalysisProvider expects a Zod responseSchema and returns parsed T.
+//   - Craft phases want raw assistant text (fenced JSON, parsed by the
+//     phase itself).
+//
+// Bridge strategy: pass a passthrough Zod schema (`z.object({ raw: z.string() })`)
+// so the underlying provider yields a structured object whose single field
+// carries the raw response. Phases then strip the envelope and parse as
+// usual. This matches option (b) from the TODO in provider.ts.
+
+import { z } from 'zod';
+import type {
+  AnthropicAnalysisProvider,
+  ClaudeCliAnalysisProvider,
+  OpenAICompatibleAnalysisProvider,
+} from '@harness-engineering/intelligence';
+import type { LlmCallCost, LlmProvider, VisionInput } from './provider.js';
+
+const RAW_SCHEMA = z.object({ raw: z.string() });
+
+const RAW_INSTRUCTIONS =
+  'Return a JSON object with a single field "raw" whose string value is the fenced JSON block ' +
+  'you would normally emit. Do not add prose outside the JSON object.';
+
+interface AnalyzeFn {
+  analyze<T>(req: {
+    prompt: string;
+    systemPrompt?: string;
+    responseSchema: z.ZodType;
+    model?: string;
+    maxTokens?: number;
+  }): Promise<{
+    result: T;
+    tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
+    model: string;
+    latencyMs: number;
+  }>;
+}
+
+/**
+ * Wraps any AnalysisProvider into the LlmProvider surface. Used by the
+ * ClaudeCli and Anthropic adapters below; exported so future craft skills
+ * that want to plug their own AnalysisProvider can do so without
+ * re-implementing the bridge.
+ */
+export class AnalysisProviderAdapter implements LlmProvider {
+  readonly providerId: string;
+  readonly model: string;
+
+  private readonly inner: AnalyzeFn;
+  private readonly costs: LlmCallCost[] = [];
+
+  constructor(opts: { providerId: string; model: string; inner: AnalyzeFn }) {
+    this.providerId = opts.providerId;
+    this.model = opts.model;
+    this.inner = opts.inner;
+  }
+
+  async callText(prompt: string, opts?: { systemPrompt?: string }): Promise<string> {
+    const wrappedSystem = [opts?.systemPrompt, RAW_INSTRUCTIONS].filter(Boolean).join('\n\n');
+    const response = await this.inner.analyze<{ raw: string }>({
+      prompt,
+      systemPrompt: wrappedSystem,
+      responseSchema: RAW_SCHEMA,
+    });
+    this.recordCost({
+      provider: this.providerId,
+      model: response.model || this.model,
+      inputTokens: response.tokenUsage.inputTokens,
+      outputTokens: response.tokenUsage.outputTokens,
+      costUsd: 0,
+    });
+    return response.result.raw;
+  }
+
+  async callVision(_prompt: string, _image: VisionInput): Promise<string> {
+    throw new Error(
+      `${this.providerId} adapter does not implement callVision — wire vision when needed.`
+    );
+  }
+
+  recordCost(cost: LlmCallCost): void {
+    this.costs.push(cost);
+  }
+
+  getCosts(): readonly LlmCallCost[] {
+    return this.costs;
+  }
+}
+
+export function adaptClaudeCli(inner: ClaudeCliAnalysisProvider, model?: string): LlmProvider {
+  return new AnalysisProviderAdapter({
+    providerId: 'claude-cli',
+    model: model ?? 'claude',
+    inner: inner as unknown as AnalyzeFn,
+  });
+}
+
+export function adaptAnthropic(inner: AnthropicAnalysisProvider, model?: string): LlmProvider {
+  return new AnalysisProviderAdapter({
+    providerId: 'anthropic',
+    model: model ?? 'claude-sonnet-4-20250514',
+    inner: inner as unknown as AnalyzeFn,
+  });
+}
+
+export function adaptOpenAICompatible(
+  inner: OpenAICompatibleAnalysisProvider,
+  model?: string
+): LlmProvider {
+  return new AnalysisProviderAdapter({
+    providerId: 'openai-compatible',
+    model: model ?? 'unknown',
+    inner: inner as unknown as AnalyzeFn,
+  });
+}

--- a/packages/cli/src/shared/craft/llm/in-session.ts
+++ b/packages/cli/src/shared/craft/llm/in-session.ts
@@ -1,0 +1,78 @@
+// packages/cli/src/shared/craft/llm/in-session.ts
+//
+// InSessionLlmProvider — collects prompts instead of calling an LLM.
+//
+// The craft skill family's MVP path calls a real LLM provider that returns
+// fenced JSON for each (target, rubric) prompt. The "in-session" provider
+// inverts that: when a phase calls `callText`, the provider records the
+// prompt and throws `PromptDeferredError`. The orchestrator catches that
+// sentinel, accumulates the prompts, and returns them to the calling agent
+// (the host chat session) which produces the actual judgments and feeds
+// them back via a second MCP tool invocation (`<skill>_finalize`).
+//
+// This makes the craft pipeline behave correctly when invoked from inside
+// a Claude Code chat: the host model performs the judgment in-conversation,
+// no API key is required, and no nested CLI invocation is spawned.
+
+import type { LlmCallCost, LlmProvider, VisionInput } from './provider.js';
+
+/** Sentinel thrown by InSessionLlmProvider.callText to defer the call. */
+export class PromptDeferredError extends Error {
+  readonly promptId: string;
+
+  constructor(promptId: string) {
+    super(`In-session prompt ${promptId} deferred to calling agent`);
+    this.name = 'PromptDeferredError';
+    this.promptId = promptId;
+  }
+}
+
+/** One queued prompt awaiting a response from the calling agent. */
+export interface DeferredPrompt {
+  promptId: string;
+  systemPrompt: string | undefined;
+  userPrompt: string;
+}
+
+/**
+ * Provider that records prompts and throws PromptDeferredError instead of
+ * calling an LLM. Read out the queue with `getDeferred()` after the
+ * orchestrator finishes its sweep.
+ */
+export class InSessionLlmProvider implements LlmProvider {
+  readonly providerId = 'in-session';
+  readonly model = 'host-chat';
+
+  private readonly deferred: DeferredPrompt[] = [];
+  private readonly costs: LlmCallCost[] = [];
+  private counter = 0;
+
+  async callText(prompt: string, opts?: { systemPrompt?: string }): Promise<string> {
+    const promptId = `p${(++this.counter).toString(36)}`;
+    this.deferred.push({
+      promptId,
+      systemPrompt: opts?.systemPrompt,
+      userPrompt: prompt,
+    });
+    throw new PromptDeferredError(promptId);
+  }
+
+  async callVision(_prompt: string, _image: VisionInput): Promise<string> {
+    throw new Error(
+      'InSessionLlmProvider.callVision is not implemented — vision flows must use a real provider.'
+    );
+  }
+
+  recordCost(cost: LlmCallCost): void {
+    this.costs.push(cost);
+  }
+
+  getCosts(): readonly LlmCallCost[] {
+    return this.costs;
+  }
+
+  /** Read out the queue of deferred prompts (in the order callText was invoked). */
+  getDeferred(): readonly DeferredPrompt[] {
+    return this.deferred;
+  }
+}

--- a/packages/cli/src/shared/craft/llm/lazy-local-adapter.ts
+++ b/packages/cli/src/shared/craft/llm/lazy-local-adapter.ts
@@ -1,0 +1,120 @@
+// packages/cli/src/shared/craft/llm/lazy-local-adapter.ts
+//
+// Lazy resolver for `local` / `pi` backends that declare a prefer-and-
+// fallback model list. The first `callText` probes the endpoint's
+// `/v1/models`, walks the configured list in order, and constructs an
+// OpenAICompatibleAnalysisProvider against the first model that's
+// actually loaded. Subsequent calls reuse the resolved provider.
+//
+// Why lazy: getProvider() is sync and craft skills make many one-shot
+// calls per run. Pushing the probe into callText keeps the sync
+// contract intact and amortizes the probe over the run's prompts.
+//
+// On total miss, throws a clear error naming both lists so the operator
+// can `ollama pull <id>` or update their config.
+
+import { OpenAICompatibleAnalysisProvider } from '@harness-engineering/intelligence';
+import { defaultFetchModels } from '@harness-engineering/orchestrator';
+import type { LlmCallCost, LlmProvider, VisionInput } from './provider.js';
+import { AnalysisProviderAdapter } from './adapters.js';
+
+export interface LazyLocalAdapterOptions {
+  endpoint: string;
+  apiKey: string;
+  /** Ordered prefer list. Walked in order on first callText. */
+  configured: string[];
+  /** Optional injection for tests. Defaults to the orchestrator's defaultFetchModels. */
+  fetchModels?: (endpoint: string, apiKey?: string) => Promise<string[]>;
+  /** Per-request timeout for the LLM call itself (not the probe). */
+  llmTimeoutMs?: number;
+}
+
+/**
+ * Wraps an OpenAICompatibleAnalysisProvider with a deferred model
+ * resolution step. Implements LlmProvider so it slots into the craft
+ * `callText` contract without phase-side changes.
+ */
+export class LazyLocalAdapter implements LlmProvider {
+  readonly providerId: string;
+  readonly model: string;
+
+  private readonly opts: LazyLocalAdapterOptions;
+  private readonly costs: LlmCallCost[] = [];
+  /** Cached resolution. Populated on first probe; subsequent calls reuse. */
+  private resolved: { provider: LlmProvider; modelId: string } | null = null;
+  private resolvePromise: Promise<{ provider: LlmProvider; modelId: string }> | null = null;
+
+  constructor(opts: LazyLocalAdapterOptions, providerId = 'local') {
+    this.opts = opts;
+    this.providerId = providerId;
+    // Best-effort label for telemetry until the probe resolves.
+    this.model = opts.configured[0] ?? 'unresolved';
+  }
+
+  async callText(prompt: string, callOpts?: { systemPrompt?: string }): Promise<string> {
+    const { provider } = await this.resolve();
+    return provider.callText(prompt, callOpts);
+  }
+
+  async callVision(_prompt: string, _image: VisionInput): Promise<string> {
+    throw new Error(`${this.providerId}: callVision is not wired for local backends.`);
+  }
+
+  recordCost(cost: LlmCallCost): void {
+    this.costs.push(cost);
+  }
+
+  getCosts(): readonly LlmCallCost[] {
+    return this.costs;
+  }
+
+  /** Test/debug surface — read the resolved model id (null before first probe). */
+  getResolvedModel(): string | null {
+    return this.resolved?.modelId ?? null;
+  }
+
+  private async resolve(): Promise<{ provider: LlmProvider; modelId: string }> {
+    if (this.resolved !== null) return this.resolved;
+    if (this.resolvePromise !== null) return this.resolvePromise;
+    const fetcher = this.opts.fetchModels ?? defaultFetchModels;
+    this.resolvePromise = (async () => {
+      let detected: string[];
+      try {
+        detected = await fetcher(this.opts.endpoint, this.opts.apiKey);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `${this.providerId}: probe failed against ${this.opts.endpoint}: ${message}. ` +
+            'Is the server running? (Ollama: `ollama serve`; LM Studio: enable the server.)',
+          { cause: err }
+        );
+      }
+      const match = this.opts.configured.find((id) => detected.includes(id));
+      if (match === undefined) {
+        throw new Error(
+          `${this.providerId}: no configured model is loaded at ${this.opts.endpoint}. ` +
+            `Configured: [${this.opts.configured.join(', ')}]. ` +
+            `Detected: [${detected.join(', ')}]. ` +
+            'Load one of the configured models or update agent.backends.<name>.model.'
+        );
+      }
+      const inner = new OpenAICompatibleAnalysisProvider({
+        apiKey: this.opts.apiKey,
+        baseUrl: this.opts.endpoint,
+        defaultModel: match,
+      });
+      const provider = new AnalysisProviderAdapter({
+        providerId: this.providerId,
+        model: match,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        inner: inner as any,
+      });
+      const resolved = { provider, modelId: match };
+      this.resolved = resolved;
+      return resolved;
+    })().finally(() => {
+      this.resolvePromise = null;
+    });
+    return this.resolvePromise;
+  }
+}

--- a/packages/cli/src/shared/craft/llm/orchestrator-md.ts
+++ b/packages/cli/src/shared/craft/llm/orchestrator-md.ts
@@ -1,0 +1,58 @@
+// packages/cli/src/shared/craft/llm/orchestrator-md.ts
+//
+// Synchronous reader for agent.backends declared in harness.orchestrator.md.
+// Used as a migration-bridge fallback by the craft LLM selector when
+// harness.config.json doesn't declare agent.backends yet.
+//
+// The orchestrator package owns the async, fully-validated loader. This
+// helper does the minimum needed to surface `agent.backends` to the craft
+// selector — it walks up from a starting directory, reads the YAML
+// frontmatter, and returns the backends map. Bad input → returns null
+// (callers fall through to the built-in default).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parse } from 'yaml';
+
+const FILENAME = 'harness.orchestrator.md';
+
+export function findOrchestratorMd(startDir: string): string | null {
+  let cur = path.resolve(startDir);
+  const root = path.parse(cur).root;
+  while (cur !== root) {
+    const candidate = path.join(cur, FILENAME);
+    if (fs.existsSync(candidate)) return candidate;
+    cur = path.dirname(cur);
+  }
+  return null;
+}
+
+export function readBackendsFromOrchestratorMd(startDir: string): Record<string, unknown> | null {
+  const file = findOrchestratorMd(startDir);
+  if (file === null) return null;
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const parts = raw.split('---');
+  if (parts.length < 3) return null;
+  const yamlContent = parts[1]!.trim();
+
+  let parsed: unknown;
+  try {
+    parsed = parse(yamlContent);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+
+  const agent = (parsed as { agent?: unknown }).agent;
+  if (agent === null || typeof agent !== 'object') return null;
+  const backends = (agent as { backends?: unknown }).backends;
+  if (backends === null || typeof backends !== 'object') return null;
+  return backends as Record<string, unknown>;
+}

--- a/packages/cli/src/shared/craft/llm/provider.ts
+++ b/packages/cli/src/shared/craft/llm/provider.ts
@@ -1,6 +1,28 @@
 // packages/cli/src/shared/craft/llm/provider.ts
 //
 // Shared LLM provider adapter for the craft skill family.
+
+import { InSessionLlmProvider } from './in-session.js';
+import { adaptAnthropic, adaptClaudeCli, adaptOpenAICompatible } from './adapters.js';
+import { LazyLocalAdapter } from './lazy-local-adapter.js';
+import {
+  AnthropicAnalysisProvider,
+  ClaudeCliAnalysisProvider,
+  OpenAICompatibleAnalysisProvider,
+} from '@harness-engineering/intelligence';
+import { findConfigFile, loadConfig } from '../../../config/loader.js';
+import { readBackendsFromOrchestratorMd } from './orchestrator-md.js';
+
+export { InSessionLlmProvider, PromptDeferredError } from './in-session.js';
+export type { DeferredPrompt } from './in-session.js';
+export {
+  AnalysisProviderAdapter,
+  adaptAnthropic,
+  adaptClaudeCli,
+  adaptOpenAICompatible,
+} from './adapters.js';
+export { LazyLocalAdapter } from './lazy-local-adapter.js';
+export type { LazyLocalAdapterOptions } from './lazy-local-adapter.js';
 //
 // Extracted from packages/cli/src/design-craft/llm/provider.ts on the
 // 2nd-non-design-craft-consumer trigger (spec-craft). naming-craft and
@@ -13,13 +35,25 @@
 //   - `getProvider({ provider, model })` returns the mock for now and
 //     records a TODO for the real integration.
 //
-// TODO (out of MVP scope): wire `getProvider` to `packages/intelligence/`'s
-// analysis-provider surface (AnthropicAnalysisProvider /
-// OpenAICompatibleAnalysisProvider / ClaudeCliAnalysisProvider). The
-// intelligence provider currently expects a Zod responseSchema; craft
-// phases want free-form text (fenced JSON parsed by phases/critique.ts).
-// Two-line bridge: either (a) extend the intelligence interface to expose
-// raw text mode, or (b) wrap calls in a passthrough Zod schema.
+// `getProvider` dispatches on configuration so consumers can opt into
+// different backends without code changes. Resolution order:
+//
+//   1. Explicit opts.mode  (test code / programmatic override)
+//   2. HARNESS_CRAFT_LLM   (env var — CI / test isolation escape hatch)
+//   3. harness.config.json → craft.llm.provider  (canonical user config)
+//   4. Built-in default: in-session
+//
+// Modes:
+//   in-session  → host-chat performs judgment (default)
+//   claude-cli  → shell out to local `claude` CLI
+//   anthropic   → direct Anthropic API (requires ANTHROPIC_API_KEY)
+//   mock        → deterministic mock (tests + smoke runs)
+//
+// In-session is the default: when a craft skill runs from inside a Claude
+// Code chat, prompts are deferred back to the host model via a two-step
+// MCP flow (`<skill>` collects prompts → host answers → `<skill>_finalize`
+// stitches findings). See in-session.ts for the sentinel-throw mechanism
+// and the naming-craft orchestrator for the consumer pattern.
 //
 // Honors ADR 0018 (LLM-judgment skill pattern):
 //   - `recordCost` is a first-class method so every skill invocation
@@ -135,12 +169,297 @@ export class MockLlmProvider implements LlmProvider {
 }
 
 /**
- * Factory for the provider used by phase implementations.
- *
- * MVP behavior: always returns a `MockLlmProvider`. The `provider`/`model`
- * args are accepted now so phase implementations can pass them through
- * unchanged when the real integration lands.
+ * The provider modes the craft selector ultimately picks. Notice that
+ * backend-typed modes (anthropic/openai/local/...) come from a named
+ * entry in `agent.backends`, not from craft config itself.
  */
-export function getProvider(_opts?: { provider?: string; model?: string }): LlmProvider {
-  return new MockLlmProvider();
+export type CraftLlmMode =
+  | 'in-session'
+  | 'mock'
+  | 'claude'
+  | 'anthropic'
+  | 'openai'
+  | 'gemini'
+  | 'local'
+  | 'pi';
+
+export interface CraftLlmResolution {
+  mode: CraftLlmMode;
+  /** Populated when the selection came from agent.backends[<backend>]. */
+  backendName?: string;
+  /** The backend definition copied from agent.backends, if applicable. */
+  backendDef?: Record<string, unknown>;
+}
+
+function hasEnvValue(raw: string): boolean {
+  return raw.length > 0;
+}
+
+/**
+ * Resolve the active provider selection. Precedence:
+ *   1. opts.mode  (explicit override — test code / programmatic)
+ *   2. HARNESS_CRAFT_LLM env  (CI / test escape hatch). Values:
+ *        'in-session', 'mock', or the name of an entry in agent.backends.
+ *   3. craft.llm.backend  → look up agent.backends[name]
+ *   4. craft.llm.mode     → 'in-session' | 'mock'
+ *   5. Built-in default: in-session
+ */
+export function resolveCraftLlmConfig(opts: { projectRoot?: string } = {}): CraftLlmResolution {
+  const projectRoot = opts.projectRoot ?? process.cwd();
+  const fileConfig = readCraftConfigFromFile(projectRoot);
+  const envRaw = (process.env.HARNESS_CRAFT_LLM ?? '').trim();
+
+  // Env override: 'in-session' / 'mock' / <backend-name>.
+  if (hasEnvValue(envRaw)) {
+    if (envRaw === 'in-session' || envRaw === 'mock') {
+      return { mode: envRaw };
+    }
+    const def = fileConfig?.backends?.[envRaw];
+    if (def !== undefined && typeof def === 'object' && def !== null) {
+      const backendDef = def as Record<string, unknown>;
+      const type = backendDef.type;
+      if (typeof type === 'string' && isBackendType(type)) {
+        return { mode: type, backendName: envRaw, backendDef };
+      }
+    }
+    // Fall through to config-file resolution if the env value doesn't match a known backend.
+  }
+
+  // Config-file resolution.
+  const backendName = fileConfig?.craft?.backend;
+  if (fileConfig !== null && typeof backendName === 'string' && backendName.length > 0) {
+    const def = fileConfig.backends?.[backendName];
+    if (def === undefined || typeof def !== 'object' || def === null) {
+      throw new Error(
+        `craft.llm.backend="${backendName}" references an entry that is missing from agent.backends.`
+      );
+    }
+    const backendDef = def as Record<string, unknown>;
+    const type = backendDef.type;
+    if (typeof type !== 'string' || !isBackendType(type)) {
+      throw new Error(
+        `agent.backends["${backendName}"] has unsupported type "${String(type)}" for craft skills.`
+      );
+    }
+    return { mode: type, backendName, backendDef };
+  }
+
+  const mode = fileConfig?.craft?.mode;
+  if (mode === 'in-session' || mode === 'mock') return { mode };
+
+  return { mode: 'in-session' };
+}
+
+/** Back-compat shim — returns only the mode. */
+export function resolveCraftLlmMode(envValue?: string): CraftLlmMode {
+  if (envValue !== undefined) {
+    const trimmed = envValue.trim();
+    if (trimmed === 'in-session' || trimmed === 'mock') return trimmed;
+  }
+  return resolveCraftLlmConfig().mode;
+}
+
+const BACKEND_TYPES = ['claude', 'anthropic', 'openai', 'gemini', 'local', 'pi', 'mock'] as const;
+function isBackendType(t: string): t is (typeof BACKEND_TYPES)[number] {
+  return (BACKEND_TYPES as readonly string[]).includes(t);
+}
+
+interface FileCraftView {
+  craft?: { backend?: string; mode?: 'in-session' | 'mock' };
+  backends?: Record<string, unknown>;
+  /** Set when backends were sourced from harness.orchestrator.md, not harness.config.json. */
+  backendsFromOrchestratorMd?: boolean;
+}
+
+function readJsonCraftView(startDir: string): FileCraftView {
+  const view: FileCraftView = {};
+  const found = findConfigFile(startDir);
+  if (!found.ok) return view;
+  const loaded = loadConfig(found.value);
+  if (!loaded.ok) return view;
+  const craft = loaded.value.craft?.llm;
+  if (craft !== undefined) {
+    view.craft = {};
+    if (craft.backend !== undefined) view.craft.backend = craft.backend;
+    if (craft.mode !== undefined) view.craft.mode = craft.mode;
+  }
+  const backends = loaded.value.agent?.backends;
+  if (backends !== undefined) view.backends = backends as Record<string, unknown>;
+  return view;
+}
+
+function readCraftConfigFromFile(startDir: string): FileCraftView | null {
+  const view = readJsonCraftView(startDir);
+
+  // Migration: if harness.config.json didn't declare agent.backends, fall
+  // back to harness.orchestrator.md so users who already maintain backends
+  // there don't have to duplicate them. Emits a one-time deprecation
+  // warning so they know to migrate.
+  if (view.backends === undefined) {
+    const fromMd = readBackendsFromOrchestratorMd(startDir);
+    if (fromMd !== null) {
+      view.backends = fromMd;
+      view.backendsFromOrchestratorMd = true;
+      warnOrchestratorMdFallback();
+    }
+  }
+
+  return view.craft !== undefined || view.backends !== undefined ? view : null;
+}
+
+let warnedOrchestratorMd = false;
+function warnOrchestratorMdFallback(): void {
+  if (warnedOrchestratorMd) return;
+  warnedOrchestratorMd = true;
+  if (process.env.HARNESS_SUPPRESS_BACKEND_MIGRATION_WARNING) return;
+  console.warn(
+    '[craft] agent.backends read from harness.orchestrator.md. ' +
+      'Run `harness migrate backends` to copy them into harness.config.json ' +
+      '(single source of truth). Suppress with HARNESS_SUPPRESS_BACKEND_MIGRATION_WARNING=1.'
+  );
+}
+
+/**
+ * Factory for the provider used by phase implementations. Dispatch and
+ * provider-specific settings flow from {@link resolveCraftLlmConfig}.
+ *
+ * Test code that wants a specific provider should construct it directly
+ * (MockLlmProvider, InSessionLlmProvider) rather than going through here.
+ */
+export function getProvider(opts?: {
+  mode?: 'in-session' | 'mock';
+  projectRoot?: string;
+}): LlmProvider {
+  // Explicit override — only the two non-backend modes can be forced via
+  // opts.mode (backend-typed modes need an agent.backends entry).
+  if (opts?.mode === 'in-session') return new InSessionLlmProvider();
+  if (opts?.mode === 'mock') return new MockLlmProvider();
+
+  const resolved = resolveCraftLlmConfig(
+    opts?.projectRoot !== undefined ? { projectRoot: opts.projectRoot } : {}
+  );
+  return providerForResolution(resolved);
+}
+
+function providerForResolution(resolved: CraftLlmResolution): LlmProvider {
+  switch (resolved.mode) {
+    case 'in-session':
+      return new InSessionLlmProvider();
+    case 'mock':
+      return new MockLlmProvider();
+    case 'claude':
+      return buildClaudeProvider(resolved);
+    case 'anthropic':
+      return buildAnthropicProvider(resolved);
+    case 'openai':
+    case 'local':
+    case 'pi':
+      return buildOpenAICompatibleProvider(resolved);
+    case 'gemini':
+      throw new Error(
+        `agent.backends["${resolved.backendName}"]: 'gemini' backend is not yet wired into the craft adapter.`
+      );
+  }
+}
+
+function buildClaudeProvider(resolved: CraftLlmResolution): LlmProvider {
+  const def = resolved.backendDef ?? {};
+  const command = stringField(def, 'command');
+  return adaptClaudeCli(new ClaudeCliAnalysisProvider(command !== undefined ? { command } : {}));
+}
+
+function buildAnthropicProvider(resolved: CraftLlmResolution): LlmProvider {
+  const def = resolved.backendDef ?? {};
+  const model = stringField(def, 'model');
+  if (model === undefined) {
+    throw new Error(
+      `agent.backends["${resolved.backendName}"]: 'anthropic' backend requires a 'model'.`
+    );
+  }
+  const apiKey = stringField(def, 'apiKey') ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      `agent.backends["${resolved.backendName}"]: 'anthropic' backend requires apiKey or ANTHROPIC_API_KEY.`
+    );
+  }
+  return adaptAnthropic(new AnthropicAnalysisProvider({ apiKey, defaultModel: model }), model);
+}
+
+function pickConfiguredModels(modelField: unknown): string[] {
+  if (typeof modelField === 'string') return [modelField];
+  if (Array.isArray(modelField)) {
+    return modelField.filter((m): m is string => typeof m === 'string');
+  }
+  return [];
+}
+
+interface OpenAICompatibleInputs {
+  endpoint: string;
+  apiKey: string;
+  configured: string[];
+}
+
+function resolveOpenAICompatibleEndpoint(resolved: CraftLlmResolution): string {
+  const def = resolved.backendDef ?? {};
+  const fallback = resolved.mode === 'openai' ? 'https://api.openai.com/v1' : undefined;
+  const endpoint = stringField(def, 'endpoint') ?? fallback;
+  if (endpoint === undefined) {
+    throw new Error(
+      `agent.backends["${resolved.backendName}"]: '${resolved.mode}' backend requires 'endpoint'.`
+    );
+  }
+  return endpoint;
+}
+
+function resolveOpenAICompatibleApiKey(resolved: CraftLlmResolution): string {
+  const def = resolved.backendDef ?? {};
+  const fallback = resolved.mode === 'openai' ? undefined : 'local';
+  const apiKey = stringField(def, 'apiKey') ?? process.env.OPENAI_API_KEY ?? fallback;
+  if (!apiKey) {
+    throw new Error(
+      `agent.backends["${resolved.backendName}"]: 'openai' backend requires apiKey or OPENAI_API_KEY.`
+    );
+  }
+  return apiKey;
+}
+
+function resolveOpenAICompatibleInputs(resolved: CraftLlmResolution): OpenAICompatibleInputs {
+  const configured = pickConfiguredModels(resolved.backendDef?.model);
+  if (configured.length === 0) {
+    throw new Error(
+      `agent.backends["${resolved.backendName}"]: '${resolved.mode}' backend requires 'model' (string or non-empty array of strings).`
+    );
+  }
+  return {
+    endpoint: resolveOpenAICompatibleEndpoint(resolved),
+    apiKey: resolveOpenAICompatibleApiKey(resolved),
+    configured,
+  };
+}
+
+function buildOpenAICompatibleProvider(resolved: CraftLlmResolution): LlmProvider {
+  const { endpoint, apiKey, configured } = resolveOpenAICompatibleInputs(resolved);
+
+  // Single configured model → direct adapter, no probe (cheaper, predictable).
+  if (configured.length === 1) {
+    return adaptOpenAICompatible(
+      new OpenAICompatibleAnalysisProvider({
+        apiKey,
+        baseUrl: endpoint,
+        defaultModel: configured[0]!,
+      }),
+      configured[0]!
+    );
+  }
+
+  // Multiple configured models → lazy probe on first callText.
+  return new LazyLocalAdapter(
+    { endpoint, apiKey, configured },
+    resolved.mode === 'pi' ? 'pi' : 'local'
+  );
+}
+
+function stringField(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  return typeof v === 'string' ? v : undefined;
 }

--- a/packages/cli/src/shared/craft/runs/store.ts
+++ b/packages/cli/src/shared/craft/runs/store.ts
@@ -1,0 +1,89 @@
+// packages/cli/src/shared/craft/runs/store.ts
+//
+// Persists in-session craft runs to disk so a two-step MCP flow
+// (collect → finalize) can resume across separate tool calls.
+//
+// Layout:
+//   <projectRoot>/.harness/craft/runs/<runId>.json
+//
+// One run-state file per active runId. The orchestrator that consumes
+// this is responsible for deleting the file after a successful finalize
+// (or letting it expire — see `pruneOldRuns`).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const RUN_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+export interface CraftRunState<TMeta> {
+  /** Schema version for forward compatibility. */
+  v: 1;
+  runId: string;
+  skill: string;
+  createdAt: number;
+  /** Skill-specific metadata sufficient to reconstruct findings from responses. */
+  meta: TMeta;
+}
+
+function runsDir(projectRoot: string): string {
+  return path.join(projectRoot, '.harness', 'craft', 'runs');
+}
+
+function runPath(projectRoot: string, runId: string): string {
+  return path.join(runsDir(projectRoot), `${runId}.json`);
+}
+
+export function saveRunState<TMeta>(
+  projectRoot: string,
+  state: CraftRunState<TMeta>
+): { runFile: string } {
+  const dir = runsDir(projectRoot);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = runPath(projectRoot, state.runId);
+  fs.writeFileSync(file, JSON.stringify(state, null, 2));
+  return { runFile: file };
+}
+
+export function loadRunState<TMeta>(
+  projectRoot: string,
+  runId: string
+): CraftRunState<TMeta> | null {
+  const file = runPath(projectRoot, runId);
+  if (!fs.existsSync(file)) return null;
+  try {
+    const raw = fs.readFileSync(file, 'utf-8');
+    return JSON.parse(raw) as CraftRunState<TMeta>;
+  } catch {
+    return null;
+  }
+}
+
+export function deleteRunState(projectRoot: string, runId: string): void {
+  const file = runPath(projectRoot, runId);
+  try {
+    fs.unlinkSync(file);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Best-effort cleanup of run-state files older than TTL. Swallow errors. */
+export function pruneOldRuns(projectRoot: string, now: number = Date.now()): void {
+  const dir = runsDir(projectRoot);
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const full = path.join(dir, entry.name);
+    try {
+      const stat = fs.statSync(full);
+      if (now - stat.mtimeMs > RUN_TTL_MS) fs.unlinkSync(full);
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/packages/cli/src/skill/health-snapshot.ts
+++ b/packages/cli/src/skill/health-snapshot.ts
@@ -6,6 +6,7 @@
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { logger } from '../output/logger';
 
 /** Granular check results from assess_project and related tools. */
 export interface HealthChecks {
@@ -133,13 +134,28 @@ export function deriveSignals(checks: HealthChecks, metrics: HealthMetrics): str
 
 interface ToolResult {
   content: Array<{ type: string; text: string }>;
+  isError?: boolean;
 }
 
 const DEFAULT_CHECK = { passed: true, issueCount: 0 };
 
-/** Extract the first text content from a tool result and parse as JSON. */
-function parseToolResult(result: ToolResult): Record<string, unknown> {
-  return JSON.parse(result.content[0]?.text ?? '{}');
+/**
+ * Extract the first text content from a tool result and parse as JSON.
+ * On `isError` or invalid JSON, warn and return `{}` so callers fall back to defaults
+ * instead of crashing the surrounding pipeline.
+ */
+function parseToolResult(result: ToolResult, toolName: string): Record<string, unknown> {
+  const text = result.content[0]?.text ?? '{}';
+  if (result.isError) {
+    logger.warn(`${toolName} reported an error: ${text}`);
+    return {};
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    logger.warn(`${toolName} returned non-JSON output: ${text.slice(0, 120)}`);
+    return {};
+  }
 }
 
 /** Build a map of check name to pass/issue from assess_project output. */
@@ -217,11 +233,13 @@ export async function runHealthChecks(projectPath: string): Promise<HealthChecks
     handleRunSecurityScan({ path: projectPath }),
   ]);
 
-  const assessData = parseToolResult(assessResult);
+  const assessData = parseToolResult(assessResult, 'assess_project');
   const checkMap = buildCheckMap(assessData);
-  const { circularDeps, layerViolations } = countViolations(parseToolResult(depsResult));
-  const entropyGranular = parseEntropyGranular(parseToolResult(entropyResult));
-  const criticalCount = countCriticalFindings(parseToolResult(securityResult));
+  const { circularDeps, layerViolations } = countViolations(
+    parseToolResult(depsResult, 'check_dependencies')
+  );
+  const entropyGranular = parseEntropyGranular(parseToolResult(entropyResult, 'detect_entropy'));
+  const criticalCount = countCriticalFindings(parseToolResult(securityResult, 'run_security_scan'));
 
   return assembleHealthChecks(
     checkMap,

--- a/packages/cli/tests/commands/migrate-backends.test.ts
+++ b/packages/cli/tests/commands/migrate-backends.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runMigrateBackends } from '../../src/commands/migrate-backends';
+
+describe('migrate-backends', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-backends-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeOrchestratorMd(yaml: string): void {
+    fs.writeFileSync(
+      path.join(tmp, 'harness.orchestrator.md'),
+      `---\n${yaml}\n---\n\nprompt template`
+    );
+  }
+
+  function writeConfigJson(obj: object): void {
+    fs.writeFileSync(path.join(tmp, 'harness.config.json'), JSON.stringify(obj, null, 2));
+  }
+
+  it('no-ops when harness.orchestrator.md does not exist', async () => {
+    const r = await runMigrateBackends({ cwd: tmp });
+    expect(r.status).toBe('noop');
+    expect(r.message).toMatch(/No harness.orchestrator.md/);
+  });
+
+  it('no-ops when orchestrator.md has no agent.backends', async () => {
+    writeOrchestratorMd('tracker:\n  kind: roadmap');
+    writeConfigJson({ version: 1 });
+    const r = await runMigrateBackends({ cwd: tmp });
+    expect(r.status).toBe('noop');
+  });
+
+  it('errors when harness.config.json is missing', async () => {
+    writeOrchestratorMd('agent:\n  backends:\n    primary: { type: claude, command: claude }');
+    const r = await runMigrateBackends({ cwd: tmp });
+    expect(r.status).toBe('error');
+    expect(r.message).toMatch(/harness.config.json not found/);
+  });
+
+  it('copies backends into harness.config.json', async () => {
+    writeOrchestratorMd(
+      [
+        'agent:',
+        '  backends:',
+        '    primary: { type: claude, command: claude }',
+        '    ollama:',
+        '      type: local',
+        '      endpoint: http://localhost:11434/v1',
+        '      model: deepseek-coder-v2',
+      ].join('\n')
+    );
+    writeConfigJson({ version: 1 });
+    const r = await runMigrateBackends({ cwd: tmp });
+    expect(r.status).toBe('ok');
+
+    const written = JSON.parse(fs.readFileSync(path.join(tmp, 'harness.config.json'), 'utf-8')) as {
+      agent: { backends: Record<string, unknown> };
+    };
+    expect(written.agent.backends).toBeDefined();
+    expect(Object.keys(written.agent.backends)).toEqual(['primary', 'ollama']);
+    expect((written.agent.backends.ollama as Record<string, unknown>).type).toBe('local');
+  });
+
+  it('copies routing when present', async () => {
+    writeOrchestratorMd(
+      [
+        'agent:',
+        '  backends:',
+        '    primary: { type: claude, command: claude }',
+        '  routing:',
+        '    default: primary',
+      ].join('\n')
+    );
+    writeConfigJson({ version: 1 });
+    const r = await runMigrateBackends({ cwd: tmp });
+    expect(r.status).toBe('ok');
+
+    const written = JSON.parse(fs.readFileSync(path.join(tmp, 'harness.config.json'), 'utf-8')) as {
+      agent: { routing: { default: string } };
+    };
+    expect(written.agent.routing.default).toBe('primary');
+  });
+
+  it('refuses to overwrite existing agent.backends without --force', async () => {
+    writeOrchestratorMd('agent:\n  backends:\n    primary: { type: claude }');
+    writeConfigJson({
+      version: 1,
+      agent: { executor: 'subprocess', backends: { existing: { type: 'mock' } } },
+    });
+    const r = await runMigrateBackends({ cwd: tmp });
+    expect(r.status).toBe('error');
+    expect(r.message).toMatch(/already declares agent.backends/);
+  });
+
+  it('overwrites with --force', async () => {
+    writeOrchestratorMd('agent:\n  backends:\n    primary: { type: claude }');
+    writeConfigJson({
+      version: 1,
+      agent: { executor: 'subprocess', backends: { existing: { type: 'mock' } } },
+    });
+    const r = await runMigrateBackends({ cwd: tmp, force: true });
+    expect(r.status).toBe('ok');
+    const written = JSON.parse(fs.readFileSync(path.join(tmp, 'harness.config.json'), 'utf-8')) as {
+      agent: { backends: Record<string, unknown> };
+    };
+    expect(written.agent.backends).toHaveProperty('primary');
+    expect(written.agent.backends).not.toHaveProperty('existing');
+  });
+
+  it('dry-run does not write the file', async () => {
+    writeOrchestratorMd('agent:\n  backends:\n    primary: { type: claude }');
+    writeConfigJson({ version: 1 });
+    const before = fs.readFileSync(path.join(tmp, 'harness.config.json'), 'utf-8');
+    const r = await runMigrateBackends({ cwd: tmp, dryRun: true });
+    expect(r.status).toBe('ok');
+    expect(r.message).toMatch(/dry-run/);
+    const after = fs.readFileSync(path.join(tmp, 'harness.config.json'), 'utf-8');
+    expect(after).toBe(before);
+  });
+});

--- a/packages/cli/tests/commands/models-probe.test.ts
+++ b/packages/cli/tests/commands/models-probe.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runModelsProbe } from '../../src/commands/models';
+
+const ORIG_FETCH = globalThis.fetch;
+
+function mockFetchResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: 'OK',
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('harness models probe', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'models-probe-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    globalThis.fetch = ORIG_FETCH;
+  });
+
+  function writeConfig(obj: object): string {
+    const file = path.join(tmp, 'harness.config.json');
+    fs.writeFileSync(file, JSON.stringify({ version: 1, ...obj }, null, 2));
+    return file;
+  }
+
+  it('errors when no config and no --endpoint is given', async () => {
+    const result = await runModelsProbe({});
+    expect(result.status).toBe('error');
+  });
+
+  it('reports resolved=null when no configured model is loaded', async () => {
+    const cfg = writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: {
+            type: 'local',
+            endpoint: 'http://localhost:11434/v1',
+            model: ['gemma-4-e4b', 'qwen3:8b'],
+          },
+        },
+      },
+    });
+    globalThis.fetch = vi.fn(async () =>
+      mockFetchResponse({ data: [{ id: 'llama3:8b' }, { id: 'mistral:7b' }] })
+    ) as typeof fetch;
+
+    const result = await runModelsProbe({ configPath: cfg });
+    expect(result.status).toBe('no-match');
+    expect(result.backend).toBe('ollama');
+    expect(result.configured).toEqual(['gemma-4-e4b', 'qwen3:8b']);
+    expect(result.detected).toEqual(['llama3:8b', 'mistral:7b']);
+    expect(result.resolved).toBeNull();
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('reports the first configured model that is loaded', async () => {
+    const cfg = writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: {
+            type: 'local',
+            endpoint: 'http://localhost:11434/v1',
+            model: ['gemma-4-e4b', 'qwen3:8b', 'deepseek-coder-v2'],
+          },
+        },
+      },
+    });
+    globalThis.fetch = vi.fn(async () =>
+      mockFetchResponse({ data: [{ id: 'qwen3:8b' }, { id: 'mistral:7b' }] })
+    ) as typeof fetch;
+
+    const result = await runModelsProbe({ configPath: cfg });
+    expect(result.status).toBe('ok');
+    expect(result.resolved).toBe('qwen3:8b');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('auto-selects the first local/pi backend when --backend is omitted', async () => {
+    const cfg = writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          primary: { type: 'claude', command: 'claude' },
+          lmstudio: { type: 'local', endpoint: 'http://localhost:1234/v1', model: 'gemma' },
+        },
+      },
+    });
+    globalThis.fetch = vi.fn(async () =>
+      mockFetchResponse({ data: [{ id: 'gemma' }] })
+    ) as typeof fetch;
+
+    const result = await runModelsProbe({ configPath: cfg });
+    expect(result.backend).toBe('lmstudio');
+    expect(result.resolved).toBe('gemma');
+  });
+
+  it('respects --backend selection', async () => {
+    const cfg = writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: {
+            type: 'local',
+            endpoint: 'http://localhost:11434/v1',
+            model: 'qwen3:8b',
+          },
+          lmstudio: {
+            type: 'local',
+            endpoint: 'http://localhost:1234/v1',
+            model: 'gemma',
+          },
+        },
+      },
+    });
+    globalThis.fetch = vi.fn(async () =>
+      mockFetchResponse({ data: [{ id: 'gemma' }] })
+    ) as typeof fetch;
+
+    const result = await runModelsProbe({ configPath: cfg, backend: 'lmstudio' });
+    expect(result.backend).toBe('lmstudio');
+    expect(result.endpoint).toBe('http://localhost:1234/v1');
+    expect(result.resolved).toBe('gemma');
+  });
+
+  it('surfaces probe network errors with context', async () => {
+    const cfg = writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: {
+            type: 'local',
+            endpoint: 'http://localhost:11434/v1',
+            model: 'qwen3:8b',
+          },
+        },
+      },
+    });
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as typeof fetch;
+
+    const result = await runModelsProbe({ configPath: cfg });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/ECONNREFUSED/);
+  });
+
+  it('errors when no local/pi backend exists in config', async () => {
+    const cfg = writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          primary: { type: 'claude', command: 'claude' },
+        },
+      },
+    });
+    const result = await runModelsProbe({ configPath: cfg });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/No local backend/);
+  });
+});

--- a/packages/cli/tests/mcp/server-integration.test.ts
+++ b/packages/cli/tests/mcp/server-integration.test.ts
@@ -81,7 +81,9 @@ describe('MCP Server Integration', () => {
     expect(names).toContain('knowledge_craft');
     // craft-pipeline #10 — security-craft
     expect(names).toContain('security_craft');
-    expect(tools).toHaveLength(80);
+    // naming-craft adds a second tool (naming_craft_finalize) for the in-session two-step flow.
+    expect(names).toContain('naming_craft_finalize');
+    expect(tools).toHaveLength(81);
   });
 
   it('all tool definitions have inputSchema', () => {

--- a/packages/cli/tests/mcp/server.test.ts
+++ b/packages/cli/tests/mcp/server.test.ts
@@ -11,9 +11,9 @@ describe('MCP Server', () => {
     expect(server).toBeDefined();
   });
 
-  it('registers all 80 tools', () => {
+  it('registers all 81 tools', () => {
     const tools = getToolDefinitions();
-    expect(tools).toHaveLength(80);
+    expect(tools).toHaveLength(81);
   });
 
   it('registers all 9 resources', () => {

--- a/packages/cli/tests/mcp/tools/naming-craft.test.ts
+++ b/packages/cli/tests/mcp/tools/naming-craft.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  handleNamingCraft,
+  handleNamingCraftFinalize,
+  namingCraftDefinition,
+  namingCraftFinalizeDefinition,
+} from '../../../src/mcp/tools/naming-craft';
+
+describe('naming_craft MCP tool', () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-craft-mcp-'));
+    savedEnv = process.env.HARNESS_CRAFT_LLM;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedEnv;
+  });
+
+  it('definition exposes mode and promptBudget on input schema', () => {
+    expect(namingCraftDefinition.inputSchema.properties).toHaveProperty('mode');
+    expect(namingCraftDefinition.inputSchema.properties).toHaveProperty('promptBudget');
+  });
+
+  it('finalize definition declares path, runId, responses as required', () => {
+    expect(namingCraftFinalizeDefinition.inputSchema.required).toEqual([
+      'path',
+      'runId',
+      'responses',
+    ]);
+  });
+
+  it('rejects missing path', async () => {
+    // @ts-expect-error testing runtime validation
+    const r = await handleNamingCraft({});
+    expect(r.isError).toBe(true);
+    expect(r.content[0]!.text).toContain('path');
+  });
+
+  it('returns pendingPrompts when mode=in-session', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src.ts'), `export const foo = 1;\n`);
+    const r = await handleNamingCraft({ path: tmpDir, mode: 'in-session' });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(parsed.status).toBe('collected');
+    expect(parsed.pendingPrompts.length).toBeGreaterThan(0);
+    expect(parsed.runId).toBeTruthy();
+  });
+
+  it('routes a round-trip through naming_craft → naming_craft_finalize', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src.ts'), `export const foo = 1;\n`);
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    const collect = await handleNamingCraft({ path: tmpDir });
+    const collected = JSON.parse(collect.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(collected.status).toBe('collected');
+
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"polish","impact":"small","confidence":"medium","message":"x"}\n```'
+          : '```json\nnull\n```',
+    }));
+
+    const finalize = await handleNamingCraftFinalize({
+      path: tmpDir,
+      runId: collected.runId,
+      responses,
+    });
+    expect(finalize.isError).toBeFalsy();
+    const out = JSON.parse(finalize.content[0]!.text) as {
+      findings: unknown[];
+      summary: { runId: string };
+    };
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.summary.runId).toBe(collected.runId);
+  });
+
+  it('finalize rejects when responses is not an array', async () => {
+    const r = await handleNamingCraftFinalize({
+      path: tmpDir,
+      runId: 'abc',
+      // @ts-expect-error testing runtime validation
+      responses: 'oops',
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it('auto-routes to inline when HARNESS_CRAFT_LLM=mock and mode is unspecified', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src.ts'), `export const foo = 1;\n`);
+    process.env.HARNESS_CRAFT_LLM = 'mock';
+    const r = await handleNamingCraft({ path: tmpDir });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      findings: unknown[];
+      summary: { llmCalls: { provider: string } };
+    };
+    // Inline path returns the standard NamingCraftOutput shape.
+    expect(parsed).toHaveProperty('findings');
+    expect(parsed.summary.llmCalls.provider).toBe('mock');
+  });
+});

--- a/packages/cli/tests/naming-craft/in-session.test.ts
+++ b/packages/cli/tests/naming-craft/in-session.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  collectNamingCraftPrompts,
+  finalizeNamingCraft,
+  runNamingCraft,
+} from '../../src/naming-craft';
+import { InSessionLlmProvider } from '../../src/naming-craft/llm/provider';
+
+describe('naming-craft in-session flow', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'naming-craft-insession-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(rel: string, content: string): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  it('collect returns prompts and persists run state', async () => {
+    writeFile('src/orders.ts', `export function processData(orders) { return orders; }\n`);
+    const result = await collectNamingCraftPrompts({ path: tmpDir });
+    expect(result.status).toBe('collected');
+    expect(result.pendingPrompts.length).toBeGreaterThan(0);
+    expect(result.pendingPrompts[0]!.promptId).toMatch(/^p/);
+    expect(result.pendingPrompts[0]!.userPrompt).toContain('processData');
+    expect(result.runFile).toBeDefined();
+    expect(fs.existsSync(result.runFile!)).toBe(true);
+  });
+
+  it('finalize parses responses into NamingFindings and deletes the run-state file', async () => {
+    writeFile('src/orders.ts', `export function processData(orders) { return orders; }\n`);
+    const collected = await collectNamingCraftPrompts({ path: tmpDir });
+
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"polish","impact":"medium","confidence":"high","message":"vague verb"}\n```'
+          : '```json\nnull\n```',
+    }));
+
+    const out = await finalizeNamingCraft({
+      path: tmpDir,
+      runId: collected.runId,
+      responses,
+    });
+
+    expect(out.findings.length).toBe(1);
+    expect(out.findings[0]!.target.identifier).toBe('processData');
+    expect(out.findings[0]!.tier).toBe('polish');
+    expect(out.findings[0]!.confidence).toBe('high');
+    expect(out.summary.llmCalls.provider).toBe('in-session');
+    expect(out.summary.runId).toBe(collected.runId);
+    expect(fs.existsSync(collected.runFile!)).toBe(false);
+  });
+
+  it('budget guard bails when projected prompts exceed the cap', async () => {
+    // 5 files × ~3 identifiers × 6 rubrics ≈ 90 prompts; a budget of 5 forces bail.
+    for (let i = 0; i < 5; i++) {
+      writeFile(
+        `src/file${i}.ts`,
+        `export function foo${i}() {}\nexport const bar${i} = 1;\nexport type Baz${i} = number;\n`
+      );
+    }
+    const result = await collectNamingCraftPrompts({ path: tmpDir, promptBudget: 5 });
+    expect(result.status).toBe('budget-exceeded');
+    expect(result.pendingPrompts).toHaveLength(0);
+    expect(result.hint).toContain('budget');
+    expect(result.projection.budget).toBe(5);
+  });
+
+  it('runNamingCraft refuses an InSessionLlmProvider with a clear error', async () => {
+    writeFile('src/x.ts', `export const foo = 1;\n`);
+    const provider = new InSessionLlmProvider();
+    await expect(runNamingCraft({ path: tmpDir, __testProvider: provider })).rejects.toThrow(
+      /two-step flow|in-session/
+    );
+  });
+
+  it('finalize errors when runId is unknown', async () => {
+    await expect(
+      finalizeNamingCraft({
+        path: tmpDir,
+        runId: '00000000-0000-0000-0000-000000000000',
+        responses: [],
+      })
+    ).rejects.toThrow(/no persisted run/);
+  });
+
+  it('finalize silently skips responses whose promptId is unknown', async () => {
+    writeFile('src/x.ts', `export const foo = 1;\n`);
+    const collected = await collectNamingCraftPrompts({ path: tmpDir });
+    const out = await finalizeNamingCraft({
+      path: tmpDir,
+      runId: collected.runId,
+      responses: [
+        {
+          promptId: 'nonexistent',
+          raw: '```json\n{"tier":"polish","impact":"medium","confidence":"high","message":"x"}\n```',
+        },
+      ],
+    });
+    expect(out.findings).toHaveLength(0);
+  });
+});

--- a/packages/cli/tests/naming-craft/integration.test.ts
+++ b/packages/cli/tests/naming-craft/integration.test.ts
@@ -23,7 +23,7 @@ describe('runNamingCraft (integration)', () => {
   }
 
   it('walks empty project and emits zero findings', async () => {
-    const out = await runNamingCraft({ path: tmpDir });
+    const out = await runNamingCraft({ path: tmpDir, __testProvider: new MockLlmProvider() });
     expect(out.findings).toEqual([]);
     expect(out.summary.catalog.rubricsApplied).toHaveLength(6);
   });
@@ -48,7 +48,11 @@ describe('runNamingCraft (integration)', () => {
     for (let i = 0; i < 5; i++) {
       writeFile(`src/file${i}.ts`, `const x${i} = ${i};\n`);
     }
-    const out = await runNamingCraft({ path: tmpDir, maxFiles: 2 });
+    const out = await runNamingCraft({
+      path: tmpDir,
+      maxFiles: 2,
+      __testProvider: new MockLlmProvider(),
+    });
     // 5 files written, cap to 2: convention sampling still works but only
     // 2 files are scanned for findings. Verify by summary metadata path.
     expect(out.summary.llmCalls.count).toBeLessThanOrEqual(2 * 6 * 15);
@@ -56,7 +60,7 @@ describe('runNamingCraft (integration)', () => {
 
   it('derives camelCase convention from a uniformly camelCase project', async () => {
     writeFile('src/a.ts', `const userName = 1;\nconst retryCount = 2;\nconst maxBuffer = 3;\n`);
-    const out = await runNamingCraft({ path: tmpDir });
+    const out = await runNamingCraft({ path: tmpDir, __testProvider: new MockLlmProvider() });
     expect(out.summary.convention.variables).toBe('camelCase');
   });
 

--- a/packages/cli/tests/setup.ts
+++ b/packages/cli/tests/setup.ts
@@ -1,0 +1,10 @@
+// Vitest global setup. Runs once before any test file is loaded.
+//
+// Sets HARNESS_CRAFT_LLM=mock by default so tests that exercise craft
+// skills get deterministic mock behavior without each having to opt in.
+// Tests that need to verify production defaults (in-session) override
+// this in their own beforeEach by deleting or reassigning the env var.
+
+if (!process.env.HARNESS_CRAFT_LLM) {
+  process.env.HARNESS_CRAFT_LLM = 'mock';
+}

--- a/packages/cli/tests/shared/craft/lazy-local-adapter.test.ts
+++ b/packages/cli/tests/shared/craft/lazy-local-adapter.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LazyLocalAdapter } from '../../../src/shared/craft/llm/lazy-local-adapter';
+
+describe('LazyLocalAdapter', () => {
+  it('resolves to the first configured model that the endpoint reports as loaded', async () => {
+    const fetchModels = vi.fn(async () => ['qwen3:8b', 'deepseek-coder-v2']);
+    const adapter = new LazyLocalAdapter({
+      endpoint: 'http://localhost:11434/v1',
+      apiKey: 'ollama',
+      configured: ['gemma-4-e4b', 'qwen3:8b', 'deepseek-coder-v2'],
+      fetchModels,
+    });
+
+    // Pre-call: resolution hasn't happened yet.
+    expect(adapter.getResolvedModel()).toBeNull();
+
+    // Trigger resolution by calling callText — but the underlying OpenAI
+    // adapter will reach for the real HTTP client. We catch the resulting
+    // network error and still inspect the resolution.
+    try {
+      await adapter.callText('test prompt');
+    } catch {
+      /* expected — no actual server */
+    }
+    expect(adapter.getResolvedModel()).toBe('qwen3:8b');
+    expect(fetchModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches resolution across calls (probe runs exactly once)', async () => {
+    const fetchModels = vi.fn(async () => ['gemma-4-e4b']);
+    const adapter = new LazyLocalAdapter({
+      endpoint: 'http://localhost:1234/v1',
+      apiKey: 'lm-studio',
+      configured: ['gemma-4-e4b', 'qwen3:8b'],
+      fetchModels,
+    });
+
+    for (let i = 0; i < 3; i++) {
+      try {
+        await adapter.callText(`prompt-${i}`);
+      } catch {
+        /* expected */
+      }
+    }
+    expect(fetchModels).toHaveBeenCalledTimes(1);
+    expect(adapter.getResolvedModel()).toBe('gemma-4-e4b');
+  });
+
+  it('errors clearly when no configured model is loaded', async () => {
+    const fetchModels = vi.fn(async () => ['llama3:8b', 'mistral:7b']);
+    const adapter = new LazyLocalAdapter({
+      endpoint: 'http://localhost:11434/v1',
+      apiKey: 'ollama',
+      configured: ['gemma-4-e4b', 'qwen3:8b'],
+      fetchModels,
+    });
+
+    await expect(adapter.callText('p')).rejects.toThrow(
+      /no configured model is loaded.*Configured.*Detected/s
+    );
+  });
+
+  it('errors with server-down hint when probe fails', async () => {
+    const fetchModels = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const adapter = new LazyLocalAdapter({
+      endpoint: 'http://localhost:11434/v1',
+      apiKey: 'ollama',
+      configured: ['gemma-4-e4b'],
+      fetchModels,
+    });
+
+    await expect(adapter.callText('p')).rejects.toThrow(/probe failed.*Is the server running/);
+  });
+
+  it('callVision throws (not wired for local backends)', async () => {
+    const adapter = new LazyLocalAdapter({
+      endpoint: 'http://localhost:11434/v1',
+      apiKey: 'ollama',
+      configured: ['gemma-4-e4b'],
+      fetchModels: async () => ['gemma-4-e4b'],
+    });
+    await expect(adapter.callVision('p', {})).rejects.toThrow(/callVision is not wired/);
+  });
+
+  it('uses providerId "pi" when constructed for a pi backend', () => {
+    const adapter = new LazyLocalAdapter(
+      {
+        endpoint: 'http://localhost:1234/v1',
+        apiKey: 'pi',
+        configured: ['gemma-4-e4b'],
+        fetchModels: async () => ['gemma-4-e4b'],
+      },
+      'pi'
+    );
+    expect(adapter.providerId).toBe('pi');
+  });
+});

--- a/packages/cli/tests/shared/craft/llm-provider.test.ts
+++ b/packages/cli/tests/shared/craft/llm-provider.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  getProvider,
+  resolveCraftLlmMode,
+  resolveCraftLlmConfig,
+  InSessionLlmProvider,
+  PromptDeferredError,
+  MockLlmProvider,
+} from '../../../src/shared/craft/llm/provider';
+
+describe('resolveCraftLlmMode', () => {
+  let savedEnv: string | undefined;
+  beforeEach(() => {
+    savedEnv = process.env.HARNESS_CRAFT_LLM;
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedEnv;
+  });
+
+  it('returns mock when env is mock', () => {
+    process.env.HARNESS_CRAFT_LLM = 'mock';
+    expect(resolveCraftLlmMode()).toBe('mock');
+  });
+
+  it('returns in-session when env is in-session', () => {
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    expect(resolveCraftLlmMode()).toBe('in-session');
+  });
+});
+
+describe('getProvider (explicit overrides)', () => {
+  it('returns InSessionLlmProvider for mode=in-session', () => {
+    expect(getProvider({ mode: 'in-session' })).toBeInstanceOf(InSessionLlmProvider);
+  });
+
+  it('returns MockLlmProvider for mode=mock', () => {
+    expect(getProvider({ mode: 'mock' })).toBeInstanceOf(MockLlmProvider);
+  });
+});
+
+describe('resolveCraftLlmConfig (config-file driven)', () => {
+  let tmp: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'craft-cfg-'));
+    savedEnv = process.env.HARNESS_CRAFT_LLM;
+    delete process.env.HARNESS_CRAFT_LLM;
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedEnv;
+  });
+
+  function writeConfig(content: object): void {
+    fs.writeFileSync(
+      path.join(tmp, 'harness.config.json'),
+      JSON.stringify({ version: 1, ...content }, null, 2)
+    );
+  }
+
+  it('returns in-session when no config exists', () => {
+    expect(resolveCraftLlmConfig({ projectRoot: tmp }).mode).toBe('in-session');
+  });
+
+  it('honors craft.llm.mode=mock', () => {
+    writeConfig({ craft: { llm: { mode: 'mock' } } });
+    expect(resolveCraftLlmConfig({ projectRoot: tmp }).mode).toBe('mock');
+  });
+
+  it('resolves craft.llm.backend to a named entry in agent.backends', () => {
+    writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: {
+            type: 'local',
+            endpoint: 'http://localhost:11434/v1',
+            model: 'deepseek-coder-v2',
+          },
+        },
+      },
+      craft: { llm: { backend: 'ollama' } },
+    });
+    const r = resolveCraftLlmConfig({ projectRoot: tmp });
+    expect(r.mode).toBe('local');
+    expect(r.backendName).toBe('ollama');
+    expect(r.backendDef?.endpoint).toBe('http://localhost:11434/v1');
+  });
+
+  it('throws when craft.llm.backend references a missing entry', () => {
+    writeConfig({ craft: { llm: { backend: 'nonexistent' } } });
+    expect(() => resolveCraftLlmConfig({ projectRoot: tmp })).toThrow(
+      /missing from agent.backends/
+    );
+  });
+
+  it('env HARNESS_CRAFT_LLM=<backend-name> picks that backend at runtime', () => {
+    writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: { type: 'local', endpoint: 'http://localhost:11434/v1', model: 'qwen3' },
+        },
+      },
+    });
+    process.env.HARNESS_CRAFT_LLM = 'ollama';
+    const r = resolveCraftLlmConfig({ projectRoot: tmp });
+    expect(r.mode).toBe('local');
+    expect(r.backendName).toBe('ollama');
+  });
+
+  it('env HARNESS_CRAFT_LLM=mock wins over config-file backend', () => {
+    writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: { type: 'local', endpoint: 'http://localhost:11434/v1', model: 'qwen3' },
+        },
+      },
+      craft: { llm: { backend: 'ollama' } },
+    });
+    process.env.HARNESS_CRAFT_LLM = 'mock';
+    expect(resolveCraftLlmConfig({ projectRoot: tmp }).mode).toBe('mock');
+  });
+
+  it('instantiates a MockLlmProvider when resolution → mock', () => {
+    writeConfig({ craft: { llm: { mode: 'mock' } } });
+    expect(getProvider({ projectRoot: tmp })).toBeInstanceOf(MockLlmProvider);
+  });
+
+  it('instantiates an InSessionLlmProvider when resolution → in-session', () => {
+    writeConfig({ craft: { llm: { mode: 'in-session' } } });
+    expect(getProvider({ projectRoot: tmp })).toBeInstanceOf(InSessionLlmProvider);
+  });
+
+  it('errors when anthropic backend has no apiKey and no env var', () => {
+    writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          remote: { type: 'anthropic', model: 'claude-sonnet-4-6' },
+        },
+      },
+      craft: { llm: { backend: 'remote' } },
+    });
+    const savedKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      expect(() => getProvider({ projectRoot: tmp })).toThrow(/apiKey or ANTHROPIC_API_KEY/);
+    } finally {
+      if (savedKey !== undefined) process.env.ANTHROPIC_API_KEY = savedKey;
+    }
+  });
+
+  it('errors when local backend has no endpoint', () => {
+    writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          // model present but no endpoint — schema requires endpoint, so this is invalid config;
+          // verify the loader rejects it (loadConfig returns Err → resolveCraftLlmConfig falls through).
+          ollama: { type: 'local', model: 'qwen3' },
+        },
+      },
+      craft: { llm: { backend: 'ollama' } },
+    });
+    // Invalid config means the file fails to load entirely; selector falls through to default.
+    expect(resolveCraftLlmConfig({ projectRoot: tmp }).mode).toBe('in-session');
+  });
+});
+
+describe('InSessionLlmProvider', () => {
+  it('throws PromptDeferredError and records the prompt', async () => {
+    const p = new InSessionLlmProvider();
+    await expect(p.callText('prompt body', { systemPrompt: 'system body' })).rejects.toBeInstanceOf(
+      PromptDeferredError
+    );
+    const deferred = p.getDeferred();
+    expect(deferred).toHaveLength(1);
+    expect(deferred[0]!.userPrompt).toBe('prompt body');
+    expect(deferred[0]!.systemPrompt).toBe('system body');
+    expect(deferred[0]!.promptId).toMatch(/^p/);
+  });
+
+  it('assigns distinct promptIds for sequential calls', async () => {
+    const p = new InSessionLlmProvider();
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      try {
+        await p.callText(`prompt-${i}`);
+      } catch (err) {
+        if (err instanceof PromptDeferredError) ids.push(err.promptId);
+      }
+    }
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('throws on callVision (not implemented for in-session)', async () => {
+    const p = new InSessionLlmProvider();
+    await expect(p.callVision('hi', {})).rejects.toThrow(/callVision/);
+  });
+});

--- a/packages/cli/tests/skill/health-snapshot.test.ts
+++ b/packages/cli/tests/skill/health-snapshot.test.ts
@@ -412,6 +412,43 @@ describe('runHealthChecks', () => {
     expect(checks.docs.undocumentedCount).toBe(5);
     expect(checks.lint.passed).toBe(true);
   });
+
+  it('does not crash when a tool returns isError with non-JSON text', async () => {
+    // Regression: previously parseToolResult called JSON.parse on the error text and
+    // crashed with `Unexpected token 'E', "Error: Max"... is not valid JSON`, breaking
+    // `harness recommend` whenever any sub-check failed.
+    vi.doMock('../../src/mcp/tools/assess-project', () => ({
+      handleAssessProject: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify({ healthy: true, checks: [] }) }],
+      }),
+    }));
+    vi.doMock('../../src/mcp/tools/architecture', () => ({
+      handleCheckDependencies: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify({ valid: true, violations: [] }) }],
+      }),
+    }));
+    vi.doMock('../../src/mcp/tools/entropy', () => ({
+      handleDetectEntropy: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'Error: Maximum call stack size exceeded' }],
+        isError: true,
+      }),
+    }));
+    vi.doMock('../../src/mcp/tools/security', () => ({
+      handleRunSecurityScan: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify({ findings: [] }) }],
+      }),
+    }));
+
+    const { runHealthChecks } = await import('../../src/skill/health-snapshot');
+    const checks = await runHealthChecks('/tmp/test-project');
+
+    // Failed tool degrades to default zero counts; other tools continue.
+    expect(checks.entropy.deadExports).toBe(0);
+    expect(checks.entropy.deadFiles).toBe(0);
+    expect(checks.entropy.driftCount).toBe(0);
+    expect(checks.deps.circularDeps).toBe(0);
+    expect(checks.security.criticalCount).toBe(0);
+  });
 });
 
 describe('runGraphMetrics', () => {

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    setupFiles: ['tests/setup.ts'],
     testTimeout: 30_000,
     hookTimeout: 30_000,
     coverage: {

--- a/packages/core/src/entropy/fixers/suggestions.ts
+++ b/packages/core/src/entropy/fixers/suggestions.ts
@@ -124,18 +124,17 @@ export function generateSuggestions(
   drift?: DriftReport,
   patterns?: PatternReport
 ): SuggestionReport {
-  const suggestions: Suggestion[] = [];
+  let suggestions: Suggestion[] = [];
 
+  // Avoid spread-into-push; large reports can exceed V8's argument-count limit.
   if (deadCode) {
-    suggestions.push(...generateDeadCodeSuggestions(deadCode));
+    suggestions = suggestions.concat(generateDeadCodeSuggestions(deadCode));
   }
-
   if (drift) {
-    suggestions.push(...generateDriftSuggestions(drift));
+    suggestions = suggestions.concat(generateDriftSuggestions(drift));
   }
-
   if (patterns) {
-    suggestions.push(...generatePatternSuggestions(patterns));
+    suggestions = suggestions.concat(generatePatternSuggestions(patterns));
   }
 
   // Sort by priority

--- a/packages/core/tests/entropy/fixers/suggestions.test.ts
+++ b/packages/core/tests/entropy/fixers/suggestions.test.ts
@@ -285,4 +285,34 @@ describe('generateSuggestions', () => {
     };
     expect(generateSuggestions(largeReport).estimatedEffort).toBe('large');
   });
+
+  it('handles very large drift reports without RangeError', () => {
+    // Regression: a large monorepo can produce >100k drift entries from graph-based
+    // stale-edge detection. `suggestions.push(...subList)` spreads as call args, hitting
+    // V8's argument-count limit (~65k) and throwing "Maximum call stack size exceeded".
+    const driftCount = 200_000;
+    const driftReport: DriftReport = {
+      drifts: Array.from({ length: driftCount }, (_, i) => ({
+        type: 'api-signature' as const,
+        docFile: `/project/docs/api-${i}.md`,
+        line: i,
+        reference: `ref${i}`,
+        context: 'code-block' as const,
+        issue: 'SIGNATURE_CHANGED' as const,
+        details: 'd',
+        confidence: 'medium' as const,
+      })),
+      stats: {
+        docsScanned: 1,
+        referencesChecked: driftCount,
+        driftsFound: driftCount,
+        byType: { api: driftCount, example: 0, structure: 0 },
+      },
+      severity: 'high',
+    };
+
+    const result = generateSuggestions(undefined, driftReport);
+    expect(result.suggestions.length).toBe(driftCount);
+    expect(result.byPriority.medium.length).toBe(driftCount);
+  });
 });

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -35,6 +35,21 @@ export { migrateAgentConfig } from './agent/config-migration';
 export type { MigrationResult } from './agent/config-migration';
 export { createBackend } from './agent/backend-factory';
 
+// Re-export the workflow Zod schemas so other packages (cli config, tests)
+// can validate `agent.backends` / `agent.routing` against the same source
+// of truth used by the orchestrator at runtime.
+export { BackendDefSchema, RoutingConfigSchema, RoutingValueSchema } from './workflow/schema';
+
+// Re-export the local-model probe primitives so the craft skill family
+// (and any other downstream consumer) can resolve `/v1/models` against
+// the same fetch/normalize implementation the orchestrator runtime uses.
+export {
+  defaultFetchModels,
+  normalizeLocalModel,
+  LocalModelResolver,
+} from './agent/local-model-resolver';
+export type { LocalModelResolverOptions, ResolverLogger } from './agent/local-model-resolver';
+
 // Phase 1 sync-main helper public surface. Wired into the maintenance
 // scheduler in Phase 2; exported here so the CLI can wrap it directly.
 export { syncMain } from './maintenance/sync-main';


### PR DESCRIPTION
## Summary

- Replaces the always-mock craft LLM provider with a config-driven selector that consumes `agent.backends` from `harness.config.json` (single source of truth, shared with the orchestrator).
- Wires real providers: Anthropic, OpenAI, any OpenAI-compatible endpoint (Ollama, LM Studio, vLLM, LiteLLM), Claude CLI, mock, and a new **in-session** mode that defers prompts to the host chat session via a two-step MCP flow.
- Adds local-model support: `local`/`pi` backends accept `model: string | string[]`; the new `LazyLocalAdapter` probes `/v1/models` on first use and resolves to the first loaded model (mirrors the orchestrator's `LocalModelResolver` semantics).
- Adds `harness models probe` — focused primitive under a new `models` command group. The fuller LMLM (Local Model Lifecycle Manager) phases extend the same group with `status` / `suggest` / `pool` / `proposals` / etc.
- Adds `harness migrate backends` (under existing `migrate` command) — copies `agent.backends` from `harness.orchestrator.md` into `harness.config.json` so both files share one source of truth.
- Runtime fallback: if `harness.config.json` doesn't declare backends, the craft selector still reads them from `harness.orchestrator.md` and emits a one-time deprecation warning pointing at the migration command. Zero-friction migration.
- Strips "Hermes Phase N" from user-facing CLI/MCP descriptions (kept the same prefix in code comments, where it's useful provenance).

## Configuration shape

```jsonc
{
  "agent": {
    "backends": {
      "primary":  { "type": "claude",    "command": "claude" },
      "ollama":   { "type": "local",     "endpoint": "http://localhost:11434/v1", "model": ["deepseek-coder-v2", "qwen3:8b"] },
      "openai":   { "type": "openai",    "model": "gpt-4o-mini" },
      "remote":   { "type": "anthropic", "model": "claude-sonnet-4-6" }
    }
  },
  "craft": {
    "llm": { "backend": "ollama" }       // or { "mode": "in-session" | "mock" }
  }
}
```

Resolution: explicit `opts.mode` → `HARNESS_CRAFT_LLM` env → `craft.llm.backend`/`mode` → built-in default (`in-session`).

## Naming-craft in-session flow

`naming_craft({mode: 'in-session'})` walks the project, builds prompts, persists run state, and returns the prompts to the calling agent. The host model answers, then `naming_craft_finalize({runId, responses})` parses fenced JSON into 3-axis findings. Budget guard at 100 prompts.

## Test plan

- [x] Vitest: 3703/3703 tests pass (cli) + 24321/24321 (skills parity, includes platform-synced SKILL.md)
- [x] Typecheck clean
- [x] Lint clean
- [x] Build clean (cli + orchestrator dist regenerated)
- [x] Architecture check: no complexity-NEW errors (refactored `runModelsProbe` and `providerForResolution` into focused helpers)
- [x] Generated docs in sync (`pnpm generate-docs --check`)
- [x] Round-trip naming-craft → naming-craft-finalize integration test (lazy adapter, in-session, mock)
- [x] Migration: orchestrator.md → harness.config.json round-trip with `--dry-run` / `--force` semantics

## Files of note

**New**
- `packages/cli/src/shared/craft/llm/{in-session,adapters,lazy-local-adapter,orchestrator-md}.ts`
- `packages/cli/src/shared/craft/runs/store.ts`
- `packages/cli/src/commands/{migrate-backends,models}.ts`
- `packages/cli/tests/setup.ts` (vitest env defaults)
- Test files for each new surface

**Modified**
- `packages/cli/src/shared/craft/llm/provider.ts` — config-driven `getProvider()` + `resolveCraftLlmConfig()`
- `packages/cli/src/config/schema.ts` — extends `agent` with `backends` + `routing` (re-exported from orchestrator); adds `craft.llm`
- `packages/cli/src/naming-craft/index.ts` + `phases/critique.ts` — split into `collectPrompts` / `finalize`
- `packages/cli/src/mcp/{server.ts, tools/naming-craft.ts}` — adds `naming_craft_finalize` (now 81 tools)
- `packages/cli/src/commands/migrate.ts` — adds `backends` subcommand
- `packages/orchestrator/src/index.ts` — re-exports `BackendDefSchema`, `RoutingConfigSchema`, `LocalModelResolver`, `defaultFetchModels`, `normalizeLocalModel`
- `agents/skills/{claude-code,cursor,gemini-cli,codex}/naming-craft/SKILL.md` — documents the in-session flow + config + migration
- Various CLI/MCP descriptions — Hermes scrub