### PR TITLE
feat(local-models): scaffold LMLM Phase 0 — package + config block

### DIFF
--- a/.changeset/lmlm-phase0-scaffolding.md
+++ b/.changeset/lmlm-phase0-scaffolding.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/local-models': patch
+'@harness-engineering/types': minor
+'@harness-engineering/cli': minor
+---
+
+Scaffolds the Local Model Lifecycle Manager (LMLM) — Phase 0.
+
+- New package `@harness-engineering/local-models` (empty barrel, no business logic yet).
+- New types in `@harness-engineering/types`: `LocalModelsConfig`, `LocalModelsPoolConfig`, `LocalModelsRefreshConfig`, `LocalModelsInstallerConfig`, `LocalModelsHardwareOverride`, plus platform/installer unions.
+- New optional `localModels` block on `HarnessConfigSchema` in the CLI, with Zod defaults that match the spec (24h refresh, 100GB budget, Ollama installer, opt-in disabled by default).
+
+Disabled by default; `harness validate` on existing configs remains green. Hardware detection, ranking, pool management, installer, proposal lifecycle, scheduler, HTTP/WS surfaces, CLI commands, and dashboard panel land in subsequent phases per `docs/changes/local-model-lifecycle-manager/proposal.md`.

--- a/docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase0-scaffolding-plan.md
+++ b/docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase0-scaffolding-plan.md
@@ -1,0 +1,145 @@
+# Plan: LMLM Phase 0 — Package Scaffolding
+
+**Date:** 2026-05-27 | **Spec:** `docs/changes/local-model-lifecycle-manager/proposal.md` (Phase 0 only) | **Tasks:** 7 | **Time:** ~45 min | **Integration Tier:** small | **Session:** `changes--local-model-lifecycle-manager--phase0`
+
+## Goal
+
+Stand up the empty `@harness-engineering/local-models` package wired into the monorepo with no business logic. Add the `LocalModelsConfig` type stub in `@harness-engineering/types` and the corresponding optional config block to the CLI schema so a config file may declare the block without failing validation. After this phase: `pnpm build && pnpm test && pnpm typecheck` green; `harness validate` passes on a config with `localModels` absent (N4) and a config with the block present.
+
+## Phase 0 Scope (from spec, Phase 0 paragraph, lines 390–401)
+
+In:
+
+- Create `packages/local-models/` with `package.json`, `tsconfig.json`, `tsconfig.build.json`, `vitest.config.mts`, empty `src/index.ts`, smoke test
+- Register in monorepo via `tsconfig.json` references (workspace glob `packages/*` already picks up the dir)
+- Wire workspace dependency into `packages/cli` and `packages/orchestrator` (devDep only — no imports yet)
+- Add `LocalModelsConfig` type stub in `packages/types/src/local-models.ts` + barrel re-export
+- Extend CLI `HarnessConfigSchema` with optional `localModels: LocalModelsConfigSchema.optional()` field
+
+Out of Phase 0 (deferred to later phases):
+
+- Any hardware-detection, ranker, installer, pool, proposal, scheduler logic
+- Any orchestrator wiring beyond a workspace dep declaration
+- Any HTTP routes, WS topics, dashboard panel, CLI commands
+- Any proposal-schema refactor (D11 lands in Phase 5a)
+
+## Observable Truths (Acceptance Criteria — Phase 0 only)
+
+1. **OT1**: `pnpm install` from repo root succeeds; `@harness-engineering/local-models` resolves as a workspace package.
+2. **OT2**: `pnpm --filter @harness-engineering/local-models build` produces `packages/local-models/dist/index.{js,mjs,d.ts}`.
+3. **OT3**: `pnpm --filter @harness-engineering/local-models test` runs the smoke test and reports it green.
+4. **OT4**: `pnpm --filter @harness-engineering/local-models typecheck` returns 0.
+5. **OT5**: `pnpm --filter @harness-engineering/types build && pnpm --filter @harness-engineering/cli typecheck` are green after `LocalModelsConfig` is added.
+6. **OT6**: A config with no `localModels` block parses successfully (N4 from success criteria).
+7. **OT7**: A config with `localModels: { enabled: false }` parses successfully and `enabled` defaults to `false` when absent.
+8. **OT8**: `harness validate` (run from repo root) passes against the project's own `harness.config.json` (which has no `localModels` block).
+9. **OT9 (architecture)**: New package is added to `tsconfig.json` references and conforms to the existing layer model. Because v1 has no cross-package imports yet, no entry in `harness.config.json` `layers` is required in Phase 0; this lands in Phase 1+ when the orchestrator begins importing the package.
+
+## Skill Recommendations
+
+From `docs/changes/local-model-lifecycle-manager/SKILLS.md`:
+
+- `ts-zod-integration` (apply) — used to define `LocalModelsConfigSchema` with sensible defaults
+
+## File Map
+
+- CREATE `packages/local-models/package.json`
+- CREATE `packages/local-models/tsconfig.json`
+- CREATE `packages/local-models/tsconfig.build.json`
+- CREATE `packages/local-models/vitest.config.mts`
+- CREATE `packages/local-models/src/index.ts` (empty barrel + a single exported VERSION string so the smoke test has something concrete to assert)
+- CREATE `packages/local-models/tests/smoke.test.ts`
+- CREATE `packages/local-models/README.md` (one-paragraph stub pointing at the spec)
+- MODIFY `tsconfig.json` (root) — add `{ "path": "./packages/local-models" }` to `references`
+- MODIFY `packages/cli/package.json` — add `@harness-engineering/local-models` to `devDependencies` (workspace:\*)
+- MODIFY `packages/orchestrator/package.json` — add `@harness-engineering/local-models` to `devDependencies` (workspace:\*)
+- CREATE `packages/types/src/local-models.ts` — `LocalModelsConfig` interface + helper types
+- MODIFY `packages/types/src/index.ts` — re-export from `./local-models.js`
+- MODIFY `packages/cli/src/config/schema.ts` — add `LocalModelsConfigSchema` (zod) + add `localModels` field on `HarnessConfigSchema`
+- CREATE `.changeset/lmlm-phase0-scaffolding.md`
+
+## Skeleton
+
+1. Package scaffold files (~3 tasks)
+2. Workspace registration (~1 task)
+3. Types stub + CLI schema (~2 tasks)
+4. Changeset + verification gate (~1 task)
+
+**Estimated total:** 7 tasks, ~45 min.
+
+## Uncertainties
+
+- **[ASSUMPTION]** Workspace `pnpm-workspace.yaml` glob `packages/*` automatically picks up the new package; no edit to that file required.
+- **[ASSUMPTION]** The `harness.config.json` JSON schema referenced in the spec lives in the CLI's Zod schema (`packages/cli/src/config/schema.ts`), not in a separate JSON-Schema file. Confirmed by reading the file.
+- **[DEFERRABLE]** Whether the dashboard package also gets a `devDependencies` workspace declaration is deferred to Phase 8 (dashboard) — Phase 0 only wires cli + orchestrator.
+- **[DEFERRABLE]** Whether to add a layer entry for `local-models` to `harness.config.json` is deferred until Phase 1 (hardware detection) introduces actual code that other packages will import.
+
+## Tasks
+
+### Task 1: Create the package scaffold (package.json, tsconfigs, vitest config)
+
+**Depends on:** none | **Files:** `packages/local-models/{package.json,tsconfig.json,tsconfig.build.json,vitest.config.mts}`
+
+1. Mirror `packages/types/package.json` (tsup build, vitest test, lint, typecheck, clean scripts) with name `@harness-engineering/local-models`, version `0.1.0`, deps: `zod ^3.25.76`, devDeps: `tsup`, `vitest`, `@vitest/coverage-v8`.
+2. Mirror `packages/types/tsconfig.json` (composite) and `packages/types/tsconfig.build.json` (incremental off).
+3. Mirror `packages/types/vitest.config.mts`.
+
+### Task 2: Create empty barrel + smoke test
+
+**Depends on:** Task 1 | **Files:** `packages/local-models/src/index.ts`, `packages/local-models/tests/smoke.test.ts`, `packages/local-models/README.md`
+
+1. `src/index.ts` exports `export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const;` plus an `export const LOCAL_MODELS_VERSION = '0.1.0' as const;`. No business logic.
+2. `tests/smoke.test.ts` imports the constants and asserts their values.
+3. `README.md` is one paragraph: "Hardware-aware local-model recommender + pool manager. See `docs/changes/local-model-lifecycle-manager/proposal.md`. Phase 0 — scaffolding only; no business logic yet."
+
+### Task 3: Register in root tsconfig + workspace dep declarations
+
+**Depends on:** Task 1 | **Files:** `tsconfig.json` (root), `packages/cli/package.json`, `packages/orchestrator/package.json`
+
+1. Add `{ "path": "./packages/local-models" }` to the `references` array in root `tsconfig.json`.
+2. In `packages/cli/package.json`, add `"@harness-engineering/local-models": "workspace:*"` to `devDependencies` (keep sorted).
+3. In `packages/orchestrator/package.json`, same as above.
+
+### Task 4: Add `LocalModelsConfig` type stub to `@harness-engineering/types`
+
+**Depends on:** none | **Files:** `packages/types/src/local-models.ts`, `packages/types/src/index.ts`
+
+1. Create `packages/types/src/local-models.ts` with the `LocalModelsConfig` shape from the spec's Config schema (lines 178–198): `enabled`, `pool: { diskBudgetGb, allowedOrgs, allowedFamilies }`, `refresh: { intervalMs, proposalThreshold, jitterMs }`, `installer: { backend, ollamaEndpoint }`, `hardware: { override? }`. All fields optional except none — the entire block is optional. Add JSDoc on each field referencing the spec decision (D1, D9, D14).
+2. Re-export from `packages/types/src/index.ts` via `export * from './local-models.js';`.
+
+### Task 5: Add `LocalModelsConfigSchema` to CLI schema and wire onto `HarnessConfigSchema`
+
+**Depends on:** Task 4 | **Files:** `packages/cli/src/config/schema.ts`
+
+1. Add a `LocalModelsConfigSchema` (zod) mirroring the type from Task 4, with sensible defaults (`enabled: false`, `pool.diskBudgetGb: 100`, `refresh.intervalMs: 86_400_000`, `refresh.proposalThreshold: 5`, `refresh.jitterMs: 600_000`, `installer.backend: 'ollama'`, `installer.ollamaEndpoint: 'http://localhost:11434'`).
+2. `refresh.intervalMs` floor: `.min(3_600_000, 'minimum 1h')` per D9.
+3. `pool.allowedOrgs: z.array(z.string()).default([])`, `pool.allowedFamilies: z.array(z.string()).default([])`.
+4. `installer.backend: z.enum(['ollama', 'advisory']).default('ollama')`.
+5. Add `localModels: LocalModelsConfigSchema.optional()` as a new field on `HarnessConfigSchema` (after `osvGuard`).
+
+### Task 6: Add changeset entry
+
+**Depends on:** Tasks 1–5 | **Files:** `.changeset/lmlm-phase0-scaffolding.md`
+
+1. Standard changeset with `patch` bumps for `@harness-engineering/local-models` (new), `@harness-engineering/types` (new export), `@harness-engineering/cli` (new schema field).
+2. Body: "Scaffolds the Local Model Lifecycle Manager package (Phase 0). No runtime behavior; foundation for hardware detection, ranking, pool management, and proposal lifecycle in subsequent phases."
+
+### Task 7: Verification gate — install, build, typecheck, test, validate
+
+**Depends on:** Tasks 1–6 | **Files:** none
+
+1. `pnpm install` at repo root.
+2. `pnpm --filter @harness-engineering/local-models build && pnpm --filter @harness-engineering/local-models test && pnpm --filter @harness-engineering/local-models typecheck` — all green (OT2–OT4).
+3. `pnpm --filter @harness-engineering/types build` — green (OT5 prerequisite).
+4. `pnpm --filter @harness-engineering/cli typecheck` — green (OT5).
+5. `pnpm exec harness validate` from repo root — green (OT8).
+6. If any step fails: stop, diagnose, fix, re-run.
+
+## Integration Notes
+
+This phase's integration footprint is intentionally minimal:
+
+- **Registration**: workspace package + tsconfig references + cli/orchestrator devDep declarations
+- **Knowledge graph**: no new concepts entered in Phase 0; the spec's listed concepts (Local Model Pool, Model Proposal, etc.) land when their implementations land
+- **ADRs**: none in Phase 0; the spec's seven ADRs land alongside the code that justifies them (Phases 3, 5, 6 primarily)
+- **Docs**: none in Phase 0 beyond the package README stub; the `local-model-lifecycle.md` knowledge entry and operator guide land in Phase 9

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -599,6 +599,64 @@ export const CraftConfigSchema = z.object({
     .optional(),
 });
 
