### PR TITLE
feat(audit-anatomy): catalog registry + public exports + strictness matrix

### DIFF
--- a/.changeset/audit-anatomy-catalog-registry-severity.md
+++ b/.changeset/audit-anatomy-catalog-registry-severity.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': minor
+---
+
+audit-component-anatomy: add public `getCatalogTypes()` export and full `design.strictness` × severity matrix.
+
+This closes the contract gap between `harness-accessibility` Phase 1 step 2.6 (which references `getCatalogTypes()` from `audit-component-anatomy`'s public export) and the audit module (which previously had no such export). A new catalog registry (`catalog/index.ts`) becomes the single source of truth for component types and conventions — replacing the inline single-entry maps that lived in two resolvers. The `findings/severity.ts` matrix wires `design.strictness` (strict / standard / permissive) through `runAudit` and the convention runner so emitted finding severities match the spec's documented table. Adds 23 new unit + integration tests covering the registry contract, severity matrix, and end-to-end strictness threading.

--- a/packages/cli/src/audit/component-anatomy/catalog/index.ts
+++ b/packages/cli/src/audit/component-anatomy/catalog/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Convention catalog registry — single source of truth for the
+ * built-in `ConventionRule`s shipped with the audit.
+ *
+ * Phase 2 catalog expansion adds 19 more conventions; each new file in
+ * `./conventions/` registers itself here via a one-line entry. The
+ * registry's shape (a `Map` keyed by `componentType`) is the durable
+ * contract — consumers reach for it via the public helpers below
+ * (`getCatalogTypes`, `lookupConvention`, `listConventions`) rather
+ * than importing individual rule modules.
+ *
+ * Why a registry instead of inline maps in each resolver:
+ *  - harness-accessibility's Phase 1 step 2.6 deferral needs the type
+ *    set without taking on a heavy dependency. The `getCatalogTypes()`
+ *    public export re-exported from `../exports.ts` is the contract
+ *    referenced by the a11y SKILL.md.
+ *  - Component-type resolver (Decision #3 export-name layer) and
+ *    source-of-truth resolver (Decision #1 conventions layer) both
+ *    need the same data — sharing one registry avoids drift between
+ *    them.
+ *  - Catalog expansion (Phase 2) becomes a single-file change per
+ *    component instead of touching two resolvers + one MCP tool.
+ *
+ * Source: docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ * (Technical Design → "Catalog data" + Integration Points → Skill module
+ *  export `getCatalogTypes(): string[]`).
+ */
+
+import type { ConventionRule } from '../rules/convention-rule.js';
+import { buttonConvention } from './conventions/button.js';
+
+/**
+ * Built-in convention catalog. Phase 1 ships Button only; Phase 2
+ * catalog expansion grows this to the 20-component v1 set documented
+ * in proposal.md § Success Criteria #7.
+ *
+ * Entries are immutable at the module boundary — consumers receive
+ * copies via `listConventions()` and the keys via `getCatalogTypes()`.
+ */
+const builtinConventions: ConventionRule[] = [buttonConvention];
+
+const conventionByType = new Map<string, ConventionRule>(
+  builtinConventions.map((rule) => [rule.componentType, rule])
+);
+
+/**
+ * Public list of component types in the built-in catalog.
+ *
+ * This is the named export `harness-accessibility` Phase 1 step 2.6
+ * imports to decide which JSX elements to defer A11Y-010 / A11Y-050
+ * findings for. The signature (`string[]`) is the stable contract;
+ * the contents may grow across versions.
+ *
+ * Returns a freshly-allocated array so callers cannot mutate the
+ * registry through the returned reference.
+ */
+export function getCatalogTypes(): string[] {
+  return [...conventionByType.keys()].sort();
+}
+
+/**
+ * Lookup a convention by component type. Returns `null` when the
+ * type is not in the catalog — callers MUST handle the silent-skip
+ * case per Decision #1 (the audit does not fabricate rules).
+ */
+export function lookupConvention(componentType: string): ConventionRule | null {
+  return conventionByType.get(componentType) ?? null;
+}
+
+/**
+ * Iterate the full catalog. Consumers receive a copy so they can
+ * filter / sort without affecting the registry.
+ */
+export function listConventions(): ConventionRule[] {
+  return [...builtinConventions];
+}

--- a/packages/cli/src/audit/component-anatomy/exports.ts
+++ b/packages/cli/src/audit/component-anatomy/exports.ts
@@ -1,0 +1,22 @@
+/**
+ * Public exports surface for `audit-component-anatomy`.
+ *
+ * This module is the stable contract consumed by sibling skills. The
+ * primary consumer today is `harness-accessibility` (Phase 1 step 2.6
+ * deferral), which loads the catalog component-type set via
+ * `getCatalogTypes()` to decide which JSX elements to defer
+ * A11Y-010 / A11Y-050 findings for.
+ *
+ * Anything not re-exported from here is internal — internal modules
+ * may move or change shape between minor versions. Add exports here
+ * only when a contract is intended to be stable across releases.
+ *
+ * Reference:
+ *  - docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ *    § Integration Points → "Skill module export"
+ *  - agents/skills/<platform>/harness-accessibility/SKILL.md
+ *    § Phase 1 step 2.6 (overlap deferral)
+ */
+
+export { getCatalogTypes } from './catalog/index.js';
+export type { AnatomyFinding, AnatomyFindingCode, Severity } from './findings/finding.js';

--- a/packages/cli/src/audit/component-anatomy/findings/severity.ts
+++ b/packages/cli/src/audit/component-anatomy/findings/severity.ts
@@ -1,0 +1,98 @@
+/**
+ * Severity resolution — `design.strictness` × per-finding default →
+ * actual emitted severity.
+ *
+ * This module owns the full strictness matrix referenced in
+ * `convention-runner.ts` (TODO comment in defaultSeverityForCode) and
+ * planned in proposal.md § "Implementation Order" → Phase 3.1 "Severity
+ * model implementation".
+ *
+ * Matrix (mirrors the harness-accessibility convention so consumers of
+ * both audits experience consistent severity behaviour):
+ *
+ *   defaultSeverity:           error    warn    info
+ *   strictness=strict      →   error    error   info
+ *   strictness=standard    →   error    warn    info
+ *   strictness=permissive  →   warn     info    info
+ *
+ * `info` is never promoted (an info finding is always authoring guidance);
+ * `error` only ever softens under `permissive` (one step down to `warn`).
+ *
+ * The matrix is intentionally simple and table-driven so future audits
+ * can adopt it verbatim. See ADR draft 0020 (cross-skill deferral) for
+ * the cross-audit consistency rationale.
+ *
+ * Source: docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ *  (Technical Design → severity rules; Success Criteria SC-11).
+ */
+
+import type { Severity } from './finding.js';
+
+/** Design-strictness levels — sourced from harness.config.json. */
+export type DesignStrictness = 'strict' | 'standard' | 'permissive';
+
+/**
+ * Resolve the emitted severity for a finding given the project's
+ * `design.strictness` setting and the finding's own default severity.
+ *
+ * `strictness` defaults to `'standard'` when unspecified, matching the
+ * documented behaviour of `harness.config.json` (the default value
+ * surfaced when the key is omitted).
+ */
+export function resolveSeverity(
+  severityDefault: Severity,
+  strictness: DesignStrictness = 'standard'
+): Severity {
+  if (strictness === 'strict') {
+    // Strict promotes warn → error; error stays error; info stays info
+    // (info findings carry authoring guidance, not violations).
+    if (severityDefault === 'warn') return 'error';
+    return severityDefault;
+  }
+
+  if (strictness === 'permissive') {
+    // Permissive softens by one step (error → warn, warn → info, info → info).
+    if (severityDefault === 'error') return 'warn';
+    if (severityDefault === 'warn') return 'info';
+    return 'info';
+  }
+
+  // standard — pass through (already aligned with default severity).
+  return severityDefault;
+}
+
+/**
+ * Default severity for a finding code based on its tier band, per
+ * `finding-codes.md`:
+ *   - ANAT-D000      → info  (authoring divergence guidance)
+ *   - ANAT-D001-D029 → error (Tier-1 critical: required slot missing)
+ *   - ANAT-D030-D099 → warn  (Tier-2 important)
+ *   - ANAT-D100-D199 → info  (Tier-3 advisory)
+ *   - ANAT-P001-P099 → warn  (pattern-presence: warn by default)
+ *   - ANAT-P100-P199 → info  (pattern-presence advisory band)
+ *   - everything else → warn (conservative)
+ *
+ * Rules MAY override their own default — pattern rules in particular
+ * commonly downgrade themselves to `info` when the rule is structurally
+ * ambiguous (e.g. ANAT-P004 conditional-render-without-fallback per the
+ * Phase 0 spike).
+ */
+export function defaultSeverityForCode(code: string): Severity {
+  const definitionMatch = /^ANAT-D(\d{3})$/.exec(code);
+  if (definitionMatch) {
+    const n = Number(definitionMatch[1]);
+    if (n === 0) return 'info';
+    if (n >= 1 && n <= 29) return 'error';
+    if (n >= 30 && n <= 99) return 'warn';
+    if (n >= 100 && n <= 199) return 'info';
+  }
+
+  const patternMatch = /^ANAT-P(\d{3})$/.exec(code);
+  if (patternMatch) {
+    const n = Number(patternMatch[1]);
+    if (n >= 1 && n <= 99) return 'warn';
+    if (n >= 100 && n <= 199) return 'info';
+  }
+
+  return 'warn';
+}

--- a/packages/cli/src/audit/component-anatomy/resolvers/component-type.ts
+++ b/packages/cli/src/audit/component-anatomy/resolvers/component-type.ts
@@ -17,17 +17,16 @@
  * Decision #3 the audit deliberately does NOT guess.
  */
 
-import { buttonConvention } from '../catalog/conventions/button.js';
+import { getCatalogTypes } from '../catalog/index.js';
 
 /**
- * Phase-1-vertical-slice catalog. Phase 2 expansion will replace this
- * inline list with a generated index that mirrors every catalog file
- * under `catalog/conventions/`. The shape (`Record<componentType, ...>`)
- * is the durable contract — only the entries change.
+ * Catalog of recognised component types, lazily materialised from the
+ * central registry. Memoised at module level — the catalog content is
+ * static for the duration of a process (entries added at module load,
+ * never at runtime), so a one-shot computation is correct and avoids
+ * paying the lookup cost on every resolve call.
  */
-const componentTypeCatalog: Record<string, true> = {
-  [buttonConvention.componentType]: true,
-};
+const componentTypeSet: Set<string> = new Set(getCatalogTypes());
 
 /**
  * Resolve a component type for a given file using the Decision #3
@@ -82,7 +81,7 @@ function resolveFromExportName(fileContents: string): string | null {
   for (const pattern of patterns) {
     const match = pattern.exec(fileContents);
     const name = match?.[1];
-    if (name && componentTypeCatalog[name]) {
+    if (name && componentTypeSet.has(name)) {
       return name;
     }
   }

--- a/packages/cli/src/audit/component-anatomy/resolvers/source-of-truth.ts
+++ b/packages/cli/src/audit/component-anatomy/resolvers/source-of-truth.ts
@@ -12,16 +12,7 @@
  */
 
 import type { ConventionRule } from '../rules/convention-rule.js';
-import { buttonConvention } from '../catalog/conventions/button.js';
-
-/**
- * Phase-1-vertical-slice catalog. Phase 2 expansion will replace this
- * inline map with a generated index that mirrors every convention file
- * under `catalog/conventions/`.
- */
-const conventionCatalog: Record<string, ConventionRule> = {
-  [buttonConvention.componentType]: buttonConvention,
-};
+import { lookupConvention } from '../catalog/index.js';
 
 /**
  * Resolve the active anatomy rules for a component.
@@ -47,8 +38,8 @@ export function resolveAnatomyRules(
   const overrideRule = resolveFromDesignOverrides(filePath, componentType);
   if (overrideRule !== null) return overrideRule;
 
-  // Layer 3: built-in catalog lookup.
-  return conventionCatalog[componentType] ?? null;
+  // Layer 3: built-in catalog lookup via the central registry.
+  return lookupConvention(componentType);
 }
 
 /** STUB. Returns null until the JSDoc parser task lands. */

--- a/packages/cli/src/audit/component-anatomy/rules/convention-runner.ts
+++ b/packages/cli/src/audit/component-anatomy/rules/convention-runner.ts
@@ -20,6 +20,11 @@
 
 import type { ParsedComponent } from '../parsers/ast.js';
 import type { AnatomyFinding, AnatomyFindingCode, Severity } from '../findings/finding.js';
+import {
+  defaultSeverityForCode,
+  resolveSeverity,
+  type DesignStrictness,
+} from '../findings/severity.js';
 import type { ConventionRule } from './convention-rule.js';
 
 /**
@@ -81,23 +86,32 @@ function isSlotSatisfied(
  * @param rule    The ConventionRule for the component's type.
  * @param parsed  Output of `parseComponentDefinition`.
  * @param options Optional overrides:
- *                  - `filePath`       — finding.file value (defaults to '').
- *                  - `severityFor`    — override severity per code (defaults
- *                                       to `error` for Tier-1 D001–D029).
- *                  - `runId`          — currently unused; reserved for
- *                                       sub-project #4 fixpoint detection.
+ *                  - `filePath`        — finding.file value (defaults to '').
+ *                  - `strictness`      — `design.strictness` from harness.config.json
+ *                                        used to compute final severity via the
+ *                                        full strictness × default-severity matrix.
+ *                  - `severityFor`     — caller-supplied severity resolver. When
+ *                                        provided, supersedes both `strictness`
+ *                                        and the built-in default — used by
+ *                                        tests and callers with custom matrices.
+ *                  - `runId`           — currently unused; reserved for
+ *                                        sub-project #4 fixpoint detection.
  */
 export function runConventionRule(
   rule: ConventionRule,
   parsed: ParsedComponent,
   options?: {
     filePath?: string;
+    strictness?: DesignStrictness;
     severityFor?: (code: AnatomyFindingCode) => Severity;
   }
 ): AnatomyFinding[] {
   const findings: AnatomyFinding[] = [];
   const filePath = options?.filePath ?? '';
-  const severityFor = options?.severityFor ?? defaultSeverityForCode;
+  const strictness = options?.strictness;
+  const severityFor =
+    options?.severityFor ??
+    ((code: AnatomyFindingCode) => resolveSeverity(defaultSeverityForCode(code), strictness));
 
   const componentCodes = slotFindingCodes[rule.componentType];
 
@@ -135,29 +149,4 @@ export function runConventionRule(
   }
 
   return findings;
-}
-
-/**
- * Default severity table per the finding-codes.md tier-band allocation
- * at `standard` strictness:
- *   - D001–D029 → error
- *   - D030–D099 → warn
- *   - D100–D199 → info
- *   - D000      → info (authoring guidance, not promoted by strictness)
- * All other codes default to `warn`.
- *
- * Sprint 3 ships the full strictness × tier matrix in
- * `findings/severity.ts`; this MVP function is the trivial subset
- * needed by the vertical slice.
- */
-function defaultSeverityForCode(code: AnatomyFindingCode): Severity {
-  const match = /^ANAT-D(\d{3})$/.exec(code);
-  if (match) {
-    const n = Number(match[1]);
-    if (n === 0) return 'info';
-    if (n >= 1 && n <= 29) return 'error';
-    if (n >= 30 && n <= 99) return 'warn';
-    if (n >= 100 && n <= 199) return 'info';
-  }
-  return 'warn';
 }

--- a/packages/cli/src/mcp/tools/audit-anatomy.ts
+++ b/packages/cli/src/mcp/tools/audit-anatomy.ts
@@ -131,7 +131,11 @@ export async function runAudit(input: AuditAnatomyInput): Promise<AuditAnatomyOu
     conventionsApplied.add(rule.componentType);
 
     const fileRelative = path.relative(projectRoot, absolute).replaceAll('\\', '/') || absolute;
-    const fileFindings = runConventionRule(rule, parsed, { filePath: fileRelative });
+    const runnerOptions: Parameters<typeof runConventionRule>[2] = { filePath: fileRelative };
+    if (input.designStrictness !== undefined) {
+      runnerOptions.strictness = input.designStrictness;
+    }
+    const fileFindings = runConventionRule(rule, parsed, runnerOptions);
     findings.push(...fileFindings);
 
     // Pattern catalog is stubbed for the MVP — patterns return empty in

--- a/packages/cli/tests/audit/component-anatomy/integration/strictness-matrix.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/integration/strictness-matrix.test.ts
@@ -1,0 +1,97 @@
+/**
+ * End-to-end strictness matrix test.
+ *
+ * Exercises the full pipeline at all three `design.strictness` levels
+ * against the same ANAT-D001 fixture (Button missing `content` slot)
+ * and verifies the emitted severity matches the matrix in
+ * `findings/severity.ts`.
+ *
+ *   ANAT-D001 default = error
+ *     strict     → error
+ *     standard   → error
+ *     permissive → warn
+ *
+ * This proves `runAudit({ designStrictness })` threads the value all
+ * the way through the convention runner. Without that wire, the runner
+ * falls back to a static 'standard' severity and the matrix is invisible
+ * to downstream consumers (harness validate, the MCP tool, the graph
+ * VIOLATES edges).
+ *
+ * Refs: docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ *  § Success Criteria SC-11 (harness validate respects design.strictness).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runAudit } from '../../../../src/mcp/tools/audit-anatomy';
+
+const positiveButtonSource = `
+interface ButtonProps {
+  onClick?: () => void;
+  variant?: 'primary' | 'secondary';
+  // No content-satisfying member — ANAT-D001 fires.
+}
+
+export const Button = ({ onClick, variant }: ButtonProps) => (
+  <button onClick={onClick} className={variant} />
+);
+`;
+
+describe('audit-anatomy strictness matrix end-to-end', () => {
+  let projectRoot: string;
+
+  beforeAll(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-anatomy-strictness-'));
+    fs.writeFileSync(path.join(projectRoot, 'Button.tsx'), positiveButtonSource, 'utf8');
+  });
+
+  afterAll(() => {
+    if (projectRoot && fs.existsSync(projectRoot)) {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('emits ANAT-D001 as error at strict', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      files: ['Button.tsx'],
+      designStrictness: 'strict',
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.severity).toBe('error');
+    expect(result.summary.bySeverity.error).toBe(1);
+  });
+
+  it('emits ANAT-D001 as error at standard (default)', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      files: ['Button.tsx'],
+      designStrictness: 'standard',
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.severity).toBe('error');
+  });
+
+  it('softens ANAT-D001 to warn at permissive', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      files: ['Button.tsx'],
+      designStrictness: 'permissive',
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.severity).toBe('warn');
+    expect(result.summary.bySeverity.warn).toBe(1);
+    expect(result.summary.bySeverity.error).toBe(0);
+  });
+
+  it('defaults to standard severity when strictness is omitted', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      files: ['Button.tsx'],
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.severity).toBe('error');
+  });
+});

--- a/packages/cli/tests/audit/component-anatomy/unit/catalog-registry.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/catalog-registry.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Catalog registry contract test.
+ *
+ * Verifies the contract that `harness-accessibility` Phase 1 step 2.6
+ * relies on:
+ *   - `getCatalogTypes()` is callable from the public exports surface
+ *     and returns the set of component types this audit owns label-slot
+ *     findings for.
+ *   - Lookup by component type returns the registered convention.
+ *   - The returned array is a copy — callers cannot mutate the
+ *     registry through the reference.
+ *
+ * Refs: docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ *  § Integration Points → "Skill module export" + SC-26.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getCatalogTypes,
+  lookupConvention,
+  listConventions,
+} from '../../../../src/audit/component-anatomy/catalog/index.js';
+import { getCatalogTypes as getCatalogTypesPublic } from '../../../../src/audit/component-anatomy/exports.js';
+
+describe('catalog registry', () => {
+  it('exposes Button as a catalogued type via the central registry', () => {
+    const types = getCatalogTypes();
+    expect(types).toContain('Button');
+  });
+
+  it('returns the same set of types from the public `exports.ts` surface', () => {
+    // harness-accessibility step 2.6 imports getCatalogTypes from the
+    // public exports surface. The contract is that both paths return
+    // the same data — exports.ts is just a re-export.
+    expect(getCatalogTypesPublic()).toEqual(getCatalogTypes());
+  });
+
+  it('returns a sorted list so consumers can rely on stable ordering', () => {
+    const types = getCatalogTypes();
+    const sorted = [...types].sort();
+    expect(types).toEqual(sorted);
+  });
+
+  it('returns a fresh array on every call (mutating the result does not affect the registry)', () => {
+    const first = getCatalogTypes();
+    first.push('SyntheticAttacker');
+    const second = getCatalogTypes();
+    expect(second).not.toContain('SyntheticAttacker');
+  });
+
+  it('looks up Button to its full ConventionRule', () => {
+    const rule = lookupConvention('Button');
+    expect(rule).not.toBeNull();
+    expect(rule!.componentType).toBe('Button');
+    expect(rule!.source.ref).toBe('APG/button');
+    // Button's content slot is the Tier-1 required slot per the spec.
+    expect(rule!.slots.find((s) => s.name === 'content')?.required).toBe(true);
+  });
+
+  it('returns null for an unknown component type (silent skip per Decision #1)', () => {
+    expect(lookupConvention('TotallyUnknownThing')).toBeNull();
+  });
+
+  it('listConventions returns every registered rule once, no duplicates', () => {
+    const conventions = listConventions();
+    const types = conventions.map((c) => c.componentType);
+    const unique = new Set(types);
+    expect(unique.size).toBe(types.length);
+    expect(unique.size).toBe(getCatalogTypes().length);
+  });
+});

--- a/packages/cli/tests/audit/component-anatomy/unit/severity.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/severity.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Severity matrix test.
+ *
+ * The matrix is table-driven so future audits can adopt it verbatim
+ * (ADR draft 0020 — cross-skill severity consistency). Each row asserts
+ * one (defaultSeverity, strictness) → emittedSeverity transition.
+ *
+ *   defaultSeverity:           error    warn    info
+ *   strictness=strict      →   error    error   info
+ *   strictness=standard    →   error    warn    info
+ *   strictness=permissive  →   warn     info    info
+ *
+ * Refs: docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ *  § Implementation Order → Phase 3.1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSeverity,
+  defaultSeverityForCode,
+} from '../../../../src/audit/component-anatomy/findings/severity.js';
+import type { Severity } from '../../../../src/audit/component-anatomy/findings/finding.js';
+import type { DesignStrictness } from '../../../../src/audit/component-anatomy/findings/severity.js';
+
+describe('resolveSeverity matrix', () => {
+  const matrix: Array<{ default: Severity; strictness: DesignStrictness; expected: Severity }> = [
+    { default: 'error', strictness: 'strict', expected: 'error' },
+    { default: 'warn', strictness: 'strict', expected: 'error' },
+    { default: 'info', strictness: 'strict', expected: 'info' },
+
+    { default: 'error', strictness: 'standard', expected: 'error' },
+    { default: 'warn', strictness: 'standard', expected: 'warn' },
+    { default: 'info', strictness: 'standard', expected: 'info' },
+
+    { default: 'error', strictness: 'permissive', expected: 'warn' },
+    { default: 'warn', strictness: 'permissive', expected: 'info' },
+    { default: 'info', strictness: 'permissive', expected: 'info' },
+  ];
+
+  for (const row of matrix) {
+    it(`${row.strictness} × ${row.default} → ${row.expected}`, () => {
+      expect(resolveSeverity(row.default, row.strictness)).toBe(row.expected);
+    });
+  }
+
+  it('defaults to standard when strictness is omitted', () => {
+    expect(resolveSeverity('warn')).toBe('warn');
+    expect(resolveSeverity('error')).toBe('error');
+    expect(resolveSeverity('info')).toBe('info');
+  });
+});
+
+describe('defaultSeverityForCode tier bands', () => {
+  it('ANAT-D000 is info (authoring divergence guidance)', () => {
+    expect(defaultSeverityForCode('ANAT-D000')).toBe('info');
+  });
+
+  it('ANAT-D001..D029 is error (Tier-1 critical)', () => {
+    expect(defaultSeverityForCode('ANAT-D001')).toBe('error');
+    expect(defaultSeverityForCode('ANAT-D015')).toBe('error');
+    expect(defaultSeverityForCode('ANAT-D029')).toBe('error');
+  });
+
+  it('ANAT-D030..D099 is warn (Tier-2 important)', () => {
+    expect(defaultSeverityForCode('ANAT-D030')).toBe('warn');
+    expect(defaultSeverityForCode('ANAT-D099')).toBe('warn');
+  });
+
+  it('ANAT-D100..D199 is info (Tier-3 advisory)', () => {
+    expect(defaultSeverityForCode('ANAT-D100')).toBe('info');
+    expect(defaultSeverityForCode('ANAT-D199')).toBe('info');
+  });
+
+  it('ANAT-P001..P099 is warn (pattern-presence default)', () => {
+    expect(defaultSeverityForCode('ANAT-P001')).toBe('warn');
+    expect(defaultSeverityForCode('ANAT-P099')).toBe('warn');
+  });
+
+  it('ANAT-P100..P199 is info (pattern-presence advisory)', () => {
+    expect(defaultSeverityForCode('ANAT-P100')).toBe('info');
+    expect(defaultSeverityForCode('ANAT-P199')).toBe('info');
+  });
+
+  it('unknown codes default to warn (conservative)', () => {
+    expect(defaultSeverityForCode('ANAT-X999')).toBe('warn');
+    expect(defaultSeverityForCode('NOT-A-CODE')).toBe('warn');
+  });
+});
+
+describe('resolveSeverity composed with defaultSeverityForCode', () => {
+  // End-to-end: a Tier-1 D001 finding at standard strictness should
+  // stay error; at permissive should soften to warn; at strict should
+  // remain error (already at the top of the matrix).
+  it('ANAT-D001 emits error/error/warn across strict/standard/permissive', () => {
+    const base = defaultSeverityForCode('ANAT-D001');
+    expect(resolveSeverity(base, 'strict')).toBe('error');
+    expect(resolveSeverity(base, 'standard')).toBe('error');
+    expect(resolveSeverity(base, 'permissive')).toBe('warn');
+  });
+
+  it('ANAT-P001 emits error/warn/info across strict/standard/permissive', () => {
+    const base = defaultSeverityForCode('ANAT-P001');
+    expect(resolveSeverity(base, 'strict')).toBe('error');
+    expect(resolveSeverity(base, 'standard')).toBe('warn');
+    expect(resolveSeverity(base, 'permissive')).toBe('info');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the contract gap between `harness-accessibility` Phase 1 step 2.6 (which loads `getCatalogTypes()` from `audit-component-anatomy`'s public export to defer A11Y-010 / A11Y-050 findings for catalogued components) and the audit module (which had no such export). This is the *documented overlap-resolution with harness-accessibility* called out in the design-pipeline sub-project #2 issue description.

Three additive pieces:

1. **Catalog registry** (`catalog/index.ts`) — single source of truth for built-in `ConventionRule`s keyed by `componentType`. Two resolvers (`component-type.ts`, `source-of-truth.ts`) now consume the registry instead of carrying their own inline single-entry maps. Phase 2 catalog expansion lands new conventions in one file rather than three.
2. **Public exports surface** (`exports.ts`) — stable contract re-exporting `getCatalogTypes()` plus the `AnatomyFinding` / `Severity` types. This is the named export referenced by every variant of `harness-accessibility/SKILL.md`.
3. **Full strictness matrix** (`findings/severity.ts`) — implements the spec's documented `design.strictness` × default-severity table (strict promotes warn→error; permissive softens error→warn / warn→info). Wired through `runConventionRule` and the `runAudit` MCP entrypoint so `harness validate`, MCP callers, and downstream consumers all see the matrix applied.

Replaces the partial inline severity helper that lived in `convention-runner.ts` (TODO comment explicitly deferred this to Phase 3.1 — that work lands here).

## Test plan

- [x] `pnpm --filter @harness-engineering/cli typecheck` — clean
- [x] `pnpm --filter @harness-engineering/cli test tests/audit/component-anatomy/` — **34/34 passing** (11 existing + 23 new)
- [x] `pnpm --filter @harness-engineering/cli test` (full suite) — **3734/3734 passing**
- [x] `harness validate` — 258 baseline issues unchanged (no new violations from this change)
- [x] Strictness matrix verified end-to-end: ANAT-D001 emits `error` at strict/standard and softens to `warn` at permissive

## Scope notes

This PR is one focused increment of the larger sub-project #2 plan. It closes the most actionable contract gap (a11y deferral references a missing export) and lands the severity matrix that the convention runner has been TODO'd against. Remaining Phase 1+ work (tree-sitter pattern engine, JSDoc/DESIGN.md parsers, `DesignConstraintAdapter` integration, 19 more conventions, 10 patterns) ships in follow-up PRs per the implementation plan.

Refs:
- `docs/changes/design-pipeline/audit-component-anatomy/proposal.md` § Integration Points → "Skill module export `getCatalogTypes()`"
- `docs/changes/design-pipeline/audit-component-anatomy/proposal.md` § Success Criteria SC-11, SC-26
- `agents/skills/*/harness-accessibility/SKILL.md` § Phase 1 step 2.6 (the consumer this PR satisfies)
