### PR TITLE
feat(local-models): LMLM Phase 2a — HuggingFace client + cache + frozen snapshot

### DIFF
--- a/.changeset/lmlm-phase2a-hf-client-snapshot.md
+++ b/.changeset/lmlm-phase2a-hf-client-snapshot.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/local-models': minor
+---
+
+Adds Phase 2a of the Local Model Lifecycle Manager — the HuggingFace data plane and the frozen benchmark snapshot.
+
+- `HuggingFaceClient` is a typed wrapper over the public HF REST endpoints (`/api/models`, `/api/models/:repo`). Every failure mode maps to a stable `HuggingFaceClientError` code (`HF_NOT_FOUND`, `HF_UNAUTHORIZED`, `HF_UNAVAILABLE`, `HF_NETWORK`, `HF_PARSE`) so the cache and the future ranker can branch deterministically.
+- `HuggingFaceCache` is a versioned in-memory + on-disk cache for HF responses. The on-disk file at `~/.harness/local-models/cache/huggingface.json` is written atomically via tmp + rename (mirrors the proposal's O2 invariant). Missing, malformed, or schema-mismatched files reset to an empty cache and emit a structured warning instead of throwing.
+- `loadFrozenSnapshot` returns the bundled benchmark snapshot the orchestrator falls back to when HF and the live leaderboard sources are unreachable (S4). The loader is intentionally lenient — malformed or schema-invalid input yields a typed warning and an empty snapshot, never a throw.
+- A seed `snapshot.json` ships three placeholder models across Qwen / DeepSeek / Llama so Phase 2c has something to merge against on its first run.
+- The HF `fetcher` and the cache filesystem are injected through narrow interfaces — unit tests stay fully deterministic without touching the network or the real `~/.harness` directory.
+
+No orchestrator, CLI, dashboard, or HTTP wiring yet. VRAM/speed math (Phase 2b), evidence + recency grading (Phase 2c), the merge algorithm (Phase 2c), the `RankedModel` orchestrator (Phase 2d), and the parity tests against the whichllm reference outputs (Phase 2d) land in subsequent slices. LMLM remains opt-in and disabled by default per Phase 0.

--- a/docs/changes/local-model-lifecycle-manager/plans/2026-05-28-phase2a-hf-client-snapshot-plan.md
+++ b/docs/changes/local-model-lifecycle-manager/plans/2026-05-28-phase2a-hf-client-snapshot-plan.md
@@ -1,0 +1,185 @@
+# Plan: LMLM Phase 2a — HuggingFace client + cache + frozen snapshot
+
+**Date:** 2026-05-28 | **Spec:** `docs/changes/local-model-lifecycle-manager/proposal.md` (Phase 2, lines 414–429) | **Tasks:** 7 | **Time:** ~3 hours | **Integration Tier:** small | **Session:** `changes--local-model-lifecycle-manager--phase2a`
+
+## Goal
+
+Stand up the data plane the ranker (Phase 2b–d) will consume: a typed `HuggingFaceClient` over the public HF REST endpoints (`/api/models`, `/api/models/:repo`), an in-memory + on-disk cache for those responses, and a frozen benchmark snapshot the orchestrator can fall back to when HF and the live leaderboard sources are unreachable. None of these surfaces require the VRAM/speed math or the merge algorithm — they are independently testable infrastructure that locks down the contract Phase 2b–d will build on top of.
+
+Phase 2a does **not** ship the ranker, the evidence/recency math, the live benchmark source adapters, or any orchestrator wiring. It ships the bricks; later phases stack them.
+
+## Phase 2a Scope (from spec Phase 2, lines 414–429)
+
+In:
+
+- `src/huggingface/types.ts` — `HuggingFaceModel`, `HuggingFaceModelDetail`, `HuggingFaceListOptions`, `HuggingFaceClientOptions`, `HuggingFaceFetcher`, `HuggingFaceFetchResponse`, `HuggingFaceErrorCode`
+- `src/huggingface/client.ts` — typed wrapper over `/api/models` and `/api/models/:repo`; injected `fetcher` DI seam mirrors Phase 1's `ShellRunner`; every failure mode maps to a `HuggingFaceClientError` with a stable `code`
+- `src/huggingface/cache.ts` — versioned in-memory map + atomic on-disk JSON file at `~/.harness/local-models/cache/huggingface.json` (tmp + rename — O2 invariant); tolerates missing / malformed / version-mismatched files by resetting to empty and emitting a structured warning
+- `src/huggingface/index.ts` — public barrel
+- `src/ranker/benchmarks/types.ts` — `BenchmarkEvidence`, `BenchmarkObservation`, `ModelBenchmark`, `BenchmarkSnapshot`, `BenchmarkSnapshotLoadResult`, `BenchmarkSnapshotWarning`, `emptySnapshot`
+- `src/ranker/benchmarks/snapshot.ts` — `loadFrozenSnapshot()` reading `./snapshot.json`; structural validation; never throws (S4)
+- `src/ranker/benchmarks/snapshot.json` — seed snapshot (≥ 3 models across distinct families) so Phase 2c has something to merge against on its first run
+- `src/ranker/benchmarks/index.ts` + `src/ranker/index.ts` — barrels that re-export the snapshot loader and types
+- `src/index.ts` — re-export `./huggingface/index.js` and `./ranker/index.js`
+- Tests for each module under `tests/huggingface/` and `tests/ranker/benchmarks/` plus a fixture HF list response
+
+Out of Phase 2a (deferred to 2b–d):
+
+- VRAM math (`ranker/vram.ts`) and speed math (`ranker/speed.ts`) — Phase 2b
+- Evidence grading and lineage-aware recency demotion — Phase 2c
+- Live benchmark source adapters (Open LLM Leaderboard, LiveBench, …) and the cross-source merge — Phase 2c
+- The `RankedModel` type and the `algorithm.ts` orchestrator that produces it — Phase 2d
+- Parity tests against `m3-max-36gb.json` / `rtx-4090-24gb.json` (Q1, Q2) — Phase 2d, once the algorithm exists
+- HTTP routes, CLI commands, dashboard panel — Phases 7–8
+- Orchestrator wiring — Phase 6 (when the scheduler boots)
+
+## Observable Truths (Acceptance Criteria — Phase 2a only)
+
+1. **OT1**: `HuggingFaceClient.listModels()` issues exactly one `GET /api/models?...` call through the injected `fetcher`, parses the array response into `HuggingFaceModel[]`, and never reads from the cache itself (caching is the caller's responsibility — Phase 2c).
+2. **OT2**: When the fetcher resolves with `status: 404`, the client throws a `HuggingFaceClientError` with `code: 'HF_NOT_FOUND'` and the original status / URL attached. `401`/`403` → `'HF_UNAUTHORIZED'`. `429` and `5xx` → `'HF_UNAVAILABLE'`. Network rejections → `'HF_NETWORK'`. Non-JSON bodies → `'HF_PARSE'`.
+3. **OT3**: `HuggingFaceClient.getModel('Qwen/Qwen3-32B-GGUF')` URL-encodes the repo id (the `/` is preserved via `encodeURI`) so the request lands on `/api/models/Qwen/Qwen3-32B-GGUF`, not `/api/models/Qwen%2FQwen3-32B-GGUF`.
+4. **OT4**: `HuggingFaceCache.get(key)` returns `undefined` for missing entries and for entries whose age (now − storedAt) is `>= ttlMs`. Within the TTL window it returns the stored value verbatim.
+5. **OT5**: `HuggingFaceCache.persist()` writes a versioned envelope to `${path}.tmp` first and renames to `path` (verified by asserting `writeFile` is called with the `.tmp` suffix and `rename` is called with the matching source/destination). A second `load()` after `persist()` rehydrates the same entries.
+6. **OT6**: `HuggingFaceCache.load()` on a missing file returns silently with an empty memory map; on malformed JSON it emits a structured `onWarn` and resets to empty; on a schema-version mismatch it emits a warning and resets to empty. None of those paths throw.
+7. **OT7**: `loadFrozenSnapshot()` on the bundled `snapshot.json` returns `source: 'frozen'` with `warnings: []` and `snapshot.models.length >= 3`.
+8. **OT8**: `loadFrozenSnapshot({ reader: async () => '{bad-json' })` returns `source: 'fallback'`, an empty snapshot, and a single `snapshot_parse_failed` warning. A reader that throws yields `snapshot_read_failed`; a syntactically valid but structurally invalid payload yields `snapshot_schema_invalid`. The function never throws.
+9. **OT9**: `pnpm --filter @harness-engineering/local-models build`, `typecheck`, and `test` are all green.
+10. **OT10**: Existing Phase 1 hardware tests pass unchanged; the new tests live alongside them without new flakes.
+
+## Skill Recommendations
+
+- `gof-strategy` (reference) — the injected `fetcher` and `CacheFilesystem` are interchangeable strategies; tests substitute deterministic implementations without monkey-patching globals.
+- `tdd-classicist` (reference) — each unit's tests are pure and dependency-injected; no live network, no real `~/.harness` writes.
+
+## File Map
+
+- CREATE `packages/local-models/src/huggingface/types.ts`
+- EXISTS `packages/local-models/src/huggingface/client.ts` (regenerated last session; needs `types.ts` + `exactOptionalPropertyTypes` fix)
+- EXISTS `packages/local-models/src/huggingface/cache.ts`
+- EXISTS `packages/local-models/src/huggingface/index.ts`
+- EXISTS `packages/local-models/src/ranker/benchmarks/types.ts`
+- EXISTS `packages/local-models/src/ranker/benchmarks/snapshot.ts` (needs an `exactOptionalPropertyTypes` fix in `validateModel`)
+- EXISTS `packages/local-models/src/ranker/benchmarks/snapshot.json`
+- EXISTS `packages/local-models/src/ranker/benchmarks/index.ts`
+- EXISTS `packages/local-models/src/ranker/index.ts`
+- MODIFY `packages/local-models/src/index.ts` (already updated to export the new barrels)
+- CREATE `packages/local-models/tests/huggingface/client.test.ts`
+- CREATE `packages/local-models/tests/huggingface/cache.test.ts`
+- CREATE `packages/local-models/tests/ranker/benchmarks/snapshot.test.ts`
+- CREATE `packages/local-models/tests/fixtures/hf-list-qwen-trending.json`
+- CREATE `.changeset/lmlm-phase2a-hf-client-snapshot.md`
+- MODIFY `packages/local-models/README.md` — single-paragraph Phase 2a note
+
+## Skeleton
+
+1. Land the missing `huggingface/types.ts` and close the `exactOptionalPropertyTypes` gaps in `client.ts` / `snapshot.ts` so `pnpm typecheck` is green again. (~1 task)
+2. Test the HF client end-to-end through an injected fetcher: success, every error code, URL encoding, timeout/abort. (~1 task)
+3. Test the cache end-to-end through an injected filesystem: load/persist round-trip, TTL boundary, malformed file, version mismatch. (~1 task)
+4. Test the snapshot loader: bundled JSON happy path + every fallback branch through injected readers. (~1 task)
+5. Verification gate. (~1 task)
+6. Changeset + README touch-up. (~1 task)
+
+**Estimated total:** 7 tasks, ~3 hours.
+
+## Uncertainties
+
+- **[ASSUMPTION]** `fetch` is globally available — Node ≥ 18 guarantees it (matches the monorepo baseline already stated in the spec's Assumptions section). No `node-fetch` / `undici` dependency added.
+- **[ASSUMPTION]** The HF `/api/models` and `/api/models/:repo` shapes are backward-compatible. The client extracts only `id`, `downloads`, `likes`, `lastModified`, `tags`, `license`, `author`, and `siblings[].rfilename` — fields the spec calls out (lines 88–91). Other fields are ignored, so additive HF changes don't break us.
+- **[ASSUMPTION]** The seed snapshot ships three models (Qwen3-32B, DeepSeek-R1-Distill-Qwen-32B, Llama-3.3-70B) with single observations each. Phase 2c will replace this with a curated set sourced from the real leaderboards; the count and contents are intentionally minimal so the seed isn't read as a recommendation.
+- **[DEFERRABLE]** Pagination — the HF list endpoint caps at 100 per request and we only need the top trending slice in Phase 2c. Pagination lands when (and if) Phase 2c's source adapters need it.
+- **[DEFERRABLE]** ETag / `If-None-Match` round-trips — the cache TTL is the sole freshness mechanism in 2a. Conditional GETs land in 2c once the scheduler can act on `304` responses.
+
+## Tasks
+
+### Task 1: Land `huggingface/types.ts` + close `exactOptionalPropertyTypes` gaps
+
+**Depends on:** none | **Files:** `src/huggingface/types.ts`, `src/huggingface/client.ts`, `src/ranker/benchmarks/snapshot.ts`
+
+1. Author `types.ts` with the shapes the client and barrel reference:
+   - `HuggingFaceModel` — `{ id; downloads; likes; lastModified?; tags; license?; author? }`
+   - `HuggingFaceModelDetail extends HuggingFaceModel` — adds `siblings: { rfilename: string }[]`
+   - `HuggingFaceListOptions` — `{ search?; author?; filter?; sort?; limit?; signal? }`
+   - `HuggingFaceClientOptions` — `{ baseUrl?; token?; fetcher?; timeoutMs? }`
+   - `HuggingFaceFetcher` — `(url: string, init: { signal?: AbortSignal; headers?: Record<string, string> }) => Promise<HuggingFaceFetchResponse>`
+   - `HuggingFaceFetchResponse` — `{ status; json(); text() }`
+   - `HuggingFaceErrorCode` — `'HF_NOT_FOUND' | 'HF_UNAUTHORIZED' | 'HF_UNAVAILABLE' | 'HF_NETWORK' | 'HF_PARSE'`
+2. `client.ts`: change the `HuggingFaceClientError` constructor to only assign `status`/`url` when defined (use spread or explicit `if`); use spread in the throw sites so undefined optionals never leak into the property bag. Keep the public class shape unchanged.
+3. `snapshot.ts` (`validateModel`): only set `ollamaName` / `activeB` keys when present. Pattern: build the object via spread (`...(typeof value.ollamaName === 'string' ? { ollamaName: value.ollamaName } : {})`).
+
+Acceptance: `pnpm --filter @harness-engineering/local-models typecheck` clean.
+
+### Task 2: HF client tests
+
+**Depends on:** Task 1 | **Files:** `tests/huggingface/client.test.ts`, `tests/fixtures/hf-list-qwen-trending.json`
+
+1. Fixture: a 2-entry trimmed `/api/models?author=Qwen&sort=trending` response covering `id`, `downloads`, `likes`, `lastModified`, `tags`, `license`.
+2. Tests:
+   - Happy path `listModels({ author: 'Qwen', sort: 'trending', limit: 100 })` — asserts the URL the fetcher sees and the parsed array.
+   - `getModel('Qwen/Qwen3-32B-GGUF')` — asserts the path preserves the slash.
+   - Error mapping: `404 → HF_NOT_FOUND`, `401 → HF_UNAUTHORIZED`, `429 → HF_UNAVAILABLE`, `503 → HF_UNAVAILABLE`, network rejection → `HF_NETWORK`, malformed body → `HF_PARSE`.
+   - Timeout: pass a `timeoutMs: 1` and a fetcher that never resolves; assert the error is `HF_NETWORK` with `cause.name === 'AbortError'`.
+   - Authorization: pass `token: 'abc'` and assert the fetcher receives `Authorization: Bearer abc`. Without a token and `HF_TOKEN` unset, no Authorization header is set.
+
+### Task 3: Cache tests
+
+**Depends on:** Task 1 | **Files:** `tests/huggingface/cache.test.ts`
+
+1. In-memory `CacheFilesystem` stub backed by a `Map<string, string>` with controllable `ENOENT` injection.
+2. Tests:
+   - `set` then `get` returns the value within TTL.
+   - `get` returns undefined when `now - storedAt >= ttlMs` (boundary check).
+   - `persist()` writes to `${path}.tmp` then `rename`s; the second `HuggingFaceCache` against the same fs rehydrates the entries.
+   - `load()` on missing file leaves memory empty without warnings.
+   - `load()` on malformed JSON triggers exactly one `onWarn` and resets memory.
+   - `load()` on a schema-version-mismatched payload triggers exactly one `onWarn` and resets memory.
+
+### Task 4: Snapshot loader tests
+
+**Depends on:** Task 1 | **Files:** `tests/ranker/benchmarks/snapshot.test.ts`
+
+1. Happy path against the bundled `snapshot.json` (no `reader` passed): `source: 'frozen'`, `warnings: []`, `models.length >= 3`.
+2. Reader-throws branch: returns `'snapshot_read_failed'`.
+3. Reader returns invalid JSON: returns `'snapshot_parse_failed'`.
+4. Reader returns valid JSON with a wrong `version`: returns `'snapshot_schema_invalid'`.
+5. Reader returns valid JSON missing the `models` array: returns `'snapshot_schema_invalid'`.
+6. Reader returns valid JSON with an observation missing `evidence`: returns `'snapshot_schema_invalid'`.
+
+### Task 5: Verification gate
+
+**Depends on:** Tasks 1–4 | **Files:** none
+
+1. `pnpm --filter @harness-engineering/types build` (consumers need the d.ts).
+2. `pnpm --filter @harness-engineering/local-models typecheck` — green.
+3. `pnpm --filter @harness-engineering/local-models test` — green; all Phase 1 tests + the new Phase 2a tests pass.
+4. `pnpm --filter @harness-engineering/local-models build` — green.
+5. `pnpm exec harness validate` from repo root — green (legacy config still parses).
+
+### Task 6: Changeset
+
+**Depends on:** Tasks 1–5 | **Files:** `.changeset/lmlm-phase2a-hf-client-snapshot.md`
+
+1. `minor` bump on `@harness-engineering/local-models`.
+2. Body summarises the three new bricks (HF client, cache, frozen snapshot) and explicitly notes the ranker math + algorithm orchestrator land in 2b–d.
+
+### Task 7: README + plan integration
+
+**Depends on:** Tasks 1–6 | **Files:** `packages/local-models/README.md`
+
+1. Append a short Phase 2a section describing the new public exports and the still-pending phases. Keep the file under a page.
+
+## Integration Notes
+
+Phase 2a's integration footprint stays at the package boundary:
+
+- The new exports (`HuggingFaceClient`, `HuggingFaceCache`, `loadFrozenSnapshot`, the shared types) are surfaced through the package barrel only. No orchestrator, CLI, dashboard, or HTTP wiring lands here.
+- **Phase 2b (VRAM/Speed)** is pure math and doesn't consume the HF client.
+- **Phase 2c (Evidence + Recency + Merge)** consumes `HuggingFaceClient` (popularity weighting) and `loadFrozenSnapshot` (offline fallback).
+- **Phase 2d (Algorithm)** consumes all of the above plus Phase 1's `HardwareDetector` to produce `RankedModel[]`.
+- **Phase 6 (Scheduler)** owns the cache's lifecycle (when to `persist()`).
+- **Phase 7 (HTTP)** does not expose the HF client or cache directly; it exposes only the ranker output.
+
+**Knowledge graph**: no new concepts entered in Phase 2a. `Model Benchmark` becomes a first-class concept in Phase 2c when the merge algorithm lands.
+
+**ADRs**: none in Phase 2a. ADR-NNNN+1 (TS port of ranking algorithm, not whichllm wrapper) lands with Phase 2d when the algorithm itself ships.
+
+**Docs**: changeset entry + a short README note. The full `local-model-lifecycle.md` knowledge entry and operator guide land in Phase 9.

--- a/packages/local-models/README.md
+++ b/packages/local-models/README.md
@@ -6,7 +6,16 @@ See [`docs/changes/local-model-lifecycle-manager/proposal.md`](../../docs/change
 
 ## Status
 
-**Phase 0 — scaffolding only.** No business logic yet. Hardware detection, ranking, pool management, Ollama installer, proposal engine, and scheduler ship in subsequent phases.
+**Phase 2a — HuggingFace client + cache + frozen benchmark snapshot.**
+
+Public surface so far:
+
+- `HardwareDetector` / `detectHardware` (Phase 1) — Apple Silicon, NVIDIA, CPU profiles with fallback warnings.
+- `HuggingFaceClient` (Phase 2a) — typed wrapper over `/api/models` and `/api/models/:repo` with stable error codes and an injected `fetcher` DI seam.
+- `HuggingFaceCache` (Phase 2a) — in-memory + atomically-persisted on-disk cache (TTL 24h) for HF responses.
+- `loadFrozenSnapshot` (Phase 2a) — bundled benchmark snapshot loader the orchestrator falls back to when live sources are unreachable (S4).
+
+VRAM / speed math, evidence + recency grading, live benchmark sources, the merge algorithm, the `RankedModel` orchestrator, the pool manager, the Ollama installer, the proposal engine, the scheduler, and the HTTP / CLI / dashboard surfaces ship in Phases 2b–9 per the spec.
 
 ## Goals (recap)
 

--- a/packages/local-models/src/huggingface/cache.ts
+++ b/packages/local-models/src/huggingface/cache.ts
@@ -1,0 +1,210 @@
+/**
+ * `HuggingFaceCache` — in-memory + on-disk cache for HF responses.
+ *
+ * The orchestrator's background scheduler (Phase 6) refreshes ranking on a
+ * 24h cadence by default. The cache absorbs every redundant call between
+ * refreshes so an interactive `harness models suggest` and the scheduler tick
+ * share data without re-hitting the HF API.
+ *
+ * The on-disk layer is a single JSON file written atomically (tmp + rename)
+ * so a crash mid-write cannot corrupt it (mirrors the proposal's O2 invariant
+ * for the pool state file). Every read tolerates a missing or malformed file
+ * by returning an empty cache — the next live request repopulates it.
+ *
+ * Cache schema is versioned (`CACHE_VERSION`). Loading a file with a
+ * mismatched version returns an empty cache so an algorithm change that
+ * affects key derivation doesn't silently return stale data.
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (lines 89, 414–429; S4, O2)
+ */
+
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+const CACHE_VERSION = 1;
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1_000;
+
+/** Default on-disk cache location. Mirrors the spec's `~/.harness/local-models/` convention. */
+export const DEFAULT_CACHE_PATH = join(
+  homedir(),
+  '.harness',
+  'local-models',
+  'cache',
+  'huggingface.json'
+);
+
+/** Entry envelope. `storedAt` drives TTL; `value` is the serialized HF payload. */
+export interface CacheEntry<T> {
+  storedAt: number;
+  value: T;
+}
+
+interface CacheFile {
+  version: number;
+  entries: Record<string, CacheEntry<unknown>>;
+}
+
+/** Optional clock and filesystem ports — tests inject deterministic stubs. */
+export interface HuggingFaceCacheOptions {
+  /** Absolute path to the cache file. Defaults to `~/.harness/local-models/cache/huggingface.json`. */
+  path?: string;
+  /** Per-entry TTL in milliseconds. Defaults to 24h. */
+  ttlMs?: number;
+  /** Clock for testability. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Filesystem port. Defaults to `node:fs/promises` adapter. */
+  fs?: CacheFilesystem;
+  /** Optional structured logger; defaults to a silent no-op. */
+  onWarn?: (message: string, cause?: unknown) => void;
+}
+
+/**
+ * Narrow filesystem surface the cache needs. Tests substitute an in-memory
+ * implementation; production uses `node:fs/promises`.
+ */
+export interface CacheFilesystem {
+  readFile(path: string): Promise<string>;
+  writeFile(path: string, contents: string): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  mkdir(path: string, options: { recursive: boolean }): Promise<void>;
+}
+
+const defaultFs: CacheFilesystem = {
+  readFile: (path) => readFile(path, 'utf-8'),
+  writeFile: (path, contents) => writeFile(path, contents, 'utf-8'),
+  rename: (from, to) => rename(from, to),
+  mkdir: (path, options) => mkdir(path, options).then(() => undefined),
+};
+
+function emptyFile(): CacheFile {
+  return { version: CACHE_VERSION, entries: {} };
+}
+
+/**
+ * Versioned, TTL'd cache. `get` short-circuits stale entries; `set` writes
+ * memory immediately and schedules a debounced flush to disk via the public
+ * `persist()` call so test code can opt into deterministic flushing.
+ */
+export class HuggingFaceCache {
+  private readonly path: string;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly fs: CacheFilesystem;
+  private readonly onWarn: (message: string, cause?: unknown) => void;
+  private memory: Record<string, CacheEntry<unknown>> = {};
+  private loaded = false;
+
+  constructor(options: HuggingFaceCacheOptions = {}) {
+    this.path = options.path ?? DEFAULT_CACHE_PATH;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? (() => Date.now());
+    this.fs = options.fs ?? defaultFs;
+    this.onWarn = options.onWarn ?? (() => undefined);
+  }
+
+  /**
+   * Hydrate the in-memory map from the on-disk file. Idempotent — repeated
+   * calls are no-ops. Tolerates: missing file, malformed JSON, schema-version
+   * mismatch. None of those throw; all reset the cache to empty and emit a
+   * structured warning.
+   */
+  async load(): Promise<void> {
+    if (this.loaded) return;
+    this.loaded = true;
+    let raw: string;
+    try {
+      raw = await this.fs.readFile(this.path);
+    } catch (err) {
+      if (isNotFound(err)) {
+        this.memory = {};
+        return;
+      }
+      this.onWarn(`huggingface cache read failed at ${this.path}`, err);
+      this.memory = {};
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      this.onWarn(`huggingface cache file is not valid JSON at ${this.path}`, err);
+      this.memory = {};
+      return;
+    }
+    if (!isCacheFile(parsed) || parsed.version !== CACHE_VERSION) {
+      this.onWarn(`huggingface cache schema version mismatch at ${this.path}`);
+      this.memory = {};
+      return;
+    }
+    this.memory = { ...parsed.entries };
+  }
+
+  /**
+   * Return the value for `key` if present and within `ttlMs`. Stale or
+   * missing entries return `undefined`; the caller treats both as a miss and
+   * issues a live request.
+   *
+   * The freshness window is **exclusive** of the TTL boundary: an entry whose
+   * age equals `ttlMs` is considered stale, matching the documented OT4.
+   */
+  get<T>(key: string): T | undefined {
+    const entry = this.memory[key];
+    if (!entry) return undefined;
+    const age = this.now() - entry.storedAt;
+    if (age >= this.ttlMs) return undefined;
+    return entry.value as T;
+  }
+
+  /** Insert or overwrite an entry in memory. Call `persist()` to flush to disk. */
+  set<T>(key: string, value: T): void {
+    this.memory[key] = { storedAt: this.now(), value };
+  }
+
+  /** Remove every entry. Useful for tests; orchestrator code should prefer TTL expiry. */
+  clear(): void {
+    this.memory = {};
+  }
+
+  /** Snapshot of the in-memory entries. Returned by value so callers can't mutate state. */
+  snapshot(): Record<string, CacheEntry<unknown>> {
+    return { ...this.memory };
+  }
+
+  /**
+   * Atomically persist the current memory map to disk. Writes to
+   * `${path}.tmp` first, then renames — `rename` is atomic on POSIX and
+   * Windows when source and destination share a volume. A crash between the
+   * write and the rename leaves the previous good file intact (O2).
+   */
+  async persist(): Promise<void> {
+    const file: CacheFile = { version: CACHE_VERSION, entries: this.memory };
+    const tmp = `${this.path}.tmp`;
+    await this.fs.mkdir(dirname(this.path), { recursive: true });
+    await this.fs.writeFile(tmp, JSON.stringify(file, null, 2));
+    await this.fs.rename(tmp, this.path);
+  }
+}
+
+function isCacheFile(value: unknown): value is CacheFile {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.version === 'number' &&
+    typeof obj.entries === 'object' &&
+    obj.entries !== null &&
+    !Array.isArray(obj.entries)
+  );
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: string }).code === 'ENOENT'
+  );
+}
+
+/** Internal accessor for tests; not exported from the package barrel. */
+export const __testing = { CACHE_VERSION, emptyFile };

