### PR TITLE
feat: ship CI workflow template on init (#540)

### DIFF
--- a/.changeset/ci-workflow-template.md
+++ b/.changeset/ci-workflow-template.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Ship a complete CI workflow on `harness init`. Projects now inherit
+`.github/workflows/ci.yml` automatically — a single fail-fast GitHub Actions job
+that builds, lints, and tests (language-appropriate for TypeScript, Python, Go,
+Rust, and Java) and runs the consolidated `harness ci check` gate on every pull
+request and push to `main`. The workflow is written for both new and existing
+projects and never overwrites an existing workflow file.
+
+`harness ci init` and `harness init` now route through a single CI generator
+(ADR 0037), so the two paths cannot drift; the enriched GitHub output replaces the
+gate-only `harness.yml` with `ci.yml`. The generated workflow installs the harness
+CLI before the gate and deliberately contains no auto-baseline-update / `git push`
+step (roadmap #525). `harness ci init` also gains a `--language` option.

--- a/.harness/learnings.md
+++ b/.harness/learnings.md
@@ -50,3 +50,9 @@ When implementing directory traversal for code scanning/ingestion, ensure defaul
 - **Git**: `.git` (Crucial to avoid scanning internal git objects)
 - **Tools**: `.vscode`, `.idea`, `.harness`
 - **Test Artifacts**: `coverage`, `.nyc_output`
+
+## CI Workflow Template (#540) — 2026-06-23
+
+- When a generated CI workflow runs `harness ci check`, it MUST first install the CLI (`npm install -g @harness-engineering/cli`). GitHub-hosted ubuntu runners ship Node+npm for any project language, so a global install works universally; omitting it fails the gate with exit 127 (command-not-found), not a real check failure.
+- In generated TS GitHub workflows, `pnpm/action-setup` must precede `actions/setup-node` — `setup-node`'s `cache: 'pnpm'` needs pnpm already on PATH. Mirror the dogfood `.github/workflows/ci.yml` ordering when disseminating it.
+- Single-generator rule (ADR 0037): both `harness init` (scaffold-time) and `harness ci init` (on-demand) route through one `generateCIConfig`; never add a second `templates/ci/` YAML source — it drifts.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -237,7 +237,7 @@ harness ci init --checks validate,deps,docs,arch
 
 Generated files:
 
-- **GitHub Actions:** `.github/workflows/harness.yml`
+- **GitHub Actions:** `.github/workflows/ci.yml`
 - **GitLab CI:** `.gitlab-ci-harness.yml`
 - **Generic:** `harness-ci.sh` (executable shell script)
 

--- a/docs/changes/ci-workflow-template/plans/2026-06-23-ci-workflow-template-plan.md
+++ b/docs/changes/ci-workflow-template/plans/2026-06-23-ci-workflow-template-plan.md
@@ -1,0 +1,353 @@
+# Plan: CI Workflow Template
+
+**Date:** 2026-06-23 | **Spec:** docs/changes/ci-workflow-template/proposal.md | **Tasks:** 11 | **Time:** ~46 min | **Integration Tier:** medium
+
+> **Environment:** All work happens in the worktree `/Users/cwarner/Projects/harness-engineering-540-ci-template` (branch `feat/540-ci-workflow-template`). Use Node 22 (`nvm use 22`) for every `pnpm`/`harness`/`vitest` command — Node 26 breaks `better-sqlite3` and the pre-push hook. All paths below are relative to the worktree root.
+
+## Goal
+
+`harness init` (and `harness ci init`) writes a single blocking GitHub Actions workflow (`.github/workflows/ci.yml`) that builds, lints, tests (language-appropriate), and runs `harness ci check` as the gate — reaching existing repos without overwriting a hand-tuned workflow.
+
+## Observable Truths (Acceptance Criteria)
+
+1. The system shall write `.github/workflows/ci.yml` containing build + lint + test steps followed by a `harness ci check --json` step when `harness init` runs on a fresh project.
+2. The generated workflow shall trigger on `pull_request: [main]` and `push: [main]`, and when `harness ci check` exits non-zero the workflow run shall fail (single fail-fast job).
+3. Language shall be reflected in generated steps: Python emits `pytest` + `ruff check .`; Go emits `go test ./...` + `golangci-lint run`; Rust emits `cargo test` + `cargo clippy`; Java emits `mvn -B verify`; TS/default emits `pnpm build`/`pnpm lint`/`pnpm test`.
+4. When `harness init` runs in an existing project with no workflow file, the system shall write `.github/workflows/ci.yml`; if a workflow file already exists at that path, the system shall not overwrite it.
+5. The generated workflow shall not contain any auto-baseline-update or `git push` step.
+6. Exactly one GitHub Actions generator shall exist — `harness init` and `harness ci init` produce the same `ci.yml`; the gate-only `harness.yml` filename is retired. GitLab and generic generators are unchanged.
+7. `harness validate` passes.
+
+## Uncertainties
+
+- [ASSUMPTION] The init flow injects the generated workflow into the engine's `RenderedFiles` set before `engine.write()`, and `.github/workflows/ci.yml` is added to `HARNESS_CONFIG_FILES` so existing-project mode (engine.ts:307) emits it and non-overwrite (engine.ts:323) protects an existing file. This is the spec's stated approach (proposal lines 99-103). If injecting into `RenderedFiles` proves awkward, Task 8 falls back to a discrete post-write call in `scaffoldProject` that itself checks `fs.existsSync` before writing — Task 9's tests still pin the same observable behavior. (Resolved to the injection approach; fallback noted.)
+- [ASSUMPTION] The CI generator's new `opts.language` accepts the same lowercase strings the init flow uses (`typescript`, `python`, `go`, `rust`, `java`); unknown/undefined falls back to TS defaults. (Matches `InitOptions.language` and the engine's language handling.)
+- [DEFERRABLE] Exact runtime-setup action versions (e.g. `setup-python@v5`) — concrete values chosen in Task 2/3, refinable during execution without changing task structure.
+- [DEFERRABLE] `CIInitOptions` in `packages/types/src/ci.ts` does not currently carry `language`. The generator signature uses an inline `opts?: { language?: string }` per the spec, so the shared type need not change. If a future caller wants the typed option, add it then (YAGNI now).
+
+## File Map
+
+- MODIFY `packages/cli/src/commands/ci/init.ts` (add `language` option, per-language step blocks, enrich GitHub job, retire `harness.yml` filename → `ci.yml`)
+- MODIFY `packages/cli/tests/ci/init.test.ts` (per-language snapshot / content assertions; updated filename)
+- MODIFY `packages/cli/src/commands/init.ts` (wire `generateCIConfig` into scaffold + inject into write set)
+- MODIFY `packages/cli/src/templates/engine.ts` (classify `.github/workflows/ci.yml` as harness-managed)
+- MODIFY `packages/cli/tests/integration/init.test.ts` (new-project writes ci.yml; existing-project-with-workflow skips; language drives steps)
+- MODIFY `docs/standard/implementation.md` (CI ships on init)
+- CREATE `docs/knowledge/decisions/NNNN-single-ci-generator.md` (ADR for D1)
+
+## Skeleton
+
+1. Per-language CI generator with snapshot tests (~4 tasks, ~17 min)
+2. Enrich GitHub job + retire harness.yml (~2 tasks, ~8 min)
+3. Init wiring + harness-managed classification (~2 tasks, ~9 min)
+4. Init integration tests (~1 task, ~5 min)
+5. Documentation + ADR (integration) (~2 tasks, ~7 min)
+
+**Estimated total:** 11 tasks, ~46 minutes.
+_Skeleton approved: pending (presented at sign-off)._
+
+---
+
+## Tasks
+
+### Task 1: Add language-to-steps mapping + `language` option to generator (TDD — write failing test first)
+
+**Depends on:** none | **Files:** `packages/cli/tests/ci/init.test.ts`, `packages/cli/src/commands/ci/init.ts`
+
+1. In `packages/cli/tests/ci/init.test.ts`, add a new `describe('generateCIConfig — language', ...)` block with a test that the default/typescript GitHub output contains `pnpm i --frozen-lockfile`, `pnpm build`, `pnpm lint`, `pnpm test`:
+   ```ts
+   it('emits TypeScript/default steps for github', () => {
+     const result = generateCIConfig({ platform: 'github', language: 'typescript' });
+     expect(result.ok).toBe(true);
+     if (!result.ok) return;
+     expect(result.value.content).toContain('pnpm i --frozen-lockfile');
+     expect(result.value.content).toContain('pnpm build');
+     expect(result.value.content).toContain('pnpm lint');
+     expect(result.value.content).toContain('pnpm test');
+   });
+   ```
+   Note: `generateCIConfig` options type does not yet accept `language` — this also forces the type change.
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe failure (type error / missing steps).
+3. In `packages/cli/src/commands/ci/init.ts`, add a language step map above `generateGitHubActions`:
+   ```ts
+   interface LanguageSteps {
+     setup: string; // YAML lines for runtime setup step(s), indented for steps list
+     install: string;
+     build?: string;
+     lint?: string;
+     test: string;
+   }
+
+   function stepsForLanguage(language?: string): LanguageSteps {
+     switch (language) {
+       case 'python':
+         return {
+           setup: `      - uses: actions/setup-python@v5\n        with:\n          python-version: '3.12'`,
+           install: 'pip install -e .',
+           lint: 'ruff check .',
+           test: 'pytest',
+         };
+       case 'go':
+         return {
+           setup: `      - uses: actions/setup-go@v5\n        with:\n          go-version: 'stable'`,
+           install: 'go mod download',
+           build: 'go build ./...',
+           lint: 'golangci-lint run',
+           test: 'go test ./...',
+         };
+       case 'rust':
+         return {
+           setup: `      - uses: dtolnay/rust-toolchain@stable`,
+           install: 'cargo fetch',
+           build: 'cargo build',
+           lint: 'cargo clippy',
+           test: 'cargo test',
+         };
+       case 'java':
+         return {
+           setup: `      - uses: actions/setup-java@v4\n        with:\n          distribution: 'temurin'\n          java-version: '21'`,
+           install: 'mvn -B -q install -DskipTests',
+           test: 'mvn -B verify',
+         };
+       case 'typescript':
+       default:
+         return {
+           setup: `      - uses: actions/setup-node@v4\n        with:\n          node-version: '22'\n      - uses: pnpm/action-setup@v4`,
+           install: 'pnpm i --frozen-lockfile',
+           build: 'pnpm build',
+           lint: 'pnpm lint',
+           test: 'pnpm test',
+         };
+     }
+   }
+   ```
+4. Do NOT yet rewrite `generateGitHubActions` body — that is Task 2. For now, extend the generator option types so the test compiles: change `generateCIConfig` options to `{ platform: CIPlatform; checks?: CICheckName[]; language?: string }`, and thread `language` to a temporary `generateGitHubActions(skipFlag, language)` signature that still returns the old body (steps unused yet) — the TS-default test will still fail on missing `pnpm build` content, which Task 2 fixes. (If preferred, defer the content assertion to Task 2 by marking this test `.skip` — but keep the type wiring here.)
+5. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — the type compiles; content test may remain red until Task 2.
+6. Run: `nvm use 22 && pnpm harness validate`
+7. Commit: `feat(ci): add per-language step mapping to CI generator`
+
+### Task 2: Enrich `generateGitHubActions` into a single fail-fast `ci` job (TDD)
+
+**Depends on:** Task 1 | **Files:** `packages/cli/tests/ci/init.test.ts`, `packages/cli/src/commands/ci/init.ts`
+
+1. In `packages/cli/tests/ci/init.test.ts`, assert the enriched job shape for default/TS:
+   ```ts
+   it('emits a single fail-fast ci job with checkout, setup, install, build, lint, test, gate', () => {
+     const r = generateCIConfig({ platform: 'github', language: 'typescript' });
+     expect(r.ok).toBe(true);
+     if (!r.ok) return;
+     const c = r.value.content;
+     expect(c).toContain('actions/checkout@v4');
+     expect(c).toMatch(/jobs:\s*\n\s*ci:/);
+     expect(c).toContain('pnpm i --frozen-lockfile');
+     expect(c).toContain('pnpm build');
+     expect(c).toContain('harness ci check --json');
+     // gate is the last step
+     expect(c.trimEnd().endsWith("run: harness ci check --json")).toBe(true);
+   });
+   it('excludes any baseline-refresh or git push step', () => {
+     const r = generateCIConfig({ platform: 'github' });
+     if (!r.ok) return;
+     expect(r.value.content).not.toMatch(/git push/);
+     expect(r.value.content).not.toMatch(/refresh-baselines|baseline.*update/i);
+   });
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe failure.
+3. Rewrite `generateGitHubActions(skipFlag: string, language?: string): string` so it emits one `ci` job, building the steps list from `stepsForLanguage(language)`. Keep `name: CI`, the `on: push:[main] / pull_request:[main]` triggers, and the `concurrency` cancel-in-progress block. Compose steps in order: `actions/checkout@v4`, `<setup>`, install, build (if present), lint (if present), test, then `harness ci check --json${skipFlag}` as the final step. Use `- name:`/`run:` for each command step. No baseline/git-push steps.
+4. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe pass (all language + structure tests, including the Task 1 TS-default content test).
+5. Run: `nvm use 22 && pnpm harness validate`
+6. Commit: `feat(ci): emit enriched single fail-fast GitHub Actions job`
+
+### Task 3: Per-language snapshot tests for Python, Go, Rust, Java (TDD)
+
+**Depends on:** Task 2 | **Files:** `packages/cli/tests/ci/init.test.ts`
+
+1. Add per-language assertions (one test each) verifying the distinctive commands:
+   ```ts
+   it('python project emits pytest and ruff', () => {
+     const r = generateCIConfig({ platform: 'github', language: 'python' });
+     if (!r.ok) return;
+     expect(r.value.content).toContain('setup-python');
+     expect(r.value.content).toContain('ruff check .');
+     expect(r.value.content).toContain('pytest');
+   });
+   it('go project emits go test and golangci-lint', () => {
+     const r = generateCIConfig({ platform: 'github', language: 'go' });
+     if (!r.ok) return;
+     expect(r.value.content).toContain('go build ./...');
+     expect(r.value.content).toContain('golangci-lint run');
+     expect(r.value.content).toContain('go test ./...');
+   });
+   it('rust project emits cargo build/clippy/test', () => {
+     const r = generateCIConfig({ platform: 'github', language: 'rust' });
+     if (!r.ok) return;
+     expect(r.value.content).toContain('cargo build');
+     expect(r.value.content).toContain('cargo clippy');
+     expect(r.value.content).toContain('cargo test');
+   });
+   it('java project emits mvn verify', () => {
+     const r = generateCIConfig({ platform: 'github', language: 'java' });
+     if (!r.ok) return;
+     expect(r.value.content).toContain('setup-java');
+     expect(r.value.content).toContain('mvn -B verify');
+   });
+   it('unknown language falls back to TypeScript defaults', () => {
+     const r = generateCIConfig({ platform: 'github', language: 'cobol' });
+     if (!r.ok) return;
+     expect(r.value.content).toContain('pnpm test');
+   });
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe pass (generator already supports these from Task 1/2).
+3. Run: `nvm use 22 && pnpm harness validate`
+4. Commit: `test(ci): cover per-language CI generation`
+
+### Task 4: Verify GitLab/generic generators unchanged (regression guard)
+
+**Depends on:** Task 3 | **Files:** `packages/cli/tests/ci/init.test.ts`
+
+1. Confirm the existing GitLab and generic tests still pass and that passing `language` does not alter their output. Add a guard test:
+   ```ts
+   it('language option does not affect gitlab/generic output', () => {
+     const g1 = generateCIConfig({ platform: 'gitlab' });
+     const g2 = generateCIConfig({ platform: 'gitlab', language: 'python' });
+     if (!g1.ok || !g2.ok) return;
+     expect(g2.value.content).toBe(g1.value.content);
+     const s1 = generateCIConfig({ platform: 'generic' });
+     const s2 = generateCIConfig({ platform: 'generic', language: 'go' });
+     if (!s1.ok || !s2.ok) return;
+     expect(s2.value.content).toBe(s1.value.content);
+   });
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe pass.
+3. Run: `nvm use 22 && pnpm harness validate`
+4. Commit: `test(ci): guard gitlab/generic generators against language option`
+
+### Task 5: Retire the gate-only `harness.yml` filename → `ci.yml` (TDD)
+
+**Depends on:** Task 4 | **Files:** `packages/cli/tests/ci/init.test.ts`, `packages/cli/src/commands/ci/init.ts`
+
+1. Update the existing filename assertion in `packages/cli/tests/ci/init.test.ts` from `.github/workflows/harness.yml` to `.github/workflows/ci.yml`:
+   ```ts
+   expect(result.value.filename).toBe('.github/workflows/ci.yml');
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe failure.
+3. In `packages/cli/src/commands/ci/init.ts`, change the `github` generator entry filename from `.github/workflows/harness.yml` to `.github/workflows/ci.yml`. The `github` generator's `generate` must now pass `language`; since the `generators` record's `generate` signature is `(skip: string) => string`, adapt `generateCIConfig` so the GitHub branch calls `generateGitHubActions(skipFlag, language)` directly (special-case github, or widen the record's generate type to accept an optional language).
+4. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe pass.
+5. Run: `nvm use 22 && pnpm harness validate`
+6. Commit: `feat(ci): write .github/workflows/ci.yml and retire harness.yml`
+
+### Task 6: Thread `language` through `harness ci init` action (TDD)
+
+**Depends on:** Task 5 | **Files:** `packages/cli/tests/ci/init.test.ts`, `packages/cli/src/commands/ci/init.ts`
+
+1. The `harness ci init` command (`createInitCommand` / `runInitAction` in `ci/init.ts`) does not pass `language`. Add a unit test asserting `generateCIConfig` is reachable with a language through the command's option plumbing. Since `runInitAction` writes to disk, instead test the option-resolution helper. Add a `--language` option to the command and a test that resolving opts produces the expected `configOpts.language`. Minimal test: assert the command registers a `--language` option:
+   ```ts
+   import { createInitCommand } from '../../src/commands/ci/init';
+   it('ci init command accepts --language', () => {
+     const cmd = createInitCommand();
+     const opt = cmd.options.find((o) => o.long === '--language');
+     expect(opt).toBeDefined();
+   });
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe failure.
+3. In `ci/init.ts`: add `.option('--language <language>', 'Project language for build/lint/test steps')` to `createInitCommand`; in `runInitAction`, read `opts.language` and set `configOpts.language = opts.language` when present. `detectPlatform()` already defaults platform.
+4. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe pass.
+5. Run: `nvm use 22 && pnpm harness validate`
+6. Commit: `feat(ci): accept --language on harness ci init`
+
+### Task 7: Classify `.github/workflows/ci.yml` as harness-managed (TDD)
+
+**Depends on:** Task 6 | **Files:** `packages/cli/tests/integration/init.test.ts` (or a new engine unit test), `packages/cli/src/templates/engine.ts`
+
+1. Add a unit test asserting the engine treats the CI workflow as a harness-managed file so existing-project mode does not skip it. In `packages/cli/tests/integration/init.test.ts` add:
+   ```ts
+   import { TemplateEngine } from '../../src/templates/engine';
+   it('writes ci.yml in existing-project mode', () => {
+     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-ci-existing-'));
+     fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x"}'); // existing-project marker
+     const engine = new TemplateEngine(require('../../src/utils/paths').resolveTemplatesDir());
+     const res = engine.write(
+       { files: [{ relativePath: '.github/workflows/ci.yml', content: 'name: CI\n' }] } as any,
+       tmp,
+       { overwrite: false, existingProject: true }
+     );
+     expect(res.ok).toBe(true);
+     expect(fs.existsSync(path.join(tmp, '.github/workflows/ci.yml'))).toBe(true);
+     fs.rmSync(tmp, { recursive: true });
+   });
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/integration/init.test.ts` — observe failure (existing-project gate skips non-config file).
+3. In `packages/cli/src/templates/engine.ts`, add `.github/workflows/ci.yml` to the `HARNESS_CONFIG_FILES` set (line ~70) so `isHarnessConfigFile` returns true and the existing-project branch (line 307) does not `continue` past it. Non-overwrite (line 323) is unchanged and still protects an existing file.
+4. Run: `nvm use 22 && npx vitest run packages/cli/tests/integration/init.test.ts` — observe pass.
+5. Run: `nvm use 22 && pnpm harness validate`
+6. Commit: `feat(init): classify CI workflow as a harness-managed file`
+
+### Task 8: Wire `generateCIConfig` into `scaffoldProject` write set (TDD)
+
+**Depends on:** Task 7 | **Files:** `packages/cli/tests/integration/init.test.ts`, `packages/cli/src/commands/init.ts`
+
+1. Add an integration test that a fresh `runInit` produces `.github/workflows/ci.yml` with the gate:
+   ```ts
+   it('init writes .github/workflows/ci.yml with build/lint/test + gate', async () => {
+     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-ci-'));
+     const r = await runInit({ cwd: tmp, name: 'ci-proj', level: 'basic' });
+     expect(r.ok).toBe(true);
+     const wf = path.join(tmp, '.github/workflows/ci.yml');
+     expect(fs.existsSync(wf)).toBe(true);
+     const c = fs.readFileSync(wf, 'utf-8');
+     expect(c).toContain('harness ci check --json');
+     expect(c).toContain('pnpm test');
+     expect(c).not.toMatch(/git push/);
+     fs.rmSync(tmp, { recursive: true });
+   });
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/integration/init.test.ts` — observe failure.
+3. In `packages/cli/src/commands/init.ts`, inside `scaffoldProject`, before calling `engine.write(...)`, import and call `generateCIConfig` (from `./ci/init`) with `{ platform: 'github', ...(language && { language }) }`, then push the generated file into `renderResult.value.files` as `{ relativePath: result.value.filename, content: result.value.content }` (guard `result.ok`). Because `.github/workflows/ci.yml` is now harness-managed (Task 7), `engine.write` emits it in both fresh and existing-project mode and skips it when the file already exists. Detect platform via the existing `detectPlatform` if exported, else default to `'github'` per D5 (export `detectPlatform` from `ci/init.ts` if needed — small, keep it minimal).
+4. Run: `nvm use 22 && npx vitest run packages/cli/tests/integration/init.test.ts` — observe pass.
+5. Run: `nvm use 22 && pnpm harness validate && pnpm harness check-deps`
+6. Commit: `feat(init): write CI workflow on scaffold via the single generator`
+
+### Task 9: Integration test — existing-workflow non-overwrite + language-driven steps (TDD) `[checkpoint:human-verify]`
+
+**Depends on:** Task 8 | **Files:** `packages/cli/tests/integration/init.test.ts`
+
+1. Add two tests:
+   ```ts
+   it('does not overwrite an existing ci.yml', async () => {
+     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-ci-keep-'));
+     fs.mkdirSync(path.join(tmp, '.github/workflows'), { recursive: true });
+     fs.writeFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'name: Hand-tuned\n');
+     await runInit({ cwd: tmp, name: 'keep', level: 'basic' });
+     expect(fs.readFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'utf-8')).toBe('name: Hand-tuned\n');
+     fs.rmSync(tmp, { recursive: true });
+   });
+   it('language drives the generated steps (python)', async () => {
+     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-ci-py-'));
+     await runInit({ cwd: tmp, name: 'py', language: 'python' });
+     const c = fs.readFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'utf-8');
+     expect(c).toContain('pytest');
+     fs.rmSync(tmp, { recursive: true });
+   });
+   ```
+2. Run: `nvm use 22 && npx vitest run packages/cli/tests/integration/init.test.ts` — observe pass (behavior delivered by Tasks 7-8).
+3. Run the full CI-related suites: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts packages/cli/tests/integration/init.test.ts packages/cli/tests/commands/init.test.ts`
+4. Run: `nvm use 22 && pnpm harness validate`
+5. [checkpoint:human-verify] Show the generated `ci.yml` for a TS and a Python project (`runInit` into a tmp dir and print). Confirm with the requester that the YAML is well-formed and the step order matches the spec before proceeding to docs.
+6. Commit: `test(init): cover non-overwrite and language-driven CI generation`
+
+### Task 10: Documentation update — CI ships on init
+
+**Depends on:** Task 9 | **Files:** `docs/standard/implementation.md` | **Category:** integration
+
+1. In `docs/standard/implementation.md`, update the CI section to state that `harness init` now writes `.github/workflows/ci.yml` (build + lint + test + `harness ci check`) automatically for new and existing projects, never overwriting an existing workflow; `harness ci init` remains the on-demand path through the same generator. Note that `harness.yml` is retired in favor of `ci.yml`. Keep edits scoped to the CI subsection.
+2. Run: `nvm use 22 && pnpm harness validate`
+3. Commit: `docs(standard): CI workflow now ships on harness init`
+
+### Task 11: ADR for single-generator consolidation (D1)
+
+**Depends on:** Task 10 | **Files:** `docs/knowledge/decisions/NNNN-single-ci-generator.md` | **Category:** integration
+
+1. Determine the next ADR number: `ls docs/knowledge/decisions/ | sort | tail -3` and pick the next zero-padded integer.
+2. Create `docs/knowledge/decisions/NNNN-single-ci-generator.md` recording D1: scaffold-time generation (`harness init`) and on-demand generation (`harness ci init`) share one source (`generateCIConfig`); no parallel `templates/ci/` generator. Capture context (drift is the entropy STRATEGY exists to prevent), decision, consequences (GitLab/generic stay simple; future language enrichment is one place), and links to roadmap #540, #525 (no auto-baseline step), #541 (required-review, separate). Match the existing ADR template structure in that directory.
+3. Run: `nvm use 22 && pnpm harness validate`
+4. Commit: `docs(adr): single CI generator for init and ci init`

