### PR TITLE
chore(roadmap): mark design-pipeline #4 check-design verifier as done

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1996,9 +1996,9 @@ last_manual_edit: 2026-05-24T15:27:04.258Z
 
 ### design-pipeline sub-project #4: harness check-design verifier
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/design-pipeline/check-design-verifier/proposal.md
-- **Summary:** Convergence-verifier the design align skills rerun after each fix batch — equivalent of harness check-docs in docs-pipeline. Two options to decide during brainstorm: new harness check-design CLI command vs. extension of harness validate. Hooks into existing DesignConstraintAdapter. Prerequisite for the align skill in sub-project #1.
+- **Summary:** Convergence-verifier the design align skills rerun after each fix batch — equivalent of harness check-docs in docs-pipeline. Two options to decide during brainstorm: new harness check-design CLI command vs. extension of harness validate. Hooks into existing DesignConstraintAdapter. Prerequisite for the align skill in sub-project #1. Shipped in PR #394 (commit d1c9bda5): new `harness check-design` CLI command composing audit-anatomy + design-craft critique with direct programmatic invocation, graph persistence via `DesignConstraintAdapter.recordFindings()`, graceful per-verifier degradation, and exit-code semantics matching `check-docs` (0 clean / 1 error findings / 2 verifier failure). Subsequent design-pipeline sub-projects #1 (detect-design-drift) and #3 (audit-brand-compliance) were folded in as additional verifiers per the proposal's "5-line addition" plan. The Verifier-shape convention noted in the v1 comment was formally extracted into `packages/cli/src/shared/verifier.ts` at the 4th-verifier threshold (audit-brand-compliance, PR for sub-project #3).
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —


### PR DESCRIPTION
## Summary

PR #394 (commit d1c9bda5) shipped the `harness check-design` CLI command on 2026-05-24, but the design-pipeline sub-project #4 roadmap entry never picked up the status flip — it still read `Status: in-progress`.

Subsequent design-pipeline sub-projects #1 (detect-design-drift, PR #396) and #3 (audit-brand-compliance, commit c5f8d016) folded themselves in as additional verifiers per the proposal's "5-line addition" plan, and the Verifier-shape convention noted in the v1 comment was formally extracted into `packages/cli/src/shared/verifier.ts` at the 4th-verifier threshold.

This PR flips `Status: in-progress` → `Status: done` and expands the summary with shipping details matching the format used by other completed sub-projects (#10 security-craft, Hermes phases).

## Test plan

- [x] `git diff --stat` → single-file change in `docs/roadmap.md` (2 insertions, 2 deletions)
- [x] `pnpm --filter @harness-engineering/cli test -- tests/commands/check-design.test.ts` → 16 / 16 passed
- [x] `harness validate` → no new findings introduced (267 pre-existing design-drift findings present on main; arch-baseline regressions pre-existing on main)
- [x] `pnpm generate-docs` → reference docs unchanged

## Related

- Implementation PR: #394 (`feat(cli): add harness check-design verifier`, commit d1c9bda5)
- Follow-up doc PR: #440 (lists `check-design` in AGENTS.md Validation & Checks one-liner)