### PR TITLE
ci: auto-approve github-actions baseline-refresh PRs

### DIFF
--- a/.github/workflows/auto-approve-baselines.yml
+++ b/.github/workflows/auto-approve-baselines.yml
@@ -1,0 +1,32 @@
+name: Auto-approve baseline refresh PRs
+
+# The refresh-baselines job in ci.yml opens a PR from github-actions[bot] when
+# direct push to main is blocked by the ruleset. That PR sits waiting on a
+# required review. This workflow approves it automatically so `gh pr merge --auto`
+# (set in ci.yml) can complete once checks pass.
+#
+# Scope is intentionally narrow: branch prefix + title + author all must match.
+# Approval uses BASELINE_AUTOAPPROVE_PAT because GITHUB_TOKEN cannot approve PRs
+# and an author cannot approve their own PR.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve:
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'chore/refresh-baselines-') &&
+      github.event.pull_request.title == 'chore: refresh baselines after merge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.BASELINE_AUTOAPPROVE_PAT }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review "$PR_URL" --approve --body "Auto-approved: baseline refresh from github-actions[bot]."


### PR DESCRIPTION
## Summary
- Add a workflow that auto-approves PRs from `github-actions[bot]` titled `chore: refresh baselines after merge` on branches `chore/refresh-baselines-*`.
- Lets the existing `--auto --squash` merge (set in `ci.yml`'s `refresh-baselines` job) complete without a human approval that adds no value.
- Approval uses repo secret `BASELINE_AUTOAPPROVE_PAT` because `GITHUB_TOKEN` can't approve PRs and a PR author can't self-approve.

## Test plan
- [ ] After merge, watch the next refresh-baselines PR auto-approve and auto-merge.
- [ ] Confirm scope filter ignores unrelated PRs (only matches bot + branch prefix + title).