### PR TITLE
fix(core): reduce drift detector false positives on ADR-heavy projects (#492)

### DIFF
--- a/.changeset/fix-chat-492-drift-detector-false-positives.md
+++ b/.changeset/fix-chat-492-drift-detector-false-positives.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/core': patch
+---
+
+Reduce `harness cleanup --type drift` false positives on ADR-heavy projects (chat-492):
+
+- Inline-reference extractor now rejects BCP-47 locale codes (`vi`, `cs`, `pt-BR`, `zh-Hant-CN`) and file-name backticks (`AGENTS.md`, `harness.config.json`, `.gitignore`) so they no longer surface as "symbol not found" drift.
+- API-signature drift detection skips refs inside forward-looking docs by default: `docs/architecture/`, `docs/decisions/`, `docs/proposals/`, `docs/adr/`. These describe intended future code and shouldn't drift-check against the current codebase. Configurable via `DriftConfig.forwardLookingPaths`.
+- Markdown link parser splits `file.md#anchor` before the file-existence check, eliminating false-positive structure drift on anchor links. When the file exists, the anchor is validated against the target file's GFM-slugged headings — surfacing as `link-anchor` context with `medium` confidence so real typos (e.g. em-dash slug mistakes) still get caught.

--- a/packages/core/src/entropy/config/schema.ts
+++ b/packages/core/src/entropy/config/schema.ts
@@ -89,6 +89,7 @@ const DriftConfigSchema = z.object({
   checkExamples: z.boolean().optional(),
   checkStructure: z.boolean().optional(),
   ignorePatterns: z.array(z.string()).optional(),
+  forwardLookingPaths: z.array(z.string()).optional(),
 });
 
 // DeadCodeConfig schema

--- a/packages/core/src/entropy/detectors/drift.ts
+++ b/packages/core/src/entropy/detectors/drift.ts
@@ -101,13 +101,33 @@ export function findPossibleMatches(
     .map((m) => m.name);
 }
 
+// Default doc-path prefixes that describe intended future code (ADRs,
+// decisions, proposals). API-signature drift inside these docs is suppressed
+// — symbols there describe the design, not the codebase. Override via
+// DriftConfig.forwardLookingPaths.
+const DEFAULT_FORWARD_LOOKING_PATHS = [
+  'docs/architecture/',
+  'docs/decisions/',
+  'docs/proposals/',
+  'docs/adr/',
+];
+
 const DEFAULT_DRIFT_CONFIG: DriftConfig = {
   docPaths: [],
   checkApiSignatures: true,
   checkExamples: true,
   checkStructure: true,
   ignorePatterns: [],
+  forwardLookingPaths: DEFAULT_FORWARD_LOOKING_PATHS,
 };
+
+// Match either as relative-path prefix (`docs/architecture/foo.md`) or as a
+// substring anywhere in the absolute resolved path. The latter handles cases
+// where the snapshot stores absolute paths.
+function isForwardLookingDoc(docPath: string, forwardLookingPaths: string[]): boolean {
+  const normalized = docPath.replaceAll('\\', '/');
+  return forwardLookingPaths.some((prefix) => normalized.includes(prefix));
+}
 
 /**
  * Check API signature drift - docs reference symbols that don't exist
@@ -121,6 +141,13 @@ function checkApiSignatureDrift(
 
   for (const ref of snapshot.codeReferences) {
     if (config.ignorePatterns.some((p) => ref.reference.match(new RegExp(p)))) {
+      continue;
+    }
+
+    // Forward-looking docs (ADRs, decisions, proposals) describe intended
+    // future code; their referenced symbols are not codebase drift. See
+    // github issue #492.
+    if (isForwardLookingDoc(ref.docFile, config.forwardLookingPaths)) {
       continue;
     }
 
@@ -156,11 +183,24 @@ function checkApiSignatureDrift(
   return drifts;
 }
 
+interface MarkdownLink {
+  /** Raw link as written, including any `#anchor` portion. */
+  raw: string;
+  /** File path portion (no anchor). */
+  path: string;
+  /** Anchor portion without the leading `#`, or undefined when absent. */
+  anchor?: string;
+  line: number;
+}
+
 /**
- * Extract file/directory links from markdown content
+ * Extract file/directory links from markdown content.
+ *
+ * Splits `file.md#anchor` into `path = file.md` and `anchor = anchor` so the
+ * existence check operates on the file path alone (see github issue #492).
  */
