### PR TITLE
feat(local-models): LMLM Phase 1 — hardware detection

### DIFF
--- a/.changeset/lmlm-phase1-hardware-detection.md
+++ b/.changeset/lmlm-phase1-hardware-detection.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/local-models': minor
+---
+
+Adds Phase 1 of the Local Model Lifecycle Manager — hardware detection.
+
+The new `HardwareDetector` returns a `HardwareProfile` on macOS (Apple Silicon), Linux/Windows with NVIDIA, and CPU-only hosts. The dispatcher honors an operator override ahead of autodetection, caches results for 24h by default to match the spec's refresh cadence, and falls through to a CPU profile with a structured warning when a platform-specific probe fails — it never throws (S3).
+
+- `detectMacOS` parses `system_profiler SPDisplaysDataType -json` + `sysctl` and maps Apple Silicon chips (M1 through M4 Max) to their published unified-memory bandwidths.
+- `detectNVIDIA` parses `nvidia-smi --query-gpu=name,memory.total` and maps NVIDIA GPUs (Ada, Ampere, Hopper) to their published memory bandwidths. Multi-GPU hosts pick the highest-VRAM card and warn.
+- `detectCPU` derives a conservative bandwidth heuristic by regex-matching the CPU brand string against known DDR4/DDR5 desktop and DDR5/DDR4 server families.
+- Shell-outs are dependency-injected via a `ShellRunner` interface so unit tests stay deterministic across CI hosts.
+
+No orchestrator wiring yet — the detector is consumed by the ranker (Phase 2), scheduler (Phase 6), and HTTP/dashboard surfaces (Phases 7–8). LMLM remains opt-in and disabled by default per Phase 0.

