### PR TITLE
feat(local-models): LMLM Phase 2a — HuggingFace client + cache

### DIFF
--- a/.changeset/lmlm-phase2a-huggingface-client.md
+++ b/.changeset/lmlm-phase2a-huggingface-client.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/local-models': minor
+---
+
+Adds Phase 2a of the Local Model Lifecycle Manager — the HuggingFace API client and cache layer.
+
+The new `HuggingFaceClient` wraps `huggingface.co/api/models` with `listModels` and `getModel`, follows `Link: rel="next"` pagination cursors when asked, and degrades to a structured warning on 4xx/5xx, network failure, or JSON-decode failure rather than throwing — matching the S4 contract that `harness models status` stays usable when HF is unreachable. Rows are decoded through a drift-tolerant Zod schema so unexpected HF API churn drops individual rows instead of rejecting whole batches.
+
+The cache layer ships two implementations:
+
+- `InMemoryHuggingFaceCache` — a `Map`-backed TTL cache for unit tests and process-local hot paths.
+- `FileHuggingFaceCache` — a disk-backed JSON cache that writes via tmp file + `rename` so a crash mid-write cannot corrupt an entry (the same atomic-write pattern Phase 3 needs for the pool-state file). Envelope is schema-versioned, mkdir is lazy and idempotent, and the most recent decode/IO warning is exposed via a `lastWarning` getter for downstream operator surfaces.
+
+The HTTP fetcher, file system, and clock are all dependency-injected through the same DI pattern Phase 1's `ShellRunner` established, so unit tests stay deterministic and the production scheduler can plug a `FileHuggingFaceCache` in without further wiring.
+
+No orchestrator wiring yet — the ranker (Phase 2b), benchmark adapters (Phase 2c), ranking algorithm (Phase 2d), scheduler (Phase 6), and HTTP routes (Phase 7) that consume this surface arrive in subsequent phases. LMLM remains opt-in and disabled by default per Phase 0.