+/**
+ * Schema for the Local Model Lifecycle Manager (LMLM) config block.
+ *
+ * Phase 0 stub — declares the shape so configs may reference it. Runtime
+ * behavior (hardware detect, ranker, pool, installer, proposal loop) lands
+ * in Phases 1–9. Setting `enabled: false` (default) makes LMLM byte-identical
+ * to the prior orchestrator (success-criterion F9 / N4).
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md
+ */
+export const LocalModelsHardwareOverrideSchema = z.object({
+  platform: z.enum(['macos', 'nvidia', 'cpu']),
+  vramGb: z.number().positive(),
+  bandwidthGbps: z.number().positive(),
+  ramGb: z.number().positive().optional(),
+  gpuName: z.string().optional(),
+  cpuName: z.string().optional(),
+});
+
+export const LocalModelsPoolConfigSchema = z.object({
+  /** Hard ceiling on total on-disk size of installed pool members. */
+  diskBudgetGb: z.number().positive().default(100),
+  /** Hugging Face org allowlist. Models outside these orgs cannot be installed (D1). */
+  allowedOrgs: z.array(z.string()).default([]),
+  /** Optional family allowlist; empty means "all families under the allowed orgs". */
+  allowedFamilies: z.array(z.string()).default([]),
+});
+
+export const LocalModelsRefreshConfigSchema = z.object({
+  /** Re-rank cadence in ms. Floor 1h to keep HF API usage civil (D9). */
+  intervalMs: z.number().int().min(3_600_000, 'minimum 1h').default(86_400_000),
+  /** Minimum score delta to emit a swap proposal (D2). */
+  proposalThreshold: z.number().nonnegative().default(5),
+  /** Random jitter added to the interval to avoid thundering herd (D9). */
+  jitterMs: z.number().int().nonnegative().default(600_000),
+});
+
+export const LocalModelsInstallerConfigSchema = z.object({
+  /** `'ollama'` performs auto-install via REST; `'advisory'` emits copy-paste only (D4). */
+  backend: z.enum(['ollama', 'advisory']).default('ollama'),
+  /** Ollama REST endpoint. Only consulted when `backend === 'ollama'`. */
+  ollamaEndpoint: z.string().url().default('http://localhost:11434'),
+});
+
+export const LocalModelsConfigSchema = z.object({
+  /** Opt-in switch. Default false preserves today's behavior. */
+  enabled: z.boolean().default(false),
+  pool: LocalModelsPoolConfigSchema.default({}),
+  refresh: LocalModelsRefreshConfigSchema.default({}),
+  installer: LocalModelsInstallerConfigSchema.default({}),
+  hardware: z
+    .object({
+      /** Manual override that skips autodetection (D7 fallback path). */
+      override: LocalModelsHardwareOverrideSchema.optional(),
+    })
+    .optional(),
+});
+
 export const HarnessConfigSchema = z.object({
   /** Configuration schema version */
   version: z.literal(1),
@@ -737,6 +795,12 @@ export const HarnessConfigSchema = z.object({
       cacheTtlHours: z.number().positive().default(24),
     })
     .optional(),
+  /**
+   * Local Model Lifecycle Manager (LMLM) configuration. Optional and
+   * disabled by default (`enabled: false`); see
+   * `docs/changes/local-model-lifecycle-manager/proposal.md`.
+   */
+  localModels: LocalModelsConfigSchema.optional(),
 });
 
 /**

--- a/packages/local-models/README.md
+++ b/packages/local-models/README.md
@@ -1,0 +1,20 @@
+# @harness-engineering/local-models
+
+Hardware-aware local-model recommender, pool manager, and proposal engine for Harness Engineering's **Local Model Lifecycle Manager (LMLM)**.
+
+See [`docs/changes/local-model-lifecycle-manager/proposal.md`](../../docs/changes/local-model-lifecycle-manager/proposal.md) for the full spec.
+
+## Status
+
+**Phase 0 — scaffolding only.** No business logic yet. Hardware detection, ranking, pool management, Ollama installer, proposal engine, and scheduler ship in subsequent phases.
+
+## Goals (recap)
+
+- Detect the operator's hardware (Apple Silicon / NVIDIA / CPU) and rank Hugging Face models for that hardware.
+- Manage a disk-budget-bounded pool of installed Ollama models within an operator-approved org/family allowlist.
+- Propose pool changes through the existing hermes-phase-4 review queue with single approve/reject UX.
+- Drive recommendations via the live HuggingFace API with a frozen-snapshot fallback for offline environments.
+
+## License
+
+MIT

--- a/packages/local-models/package.json
+++ b/packages/local-models/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@harness-engineering/local-models",
+  "version": "0.1.0",
+  "description": "Hardware-aware local-model recommender, pool manager, and proposal engine for Harness Engineering (LMLM)",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --tsconfig tsconfig.build.json",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "node ../../scripts/clean.mjs dist",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "harness",
+    "engineering",
+    "local-models",
+    "ollama",
+    "huggingface",
+    "ai",
+    "agents"
+  ],
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Intense-Visions/harness-engineering.git",
+    "directory": "packages/local-models"
+  },
+  "bugs": {
+    "url": "https://github.com/Intense-Visions/harness-engineering/issues"
+  },
+  "homepage": "https://github.com/Intense-Visions/harness-engineering/tree/main/packages/local-models#readme",
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/local-models/src/index.ts
+++ b/packages/local-models/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @harness-engineering/local-models
+ *
+ * Hardware-aware local-model recommender, pool manager, and proposal engine
+ * for Harness Engineering's Local Model Lifecycle Manager (LMLM).
+ *
+ * Phase 0 — scaffolding only. The public surface (HardwareDetector,
+ * ModelRanker, PoolManager, ProposalEngine, ModelRecommender) lands in
+ * subsequent phases per `docs/changes/local-model-lifecycle-manager/proposal.md`.
+ */
+
+export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const;
+export const LOCAL_MODELS_VERSION = '0.1.0' as const;

