### PR TITLE
chore(roadmap): mark central-telemetry as done (#138)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1152,14 +1152,15 @@ last_manual_edit: 2026-06-02T13:32:41.296Z
 
 ### Central Telemetry Collection
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/central-telemetry/proposal.md
 - **Summary:** Anonymous product analytics via PostHog HTTP API with granular opt-in identity and zero vendor dependencies
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/central-telemetry/plans/2026-04-10-central-telemetry-phase1-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#138
+- **Updated-At:** 2026-06-02T12:42:00.000Z
 
 ### Compound Engineering Adoption: Strategic Anchor
 


### PR DESCRIPTION
## Summary

The Central Telemetry Collection initiative (#138) has fully landed on main across all five phases. This PR closes the loop by updating the roadmap entry from `planned` → `done` and pointing it at the Phase 1 plan.

### What already shipped on main

- **Types** (`packages/types/src/telemetry.ts`): `TelemetryConfig`, `TelemetryIdentity`, `ConsentState`, `TelemetryEvent`
- **Core** (`packages/core/src/telemetry/`): `consent.ts`, `install-id.ts`, `collector.ts`, `transport.ts`
- **CLI** (`packages/cli/src/commands/telemetry/`): `identify`, `status`, `test`
- **Hook** (`packages/cli/src/hooks/telemetry-reporter.js`): Stop hook with cursor-based dedup, first-run notice, silent failure
- **Docs**: `docs/reference/configuration.md` (`## telemetry` section), `AGENTS.md` (Telemetry subsystem entry)
- **Gitignore**: `.harness/.install-id`, `.harness/telemetry.json`, `.harness/.telemetry-notice-shown` ignored

### Acceptance criteria status

All ten success criteria from `docs/changes/central-telemetry/proposal.md` are met:

- Default-on anonymous capture with install ID, OS, Node version, harness version, skill name, duration, outcome
- Identity fields (`project`/`team`/`alias`) only sent when present in `.harness/telemetry.json`
- `DO_NOT_TRACK=1` and `HARNESS_TELEMETRY_OPTOUT=1` short-circuit consent (env vars win)
- `telemetry.enabled: false` in `harness.config.json` disables sending
- First-run notice gated by `.harness/.telemetry-notice-shown`
- Zero new production dependencies — built on Node's `fetch`/`AbortSignal.timeout`/`crypto.randomUUID`
- Silent failure path: 3 attempts, linear backoff, 5s timeout, never throws
- `harness telemetry identify` / `status` wired and tested

### Tests

- `pnpm --filter @harness-engineering/core test tests/telemetry/` → **5 files, 37 tests passing**
- `pnpm --filter @harness-engineering/cli test tests/hooks/telemetry-reporter.test.ts tests/commands/telemetry.test.ts` → **2 files, 25 tests passing**

## Test plan

- [x] Core telemetry suite passes (consent, install-id, collector, transport, integration)
- [x] CLI telemetry-reporter + telemetry command suites pass
- [x] Roadmap diff is the only source change
- [ ] CI green

Closes #138