### PR TITLE
fix(skills): commit docs/changes/<feature>/ artifacts in brainstorming and planning

### DIFF
--- a/.claude-plugin/agents/harness-planner.md
+++ b/.claude-plugin/agents/harness-planner.md
@@ -319,7 +319,16 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 5. **Check failures log.** Read `.harness/failures.md`. If planned approaches match known failures, flag them.
 6. **Run soundness review.** Invoke `harness-soundness-review --mode plan` against the draft. Do not proceed until the review converges with no remaining issues.
 7. **Write the plan to `docs/changes/<topic>/plans/`.** Naming: `YYYY-MM-DD-<feature-name>-plan.md`. Resolve `<topic>` from the spec path — if the spec lives at `docs/changes/<topic>/proposal.md`, the plan goes in the sibling `plans/` directory. If the spec is not under `docs/changes/`, fall back to `docs/plans/` and flag the spec location for human review. Create directories as needed.
-8. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
+8. **Commit plan artifact.** Immediately after writing the plan, commit it so the paper trail enters git history at planning time, not after execution:
+
+   ```bash
+   git add docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md
+   git commit -m "docs(<topic>): add plan"
+   ```
+
+   Use `docs/plans/` if the spec is not under `docs/changes/<topic>/`. Do not skip — `harness-execution` commits only implementation files, so a plan uncommitted here stays untracked until someone notices. If a pre-commit hook reformats the file, re-add and re-commit.
+
+9. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
    - Session-scoped (preferred): `.harness/sessions/<session-slug>/handoff.json`
    - Global (fallback, **deprecated**): `.harness/handoff.json`
 
@@ -327,11 +336,11 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
    Fields: `fromSkill`, `phase`, `summary`, `completed`, `pending`, `concerns`, `decisions`, `contextKeywords`.
 
-9. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
+10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-10. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
 
-11. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
+12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 
 ---
 
@@ -417,6 +426,7 @@ When referencing existing code in task specs, cite evidence using `file:line` fo
 
 - **`harness validate`** — Run in Phase 4 (before writing plan) and included in every task.
 - **`harness check-deps`** — Referenced in tasks adding imports or creating modules.
+- **Plan commit** — After writing the plan (Phase 4 Step 8), commit `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` so the paper trail enters git history at planning time. `harness-execution` does not backfill — see issue #487.
 - **Plan location** — `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` when the spec lives under `docs/changes/<topic>/proposal.md`; otherwise `docs/plans/` as a fallback.
 - **Handoff** — Once approved, invoke harness-execution for task-by-task implementation.
 - **Session directory** — Session-scoped writes go to `.harness/sessions/<slug>/`. Structure: `handoff.json`, `state.json`, `artifacts.json` (registry of spec/plan paths and produced file lists). Global `.harness/handoff.json` is deprecated for session-aware invocations.

--- a/.cursor-plugin/agents/harness-planner.md
+++ b/.cursor-plugin/agents/harness-planner.md
@@ -318,7 +318,16 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 5. **Check failures log.** Read `.harness/failures.md`. If planned approaches match known failures, flag them.
 6. **Run soundness review.** Invoke `harness-soundness-review --mode plan` against the draft. Do not proceed until the review converges with no remaining issues.
 7. **Write the plan to `docs/changes/<topic>/plans/`.** Naming: `YYYY-MM-DD-<feature-name>-plan.md`. Resolve `<topic>` from the spec path — if the spec lives at `docs/changes/<topic>/proposal.md`, the plan goes in the sibling `plans/` directory. If the spec is not under `docs/changes/`, fall back to `docs/plans/` and flag the spec location for human review. Create directories as needed.
-8. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
+8. **Commit plan artifact.** Immediately after writing the plan, commit it so the paper trail enters git history at planning time, not after execution:
+
+   ```bash
+   git add docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md
+   git commit -m "docs(<topic>): add plan"
+   ```
+
+   Use `docs/plans/` if the spec is not under `docs/changes/<topic>/`. Do not skip — `harness-execution` commits only implementation files, so a plan uncommitted here stays untracked until someone notices. If a pre-commit hook reformats the file, re-add and re-commit.
+
+9. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
    - Session-scoped (preferred): `.harness/sessions/<session-slug>/handoff.json`
    - Global (fallback, **deprecated**): `.harness/handoff.json`
 