--- a/packages/local-models/tests/smoke.test.ts
+++ b/packages/local-models/tests/smoke.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { LOCAL_MODELS_PACKAGE, LOCAL_MODELS_VERSION } from '../src/index.js';
+
+describe('@harness-engineering/local-models scaffold', () => {
+  it('exposes the package identifier constant', () => {
+    expect(LOCAL_MODELS_PACKAGE).toBe('@harness-engineering/local-models');
+  });
+
+  it('exposes a version constant matching package.json', () => {
+    expect(LOCAL_MODELS_VERSION).toBe('0.1.0');
+  });
+});

--- a/packages/local-models/tsconfig.build.json
+++ b/packages/local-models/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/local-models/tsconfig.json
+++ b/packages/local-models/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/local-models/vitest.config.mts
+++ b/packages/local-models/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    testTimeout: 15_000,
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/index.ts'],
+      processingConcurrency: 1,
+    },
+  },
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -279,6 +279,17 @@ export type {
   NotificationDeliveryResult,
 } from './notifications';
 
+// --- Local Model Lifecycle Manager (LMLM) — Phase 0 ---
+export type {
+  LocalModelsPlatform,
+  LocalModelsInstallerBackend,
+  LocalModelsHardwareOverride,
+  LocalModelsPoolConfig,
+  LocalModelsRefreshConfig,
+  LocalModelsInstallerConfig,
+  LocalModelsConfig,
+} from './local-models';
+
 // --- Skill Proposals (Hermes Phase 4) ---
 export {
   SkillProvenanceSchema,

--- a/packages/types/src/local-models.ts
+++ b/packages/types/src/local-models.ts
@@ -1,0 +1,85 @@
+/**
+ * Local Model Lifecycle Manager (LMLM) — configuration types.
+ *
+ * Phase 0 stub. Mirrors the config block defined in
+ * `docs/changes/local-model-lifecycle-manager/proposal.md` (lines 178–198).
+ * Runtime behavior arrives in Phases 1–9; this file only declares the shape
+ * so consumers (CLI schema, orchestrator wiring) can reference it.
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md
+ */
+
+/** Platforms supported for hardware detection (D7). AMD/ROCm deferred to v2. */
+export type LocalModelsPlatform = 'macos' | 'nvidia' | 'cpu';
+
+/** Installer backend choice (D4). `'advisory'` emits copy-paste commands only. */
+export type LocalModelsInstallerBackend = 'ollama' | 'advisory';
+
+/**
+ * Optional manual override that skips hardware autodetection. When set, the
+ * detector returns this profile verbatim and does not shell out.
+ */
+export interface LocalModelsHardwareOverride {
+  platform: LocalModelsPlatform;
+  vramGb: number;
+  bandwidthGbps: number;
+  ramGb?: number;
+  gpuName?: string;
+  cpuName?: string;
+}
+
+/**
+ * Pool bounds — the operator's approved trust line. The orchestrator may
+ * auto-pull, swap, and evict only within these bounds (D1).
+ */
+export interface LocalModelsPoolConfig {
+  /** Hard ceiling on total on-disk size of installed pool members. */
+  diskBudgetGb: number;
+  /**
+   * Hugging Face organization names whose models the orchestrator is allowed
+   * to install (e.g., `'Qwen'`, `'deepseek-ai'`, `'meta-llama'`).
+   */
+  allowedOrgs: string[];
+  /**
+   * Optional model-family allowlist. Empty array means "all families under
+   * the allowed orgs are permitted".
+   */
+  allowedFamilies: string[];
+}
+
+/**
+ * Background refresh + proposal-emission cadence (D9). Defaults: 24h with
+ * ±10min jitter. Minimum interval 1h to keep HF API usage civil.
+ */
+export interface LocalModelsRefreshConfig {
+  /** Re-rank cadence in milliseconds. Default 86_400_000 (24h). Minimum 3_600_000 (1h). */
+  intervalMs: number;
+  /** Minimum score delta required to emit a swap proposal. Default 5. */
+  proposalThreshold: number;
+  /** Random jitter added to the interval to avoid thundering herd. Default 600_000 (10min). */
+  jitterMs: number;
+}
+
+/** Installer adapter configuration. Only `backend: 'ollama'` performs auto-install in v1. */
+export interface LocalModelsInstallerConfig {
+  backend: LocalModelsInstallerBackend;
+  /** Ollama REST endpoint. Only consulted when `backend === 'ollama'`. */
+  ollamaEndpoint: string;
+}
+
+/**
+ * Top-level config block for LMLM. Lives under `localModels` on the root
+ * harness config. Opt-in (`enabled: false` by default) preserves today's
+ * behavior — disabling LMLM is byte-identical to the prior orchestrator.
+ */
+export interface LocalModelsConfig {
+  /** Opt-in switch. Default false; when false, no LMLM code paths execute. */
+  enabled: boolean;
+  pool: LocalModelsPoolConfig;
+  refresh: LocalModelsRefreshConfig;
+  installer: LocalModelsInstallerConfig;
+  hardware?: {
+    /** Manual override that skips autodetection (D7 fallback path). */
+    override?: LocalModelsHardwareOverride;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 1.6.4(@algolia/client-search@5.52.1)(search-insights@2.17.3)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.2)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -485,6 +485,22 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
+
+  packages/local-models:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/orchestrator:
     dependencies:
@@ -10020,7 +10036,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -10088,7 +10104,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "./packages/linter-gen" },
     { "path": "./packages/intelligence" },
     { "path": "./packages/orchestrator" },
-    { "path": "./packages/dashboard" }
+    { "path": "./packages/dashboard" },
+    { "path": "./packages/local-models" }
   ]
 }


