### PR TITLE
docs(roadmap): mark auto-promotion (#574) as done

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1200,7 +1200,7 @@ last_manual_edit: 2026-06-24T12:26:21.993Z
 
 ### Auto-promotion of brainstormed roadmap items
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/brainstorm-auto-promote/proposal.md
 - **Summary:** Brainstorming Phase 4 promotes existing backlog rows to planned atomically with the spec commit, via new `manage_roadmap action: promote`. Sub-project 1 of 4 in the brainstorm-driven roadmap loop initiative.
 - **Blockers:** —


### PR DESCRIPTION
## What

Marks the **Auto-promotion of brainstormed roadmap items** entry (#574) as `done` in `docs/roadmap.md`.

## Why

The feature shipped via **PR #628** (merged to `main`), but its roadmap row was still listed as `planned`. This brings the roadmap in sync with the merged state.

## Scope

A single-line status flip. While reconciling, the local working tree also contained buggy `promote`-action output — a status/assignee flip on an unrelated item (#537, matching the known `manage_roadmap` assign-corruption pattern), an assignment-table de-format, and two auto-generated JSON drift files. **Those were discarded, not committed** — this PR is intentionally just the one legitimate sync.

Authored in an isolated worktree off `origin/main` to avoid concurrent-automation churn in the main checkout.