### PR TITLE
fix: cross-phase review followups + pre-push reliability

### DIFF
--- a/.changeset/fix-deep-review-double-emission.md
+++ b/.changeset/fix-deep-review-double-emission.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix `runDeepReview` in `review-changes` MCP tool emitting the full unpaginated `findings` array via the embedded `pipeline` payload. After passing `_skipPagination: true` to the inner review call, the wrapper was re-emitting `pipeline: parsed` which still carried the full list, silently defeating the intent of the 22dd345f9 "double pagination" fix for any client reading `pipeline.findings`. Now strips `findings` and `findingCount` out of `pipeline` before re-emitting, keeping the paginated top-level fields as the canonical response shape. Surfaced by cross-phase review of the paged-mcp-tool-responses spec.

--- a/.changeset/fix-lazy-local-adapter-timeout.md
+++ b/.changeset/fix-lazy-local-adapter-timeout.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Wire the previously-dead `LazyLocalAdapterOptions.llmTimeoutMs` through to the inner `OpenAICompatibleAnalysisProvider`. Without this, callers pointing at an unreachable local endpoint (LM Studio not running, Ollama not started) blocked for ~7s per call as the OpenAI SDK ran its default 90s timeout + `maxRetries: 2` exponential backoff before throwing. Now `llmTimeoutMs` actually applies — fail-fast on unreachable endpoints when configured.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,6 +7,11 @@ pnpm run check:changesets
 # Format check catches files missed by lint-staged (e.g., from merges).
 pnpm run format:check
 pnpm run typecheck
-pnpm run test:ci
+# Cap turbo concurrency to 2 packages-at-a-time. Without this, filesystem/sqlite/HTTP-heavy
+# tests (search index, hooks, gateway/deliveries, lazy-local-adapter probe) flake under
+# the compound load of ~21 packages running test:coverage in parallel, each with its own
+# vitest worker pool. CI uses `pnpm test:ci` directly without the cap because GitHub
+# Actions runners have far fewer competing processes.
+pnpm exec turbo run test:coverage --concurrency=2
 node scripts/coverage-ratchet.mjs
 pnpm run generate-docs --check

--- a/docs/changes/claude-mem-patterns/storage-conventions/conventions.md
+++ b/docs/changes/claude-mem-patterns/storage-conventions/conventions.md
@@ -6,12 +6,14 @@ This document describes the storage patterns, access characteristics, and future
 
 ## 1. File Inventory
 
-| Pattern                | File                  | Constant              | Format                                                          | Write             | Read                         | Scope            |
-| ---------------------- | --------------------- | --------------------- | --------------------------------------------------------------- | ----------------- | ---------------------------- | ---------------- |
-| Progressive Disclosure | `learnings.md`        | `LEARNINGS_FILE`      | Markdown with `<!-- hash:XXX tags:a,b -->` frontmatter comments | Append-only       | Full scan + index extraction | Global + session |
-| Content Deduplication  | `content-hashes.json` | `CONTENT_HASHES_FILE` | JSON object (`ContentHashIndex`)                                | Read-modify-write | Key lookup by hash           | Global + session |
-| Structured Event Log   | `events.jsonl`        | `EVENTS_FILE`         | JSONL (one `SkillEvent` JSON object per line)                   | Append-only       | Tail-read (most recent N)    | Global + session |
-| AST Code Navigation    | (none)                | —                     | In-memory tree-sitter parser cache                              | —                 | Read-only (source files)     | Process lifetime |
+| Pattern                | File                  | Constant              | Format                                                          | Write                | Read                         | Scope                             |
+| ---------------------- | --------------------- | --------------------- | --------------------------------------------------------------- | -------------------- | ---------------------------- | --------------------------------- |
+| Progressive Disclosure | `learnings.md`        | `LEARNINGS_FILE`      | Markdown with `<!-- hash:XXX tags:a,b -->` frontmatter comments | Append-only (locked) | Full scan + index extraction | Global + session                  |
+| Content Deduplication  | `content-hashes.json` | `CONTENT_HASHES_FILE` | JSON object (`ContentHashIndex`)                                | Read-modify-write    | Key lookup by hash           | Global + session (learnings only) |
+| Structured Event Log   | `events.jsonl`        | `EVENTS_FILE`         | JSONL (one `SkillEvent` JSON object per line)                   | Append-only          | Tail-read (most recent N)    | Global + session                  |
+| AST Code Navigation    | (none)                | —                     | In-memory tree-sitter parser cache                              | —                    | Read-only (source files)     | Process lifetime                  |
+
+> **Note:** `content-hashes.json` backs **learnings dedup only**. Event dedup uses an in-memory hash set rebuilt from `events.jsonl` on first access — see §3 for the split.
 
 ### File Locations
 
