### PR TITLE
feat(strategic-anchor): ingest STRATEGY.md as business_fact nodes (phases 7-8)

### DIFF
--- a/.changeset/strategic-anchor-phase-7-ingestor.md
+++ b/.changeset/strategic-anchor-phase-7-ingestor.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/graph': minor
+---
+
+Add `BusinessKnowledgeIngestor.ingestStrategy()` for the Strategic Anchor system (phase 7). Reads a repo-root `STRATEGY.md` and emits one `business_fact` node per non-empty section, tagged with `metadata.domain === 'strategy'` and `metadata.source === 'STRATEGY.md'`. Soft-fails on missing file. Wired into `KnowledgePipelineRunner.extract()` alongside the existing business-knowledge and solutions ingestors. Adds `@harness-engineering/types` as a workspace dependency to pull the strategy contract via type-only imports; runtime section-name constants are inlined locally to preserve the graph → types layer boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,72 @@ This is the single source of truth for AI agents working on the Harness Engineer
 
 **Complete** — All core packages (types, core, cli, eslint-plugin, linter-gen, graph, intelligence, dashboard, orchestrator), 741 skills (claude-code, gemini-cli, codex, and cursor), 12 personas, 19 templates, and 3 progressive examples are implemented. The project is in adoption and refinement mode. See `examples/` for progressive tutorials.
 
+## Strategic Anchor
+
+This repository ships a **Strategic Anchor system** for projects that adopt
+harness. The anchor lives at `STRATEGY.md` in the repo root (peer of
+`README.md`) and grounds downstream agent skills with product-level context
+that the codebase alone cannot supply.
+
+### What STRATEGY.md is
+
+A short, durable file with five required sections (`Target problem`,
+`Our approach`, `Who it's for`, `Key metrics`, `Tracks`) plus three optional
+sections (`Milestones`, `Not working on`, `Marketing`). Frontmatter carries
+`name`, `last_updated` (ISO date), and `version`. Schema authority lives in
+`packages/types/src/strategy.ts` (cross-layer contract) and
+`packages/core/src/strategy/schema.ts` (Zod runtime validator). `harness validate`
+checks shape when the file exists.
+
+### How agents should read it
+
+1. **Before brainstorming a new feature** — `harness-brainstorming` Phase 1
+   EXPLORE reads `STRATEGY.md` if present and cites it as grounding in the
+   spec's `evidence` section. If a feature contradicts the strategy, surface
+   the contradiction explicitly during EVALUATE rather than auto-resolving.
+
+2. **Before picking the next roadmap item** — `harness-roadmap-pilot` Phase 2
+   RECOMMEND reads `STRATEGY.md` and applies strategy-alignment as a
+   tiebreaker bonus on top of impact × confidence ÷ effort.
+
+3. **Before generating candidate ideas** — `harness-ideate` reads
+   `STRATEGY.md` as grounding before producing ranked ideation under
+   `docs/ideation/<slug>-YYYY-MM-DD.md`.
+
+4. **As graph-queryable facts** — `BusinessKnowledgeIngestor.ingestStrategy`
+   (in `packages/graph/src/ingest/`) emits one `business_fact` node per
+   non-empty section. Nodes are tagged with `metadata.domain === 'strategy'`
+   and `metadata.source === 'STRATEGY.md'`. Query examples:
+   - `findNodes({ type: 'business_fact' })` filtered by `metadata.domain === 'strategy'`
+     returns all strategy sections.
+   - `getNode('bk:strategy:target-problem')` returns the target-problem fact.
+
+### What agents must not do
+
+- **Do not auto-generate `STRATEGY.md` from code, commits, ADRs, or roadmap state.**
+  Strategy is interview-driven only ([ADR-0036](docs/knowledge/decisions/0036-strategy-is-interview-driven.md)).
+  The interview lives in the `harness-strategy` skill and enforces pushback
+  rules (fluff detection, goal-as-strategy rejection,
+  feature-list-as-strategy rejection) capped at 2 rounds per section.
+- **Do not write `STRATEGY.md` section bodies** from any skill other than
+  `harness-strategy`. (Tooling may bump `version` / `last_updated`
+  frontmatter; section bodies are off-limits.)
+- **Do not conflate `STRATEGY.md` with `harness-roadmap.md`.** Strategy is
+  durable product-level anchor; roadmap is tactical phase tracker. See
+  [ADR-0035](docs/knowledge/decisions/0035-strategy-anchor-vs-roadmap-md.md)
+  and [`docs/conventions/strategy-vs-roadmap.md`](docs/conventions/strategy-vs-roadmap.md).
+- **Do not block on absence.** STRATEGY.md is opt-in. Every consumer
+  soft-fails when the file is missing — agents must do the same.
+
+### Adoption surface
+
+- `/harness:strategy` — run interview / update STRATEGY.md.
+- `/harness:ideate` — generate ranked candidate ideas grounded in strategy.
+- `initialize-harness-project` Phase 3 — 3-way yes/no/later question on
+  capturing strategy at project init. Decline persists in
+  `.harness/state.json` as `init.strategy.declined: true` so re-runs
+  respect prior decision.
+
 ## Repository Structure
 
 This is a **monorepo** using pnpm workspaces and Turborepo for orchestration.

--- a/docs/conventions/strategy-vs-roadmap.md
+++ b/docs/conventions/strategy-vs-roadmap.md
@@ -83,7 +83,7 @@ Items have:
 - "feat: compound-engineering Strategic Anchor phase 7 — assignee: chad@,
   status: in-progress, blocked_by: none."
 - "chore: bump @harness-engineering/graph version on release — status: planned."
-- "spec: docs/changes/<feature>/proposal.md — status: review."
+- `spec: docs/changes/<feature>/proposal.md — status: review.`
 
 ### Does NOT belong in roadmap
 

