### PR TITLE
feat(audit-anatomy): EmptyState convention with ANAT-D020 (design-pipeline #2)

### DIFF
--- a/.changeset/audit-anatomy-empty-state-convention.md
+++ b/.changeset/audit-anatomy-empty-state-convention.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': minor
+---
+
+audit-component-anatomy: add EmptyState convention with `ANAT-D020` (missing required `headline` slot).
+
+Phase 2 catalog expansion — third component after Button and Input. `EmptyState` joins the registry returned by `getCatalogTypes()`. Unlike Button/Input, EmptyState sources from Open UI rather than APG (it is not an interactive ARIA pattern). The convention runner emits `ANAT-D020` (severity `error` at standard strictness, `warn` at permissive) when an EmptyState definition's prop type exposes none of the three documented satisfiers: `title` prop, `headline` prop, or typed `children`. Other anatomy parts (icon, description, primary/secondary action slots, default state, the zero-data / no-results / error variants, and sizes) ship on the convention for catalog completeness but are not yet wired to finding codes — those bands (`ANAT-D021`–`ANAT-D029` Tier-1 overflow, `ANAT-D030+` Tier-2) are reserved for follow-up tasks. Adds 7 new integration tests covering each satisfier path, strictness=permissive softening + strictness=strict cap, and Button+Input+EmptyState three-way partition; 2 catalog-registry unit tests assert EmptyState's presence and Tier-1 slot shape.

--- a/packages/cli/src/audit/component-anatomy/catalog/conventions/empty-state.ts
+++ b/packages/cli/src/audit/component-anatomy/catalog/conventions/empty-state.ts
@@ -1,0 +1,140 @@
+/**
+ * EmptyState convention — Phase 2 catalog expansion (component #3 of 20).
+ *
+ * Source spec (Phase 0 paper artifact):
+ *   docs/changes/design-pipeline/audit-component-anatomy/phase-0-schema-spike/conventions/empty-state.md
+ *
+ * Authoritative external source (per Phase 0 review):
+ *   - Open UI — empty-state research entry
+ *     https://open-ui.org/components/empty-state.research/
+ *
+ * APG does not catalog EmptyState (it is not an interactive ARIA pattern),
+ * so Open UI is the most authoritative public reference per the source
+ * hierarchy in Decision #5.
+ *
+ * Tier-1 (required) scope for v1:
+ *   `headline` slot — an EmptyState definition that exposes no headline
+ *   affordance (no `title` prop, no `headline` prop, no children typed
+ *   as the headline) cannot communicate its purpose. An EmptyState
+ *   without a message is indistinguishable from a layout bug — this is
+ *   the canonical Open-UI violation and the ANAT-D020 finding code.
+ *
+ * EmptyState is the canonical empty-data affordance: shown when a list,
+ * table, search result, or dashboard has nothing to render. As a
+ * component, it has its own anatomy (icon, headline, description, primary
+ * action, secondary action). The schema fits cleanly — see Phase 0
+ * review.md §EmptyState for the cross-reference with pattern findings
+ * (ANAT-P001 et al.) that name EmptyState as their fix target.
+ *
+ * Tier-2 / Tier-3 anatomy (description, primary/secondary action,
+ * default state, variants like zero-data/no-results/error, and sizes)
+ * is included on the rule so the registry stays the single source of
+ * truth, but the convention runner does not yet emit findings for those
+ * — the D021-D029 Tier-1 overflow band and the D030+ Tier-2 bucket are
+ * reserved for follow-up tasks per finding-codes.md.
+ */
+
+import type { ConventionRule } from '../../rules/convention-rule.js';
+
+export const emptyStateConvention: ConventionRule = {
+  componentType: 'EmptyState',
+  slots: [
+    {
+      name: 'icon',
+      required: false,
+      fixHint:
+        'Optional decorative icon (`aria-hidden`). Conventional — Open UI proposal lists it ' +
+        'as part of the canonical EmptyState anatomy.',
+    },
+    {
+      name: 'headline',
+      required: true,
+      fixHint:
+        'Required short message (one sentence) explaining the empty condition. Accept as a ' +
+        '`title` / `headline` prop (string) or as the first text child. Without a headline ' +
+        'the component cannot communicate its purpose — an EmptyState without a message is ' +
+        'indistinguishable from a layout bug.',
+    },
+    {
+      name: 'description',
+      required: false,
+      fixHint:
+        'Optional longer message giving context or next-step guidance. Accept as ' +
+        '`description` prop or as additional text children.',
+    },
+    {
+      name: 'primary-action',
+      required: false,
+      fixHint:
+        "Optional CTA (e.g., 'Create your first project'). Accept as `action` prop or as a " +
+        '`<Button>` child slot. Strongly recommended when the empty state is recoverable.',
+    },
+    {
+      name: 'secondary-action',
+      required: false,
+      fixHint:
+        "Optional secondary CTA (e.g., 'Import from CSV'). Same prop/slot shape as " +
+        '`primary-action`.',
+    },
+  ],
+  states: [
+    {
+      name: 'default',
+      required: true,
+      exclusive: false,
+      fixHint:
+        'EmptyState renders one visual state. Required-by-default; flagged only if the ' +
+        'component conditionally returns null on its own props. ANAT-D021 covers this case ' +
+        'once the runner extends to control-flow analysis.',
+    },
+  ],
+  variants: [
+    {
+      name: 'zero-data',
+      required: false,
+      fixHint:
+        "Variant for 'no items have ever existed' (e.g., empty inbox on day one). Expose via " +
+        '`variant` prop. The headline/icon usually skew encouraging.',
+    },
+    {
+      name: 'no-results',
+      required: false,
+      fixHint:
+        "Variant for 'filter or search returned nothing' (data exists but is filtered out). " +
+        'Expose via `variant` prop. The action usually offers to clear filters.',
+    },
+    {
+      name: 'error',
+      required: false,
+      fixHint:
+        "Variant for 'failed to load.' Often a separate component, but EmptyState may " +
+        'absorb it; expose via `variant` prop and ensure the icon/headline communicate ' +
+        'failure rather than emptiness.',
+    },
+  ],
+  sizes: [
+    {
+      name: 'sm',
+      required: false,
+      fixHint:
+        'Optional sizing token via `size` prop — used when EmptyState appears inside a ' +
+        'small panel rather than as a full-page state.',
+    },
+    {
+      name: 'md',
+      required: false,
+      fixHint: 'Default size; usually implicit when `size` prop is absent.',
+    },
+    {
+      name: 'lg',
+      required: false,
+      fixHint:
+        'Full-page empty state; usually implicit when EmptyState is the only child of the ' +
+        'route container.',
+    },
+  ],
+  source: {
+    ref: 'OpenUI/empty-state',
+    url: 'https://open-ui.org/components/empty-state.research/',
+  },
+};

--- a/packages/cli/src/audit/component-anatomy/catalog/index.ts
+++ b/packages/cli/src/audit/component-anatomy/catalog/index.ts
@@ -28,6 +28,7 @@
 
 import type { ConventionRule } from '../rules/convention-rule.js';
 import { buttonConvention } from './conventions/button.js';
+import { emptyStateConvention } from './conventions/empty-state.js';
 import { inputConvention } from './conventions/input.js';
 
 /**
@@ -39,7 +40,11 @@ import { inputConvention } from './conventions/input.js';
  * Entries are immutable at the module boundary — consumers receive
  * copies via `listConventions()` and the keys via `getCatalogTypes()`.
  */
-const builtinConventions: ConventionRule[] = [buttonConvention, inputConvention];
+const builtinConventions: ConventionRule[] = [
+  buttonConvention,
+  emptyStateConvention,
+  inputConvention,
+];
 
 const conventionByType = new Map<string, ConventionRule>(
   builtinConventions.map((rule) => [rule.componentType, rule])

--- a/packages/cli/src/audit/component-anatomy/rules/convention-runner.ts
+++ b/packages/cli/src/audit/component-anatomy/rules/convention-runner.ts
@@ -32,10 +32,15 @@ import type { ConventionRule } from './convention-rule.js';
  *
  * Phase 2 catalog expansion extends this map per the finding-codes.md
  * range allocation. Current assignments:
- *   - ANAT-D001 — Button.content (Phase 1 vertical slice)
- *   - ANAT-D004 — Input.label    (Phase 2 catalog expansion: first
- *                                 Tier-1 critical for Input; primary
- *                                 a11y deferral overlap with A11Y-050)
+ *   - ANAT-D001 — Button.content      (Phase 1 vertical slice)
+ *   - ANAT-D004 — Input.label         (Phase 2 catalog expansion: first
+ *                                      Tier-1 critical for Input; primary
+ *                                      a11y deferral overlap with A11Y-050)
+ *   - ANAT-D020 — EmptyState.headline (Phase 2 catalog expansion: first
+ *                                      Tier-1 critical for EmptyState;
+ *                                      sourced from Open UI rather than
+ *                                      APG since EmptyState is not an
+ *                                      interactive ARIA pattern)
  *
  * Remaining Tier-1 codes in D004–D029 are assigned in landing order as
  * Phase 2 conventions ship per the finding-codes.md reservation table.
@@ -50,6 +55,9 @@ const slotFindingCodes: Record<string, Record<string, AnatomyFindingCode>> = {
   },
   Input: {
     label: 'ANAT-D004',
+  },
+  EmptyState: {
+    headline: 'ANAT-D020',
   },
 };
 
@@ -90,6 +98,15 @@ function isSlotSatisfied(
     return (
       memberSet.has('label') || memberSet.has('aria-label') || memberSet.has('aria-labelledby')
     );
+  }
+
+  if (componentType === 'EmptyState' && slotName === 'headline') {
+    // Per finding-codes.md ANAT-D020 satisfiability: any of `title` prop,
+    // `headline` prop, or `children` (the headline rendered as the first
+    // text child). Names only — Phase 1 satisfiability stance matches
+    // ANAT-D001 and ANAT-D004 (no type-compatibility check on `children`
+    // — its presence as a typed member is sufficient).
+    return memberSet.has('title') || memberSet.has('headline') || memberSet.has('children');
   }
 
   // Fallback: exact-name match. Future slots can register specialised

--- a/packages/cli/tests/audit/component-anatomy/integration/empty-state-convention.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/integration/empty-state-convention.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Integration test for the EmptyState convention (Phase 2 catalog
+ * expansion #3).
+ *
+ * Exercises the full pipeline end-to-end for the third catalogued
+ * component:
+ *
+ *   resolveComponentType  →  resolveAnatomyRules  →  parseComponentDefinition
+ *                          →  runConventionRule    →  runAudit (MCP)
+ *
+ * Covers ANAT-D020 (EmptyState: missing required `headline` slot) at
+ * all three supported headline satisfiers (`title`, `headline`, and
+ * typed `children`) and the silent-skip case for an EmptyState
+ * definition whose prop type is missing every headline affordance.
+ *
+ * Refs: docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ * (Phase 2 catalog expansion; Success Criteria #1 for EmptyState);
+ * finding-codes.md § ANAT-D020 satisfiability table;
+ * phase-0-schema-spike/conventions/empty-state.md.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runAudit } from '../../../../src/mcp/tools/audit-anatomy';
+
+const positiveEmptyStateSource = `
+interface EmptyStateProps {
+  icon?: React.ReactNode;
+  description?: string;
+  action?: React.ReactNode;
+  // No \`title\`, \`headline\`, or \`children\` prop — ANAT-D020 fires.
+}
+
+export const EmptyState = ({ icon, description, action }: EmptyStateProps) => (
+  <div className="empty-state">
+    {icon}
+    {description && <p>{description}</p>}
+    {action}
+  </div>
+);
+`;
+
+const negativeEmptyStateWithTitle = `
+interface EmptyStateProps {
+  title: string;
+  icon?: React.ReactNode;
+  description?: string;
+  action?: React.ReactNode;
+}
+
+export const EmptyState = ({ title, icon, description, action }: EmptyStateProps) => (
+  <div className="empty-state">
+    {icon}
+    <h2>{title}</h2>
+    {description && <p>{description}</p>}
+    {action}
+  </div>
+);
+`;
+
+const negativeEmptyStateWithHeadline = `
+interface EmptyStateProps {
+  headline: string;
+  description?: string;
+}
+
+export const EmptyState = ({ headline, description }: EmptyStateProps) => (
+  <div>
+    <h2>{headline}</h2>
+    {description && <p>{description}</p>}
+  </div>
+);
+`;
+
+const negativeEmptyStateWithChildren = `
+interface EmptyStateProps {
+  children: React.ReactNode;
+}
+
+export const EmptyState = ({ children }: EmptyStateProps) => (
+  <div className="empty-state">{children}</div>
+);
+`;
+
+describe('audit-anatomy EmptyState convention — ANAT-D020', () => {
+  let projectRoot: string;
+  let positivePath: string;
+  let withTitlePath: string;
+  let withHeadlinePath: string;
+  let withChildrenPath: string;
+
+  beforeAll(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-anatomy-empty-state-'));
+    positivePath = path.join(projectRoot, 'PositiveEmptyState.tsx');
+    withTitlePath = path.join(projectRoot, 'WithTitleEmptyState.tsx');
+    withHeadlinePath = path.join(projectRoot, 'WithHeadlineEmptyState.tsx');
+    withChildrenPath = path.join(projectRoot, 'WithChildrenEmptyState.tsx');
+    fs.writeFileSync(positivePath, positiveEmptyStateSource, 'utf8');
+    fs.writeFileSync(withTitlePath, negativeEmptyStateWithTitle, 'utf8');
+    fs.writeFileSync(withHeadlinePath, negativeEmptyStateWithHeadline, 'utf8');
+    fs.writeFileSync(withChildrenPath, negativeEmptyStateWithChildren, 'utf8');
+  });
+
+  afterAll(() => {
+    if (projectRoot && fs.existsSync(projectRoot)) {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('emits exactly one ANAT-D020 finding for an EmptyState missing every headline affordance', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      mode: 'fast',
+      files: ['PositiveEmptyState.tsx'],
+    });
+
+    expect(result.findings).toHaveLength(1);
+    const finding = result.findings[0]!;
+    expect(finding.code).toBe('ANAT-D020');
+    expect(finding.severity).toBe('error');
+    expect(finding.componentType).toBe('EmptyState');
+    expect(finding.file).toBe('PositiveEmptyState.tsx');
+    expect(finding.rule.source).toBe('OpenUI/empty-state');
+    expect(finding.fix.kind).toBe('manual');
+    // Fix hint references the satisfying affordances callers can choose from.
+    expect(finding.fix.description).toMatch(/title|headline|children/);
+
+    expect(result.summary.bySeverity.error).toBe(1);
+    expect(result.summary.byCode['ANAT-D020']).toBe(1);
+    expect(result.catalog.conventionsApplied).toEqual(['EmptyState']);
+  });
+
+  it('emits zero findings for an EmptyState that accepts a `title` prop', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      mode: 'fast',
+      files: ['WithTitleEmptyState.tsx'],
+    });
+
+    expect(result.findings).toHaveLength(0);
+    expect(result.summary.bySeverity.error).toBe(0);
+    expect(result.catalog.conventionsApplied).toEqual(['EmptyState']);
+  });
+
+  it('emits zero findings for an EmptyState that accepts a `headline` prop', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      mode: 'fast',
+      files: ['WithHeadlineEmptyState.tsx'],
+    });
+
+    expect(result.findings).toHaveLength(0);
+    expect(result.catalog.conventionsApplied).toEqual(['EmptyState']);
+  });
+
+  it('emits zero findings for an EmptyState that accepts typed `children`', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      mode: 'fast',
+      files: ['WithChildrenEmptyState.tsx'],
+    });
+
+    expect(result.findings).toHaveLength(0);
+    expect(result.catalog.conventionsApplied).toEqual(['EmptyState']);
+  });
+
+  it('respects strictness=permissive — softens ANAT-D020 from error to warn', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      mode: 'fast',
+      files: ['PositiveEmptyState.tsx'],
+      designStrictness: 'permissive',
+    });
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.code).toBe('ANAT-D020');
+    expect(result.findings[0]!.severity).toBe('warn');
+    expect(result.summary.bySeverity.warn).toBe(1);
+    expect(result.summary.bySeverity.error).toBe(0);
+  });
+
+  it('respects strictness=strict — ANAT-D020 stays at error (already top severity)', async () => {
+    const result = await runAudit({
+      path: projectRoot,
+      mode: 'fast',
+      files: ['PositiveEmptyState.tsx'],
+      designStrictness: 'strict',
+    });
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.severity).toBe('error');
+  });
+
+  it('partitions findings across Button, Input, and EmptyState fixtures in one run', async () => {
+    // Add a Button-missing-content fixture and an Input-missing-label
+    // fixture alongside the EmptyState one so the multi-component path is
+    // exercised — catalogue applies all three conventions in the same call
+    // without cross-contamination.
+    const buttonPath = path.join(projectRoot, 'NoContentButton.tsx');
+    fs.writeFileSync(
+      buttonPath,
+      `interface ButtonProps { onClick?: () => void; }\nexport const Button = ({ onClick }: ButtonProps) => <button onClick={onClick} />;\n`,
+      'utf8'
+    );
+    const inputPath = path.join(projectRoot, 'NoLabelInput.tsx');
+    fs.writeFileSync(
+      inputPath,
+      `interface InputProps { value?: string; }\nexport const Input = ({ value }: InputProps) => <input value={value} />;\n`,
+      'utf8'
+    );
+
+    const result = await runAudit({
+      path: projectRoot,
+      mode: 'fast',
+      files: ['PositiveEmptyState.tsx', 'NoContentButton.tsx', 'NoLabelInput.tsx'],
+    });
+
+    expect(result.findings).toHaveLength(3);
+    const codes = result.findings.map((f) => f.code).sort();
+    expect(codes).toEqual(['ANAT-D001', 'ANAT-D004', 'ANAT-D020']);
+    expect(result.catalog.conventionsApplied).toEqual(['Button', 'EmptyState', 'Input']);
+  });
+});

