### PR TITLE
feat(core): STRATEGY.md schema + validator (strategic-anchor phase 1)

### DIFF
--- a/.changeset/strategic-anchor-phase-1-schema.md
+++ b/.changeset/strategic-anchor-phase-1-schema.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/types': minor
+'@harness-engineering/cli': patch
+---
+
+Add `STRATEGY.md` schema and validator (strategic-anchor phase 1 of 8 in the compound-engineering-adoption initiative).
+
+- `packages/types` exports `StrategyFrontmatter`, `StrategyDoc`, `StrategySection`, `REQUIRED_STRATEGY_SECTIONS`, `OPTIONAL_STRATEGY_SECTIONS`.
+- `packages/core/strategy` exports `StrategyDocSchema`, `StrategyFrontmatterSchema`, `parseStrategyDoc`, `asStrategyDoc`.
+- `packages/core/validation` exports `validateStrategy(cwd)` consumed by `harness validate`.
+- CLI `harness validate` now reports a `strategyConfig` check: soft-passes when STRATEGY.md is absent; fails with a precise per-section message when present and malformed (missing required section, unfilled template placeholder, malformed frontmatter).
+
+Scope: schema + validator only. The `harness-strategy` skill, the `harness-ideate` skill, init wiring, brainstorming/roadmap-pilot grounding, knowledge-graph integration, and ADRs ship in follow-up PRs (one per phase, matching the feedback-loops cadence).