@@ -326,11 +335,11 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
    Fields: `fromSkill`, `phase`, `summary`, `completed`, `pending`, `concerns`, `decisions`, `contextKeywords`.
 
-9. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
+10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-10. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
 
-11. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
+12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 
 ---
 
@@ -416,6 +425,7 @@ When referencing existing code in task specs, cite evidence using `file:line` fo
 
 - **`harness validate`** — Run in Phase 4 (before writing plan) and included in every task.
 - **`harness check-deps`** — Referenced in tasks adding imports or creating modules.
+- **Plan commit** — After writing the plan (Phase 4 Step 8), commit `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` so the paper trail enters git history at planning time. `harness-execution` does not backfill — see issue #487.
 - **Plan location** — `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` when the spec lives under `docs/changes/<topic>/proposal.md`; otherwise `docs/plans/` as a fallback.
 - **Handoff** — Once approved, invoke harness-execution for task-by-task implementation.
 - **Session directory** — Session-scoped writes go to `.harness/sessions/<slug>/`. Structure: `handoff.json`, `state.json`, `artifacts.json` (registry of spec/plan paths and produced file lists). Global `.harness/handoff.json` is deprecated for session-aware invocations.

--- a/.gemini-extension/commands/brainstorming.toml
+++ b/.gemini-extension/commands/brainstorming.toml
@@ -186,14 +186,23 @@ These flow into `handoff.json` `contextKeywords` field. Select keywords that hel
 
    The human must explicitly approve before this skill is complete.
 
-7. **Add feature to roadmap.** If `docs/roadmap.md` exists:
+7. **Commit spec artifacts.** After approval, commit the spec and skill recommendations so the paper trail enters git history at sign-off rather than retroactively:
+
+   ```bash
+   git add docs/changes/<feature>/proposal.md docs/changes/<feature>/SKILLS.md
+   git commit -m "docs(<feature>): add spec"
+   ```
+
+   Do not skip this step. `harness-execution` commits only implementation files, so a spec uncommitted here stays untracked until someone notices. If a pre-commit hook reformats either file, re-add and re-commit.
+
+8. **Add feature to roadmap.** If `docs/roadmap.md` exists:
    - Derive feature name from the spec title (the H1 heading).
    - Call `manage_roadmap` with action `add`, `status: "planned"`, `milestone: "Current Work"`, and the spec path.
    - If the feature already exists, skip silently.
    - If `manage_roadmap` is unavailable, fall back to `parseRoadmap`/`serializeRoadmap` from core. Warn: "External sync skipped (MCP unavailable). Run `manage_roadmap sync` when MCP is restored."
    - If no roadmap exists, skip silently.
 
-8. **Write handoff and suggest transition.** After approval:
+9. **Write handoff and suggest transition.** After approval:
 
    Write handoff to the session-scoped path when a session slug is known, otherwise fall back to the global path:
    - Session-scoped (preferred): `.harness/sessions/<session-slug>/handoff.json`
@@ -325,6 +334,7 @@ Technical claims about existing code, architecture, or tradeoffs MUST cite evide
 - **Spec location** -- `docs/changes/<feature>/proposal.md`.
 - **Handoff** -- Once approved, invoke harness-planning to create the implementation plan.
 - **Session directory** — When session slug is known, handoff goes to `.harness/sessions/<slug>/handoff.json`. The session directory structure is: `handoff.json`, `state.json`, `artifacts.json` (registry of spec/plan paths and file lists). Do not write to `.harness/handoff.json` in session context.
+- **Spec commit** -- After sign-off (Phase 4 Step 7), commit `docs/changes/<feature>/proposal.md` and `docs/changes/<feature>/SKILLS.md` so the spec enters git history at approval, not retroactively. `harness-execution` does not backfill these — see issue #487.
 - **Roadmap sync** -- After approval, call `manage_roadmap` action `add` to register as `planned`. Skip silently if no roadmap. Duplicates ignored.
 - **`emit_interaction`** -- End of Phase 4 to suggest transition to harness-planning (confirmed transition).
 