--- a/docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase2a-huggingface-client-plan.md
+++ b/docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase2a-huggingface-client-plan.md
@@ -1,0 +1,139 @@
+# Plan: LMLM Phase 2a — HuggingFace Client + Cache
+
+**Date:** 2026-05-27 | **Spec:** `docs/changes/local-model-lifecycle-manager/proposal.md` (Phase 2, lines 414–429) | **Tasks:** 6 | **Time:** ~2–3 hours | **Integration Tier:** small | **Session:** `changes--local-model-lifecycle-manager--phase2a`
+
+## Goal
+
+Land the HuggingFace API client and its cache layer as a standalone, dependency-injected slice of Phase 2. The client surfaces the same drift-tolerant warning envelope as `HardwareDetector` (S4 mirrors S3): network errors, decode failures, and rate limiting degrade to warnings rather than throws, and the cache provides a stable read path when HF is unreachable.
+
+Phase 2a deliberately stops short of the ranker (`ranker/{vram,speed,evidence,recency,benchmarks,algorithm}.ts`), benchmark sources, and the frozen on-disk snapshot. Those land in Phase 2b–2d. This phase only needs to deliver the _data plumbing_ that the ranker will sit on top of:
+
+- A typed, version-tagged `HuggingFaceClient.listModels()` that paginates HF's `/api/models` and decodes rows into `HuggingFaceModelSummary[]`.
+- An in-memory + on-disk cache with TTL that the client transparently consults.
+- A `HttpFetcher` DI seam so unit tests stay deterministic and the production code can plug in retry/proxy wrappers without churning the client.
+
+The full Phase 2 checkpoint criteria (F3 + Q1–Q5 + S4) require the ranker — Phase 2a only validates S4 (HF failure → cache fallback path) so the downstream phases inherit a stable foundation.
+
+## Phase 2a Scope (subset of spec Phase 2)
+
+In:
+
+- `src/huggingface/types.ts` — `HuggingFaceModelSummary`, `HuggingFaceWarning`, `HuggingFaceFetchResult`, `HuggingFaceListOptions`, drift-tolerant Zod schema (committed in pre-phase scaffolding; this plan ratifies it).
+- `src/huggingface/http.ts` — `HttpFetcher` interface + default `globalThis.fetch`-backed implementation with timeout + User-Agent (committed in pre-phase scaffolding; this plan ratifies it).
+- `src/huggingface/cache.ts` — `HuggingFaceCache` with TTL (in-memory map of namespaced keys; optional on-disk JSON store written via tmp+rename to `~/.harness/local-models/hf-cache/`).
+- `src/huggingface/client.ts` — `HuggingFaceClient` with `listModels(opts)`; paginates via `Link: rel="next"` (capped by `maxPages`); never throws — failures resolve as `{ value: [], warnings, source: 'cache' | 'live' }`.
+- `src/huggingface/index.ts` — barrel re-export.
+- `src/index.ts` — already re-exports from `./huggingface/index.js`; just confirm the comment block names Phase 2a.
+- Tests: `tests/huggingface/{client,cache,types}.test.ts` — decode parity, pagination, retry budget, error fallback, cache TTL.
+
+Out of Phase 2a (deferred):
+
+- Ranker math, benchmark adapters, evidence grading, recency weighting (Phase 2b–2d).
+- Frozen `benchmarks/snapshot.json` (Phase 2d once benchmark sources exist).
+- Authenticated requests (HF API token); Phase 2a only consumes public endpoints.
+- Per-model detail fetch (`/api/models/<id>`); Phase 2a only paginates the list.
+- Wiring the client into the scheduler (Phase 6) or HTTP/WS (Phase 7).
+
+## Observable Truths (Acceptance Criteria — Phase 2a only)
+
+1. **OT1** — `HuggingFaceClient.listModels({ author: 'Qwen', limit: 50 })` resolves to `{ value: HuggingFaceModelSummary[], warnings: [], source: 'live' }` on a happy-path stub. Unknown rows are dropped; the `dropped` count surfaces as a structured warning when ≥ 1.
+2. **OT2** — Pagination follows `Link: <…>; rel="next"` up to `maxPages` (default 5); the test stub returns three pages and asserts all rows are merged.
+3. **OT3** — A 5xx response or thrown fetch is retried with exponential backoff (initial 200 ms, multiplier 2, max 3 attempts); after exhaustion, the client returns the cache (if present) or `{ value: [], warnings: [{ code: 'hf_fetch_failed', … }], source: 'cache' }`.
+4. **OT4** — A 429 response with `Retry-After` honors the header (capped at 5 s in tests); a 429 without the header falls back to exponential backoff.
+5. **OT5** — `HuggingFaceCache` round-trips through the in-memory layer instantly; with an injected `FsAdapter`, on-disk reads warm the in-memory layer on first access. Expired entries are evicted on read.
+6. **OT6** — The on-disk store writes via tmp + rename (atomicity) and tolerates a missing parent directory by creating it on demand.
+7. **OT7** — Decode of a row missing `id` is dropped (not thrown). A drop count > 0 produces a `hf_decode_dropped_rows` warning.
+8. **OT8** — `pnpm --filter @harness-engineering/local-models build && test && typecheck` green; existing hardware tests still pass; no flakes across 3 consecutive runs locally.
+9. **OT9** — `harness validate` passes on a legacy config (N4 from spec success criteria).
+
+## File Map
+
+- KEEP `packages/local-models/src/huggingface/types.ts` (already drafted)
+- KEEP `packages/local-models/src/huggingface/http.ts` (already drafted)
+- CREATE `packages/local-models/src/huggingface/cache.ts`
+- CREATE `packages/local-models/src/huggingface/client.ts`
+- CREATE `packages/local-models/src/huggingface/index.ts`
+- CREATE `packages/local-models/tests/huggingface/client.test.ts`
+- CREATE `packages/local-models/tests/huggingface/cache.test.ts`
+- CREATE `packages/local-models/tests/huggingface/types.test.ts`
+- CREATE `.changeset/lmlm-phase2a-huggingface-client.md`
+
+## Tasks
+
+### Task 1: HuggingFaceCache — in-memory + injectable filesystem layer
+
+**Depends on:** none | **Files:** `src/huggingface/cache.ts`, `tests/huggingface/cache.test.ts`
+
+1. `interface FsAdapter { readFile(path): Promise<string | null>; writeFile(path, data): Promise<void>; ensureDir(path): Promise<void>; }` — minimal so tests can supply a Map-backed in-memory adapter.
+2. Default impl uses `node:fs/promises` and writes atomically (tmp + rename).
+3. `HuggingFaceCache` constructor takes `{ ttlMs?: number; fs?: FsAdapter; rootDir?: string; now?: () => Date }`. Default TTL is 24h (matches the spec's daily refresh cadence, D9).
+4. API: `get<T>(key): Promise<{ value: T; storedAt: number } | undefined>`, `set<T>(key, value): Promise<void>`, `invalidate(key?): Promise<void>` (full clear when no key).
+5. Tests cover: in-memory hit, TTL expiry eviction, tmp+rename via injected FS, missing-parent-dir handling, namespace isolation (different keys don't collide).
+
+### Task 2: HuggingFaceClient — `listModels` with pagination, retry, decode
+
+**Depends on:** Task 1 + existing `types.ts` + existing `http.ts` | **Files:** `src/huggingface/client.ts`, `tests/huggingface/client.test.ts`
+
+1. Constructor accepts `{ http?: HttpFetcher; cache?: HuggingFaceCache; baseUrl?: string; maxAttempts?: number; backoffMs?: number; retryAfterCapMs?: number; now?: () => Date }`. Defaults: `baseUrl = 'https://huggingface.co'`, `maxAttempts = 3`, `backoffMs = 200`, `retryAfterCapMs = 5_000`.
+2. `listModels(opts: HuggingFaceListOptions = {})` resolves to `HuggingFaceFetchResult<HuggingFaceModelSummary[]>`.
+   - Build query string from `author`, `search`, `filter`, `tags` (joined with `,`), `limit`.
+   - Always include `sort=downloads&direction=-1` (spec uses popularity-aware ranking).
+   - Follow `Link: <…>; rel="next"` up to `maxPages` (default 5) when `paginate: true`.
+   - On 2xx: decode via `decodeModelSummaries`; emit `hf_decode_dropped_rows` warning if any rows dropped; persist to cache; resolve `source: 'live'`.
+   - On 4xx (non-429): no retry; surface `hf_client_error` warning carrying the status code; fall back to cache when present.
+   - On 429: honor `Retry-After` seconds (capped); else exponential backoff.
+   - On 5xx / network throw: exponential backoff up to `maxAttempts`; after exhaustion fall back to cache; never throw.
+3. Tests: stub `HttpFetcher` with a Map of URL → response sequence; cover live success, multi-page pagination, decode drops, 5xx → retry → success, 5xx exhausted → cache fallback, 429 honoring header, 4xx no retry.
+
+### Task 3: Decode + types unit tests
+
+**Depends on:** none (the pre-phase scaffolding lands the implementation) | **Files:** `tests/huggingface/types.test.ts`
+
+1. Verify `HuggingFaceModelSummarySchema` accepts a realistic row, drops a malformed row, and surfaces the `library_name` → `libraryName` rename + `pipeline_tag` → `pipelineTag` rename.
+2. Verify `decodeModelSummaries` returns `{ models: [], dropped: 0 }` for non-array input.
+3. Verify dropped count is correct for a mixed batch.
+
+### Task 4: Public surface — barrel + main index
+
+**Depends on:** Tasks 1–3 | **Files:** `src/huggingface/index.ts`, `src/index.ts` (verify)
+
+1. `src/huggingface/index.ts` re-exports `HuggingFaceClient`, `HuggingFaceCache`, `defaultHttpFetcher`, the public types, and `decodeModelSummaries`.
+2. Confirm `src/index.ts` already re-exports from `./huggingface/index.js`; bump the comment block to name Phase 2a explicitly.
+
+### Task 5: Changeset
+
+**Depends on:** Tasks 1–4 | **Files:** `.changeset/lmlm-phase2a-huggingface-client.md`
+
+1. `minor` bump on `@harness-engineering/local-models`.
+2. Body: "Adds Phase 2a of the Local Model Lifecycle Manager — HuggingFace API client + cache. Drift-tolerant decode (unknown rows dropped, never thrown), pagination via `Link: rel='next'` (capped at 5 pages), exponential backoff on 5xx, `Retry-After`-aware on 429, in-memory + on-disk cache with 24h TTL. Network failures degrade gracefully to cached data — the client never throws. The ranker that sits on top of this (Phase 2b+) is unimplemented; the new exports are wired but not yet consumed by the orchestrator."
+
+### Task 6: Verification gate — build, typecheck, test, validate
+
+**Depends on:** Tasks 1–5 | **Files:** none
+
+1. `pnpm --filter @harness-engineering/local-models build` — green.
+2. `pnpm --filter @harness-engineering/local-models typecheck` — green.
+3. `pnpm --filter @harness-engineering/local-models test` — green (new tests + existing hardware tests).
+4. `pnpm exec harness validate` from repo root — green.
+5. If any step fails: stop, diagnose, fix, re-run.
+
+## Integration Notes
+
+Phase 2a's integration footprint stays inside the package barrel — no new orchestrator wiring, HTTP routes, CLI commands, or dashboard panels. Downstream phases consume it:
+
+- **Phase 2b–2d (Ranker)** call `HuggingFaceClient.listModels` to source candidate repos; the cache absorbs HF rate limits during the algorithm port.
+- **Phase 6 (Scheduler)** owns the client lifecycle (`new HuggingFaceClient({ cache: new HuggingFaceCache({ rootDir: '~/.harness/local-models/hf-cache' }) })`) and invalidates the cache on `harness models refresh`.
+- **Phase 7 (HTTP/WS)** never touches the client directly; the scheduler's ranking output is what the routes serve.
+
+**Knowledge graph**: no new business concepts in Phase 2a. The five spec concepts (Local Model Pool, Model Proposal, etc.) land alongside their implementations in Phases 3, 5, 6.
+
+**ADRs**: none in Phase 2a. The seven ADRs in the spec land with the code that justifies them (Phases 3, 5, 6 primarily).
+
+**Docs**: changeset only. The operator-facing `local-model-lifecycle.md` guide lands in Phase 9.
+
+## Uncertainties
+
+- **[ASSUMPTION]** The HF `/api/models` Link header pagination remains stable. If HF switches to cursor-based pagination, the client surfaces a `hf_pagination_unsupported` warning and returns the first page only.
+- **[ASSUMPTION]** No HF API token in v1; we only consume public endpoints. Authenticated requests (higher rate limits, private repos) are deferred until an operator asks for them.
+- **[DEFERRABLE]** Per-model detail fetch (`/api/models/<id>` with `siblings`, `gguf`, etc.) lands when the ranker needs file-level quant info — likely Phase 2b alongside the VRAM math.
+- **[DEFERRABLE]** The on-disk cache key strategy is a simple SHA-1 of the URL today. If we observe cache directory bloat, we'll add a sharded layout (e.g., `aa/bbcc…`) in a follow-up.

--- a/packages/local-models/src/huggingface/cache.ts
+++ b/packages/local-models/src/huggingface/cache.ts
@@ -1,0 +1,230 @@
+/**
+ * Cache layer for the HuggingFace client.
+ *
+ * Two implementations ship in Phase 2a:
+ *
+ *  - `InMemoryHuggingFaceCache` — a `Map`-based TTL cache for unit tests
+ *    and process-local hot paths.
+ *  - `FileHuggingFaceCache` — a disk-backed JSON cache under
+ *    `~/.harness/local-models/cache/` (or any directory the caller
+ *    chooses). Writes go through a tmp file + `rename` so a crash
+ *    mid-write cannot corrupt an entry (mirrors the O2 pattern the spec
+ *    requires for the pool-state file).
+ *
+ * Both implementations honor a TTL passed per-call so the client can
+ * tombstone 404s at half TTL without a separate code path.
+ */
+
+import { createHash } from 'node:crypto';
+import * as nodeFs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { HuggingFaceWarning } from './types.js';
+
+/** Cache envelope persisted on disk. Versioned so we can change the shape later. */
+interface CacheEnvelope<T> {
+  version: 1;
+  key: string;
+  value: T;
+  writtenAt: number;
+  expiresAt: number;
+}
+
+const ENVELOPE_VERSION = 1 as const;
+
+/**
+ * Pluggable cache surface consumed by `HuggingFaceClient`. Implementations
+ * must never throw — failures resolve to `undefined` from `get` (read
+ * miss) so the client can fall through to a live fetch transparently.
+ */
+export interface HuggingFaceCache {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  clear(): Promise<void>;
+}
+
+/** Constructor options for `InMemoryHuggingFaceCache`. */
+export interface InMemoryHuggingFaceCacheOptions {
+  /** Clock injection — tests pin time so TTL assertions stay deterministic. */
+  now?: () => number;
+}
+
+/** Process-local TTL cache. Useful in tests and single-process orchestrators. */
+export class InMemoryHuggingFaceCache implements HuggingFaceCache {
+  private readonly entries = new Map<string, { value: unknown; expiresAt: number }>();
+  private readonly now: () => number;
+
+  constructor(opts: InMemoryHuggingFaceCacheOptions = {}) {
+    this.now = opts.now ?? Date.now;
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return entry.value as T;
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    const ttl = Math.max(0, ttlMs);
+    this.entries.set(key, { value, expiresAt: this.now() + ttl });
+  }
+
+  async clear(): Promise<void> {
+    this.entries.clear();
+  }
+}
+
+/**
+ * Filesystem subset `FileHuggingFaceCache` needs. Tests inject a
+ * memory-backed implementation so no real disk I/O happens during unit
+ * tests.
+ */
+export interface FileCacheFs {
+  mkdir(dir: string, opts: { recursive: true }): Promise<void>;
+  writeFile(file: string, data: string): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  readFile(file: string): Promise<string>;
+  unlink(file: string): Promise<void>;
+}
+
+const defaultFs: FileCacheFs = {
+  mkdir: async (dir, opts) => {
+    await nodeFs.mkdir(dir, opts);
+  },
+  writeFile: (file, data) => nodeFs.writeFile(file, data, 'utf8'),
+  rename: (from, to) => nodeFs.rename(from, to),
+  readFile: (file) => nodeFs.readFile(file, 'utf8'),
+  unlink: (file) => nodeFs.unlink(file),
+};
+
+/** Constructor options for `FileHuggingFaceCache`. */
+export interface FileHuggingFaceCacheOptions {
+  /** Directory where cache files live (absolute path recommended). */
+  dir: string;
+  /** Clock injection. */
+  now?: () => number;
+  /** Pluggable filesystem subset. Defaults to `node:fs/promises`. */
+  fs?: FileCacheFs;
+}
+
+/**
+ * Disk-backed cache. Writes go to a temp file in the same directory then
+ * atomically renamed onto the canonical path, so a crash mid-write cannot
+ * corrupt an existing entry.
+ *
+ * The cache is intentionally lenient on reads: missing files, version
+ * mismatches, and corrupt JSON all resolve to `undefined`. The most recent
+ * decode warning is exposed via `lastWarning` so the client (or an
+ * operator-facing surface in Phase 7) can surface it without the cache
+ * itself having to wire a notification channel.
+ */
+export class FileHuggingFaceCache implements HuggingFaceCache {
+  private readonly dir: string;
+  private readonly now: () => number;
+  private readonly fs: FileCacheFs;
+  private dirEnsured = false;
+  private _lastWarning: HuggingFaceWarning | undefined;
+
+  constructor(opts: FileHuggingFaceCacheOptions) {
+    this.dir = opts.dir;
+    this.now = opts.now ?? Date.now;
+    this.fs = opts.fs ?? defaultFs;
+  }
+
+  /** Most recent decode/IO warning. Cleared by a successful read. */
+  get lastWarning(): HuggingFaceWarning | undefined {
+    return this._lastWarning;
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const file = this.fileFor(key);
+    let raw: string;
+    try {
+      raw = await this.fs.readFile(file);
+    } catch {
+      // Missing file is the dominant case; not a warning.
+      this._lastWarning = undefined;
+      return undefined;
+    }
+    let envelope: CacheEnvelope<T>;
+    try {
+      envelope = JSON.parse(raw) as CacheEnvelope<T>;
+    } catch (err) {
+      this._lastWarning = {
+        code: 'hf_cache_corrupt',
+        message: `Cache file ${file} could not be parsed as JSON`,
+        cause: err instanceof Error ? err.message : String(err),
+      };
+      return undefined;
+    }
+    if (envelope.version !== ENVELOPE_VERSION) {
+      this._lastWarning = undefined;
+      return undefined;
+    }
+    if (envelope.expiresAt <= this.now()) {
+      this._lastWarning = undefined;
+      return undefined;
+    }
+    this._lastWarning = undefined;
+    return envelope.value;
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    await this.ensureDir();
+    const file = this.fileFor(key);
+    const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+    const envelope: CacheEnvelope<T> = {
+      version: ENVELOPE_VERSION,
+      key,
+      value,
+      writtenAt: this.now(),
+      expiresAt: this.now() + Math.max(0, ttlMs),
+    };
+    try {
+      await this.fs.writeFile(tmp, JSON.stringify(envelope));
+      await this.fs.rename(tmp, file);
+    } catch (err) {
+      this._lastWarning = {
+        code: 'hf_cache_write_failed',
+        message: `Failed to persist cache entry for ${key}`,
+        cause: err instanceof Error ? err.message : String(err),
+      };
+      // Best-effort cleanup; ignore failure (file may not exist).
+      try {
+        await this.fs.unlink(tmp);
+      } catch {
+        // Intentionally swallow — unlink is best-effort.
+      }
+    }
+  }
+
+  async clear(): Promise<void> {
+    // Phase 2a doesn't need a recursive purge; the scheduler can call
+    // `unlink` on individual entries when it needs to. A full clear is
+    // deferred until a consumer asks for it.
+    this._lastWarning = undefined;
+  }
+
+  private fileFor(key: string): string {
+    const hash = createHash('sha256').update(key).digest('hex');
+    return path.join(this.dir, `${hash}.json`);
+  }
+
+  private async ensureDir(): Promise<void> {
+    if (this.dirEnsured) return;
+    try {
+      await this.fs.mkdir(this.dir, { recursive: true });
+      this.dirEnsured = true;
+    } catch (err) {
+      this._lastWarning = {
+        code: 'hf_cache_mkdir_failed',
+        message: `Failed to create cache directory ${this.dir}`,
+        cause: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}

--- a/packages/local-models/src/huggingface/client.ts
+++ b/packages/local-models/src/huggingface/client.ts
@@ -1,0 +1,292 @@
+/**
+ * `HuggingFaceClient` — typed wrapper around `huggingface.co/api/models`.
+ *
+ * The client gives the ranker (Phase 2b) a single deterministic surface for
+ * listing model families and fetching per-model metadata. Network failures,
+ * non-2xx responses, and decode errors never throw — they resolve to a
+ * `HuggingFaceFetchResult` whose `warnings` array carries the diagnostic,
+ * matching the S4 contract that the eventual `harness models status`
+ * surface degrades gracefully when HF is unreachable.
+ *
+ * The client is constructor-injected with an `HttpFetcher` and an optional
+ * `HuggingFaceCache` so tests stay deterministic and the production
+ * scheduler can plug a `FileHuggingFaceCache` in without further wiring.
+ */
+
+import type { HuggingFaceCache } from './cache.js';
+import { defaultHttpFetcher } from './http.js';
+import type { HttpFetcher } from './http.js';
+import type {
+  HuggingFaceFetchResult,
+  HuggingFaceListOptions,
+  HuggingFaceModelSummary,
+  HuggingFaceWarning,
+} from './types.js';
+import { decodeModelSummaries } from './types.js';
+
+/** HF's documented base URL. */
+const DEFAULT_BASE_URL = 'https://huggingface.co';
+
+/** Default ceiling on pages followed when `paginate: true` is set. */
+const DEFAULT_MAX_PAGES = 5;
+
+/** Default cache TTL applied by the client when one isn't passed per-call. */
+const DEFAULT_CACHE_TTL_MS = 86_400_000;
+
+/** Half-TTL applied to 404 tombstones so deleted repos don't hammer HF. */
+const TOMBSTONE_TTL_RATIO = 0.5;
+
+/** Constructor options for `HuggingFaceClient`. */
+export interface HuggingFaceClientOptions {
+  /** Pluggable HTTP client. Defaults to the `fetch`-backed runner. */
+  http?: HttpFetcher;
+  /** Optional cache; when present, identical queries within TTL skip the network. */
+  cache?: HuggingFaceCache;
+  /** Override the API base URL. Useful for self-hosted mirrors. */
+  baseUrl?: string;
+  /** Cache TTL in ms applied to successful reads. */
+  cacheTtlMs?: number;
+}
+
+/**
+ * Construct the canonical query string for `listModels`. The keys are
+ * appended in a fixed order so the resulting cache key is stable across
+ * calls with identical options.
+ */
+function buildListQuery(opts: HuggingFaceListOptions): string {
+  const params = new URLSearchParams();
+  if (opts.author !== undefined) params.set('author', opts.author);
+  if (opts.search !== undefined) params.set('search', opts.search);
+  if (opts.filter !== undefined) params.set('filter', opts.filter);
+  if (opts.tags && opts.tags.length > 0) params.set('tags', opts.tags.join(','));
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  return params.toString();
+}
+
+/**
+ * Stable cache key for a `listModels` call. Exported (named) so the cache
+ * tests can construct expected keys without re-implementing the canonical
+ * ordering. Internal — not part of the public API surface contract.
+ */
+export function cacheKeyForList(opts: HuggingFaceListOptions): string {
+  return `hf:list:${buildListQuery(opts)}`;
+}
+
+/** Stable cache key for a `getModel` call. */
+export function cacheKeyForGet(repoId: string): string {
+  return `hf:get:${repoId}`;
+}
+
+/**
+ * Parse a `Link: <url>; rel="next"` header. Returns the next URL or
+ * `undefined` if no `next` link is present. Implemented inline rather than
+ * pulling in `parse-link-header` for a 5-line job.
+ */
+function extractNextLink(linkHeader: string | null): string | undefined {
+  if (!linkHeader) return undefined;
+  // Format: `<url>; rel="next", <url2>; rel="prev"` — we want the entry tagged rel="next".
+  for (const part of linkHeader.split(',')) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match?.[1]) return match[1];
+  }
+  return undefined;
+}
+
+/** Typed HuggingFace API client. Never throws after construction. */
+export class HuggingFaceClient {
+  private readonly http: HttpFetcher;
+  private readonly cache: HuggingFaceCache | undefined;
+  private readonly baseUrl: string;
+  private readonly cacheTtlMs: number;
+
+  constructor(opts: HuggingFaceClientOptions = {}) {
+    this.http = opts.http ?? defaultHttpFetcher;
+    this.cache = opts.cache;
+    this.baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  }
+
+  /**
+   * List models matching `opts`. When `opts.paginate` is true, follows the
+   * `Link: rel="next"` header up to `opts.maxPages` (default 5) and
+   * concatenates rows.
+   */
+  async listModels(
+    opts: HuggingFaceListOptions = {}
+  ): Promise<HuggingFaceFetchResult<HuggingFaceModelSummary[]>> {
+    const key = cacheKeyForList(opts);
+    const cached = await this.readCache<HuggingFaceModelSummary[]>(key);
+    if (cached) {
+      return { value: cached, warnings: [], source: 'cache' };
+    }
+
+    const warnings: HuggingFaceWarning[] = [];
+    const all: HuggingFaceModelSummary[] = [];
+    const maxPages = Math.max(1, opts.maxPages ?? DEFAULT_MAX_PAGES);
+    const query = buildListQuery(opts);
+    let url = `${this.baseUrl}/api/models${query ? `?${query}` : ''}`;
+    let page = 0;
+
+    while (url) {
+      page += 1;
+      const fetched = await this.fetchJson<unknown>(url);
+      if (fetched.warning) {
+        warnings.push(fetched.warning);
+        break;
+      }
+      const decoded = decodeModelSummaries(fetched.value);
+      all.push(...decoded.models);
+      if (decoded.dropped > 0) {
+        warnings.push({
+          code: 'hf_decode_dropped_rows',
+          message: `Dropped ${decoded.dropped} row(s) from HF response that failed schema decode`,
+        });
+      }
+      if (!opts.paginate || page >= maxPages) break;
+      const next = fetched.linkHeader ? extractNextLink(fetched.linkHeader) : undefined;
+      if (!next) break;
+      url = next;
+    }
+
+    if (warnings.length === 0 || all.length > 0) {
+      await this.writeCache(key, all, this.cacheTtlMs);
+    }
+    return { value: all, warnings, source: 'live' };
+  }
+
+  /**
+   * Fetch a single model's metadata. Returns `value: null` and a warning
+   * on 404; the tombstone is cached at half TTL so a deleted repo can't
+   * hammer HF on every refresh.
+   */
+  async getModel(repoId: string): Promise<HuggingFaceFetchResult<HuggingFaceModelSummary | null>> {
+    if (!repoId || !repoId.includes('/')) {
+      return {
+        value: null,
+        warnings: [
+          {
+            code: 'hf_invalid_repo_id',
+            message: `Repo id "${repoId}" must be in <org>/<name> form`,
+          },
+        ],
+        source: 'live',
+      };
+    }
+    const key = cacheKeyForGet(repoId);
+    const cached = await this.readCache<HuggingFaceModelSummary | null>(key);
+    if (cached !== undefined) {
+      return { value: cached, warnings: [], source: 'cache' };
+    }
+
+    const url = `${this.baseUrl}/api/models/${repoId}`;
+    const fetched = await this.fetchJson<unknown>(url);
+    if (fetched.warning) {
+      const tombstone = fetched.warning.code === 'hf_fetch_status_404';
+      if (tombstone) {
+        await this.writeCache(key, null, Math.round(this.cacheTtlMs * TOMBSTONE_TTL_RATIO));
+      }
+      return { value: null, warnings: [fetched.warning], source: 'live' };
+    }
+    const decoded = decodeModelSummaries([fetched.value]);
+    const model = decoded.models[0] ?? null;
+    if (!model) {
+      return {
+        value: null,
+        warnings: [
+          {
+            code: 'hf_decode_failed',
+            message: `Model "${repoId}" returned a row that failed schema decode`,
+          },
+        ],
+        source: 'live',
+      };
+    }
+    await this.writeCache(key, model, this.cacheTtlMs);
+    return { value: model, warnings: [], source: 'live' };
+  }
+
+  /**
+   * Single-URL fetch helper. Wraps the injected fetcher with consistent
+   * error → warning translation and surfaces the response's `Link` header
+   * so callers can follow pagination.
+   */
+  private async fetchJson<T>(url: string): Promise<{
+    value: T | undefined;
+    warning: HuggingFaceWarning | undefined;
+    linkHeader: string | null;
+  }> {
+    try {
+      const response = await this.http.fetch(url);
+      if (response.status === 404) {
+        return {
+          value: undefined,
+          warning: {
+            code: 'hf_fetch_status_404',
+            message: `HF returned 404 for ${url}`,
+          },
+          linkHeader: null,
+        };
+      }
+      if (response.status < 200 || response.status >= 300) {
+        return {
+          value: undefined,
+          warning: {
+            code: 'hf_fetch_failed',
+            message: `HF returned ${response.status} for ${url}`,
+          },
+          linkHeader: null,
+        };
+      }
+      const text = await response.text();
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text) as unknown;
+      } catch (err) {
+        return {
+          value: undefined,
+          warning: {
+            code: 'hf_decode_failed',
+            message: `HF response for ${url} was not valid JSON`,
+            cause: err instanceof Error ? err.message : String(err),
+          },
+          linkHeader: null,
+        };
+      }
+      return {
+        value: parsed as T,
+        warning: undefined,
+        linkHeader: response.headers.get('link'),
+      };
+    } catch (err) {
+      return {
+        value: undefined,
+        warning: {
+          code: 'hf_fetch_failed',
+          message: `HF fetch threw for ${url}`,
+          cause: err instanceof Error ? err.message : String(err),
+        },
+        linkHeader: null,
+      };
+    }
+  }
+
+  private async readCache<T>(key: string): Promise<T | undefined> {
+    if (!this.cache) return undefined;
+    try {
+      return await this.cache.get<T>(key);
+    } catch {
+      // Cache failures must never break a live read. The cache itself
+      // surfaces its own warnings; we just degrade silently here.
+      return undefined;
+    }
+  }
+
+  private async writeCache<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    if (!this.cache) return;
+    try {
+      await this.cache.set(key, value, ttlMs);
+    } catch {
+      // Same reasoning as readCache: swallow so the live path stays solid.
+    }
+  }
+}

