### PR TITLE
docs(roadmap): add #620 — make pre-push test:coverage gate deterministic

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2945,6 +2945,17 @@ last_manual_edit: 2026-06-24T12:26:21.993Z
 - **Priority:** P2
 - **External-ID:** github:Intense-Visions/harness-engineering#570
 
+### Make pre-push test:coverage gate deterministic — isolate parallel-unsafe tests
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** The husky pre-push gate runs `turbo run test:coverage --concurrency=2` across all packages; several heavy IO/git tests are parallel-unsafe and flake non-deterministically under contention — the failing test/package moves run-to-run (observed: `cli#test:coverage`, then `orchestrator#test:coverage`, then cli again). All pass in isolation; CI (clean runner) tolerates them. Known offenders: `packages/cli/tests/hooks/adoption-tracker.test.ts` (writes shared project-root `.harness/metrics/adoption.jsonl` not its tmpdir), `packages/cli/tests/copy-craft/extract-commits.test.ts`, `packages/cli/tests/integration/cli.test.ts` (spawns the CLI; 30s timeout under load). A flaky gate that blocks good pushes is itself an anti-harness pattern — it erodes trust like the "warns but doesn't stop" hooks this milestone targets, inverted (stops, for the wrong reason); on 2026-06-24 it flaked 3+ consecutive times on docs-only changes, forcing API-side landing. Fix: make the heavy tests concurrency-safe (per-test tmpdir + `chdir`, never touch repo-root shared files), or pool-isolate via vitest `poolOptions`/`--no-file-parallelism`; also investigate the turbo-cache miss where `packages/cli/.harness/arch/baselines.json` (auto-mutated by the commit/push arch check) busts cli's `test:coverage` input hash and forces a full re-run. Source: dogfood 2026-06-24 (audit-harness-strength + roadmap-sync pushes).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P1
+- **External-ID:** github:Intense-Visions/harness-engineering#620
+
 ## Assignment History
 
 | Feature                                                          | Assignee                      | Action   | Date       |


### PR DESCRIPTION
Adds a v5.0 roadmap item (issue #620) to fix the flaky pre-push `test:coverage` gate.

The husky pre-push runs `turbo run test:coverage --concurrency=2`; parallel-unsafe heavy IO/git tests (`adoption-tracker`, `extract-commits`, `cli.test.ts` version/help) flake non-deterministically — the failing package moves run-to-run, all pass in isolation, CI tolerates them. A flaky gate that blocks good pushes is itself an anti-harness pattern (the inverse of 'warns but doesn't stop'); it flaked 3+ times on docs-only changes on 2026-06-24, forcing API-side landing.

Fix (in the issue): isolate heavy tests to per-test tmpdirs + chdir / pool-isolate via vitest poolOptions; investigate the `baselines.json` turbo-cache bust. Priority P1.

Docs-only; landed via contents API to avoid the very gate it describes.