--- a/docs/conventions/strategy-vs-roadmap.md
+++ b/docs/conventions/strategy-vs-roadmap.md
@@ -1,0 +1,136 @@
+# Strategy vs Roadmap: Operational Guidance
+
+This document gives contributors concrete guidance on what belongs in
+`STRATEGY.md` versus what belongs in `harness-roadmap.md` / `docs/roadmap.md`.
+For the architectural rationale, see
+[ADR-0035](../knowledge/decisions/0035-strategy-anchor-vs-roadmap-md.md).
+For why strategy is interview-driven, see
+[ADR-0036](../knowledge/decisions/0036-strategy-is-interview-driven.md).
+
+## TL;DR
+
+- `STRATEGY.md` — **why we exist** (target problem, persona, key metrics, tracks of work). Rare edits. Repo root, peer of `README.md`.
+- `harness-roadmap.md` / `docs/roadmap.md` — **what we're doing this phase** (items, owners, statuses, blockers). Frequent edits.
+
+If you find yourself updating STRATEGY.md on every sprint, you are using it
+wrong. If you find yourself describing the company's distinctive bet in
+roadmap.md, you are also using it wrong.
+
+## Decision Tree
+
+Ask, in order:
+
+1. **Is this a fact that will still be true a year from now?**
+   → STRATEGY.md (probably).
+2. **Is this a state that changes every few days / weeks?**
+   → roadmap (always).
+3. **Is this a commitment about _direction_ (where the product is going)?**
+   → STRATEGY.md.
+4. **Is this a commitment about _execution_ (who, by when, blocked on what)?**
+   → roadmap.
+
+When in doubt: a STRATEGY.md update should feel like an event worth telling
+the team about. A roadmap update is routine.
+
+## STRATEGY.md: The Anchor
+
+Sections (defined in `packages/types/src/strategy.ts`):
+
+- **Target problem** — what specifically is broken in the world.
+- **Our approach** — our distinctive bet on how to solve it.
+- **Who it's for** — specific persona, not "developers" generically.
+- **Key metrics** — what counts as winning, where it's measured.
+- **Tracks** — the small set of coherent investments we're making.
+- _Optional_: **Milestones**, **Not working on**, **Marketing**.
+
+Authored via `harness-strategy` skill with pushback rules
+(fluff / goal-as-strategy / feature-list-as-strategy detectors capped at
+2 rounds per section). Schema validation rejects header-only "completed"
+docs and unfilled template placeholders (`packages/core/src/strategy/schema.ts`).
+
+### Belongs in STRATEGY.md
+
+- "We exist because mid-sized engineering teams lose track of why a
+  project is being worked on once handoffs happen mid-phase."
+- "Our bet is that a small durable anchor file beats wiki pages because
+  agents can read it as grounding."
+- "Tracks: anchor adoption, downstream grounding, agent-discoverable
+  surface."
+- "Key metric: percentage of brainstorm specs that cite STRATEGY.md as
+  evidence."
+
+### Does NOT belong in STRATEGY.md
+
+- "Phase 7 ships 2026-Q2." → roadmap (or, if the date matters strategically,
+  put a single bullet under the optional `Milestones` section).
+- "Track X is blocked on Y team." → roadmap.
+- "Add feature A, B, C." → That's a feature list, not a strategy. Push back
+  for the underlying coherent action (this is one of the three anti-patterns
+  the interview rejects).
+
+## harness-roadmap.md / docs/roadmap.md: The Tracker
+
+Authored mechanically via `manage_roadmap` and `harness-roadmap-pilot`.
+Items have:
+
+- `kind` (issue / spec / chore), `title`, `status` (planned / in-progress / blocked / done),
+  `owner`, `phase`, `blocked_by`, `depends_on`.
+- Free-form context lives in the linked spec or change doc, not in the
+  roadmap row.
+
+### Belongs in roadmap
+
+- "feat: compound-engineering Strategic Anchor phase 7 — assignee: chad@,
+  status: in-progress, blocked_by: none."
+- "chore: bump @harness-engineering/graph version on release — status: planned."
+- "spec: docs/changes/<feature>/proposal.md — status: review."
+
+### Does NOT belong in roadmap
+
+- "We exist to help agent-first teams." → STRATEGY.md.
+- "Our distinctive bet is that mechanical enforcement beats code review." →
+  STRATEGY.md.
+
+## How They Connect at Runtime
+
+Both files feed downstream skills as grounding, but through separate paths:
+
+- `harness-brainstorming` Phase 1 EXPLORE reads `STRATEGY.md` if present.
+  It does **not** read the roadmap (the brainstorm scopes a new spec, not
+  the next phase item).
+- `harness-roadmap-pilot` Phase 2 RECOMMEND reads **both**: the roadmap
+  for items + impact × confidence ÷ effort scoring, and STRATEGY.md for
+  the strategy-alignment tiebreaker bonus.
+- `BusinessKnowledgeIngestor.ingestStrategy`
+  (`packages/graph/src/ingest/BusinessKnowledgeIngestor.ts`) emits
+  `business_fact` nodes from `STRATEGY.md` with
+  `metadata.domain === 'strategy'`. The roadmap is **not** ingested into
+  the knowledge graph — it's an execution-state artifact, not a fact source.
+
+## Common Mistakes
+
+- **Embedding milestone updates in the strategy doc.** Symptom: `last_updated`
+  ticks every week. Fix: move to roadmap; restore strategy's durability.
+- **Describing the company's bet in roadmap row context.** Symptom: a
+  multi-paragraph "why" attached to a roadmap item. Fix: move the "why" to
+  the spec doc; let the roadmap row stay terse.
+- **Re-running `harness-strategy` to capture phase-level progress.** Symptom:
+  Tracks balloon with implementation details. Fix: rephrase the track as a
+  coherent investment ("downstream grounding") rather than a task list
+  ("wire brainstorming, then roadmap-pilot, then…").
+- **Treating absent STRATEGY.md as broken.** Soft-fail throughout — the init
+  step is opt-in, and downstream skills degrade silently. Pestering existing
+  projects is an anti-pattern.
+
+## See Also
+
+- [ADR-0035](../knowledge/decisions/0035-strategy-anchor-vs-roadmap-md.md) —
+  STRATEGY.md vs roadmap.md separation of concerns.
+- [ADR-0036](../knowledge/decisions/0036-strategy-is-interview-driven.md) —
+  why strategy is interview-driven and never auto-generated.
+- `agents/skills/claude-code/harness-strategy/SKILL.md` — interview skill.
+- `agents/skills/claude-code/harness-roadmap-pilot/SKILL.md` — roadmap
+  prioritization skill.
+- `packages/core/src/strategy/schema.ts` — Zod schema and validator.
+- `packages/graph/src/ingest/BusinessKnowledgeIngestor.ts` — `ingestStrategy`
+  method.

