### PR TITLE
fix(brainstorming): make Architectural Decisions a reference, not a duplicate

### DIFF
--- a/agents/skills/claude-code/harness-brainstorming/SKILL.md
+++ b/agents/skills/claude-code/harness-brainstorming/SKILL.md
@@ -116,7 +116,7 @@ These flow into `handoff.json` `contextKeywords` field. Select keywords that hel
    - **Entry Points** -- Which system entry points does this feature touch or create? (e.g., new CLI command, new MCP tool, new skill, new API route, new barrel export)
    - **Registrations Required** -- What registrations are needed for the feature to be discoverable? (e.g., barrel export regeneration, skill tier assignment, route registration)
    - **Documentation Updates** -- What docs need updating to reflect the new capability? (e.g., AGENTS.md section, API docs, README, guides)
-   - **Architectural Decisions** -- What decisions warrant ADRs? List the decision and a one-line rationale. Only for medium/large tier changes -- omit for small changes.
+   - **Architectural Decisions** -- Which decisions from the **Decisions made** section rise to a standalone ADR? Reference each by name with a one-line note on _why_ it warrants an ADR. Do **not** restate the decisions here -- this subsection points back to the canonical **Decisions made** section; duplicating them creates two sources that drift (spec-craft flags this as SPEC-R004). Only for medium/large tier changes -- "None" for small changes.
    - **Knowledge Impact** -- What domain concepts, patterns, or relationships should enter the knowledge graph?
 
    If the feature is a small change (bug fix, config tweak, < 3 files), the section may contain only Entry Points and Registrations Required with "None" for the others. The section must still be present.


### PR DESCRIPTION
Closes #585.

## Problem

`harness-brainstorming`'s spec template defines two homes for decisions — the canonical **Decisions made** section and the **Architectural Decisions** subsection under **Integration Points**. The latter's wording ("List the decision and a one-line rationale") reads as *restate the decision here*, so authors copy rows into both and they drift.

`harness:spec-craft` flagged this as **SPEC-R004** across **6 downstream proposals** that used this template (one had 5 duplicated rows).

## Fix

One-line wording change in `agents/skills/claude-code/harness-brainstorming/SKILL.md`: the subsection is now an explicit pointer to the **ADR-worthy subset** of decisions — referenced by name with a one-line note on why each warrants an ADR — and says, in so many words, *do not restate the decisions here*.

## Verification

Prose-only change to one skill file. Verified locally: prettier `--check` clean; the edited line is not captured by any test snapshot (`snapshot.test.ts.snap` snapshots the skill index/metadata, not bodies); platform variants are generated from this claude-code source at build, so this is the single source of truth. CI covers the rest.