### PR TITLE
fix(test): deterministic hook tests — direct stdin instead of cat|node pipe (#619)

### DIFF
--- a/packages/cli/tests/hooks/adoption-tracker.test.ts
+++ b/packages/cli/tests/hooks/adoption-tracker.test.ts
@@ -7,18 +7,15 @@ import { tmpdir } from 'node:os';
 const HOOK_PATH = resolve(__dirname, '../../src/hooks/adoption-tracker.js');
 
 function runHook(stdinData: string, cwd: string): { exitCode: number; stderr: string } {
-  const stdinFile = join(cwd, '.stdin-data.json');
-  writeFileSync(stdinFile, stdinData);
-  const result = spawnSync('sh', ['-c', `cat "${stdinFile}" | node "${HOOK_PATH}"`], {
+  // Pass stdin directly via spawnSync's `input` option (issue 619): the previous
+  // `cat <file> | node` pipe intermittently delivered empty/partial stdin under
+  // v8 coverage, tripping the hooks' fail-open path. macOS CI is the gate.
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
     encoding: 'utf-8',
     cwd,
     timeout: 60000,
   });
-  try {
-    rmSync(stdinFile, { force: true });
-  } catch {
-    /* ignore */
-  }
   return {
     exitCode: result.status ?? (result.signal ? 0 : 1),
     stderr: result.stderr ?? '',

--- a/packages/cli/tests/hooks/block-no-verify.test.ts
+++ b/packages/cli/tests/hooks/block-no-verify.test.ts
@@ -1,23 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { resolve, join } from 'node:path';
-import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
 
 const HOOK_PATH = resolve(__dirname, '../../src/hooks/block-no-verify.js');
 
 function runHook(stdinData: string): { exitCode: number; stderr: string } {
-  const stdinFile = join(mkdtempSync(join(tmpdir(), 'bnv-')), 'stdin.json');
-  writeFileSync(stdinFile, stdinData);
-  const result = spawnSync('sh', ['-c', `cat "${stdinFile}" | node "${HOOK_PATH}"`], {
+  // Pass stdin directly via spawnSync's `input` option (issue 619): the previous
+  // `cat <file> | node` pipe intermittently delivered empty/partial stdin under
+  // v8 coverage, tripping the hooks' fail-open path. macOS CI is the gate.
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
     encoding: 'utf-8',
     timeout: 60000,
   });
-  try {
-    rmSync(stdinFile, { force: true });
-  } catch {
-    /* ignore */
-  }
   return {
     exitCode: result.status ?? 1,
     stderr: result.stderr ?? '',

--- a/packages/cli/tests/hooks/cost-tracker.test.ts
+++ b/packages/cli/tests/hooks/cost-tracker.test.ts
@@ -8,18 +8,15 @@ const HOOK_PATH = resolve(__dirname, '../../src/hooks/cost-tracker.js');
 
 function runHook(stdinData: string, cwd?: string): { exitCode: number; stderr: string } {
   const dir = cwd ?? process.cwd();
-  const stdinFile = join(dir, '.stdin-data.json');
-  writeFileSync(stdinFile, stdinData);
-  const result = spawnSync('sh', ['-c', `cat "${stdinFile}" | node "${HOOK_PATH}"`], {
+  // Pass stdin directly via spawnSync's `input` option (issue 619): the previous
+  // `cat <file> | node` pipe intermittently delivered empty/partial stdin under
+  // v8 coverage, tripping the hooks' fail-open path. macOS CI is the gate.
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
     encoding: 'utf-8',
     cwd: dir,
     timeout: 60000,
   });
-  try {
-    rmSync(stdinFile, { force: true });
-  } catch {
-    /* ignore */
-  }
   return {
     exitCode: result.status ?? (result.signal ? 0 : 1),
     stderr: result.stderr ?? '',

--- a/packages/cli/tests/hooks/pre-compact-state.test.ts
+++ b/packages/cli/tests/hooks/pre-compact-state.test.ts
@@ -11,20 +11,18 @@ function runHook(
   cwd?: string
 ): { exitCode: number; stdout: string; stderr: string } {
   const dir = cwd ?? process.cwd();
-  // Write stdin to a temp file and pipe via shell — readFileSync(0) is unreliable
-  // with spawnSync's input option on macOS CI
-  const stdinFile = join(dir, '.stdin-data.json');
-  writeFileSync(stdinFile, stdinData);
-  const result = spawnSync('sh', ['-c', `cat "${stdinFile}" | node "${HOOK_PATH}"`], {
+  // History: a temp-file `cat <file> | node` pipe replaced spawnSync's `input`
+  // option because `input` + readFileSync(0) was once thought unreliable on
+  // macOS CI. That pipe was the actual culprit (issue 619): under v8 coverage it
+  // intermittently delivered empty/partial stdin to the piped node process,
+  // tripping the hook's fail-open path and flaking the suite. We now pass stdin
+  // directly via `input`; macOS CI is the validation gate for readFileSync(0).
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
     encoding: 'utf-8',
     cwd: dir,
     timeout: 60000,
   });
-  try {
-    rmSync(stdinFile, { force: true });
-  } catch {
-    /* ignore */
-  }
   return {
     exitCode: result.status ?? (result.signal ? 0 : 1),
     stdout: result.stdout ?? '',

--- a/packages/cli/tests/hooks/protect-config.test.ts
+++ b/packages/cli/tests/hooks/protect-config.test.ts
@@ -1,23 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { resolve, join } from 'node:path';
-import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
 
 const HOOK_PATH = resolve(__dirname, '../../src/hooks/protect-config.js');
 
 function runHook(stdinData: string): { exitCode: number; stderr: string } {
-  const stdinFile = join(mkdtempSync(join(tmpdir(), 'pc-')), 'stdin.json');
-  writeFileSync(stdinFile, stdinData);
-  const result = spawnSync('sh', ['-c', `cat "${stdinFile}" | node "${HOOK_PATH}"`], {
+  // Pass stdin directly via spawnSync's `input` option (issue 619): the previous
+  // `cat <file> | node` pipe intermittently delivered empty/partial stdin under
+  // v8 coverage, tripping the hooks' fail-open path. macOS CI is the gate.
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
     encoding: 'utf-8',
     timeout: 60000,
   });
-  try {
-    rmSync(stdinFile, { force: true });
-  } catch {
-    /* ignore */
-  }
   return {
     exitCode: result.status ?? 1,
     stderr: result.stderr ?? '',

--- a/packages/cli/tests/hooks/quality-gate.test.ts
+++ b/packages/cli/tests/hooks/quality-gate.test.ts
@@ -8,18 +8,15 @@ const HOOK_PATH = resolve(__dirname, '../../src/hooks/quality-gate.js');
 
 function runHook(stdinData: string, cwd?: string): { exitCode: number; stderr: string } {
   const dir = cwd ?? process.cwd();
-  const stdinFile = join(dir, '.stdin-data.json');
-  writeFileSync(stdinFile, stdinData);
-  const result = spawnSync('sh', ['-c', `cat "${stdinFile}" | node "${HOOK_PATH}"`], {
+  // Pass stdin directly via spawnSync's `input` option (issue 619): the previous
+  // `cat <file> | node` pipe intermittently delivered empty/partial stdin under
+  // v8 coverage, tripping the hooks' fail-open path. macOS CI is the gate.
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
     encoding: 'utf-8',
     cwd: dir,
     timeout: 60000,
   });
-  try {
-    rmSync(stdinFile, { force: true });
-  } catch {
-    /* ignore */
-  }
   return {
     exitCode: result.signal ? 0 : (result.status ?? 1),
     stderr: result.stderr ?? '',

--- a/packages/cli/tests/hooks/telemetry-reporter.test.ts
+++ b/packages/cli/tests/hooks/telemetry-reporter.test.ts
@@ -11,8 +11,6 @@ function runHook(
   cwd: string,
   env?: Record<string, string>
 ): { exitCode: number; stderr: string } {
-  const stdinFile = join(cwd, '.stdin-data.json');
-  writeFileSync(stdinFile, stdinData);
   // Sanitize telemetry opt-out vars from the inherited base env so each test
   // fully controls telemetry state via the explicit `env` arg. The global test
   // setup sets DO_NOT_TRACK=1 by default (to keep telemetry export from making
@@ -21,17 +19,16 @@ function runHook(
   const baseEnv = { ...process.env };
   delete baseEnv.DO_NOT_TRACK;
   delete baseEnv.HARNESS_TELEMETRY_OPTOUT;
-  const result = spawnSync('sh', ['-c', `cat "${stdinFile}" | node "${HOOK_PATH}"`], {
+  // Pass stdin directly via spawnSync's `input` option (issue 619): the previous
+  // `cat <file> | node` pipe intermittently delivered empty/partial stdin under
+  // v8 coverage, tripping the hooks' fail-open path. macOS CI is the gate.
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
     encoding: 'utf-8',
     cwd,
     timeout: 60000,
     env: { ...baseEnv, ...env },
   });
-  try {
-    rmSync(stdinFile, { force: true });
-  } catch {
-    /* ignore */
-  }
   return {
     exitCode: result.status ?? (result.signal ? 0 : 1),
     stderr: result.stderr ?? '',


### PR DESCRIPTION
Closes #619.

## Problem

The pre-push `turbo run test:coverage --concurrency=2` flaked non-deterministically in `tests/hooks/*`. Root cause (see #619 for the full investigation): the hook test helpers spawned the hook via `spawnSync('sh', ['-c', 'cat "<file>" | node "<HOOK>"'])`, and the piped `node` process intermittently read **empty/partial stdin** → the hook returned its fail-open result → assertion failed. **v8 coverage amplifies it** (spawn-heavy set: serial + no-coverage = 8/8 clean; serial + *with* coverage = ~1/5 flaky). It is per-spawn and not fixable by test pooling/grouping (a vitest `test.projects` split was tried and flaked at the same rate).

## Fix

Replace the `cat | sh | node` stdin-pipe with direct stdin via `spawnSync('node', [HOOK], { input: stdinData })` in the 7 affected hook test helpers:
`adoption-tracker`, `block-no-verify`, `cost-tracker`, `pre-compact-state`, `protect-config`, `quality-gate`, `telemetry-reporter`. (`sentinel.test.ts` already used `{ input }`.)

- Production code unchanged (`GIT_TIMEOUT_MS` stays `10_000`).
- Test count unchanged (3941); **4/4 clean** full-suite coverage runs locally (pre-fix baseline reproduced the flake).

## ⚠️ Reviewer note — validate macOS CI specifically

`pre-compact-state.test.ts` previously documented that the team moved *away* from `{ input }` because it was unreliable with `readFileSync(0)` on **macOS CI**, and switched to the `cat` pipe. All production hooks read stdin via `readFileSync(0)`. This PR reverses that decision because the pipe caused the coverage-amplified empty-stdin race. **The macOS CI job is the validation gate**: green there confirms `{ input }` + `readFileSync(0)` is reliable (note `sentinel.test.ts` has already been running this combination in the suite). If macOS regresses, the fallback is a retry-on-empty-stdin helper rather than reverting to the pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)