--- a/packages/cli/tests/audit/component-anatomy/unit/catalog-registry.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/catalog-registry.test.ts
@@ -33,6 +33,11 @@ describe('catalog registry', () => {
     expect(types).toContain('Input');
   });
 
+  it('exposes EmptyState as a catalogued type (Phase 2 expansion #3)', () => {
+    const types = getCatalogTypes();
+    expect(types).toContain('EmptyState');
+  });
+
   it('returns the same set of types from the public `exports.ts` surface', () => {
     // harness-accessibility step 2.6 imports getCatalogTypes from the
     // public exports surface. The contract is that both paths return
@@ -72,6 +77,24 @@ describe('catalog registry', () => {
     expect(rule!.slots.find((s) => s.name === 'label')?.required).toBe(true);
     expect(rule!.slots.find((s) => s.name === 'helper-text')?.required).toBe(false);
     expect(rule!.slots.find((s) => s.name === 'error-text')?.required).toBe(false);
+  });
+
+  it('looks up EmptyState to its full ConventionRule with headline as the required Tier-1 slot', () => {
+    const rule = lookupConvention('EmptyState');
+    expect(rule).not.toBeNull();
+    expect(rule!.componentType).toBe('EmptyState');
+    // EmptyState sources from Open UI rather than APG — APG does not
+    // catalog EmptyState (not an interactive ARIA pattern). Per
+    // Decision #5's source hierarchy, Open UI is the next-most
+    // authoritative public reference.
+    expect(rule!.source.ref).toBe('OpenUI/empty-state');
+    expect(rule!.slots.find((s) => s.name === 'headline')?.required).toBe(true);
+    // Per Phase 0 spec § EmptyState: headline is the ONLY required
+    // slot. icon, description, and the action slots are optional.
+    expect(rule!.slots.find((s) => s.name === 'icon')?.required).toBe(false);
+    expect(rule!.slots.find((s) => s.name === 'description')?.required).toBe(false);
+    expect(rule!.slots.find((s) => s.name === 'primary-action')?.required).toBe(false);
+    expect(rule!.slots.find((s) => s.name === 'secondary-action')?.required).toBe(false);
   });
 
   it('returns null for an unknown component type (silent skip per Decision #1)', () => {


### PR DESCRIPTION
## Summary

Adds the **EmptyState** convention to `audit-component-anatomy` — the third entry in the catalog after Button + Input, advancing design-pipeline sub-project #2 toward the v1 20-component goal (SC-7).

Wires `ANAT-D020` (EmptyState: missing required `headline` slot) into the convention runner. Headline is the only Tier-1 required slot per the Phase 0 spec — the runner satisfies it from any of `title`, `headline`, or typed `children`, matching the Phase 1 name-only satisfiability stance used by ANAT-D001 (Button) and ANAT-D004 (Input).

Unlike Button/Input, EmptyState sources from **Open UI** rather than APG since EmptyState is not an interactive ARIA pattern. This is the first non-APG-sourced convention in the catalog and exercises the source-hierarchy fallback documented in Decision #5.

## What changed

- **`packages/cli/src/audit/component-anatomy/catalog/conventions/empty-state.ts`** (new): full ConventionRule with all five slots (icon, headline, description, primary-action, secondary-action), the default state, three variants (zero-data / no-results / error), three sizes, and Open-UI source citation. Only `headline` is `required: true` in v1.
- **`catalog/index.ts`**: register `emptyStateConvention` in the built-in registry.
- **`rules/convention-runner.ts`**: add `EmptyState.headline → ANAT-D020` to `slotFindingCodes` and add the satisfiability rule (`title` OR `headline` OR `children`).
- **Tests**: 7 new integration cases (positive + 3 negative satisfiers + permissive softening + strict cap + three-way Button/Input/EmptyState partition) and 2 new catalog-registry unit cases.

## Test plan

- [x] `pnpm -F @harness-engineering/cli test tests/audit/component-anatomy/` — 51 / 51 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `harness validate` — no new findings introduced (267 pre-existing issues unchanged)
- [x] Changeset added (`@harness-engineering/cli` minor — catalog addition is a stable additive change to `getCatalogTypes()`)

## References

- Spec: `docs/changes/design-pipeline/audit-component-anatomy/proposal.md` (Phase 2 catalog expansion, SC-7)
- Finding code: `docs/changes/design-pipeline/audit-component-anatomy/finding-codes.md` § ANAT-D020 (severity, satisfiability table, message template)
- Phase 0 spec: `phase-0-schema-spike/conventions/empty-state.md`