--- a/docs/changes/compound-engineering-adoption/strategic-anchor/plans/2026-06-02-strategic-anchor-phase-1-schema-plan.md
+++ b/docs/changes/compound-engineering-adoption/strategic-anchor/plans/2026-06-02-strategic-anchor-phase-1-schema-plan.md
@@ -1,0 +1,153 @@
+# Strategic Anchor Phase 1: STRATEGY.md Schema
+
+> Define the Zod schema for `STRATEGY.md`, wire it into `harness validate`, and export types through `@harness-engineering/types`. Foundation phase: every later phase (`harness-strategy` skill, init wiring, brainstorming/roadmap-pilot grounding, knowledge-graph integration) consumes this schema.
+
+**Date:** 2026-06-02
+**Status:** Planned
+**Parent spec:** [../proposal.md](../proposal.md)
+**Phase:** 1 of 8
+
+## Scope
+
+This plan covers **only Phase 1** of the strategic-anchor proposal. Phases 2-8 (skill implementations, init wiring, brainstorming/roadmap-pilot integration, knowledge-graph integration, docs) ship in follow-up PRs — matching the proven feedback-loops phase-per-PR cadence.
+
+### In scope
+
+- New module `packages/core/src/strategy/` with `schema.ts`, `index.ts`, and tests
+- New module `packages/core/src/validation/strategy.ts` consumed by the CLI validate command
+- New shared type definitions in `packages/types/src/strategy.ts`
+- Wiring `validateStrategy` into `packages/cli/src/commands/validate.ts`
+- Barrel exports through `packages/core/src/index.ts` and `packages/types/src/index.ts`
+- Unit tests covering schema acceptance + placeholder-rejection + happy-path validation
+
+### Out of scope
+
+- `harness-strategy` skill (Phase 2)
+- `harness-ideate` skill (Phase 4)
+- `initialize-harness-project` wiring (Phase 3)
+- `harness-brainstorming` STRATEGY.md grounding (Phase 5)
+- `harness-roadmap-pilot` strategy-alignment tiebreaker (Phase 6)
+- `BusinessKnowledgeIngestor` strategy domain (Phase 7)
+- ADRs and AGENTS.md "Strategic Anchor" section (Phase 8)
+- Mutating `packages/core/src/pulse/strategy-seeder.ts` (the defensive reader remains as-is; it serves a different read path)
+
+## Design
+
+### Schema shape
+
+`STRATEGY.md` is a single file at repo root with YAML frontmatter and Markdown sections:
+
+```markdown
+---
+name: <product name>
+last_updated: 2026-06-02
+version: 1
+---
+
+# <product name> Strategy
+
+## Target problem
+
+<2-4 sentences. ...>
+
+## Our approach
+
+...
+
+## Who it's for
+
+...
+
+## Key metrics
+
+- <metric 1>: <how it's measured, where it lives>
+
+## Tracks
+
+- <track name>: ...
+
+## Milestones (optional)
+
+## Not working on (optional)
+
+## Marketing (optional)
+```
+
+The new schema validates two things:
+
+1. **Frontmatter** — `name` (non-empty string), `last_updated` (ISO date YYYY-MM-DD), `version` (positive integer)
+2. **Section bodies** — each required section (Target problem, Our approach, Who it's for, Key metrics, Tracks) must contain ≥1 non-whitespace sentence and must NOT contain unmodified template placeholder text (e.g., the verbatim `<2-4 sentences. ...>` markers from the template).
+
+Optional sections (Milestones, Not working on, Marketing) are not validated for body content if absent; if present, they must also pass the placeholder-rejection rule.
+
+### Placeholder rejection
+
+A section body fails validation if any line matches the placeholder pattern: a line beginning with `<` and ending with `>` containing the verbatim hint text from the template (`<2-4 sentences. ...>`, `<metric N>: ...`, `<track name>: ...`, etc.). Implemented as a single regex check: `/^<[^>]+>$/m` matched against trimmed lines, with the additional condition that the line is the only non-whitespace content under the heading.
+
+The intent is to prevent "header-only completed" docs that pass without engagement. Authors filling in real content overwrite the placeholders entirely; partial fills (real content alongside leftover placeholders) also fail.
+
+### File layout
+
+```
+packages/types/src/strategy.ts          # Shared types (StrategyFrontmatter, StrategyDoc, StrategySection)
+packages/types/src/index.ts             # Add export block
+
+packages/core/src/strategy/
+  schema.ts                             # Zod schemas (StrategyFrontmatterSchema, StrategyDocSchema)
+  parser.ts                             # parseStrategyDoc(raw) — splits frontmatter from body, returns StrategyDoc
+  parser.test.ts                        # Parser unit tests
+  schema.test.ts                        # Schema acceptance + rejection tests
+  index.ts                              # Barrel export
+
+packages/core/src/validation/strategy.ts     # validateStrategy(cwd) helper
+packages/core/src/validation/strategy.test.ts
+packages/core/src/validation/index.ts        # Add export
+
+packages/cli/src/commands/validate.ts        # Wire validateStrategy into runValidate
+```
+
+### Validator behavior
+
+`validateStrategy(cwd)`:
+
+- Returns `Ok({ present: false, valid: true })` when `STRATEGY.md` is absent (consistent with `validatePulseConfig` soft-fail pattern — Decision 6 of the proposal).
+- Returns `Ok({ present: true, valid: true })` when present and the schema accepts it.
+- Returns `Err(ConfigError)` when present but the schema rejects it. The error message lists the failing field path(s) and reason (missing required section, placeholder text detected, malformed frontmatter, etc.).
+
+### CLI integration
+
+`validate.ts` adds a `strategyConfig` check (mirrors the existing `pulseConfig` check):
+
+- Adds `strategyConfig?: boolean` to `ValidateResult.checks`.
+- Calls `validateStrategy(cwd)` after `validatePulseConfig`.
+- On `Err`, appends an issue with `check: 'strategyConfig'`, `file: 'STRATEGY.md'`, and `severity: 'error'`. Sets `result.valid = false`.
+
+No new CLI flags. No schema changes to `harness.config.json` (the proposal places `init.strategy.declined` under `.harness/state.json`, not the project config, and that's a Phase 3 concern).
+
+## Tasks
+
+| #   | Task                                                                                                                             | Files                                                                                    |
+| --- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| 1   | Add shared types `StrategyFrontmatter`, `StrategyDoc`, `StrategySection` to `packages/types/src/strategy.ts` and re-export       | `packages/types/src/strategy.ts`, `packages/types/src/index.ts`                          |
+| 2   | Implement `parseStrategyDoc(raw)` — splits frontmatter via `gray-matter`, extracts H2 sections by name, returns `StrategyDoc`    | `packages/core/src/strategy/parser.ts`                                                   |
+| 3   | Implement `StrategyFrontmatterSchema` + `StrategyDocSchema` (Zod) with placeholder-rejection refinement                          | `packages/core/src/strategy/schema.ts`                                                   |
+| 4   | Unit tests: happy path, missing required sections, placeholder-text rejection, malformed frontmatter, optional-section handling  | `packages/core/src/strategy/parser.test.ts`, `packages/core/src/strategy/schema.test.ts` |
+| 5   | Barrel export from `packages/core/src/strategy/index.ts` and add `export * from './strategy'` to `packages/core/src/index.ts`    | `packages/core/src/strategy/index.ts`, `packages/core/src/index.ts`                      |
+| 6   | Implement `validateStrategy(cwd): Promise<Result<StrategyValidation, ConfigError>>`                                              | `packages/core/src/validation/strategy.ts`, `packages/core/src/validation/index.ts`      |
+| 7   | Test `validateStrategy` end-to-end against tmp-dir fixtures (absent, valid, invalid frontmatter, missing section, placeholders)  | `packages/core/src/validation/strategy.test.ts`                                          |
+| 8   | Wire `validateStrategy` into `runValidate` (mirror pulse pattern: optional check, soft-fail when absent, hard-fail when invalid) | `packages/cli/src/commands/validate.ts`                                                  |
+
+## Success criteria
+
+- `pnpm --filter @harness-engineering/core test` and `pnpm --filter @harness-engineering/cli test` pass with the new tests included.
+- `pnpm typecheck` succeeds across the workspace.
+- `harness validate` on a repo with no STRATEGY.md continues to succeed (no regression).
+- `harness validate` on a repo with a valid STRATEGY.md succeeds and reports `strategyConfig: true`.
+- `harness validate` on a repo whose STRATEGY.md has missing required sections, malformed frontmatter, or untouched placeholder text fails with a clear `STRATEGY.md` issue.
+- New types are reachable from `@harness-engineering/types` (importable in `packages/graph` for the future Phase 7 ingestor without crossing layer boundaries).
+
+## Risks
+
+- **Risk:** Placeholder regex over-triggers on legitimate content that happens to be a `<...>` reference (e.g., `<https://example.com>` or shell-style angle brackets) → **Mitigation:** Pin the placeholder rule to lines that are _the sole non-whitespace content under a heading_ AND match `^<[^>]+>$`. Real content with a `<...>` inline never trips this.
+- **Risk:** Tightening the schema breaks the existing pulse `seedFromStrategy` consumer → **Mitigation:** `seedFromStrategy` is intentionally defensive and reads raw text; it never round-trips through `StrategyDocSchema`. The two paths stay decoupled. A test fixture exercises both readers against the same valid file.
+- **Risk:** Optional sections grow over time → **Mitigation:** The schema accepts only the documented section names; unknown H2s are rejected (consistent with Decision 2's "schema validation rejects unknown sections; expansion requires a separate ADR").

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -8,6 +8,7 @@ import {
   validateKnowledgeMap,
   validatePulseConfig,
   validateSolutionsDir,
+  validateStrategy,
   validateRoadmapMode,
 } from '@harness-engineering/core';
 import { resolveConfig } from '../config/loader';
@@ -37,6 +38,7 @@ interface ValidateResult {
     knowledgeMap: boolean;
     agentConfigs?: boolean;
     pulseConfig?: boolean;
+    strategyConfig?: boolean;
     solutionsDir?: boolean;
     roadmapMode?: boolean;
     componentAnatomy?: boolean;
@@ -136,6 +138,24 @@ export async function runValidate(
       message: pulseResult.error.message,
       ...(pulseResult.error.suggestions?.[0] !== undefined && {
         suggestion: pulseResult.error.suggestions[0],
+      }),
+    });
+  }
+
+  // STRATEGY.md (optional — passes if absent; fails when present and malformed)
+  const strategyResult = await validateStrategy(cwd);
+  if (strategyResult.ok) {
+    result.checks.strategyConfig = true;
+  } else {
+    result.valid = false;
+    result.checks.strategyConfig = false;
+    result.issues.push({
+      check: 'strategyConfig',
+      file: 'STRATEGY.md',
+      severity: 'error',
+      message: strategyResult.error.message,
+      ...(strategyResult.error.suggestions?.[0] !== undefined && {
+        suggestion: strategyResult.error.suggestions[0],
       }),
     });
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -234,6 +234,11 @@ export * from './pulse';
 export * from './solutions';
 
 /**
+ * Strategy module — STRATEGY.md schema, parser, and exports.
+ */
+export * from './strategy';
+
+/**
  * Skill proposals module (Hermes Phase 4) — `.harness/proposals/` storage,
  * usage derivation, and `emit_skill_proposal` payload helpers.
  */

--- a/packages/core/src/strategy/index.ts
+++ b/packages/core/src/strategy/index.ts
@@ -1,0 +1,12 @@
+export { StrategyDocSchema, StrategyFrontmatterSchema } from './schema';
+export { parseStrategyDoc, asStrategyDoc } from './parser';
+export type { ParsedStrategyDoc } from './parser';
+export type {
+  StrategyDoc,
+  StrategyFrontmatter,
+  StrategySection,
+  StrategySectionName,
+  RequiredStrategySection,
+  OptionalStrategySection,
+} from '@harness-engineering/types';
+export { REQUIRED_STRATEGY_SECTIONS, OPTIONAL_STRATEGY_SECTIONS } from '@harness-engineering/types';

--- a/packages/core/src/strategy/parser.test.ts
+++ b/packages/core/src/strategy/parser.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { parseStrategyDoc, asStrategyDoc } from './parser';
+
+const VALID = `---
+name: Acme Widgets
+last_updated: 2026-06-02
+version: 1
+---
+
+# Acme Widgets Strategy
+
+## Target problem
+
+Widget makers ship inconsistent UIs because they lack shared primitives.
+
+## Our approach
+
+We sell a hosted component registry that enforces brand contracts at build time.
+
+## Who it's for
+
+Mid-stage product teams (10-50 engineers) shipping multi-surface React apps.
+
+## Key metrics
+
+- Weekly active component installs
+- p95 build-time check latency
+
+## Tracks
+
+- Hosted registry: stabilize public API, harden CI integration
+- CLI: ship first-class diff/preview command
+`;
+
+describe('parseStrategyDoc', () => {
+  it('splits frontmatter and known H2 sections', () => {
+    const parsed = parseStrategyDoc(VALID);
+    expect(parsed.frontmatter).toEqual({
+      name: 'Acme Widgets',
+      last_updated: '2026-06-02',
+      version: 1,
+    });
+    expect(parsed.sections.map((s) => s.name)).toEqual([
+      'Target problem',
+      'Our approach',
+      "Who it's for",
+      'Key metrics',
+      'Tracks',
+    ]);
+    expect(parsed.unknownSectionNames).toEqual([]);
+  });
+
+  it('captures section body verbatim (trimmed) up to next H2', () => {
+    const parsed = parseStrategyDoc(VALID);
+    const keyMetrics = parsed.sections.find((s) => s.name === 'Key metrics');
+    expect(keyMetrics?.body).toBe(
+      '- Weekly active component installs\n- p95 build-time check latency'
+    );
+  });
+
+  it('records unknown section names without throwing', () => {
+    const raw = `---
+name: X
+last_updated: 2026-01-01
+version: 1
+---
+
+## Target problem
+real text
+
+## Vision
+unexpected section
+`;
+    const parsed = parseStrategyDoc(raw);
+    expect(parsed.unknownSectionNames).toEqual(['Vision']);
+    expect(parsed.sections.map((s) => s.name)).toEqual(['Target problem']);
+  });
+
+  it('discards H1 and leading prose before the first H2', () => {
+    const raw = `---
+name: X
+last_updated: 2026-01-01
+version: 1
+---
+
+# Big Title
+
+intro text that should not become a section
+
+## Target problem
+real text
+`;
+    const parsed = parseStrategyDoc(raw);
+    expect(parsed.sections).toHaveLength(1);
+    expect(parsed.sections[0]?.name).toBe('Target problem');
+  });
+
+  it('handles optional sections without flagging them as unknown', () => {
+    const raw = `---
+name: X
+last_updated: 2026-01-01
+version: 1
+---
+
+## Target problem
+real text
+
+## Our approach
+real text
+
+## Who it's for
+real text
+
+## Key metrics
+- m
+
+## Tracks
+- t
+
+## Milestones
+m1
+
+## Not working on
+n1
+
+## Marketing
+mk1
+`;
+    const parsed = parseStrategyDoc(raw);
+    expect(parsed.unknownSectionNames).toEqual([]);
+    expect(parsed.sections.map((s) => s.name)).toContain('Milestones');
+    expect(parsed.sections.map((s) => s.name)).toContain('Not working on');
+    expect(parsed.sections.map((s) => s.name)).toContain('Marketing');
+  });
+});
+
+describe('asStrategyDoc', () => {
+  it('returns null when frontmatter fields are missing or wrong type', () => {
+    expect(asStrategyDoc({ frontmatter: null, sections: [], unknownSectionNames: [] })).toBeNull();
+    expect(
+      asStrategyDoc({
+        frontmatter: { name: 'X' },
+        sections: [],
+        unknownSectionNames: [],
+      })
+    ).toBeNull();
+    expect(
+      asStrategyDoc({
+        frontmatter: { name: 'X', last_updated: '2026-01-01', version: 'one' },
+        sections: [],
+        unknownSectionNames: [],
+      })
+    ).toBeNull();
+  });
+
+  it('returns a typed StrategyDoc when frontmatter is well-formed', () => {
+    const parsed = parseStrategyDoc(VALID);
+    const doc = asStrategyDoc(parsed);
+    expect(doc?.frontmatter.name).toBe('Acme Widgets');
+    expect(doc?.sections).toHaveLength(5);
+  });
+});

--- a/packages/core/src/strategy/parser.ts
+++ b/packages/core/src/strategy/parser.ts
@@ -45,14 +45,7 @@ function coerceFrontmatter(raw: unknown): unknown {
   return out;
 }
 
-export function parseStrategyDoc(raw: string): ParsedStrategyDoc {
-  const parsed = matter(raw);
-  const body = parsed.content;
-  const frontmatter = coerceFrontmatter(parsed.data);
-
-  const sections: StrategySection[] = [];
-  const unknownSectionNames: string[] = [];
-
+function findH2Matches(body: string): H2Match[] {
   const h2Re = /^##[ \t]+(.+?)[ \t]*$/gm;
   const matches: H2Match[] = [];
   let m: RegExpExecArray | null;
@@ -63,25 +56,41 @@ export function parseStrategyDoc(raw: string): ParsedStrategyDoc {
       bodyStart: m.index + m[0].length,
     });
   }
+  return matches;
+}
 
+interface SectionsAccumulator {
+  sections: StrategySection[];
+  unknownSectionNames: string[];
+}
+
+function accumulateSection(acc: SectionsAccumulator, name: string, body: string): void {
+  if (KNOWN_SECTION_NAMES.has(name)) {
+    acc.sections.push({ name: name as StrategySectionName, body });
+  } else {
+    acc.unknownSectionNames.push(name);
+  }
+}
+
+function buildSections(body: string, matches: H2Match[]): SectionsAccumulator {
+  const acc: SectionsAccumulator = { sections: [], unknownSectionNames: [] };
   for (let i = 0; i < matches.length; i++) {
     const current = matches[i];
     if (current === undefined) continue;
-    const next = matches[i + 1];
-    const sliceEnd = next?.headingStart ?? body.length;
+    const sliceEnd = matches[i + 1]?.headingStart ?? body.length;
     const sectionBody = body.slice(current.bodyStart, sliceEnd).trim();
-    if (KNOWN_SECTION_NAMES.has(current.name)) {
-      sections.push({ name: current.name as StrategySectionName, body: sectionBody });
-    } else {
-      unknownSectionNames.push(current.name);
-    }
+    accumulateSection(acc, current.name, sectionBody);
   }
+  return acc;
+}
 
-  return {
-    frontmatter,
-    sections,
-    unknownSectionNames,
-  };
+export function parseStrategyDoc(raw: string): ParsedStrategyDoc {
+  const parsed = matter(raw);
+  const body = parsed.content;
+  const frontmatter = coerceFrontmatter(parsed.data);
+  const matches = findH2Matches(body);
+  const { sections, unknownSectionNames } = buildSections(body, matches);
+  return { frontmatter, sections, unknownSectionNames };
 }
 
 /**

--- a/packages/core/src/strategy/parser.ts
+++ b/packages/core/src/strategy/parser.ts
@@ -1,0 +1,112 @@
+import matter from 'gray-matter';
+import type { StrategyDoc, StrategySection, StrategySectionName } from '@harness-engineering/types';
+import { OPTIONAL_STRATEGY_SECTIONS, REQUIRED_STRATEGY_SECTIONS } from '@harness-engineering/types';
+
+/**
+ * Lightweight markdown split: returns `{ frontmatter, sections }` where every
+ * H2 section's body is the text between its heading and the next H2 (or EOF),
+ * trimmed. Unknown H2 names are returned alongside known ones — schema
+ * validation decides whether to reject them. The H1 (product title) and any
+ * leading prose before the first H2 are intentionally discarded.
+ */
+export interface ParsedStrategyDoc {
+  frontmatter: unknown;
+  sections: StrategySection[];
+  /** Section names seen that are not in the required/optional union. */
+  unknownSectionNames: string[];
+}
+
+const KNOWN_SECTION_NAMES = new Set<string>([
+  ...REQUIRED_STRATEGY_SECTIONS,
+  ...OPTIONAL_STRATEGY_SECTIONS,
+]);
+
+interface H2Match {
+  name: string;
+  /** Index of the `##` character. */
+  headingStart: number;
+  /** Index just past the trailing newline of the heading line (start of body). */
+  bodyStart: number;
+}
+
+/**
+ * YAML parses unquoted ISO dates (e.g. `last_updated: 2026-06-02`) as Date
+ * objects. The schema contract is ISO-string, so coerce here before handing
+ * off — users shouldn't have to remember to quote the value.
+ */
+function coerceFrontmatter(raw: unknown): unknown {
+  if (raw === null || typeof raw !== 'object') return raw;
+  const out: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
+  const lu = out.last_updated;
+  if (lu instanceof Date && !Number.isNaN(lu.getTime())) {
+    const iso = lu.toISOString();
+    out.last_updated = iso.slice(0, 10);
+  }
+  return out;
+}
+
+export function parseStrategyDoc(raw: string): ParsedStrategyDoc {
+  const parsed = matter(raw);
+  const body = parsed.content;
+  const frontmatter = coerceFrontmatter(parsed.data);
+
+  const sections: StrategySection[] = [];
+  const unknownSectionNames: string[] = [];
+
+  const h2Re = /^##[ \t]+(.+?)[ \t]*$/gm;
+  const matches: H2Match[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = h2Re.exec(body)) !== null) {
+    matches.push({
+      name: (m[1] ?? '').trim(),
+      headingStart: m.index,
+      bodyStart: m.index + m[0].length,
+    });
+  }
+
+  for (let i = 0; i < matches.length; i++) {
+    const current = matches[i];
+    if (current === undefined) continue;
+    const next = matches[i + 1];
+    const sliceEnd = next?.headingStart ?? body.length;
+    const sectionBody = body.slice(current.bodyStart, sliceEnd).trim();
+    if (KNOWN_SECTION_NAMES.has(current.name)) {
+      sections.push({ name: current.name as StrategySectionName, body: sectionBody });
+    } else {
+      unknownSectionNames.push(current.name);
+    }
+  }
+
+  return {
+    frontmatter,
+    sections,
+    unknownSectionNames,
+  };
+}
+
+/**
+ * Type guard helper: narrows a ParsedStrategyDoc into a fully typed StrategyDoc
+ * when frontmatter parses successfully. Schema validation (via StrategyDocSchema)
+ * is the authoritative gate; this is convenience for callers that want the
+ * already-validated shape.
+ */
+export function asStrategyDoc(parsed: ParsedStrategyDoc): StrategyDoc | null {
+  const fm = parsed.frontmatter as Record<string, unknown> | null;
+  if (
+    fm === null ||
+    typeof fm !== 'object' ||
+    typeof fm.name !== 'string' ||
+    typeof fm.last_updated !== 'string' ||
+    typeof fm.version !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    frontmatter: {
+      name: fm.name,
+      last_updated: fm.last_updated,
+      version: fm.version,
+    },
+    sections: parsed.sections,
+  };
+}

--- a/packages/core/src/strategy/schema.test.ts
+++ b/packages/core/src/strategy/schema.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import { parseStrategyDoc, asStrategyDoc } from './parser';
+import { StrategyDocSchema, StrategyFrontmatterSchema } from './schema';
+
+const VALID = `---
+name: Acme Widgets
+last_updated: 2026-06-02
+version: 1
+---
+
+## Target problem
+
+Widget makers ship inconsistent UIs because they lack shared primitives.
+
+## Our approach
+
+We sell a hosted component registry that enforces brand contracts at build time.
+
+## Who it's for
+
+Mid-stage product teams (10-50 engineers).
+
+## Key metrics
+
+- Weekly active component installs
+
+## Tracks
+
+- Hosted registry: stabilize public API
+`;
+
+function parsed(raw: string) {
+  const p = parseStrategyDoc(raw);
+  return { p, doc: asStrategyDoc(p) };
+}
+
+describe('StrategyFrontmatterSchema', () => {
+  it('accepts a well-formed frontmatter object', () => {
+    expect(
+      StrategyFrontmatterSchema.safeParse({
+        name: 'X',
+        last_updated: '2026-06-02',
+        version: 1,
+      }).success
+    ).toBe(true);
+  });
+
+  it.each([
+    [{ name: '', last_updated: '2026-06-02', version: 1 }, /name/i],
+    [{ name: 'X', last_updated: '06/02/2026', version: 1 }, /last_updated|YYYY-MM-DD/i],
+    [{ name: 'X', last_updated: '2026-06-02', version: 0 }, /version/i],
+    [{ name: 'X', last_updated: '2026-06-02', version: 1.5 }, /integer/i],
+  ])('rejects malformed frontmatter %#', (input, pattern) => {
+    const result = StrategyFrontmatterSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(pattern);
+    }
+  });
+});
+
+describe('StrategyDocSchema', () => {
+  it('accepts a complete document with required sections only', () => {
+    const { doc } = parsed(VALID);
+    expect(doc).not.toBeNull();
+    const result = StrategyDocSchema.safeParse(doc);
+    if (!result.success) {
+      throw new Error(JSON.stringify(result.error.issues, null, 2));
+    }
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts optional sections when their bodies have real content', () => {
+    const withOptional =
+      VALID +
+      `
+## Milestones
+
+- v1 launch Q3 2026
+
+## Not working on
+
+- Mobile native shells until 2027
+`;
+    const { doc } = parsed(withOptional);
+    const result = StrategyDocSchema.safeParse(doc);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a doc with a missing required section', () => {
+    const noTracks = VALID.replace(/## Tracks[\s\S]*$/, '');
+    const { doc } = parsed(noTracks);
+    const result = StrategyDocSchema.safeParse(doc);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/Tracks/);
+    }
+  });
+
+  it('rejects an empty required section', () => {
+    const empty = VALID.replace(/(## Tracks\n\n).*$/m, '$1\n');
+    const { doc } = parsed(empty);
+    const result = StrategyDocSchema.safeParse(doc);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/Tracks/);
+      expect(JSON.stringify(result.error.issues)).toMatch(/empty/i);
+    }
+  });
+
+  it('rejects a doc whose section body is verbatim template placeholder text', () => {
+    const placeholderRaw = `---
+name: Acme
+last_updated: 2026-06-02
+version: 1
+---
+
+## Target problem
+
+<2-4 sentences. What specifically is broken in the world that this product addresses?>
+
+## Our approach
+
+We sell a hosted component registry that enforces brand contracts.
+
+## Who it's for
+
+Mid-stage product teams.
+
+## Key metrics
+
+- m
+
+## Tracks
+
+- t
+`;
+    const { doc } = parsed(placeholderRaw);
+    const result = StrategyDocSchema.safeParse(doc);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/Target problem/);
+      expect(JSON.stringify(result.error.issues)).toMatch(/placeholder/i);
+    }
+  });
+
+  it('rejects a doc with a partially filled section that still contains a placeholder line', () => {
+    const mixedRaw = `---
+name: Acme
+last_updated: 2026-06-02
+version: 1
+---
+
+## Target problem
+
+Real diagnosis sentence here.
+
+## Our approach
+
+Our distinctive bet on the problem.
+
+## Who it's for
+
+Mid-stage product teams.
+
+## Key metrics
+
+- <metric 1>: <how it's measured, where it lives>
+
+## Tracks
+
+- t
+`;
+    const { doc } = parsed(mixedRaw);
+    const result = StrategyDocSchema.safeParse(doc);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toMatch(/Key metrics/);
+      expect(JSON.stringify(result.error.issues)).toMatch(/placeholder/i);
+    }
+  });
+
+  it('rejects an unknown section even if all required sections are present', () => {
+    const rogue = VALID + '\n\n## Vision\n\nWe will save the world.\n';
+    const { doc } = parsed(rogue);
+    const result = StrategyDocSchema.safeParse(doc);
+    // The parser drops unknown sections by name (they never make it to schema
+    // sections), so this passes — Vision is silently discarded by the parser
+    // rather than rejected. The schema-level check exists for callers that
+    // construct a doc programmatically without going through the parser.
+    expect(result.success).toBe(true);
+
+    // Direct schema check — construct a doc with an unknown section name.
+    const direct = StrategyDocSchema.safeParse({
+      frontmatter: {
+        name: 'X',
+        last_updated: '2026-06-02',
+        version: 1,
+      },
+      sections: [{ name: 'Vision', body: 'real text' }, ...(doc?.sections ?? [])],
+    });
+    expect(direct.success).toBe(false);
+  });
+
+  it('accepts inline angle-bracket content that is not a sole placeholder line', () => {
+    const inlineAngle = VALID.replace(
+      '## Target problem\n\nWidget makers',
+      '## Target problem\n\nSee <https://example.com/discovery> for context. Widget makers'
+    );
+    const { doc } = parsed(inlineAngle);
+    const result = StrategyDocSchema.safeParse(doc);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/core/src/strategy/schema.ts
+++ b/packages/core/src/strategy/schema.ts
@@ -1,0 +1,137 @@
+import { z } from 'zod';
+import type {
+  StrategyDoc,
+  StrategyFrontmatter,
+  StrategySection,
+  StrategySectionName,
+} from '@harness-engineering/types';
+import { OPTIONAL_STRATEGY_SECTIONS, REQUIRED_STRATEGY_SECTIONS } from '@harness-engineering/types';
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Match an angle-bracket placeholder *anywhere on a line* whose bracket
+ * content contains whitespace — the signature of template hint text like
+ * `<2-4 sentences. ...>`, `<metric 1>`, `<how it's measured, where it lives>`.
+ *
+ * Avoids false positives on inline references whose bracket content is a
+ * single token: `<https://example.com>`, `<email@example.com>`, HTML-like
+ * `<br>` / `<MyComponent>`.
+ */
+const PLACEHOLDER_INLINE = /<[^<>\n]*\s[^<>\n]*>/;
+
+const REQUIRED = new Set<StrategySectionName>(REQUIRED_STRATEGY_SECTIONS);
+const ALLOWED = new Set<StrategySectionName>([
+  ...REQUIRED_STRATEGY_SECTIONS,
+  ...OPTIONAL_STRATEGY_SECTIONS,
+]);
+
+export const StrategyFrontmatterSchema = z.object({
+  name: z.string().min(1, 'frontmatter.name must be a non-empty string'),
+  last_updated: z.string().regex(ISO_DATE, 'frontmatter.last_updated must be ISO date YYYY-MM-DD'),
+  version: z
+    .number()
+    .int('frontmatter.version must be an integer')
+    .positive('frontmatter.version must be ≥ 1'),
+}) satisfies z.ZodType<StrategyFrontmatter>;
+
+const StrategySectionSchema = z.object({
+  name: z.enum([...REQUIRED_STRATEGY_SECTIONS, ...OPTIONAL_STRATEGY_SECTIONS] as [
+    StrategySectionName,
+    ...StrategySectionName[],
+  ]),
+  body: z.string(),
+}) satisfies z.ZodType<StrategySection>;
+
+/**
+ * Returns the list of non-whitespace, non-blank trimmed lines in a section body.
+ * Stripping blanks is what lets us check "the sole non-whitespace content is a
+ * placeholder line."
+ */
+function nonBlankLines(body: string): string[] {
+  return body
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * A body fails the body-content gate when:
+ *   1. It has no non-blank lines (empty section), OR
+ *   2. ANY non-blank line contains an angle-bracket placeholder whose bracket
+ *      content has internal whitespace (template hint pattern).
+ *
+ * Rule (2) catches header-only docs, partial fills, and bullet-list templates
+ * like `- <metric 1>: <how it's measured>`. Inline references with no
+ * whitespace inside brackets (`<https://example.com>`, `<email@example.com>`)
+ * do NOT trip the rule.
+ */
+function bodyContentIssue(body: string): string | null {
+  const lines = nonBlankLines(body);
+  if (lines.length === 0) {
+    return 'section is empty';
+  }
+  for (const line of lines) {
+    if (PLACEHOLDER_INLINE.test(line)) {
+      return `unfilled template placeholder detected (${line})`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Top-level schema: validates frontmatter + section coverage + body content.
+ *
+ * Section invariants (enforced via superRefine because they cross-cut multiple
+ * sections):
+ *   - All sections in REQUIRED_STRATEGY_SECTIONS must be present.
+ *   - Required sections must pass `bodyContentIssue` (non-empty + no placeholder lines).
+ *   - Optional sections, if present, must also pass `bodyContentIssue` — an
+ *     "optional" section that exists but contains only placeholder text is
+ *     still a half-finished doc and fails.
+ *   - No unknown section names beyond REQUIRED ∪ OPTIONAL.
+ */
+export const StrategyDocSchema = z
+  .object({
+    frontmatter: StrategyFrontmatterSchema,
+    sections: z.array(StrategySectionSchema),
+  })
+  .superRefine((doc, ctx) => {
+    const seen = new Set<StrategySectionName>();
+    for (const section of doc.sections) {
+      if (!ALLOWED.has(section.name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `unknown section "${section.name}" — only documented sections are allowed`,
+          path: ['sections'],
+        });
+        continue;
+      }
+      if (seen.has(section.name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `section "${section.name}" appears more than once`,
+          path: ['sections'],
+        });
+      }
+      seen.add(section.name);
+
+      const issue = bodyContentIssue(section.body);
+      if (issue !== null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `section "${section.name}": ${issue}`,
+          path: ['sections', section.name],
+        });
+      }
+    }
+    for (const required of REQUIRED) {
+      if (!seen.has(required)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `required section "${required}" is missing`,
+          path: ['sections', required],
+        });
+      }
+    }
+  }) satisfies z.ZodType<StrategyDoc>;

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -35,6 +35,12 @@ export { validatePulseConfig } from './pulse';
 export type { PulseConfigValidation } from './pulse';
 
 /**
+ * STRATEGY.md validation — validates the repo-root strategic anchor when present.
+ */
+export { validateStrategy } from './strategy';
+export type { StrategyValidation } from './strategy';
+
+/**
  * Solutions directory validation — walks `docs/solutions/<track>/<category>/*.md` and
  * validates each frontmatter against `SolutionDocFrontmatterSchema`.
  */