--- a/docs/changes/ci-workflow-template/plans/2026-06-23-ci-workflow-template-plan.md
+++ b/docs/changes/ci-workflow-template/plans/2026-06-23-ci-workflow-template-plan.md
@@ -69,6 +69,7 @@ _Skeleton approved: pending (presented at sign-off)._
    Note: `generateCIConfig` options type does not yet accept `language` — this also forces the type change.
 2. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — observe failure (type error / missing steps).
 3. In `packages/cli/src/commands/ci/init.ts`, add a language step map above `generateGitHubActions`:
+
    ```ts
    interface LanguageSteps {
      setup: string; // YAML lines for runtime setup step(s), indented for steps list
@@ -121,6 +122,7 @@ _Skeleton approved: pending (presented at sign-off)._
      }
    }
    ```
+
 4. Do NOT yet rewrite `generateGitHubActions` body — that is Task 2. For now, extend the generator option types so the test compiles: change `generateCIConfig` options to `{ platform: CIPlatform; checks?: CICheckName[]; language?: string }`, and thread `language` to a temporary `generateGitHubActions(skipFlag, language)` signature that still returns the old body (steps unused yet) — the TS-default test will still fail on missing `pnpm build` content, which Task 2 fixes. (If preferred, defer the content assertion to Task 2 by marking this test `.skip` — but keep the type wiring here.)
 5. Run: `nvm use 22 && npx vitest run packages/cli/tests/ci/init.test.ts` — the type compiles; content test may remain red until Task 2.
 6. Run: `nvm use 22 && pnpm harness validate`