--- a/docs/knowledge/decisions/0035-strategy-anchor-vs-roadmap-md.md
+++ b/docs/knowledge/decisions/0035-strategy-anchor-vs-roadmap-md.md
@@ -1,0 +1,70 @@
+---
+number: 0035
+title: STRATEGY.md vs roadmap.md separation of concerns
+date: 2026-06-02
+status: accepted
+tier: medium
+source: docs/changes/compound-engineering-adoption/strategic-anchor/proposal.md
+---
+
+## Context
+
+Harness shipped the Strategic Anchor system in phases 1–7: a repo-root `STRATEGY.md` anchor, `harness-strategy` interview skill, `harness-ideate` ranked-ideation skill, init wiring, brainstorming/roadmap-pilot grounding, and a `business_fact`-domain ingestor. Two adjacent artifacts now coexist:
+
+- `STRATEGY.md` — durable product-level anchor (target problem, persona, key metrics, tracks of work).
+- `harness-roadmap.md` / `docs/roadmap.md` — tactical phase tracker (status, owners, blockers, per-phase notes).
+
+Without an explicit boundary, downstream skills and humans drift between them — e.g. embedding milestone updates in `STRATEGY.md`, or asking `roadmap.md` to justify _why_ a track exists. The boundary needs to be load-bearing because both files feed downstream skills as grounding (`harness-brainstorming` reads strategy; `harness-roadmap-pilot` reads both).
+
+## Decision
+
+The two artifacts have **distinct lifecycles, scopes, and update cadences**:
+
+| Axis             | `STRATEGY.md`                                       | `roadmap.md` / `harness-roadmap.md`                                    |
+| ---------------- | --------------------------------------------------- | ---------------------------------------------------------------------- |
+| Scope            | Product-level (what the product is, who it's for)   | Phase-level (what is being built, by whom, when)                       |
+| Lifecycle        | Per-product — survives across all milestones        | Per-phase — items added/closed as work moves                           |
+| Update cadence   | Rare (quarters/years), via `harness-strategy` skill | Frequent (days/weeks), via `harness-roadmap-pilot` / `manage_roadmap`  |
+| Authoring        | Interview-driven, schema-validated                  | Mechanical from spec + execution state                                 |
+| Schema authority | `packages/core/src/strategy/schema.ts` (Zod)        | `packages/cli/src/commands/manage-roadmap.ts` + roadmap-tracker schema |
+| Discovery        | Repo root (peer of `README.md`)                     | `docs/` or `harness-roadmap.md`                                        |
+
+Downstream consumers ground on each separately:
+
+- `harness-brainstorming` Phase 1 EXPLORE — reads STRATEGY.md only (strategic context for new specs).
+- `harness-roadmap-pilot` Phase 2 RECOMMEND — reads both; strategy-alignment is a tiebreaker bonus on top of roadmap-tracker impact × confidence ÷ effort.
+- `BusinessKnowledgeIngestor.ingestStrategy` — emits `business_fact` nodes from STRATEGY.md sections; the roadmap is **not** ingested.
+
+Editing one for the other's purpose is the canonical anti-pattern. Examples that belong in STRATEGY.md but commonly leak into roadmaps: "we exist because…", "our distinctive bet is…". Examples that belong in roadmap.md but commonly leak into strategy: "Q3 milestones", "current blocker on track X" (the optional `Milestones` section in STRATEGY.md is for product-level anchors like "v2 GA", not phase tracking).
+
+## Consequences
+
+**Positive:**
+
+- Downstream skills can read the right grounding artifact without conflating concerns.
+- Strategy stays small and high-signal — the schema validator's placeholder-rejection rule (`packages/core/src/strategy/schema.ts`) prevents header-only padding.
+- Roadmap stays mechanical — owners, statuses, and blockers come from execution state, not strategic prose.
+- `BusinessKnowledgeIngestor` ingests strategy sections as `business_fact` nodes without ever touching the roadmap, so graph queries can filter by `metadata.domain === 'strategy'` cleanly.
+
+**Negative:**
+
+- Authors must pick the right home for a fact at write time. The conventions doc (`docs/conventions/strategy-vs-roadmap.md`) carries that load with worked examples.
+- Maintaining two files is more discipline than maintaining one; mitigated by the rare-update cadence of STRATEGY.md.
+
+**Neutral:**
+
+- The boundary is documentary, not enforced by a linter today. The schema-validator's placeholder-rejection and section-allowlist catches the most common drift (sections that don't belong); section-name sprawl is rejected automatically.
+
+## Alternatives considered
+
+- **Fold strategy sections into `roadmap.md` as a preamble.** Rejected — different lifecycles, different audiences. The roadmap's frequent edits would force strategy sections to be re-touched on every phase change, eroding the durability that makes the anchor useful.
+- **Auto-derive strategy from the roadmap.** Rejected — strategy is a forward-looking commitment, not a summary of recent work. ADR-0036 codifies the interview-only stance.
+- **Generate `roadmap.md` from STRATEGY.md tracks.** Rejected — strategy tracks are coarse-grained ("Anchor adoption"); roadmap items are fine-grained phases. The mapping is many-to-many and humans make it.
+
+## Implementation
+
+- `STRATEGY.md` schema lives in `packages/core/src/strategy/schema.ts`; runtime validator hooked into `harness validate` via `packages/cli/src/commands/validate.ts`.
+- `BusinessKnowledgeIngestor.ingestStrategy` (`packages/graph/src/ingest/BusinessKnowledgeIngestor.ts`) emits `bk:strategy:<section-slug>` nodes with `metadata.domain === 'strategy'`.
+- `KnowledgePipelineRunner.extract` invokes `ingestStrategy(<projectDir>/STRATEGY.md)` alongside the existing business-knowledge and solutions ingestors; missing file is soft-failed.
+- `harness-brainstorming` Phase 1 EXPLORE and `harness-roadmap-pilot` Phase 2 RECOMMEND already cite STRATEGY.md when present (shipped in phases 5 and 6).
+- Convention doc: `docs/conventions/strategy-vs-roadmap.md`.

