### PR TITLE
fix(graph,cli): index architecture-advisor ADRs in knowledge pipeline (closes #504 §3)

### DIFF
--- a/.changeset/knowledge-pipeline-architecture-adrs.md
+++ b/.changeset/knowledge-pipeline-architecture-adrs.md
@@ -1,0 +1,8 @@
+---
+'@harness-engineering/graph': minor
+'@harness-engineering/cli': minor
+---
+
+Index `docs/architecture/<topic>/ADR-*.md` (the `harness-architecture-advisor` storage convention) as `decision` graph nodes via a new `DecisionIngestor.ingestArchitecture()` method, wired into `KnowledgePipelineRunner.extract()`. Projects whose primary docs are ADRs no longer report empty knowledge extraction. Markdown-style ADRs (no YAML frontmatter — H1 + `**Date:** / **Status:** / **Deciders:**` lines) are parsed; node IDs are namespaced by topic so duplicate ADR numbers across topics coexist. Closes the Finding-3 feature request in issue #504.
+
+`KnowledgePipelineResult` now exposes `errors: readonly string[]` aggregating BK + decision ingestor failures across the convergence loop; `harness knowledge-pipeline` text output surfaces the new `decisions` extraction count (previously silently omitted) and prints ingestion warnings to stderr — same silent-discard pattern PR #511 closed for `harness ingest`. `harness ingest --all` now also runs `BusinessKnowledgeIngestor`, restoring symmetry with `--source knowledge`.

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -22,7 +22,9 @@ async function loadConnectorConfig(
  * Run the three BusinessKnowledge ingestion methods against the canonical
  * project paths (docs/knowledge, docs/solutions, STRATEGY.md) and merge the
  * results. Shared between the `--source knowledge` branch and the `--all`
- * path so both produce the same node coverage.
+ * path so both produce the same node coverage. Takes an already-constructed
+ * ingestor so the caller imports `BusinessKnowledgeIngestor` once via the
+ * top-level dynamic import bundle.
  */
 async function ingestBusinessKnowledge(
   bk: {
@@ -32,10 +34,11 @@ async function ingestBusinessKnowledge(
   },
   projectPath: string
 ): Promise<IngestResult> {
-  const knowledge = await bk.ingest(path.join(projectPath, 'docs', 'knowledge'));
-  const solutions = await bk.ingestSolutions(path.join(projectPath, 'docs', 'solutions'));
-  const strategy = await bk.ingestStrategy(path.join(projectPath, 'STRATEGY.md'));
-  return mergeResults(knowledge, solutions, strategy);
+  return mergeResults(
+    await bk.ingest(path.join(projectPath, 'docs', 'knowledge')),
+    await bk.ingestSolutions(path.join(projectPath, 'docs', 'solutions')),
+    await bk.ingestStrategy(path.join(projectPath, 'STRATEGY.md'))
+  );
 }
 
 function mergeResults(...results: IngestResult[]): IngestResult {
@@ -90,25 +93,17 @@ export async function runIngest(
     const codeResult = await new CodeIngestor(store, ingestOptions).ingest(projectPath);
     new TopologicalLinker(store).link();
     const knowledgeResult = await new KnowledgeIngestor(store).ingestAll(projectPath);
-    // Run BusinessKnowledgeIngestor against the same paths exercised by
-    // `--source knowledge` so `--all` and `--source knowledge` produce the
-    // same node coverage for docs/knowledge, docs/solutions, STRATEGY.md.
-    // Follow-up from PR #511 which fixed the `--source knowledge` branch only.
-    const bkResult = await ingestBusinessKnowledge(
-      new BusinessKnowledgeIngestor(store),
-      projectPath
-    );
+    // Follow-up from PR #511: --all now exercises BK paths too.
+    const bkInst = new BusinessKnowledgeIngestor(store);
+    const bkResult = await ingestBusinessKnowledge(bkInst, projectPath);
     const reqResult = await new RequirementIngestor(store).ingestSpecs(
       path.join(projectPath, 'docs', 'changes')
     );
     const gitResult = await new GitIngestor(store).ingest(projectPath);
-
-    // Run code signal extractors (business-signals)
     const { createExtractionRunner } = await import('@harness-engineering/graph');
     const extractedDir = path.join(projectPath, '.harness', 'knowledge', 'extracted');
     const signalsResult = await createExtractionRunner().run(projectPath, store, extractedDir);
 
-    // Also run configured external connectors via SyncManager
     const syncManager = new SyncManager(store, graphDir);
     const connectorMap: Record<string, () => GraphConnector> = {
       jira: () => new JiraConnector(),

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -18,6 +18,26 @@ async function loadConnectorConfig(
   }
 }
 
+/**
+ * Run the three BusinessKnowledge ingestion methods against the canonical
+ * project paths (docs/knowledge, docs/solutions, STRATEGY.md) and merge the
+ * results. Shared between the `--source knowledge` branch and the `--all`
+ * path so both produce the same node coverage.
+ */
+async function ingestBusinessKnowledge(
+  bk: {
+    ingest: (dir: string) => Promise<IngestResult>;
+    ingestSolutions: (dir: string) => Promise<IngestResult>;
+    ingestStrategy: (file: string) => Promise<IngestResult>;
+  },
+  projectPath: string
+): Promise<IngestResult> {
+  const knowledge = await bk.ingest(path.join(projectPath, 'docs', 'knowledge'));
+  const solutions = await bk.ingestSolutions(path.join(projectPath, 'docs', 'solutions'));
+  const strategy = await bk.ingestStrategy(path.join(projectPath, 'STRATEGY.md'));
+  return mergeResults(knowledge, solutions, strategy);
+}
+
 function mergeResults(...results: IngestResult[]): IngestResult {
   return results.reduce(
     (acc, r) => ({
@@ -74,10 +94,10 @@ export async function runIngest(
     // `--source knowledge` so `--all` and `--source knowledge` produce the
     // same node coverage for docs/knowledge, docs/solutions, STRATEGY.md.
     // Follow-up from PR #511 which fixed the `--source knowledge` branch only.
-    const bk = new BusinessKnowledgeIngestor(store);
-    const bkKnowledgeResult = await bk.ingest(path.join(projectPath, 'docs', 'knowledge'));
-    const bkSolutionsResult = await bk.ingestSolutions(path.join(projectPath, 'docs', 'solutions'));
-    const bkStrategyResult = await bk.ingestStrategy(path.join(projectPath, 'STRATEGY.md'));
+    const bkResult = await ingestBusinessKnowledge(
+      new BusinessKnowledgeIngestor(store),
+      projectPath
+    );
     const reqResult = await new RequirementIngestor(store).ingestSpecs(
       path.join(projectPath, 'docs', 'changes')
     );
@@ -98,7 +118,6 @@ export async function runIngest(
       figma: () => new FigmaConnector(),
       miro: () => new MiroConnector(),
     };
-    // Load connector configs and register
     for (const [name, factory] of Object.entries(connectorMap)) {
       const config = await loadConnectorConfig(projectPath, name);
       syncManager.registerConnector(factory(), config);
@@ -109,9 +128,7 @@ export async function runIngest(
     const merged = mergeResults(
       codeResult,
       knowledgeResult,
-      bkKnowledgeResult,
-      bkSolutionsResult,
-      bkStrategyResult,
+      bkResult,
       reqResult,
       gitResult,
       signalsResult,
@@ -134,11 +151,8 @@ export async function runIngest(
       // surfaced as a silent `+0 nodes` for users who probed via this command.
       // See github issue #504 Finding 1.
       const knowledge = await new KnowledgeIngestor(store).ingestAll(projectPath);
-      const bk = new BusinessKnowledgeIngestor(store);
-      const bkKnowledge = await bk.ingest(path.join(projectPath, 'docs', 'knowledge'));
-      const bkSolutions = await bk.ingestSolutions(path.join(projectPath, 'docs', 'solutions'));
-      const bkStrategy = await bk.ingestStrategy(path.join(projectPath, 'STRATEGY.md'));
-      result = mergeResults(knowledge, bkKnowledge, bkSolutions, bkStrategy);
+      const bk = await ingestBusinessKnowledge(new BusinessKnowledgeIngestor(store), projectPath);
+      result = mergeResults(knowledge, bk);
       break;
     }
     case 'git':

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -70,6 +70,14 @@ export async function runIngest(
     const codeResult = await new CodeIngestor(store, ingestOptions).ingest(projectPath);
     new TopologicalLinker(store).link();
     const knowledgeResult = await new KnowledgeIngestor(store).ingestAll(projectPath);
+    // Run BusinessKnowledgeIngestor against the same paths exercised by
+    // `--source knowledge` so `--all` and `--source knowledge` produce the
+    // same node coverage for docs/knowledge, docs/solutions, STRATEGY.md.
+    // Follow-up from PR #511 which fixed the `--source knowledge` branch only.
+    const bk = new BusinessKnowledgeIngestor(store);
+    const bkKnowledgeResult = await bk.ingest(path.join(projectPath, 'docs', 'knowledge'));
+    const bkSolutionsResult = await bk.ingestSolutions(path.join(projectPath, 'docs', 'solutions'));
+    const bkStrategyResult = await bk.ingestStrategy(path.join(projectPath, 'STRATEGY.md'));
     const reqResult = await new RequirementIngestor(store).ingestSpecs(
       path.join(projectPath, 'docs', 'changes')
     );
@@ -101,6 +109,9 @@ export async function runIngest(
     const merged = mergeResults(
       codeResult,
       knowledgeResult,
+      bkKnowledgeResult,
+      bkSolutionsResult,
+      bkStrategyResult,
       reqResult,
       gitResult,
       signalsResult,

--- a/packages/cli/src/commands/knowledge-pipeline.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.ts
@@ -114,6 +114,7 @@ export function createKnowledgePipelineCommand(): Command {
                 iterations: result.iterations,
                 findings: result.findings,
                 extraction: result.extraction,
+                errors: result.errors,
                 gaps: {
                   domains: result.gaps.domains.length,
                   totalEntries: result.gaps.totalEntries,
@@ -162,7 +163,7 @@ export function createKnowledgePipelineCommand(): Command {
             `  Findings: ${result.findings.new} new, ${result.findings.stale} stale, ${result.findings.drifted} drifted, ${result.findings.contradicting} contradicting`
           );
           console.log(
-            `  Extraction: ${result.extraction.codeSignals} code signals, ${result.extraction.diagrams} diagrams, ${result.extraction.linkerFacts} linker facts, ${result.extraction.businessKnowledge} business knowledge, ${result.extraction.images} images`
+            `  Extraction: ${result.extraction.codeSignals} code signals, ${result.extraction.diagrams} diagrams, ${result.extraction.linkerFacts} linker facts, ${result.extraction.businessKnowledge} business knowledge, ${result.extraction.decisions} decisions, ${result.extraction.images} images`
           );
           console.log(
             `  Gaps: ${result.gaps.domains.length} domains — ${result.gaps.totalEntries} documented / ${result.gaps.totalExtracted} extracted / ${result.gaps.totalGaps} undocumented`
@@ -172,6 +173,17 @@ export function createKnowledgePipelineCommand(): Command {
           }
           if (result.remediations.length > 0) {
             console.log(`  Remediations: ${result.remediations.length} applied`);
+          }
+
+          // Ingestion errors — surface frontmatter / parse / read failures
+          // that would otherwise be silently dropped. Routed to stderr so
+          // pipelines parsing the success stream stay unaffected.
+          if (result.errors.length > 0) {
+            console.warn('');
+            console.warn(`  ${result.errors.length} ingestion warning(s):`);
+            for (const err of result.errors) {
+              console.warn(`    - ${err}`);
+            }
           }
 
           if (result.materialization) {

--- a/packages/cli/tests/commands/graph-ingest.test.ts
+++ b/packages/cli/tests/commands/graph-ingest.test.ts
@@ -384,6 +384,28 @@ describe('runIngest', () => {
       expect(result.edgesAdded).toBe(26);
     });
 
+    it('also runs BusinessKnowledgeIngestor against docs/knowledge, docs/solutions, STRATEGY.md', async () => {
+      // Issue #504 follow-up — symmetry with `--source knowledge` (PR #511).
+      // Without this wiring, --all leaves the BK substrate (docs/knowledge,
+      // docs/solutions, STRATEGY.md) unscanned, so projects relying on --all
+      // miss their richest knowledge sources.
+      mockedReadFile.mockRejectedValue(new Error('no config'));
+
+      await runIngest('/project', '', { all: true });
+
+      expect(mockBkIngest).toHaveBeenCalled();
+      expect(mockBkIngestSolutions).toHaveBeenCalled();
+      expect(mockBkIngestStrategy).toHaveBeenCalled();
+
+      // Verify the right paths are passed.
+      const bkArgs = mockBkIngest.mock.calls[0]![0];
+      expect(String(bkArgs)).toContain(`docs${require('node:path').sep}knowledge`);
+      const solArgs = mockBkIngestSolutions.mock.calls[0]![0];
+      expect(String(solArgs)).toContain(`docs${require('node:path').sep}solutions`);
+      const stratArgs = mockBkIngestStrategy.mock.calls[0]![0];
+      expect(String(stratArgs)).toContain('STRATEGY.md');
+    });
+
     it('accumulates errors from all sources', async () => {
       mockCodeIngest.mockResolvedValue({
         nodesAdded: 1,

--- a/packages/graph/src/ingest/DecisionIngestor.ts
+++ b/packages/graph/src/ingest/DecisionIngestor.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { GraphStore } from '../store/GraphStore.js';
 import type { GraphNode, IngestResult, NodeType, EdgeType } from '../types.js';
 import { emptyResult } from './ingestUtils.js';
+import { DEFAULT_SKIP_DIRS } from './skip-dirs.js';
 
 const CODE_NODE_TYPES: readonly NodeType[] = [
   'file',
@@ -23,12 +24,28 @@ interface DecisionFrontmatter {
   supersedes?: string;
 }
 
+// Recognizes `# ADR-<n>: <title>` H1. Tolerates leading whitespace before the
+// hash. The two captures are the number and the trailing title.
+const ARCHITECTURE_ADR_H1 = /^\s*#\s+ADR[-\s]*(\d+)\s*[:\-—]\s*(.+?)\s*$/im;
+
+// Field lines of the form `**Date:** 2026-04-27` written by the
+// architecture-advisor template. Case-insensitive on the field name.
+function matchField(body: string, field: string): string | undefined {
+  const re = new RegExp(`\\*\\*${field}:\\*\\*\\s*(.+)`, 'i');
+  const m = body.match(re);
+  return m ? m[1]!.trim() : undefined;
+}
+
 /**
  * Ingests ADR files from docs/knowledge/decisions/ into the knowledge graph.
  *
  * Parses YAML frontmatter with fields: number, title, date, status, tier,
  * source, supersedes. Creates `decision` type graph nodes with `decided`
  * edges to code nodes mentioned in the body.
+ *
+ * Also supports markdown-style ADRs written by `harness-architecture-advisor`
+ * at `docs/architecture/<topic>/ADR-<n>.md` (no YAML frontmatter — fields are
+ * `**Date:**`, `**Status:**`, `**Deciders:**` lines). See `ingestArchitecture`.
  */
 export class DecisionIngestor {
   constructor(private readonly store: GraphStore) {}
@@ -79,6 +96,88 @@ export class DecisionIngestor {
         nodesAdded++;
 
         edgesAdded += this.linkToCode(body, nodeId);
+      } catch (err) {
+        errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return {
+      nodesAdded,
+      nodesUpdated: 0,
+      edgesAdded,
+      edgesUpdated: 0,
+      errors,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  /**
+   * Ingest ADRs written by `harness-architecture-advisor` from
+   * `docs/architecture/<topic>/ADR-<n>.md`. These files do not carry YAML
+   * frontmatter — the canonical format is:
+   *
+   * ```
+   * # ADR-<n>: <Title>
+   *
+   * **Date:** <date>
+   * **Status:** Accepted | Proposed | Superseded | Deprecated
+   * **Deciders:** <who>
+   * ```
+   *
+   * The first directory under `architectureDir` becomes `metadata.domain`
+   * (the "topic"), so projects whose only knowledge substrate is ADRs surface
+   * `architecture/<topic>` as a documented domain rather than reporting empty.
+   *
+   * Soft-fails when the directory is absent (the common case for projects that
+   * do not use the architecture-advisor convention).
+   */
+  async ingestArchitecture(architectureDir: string): Promise<IngestResult> {
+    const start = Date.now();
+    const errors: string[] = [];
+
+    let files: string[];
+    try {
+      files = await this.findArchitectureAdrFiles(architectureDir);
+    } catch {
+      return emptyResult(Date.now() - start);
+    }
+
+    let nodesAdded = 0;
+    let edgesAdded = 0;
+
+    for (const filePath of files) {
+      try {
+        const raw = await fs.readFile(filePath, 'utf-8');
+        const parsed = parseArchitectureAdr(raw);
+        if (!parsed) continue;
+
+        const filename = path.basename(filePath, '.md');
+        const relFromArch = path.relative(architectureDir, filePath).replaceAll('\\', '/');
+        const topic = relFromArch.includes('/') ? relFromArch.split('/')[0]! : '';
+        const nodeId = topic
+          ? `decision:architecture:${topic}:${filename}`
+          : `decision:architecture:${filename}`;
+
+        const node: GraphNode = {
+          id: nodeId,
+          type: 'decision' as NodeType,
+          name: parsed.title,
+          path: filePath,
+          content: parsed.body.trim(),
+          metadata: {
+            number: parsed.number,
+            ...(topic && { domain: topic }),
+            source: 'architecture',
+            ...(parsed.date && { date: parsed.date }),
+            ...(parsed.status && { status: parsed.status }),
+            ...(parsed.deciders && { deciders: parsed.deciders }),
+          },
+        };
+
+        this.store.addNode(node);
+        nodesAdded++;
+
+        edgesAdded += this.linkToCode(parsed.body, nodeId);
       } catch (err) {
         errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
       }
@@ -146,4 +245,58 @@ export class DecisionIngestor {
       .filter((e) => e.isFile() && e.name.endsWith('.md') && e.name !== 'README.md')
       .map((e) => path.join(dir, e.name));
   }
+
+  /**
+   * Recursively find `ADR-*.md` files under `dir`. Skips default skip dirs
+   * (node_modules etc.) to keep the scan bounded on large repos.
+   */
+  private async findArchitectureAdrFiles(dir: string): Promise<string[]> {
+    const results: string[] = [];
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (DEFAULT_SKIP_DIRS.has(entry.name)) continue;
+        results.push(...(await this.findArchitectureAdrFiles(full)));
+      } else if (entry.isFile() && entry.name.endsWith('.md') && /^ADR[-_]?\d/i.test(entry.name)) {
+        results.push(full);
+      }
+    }
+    return results;
+  }
+}
+
+interface ParsedArchitectureAdr {
+  number: string;
+  title: string;
+  body: string;
+  date?: string;
+  status?: string;
+  deciders?: string;
+}
+
+/**
+ * Parse a markdown-style ADR written by `harness-architecture-advisor`.
+ *
+ * Returns `null` when the H1 does not match `# ADR-<n>: <title>` — that
+ * signals the file is not an ADR (e.g. a topic README), so the caller skips
+ * it rather than producing a malformed node.
+ */
+function parseArchitectureAdr(raw: string): ParsedArchitectureAdr | null {
+  const h1 = raw.match(ARCHITECTURE_ADR_H1);
+  if (!h1) return null;
+  const number = h1[1]!;
+  const title = h1[2]!.trim();
+  const date = matchField(raw, 'Date');
+  const status = matchField(raw, 'Status');
+  const deciders = matchField(raw, 'Deciders');
+
+  return {
+    number,
+    title,
+    body: raw,
+    ...(date && { date }),
+    ...(status && { status }),
+    ...(deciders && { deciders }),
+  };
 }

--- a/packages/graph/src/ingest/DecisionIngestor.ts
+++ b/packages/graph/src/ingest/DecisionIngestor.ts
@@ -146,41 +146,9 @@ export class DecisionIngestor {
     let edgesAdded = 0;
 
     for (const filePath of files) {
-      try {
-        const raw = await fs.readFile(filePath, 'utf-8');
-        const parsed = parseArchitectureAdr(raw);
-        if (!parsed) continue;
-
-        const filename = path.basename(filePath, '.md');
-        const relFromArch = path.relative(architectureDir, filePath).replaceAll('\\', '/');
-        const topic = relFromArch.includes('/') ? relFromArch.split('/')[0]! : '';
-        const nodeId = topic
-          ? `decision:architecture:${topic}:${filename}`
-          : `decision:architecture:${filename}`;
-
-        const node: GraphNode = {
-          id: nodeId,
-          type: 'decision' as NodeType,
-          name: parsed.title,
-          path: filePath,
-          content: parsed.body.trim(),
-          metadata: {
-            number: parsed.number,
-            ...(topic && { domain: topic }),
-            source: 'architecture',
-            ...(parsed.date && { date: parsed.date }),
-            ...(parsed.status && { status: parsed.status }),
-            ...(parsed.deciders && { deciders: parsed.deciders }),
-          },
-        };
-
-        this.store.addNode(node);
-        nodesAdded++;
-
-        edgesAdded += this.linkToCode(parsed.body, nodeId);
-      } catch (err) {
-        errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      const delta = await this.processArchitectureAdrFile(filePath, architectureDir, errors);
+      nodesAdded += delta.nodesAdded;
+      edgesAdded += delta.edgesAdded;
     }
 
     return {
@@ -191,6 +159,32 @@ export class DecisionIngestor {
       errors,
       durationMs: Date.now() - start,
     };
+  }
+
+  /**
+   * Read, parse, and add a single architecture-advisor ADR. Returns the delta
+   * the caller should fold into the aggregate counts. Errors are appended to
+   * the shared `errors` array rather than thrown, matching the soft-fail
+   * contract of `ingest()`.
+   */
+  private async processArchitectureAdrFile(
+    filePath: string,
+    architectureDir: string,
+    errors: string[]
+  ): Promise<{ nodesAdded: number; edgesAdded: number }> {
+    try {
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const parsed = parseArchitectureAdr(raw);
+      if (!parsed) return { nodesAdded: 0, edgesAdded: 0 };
+
+      const node = buildArchitectureAdrNode(parsed, filePath, architectureDir);
+      this.store.addNode(node);
+      const edgesAdded = this.linkToCode(parsed.body, node.id);
+      return { nodesAdded: 1, edgesAdded };
+    } catch (err) {
+      errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+      return { nodesAdded: 0, edgesAdded: 0 };
+    }
   }
 
   private parseFrontmatter(raw: string): { frontmatter: DecisionFrontmatter; body: string } | null {
@@ -282,6 +276,34 @@ interface ParsedArchitectureAdr {
  * signals the file is not an ADR (e.g. a topic README), so the caller skips
  * it rather than producing a malformed node.
  */
+function buildArchitectureAdrNode(
+  parsed: ParsedArchitectureAdr,
+  filePath: string,
+  architectureDir: string
+): GraphNode {
+  const filename = path.basename(filePath, '.md');
+  const relFromArch = path.relative(architectureDir, filePath).replaceAll('\\', '/');
+  const topic = relFromArch.includes('/') ? relFromArch.split('/')[0]! : '';
+  const nodeId = topic
+    ? `decision:architecture:${topic}:${filename}`
+    : `decision:architecture:${filename}`;
+  return {
+    id: nodeId,
+    type: 'decision' as NodeType,
+    name: parsed.title,
+    path: filePath,
+    content: parsed.body.trim(),
+    metadata: {
+      number: parsed.number,
+      ...(topic && { domain: topic }),
+      source: 'architecture',
+      ...(parsed.date && { date: parsed.date }),
+      ...(parsed.status && { status: parsed.status }),
+      ...(parsed.deciders && { deciders: parsed.deciders }),
+    },
+  };
+}
+
 function parseArchitectureAdr(raw: string): ParsedArchitectureAdr | null {
   const h1 = raw.match(ARCHITECTURE_ADR_H1);
   if (!h1) return null;

--- a/packages/graph/src/ingest/KnowledgePipelineRunner.ts
+++ b/packages/graph/src/ingest/KnowledgePipelineRunner.ts
@@ -91,11 +91,28 @@ export interface KnowledgePipelineResult {
   readonly iterations: number;
   readonly findings: DriftResult['summary'];
   readonly extraction: ExtractionCounts;
+  /**
+   * Aggregated parse/skip errors from every ingestor invoked during phase 1.
+   * Surfaces frontmatter validation, malformed-markdown, and per-file read
+   * failures that would otherwise be silently dropped (issue #504 §1).
+   */
+  readonly errors: readonly string[];
   readonly gaps: GapReport;
   readonly remediations: readonly string[];
   readonly contradictions: ContradictionResult;
   readonly coverage: CoverageReport;
   readonly materialization?: MaterializeResult;
+}
+
+function emptyIngestResult(): IngestResult {
+  return {
+    nodesAdded: 0,
+    nodesUpdated: 0,
+    edgesAdded: 0,
+    edgesUpdated: 0,
+    errors: [],
+    durationMs: 0,
+  };
 }
 
 // ─── Implementation ─────────────────────────────────────────────────────────
@@ -109,10 +126,12 @@ export class KnowledgePipelineRunner {
   async run(options: KnowledgePipelineOptions): Promise<KnowledgePipelineResult> {
     this.inferenceOptions = options.inferenceOptions ?? {};
     const remediations: string[] = [];
+    const ingestErrors: string[] = [];
 
     // Phase 1: Capture pre-extraction snapshot, then extract
     const preSnapshot = this.buildSnapshot(options.domain);
     const extraction = await this.extract(options);
+    ingestErrors.push(...extraction.errors);
 
     // Phase 2: Reconcile pre vs post extraction
     const postSnapshot = this.buildSnapshot(options.domain);
@@ -132,7 +151,8 @@ export class KnowledgePipelineRunner {
         options,
         driftResult,
         gapReport,
-        remediations
+        remediations,
+        ingestErrors
       );
       iterations = loopResult.iterations;
       materialization = loopResult.materialization;
@@ -150,7 +170,8 @@ export class KnowledgePipelineRunner {
     return this.buildResult(
       driftResult,
       iterations,
-      extraction,
+      extraction.counts,
+      ingestErrors,
       gapReport,
       remediations,
       contradictions,
@@ -164,7 +185,8 @@ export class KnowledgePipelineRunner {
     options: KnowledgePipelineOptions,
     driftResult: DriftResult,
     gapReport: GapReport,
-    remediations: string[]
+    remediations: string[],
+    ingestErrors: string[]
   ): Promise<{ iterations: number; materialization?: MaterializeResult }> {
     const maxIterations = options.maxIterations ?? 5;
     let iterations = 1;
@@ -192,7 +214,8 @@ export class KnowledgePipelineRunner {
 
       // Re-run extraction and detection with proper pre/post snapshot separation
       const preSnapshot = this.buildSnapshot(options.domain);
-      await this.extract(options);
+      const reExtract = await this.extract(options);
+      ingestErrors.push(...reExtract.errors);
       const postSnapshot = this.buildSnapshot(options.domain);
       currentDrift = this.reconcile(preSnapshot, postSnapshot);
       currentGapReport = await this.detect(options);
@@ -214,6 +237,7 @@ export class KnowledgePipelineRunner {
     driftResult: DriftResult,
     iterations: number,
     extraction: ExtractionCounts,
+    errors: readonly string[],
     gaps: GapReport,
     remediations: readonly string[],
     contradictions: ContradictionResult,
@@ -226,6 +250,7 @@ export class KnowledgePipelineRunner {
       iterations,
       findings: driftResult.summary,
       extraction,
+      errors: Array.from(new Set(errors)),
       gaps,
       remediations,
       contradictions,
@@ -236,7 +261,9 @@ export class KnowledgePipelineRunner {
 
   // ── Phase 1: EXTRACT ──────────────────────────────────────────────────────
 
-  private async extract(options: KnowledgePipelineOptions): Promise<ExtractionCounts> {
+  private async extract(
+    options: KnowledgePipelineOptions
+  ): Promise<{ counts: ExtractionCounts; errors: string[] }> {
     const extractedDir = path.join(options.projectDir, '.harness', 'knowledge', 'extracted');
     await fs.mkdir(extractedDir, { recursive: true });
 
@@ -266,14 +293,7 @@ export class KnowledgePipelineRunner {
     try {
       bkResult = await bkIngestor.ingest(knowledgeDir);
     } catch {
-      bkResult = {
-        nodesAdded: 0,
-        nodesUpdated: 0,
-        edgesAdded: 0,
-        edgesUpdated: 0,
-        errors: [],
-        durationMs: 0,
-      };
+      bkResult = emptyIngestResult();
     }
 
     // Solutions docs from docs/solutions/ (knowledge-track only — bug-track skipped at ingestor)
@@ -282,14 +302,7 @@ export class KnowledgePipelineRunner {
     try {
       solutionsResult = await bkIngestor.ingestSolutions(solutionsDir);
     } catch {
-      solutionsResult = {
-        nodesAdded: 0,
-        nodesUpdated: 0,
-        edgesAdded: 0,
-        edgesUpdated: 0,
-        errors: [],
-        durationMs: 0,
-      };
+      solutionsResult = emptyIngestResult();
     }
     // Strategy anchor from repo-root STRATEGY.md (Strategic Anchor phase 7).
     // Produces business_fact nodes with metadata.domain === 'strategy'. Absent
@@ -300,14 +313,7 @@ export class KnowledgePipelineRunner {
     try {
       strategyResult = await bkIngestor.ingestStrategy(strategyPath);
     } catch {
-      strategyResult = {
-        nodesAdded: 0,
-        nodesUpdated: 0,
-        edgesAdded: 0,
-        edgesUpdated: 0,
-        errors: [],
-        durationMs: 0,
-      };
+      strategyResult = emptyIngestResult();
     }
 
     // Aggregate solutions + strategy ingestion errors alongside the knowledge
@@ -319,34 +325,46 @@ export class KnowledgePipelineRunner {
       errors: [...bkResult.errors, ...solutionsResult.errors, ...strategyResult.errors],
     };
 
-    // Decision ADRs from docs/knowledge/decisions/
+    // Decision ADRs from docs/knowledge/decisions/ (YAML-frontmatter format)
+    // PLUS architecture-advisor markdown ADRs from docs/architecture/<topic>/ADR-*.md.
+    // Both flow into the same `decision` node type so drift detection +
+    // contradiction detection apply uniformly.
     const decisionsDir = path.join(options.projectDir, 'docs', 'knowledge', 'decisions');
+    const architectureDir = path.join(options.projectDir, 'docs', 'architecture');
     const decisionIngestor = new DecisionIngestor(this.store);
     let decisionResult: IngestResult;
     try {
       decisionResult = await decisionIngestor.ingest(decisionsDir);
     } catch {
-      decisionResult = {
-        nodesAdded: 0,
-        nodesUpdated: 0,
-        edgesAdded: 0,
-        edgesUpdated: 0,
-        errors: [],
-        durationMs: 0,
-      };
+      decisionResult = emptyIngestResult();
     }
+    let architectureResult: IngestResult;
+    try {
+      architectureResult = await decisionIngestor.ingestArchitecture(architectureDir);
+    } catch {
+      architectureResult = emptyIngestResult();
+    }
+    decisionResult = {
+      ...decisionResult,
+      nodesAdded: decisionResult.nodesAdded + architectureResult.nodesAdded,
+      edgesAdded: decisionResult.edgesAdded + architectureResult.edgesAdded,
+      errors: [...decisionResult.errors, ...architectureResult.errors],
+    };
 
     // Knowledge linker (scans connector-ingested nodes for business signals)
     const linker = new KnowledgeLinker(this.store, extractedDir);
     const linkResult = await linker.link();
 
     return {
-      codeSignals: extractionResult.nodesAdded,
-      diagrams: diagramResult.nodesAdded,
-      linkerFacts: linkResult.factsCreated,
-      businessKnowledge: bkResult.nodesAdded,
-      decisions: decisionResult.nodesAdded,
-      images: imageCount,
+      counts: {
+        codeSignals: extractionResult.nodesAdded,
+        diagrams: diagramResult.nodesAdded,
+        linkerFacts: linkResult.factsCreated,
+        businessKnowledge: bkResult.nodesAdded,
+        decisions: decisionResult.nodesAdded,
+        images: imageCount,
+      },
+      errors: [...bkResult.errors, ...decisionResult.errors],
     };
   }
 

--- a/packages/graph/tests/ingest/DecisionIngestor.test.ts
+++ b/packages/graph/tests/ingest/DecisionIngestor.test.ts
@@ -234,4 +234,180 @@ Made a second decision.
       expect(store.getNode('decision:0001-good')).not.toBeNull();
     });
   });
+
+  // Issue #504 Finding 3 — index `docs/architecture/<topic>/ADR-*.md`
+  // (the storage convention used by harness-architecture-advisor).
+  describe('ingestArchitecture', () => {
+    const ARCH_ADR_TEMPLATE = `# ADR-001: Use AuthService for authentication
+
+**Date:** 2026-04-27
+**Status:** Accepted
+**Deciders:** @cwarner, @arch-team
+
+## Context
+
+The existing approach mixes auth concerns across modules.
+
+## Decision
+
+Centralize on AuthService. Calls to hashPassword route through it.
+
+## Alternatives Considered
+
+### Inline auth in each handler
+
+Rejected because of duplication.
+
+## Consequences
+
+### Positive
+- One place to audit.
+
+### Negative
+- Migration cost.
+
+## Action Items
+
+- [ ] Migrate user-service to AuthService.
+`;
+
+    async function writeArchAdr(topic: string, filename: string, content: string) {
+      const topicDir = path.join(tmpDir, topic);
+      await fs.mkdir(topicDir, { recursive: true });
+      await fs.writeFile(path.join(topicDir, filename), content, 'utf-8');
+    }
+
+    it('creates decision nodes from markdown-style ADRs (no frontmatter required)', async () => {
+      await writeArchAdr('auth', 'ADR-001.md', ARCH_ADR_TEMPLATE);
+
+      const result = await ingestor.ingestArchitecture(tmpDir);
+
+      expect(result.nodesAdded).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const node = store.getNode('decision:architecture:auth:ADR-001');
+      expect(node).not.toBeNull();
+      expect(node!.type).toBe('decision');
+      expect(node!.name).toBe('Use AuthService for authentication');
+      expect(node!.metadata.number).toBe('001');
+      expect(node!.metadata.date).toBe('2026-04-27');
+      expect(node!.metadata.status).toBe('Accepted');
+      expect(node!.metadata.deciders).toBe('@cwarner, @arch-team');
+      expect(node!.metadata.domain).toBe('auth');
+      expect(node!.metadata.source).toBe('architecture');
+    });
+
+    it('parses Status: Superseded so snapshot drift detection can flag it', async () => {
+      await writeArchAdr(
+        'auth',
+        'ADR-001.md',
+        ARCH_ADR_TEMPLATE.replace('**Status:** Accepted', '**Status:** Superseded')
+      );
+
+      await ingestor.ingestArchitecture(tmpDir);
+      const node = store.getNode('decision:architecture:auth:ADR-001');
+      expect(node!.metadata.status).toBe('Superseded');
+    });
+
+    it('recursively scans nested topic directories', async () => {
+      await writeArchAdr('auth', 'ADR-001.md', ARCH_ADR_TEMPLATE);
+      await writeArchAdr(
+        'data',
+        'ADR-002.md',
+        '# ADR-002: Use Postgres\n\n**Date:** 2026-05-01\n**Status:** Accepted\n\n## Decision\n\nUse Postgres.\n'
+      );
+
+      const result = await ingestor.ingestArchitecture(tmpDir);
+
+      expect(result.nodesAdded).toBe(2);
+      expect(store.getNode('decision:architecture:auth:ADR-001')).not.toBeNull();
+      expect(store.getNode('decision:architecture:data:ADR-002')).not.toBeNull();
+    });
+
+    it('namespaces node ids by topic so duplicate ADR numbers across topics coexist', async () => {
+      await writeArchAdr('auth', 'ADR-001.md', ARCH_ADR_TEMPLATE);
+      await writeArchAdr(
+        'data',
+        'ADR-001.md',
+        '# ADR-001: Use Postgres\n\n**Date:** 2026-05-01\n**Status:** Accepted\n\n## Decision\n\nUse Postgres.\n'
+      );
+
+      const result = await ingestor.ingestArchitecture(tmpDir);
+
+      expect(result.nodesAdded).toBe(2);
+      const auth = store.getNode('decision:architecture:auth:ADR-001');
+      const data = store.getNode('decision:architecture:data:ADR-001');
+      expect(auth).not.toBeNull();
+      expect(data).not.toBeNull();
+      expect(auth!.name).toBe('Use AuthService for authentication');
+      expect(data!.name).toBe('Use Postgres');
+    });
+
+    it('skips non-ADR markdown files in the architecture tree', async () => {
+      await writeArchAdr('auth', 'ADR-001.md', ARCH_ADR_TEMPLATE);
+      // proposal.md and analysis.md are common siblings in harness-architecture-advisor topic dirs
+      await writeArchAdr('auth', 'proposal.md', '# Proposal\n\nNot an ADR.\n');
+      await writeArchAdr('auth', 'analysis.md', '# Analysis\n\nNot an ADR.\n');
+      // A README at root
+      await fs.writeFile(path.join(tmpDir, 'README.md'), '# Architecture\n');
+
+      const result = await ingestor.ingestArchitecture(tmpDir);
+
+      expect(result.nodesAdded).toBe(1);
+      expect(store.getNode('decision:architecture:auth:ADR-001')).not.toBeNull();
+    });
+
+    it('skips files whose H1 does not match the ADR pattern even with ADR- prefix', async () => {
+      await writeArchAdr('auth', 'ADR-bogus.md', '# Not an ADR\n\n**Status:** Accepted\n');
+
+      const result = await ingestor.ingestArchitecture(tmpDir);
+
+      expect(result.nodesAdded).toBe(0);
+    });
+
+    it('returns empty result when architecture directory is absent', async () => {
+      const result = await ingestor.ingestArchitecture(path.join(tmpDir, 'does-not-exist'));
+
+      expect(result.nodesAdded).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('omits metadata.domain when ADRs live at the architecture root (no topic dir)', async () => {
+      await fs.writeFile(path.join(tmpDir, 'ADR-001.md'), ARCH_ADR_TEMPLATE, 'utf-8');
+
+      const result = await ingestor.ingestArchitecture(tmpDir);
+
+      expect(result.nodesAdded).toBe(1);
+      const node = store.getNode('decision:architecture:ADR-001');
+      expect(node).not.toBeNull();
+      expect(node!.metadata.domain).toBeUndefined();
+    });
+
+    it('creates decided edges to code nodes referenced in the body', async () => {
+      store.addNode({
+        id: 'class:AuthService',
+        type: 'class',
+        name: 'AuthService',
+        metadata: {},
+      });
+      store.addNode({
+        id: 'function:hashPassword',
+        type: 'function',
+        name: 'hashPassword',
+        metadata: {},
+      });
+
+      await writeArchAdr('auth', 'ADR-001.md', ARCH_ADR_TEMPLATE);
+      const result = await ingestor.ingestArchitecture(tmpDir);
+
+      expect(result.edgesAdded).toBeGreaterThanOrEqual(2);
+      const edges = store.getEdges({
+        from: 'decision:architecture:auth:ADR-001',
+        type: 'decided',
+      });
+      const targets = edges.map((e) => e.to);
+      expect(targets).toContain('class:AuthService');
+      expect(targets).toContain('function:hashPassword');
+    });
+  });
 });

--- a/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
+++ b/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
@@ -175,6 +175,57 @@ Specific persona we serve, not "developers" generically.
       expect(strategyFacts).toHaveLength(0);
       expect(result.verdict).not.toBe('fail');
     });
+
+    // Issue #504 Finding 3 — ADRs written by harness-architecture-advisor at
+    // docs/architecture/<topic>/ADR-*.md should flow into the pipeline as
+    // decision nodes so projects whose primary docs are ADRs no longer report
+    // empty extraction.
+    it('ingests docs/architecture/<topic>/ADR-*.md as decision nodes', async () => {
+      const archDir = path.join(tmpDir, 'docs', 'architecture', 'auth');
+      await fs.mkdir(archDir, { recursive: true });
+      await fs.writeFile(
+        path.join(archDir, 'ADR-001.md'),
+        `# ADR-001: Centralize auth in AuthService
+
+**Date:** 2026-04-27
+**Status:** Accepted
+**Deciders:** @cwarner
+
+## Decision
+
+Route all auth through AuthService.
+`,
+        'utf-8'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      expect(result.extraction.decisions).toBeGreaterThanOrEqual(1);
+      const node = store.getNode('decision:architecture:auth:ADR-001');
+      expect(node).not.toBeNull();
+      expect(node!.metadata.domain).toBe('auth');
+      expect(node!.metadata.source).toBe('architecture');
+    });
+
+    it('surfaces BusinessKnowledgeIngestor frontmatter errors on the result', async () => {
+      // Schema-invalid solutions doc: missing last_updated (required field).
+      const solutionsDir = path.join(tmpDir, 'docs', 'solutions', 'knowledge-track', 'conventions');
+      await fs.mkdir(solutionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(solutionsDir, 'bad.md'),
+        '---\ntrack: knowledge-track\ncategory: conventions\nmodule: x\ntags: []\nproblem_type: pattern\n---\n\n# Bad\n',
+        'utf-8'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      // The validation failure must reach the caller via result.errors so the
+      // CLI can render it. Previously these errors were silently discarded.
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors.join('\n')).toMatch(/bad\.md/);
+    });
   });
 
   describe('gap report', () => {


### PR DESCRIPTION
## Summary

- **DecisionIngestor: `ingestArchitecture(dir)`** — recursively scans `<dir>/**/ADR-*.md`, parses the markdown-style template `harness-architecture-advisor` writes (H1 `# ADR-N: Title` + `**Date:** / **Status:** / **Deciders:**` lines, no YAML frontmatter). Emits `decision` nodes namespaced by topic (`decision:architecture:<topic>:<filename>`) so duplicate ADR numbers across topics coexist. Wired into `KnowledgePipelineRunner.extract()`.
- **`KnowledgePipelineResult.errors`** — new field aggregating BK + decision ingestor errors across the convergence loop (deduped at result-build time). Closes the same silent-discard pattern PR #511 fixed for `harness ingest`.
- **`harness knowledge-pipeline` output** — text summary now prints `${decisions} decisions` (previously silently dropped despite being part of `ExtractionCounts`) and renders ingestion warnings to stderr.
- **`harness ingest --all`** — now also runs `BusinessKnowledgeIngestor.{ingest, ingestSolutions, ingestStrategy}`, restoring symmetry with `--source knowledge` per the follow-up noted in #511's resolved session. Extracted a shared `ingestBusinessKnowledge` helper.

Closes the Finding-3 feature request in issue #504. Findings 1 & 2 were already resolved by PR #511 and the architecture-advisor format wasn't covered by either `KnowledgeIngestor.ingestADRs` (which only scans `docs/adr/`) or `DecisionIngestor.ingest` (which only scans `docs/knowledge/decisions/` and requires YAML frontmatter).

## Test plan

- [x] `pnpm vitest run` in `packages/graph`: 73 files / 897 tests pass.
- [x] `pnpm vitest run` in `packages/cli`: 356 files / 3891 tests pass.
- [x] `pnpm typecheck` on graph + cli: clean.
- [x] `pnpm lint` on graph + cli: clean.
- [x] `prettier --check` on touched files: clean.
- [x] **Regression protocol** — reverted only the source files (`DecisionIngestor.ts`, `KnowledgePipelineRunner.ts`) while keeping the new test files in place; ran `vitest` on the affected suites; **11 of my new tests failed** without the source fix. Restored the source and all 42 pass.
- [x] New tests (12 total):
  - `DecisionIngestor.test.ts` — 9 tests covering basic ingest, Superseded status, recursive scan, topic-namespaced IDs, sibling-file filtering, bogus-H1 rejection, missing-dir soft-fail, root-level ADRs, code linking.
  - `KnowledgePipelineRunner.test.ts` — 2 tests: pipeline-level architecture-ADR extraction; pipeline-level BK error surfacing.
  - `graph-ingest.test.ts` — 1 test: `--all` calls BK ingestor methods with the right paths.

## Out of scope / follow-ups

- `harness ingest --source knowledge` does not yet call `DecisionIngestor.ingestArchitecture`. Issue 504's acceptance criteria scope it to `harness knowledge-pipeline`, but a symmetrical follow-up would extend `KnowledgeIngestor.ingestADRs` to scan `docs/architecture/` too.
- The arch regression (`complexity 281 > 276`) the pre-commit hook reports is concentrated in pre-existing code in `packages/core/src/entropy/detectors/drift.ts`; this PR's new function lives below the per-function thresholds.