@@ -143,7 +145,7 @@ _Skeleton approved: pending (presented at sign-off)._
      expect(c).toContain('pnpm build');
      expect(c).toContain('harness ci check --json');
      // gate is the last step
-     expect(c.trimEnd().endsWith("run: harness ci check --json")).toBe(true);
+     expect(c.trimEnd().endsWith('run: harness ci check --json')).toBe(true);
    });
    it('excludes any baseline-refresh or git push step', () => {
      const r = generateCIConfig({ platform: 'github' });
@@ -318,7 +320,9 @@ _Skeleton approved: pending (presented at sign-off)._
      fs.mkdirSync(path.join(tmp, '.github/workflows'), { recursive: true });
      fs.writeFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'name: Hand-tuned\n');
      await runInit({ cwd: tmp, name: 'keep', level: 'basic' });
-     expect(fs.readFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'utf-8')).toBe('name: Hand-tuned\n');
+     expect(fs.readFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'utf-8')).toBe(
+       'name: Hand-tuned\n'
+     );
      fs.rmSync(tmp, { recursive: true });
    });
    it('language drives the generated steps (python)', async () => {

--- a/docs/changes/ci-workflow-template/proposal.md
+++ b/docs/changes/ci-workflow-template/proposal.md
@@ -1,0 +1,159 @@
+# CI Workflow Template
+
+## Overview
+
+Adopters of harness currently write their CI from scratch, inheriting none of the
+project's hard-won wisdom — the dogfood's `.github/workflows/ci.yml` lives in this
+repo, not in anything an adopter receives. This is the largest "ships assembled vs
+ships in pieces" gap (roadmap #540).
+
+This change enriches harness's **existing** CI generator (`generateCIConfig` in
+`packages/cli/src/commands/ci/init.ts`) so that a project running `harness init`
+inherits a complete, blocking GitHub Actions workflow: build, lint, and test
+(language-appropriate) followed by the consolidated `harness ci check` gate, on
+every pull request and every push to `main`. There is **one** CI generator — both
+`harness init` (automatic, scaffold-time) and `harness ci init` (on-demand) route
+through it, so the two paths cannot drift.
+
+**Strategic grounding** (`STRATEGY.md#our-approach`): "constraints fire in real
+time, so agents self-correct mid-stream… Humans own the thinking layer; the harness
+mechanically polices everything below it." A CI workflow that *stops* a merge on
+violation is that bet embodied off-repo. The primary persona
+(`STRATEGY.md#who-its-for`) is the adopter 3–6 months in who already has a repo —
+hence the workflow must reach existing projects, not just new scaffolds.
+
+### Goals
+
+- `harness init` writes `.github/workflows/ci.yml` that builds, lints, tests, and
+  runs `harness ci check` as a blocking gate.
+- A single GitHub Actions generator — no second YAML source that drifts.
+- The workflow reaches existing-repo adopters, not only fresh scaffolds.
+
+### Non-goals
+
+- The required multi-persona review action — that is roadmap **#541**
+  (`required-review.yml.hbs`). This workflow may reference it but does not implement it.
+- A portable coverage-ratchet primitive. The dogfood ratchets coverage with a
+  repo-local `scripts/coverage-ratchet.mjs`; there is no `harness` coverage primitive
+  to invoke portably. Building one is out of scope (YAGNI) and a separate item if wanted.
+- Language-aware enrichment of the GitLab and generic generators. GitHub is the named
+  target and dominant platform; revisit on real demand.
+
+## Decisions
+
+| #  | Decision | Rationale |
+| -- | -------- | --------- |
+| D1 | Enrich `generateCIConfig`; both `harness init` and `harness ci init` route through it. No new `templates/ci/` directory. | Single generator, single source. A second generator would drift — the exact entropy STRATEGY exists to prevent. Revised from an initial `templates/ci/` idea on discovering the existing command. |
+| D2 | The harness-gate step is the consolidated `harness ci check` (which runs validate/deps/docs/entropy/security/perf/phase-gate/arch/traceability via `runCIChecks`), not separate `validate`/`check-arch`/`check-deps` invocations. | Already battle-tested with correct blocking exit codes (1 = checks failed, 2 = internal error). Loosely-listed individual commands in the roadmap text are superseded by the better primitive. |
+| D3 | Build/test/lint steps are language-conditional with concrete per-language defaults (TS, Python, Go, Rust, Java). | Reuses the `language` the init flow already knows; ships runnable commands, not `# TODO` placeholders. |
+| D4 | The generated workflow excludes any auto-baseline-update / `git push` step. | Reproducing the dogfood's `refresh-baselines` job would embody the failure pattern roadmap #525 and `STRATEGY.md` condemn: "a harness that warns but doesn't stop is not a harness." |
+| D5 | `harness init` writes the workflow by default for new **and** existing projects, and never overwrites a workflow file that already exists. | Delivers "inherit on init" to the primary (existing-repo) persona; the engine's non-overwrite default (`engine.ts:323`) protects a hand-tuned workflow. |
+| D6 | The enriched GitHub generator writes `.github/workflows/ci.yml`; the gate-only `harness.yml` output is retired in favor of it. | One canonical workflow per project. Avoids an adopter ending up with both `ci.yml` and a divergent `harness.yml`. The gate still runs — inside `ci.yml`. |
+| D7 | Single-job, sequential, fail-fast workflow. | The load-bearing minimum: one clear blocking pipeline an adopter immediately understands. Splitting into separate jobs only pays off once branch protection needs named status checks (YAGNI). |
+
+## Technical Design
+
+### Generator: `generateGitHubActions`
+
+**File:** `packages/cli/src/commands/ci/init.ts`
+
+Extend the signature to accept the detected language:
+
+```
+generateGitHubActions(skipFlag: string, opts?: { language?: string }): string
+```
+
+It emits one `ci` job:
+
+1. `actions/checkout`
+2. language runtime setup (e.g. `setup-node` + `pnpm/action-setup` for TS; `setup-python` for Python; `setup-go`; `dtolnay/rust-toolchain`; `setup-java`)
+3. install dependencies
+4. build
+5. lint
+6. test
+7. `harness ci check --json${skipFlag}`
+
+Steps 2–6 are language-conditional; step 7 is universal. Triggers (`push: [main]`,
+`pull_request: [main]`) and the `concurrency` cancel-in-progress block carry over
+from the current generator. The job is fail-fast: a failed earlier step blocks the
+gate, so a broken build never reports green.
+
+**Per-language defaults (initial set):**
+
+| Language | install | build | lint | test |
+| -------- | ------- | ----- | ---- | ---- |
+| TypeScript / default | `pnpm i --frozen-lockfile` | `pnpm build` | `pnpm lint` | `pnpm test` |
+| Python | `pip install -e .` | — | `ruff check .` | `pytest` |
+| Go | `go mod download` | `go build ./...` | `golangci-lint run` | `go test ./...` |
+| Rust | `cargo fetch` | `cargo build` | `cargo clippy` | `cargo test` |
+| Java | `mvn -B -q install -DskipTests` | (covered by verify) | — | `mvn -B verify` |
+
+Unknown / unspecified language falls back to the TypeScript defaults (the engine's
+existing behavior for the JS/TS path).
+
+### Init wiring
+
+**File:** `packages/cli/src/commands/init` (the init command flow) → `TemplateEngine`
+
+After scaffold, the init flow calls
+`generateCIConfig({ platform: detectPlatform() ?? 'github', language })` and writes
+the result through the engine's non-overwrite path. The generated workflow is
+classified as a harness-managed file (alongside `harness.config.json`, `AGENTS.md`)
+so that existing-project mode — which today writes only harness-config files
+(`engine.ts:303`) — still emits it.
+
+**Behavioral requirements (EARS):**
+
+- When `harness init` runs and no workflow file exists at the target path, the system
+  shall write the generated CI workflow.
+- If a workflow file already exists at the target path, the system shall not overwrite it.
+- When `harness ci check` exits non-zero in the generated workflow, the workflow run
+  shall fail.
+
+## Integration Points
+
+- **Entry Points:** `harness init` (new behavior — writes the CI workflow as part of
+  scaffolding); `harness ci init` (existing command, now routing through the enriched
+  generator).
+- **Registrations Required:** None. No new command, skill, MCP tool, or barrel export.
+  The change threads `language` into `generateCIConfig`'s options type and adds the
+  workflow to the set of harness-managed files written in existing-project mode.
+- **Documentation Updates:** `docs/standard/implementation.md` (CI now ships on init,
+  not hand-written later); `harness init` / `harness ci init` command help and docs;
+  AGENTS.md CI section if present.
+- **Architectural Decisions:** **D1** (single-generator consolidation) warrants a
+  short ADR — it establishes the precedent that scaffold-time generation and
+  on-demand generation share one source rather than maintaining parallel generators.
+  The remaining decisions are local to this change.
+- **Knowledge Impact:** the concept "CI ships assembled on init"; the relationship
+  between `harness init`, `generateCIConfig`, and `harness ci check` as the single
+  blocking gate; the anti-pattern record that generated CI must not auto-update
+  baselines (links #525).
+
+## Success Criteria
+
+1. `harness init` on a fresh project writes `.github/workflows/ci.yml` containing
+   build + lint + test + `harness ci check`.
+2. The workflow triggers on pull requests and pushes to `main`, and the run **fails**
+   when `harness ci check` exits non-zero.
+3. Language is reflected in the generated steps: a Python project runs `pytest`, a Go
+   project runs `go test ./...`, a Rust project runs `cargo test`, etc.
+4. Running `init` in an existing project with no workflow writes one; running it where
+   a workflow already exists leaves that file untouched.
+5. No auto-baseline-update or `git push` step appears anywhere in the generated workflow.
+6. Exactly one GitHub Actions generator exists in the codebase — `harness init` and
+   `harness ci init` produce the same `ci.yml`; no duplicated YAML string template.
+7. `harness validate` passes.
+
+## Implementation Order
+
+1. Extend `generateCIConfig` / `generateGitHubActions` with a `language` option; add
+   per-language step blocks. Unit tests: per-language snapshot of the generated YAML.
+2. Enrich the GitHub generator (build/lint/test + gate, single fail-fast job, no
+   baseline-refresh job); retire the gate-only `harness.yml` output in favor of `ci.yml`.
+3. Wire `harness init` to call the generator with detected platform/language; classify
+   the workflow as a harness-managed file so existing-project mode emits it; preserve
+   non-overwrite.
+4. Integration tests: new project writes `ci.yml`; existing project with a workflow
+   skips; language detection drives the right steps.
+5. Documentation updates.

--- a/docs/changes/ci-workflow-template/proposal.md
+++ b/docs/changes/ci-workflow-template/proposal.md
@@ -17,7 +17,7 @@ through it, so the two paths cannot drift.
 
 **Strategic grounding** (`STRATEGY.md#our-approach`): "constraints fire in real
 time, so agents self-correct mid-stream… Humans own the thinking layer; the harness
-mechanically polices everything below it." A CI workflow that *stops* a merge on
+mechanically polices everything below it." A CI workflow that _stops_ a merge on
 violation is that bet embodied off-repo. The primary persona
 (`STRATEGY.md#who-its-for`) is the adopter 3–6 months in who already has a repo —
 hence the workflow must reach existing projects, not just new scaffolds.
@@ -41,15 +41,15 @@ hence the workflow must reach existing projects, not just new scaffolds.
 
 ## Decisions
 
-| #  | Decision | Rationale |
-| -- | -------- | --------- |
-| D1 | Enrich `generateCIConfig`; both `harness init` and `harness ci init` route through it. No new `templates/ci/` directory. | Single generator, single source. A second generator would drift — the exact entropy STRATEGY exists to prevent. Revised from an initial `templates/ci/` idea on discovering the existing command. |
-| D2 | The harness-gate step is the consolidated `harness ci check` (which runs validate/deps/docs/entropy/security/perf/phase-gate/arch/traceability via `runCIChecks`), not separate `validate`/`check-arch`/`check-deps` invocations. | Already battle-tested with correct blocking exit codes (1 = checks failed, 2 = internal error). Loosely-listed individual commands in the roadmap text are superseded by the better primitive. |
-| D3 | Build/test/lint steps are language-conditional with concrete per-language defaults (TS, Python, Go, Rust, Java). | Reuses the `language` the init flow already knows; ships runnable commands, not `# TODO` placeholders. |
-| D4 | The generated workflow excludes any auto-baseline-update / `git push` step. | Reproducing the dogfood's `refresh-baselines` job would embody the failure pattern roadmap #525 and `STRATEGY.md` condemn: "a harness that warns but doesn't stop is not a harness." |
-| D5 | `harness init` writes the workflow by default for new **and** existing projects, and never overwrites a workflow file that already exists. | Delivers "inherit on init" to the primary (existing-repo) persona; the engine's non-overwrite default (`engine.ts:323`) protects a hand-tuned workflow. |
-| D6 | The enriched GitHub generator writes `.github/workflows/ci.yml`; the gate-only `harness.yml` output is retired in favor of it. | One canonical workflow per project. Avoids an adopter ending up with both `ci.yml` and a divergent `harness.yml`. The gate still runs — inside `ci.yml`. |
-| D7 | Single-job, sequential, fail-fast workflow. | The load-bearing minimum: one clear blocking pipeline an adopter immediately understands. Splitting into separate jobs only pays off once branch protection needs named status checks (YAGNI). |
+| #   | Decision                                                                                                                                                                                                                          | Rationale                                                                                                                                                                                         |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Enrich `generateCIConfig`; both `harness init` and `harness ci init` route through it. No new `templates/ci/` directory.                                                                                                          | Single generator, single source. A second generator would drift — the exact entropy STRATEGY exists to prevent. Revised from an initial `templates/ci/` idea on discovering the existing command. |
+| D2  | The harness-gate step is the consolidated `harness ci check` (which runs validate/deps/docs/entropy/security/perf/phase-gate/arch/traceability via `runCIChecks`), not separate `validate`/`check-arch`/`check-deps` invocations. | Already battle-tested with correct blocking exit codes (1 = checks failed, 2 = internal error). Loosely-listed individual commands in the roadmap text are superseded by the better primitive.    |
+| D3  | Build/test/lint steps are language-conditional with concrete per-language defaults (TS, Python, Go, Rust, Java).                                                                                                                  | Reuses the `language` the init flow already knows; ships runnable commands, not `# TODO` placeholders.                                                                                            |
+| D4  | The generated workflow excludes any auto-baseline-update / `git push` step.                                                                                                                                                       | Reproducing the dogfood's `refresh-baselines` job would embody the failure pattern roadmap #525 and `STRATEGY.md` condemn: "a harness that warns but doesn't stop is not a harness."              |
+| D5  | `harness init` writes the workflow by default for new **and** existing projects, and never overwrites a workflow file that already exists.                                                                                        | Delivers "inherit on init" to the primary (existing-repo) persona; the engine's non-overwrite default (`engine.ts:323`) protects a hand-tuned workflow.                                           |
+| D6  | The enriched GitHub generator writes `.github/workflows/ci.yml`; the gate-only `harness.yml` output is retired in favor of it.                                                                                                    | One canonical workflow per project. Avoids an adopter ending up with both `ci.yml` and a divergent `harness.yml`. The gate still runs — inside `ci.yml`.                                          |
+| D7  | Single-job, sequential, fail-fast workflow.                                                                                                                                                                                       | The load-bearing minimum: one clear blocking pipeline an adopter immediately understands. Splitting into separate jobs only pays off once branch protection needs named status checks (YAGNI).    |
 
 ## Technical Design
 
@@ -80,13 +80,13 @@ gate, so a broken build never reports green.
 
 **Per-language defaults (initial set):**
 
-| Language | install | build | lint | test |
-| -------- | ------- | ----- | ---- | ---- |
-| TypeScript / default | `pnpm i --frozen-lockfile` | `pnpm build` | `pnpm lint` | `pnpm test` |
-| Python | `pip install -e .` | — | `ruff check .` | `pytest` |
-| Go | `go mod download` | `go build ./...` | `golangci-lint run` | `go test ./...` |
-| Rust | `cargo fetch` | `cargo build` | `cargo clippy` | `cargo test` |
-| Java | `mvn -B -q install -DskipTests` | (covered by verify) | — | `mvn -B verify` |
+| Language             | install                         | build               | lint                | test            |
+| -------------------- | ------------------------------- | ------------------- | ------------------- | --------------- |
+| TypeScript / default | `pnpm i --frozen-lockfile`      | `pnpm build`        | `pnpm lint`         | `pnpm test`     |
+| Python               | `pip install -e .`              | —                   | `ruff check .`      | `pytest`        |
+| Go                   | `go mod download`               | `go build ./...`    | `golangci-lint run` | `go test ./...` |
+| Rust                 | `cargo fetch`                   | `cargo build`       | `cargo clippy`      | `cargo test`    |
+| Java                 | `mvn -B -q install -DskipTests` | (covered by verify) | —                   | `mvn -B verify` |
 
 Unknown / unspecified language falls back to the TypeScript defaults (the engine's
 existing behavior for the JS/TS path).

--- a/docs/guides/automation-overview.md
+++ b/docs/guides/automation-overview.md
@@ -86,7 +86,7 @@ npm install -g @harness-engineering/cli
 harness ci init
 
 # 3. Commit the generated workflow file
-git add .github/workflows/harness.yml
+git add .github/workflows/ci.yml
 git commit -m "ci: add harness checks"
 ```
 

--- a/docs/guides/ci-cd-validation.md
+++ b/docs/guides/ci-cd-validation.md
@@ -159,7 +159,7 @@ The `--json` flag makes output machine-parseable for downstream steps (PR commen
 harness ci init --platform github
 ```
 
-This generates `.github/workflows/harness.yml`. Commit and push.
+This generates `.github/workflows/ci.yml`. Commit and push.
 
 ### Manual Setup
 

--- a/docs/guides/designer-quickstart.md
+++ b/docs/guides/designer-quickstart.md
@@ -581,7 +581,7 @@ When the design block is configured in `harness.config.json`, these checks autom
 harness ci init --platform github
 ```
 
-Generates a `.github/workflows/harness.yml` that:
+Generates a `.github/workflows/ci.yml` that:
 
 - Runs checks on push to main and on pull requests
 - Posts a summary comment on the PR

--- a/docs/guides/devops-quickstart.md
+++ b/docs/guides/devops-quickstart.md
@@ -242,7 +242,7 @@ harness ci init --platform github
 harness ci check
 
 # Commit the generated config
-git add .github/workflows/harness.yml .harness/ harness.config.json
+git add .github/workflows/ci.yml .harness/ harness.config.json
 git commit -m "ci: add harness engineering checks"
 ```
 

--- a/docs/guides/qa-quickstart.md
+++ b/docs/guides/qa-quickstart.md
@@ -502,7 +502,7 @@ Runs 9 checks in sequence:
 harness ci init --platform github
 ```
 
-Generates a `.github/workflows/harness.yml` that:
+Generates a `.github/workflows/ci.yml` that:
 
 - Runs checks on push to main and on pull requests
 - Posts a summary comment on the PR

--- a/docs/guides/recipes/github-actions-harness.yml
+++ b/docs/guides/recipes/github-actions-harness.yml
@@ -1,5 +1,5 @@
 # Harness CI Check — GitHub Actions Workflow
-# Copy this file to .github/workflows/harness.yml in your project
+# Copy this file to .github/workflows/ci.yml in your project
 # Or generate it with: harness ci init --platform github
 
 name: Harness Checks

--- a/docs/guides/security-quickstart.md
+++ b/docs/guides/security-quickstart.md
@@ -473,7 +473,7 @@ This scans only changed files, reports only critical findings, and outputs JSON 
 harness ci init --platform github
 ```
 
-Generates a `.github/workflows/harness.yml`. To add a dedicated security gate:
+Generates a `.github/workflows/ci.yml`. To add a dedicated security gate:
 
 ```yaml
 - name: Security Gate

--- a/docs/knowledge/decisions/0037-single-ci-generator.md
+++ b/docs/knowledge/decisions/0037-single-ci-generator.md
@@ -1,0 +1,72 @@
+---
+number: 0037
+title: A single CI workflow generator for harness init and harness ci init
+date: 2026-06-23
+status: accepted
+tier: medium
+source: docs/changes/ci-workflow-template/proposal.md
+---
+
+## Context
+
+Harness writes a GitHub Actions workflow in two places:
+
+- **Scaffold time** — `harness init` provisions a new (or existing) project and should leave behind a working CI gate so the entropy that STRATEGY exists to prevent never gets a foothold.
+- **On demand** — `harness ci init` regenerates or adds the workflow for a project that already exists.
+
+If these two paths owned separate generators (for example, an `init`-time template under `packages/cli/src/templates/ci/` and the on-demand `generateCIConfig` in `packages/cli/src/commands/ci/init.ts`), they would drift: a fix to the gate step, a new language, or a trigger change would have to be made twice and would silently diverge. Drift between two "sources of truth" for the same artifact is precisely the entropy the harness standard is built to prevent — a generated CI file is no exception.
+
+Historically the on-demand path emitted a gate-only `.github/workflows/harness.yml` that ran nothing but `harness ci check`, while scaffolding emitted nothing. The CI workflow template work (roadmap #540) unified both behind one enriched generator that builds, lints, tests (language-appropriate), and then gates.
+
+## Decision
+
+**Exactly one GitHub Actions generator exists** — `generateCIConfig` in `packages/cli/src/commands/ci/init.ts`. Both entry points consume it:
+
+- `harness init` injects `generateCIConfig({ platform: 'github', ...(language && { language }) })` into the engine's rendered-files set before `engine.write()`, so the same `.github/workflows/ci.yml` is produced at scaffold time.
+- `harness ci init` calls `generateCIConfig` directly, honouring `--platform` and `--language`.
+
+There is **no parallel generator under `packages/cli/src/templates/ci/`**. The single generator:
+
+- writes `.github/workflows/ci.yml` (the gate-only `harness.yml` filename is retired);
+- emits one fail-fast `ci` job: checkout → language setup → install → build? → lint? → test → install harness CLI → `harness ci check --json` gate;
+- reflects language in its steps (Python → `pytest` + `ruff`; Go → `go test ./...` + `golangci-lint`; Rust → `cargo test` + `clippy`; Java → `mvn -B verify`; TS/default → `pnpm` build/lint/test), falling back to TS defaults for unknown languages;
+- installs the CLI (`npm install -g @harness-engineering/cli`) immediately before the gate so the gate runs on any GitHub-hosted runner regardless of project language (GitHub-hosted `ubuntu-latest` ships Node+npm);
+- contains **no** auto-baseline-update or `git push` step;
+- is classified as a harness-managed file (`HARNESS_CONFIG_FILES` in `packages/cli/src/templates/engine.ts`) so existing-project mode emits it, while the engine's non-overwrite path preserves a hand-tuned `ci.yml` that already exists.
+
+GitLab and generic generators are unchanged and remain simple; the `language` option does not affect their output.
+
+## Consequences
+
+**Positive:**
+
+- One place to fix the gate, add a language, or change triggers — scaffold-time and on-demand output cannot diverge.
+- New-project and existing-project flows reach the same `ci.yml`; existing hand-tuned workflows are never clobbered.
+- Future language enrichment (more linters, matrix builds) lands in `stepsForLanguage` once and propagates to both callers.
+
+**Negative:**
+
+- The single generator now carries per-language branching it did not before, making `ci/init.ts` larger. Mitigated by the small, table-like `stepsForLanguage` switch.
+
+**Neutral:**
+
+- The shared `CIInitOptions` type in `packages/types/src/ci.ts` does not carry `language`; the generator uses an inline option type. If a typed caller ever needs it, add it then (YAGNI now).
+
+## Alternatives considered
+
+- **Separate scaffold-time template + on-demand generator.** Rejected — guarantees drift between two artifacts that must stay identical; contradicts the anti-entropy purpose of the harness standard.
+- **Keep the gate-only `harness.yml` and add a richer `ci.yml` alongside.** Rejected — two GitHub workflows competing as the "harness gate" is exactly the ambiguity D1 removes; the gate-only filename is retired.
+- **Detect the platform inside `scaffoldProject`.** Deferred — scaffolding defaults to `github` per D5; `harness ci init` retains `--platform`/`detectPlatform`. Wiring detection into init is YAGNI until a non-GitHub scaffold target appears.
+
+## Implementation
+
+- Generator: `generateCIConfig` + `stepsForLanguage` + `generateGitHubActions` in `packages/cli/src/commands/ci/init.ts`.
+- Scaffold wiring: `scaffoldProject` in `packages/cli/src/commands/init.ts` injects the generated file into the engine's rendered-files set before `engine.write()`.
+- Harness-managed classification: `.github/workflows/ci.yml` added to `HARNESS_CONFIG_FILES` in `packages/cli/src/templates/engine.ts`; non-overwrite path protects an existing file.
+- Tests: `packages/cli/tests/ci/init.test.ts` (per-language + structure + CLI-install-before-gate), `packages/cli/tests/integration/init.test.ts` (existing-project emit, non-overwrite, language-driven steps).
+
+## Links
+
+- Roadmap #540 — CI workflow template (this work).
+- Roadmap #525 — no auto-baseline step in generated CI (the generator omits any baseline-refresh/`git push`).
+- Roadmap #541 — required-review enforcement (separate concern; not part of this generator).

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -650,6 +650,7 @@ Generate CI configuration for harness checks
 **Options:**
 
 - `--platform` — CI platform: github, gitlab, or generic
+- `--language` — Project language for build/lint/test steps
 - `--checks` — Comma-separated list of checks to include
 
 ### `harness ci notify <report>`

--- a/docs/standard/implementation.md
+++ b/docs/standard/implementation.md
@@ -716,7 +716,9 @@ describe('Architecture: Layers', () => {
 
 ### Step 4: Set Up CI/CD Validation
 
-Create `.github/workflows/architecture.yml`:
+> **CI ships on init.** `harness init` now writes `.github/workflows/ci.yml` automatically for both new and existing projects — a single fail-fast job that runs build + lint + test (language-appropriate) followed by `harness ci check` as the gate. It never overwrites an existing workflow at that path, so a hand-tuned `ci.yml` is preserved. `harness ci init` remains the on-demand path through the same generator (use `--language` and `--platform` to target Python, Go, Rust, Java, or GitLab/generic). The generated workflow installs the harness CLI (`npm install -g @harness-engineering/cli`) immediately before the gate so it runs on any GitHub-hosted runner regardless of project language, and contains no auto-baseline-update or `git push` step. The retired gate-only `harness.yml` filename is replaced by `ci.yml`.
+
+The architecture-validation workflow below is an illustrative example of an additional, hand-authored gate. Create `.github/workflows/architecture.yml`:
 
 ```yaml
 name: Architecture Validation

--- a/packages/cli/src/commands/ci/init.ts
+++ b/packages/cli/src/commands/ci/init.ts
@@ -30,8 +30,71 @@ function buildSkipFlag(checks?: CICheckName[]): string {
   return ` --skip ${skipChecks.join(',')}`;
 }
 
-function generateGitHubActions(skipFlag: string): string {
-  return `name: Harness Checks
+interface LanguageSteps {
+  setup: string; // YAML lines for runtime setup step(s), indented for steps list
+  install: string;
+  build?: string;
+  lint?: string;
+  test: string;
+}
+
+function stepsForLanguage(language?: string): LanguageSteps {
+  switch (language) {
+    case 'python':
+      return {
+        setup: `      - uses: actions/setup-python@v5\n        with:\n          python-version: '3.12'`,
+        install: 'pip install -e .',
+        lint: 'ruff check .',
+        test: 'pytest',
+      };
+    case 'go':
+      return {
+        setup: `      - uses: actions/setup-go@v5\n        with:\n          go-version: 'stable'`,
+        install: 'go mod download',
+        build: 'go build ./...',
+        lint: 'golangci-lint run',
+        test: 'go test ./...',
+      };
+    case 'rust':
+      return {
+        setup: `      - uses: dtolnay/rust-toolchain@stable`,
+        install: 'cargo fetch',
+        build: 'cargo build',
+        lint: 'cargo clippy',
+        test: 'cargo test',
+      };
+    case 'java':
+      return {
+        setup: `      - uses: actions/setup-java@v4\n        with:\n          distribution: 'temurin'\n          java-version: '21'`,
+        install: 'mvn -B -q install -DskipTests',
+        test: 'mvn -B verify',
+      };
+    case 'typescript':
+    default:
+      return {
+        setup: `      - uses: actions/setup-node@v4\n        with:\n          node-version: '22'\n      - uses: pnpm/action-setup@v4`,
+        install: 'pnpm i --frozen-lockfile',
+        build: 'pnpm build',
+        lint: 'pnpm lint',
+        test: 'pnpm test',
+      };
+  }
+}
+
+function generateGitHubActions(skipFlag: string, language?: string): string {
+  const steps = stepsForLanguage(language);
+
+  const commandSteps: string[] = [];
+  commandSteps.push(`      - name: Install dependencies\n        run: ${steps.install}`);
+  if (steps.build) {
+    commandSteps.push(`      - name: Build\n        run: ${steps.build}`);
+  }
+  if (steps.lint) {
+    commandSteps.push(`      - name: Lint\n        run: ${steps.lint}`);
+  }
+  commandSteps.push(`      - name: Test\n        run: ${steps.test}`);
+
+  return `name: CI
 
 on:
   push:
@@ -44,15 +107,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  harness:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - run: npm install -g @harness-engineering/cli
-      - name: Run harness checks
+${steps.setup}
+${commandSteps.join('\n')}
+      - name: Harness gate
         run: harness ci check --json${skipFlag}
 `;
 }
@@ -102,12 +163,16 @@ exit $EXIT_CODE
 export function generateCIConfig(options: {
   platform: CIPlatform;
   checks?: CICheckName[];
+  language?: string;
 }): Result<GenerateResult, CLIError> {
-  const { platform, checks } = options;
+  const { platform, checks, language } = options;
   const skipFlag = buildSkipFlag(checks);
 
   const generators: Record<CIPlatform, { filename: string; generate: (skip: string) => string }> = {
-    github: { filename: '.github/workflows/harness.yml', generate: generateGitHubActions },
+    github: {
+      filename: '.github/workflows/harness.yml',
+      generate: (skip: string) => generateGitHubActions(skip, language),
+    },
     gitlab: { filename: '.gitlab-ci-harness.yml', generate: generateGitLabCI },
     generic: { filename: 'harness-ci.sh', generate: generateGenericScript },
   };

--- a/packages/cli/src/commands/ci/init.ts
+++ b/packages/cli/src/commands/ci/init.ts
@@ -72,7 +72,7 @@ function stepsForLanguage(language?: string): LanguageSteps {
     case 'typescript':
     default:
       return {
-        setup: `      - uses: actions/setup-node@v4\n        with:\n          node-version: '22'\n      - uses: pnpm/action-setup@v4`,
+        setup: `      - uses: pnpm/action-setup@v4\n      - uses: actions/setup-node@v4\n        with:\n          node-version: '22'`,
         install: 'pnpm i --frozen-lockfile',
         build: 'pnpm build',
         lint: 'pnpm lint',

--- a/packages/cli/src/commands/ci/init.ts
+++ b/packages/cli/src/commands/ci/init.ts
@@ -113,6 +113,8 @@ jobs:
       - uses: actions/checkout@v4
 ${steps.setup}
 ${commandSteps.join('\n')}
+      - name: Install harness CLI
+        run: npm install -g @harness-engineering/cli
       - name: Harness gate
         run: harness ci check --json${skipFlag}
 `;

--- a/packages/cli/src/commands/ci/init.ts
+++ b/packages/cli/src/commands/ci/init.ts
@@ -170,7 +170,7 @@ export function generateCIConfig(options: {
 
   const generators: Record<CIPlatform, { filename: string; generate: (skip: string) => string }> = {
     github: {
-      filename: '.github/workflows/harness.yml',
+      filename: '.github/workflows/ci.yml',
       generate: (skip: string) => generateGitHubActions(skip, language),
     },
     gitlab: { filename: '.gitlab-ci-harness.yml', generate: generateGitLabCI },

--- a/packages/cli/src/commands/ci/init.ts
+++ b/packages/cli/src/commands/ci/init.ts
@@ -205,7 +205,7 @@ function writeGeneratedConfig(filename: string, content: string, platform: CIPla
 }
 
 async function runInitAction(
-  opts: { platform?: string; checks?: string },
+  opts: { platform?: string; checks?: string; language?: string },
   globalOpts: { json?: boolean }
 ): Promise<void> {
   const platform: CIPlatform =
@@ -217,6 +217,7 @@ async function runInitAction(
 
   const configOpts: Parameters<typeof generateCIConfig>[0] = { platform };
   if (checks) configOpts.checks = checks;
+  if (opts.language) configOpts.language = opts.language;
   const result = generateCIConfig(configOpts);
 
   if (!result.ok) {
@@ -239,6 +240,7 @@ export function createInitCommand(): Command {
   return new Command('init')
     .description('Generate CI configuration for harness checks')
     .option('--platform <platform>', 'CI platform: github, gitlab, or generic')
+    .option('--language <language>', 'Project language for build/lint/test steps')
     .option('--checks <list>', 'Comma-separated list of checks to include')
     .action(async (opts, cmd) => {
       await runInitAction(opts, cmd.optsWithGlobals());

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -138,12 +138,17 @@ function scaffoldProject(
   // generator (generateCIConfig). It is classified as a harness-managed file
   // (engine.ts HARNESS_CONFIG_FILES), so engine.write emits it in both fresh
   // and existing-project mode and skips it when a workflow already exists.
-  const ciResult = generateCIConfig({ platform: 'github', ...(language && { language }) });
+  const ciResult = generateCIConfig({
+    platform: 'github',
+    ...(language !== undefined && { language }),
+  });
   if (ciResult.ok) {
     renderResult.value.files.push({
       relativePath: ciResult.value.filename,
       content: ciResult.value.content,
     });
+  } else {
+    logger.warn(`CI workflow was not generated: ${ciResult.error.message}`);
   }
 
   const existingProject = !force && engine.isExistingProject(cwd);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,7 @@ import { logger } from '../output/logger';
 import { CLIError, ExitCode } from '../utils/errors';
 import { resolveTemplatesDir } from '../utils/paths';
 import { setupMcp } from './setup-mcp';
+import { generateCIConfig } from './ci/init';
 
 interface InitOptions {
   cwd?: string;
@@ -132,6 +133,18 @@ function scaffoldProject(
     ...(language !== undefined && { language }),
   });
   if (!renderResult.ok) return Err(new CLIError(renderResult.error.message, ExitCode.ERROR));
+
+  // Inject the GitHub Actions CI workflow into the write set via the single
+  // generator (generateCIConfig). It is classified as a harness-managed file
+  // (engine.ts HARNESS_CONFIG_FILES), so engine.write emits it in both fresh
+  // and existing-project mode and skips it when a workflow already exists.
+  const ciResult = generateCIConfig({ platform: 'github', ...(language && { language }) });
+  if (ciResult.ok) {
+    renderResult.value.files.push({
+      relativePath: ciResult.value.filename,
+      content: ciResult.value.content,
+    });
+  }
 
   const existingProject = !force && engine.isExistingProject(cwd);
 

--- a/packages/cli/src/templates/engine.ts
+++ b/packages/cli/src/templates/engine.ts
@@ -67,7 +67,12 @@ const NON_JSON_PACKAGE_CONFIGS = new Set([
 ]);
 
 /** Files that are part of harness infrastructure, not project scaffolding. */
-const HARNESS_CONFIG_FILES = new Set(['harness.config.json', 'AGENTS.md', '.harness/.gitignore']);
+const HARNESS_CONFIG_FILES = new Set([
+  'harness.config.json',
+  'AGENTS.md',
+  '.harness/.gitignore',
+  '.github/workflows/ci.yml',
+]);
 
 /** OS-generated files that may exist on a contributor's machine but are not part of any template. */
 const IGNORED_TEMPLATE_FILES = new Set(['.DS_Store', 'Thumbs.db', 'desktop.ini']);

--- a/packages/cli/tests/ci/init.test.ts
+++ b/packages/cli/tests/ci/init.test.ts
@@ -70,4 +70,52 @@ describe('generateCIConfig — language', () => {
     expect(r.value.content).not.toMatch(/git push/);
     expect(r.value.content).not.toMatch(/refresh-baselines|baseline.*update/i);
   });
+
+  it('python project emits pytest and ruff', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'python' });
+    if (!r.ok) return;
+    expect(r.value.content).toContain('setup-python');
+    expect(r.value.content).toContain('ruff check .');
+    expect(r.value.content).toContain('pytest');
+  });
+
+  it('go project emits go test and golangci-lint', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'go' });
+    if (!r.ok) return;
+    expect(r.value.content).toContain('go build ./...');
+    expect(r.value.content).toContain('golangci-lint run');
+    expect(r.value.content).toContain('go test ./...');
+  });
+
+  it('rust project emits cargo build/clippy/test', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'rust' });
+    if (!r.ok) return;
+    expect(r.value.content).toContain('cargo build');
+    expect(r.value.content).toContain('cargo clippy');
+    expect(r.value.content).toContain('cargo test');
+  });
+
+  it('java project emits mvn verify', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'java' });
+    if (!r.ok) return;
+    expect(r.value.content).toContain('setup-java');
+    expect(r.value.content).toContain('mvn -B verify');
+  });
+
+  it('unknown language falls back to TypeScript defaults', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'cobol' });
+    if (!r.ok) return;
+    expect(r.value.content).toContain('pnpm test');
+  });
+
+  it('language option does not affect gitlab/generic output', () => {
+    const g1 = generateCIConfig({ platform: 'gitlab' });
+    const g2 = generateCIConfig({ platform: 'gitlab', language: 'python' });
+    if (!g1.ok || !g2.ok) return;
+    expect(g2.value.content).toBe(g1.value.content);
+    const s1 = generateCIConfig({ platform: 'generic' });
+    const s2 = generateCIConfig({ platform: 'generic', language: 'go' });
+    if (!s1.ok || !s2.ok) return;
+    expect(s2.value.content).toBe(s1.value.content);
+  });
 });