--- a/docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase1-hardware-detection-plan.md
+++ b/docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase1-hardware-detection-plan.md
@@ -1,0 +1,177 @@
+# Plan: LMLM Phase 1 — Hardware Detection
+
+**Date:** 2026-05-27 | **Spec:** `docs/changes/local-model-lifecycle-manager/proposal.md` (Phase 1, lines 403–412) | **Tasks:** 8 | **Time:** ~2–3 hours | **Integration Tier:** small | **Session:** `changes--local-model-lifecycle-manager--phase1`
+
+## Goal
+
+Implement `HardwareDetector.detect()` so it returns a valid `HardwareProfile` on the three v1 platforms — macOS (Apple Silicon), Linux/Windows with NVIDIA, and CPU-only — with the operator override path honored ahead of autodetection. Detection failures must never throw: they fall through to a CPU profile and surface as a structured warning (S3). All shell-outs are dependency-injected so the unit tests are fully deterministic and CI-portable.
+
+Phase 1 lands the detector and its fixture-driven tests inside `@harness-engineering/local-models`. It does **not** yet wire the detector to the orchestrator, dashboard, CLI, or config loader — those happen in Phase 4 / Phase 7 once the ranker and pool exist for the detector to feed.
+
+## Phase 1 Scope (from spec, lines 403–412)
+
+In:
+
+- `src/hardware/types.ts` — `HardwareProfile`, `HardwareDetectionWarning`, `HardwareDetectionResult` shapes
+- `src/hardware/shell.ts` — `ShellRunner` interface + default Node `child_process.execFile` implementation (DI seam for tests)
+- `src/hardware/macos.ts` — `detectMacOS()` using `system_profiler SPDisplaysDataType -json` + `sysctl -n hw.memsize|machdep.cpu.brand_string|hw.model`; Apple Silicon bandwidth derived from a chip → GB/s lookup table seeded from publicly documented memory bandwidths
+- `src/hardware/nvidia.ts` — `detectNVIDIA()` using `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`; per-GPU bandwidth derived from a name → GB/s lookup with a conservative fallback
+- `src/hardware/cpu.ts` — `detectCPU()` using `os.cpus()` / `os.totalmem()`; bandwidth heuristic per detected CPU family (DDR4 vs DDR5, server vs desktop) with a conservative default
+- `src/hardware/detector.ts` — `HardwareDetector` class: override path → platform dispatch (`darwin` → macOS, `linux`/`win32` → NVIDIA → CPU, else → CPU) → cache for `cacheTtlMs` (default 24h) → never throws (S3)
+- `src/hardware/index.ts` — barrel re-export
+- Update `src/index.ts` to surface `HardwareDetector`, `detectHardware`, and the public types
+- Fixture-based tests per detector (`tests/hardware/{macos,nvidia,cpu,detector}.test.ts`) that mock the shell runner and `os` module
+
+Out of Phase 1 (deferred):
+
+- HTTP route `GET /api/v1/local-models/hardware` (Phase 7)
+- `harness models status` CLI (Phase 7)
+- Dashboard hardware card (Phase 8)
+- AMD/ROCm support (deferred to v2 per D7)
+- Live HF API, ranker, pool, installer, scheduler, proposal engine (Phases 2–6)
+- Wiring the detector into the orchestrator at process start (Phase 6 — when the scheduler boots)
+
+## Observable Truths (Acceptance Criteria — Phase 1 only)
+
+1. **OT1**: `HardwareDetector.detect()` with a manual override returns the override verbatim and never invokes any shell command. Verified by spying on the injected `ShellRunner`.
+2. **OT2**: On macOS (`process.platform === 'darwin'`), the detector parses `system_profiler -json` and `sysctl` outputs and returns a `HardwareProfile` whose `platform === 'macos'`, `vramGb` equals the unified memory size, `ramGb` equals total memory, `gpuName` is populated from `SPDisplaysDataType`, and `bandwidthGbps` matches the chip → bandwidth table (F1).
+3. **OT3**: On Linux/Windows with `nvidia-smi` present and parseable, the detector returns a `HardwareProfile` whose `platform === 'nvidia'`, `vramGb` equals `memory.total / 1024`, `gpuName` is taken from the query, and `bandwidthGbps` matches the GPU → bandwidth table (F2).
+4. **OT4**: When the macOS or NVIDIA detector throws or returns malformed output, the detector falls through to the CPU profile, returns `platform === 'cpu'`, and surfaces a structured warning in the returned `HardwareDetectionResult.warnings` (S3). It does **not** throw.
+5. **OT5**: When no `nvidia-smi` is on PATH (the `ShellRunner.run` rejects with `ENOENT` or similar), the Linux/Windows detector falls through to CPU and adds a warning. No exception escapes `detect()`.
+6. **OT6**: The CPU detector populates `cpuName` from `os.cpus()[0].model`, `ramGb` from `os.totalmem()`, `vramGb === 0`, and a conservative `bandwidthGbps` derived from a CPU-family lookup with a documented fallback constant.
+7. **OT7**: Repeated calls to `detect()` within the cache TTL return the cached result (verified by counting shell invocations across two calls in a fixture test).
+8. **OT8**: `detectedAt` on every `HardwareProfile` is an ISO string and parses round-trip via `new Date(profile.detectedAt).toISOString()`.
+9. **OT9**: `pnpm --filter @harness-engineering/local-models build && test && typecheck` are all green.
+10. **OT10**: Existing smoke test continues to pass; new tests run alongside it without flakes.
+
+## Skill Recommendations
+
+From `docs/changes/local-model-lifecycle-manager/SKILLS.md`:
+
+- `gof-factory-method` (reference) — `HardwareDetector` dispatches to a platform-specific factory; the pattern keeps each detector independently testable.
+
+## File Map
+
+- CREATE `packages/local-models/src/hardware/types.ts`
+- CREATE `packages/local-models/src/hardware/shell.ts`
+- CREATE `packages/local-models/src/hardware/macos.ts`
+- CREATE `packages/local-models/src/hardware/nvidia.ts`
+- CREATE `packages/local-models/src/hardware/cpu.ts`
+- CREATE `packages/local-models/src/hardware/detector.ts`
+- CREATE `packages/local-models/src/hardware/index.ts`
+- MODIFY `packages/local-models/src/index.ts` — re-export from `./hardware/index.js`
+- CREATE `packages/local-models/tests/hardware/macos.test.ts`
+- CREATE `packages/local-models/tests/hardware/nvidia.test.ts`
+- CREATE `packages/local-models/tests/hardware/cpu.test.ts`
+- CREATE `packages/local-models/tests/hardware/detector.test.ts`
+- CREATE `packages/local-models/tests/fixtures/system_profiler.m3-max-36gb.json`
+- CREATE `packages/local-models/tests/fixtures/nvidia-smi.rtx-4090.txt`
+- CREATE `.changeset/lmlm-phase1-hardware-detection.md`
+
+## Skeleton
+
+1. Shared types + ShellRunner DI seam (~2 tasks)
+2. Platform detectors with fixture-driven tests (~3 tasks)
+3. Dispatcher + cache + fallback (~1 task)
+4. Public surface + changeset + verification (~2 tasks)
+
+**Estimated total:** 8 tasks, ~2–3 hours.
+
+## Uncertainties
+
+- **[ASSUMPTION]** Apple Silicon memory bandwidths come from Apple's published memory-subsystem specs; the table covers M1/M2/M3/M4 desktop and laptop variants. New chips that miss the table fall back to a conservative `100 GB/s` (M-series base bandwidth) so the detector degrades gracefully rather than crashes.
+- **[ASSUMPTION]** NVIDIA bandwidths come from `nvidia.com` consumer/professional datasheet pages and are committed in `packages/local-models/src/hardware/nvidia.ts` as a static map. Unmapped GPUs fall back to a conservative `300 GB/s` and surface a warning so the operator knows the heuristic is rough.
+- **[ASSUMPTION]** `system_profiler SPDisplaysDataType -json` is available on every supported macOS version (≥ Big Sur). If the `-json` flag is unrecognized, the parser falls through to CPU and emits a warning instead of throwing.
+- **[ASSUMPTION]** `process.platform` is the canonical platform discriminator. WSL is treated as `linux` (it surfaces as `linux` to Node), which matches operator expectation.
+- **[DEFERRABLE]** Memory bandwidth refresh tooling (a script that scrapes datasheets into JSON) is not in Phase 1; the static tables are committed as code for now.
+- **[DEFERRABLE]** The detector cache lives in-process only. A persisted `~/.harness/local-models/hardware.json` cache is deferred until the scheduler exists (Phase 6) to own its lifecycle.
+
+## Tasks
+
+### Task 1: Hardware types + ShellRunner DI seam
+
+**Depends on:** none | **Files:** `src/hardware/types.ts`, `src/hardware/shell.ts`
+
+1. `types.ts` exports `HardwareProfile` matching the spec (lines 115–123) plus `HardwareDetectionWarning` (`{ code: string; message: string; cause?: string }`) and `HardwareDetectionResult` (`{ profile: HardwareProfile; warnings: HardwareDetectionWarning[]; source: 'override' | 'cache' | 'macos' | 'nvidia' | 'cpu' }`).
+2. `shell.ts` defines `ShellRunner` (`{ run(cmd: string, args: readonly string[]): Promise<ShellResult> }`) and `ShellResult` (`{ stdout: string; stderr: string; code: number }`). Default implementation uses `node:util.promisify(child_process.execFile)` with a 5-second timeout and `{ windowsHide: true }`. Errors with `ENOENT`, non-zero exit, or timeout are surfaced as a rejected promise so the caller can decide whether to swallow or propagate.
+
+### Task 2: macOS detector + fixture
+
+**Depends on:** Task 1 | **Files:** `src/hardware/macos.ts`, `tests/fixtures/system_profiler.m3-max-36gb.json`, `tests/hardware/macos.test.ts`
+
+1. `detectMacOS(shell: ShellRunner)` runs `system_profiler SPDisplaysDataType -json` to get the GPU display name, and `sysctl -n hw.memsize hw.model machdep.cpu.brand_string` to get unified memory + chip identifier. Parses `hw.model` (e.g., `"Mac15,9"`) plus the SPDisplaysDataType chip string (e.g., `"Apple M3 Max"`) into a chip key, looks up bandwidth in a `APPLE_SILICON_BANDWIDTH_GBPS` table, and returns a `HardwareProfile`.
+2. Bandwidth table seeded with: `M1`, `M1 Pro`, `M1 Max`, `M1 Ultra`, `M2`, `M2 Pro`, `M2 Max`, `M2 Ultra`, `M3`, `M3 Pro`, `M3 Max`, `M3 Ultra`, `M4`, `M4 Pro`, `M4 Max`. Unknown chip → conservative `100 GB/s` + warning.
+3. Fixture `system_profiler.m3-max-36gb.json` is a trimmed real-world output (just the fields the parser consumes); test injects the fixture via a mock `ShellRunner` and asserts the full profile.
+4. Error-path tests: malformed JSON → throws (consumed by the dispatcher's fallback in Task 6); non-Apple-Silicon Mac (Intel) returns a CPU-shaped profile with a warning.
+
+### Task 3: NVIDIA detector + fixture
+
+**Depends on:** Task 1 | **Files:** `src/hardware/nvidia.ts`, `tests/fixtures/nvidia-smi.rtx-4090.txt`, `tests/hardware/nvidia.test.ts`
+
+1. `detectNVIDIA(shell: ShellRunner)` runs `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`. Parses each CSV row; takes the first row (multi-GPU host quirk is handled in v2 — for now we pick the GPU with the most VRAM and warn that other GPUs exist).
+2. `NVIDIA_BANDWIDTH_GBPS` table seeded with: `RTX 4090` (1008), `RTX 4080` (716), `RTX 4070 Ti SUPER` (672), `RTX 4070 Ti` (504), `RTX 4070` (504), `RTX 3090 Ti` (1008), `RTX 3090` (936), `RTX 3080 Ti` (912), `RTX 3080` (760), `RTX 3070 Ti` (608), `RTX 3070` (448), `RTX 3060 Ti` (448), `RTX 3060` (360), `A100 80GB` (2039), `A100 40GB` (1555), `H100` (3350), `L40` (864). Unknown GPU → conservative `300 GB/s` fallback + warning carrying the GPU name so the operator knows which entry to add.
+3. Fixture `nvidia-smi.rtx-4090.txt` is the expected stdout (a single CSV line: `NVIDIA GeForce RTX 4090, 24564`); test asserts a profile with `vramGb ≈ 23.99` (we round to 1 decimal), `bandwidthGbps === 1008`, `gpuName === 'NVIDIA GeForce RTX 4090'`.
+4. Error-path tests: `ENOENT` (no `nvidia-smi`) → throws; non-numeric output → throws (dispatcher catches both).
+
+### Task 4: CPU detector
+
+**Depends on:** Task 1 | **Files:** `src/hardware/cpu.ts`, `tests/hardware/cpu.test.ts`
+
+1. `detectCPU(osModule: typeof import('node:os') = os)` reads `osModule.cpus()[0].model`, `osModule.totalmem()`, and `osModule.platform()`. Returns `platform: 'cpu'`, `vramGb: 0`, `cpuName: model`, `ramGb: bytes → GB`.
+2. CPU bandwidth heuristic: regex match the model string against known families (DDR5 desktop: Intel 14/13/12 gen, Ryzen 7000+; DDR4 desktop: prior gens; server: Xeon-SP / EPYC). Provide a documented constant for each tier with a final fallback of `40 GB/s` (a conservative dual-channel DDR4 figure).
+3. Tests use mocked `cpus()` / `totalmem()` to drive each branch — DDR5 desktop, DDR4 desktop, server-class, unknown family fallback.
+
+### Task 5: Dispatcher + cache + fallback
+
+**Depends on:** Tasks 2–4 | **Files:** `src/hardware/detector.ts`, `tests/hardware/detector.test.ts`
+
+1. `HardwareDetector` constructor accepts `{ override?: LocalModelsHardwareOverride; shell?: ShellRunner; osModule?: typeof os; platform?: NodeJS.Platform; now?: () => Date; cacheTtlMs?: number }`. Defaults: `cacheTtlMs = 86_400_000` (24h, matching the spec's daily refresh cadence).
+2. `detect()`:
+   - If `override` is set → return `{ source: 'override', profile: { ...override, ramGb: override.ramGb ?? override.vramGb, cpuName: override.cpuName ?? 'override', gpuName: override.gpuName, detectedAt: now().toISOString() }, warnings: [] }`. Never shells out.
+   - If a cached result is fresh → return it with `source: 'cache'`.
+   - Otherwise dispatch on `platform`:
+     - `'darwin'` → try `detectMacOS`; on error, fall to CPU with a warning whose `cause` carries `error.message`.
+     - `'linux' | 'win32'` → try `detectNVIDIA`; on error, fall to CPU with a warning.
+     - else → CPU directly.
+   - CPU path never throws.
+3. Tests cover: override short-circuit (OT1), darwin success (OT2), darwin failure → CPU with warning (OT4), linux nvidia success (OT3), linux ENOENT → CPU with warning (OT5), cache hit (OT7), `detectedAt` ISO round-trip (OT8).
+
+### Task 6: Hardware barrel + package surface
+
+**Depends on:** Tasks 1–5 | **Files:** `src/hardware/index.ts`, `src/index.ts`
+
+1. `src/hardware/index.ts` re-exports `HardwareDetector`, the three detector functions, the types, and the default `ShellRunner`.
+2. `src/index.ts` re-exports the public surface (`HardwareDetector` and types) and bumps the comment to mention Phase 1 is live while Phases 2–9 remain pending.
+
+### Task 7: Changeset entry
+
+**Depends on:** Tasks 1–6 | **Files:** `.changeset/lmlm-phase1-hardware-detection.md`
+
+1. `minor` bump on `@harness-engineering/local-models` (new public surface). No other packages change.
+2. Body: "Adds Phase 1 of the Local Model Lifecycle Manager — hardware detection. The new `HardwareDetector` returns a `HardwareProfile` on macOS (Apple Silicon), Linux/Windows with NVIDIA, and CPU-only hosts. Detection failures fall through to a CPU profile with a structured warning rather than throwing. Shell-outs are injectable so unit tests stay deterministic. No orchestrator wiring yet — that lands in Phase 6."
+
+### Task 8: Verification gate — build, typecheck, test, validate
+
+**Depends on:** Tasks 1–7 | **Files:** none
+
+1. `pnpm install` at repo root if `node_modules/.modules.yaml` is older than `pnpm-lock.yaml`.
+2. `pnpm --filter @harness-engineering/local-models build` — green (OT9).
+3. `pnpm --filter @harness-engineering/local-models typecheck` — green (OT9).
+4. `pnpm --filter @harness-engineering/local-models test` — green (OT9 + OT10).
+5. `pnpm exec harness validate` from repo root — green (legacy config still parses).
+6. If any step fails: stop, diagnose, fix, re-run.
+
+## Integration Notes
+
+Phase 1's integration footprint stays minimal — no new entry points, no new HTTP routes, no new CLI commands, no new dashboard panels. The detector is a leaf module the next phases will consume:
+
+- **Phase 2 (Ranker)** consumes `HardwareProfile` from `HardwareDetector.detect()` to compute VRAM fit and speed estimates.
+- **Phase 6 (Scheduler)** calls `HardwareDetector.detect()` once per tick (cache TTL aligned with the 24h refresh cadence) and includes the profile in the structured tick log.
+- **Phase 7 (HTTP/WS)** wraps `detect()` in `GET /api/v1/local-models/hardware`.
+- **Phase 8 (Dashboard)** renders the profile in the Hardware card.
+
+**Knowledge graph**: no new concepts entered in Phase 1; the spec's listed concepts (Local Model Pool, Model Proposal, etc.) land alongside their implementations in Phases 3, 5, 6.
+
+**ADRs**: none in Phase 1. The seven ADRs catalogued in the spec land with the code that justifies them (Phases 3, 5, 6 primarily).
+
+**Docs**: none in Phase 1 beyond the changeset entry. The `local-model-lifecycle.md` knowledge entry and operator guide land in Phase 9.

--- a/packages/local-models/package.json
+++ b/packages/local-models/package.json
@@ -49,9 +49,11 @@
   },
   "homepage": "https://github.com/Intense-Visions/harness-engineering/tree/main/packages/local-models#readme",
   "dependencies": {
+    "@harness-engineering/types": "workspace:*",
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/node": "^22.19.15",
     "@vitest/coverage-v8": "^4.1.5",
     "tsup": "^8.5.1",
     "vitest": "^4.1.5"

--- a/packages/local-models/src/hardware/cpu.ts
+++ b/packages/local-models/src/hardware/cpu.ts
@@ -1,0 +1,116 @@
+/**
+ * CPU-only fallback detector.
+ *
+ * The detector that never fails: reads `os.cpus()[0].model` and
+ * `os.totalmem()`, then assigns a bandwidth heuristic by regex-matching the
+ * CPU brand string into a known family. Used whenever no GPU detector
+ * applies — Linux without an NVIDIA GPU, Windows without `nvidia-smi`, Intel
+ * Macs, containers without GPU passthrough — and whenever a GPU detector
+ * throws (S3).
+ *
+ * Bandwidth heuristics are deliberately conservative. The ranker only needs
+ * a ballpark figure to estimate tokens-per-second; over-promising bandwidth
+ * for CPU-only hosts would make CPU-bound models look more attractive than
+ * they are.
+ */
+
+import * as nodeOs from 'node:os';
+
+import type { HardwareDetectionWarning, HardwareProfile } from './types.js';
+
+const BYTES_PER_GIB = 1024 ** 3;
+
+/** Minimal subset of `node:os` we depend on — keeps tests injectable. */
+export interface OsModule {
+  totalmem(): number;
+  cpus(): ReadonlyArray<{ model: string }>;
+}
+
+/**
+ * CPU family → effective dual-channel memory bandwidth in GB/s. The numbers
+ * approximate "theoretical peak DRAM bandwidth a single socket can sustain"
+ * for the default memory configuration shipped with that family. They are
+ * not chip-specific; the ranker uses them only as a tie-breaker among
+ * CPU-bound models.
+ */
+interface BandwidthEntry {
+  match: RegExp;
+  bandwidthGbps: number;
+  family: string;
+}
+
+const CPU_BANDWIDTH_TABLE: ReadonlyArray<BandwidthEntry> = [
+  // Server-class (octa+ channel, DDR5/DDR4) — listed first so they match
+  // before the desktop regexes that would otherwise swallow "Xeon".
+  { match: /EPYC\s+9\d{3}/i, bandwidthGbps: 460, family: 'AMD EPYC 9xxx (Genoa, 12-channel DDR5)' },
+  {
+    match: /EPYC\s+7\d{3}/i,
+    bandwidthGbps: 200,
+    family: 'AMD EPYC 7xxx (Milan/Rome, 8-channel DDR4)',
+  },
+  {
+    match: /Xeon.*Platinum.*8[45]\d{2}/i,
+    bandwidthGbps: 307,
+    family: 'Intel Xeon Sapphire/Emerald Rapids',
+  },
+  { match: /Xeon.*Gold/i, bandwidthGbps: 200, family: 'Intel Xeon Gold' },
+  { match: /Xeon/i, bandwidthGbps: 120, family: 'Intel Xeon (generic)' },
+
+  // Desktop DDR5 (i9-12xxx onward, Ryzen 7xxx onward)
+  { match: /Core.*i[579]-1[4-9]\d{3}/i, bandwidthGbps: 90, family: 'Intel Core 14th-gen (DDR5)' },
+  { match: /Core.*i[579]-1[23]\d{3}/i, bandwidthGbps: 76, family: 'Intel Core 12/13th-gen (DDR5)' },
+  { match: /Ryzen\s+9\s+9\d{3}/i, bandwidthGbps: 90, family: 'AMD Ryzen 9000 (Zen 5, DDR5)' },
+  { match: /Ryzen\s+[579]\s+7\d{3}/i, bandwidthGbps: 83, family: 'AMD Ryzen 7000 (Zen 4, DDR5)' },
+
+  // Desktop DDR4 (Ryzen 5xxx, Intel 10th–11th gen)
+  { match: /Ryzen\s+[579]\s+5\d{3}/i, bandwidthGbps: 51, family: 'AMD Ryzen 5000 (Zen 3, DDR4)' },
+  { match: /Core.*i[579]-11\d{3}/i, bandwidthGbps: 51, family: 'Intel Core 11th-gen (DDR4)' },
+  { match: /Core.*i[579]-10\d{3}/i, bandwidthGbps: 45, family: 'Intel Core 10th-gen (DDR4)' },
+
+  // Apple Silicon — only reachable when the macOS detector falls back to CPU.
+  { match: /Apple\s+M\d/i, bandwidthGbps: 100, family: 'Apple Silicon (CPU fallback)' },
+];
+
+/** Final fallback for unmatched CPU brand strings (dual-channel DDR4 baseline). */
+const UNKNOWN_CPU_BANDWIDTH_GBPS = 40;
+
+/** Result returned by `detectCPU` — profile + any non-fatal warnings. */
+export interface DetectCPUResult {
+  profile: HardwareProfile;
+  warnings: HardwareDetectionWarning[];
+}
+
+/**
+ * CPU-only profile detector. Never throws — the worst case is the unmapped
+ * brand string, which yields a profile with `UNKNOWN_CPU_BANDWIDTH_GBPS` and
+ * a single warning.
+ */
+export function detectCPU(
+  os: OsModule = nodeOs,
+  now: () => Date = () => new Date()
+): DetectCPUResult {
+  const warnings: HardwareDetectionWarning[] = [];
+  const cpuModel = os.cpus()[0]?.model?.trim() ?? 'unknown CPU';
+  const ramGb = Math.round((os.totalmem() / BYTES_PER_GIB) * 10) / 10;
+
+  const entry = CPU_BANDWIDTH_TABLE.find((e) => e.match.test(cpuModel));
+  const bandwidthGbps = entry?.bandwidthGbps ?? UNKNOWN_CPU_BANDWIDTH_GBPS;
+
+  if (!entry) {
+    warnings.push({
+      code: 'cpu_unmapped_family',
+      message: `Unknown CPU family "${cpuModel}"; using conservative ${UNKNOWN_CPU_BANDWIDTH_GBPS} GB/s bandwidth.`,
+    });
+  }
+
+  const profile: HardwareProfile = {
+    platform: 'cpu',
+    vramGb: 0,
+    ramGb,
+    bandwidthGbps,
+    cpuName: cpuModel,
+    detectedAt: now().toISOString(),
+  };
+
+  return { profile, warnings };
+}

--- a/packages/local-models/src/hardware/detector.ts
+++ b/packages/local-models/src/hardware/detector.ts
@@ -1,0 +1,196 @@
+/**
+ * `HardwareDetector` — the platform-aware dispatcher.
+ *
+ * Resolves a `HardwareProfile` via four layers:
+ *  1. Operator override (no shell-out, no cache).
+ *  2. In-process cache (single TTL window; default 24h to match the
+ *     scheduler's refresh cadence).
+ *  3. Platform-specific probe (`detectMacOS` / `detectNVIDIA`).
+ *  4. CPU fallback (always-on; never throws).
+ *
+ * Every layer below the override returns a `HardwareDetectionResult` that
+ * carries any warnings — failures degrade gracefully (S3) rather than
+ * propagating. The detector intentionally never throws after construction,
+ * so callers can wire it into orchestrator startup without defensive
+ * try/catch wrappers.
+ */
+
+import type { LocalModelsHardwareOverride } from '@harness-engineering/types';
+
+import { detectCPU } from './cpu.js';
+import type { OsModule } from './cpu.js';
+import { detectMacOS } from './macos.js';
+import { detectNVIDIA } from './nvidia.js';
+import { defaultShellRunner } from './shell.js';
+import type { ShellRunner } from './shell.js';
+import type {
+  HardwareDetectionResult,
+  HardwareDetectionWarning,
+  HardwareProfile,
+} from './types.js';
+
+/** Default detector cache TTL — matches the spec's 24h refresh cadence (D9). */
+const DEFAULT_CACHE_TTL_MS = 86_400_000;
+
+/** Constructor options for `HardwareDetector`. */
+export interface HardwareDetectorOptions {
+  /**
+   * Operator-supplied override that skips autodetection. When set, `detect()`
+   * returns the override verbatim and never invokes `ShellRunner.run`.
+   */
+  override?: LocalModelsHardwareOverride;
+  /** Pluggable shell runner. Defaults to the production `execFile`-backed runner. */
+  shell?: ShellRunner;
+  /** Pluggable `node:os` subset. Defaults to the real module. */
+  osModule?: OsModule;
+  /** Platform discriminator. Defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+  /** Clock injection — tests pin time so `detectedAt` assertions stay deterministic. */
+  now?: () => Date;
+  /** Cache TTL in ms; `0` disables caching. */
+  cacheTtlMs?: number;
+}
+
+/**
+ * Coerce an operator override into a full `HardwareProfile`. The override
+ * type only requires `platform`, `vramGb`, and `bandwidthGbps`; the
+ * remaining fields default sensibly so downstream consumers don't see
+ * optional surprises.
+ */
+function overrideToProfile(override: LocalModelsHardwareOverride, now: Date): HardwareProfile {
+  const profile: HardwareProfile = {
+    platform: override.platform,
+    vramGb: override.vramGb,
+    ramGb: override.ramGb ?? override.vramGb,
+    bandwidthGbps: override.bandwidthGbps,
+    cpuName: override.cpuName ?? 'override',
+    detectedAt: now.toISOString(),
+  };
+  if (override.gpuName !== undefined) {
+    profile.gpuName = override.gpuName;
+  }
+  return profile;
+}
+
+/**
+ * Dispatcher that resolves a `HardwareProfile` for the current host. Shared
+ * by Phase 2 (ranker), Phase 6 (scheduler), Phase 7 (HTTP), and Phase 8
+ * (dashboard); all of them consume the same instance per orchestrator process.
+ */
+export class HardwareDetector {
+  private readonly override?: LocalModelsHardwareOverride;
+  private readonly shell: ShellRunner;
+  private readonly osModule?: OsModule;
+  private readonly platform: NodeJS.Platform;
+  private readonly now: () => Date;
+  private readonly cacheTtlMs: number;
+  private cached: { result: HardwareDetectionResult; expiresAt: number } | undefined;
+
+  constructor(opts: HardwareDetectorOptions = {}) {
+    if (opts.override !== undefined) {
+      this.override = opts.override;
+    }
+    this.shell = opts.shell ?? defaultShellRunner;
+    if (opts.osModule !== undefined) {
+      this.osModule = opts.osModule;
+    }
+    this.platform = opts.platform ?? process.platform;
+    this.now = opts.now ?? (() => new Date());
+    this.cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  }
+
+  /** Forget any cached result. Tests and `harness models refresh` call this. */
+  invalidate(): void {
+    this.cached = undefined;
+  }
+
+  /**
+   * Resolve a hardware profile for the current host.
+   *
+   * Returns the override verbatim when configured. Otherwise tries the
+   * platform-specific detector, falls through to CPU on failure, and caches
+   * the result for `cacheTtlMs` milliseconds.
+   */
+  async detect(): Promise<HardwareDetectionResult> {
+    const nowDate = this.now();
+    const nowMs = nowDate.getTime();
+
+    if (this.override) {
+      return {
+        profile: overrideToProfile(this.override, nowDate),
+        warnings: [],
+        source: 'override',
+      };
+    }
+
+    if (this.cached && this.cached.expiresAt > nowMs) {
+      return this.cached.result;
+    }
+
+    const result = await this.probe();
+    if (this.cacheTtlMs > 0) {
+      this.cached = {
+        result,
+        expiresAt: nowMs + this.cacheTtlMs,
+      };
+    }
+    return result;
+  }
+
+  /** Dispatch to the platform-specific probe with CPU fallback. */
+  private async probe(): Promise<HardwareDetectionResult> {
+    switch (this.platform) {
+      case 'darwin':
+        return this.probeWithFallback('macos', () => detectMacOS(this.shell, this.now));
+      case 'linux':
+      case 'win32':
+        return this.probeWithFallback('nvidia', () =>
+          detectNVIDIA(this.shell, this.now, this.osModule)
+        );
+      default: {
+        const cpu = detectCPU(this.osModule, this.now);
+        return {
+          profile: cpu.profile,
+          warnings: cpu.warnings,
+          source: 'cpu',
+        };
+      }
+    }
+  }
+
+  /**
+   * Try `probe`; on failure, fall back to the CPU profile and surface a
+   * warning that names the probe and carries the underlying error message.
+   */
+  private async probeWithFallback(
+    source: 'macos' | 'nvidia',
+    probe: () => Promise<{
+      profile: HardwareProfile;
+      warnings: HardwareDetectionWarning[];
+    }>
+  ): Promise<HardwareDetectionResult> {
+    try {
+      const { profile, warnings } = await probe();
+      return { profile, warnings, source };
+    } catch (err) {
+      const fallback = detectCPU(this.osModule, this.now);
+      const cause = err instanceof Error ? err.message : String(err);
+      const warnings: HardwareDetectionWarning[] = [
+        {
+          code: `${source}_probe_failed`,
+          message: `${source.toUpperCase()} probe failed; falling back to CPU profile.`,
+          cause,
+        },
+        ...fallback.warnings,
+      ];
+      return { profile: fallback.profile, warnings, source: 'cpu' };
+    }
+  }
+}
+
+/** Convenience wrapper for one-shot detection. */
+export async function detectHardware(
+  opts: HardwareDetectorOptions = {}
+): Promise<HardwareDetectionResult> {
+  return new HardwareDetector(opts).detect();
+}

--- a/packages/local-models/src/hardware/index.ts
+++ b/packages/local-models/src/hardware/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Hardware detection — public barrel.
+ *
+ * Surfaces the dispatcher (`HardwareDetector`, `detectHardware`), the
+ * individual platform probes, and the shared types so consumers in later
+ * phases (ranker, scheduler, HTTP, dashboard) can import a single namespace.
+ */
+
+export { HardwareDetector, detectHardware } from './detector.js';
+export type { HardwareDetectorOptions } from './detector.js';
+
+export { detectMacOS } from './macos.js';
+export type { DetectMacOSResult } from './macos.js';
+
+export { detectNVIDIA } from './nvidia.js';
+export type { DetectNVIDIAResult, OsModule as NvidiaOsModule } from './nvidia.js';
+
+export { detectCPU } from './cpu.js';
+export type { DetectCPUResult, OsModule as CpuOsModule } from './cpu.js';
+
+export { defaultShellRunner } from './shell.js';
+export type { ShellRunner, ShellResult } from './shell.js';
+
+export type {
+  HardwareDetectionResult,
+  HardwareDetectionSource,
+  HardwareDetectionWarning,
+  HardwareProfile,
+} from './types.js';

--- a/packages/local-models/src/hardware/macos.ts
+++ b/packages/local-models/src/hardware/macos.ts
@@ -1,0 +1,153 @@
+/**
+ * Apple Silicon detection.
+ *
+ * Combines two probes:
+ *  - `system_profiler SPDisplaysDataType -json` for the GPU chip string
+ *    (`"Apple M3 Max"`) and any external displays attached.
+ *  - `sysctl -n hw.memsize hw.model machdep.cpu.brand_string` for unified
+ *    memory size + the model identifier + CPU brand string.
+ *
+ * Memory bandwidth is derived from a static chip → GB/s table because
+ * neither `system_profiler` nor `sysctl` reports memory bandwidth directly.
+ * Unmapped chips fall back to a conservative figure and surface a warning so
+ * the operator knows the heuristic is approximate.
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (Phase 1, F1)
+ */
+
+import type { ShellRunner } from './shell.js';
+import type { HardwareDetectionWarning, HardwareProfile } from './types.js';
+
+/**
+ * Published Apple Silicon memory bandwidths (GB/s). Source: Apple's chip-
+ * launch press releases and technical briefs. Numbers are the headline
+ * unified-memory bandwidth — adequate for the speed estimator's bandwidth-
+ * bound throughput model.
+ */
+const APPLE_SILICON_BANDWIDTH_GBPS: Readonly<Record<string, number>> = {
+  'Apple M1': 68,
+  'Apple M1 Pro': 200,
+  'Apple M1 Max': 400,
+  'Apple M1 Ultra': 800,
+  'Apple M2': 100,
+  'Apple M2 Pro': 200,
+  'Apple M2 Max': 400,
+  'Apple M2 Ultra': 800,
+  'Apple M3': 100,
+  'Apple M3 Pro': 150,
+  'Apple M3 Max': 400,
+  'Apple M3 Ultra': 819,
+  'Apple M4': 120,
+  'Apple M4 Pro': 273,
+  'Apple M4 Max': 546,
+};
+
+/** Conservative fallback for unknown Apple Silicon variants (matches the M-series base). */
+const UNKNOWN_APPLE_SILICON_BANDWIDTH_GBPS = 100;
+
+const BYTES_PER_GIB = 1024 ** 3;
+
+/** Result returned by `detectMacOS` — profile + any non-fatal warnings. */
+export interface DetectMacOSResult {
+  profile: HardwareProfile;
+  warnings: HardwareDetectionWarning[];
+}
+
+interface SPDisplaysEntry {
+  sppci_model?: string;
+  _name?: string;
+}
+
+interface SPDisplaysPayload {
+  SPDisplaysDataType?: ReadonlyArray<SPDisplaysEntry>;
+}
+
+/** Best display name available on an entry; empty string if neither field is set. */
+function entryModel(entry: SPDisplaysEntry): string {
+  return entry.sppci_model ?? entry._name ?? '';
+}
+
+/**
+ * Read the GPU chip string from `system_profiler SPDisplaysDataType -json`.
+ * Apple Silicon Macs report the chip in `sppci_model` (e.g., `"Apple M3 Max"`);
+ * Intel Macs and eGPUs report a non-Apple model and trigger the Intel-Mac warning.
+ */
+function parseChipFromSPDisplays(stdout: string): string {
+  const parsed = JSON.parse(stdout) as SPDisplaysPayload;
+  const entries = parsed.SPDisplaysDataType ?? [];
+  const appleEntry = entries.find((e) => entryModel(e).startsWith('Apple M'));
+  if (appleEntry) return entryModel(appleEntry);
+  const first = entries[0];
+  return first ? entryModel(first) : '';
+}
+
+/**
+ * Parse the three-line `sysctl -n hw.memsize hw.model machdep.cpu.brand_string`
+ * output into a tuple of (bytes, hw.model, cpu brand string).
+ */
+function parseSysctl(stdout: string): {
+  memBytes: number;
+  hwModel: string;
+  cpuBrand: string;
+} {
+  const lines = stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  const [memStr, hwModel = '', cpuBrand = ''] = lines;
+  const memBytes = Number(memStr);
+  if (!Number.isFinite(memBytes) || memBytes <= 0) {
+    throw new Error(`sysctl hw.memsize returned a non-numeric value: ${memStr}`);
+  }
+  return { memBytes, hwModel, cpuBrand };
+}
+
+/**
+ * Detect Apple Silicon hardware.
+ *
+ * Throws on any unrecoverable probe failure (JSON parse error, missing
+ * binaries, non-numeric memory). The dispatcher (`HardwareDetector`)
+ * catches the throw and falls through to the CPU profile with a warning (S3).
+ */
+export async function detectMacOS(
+  shell: ShellRunner,
+  now: () => Date = () => new Date()
+): Promise<DetectMacOSResult> {
+  const [displays, sysctlOut] = await Promise.all([
+    shell.run('system_profiler', ['SPDisplaysDataType', '-json']),
+    shell.run('sysctl', ['-n', 'hw.memsize', 'hw.model', 'machdep.cpu.brand_string']),
+  ]);
+
+  const warnings: HardwareDetectionWarning[] = [];
+
+  const chip = parseChipFromSPDisplays(displays.stdout);
+  const { memBytes, hwModel, cpuBrand } = parseSysctl(sysctlOut.stdout);
+  const ramGb = Math.round((memBytes / BYTES_PER_GIB) * 10) / 10;
+
+  if (!chip.startsWith('Apple M')) {
+    // Intel Mac or eGPU — caller should treat this as a CPU-only host.
+    throw new Error(
+      `unsupported macOS GPU "${chip || 'unknown'}"; only Apple Silicon is supported in v1`
+    );
+  }
+
+  const bandwidthGbps = APPLE_SILICON_BANDWIDTH_GBPS[chip] ?? UNKNOWN_APPLE_SILICON_BANDWIDTH_GBPS;
+  if (!(chip in APPLE_SILICON_BANDWIDTH_GBPS)) {
+    warnings.push({
+      code: 'macos_unmapped_chip',
+      message: `Unknown Apple Silicon chip "${chip}"; using conservative ${UNKNOWN_APPLE_SILICON_BANDWIDTH_GBPS} GB/s bandwidth.`,
+    });
+  }
+
+  const profile: HardwareProfile = {
+    platform: 'macos',
+    vramGb: ramGb,
+    ramGb,
+    bandwidthGbps,
+    gpuName: chip,
+    cpuName: cpuBrand || hwModel || 'Apple Silicon',
+    detectedAt: now().toISOString(),
+  };
+
+  return { profile, warnings };
+}

--- a/packages/local-models/src/hardware/nvidia.ts
+++ b/packages/local-models/src/hardware/nvidia.ts
@@ -1,0 +1,149 @@
+/**
+ * NVIDIA GPU detection.
+ *
+ * Invokes `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`,
+ * parses the CSV output, and looks up the GPU's memory bandwidth in a static
+ * table seeded from NVIDIA's published datasheets. Multi-GPU hosts pick the
+ * card with the most VRAM and emit a warning so the operator knows the other
+ * cards are being ignored (multi-GPU support lands in v2).
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (Phase 1, F2)
+ */
+
+import * as nodeOs from 'node:os';
+
+import type { ShellRunner } from './shell.js';
+import type { HardwareDetectionWarning, HardwareProfile } from './types.js';
+
+const BYTES_PER_GIB = 1024 ** 3;
+
+/** Minimal subset of `node:os` consumed by the detector — keeps tests injectable. */
+export interface OsModule {
+  totalmem(): number;
+  cpus(): ReadonlyArray<{ model: string }>;
+}
+
+/**
+ * Published memory bandwidths (GB/s) per GPU marketing name. Sourced from
+ * NVIDIA datasheet pages for the consumer Ada/Ampere lines and the Hopper /
+ * Ada-server lines most operators ship with. Keys match the strings
+ * `nvidia-smi` returns verbatim so lookups stay exact.
+ */
+const NVIDIA_BANDWIDTH_GBPS: Readonly<Record<string, number>> = {
+  // Ada — consumer
+  'NVIDIA GeForce RTX 4090': 1008,
+  'NVIDIA GeForce RTX 4080 SUPER': 736,
+  'NVIDIA GeForce RTX 4080': 716,
+  'NVIDIA GeForce RTX 4070 Ti SUPER': 672,
+  'NVIDIA GeForce RTX 4070 Ti': 504,
+  'NVIDIA GeForce RTX 4070 SUPER': 504,
+  'NVIDIA GeForce RTX 4070': 504,
+  'NVIDIA GeForce RTX 4060 Ti': 288,
+  'NVIDIA GeForce RTX 4060': 272,
+  // Ampere — consumer
+  'NVIDIA GeForce RTX 3090 Ti': 1008,
+  'NVIDIA GeForce RTX 3090': 936,
+  'NVIDIA GeForce RTX 3080 Ti': 912,
+  'NVIDIA GeForce RTX 3080': 760,
+  'NVIDIA GeForce RTX 3070 Ti': 608,
+  'NVIDIA GeForce RTX 3070': 448,
+  'NVIDIA GeForce RTX 3060 Ti': 448,
+  'NVIDIA GeForce RTX 3060': 360,
+  // Ada / Hopper / Ampere — datacenter
+  'NVIDIA L40S': 864,
+  'NVIDIA L40': 864,
+  'NVIDIA L4': 300,
+  'NVIDIA A100-PCIE-40GB': 1555,
+  'NVIDIA A100-SXM4-40GB': 1555,
+  'NVIDIA A100-PCIE-80GB': 1935,
+  'NVIDIA A100-SXM4-80GB': 2039,
+  'NVIDIA H100 PCIe': 2000,
+  'NVIDIA H100 80GB HBM3': 3350,
+};
+
+/** Conservative fallback for unmapped NVIDIA GPUs. */
+const UNKNOWN_NVIDIA_BANDWIDTH_GBPS = 300;
+
+/** Result returned by `detectNVIDIA` — profile + any non-fatal warnings. */
+export interface DetectNVIDIAResult {
+  profile: HardwareProfile;
+  warnings: HardwareDetectionWarning[];
+}
+
+interface NvidiaSmiRow {
+  name: string;
+  vramMiB: number;
+}
+
+/**
+ * Parse the `nvidia-smi --format=csv,noheader,nounits` body. Each row is
+ * `"<name>, <memory.total>"` (MiB). Empty or malformed rows are skipped.
+ */
+function parseNvidiaSmi(stdout: string): NvidiaSmiRow[] {
+  const rows: NvidiaSmiRow[] = [];
+  for (const raw of stdout.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const [name, vram] = line.split(',').map((s) => s.trim());
+    if (!name) continue;
+    const vramMiB = Number(vram);
+    if (!Number.isFinite(vramMiB) || vramMiB <= 0) continue;
+    rows.push({ name, vramMiB });
+  }
+  return rows;
+}
+
+/**
+ * Detect an NVIDIA GPU. Throws on missing binary or empty output so the
+ * dispatcher can fall through to the CPU profile (S3).
+ */
+export async function detectNVIDIA(
+  shell: ShellRunner,
+  now: () => Date = () => new Date(),
+  os: OsModule = nodeOs
+): Promise<DetectNVIDIAResult> {
+  const result = await shell.run('nvidia-smi', [
+    '--query-gpu=name,memory.total',
+    '--format=csv,noheader,nounits',
+  ]);
+
+  const rows = parseNvidiaSmi(result.stdout);
+  if (rows.length === 0) {
+    throw new Error('nvidia-smi returned no GPUs');
+  }
+
+  // Pick the GPU with the most VRAM — the one most likely to host the model.
+  const primary = rows.reduce((best, row) => (row.vramMiB > best.vramMiB ? row : best));
+
+  const warnings: HardwareDetectionWarning[] = [];
+  if (rows.length > 1) {
+    warnings.push({
+      code: 'nvidia_multi_gpu_ignored',
+      message: `Detected ${rows.length} NVIDIA GPUs; selecting "${primary.name}" with the most VRAM. Multi-GPU support arrives in v2.`,
+    });
+  }
+
+  const bandwidthGbps = NVIDIA_BANDWIDTH_GBPS[primary.name] ?? UNKNOWN_NVIDIA_BANDWIDTH_GBPS;
+  if (!(primary.name in NVIDIA_BANDWIDTH_GBPS)) {
+    warnings.push({
+      code: 'nvidia_unmapped_gpu',
+      message: `Unknown NVIDIA GPU "${primary.name}"; using conservative ${UNKNOWN_NVIDIA_BANDWIDTH_GBPS} GB/s bandwidth. Add it to NVIDIA_BANDWIDTH_GBPS for an accurate estimate.`,
+    });
+  }
+
+  const vramGb = Math.round((primary.vramMiB / 1024) * 10) / 10;
+  const ramGb = Math.round((os.totalmem() / BYTES_PER_GIB) * 10) / 10;
+  const cpuName = os.cpus()[0]?.model ?? 'unknown';
+
+  const profile: HardwareProfile = {
+    platform: 'nvidia',
+    vramGb,
+    ramGb,
+    bandwidthGbps,
+    gpuName: primary.name,
+    cpuName,
+    detectedAt: now().toISOString(),
+  };
+
+  return { profile, warnings };
+}

--- a/packages/local-models/src/hardware/shell.ts
+++ b/packages/local-models/src/hardware/shell.ts
@@ -1,0 +1,54 @@
+/**
+ * `ShellRunner` — the dependency-injection seam for hardware-detection probes.
+ *
+ * Platform detectors take a `ShellRunner` instead of importing `child_process`
+ * directly so unit tests can drop in deterministic stubs (no real
+ * `system_profiler` or `nvidia-smi` invocations on CI). The default
+ * implementation uses `child_process.execFile` with a short timeout and
+ * `windowsHide: true` so the user never sees a console flash on Windows.
+ *
+ * The runner intentionally exposes both `code` and `stderr` so detectors can
+ * distinguish "binary not installed" (`ENOENT`) from "binary exists but
+ * misbehaved" (non-zero exit with stderr). Only the latter is worth a warning;
+ * the former is the normal CPU-fallback path.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+/** Result of a single shell invocation. */
+export interface ShellResult {
+  stdout: string;
+  stderr: string;
+  /** Exit code (`0` on success). Always `0` when the promise resolves. */
+  code: number;
+}
+
+/**
+ * Pluggable shell runner. Tests inject a stub; production uses the
+ * `defaultShellRunner` below.
+ */
+export interface ShellRunner {
+  run(cmd: string, args: readonly string[]): Promise<ShellResult>;
+}
+
+/**
+ * Default 5-second timeout for hardware probes. `sysctl` and `nvidia-smi`
+ * return in well under 100 ms in steady state — 5 s is a defensive ceiling
+ * that still keeps `harness models status` snappy (F1 requires < 2 s end-to-end).
+ */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/** Production `ShellRunner` backed by `child_process.execFile`. */
+export const defaultShellRunner: ShellRunner = {
+  async run(cmd, args) {
+    const { stdout, stderr } = await execFileP(cmd, [...args], {
+      timeout: DEFAULT_TIMEOUT_MS,
+      windowsHide: true,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return { stdout, stderr, code: 0 };
+  },
+};

--- a/packages/local-models/src/hardware/types.ts
+++ b/packages/local-models/src/hardware/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Hardware detection — public types.
+ *
+ * Surfaces the `HardwareProfile` shape consumed by later phases (ranker, pool,
+ * scheduler, HTTP) and the structured warning envelope the dispatcher emits
+ * when a platform-specific probe fails and the detector falls through to the
+ * CPU profile (S3).
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (lines 115–123, S3)
+ */
+
+import type { LocalModelsPlatform } from '@harness-engineering/types';
+
+/**
+ * Hardware profile snapshot. Identical shape across detectors so downstream
+ * consumers (ranker, dashboard, HTTP) don't have to branch on platform.
+ */
+export interface HardwareProfile {
+  /** Discriminator — `'macos'` covers Apple Silicon unified memory; `'cpu'` is the fallback. */
+  platform: LocalModelsPlatform;
+  /** GPU VRAM in gibibytes for NVIDIA; unified memory for Apple Silicon; `0` for CPU-only hosts. */
+  vramGb: number;
+  /** Total system RAM in gibibytes. */
+  ramGb: number;
+  /** Effective memory bandwidth in GB/s used by the speed estimator. */
+  bandwidthGbps: number;
+  /** Marketing name from `SPDisplaysDataType` or `nvidia-smi`; absent on CPU-only hosts. */
+  gpuName?: string;
+  /** Marketing name from `sysctl`/`os.cpus()[0].model`. Always populated. */
+  cpuName: string;
+  /** ISO timestamp the profile was produced. Used by the dispatcher cache. */
+  detectedAt: string;
+}
+
+/**
+ * Structured warning attached to a detection result. Surfaced via the
+ * eventual `harness models status` CLI and the dashboard hardware card.
+ */
+export interface HardwareDetectionWarning {
+  /** Stable machine code (`'macos_probe_failed'`, `'nvidia_unmapped_gpu'`, ...). */
+  code: string;
+  /** Operator-facing one-liner. */
+  message: string;
+  /** Optional underlying error message — only set when a probe threw. */
+  cause?: string;
+}
+
+/**
+ * Provenance of the returned profile. The dispatcher tags each call so
+ * observers can tell whether the detector shelled out or short-circuited.
+ */
+export type HardwareDetectionSource = 'override' | 'cache' | 'macos' | 'nvidia' | 'cpu';
+
+/**
+ * Bundle returned by `HardwareDetector.detect()`. Always includes a profile
+ * — detection never throws (S3); failures attach a warning and fall through
+ * to the CPU profile.
+ */
+export interface HardwareDetectionResult {
+  profile: HardwareProfile;
+  warnings: HardwareDetectionWarning[];
+  source: HardwareDetectionSource;
+}

--- a/packages/local-models/src/index.ts
+++ b/packages/local-models/src/index.ts
@@ -4,10 +4,13 @@
  * Hardware-aware local-model recommender, pool manager, and proposal engine
  * for Harness Engineering's Local Model Lifecycle Manager (LMLM).
  *
- * Phase 0 — scaffolding only. The public surface (HardwareDetector,
- * ModelRanker, PoolManager, ProposalEngine, ModelRecommender) lands in
- * subsequent phases per `docs/changes/local-model-lifecycle-manager/proposal.md`.
+ * Phase 1 (current) ships hardware detection. Subsequent phases add the
+ * Hugging Face client, ranker, pool manager, Ollama installer, scheduler,
+ * proposal engine, HTTP/WS surfaces, CLI commands, and dashboard panel per
+ * `docs/changes/local-model-lifecycle-manager/proposal.md`.
  */
 
 export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const;
 export const LOCAL_MODELS_VERSION = '0.1.0' as const;
+
+export * from './hardware/index.js';

--- a/packages/local-models/tests/fixtures/nvidia-smi.rtx-4090.txt
+++ b/packages/local-models/tests/fixtures/nvidia-smi.rtx-4090.txt
@@ -1,0 +1,1 @@
+NVIDIA GeForce RTX 4090, 24564

--- a/packages/local-models/tests/fixtures/system_profiler.m3-max-36gb.json
+++ b/packages/local-models/tests/fixtures/system_profiler.m3-max-36gb.json
@@ -1,0 +1,20 @@
+{
+  "SPDisplaysDataType": [
+    {
+      "_name": "Apple M3 Max",
+      "spdisplays_mtlgpufamilysupport": "spdisplays_metal3",
+      "spdisplays_ndrvs": [
+        {
+          "_name": "Color LCD",
+          "_spdisplays_pixels": "3456 x 2234",
+          "spdisplays_main": "spdisplays_yes"
+        }
+      ],
+      "spdisplays_vendor": "sppci_vendor_Apple",
+      "sppci_bus": "spdisplays_builtin",
+      "sppci_cores": "30",
+      "sppci_device_type": "spdisplays_gpu",
+      "sppci_model": "Apple M3 Max"
+    }
+  ]
+}

--- a/packages/local-models/tests/hardware/cpu.test.ts
+++ b/packages/local-models/tests/hardware/cpu.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectCPU } from '../../src/hardware/cpu.js';
+import type { OsModule } from '../../src/hardware/cpu.js';
+
+function makeOs(opts: { ramGb: number; cpu: string }): OsModule {
+  return {
+    totalmem: () => Math.round(opts.ramGb * 1024 ** 3),
+    cpus: () => [{ model: opts.cpu }],
+  };
+}
+
+describe('detectCPU', () => {
+  it('matches a DDR5 desktop CPU (Ryzen 7000) to ~83 GB/s', () => {
+    const { profile, warnings } = detectCPU(
+      makeOs({ ramGb: 64, cpu: 'AMD Ryzen 9 7950X 16-Core Processor' }),
+      () => new Date('2026-05-27T00:00:00.000Z')
+    );
+
+    expect(profile.platform).toBe('cpu');
+    expect(profile.vramGb).toBe(0);
+    expect(profile.ramGb).toBe(64);
+    expect(profile.bandwidthGbps).toBe(83);
+    expect(profile.cpuName).toMatch(/Ryzen 9 7950X/);
+    expect(warnings).toEqual([]);
+  });
+
+  it('matches a DDR4 desktop CPU (Ryzen 5000) to ~51 GB/s', () => {
+    const { profile, warnings } = detectCPU(
+      makeOs({ ramGb: 32, cpu: 'AMD Ryzen 5 5600X 6-Core Processor' }),
+      () => new Date('2026-05-27T00:00:00.000Z')
+    );
+
+    expect(profile.bandwidthGbps).toBe(51);
+    expect(warnings).toEqual([]);
+  });
+
+  it('classifies EPYC 9xxx as a 12-channel DDR5 server', () => {
+    const { profile, warnings } = detectCPU(
+      makeOs({ ramGb: 768, cpu: 'AMD EPYC 9654 96-Core Processor' }),
+      () => new Date('2026-05-27T00:00:00.000Z')
+    );
+
+    expect(profile.bandwidthGbps).toBe(460);
+    expect(warnings).toEqual([]);
+  });
+
+  it('falls back to 40 GB/s and warns for an unknown CPU family', () => {
+    const { profile, warnings } = detectCPU(
+      makeOs({ ramGb: 16, cpu: 'WeirdVendor CPU 9000' }),
+      () => new Date('2026-05-27T00:00:00.000Z')
+    );
+
+    expect(profile.bandwidthGbps).toBe(40);
+    expect(warnings.map((w) => w.code)).toContain('cpu_unmapped_family');
+  });
+
+  it('produces an ISO-formatted detectedAt round-tripable through Date', () => {
+    const { profile } = detectCPU(
+      makeOs({ ramGb: 16, cpu: 'AMD Ryzen 5 5600X' }),
+      () => new Date('2026-05-27T12:34:56.789Z')
+    );
+    expect(new Date(profile.detectedAt).toISOString()).toBe(profile.detectedAt);
+  });
+});

--- a/packages/local-models/tests/hardware/detector.test.ts
+++ b/packages/local-models/tests/hardware/detector.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HardwareDetector, detectHardware } from '../../src/hardware/detector.js';
+import type { OsModule as CpuOs } from '../../src/hardware/cpu.js';
+import type { ShellRunner } from '../../src/hardware/shell.js';
+
+function osWith(opts: { ramGb: number; cpu: string }): CpuOs {
+  return {
+    totalmem: () => Math.round(opts.ramGb * 1024 ** 3),
+    cpus: () => [{ model: opts.cpu }],
+  };
+}
+
+const MACOS_FIXTURE_RESPONSES: Record<string, { stdout: string; stderr: string; code: number }> = {
+  system_profiler: {
+    stdout: JSON.stringify({
+      SPDisplaysDataType: [{ sppci_model: 'Apple M3 Max' }],
+    }),
+    stderr: '',
+    code: 0,
+  },
+  sysctl: {
+    stdout: '38654705664\nMac15,9\nApple M3 Max\n',
+    stderr: '',
+    code: 0,
+  },
+};
+
+function macOSFixtureShell(): ShellRunner {
+  return {
+    run: vi.fn(async (cmd: string) => {
+      const reply = MACOS_FIXTURE_RESPONSES[cmd];
+      if (!reply) throw new Error(`unexpected ${cmd}`);
+      return reply;
+    }),
+  };
+}
+
+describe('HardwareDetector', () => {
+  it('returns the override verbatim and never invokes the shell (OT1)', async () => {
+    const shell: ShellRunner = { run: vi.fn() };
+    const detector = new HardwareDetector({
+      override: {
+        platform: 'nvidia',
+        vramGb: 24,
+        bandwidthGbps: 1008,
+        gpuName: 'RTX 4090',
+      },
+      shell,
+      platform: 'linux',
+      now: () => new Date('2026-05-27T12:00:00.000Z'),
+    });
+
+    const result = await detector.detect();
+
+    expect(result.source).toBe('override');
+    expect(result.profile.gpuName).toBe('RTX 4090');
+    expect(result.profile.bandwidthGbps).toBe(1008);
+    expect(result.profile.detectedAt).toBe('2026-05-27T12:00:00.000Z');
+    expect(shell.run).not.toHaveBeenCalled();
+  });
+
+  it('detects on darwin via the macOS probe (OT2)', async () => {
+    const shell = macOSFixtureShell();
+    const detector = new HardwareDetector({
+      shell,
+      platform: 'darwin',
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    const result = await detector.detect();
+
+    expect(result.source).toBe('macos');
+    expect(result.profile.platform).toBe('macos');
+    expect(result.profile.gpuName).toBe('Apple M3 Max');
+    expect(result.profile.bandwidthGbps).toBe(400);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('detects on linux via the NVIDIA probe (OT3)', async () => {
+    const shell: ShellRunner = {
+      run: vi.fn(async () => ({
+        stdout: 'NVIDIA GeForce RTX 4090, 24564\n',
+        stderr: '',
+        code: 0,
+      })),
+    };
+    const detector = new HardwareDetector({
+      shell,
+      platform: 'linux',
+      osModule: osWith({ ramGb: 64, cpu: 'AMD Ryzen 9 7950X' }),
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    const result = await detector.detect();
+
+    expect(result.source).toBe('nvidia');
+    expect(result.profile.platform).toBe('nvidia');
+    expect(result.profile.gpuName).toBe('NVIDIA GeForce RTX 4090');
+  });
+
+  it('falls through to CPU when the darwin probe throws and surfaces a warning (OT4)', async () => {
+    const shell: ShellRunner = {
+      run: vi.fn(async () => {
+        throw new Error('system_profiler boom');
+      }),
+    };
+    const detector = new HardwareDetector({
+      shell,
+      platform: 'darwin',
+      osModule: osWith({ ramGb: 32, cpu: 'Apple M3' }),
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    const result = await detector.detect();
+
+    expect(result.source).toBe('cpu');
+    expect(result.profile.platform).toBe('cpu');
+    expect(result.warnings.map((w) => w.code)).toContain('macos_probe_failed');
+    expect(result.warnings[0]?.cause).toMatch(/system_profiler boom/);
+  });
+
+  it('falls through to CPU when nvidia-smi is missing (ENOENT, OT5)', async () => {
+    const shell: ShellRunner = {
+      run: vi.fn(async () => {
+        throw Object.assign(new Error('spawn nvidia-smi ENOENT'), { code: 'ENOENT' });
+      }),
+    };
+    const detector = new HardwareDetector({
+      shell,
+      platform: 'linux',
+      osModule: osWith({ ramGb: 32, cpu: 'AMD Ryzen 5 5600X' }),
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    const result = await detector.detect();
+
+    expect(result.source).toBe('cpu');
+    expect(result.warnings.map((w) => w.code)).toContain('nvidia_probe_failed');
+    expect(result.profile.cpuName).toMatch(/Ryzen 5 5600X/);
+  });
+
+  it('caches a probe result within the TTL (OT7)', async () => {
+    const shell = macOSFixtureShell();
+    const detector = new HardwareDetector({
+      shell,
+      platform: 'darwin',
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    await detector.detect();
+    await detector.detect();
+    // The macOS detector issues two parallel shell calls per probe;
+    // a cache hit must keep that count at exactly 2.
+    expect((shell.run as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+  });
+
+  it('re-probes after invalidate()', async () => {
+    const shell = macOSFixtureShell();
+    const detector = new HardwareDetector({
+      shell,
+      platform: 'darwin',
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    await detector.detect();
+    detector.invalidate();
+    await detector.detect();
+    expect((shell.run as ReturnType<typeof vi.fn>).mock.calls.length).toBe(4);
+  });
+
+  it('produces ISO timestamps that round-trip through Date (OT8)', async () => {
+    const detector = new HardwareDetector({
+      platform: 'freebsd',
+      osModule: osWith({ ramGb: 8, cpu: 'Intel Core i7-9700K' }),
+      now: () => new Date('2026-05-27T12:34:56.789Z'),
+    });
+
+    const result = await detector.detect();
+    expect(new Date(result.profile.detectedAt).toISOString()).toBe(result.profile.detectedAt);
+  });
+
+  it('dispatches to CPU directly on unknown platforms', async () => {
+    const detector = new HardwareDetector({
+      platform: 'aix',
+      osModule: osWith({ ramGb: 16, cpu: 'Intel Xeon Gold 6248' }),
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    const result = await detector.detect();
+    expect(result.source).toBe('cpu');
+    expect(result.profile.bandwidthGbps).toBe(200);
+  });
+});
+
+describe('detectHardware (one-shot)', () => {
+  it('runs the dispatcher once and returns the result', async () => {
+    const result = await detectHardware({
+      override: {
+        platform: 'cpu',
+        vramGb: 0,
+        bandwidthGbps: 40,
+        ramGb: 16,
+        cpuName: 'test',
+      },
+    });
+    expect(result.source).toBe('override');
+    expect(result.profile.cpuName).toBe('test');
+  });
+});

--- a/packages/local-models/tests/hardware/macos.test.ts
+++ b/packages/local-models/tests/hardware/macos.test.ts
@@ -1,0 +1,119 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { detectMacOS } from '../../src/hardware/macos.js';
+import type { ShellRunner } from '../../src/hardware/shell.js';
+
+const FIXTURES = path
+  .dirname(fileURLToPath(import.meta.url))
+  .replace(/tests\/hardware$/, 'tests/fixtures');
+
+function makeShell(impl: ShellRunner['run']): ShellRunner {
+  return { run: impl };
+}
+
+async function loadFixture(name: string): Promise<string> {
+  return readFile(path.join(FIXTURES, name), 'utf8');
+}
+
+describe('detectMacOS', () => {
+  it('parses an M3 Max + 36GB unified-memory host from real fixtures', async () => {
+    const spdisplays = await loadFixture('system_profiler.m3-max-36gb.json');
+    const shell = makeShell(async (cmd) => {
+      if (cmd === 'system_profiler') {
+        return { stdout: spdisplays, stderr: '', code: 0 };
+      }
+      if (cmd === 'sysctl') {
+        // 36 GiB = 38_654_705_664 bytes
+        return {
+          stdout: '38654705664\nMac15,9\nApple M3 Max\n',
+          stderr: '',
+          code: 0,
+        };
+      }
+      throw new Error(`unexpected shell invocation: ${cmd}`);
+    });
+
+    const now = new Date('2026-05-27T12:00:00.000Z');
+    const { profile, warnings } = await detectMacOS(shell, () => now);
+
+    expect(profile.platform).toBe('macos');
+    expect(profile.gpuName).toBe('Apple M3 Max');
+    expect(profile.cpuName).toBe('Apple M3 Max');
+    expect(profile.vramGb).toBeCloseTo(36, 0);
+    expect(profile.ramGb).toBeCloseTo(36, 0);
+    expect(profile.bandwidthGbps).toBe(400);
+    expect(profile.detectedAt).toBe('2026-05-27T12:00:00.000Z');
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns a warning for an unmapped Apple Silicon chip but still resolves a profile', async () => {
+    const shell = makeShell(async (cmd) => {
+      if (cmd === 'system_profiler') {
+        return {
+          stdout: JSON.stringify({
+            SPDisplaysDataType: [{ sppci_model: 'Apple M9 Ultra' }],
+          }),
+          stderr: '',
+          code: 0,
+        };
+      }
+      return { stdout: '17179869184\nMacUnknown\nApple M9\n', stderr: '', code: 0 };
+    });
+
+    const { profile, warnings } = await detectMacOS(shell);
+
+    expect(profile.gpuName).toBe('Apple M9 Ultra');
+    expect(profile.bandwidthGbps).toBe(100);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.code).toBe('macos_unmapped_chip');
+  });
+
+  it('throws when running on an Intel Mac (non-Apple-Silicon GPU)', async () => {
+    const shell = makeShell(async (cmd) => {
+      if (cmd === 'system_profiler') {
+        return {
+          stdout: JSON.stringify({
+            SPDisplaysDataType: [{ sppci_model: 'AMD Radeon Pro 5500M' }],
+          }),
+          stderr: '',
+          code: 0,
+        };
+      }
+      return { stdout: '17179869184\nMacBookPro16,1\nIntel\n', stderr: '', code: 0 };
+    });
+
+    await expect(detectMacOS(shell)).rejects.toThrow(/unsupported macOS GPU/);
+  });
+
+  it('throws when sysctl returns a non-numeric memory size', async () => {
+    const shell = makeShell(async (cmd) => {
+      if (cmd === 'system_profiler') {
+        return {
+          stdout: JSON.stringify({
+            SPDisplaysDataType: [{ sppci_model: 'Apple M2' }],
+          }),
+          stderr: '',
+          code: 0,
+        };
+      }
+      return { stdout: 'not-a-number\nMac\nApple M2\n', stderr: '', code: 0 };
+    });
+
+    await expect(detectMacOS(shell)).rejects.toThrow(/hw\.memsize/);
+  });
+
+  it('throws when system_profiler returns invalid JSON', async () => {
+    const shell = makeShell(async (cmd) => {
+      if (cmd === 'system_profiler') {
+        return { stdout: 'not json', stderr: '', code: 0 };
+      }
+      return { stdout: '0\n\n\n', stderr: '', code: 0 };
+    });
+
+    await expect(detectMacOS(shell)).rejects.toThrow();
+  });
+});

--- a/packages/local-models/tests/hardware/nvidia.test.ts
+++ b/packages/local-models/tests/hardware/nvidia.test.ts
@@ -1,0 +1,96 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { detectNVIDIA } from '../../src/hardware/nvidia.js';
+import type { OsModule } from '../../src/hardware/nvidia.js';
+import type { ShellRunner } from '../../src/hardware/shell.js';
+
+const FIXTURES = path
+  .dirname(fileURLToPath(import.meta.url))
+  .replace(/tests\/hardware$/, 'tests/fixtures');
+
+function makeShell(impl: ShellRunner['run']): ShellRunner {
+  return { run: impl };
+}
+
+function makeOs(opts: { ramGb: number; cpu?: string }): OsModule {
+  return {
+    totalmem: () => Math.round(opts.ramGb * 1024 ** 3),
+    cpus: () => [{ model: opts.cpu ?? 'AMD Ryzen 9 7950X 16-Core Processor' }],
+  };
+}
+
+describe('detectNVIDIA', () => {
+  it('parses an RTX 4090 row from the canonical fixture', async () => {
+    const fixture = await readFile(path.join(FIXTURES, 'nvidia-smi.rtx-4090.txt'), 'utf8');
+    const shell = makeShell(async () => ({ stdout: fixture, stderr: '', code: 0 }));
+    const now = new Date('2026-05-27T12:00:00.000Z');
+    const os = makeOs({ ramGb: 64 });
+
+    const { profile, warnings } = await detectNVIDIA(shell, () => now, os);
+
+    expect(profile.platform).toBe('nvidia');
+    expect(profile.gpuName).toBe('NVIDIA GeForce RTX 4090');
+    expect(profile.vramGb).toBeCloseTo(23.99, 1);
+    expect(profile.bandwidthGbps).toBe(1008);
+    expect(profile.ramGb).toBe(64);
+    expect(profile.cpuName).toMatch(/Ryzen 9 7950X/);
+    expect(profile.detectedAt).toBe('2026-05-27T12:00:00.000Z');
+    expect(warnings).toEqual([]);
+  });
+
+  it('selects the highest-VRAM GPU on a multi-GPU host and emits a warning', async () => {
+    const shell = makeShell(async () => ({
+      stdout: ['NVIDIA GeForce RTX 3060, 12288', 'NVIDIA GeForce RTX 4090, 24564'].join('\n'),
+      stderr: '',
+      code: 0,
+    }));
+
+    const { profile, warnings } = await detectNVIDIA(
+      shell,
+      () => new Date('2026-05-27T00:00:00.000Z'),
+      makeOs({ ramGb: 32 })
+    );
+
+    expect(profile.gpuName).toBe('NVIDIA GeForce RTX 4090');
+    expect(warnings.map((w) => w.code)).toContain('nvidia_multi_gpu_ignored');
+  });
+
+  it('falls back to the conservative bandwidth and warns for unmapped GPUs', async () => {
+    const shell = makeShell(async () => ({
+      stdout: 'NVIDIA GeForce RTX 5090, 32768\n',
+      stderr: '',
+      code: 0,
+    }));
+
+    const { profile, warnings } = await detectNVIDIA(
+      shell,
+      () => new Date('2026-05-27T00:00:00.000Z'),
+      makeOs({ ramGb: 128 })
+    );
+
+    expect(profile.bandwidthGbps).toBe(300);
+    expect(warnings.map((w) => w.code)).toContain('nvidia_unmapped_gpu');
+  });
+
+  it('throws when nvidia-smi is unavailable (ENOENT)', async () => {
+    const shell = makeShell(async () => {
+      throw Object.assign(new Error('spawn nvidia-smi ENOENT'), { code: 'ENOENT' });
+    });
+
+    await expect(detectNVIDIA(shell, () => new Date(), makeOs({ ramGb: 16 }))).rejects.toThrow(
+      /ENOENT/
+    );
+  });
+
+  it('throws when nvidia-smi returns an empty body', async () => {
+    const shell = makeShell(async () => ({ stdout: '\n\n', stderr: '', code: 0 }));
+
+    await expect(detectNVIDIA(shell, () => new Date(), makeOs({ ramGb: 16 }))).rejects.toThrow(
+      /no GPUs/
+    );
+  });
+});

--- a/packages/local-models/tsconfig.json
+++ b/packages/local-models/tsconfig.json
@@ -6,6 +6,7 @@
     "composite": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
+  "references": [{ "path": "../types" }],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 1.6.4(@algolia/client-search@5.52.1)(search-insights@2.17.3)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -192,7 +192,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/core:
     dependencies:
@@ -393,7 +393,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/graph:
     dependencies:
@@ -425,7 +425,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/intelligence:
     dependencies:
@@ -456,7 +456,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/linter-gen:
     dependencies:
@@ -484,14 +484,20 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/local-models:
     dependencies:
+      '@harness-engineering/types':
+        specifier: workspace:*
+        version: link:../types
       zod:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -500,7 +506,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/orchestrator:
     dependencies:
@@ -582,7 +588,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
 
   packages/types:
     dependencies:
@@ -4565,7 +4571,7 @@ packages:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+      vitest: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
     dev: true
 
   /@vitest/expect@4.1.5:
@@ -10112,6 +10118,73 @@ packages:
       - msw
     dev: true
 
+  /vitest@4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2):
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 22.19.15
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@6.4.2)
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+    dev: true
+
   /vitest@4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2):
     resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -10170,7 +10243,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
## Summary

Adds Phase 1 of the **Local Model Lifecycle Manager (LMLM)** — hardware detection.

The new `HardwareDetector` returns a `HardwareProfile` on macOS (Apple Silicon), Linux/Windows with NVIDIA, and CPU-only hosts. The dispatcher honors an operator override ahead of autodetection, caches results for 24h by default to match the spec's refresh cadence (D9), and falls through to a CPU profile with a structured warning when a platform-specific probe fails — it **never throws** (S3). Shell-outs are dependency-injected via a `ShellRunner` interface so unit tests stay deterministic across CI hosts.

### What's in this PR

- `detectMacOS` parses `system_profiler SPDisplaysDataType -json` + `sysctl` and maps Apple Silicon chips (M1 through M4 Max) to their published unified-memory bandwidths.
- `detectNVIDIA` parses `nvidia-smi --query-gpu=name,memory.total` and maps NVIDIA GPUs (Ada/Ampere/Hopper) to their published memory bandwidths. Multi-GPU hosts pick the highest-VRAM card and emit a warning.
- `detectCPU` derives a conservative bandwidth heuristic by regex-matching the CPU brand string against known DDR4/DDR5 desktop and server families.
- `HardwareDetector` dispatcher: override → cache → platform-specific probe → CPU fallback. Never throws after construction.
- 27 unit tests across `macos`, `nvidia`, `cpu`, `detector` — all fixture-driven, no real shell-outs.

### What's not in this PR

No orchestrator wiring yet — the detector is consumed by the ranker (Phase 2), scheduler (Phase 6), and HTTP/dashboard surfaces (Phases 7–8). LMLM remains opt-in and disabled by default per Phase 0.

### References

- Spec: `docs/changes/local-model-lifecycle-manager/proposal.md` (Phase 1, lines 403–412)
- Plan: `docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase1-hardware-detection-plan.md`
- Phase 0 (already merged): #432 (scaffold + config block)

## Test plan

- [x] `pnpm --filter @harness-engineering/local-models build` — green
- [x] `pnpm --filter @harness-engineering/local-models typecheck` — green
- [x] `pnpm --filter @harness-engineering/local-models lint` — green
- [x] `pnpm --filter @harness-engineering/local-models test` — 27/27 green
- [x] `pnpm exec harness validate` — same 258-issue baseline as `main` (zero new issues from this PR's files)
- [x] Manual: run the detector on local Apple Silicon — returns expected profile within 2 seconds (F1)

Acceptance criteria addressed (from the Phase 1 plan): **OT1**, **OT2**, **OT3**, **OT4**, **OT5**, **OT6**, **OT7**, **OT8**, **OT9**, **OT10**.