### PR TITLE
docs: add STRATEGY.md and refresh roadmap assignees

### DIFF
--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,41 @@
+---
+name: Harness Engineering
+last_updated: '2026-06-03'
+version: 1
+---
+
+# Harness Engineering Strategy
+
+## Target problem
+
+AI coding agents are fast but unreliable without structure. Left unconstrained, they compound drift — circular dependencies, layer violations, dead code, documentation rot — that humans then absorb as code-review backlogs and manual checklists. Conventions and prompts don't survive iteration: each agent invocation starts cold, re-litigates settled architectural decisions, and inflates entropy debt. Teams currently choose between babysitting the agent or paying the cleanup tax. Neither scales.
+
+## Our approach
+
+The substrate the agent runs on, not the agent itself, determines reliability. We bet on **encoding architectural decisions, process discipline, and strategic intent as machine-checkable constraints** — layered dependency rules in ESLint, entropy rules in detectors, workflow rigidity in skills, durable grounding in a knowledge graph and STRATEGY.md. Constraints fire in real time, so agents self-correct mid-stream instead of accumulating cleanup debt downstream. Humans own the thinking layer (specs, decisions, strategy); the harness mechanically polices everything below it. The wager: **constraints-as-code outperforms prompts-and-conventions** at every scale, and compounds — each constraint added now removes a class of future drift.
+
+## Who it's for
+
+**Primary persona:** tech leads and senior engineers on teams that have adopted AI coding agents (Claude Code, Cursor, Gemini CLI, Codex) and are running into the second-order cost — architectural drift, layer violations, doc rot, and ballooning PR-review backlogs. They typically already have a CLAUDE.md / AGENTS.md / conventions doc, prompt templates, and a code-review checklist, but those are _conventions without enforcement_ — agents drift back to bad patterns the moment a session forgets the prompt. They are not the marginal user trying agents for the first time; they're the user 3–6 months in, watching the cleanup tax compound.
+
+**Secondary persona:** individual developers running agents heavily (10+ sessions/week) who are paying the cleanup tax themselves. Same diagnosis, smaller blast radius.
+
+## Key metrics
+
+- **Agent Autonomy:** % of merged PRs in `Intense-Visions/harness-engineering` whose commits are 100% bot/automation (no human code commits), measured monthly via the GitHub API and reported in `docs/standard/kpis.md`.
+- **Harness Coverage:** ratio of documented architectural rules that carry mechanical enforcement (ESLint rule, validator, schema, hook) to total documented rules, surfaced via `harness validate` baselines tracked in `.harness/architecture/timeline.json`.
+- **Context Density:** count of load-bearing knowledge nodes (ADRs, principles, conventions, STRATEGY.md sections) reachable via the knowledge graph per package, measured by `@harness-engineering/graph` and reported by `harness insights`.
+- **Drift Floor:** layer-violation / dependency-violation / entropy-finding count introduced per merged PR over a 30-day rolling window, reported by `harness validate` in CI and aggregated to `.harness/security/timeline.json` and the architecture timeline.
+- **External Adoption:** distinct projects running harness in the last 30 days, surfaced by anonymous telemetry (DO_NOT_TRACK respected); tells us whether the bet generalizes off-repo.
+
+## Tracks
+
+- **Upstream grounding:** make the strategic and knowledge substrate (STRATEGY.md, knowledge graph, principles, ADRs) durable enough that downstream skills ground reliably instead of starting cold each invocation. Current: strategic-anchor skill (Phases 3-7 wire it into brainstorming, ideate, roadmap-pilot, knowledge graph); v4.0 Business Knowledge System.
+- **Ceiling-raising via LLM judgment:** add craft-pipeline skills that critique _quality_ (naming, prose, code shape, spec clarity, threat models) beyond what rule-based linters can catch. Current: complete the craft family — docs-craft, code-craft, api-craft, cli-ergonomics are the remaining four; six already shipped (naming, spec, test, copy, knowledge, security).
+- **Compounding feedback loops:** invest in mechanisms that make agents and skills _measurably improve_ over time rather than holding steady. Current: skill proposal loop, skill effectiveness baselines, trust scoring, prompt injection from historical outcomes.
+- **Multi-client portability:** keep the harness usable across Claude Code, Cursor, Codex, Gemini CLI, and OpenCode without forking the substrate. Current: marketplace plugins per client, per-skill / per-cognitive-mode backend routing, gateway API for external bridges.
+- **External adoption flywheel:** make the harness valuable enough off-repo that the constraints-as-code thesis gets tested at scale. Current: skill marketplace, constraint sharing bundles, harness:blueprint for codebase courseware, telemetry-driven adoption insights.
+
+## Marketing
+
+Stop babysitting your AI agent. Harness encodes your architectural decisions, conventions, and strategic intent as machine-checkable constraints — agents get real-time feedback when they violate boundaries, drift is detected and cleaned automatically, and every rule is validated on every change. The result: **humans stay in the thinking layer (specs, design, strategy) and AI reliably executes the rest.** Scale agent-assisted development across your team without the entropy tax.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ version: 1
 created: 2026-03-21
 updated: 2026-05-27
 last_synced: 2026-06-02T13:29:44.005Z