--- a/packages/cli/tests/ci/init.test.ts
+++ b/packages/cli/tests/ci/init.test.ts
@@ -38,3 +38,36 @@ describe('generateCIConfig', () => {
     expect(result.value.content).toContain('--skip');
   });
 });
+
+describe('generateCIConfig — language', () => {
+  it('emits TypeScript/default steps for github', () => {
+    const result = generateCIConfig({ platform: 'github', language: 'typescript' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.content).toContain('pnpm i --frozen-lockfile');
+    expect(result.value.content).toContain('pnpm build');
+    expect(result.value.content).toContain('pnpm lint');
+    expect(result.value.content).toContain('pnpm test');
+  });
+
+  it('emits a single fail-fast ci job with checkout, setup, install, build, lint, test, gate', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'typescript' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const c = r.value.content;
+    expect(c).toContain('actions/checkout@v4');
+    expect(c).toMatch(/jobs:\s*\n\s*ci:/);
+    expect(c).toContain('pnpm i --frozen-lockfile');
+    expect(c).toContain('pnpm build');
+    expect(c).toContain('harness ci check --json');
+    // gate is the last step
+    expect(c.trimEnd().endsWith('run: harness ci check --json')).toBe(true);
+  });
+
+  it('excludes any baseline-refresh or git push step', () => {
+    const r = generateCIConfig({ platform: 'github' });
+    if (!r.ok) return;
+    expect(r.value.content).not.toMatch(/git push/);
+    expect(r.value.content).not.toMatch(/refresh-baselines|baseline.*update/i);
+  });
+});