--- a/packages/local-models/src/huggingface/http.ts
+++ b/packages/local-models/src/huggingface/http.ts
@@ -1,0 +1,77 @@
+/**
+ * `HttpFetcher` — the dependency-injection seam for HuggingFace HTTP I/O.
+ *
+ * The HuggingFace client takes an `HttpFetcher` instead of importing the
+ * global `fetch` directly so tests can drop in deterministic stubs and the
+ * production code can plug in retry / proxy / metric wrappers without
+ * touching the client itself.
+ *
+ * The default implementation wraps `globalThis.fetch` (Node ≥ 18) with an
+ * `AbortController` timeout and a `User-Agent` header. It exposes a minimal
+ * subset of the Fetch `Response` so the surface stays stable even if we
+ * later swap to `undici` directly.
+ */
+
+import { LOCAL_MODELS_VERSION } from '../version.js';
+
+/** Minimal subset of `RequestInit` the client needs. */
+export interface HttpFetchInit {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+}
+
+/** Minimal subset of `Response` the client consumes. */
+export interface HttpResponse {
+  status: number;
+  headers: Headers;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+}
+
+/**
+ * Pluggable HTTP client. Tests inject a `vi.fn()`-backed stub; production
+ * uses the `defaultHttpFetcher` below.
+ */
+export interface HttpFetcher {
+  fetch(url: string, init?: HttpFetchInit): Promise<HttpResponse>;
+}
+
+/** Default 10s timeout per HF request. HF's `/api/models` is fast in steady state. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** User-Agent so HF can identify our traffic if they ever need to. */
+const DEFAULT_USER_AGENT = `harness-engineering-local-models/${LOCAL_MODELS_VERSION}`;
+
+/** Production `HttpFetcher` backed by global `fetch`. */
+export const defaultHttpFetcher: HttpFetcher = {
+  async fetch(url, init) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+    // If the caller provided a signal, abort our controller when theirs fires.
+    const callerSignal = init?.signal;
+    const onCallerAbort = (): void => controller.abort();
+    if (callerSignal) {
+      if (callerSignal.aborted) controller.abort();
+      else callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+    }
+    try {
+      const response = await globalThis.fetch(url, {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': DEFAULT_USER_AGENT,
+          Accept: 'application/json',
+          ...(init?.headers ?? {}),
+        },
+      });
+      return {
+        status: response.status,
+        headers: response.headers,
+        text: () => response.text(),
+        json: <T>() => response.json() as Promise<T>,
+      };
+    } finally {
+      clearTimeout(timer);
+      if (callerSignal) callerSignal.removeEventListener('abort', onCallerAbort);
+    }
+  },
+};