--- a/.gemini-extension/commands/planning.toml
+++ b/.gemini-extension/commands/planning.toml
@@ -314,7 +314,16 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 5. **Check failures log.** Read `.harness/failures.md`. If planned approaches match known failures, flag them.
 6. **Run soundness review.** Invoke `harness-soundness-review --mode plan` against the draft. Do not proceed until the review converges with no remaining issues.
 7. **Write the plan to `docs/changes/<topic>/plans/`.** Naming: `YYYY-MM-DD-<feature-name>-plan.md`. Resolve `<topic>` from the spec path — if the spec lives at `docs/changes/<topic>/proposal.md`, the plan goes in the sibling `plans/` directory. If the spec is not under `docs/changes/`, fall back to `docs/plans/` and flag the spec location for human review. Create directories as needed.
-8. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
+8. **Commit plan artifact.** Immediately after writing the plan, commit it so the paper trail enters git history at planning time, not after execution:
+
+   ```bash
+   git add docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md
+   git commit -m "docs(<topic>): add plan"
+   ```
+
+   Use `docs/plans/` if the spec is not under `docs/changes/<topic>/`. Do not skip — `harness-execution` commits only implementation files, so a plan uncommitted here stays untracked until someone notices. If a pre-commit hook reformats the file, re-add and re-commit.
+
+9. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
    - Session-scoped (preferred): `.harness/sessions/<session-slug>/handoff.json`
    - Global (fallback, **deprecated**): `.harness/handoff.json`
 
@@ -322,11 +331,11 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
    Fields: `fromSkill`, `phase`, `summary`, `completed`, `pending`, `concerns`, `decisions`, `contextKeywords`.
 
-9. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
+10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-10. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
 
-11. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
+12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 
 ---
 
@@ -412,6 +421,7 @@ When referencing existing code in task specs, cite evidence using `file:line` fo
 
 - **`harness validate`** — Run in Phase 4 (before writing plan) and included in every task.
 - **`harness check-deps`** — Referenced in tasks adding imports or creating modules.
+- **Plan commit** — After writing the plan (Phase 4 Step 8), commit `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` so the paper trail enters git history at planning time. `harness-execution` does not backfill — see issue #487.
 - **Plan location** — `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` when the spec lives under `docs/changes/<topic>/proposal.md`; otherwise `docs/plans/` as a fallback.
 - **Handoff** — Once approved, invoke harness-execution for task-by-task implementation.
 - **Session directory** — Session-scoped writes go to `.harness/sessions/<slug>/`. Structure: `handoff.json`, `state.json`, `artifacts.json` (registry of spec/plan paths and produced file lists). Global `.harness/handoff.json` is deprecated for session-aware invocations.

--- a/agents/skills/claude-code/harness-brainstorming/SKILL.md
+++ b/agents/skills/claude-code/harness-brainstorming/SKILL.md
@@ -166,14 +166,23 @@ These flow into `handoff.json` `contextKeywords` field. Select keywords that hel
 
    The human must explicitly approve before this skill is complete.
 
-7. **Add feature to roadmap.** If `docs/roadmap.md` exists:
+7. **Commit spec artifacts.** After approval, commit the spec and skill recommendations so the paper trail enters git history at sign-off rather than retroactively:
+
+   ```bash
+   git add docs/changes/<feature>/proposal.md docs/changes/<feature>/SKILLS.md
+   git commit -m "docs(<feature>): add spec"
+   ```
+
+   Do not skip this step. `harness-execution` commits only implementation files, so a spec uncommitted here stays untracked until someone notices. If a pre-commit hook reformats either file, re-add and re-commit.
+
+8. **Add feature to roadmap.** If `docs/roadmap.md` exists:
    - Derive feature name from the spec title (the H1 heading).
    - Call `manage_roadmap` with action `add`, `status: "planned"`, `milestone: "Current Work"`, and the spec path.
    - If the feature already exists, skip silently.
    - If `manage_roadmap` is unavailable, fall back to `parseRoadmap`/`serializeRoadmap` from core. Warn: "External sync skipped (MCP unavailable). Run `manage_roadmap sync` when MCP is restored."
    - If no roadmap exists, skip silently.
 