### PR DESCRIPTION
## Summary

First slice of the Local Model Lifecycle Manager (LMLM) — **Phase 0 scaffolding only**. No business logic yet.

This PR stands up the foundation so subsequent phases (hardware detect, ranker, pool manager, Ollama installer, proposal engine, scheduler, HTTP/WS surfaces, CLI commands, dashboard) can land incrementally.

### What's in
- New empty barrel package `@harness-engineering/local-models` with `package.json`, tsconfig, build config, vitest config, README, and a smoke test asserting exported constants.
- New types in `@harness-engineering/types`: `LocalModelsConfig`, `LocalModelsPoolConfig`, `LocalModelsRefreshConfig`, `LocalModelsInstallerConfig`, `LocalModelsHardwareOverride`, plus `LocalModelsPlatform` and `LocalModelsInstallerBackend` unions.
- Optional `localModels: LocalModelsConfigSchema.optional()` field on `HarnessConfigSchema` with spec-matching defaults: 24h refresh (floor 1h), 100GB budget, Ollama installer, score-delta threshold 5, 10min jitter.
- New package registered in root `tsconfig.json` references.
- Changeset entry (patch for new package, minor for types/cli additive surface).
- Phase 0 plan document under `docs/changes/local-model-lifecycle-manager/plans/`.