--- a/docs/knowledge/decisions/0036-strategy-is-interview-driven.md
+++ b/docs/knowledge/decisions/0036-strategy-is-interview-driven.md
@@ -1,0 +1,62 @@
+---
+number: 0036
+title: Strategy is interview-driven, never auto-generated
+date: 2026-06-02
+status: accepted
+tier: medium
+source: docs/changes/compound-engineering-adoption/strategic-anchor/proposal.md
+---
+
+## Context
+
+Strategic-Anchor introduces `STRATEGY.md` (target problem, persona, key metrics, tracks) as the upstream anchor that grounds `harness-brainstorming`, `harness-ideate`, and `harness-roadmap-pilot`. There are two ways a strategy doc could be produced:
+
+1. **Auto-generated** — derive from commit history, code patterns, ADRs, or roadmap state.
+2. **Interview-driven** — `harness-strategy` runs a structured Q&A with pushback rules and writes only what the human commits to in plain language.
+
+Auto-generation is attractive (zero-friction adoption, always-fresh) but produces a fundamentally different artifact: a backward-looking summary of what the repo has been doing, not a forward-looking commitment to what the team is _trying_ to do. Rumelt's _Good Strategy Bad Strategy_ frames the failure mode: strategy that describes activity is "bad strategy"; strategy that diagnoses a problem and bets on a coherent action is "good strategy". Derived strategy is structurally biased toward the former.
+
+## Decision
+
+`STRATEGY.md` is **interview-driven only**. There is no path that auto-generates strategy content from code, commits, ADRs, roadmap state, or any other artifact in the repo.
+
+Concretely:
+
+- `harness-strategy` Phase 1 (first-run) and Phase 2 (update) interview the human and write what the human says. AI helps with the _questions_ (fluff detection, goal-as-strategy rejection, feature-list-as-strategy rejection — capped at 2 rounds per section) but never with the _answers_.
+- `harness-ideate` reads `STRATEGY.md` as grounding to rank candidate ideas; it does **not** write back into `STRATEGY.md`.
+- `BusinessKnowledgeIngestor.ingestStrategy` extracts `business_fact` nodes _from_ `STRATEGY.md` to populate the graph; it does **not** infer or backfill strategy.
+- `harness-brainstorming` and `harness-roadmap-pilot` cite STRATEGY.md as evidence and surface contradictions during EVALUATE; they never patch the strategy file.
+- No CLI or skill is allowed to write `STRATEGY.md` content other than `harness-strategy`. (Schema bump / `last_updated` tick can be touched by tooling; **section bodies** are interview-only.)
+
+Pushback rules from `agents/skills/claude-code/harness-strategy/references/interview.md` are the load-bearing element: they are what convert "captured what you said" into "captured a strategy that survives criticism." Removing pushback would collapse the interview into transcription.
+
+## Consequences
+
+**Positive:**
+
+- The doc represents an actual human commitment. Downstream skills can treat it as load-bearing grounding rather than as a summary they need to sanity-check.
+- Anti-patterns (fluff, goals-as-strategy, feature-lists-as-strategy) are rejected at write time, where the human can rephrase, rather than at read time, where downstream skills would have to defend against them.
+- No risk that AI-derived strategy becomes a self-fulfilling prophecy ("the code looks like X, so strategy says X, so we keep building X").
+
+**Negative:**
+
+- Adoption requires the interview, which has friction. Mitigated by the init step's 3-way yes/no/later option (decline recorded in `.harness/state.json` as `init.strategy.declined: true` so re-runs respect prior decision).
+- A bad strategy doc is still possible — pushback caps at 2 rounds. The cap is the disable mechanism (no `--skip-pushback` flag exists).
+
+**Neutral:**
+
+- Downstream skills must soft-fail when `STRATEGY.md` is absent. This is already wired (`BusinessKnowledgeIngestor.ingestStrategy` returns an empty result; brainstorming/roadmap-pilot fall through silently).
+
+## Alternatives considered
+
+- **Derive a draft strategy from commits + ADRs and let the human edit.** Rejected — the draft anchors thinking. Humans will rationalize what they see instead of diagnosing afresh. The cost of a blank page is the value of the doc.
+- **Hybrid: auto-fill Tracks from `harness-roadmap` items; interview only for Target Problem / Approach / Persona.** Rejected — Tracks are the strategic-vs-tactical seam. Auto-filled tracks would inherit the roadmap's tactical granularity and lifecycle (ADR-0035).
+- **Allow `harness-ideate` to propose a strategy update when a critical mass of generated ideas contradicts the current strategy.** Deferred — interesting but premature. Today, the contradiction surfaces during EVALUATE in brainstorming; the human decides whether to re-run `harness-strategy`.
+
+## Implementation
+
+- `harness-strategy` skill (`agents/skills/claude-code/harness-strategy/SKILL.md`) runs the interview with pushback rules.
+- `agents/skills/claude-code/harness-strategy/references/interview.md` defines the three anti-pattern detectors (fluff / goal / feature-list) and the 2-round cap.
+- `BusinessKnowledgeIngestor.ingestStrategy` (`packages/graph/src/ingest/BusinessKnowledgeIngestor.ts`) reads `STRATEGY.md` and emits `business_fact` nodes — read-only on the file.
+- `KnowledgePipelineRunner.extract` invokes `ingestStrategy` alongside other ingestors with a try/catch that soft-fails on absence.
+- Init flow (`agents/skills/claude-code/initialize-harness-project/SKILL.md` Phase 3) records `init.strategy.declined: true` in `.harness/state.json` when the user declines.

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -29,6 +29,7 @@
     "bench": "vitest bench"
   },
   "dependencies": {
+    "@harness-engineering/types": "workspace:*",
     "minimatch": "^10.2.5",
     "zod": "^3.25.76"
   },