-8. **Write handoff and suggest transition.** After approval:
+9. **Write handoff and suggest transition.** After approval:
 
    Write handoff to the session-scoped path when a session slug is known, otherwise fall back to the global path:
    - Session-scoped (preferred): `.harness/sessions/<session-slug>/handoff.json`
@@ -305,6 +314,7 @@ Technical claims about existing code, architecture, or tradeoffs MUST cite evide
 - **Spec location** -- `docs/changes/<feature>/proposal.md`.
 - **Handoff** -- Once approved, invoke harness-planning to create the implementation plan.
 - **Session directory** — When session slug is known, handoff goes to `.harness/sessions/<slug>/handoff.json`. The session directory structure is: `handoff.json`, `state.json`, `artifacts.json` (registry of spec/plan paths and file lists). Do not write to `.harness/handoff.json` in session context.
+- **Spec commit** -- After sign-off (Phase 4 Step 7), commit `docs/changes/<feature>/proposal.md` and `docs/changes/<feature>/SKILLS.md` so the spec enters git history at approval, not retroactively. `harness-execution` does not backfill these — see issue #487.
 - **Roadmap sync** -- After approval, call `manage_roadmap` action `add` to register as `planned`. Skip silently if no roadmap. Duplicates ignored.
 - **`emit_interaction`** -- End of Phase 4 to suggest transition to harness-planning (confirmed transition).
 

--- a/agents/skills/claude-code/harness-planning/SKILL.md
+++ b/agents/skills/claude-code/harness-planning/SKILL.md
@@ -294,7 +294,16 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 5. **Check failures log.** Read `.harness/failures.md`. If planned approaches match known failures, flag them.
 6. **Run soundness review.** Invoke `harness-soundness-review --mode plan` against the draft. Do not proceed until the review converges with no remaining issues.
 7. **Write the plan to `docs/changes/<topic>/plans/`.** Naming: `YYYY-MM-DD-<feature-name>-plan.md`. Resolve `<topic>` from the spec path — if the spec lives at `docs/changes/<topic>/proposal.md`, the plan goes in the sibling `plans/` directory. If the spec is not under `docs/changes/`, fall back to `docs/plans/` and flag the spec location for human review. Create directories as needed.
-8. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
+8. **Commit plan artifact.** Immediately after writing the plan, commit it so the paper trail enters git history at planning time, not after execution:
+
+   ```bash
+   git add docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md
+   git commit -m "docs(<topic>): add plan"
+   ```
+
+   Use `docs/plans/` if the spec is not under `docs/changes/<topic>/`. Do not skip — `harness-execution` commits only implementation files, so a plan uncommitted here stays untracked until someone notices. If a pre-commit hook reformats the file, re-add and re-commit.
+
+9. **Write handoff.** Write to the session-scoped path when session slug is known, otherwise fall back to global path:
    - Session-scoped (preferred): `.harness/sessions/<session-slug>/handoff.json`
    - Global (fallback, **deprecated**): `.harness/handoff.json`
 
@@ -302,11 +311,11 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
    Fields: `fromSkill`, `phase`, `summary`, `completed`, `pending`, `concerns`, `decisions`, `contextKeywords`.
 
-9. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
+10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-10. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
 
-11. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
+12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 
 ---
 
@@ -392,6 +401,7 @@ When referencing existing code in task specs, cite evidence using `file:line` fo
 
 - **`harness validate`** — Run in Phase 4 (before writing plan) and included in every task.
 - **`harness check-deps`** — Referenced in tasks adding imports or creating modules.
+- **Plan commit** — After writing the plan (Phase 4 Step 8), commit `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` so the paper trail enters git history at planning time. `harness-execution` does not backfill — see issue #487.
 - **Plan location** — `docs/changes/<topic>/plans/YYYY-MM-DD-<feature-name>-plan.md` when the spec lives under `docs/changes/<topic>/proposal.md`; otherwise `docs/plans/` as a fallback.
 - **Handoff** — Once approved, invoke harness-execution for task-by-task implementation.
 - **Session directory** — Session-scoped writes go to `.harness/sessions/<slug>/`. Structure: `handoff.json`, `state.json`, `artifacts.json` (registry of spec/plan paths and produced file lists). Global `.harness/handoff.json` is deprecated for session-aware invocations.