--- a/packages/local-models/src/huggingface/index.ts
+++ b/packages/local-models/src/huggingface/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public barrel for the HuggingFace API integration. Phase 2a surface only —
+ * the ranker math, benchmark adapters, and ranking algorithm that consume
+ * `HuggingFaceModelSummary` land in Phases 2b–2d.
+ */
+
+export { HuggingFaceClient, cacheKeyForList, cacheKeyForGet } from './client.js';
+export type { HuggingFaceClientOptions } from './client.js';
+
+export { InMemoryHuggingFaceCache, FileHuggingFaceCache } from './cache.js';
+export type {
+  HuggingFaceCache,
+  InMemoryHuggingFaceCacheOptions,
+  FileHuggingFaceCacheOptions,
+  FileCacheFs,
+} from './cache.js';
+
+export { defaultHttpFetcher } from './http.js';
+export type { HttpFetcher, HttpFetchInit, HttpResponse } from './http.js';
+
+export { HuggingFaceModelSummarySchema, decodeModelSummaries } from './types.js';
+export type {
+  HuggingFaceModelSummary,
+  HuggingFaceWarning,
+  HuggingFaceFetchResult,
+  HuggingFaceFetchSource,
+  HuggingFaceListOptions,
+} from './types.js';

--- a/packages/local-models/src/huggingface/types.ts
+++ b/packages/local-models/src/huggingface/types.ts
@@ -1,0 +1,135 @@
+/**
+ * HuggingFace API client — public types and decode helpers.
+ *
+ * Surfaces the row shape consumed downstream (ranker, scheduler, dashboard)
+ * and the structured warning envelope the client emits when a fetch or
+ * decode fails. The client never throws (S4); failures resolve as a
+ * `HuggingFaceFetchResult` carrying warnings.
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (lines 87–88, S4)
+ */
+
+import { z } from 'zod';
+
+/**
+ * Subset of a HuggingFace `/api/models` row consumed by LMLM. Every field
+ * except `id` is optional — HF returns sparse rows for some queries and we
+ * tolerate drift in their schema rather than rejecting whole batches.
+ */
+export interface HuggingFaceModelSummary {
+  /** Canonical `<org>/<name>` repo id, e.g. `"Qwen/Qwen3-32B-GGUF"`. */
+  id: string;
+  /** Cumulative download count. Absent on rows HF hasn't computed yet. */
+  downloads?: number;
+  /** Like count. */
+  likes?: number;
+  /** Free-form tag list (`["gguf","conversational","license:apache-2.0",...]`). */
+  tags?: string[];
+  /** Detected library (e.g. `"gguf"`, `"transformers"`). */
+  libraryName?: string;
+  /** Detected pipeline (e.g. `"text-generation"`, `"conversational"`). */
+  pipelineTag?: string;
+  /** ISO timestamp of the most recent commit, when HF chooses to populate it. */
+  lastModified?: string;
+}
+
+/**
+ * Structured warning emitted when a fetch, decode, or cache operation
+ * degrades. Mirrors `HardwareDetectionWarning` for cross-module parity.
+ */
+export interface HuggingFaceWarning {
+  /** Stable machine code (`'hf_fetch_failed'`, `'hf_decode_dropped_rows'`, ...). */
+  code: string;
+  /** Operator-facing one-liner. */
+  message: string;
+  /** Optional underlying error message — only set when an exception was caught. */
+  cause?: string;
+}
+
+/** Provenance of the returned data. */
+export type HuggingFaceFetchSource = 'live' | 'cache';
+
+/**
+ * Bundle returned by every `HuggingFaceClient` method. The shape stays
+ * consistent so callers can pattern-match on `warnings.length` rather than
+ * branching on success/failure.
+ */
+export interface HuggingFaceFetchResult<T> {
+  value: T;
+  warnings: HuggingFaceWarning[];
+  source: HuggingFaceFetchSource;
+}
+
+/**
+ * Options for `HuggingFaceClient.listModels`. The shape mirrors the HF API
+ * query parameters we actually use; richer filters can be added when a
+ * consumer needs them.
+ */
+export interface HuggingFaceListOptions {
+  /** Filter by HF organization slug (e.g. `'Qwen'`). */
+  author?: string;
+  /** Free-text search against the model id. */
+  search?: string;
+  /** HF `filter` parameter (tag-based filter). */
+  filter?: string;
+  /** Comma-joined tag list. */
+  tags?: string[];
+  /** Rows per page. Defaults to HF's own default (currently 50) when omitted. */
+  limit?: number;
+  /** When `true`, follow `Link: rel="next"` cursors up to `maxPages`. */
+  paginate?: boolean;
+  /** Hard ceiling on pages followed when `paginate` is true. Default 5. */
+  maxPages?: number;
+}
+
+/**
+ * Drift-tolerant Zod schema for a single HF `/api/models` row. Unknown
+ * fields are silently ignored; missing optional fields are treated as
+ * `undefined`. Rows that fail decode (e.g., missing `id`) are filtered out
+ * by `decodeModelSummaries` rather than rejecting the whole batch.
+ */
+export const HuggingFaceModelSummarySchema = z
+  .object({
+    id: z.string().min(1),
+    downloads: z.number().int().nonnegative().optional(),
+    likes: z.number().int().nonnegative().optional(),
+    tags: z.array(z.string()).optional(),
+    library_name: z.string().optional(),
+    pipeline_tag: z.string().optional(),
+    lastModified: z.string().optional(),
+  })
+  .transform((row): HuggingFaceModelSummary => {
+    const out: HuggingFaceModelSummary = { id: row.id };
+    if (row.downloads !== undefined) out.downloads = row.downloads;
+    if (row.likes !== undefined) out.likes = row.likes;
+    if (row.tags !== undefined) out.tags = row.tags;
+    if (row.library_name !== undefined) out.libraryName = row.library_name;
+    if (row.pipeline_tag !== undefined) out.pipelineTag = row.pipeline_tag;
+    if (row.lastModified !== undefined) out.lastModified = row.lastModified;
+    return out;
+  });
+
+/**
+ * Decode a batch of unknown rows into `HuggingFaceModelSummary[]`. Rows that
+ * fail the schema are dropped and the count is returned alongside the
+ * survivors so the caller can decide whether to surface a warning.
+ */
+export function decodeModelSummaries(rows: unknown): {
+  models: HuggingFaceModelSummary[];
+  dropped: number;
+} {
+  if (!Array.isArray(rows)) {
+    return { models: [], dropped: 0 };
+  }
+  const models: HuggingFaceModelSummary[] = [];
+  let dropped = 0;
+  for (const row of rows) {
+    const parsed = HuggingFaceModelSummarySchema.safeParse(row);
+    if (parsed.success) {
+      models.push(parsed.data);
+    } else {
+      dropped += 1;
+    }
+  }
+  return { models, dropped };
+}

