### PR TITLE
chore(roadmap): mark Hermes Phase 2 as done

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 project: harness-engineering
 version: 1
 created: 2026-03-21
-updated: 2026-05-17
+updated: 2026-05-27
 last_synced: 2026-05-23T20:39:30.138Z
 last_manual_edit: 2026-05-24T15:27:04.258Z
 ---
@@ -1197,11 +1197,11 @@ last_manual_edit: 2026-05-24T15:27:04.258Z
 
 ### Hermes Phase 2: Custom Maintenance Jobs
 
-- **Status:** planned
-- **Spec:** docs/changes/hermes-adoption/proposal.md
+- **Status:** done
+- **Spec:** docs/changes/hermes-phase-2-custom-jobs/proposal.md
 - **Summary:** Extend MaintenanceScheduler beyond 21 built-in tasks: user-defined custom jobs with output persistence, context_from chaining, skill-content injection, origin tracking, arbitrary pre-check scripts. Plus pre-launch OSV malware guard on MCP/npx packages and expanded cleanup-sessions to general .harness disk hygiene. From Hermes adoption meta-spec.
-- **Blockers:** Hermes Phase 0: Gateway API + Telemetry
-- **Plan:** —
+- **Blockers:** —
+- **Plan:** docs/changes/hermes-phase-2-custom-jobs/plans/2026-05-17-main-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#312


### PR DESCRIPTION
## Summary

Roadmap-sync only. Phase 2 (custom maintenance jobs + OSV pre-launch
guard + `.harness/` disk hygiene) shipped in PR #349 (commit 4aa241fa),
but the roadmap entry was still `planned` with a stale spec pointer
and a now-resolved blocker on Phase 0.

This change updates the `Hermes Phase 2: Custom Maintenance Jobs`
entry in `docs/roadmap.md`:

- **Status:** planned → done
- **Spec:** `docs/changes/hermes-adoption/proposal.md` (meta) → `docs/changes/hermes-phase-2-custom-jobs/proposal.md` (dedicated)
- **Plan:** — → `docs/changes/hermes-phase-2-custom-jobs/plans/2026-05-17-main-plan.md`
- **Blockers:** `Hermes Phase 0: Gateway API + Telemetry` → — (Phase 0 is done)
- Bumps frontmatter `updated:` to 2026-05-27

No code changes. `harness validate` shows 267 pre-existing issues on
main, untouched by this diff.

## Test plan

- [x] Confirm all Phase 2 implementation artifacts exist in main (output-store, check-script-runner, context-resolver, custom-task-validator, OSV client, mcp-guard CLI, ADR 0015, knowledge doc)
- [x] Confirm `harness validate` issue count unchanged vs. main (still 267)
- [x] Roadmap entry now points at the dedicated phase spec and main plan

Closes `hermes-phase-2-custo-5db5d751`