### What's not in (deferred to subsequent phases)
- Phase 1: hardware detection (macOS / NVIDIA / CPU)
- Phase 2: ranker + HF client + frozen snapshot
- Phase 3: pool manager + Ollama installer
- Phase 4: LocalModelResolver pool integration
- Phase 5a/5b: proposal schema generalization + model proposal engine
- Phase 6: background scheduler + drift reconciliation
- Phase 7: HTTP routes + WS topics + notification sinks
- Phase 8: dashboard panel
- Phase 9: ADRs + knowledge docs + plugin regeneration

### Spec invariant respected
- `enabled: false` (default) → no LMLM code paths execute; orchestrator behavior is byte-identical to today's (success-criterion F9 / N4).

## Test plan
- [x] `pnpm install` succeeds; new workspace resolves
- [x] `pnpm --filter @harness-engineering/local-models build` produces dist outputs
- [x] `pnpm --filter @harness-engineering/local-models test` — smoke test green (2 tests)
- [x] `pnpm --filter @harness-engineering/local-models typecheck` green
- [x] `pnpm --filter @harness-engineering/local-models lint` green
- [x] `pnpm --filter @harness-engineering/types build && pnpm --filter @harness-engineering/cli typecheck` green
- [x] CLI config tests (131 tests) all pass — schema additions parse correctly with no `localModels` block (legacy compat) and with the block present (defaults applied)
- [x] `harness validate` issue count unchanged from baseline (258 issues both before and after — pre-existing design-token violations in files unrelated to this PR)

## Refs
- Spec: `docs/changes/local-model-lifecycle-manager/proposal.md` (Phase 0, lines 390–401)
- Issue identifier: `local-model-lifecycl-87ed51b9`