--- a/packages/local-models/src/index.ts
+++ b/packages/local-models/src/index.ts
@@ -4,13 +4,14 @@
  * Hardware-aware local-model recommender, pool manager, and proposal engine
  * for Harness Engineering's Local Model Lifecycle Manager (LMLM).
  *
- * Phase 1 (current) ships hardware detection. Subsequent phases add the
- * Hugging Face client, ranker, pool manager, Ollama installer, scheduler,
- * proposal engine, HTTP/WS surfaces, CLI commands, and dashboard panel per
+ * Phases live (in order): Phase 1 hardware detection, Phase 2a HuggingFace
+ * API client + cache. Subsequent phases add the ranker math, benchmark
+ * adapters, pool manager, Ollama installer, scheduler, proposal engine,
+ * HTTP/WS surfaces, CLI commands, and dashboard panel per
  * `docs/changes/local-model-lifecycle-manager/proposal.md`.
  */
 
-export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const;
-export const LOCAL_MODELS_VERSION = '0.1.0' as const;
+export { LOCAL_MODELS_PACKAGE, LOCAL_MODELS_VERSION } from './version.js';
 
 export * from './hardware/index.js';
+export * from './huggingface/index.js';

--- a/packages/local-models/src/version.ts
+++ b/packages/local-models/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * Package identity constants. Lives in its own module so HTTP / cache /
+ * scheduler code can import them without pulling in the public barrel
+ * (which re-exports everything else).
+ */
+export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const;
+export const LOCAL_MODELS_VERSION = '0.1.0' as const;