--- a/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+++ b/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { z } from 'zod';
+import type { StrategySectionName } from '@harness-engineering/types';
 import type { GraphStore } from '../store/GraphStore.js';
 import type { GraphNode, IngestResult, NodeType, EdgeType } from '../types.js';
 import { emptyResult } from './ingestUtils.js';
@@ -74,6 +75,34 @@ const CODE_NODE_TYPES: readonly NodeType[] = [
   'variable',
 ];
 const MEASURABLE_TYPES = new Set<string>(['business_process', 'business_concept']);
+
+// Local mirror of REQUIRED_STRATEGY_SECTIONS / OPTIONAL_STRATEGY_SECTIONS from
+// @harness-engineering/types. Inlined because the graph layer takes types-only
+// imports from @harness-engineering/types (see types/src/strategy.ts header) —
+// runtime constants must be local. Any divergence is caught by
+// BusinessKnowledgeIngestor.strategy tests, which assert section coverage
+// against the same canonical list.
+const STRATEGY_REQUIRED_SECTIONS: readonly StrategySectionName[] = [
+  'Target problem',
+  'Our approach',
+  "Who it's for",
+  'Key metrics',
+  'Tracks',
+];
+const STRATEGY_OPTIONAL_SECTIONS: readonly StrategySectionName[] = [
+  'Milestones',
+  'Not working on',
+  'Marketing',
+];
+const STRATEGY_KNOWN_SECTIONS = new Set<string>([
+  ...STRATEGY_REQUIRED_SECTIONS,
+  ...STRATEGY_OPTIONAL_SECTIONS,
+]);
+
+// Frontmatter placeholder marker — same prefix the harness-strategy template
+// uses for unfilled section bodies (e.g. `<2-4 sentences. ...>`). Sections
+// whose body matches this verbatim placeholder are not ingested.
+const STRATEGY_PLACEHOLDER_RE = /^<[^>]+>\s*$/;
 
 interface Frontmatter {
   type: string;
@@ -174,6 +203,87 @@ export class BusinessKnowledgeIngestor {
       edgesUpdated: 0,
       errors,
       durationMs: Date.now() - start,
+    };
+  }
+
+  /**
+   * Ingest the repo-root STRATEGY.md anchor as `business_fact` nodes — one per
+   * non-empty section. Soft-fails when the file is absent (returns empty result
+   * with no errors) so existing projects without a strategy doc keep working.
+   *
+   * Each emitted node carries `metadata.domain === 'strategy'` and
+   * `metadata.source === 'STRATEGY.md'`, making the strategy domain
+   * discoverable through the same filters as other business-knowledge nodes.
+   */
+  async ingestStrategy(strategyPath: string): Promise<IngestResult> {
+    const start = Date.now();
+    const errors: string[] = [];
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(strategyPath, 'utf-8');
+    } catch {
+      // Absent file is the common case; do not surface as an error.
+      return emptyResult(Date.now() - start);
+    }
+
+    const parsed = parseStrategyMarkdown(raw);
+    if (!parsed) {
+      errors.push(`${strategyPath}: no frontmatter found`);
+      return { ...emptyResult(Date.now() - start), errors };
+    }
+
+    const relPath = path.basename(strategyPath);
+    let nodesAdded = 0;
+    for (const section of parsed.sections) {
+      const node = this.buildStrategyNode(section, parsed.frontmatter, relPath);
+      if (node === null) continue;
+      this.store.addNode(node);
+      nodesAdded++;
+    }
+
+    return {
+      nodesAdded,
+      nodesUpdated: 0,
+      edgesAdded: 0,
+      edgesUpdated: 0,
+      errors,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  /**
+   * Build a single STRATEGY.md `business_fact` node from a parsed section.
+   * Returns null when the section is unknown, empty, or carries unfilled
+   * template placeholder text — callers iterate and skip nulls.
+   */
+  private buildStrategyNode(
+    section: { name: string; body: string },
+    frontmatter: Record<string, unknown>,
+    relPath: string
+  ): GraphNode | null {
+    if (!STRATEGY_KNOWN_SECTIONS.has(section.name)) return null;
+    const body = section.body.trim();
+    if (body.length === 0) return null;
+    if (STRATEGY_PLACEHOLDER_RE.test(body)) return null;
+
+    const productName = typeof frontmatter.name === 'string' ? frontmatter.name : 'unnamed-product';
+    return {
+      id: `bk:strategy:${slugifyStrategySection(section.name)}`,
+      type: 'business_fact',
+      name: section.name,
+      path: relPath,
+      content: body,
+      metadata: {
+        domain: 'strategy',
+        source: 'STRATEGY.md',
+        section_name: section.name,
+        product_name: productName,
+        ...(typeof frontmatter.last_updated === 'string' && {
+          last_updated: frontmatter.last_updated,
+        }),
+        ...(typeof frontmatter.version === 'number' && { version: frontmatter.version }),
+      },
     };
   }
 
@@ -336,6 +446,74 @@ function parseFrontmatter(raw: string): { frontmatter: Frontmatter; body: string
     frontmatter: frontmatter as unknown as Frontmatter,
     body,
   };
+}
+
+/**
+ * Convert a strategy section name into the kebab-case slug used as the trailing
+ * segment of its `bk:strategy:<slug>` node id. Lowercases, strips apostrophes,
+ * collapses runs of non-alphanumeric characters to single hyphens, and trims
+ * leading/trailing hyphens — so `"Who it's for"` becomes `who-its-for`.
+ */
+function slugifyStrategySection(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/'/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Minimal STRATEGY.md parser — mirrors @harness-engineering/core's
+ * parseStrategyDoc shape (frontmatter + H2 sections) without pulling in the
+ * gray-matter runtime, which the graph layer doesn't depend on. Returns null
+ * when no frontmatter is found; returns sections with raw (un-validated)
+ * names so the caller can filter against the known-section allowlist.
+ */
+function parseStrategyMarkdown(raw: string): {
+  frontmatter: Record<string, unknown>;
+  sections: { name: string; body: string }[];
+} | null {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) return null;
+  const yamlBlock = match[1]!;
+  const body = match[2]!;
+
+  const frontmatter: Record<string, unknown> = {};
+  for (const line of yamlBlock.split(/\r?\n/)) {
+    const kvMatch = line.match(/^(\w+):\s*(.+)$/);
+    if (!kvMatch) continue;
+    const key = kvMatch[1]!;
+    const rawValue = kvMatch[2]!.trim();
+    const unquoted = rawValue.replace(/^["']|["']$/g, '');
+    const asNumber = Number(unquoted);
+    if (unquoted !== '' && !Number.isNaN(asNumber) && /^-?\d+(?:\.\d+)?$/.test(unquoted)) {
+      frontmatter[key] = asNumber;
+    } else {
+      frontmatter[key] = unquoted;
+    }
+  }
+
+  const sections: { name: string; body: string }[] = [];
+  const h2Re = /^##[ \t]+(.+?)[ \t]*$/gm;
+  const matches: { name: string; headingStart: number; bodyStart: number }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = h2Re.exec(body)) !== null) {
+    matches.push({
+      name: (m[1] ?? '').trim(),
+      headingStart: m.index,
+      bodyStart: m.index + m[0].length,
+    });
+  }
+  for (let i = 0; i < matches.length; i++) {
+    const current = matches[i]!;
+    const sliceEnd = matches[i + 1]?.headingStart ?? body.length;
+    sections.push({
+      name: current.name,
+      body: body.slice(current.bodyStart, sliceEnd).trim(),
+    });
+  }
+
+  return { frontmatter, sections };
 }
 
 function parseSolutionFrontmatter(

--- a/packages/graph/src/ingest/KnowledgePipelineRunner.ts
+++ b/packages/graph/src/ingest/KnowledgePipelineRunner.ts
@@ -291,12 +291,32 @@ export class KnowledgePipelineRunner {
         durationMs: 0,
       };
     }