-function extractFileLinks(content: string): { link: string; line: number }[] {
-  const links: { link: string; line: number }[] = [];
+function extractFileLinks(content: string): MarkdownLink[] {
+  const links: MarkdownLink[] = [];
   const lines = content.split('\n');
 
   for (let i = 0; i < lines.length; i++) {
@@ -172,15 +212,23 @@ function extractFileLinks(content: string): { link: string; line: number }[] {
     let match;
     while ((match = linkRegex.exec(line)) !== null) {
       const linkPath = match[2];
-      // Only check relative paths to files (not URLs)
-      if (
-        linkPath &&
-        !linkPath.startsWith('http') &&
-        !linkPath.startsWith('#') &&
-        (linkPath.includes('.') || linkPath.startsWith('..'))
-      ) {
-        links.push({ link: linkPath, line: i + 1 });
-      }
+      if (!linkPath) continue;
+      if (linkPath.startsWith('http')) continue;
+      if (linkPath.startsWith('#')) continue;
+      if (!linkPath.includes('.') && !linkPath.startsWith('..')) continue;
+
+      const hashIdx = linkPath.indexOf('#');
+      const filePart = hashIdx === -1 ? linkPath : linkPath.slice(0, hashIdx);
+      const anchorPart = hashIdx === -1 ? undefined : linkPath.slice(hashIdx + 1);
+      // Anchor-only links (`#section`) were already filtered above; here
+      // a leading `#` would mean an empty filePart and we should skip.
+      if (!filePart) continue;
+      links.push({
+        raw: linkPath,
+        path: filePart,
+        ...(anchorPart ? { anchor: anchorPart } : {}),
+        line: i + 1,
+      });
     }
   }
 
@@ -188,7 +236,42 @@ function extractFileLinks(content: string): { link: string; line: number }[] {
 }
 
 /**
- * Check structure drift - docs reference files/directories that don't exist
+ * GFM-style heading slug: lowercase, spaces → hyphens, drop characters that
+ * aren't alphanumeric / hyphens. Mirrors GitHub's behavior well enough for
+ * the common case (no full Unicode normalization, but matches typical
+ * hand-written anchors).
+ */
+function slugifyHeading(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+async function extractHeadingSlugs(filePath: string): Promise<Set<string>> {
+  const slugs = new Set<string>();
+  let content: string;
+  try {
+    const fs = await import('node:fs/promises');
+    content = await fs.readFile(filePath, 'utf-8');
+  } catch {
+    return slugs;
+  }
+  const headingRe = /^#{1,6}[ \t]+(.+?)[ \t]*#*\s*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = headingRe.exec(content)) !== null) {
+    const heading = m[1];
+    if (heading) slugs.add(slugifyHeading(heading));
+  }
+  return slugs;
+}
+
+/**
+ * Check structure drift - docs reference files/directories that don't exist.
+ * When a link targets `file.md#anchor`, the file portion is checked for
+ * existence first; if the file exists, the anchor is validated against the
+ * target file's GFM-slugged headings (see github issue #492).
  */
 async function checkStructureDrift(
   snapshot: CodebaseSnapshot,
@@ -199,22 +282,42 @@ async function checkStructureDrift(
   for (const doc of snapshot.docs) {
     const fileLinks = extractFileLinks(doc.content);
 
-    for (const { link, line } of fileLinks) {
-      const resolvedPath = resolve(dirname(doc.path), link);
+    for (const link of fileLinks) {
+      const resolvedPath = resolve(dirname(doc.path), link.path);
       const exists = await fileExists(resolvedPath);
 
       if (!exists) {
         drifts.push({
           type: 'structure',
           docFile: doc.path,
-          line,
-          reference: link,
+          line: link.line,
+          reference: link.raw,
           context: 'link',
           issue: 'NOT_FOUND',
-          details: `File "${link}" referenced in documentation does not exist`,
+          details: `File "${link.path}" referenced in documentation does not exist`,
           suggestion: 'Update the link or remove the reference',
           confidence: 'high',
         });
+        continue;
+      }
+
+      if (link.anchor && resolvedPath.toLowerCase().endsWith('.md')) {
+        const slugs = await extractHeadingSlugs(resolvedPath);
+        // Only emit when we successfully read headings — empty set on read
+        // failure means we should not pretend the anchor is broken.
+        if (slugs.size > 0 && !slugs.has(link.anchor.toLowerCase())) {
+          drifts.push({
+            type: 'structure',
+            docFile: doc.path,
+            line: link.line,
+            reference: link.raw,
+            context: 'link-anchor',
+            issue: 'NOT_FOUND',
+            details: `Anchor "#${link.anchor}" not found in "${link.path}"`,
+            suggestion: 'Check the target file for the correct heading slug',
+            confidence: 'medium',
+          });
+        }
       }
     }
   }

--- a/packages/core/src/entropy/snapshot.ts
+++ b/packages/core/src/entropy/snapshot.ts
@@ -77,6 +77,26 @@ function extractCodeBlocks(content: string): CodeBlock[] {
 /**
  * Extract inline backtick references from markdown
  */
+// Reject patterns for inline-ref extraction. These tokens technically match
+// the broad identifier shape but never refer to code symbols, so passing
+// them downstream to drift-detection produces noisy false positives. See
+// github issue #492.
+//
+// - BCP-47 locale codes (`vi`, `pt-BR`, `zh-Hant-CN`) commonly appear in
+//   roadmap docs as i18n targets.
+// - File-name suffixes (`AGENTS.md`, `harness.config.json`) appear in
+//   backticks as filesystem references. The identifier regex treats
+//   `.md` / `.json` as `.method` segments and incorrectly accepts them.
+const BCP47_LOCALE_RE = /^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2,4})?$/;
+const FILE_REFERENCE_RE =
+  /\.(md|json|toml|yaml|yml|txt|csv|html|xml|jsonl|env|ini|lock|gitignore|sh|sql)$/i;
+
+function isLikelySymbolReference(reference: string): boolean {
+  if (BCP47_LOCALE_RE.test(reference)) return false;
+  if (FILE_REFERENCE_RE.test(reference)) return false;
+  return /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*(\(.*\))?$/.test(reference);
+}
+
 function extractInlineRefs(content: string): InlineReference[] {
   const refs: InlineReference[] = [];
   const lines = content.split('\n');
@@ -90,8 +110,7 @@ function extractInlineRefs(content: string): InlineReference[] {
     while ((match = regex.exec(line)) !== null) {
       const reference = match[1];
       if (reference === undefined) continue;
-      // Filter out code snippets, keep likely symbol references
-      if (reference.match(/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*(\(.*\))?$/)) {
+      if (isLikelySymbolReference(reference)) {
         refs.push({
           reference: reference.replace(/\(.*\)$/, ''), // Remove function parens
           line: i + 1,

--- a/packages/core/src/entropy/types/config.ts
+++ b/packages/core/src/entropy/types/config.ts
@@ -12,6 +12,15 @@ export interface DriftConfig {
   checkExamples: boolean;
   checkStructure: boolean;
   ignorePatterns: string[];
+  /**
+   * Path prefixes (relative or absolute substrings) for docs that describe
+   * intended future code rather than the current codebase. API-signature
+   * drift is suppressed for refs inside these docs — see github issue #492.
+   *
+   * Default: ['docs/architecture/', 'docs/decisions/', 'docs/proposals/',
+   * 'docs/adr/']. Override via the entropy config to extend or replace.
+   */
+  forwardLookingPaths: string[];
 }
 
 export interface DeadCodeConfig {

--- a/packages/core/tests/entropy/detectors/drift.test.ts
+++ b/packages/core/tests/entropy/detectors/drift.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   findPossibleMatches,
   levenshteinDistance,
@@ -7,6 +7,8 @@ import {
 import { buildSnapshot } from '../../../src/entropy/snapshot';
 import { TypeScriptParser } from '../../../src/shared/parsers';
 import { join } from 'path';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 
 describe('fuzzy matching', () => {
   describe('levenshteinDistance', () => {
@@ -98,5 +100,233 @@ describe('detectDocDrift', () => {
       const structureDrifts = result.value.drifts.filter((d) => d.type === 'structure');
       expect(structureDrifts.some((d) => d.reference.includes('missing-file.ts'))).toBe(true);
     }
+  });
+});
+
+// Regression: github issue #492. ADR-heavy projects emitted 38/41 false
+// positives across three categories — forward-looking refs, file-name
+// backticks/locales (extraction-layer), and anchor links. Tests below cover
+// the drift-detector-layer fixes (forward-looking suppression and
+// anchor-aware link parsing).
+describe('drift detector — issue #492 regressions', () => {
+  const parser = new TypeScriptParser();
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'drift-492-'));
+    await mkdir(join(projectDir, 'src'), { recursive: true });
+    await mkdir(join(projectDir, 'docs', 'architecture', 'persistence'), { recursive: true });
+    await writeFile(
+      join(projectDir, 'src', 'index.ts'),
+      'export function realFunction() { return 1; }\n'
+    );
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  describe('forward-looking docs (ADRs, decisions, proposals)', () => {
+    it('suppresses api-signature drift for symbols inside docs/architecture/**', async () => {
+      await writeFile(
+        join(projectDir, 'docs', 'architecture', 'persistence', 'ADR-0001-future.md'),
+        [
+          '# ADR-0001: Future persistence',
+          '',
+          'We will introduce `IssueReward`, `IssuePoints`, `BAO_SENT`, `defer_response`',
+          'and `respond_later` symbols. None of these exist in the codebase yet.',
+        ].join('\n')
+      );
+
+      const snapshotResult = await buildSnapshot({
+        rootDir: projectDir,
+        parser,
+        analyze: { drift: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+      expect(snapshotResult.ok).toBe(true);
+      if (!snapshotResult.ok) return;
+
+      const result = await detectDocDrift(snapshotResult.value, {
+        checkApiSignatures: true,
+        checkExamples: false,
+        checkStructure: false,
+        docPaths: [],
+        ignorePatterns: [],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const apiDrifts = result.value.drifts.filter((d) => d.type === 'api-signature');
+      expect(apiDrifts).toHaveLength(0);
+    });
+
+    it('still surfaces api-signature drift for refs in non-forward-looking docs', async () => {
+      await mkdir(join(projectDir, 'docs', 'reference'), { recursive: true });
+      await writeFile(
+        join(projectDir, 'docs', 'reference', 'api.md'),
+        '# API\n\nSee `IssueReward` for details.\n'
+      );
+
+      const snapshotResult = await buildSnapshot({
+        rootDir: projectDir,
+        parser,
+        analyze: { drift: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+      expect(snapshotResult.ok).toBe(true);
+      if (!snapshotResult.ok) return;
+
+      const result = await detectDocDrift(snapshotResult.value, {
+        checkApiSignatures: true,
+        checkExamples: false,
+        checkStructure: false,
+        docPaths: [],
+        ignorePatterns: [],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const apiDrifts = result.value.drifts.filter((d) => d.type === 'api-signature');
+      expect(apiDrifts.some((d) => d.reference === 'IssueReward')).toBe(true);
+    });
+
+    it('respects a custom forwardLookingPaths override', async () => {
+      await mkdir(join(projectDir, 'docs', 'rfcs'), { recursive: true });
+      await writeFile(
+        join(projectDir, 'docs', 'rfcs', 'rfc-001.md'),
+        '# RFC 001\n\nIntroduces `FuturePlannedSymbol`.\n'
+      );
+
+      const snapshotResult = await buildSnapshot({
+        rootDir: projectDir,
+        parser,
+        analyze: { drift: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+      expect(snapshotResult.ok).toBe(true);
+      if (!snapshotResult.ok) return;
+
+      const result = await detectDocDrift(snapshotResult.value, {
+        checkApiSignatures: true,
+        checkExamples: false,
+        checkStructure: false,
+        docPaths: [],
+        ignorePatterns: [],
+        forwardLookingPaths: ['docs/rfcs/'],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const apiDrifts = result.value.drifts.filter((d) => d.type === 'api-signature');
+      expect(apiDrifts).toHaveLength(0);
+    });
+  });
+
+  describe('anchor-aware link parsing', () => {
+    it('treats file.md#anchor as link to file.md (file existence passes)', async () => {
+      await writeFile(
+        join(projectDir, 'docs', 'index.md'),
+        [
+          '# Index',
+          '',
+          '- [Architecture](architecture/persistence/ADR-0001-with-anchors.md#section-one)',
+        ].join('\n')
+      );
+      await writeFile(
+        join(projectDir, 'docs', 'architecture', 'persistence', 'ADR-0001-with-anchors.md'),
+        ['# ADR-0001', '', '## Section One', '', 'Body.'].join('\n')
+      );
+
+      const snapshotResult = await buildSnapshot({
+        rootDir: projectDir,
+        parser,
+        analyze: { drift: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+      expect(snapshotResult.ok).toBe(true);
+      if (!snapshotResult.ok) return;
+
+      const result = await detectDocDrift(snapshotResult.value, {
+        checkApiSignatures: false,
+        checkExamples: false,
+        checkStructure: true,
+        docPaths: [],
+        ignorePatterns: [],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // No structure drift expected — file exists and anchor exists.
+      const structureDrifts = result.value.drifts.filter((d) => d.type === 'structure');
+      expect(structureDrifts).toHaveLength(0);
+    });
+
+    it('emits anchor drift when file exists but anchor does not match any heading', async () => {
+      // Real-world variant from the reporter: em-dash slug typo.
+      await writeFile(
+        join(projectDir, 'docs', 'index.md'),
+        '[bad](architecture/persistence/ADR-0001-anchor-typo.md#nonexistent-anchor)\n'
+      );
+      await writeFile(
+        join(projectDir, 'docs', 'architecture', 'persistence', 'ADR-0001-anchor-typo.md'),
+        ['# ADR-0001', '', '## Real Section', '', 'Body.'].join('\n')
+      );
+
+      const snapshotResult = await buildSnapshot({
+        rootDir: projectDir,
+        parser,
+        analyze: { drift: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+      expect(snapshotResult.ok).toBe(true);
+      if (!snapshotResult.ok) return;
+
+      const result = await detectDocDrift(snapshotResult.value, {
+        checkApiSignatures: false,
+        checkExamples: false,
+        checkStructure: true,
+        docPaths: [],
+        ignorePatterns: [],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const structureDrifts = result.value.drifts.filter((d) => d.type === 'structure');
+      expect(structureDrifts).toHaveLength(1);
+      expect(structureDrifts[0]?.context).toBe('link-anchor');
+      expect(structureDrifts[0]?.details).toContain('nonexistent-anchor');
+    });
+
+    it('still emits file-not-found drift when the file portion is missing', async () => {
+      await writeFile(
+        join(projectDir, 'docs', 'index.md'),
+        '[missing](architecture/does-not-exist.md#anything)\n'
+      );
+
+      const snapshotResult = await buildSnapshot({
+        rootDir: projectDir,
+        parser,
+        analyze: { drift: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+      expect(snapshotResult.ok).toBe(true);
+      if (!snapshotResult.ok) return;
+
+      const result = await detectDocDrift(snapshotResult.value, {
+        checkApiSignatures: false,
+        checkExamples: false,
+        checkStructure: true,
+        docPaths: [],
+        ignorePatterns: [],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const structureDrifts = result.value.drifts.filter((d) => d.type === 'structure');
+      expect(structureDrifts).toHaveLength(1);
+      expect(structureDrifts[0]?.context).toBe('link');
+      expect(structureDrifts[0]?.details).toContain('does-not-exist.md');
+    });
   });
 });

--- a/packages/core/tests/entropy/snapshot.test.ts
+++ b/packages/core/tests/entropy/snapshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   resolveEntryPoints,
   parseDocumentationFile,
@@ -165,6 +165,77 @@ describe('parseDocumentationFile', () => {
       expect(result.value.inlineRefs.length).toBeGreaterThan(0);
       expect(result.value.inlineRefs.some((r) => r.reference === 'createUser')).toBe(true);
     }
+  });
+
+  // Regression: github issue #492. BCP-47 locale codes and file-name
+  // backticks were being accepted as code references and downstream
+  // surfaced as "symbol not found" drift findings.
+  describe('inline reference filtering', () => {
+    let tmpFile: string;
+    beforeEach(async () => {
+      const os = await import('node:os');
+      const fs = await import('node:fs/promises');
+      tmpFile = join(os.tmpdir(), `inline-ref-filter-${Date.now()}.md`);
+      await fs.writeFile(
+        tmpFile,
+        [
+          '# Roadmap',
+          '',
+          'Expand i18n locales: `vi`, `cs`, `ne`, `en`, `hi`, `pt-BR`, `zh-Hant-CN`.',
+          '',
+          'See `AGENTS.md` and `harness.config.json` for setup.',
+          '',
+          'Also see `package.json`, `tsconfig.json`, `.gitignore`.',
+          '',
+          'Real code symbols: `createUser`, `User.email`, `findUserById()`.',
+          '',
+        ].join('\n')
+      );
+    });
+    afterEach(async () => {
+      const fs = await import('node:fs/promises');
+      try {
+        await fs.unlink(tmpFile);
+      } catch {
+        // best-effort
+      }
+    });
+
+    it('rejects BCP-47 locale codes as inline references', async () => {
+      const result = await parseDocumentationFile(tmpFile);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const refs = result.value.inlineRefs.map((r) => r.reference);
+      for (const locale of ['vi', 'cs', 'ne', 'en', 'hi', 'pt-BR', 'zh-Hant-CN']) {
+        expect(refs).not.toContain(locale);
+      }
+    });
+
+    it('rejects file-name backticks (.md, .json, .gitignore) as inline references', async () => {
+      const result = await parseDocumentationFile(tmpFile);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const refs = result.value.inlineRefs.map((r) => r.reference);
+      for (const fileRef of [
+        'AGENTS.md',
+        'harness.config.json',
+        'package.json',
+        'tsconfig.json',
+        '.gitignore',
+      ]) {
+        expect(refs).not.toContain(fileRef);
+      }
+    });
+
+    it('still accepts genuine code symbols (createUser, User.email)', async () => {
+      const result = await parseDocumentationFile(tmpFile);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const refs = result.value.inlineRefs.map((r) => r.reference);
+      expect(refs).toContain('createUser');
+      expect(refs).toContain('User.email');
+      expect(refs).toContain('findUserById');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #492 — the three concrete improvements requested. On the reporter's project (TS + Next.js, 4 ADRs, locale-code roadmap, anchor-linked docs) the drift detector previously raised 41 findings, 38 of which were false positives.

### Layered fixes

1. **Extraction-layer filter** (`packages/core/src/entropy/snapshot.ts`) — `isLikelySymbolReference()` rejects BCP-47 locale codes (`vi`, `pt-BR`, `zh-Hant-CN`) and file-name backticks (`AGENTS.md`, `harness.config.json`, `.gitignore`) before the identifier regex. Removes categories 1 + 2 (~9 false positives) at the source so they never reach the drift detector or downstream graph consumers.

2. **Forward-looking docs suppression** (`packages/core/src/entropy/detectors/drift.ts` + `types/config.ts` + `config/schema.ts`) — new `DriftConfig.forwardLookingPaths` with default `['docs/architecture/', 'docs/decisions/', 'docs/proposals/', 'docs/adr/']`. `checkApiSignatureDrift` skips refs whose `docFile` contains any prefix. Per the reporter's preference, this is the directory-convention approach (matches `harness-architecture-advisor`'s storage convention). Removes the 22 ADR-symbol false positives. Suppression is **api-signature only** — structure (link) drift still runs in ADRs because broken-link visibility there is still valuable.

3. **Anchor-aware link parsing** — `extractFileLinks` now splits `file.md#anchor` into `{path, anchor}` and passes only `path` to `fileExists()`. When the file exists and ends in `.md`, the anchor is validated against the target file's GFM-slugged H1–H6 headings; mismatch emits a new `link-anchor` drift with `medium` confidence. Removes 8 of 9 anchor false positives AND catches the one real bug the reporter mentioned (em-dash → double-dash slug typo).

### Out of scope (deferred)

- Frontmatter-based opt-out (`harness.drift_check: false`) — directory convention covers the common case the reporter described. Easy follow-up if needed.
- `harness check-docs` undocumented-file acceptance criteria (reporter noted these were unclear) — separate issue.

## Test plan

- [x] `pnpm vitest run` in `packages/core` — 2976 pass (1 pre-existing skip). 9 new regression tests:
  - 3 in `snapshot.test.ts > inline reference filtering`: BCP-47 rejection, file-name rejection, real-symbol regression guard.
  - 6 in `drift.test.ts > issue #492 regressions`: ADR suppression default, non-forward-looking guard, custom `forwardLookingPaths` override, anchor split happy path, anchor mismatch detection, file-not-found regression guard.
- [x] `pnpm vitest run` in `packages/cli` — 3890 pass (downstream of core types).
- [x] `pnpm typecheck` clean in both packages.
- [x] `pnpm lint` clean in both packages.
- [x] `pnpm build` clean in core.
- [ ] Manual: re-run `harness cleanup --type drift` against the reporter's project shape and confirm findings drop from 41 to ≤ 3.

## Acceptance criteria (from issue)

> Re-running `/harness:docs-pipeline` on an equivalent ADR-heavy project produces ≤3 findings (the real ones), not 41.

The three categories named in the issue are all handled — by static reading and unit-test coverage. Real-world end-to-end confirmation is the remaining manual step.

> No false negatives introduced (the real em-dash anchor typo still gets caught).

Bonus anchor validation catches it directly. Regression test `emits anchor drift when file exists but anchor does not match any heading` exercises this path.