--- a/packages/cli/tests/ci/init.test.ts
+++ b/packages/cli/tests/ci/init.test.ts
@@ -50,6 +50,18 @@ describe('generateCIConfig — language', () => {
     expect(result.value.content).toContain('pnpm test');
   });
 
+  it('sets up pnpm before setup-node in the TS setup (matches project ci.yml)', () => {
+    const result = generateCIConfig({ platform: 'github', language: 'typescript' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const c = result.value.content;
+    const pnpmIdx = c.indexOf('pnpm/action-setup@v4');
+    const nodeIdx = c.indexOf('actions/setup-node@v4');
+    expect(pnpmIdx).toBeGreaterThan(-1);
+    expect(nodeIdx).toBeGreaterThan(-1);
+    expect(pnpmIdx).toBeLessThan(nodeIdx);
+  });
+
   it('emits a single fail-fast ci job with checkout, setup, install, build, lint, test, gate', () => {
     const r = generateCIConfig({ platform: 'github', language: 'typescript' });
     expect(r.ok).toBe(true);

--- a/packages/cli/tests/ci/init.test.ts
+++ b/packages/cli/tests/ci/init.test.ts
@@ -64,6 +64,29 @@ describe('generateCIConfig — language', () => {
     expect(c.trimEnd().endsWith('run: harness ci check --json')).toBe(true);
   });
 
+  it('installs the harness CLI immediately before the gate (language-independent)', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'typescript' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const c = r.value.content;
+    expect(c).toContain('npm install -g @harness-engineering/cli');
+    const installIdx = c.indexOf('npm install -g @harness-engineering/cli');
+    const gateIdx = c.indexOf('harness ci check --json');
+    expect(installIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeGreaterThan(installIdx);
+  });
+
+  it('installs the harness CLI for a non-Node language (python)', () => {
+    const r = generateCIConfig({ platform: 'github', language: 'python' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const c = r.value.content;
+    expect(c).toContain('npm install -g @harness-engineering/cli');
+    const installIdx = c.indexOf('npm install -g @harness-engineering/cli');
+    const gateIdx = c.indexOf('harness ci check --json');
+    expect(gateIdx).toBeGreaterThan(installIdx);
+  });
+
   it('excludes any baseline-refresh or git push step', () => {
     const r = generateCIConfig({ platform: 'github' });
     if (!r.ok) return;

--- a/packages/cli/tests/ci/init.test.ts
+++ b/packages/cli/tests/ci/init.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateCIConfig } from '../../src/commands/ci/init';
+import { generateCIConfig, createInitCommand } from '../../src/commands/ci/init';
 
 describe('generateCIConfig', () => {
   it('generates GitHub Actions workflow content', () => {
@@ -106,6 +106,12 @@ describe('generateCIConfig — language', () => {
     const r = generateCIConfig({ platform: 'github', language: 'cobol' });
     if (!r.ok) return;
     expect(r.value.content).toContain('pnpm test');
+  });
+
+  it('ci init command accepts --language', () => {
+    const cmd = createInitCommand();
+    const opt = cmd.options.find((o) => o.long === '--language');
+    expect(opt).toBeDefined();
   });
 
   it('language option does not affect gitlab/generic output', () => {

--- a/packages/cli/tests/ci/init.test.ts
+++ b/packages/cli/tests/ci/init.test.ts
@@ -6,7 +6,7 @@ describe('generateCIConfig', () => {
     const result = generateCIConfig({ platform: 'github' });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.filename).toBe('.github/workflows/harness.yml');
+    expect(result.value.filename).toBe('.github/workflows/ci.yml');
     expect(result.value.content).toContain('harness ci check');
     expect(result.value.content).toContain('on:');
   });

--- a/packages/cli/tests/integration/init.test.ts
+++ b/packages/cli/tests/integration/init.test.ts
@@ -338,4 +338,17 @@ describe('harness init — CI workflow', () => {
     expect(fs.existsSync(path.join(tmp, '.github/workflows/ci.yml'))).toBe(true);
     fs.rmSync(tmp, { recursive: true });
   });
+
+  it('init writes .github/workflows/ci.yml with build/lint/test + gate', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-ci-'));
+    const r = await runInit({ cwd: tmp, name: 'ci-proj', level: 'basic' });
+    expect(r.ok).toBe(true);
+    const wf = path.join(tmp, '.github/workflows/ci.yml');
+    expect(fs.existsSync(wf)).toBe(true);
+    const c = fs.readFileSync(wf, 'utf-8');
+    expect(c).toContain('harness ci check --json');
+    expect(c).toContain('pnpm test');
+    expect(c).not.toMatch(/git push/);
+    fs.rmSync(tmp, { recursive: true });
+  });
 });

--- a/packages/cli/tests/integration/init.test.ts
+++ b/packages/cli/tests/integration/init.test.ts
@@ -370,4 +370,20 @@ describe('harness init — CI workflow', () => {
     expect(c).toContain('pytest');
     fs.rmSync(tmp, { recursive: true });
   });
+
+  it('creates ci.yml in an existing project with no workflow (primary persona)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-ci-existing-proj-'));
+    // Seed an existing-project marker; no .github/workflows/ci.yml present.
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"existing-app"}');
+
+    const r = await runInit({ cwd: tmp, name: 'existing-app', level: 'basic' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const wf = path.join(tmp, '.github/workflows/ci.yml');
+    expect(fs.existsSync(wf)).toBe(true);
+    const c = fs.readFileSync(wf, 'utf-8');
+    expect(c).toContain('harness ci check --json');
+    fs.rmSync(tmp, { recursive: true });
+  });
 });

--- a/packages/cli/tests/integration/init.test.ts
+++ b/packages/cli/tests/integration/init.test.ts
@@ -351,4 +351,23 @@ describe('harness init — CI workflow', () => {
     expect(c).not.toMatch(/git push/);
     fs.rmSync(tmp, { recursive: true });
   });
+
+  it('does not overwrite an existing ci.yml', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-ci-keep-'));
+    fs.mkdirSync(path.join(tmp, '.github/workflows'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'name: Hand-tuned\n');
+    await runInit({ cwd: tmp, name: 'keep', level: 'basic' });
+    expect(fs.readFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'utf-8')).toBe(
+      'name: Hand-tuned\n'
+    );
+    fs.rmSync(tmp, { recursive: true });
+  });
+
+  it('language drives the generated steps (python)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-ci-py-'));
+    await runInit({ cwd: tmp, name: 'py', language: 'python' });
+    const c = fs.readFileSync(path.join(tmp, '.github/workflows/ci.yml'), 'utf-8');
+    expect(c).toContain('pytest');
+    fs.rmSync(tmp, { recursive: true });
+  });
 });

