### PR TITLE
docs(knowledge): 4 design-craft pattern entries (LLM judgment, vocabulary, catalogs, B')

### DIFF
--- a/docs/knowledge/design/craft-output-vocabulary.md
+++ b/docs/knowledge/design/craft-output-vocabulary.md
@@ -1,0 +1,108 @@
+---
+type: business_concept
+domain: design
+tags: [craft, findings, output, tier, impact, confidence, radar, benchmark, vocabulary]
+---
+
+# Craft Output Vocabulary
+
+The **craft output vocabulary** is the shared finding and scoring shape used by LLM-judgment skills in the craft domain. It pairs a **3-axis per-finding model** (tier × impact × confidence) with a **5-dimension radar** for holistic scoring. Codified by [ADR 0019](../decisions/0019-3-axis-craft-output-model.md). First instance: `harness-design-craft` (`CRAFT-C*`, `CRAFT-P*`, `CRAFT-B*` findings).
+
+## Why a new vocabulary
+
+The existing `severity: 'error' | 'warn' | 'info'` vocabulary fits rule-based skills because rule outputs are binary. For craft-domain LLM-judgment outputs (see [[llm-judgment-skills]]) the standard severity vocabulary fails three ways:
+
+1. **Craft findings are not binary** — "the body-text leading is slightly tight" is not "an error." Forcing it into `warn` is adversarial; forcing it into `info` buries it.
+2. **Importance is two-dimensional** — a hierarchy collapse and a spring-physics polish opportunity sit at different *tiers* of craft AND have different *impact*. Collapsing both into single severity loses reviewer-actionable signal.
+3. **LLM confidence is real** — a 95%-confident "no primary action" deserves different treatment from a 40%-confident "illustration might feel off-brand."
+
+## Per-finding: the 3-axis model
+
+Every CRITIQUE and POLISH finding (`CRAFT-C*`, `CRAFT-P*`) carries three orthogonal axes:
+
+### Axis 1 — `tier: 'foundational' | 'polish' | 'aspirational'`
+
+Where on the craft maturity ladder does the finding sit?
+
+| Tier            | Meaning                                                                                                                                                | Reviewer treatment                                              |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| `foundational`  | Design fails a baseline craft expectation (no hierarchy, no primary action, illegible contrast, disorienting motion).                                  | Near-mandatory to address before shipping.                      |
+| `polish`        | Design meets baseline but misses a refinement competent execution would include (cubic-bezier vs spring motion, tight body leading, generic illustration). | Bulk of the elevation work.                                     |
+| `aspirational`  | Design is competent and refined but could reach beyond (signature motion language, brand-distinctive illustration, custom micro-interaction).             | Ceiling-raising — take when budget allows, skip without shame.  |
+
+### Axis 2 — `impact: 'small' | 'medium' | 'large'`
+
+The blast radius — how much does fixing it move the needle?
+
+| Impact   | Meaning                                                                                          | Reviewer treatment                  |
+| -------- | ------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| `large`  | Addressing changes how the design *reads* at a glance.                                          | Front of the work queue.            |
+| `medium` | Noticeably improves the experience but does not change the design's character.                  | Most polish-tier findings sit here. |
+| `small`  | Refinement detail.                                                                               | Batch into "polish passes."         |
+
+### Axis 3 — `confidence: 'high' | 'medium' | 'low'`
+
+The LLM's self-reported certainty in the judgment. Required by [[llm-judgment-skills]] / ADR 0018. See the confidence semantics there.
+
+### Derived priority
+
+A deterministic `priority: number` is computed per finding from the 3-axis triple. Default weighting: tier dominates impact dominates confidence. The weights are documented in `derivePriority` and skills MAY expose a strictness knob (`strict / standard / permissive`) that shifts the gate threshold along the priority axis without changing underlying values.
+
+The derivation is **deterministic** so downstream sorting, gating, and convergence-verifier fixpoint detection are reproducible even when the LLM payload is not.
+
+## Holistic scoring: the 5-dim radar
+
+Where per-finding outputs use 3-axis, BENCHMARK-phase outputs use a five-dimension radar (matching the [alchaincyf/huashu-design](../../changes/design-pipeline/REFERENCES.md) prior art). Each `CRAFT-B*` benchmark identifier scores a component against curated exemplars across:
+
+| Dimension                | Captures                                                                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `philosophicalCoherence` | Does the design hang together as a unified statement? Is there a discernible point of view? Does every element reinforce the same aesthetic intent?    |
+| `hierarchy`              | Visual hierarchy clarity. Primary vs secondary vs tertiary distinctions. No element competes for attention with another at the same level.             |
+| `craftExecution`         | Polish, refinement, attention to detail. Typography, spacing, motion, color — all executed at competent-to-stunning standard.                          |
+| `function`               | Does it work for the user? Is the design serving the task or fighting it? Is the IA legible, the affordances discoverable, the interactions efficient? |
+| `innovation`             | Does the design contribute something distinctive? Is there a signature move, a memorable detail, an unexpected delight? Or is it competently generic?  |
+
+Each dimension carries `{ score: 0-100, confidence, notes }`. The skill emits an `overall: { score, confidence }` aggregated via documented weighting (default: equal weight) AND a `gaps: string[]` narrative for cross-dimension analysis the radar cannot capture.
+
+## Phase / output mapping
+
+| Phase     | Finding code family | Output model      | Cardinality              |
+| --------- | ------------------- | ----------------- | ------------------------ |
+| CRITIQUE  | `CRAFT-C*`          | 3-axis            | Many findings per audit. |
+| POLISH    | `CRAFT-P*`          | 3-axis + before/after | Many findings per audit. |
+| BENCHMARK | `CRAFT-B*`          | 5-dim radar       | One score per benchmarked component, multiple per audit. |
+
+Both vocabularies co-exist in a single `DesignCraftOutput` because they answer different questions (per-issue vs holistic).
+
+## Severity translation (escape hatch)
+
+For consumers that genuinely need `error/warn/info` (legacy reporters, external CI, GitHub annotations), the skill exposes a deterministic derivation:
+
+```
+foundational + (large|medium) + (high|medium)  → error
+foundational + small | polish + large + high   → warn
+everything else                                → info
+```
+
+This derivation is **informational and does NOT replace the 3-axis output.** Skills using derived severity in enforcement gates MUST also expose the underlying 3-axis triple so reviewers can audit the mapping.
+
+## What the vocabulary does NOT specify
+
+- The exact priority-derivation weights — those are skill-local and may evolve with usage data (versioned via the catalog's [[living-catalogs]] / ADR 0020 mechanics).
+- The number of radar dimensions for non-craft domains — skills in adjacent domains (copy-craft, accessibility-narrative, motion-language) MAY adopt the 5-dim shape OR file a domain-appropriate alternative. The 3-axis per-finding shape is the part that should NOT change without superseding ADR 0019.
+- The exact rendering of confidence in markdown — italic, prefix, callout — beyond the requirement that low-confidence findings be visually distinguished.
+
+## Anti-patterns to avoid
+
+- **Collapsing tier into severity** — `foundational` is not "error"; mapping it directly destroys the craft-ladder distinction.
+- **Hiding low-confidence findings** — see [[llm-judgment-skills]] §confidence. Low-confidence is the signal a human reviewer needs.
+- **Synthetic precision** — emitting `priority: 73.4` and treating the second decimal as meaningful. Priority is a deterministic sort key, not a craft score.
+- **Mixing per-finding and holistic outputs in the same list** — CRITIQUE/POLISH findings and BENCHMARK scores answer different questions; format them as separate sections, not interleaved entries.
+
+## Related
+
+- ADR: [0019 — 3-axis craft output model](../decisions/0019-3-axis-craft-output-model.md)
+- Parent pattern: [[llm-judgment-skills]] / [ADR 0018](../decisions/0018-llm-judgment-skill-pattern.md) — confidence-as-first-class is required by ADR 0018 §1.
+- Companion patterns: [[living-catalogs]] (catalog `findingTemplate` carries the 3-axis defaults per entry), [[detect-and-offer]] (precondition state shapes rubric/exemplar selection that drives output).
+- First instance: [`harness-design-craft`](../../changes/design-pipeline/design-craft-elevator/proposal.md) — `CRAFT-C*`, `CRAFT-P*`, `CRAFT-B*` codes. Finding code reference: [`finding-codes.md`](../../changes/design-pipeline/design-craft-elevator/finding-codes.md).
+- Prior art: REFERENCES #4 (alchaincyf/huashu-design — proven 5-dim radar shape), #3 (emilkowalski/skill — judgment-heavy review-checklist vocabulary), #7 (Atlassian eslint-plugin-design-system — multi-field rule schema validating "more than one axis").

--- a/docs/knowledge/design/living-catalogs.md
+++ b/docs/knowledge/design/living-catalogs.md
@@ -1,0 +1,135 @@
+---
+type: business_concept
+domain: design
+tags: [catalog, growth, contribution, signal-loop, versioning, deprecation, seed, h-pattern]
+---
+
+# Living Catalogs (the H Pattern)
+
+A **living catalog** is a corpus of structured content (rubrics, patterns, exemplars, anatomy contracts, forbidden-phrase lists, tone matrices) that drives a skill's finding generation AND grows over time through a deliberate combination of curation and operational signal. The pattern is codified by [ADR 0020](../decisions/0020-living-catalog-h-pattern.md) and labeled "H" after the brainstorm's option labeling: **seed + growth infrastructure as a single coordinated deliverable**. First instance: `harness-design-craft` (10 rubrics + 15 patterns + 50 exemplars + growth infra at v1).
+
+## Why catalogs rot without infrastructure
+
+Catalog-backed skills face a structural problem rule-based skills do not: **the catalog rots.** Prior-art catalogs that shipped without growth infrastructure stalled at 30–50 entries — `pbakaus/impeccable` (29 rules), `getdesign.md` (~50 analyses) — because:
+
+1. **Curator bottleneck** — single-owner growth halts when the owner's attention shifts.
+2. **Signal disconnect** — top-down catalogs miss patterns that operational signal reveals matter ("this same finding recurs in 12 audits").
+3. **No measurement, no pruning** — dead entries accumulate indefinitely without per-entry usage counters.
+4. **No versioning, no deprecation path** — superseded entries either get hard-deleted (breaking historical citations) or silently linger (creating contradictions).
+5. **No contribution gate** — drive-by additions degrade quality.
+
+The shared property of catalogs that grow without curator-burnout is **seed + growth infrastructure**: ship a curated seed corpus AND the contribution format, review process, signal loop, measurement scaffolding, and versioning lanes from day 1.
+
+## The six required components
+
+A living catalog has six components, all infrastructure-level (reusable across catalog-backed skills):
+
+### 1. Curated seed catalog
+
+A hand-authored, peer-reviewed first-version corpus sized to make the skill immediately useful without overspending curator attention. For `harness-design-craft`: 10 rubrics + 15 patterns + 50 exemplars — each rubric covers one named craft dimension, each pattern is wired end-to-end (when-detected → before/after), each exemplar carries radar reference scores and a citation rationale.
+
+Future catalog-backed skills MUST document their seed shape in their spec and justify the seed size — too small = not useful, too large = curator-author bottleneck.
+
+### 2. Contribution format (schema-validated)
+
+Every catalog entry conforms to a schema enforced at PR time. Required fields for ALL entries:
+
+```yaml
+id: <kebab-case unique id>
+version: 1 # incremented on substantive change
+status: stable | draft | deprecated
+authoredAt: YYYY-MM-DD
+contributors: [@handle, ...]
+source: { ref: <citation key>, url: <canonical url> }
+```
+
+Type-specific fields layer on top (e.g. rubrics carry `prompt` + `findingTemplate`; patterns carry `applicableTo` + `before` + `after`; exemplars carry `componentType` + `radarReference` + `citationCount`).
+
+The schema MUST be exposed as a validator that PR CI calls automatically. Entries failing validation MUST be rejected at PR time with actionable errors, not merged-and-fixed-later.
+
+### 3. Review process (documented + enforced)
+
+Catalog additions are reviewed against a documented checklist before merge:
+
+- Schema conformance (automatic — Component 2).
+- Source provenance — is the citation real and authoritative?
+- Duplicate detection — does this overlap an existing entry?
+- Quality threshold — does the entry meet the seed-corpus standard?
+- Status appropriateness — `draft` (rookie) or `stable` (vetted)?
+
+For `harness-design-craft` the checklist lives at [`contribution.md`](../../changes/design-pipeline/design-craft-elevator/contribution.md). Future catalog-backed skills MUST publish an analogous checklist in their spec directory.
+
+### 4. Signal feedback loop (operational → catalog)
+
+The skill aggregates findings across audits and surfaces **recurring finding-shapes** as candidate catalog additions. For `harness-design-craft`: `contribution/signal.ts` watches CRITIQUE findings; when the same shape (rubric × target-pattern × tier) recurs N≥5 times across distinct projects/components, it exports a proposal to `.harness/design-craft/proposals/` carrying:
+
+- Finding-shape signature
+- Recurrence count + sample projects
+- Suggested catalog entry skeleton
+- Provenance: which audits/runIds contributed
+
+The proposal flows into the same review process (Component 3) but with operational-signal provenance attached. **This is the mechanism that breaks the curator bottleneck**: the catalog grows from what reviewers actually keep flagging, not from a single person's hypothesis.
+
+Threshold N is configurable per skill via `harness.config.json.<skill>.signal.proposalThreshold`.
+
+### 5. Usage measurement
+
+Every catalog entry carries a per-use counter:
+
+- **Rubrics:** per-rubric trigger count (audits invoked it).
+- **Patterns:** per-pattern apply count (findings cited it).
+- **Exemplars:** per-exemplar cite count (BENCHMARK scores cited it).
+
+Counters are exposed via a stable export (for design-craft: `getCatalogStats()`) and surfaced to the dashboard. Dead entries (zero usage over a documented window — design-craft uses 6 months) are flagged for deprecation review.
+
+### 6. Versioning and deprecation lane
+
+Every entry's `version: number` increments on substantive change. Every entry's `status` field is one of:
+
+| Status        | Meaning                                                                                                                            | Default catalog load                                                             |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `stable`      | Vetted, in active use.                                                                                                             | Yes.                                                                             |
+| `draft`       | Proposed, under review.                                                                                                            | Only when `catalog.includeDraft: true`.                                          |
+| `deprecated`  | Superseded or proven harmful. Retained for historical citation resolution. Carries `deprecatedAt` and optional `replacedBy: <id>`. | No — but citations in historical reports MUST still resolve (with annotation). |
+
+The historical-citation requirement is mandatory for the convergence verifier (sub-project #4) to compare findings across runs without false fixpoints.
+
+## Growth trajectory
+
+For `harness-design-craft`, the seed-plus-growth model targets (per [`growth-trajectory.md`](../../changes/design-pipeline/design-craft-elevator/growth-trajectory.md)):
+
+| Horizon       | Rubrics | Patterns | Exemplars |
+| ------------- | ------- | -------- | --------- |
+| v1 (week 4)   | 10      | 15       | 50        |
+| 6 months      | ~15     | 35       | 150       |
+| 12-24 months  | 20      | 75       | 400       |
+
+Rubrics plateau as craft dimensions stabilize; patterns and exemplars continue growing via signal + community contribution. These are projections, not commitments.
+
+## What the pattern does NOT mandate
+
+- The seed size — that is domain-specific. The pattern requires *justifying* the seed size in the spec.
+- The catalog file layout — YAML, JSON, or hybrid is the skill's choice. The contribution validator enforces the schema regardless.
+- The signal threshold N — defaults to 5 for design-craft but is configurable per skill.
+- The dashboard rendering of catalog stats — skills may surface per-entry breakdowns, aggregate counters, or both.
+
+## Anti-patterns to avoid
+
+- **Seed-only catalogs** — Option E in the brainstorm. Same fate as the prior-art stalls (impeccable, getdesign.md) on a 12-month horizon.
+- **Growth-only catalogs (no seed)** — Option F. Nothing user-facing at v1; no signal to drive growth without initial usage.
+- **"Growth optional" framing** — Option G. "Optional" means "skipped." Growth infrastructure must be built in, not bolted on.
+- **Hard-deleting deprecated entries** — breaks citations in historical reports and confuses the convergence verifier's fixpoint detection. Always retain deprecated entries with `deprecatedAt` + `replacedBy`.
+- **Mixing draft and stable in default loads** — drafts are unproven; loading them by default contaminates production output with low-confidence content.
+- **Bypassing the contribution validator** — every entry must round-trip through schema validation at PR time. "Just this once" entries are how catalogs rot.
+
+## Related
+
+- ADR: [0020 — Living catalog with growth infrastructure (the H pattern)](../decisions/0020-living-catalog-h-pattern.md)
+- Companion patterns: [[llm-judgment-skills]] (catalog citations populate `cite` blocks on 3-axis findings), [[craft-output-vocabulary]] (catalog `findingTemplate` carries 3-axis defaults), [[detect-and-offer]] (catalog quality is most useful when AestheticIntent is declared upstream).
+- First instance: [`harness-design-craft`](../../changes/design-pipeline/design-craft-elevator/proposal.md). Contribution checklist: [`contribution.md`](../../changes/design-pipeline/design-craft-elevator/contribution.md). Growth model: [`growth-trajectory.md`](../../changes/design-pipeline/design-craft-elevator/growth-trajectory.md). Finding codes: [`finding-codes.md`](../../changes/design-pipeline/design-craft-elevator/finding-codes.md).
+- Prior art:
+  - REFERENCES #8 (ARIA APG) — gated contribution model that keeps quality high.
+  - REFERENCES #1 (awesome-design-md) — community-PR-driven growth that works.
+  - REFERENCES #2 (pbakaus/impeccable) — fixed-catalog stall pattern (negative example, ~29 rules).
+  - REFERENCES #37 (getdesign.md) — single-curator stall pattern (negative example, ~50 entries).
+- Related: [ADR 0016 — Skill proposal workflow](../decisions/0016-skill-proposal-workflow.md) demonstrates the signal-to-promotion lane at the skill-corpus level (parallel pattern at a different layer).

--- a/docs/knowledge/design/llm-judgment-skills.md
+++ b/docs/knowledge/design/llm-judgment-skills.md
@@ -1,0 +1,87 @@
+---
+type: business_concept
+domain: design
+tags: [skills, llm, judgment, design-craft, confidence, mode-selection, intelligence-provider]
+---
+
+# LLM-Judgment Skills
+
+An **LLM-judgment skill** is a harness skill whose primary finding stream is produced by an LLM exercising taste, judgment, or aesthetic critique — not by deterministic rule evaluation. The pattern is codified by [ADR 0018](../decisions/0018-llm-judgment-skill-pattern.md). First instance: [`harness-design-craft`](../../changes/design-pipeline/design-craft-elevator/proposal.md).
+
+## Why a distinct pattern
+
+Rule-based skills (`detect-design-drift`, `audit-component-anatomy`, `harness-design`) produce binary outputs from deterministic checks. The standard `severity: 'error' | 'warn' | 'info'` vocabulary fits because the underlying judgment IS binary — the rule either fires or it does not.
+
+LLM-judgment skills break four assumptions that rule-based infrastructure relies on:
+
+1. **Outputs are non-deterministic** — two runs over the same input produce overlapping-but-not-identical finding sets.
+2. **Confidence is real and must be visible** — a 95%-confident judgment deserves different treatment from a 40%-confident one; collapsing both to `warn` destroys signal.
+3. **Cost and latency are first-class** — text-LLM calls are cents and seconds, vision-LLM calls are dimes and tens-of-seconds; routine CI cannot afford every mode every time.
+4. **Determinism must wrap the payload** — finding codes, citations, derived priority, and runIds must be stable so the convergence verifier and graph adapters see a fixed contract while the judgment varies.
+
+## The four required properties
+
+LLM-judgment skills MUST satisfy all four (per ADR 0018):
+
+| Property                                  | Requirement                                                                                                                                                                                                                                |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **1. Confidence as first-class output**   | Every finding carries `confidence: 'high' \| 'medium' \| 'low'`, emitted by the LLM (not derived post-hoc). Low-confidence findings are surfaced with visual distinction (italic, `(low confidence:)` prefix) and excluded from enforcement by default. |
+| **2. Deterministic skeleton wraps judgment** | Stable `code` (e.g. `CRAFT-C001`), `cite` block (catalog id, never an LLM hallucination), `target` block (`file` / `line` / `component`), `derived` block (priority computed deterministically), and `summary.runId` for fixpoint detection. |
+| **3. Explicit mode selection**            | Skills with both text and vision modes expose `mode: 'fast' \| 'deep'` (or analogous) as top-level input. Default is the cheaper mode. No auto-escalation. Cost tracking exposed via `summary.llmCalls.{provider, model, count, costUsd}`.    |
+| **4. Provider integration via intelligence** | Skills wrap `packages/intelligence/` rather than calling provider SDKs directly — centralizes cost accounting, vision-vs-text variant selection, provider fallback, and mock-injection for CI tests.                                            |
+
+A fifth property — **soft dependency with progressive upgrade** — applies to LLM-judgment skills that benefit from upstream declared intent. See [[detect-and-offer]] and ADR 0021.
+
+## Confidence semantics
+
+| Value     | Meaning                                                                              | Treatment                                                                |
+| --------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| `high`    | Model is confident; finding is well-supported by rubric + evidence.                  | Treat as thoughtful peer assertion. May feed enforcement gates.          |
+| `medium`  | Model sees the issue but acknowledges alternative readings.                          | Treat as discussion item. Surface in main output.                        |
+| `low`     | Model is unsure; finding may not survive human inspection.                           | Investigation candidate, NOT enforcement. Visually distinguished. Excluded from gates by default. |
+
+LLMs are demonstrably more honest when asked to self-report confidence than when their outputs are post-filtered. Dropping low-confidence findings hides cases where the model genuinely does not know — exactly the signal a human reviewer needs.
+
+## Fast vs deep mode
+
+Mode selection is **explicit and opt-in**, not heuristic-driven:
+
+| Mode    | Calls            | Cost           | Use case                                                                 |
+| ------- | ---------------- | -------------- | ------------------------------------------------------------------------ |
+| `fast`  | text-LLM only    | cents / call   | Default. Routine CI, autopilot, in-editor critique, fast iteration loops. |
+| `deep`  | text + vision    | dimes / call   | Designer-led ceiling-raising; release-quality elevation; preflight reviews. |
+
+Cost tracking is mandatory: `summary.llmCalls.costUsd` must accumulate per-call records so operators can budget LLM spend without per-skill bespoke accounting.
+
+## Composing with other patterns
+
+LLM-judgment skills typically co-adopt several companion patterns:
+
+- **Output vocabulary** — see [[craft-output-vocabulary]] / ADR 0019 for the 3-axis (tier × impact × confidence) and 5-dim radar shapes used by craft-domain LLM-judgment skills.
+- **Catalog backing** — see [[living-catalogs]] / ADR 0020 for the seed + growth infrastructure used by LLM-judgment skills whose findings cite a corpus of rubrics, patterns, or exemplars.
+- **Soft dependency upgrade** — see [[detect-and-offer]] / ADR 0021 for the precondition detection + inline-chain-to-upstream pattern when LLM-judgment quality depends on upstream declared intent.
+
+A craft-domain LLM-judgment skill (`harness-design-craft`) typically uses all three. Domain-specific LLM-judgment skills (e.g. a future `copy-craft` or `accessibility-narrative`) may compose a subset.
+
+## What the pattern does NOT mandate
+
+- A specific output vocabulary — but ADR 0019 is the recommended default for craft-domain skills.
+- A specific catalog shape — but ADR 0020 is the recommended default for catalog-backed skills.
+- A specific render pipeline — vision-mode implementations may use playwright, storybook test-runner, browser-use, etc.
+- A specific cost budget — that is operator policy, not skill policy.
+
+## Anti-patterns to avoid
+
+- **Silent confidence collapse** — never map `low` to a higher tier in the markdown output. Reviewers must be able to see "the model wasn't sure."
+- **Auto-escalation to deep mode** — never decide on the user's behalf to spend 10x more per call. Mode is the caller's choice.
+- **Direct provider SDK calls** — every direct call to Anthropic / OpenAI / Vertex bypasses cost accounting and provider fallback. Always route through `packages/intelligence/`.
+- **Per-skill cost ledgers** — never invent skill-local cost tracking. The shared ledger pattern means an org can cap "LLM spend" globally.
+- **Treating LLM output as authoritative** — the deterministic skeleton (codes, cites, derived priority) is what downstream consumers depend on. The judgment payload is non-deterministic by design.
+
+## Related
+
+- ADR: [0018 — LLM-judgment-based skill pattern](../decisions/0018-llm-judgment-skill-pattern.md)
+- First instance: [`harness-design-craft`](../../changes/design-pipeline/design-craft-elevator/proposal.md)
+- Companion patterns: [[craft-output-vocabulary]], [[living-catalogs]], [[detect-and-offer]]
+- Intelligence provider: `packages/intelligence/` — wraps provider SDKs with cost tracking and vision-variant selection.
+- Prior art: [REFERENCES.md](../../changes/design-pipeline/REFERENCES.md) #3 (emilkowalski/skill — judgment-heavy SKILL.md prose), #4 (alchaincyf/huashu-design — 5-dim radar from LLM critique).

--- a/docs/knowledge/skills/detect-and-offer.md
+++ b/docs/knowledge/skills/detect-and-offer.md
@@ -1,0 +1,150 @@
+---
+type: business_concept
+domain: skills
+tags: [skills, soft-dependency, upgrade, skill-transition, autoCapture, b-prime, preconditions]
+---
+
+# Detect-and-Offer (the B' Pattern)
+
+**Detect-and-offer** is the harness pattern for skills with soft dependencies on upstream context produced by another skill. Instead of hard-failing when the upstream artifact is absent or silently degrading without telling the user, the skill **detects missing preconditions and offers an inline upgrade chain** to the upstream skill via the existing skill-transition machinery. Codified by [ADR 0021](../decisions/0021-detect-and-offer-b-prime-pattern.md). Labeled "B'" (B-prime) after the brainstorm's option labeling: B (standalone, no dependency) with a progressive upgrade path. First instance: `harness-design-craft` softly depends on `harness-design`'s `AestheticIntent`.
+
+## Why neither hard-fail nor silent-degrade works
+
+Skills that benefit from upstream context (declared intent, brand voice, anatomy contracts) face two failure modes that should be avoided:
+
+1. **Hard-fail when upstream artifact is absent.** The skill refuses to run until the user invokes the upstream skill first. Pipeline-correct but hostile in practice — the user wanted to evaluate THIS skill, not first traverse a prerequisite tree.
+2. **Silent degradation when upstream artifact is absent.** The skill runs in fallback mode but never tells the user that the richer mode existed. Result: worse output, no path to fix it, no visibility into the gap.
+
+B' is the third path: **soft dependency with detect-and-offer + skill-transition chain**. The skill works standalone with fallback prompts AND surfaces the upgrade inline when preconditions are missing AND uses the existing transition machinery to chain to the upstream skill on demand AND re-enters cleanly in its richer mode.
+
+## The four required components
+
+A B'-pattern skill MUST satisfy all four (per ADR 0021):
+
+### Component 1 — Precondition detection
+
+The skill defines an explicit set of precondition checks. Each is a deterministic boolean predicate over project state. For `harness-design-craft` (in `resolvers/preconditions.ts`):
+
+| Precondition                  | Check                                                          |
+| ----------------------------- | -------------------------------------------------------------- |
+| `designMdExists`              | `design-system/DESIGN.md` present.                             |
+| `aestheticIntentDeclared`     | DESIGN.md has Aesthetic Direction section populated.           |
+| `tokensExist`                 | `design-system/tokens.json` present.                           |
+| `componentRegistryPopulated`  | DESIGN.md has Component Registry section (for vision targets). |
+
+Each is checked at invocation time. The result is recorded on `summary.preconditions` so the user can see what was detected even when no offer was made.
+
+Future B'-pattern skills MUST publish their precondition list in their spec and SHOULD record precondition state in their output summary.
+
+### Component 2 — Offer payload construction
+
+When one or more preconditions are missing AND `autoCapture` allows offering, the skill constructs an `upgradeOffer`:
+
+```ts
+{
+  message: string;  // human-readable: what is missing + what the upgrade unlocks
+  options: Array<{
+    id: string;
+    label: string;            // user-facing
+    chainedSkill?: string;    // upstream skill to chain to
+    chainedPhases?: string[]; // specific phases (e.g. ['intent', 'direction'])
+  }>;
+}
+```
+
+The standard option set is:
+
+| Option         | Behavior                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------- |
+| `yes-now`      | Chain to the upstream skill immediately, then re-enter this skill.                                 |
+| `yes-later`    | Record the preference. Do not chain now. Subsequent invocations re-prompt (until configured off). |
+| `no-thanks`    | Proceed with fallback mode. Do not re-prompt this session.                                         |
+| `skip-always`  | Set `autoCapture: 'skip'` in config. Never prompt again.                                           |
+
+Skills MAY add domain-specific options (e.g. `harness-design-craft` adds `intent-only` to chain only the INTENT phase, not DIRECTION).
+
+The offer is surfaced via `emit_interaction` with `type: 'question'` so the user sees options and chooses.
+
+### Component 3 — Skill-transition chain
+
+When the user chooses an upgrade option that includes a `chainedSkill`, the skill emits:
+
+```ts
+emit_interaction({
+  type: 'transition',
+  transition: {
+    completedPhase: <this-skill's-phase>,
+    suggestedNext: <chained-skill>,
+    suggestedNextPhases: <chained-phases>,
+    reason: 'precondition-fulfillment',
+    chainedFrom: { skill: <this-skill>, runId: <runId>,
+                   reentryHint: <state needed to re-enter> },
+    requiresConfirmation: false,  // user already confirmed via offer
+  },
+});
+```
+
+The harness runner processes the transition, invokes the chained skill with the specified phases, and on completion re-enters the original skill via `chainedFrom.reentryHint`. The original skill re-runs precondition detection (now-satisfied) and produces output in its richer mode.
+
+**B' reuses the existing skill-transition machinery** — no new chain-call infrastructure is introduced. The harness orchestrator already understands transitions and handoffs; B' adds the convention for using them for precondition fulfillment.
+
+### Component 4 — Re-entry and idempotency
+
+The original skill MUST be idempotent on re-entry. Re-running precondition detection on the now-satisfied state must produce the same downstream behavior as if the user had run the upstream skill manually first:
+
+- The skill MUST NOT double-emit findings on re-entry.
+- The skill MUST treat the re-entry as a fresh invocation that happens to find preconditions satisfied — same finding codes, same runId semantics, same output shape.
+- The skill MUST record in `summary` that re-entry occurred (for audit-trail purposes) without changing the user-facing output.
+
+## The `autoCapture` config
+
+Every B'-pattern skill MUST expose a config knob (default name `autoCapture`) with three values:
+
+| Value            | Behavior                                                                                            | Use case                                         |
+| ---------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `prompt` (default) | Detect missing preconditions and emit the offer payload for user choice.                            | Interactive use (CLI, IDE).                      |
+| `auto`           | Detect missing preconditions and automatically chain to the upstream skill without prompting.       | Headless / autopilot use where prompting blocks. |
+| `skip`           | Detect missing preconditions but do NOT offer or chain. Proceed with fallback silently.             | CI gates that must not prompt or auto-invoke.    |
+
+The knob lives at `harness.config.json.<skill>.autoCapture` and is overridable per-invocation via the skill's MCP input.
+
+## When to use B'
+
+Use B' when **all** of the following hold:
+
+- The skill's output is meaningfully richer when an upstream artifact exists.
+- The upstream artifact is producible by another skill in the harness ecosystem.
+- The richer output is not strictly required — fallback mode is still useful.
+- The user might invoke this skill without knowing the upstream exists.
+
+Counter-indications (do not use B' when):
+
+- The upstream artifact is project-mandatory (hard dependency is correct — e.g. `harness validate` requires `harness.config.json`).
+- The upstream chain is expensive (e.g. multi-hour analysis) — users should opt in via explicit invocation, not an inline offer.
+- The skill is a low-level primitive (e.g. graph queries) where injecting offer UI would be intrusive.
+
+## What the pattern does NOT mandate
+
+- The specific preconditions — those are domain-specific.
+- The specific chain target — B' is shape-agnostic about which upstream skill is chained to (`harness-design-craft` → `harness-design`; future skills may chain to other targets).
+- The specific fallback mode — skills may produce reduced output, a stub with a single "preconditions missing" finding, or anything in between. The pattern only requires that the fallback be documented and the offer make the upgrade visible.
+- The re-entry mechanism for skills not using the existing skill-transition machinery — skills that need custom re-entry SHOULD file a superseding ADR.
+
+## Anti-patterns to avoid
+
+- **Hard-fail on missing preconditions** — Option A in the brainstorm. Hostile first-run; blocks users with no upstream artifact.
+- **Silent degradation** — Option C. Hides the upgrade opportunity; user gets worse output without knowing why.
+- **Prompt user to manually invoke upstream** — Option D. Context-switch tax; user has to remember commands and return to the original skill.
+- **Auto-invoke upstream without asking (when in `prompt` mode)** — Option E. Surprise side effects; user did not consent to a multi-question elicitation.
+- **Non-idempotent re-entry** — re-running the skill after the chain completes must not double-emit findings or double-count graph writes. Re-entry idempotency is a non-trivial invariant.
+- **Skipping the offer payload entirely** — even when the user has `autoCapture: 'auto'`, the chain transition must be recorded on `summary.preconditions` so audit trails see what happened.
+
+## Related
+
+- ADR: [0021 — Detect-and-offer progressive upgrade pattern (the B' pattern)](../decisions/0021-detect-and-offer-b-prime-pattern.md)
+- Parent pattern: [[llm-judgment-skills]] / [ADR 0018](../decisions/0018-llm-judgment-skill-pattern.md) §4 — soft dependency + progressive upgrade is a required property of LLM-judgment skills that benefit from upstream intent.
+- Companion patterns: [[craft-output-vocabulary]] (precondition state shapes the rubric/exemplar selection that drives output), [[living-catalogs]] (catalog quality is most useful when intent-anchored).
+- First instance: [`harness-design-craft`](../../changes/design-pipeline/design-craft-elevator/proposal.md). Precondition resolver: `packages/cli/src/design-craft/resolvers/preconditions.ts` (planned per spec). `autoCapture` config: `harness.config.json.design.craft.autoCapture`.
+- Mechanism: harness skill-transition machinery (`emit_interaction { type: 'transition' }`) — reused by B' for chain construction. See [[skill-lifecycle]] §"Skill-to-Skill Transitions".
+- Prior art: REFERENCES #12 (Frontify Brand Intelligence + MCP) — establishes the "detect and use upstream context if available" half of the pattern; B' adds the "offer to populate inline" half.
+- Related: [ADR 0011 — Orchestrator gateway API contract](../decisions/0011-orchestrator-gateway-api-contract.md) (chain invocations cross the gateway and require scope considerations), [ADR 0016 — Skill proposal workflow](../decisions/0016-skill-proposal-workflow.md) (skill-transition machinery used in a different chain shape).


### PR DESCRIPTION
## Summary

Files **Task 71** of the design-craft-elevator plan and closes **success criterion #32**: four knowledge entries codifying the patterns the sub-project introduces. Each entry summarizes its parent ADR (0018-0021) in lookup-oriented prose so future skill authors can recognize the pattern and reach for it without re-reading the full ADR.

| Entry | Codifies | Parent ADR |
| ----- | -------- | ---------- |
| `docs/knowledge/design/llm-judgment-skills.md` | The four required properties for LLM-judgment skills — confidence as first-class output, deterministic skeleton wraps judgment payload, explicit mode selection, intelligence-provider integration. Fast-vs-deep mode trade-offs. | ADR 0018 |
| `docs/knowledge/design/craft-output-vocabulary.md` | 3-axis (tier × impact × confidence) per-finding model + 5-dim radar (philosophicalCoherence/hierarchy/craftExecution/function/innovation) for holistic BENCHMARK scoring. Phase-to-output mapping (`CRAFT-C*`, `CRAFT-P*`, `CRAFT-B*`), deterministic priority derivation, escape-hatch severity translation. | ADR 0019 |
| `docs/knowledge/design/living-catalogs.md` | The H pattern's six required components (seed corpus, schema-validated contribution format, documented review process, signal feedback loop, usage measurement, versioning/deprecation lane). Prior-art stall examples (`pbakaus/impeccable` ~29, `getdesign.md` ~50). Growth-trajectory table. | ADR 0020 |
| `docs/knowledge/skills/detect-and-offer.md` | B' pattern's four required components (precondition detection, offer payload, skill-transition chain via existing `emit_interaction` machinery, re-entry idempotency). The `autoCapture` config (prompt/auto/skip). When to use vs counter-indications. | ADR 0021 |

Each entry links back to its parent ADR, the first instance (`harness-design-craft`), the companion patterns (via `[[name]]` wikilinks across the four), the relevant prior art from `REFERENCES.md`, and (where applicable) the related earlier ADRs (0011 gateway contract, 0016 skill proposal workflow).

Creates the new `docs/knowledge/design/` taxonomy node (sibling to `architecture/`, `cli/`, `core/`, `skills/`, etc.) since this is the first batch of design-domain knowledge entries.

## Why now

Spec lines 467-470 and plan Task 71 commit to filing these four entries; they are the lookup-oriented twin of the four ADRs already filed. Reviewers and future skill authors approach the same patterns from two different angles: the ADR for the *why* and the lifecycle, the knowledge entry for the *what* and the *how-to-recognize-it*. Filing the knowledge half closes the documentation half of the sub-project (success criterion #32) and prepares the ground for sub-project #3 (audit-brand-compliance) which will be the second consumer of all four patterns.

## Scope

- **Non-conflicting with open PRs.** Touches only `docs/knowledge/design/` (new) and adds one file under `docs/knowledge/skills/`. Does **not** touch `finding-codes.md`, `catalog-seed.test.ts`, or any catalog index — so it lands cleanly alongside #480 (B004-B005 exemplars) and #481 (P006-P007 patterns).
- **No code changes.** Docs-only.
- **No changeset required** — per `scripts/check-changesets.mjs`: *"Tests, .harness state, docs, and changelogs are not publishable and never require a changeset."*

## Verification

- [x] `harness validate` — exit 0 (pre-existing design-drift warnings on main unchanged).
- [x] All inter-entry wikilinks (`[[llm-judgment-skills]]`, `[[craft-output-vocabulary]]`, `[[living-catalogs]]`, `[[detect-and-offer]]`, `[[skill-lifecycle]]`) resolve to existing files.
- [x] All ADR references (0011, 0016, 0018-0021) resolve under `docs/knowledge/decisions/`.
- [x] All spec references (`proposal.md`, `finding-codes.md`, `contribution.md`, `growth-trajectory.md`) resolve under `docs/changes/design-pipeline/design-craft-elevator/`.
- [x] REFERENCES citations match the entries already used in ADRs 0018-0021.
- [x] Pre-push hooks (changeset check, format check, typecheck, test:ci, coverage ratchet, generate-docs) all green.

## Closes

- design-craft-elevator plan Task 71
- design-craft-elevator success criterion #32 (four knowledge entries filed under `docs/knowledge/design/` and `docs/knowledge/skills/`)