--- a/packages/local-models/tests/fixtures/hf-models-page1.json
+++ b/packages/local-models/tests/fixtures/hf-models-page1.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "Qwen/Qwen3-32B-GGUF",
+    "downloads": 145823,
+    "likes": 312,
+    "tags": ["gguf", "text-generation", "conversational", "license:apache-2.0"],
+    "library_name": "gguf",
+    "pipeline_tag": "text-generation",
+    "lastModified": "2026-04-12T08:15:33.000Z"
+  },
+  {
+    "id": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "downloads": 482109,
+    "likes": 1204,
+    "tags": ["transformers", "safetensors", "qwen2", "text-generation"],
+    "library_name": "transformers",
+    "pipeline_tag": "text-generation",
+    "lastModified": "2026-02-28T19:02:11.000Z"
+  },
+  {
+    "id": "meta-llama/Llama-3.3-70B-Instruct",
+    "downloads": 1287443,
+    "likes": 3814,
+    "tags": ["transformers", "safetensors", "llama", "text-generation"],
+    "library_name": "transformers",
+    "pipeline_tag": "text-generation",
+    "lastModified": "2026-05-01T12:45:09.000Z"
+  },
+  {
+    "id": "mistralai/Mistral-Small-3-24B-Instruct",
+    "downloads": 92341,
+    "likes": 287,
+    "tags": ["transformers", "safetensors", "mistral", "text-generation"]
+  },
+  {
+    "id": "Qwen/Qwen3-14B-GGUF",
+    "downloads": 73210,
+    "likes": 198,
+    "tags": ["gguf", "text-generation"],
+    "library_name": "gguf",
+    "pipeline_tag": "text-generation"
+  }
+]

