### PR TITLE
fix(orchestrator): seed brainstorm handoff artifacts into fresh worktrees

### DIFF
--- a/.changeset/fix-orchestrator-seed-worktree-artifacts.md
+++ b/.changeset/fix-orchestrator-seed-worktree-artifacts.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/orchestrator': patch
+'@harness-engineering/types': patch
+---
+
+fix(orchestrator): seed brainstorm handoff artifacts into fresh worktrees
+
+New worktrees are checked out from a committed remote ref (e.g. `origin/main`),
+so they did not inherit the uncommitted artifacts of the brainstorm →
+orchestrator handoff — the proposal under `.harness/proposals/` and the promoted
+row in `docs/roadmap.md`. A dispatched agent saw the roadmap entry (the tracker
+reads the live working tree) but could not find its proposal and stalled.
+
+`WorkspaceManager.ensureWorkspace` now seeds those paths from the root working
+tree into each fresh worktree (best-effort: missing sources skipped, copy
+failures swallowed). Seed paths default to `['.harness/proposals',
+'docs/roadmap.md']`, are overridable via the new `WorkspaceConfig.seedPaths`,
+and the orchestrator derives the roadmap entry from the configured tracker
+`filePath` so a non-default roadmap location is still carried over.

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -77,6 +77,25 @@ import { resolveOrchestratorId } from './core/orchestrator-identity';
 import { StreamRecorder } from './core/stream-recorder';
 
 /**
+ * Derives the worktree seed paths from a workflow config when
+ * {@link WorkspaceConfig.seedPaths} is not set explicitly.
+ *
+ * A new worktree is checked out from a committed remote ref and therefore lacks
+ * the uncommitted artifacts of the brainstorm → orchestrator handoff. Seeding
+ * carries them over: the proposal directory, plus the roadmap file at its
+ * *configured* location — a roadmap tracker may point `filePath` somewhere
+ * other than the default `docs/roadmap.md`, and the default seed list would
+ * otherwise miss it.
+ */
+export function deriveSeedPaths(config: WorkflowConfig): string[] {
+  const roadmapPath =
+    config.tracker.kind === 'roadmap' && config.tracker.filePath
+      ? config.tracker.filePath
+      : 'docs/roadmap.md';
+  return ['.harness/proposals', roadmapPath];
+}
+
+/**
  * The central orchestrator that manages the lifecycle of coding agents.
  *
  * It polls an issue tracker for candidate tasks, manages ephemeral workspaces,
@@ -305,16 +324,25 @@ export class Orchestrator extends EventEmitter {
 
     // Initialize adapters based on config or overrides
     this.tracker = overrides?.tracker || this.createTracker();
-    this.workspace = new WorkspaceManager(config.workspace, {
-      emitEvent: (event) => {
-        // Phase 3 / spec D6 / R4: surface worktree base-ref fallback in
-        // the same maintenance/event stream the dashboard subscribes to.
-        // Two parallel channels mirror the maintenance task pattern at
-        // orchestrator.ts:520-534: WebSocket fan-out + Node EventEmitter.
-        this.server?.broadcastMaintenance('maintenance:baseref_fallback', event);
-        this.emit('maintenance:baseref_fallback', event);
+    this.workspace = new WorkspaceManager(
+      {
+        ...config.workspace,
+        // Seed the brainstorm handoff artifacts into each fresh worktree. An
+        // explicit `seedPaths` wins; otherwise derive from the tracker config
+        // so a non-default roadmap location is still carried over.
+        seedPaths: config.workspace.seedPaths ?? deriveSeedPaths(config),
       },
-    });
+      {
+        emitEvent: (event) => {
+          // Phase 3 / spec D6 / R4: surface worktree base-ref fallback in
+          // the same maintenance/event stream the dashboard subscribes to.
+          // Two parallel channels mirror the maintenance task pattern at
+          // orchestrator.ts:520-534: WebSocket fan-out + Node EventEmitter.
+          this.server?.broadcastMaintenance('maintenance:baseref_fallback', event);
+          this.emit('maintenance:baseref_fallback', event);
+        },
+      }
+    );
     this.hooks = new WorkspaceHooks(config.hooks);
     this.renderer = new PromptRenderer();
     // Spec 2 SC30 / Task 11: capture the test-only backend override (if

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -129,6 +129,12 @@ export class WorkspaceManager {
       const baseRef = await this.resolveBaseRef(repoRoot);
       await this.git(['worktree', 'add', '--detach', workspacePath, baseRef], repoRoot);
 
+      // Overlay uncommitted handoff artifacts (brainstorm proposal + promoted
+      // roadmap row) from the root working tree. The worktree was just checked
+      // out from a committed remote ref and would otherwise lack them, leaving
+      // a dispatched agent with a roadmap entry but no proposal to work from.
+      await this.seedWorkspace(workspacePath, repoRoot);
+
       return Ok(workspacePath);
     } catch (error) {
       return Err(error instanceof Error ? error : new Error(String(error)));
@@ -145,6 +151,54 @@ export class WorkspaceManager {
       await this.git(['fetch', 'origin', '--quiet'], repoRoot);
     } catch {
       // Intentional: proceed with whatever refs already exist locally.
+    }
+  }
+
+  /**
+   * Default paths seeded into a fresh worktree when {@link WorkspaceConfig.seedPaths}
+   * is unset — the artifacts produced by the brainstorm → orchestrator handoff.
+   */
+  private static readonly DEFAULT_SEED_PATHS = ['.harness/proposals', 'docs/roadmap.md'];
+
+  /**
+   * Copies the configured seed paths from the root working tree into a
+   * freshly-created worktree, overlaying the committed checkout.
+   *
+   * A new worktree is based on a committed remote ref, so it does not contain
+   * uncommitted artifacts that exist only in the root working tree (a
+   * just-written proposal under `.harness/proposals/`, a promoted row in
+   * `docs/roadmap.md`). Seeding carries them over so a dispatched agent sees
+   * the same state the orchestrator dispatched from.
+   *
+   * Best-effort by design: a missing source is skipped, and a copy failure is
+   * swallowed — neither must ever block dispatch.
+   */
+  private async seedWorkspace(workspacePath: string, repoRoot: string): Promise<void> {
+    const seedPaths = this.config.seedPaths ?? WorkspaceManager.DEFAULT_SEED_PATHS;
+    for (const entry of seedPaths) {
+      // Seed paths are repo-relative by convention, but a configured roadmap
+      // location may arrive absolute. Relativize against the repo root and skip
+      // anything that escapes it, so seeding can never copy a source from — or
+      // write a destination — outside the worktree.
+      const rel = path.isAbsolute(entry)
+        ? path.relative(repoRoot, entry).replaceAll('\\', '/')
+        : entry;
+      if (!rel || rel === '..' || rel.startsWith('../') || path.isAbsolute(rel)) {
+        continue;
+      }
+      const src = path.join(repoRoot, rel);
+      try {
+        // Only carry over what actually exists in the root working tree.
+        await fs.access(src);
+      } catch {
+        continue;
+      }
+      const dest = path.join(workspacePath, rel);
+      try {
+        await fs.cp(src, dest, { recursive: true, force: true });
+      } catch {
+        // Seeding is an enhancement, not a precondition for dispatch.
+      }
     }
   }
 