--- a/packages/local-models/src/huggingface/client.ts
+++ b/packages/local-models/src/huggingface/client.ts
@@ -1,0 +1,298 @@
+/**
+ * `HuggingFaceClient` — typed wrapper over the public HF REST endpoints LMLM
+ * needs (`/api/models`, `/api/models/:repo`). The client never throws raw
+ * `fetch` errors: every failure maps to a `HuggingFaceClientError` with a
+ * stable `code` so the cache (Phase 2a), the snapshot fallback (Phase 2a),
+ * and the eventual ranker (Phase 2c–d) can branch deterministically.
+ *
+ * The `fetcher` constructor option is the DI seam: tests inject a stub and
+ * never make real network calls. The default `fetcher` wraps the global
+ * `fetch` so production code is one line. This mirrors the `ShellRunner`
+ * pattern from Phase 1's hardware detection (Plan, OT1).
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (lines 88–91, 414–429)
+ */
+
+import type {
+  HuggingFaceClientOptions,
+  HuggingFaceErrorCode,
+  HuggingFaceFetcher,
+  HuggingFaceFetchResponse,
+  HuggingFaceListOptions,
+  HuggingFaceModel,
+  HuggingFaceModelDetail,
+} from './types.js';
+
+const DEFAULT_BASE_URL = 'https://huggingface.co';
+const DEFAULT_TIMEOUT_MS = 8_000;
+const USER_AGENT = '@harness-engineering/local-models';
+
+/**
+ * Structured error type the client throws. `code` is the contract higher
+ * layers branch on; `status` and `url` are diagnostics; the `cause` is the
+ * underlying fetcher rejection when relevant.
+ */
+export class HuggingFaceClientError extends Error {
+  readonly code: HuggingFaceErrorCode;
+  readonly status?: number;
+  readonly url?: string;
+
+  constructor(
+    code: HuggingFaceErrorCode,
+    message: string,
+    options?: { status?: number; url?: string; cause?: unknown }
+  ) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = 'HuggingFaceClientError';
+    this.code = code;
+    if (options?.status !== undefined) this.status = options.status;
+    if (options?.url !== undefined) this.url = options.url;
+  }
+}
+
+/**
+ * Default fetcher backed by the global `fetch`. Adapts the Web `Response`
+ * down to the narrow `HuggingFaceFetchResponse` surface so the client doesn't
+ * carry the full DOM lib's type baggage into tests.
+ */
+function defaultFetcher(): HuggingFaceFetcher {
+  return async (url, init) => {
+    const response = await fetch(url, init);
+    return {
+      status: response.status,
+      json: () => response.json() as Promise<unknown>,
+      text: () => response.text(),
+    } satisfies HuggingFaceFetchResponse;
+  };
+}
+
+/**
+ * Read a token from the constructor option first, falling back to the
+ * `HF_TOKEN` env var. Empty strings are treated as unset so callers can pass
+ * `process.env.HF_TOKEN` without guarding against `''`.
+ */
+function resolveToken(option: string | undefined): string | undefined {
+  if (option && option.length > 0) return option;
+  const env = process.env.HF_TOKEN;
+  if (env && env.length > 0) return env;
+  return undefined;
+}
+
+function buildHeaders(token: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'User-Agent': USER_AGENT,
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Map an HTTP status to a stable `HuggingFaceErrorCode`. The client surfaces
+ * the original status and body excerpt in the error message so operators can
+ * diagnose specifics without reading the code.
+ */
+function statusToCode(status: number): HuggingFaceErrorCode {
+  if (status === 404) return 'HF_NOT_FOUND';
+  if (status === 401 || status === 403) return 'HF_UNAUTHORIZED';
+  if (status === 429 || (status >= 500 && status <= 599)) return 'HF_UNAVAILABLE';
+  return 'HF_UNAVAILABLE';
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    (err as { name?: string }).name === 'AbortError'
+  );
+}
+
+/**
+ * Serialize query params in a stable order so cache keys are deterministic.
+ * Skips undefined / empty values to keep URLs tidy.
+ */
+function buildQueryString(params: Record<string, string | number | undefined>): string {
+  const entries = Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .sort(([a], [b]) => a.localeCompare(b)) as Array<[string, string | number]>;
+  if (entries.length === 0) return '';
+  const search = new URLSearchParams();
+  for (const [key, value] of entries) search.set(key, String(value));
+  return `?${search.toString()}`;
+}
+
+/** Narrow a `unknown` HF item into the `HuggingFaceModel` shape. */
+function parseModel(value: unknown, url: string): HuggingFaceModel {
+  if (typeof value !== 'object' || value === null) {
+    throw new HuggingFaceClientError('HF_PARSE', 'HuggingFace returned a non-object model entry', {
+      url,
+    });
+  }
+  const raw = value as Record<string, unknown>;
+  const id = raw.id ?? raw.modelId;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new HuggingFaceClientError('HF_PARSE', 'HuggingFace model entry missing id', { url });
+  }
+  const tags = Array.isArray(raw.tags)
+    ? (raw.tags.filter((t): t is string => typeof t === 'string') as readonly string[])
+    : [];
+  const author =
+    typeof raw.author === 'string' && raw.author.length > 0 ? raw.author : extractAuthor(id);
+  return {
+    id,
+    downloads: typeof raw.downloads === 'number' ? raw.downloads : 0,
+    likes: typeof raw.likes === 'number' ? raw.likes : 0,
+    tags,
+    ...(typeof raw.lastModified === 'string' ? { lastModified: raw.lastModified } : {}),
+    ...(typeof raw.license === 'string' ? { license: raw.license } : {}),
+    ...(author !== undefined ? { author } : {}),
+  };
+}
+
+/** "Qwen/Qwen3-32B-GGUF" → "Qwen". Returns `undefined` for un-namespaced ids. */
+function extractAuthor(id: string): string | undefined {
+  const slash = id.indexOf('/');
+  return slash > 0 ? id.slice(0, slash) : undefined;
+}
+
+function parseModelDetail(value: unknown, url: string): HuggingFaceModelDetail {
+  const base = parseModel(value, url);
+  const raw = value as Record<string, unknown>;
+  const siblings = Array.isArray(raw.siblings)
+    ? raw.siblings
+        .filter((s): s is { rfilename: string } => {
+          return (
+            typeof s === 'object' &&
+            s !== null &&
+            'rfilename' in s &&
+            typeof (s as { rfilename: unknown }).rfilename === 'string'
+          );
+        })
+        .map((s) => ({ rfilename: s.rfilename }))
+    : [];
+  return { ...base, siblings };
+}
+
+/**
+ * Typed wrapper around HuggingFace's read endpoints. Production callers pass
+ * no fetcher and the client uses `fetch`; tests pass a stub.
+ */
+export class HuggingFaceClient {
+  private readonly baseUrl: string;
+  private readonly token: string | undefined;
+  private readonly fetcher: HuggingFaceFetcher;
+  private readonly timeoutMs: number;
+
+  constructor(options: HuggingFaceClientOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.token = resolveToken(options.token);
+    this.fetcher = options.fetcher ?? defaultFetcher();
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /**
+   * List models matching the supplied filter. Single HF request, no
+   * pagination in Phase 2a — the ranker's first cut consumes the top-100
+   * trending result and the cache TTL absorbs subsequent calls.
+   */
+  async listModels(options: HuggingFaceListOptions = {}): Promise<HuggingFaceModel[]> {
+    const qs = buildQueryString({
+      search: options.search,
+      author: options.author,
+      filter: options.filter,
+      sort: options.sort,
+      limit: options.limit,
+    });
+    const url = `${this.baseUrl}/api/models${qs}`;
+    const body = await this.requestJson(url, options.signal);
+    if (!Array.isArray(body)) {
+      throw new HuggingFaceClientError('HF_PARSE', 'HuggingFace list endpoint returned non-array', {
+        url,
+      });
+    }
+    return body.map((entry) => parseModel(entry, url));
+  }
+
+  /**
+   * Fetch a single model's metadata (including the file manifest). Used by
+   * the ranker to enumerate available GGUF quants without a second HEAD.
+   */
+  async getModel(repoId: string, signal?: AbortSignal): Promise<HuggingFaceModelDetail> {
+    const url = `${this.baseUrl}/api/models/${encodeURI(repoId)}`;
+    const body = await this.requestJson(url, signal);
+    return parseModelDetail(body, url);
+  }
+
+  /**
+   * Compact accessor used by popularity-weighted ranking. Wraps `getModel`
+   * but discards everything except the download count so the caller doesn't
+   * carry a full detail payload through the merge pipeline.
+   */
+  async getDownloadCount(repoId: string, signal?: AbortSignal): Promise<number> {
+    const detail = await this.getModel(repoId, signal);
+    return detail.downloads;
+  }
+
+  /**
+   * Shared request path: applies headers, enforces a timeout via
+   * `AbortController` (combined with the caller's optional signal), and maps
+   * every failure mode to a `HuggingFaceClientError`. No raw fetcher error or
+   * unhandled status escapes.
+   */
+  private async requestJson(url: string, externalSignal?: AbortSignal): Promise<unknown> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    const onAbort = () => controller.abort();
+    if (externalSignal) {
+      if (externalSignal.aborted) controller.abort();
+      else externalSignal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    let response: HuggingFaceFetchResponse;
+    try {
+      response = await this.fetcher(url, {
+        signal: controller.signal,
+        headers: buildHeaders(this.token),
+      });
+    } catch (err) {
+      if (isAbortError(err)) {
+        throw new HuggingFaceClientError('HF_NETWORK', 'HuggingFace request aborted', {
+          url,
+          cause: err,
+        });
+      }
+      throw new HuggingFaceClientError('HF_NETWORK', 'HuggingFace request failed', {
+        url,
+        cause: err,
+      });
+    } finally {
+      clearTimeout(timer);
+      if (externalSignal) externalSignal.removeEventListener('abort', onAbort);
+    }
+
+    if (response.status < 200 || response.status >= 300) {
+      const code = statusToCode(response.status);
+      let detail = '';
+      try {
+        detail = (await response.text()).slice(0, 200);
+      } catch {
+        // The body read itself failed; surface only the status.
+      }
+      throw new HuggingFaceClientError(
+        code,
+        `HuggingFace request returned ${response.status}${detail ? `: ${detail}` : ''}`,
+        { status: response.status, url }
+      );
+    }
+
+    try {
+      return await response.json();
+    } catch (err) {
+      throw new HuggingFaceClientError('HF_PARSE', 'HuggingFace response was not JSON', {
+        url,
+        cause: err,
+      });
+    }
+  }
+}

--- a/packages/local-models/src/huggingface/index.ts
+++ b/packages/local-models/src/huggingface/index.ts
@@ -1,0 +1,21 @@
+/**
+ * HuggingFace integration — public barrel.
+ *
+ * Phase 2a exposes the client, cache, and shared types. Phase 2c will add
+ * benchmark source adapters that ride on top of this surface.
+ */
+
+export { HuggingFaceClient, HuggingFaceClientError } from './client.js';
+
+export { HuggingFaceCache, DEFAULT_CACHE_PATH } from './cache.js';
+export type { CacheEntry, CacheFilesystem, HuggingFaceCacheOptions } from './cache.js';
+
+export type {
+  HuggingFaceClientOptions,
+  HuggingFaceErrorCode,
+  HuggingFaceFetcher,
+  HuggingFaceFetchResponse,
+  HuggingFaceListOptions,
+  HuggingFaceModel,
+  HuggingFaceModelDetail,
+} from './types.js';

--- a/packages/local-models/src/huggingface/types.ts
+++ b/packages/local-models/src/huggingface/types.ts
@@ -1,0 +1,100 @@
+/**
+ * HuggingFace integration — public types.
+ *
+ * The client is intentionally narrow: it surfaces only the fields the ranker
+ * (Phases 2b–d) needs from `/api/models` and `/api/models/:repo`. Additive
+ * HF changes therefore don't ripple into our type surface; subtractive
+ * changes get caught here because the parser asserts shape.
+ *
+ * The `HuggingFaceFetcher` seam mirrors Phase 1's `ShellRunner` — every
+ * outbound HTTP call goes through it, so tests can substitute a deterministic
+ * stub and never hit the network.
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (lines 88–91, 414–429)
+ */
+
+/**
+ * Stable error codes the client throws via `HuggingFaceClientError`. Callers
+ * (cache, snapshot fallback, ranker) branch on `code`; the human-readable
+ * `message` is for logs and operator-facing UI, not control flow.
+ */
+export type HuggingFaceErrorCode =
+  | 'HF_NOT_FOUND'
+  | 'HF_UNAUTHORIZED'
+  | 'HF_UNAVAILABLE'
+  | 'HF_NETWORK'
+  | 'HF_PARSE';
+
+/** Narrow response surface the client adapts `fetch` down to. */
+export interface HuggingFaceFetchResponse {
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+/**
+ * Outbound HTTP transport. Production wraps `fetch`; tests inject a stub. The
+ * shape is deliberately Web-ish (`signal`, `headers`) so the default
+ * implementation is a one-liner.
+ */
+export type HuggingFaceFetcher = (
+  url: string,
+  init: { signal?: AbortSignal; headers?: Record<string, string> }
+) => Promise<HuggingFaceFetchResponse>;
+
+/** Constructor options for `HuggingFaceClient`. All fields optional. */
+export interface HuggingFaceClientOptions {
+  /** Base URL — defaults to `https://huggingface.co`. Strip trailing slashes. */
+  baseUrl?: string;
+  /** API token — defaults to `process.env.HF_TOKEN`. Empty strings are treated as unset. */
+  token?: string;
+  /** DI seam for tests. Defaults to a `fetch`-backed implementation. */
+  fetcher?: HuggingFaceFetcher;
+  /** Per-request timeout in milliseconds. Defaults to 8 seconds. */
+  timeoutMs?: number;
+}
+
+/**
+ * Query parameters accepted by `listModels`. Mirrors the HF API's standard
+ * search/filter parameters; `sort` accepts the values HF documents
+ * (`'downloads'`, `'trending'`, `'lastModified'`, …) without our client
+ * passing judgement on which are valid this week.
+ */
+export interface HuggingFaceListOptions {
+  search?: string;
+  author?: string;
+  filter?: string;
+  sort?: string;
+  limit?: number;
+  /** Caller-supplied cancellation signal. Combines with the per-request timeout. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Trimmed HF model record. Only the fields the ranker reads are typed; HF's
+ * response carries more, which is parsed-and-dropped on the way in.
+ */
+export interface HuggingFaceModel {
+  /** Stable HF repo id (`'Qwen/Qwen3-32B-GGUF'`). */
+  id: string;
+  /** Cumulative downloads across all revisions. */
+  downloads: number;
+  /** Likes — used by the popularity weighting in Phase 2c. */
+  likes: number;
+  /** ISO timestamp of the last modification, when reported. */
+  lastModified?: string;
+  /** Free-form tags (`'gguf'`, `'4-bit'`, `'mlx'`, …). */
+  tags: readonly string[];
+  /** SPDX-ish license slug when present. */
+  license?: string;
+  /** Author / org — derived from the id prefix when HF doesn't echo it explicitly. */
+  author?: string;
+}
+
+/**
+ * Detail variant returned by `/api/models/:repo`. Adds the file manifest the
+ * ranker uses to enumerate available GGUF quants (`siblings[].rfilename`).
+ */
+export interface HuggingFaceModelDetail extends HuggingFaceModel {
+  siblings: ReadonlyArray<{ rfilename: string }>;
+}

--- a/packages/local-models/src/index.ts
+++ b/packages/local-models/src/index.ts
@@ -4,9 +4,11 @@
  * Hardware-aware local-model recommender, pool manager, and proposal engine
  * for Harness Engineering's Local Model Lifecycle Manager (LMLM).
  *
- * Phase 1 (current) ships hardware detection. Subsequent phases add the
- * Hugging Face client, ranker, pool manager, Ollama installer, scheduler,
- * proposal engine, HTTP/WS surfaces, CLI commands, and dashboard panel per
+ * Phase 2a (current) adds the HuggingFace REST client, an on-disk cache,
+ * and the frozen benchmark snapshot loader on top of Phase 1's hardware
+ * detection. Subsequent phases add the VRAM/speed math, evidence/recency
+ * fusion, the algorithm port, the pool manager, the Ollama installer, the
+ * scheduler, the proposal engine, and the HTTP/WS/CLI/dashboard surfaces per
  * `docs/changes/local-model-lifecycle-manager/proposal.md`.
  */
 
@@ -14,3 +16,5 @@ export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const
 export const LOCAL_MODELS_VERSION = '0.1.0' as const;
 
 export * from './hardware/index.js';
+export * from './huggingface/index.js';
+export * from './ranker/index.js';

--- a/packages/local-models/src/ranker/benchmarks/index.ts
+++ b/packages/local-models/src/ranker/benchmarks/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Benchmark data — public barrel.
+ *
+ * Phase 2a exposes the snapshot loader and the shared types. Phase 2c will
+ * add `sources.ts` (live leaderboard adapters) and `merge.ts` (cross-source
+ * weighting + confidence) under this same namespace.
+ */
+
+export { loadFrozenSnapshot } from './snapshot.js';
+
+export {
+  emptySnapshot,
+  type BenchmarkEvidence,
+  type BenchmarkObservation,
+  type BenchmarkSnapshot,
+  type BenchmarkSnapshotLoadResult,
+  type BenchmarkSnapshotWarning,
+  type ModelBenchmark,
+} from './types.js';

--- a/packages/local-models/src/ranker/benchmarks/snapshot.json
+++ b/packages/local-models/src/ranker/benchmarks/snapshot.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "generatedAt": "2026-05-28",
+  "source": "seed",
+  "models": [
+    {
+      "hfRepoId": "Qwen/Qwen3-32B-GGUF",
+      "ollamaName": "qwen3:32b",
+      "family": "qwen3",
+      "sizeB": 32,
+      "observations": [
+        {
+          "source": "open-llm-leaderboard",
+          "benchmark": "mmlu-pro",
+          "value": 64.2,
+          "evidence": "base",
+          "observedAt": "2026-05-01"
+        }
+      ]
+    },
+    {
+      "hfRepoId": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+      "ollamaName": "deepseek-r1:32b",
+      "family": "deepseek-r1",
+      "sizeB": 32,
+      "observations": [
+        {
+          "source": "open-llm-leaderboard",
+          "benchmark": "mmlu-pro",
+          "value": 67.8,
+          "evidence": "variant",
+          "observedAt": "2026-04-22"
+        }
+      ]
+    },
+    {
+      "hfRepoId": "meta-llama/Llama-3.3-70B-Instruct-GGUF",
+      "ollamaName": "llama3.3:70b",
+      "family": "llama-3",
+      "sizeB": 70,
+      "observations": [
+        {
+          "source": "open-llm-leaderboard",
+          "benchmark": "mmlu-pro",
+          "value": 71.0,
+          "evidence": "direct",
+          "observedAt": "2026-03-15"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/local-models/src/ranker/benchmarks/snapshot.ts
+++ b/packages/local-models/src/ranker/benchmarks/snapshot.ts
@@ -1,0 +1,216 @@
+/**
+ * Frozen benchmark snapshot loader.
+ *
+ * The orchestrator falls back to this snapshot whenever the live HF + per-
+ * source fetchers are unreachable (network outage, rate limit, transient
+ * 5xx). The loader is intentionally lenient: malformed input or a schema
+ * mismatch never throws — it returns an empty snapshot with a structured
+ * warning so the ranker can still produce a (possibly empty) result instead
+ * of crashing the orchestrator (S4).
+ *
+ * The bundled `snapshot.json` is imported statically so esbuild (tsup) inlines
+ * it into the compiled output. There is no runtime file read — the snapshot
+ * is part of the bundle. Tests inject an `override` payload via the optional
+ * argument to exercise the malformed / schema-invalid / fallback paths.
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (lines 86, 414–429; S4)
+ */
+
+import bundledSnapshot from './snapshot.json' with { type: 'json' };
+import {
+  emptySnapshot,
+  type BenchmarkObservation,
+  type BenchmarkSnapshot,
+  type BenchmarkSnapshotLoadResult,
+  type BenchmarkSnapshotWarning,
+  type ModelBenchmark,
+} from './types.js';
+
+/** Today's date as an ISO `YYYY-MM-DD` string. Pure helper for the fallback envelope. */
+function todayIso(now: () => Date): string {
+  return now().toISOString().slice(0, 10);
+}
+
+/**
+ * Load and validate the frozen snapshot. Returns a structured result with a
+ * provenance label (`'frozen'` vs `'fallback'`) and any warnings. Always
+ * resolves — never throws.
+ *
+ * Test code passes `options.override` to substitute alternate data and
+ * exercise the schema-invalid path.
+ */
+export async function loadFrozenSnapshot(options?: {
+  override?: unknown;
+  now?: () => Date;
+}): Promise<BenchmarkSnapshotLoadResult> {
+  const now = options?.now ?? (() => new Date());
+  const data = options?.override ?? bundledSnapshot;
+
+  const validation = validateSnapshot(data);
+  if (!validation.ok) {
+    return fallback(
+      'snapshot_schema_invalid',
+      `Frozen benchmark snapshot failed schema validation: ${validation.reason}`,
+      now
+    );
+  }
+
+  return { snapshot: validation.snapshot, source: 'frozen', warnings: [] };
+}
+
+function fallback(
+  code: BenchmarkSnapshotWarning['code'],
+  message: string,
+  now: () => Date
+): BenchmarkSnapshotLoadResult {
+  const warning: BenchmarkSnapshotWarning = { code, message };
+  return {
+    snapshot: emptySnapshot(todayIso(now)),
+    source: 'fallback',
+    warnings: [warning],
+  };
+}
+
+interface ValidationOk {
+  ok: true;
+  snapshot: BenchmarkSnapshot;
+}
+interface ValidationFail {
+  ok: false;
+  reason: string;
+}
+type ValidationResult = ValidationOk | ValidationFail;
+
+function validateSnapshot(value: unknown): ValidationResult {
+  if (!isObject(value)) return { ok: false, reason: 'root is not an object' };
+  if (value.version !== 1)
+    return { ok: false, reason: `unsupported version ${String(value.version)}` };
+  if (typeof value.generatedAt !== 'string')
+    return { ok: false, reason: 'generatedAt is not a string' };
+  if (value.source !== 'seed' && value.source !== 'snapshot') {
+    return {
+      ok: false,
+      reason: `source must be 'seed' or 'snapshot', got ${String(value.source)}`,
+    };
+  }
+  if (!Array.isArray(value.models)) return { ok: false, reason: 'models is not an array' };
+
+  const models: ModelBenchmark[] = [];
+  for (let i = 0; i < value.models.length; i += 1) {
+    const modelResult = validateModel(value.models[i], i);
+    if (!modelResult.ok) return modelResult;
+    models.push(modelResult.model);
+  }
+
+  return {
+    ok: true,
+    snapshot: {
+      version: 1,
+      generatedAt: value.generatedAt,
+      source: value.source,
+      models,
+    },
+  };
+}
+
+function validateModel(
+  value: unknown,
+  index: number
+): { ok: true; model: ModelBenchmark } | ValidationFail {
+  if (!isObject(value)) return { ok: false, reason: `models[${index}] is not an object` };
+  if (typeof value.hfRepoId !== 'string') {
+    return { ok: false, reason: `models[${index}].hfRepoId must be a string` };
+  }
+  if (typeof value.family !== 'string') {
+    return { ok: false, reason: `models[${index}].family must be a string` };
+  }
+  if (typeof value.sizeB !== 'number') {
+    return { ok: false, reason: `models[${index}].sizeB must be a number` };
+  }
+  if (!Array.isArray(value.observations)) {
+    return { ok: false, reason: `models[${index}].observations is not an array` };
+  }
+  const observations: BenchmarkObservation[] = [];
+  for (let j = 0; j < value.observations.length; j += 1) {
+    const obs = value.observations[j];
+    const obsResult = validateObservation(obs, index, j);
+    if (!obsResult.ok) return obsResult;
+    observations.push(obsResult.observation);
+  }
+  const model: ModelBenchmark = {
+    hfRepoId: value.hfRepoId,
+    family: value.family,
+    sizeB: value.sizeB,
+    observations,
+    ...(typeof value.ollamaName === 'string' ? { ollamaName: value.ollamaName } : {}),
+    ...(typeof value.activeB === 'number' ? { activeB: value.activeB } : {}),
+  };
+  return { ok: true, model };
+}
+
+function validateObservation(
+  value: unknown,
+  modelIndex: number,
+  obsIndex: number
+): { ok: true; observation: BenchmarkObservation } | ValidationFail {
+  if (!isObject(value)) {
+    return {
+      ok: false,
+      reason: `models[${modelIndex}].observations[${obsIndex}] is not an object`,
+    };
+  }
+  if (typeof value.source !== 'string') {
+    return {
+      ok: false,
+      reason: `models[${modelIndex}].observations[${obsIndex}].source must be a string`,
+    };
+  }
+  if (typeof value.benchmark !== 'string') {
+    return {
+      ok: false,
+      reason: `models[${modelIndex}].observations[${obsIndex}].benchmark must be a string`,
+    };
+  }
+  if (typeof value.value !== 'number') {
+    return {
+      ok: false,
+      reason: `models[${modelIndex}].observations[${obsIndex}].value must be a number`,
+    };
+  }
+  if (!isEvidence(value.evidence)) {
+    return {
+      ok: false,
+      reason: `models[${modelIndex}].observations[${obsIndex}].evidence is not a known grade`,
+    };
+  }
+  if (typeof value.observedAt !== 'string') {
+    return {
+      ok: false,
+      reason: `models[${modelIndex}].observations[${obsIndex}].observedAt must be a string`,
+    };
+  }
+  return {
+    ok: true,
+    observation: {
+      source: value.source,
+      benchmark: value.benchmark,
+      value: value.value,
+      evidence: value.evidence,
+      observedAt: value.observedAt,
+    },
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isEvidence(value: unknown): value is BenchmarkObservation['evidence'] {
+  return (
+    value === 'direct' ||
+    value === 'variant' ||
+    value === 'base' ||
+    value === 'interpolated' ||
+    value === 'self-reported'
+  );
+}

--- a/packages/local-models/src/ranker/benchmarks/types.ts
+++ b/packages/local-models/src/ranker/benchmarks/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Benchmark data — public types.
+ *
+ * The ranker (Phase 2c) merges multiple benchmark sources into a single
+ * `score` per model. Phase 2a only defines the shape and the frozen-snapshot
+ * envelope; the source adapters and merge algorithm land in 2c.
+ *
+ * Evidence grading captures *how directly* a benchmark applies to the exact
+ * `(model, quant)` pair the ranker is scoring. The grades are ordered from
+ * strongest (`direct`) to weakest (`self-reported`); the merge weights each
+ * accordingly.
+ *
+ * @see docs/changes/local-model-lifecycle-manager/proposal.md (lines 80–87, 132–137)
+ */
+
+/**
+ * Evidence strength applied to a benchmark observation, in descending order
+ * of trustworthiness:
+ *
+ * - `direct`        — leaderboard ran the exact `(model, quant)` pair
+ * - `variant`       — leaderboard ran a different quant of the same model
+ * - `base`          — leaderboard ran the unquantized base
+ * - `interpolated`  — score inferred from sibling models on the same lineage
+ * - `self-reported` — published only by the model author; not independently
+ *                     verified
+ */
+export type BenchmarkEvidence = 'direct' | 'variant' | 'base' | 'interpolated' | 'self-reported';
+
+/**
+ * Single benchmark observation pulled from one source. `value` is the raw
+ * benchmark score on the source's native scale; the merge logic in 2c
+ * normalizes across sources.
+ */
+export interface BenchmarkObservation {
+  /** Stable id of the originating leaderboard (`'open-llm-leaderboard'`, `'livebench'`, …). */
+  source: string;
+  /** Benchmark slug within the source (`'arc'`, `'mmlu'`, `'humaneval'`, `'livebench-coding'`, …). */
+  benchmark: string;
+  /** Native-scale score reported by the source. */
+  value: number;
+  /** Evidence grade describing how this observation maps to the target `(model, quant)`. */
+  evidence: BenchmarkEvidence;
+  /** ISO date the observation was published or last refreshed by the source. */
+  observedAt: string;
+}
+
+/**
+ * Per-model benchmark roll-up. The frozen snapshot ships these so the ranker
+ * has a usable score even when the HF API and the live leaderboard sources
+ * are unreachable (S4).
+ */
+export interface ModelBenchmark {
+  /** Stable HF repo id (`'Qwen/Qwen3-32B-GGUF'`). */
+  hfRepoId: string;
+  /** Common Ollama name when the model is mirrored upstream; `undefined` until 2c populates the table. */
+  ollamaName?: string;
+  /** Human-readable family slug (`'qwen3'`, `'deepseek-r1'`, `'llama-3'`). */
+  family: string;
+  /** Total parameter count in billions. For MoE this is `total`. */
+  sizeB: number;
+  /** Active parameter count in billions for MoE; `undefined` for dense models. */
+  activeB?: number;
+  /** All observations contributing to this roll-up. May be empty in the seed snapshot. */
+  observations: readonly BenchmarkObservation[];
+}
+
+/**
+ * Snapshot envelope. `version` lets the 2c loader detect schema drift; a
+ * mismatch causes the loader to surface a warning and return an empty
+ * snapshot rather than risk feeding the ranker malformed data.
+ */
+export interface BenchmarkSnapshot {
+  version: 1;
+  /** ISO date the snapshot was generated. Drives 2c's recency demotion. */
+  generatedAt: string;
+  /** Provenance label: `'seed'` for the Phase 2a placeholder, `'snapshot'` once Phase 2c writes real data. */
+  source: 'seed' | 'snapshot';
+  models: readonly ModelBenchmark[];
+}
+
+/** Result returned by `loadFrozenSnapshot`. Always populated — never throws. */
+export interface BenchmarkSnapshotLoadResult {
+  snapshot: BenchmarkSnapshot;
+  /** `'frozen'` when the bundled JSON parsed; `'fallback'` when the loader had to substitute an empty snapshot. */
+  source: 'frozen' | 'fallback';
+  warnings: BenchmarkSnapshotWarning[];
+}
+
+/** Structured warning attached to a load result. */
+export interface BenchmarkSnapshotWarning {
+  code: 'snapshot_read_failed' | 'snapshot_parse_failed' | 'snapshot_schema_invalid';
+  message: string;
+  cause?: string;
+}
+
+/** Helper used by both the loader fallback and 2c's emptied-on-mismatch path. */
+export function emptySnapshot(generatedAt: string): BenchmarkSnapshot {
+  return {
+    version: 1,
+    generatedAt,
+    source: 'seed',
+    models: [],
+  };
+}

--- a/packages/local-models/src/ranker/index.ts
+++ b/packages/local-models/src/ranker/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Ranker — public barrel.
+ *
+ * Phase 2a stands up the benchmark namespace; Phase 2b adds `vram` and
+ * `speed`; Phase 2c adds `evidence`, `recency`, and the benchmark merge;
+ * Phase 2d adds `algorithm.ts`. Re-exporting the benchmarks barrel now keeps
+ * the public surface stable across phases.
+ */
+
+export * from './benchmarks/index.js';

--- a/packages/local-models/tests/fixtures/hf-list-qwen3.json
+++ b/packages/local-models/tests/fixtures/hf-list-qwen3.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "Qwen/Qwen3-32B-GGUF",
+    "modelId": "Qwen/Qwen3-32B-GGUF",
+    "downloads": 184523,
+    "likes": 412,
+    "lastModified": "2026-05-15T18:22:11.000Z",
+    "tags": ["gguf", "text-generation", "qwen3"],
+    "license": "apache-2.0",
+    "author": "Qwen"
+  },
+  {
+    "id": "Qwen/Qwen3-14B-GGUF",
+    "downloads": 92110,
+    "likes": 271,
+    "lastModified": "2026-05-04T08:11:04.000Z",
+    "tags": ["gguf", "text-generation", "qwen3"],
+    "license": "apache-2.0",
+    "author": "Qwen"
+  }
+]

--- a/packages/local-models/tests/fixtures/hf-model-qwen3-32b.json
+++ b/packages/local-models/tests/fixtures/hf-model-qwen3-32b.json
@@ -1,0 +1,15 @@
+{
+  "id": "Qwen/Qwen3-32B-GGUF",
+  "downloads": 184523,
+  "likes": 412,
+  "lastModified": "2026-05-15T18:22:11.000Z",
+  "tags": ["gguf", "text-generation", "qwen3"],
+  "license": "apache-2.0",
+  "author": "Qwen",
+  "siblings": [
+    { "rfilename": "Qwen3-32B-Q4_K_M.gguf" },
+    { "rfilename": "Qwen3-32B-Q5_K_M.gguf" },
+    { "rfilename": "Qwen3-32B-Q8_0.gguf" },
+    { "rfilename": "README.md" }
+  ]
+}

--- a/packages/local-models/tests/huggingface/cache.test.ts
+++ b/packages/local-models/tests/huggingface/cache.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+
+import { HuggingFaceCache, type CacheFilesystem } from '../../src/huggingface/cache.js';
+
+interface RecordedFsOp {
+  op: 'read' | 'write' | 'rename' | 'mkdir';
+  path: string;
+  contents?: string;
+}
+
+function makeFs(initial: Record<string, string> = {}): {
+  fs: CacheFilesystem;
+  files: Record<string, string>;
+  ops: RecordedFsOp[];
+} {
+  const files: Record<string, string> = { ...initial };
+  const ops: RecordedFsOp[] = [];
+  const fs: CacheFilesystem = {
+    async readFile(path) {
+      ops.push({ op: 'read', path });
+      if (path in files) return files[path] as string;
+      const err = new Error(`ENOENT: ${path}`) as Error & { code: string };
+      err.code = 'ENOENT';
+      throw err;
+    },
+    async writeFile(path, contents) {
+      ops.push({ op: 'write', path, contents });
+      files[path] = contents;
+    },
+    async rename(from, to) {
+      ops.push({ op: 'rename', path: `${from}->${to}` });
+      if (!(from in files)) throw new Error(`source missing: ${from}`);
+      files[to] = files[from] as string;
+      delete files[from];
+    },
+    async mkdir(path) {
+      ops.push({ op: 'mkdir', path });
+    },
+  };
+  return { fs, files, ops };
+}
+
+describe('HuggingFaceCache', () => {
+  it('returns undefined on a missing key', async () => {
+    const { fs } = makeFs();
+    const cache = new HuggingFaceCache({ path: '/tmp/cache.json', fs });
+    await cache.load();
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('returns the value for a fresh key and undefined once the TTL elapses', async () => {
+    let now = 1000;
+    const { fs } = makeFs();
+    const cache = new HuggingFaceCache({
+      path: '/tmp/cache.json',
+      ttlMs: 100,
+      now: () => now,
+      fs,
+    });
+    await cache.load();
+    cache.set('foo', { hello: 'world' });
+
+    now = 1050;
+    expect(cache.get<{ hello: string }>('foo')).toEqual({ hello: 'world' });
+
+    now = 1099;
+    expect(cache.get('foo')).toEqual({ hello: 'world' });
+
+    // TTL boundary is inclusive of staleness (age === ttlMs ⇒ stale)
+    now = 1100;
+    expect(cache.get('foo')).toBeUndefined();
+  });
+
+  it('persists atomically via tmp + rename', async () => {
+    const { fs, files, ops } = makeFs();
+    const cache = new HuggingFaceCache({
+      path: '/var/cache/huggingface.json',
+      now: () => 5_000,
+      fs,
+    });
+    await cache.load();
+    cache.set('alpha', { value: 1 });
+    cache.set('beta', { value: 2 });
+    await cache.persist();
+
+    expect(ops.map((o) => o.op)).toEqual(['read', 'mkdir', 'write', 'rename']);
+    const writeOp = ops.find((o) => o.op === 'write');
+    expect(writeOp?.path).toBe('/var/cache/huggingface.json.tmp');
+    const renameOp = ops.find((o) => o.op === 'rename');
+    expect(renameOp?.path).toBe('/var/cache/huggingface.json.tmp->/var/cache/huggingface.json');
+
+    expect(files['/var/cache/huggingface.json']).toBeTruthy();
+    const persisted = JSON.parse(files['/var/cache/huggingface.json'] as string);
+    expect(persisted.version).toBe(1);
+    expect(persisted.entries.alpha.value).toEqual({ value: 1 });
+    expect(persisted.entries.beta.storedAt).toBe(5_000);
+  });
+
+  it('hydrates from a previously persisted file', async () => {
+    const persisted = JSON.stringify({
+      version: 1,
+      entries: {
+        cached: { storedAt: 10_000, value: { hi: 'there' } },
+      },
+    });
+    const { fs } = makeFs({ '/tmp/cache.json': persisted });
+    const cache = new HuggingFaceCache({
+      path: '/tmp/cache.json',
+      ttlMs: 5_000,
+      now: () => 12_000,
+      fs,
+    });
+    await cache.load();
+    expect(cache.get<{ hi: string }>('cached')).toEqual({ hi: 'there' });
+  });
+
+  it('treats a malformed JSON file as empty and emits a warning', async () => {
+    const warnings: string[] = [];
+    const { fs } = makeFs({ '/tmp/cache.json': '{not json' });
+    const cache = new HuggingFaceCache({
+      path: '/tmp/cache.json',
+      fs,
+      onWarn: (msg) => warnings.push(msg),
+    });
+    await cache.load();
+    expect(cache.get('anything')).toBeUndefined();
+    expect(warnings.some((w) => w.includes('not valid JSON'))).toBe(true);
+  });
+
+  it('treats a schema version mismatch as empty and emits a warning', async () => {
+    const warnings: string[] = [];
+    const { fs } = makeFs({
+      '/tmp/cache.json': JSON.stringify({ version: 99, entries: {} }),
+    });
+    const cache = new HuggingFaceCache({
+      path: '/tmp/cache.json',
+      fs,
+      onWarn: (msg) => warnings.push(msg),
+    });
+    await cache.load();
+    expect(cache.get('anything')).toBeUndefined();
+    expect(warnings.some((w) => w.includes('schema version mismatch'))).toBe(true);
+  });
+
+  it('tolerates an underlying read error other than ENOENT and emits a warning', async () => {
+    const warnings: string[] = [];
+    const fs: CacheFilesystem = {
+      readFile: async () => {
+        throw new Error('EPERM denied');
+      },
+      writeFile: async () => undefined,
+      rename: async () => undefined,
+      mkdir: async () => undefined,
+    };
+    const cache = new HuggingFaceCache({
+      path: '/tmp/cache.json',
+      fs,
+      onWarn: (msg) => warnings.push(msg),
+    });
+    await cache.load();
+    expect(cache.get('anything')).toBeUndefined();
+    expect(warnings.some((w) => w.includes('cache read failed'))).toBe(true);
+  });
+
+  it('clear() removes all entries', async () => {
+    const { fs } = makeFs();
+    const cache = new HuggingFaceCache({ path: '/tmp/cache.json', fs });
+    await cache.load();
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.clear();
+    expect(cache.snapshot()).toEqual({});
+  });
+
+  it('load() is idempotent — repeated calls do not re-read the disk', async () => {
+    const { fs, ops } = makeFs();
+    const cache = new HuggingFaceCache({ path: '/tmp/cache.json', fs });
+    await cache.load();
+    await cache.load();
+    await cache.load();
+    expect(ops.filter((o) => o.op === 'read')).toHaveLength(1);
+  });
+});

--- a/packages/local-models/tests/huggingface/client.test.ts
+++ b/packages/local-models/tests/huggingface/client.test.ts
@@ -1,0 +1,225 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { HuggingFaceClient, HuggingFaceClientError } from '../../src/huggingface/client.js';
+import type { HuggingFaceFetcher, HuggingFaceFetchResponse } from '../../src/huggingface/types.js';
+
+interface RecordedCall {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function makeFetcher(
+  responder: (call: RecordedCall) => HuggingFaceFetchResponse | Promise<HuggingFaceFetchResponse>
+): {
+  fetcher: HuggingFaceFetcher;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const fetcher: HuggingFaceFetcher = async (url, init) => {
+    const call: RecordedCall = { url, headers: init?.headers ?? {} };
+    calls.push(call);
+    return responder(call);
+  };
+  return { fetcher, calls };
+}
+
+function jsonResponse(status: number, body: unknown): HuggingFaceFetchResponse {
+  return {
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function textResponse(status: number, body: string): HuggingFaceFetchResponse {
+  return {
+    status,
+    json: async () => {
+      throw new Error('not json');
+    },
+    text: async () => body,
+  };
+}
+
+async function loadFixture(name: string): Promise<unknown> {
+  const url = new URL(`../fixtures/${name}`, import.meta.url);
+  const raw = await readFile(fileURLToPath(url), 'utf-8');
+  return JSON.parse(raw);
+}
+
+describe('HuggingFaceClient', () => {
+  it('lists models with sorted query params and a Bearer header when a token is set', async () => {
+    const fixture = await loadFixture('hf-list-qwen3.json');
+    const { fetcher, calls } = makeFetcher(() => jsonResponse(200, fixture));
+
+    const client = new HuggingFaceClient({ fetcher, token: 'hf_test' });
+    const models = await client.listModels({
+      search: 'qwen3',
+      limit: 5,
+      sort: 'downloads',
+    });
+
+    expect(models).toHaveLength(2);
+    expect(models[0]).toMatchObject({
+      id: 'Qwen/Qwen3-32B-GGUF',
+      downloads: 184523,
+      likes: 412,
+      author: 'Qwen',
+    });
+    expect(models[0]?.tags).toContain('gguf');
+
+    expect(calls).toHaveLength(1);
+    const [call] = calls;
+    // Params are URL-encoded and sorted alphabetically; the order is part of OT1.
+    expect(call?.url).toBe('https://huggingface.co/api/models?limit=5&search=qwen3&sort=downloads');
+    expect(call?.headers.Authorization).toBe('Bearer hf_test');
+    expect(call?.headers.Accept).toBe('application/json');
+  });
+
+  it('omits the Bearer header when no token is configured and HF_TOKEN is unset', async () => {
+    const original = process.env.HF_TOKEN;
+    delete process.env.HF_TOKEN;
+    try {
+      const { fetcher, calls } = makeFetcher(() => jsonResponse(200, []));
+      const client = new HuggingFaceClient({ fetcher });
+      await client.listModels();
+      expect(calls[0]?.headers.Authorization).toBeUndefined();
+    } finally {
+      if (original !== undefined) process.env.HF_TOKEN = original;
+    }
+  });
+
+  it('reads HF_TOKEN from the environment when no explicit token is passed', async () => {
+    const original = process.env.HF_TOKEN;
+    process.env.HF_TOKEN = 'hf_env_token';
+    try {
+      const { fetcher, calls } = makeFetcher(() => jsonResponse(200, []));
+      const client = new HuggingFaceClient({ fetcher });
+      await client.listModels();
+      expect(calls[0]?.headers.Authorization).toBe('Bearer hf_env_token');
+    } finally {
+      if (original === undefined) delete process.env.HF_TOKEN;
+      else process.env.HF_TOKEN = original;
+    }
+  });
+
+  it('returns parsed model detail with siblings', async () => {
+    const fixture = await loadFixture('hf-model-qwen3-32b.json');
+    const { fetcher } = makeFetcher(() => jsonResponse(200, fixture));
+    const client = new HuggingFaceClient({ fetcher });
+
+    const detail = await client.getModel('Qwen/Qwen3-32B-GGUF');
+    expect(detail.id).toBe('Qwen/Qwen3-32B-GGUF');
+    expect(detail.siblings.map((s) => s.rfilename)).toEqual([
+      'Qwen3-32B-Q4_K_M.gguf',
+      'Qwen3-32B-Q5_K_M.gguf',
+      'Qwen3-32B-Q8_0.gguf',
+      'README.md',
+    ]);
+  });
+
+  it('maps 404 to HF_NOT_FOUND', async () => {
+    const { fetcher } = makeFetcher(() => textResponse(404, 'not found'));
+    const client = new HuggingFaceClient({ fetcher });
+    await expect(client.getModel('ghost/repo')).rejects.toMatchObject({
+      code: 'HF_NOT_FOUND',
+      status: 404,
+    });
+  });
+
+  it('maps 401 and 403 to HF_UNAUTHORIZED', async () => {
+    for (const status of [401, 403]) {
+      const { fetcher } = makeFetcher(() => textResponse(status, 'denied'));
+      const client = new HuggingFaceClient({ fetcher });
+      const err = await client.getModel('any/repo').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(HuggingFaceClientError);
+      expect((err as HuggingFaceClientError).code).toBe('HF_UNAUTHORIZED');
+      expect((err as HuggingFaceClientError).status).toBe(status);
+    }
+  });
+
+  it('maps 429 and 5xx to HF_UNAVAILABLE', async () => {
+    for (const status of [429, 500, 502, 503]) {
+      const { fetcher } = makeFetcher(() => textResponse(status, 'busy'));
+      const client = new HuggingFaceClient({ fetcher });
+      const err = await client.getModel('any/repo').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(HuggingFaceClientError);
+      expect((err as HuggingFaceClientError).code).toBe('HF_UNAVAILABLE');
+    }
+  });
+
+  it('maps fetcher rejection to HF_NETWORK without leaking the raw error', async () => {
+    const fetcher: HuggingFaceFetcher = async () => {
+      throw new Error('socket hang up');
+    };
+    const client = new HuggingFaceClient({ fetcher });
+    const err = await client.listModels().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(HuggingFaceClientError);
+    expect((err as HuggingFaceClientError).code).toBe('HF_NETWORK');
+  });
+
+  it('maps non-JSON response bodies to HF_PARSE', async () => {
+    const { fetcher } = makeFetcher(() => ({
+      status: 200,
+      json: async () => {
+        throw new Error('not json');
+      },
+      text: async () => 'plain text',
+    }));
+    const client = new HuggingFaceClient({ fetcher });
+    const err = await client.listModels().catch((e: unknown) => e);
+    expect((err as HuggingFaceClientError).code).toBe('HF_PARSE');
+  });
+
+  it('maps non-array list bodies to HF_PARSE', async () => {
+    const { fetcher } = makeFetcher(() => jsonResponse(200, { error: 'unexpected shape' }));
+    const client = new HuggingFaceClient({ fetcher });
+    const err = await client.listModels().catch((e: unknown) => e);
+    expect((err as HuggingFaceClientError).code).toBe('HF_PARSE');
+  });
+
+  it('respects an external abort signal', async () => {
+    const fetcher: HuggingFaceFetcher = async (_url, init) =>
+      new Promise<HuggingFaceFetchResponse>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const err = new Error('aborted') as Error & { name: string };
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+
+    const client = new HuggingFaceClient({ fetcher });
+    const controller = new AbortController();
+    const promise = client.listModels({ signal: controller.signal });
+    controller.abort();
+    const err = await promise.catch((e: unknown) => e);
+    expect((err as HuggingFaceClientError).code).toBe('HF_NETWORK');
+  });
+
+  it('derives author from the repo id when HF omits it', async () => {
+    const { fetcher } = makeFetcher(() =>
+      jsonResponse(200, [
+        {
+          id: 'mistralai/Mistral-Small-Instruct-2409',
+          downloads: 10,
+          likes: 1,
+          tags: [],
+        },
+      ])
+    );
+    const client = new HuggingFaceClient({ fetcher });
+    const [model] = await client.listModels();
+    expect(model?.author).toBe('mistralai');
+  });
+
+  it('returns just the download count from getDownloadCount', async () => {
+    const fixture = await loadFixture('hf-model-qwen3-32b.json');
+    const { fetcher } = makeFetcher(() => jsonResponse(200, fixture));
+    const client = new HuggingFaceClient({ fetcher });
+    const downloads = await client.getDownloadCount('Qwen/Qwen3-32B-GGUF');
+    expect(downloads).toBe(184523);
+  });
+});

--- a/packages/local-models/tests/ranker/benchmarks/snapshot.test.ts
+++ b/packages/local-models/tests/ranker/benchmarks/snapshot.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { loadFrozenSnapshot } from '../../../src/ranker/benchmarks/snapshot.js';
+
+describe('loadFrozenSnapshot', () => {
+  it('loads the bundled snapshot with source = "frozen"', async () => {
+    const result = await loadFrozenSnapshot();
+    expect(result.source).toBe('frozen');
+    expect(result.warnings).toEqual([]);
+    expect(result.snapshot.version).toBe(1);
+    expect(result.snapshot.source).toBe('seed');
+    expect(result.snapshot.models.length).toBeGreaterThan(0);
+
+    // Spot-check a known seed entry.
+    const qwen = result.snapshot.models.find((m) => m.hfRepoId === 'Qwen/Qwen3-32B-GGUF');
+    expect(qwen).toBeDefined();
+    expect(qwen?.family).toBe('qwen3');
+    expect(qwen?.observations[0]?.benchmark).toBe('mmlu-pro');
+  });
+
+  it('falls back when the override fails schema validation (root not object)', async () => {
+    const result = await loadFrozenSnapshot({
+      override: 'not an object',
+      now: () => new Date('2026-05-28T00:00:00.000Z'),
+    });
+    expect(result.source).toBe('fallback');
+    expect(result.snapshot.models).toEqual([]);
+    expect(result.snapshot.generatedAt).toBe('2026-05-28');
+    expect(result.warnings[0]?.code).toBe('snapshot_schema_invalid');
+  });
+
+  it('falls back on unsupported version', async () => {
+    const result = await loadFrozenSnapshot({
+      override: { version: 99, generatedAt: '2026-01-01', source: 'snapshot', models: [] },
+      now: () => new Date('2026-05-28T00:00:00.000Z'),
+    });
+    expect(result.source).toBe('fallback');
+    expect(result.warnings[0]?.message).toMatch(/unsupported version/);
+  });
+
+  it('falls back when models is not an array', async () => {
+    const result = await loadFrozenSnapshot({
+      override: { version: 1, generatedAt: '2026-01-01', source: 'snapshot', models: 'oops' },
+      now: () => new Date('2026-05-28T00:00:00.000Z'),
+    });
+    expect(result.source).toBe('fallback');
+    expect(result.warnings[0]?.reason ?? result.warnings[0]?.message).toMatch(
+      /models is not an array/
+    );
+  });
+
+  it('falls back when an observation has an unknown evidence grade', async () => {
+    const result = await loadFrozenSnapshot({
+      override: {
+        version: 1,
+        generatedAt: '2026-01-01',
+        source: 'snapshot',
+        models: [
+          {
+            hfRepoId: 'fake/repo',
+            family: 'fake',
+            sizeB: 7,
+            observations: [
+              {
+                source: 'fake-source',
+                benchmark: 'fake-bench',
+                value: 50,
+                evidence: 'made-up-grade',
+                observedAt: '2026-01-01',
+              },
+            ],
+          },
+        ],
+      },
+      now: () => new Date('2026-05-28T00:00:00.000Z'),
+    });
+    expect(result.source).toBe('fallback');
+    expect(result.warnings[0]?.message).toMatch(/not a known grade/);
+  });
+
+  it('accepts a snapshot with empty models array', async () => {
+    const result = await loadFrozenSnapshot({
+      override: { version: 1, generatedAt: '2026-04-01', source: 'snapshot', models: [] },
+    });
+    expect(result.source).toBe('frozen');
+    expect(result.snapshot.models).toEqual([]);
+    expect(result.snapshot.generatedAt).toBe('2026-04-01');
+  });
+});

--- a/packages/local-models/tsconfig.build.json
+++ b/packages/local-models/tsconfig.build.json
@@ -6,6 +6,6 @@
     "composite": false,
     "incremental": false
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["node_modules", "dist", "tests"]
 }

--- a/packages/local-models/tsconfig.json
+++ b/packages/local-models/tsconfig.json
@@ -7,6 +7,6 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "references": [{ "path": "../types" }],
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/**/*.json"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Phase 2a of the [Local Model Lifecycle Manager (LMLM)](docs/changes/local-model-lifecycle-manager/proposal.md) — the data-plane scaffold the ranker (Phases 2b–d) will consume. No business logic for ranking yet; this PR locks down the contract the algorithm port will build against.

- **`HuggingFaceClient`** — typed wrapper over `/api/models` and `/api/models/:repo` with an injected `fetcher` DI seam (mirrors Phase 1's `ShellRunner`), abort-signal support, optional bearer token (`HF_TOKEN` env fallback), and stable error codes (`HF_NOT_FOUND` / `HF_UNAUTHORIZED` / `HF_UNAVAILABLE` / `HF_NETWORK` / `HF_PARSE`). No raw `fetch` error escapes the client.
- **`HuggingFaceCache`** — versioned in-memory + on-disk cache at `~/.harness/local-models/cache/huggingface.json`. Writes use `tmp + rename` so a crash mid-write cannot corrupt the file (mirrors the proposal's O2 invariant for pool state). Missing, malformed, or schema-mismatched files reset to empty with a structured warning.
- **`loadFrozenSnapshot()`** — validates and returns the bundled benchmark snapshot the orchestrator falls back to when HF and the live leaderboard sources are unreachable (S4). Invalid input yields a typed warning and an empty snapshot, never a throw.
- **Seed `snapshot.json`** — three Qwen / DeepSeek / Llama placeholder entries so Phase 2c's merge pipeline has something non-empty to operate on.

LMLM remains opt-in and disabled by default. No orchestrator, CLI, dashboard, HTTP, or config-schema wiring lands in this phase. VRAM/speed math, evidence + recency grading, live benchmark source adapters, the merge algorithm, the `RankedModel` orchestrator, and the parity tests against whichllm reference outputs are deferred to Phases 2b–d per the LMLM proposal.

## Test plan

- [x] `pnpm --filter @harness-engineering/local-models test` — 55 tests pass (8 files)
- [x] `pnpm --filter @harness-engineering/local-models typecheck` — clean
- [x] `pnpm --filter @harness-engineering/local-models lint` — clean
- [x] `pnpm --filter @harness-engineering/local-models build` — both ESM + CJS bundles + .d.ts generated
- [x] `pnpm build` — full workspace build still green (Turbo, all 11 packages)
- [x] `harness validate` — no new findings in `packages/local-models/`

Plan reference: [`docs/changes/local-model-lifecycle-manager/plans/2026-05-28-phase2a-hf-client-snapshot-plan.md`](docs/changes/local-model-lifecycle-manager/plans/2026-05-28-phase2a-hf-client-snapshot-plan.md)