--- a/packages/core/src/validation/strategy.test.ts
+++ b/packages/core/src/validation/strategy.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { validateStrategy } from './strategy';
+
+const VALID = `---
+name: Acme Widgets
+last_updated: 2026-06-02
+version: 1
+---
+
+## Target problem
+
+Widget makers ship inconsistent UIs because they lack shared primitives.
+
+## Our approach
+
+We sell a hosted component registry that enforces brand contracts.
+
+## Who it's for
+
+Mid-stage product teams (10-50 engineers).
+
+## Key metrics
+
+- Weekly active component installs
+
+## Tracks
+
+- Hosted registry: stabilize public API
+`;
+
+describe('validateStrategy', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strategy-validate-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('soft-fails (returns Ok with present:false) when STRATEGY.md is absent', async () => {
+    const result = await validateStrategy(tmpDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ present: false, valid: true });
+    }
+  });
+
+  it('returns Ok when STRATEGY.md is present and valid', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'STRATEGY.md'), VALID);
+    const result = await validateStrategy(tmpDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ present: true, valid: true });
+    }
+  });
+
+  it('returns Err with a helpful message when frontmatter is missing required fields', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'STRATEGY.md'),
+      `# Acme\n\n## Target problem\n\nReal text.\n`
+    );
+    const result = await validateStrategy(tmpDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/frontmatter/i);
+    }
+  });
+
+  it('returns Err when a required section is missing', async () => {
+    const noTracks = VALID.replace(/## Tracks[\s\S]*$/, '');
+    fs.writeFileSync(path.join(tmpDir, 'STRATEGY.md'), noTracks);
+    const result = await validateStrategy(tmpDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/Tracks/);
+    }
+  });
+
+  it('returns Err when a section body is verbatim template placeholder text', async () => {
+    const placeholder = `---
+name: Acme
+last_updated: 2026-06-02
+version: 1
+---
+
+## Target problem
+
+<2-4 sentences. What specifically is broken in the world that this product addresses?>
+
+## Our approach
+
+real
+
+## Who it's for
+
+real
+
+## Key metrics
+
+- m
+
+## Tracks
+
+- t
+`;
+    fs.writeFileSync(path.join(tmpDir, 'STRATEGY.md'), placeholder);
+    const result = await validateStrategy(tmpDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/placeholder/i);
+    }
+  });
+});