--- a/packages/orchestrator/tests/workspace/derive-seed-paths.test.ts
+++ b/packages/orchestrator/tests/workspace/derive-seed-paths.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import type { WorkflowConfig } from '@harness-engineering/types';
+import { deriveSeedPaths } from '../../src/orchestrator';
+
+/** Minimal config stub — only the fields deriveSeedPaths reads matter. */
+function configWith(tracker: Partial<WorkflowConfig['tracker']>): WorkflowConfig {
+  return {
+    tracker: {
+      kind: 'roadmap',
+      activeStates: ['planned'],
+      terminalStates: ['done'],
+      ...tracker,
+    },
+  } as unknown as WorkflowConfig;
+}
+
+describe('deriveSeedPaths', () => {
+  it('always seeds the brainstorm proposal directory', () => {
+    expect(deriveSeedPaths(configWith({}))).toContain('.harness/proposals');
+  });
+
+  it('uses the configured roadmap filePath when the tracker is roadmap-backed', () => {
+    const paths = deriveSeedPaths(configWith({ kind: 'roadmap', filePath: 'planning/board.md' }));
+    expect(paths).toEqual(['.harness/proposals', 'planning/board.md']);
+  });
+
+  it('falls back to docs/roadmap.md when filePath is unset', () => {
+    const paths = deriveSeedPaths(configWith({ kind: 'roadmap', filePath: undefined }));
+    expect(paths).toEqual(['.harness/proposals', 'docs/roadmap.md']);
+  });
+
+  it('falls back to docs/roadmap.md for a non-roadmap tracker (filePath is not a roadmap)', () => {
+    // A github-issues tracker has no roadmap filePath semantics; seeding the
+    // default keeps a file-backed roadmap (if present) carried over.
+    const paths = deriveSeedPaths(configWith({ kind: 'github-issues', filePath: '/tmp/x.json' }));
+    expect(paths).toEqual(['.harness/proposals', 'docs/roadmap.md']);
+  });
+});