-    // Aggregate solutions ingestion errors alongside the knowledge ingestion
-    // errors so contributors get a unified view of frontmatter / parse failures.
+    // Strategy anchor from repo-root STRATEGY.md (Strategic Anchor phase 7).
+    // Produces business_fact nodes with metadata.domain === 'strategy'. Absent
+    // STRATEGY.md is the common case for existing projects — the ingestor
+    // soft-fails so adoption stays opt-in.
+    const strategyPath = path.join(options.projectDir, 'STRATEGY.md');
+    let strategyResult: IngestResult;
+    try {
+      strategyResult = await bkIngestor.ingestStrategy(strategyPath);
+    } catch {
+      strategyResult = {
+        nodesAdded: 0,
+        nodesUpdated: 0,
+        edgesAdded: 0,
+        edgesUpdated: 0,
+        errors: [],
+        durationMs: 0,
+      };
+    }
+
+    // Aggregate solutions + strategy ingestion errors alongside the knowledge
+    // ingestion errors so contributors get a unified view of frontmatter /
+    // parse failures.
     bkResult = {
       ...bkResult,
-      nodesAdded: bkResult.nodesAdded + solutionsResult.nodesAdded,
-      errors: [...bkResult.errors, ...solutionsResult.errors],
+      nodesAdded: bkResult.nodesAdded + solutionsResult.nodesAdded + strategyResult.nodesAdded,
+      errors: [...bkResult.errors, ...solutionsResult.errors, ...strategyResult.errors],
     };
 
     // Decision ADRs from docs/knowledge/decisions/