--- a/packages/cli/tests/integration/init.test.ts
+++ b/packages/cli/tests/integration/init.test.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { runInit } from '../../src/commands/init';
+import { TemplateEngine } from '../../src/templates/engine';
+import { resolveTemplatesDir } from '../../src/utils/paths';
 
 describe('harness init integration', () => {
   const levels = ['basic', 'intermediate', 'advanced'] as const;
@@ -319,5 +321,21 @@ describe('harness init integration', () => {
 
       fs.rmSync(tmpDir, { recursive: true });
     });
+  });
+});
+
+describe('harness init — CI workflow', () => {
+  it('writes ci.yml in existing-project mode', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-ci-existing-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"x"}'); // existing-project marker
+    const engine = new TemplateEngine(resolveTemplatesDir());
+    const res = engine.write(
+      { files: [{ relativePath: '.github/workflows/ci.yml', content: 'name: CI\n' }] },
+      tmp,
+      { overwrite: false, existingProject: true }
+    );
+    expect(res.ok).toBe(true);
+    expect(fs.existsSync(path.join(tmp, '.github/workflows/ci.yml'))).toBe(true);
+    fs.rmSync(tmp, { recursive: true });
   });
 });


### PR DESCRIPTION
## Summary

Closes #540. Adopters now inherit a complete, blocking CI workflow on `harness init` instead of hand-writing CI from scratch.

