### PR TITLE
feat(templates): architecture thresholds for basic/intermediate + roadmap sync

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2518,7 +2518,7 @@ last_manual_edit: 2026-06-23T20:30:00.000Z
 
 ### Build harness:outcome-eval skill
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/outcome-eval/proposal.md
 - **Summary:** The article's named #1 industry gap and the project's largest single missing piece. LLM-judgment skill that reads the spec's user-visible-behavior section + the diff + test outputs and produces a structured "did this satisfy the spec" verdict. Wire into `harness.orchestrator.md` as step 6.5 between code-review and ship. Wire into CI workflow template (item below) as required check. Uses existing primitives in `packages/intelligence` (PESL simulator, effectiveness scorer with graph-attributed execution_outcome nodes, SEL spec enrichment). Confidence calibration similar to `harness:security-craft` to manage false-positive risk. Source: Pass 1 #3, Pass 2 #3 (CRITICAL).
 - **Blockers:** —
@@ -2540,7 +2540,7 @@ last_manual_edit: 2026-06-23T20:30:00.000Z
 
 ### Ship the 5-signal dashboard panel and signals.md doc
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/five-signal-dashboard-panel/proposal.md
 - **Summary:** Article gear item #7: "the five or six signals that, if any of them moves, the senior wants to know inside the hour." Today the dashboard surfaces operational data (maintenance, routing) but no curated signal layer. Pick five: PR-merged-without-multi-persona-review, coverage-trend-down-30d, complexity-trend-up-30d, baseline-auto-update-count, eval-fail-rate. Render as the dashboard's default landing view. Document the picked five in new `docs/standard/signals.md`. Source: Pass 1 #5, Pass 2 #4, Pass 3 #11.
 - **Blockers:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2573,12 +2573,12 @@ last_manual_edit: 2026-06-23T20:30:00.000Z
 
 ### Add architecture thresholds to basic and intermediate templates
 
-- **Status:** planned
+- **Status:** in-progress
 - **Spec:** —
 - **Summary:** `templates/basic/harness.config.json.hbs` (16 lines) and `templates/intermediate/harness.config.json.hbs` (23 lines) currently ship NO `architecture.thresholds` — no complexity cap, no module-size cap, no dependency-depth cap, no security config, no entropy config, no performance config. Basic-tier adopters get a layer-linter only. Add sensible defaults: complexity ≤ 20 basic / ≤ 15 intermediate, module-size caps, dependency-depth ≤ 8, security/entropy/perf configs. Every adopter gets real gates from minute one. Source: Pass 2 #2 (CRITICAL).
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** —
+- **Assignee:** chad.warner@gmail.com
 - **Priority:** P0
 - **External-ID:** github:Intense-Visions/harness-engineering#537
 
@@ -2961,3 +2961,4 @@ last_manual_edit: 2026-06-23T20:30:00.000Z
 | Build harness:outcome-eval skill                                 | chad.warner@capillarytech.com | assigned | 2026-06-22 |
 | Ship the 5-signal dashboard panel and signals.md doc             | chad.warner@capillarytech.com | assigned | 2026-06-22 |
 | Stop the pre-commit auto-baseline-update for arch                | chad.warner@gmail.com         | assigned | 2026-06-23 |
+| Add architecture thresholds to basic and intermediate templates  | chad.warner@gmail.com         | assigned | 2026-06-23 |