--- a/packages/graph/tests/ingest/BusinessKnowledgeIngestor.strategy.test.ts
+++ b/packages/graph/tests/ingest/BusinessKnowledgeIngestor.strategy.test.ts
@@ -1,0 +1,234 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { GraphStore } from '../../src/store/GraphStore.js';
+import { BusinessKnowledgeIngestor } from '../../src/ingest/BusinessKnowledgeIngestor.js';
+
+const SAMPLE_STRATEGY = `---
+name: Sample Product
+last_updated: 2026-06-02
+version: 1
+---
+
+# Sample Product Strategy
+
+## Target problem
+
+Teams ship features without a durable record of why they exist.
+
+## Our approach
+
+A repo-root anchor file that downstream skills read for grounding.
+
+## Who it's for
+
+Engineering teams who lose strategic context across phases.
+
+## Key metrics
+
+- Adoption: percentage of repos with STRATEGY.md
+- Recall: percentage of brainstorm specs that cite strategy
+
+## Tracks
+
+- Anchor adoption: ship STRATEGY.md schema + skill
+- Downstream grounding: wire brainstorm + ideate + roadmap-pilot
+
+## Milestones
+
+- 2026-Q2: phase 7 ships
+- 2026-Q3: phase 8 ships
+
+## Marketing
+
+Public launch deferred until adoption telemetry stabilises.
+`;
+
+describe('BusinessKnowledgeIngestor.ingestStrategy', () => {
+  let store: GraphStore;
+  let ingestor: BusinessKnowledgeIngestor;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    store = new GraphStore();
+    ingestor = new BusinessKnowledgeIngestor(store);
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'strategy-ingest-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('produces a business_fact node per non-empty strategy section', async () => {
+    const strategyPath = path.join(tmpDir, 'STRATEGY.md');
+    await fs.writeFile(strategyPath, SAMPLE_STRATEGY, 'utf-8');
+
+    const result = await ingestor.ingestStrategy(strategyPath);
+
+    expect(result.nodesAdded).toBe(7); // 5 required + Milestones + Marketing
+    expect(result.errors).toEqual([]);
+
+    const facts = store.findNodes({ type: 'business_fact' });
+    expect(facts.length).toBe(7);
+    expect(facts.every((n) => n.metadata.domain === 'strategy')).toBe(true);
+    expect(facts.every((n) => n.metadata.source === 'STRATEGY.md')).toBe(true);
+  });
+
+  it('satisfies the spec contract: at least one business_fact node from a sample STRATEGY.md', async () => {
+    const strategyPath = path.join(tmpDir, 'STRATEGY.md');
+    await fs.writeFile(strategyPath, SAMPLE_STRATEGY, 'utf-8');
+
+    await ingestor.ingestStrategy(strategyPath);
+
+    const facts = store.findNodes({ type: 'business_fact' });
+    expect(facts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('uses bk:strategy:<slug> node ids with kebab-cased section names', async () => {
+    const strategyPath = path.join(tmpDir, 'STRATEGY.md');
+    await fs.writeFile(strategyPath, SAMPLE_STRATEGY, 'utf-8');
+
+    await ingestor.ingestStrategy(strategyPath);
+
+    expect(store.getNode('bk:strategy:target-problem')).not.toBeNull();
+    expect(store.getNode('bk:strategy:our-approach')).not.toBeNull();
+    expect(store.getNode('bk:strategy:who-its-for')).not.toBeNull(); // apostrophe stripped
+    expect(store.getNode('bk:strategy:key-metrics')).not.toBeNull();
+    expect(store.getNode('bk:strategy:tracks')).not.toBeNull();
+    expect(store.getNode('bk:strategy:milestones')).not.toBeNull();
+    expect(store.getNode('bk:strategy:marketing')).not.toBeNull();
+  });
+
+  it('preserves frontmatter context in node metadata', async () => {
+    const strategyPath = path.join(tmpDir, 'STRATEGY.md');
+    await fs.writeFile(strategyPath, SAMPLE_STRATEGY, 'utf-8');
+
+    await ingestor.ingestStrategy(strategyPath);
+
+    const targetProblem = store.getNode('bk:strategy:target-problem');
+    expect(targetProblem).not.toBeNull();
+    expect(targetProblem!.metadata.product_name).toBe('Sample Product');
+    expect(targetProblem!.metadata.last_updated).toBe('2026-06-02');
+    expect(targetProblem!.metadata.version).toBe(1);
+    expect(targetProblem!.metadata.section_name).toBe('Target problem');
+  });
+
+  it('soft-fails on missing STRATEGY.md (returns empty, no error)', async () => {
+    const missing = path.join(tmpDir, 'STRATEGY.md');
+
+    const result = await ingestor.ingestStrategy(missing);
+
+    expect(result.nodesAdded).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('surfaces a parse error when frontmatter is missing', async () => {
+    const strategyPath = path.join(tmpDir, 'STRATEGY.md');
+    await fs.writeFile(
+      strategyPath,
+      '# No frontmatter strategy\n\n## Target problem\n\nbody\n',
+      'utf-8'
+    );
+
+    const result = await ingestor.ingestStrategy(strategyPath);
+
+    expect(result.nodesAdded).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/no frontmatter found/);
+  });
+
+  it('skips unfilled placeholder sections', async () => {
+    const strategyPath = path.join(tmpDir, 'STRATEGY.md');
+    await fs.writeFile(
+      strategyPath,
+      `---
+name: Placeholder Product
+last_updated: 2026-06-02
+version: 1
+---
+
+# Placeholder Product Strategy
+
+## Target problem
+
+<2-4 sentences. What specifically is broken in the world that this product addresses?>
+
+## Our approach
+
+Real prose about our approach to the problem.
+
+## Who it's for
+
+<2-4 sentences. Specific persona, not "developers" generically.>
+
+## Key metrics
+
+- adoption: percent of repos
+- recall: percent of specs citing strategy
+
+## Tracks
+
+- anchor: ship STRATEGY.md
+`,
+      'utf-8'
+    );
+
+    const result = await ingestor.ingestStrategy(strategyPath);
+
+    // Placeholder bodies for "Target problem" and "Who it's for" are skipped.
+    expect(result.nodesAdded).toBe(3);
+    expect(store.getNode('bk:strategy:target-problem')).toBeNull();
+    expect(store.getNode('bk:strategy:our-approach')).not.toBeNull();
+    expect(store.getNode('bk:strategy:who-its-for')).toBeNull();
+    expect(store.getNode('bk:strategy:key-metrics')).not.toBeNull();
+    expect(store.getNode('bk:strategy:tracks')).not.toBeNull();
+  });
+
+  it('ignores unknown section names', async () => {
+    const strategyPath = path.join(tmpDir, 'STRATEGY.md');
+    await fs.writeFile(
+      strategyPath,
+      `---
+name: Unknown-Section Product
+last_updated: 2026-06-02
+version: 1
+---
+
+# Unknown-Section Product Strategy
+
+## Target problem
+
+real body
+
+## Our approach
+
+real body
+
+## Who it's for
+
+real body
+
+## Key metrics
+
+- m: a metric
+
+## Tracks
+
+- t: a track
+
+## Unknown future section
+
+This name is not in the required/optional allowlist.
+`,
+      'utf-8'
+    );
+
+    const result = await ingestor.ingestStrategy(strategyPath);
+
+    // Five known sections, unknown one is dropped silently.
+    expect(result.nodesAdded).toBe(5);
+    const facts = store.findNodes({ type: 'business_fact' });
+    expect(facts.every((n) => n.name !== 'Unknown future section')).toBe(true);
+  });
+});

--- a/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
+++ b/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
@@ -116,6 +116,65 @@ describe('KnowledgePipelineRunner', () => {
       const result = await runner.run(makeOptions());
       expect(result.extraction.codeSignals).toBe(0);
     });
+
+    it('ingests STRATEGY.md as business_fact nodes in extraction phase', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'STRATEGY.md'),
+        `---
+name: Sample Product
+last_updated: 2026-06-02
+version: 1
+---
+
+# Sample Product Strategy
+
+## Target problem
+
+A real diagnosis sentence about the problem we address.
+
+## Our approach
+
+A real distinctive bet on how we solve it.
+
+## Who it's for
+
+Specific persona we serve, not "developers" generically.
+
+## Key metrics
+
+- m: a metric
+
+## Tracks
+
+- t: a track
+`,
+        'utf-8'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      // STRATEGY.md ingestion is counted under businessKnowledge.
+      expect(result.extraction.businessKnowledge).toBeGreaterThanOrEqual(5);
+
+      const strategyFacts = store
+        .findNodes({ type: 'business_fact' })
+        .filter((n) => n.metadata?.domain === 'strategy');
+      expect(strategyFacts.length).toBeGreaterThanOrEqual(5);
+      expect(strategyFacts.every((n) => n.metadata?.source === 'STRATEGY.md')).toBe(true);
+    });
+
+    it('survives missing STRATEGY.md without error', async () => {
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      // No strategy nodes produced and no error surfaced.
+      const strategyFacts = store
+        .findNodes({ type: 'business_fact' })
+        .filter((n) => n.metadata?.domain === 'strategy');
+      expect(strategyFacts).toHaveLength(0);
+      expect(result.verdict).not.toBe('fail');
+    });
   });
 
   describe('gap report', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 1.6.4(@algolia/client-search@5.52.1)(search-insights@2.17.3)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@6.4.2)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -192,7 +192,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
 
   packages/core:
     dependencies:
