### PR TITLE
chore(orchestrator): migrate to @google/genai 2.x SDK

### DIFF
--- a/.changeset/migrate-google-genai-sdk.md
+++ b/.changeset/migrate-google-genai-sdk.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Migrate Gemini backend from the deprecated `@google/generative-ai@0.24.1` to `@google/genai@^2.0.4`. Upstream stopped publishing the old package. Public API of `GeminiBackend` is unchanged. Wraps the new `chunk.text` getter in a per-chunk try (the new SDK throws on non-text chunks like function calls), preserves accumulated token counters in the error path, and adds an empty-key guard to `healthCheck` to match `startSession`.

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.1",
     "@earendil-works/pi-coding-agent": "^0.74.1",
-    "@google/generative-ai": "^0.24.0",
+    "@google/genai": "^2.0.4",
     "@harness-engineering/core": "workspace:*",
     "@harness-engineering/graph": "workspace:*",
     "@harness-engineering/intelligence": "workspace:*",

--- a/packages/orchestrator/src/agent/backends/gemini.ts
+++ b/packages/orchestrator/src/agent/backends/gemini.ts
@@ -1,4 +1,4 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GoogleGenAI } from '@google/genai';
 import {
   AgentBackend,
   SessionStartParams,
@@ -68,18 +68,27 @@ export class GeminiBackend implements AgentBackend {
     let cacheReadTokens = 0;
 
     try {
-      const genAI = new GoogleGenerativeAI(this.config.apiKey);
-      const model = genAI.getGenerativeModel({
+      const genAI = new GoogleGenAI({ apiKey: this.config.apiKey });
+      const response = await genAI.models.generateContentStream({
         model: this.config.model,
+        contents: params.prompt,
         ...(geminiSession.systemPrompt !== undefined && {
-          systemInstruction: geminiSession.systemPrompt,
+          config: { systemInstruction: geminiSession.systemPrompt },
         }),
       });
 
-      const result = await model.generateContentStream(params.prompt);
-
-      for await (const chunk of result.stream) {
-        const text = chunk.text();
+      for await (const chunk of response) {
+        // The @google/genai chunk.text getter synthesizes text from
+        // candidates[].content.parts[] and throws when a chunk carries only
+        // non-text parts (function calls, executable code, thought summaries).
+        // Swallow the throw so a single non-text chunk does not abort the
+        // stream and drop accumulated usage counters.
+        let text: string | undefined;
+        try {
+          text = chunk.text;
+        } catch {
+          text = undefined;
+        }
         if (text) {
           const event: AgentEvent = {
             type: 'text',
@@ -110,7 +119,13 @@ export class GeminiBackend implements AgentBackend {
       return {
         success: false,
         sessionId: session.sessionId,
-        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        usage: {
+          inputTokens,
+          outputTokens,
+          totalTokens,
+          cacheCreationTokens,
+          cacheReadTokens,
+        },
         error: errorMessage,
       };
     }
@@ -145,10 +160,14 @@ export class GeminiBackend implements AgentBackend {
   }
 
   async healthCheck(): Promise<Result<void, AgentError>> {
+    if (!this.config.apiKey) {
+      return Err({
+        category: 'agent_not_found',
+        message: 'GEMINI_API_KEY is not set',
+      });
+    }
     try {
-      const genAI = new GoogleGenerativeAI(this.config.apiKey);
-      // Construct the model as a lightweight connectivity check (SDK has no dedicated ping)
-      genAI.getGenerativeModel({ model: this.config.model });
+      new GoogleGenAI({ apiKey: this.config.apiKey });
       return Ok(undefined);
     } catch (err) {
       return Err({

--- a/packages/orchestrator/tests/agent/backends/gemini.test.ts
+++ b/packages/orchestrator/tests/agent/backends/gemini.test.ts
@@ -1,48 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GeminiBackend } from '../../../src/agent/backends/gemini';
 
-// Mock @google/generative-ai before importing the backend
-vi.mock('@google/generative-ai', () => {
+// Mock @google/genai before importing the backend
+vi.mock('@google/genai', () => {
   function createMockStream() {
-    return {
-      stream: (async function* () {
-        yield {
-          text: () => 'Hello ',
-          usageMetadata: undefined,
-        };
-        yield {
-          text: () => 'world',
-          usageMetadata: {
-            promptTokenCount: 50,
-            candidatesTokenCount: 10,
-            totalTokenCount: 60,
-            cachedContentTokenCount: 15,
-          },
-        };
-      })(),
-    };
+    return (async function* () {
+      yield {
+        text: 'Hello ',
+        usageMetadata: undefined,
+      };
+      yield {
+        text: 'world',
+        usageMetadata: {
+          promptTokenCount: 50,
+          candidatesTokenCount: 10,
+          totalTokenCount: 60,
+          cachedContentTokenCount: 15,
+        },
+      };
+    })();
   }
 
   const mockGenerateContentStream = vi
     .fn()
     .mockImplementation(() => Promise.resolve(createMockStream()));
 
-  const MockGenerativeModel = vi.fn().mockImplementation(function () {
+  const MockGoogleGenAI = vi.fn().mockImplementation(function () {
     return {
-      generateContentStream: mockGenerateContentStream,
-    };
-  });
-
-  const MockGoogleGenerativeAI = vi.fn().mockImplementation(function () {
-    return {
-      getGenerativeModel: MockGenerativeModel,
+      models: { generateContentStream: mockGenerateContentStream },
     };
   });
 
   return {
-    GoogleGenerativeAI: MockGoogleGenerativeAI,
+    GoogleGenAI: MockGoogleGenAI,
     __mockGenerateContentStream: mockGenerateContentStream,
-    __MockGenerativeModel: MockGenerativeModel,
   };
 });
 
@@ -110,24 +101,32 @@ describe('GeminiBackend', () => {
   });
 
   describe('healthCheck', () => {
-    it('returns Ok when model construction succeeds', async () => {
+    it('returns Ok when SDK construction succeeds', async () => {
       const result = await backend.healthCheck();
       expect(result.ok).toBe(true);
     });
 
     it('returns Err when SDK throws during healthCheck', async () => {
-      const geminiModule = await import('@google/generative-ai');
-      // Force the GoogleGenerativeAI constructor to throw on next call
-      (geminiModule.GoogleGenerativeAI as ReturnType<typeof vi.fn>).mockImplementationOnce(
-        function () {
-          throw new Error('Invalid API key');
-        }
-      );
+      const geminiModule = await import('@google/genai');
+      // Force the GoogleGenAI constructor to throw on next call
+      (geminiModule.GoogleGenAI as ReturnType<typeof vi.fn>).mockImplementationOnce(function () {
+        throw new Error('Invalid API key');
+      });
       const failBackend = new GeminiBackend({ apiKey: 'bad-key' });
       const result = await failBackend.healthCheck();
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.message).toContain('Invalid API key');
+      }
+    });
+
+    it('returns Err when apiKey is empty (parity with startSession)', async () => {
+      const emptyKeyBackend = new GeminiBackend({ apiKey: '' });
+      const result = await emptyKeyBackend.healthCheck();
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.category).toBe('agent_not_found');
+        expect(result.error.message).toMatch(/GEMINI_API_KEY/);
       }
     });
   });
@@ -168,11 +167,11 @@ describe('GeminiBackend', () => {
       expect(result!.usage.totalTokens).toBe(60);
     });
 
-    it('passes systemInstruction to generateContentStream when systemPrompt is set', async () => {
-      const geminiModule = await import('@google/generative-ai');
-      const MockGenerativeModel = (
+    it('passes systemInstruction via config when systemPrompt is set', async () => {
+      const geminiModule = await import('@google/genai');
+      const mockGenerateContentStream = (
         geminiModule as unknown as Record<string, ReturnType<typeof vi.fn>>
-      )['__MockGenerativeModel'];
+      )['__mockGenerateContentStream'];
 
       const sessionResult = await backend.startSession({
         workspacePath: '/tmp/workspace',
@@ -194,9 +193,10 @@ describe('GeminiBackend', () => {
         next = await gen.next();
       }
 
-      // getGenerativeModel should have been called with systemInstruction
-      const modelCallArg = MockGenerativeModel.mock.calls.at(-1)?.[0];
-      expect(modelCallArg?.systemInstruction).toBe('You are a helpful coder.');
+      // generateContentStream should have been called with config.systemInstruction
+      const callArg = mockGenerateContentStream.mock.calls.at(-1)?.[0];
+      expect(callArg?.config?.systemInstruction).toBe('You are a helpful coder.');
+      expect(callArg?.contents).toBe('Help me');
     });
 
     // Regression: usage on TurnResult alone is invisible to the orchestrator's
@@ -256,15 +256,13 @@ describe('GeminiBackend', () => {
     });
 
     it('returns zero usage when stream yields no usageMetadata', async () => {
-      const geminiModule = await import('@google/generative-ai');
+      const geminiModule = await import('@google/genai');
       const mockGenerateContentStream = (
         geminiModule as unknown as Record<string, ReturnType<typeof vi.fn>>
       )['__mockGenerateContentStream'];
-      const noUsageStream = {
-        stream: (async function* () {
-          yield { text: () => 'Hi', usageMetadata: undefined };
-        })(),
-      };
+      const noUsageStream = (async function* () {
+        yield { text: 'Hi', usageMetadata: undefined };
+      })();
       mockGenerateContentStream.mockResolvedValueOnce(noUsageStream);
 
       const sessionResult = await backend.startSession({
@@ -290,8 +288,120 @@ describe('GeminiBackend', () => {
       expect(next.value.usage.totalTokens).toBe(0);
     });
 
+    it('survives chunk.text getter throwing mid-stream and preserves accumulated usage', async () => {
+      // @google/genai 2.x exposes chunk.text as a getter that throws on
+      // non-text chunks (function calls, executable code, thought summaries).
+      // The backend must not abort the stream on a single throwing chunk.
+      const geminiModule = await import('@google/genai');
+      const mockGenerateContentStream = (
+        geminiModule as unknown as Record<string, ReturnType<typeof vi.fn>>
+      )['__mockGenerateContentStream'];
+
+      const throwingChunk = {
+        usageMetadata: undefined,
+      };
+      Object.defineProperty(throwingChunk, 'text', {
+        get() {
+          throw new Error('text part unavailable');
+        },
+      });
+
+      const mixedStream = (async function* () {
+        yield { text: 'partial ', usageMetadata: undefined };
+        yield throwingChunk;
+        yield {
+          text: 'recovered',
+          usageMetadata: {
+            promptTokenCount: 42,
+            candidatesTokenCount: 7,
+            totalTokenCount: 49,
+          },
+        };
+      })();
+      mockGenerateContentStream.mockResolvedValueOnce(mixedStream);
+
+      const sessionResult = await backend.startSession({
+        workspacePath: '/tmp/workspace',
+        permissionMode: 'full',
+      });
+      expect(sessionResult.ok).toBe(true);
+      if (!sessionResult.ok) return;
+
+      const session = sessionResult.value;
+      const events: import('@harness-engineering/types').AgentEvent[] = [];
+      const gen = backend.runTurn(session, {
+        sessionId: session.sessionId,
+        prompt: 'mixed stream',
+        isContinuation: false,
+      });
+      let next = await gen.next();
+      while (!next.done) {
+        events.push(next.value);
+        next = await gen.next();
+      }
+      const result = next.value;
+
+      const textEvents = events.filter((e) => e.type === 'text');
+      const errorEvents = events.filter((e) => e.type === 'error');
+      expect(textEvents.map((e) => e.content)).toEqual(['partial ', 'recovered']);
+      expect(errorEvents.length).toBe(0);
+      expect(result.success).toBe(true);
+      expect(result.usage.inputTokens).toBe(42);
+      expect(result.usage.outputTokens).toBe(7);
+      expect(result.usage.totalTokens).toBe(49);
+    });
+
+    it('preserves accumulated usage counters in failed TurnResult when SDK throws mid-stream', async () => {
+      // Regression: prior to the fix, the outer catch hardcoded zeros for
+      // usage, dropping tokens billed before the failure from rate-limit
+      // accounting. Tokens from earlier chunks must survive the catch path.
+      const geminiModule = await import('@google/genai');
+      const mockGenerateContentStream = (
+        geminiModule as unknown as Record<string, ReturnType<typeof vi.fn>>
+      )['__mockGenerateContentStream'];
+
+      const partialThenThrowStream = (async function* () {
+        yield {
+          text: 'hello',
+          usageMetadata: {
+            promptTokenCount: 30,
+            candidatesTokenCount: 5,
+            totalTokenCount: 35,
+            cachedContentTokenCount: 12,
+          },
+        };
+        throw new Error('Stream interrupted');
+      })();
+      mockGenerateContentStream.mockResolvedValueOnce(partialThenThrowStream);
+
+      const sessionResult = await backend.startSession({
+        workspacePath: '/tmp/workspace',
+        permissionMode: 'full',
+      });
+      if (!sessionResult.ok) return;
+
+      const session = sessionResult.value;
+      const gen = backend.runTurn(session, {
+        sessionId: session.sessionId,
+        prompt: 'partial then fail',
+        isContinuation: false,
+      });
+      let next = await gen.next();
+      while (!next.done) {
+        next = await gen.next();
+      }
+      const result = next.value;
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Stream interrupted');
+      expect(result.usage.inputTokens).toBe(30);
+      expect(result.usage.outputTokens).toBe(5);
+      expect(result.usage.totalTokens).toBe(35);
+      expect(result.usage.cacheReadTokens).toBe(12);
+    });
+
     it('yields error event and returns failed TurnResult when SDK throws', async () => {
-      const geminiModule = await import('@google/generative-ai');
+      const geminiModule = await import('@google/genai');
       const mockGenerateContentStream = (
         geminiModule as unknown as Record<string, ReturnType<typeof vi.fn>>
       )['__mockGenerateContentStream'];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,9 +519,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: ^0.74.1
         version: 0.74.1(ws@8.21.0)(zod@3.25.76)
-      '@google/generative-ai':
-        specifier: ^0.24.0
-        version: 0.24.1
+      '@google/genai':
+        specifier: ^2.0.4
+        version: 2.7.0
       '@harness-engineering/core':
         specifier: workspace:*
         version: link:../core
@@ -2730,9 +2730,24 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@google/generative-ai@0.24.1:
-    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
-    engines: {node: '>=18.0.0'}
+  /@google/genai@2.7.0:
+    resolution: {integrity: sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==}
+    engines: {node: '>=20.0.0'}
+    requiresBuild: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.6.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: false
 
   /@grpc/grpc-js@1.14.3:


### PR DESCRIPTION
## Summary

- Migrate `packages/orchestrator` Gemini backend from the deprecated `@google/generative-ai@0.24.1` (upstream stopped publishing) to `@google/genai@^2.0.4`.
- Public surface of `GeminiBackend` is unchanged; SDK call sites rewritten for the new API: options-object constructor, `ai.models.generateContentStream` returning the `AsyncGenerator` directly, `chunk.text` as a getter, and `systemInstruction` under `config`.
- Addresses the runtime semantics change: the new `chunk.text` getter throws on non-text chunks (function calls, executable code, thought summaries). Per-chunk access is wrapped in a local try, and the outer error path now returns accumulated token counters instead of zeros so partial telemetry survives mid-stream failures. `healthCheck` gains the same empty-key guard as `startSession`.

`GeminiCacheAdapter` is untouched — `usageMetadata.cachedContentTokenCount` field name is preserved in the new SDK, and the adapter is type-erased via `unknown`. `packages/intelligence` had no usage of the old package and is also untouched.

## Test plan

- [x] `pnpm --filter @harness-engineering/orchestrator test` — 1401/1402 pass (1 pre-existing skip; +3 new regression tests over baseline)
- [x] `pnpm --filter @harness-engineering/orchestrator typecheck` — clean
- [x] `pnpm --filter @harness-engineering/core test` — 2976/2977 pass, confirms `GeminiCacheAdapter` unaffected
- [x] New regression tests:
  - `chunk.text` getter throws mid-stream → stream continues, no spurious error event, final usage preserved
  - SDK throws mid-stream → failed `TurnResult` carries accumulated counters (not zeros)
  - `healthCheck` with empty `apiKey` → `Err({ category: 'agent_not_found' })`, matches `startSession`
- [ ] Smoke test against real Gemini API in a follow-up if/when a key is available