@@ -27,16 +29,16 @@ This document describes the storage patterns, access characteristics, and future
         └── events.jsonl      # Session-scoped event log
 ```
 
-All paths resolve through the state module constants in `packages/core/src/state/constants.ts`.
+All paths resolve through the state module constants in `packages/core/src/state/constants.ts`. Some call sites (`learnings.ts`) import `LEARNINGS_FILE` via the re-export in `state-shared.ts` rather than directly from `constants.ts`; both routes are equivalent.
 
 ## 2. Access Patterns
 
 ### learnings.md
 
 - **Write:** `appendLearning()` appends a dated markdown bullet with `<!-- hash:XXX tags:a,b -->` frontmatter comment preceding the entry. Each write first checks `content-hashes.json` for duplicates.
-- **Read (index scan):** `loadIndexEntries()` extracts `LearningsIndexEntry` objects (hash, tags, first-line summary) without loading full entry text. Used when `depth: "index"`.
+- **Read (index scan):** `loadIndexEntries()` extracts `LearningsIndexEntry` objects (hash, tags, first-line summary, full text, optional `rootCause` / `triedAndFailed`) without invoking the relevance scorer. Used when `depth: "index"`.
 - **Read (full):** `loadBudgetedLearnings()` loads entries with relevance scoring against an intent string, within a token budget. Used when `depth: "summary"` (default) or `depth: "full"`.
-- **Concurrency:** Append-only writes are safe for single-writer scenarios. Two concurrent appends may both succeed but could interleave. No file locking implemented.
+- **Concurrency:** Protected by a file-based lock (`learnings.md.lock` opened with `O_CREAT | O_EXCL | O_WRONLY`, with bounded exponential backoff — 3 retries at 50/100/200 ms). The lock spans the dedup-check + append + `content-hashes.json` update so concurrent writers serialize cleanly. Single-process workloads pay one extra `open`/`unlink` per append; multi-process workloads serialize correctly.
 - **Corruption recovery:** Entries without frontmatter are treated as valid (backward compatible). `parseFrontmatter()` returns `null` for malformed frontmatter — the entry is included but not indexed.
 
 ### content-hashes.json
@@ -48,9 +50,10 @@ All paths resolve through the state module constants in `packages/core/src/state
 
 ### events.jsonl
 
-- **Write:** `emitEvent()` appends a single JSON line with `\n` terminator. Content hash computed from `{skill, type, summary, session}` to prevent duplicates within a session.
+- **Write:** `emitEvent()` appends a single JSON line with `\n` terminator. Content hash computed from `{skill}|{type}|{summary}|{session}` to prevent duplicates within a session.
 - **Read:** `loadEvents()` reads the file, parses each line as JSON, filters by type/session, and returns the most recent N events. `formatEventTimeline()` renders events as a compact markdown timeline.
-- **Concurrency:** Append-only JSONL is safe for concurrent writers at the OS level (each write is a single `appendFile` call). Partial writes result in an incomplete final line, which is skipped during parsing.
+- **Dedup store:** Events do **not** share `content-hashes.json` with learnings. Instead, `emitEvent` maintains an in-memory `Map<eventsPath, Set<contentHash>>` (`knownHashesCache`), populated lazily from `events.jsonl` on first access per process. The JSONL file is self-describing — each line carries its own `contentHash` — so no sidecar is needed for recovery.
+- **Concurrency:** Append-only JSONL is safe for concurrent writers at the OS level (each write is a single `appendFile` call) — no file lock is taken. Partial writes result in an incomplete final line, which is skipped during parsing. The deliberate asymmetry vs `learnings.md` (which does lock) reflects that events have no read-modify-write step and that the dedup cache is per-process, so cross-process duplicates are tolerated.
 - **Corruption recovery:** Lines that fail `JSON.parse()` are silently skipped. No self-healing rebuild needed — the format is inherently corruption-tolerant.
 
 ### AST Parser Cache