@@ -393,10 +393,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
 
   packages/graph:
     dependencies:
+      '@harness-engineering/types':
+        specifier: workspace:*
+        version: link:../types
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
@@ -425,7 +428,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
 
   packages/intelligence:
     dependencies:
@@ -456,7 +459,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
 
   packages/linter-gen:
     dependencies:
@@ -484,7 +487,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
 
   packages/local-models:
     dependencies:
@@ -506,7 +509,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
 
   packages/orchestrator:
     dependencies:
@@ -588,7 +591,7 @@ importers:
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.2)
 
   packages/types:
     dependencies:
@@ -4571,7 +4574,7 @@ packages:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
+      vitest: 4.1.5(@vitest/coverage-v8@4.1.5)(vite@6.4.2)
     dev: true
 
   /@vitest/expect@4.1.5:
@@ -10042,7 +10045,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -10103,73 +10106,6 @@ packages:
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       jsdom: 29.0.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - msw
-    dev: true
-
-  /vitest@4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(vite@6.4.2):
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
-      happy-dom: '*'
-      jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 22.19.15
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@6.4.2)
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3


### PR DESCRIPTION
## Summary

Closes phases 7 and 8 of the Strategic Anchor effort (compound-engineering issue `compound-engineering-c5ba8e44`). Phases 1–6 already shipped the schema, `harness-strategy` skill, init wiring, `harness-ideate` skill, and brainstorming + roadmap-pilot grounding. This PR adds the knowledge-graph ingestor and the supporting documentation.

### Phase 7 — BusinessKnowledgeIngestor strategy domain

- `BusinessKnowledgeIngestor.ingestStrategy()` (`packages/graph/src/ingest/BusinessKnowledgeIngestor.ts`) reads a repo-root `STRATEGY.md` and emits one `business_fact` node per non-empty section.
- Each node carries `metadata.domain === 'strategy'` and `metadata.source === 'STRATEGY.md'`, so the strategy domain is discoverable through the same filters as other business-knowledge nodes. Node IDs are `bk:strategy:<section-slug>` (kebab-cased, e.g. `bk:strategy:who-its-for`).
- Soft-fails on missing file; placeholder bodies (the `<2-4 sentences. ...>` markers from the harness-strategy template) are skipped; unknown section names are ignored silently.
- Wired into `KnowledgePipelineRunner.extract()` alongside the existing business-knowledge and solutions ingestors. Strategy nodes count toward `extraction.businessKnowledge`.
- Adds `@harness-engineering/types` as a graph workspace dependency for the type-only `StrategySectionName` import; runtime section-name constants are inlined locally to preserve the graph → types layer boundary (mirroring the existing `SolutionDocFrontmatterSchema` mirror pattern).

### Phase 8 — Documentation and ADRs

- **ADR-0035** (`docs/knowledge/decisions/0035-strategy-anchor-vs-roadmap-md.md`) — STRATEGY.md vs roadmap.md separation of concerns.
- **ADR-0036** (`docs/knowledge/decisions/0036-strategy-is-interview-driven.md`) — Strategy is interview-driven, never auto-generated.
- **AGENTS.md** — New "Strategic Anchor" section between "Project Overview" and "Repository Structure".
- **`docs/conventions/strategy-vs-roadmap.md`** — Operational guidance with decision tree and worked examples.

## Test plan

- [x] `pnpm --filter @harness-engineering/graph test` — 883 tests pass, including 8 new `BusinessKnowledgeIngestor.strategy.test.ts` cases and 2 new pipeline-level wiring tests in `KnowledgePipelineRunner.test.ts`.
- [x] `pnpm --filter @harness-engineering/core test` — 2967 tests pass.
- [x] `pnpm --filter @harness-engineering/cli test` — 3888 tests pass.
- [x] `pnpm --filter @harness-engineering/graph typecheck` + `build` + `lint` — clean.
- [x] `harness validate` — 273 pre-existing design-token issues; no new issues from this PR.
- [x] `harness check-arch` — same 47 issues as baseline (`af075682`); no new violations.
- [x] `pnpm docs build` — VitePress renders cleanly.
- [x] Spec success criteria #11 verified: BusinessKnowledgeIngestor produces at least one business_fact node from a sample STRATEGY.md.

## Notes

The pnpm-lock churn beyond the new workspace link is auto-resolved peer-dependency reshuffling (vitest config-axis variants); the only intentional change is `@harness-engineering/types: workspace:*` under `packages/graph`.