### PR TITLE
fix(graph,cli): surface silent-failure parsers for knowledge ingest (#504)

### DIFF
--- a/.changeset/fix-chat-504-knowledge-ingest-silent-zero.md
+++ b/.changeset/fix-chat-504-knowledge-ingest-silent-zero.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+'@harness-engineering/graph': patch
+---
+
+Fix two silent-failure parsers reported in chat-504:
+
+- `MermaidParser` no longer drops `.mmd` files whose first non-empty line is a `%%` comment. `detectDiagramType` now skips Mermaid comment lines (matching Mermaid's own grammar) so files starting with provenance headers like `%% Source: docs/foo.md` extract entities normally.
+- `harness ingest --source knowledge` now also runs `BusinessKnowledgeIngestor` against `docs/knowledge/`, `docs/solutions/`, and `STRATEGY.md`. Previously this command only invoked `KnowledgeIngestor`, leaving the business-knowledge substrate reachable only via `harness knowledge-pipeline` and surfacing as a silent `+0 nodes` for users who probed the natural CLI.
+- `harness ingest` CLI output now surfaces `IngestResult.errors[]` to stderr when non-empty, so frontmatter / schema validation failures stop being silently discarded. JSON output is unchanged (errors were already serialized there).

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -179,6 +179,46 @@ export async function runIngest(
   return result;
 }
 
+// Print the human-readable summary for a completed ingest run. Errors are
+// emitted to stderr so JSON consumers stay unaffected when `--json` is set.
+// Extracted from the action handler to keep `createIngestCommand` under the
+// project cyclomatic-complexity threshold and to make the per-file warning
+// behavior independently testable.
+function printIngestSummary(result: IngestResult, label: string): void {
+  console.log(
+    `Ingested (${label}): +${result.nodesAdded} nodes, +${result.edgesAdded} edges (${result.durationMs}ms)`
+  );
+  if (result.errors.length === 0) return;
+  console.warn(`  ${result.errors.length} parse/skip warning(s):`);
+  for (const err of result.errors) console.warn(`    - ${err}`);
+}
+
+async function handleIngestAction(
+  opts: { source?: string; all?: boolean; full?: boolean },
+  cmd: Command
+): Promise<void> {
+  if (!opts.source && !opts.all) {
+    console.error('Error: --source or --all is required');
+    process.exit(1);
+  }
+  const globalOpts = cmd.optsWithGlobals();
+  const projectPath = path.resolve(globalOpts.config ? path.dirname(globalOpts.config) : '.');
+  try {
+    const runOpts: { full?: boolean; all?: boolean } = {};
+    if (opts.full !== undefined) runOpts.full = opts.full;
+    if (opts.all !== undefined) runOpts.all = opts.all;
+    const result = await runIngest(projectPath, opts.source ?? '', runOpts);
+    if (globalOpts.json) {
+      console.log(JSON.stringify(result));
+    } else {
+      printIngestSummary(result, opts.all ? 'all' : (opts.source ?? ''));
+    }
+  } catch (err) {
+    console.error('Ingest failed:', err instanceof Error ? err.message : err);
+    process.exit(2);
+  }
+}
+
 export function createIngestCommand(): Command {
   return new Command('ingest')
     .description('Ingest data into the knowledge graph')
@@ -188,38 +228,5 @@ export function createIngestCommand(): Command {
     )
     .option('--all', 'Run all sources (code, knowledge, git, and configured connectors)')
     .option('--full', 'Force full re-ingestion')
-    .action(async (opts, cmd) => {
-      if (!opts.source && !opts.all) {
-        console.error('Error: --source or --all is required');
-        process.exit(1);
-      }
-      const globalOpts = cmd.optsWithGlobals();
-      const projectPath = path.resolve(globalOpts.config ? path.dirname(globalOpts.config) : '.');
-      try {
-        const result = await runIngest(projectPath, opts.source ?? '', {
-          full: opts.full,
-          all: opts.all,
-        });
-        if (globalOpts.json) {
-          console.log(JSON.stringify(result));
-        } else {
-          const label = opts.all ? 'all' : opts.source;
-          console.log(
-            `Ingested (${label}): +${result.nodesAdded} nodes, +${result.edgesAdded} edges (${result.durationMs}ms)`
-          );
-          // Surface per-file parse / schema failures that were collected into
-          // result.errors but previously thrown away by this branch. Silent
-          // `+0 nodes` made schema mismatches undebuggable (see issue #504
-          // Finding 1). Errors go to stderr so JSON consumers stay unaffected
-          // and `--json` mode still emits a clean single-line payload above.
-          if (result.errors.length > 0) {
-            console.warn(`  ${result.errors.length} parse/skip warning(s):`);
-            for (const err of result.errors) console.warn(`    - ${err}`);
-          }
-        }
-      } catch (err) {
-        console.error('Ingest failed:', err instanceof Error ? err.message : err);
-        process.exit(2);
-      }
-    });
+    .action(handleIngestAction);
 }

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -49,6 +49,7 @@ export async function runIngest(
     CodeIngestor,
     TopologicalLinker,
     KnowledgeIngestor,
+    BusinessKnowledgeIngestor,
     GitIngestor,
     RequirementIngestor,
     SyncManager,
@@ -114,9 +115,21 @@ export async function runIngest(
       result = await new CodeIngestor(store, ingestOptions).ingest(projectPath);
       new TopologicalLinker(store).link();
       break;
-    case 'knowledge':
-      result = await new KnowledgeIngestor(store).ingestAll(projectPath);
+    case 'knowledge': {
+      // Run KnowledgeIngestor (ADRs, learnings, failures, general docs) AND
+      // BusinessKnowledgeIngestor (docs/knowledge, docs/solutions, STRATEGY.md).
+      // Previously --source knowledge only ran the former, leaving the latter
+      // substrate unreachable except via `harness knowledge-pipeline` — which
+      // surfaced as a silent `+0 nodes` for users who probed via this command.
+      // See github issue #504 Finding 1.
+      const knowledge = await new KnowledgeIngestor(store).ingestAll(projectPath);
+      const bk = new BusinessKnowledgeIngestor(store);
+      const bkKnowledge = await bk.ingest(path.join(projectPath, 'docs', 'knowledge'));
+      const bkSolutions = await bk.ingestSolutions(path.join(projectPath, 'docs', 'solutions'));
+      const bkStrategy = await bk.ingestStrategy(path.join(projectPath, 'STRATEGY.md'));
+      result = mergeResults(knowledge, bkKnowledge, bkSolutions, bkStrategy);
       break;
+    }
     case 'git':
       result = await new GitIngestor(store).ingest(projectPath);
       break;
@@ -194,6 +207,15 @@ export function createIngestCommand(): Command {
           console.log(
             `Ingested (${label}): +${result.nodesAdded} nodes, +${result.edgesAdded} edges (${result.durationMs}ms)`
           );
+          // Surface per-file parse / schema failures that were collected into
+          // result.errors but previously thrown away by this branch. Silent
+          // `+0 nodes` made schema mismatches undebuggable (see issue #504
+          // Finding 1). Errors go to stderr so JSON consumers stay unaffected
+          // and `--json` mode still emits a clean single-line payload above.
+          if (result.errors.length > 0) {
+            console.warn(`  ${result.errors.length} parse/skip warning(s):`);
+            for (const err of result.errors) console.warn(`    - ${err}`);
+          }
         }
       } catch (err) {
         console.error('Ingest failed:', err instanceof Error ? err.message : err);

--- a/packages/cli/tests/commands/graph-ingest.test.ts
+++ b/packages/cli/tests/commands/graph-ingest.test.ts
@@ -27,6 +27,31 @@ const mockKnowledgeIngest = vi.fn().mockResolvedValue({
   durationMs: 50,
 });
 
+const mockBkIngest = vi.fn().mockResolvedValue({
+  nodesAdded: 0,
+  nodesUpdated: 0,
+  edgesAdded: 0,
+  edgesUpdated: 0,
+  errors: [],
+  durationMs: 0,
+});
+const mockBkIngestSolutions = vi.fn().mockResolvedValue({
+  nodesAdded: 0,
+  nodesUpdated: 0,
+  edgesAdded: 0,
+  edgesUpdated: 0,
+  errors: [],
+  durationMs: 0,
+});
+const mockBkIngestStrategy = vi.fn().mockResolvedValue({
+  nodesAdded: 0,
+  nodesUpdated: 0,
+  edgesAdded: 0,
+  edgesUpdated: 0,
+  errors: [],
+  durationMs: 0,
+});
+
 const mockGitIngest = vi.fn().mockResolvedValue({
   nodesAdded: 20,
   nodesUpdated: 2,
@@ -89,6 +114,12 @@ vi.mock('@harness-engineering/graph', () => ({
   KnowledgeIngestor: class {
     constructor() {}
     ingestAll = mockKnowledgeIngest;
+  },
+  BusinessKnowledgeIngestor: class {
+    constructor() {}
+    ingest = mockBkIngest;
+    ingestSolutions = mockBkIngestSolutions;
+    ingestStrategy = mockBkIngestStrategy;
   },
   GitIngestor: class {
     constructor() {}
@@ -158,6 +189,16 @@ beforeEach(() => {
     errors: [],
     durationMs: 50,
   });
+  for (const m of [mockBkIngest, mockBkIngestSolutions, mockBkIngestStrategy]) {
+    m.mockResolvedValue({
+      nodesAdded: 0,
+      nodesUpdated: 0,
+      edgesAdded: 0,
+      edgesUpdated: 0,
+      errors: [],
+      durationMs: 0,
+    });
+  }
   mockGitIngest.mockResolvedValue({
     nodesAdded: 20,
     nodesUpdated: 2,
@@ -228,6 +269,45 @@ describe('runIngest', () => {
       expect(result.nodesUpdated).toBe(1);
       expect(mockKnowledgeIngest).toHaveBeenCalledWith('/project');
       expect(mockStore.save).toHaveBeenCalled();
+    });
+
+    // Regression: github issue #504 Finding 1. Previously --source knowledge
+    // only ran KnowledgeIngestor, so docs/knowledge/, docs/solutions/, and
+    // STRATEGY.md were silently invisible from this command.
+    it('also runs BusinessKnowledgeIngestor against docs/knowledge, docs/solutions, STRATEGY.md', async () => {
+      await runIngest('/project', 'knowledge');
+      expect(mockBkIngest).toHaveBeenCalledWith(expect.stringMatching(/docs[\\/]knowledge$/));
+      expect(mockBkIngestSolutions).toHaveBeenCalledWith(
+        expect.stringMatching(/docs[\\/]solutions$/)
+      );
+      expect(mockBkIngestStrategy).toHaveBeenCalledWith(expect.stringMatching(/STRATEGY\.md$/));
+    });
+
+    it('aggregates nodes and errors from KnowledgeIngestor and BusinessKnowledgeIngestor', async () => {
+      mockBkIngest.mockResolvedValue({
+        nodesAdded: 5,
+        nodesUpdated: 0,
+        edgesAdded: 0,
+        edgesUpdated: 0,
+        errors: ['docs/knowledge/bad.md: missing required key "last_updated"'],
+        durationMs: 10,
+      });
+      mockBkIngestSolutions.mockResolvedValue({
+        nodesAdded: 2,
+        nodesUpdated: 0,
+        edgesAdded: 0,
+        edgesUpdated: 0,
+        errors: ['docs/solutions/x.md: no frontmatter found'],
+        durationMs: 10,
+      });
+
+      const result = await runIngest('/project', 'knowledge');
+      // 3 (KnowledgeIngestor) + 5 (bk knowledge) + 2 (bk solutions) + 0 (bk strategy)
+      expect(result.nodesAdded).toBe(10);
+      expect(result.errors).toEqual([
+        'docs/knowledge/bad.md: missing required key "last_updated"',
+        'docs/solutions/x.md: no frontmatter found',
+      ]);
     });
   });
 

--- a/packages/graph/src/ingest/parsers/mermaid.ts
+++ b/packages/graph/src/ingest/parsers/mermaid.ts
@@ -21,11 +21,14 @@ function emptyResult(diagramType: string = 'unknown'): DiagramParseResult {
   };
 }
 
-/** Detect diagram type from the first non-empty line. */
+/** Detect diagram type from the first non-empty, non-comment line. */
 function detectDiagramType(content: string): string {
   for (const line of content.split('\n')) {
     const trimmed = line.trim();
-    if (!trimmed) continue;
+    // `%%` is Mermaid's comment prefix. Files commonly start with a provenance
+    // line like `%% Source: docs/foo.md` — skip these the same way the Mermaid
+    // grammar does, otherwise the type detection bails on the first comment.
+    if (!trimmed || trimmed.startsWith('%%')) continue;
 
     if (/^(?:graph|flowchart)\b/i.test(trimmed)) return 'flowchart';
     if (/^sequenceDiagram\b/.test(trimmed)) return 'sequence';

--- a/packages/graph/tests/ingest/DiagramParser.test.ts
+++ b/packages/graph/tests/ingest/DiagramParser.test.ts
@@ -148,6 +148,32 @@ describe('MermaidParser', () => {
       expect(result.metadata.format).toBe('mermaid');
       expect(result.metadata.diagramType).toBe('unknown');
     });
+
+    // Regression: github issue #504, Finding 2. Mermaid's grammar treats `%%`
+    // as a comment, so files commonly start with `%% Source: docs/foo.md`
+    // provenance headers. Previously detectDiagramType broke on the first
+    // non-empty line and returned 'unknown' for any file with leading `%%`.
+    describe('%% comment tolerance', () => {
+      it('detects sequence type when first line is %% comment', () => {
+        const content = `%% Source: docs/foo.md\nsequenceDiagram\n    participant A\n    participant B\n    A->>B: hello`;
+        const result = parser.parse(content, 'probe.mmd');
+        expect(result.metadata.diagramType).toBe('sequence');
+        expect(result.entities.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it('detects flowchart type when preceded by multiple %% lines and blank lines', () => {
+        const content = `%% Source of truth: docs/architecture.md\n%% Last reviewed: 2026-01-01\n\nflowchart LR\n  A[Start] --> B[End]`;
+        const result = parser.parse(content, 'probe.mmd');
+        expect(result.metadata.diagramType).toBe('flowchart');
+        expect(result.entities.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it('returns unknown when ONLY %% comments are present', () => {
+        const result = parser.parse(`%% just a comment\n%% another`, 'probe.mmd');
+        expect(result.metadata.diagramType).toBe('unknown');
+        expect(result.entities).toHaveLength(0);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the two silent-failure findings reported in #504 (the ADR feature request is left for a separate planning session).

- **DiagramParser `%%` regression** — `MermaidParser.detectDiagramType` skipped only empty lines, then broke on the first non-empty line. Files starting with a `%%` provenance comment (`%% Source: docs/foo.md`) matched none of the diagram-type regexes and fell through to `unknown` → 0 entities. Now also skips Mermaid comment lines so the standard Mermaid grammar is honored.
- **`harness ingest --source knowledge` silent `+0`** — the command invoked only `KnowledgeIngestor`, which explicitly skips `docs/knowledge/` and `docs/solutions/`. The `BusinessKnowledgeIngestor` substrate was reachable only via `harness knowledge-pipeline`. Wired the BK ingestor into the `knowledge` case (knowledge dir + solutions dir + STRATEGY.md).
- **CLI error discard** — `IngestResult.errors[]` was populated by every ingestor but the success branch printed only counts. Frontmatter / schema failures (e.g. missing `last_updated`) were silently dropped. Errors now print to stderr when non-empty; JSON output is unchanged.

## Out of scope (follow-ups)

- `--all` does not yet route through `BusinessKnowledgeIngestor`; the same wiring should be applied for symmetry.
- `harness knowledge-pipeline` CLI output may have the same silent-error-discard pattern; needs separate inspection.
- ADR feature request (Finding 3): `KnowledgeIngestor.ingestADRs` only scans `docs/adr/`, not `docs/architecture/**/ADR-*.md`. Belongs in a planning pass, not this fix.

## Test plan

- [x] `pnpm vitest run` in `packages/graph` — 886 tests pass (3 new under `MermaidParser > edge cases > %% comment tolerance`)
- [x] `pnpm vitest run` in `packages/cli` — 3890 tests pass (2 new under `knowledge source`)
- [x] `pnpm typecheck` clean in both packages
- [x] `pnpm lint` clean in both packages
- [ ] Manual: build the CLI and run `harness ingest --source knowledge --full` against a probe project with valid + invalid frontmatter and confirm warnings surface
- [ ] Manual: run `harness ingest --source knowledge --json` and confirm the JSON payload structure is unchanged

## Notes

- Two commits: the fix itself, then a small refactor that pulled the Commander action callback into a top-level `handleIngestAction` so `createIngestCommand` stays under the cyclomatic-complexity ceiling.