--- a/packages/orchestrator/tests/workspace/manager.test.ts
+++ b/packages/orchestrator/tests/workspace/manager.test.ts
@@ -214,6 +214,175 @@ describe('WorkspaceManager', () => {
     });
   });
 
+  describe('seeding brainstorm handoff artifacts', () => {
+    // Regression: when a brainstorm wrote a proposal (.harness/proposals/*.json)
+    // and promoted a roadmap row (docs/roadmap.md), those artifacts live ONLY as
+    // uncommitted files in the orchestrator's root working tree. The orchestrator
+    // detects the item (it reads the live roadmap) and dispatches, but the worktree
+    // is created from a committed remote ref (origin/main) and inherited NEITHER
+    // file — so the agent had a roadmap entry but no proposal and could not continue.
+    // The fix seeds those paths from the root working tree into the fresh worktree.
+
+    function newWorktreeWithSeedSources() {
+      // .git / stale-dir checks reject (worktree is new); seed sources under the
+      // repo root resolve so they are carried over.
+      vi.mocked(fs.access).mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith('.git')) throw new Error('ENOENT');
+        if (s.startsWith('/repo/')) return undefined;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+    }
+
+    it('copies the proposal dir and roadmap from the root tree into the worktree', async () => {
+      newWorktreeWithSeedSources();
+
+      const result = await manager.ensureWorkspace('test-issue');
+      expect(result.ok).toBe(true);
+
+      const workspacePath = path.resolve('/tmp/workspaces', 'test-issue');
+      expect(fs.cp).toHaveBeenCalledWith(
+        path.join('/repo', '.harness/proposals'),
+        path.join(workspacePath, '.harness/proposals'),
+        { recursive: true, force: true }
+      );
+      expect(fs.cp).toHaveBeenCalledWith(
+        path.join('/repo', 'docs/roadmap.md'),
+        path.join(workspacePath, 'docs/roadmap.md'),
+        { recursive: true, force: true }
+      );
+    });
+
+    it('seeds AFTER the worktree is created (so it overlays the checkout)', async () => {
+      newWorktreeWithSeedSources();
+
+      await manager.ensureWorkspace('test-issue');
+
+      const addIdx = manager.gitCalls.findIndex(
+        (c) => c.args[0] === 'worktree' && c.args[1] === 'add'
+      );
+      const cpOrder = vi.mocked(fs.cp).mock.invocationCallOrder[0];
+      // The worktree-add git call must have happened before any cp.
+      expect(addIdx).toBeGreaterThanOrEqual(0);
+      expect(cpOrder).toBeGreaterThan(0);
+    });
+
+    it('skips seed paths that do not exist in the root tree', async () => {
+      // No seed sources exist → nothing is copied, dispatch still succeeds.
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+
+      const result = await manager.ensureWorkspace('test-issue');
+      expect(result.ok).toBe(true);
+      expect(fs.cp).not.toHaveBeenCalled();
+    });
+
+    it('honors a custom workspace.seedPaths override', async () => {
+      const custom = new TestableWorkspaceManager({
+        root: '/tmp/workspaces',
+        seedPaths: ['docs/specs'],
+      });
+      vi.mocked(fs.access).mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith('.git')) throw new Error('ENOENT');
+        if (s.startsWith('/repo/')) return undefined;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      custom.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+
+      await custom.ensureWorkspace('test-issue');
+
+      const workspacePath = path.resolve('/tmp/workspaces', 'test-issue');
+      expect(fs.cp).toHaveBeenCalledWith(
+        path.join('/repo', 'docs/specs'),
+        path.join(workspacePath, 'docs/specs'),
+        { recursive: true, force: true }
+      );
+      // Default paths are NOT used when an override is supplied.
+      expect(fs.cp).not.toHaveBeenCalledWith(
+        path.join('/repo', '.harness/proposals'),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('relativizes an absolute seed path against the repo root', async () => {
+      // A configured roadmap filePath may arrive absolute; it should still be
+      // seeded by copying the in-repo source to the matching worktree path.
+      const abs = new TestableWorkspaceManager({
+        root: '/tmp/workspaces',
+        seedPaths: ['/repo/docs/roadmap.md'],
+      });
+      vi.mocked(fs.access).mockImplementation(async (p) => {
+        const s = String(p);
+        if (s.endsWith('.git')) throw new Error('ENOENT');
+        if (s.startsWith('/repo/')) return undefined;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      abs.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+
+      await abs.ensureWorkspace('test-issue');
+
+      const workspacePath = path.resolve('/tmp/workspaces', 'test-issue');
+      expect(fs.cp).toHaveBeenCalledWith(
+        path.join('/repo', 'docs/roadmap.md'),
+        path.join(workspacePath, 'docs/roadmap.md'),
+        { recursive: true, force: true }
+      );
+    });
+
+    it('skips a seed path that escapes the repo root (no copy outside the worktree)', async () => {
+      const escaping = new TestableWorkspaceManager({
+        root: '/tmp/workspaces',
+        seedPaths: ['/etc/passwd'],
+      });
+      // Even if the source "exists", an escaping path must never be copied.
+      vi.mocked(fs.access).mockImplementation(async (p) => {
+        if (String(p).endsWith('.git')) throw new Error('ENOENT');
+        return undefined;
+      });
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      escaping.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+
+      const result = await escaping.ensureWorkspace('test-issue');
+      expect(result.ok).toBe(true);
+      expect(fs.cp).not.toHaveBeenCalled();
+    });
+
+    it('does not fail dispatch when a copy throws (best-effort seeding)', async () => {
+      newWorktreeWithSeedSources();
+      vi.mocked(fs.cp).mockRejectedValue(new Error('EACCES'));
+
+      const result = await manager.ensureWorkspace('test-issue');
+      expect(result.ok).toBe(true);
+    });
+  });
+
   it('removes stale directory before creating worktree', async () => {
     // First access (.git check) rejects; second access (dir exists check) resolves
     vi.mocked(fs.access)

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -270,6 +270,23 @@ export interface WorkspaceConfig {
    * branch agents off a long-running integration branch).
    */
   baseRef?: string;
+  /**
+   * Repo-relative paths to seed into a freshly-created worktree by copying
+   * them from the orchestrator's root working tree.
+   *
+   * New worktrees are based on a committed remote ref (e.g. `origin/main`), so
+   * they do NOT inherit uncommitted artifacts that live only in the root
+   * working tree. The brainstorm → orchestrator handoff produces exactly such
+   * artifacts: a proposal under `.harness/proposals/` and a promoted row in
+   * `docs/roadmap.md`, both written uncommitted. Without seeding, a dispatched
+   * agent sees a roadmap entry but cannot find its proposal and stalls.
+   *
+   * When unset, defaults to `['.harness/proposals', 'docs/roadmap.md']`. Each
+   * path is copied best-effort: missing sources are skipped and copy failures
+   * never block dispatch. Set explicitly to override (e.g. a non-default
+   * roadmap location).
+   */
+  seedPaths?: string[];
 }
 
 /**


### PR DESCRIPTION
## Problem

When an item is brainstormed while the orchestrator is running, the brainstorm flow writes two artifacts **uncommitted** into the orchestrator's root working tree:

- the proposal JSON → `.harness/proposals/{id}.json`
- the promoted roadmap row → `docs/roadmap.md`

The orchestrator's tracker reads `docs/roadmap.md` **live from the working tree**, so it *detects* the new item and dispatches. But `WorkspaceManager.ensureWorkspace` creates the worktree from a **committed remote ref** (`origin/main`) — it even wipes any existing worktree and re-fetches origin first. So the fresh worktree inherits **neither** the proposal **nor** the roadmap edit. The dispatched agent gets the item's id/title but finds no proposal on disk and a stale roadmap, and stalls.

This asymmetry — detect from the live working tree, dispatch into an `origin/main` worktree — is the root cause.

## Fix — seed the worktree

After `git worktree add`, `ensureWorkspace` now copies the handoff artifacts from the root working tree into the fresh worktree, overlaying the committed checkout.

- New `WorkspaceConfig.seedPaths?: string[]` (repo-relative). Defaults to `['.harness/proposals', 'docs/roadmap.md']`.
- Best-effort: missing sources are skipped, copy failures are swallowed, and any path that escapes the repo root is refused — seeding can never block dispatch or write outside the worktree.
- The orchestrator derives the roadmap entry from the **configured** tracker `filePath` (`deriveSeedPaths`), so a non-default roadmap location is still carried over. An explicit `seedPaths` wins.

## Files

- `packages/types/src/orchestrator.ts` — `WorkspaceConfig.seedPaths`.
- `packages/orchestrator/src/workspace/manager.ts` — `seedWorkspace()` + default + absolute-path/escape guard.
- `packages/orchestrator/src/orchestrator.ts` — `deriveSeedPaths()` + construction wiring.

## Tests

- `tests/workspace/manager.test.ts` — seeds proposal + roadmap; seeds after worktree-add; skips missing sources; custom `seedPaths` override; absolute-path relativization; escaping-path refusal; best-effort on copy failure.
- `tests/workspace/derive-seed-paths.test.ts` — configured `filePath` used; falls back to `docs/roadmap.md`.

Verified failing before the fix and passing after. Full orchestrator suite: **1412 passed / 1 skipped**. Typecheck clean.