### PR TITLE
docs(roadmap): mark Hermes Phase 2 done — sync stale entry

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1197,11 +1197,11 @@ last_manual_edit: 2026-05-24T15:27:04.258Z
 
 ### Hermes Phase 2: Custom Maintenance Jobs
 
-- **Status:** planned
-- **Spec:** docs/changes/hermes-adoption/proposal.md
+- **Status:** done
+- **Spec:** docs/changes/hermes-phase-2-custom-jobs/proposal.md
 - **Summary:** Extend MaintenanceScheduler beyond 21 built-in tasks: user-defined custom jobs with output persistence, context_from chaining, skill-content injection, origin tracking, arbitrary pre-check scripts. Plus pre-launch OSV malware guard on MCP/npx packages and expanded cleanup-sessions to general .harness disk hygiene. From Hermes adoption meta-spec.
-- **Blockers:** Hermes Phase 0: Gateway API + Telemetry
-- **Plan:** —
+- **Blockers:** —
+- **Plan:** docs/changes/hermes-phase-2-custom-jobs/plans/2026-05-17-main-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#312


### PR DESCRIPTION
## Summary

Roadmap drift fix — `docs/roadmap.md` still listed **Hermes Phase 2: Custom Maintenance Jobs** as `Status: planned` despite the implementation having merged via PR #349 on 2026-05-17 (commit `4aa241fa`, "Closes hermes-phase-2-custo-5db5d751"). All Integration Points from the spec are present in `main`:

- `maintenance` + `mcp-guard` CLI commands registered in `packages/cli/src/commands/_registry.ts`
- `trigger_maintenance_job` registered in `packages/cli/src/mcp/server.ts` + `tool-tiers.ts` (tier-1)
- `/api/v1/jobs/maintenance` declared in `docs/api/openapi.yaml`
- ADR `docs/knowledge/decisions/0015-hermes-phase-2-custom-maintenance-jobs.md`
- Knowledge artifacts `custom-maintenance-jobs.md` and `pre-launch-osv-guard.md` under `docs/knowledge/`

The deferred items called out in `4aa241fa`'s commit message also landed in follow-ups: `4610280a` (`POST /api/v1/jobs/maintenance`), `973dae5c` (404 mapping for unknown task), `9553378f` (`trigger_maintenance_job` MCP + `list_gateway_tokens`).

This PR matches the established Phase 1/3/4/5 post-merge sync pass (`10c86301`, `11abadbd`, `c5db83c0`, `6032717e`). One-file, four-line diff:

- `Status: planned` → `done`
- `Spec:` retargeted from the meta-spec to the dedicated `hermes-phase-2-custom-jobs/proposal.md`
- `Blockers: Hermes Phase 0…` → `—` (Phase 0 also done)
- `Plan:` filled in to `…/plans/2026-05-17-main-plan.md`

Closes hermes-phase-2-custo-5db5d751.

## Test plan

- [ ] CI `format:check`, `typecheck`, `test:ci`, `generate-docs --check` all green (locally clean on push)
- [ ] Visual diff on `docs/roadmap.md` shows only the four intended lines in the Phase 2 block changed