--- a/packages/cli/tests/templates/__snapshots__/snapshot.test.ts.snap
+++ b/packages/cli/tests/templates/__snapshots__/snapshot.test.ts.snap
@@ -353,8 +353,66 @@ See [architecture.md](./architecture.md) for architectural decisions.
       ]
     }
   ],
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": {
+        "max": 0
+      },
+      "layer-violations": {
+        "max": 0
+      },
+      "complexity": {
+        "max": 20
+      },
+      "module-size": {
+        "maxFiles": 50,
+        "maxLoc": 5000
+      },
+      "dependency-depth": {
+        "max": 8
+      }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ]
+  },
+  "entropy": {
+    "excludePatterns": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": {
+          "error": 20,
+          "warn": 15
+        }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": {
+          "warn": 15
+        }
+      }
+    }
+  },
   "template": {
     "level": "basic",
     "version": 1
@@ -670,8 +728,66 @@ See [architecture.md](./architecture.md) for architectural decisions.
       ]
     }
   ],
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": {
+        "max": 0
+      },
+      "layer-violations": {
+        "max": 0
+      },
+      "complexity": {
+        "max": 20
+      },
+      "module-size": {
+        "maxFiles": 50,
+        "maxLoc": 5000
+      },
+      "dependency-depth": {
+        "max": 8
+      }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ]
+  },
+  "entropy": {
+    "excludePatterns": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": {
+          "error": 20,
+          "warn": 15
+        }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": {
+          "warn": 15
+        }
+      }
+    }
+  },
   "template": {
     "level": "basic",
     "version": 1
@@ -1214,8 +1330,73 @@ export default [
       "src/api/**"
     ]
   },
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": {
+        "max": 0
+      },
+      "layer-violations": {
+        "max": 0
+      },
+      "forbidden-imports": {
+        "max": 0
+      },
+      "complexity": {
+        "max": 15
+      },
+      "coupling": {
+        "maxFanIn": 15,
+        "maxFanOut": 12
+      },
+      "module-size": {
+        "maxFiles": 40,
+        "maxLoc": 4000
+      },
+      "dependency-depth": {
+        "max": 8
+      }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ]
+  },
+  "entropy": {
+    "excludePatterns": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": {
+          "error": 15,
+          "warn": 10
+        }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": {
+          "warn": 12
+        }
+      }
+    }
+  },
   "template": {
     "level": "intermediate",
     "version": 1
@@ -1480,8 +1661,66 @@ See [architecture.md](./architecture.md) for architectural decisions.
       ]
     }
   ],
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": {
+        "max": 0
+      },
+      "layer-violations": {
+        "max": 0
+      },
+      "complexity": {
+        "max": 20
+      },
+      "module-size": {
+        "maxFiles": 50,
+        "maxLoc": 5000
+      },
+      "dependency-depth": {
+        "max": 8
+      }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ]
+  },
+  "entropy": {
+    "excludePatterns": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": {
+          "error": 20,
+          "warn": 15
+        }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": {
+          "warn": 15
+        }
+      }
+    }
+  },
   "template": {
     "level": "basic",
     "version": 1
@@ -1750,8 +1989,66 @@ See [architecture.md](./architecture.md) for architectural decisions.
       ]
     }
   ],
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": {
+        "max": 0
+      },
+      "layer-violations": {
+        "max": 0
+      },
+      "complexity": {
+        "max": 20
+      },
+      "module-size": {
+        "maxFiles": 50,
+        "maxLoc": 5000
+      },
+      "dependency-depth": {
+        "max": 8
+      }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ]
+  },
+  "entropy": {
+    "excludePatterns": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": {
+          "error": 20,
+          "warn": 15
+        }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": {
+          "warn": 15
+        }
+      }
+    }
+  },
   "template": {
     "level": "basic",
     "version": 1
@@ -2185,8 +2482,66 @@ See [architecture.md](./architecture.md) for architectural decisions.
       ]
     }
   ],
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": {
+        "max": 0
+      },
+      "layer-violations": {
+        "max": 0
+      },
+      "complexity": {
+        "max": 20
+      },
+      "module-size": {
+        "maxFiles": 50,
+        "maxLoc": 5000
+      },
+      "dependency-depth": {
+        "max": 8
+      }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ]
+  },
+  "entropy": {
+    "excludePatterns": [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/*.test.ts"
+    ],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": {
+          "error": 20,
+          "warn": 15
+        }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": {
+          "warn": 15
+        }
+      }
+    }
+  },
   "template": {
     "level": "basic",
     "version": 1

--- a/packages/cli/tests/templates/template-thresholds.test.ts
+++ b/packages/cli/tests/templates/template-thresholds.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { HarnessConfigSchema } from '../../src/config/schema';
+
+const TEMPLATES_DIR = path.resolve(__dirname, '..', '..', '..', '..', 'templates');
+
+/**
+ * Render a tier's harness.config.json.hbs the way the engine would: the config
+ * template uses a single `{{projectName}}` token, so substituting it is enough
+ * to produce parseable JSON for schema validation.
+ */
+function renderConfig(tier: string): unknown {
+  const hbs = fs.readFileSync(path.join(TEMPLATES_DIR, tier, 'harness.config.json.hbs'), 'utf-8');
+  const rendered = hbs.replace(/\{\{projectName\}\}/g, 'sample-project');
+  return JSON.parse(rendered) as unknown;
+}
+
+describe('template architecture thresholds', () => {
+  for (const tier of ['basic', 'intermediate']) {
+    it(`${tier} template renders a config valid against HarnessConfigSchema`, () => {
+      const result = HarnessConfigSchema.safeParse(renderConfig(tier));
+      expect(result.success).toBe(true);
+    });
+
+    it(`${tier} template ships architecture, security, entropy, and performance blocks`, () => {
+      const config = renderConfig(tier) as Record<string, unknown>;
+      expect(config.architecture).toBeDefined();
+      expect(config.security).toBeDefined();
+      expect(config.entropy).toBeDefined();
+      expect(config.performance).toBeDefined();
+
+      const thresholds = (config.architecture as { thresholds?: Record<string, unknown> })
+        .thresholds;
+      expect(thresholds).toBeDefined();
+      // Every adopter gets real gates from minute one — not just a layer linter.
+      expect(thresholds).toHaveProperty('circular-deps');
+      expect(thresholds).toHaveProperty('layer-violations');
+      expect(thresholds).toHaveProperty('complexity');
+      expect(thresholds).toHaveProperty('module-size');
+      expect(thresholds).toHaveProperty('dependency-depth');
+    });
+  }
+
+  it('basic uses a more lenient complexity cap than intermediate', () => {
+    const basic = renderConfig('basic') as {
+      architecture: { thresholds: { complexity: { max: number } } };
+    };
+    const intermediate = renderConfig('intermediate') as {
+      architecture: { thresholds: { complexity: { max: number } } };
+    };
+    expect(basic.architecture.thresholds.complexity.max).toBe(20);
+    expect(intermediate.architecture.thresholds.complexity.max).toBe(15);
+    expect(basic.architecture.thresholds.complexity.max).toBeGreaterThan(
+      intermediate.architecture.thresholds.complexity.max
+    );
+  });
+
+  it('both tiers cap dependency-depth at 8', () => {
+    for (const tier of ['basic', 'intermediate']) {
+      const config = renderConfig(tier) as {
+        architecture: { thresholds: { 'dependency-depth': { max: number } } };
+      };
+      expect(config.architecture.thresholds['dependency-depth'].max).toBe(8);
+    }
+  });
+});

--- a/templates/basic/harness.config.json.hbs
+++ b/templates/basic/harness.config.json.hbs
@@ -7,8 +7,42 @@
     { "name": "services", "pattern": "src/services/**", "allowedDependencies": ["types", "domain"] },
     { "name": "api", "pattern": "src/api/**", "allowedDependencies": ["types", "domain", "services"] }
   ],
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": { "max": 0 },
+      "layer-violations": { "max": 0 },
+      "complexity": { "max": 20 },
+      "module-size": { "maxFiles": 50, "maxLoc": 5000 },
+      "dependency-depth": { "max": 8 }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": ["**/node_modules/**", "**/dist/**", "**/*.test.ts"]
+  },
+  "entropy": {
+    "excludePatterns": ["**/node_modules/**", "**/dist/**", "**/*.test.ts"],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": { "error": 20, "warn": 15 }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": { "warn": 15 }
+      }
+    }
+  },
   "template": {
     "level": "basic",
     "version": 1

--- a/templates/intermediate/harness.config.json.hbs
+++ b/templates/intermediate/harness.config.json.hbs
@@ -13,8 +13,44 @@
   "boundaries": {
     "requireSchema": ["src/api/**"]
   },
+  "architecture": {
+    "enabled": true,
+    "baselinePath": ".harness/arch/baselines.json",
+    "thresholds": {
+      "circular-deps": { "max": 0 },
+      "layer-violations": { "max": 0 },
+      "forbidden-imports": { "max": 0 },
+      "complexity": { "max": 15 },
+      "coupling": { "maxFanIn": 15, "maxFanOut": 12 },
+      "module-size": { "maxFiles": 40, "maxLoc": 4000 },
+      "dependency-depth": { "max": 8 }
+    }
+  },
   "agentsMapPath": "./AGENTS.md",
   "docsDir": "./docs",
+  "security": {
+    "enabled": true,
+    "strict": false,
+    "exclude": ["**/node_modules/**", "**/dist/**", "**/*.test.ts"]
+  },
+  "entropy": {
+    "excludePatterns": ["**/node_modules/**", "**/dist/**", "**/*.test.ts"],
+    "autoFix": false
+  },
+  "performance": {
+    "complexity": {
+      "enabled": true,
+      "thresholds": {
+        "cyclomaticComplexity": { "error": 15, "warn": 10 }
+      }
+    },
+    "coupling": {
+      "enabled": true,
+      "thresholds": {
+        "fanOut": { "warn": 12 }
+      }
+    }
+  },
   "template": {
     "level": "intermediate",
     "version": 1


### PR DESCRIPTION
## Summary

Selected via `harness:roadmap-pilot` and implemented the next roadmap item, plus a roadmap sync for two already-shipped features.

### Roadmap sync
- Mark **Build harness:outcome-eval skill** (#532) and **Ship the 5-signal dashboard panel and signals.md doc** (#534) as `done` — both shipped/merged (PRs #591, #534/#595) but were still listed `planned`. Verified the in-tree artifacts before flipping status.

### Feature: architecture thresholds in templates (#537)
Basic and intermediate templates previously shipped only a layer linter — no `architecture.thresholds`, `security`, `entropy`, or `performance` config. Now every adopter gets real gates from minute one:

- **basic**: complexity ≤20, module-size 50/5000, dependency-depth ≤8, circular-deps/layer-violations 0; non-strict `security`, `entropy` excludes, complexity/coupling `performance` budgets.
- **intermediate**: complexity ≤15, coupling 15/12, module-size 40/4000, forbidden-imports gate, dependency-depth ≤8; tighter `performance` budgets.

## Testing
- New `packages/cli/tests/templates/template-thresholds.test.ts`: validates each rendered tier config against `HarnessConfigSchema` and asserts the tiered thresholds.
- Refreshed template snapshots (pure additions).
- `vitest run tests/templates/` → 148 passing; cli `tsc --noEmit` clean.

## Notes
- The pre-commit `harness validate` **arch** step reports a pre-existing baseline regression in `packages/dashboard` and `packages/graph` (module sizes) — unrelated to this templates-only change.
- Roadmap #537 left `in-progress` (flips to `done` on merge), assigned to chad.warner@gmail.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)