--- a/packages/cli/tests/integration/planning-skills-commit-artifacts.test.ts
+++ b/packages/cli/tests/integration/planning-skills-commit-artifacts.test.ts
@@ -1,0 +1,59 @@
+// packages/cli/tests/integration/planning-skills-commit-artifacts.test.ts
+//
+// Regression test for issue #487.
+// https://github.com/Intense-Visions/harness-engineering/issues/487
+//
+// harness-brainstorming and harness-planning create files under
+// docs/changes/<feature>/ but never commit them, so the planning paper trail
+// stays untracked. Each skill must commit its own artifacts:
+//   - brainstorming → commits proposal.md + SKILLS.md after sign-off
+//   - planning     → commits the plan file after writing it
+//
+// Assertions are intentionally loose on exact wording but strict on the
+// presence of a `git add docs/changes/` step and a `git commit -m "docs(`
+// message inside each skill's Phase 4 section.
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const BRAINSTORMING_SKILL_MD = path.join(
+  REPO_ROOT,
+  'agents',
+  'skills',
+  'claude-code',
+  'harness-brainstorming',
+  'SKILL.md'
+);
+const PLANNING_SKILL_MD = path.join(
+  REPO_ROOT,
+  'agents',
+  'skills',
+  'claude-code',
+  'harness-planning',
+  'SKILL.md'
+);
+
+function extractPhase4(skillMd: string): string {
+  const match = skillMd.match(/### Phase 4: VALIDATE[\s\S]*?(?=\n### |\n---\n### |\n## )/);
+  if (!match) throw new Error('Phase 4 VALIDATE section not found');
+  return match[0];
+}
+
+describe('planning chain commits docs/changes/<feature>/ artifacts (issue #487)', () => {
+  it('harness-brainstorming Phase 4 includes a git commit step for the spec', () => {
+    const md = fs.readFileSync(BRAINSTORMING_SKILL_MD, 'utf-8');
+    const phase4 = extractPhase4(md);
+
+    expect(phase4).toMatch(/git add docs\/changes\//);
+    expect(phase4).toMatch(/git commit -m "docs\(/);
+  });
+
+  it('harness-planning Phase 4 includes a git commit step for the plan', () => {
+    const md = fs.readFileSync(PLANNING_SKILL_MD, 'utf-8');
+    const phase4 = extractPhase4(md);
+
+    expect(phase4).toMatch(/git add docs\/changes\//);
+    expect(phase4).toMatch(/git commit -m "docs\(/);
+  });
+});


### PR DESCRIPTION
## Summary

- `harness-brainstorming` and `harness-planning` both write artifacts under `docs/changes/<feature>/` but never commit them. `harness-execution` commits only implementation files, so the planning paper trail stayed untracked until the developer noticed and added it manually. Reported in #487.
- Added per-skill commit steps (Option A — each skill owns its own artifact):
  - **harness-brainstorming Phase 4 Step 7** (new) commits `proposal.md` + `SKILLS.md` after sign-off with `docs(<feature>): add spec`. Subsequent steps renumbered. Added Harness Integration bullet.
  - **harness-planning Phase 4 Step 8** (new) commits the plan file immediately after writing with `docs(<topic>): add plan`. Subsequent steps renumbered. Added Harness Integration bullet.
- Regression test `packages/cli/tests/integration/planning-skills-commit-artifacts.test.ts` asserts each skill's Phase 4 section contains a `git add docs/changes/` + `git commit -m "docs("` pair. Verified failing on `main`, passing on this branch.

## Why per-skill (Option A) over the reporter's bundled-in-planning suggestion

A spec from an approved brainstorming run that never reaches planning would stay untracked under the bundled approach. Per-skill commits mean an abandoned planning attempt still leaves the spec safely committed; brainstorming and planning each own their artifact's git lifecycle.

## Test plan

- [x] Regression test fails on `main` (2/2 fail) and passes on this branch (2/2 pass)
- [x] `packages/cli/tests/integration/` — 49 tests pass
- [x] `packages/core/tests/adoption/` + `tests/state/` — 250 tests pass
- [x] `packages/types/tests/session-state.test.ts` — 8 tests pass
- [x] `harness validate` — 273 pre-existing issues, none reference changed files
- [ ] Reviewer to spot-check the renumbering in both SKILL.md files

Closes #487