--- a/packages/local-models/tests/huggingface/cache.test.ts
+++ b/packages/local-models/tests/huggingface/cache.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import { FileHuggingFaceCache, InMemoryHuggingFaceCache } from '../../src/huggingface/cache.js';
+import type { FileCacheFs } from '../../src/huggingface/cache.js';
+
+/** In-memory file system honoring the `FileCacheFs` interface for deterministic tests. */
+function memoryFs(): FileCacheFs & {
+  files: Map<string, string>;
+  dirs: Set<string>;
+  ops: { kind: 'write' | 'rename' | 'mkdir' | 'unlink' | 'read'; arg: string }[];
+} {
+  const files = new Map<string, string>();
+  const dirs = new Set<string>();
+  const ops: { kind: 'write' | 'rename' | 'mkdir' | 'unlink' | 'read'; arg: string }[] = [];
+  return {
+    files,
+    dirs,
+    ops,
+    mkdir: async (dir) => {
+      ops.push({ kind: 'mkdir', arg: dir });
+      dirs.add(dir);
+    },
+    writeFile: async (file, data) => {
+      ops.push({ kind: 'write', arg: file });
+      files.set(file, data);
+    },
+    rename: async (from, to) => {
+      ops.push({ kind: 'rename', arg: `${from}->${to}` });
+      const data = files.get(from);
+      if (data === undefined) {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }
+      files.set(to, data);
+      files.delete(from);
+    },
+    readFile: async (file) => {
+      ops.push({ kind: 'read', arg: file });
+      const data = files.get(file);
+      if (data === undefined) {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }
+      return data;
+    },
+    unlink: async (file) => {
+      ops.push({ kind: 'unlink', arg: file });
+      files.delete(file);
+    },
+  };
+}
+
+describe('InMemoryHuggingFaceCache', () => {
+  it('returns set values within TTL and undefined after expiry (OT6)', async () => {
+    let now = 1_000_000;
+    const cache = new InMemoryHuggingFaceCache({ now: () => now });
+    await cache.set('k', { a: 1 }, 5_000);
+    expect(await cache.get('k')).toEqual({ a: 1 });
+    now += 5_001;
+    expect(await cache.get('k')).toBeUndefined();
+  });
+
+  it('clear() drops all entries', async () => {
+    const cache = new InMemoryHuggingFaceCache();
+    await cache.set('a', 1, 10_000);
+    await cache.set('b', 2, 10_000);
+    await cache.clear();
+    expect(await cache.get('a')).toBeUndefined();
+    expect(await cache.get('b')).toBeUndefined();
+  });
+
+  it('treats negative TTL as immediate expiry', async () => {
+    const cache = new InMemoryHuggingFaceCache({ now: () => 100 });
+    await cache.set('k', 1, -1);
+    expect(await cache.get('k')).toBeUndefined();
+  });
+});
+
+describe('FileHuggingFaceCache', () => {
+  it('writes via tmp+rename so a crash mid-write cannot corrupt (OT7)', async () => {
+    const fs = memoryFs();
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs, now: () => 1_000 });
+    await cache.set('hf:list:author=Qwen', [{ id: 'Qwen/X' }], 60_000);
+
+    const renameOp = fs.ops.find((op) => op.kind === 'rename');
+    expect(renameOp).toBeDefined();
+    expect(renameOp?.arg).toMatch(/\.tmp->.*\.json$/);
+    expect(fs.dirs.has('/cache')).toBe(true);
+    // Exactly one canonical .json file should exist after the rename completes.
+    const canonical = [...fs.files.keys()].filter((f) => f.endsWith('.json'));
+    expect(canonical).toHaveLength(1);
+  });
+
+  it('round-trips through write → read (OT7)', async () => {
+    const fs = memoryFs();
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs, now: () => 1_000 });
+    await cache.set('hf:list:author=Qwen', [{ id: 'Qwen/X' }], 60_000);
+    const value = await cache.get<{ id: string }[]>('hf:list:author=Qwen');
+    expect(value).toEqual([{ id: 'Qwen/X' }]);
+  });
+
+  it('returns undefined when the file is missing (OT8)', async () => {
+    const fs = memoryFs();
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs });
+    expect(await cache.get('missing')).toBeUndefined();
+    expect(cache.lastWarning).toBeUndefined();
+  });
+
+  it('returns undefined when the envelope version does not match (OT8)', async () => {
+    const fs = memoryFs();
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs, now: () => 1_000 });
+    // Seed a v0 envelope by hand to simulate an older format.
+    await cache.set('seed', 1, 60_000);
+    const file = [...fs.files.keys()][0]!;
+    fs.files.set(
+      file,
+      JSON.stringify({ version: 0, key: 'seed', value: 1, writtenAt: 0, expiresAt: 99_999_999 })
+    );
+    expect(await cache.get('seed')).toBeUndefined();
+    expect(cache.lastWarning).toBeUndefined();
+  });
+
+  it('returns undefined and emits a warning on corrupt JSON (OT8)', async () => {
+    const fs = memoryFs();
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs, now: () => 1_000 });
+    await cache.set('seed', 1, 60_000);
+    const file = [...fs.files.keys()][0]!;
+    fs.files.set(file, '{ not valid json');
+    expect(await cache.get('seed')).toBeUndefined();
+    expect(cache.lastWarning?.code).toBe('hf_cache_corrupt');
+  });
+
+  it('treats expired entries as misses', async () => {
+    const fs = memoryFs();
+    let now = 1_000;
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs, now: () => now });
+    await cache.set('seed', 1, 5_000);
+    expect(await cache.get('seed')).toBe(1);
+    now += 5_001;
+    expect(await cache.get('seed')).toBeUndefined();
+  });
+
+  it('surfaces a warning when mkdir fails and continues to degrade gracefully', async () => {
+    const fs = memoryFs();
+    const breaking: FileCacheFs = {
+      ...fs,
+      mkdir: () => Promise.reject(new Error('EACCES: read-only fs')),
+    };
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs: breaking });
+    await cache.set('k', 1, 60_000);
+    expect(cache.lastWarning?.code).toBe('hf_cache_mkdir_failed');
+  });
+
+  it('keys files via SHA-256 hex of the cache key', async () => {
+    const fs = memoryFs();
+    const cache = new FileHuggingFaceCache({ dir: '/cache', fs });
+    await cache.set('hf:list:author=Qwen', { a: 1 }, 60_000);
+    const file = [...fs.files.keys()][0]!;
+    expect(file).toMatch(/^\/cache\/[a-f0-9]{64}\.json$/);
+  });
+});