@@ -64,18 +67,31 @@ All paths resolve through the state module constants in `packages/core/src/state
 
 ### Content Hashing
 
-Both learnings deduplication and event deduplication share the same hashing approach:
+Hashing utilities live in `packages/core/src/state/learnings-content.ts` (split out of `learnings.ts` to keep the blast radius small). Two distinct hash schemes coexist by design — both are slices of SHA-256:
 
 ```typescript
-// packages/core/src/state/learnings.ts
-export function normalizeLearningContent(text: string): string;
-// Strips date prefixes, skill/outcome tags, list markers; lowercases; collapses whitespace
+// packages/core/src/state/learnings-content.ts
 
+// 16-char hex hash of NORMALIZED content. Used for cross-entry dedup
+// (learnings: in content-hashes.json; events: in the in-memory cache).
 export function computeContentHash(text: string): string;
-// SHA-256 of normalized text, returned as hex string
+
+// 8-char hex hash of RAW entry text. Used only for the per-entry
+// `<!-- hash:XXX -->` frontmatter comment in learnings.md.
+export function computeEntryHash(text: string): string;
+
+export function normalizeLearningContent(text: string): string;
+// Strips date prefixes, skill/outcome/root_cause/tried tags, list/bold markers;
+// lowercases; collapses whitespace. Applied only to learnings dedup, not events.
 ```
 
-Events compute their hash from a concatenated `{skill}:{type}:{summary}:{session}` string, passed through the same `computeContentHash()` function.
+| Use site                              | Function             | Input                                                               | Width  |
+| ------------------------------------- | -------------------- | ------------------------------------------------------------------- | ------ |
+| Learnings dedup (cross-entry)         | `computeContentHash` | normalized learning text                                            | 16 hex |
+| Events dedup (cross-entry)            | `computeContentHash` | `${skill}\|${type}\|${summary}\|${session}` (raw, no normalization) | 16 hex |
+| Learnings frontmatter (per-entry tag) | `computeEntryHash`   | full bullet line, as-emitted                                        | 8 hex  |
+
+Both dedup paths funnel into `computeContentHash`, so the _function_ is shared — but the _persistence story_ is not (learnings persists hashes to `content-hashes.json`; events caches them in-memory and re-derives from JSONL on cold start).
 
 ### Token Estimation
 
@@ -104,10 +120,12 @@ interface LearningEntry {
 }
 
 interface LearningsIndexEntry {
-  hash: string;
-  tags: string[];
-  summary: string;
-  line: number;
+  hash: string; // 8-char entry hash (computeEntryHash on full bullet)
+  tags: string[]; // skill + outcome tags extracted from [skill:X]/[outcome:Y]
+  summary: string; // first line of the entry
+  fullText: string; // full entry text — needed by the relevance scorer
+  rootCause?: string; // optional [root_cause:X] tag
+  triedAndFailed?: string[]; // optional [tried:a,b,c] tag, split on comma
 }
 
 interface StorageBackend {
@@ -157,11 +175,11 @@ interface StorageBackend {
 
 ### Table Mappings
 
-| Flat File             | SQLite Table              | Schema                                                                                                                                                                          | Notes                                                                                                        |
-| --------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `learnings.md`        | `learnings`               | `id INTEGER PRIMARY KEY, content TEXT NOT NULL, hash TEXT UNIQUE NOT NULL, tags TEXT, skill TEXT, outcome TEXT, timestamp TEXT NOT NULL`                                        | FTS5 virtual table on `content` for full-text search. `hash` column replaces `content-hashes.json` entirely. |
-| `content-hashes.json` | (merged into `learnings`) | —                                                                                                                                                                               | The `hash` UNIQUE constraint on `learnings` table handles dedup. No separate table needed.                   |
-| `events.jsonl`        | `events`                  | `id INTEGER PRIMARY KEY, timestamp TEXT NOT NULL, skill TEXT NOT NULL, session TEXT, type TEXT NOT NULL, summary TEXT NOT NULL, data TEXT, refs TEXT, content_hash TEXT UNIQUE` | Index on `(session, timestamp)`. `data` and `refs` stored as JSON strings.                                   |
+| Flat File             | SQLite Table              | Schema                                                                                                                                                                                                             | Notes                                                                                                                                                                                                                                                        |
+| --------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `learnings.md`        | `learnings`               | `id INTEGER PRIMARY KEY, content TEXT NOT NULL, content_hash TEXT UNIQUE NOT NULL, entry_hash TEXT NOT NULL, tags TEXT, skill TEXT, outcome TEXT, root_cause TEXT, tried_and_failed TEXT, timestamp TEXT NOT NULL` | FTS5 virtual table on `content` for full-text search. `content_hash` (16-hex, normalized) replaces `content-hashes.json`. `entry_hash` (8-hex, raw) preserves the frontmatter tag for migration round-trips. `tried_and_failed` stored as JSON array string. |
+| `content-hashes.json` | (merged into `learnings`) | —                                                                                                                                                                                                                  | The `content_hash` UNIQUE constraint on `learnings` table handles learnings dedup. No separate table needed.                                                                                                                                                 |
+| `events.jsonl`        | `events`                  | `id INTEGER PRIMARY KEY, timestamp TEXT NOT NULL, skill TEXT NOT NULL, session TEXT, type TEXT NOT NULL, summary TEXT NOT NULL, data TEXT, refs TEXT, content_hash TEXT UNIQUE`                                    | Index on `(session, timestamp)`. `data` and `refs` stored as JSON strings. The `content_hash UNIQUE` constraint replaces the in-memory `knownHashesCache` and the JSONL cold-load scan.                                                                      |
 
 ### Migration Steps
 

--- a/packages/cli/src/mcp/tools/review-changes.ts
+++ b/packages/cli/src/mcp/tools/review-changes.ts
@@ -254,6 +254,11 @@ async function runDeepReview(
   const sorted = sortFindingsBySeverity(rawFindings);
   const paged = paginate(sorted, offset ?? 0, limit ?? 20);
 
+  // Strip the full unpaginated findings array out of the embedded pipeline payload —
+  // we already surface findings/findingCount as paginated top-level fields, and re-emitting
+  // the full list here would defeat _skipPagination and re-introduce token bloat.
+  const { findings: _full, findingCount: _fullCount, ...pipelineRest } = parsed;
+
   return {
     content: [
       {
@@ -266,7 +271,7 @@ async function runDeepReview(
           assessment: parsed.assessment,
           findingCount: parsed.findingCount,
           lineCount: diffLines,
-          pipeline: parsed,
+          pipeline: pipelineRest,
         }),
       },
     ],

--- a/packages/cli/src/shared/craft/llm/lazy-local-adapter.ts
+++ b/packages/cli/src/shared/craft/llm/lazy-local-adapter.ts
@@ -102,6 +102,7 @@ export class LazyLocalAdapter implements LlmProvider {
         apiKey: this.opts.apiKey,
         baseUrl: this.opts.endpoint,
         defaultModel: match,
+        ...(this.opts.llmTimeoutMs !== undefined ? { timeoutMs: this.opts.llmTimeoutMs } : {}),
       });
       const provider = new AnalysisProviderAdapter({
         providerId: this.providerId,

--- a/packages/cli/tests/shared/craft/lazy-local-adapter.test.ts
+++ b/packages/cli/tests/shared/craft/lazy-local-adapter.test.ts
@@ -33,6 +33,10 @@ describe('LazyLocalAdapter', () => {
       apiKey: 'lm-studio',
       configured: ['gemma-4-e4b', 'qwen3:8b'],
       fetchModels,
+      // Fail fast on the unreachable port — the test is about caching, not HTTP.
+      // Without this, the OpenAI SDK's default 90s timeout + retry backoff blows
+      // past vitest's 30s testTimeout when looping 3 calls.
+      llmTimeoutMs: 100,
     });
 
     for (let i = 0; i < 3; i++) {

--- a/packages/cli/tests/skill/health-snapshot.test.ts
+++ b/packages/cli/tests/skill/health-snapshot.test.ts
@@ -83,7 +83,7 @@ describe('isSnapshotFresh', () => {
 
   it(
     'returns true when git HEAD differs but age < 1 hour (time fallback)',
-    { timeout: 15000 },
+    { timeout: 60000 },
     () => {
       const tmpDir = createTempGitRepo();
       try {
@@ -96,7 +96,7 @@ describe('isSnapshotFresh', () => {
     }
   );
 
-  it('returns false when git HEAD differs and age is exactly 1 hour', { timeout: 15000 }, () => {
+  it('returns false when git HEAD differs and age is exactly 1 hour', { timeout: 60000 }, () => {
     const tmpDir = createTempGitRepo();
     try {
       const exactlyOneHour = new Date(Date.now() - 3_600_000).toISOString();
@@ -107,7 +107,7 @@ describe('isSnapshotFresh', () => {
     }
   });
 
-  it('returns true when git HEAD matches regardless of age', { timeout: 15000 }, () => {
+  it('returns true when git HEAD matches regardless of age', { timeout: 60000 }, () => {
     const tmpDir = createTempGitRepo();
     try {
       const realHead = realExecSync('git rev-parse HEAD', {

--- a/packages/core/src/solutions/scan-candidates/hotspot.test.ts
+++ b/packages/core/src/solutions/scan-candidates/hotspot.test.ts
@@ -27,7 +27,7 @@ describe('computeHotspots', () => {
     expect(result[0]?.path).toBe('hot.ts');
     expect(result[0]?.churn).toBe(5);
     expect(result.find((r) => r.path === 'cold.ts')).toBeUndefined();
-  }, 30_000);
+  }, 60_000);
 
   it('returns empty list on empty repo', async () => {
     const result = await computeHotspots({ since: '30d', cwd: tmp, threshold: 1 });


### PR DESCRIPTION
## Summary

While running cross-phase final-reviews on long-abandoned autopilot sessions, two real bugs and one dead production option surfaced. While trying to push the fixes, the pre-push hook surfaced a separate class of pre-existing flakiness (Node version mismatch + parallel-load timeouts). Both clusters fixed in this PR.

### Real production fixes

1. **`fix(mcp/review-changes): strip findings from embedded pipeline in deep review`** — `runDeepReview` was emitting `pipeline: parsed` with the full unpaginated `findings` array even after passing `_skipPagination: true` to the inner review call, silently undoing the `22dd345f9` "double pagination" fix for any client reading `pipeline.findings`. Surfaced by cross-phase review of `paged-mcp-tool-responses`.

2. **`fix(craft/lazy-local-adapter): wire llmTimeoutMs through to inner provider`** — `LazyLocalAdapterOptions.llmTimeoutMs` was declared but never applied. Callers pointing at unreachable local endpoints (LM Studio not running, Ollama not started) blocked for ~7s per `callText` as the OpenAI SDK ran its default 90s timeout + `maxRetries: 2` exponential backoff before throwing. Now `llmTimeoutMs` actually applies.

### Documentation fix

3. **`docs(claude-mem-patterns): align storage-conventions with implementation`** — Cross-phase review of the `claude-mem-patterns` spec surfaced 4 important doc-drift findings in the authoritative deliverable. Updated to match actual code: file locking present (not absent), `LearningsIndexEntry` shape includes `fullText`/`rootCause`/`triedAndFailed`, events dedup uses an in-memory cache (not `content-hashes.json`), and the two SHA-256 hash schemes (`computeContentHash` 16-hex vs `computeEntryHash` 8-hex) are now documented.

### Pre-push reliability

4. **`chore(husky): cap turbo concurrency in pre-push to 2`** — Without a cap, `pnpm test:ci` fans out ~21 packages running test:coverage in parallel, each with its own vitest worker pool. The compound load flakes filesystem/sqlite/HTTP-heavy tests. CI keeps using `pnpm test:ci` directly since GitHub Actions runners have less ambient process competition.

5. **`test: bump git-tempdir test timeouts to 60s`** — `createTempGitRepo`-based tests (`health-snapshot.test.ts`, `hotspot.test.ts`) run multiple synchronous `git` subprocesses in a tmpdir; under parallel load these overshoot the previous 15s/30s caps. 60s is generous for stuck-detection while accommodating realistic parallel load.

## Test plan

- [x] `pnpm exec vitest run tests/mcp/tools/pagination-integration.test.ts tests/mcp/tools/review-changes.test.ts` — 28/28 pass with `runDeepReview` fix
- [x] `pnpm exec vitest run tests/shared/craft/lazy-local-adapter.test.ts` — 6/6 pass in 7s (was timing out at 30s)
- [x] `pnpm exec turbo run test:coverage` from root with `--concurrency=2` — passes end-to-end on the local dev machine
- [x] Pre-push hook itself executes the modified test:coverage successfully
- [x] Changeset present for each `@harness-engineering/cli` patch (`.changeset/fix-deep-review-double-emission.md`, `.changeset/fix-lazy-local-adapter-timeout.md`)