`harness init` writes `.github/workflows/ci.yml` — a single fail-fast GitHub Actions job that builds, lints, and tests (language-appropriate for TypeScript, Python, Go, Rust, Java) and runs the consolidated `harness ci check` gate on every PR and push to `main`. Written for both new and existing projects; never overwrites an existing workflow.

## Key decisions

- **Single generator (ADR 0037).** Both `harness init` (scaffold-time) and `harness ci init` (on-demand) route through one `generateCIConfig` — no second YAML source that drifts. The enriched GitHub output replaces the gate-only `harness.yml` with `ci.yml`.
- **Consolidated gate.** Uses `harness ci check` (validate/deps/docs/entropy/security/perf/phase-gate/arch/traceability); correct blocking exit codes.
- **No auto-baseline anti-pattern (#525).** The generated workflow deliberately contains no auto-baseline-update / `git push` step.
- **CLI installed before the gate** so it works on any runner / language.
- `harness ci init` gains a `--language` option.

## Out of scope (by design)

- Required multi-persona review action → #541.
- Portable coverage-ratchet primitive (no such harness primitive).
- Language-aware GitLab/generic enrichment (revisit on demand).

## Testing

- Full `@harness-engineering/cli` suite green (Node 22); per-language generator snapshots + init-integration (new/existing project writes, non-overwrite, language-driven steps, existing-repo-no-workflow path).
- `harness validate` + `check-deps` pass. Verified WIRED against all 7 spec success criteria; passed final cross-phase review.

## Artifacts

- Spec: `docs/changes/ci-workflow-template/proposal.md`
- Plan: `docs/changes/ci-workflow-template/plans/2026-06-23-ci-workflow-template-plan.md`
- ADR: `docs/knowledge/decisions/0037-single-ci-generator.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)