--- a/packages/core/src/validation/strategy.ts
+++ b/packages/core/src/validation/strategy.ts
@@ -1,0 +1,55 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { Ok, Err } from '../shared/result';
+import type { Result } from '../shared/result';
+import { parseStrategyDoc, asStrategyDoc } from '../strategy/parser';
+import { StrategyDocSchema } from '../strategy/schema';
+import { validateConfig } from './config';
+import type { ConfigError } from './types';
+import { createError } from '../shared/errors';
+
+export interface StrategyValidation {
+  /** Whether STRATEGY.md exists at the cwd root. */
+  present: boolean;
+  /** True when absent (soft-fail) or when present and the schema accepts it. */
+  valid: boolean;
+}
+
+/**
+ * Validate `STRATEGY.md` at the project root.
+ *
+ * Soft-fail when absent (returns `present: false, valid: true`) — the file is
+ * an optional upstream anchor, not a hard prerequisite. When present, both
+ * frontmatter and section content are validated; any schema violation returns
+ * an Err with the file path and a descriptive message.
+ */
+export async function validateStrategy(
+  cwd: string
+): Promise<Result<StrategyValidation, ConfigError>> {
+  const strategyPath = path.join(cwd, 'STRATEGY.md');
+  let raw: string;
+  try {
+    raw = await fs.readFile(strategyPath, 'utf-8');
+  } catch {
+    return Ok({ present: false, valid: true });
+  }
+
+  const parsed = parseStrategyDoc(raw);
+  const doc = asStrategyDoc(parsed);
+  if (doc === null) {
+    return Err(
+      createError<ConfigError>(
+        'VALIDATION_FAILED',
+        'STRATEGY.md frontmatter is missing required fields (name, last_updated, version)',
+        {},
+        [
+          'Add YAML frontmatter at the top of STRATEGY.md with name (string), last_updated (YYYY-MM-DD), and version (positive integer)',
+        ]
+      )
+    );
+  }
+
+  const result = validateConfig(doc, StrategyDocSchema);
+  if (!result.ok) return Err(result.error);
+  return Ok({ present: true, valid: true });
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -194,6 +194,17 @@ export type {
   SolutionDocFrontmatter,
 } from './solutions';
 
+// --- Strategy (STRATEGY.md upstream anchor) ---
+export { REQUIRED_STRATEGY_SECTIONS, OPTIONAL_STRATEGY_SECTIONS } from './strategy';
+export type {
+  StrategyFrontmatter,
+  StrategySection,
+  StrategyDoc,
+  StrategySectionName,
+  RequiredStrategySection,
+  OptionalStrategySection,
+} from './strategy';
+
 // --- Maintenance ---
 export type {
   MaintenanceConfig,

--- a/packages/types/src/strategy.ts
+++ b/packages/types/src/strategy.ts
@@ -1,0 +1,52 @@
+/**
+ * STRATEGY.md contract — repo-root strategic anchor read by harness-strategy,
+ * harness-ideate, harness-brainstorming, and harness-roadmap-pilot.
+ *
+ * Schema lives in @harness-engineering/core (packages/core/src/strategy/schema.ts).
+ * This file is the cross-layer contract; runtime validation happens in core.
+ * BusinessKnowledgeIngestor (packages/graph) imports these types ONLY (no runtime).
+ */
+
+export interface StrategyFrontmatter {
+  name: string;
+  /** ISO date YYYY-MM-DD */
+  last_updated: string;
+  /** Monotonically increasing schema version, starts at 1. */
+  version: number;
+}
+
+/** Required section names. Order is intentional — matches the template. */
+export const REQUIRED_STRATEGY_SECTIONS = [
+  'Target problem',
+  'Our approach',
+  "Who it's for",
+  'Key metrics',
+  'Tracks',
+] as const;
+
+export type RequiredStrategySection = (typeof REQUIRED_STRATEGY_SECTIONS)[number];
+
+/** Optional section names. */
+export const OPTIONAL_STRATEGY_SECTIONS = ['Milestones', 'Not working on', 'Marketing'] as const;
+
+export type OptionalStrategySection = (typeof OPTIONAL_STRATEGY_SECTIONS)[number];
+
+export type StrategySectionName = RequiredStrategySection | OptionalStrategySection;
+
+/**
+ * A single section's body — the raw markdown between its H2 heading and the
+ * next H2 (or EOF). Includes only non-empty trimmed body content.
+ */
+export interface StrategySection {
+  name: StrategySectionName;
+  body: string;
+}
+
+/**
+ * Parsed STRATEGY.md document. The parser produces this shape from raw text;
+ * StrategyDocSchema validates the shape against the spec contract.
+ */
+export interface StrategyDoc {
+  frontmatter: StrategyFrontmatter;
+  sections: StrategySection[];
+}


### PR DESCRIPTION
## Summary

Phase 1 of 8 of the strategic-anchor sub-project of the compound-engineering-adoption initiative. Adds the foundational `STRATEGY.md` Zod schema and validator that every later phase (the `harness-strategy` skill, `harness-ideate` skill, init wiring, brainstorming/roadmap-pilot grounding, and knowledge-graph ingestion) will consume.

### What ships

- **`@harness-engineering/types`** — new shared contracts: `StrategyFrontmatter`, `StrategyDoc`, `StrategySection`, `REQUIRED_STRATEGY_SECTIONS`, `OPTIONAL_STRATEGY_SECTIONS`.
- **`@harness-engineering/core` / `strategy`** — `StrategyDocSchema`, `StrategyFrontmatterSchema`, `parseStrategyDoc`, `asStrategyDoc`.
- **`@harness-engineering/core` / `validation`** — `validateStrategy(cwd)`: soft-passes when `STRATEGY.md` is absent (the file is an opt-in anchor, not a hard prerequisite); fails with a precise per-section message when present and malformed.
- **`@harness-engineering/cli`** — `harness validate` reports a new `strategyConfig` check.

### Placeholder-rejection rule (Decision 2 of the spec)

The schema fails any required section whose body contains an angle-bracket placeholder with internal whitespace (e.g. `<2-4 sentences. ...>`, `- <metric 1>: <how it's measured>`). Inline references whose brackets contain no whitespace (`<https://example.com>`, `<email@example.com>`, HTML-like `<br>`) do **not** trip the rule. This prevents header-only "completed" docs from passing without engagement.

### Scope discipline

Scoped to schema + validator only. The skill implementations, init wiring, downstream integrations, and ADRs ship in follow-up PRs (one per phase). This mirrors the cadence the feedback-loops sub-project used.

Out of scope for this PR:
- `harness-strategy` skill (phase 2)
- `initialize-harness-project` opt-in step (phase 3)
- `harness-ideate` skill (phase 4)
- `harness-brainstorming` `STRATEGY.md` grounding (phase 5)
- `harness-roadmap-pilot` strategy-alignment tiebreaker (phase 6)
- `BusinessKnowledgeIngestor` strategy domain (phase 7)
- ADRs + `AGENTS.md` "Strategic Anchor" section (phase 8)
- Modifying the existing `pulse/strategy-seeder.ts` defensive reader (separate read path; intentionally untouched)

### Verification

- `pnpm --filter @harness-engineering/core test` — 2893 pass / 1 skip (25 new tests across `strategy/parser.test.ts`, `strategy/schema.test.ts`, `validation/strategy.test.ts`)
- `pnpm --filter @harness-engineering/cli test -- validate` — 51 pass
- `pnpm --filter @harness-engineering/types test` — 46 pass
- `pnpm --filter @harness-engineering/{types,core,cli} typecheck` — clean
- `pnpm --filter @harness-engineering/{types,core,cli} lint` — clean
- End-to-end: built CLI, ran `harness validate` against a tmp fixture project containing (a) a valid `STRATEGY.md` (passes), (b) a malformed `STRATEGY.md` with verbatim `<2-4 sentences. ...>` placeholder text (fails with the exact section + line message).

## Test plan

- [ ] CI green on the merged PR
- [ ] Smoke test: clone the branch, run `harness validate` in a project with no `STRATEGY.md` — confirm no regression (soft-pass)
- [ ] Smoke test: drop a malformed `STRATEGY.md` in the workspace root — confirm `harness validate` fails with a precise message