-last_manual_edit: 2026-06-02T13:32:41.296Z
+last_manual_edit: 2026-06-03T17:48:05.672Z
 ---
 
 # Roadmap
@@ -1057,7 +1057,7 @@ last_manual_edit: 2026-06-02T13:32:41.296Z
 - **Summary:** Carry-forward polish from init-design-roadmap-config: (S2) refresh proposal.md:146 stale Registrations bullet to reflect harness-roadmap skill invocation, (S3) add harness-roadmap to initialize-harness-project skill.yaml depends_on for symmetry with harness-design-system, plus FINAL-S1 helper extraction, FINAL-S2 'not sure' vocabulary homogenization, FINAL-S3 catalog-consistency test docstring clarification.
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** —
+- **Assignee:** @chadjw
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#257
 
@@ -1169,7 +1169,7 @@ last_manual_edit: 2026-06-02T13:32:41.296Z
 - **Summary:** Phases 1-6 shipped (schema, harness-strategy skill, init wiring, harness-ideate skill, brainstorming + roadmap-pilot grounding). Phases 7 (BusinessKnowledgeIngestor strategy domain) and 8 (ADRs + AGENTS.md "Strategic Anchor" section) outstanding.
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** orchestrator-5c895000
+- **Assignee:** @chadjw
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#262
 - **Updated-At:** 2026-06-02T23:19:00.486Z
@@ -1181,7 +1181,7 @@ last_manual_edit: 2026-06-02T13:32:41.296Z
 - **Summary:** Add harness-pulse and harness-compound skills with two new report-only maintenance tasks (product-pulse daily, compound-candidates weekly). Closes the read-side and post-mortem capture gaps. Deprecates .harness/learnings.md.
 - **Blockers:** —
 - **Plan:** docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-1-schema-foundations-plan.md, docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-2-harness-compound-skill-plan.md, docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-3-harness-pulse-skill-interview-plan.md, docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-4-pulse-run-cli-plan.md, docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-5-compound-scan-candidates-cli-plan.md, docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-6-maintenance-task-registration-plan.md, docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-7-orchestrator-cross-skill-integration-plan.md, docs/changes/compound-engineering-adoption/feedback-loops/plans/2026-05-05-feedback-loops-phase-8-documentation-and-adrs-plan.md
-- **Assignee:** orchestrator-5c895000
+- **Assignee:** @chadjw
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#263
 - **Updated-At:** 2026-06-02T13:41:59.609Z
@@ -1193,7 +1193,7 @@ last_manual_edit: 2026-06-02T13:32:41.296Z
 - **Summary:** Add adversarial reviewer + framework-persona reviewers (typescript-strict, frontend-races) + Quick/Standard/Deep depth calibration in harness-code-review. Standardizes anchored confidence rubric and unified findings schema across all review personas.
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** orchestrator-5c895000
+- **Assignee:** @chadjw
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#264
 - **Updated-At:** 2026-06-02T13:47:40.063Z
@@ -2273,3 +2273,4 @@ last_manual_edit: 2026-06-02T13:32:41.296Z
 | design-pipeline sub-project #2: audit-component-anatomy          | @chadjw  | assigned | 2026-05-23 |
 | design-pipeline sub-project #0: brand-guidelines source-of-truth | @chadjw  | assigned | 2026-05-23 |
 | design-pipeline sub-project #3: audit-brand-compliance           | @chadjw  | assigned | 2026-06-02 |
+| Init design + roadmap polish follow-ups                          | @chadjw  | assigned | 2026-06-03 |


### PR DESCRIPTION
## Summary

- Adds `STRATEGY.md` at the repo root, generated via the `/harness:strategy` first-run interview. Includes the 5 required sections (Target problem, Our approach, Who it's for, Key metrics, Tracks) plus the optional Marketing section. Frontmatter: `version: 1`, `last_updated: 2026-06-03`.
- Refreshes `docs/roadmap.md`: bumps `last_manual_edit`, sets explicit `@chadjw` assignees on the strategic-anchor / feedback-loops / code-review-rigor spec rows (replacing `—` and `orchestrator-5c895000` placeholders), and adds a new assignment-history entry.

The STRATEGY.md sections are downstream grounding for `harness-brainstorming`, `harness-ideate`, `harness-roadmap-pilot`, and the v4.0 BusinessKnowledgeIngestor strategy domain — all four soft-fail when STRATEGY.md is absent, so this anchor is purely additive.

## Test plan

- [x] `harness validate` passes (validation runs on commit via lint-staged + pre-commit hook)
- [x] `validate_strategy` MCP tool returns `{ present: true, valid: true }` after write
- [x] STRATEGY.md ≤ 100 lines body (anchor lives at ~60 lines)
- [ ] Manual reviewer scan of the assembled strategy for fluff / goal-as-strategy / feature-list-as-strategy regressions
- [ ] CI green (note: arch check shows pre-existing module-size regressions in `packages/dashboard/src/client/pages` and `packages/graph/src/ingest` — unrelated to this PR)