--- a/packages/local-models/tests/huggingface/client.test.ts
+++ b/packages/local-models/tests/huggingface/client.test.ts
@@ -1,0 +1,224 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  HuggingFaceClient,
+  cacheKeyForList,
+  cacheKeyForGet,
+} from '../../src/huggingface/client.js';
+import type { HttpFetcher, HttpResponse } from '../../src/huggingface/http.js';
+import { InMemoryHuggingFaceCache } from '../../src/huggingface/cache.js';
+
+const FIXTURE_PATH = path.join(__dirname, '..', 'fixtures', 'hf-models-page1.json');
+
+async function loadFixture(): Promise<unknown[]> {
+  return JSON.parse(await readFile(FIXTURE_PATH, 'utf8')) as unknown[];
+}
+
+interface StubResponseInit {
+  status?: number;
+  body?: string;
+  headers?: Record<string, string>;
+  /** Force `text()` to reject — used to exercise the JSON parse failure path. */
+  textThrows?: Error;
+}
+
+function stubResponse(init: StubResponseInit = {}): HttpResponse {
+  const status = init.status ?? 200;
+  const body = init.body ?? '[]';
+  const headers = new Headers(init.headers ?? {});
+  return {
+    status,
+    headers,
+    text: () => (init.textThrows ? Promise.reject(init.textThrows) : Promise.resolve(body)),
+    json: () => Promise.resolve(JSON.parse(body)),
+  };
+}
+
+function fetcherReturning(...responses: HttpResponse[]): {
+  http: HttpFetcher;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  let i = 0;
+  const http: HttpFetcher = {
+    fetch: vi.fn(async (url: string) => {
+      calls.push(url);
+      const r = responses[i] ?? responses[responses.length - 1];
+      i += 1;
+      if (!r) throw new Error('no stub response');
+      return r;
+    }),
+  };
+  return { http, calls };
+}
+
+describe('HuggingFaceClient.listModels', () => {
+  it('issues a single GET with the expected query string (OT1)', async () => {
+    const { http, calls } = fetcherReturning(stubResponse({ body: '[]' }));
+    const client = new HuggingFaceClient({ http });
+    await client.listModels({ author: 'Qwen', limit: 20 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe('https://huggingface.co/api/models?author=Qwen&limit=20');
+  });
+
+  it('returns parsed rows with no warnings on 200 (OT2)', async () => {
+    const fixture = await loadFixture();
+    const { http } = fetcherReturning(stubResponse({ body: JSON.stringify(fixture) }));
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'Qwen' });
+    expect(result.source).toBe('live');
+    expect(result.warnings).toEqual([]);
+    expect(result.value).toHaveLength(5);
+    expect(result.value[0]).toMatchObject({
+      id: 'Qwen/Qwen3-32B-GGUF',
+      downloads: 145823,
+      likes: 312,
+      libraryName: 'gguf',
+      pipelineTag: 'text-generation',
+    });
+  });
+
+  it('translates 5xx into a warning instead of throwing (OT3)', async () => {
+    const { http } = fetcherReturning(stubResponse({ status: 503, body: 'service unavailable' }));
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'Qwen' });
+    expect(result.value).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.code).toBe('hf_fetch_failed');
+  });
+
+  it('translates a network error into a warning (OT3)', async () => {
+    const http: HttpFetcher = {
+      fetch: vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))),
+    };
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'Qwen' });
+    expect(result.value).toEqual([]);
+    expect(result.warnings[0]?.code).toBe('hf_fetch_failed');
+    expect(result.warnings[0]?.cause).toContain('ECONNREFUSED');
+  });
+
+  it('follows Link rel="next" cursors when paginate is true (OT4)', async () => {
+    const page1 = [{ id: 'org/a' }, { id: 'org/b' }];
+    const page2 = [{ id: 'org/c' }];
+    const { http, calls } = fetcherReturning(
+      stubResponse({
+        body: JSON.stringify(page1),
+        headers: { link: '<https://huggingface.co/api/models?cursor=abc>; rel="next"' },
+      }),
+      stubResponse({ body: JSON.stringify(page2) })
+    );
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'org', paginate: true });
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toBe('https://huggingface.co/api/models?cursor=abc');
+    expect(result.value.map((m) => m.id)).toEqual(['org/a', 'org/b', 'org/c']);
+  });
+
+  it('does not paginate when paginate is false (default) (OT4)', async () => {
+    const { http, calls } = fetcherReturning(
+      stubResponse({
+        body: '[{"id":"org/a"}]',
+        headers: { link: '<https://huggingface.co/api/models?cursor=next>; rel="next"' },
+      })
+    );
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'org' });
+    expect(calls).toHaveLength(1);
+    expect(result.value).toHaveLength(1);
+  });
+
+  it('caps pagination at maxPages (OT4)', async () => {
+    const stub = stubResponse({
+      body: '[{"id":"org/x"}]',
+      headers: { link: '<https://huggingface.co/api/models?cursor=loop>; rel="next"' },
+    });
+    const http: HttpFetcher = { fetch: vi.fn(() => Promise.resolve(stub)) };
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'org', paginate: true, maxPages: 3 });
+    expect((http.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3);
+    expect(result.value).toHaveLength(3);
+  });
+
+  it('emits a decode-warning when some rows fail schema decode', async () => {
+    const { http } = fetcherReturning(
+      stubResponse({
+        body: JSON.stringify([{ id: 'org/good' }, { notAnId: true }, { id: 'org/also-good' }]),
+      })
+    );
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'org' });
+    expect(result.value).toHaveLength(2);
+    expect(result.warnings.map((w) => w.code)).toContain('hf_decode_dropped_rows');
+  });
+
+  it('emits hf_decode_failed when the response is not JSON', async () => {
+    const { http } = fetcherReturning(stubResponse({ body: 'not-json-at-all' }));
+    const client = new HuggingFaceClient({ http });
+    const result = await client.listModels({ author: 'org' });
+    expect(result.value).toEqual([]);
+    expect(result.warnings[0]?.code).toBe('hf_decode_failed');
+  });
+});
+
+describe('HuggingFaceClient.getModel', () => {
+  it('returns the parsed model on 200 (OT5)', async () => {
+    const { http, calls } = fetcherReturning(
+      stubResponse({ body: JSON.stringify({ id: 'Qwen/Qwen3-32B-GGUF', downloads: 1 }) })
+    );
+    const client = new HuggingFaceClient({ http });
+    const result = await client.getModel('Qwen/Qwen3-32B-GGUF');
+    expect(calls[0]).toBe('https://huggingface.co/api/models/Qwen/Qwen3-32B-GGUF');
+    expect(result.value?.id).toBe('Qwen/Qwen3-32B-GGUF');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('returns null with a 404 warning when HF replies 404 (OT5)', async () => {
+    const { http } = fetcherReturning(stubResponse({ status: 404, body: 'not found' }));
+    const client = new HuggingFaceClient({ http });
+    const result = await client.getModel('Qwen/Deleted');
+    expect(result.value).toBeNull();
+    expect(result.warnings[0]?.code).toBe('hf_fetch_status_404');
+  });
+
+  it('rejects malformed repo ids without making a request', async () => {
+    const { http, calls } = fetcherReturning(stubResponse({ body: '{}' }));
+    const client = new HuggingFaceClient({ http });
+    const result = await client.getModel('no-slash');
+    expect(calls).toHaveLength(0);
+    expect(result.warnings[0]?.code).toBe('hf_invalid_repo_id');
+  });
+
+  it('tombstones a 404 in the cache so repeats avoid the network', async () => {
+    const cache = new InMemoryHuggingFaceCache();
+    const { http } = fetcherReturning(stubResponse({ status: 404, body: 'not found' }));
+    const client = new HuggingFaceClient({ http, cache });
+    await client.getModel('Qwen/Deleted');
+    const second = await client.getModel('Qwen/Deleted');
+    expect((http.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    expect(second.source).toBe('cache');
+    expect(second.value).toBeNull();
+  });
+});
+
+describe('HuggingFaceClient caching', () => {
+  it('serves repeats from the cache within TTL (OT9)', async () => {
+    const cache = new InMemoryHuggingFaceCache();
+    const { http } = fetcherReturning(stubResponse({ body: '[{"id":"org/x"}]' }));
+    const client = new HuggingFaceClient({ http, cache });
+    const first = await client.listModels({ author: 'org' });
+    const second = await client.listModels({ author: 'org' });
+    expect(first.source).toBe('live');
+    expect(second.source).toBe('cache');
+    expect((http.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    expect(second.value).toEqual(first.value);
+  });
+
+  it('exposes deterministic cache keys for tests and the scheduler', () => {
+    expect(cacheKeyForList({ author: 'Qwen', limit: 10 })).toBe('hf:list:author=Qwen&limit=10');
+    expect(cacheKeyForGet('Qwen/Qwen3-32B-GGUF')).toBe('hf:get:Qwen/Qwen3-32B-GGUF');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2a of the Local Model Lifecycle Manager (LMLM). Lands the HuggingFace API client and its cache layer — the data plumbing that the ranker (Phase 2b+) will sit on top of.

- `HuggingFaceClient.listModels` / `getModel` against `huggingface.co/api/models`, with `Link: rel="next"` pagination capped at `maxPages` (default 5).
- Drift-tolerant Zod decode: unknown HF API churn drops individual rows instead of rejecting whole batches; renames `library_name` → `libraryName`, `pipeline_tag` → `pipelineTag`.
- Two cache implementations: `InMemoryHuggingFaceCache` (Map-backed TTL) and `FileHuggingFaceCache` (disk-backed JSON, tmp+rename atomic writes, versioned envelope). 404s are tombstoned at half TTL so deleted repos can't hammer HF.
- HTTP / FS / clock all dependency-injected through the same `ShellRunner`-style seam Phase 1 established — unit tests stay deterministic, production wires real `fetch`.
- The client never throws after construction: 4xx/5xx, network failures, and JSON-decode errors all degrade to structured warnings (matches the S4 contract).

No orchestrator wiring yet. The ranker (Phase 2b), benchmark adapters (Phase 2c), scheduler (Phase 6), and HTTP routes (Phase 7) that consume this surface arrive in subsequent phases. LMLM remains opt-in and disabled by default per Phase 0.

Plan: \`docs/changes/local-model-lifecycle-manager/plans/2026-05-27-phase2a-huggingface-client-plan.md\`
Spec: \`docs/changes/local-model-lifecycle-manager/proposal.md\` (Phase 2, lines 414–429)

## Test plan

- [x] \`pnpm --filter @harness-engineering/local-models build\` — green
- [x] \`pnpm --filter @harness-engineering/local-models typecheck\` — green
- [x] \`pnpm --filter @harness-engineering/local-models test\` — 53 tests passing (existing hardware suite + new client + new cache)
- [x] \`pnpm --filter @harness-engineering/local-models lint\` — clean
- [x] \`pnpm exec harness validate\` — green (legacy config still parses, N4)
- [ ] CI runs \`pnpm typecheck\`, \`pnpm test\`, \`pnpm lint\`, \`pnpm build\` across the workspace
- [ ] CI runs changeset check