### PR TITLE
fix(cli): resolve project-local skills in skill info/run (#587)

### DIFF
--- a/.changeset/skill-info-run-local-resolution.md
+++ b/.changeset/skill-info-run-local-resolution.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Resolve project-local skills in `skill info` and `skill run` (#587). Previously these commands resolved only through `resolveSkillsDir()`, which walks up from the compiled CLI module location first — so in a consuming repo it found the CLI's bundled skills and never the project's own `agents/skills/claude-code/<name>/`. A locally-authored skill was therefore listable via `skill list --local` but reported `Skill not found` by `info`/`run`. Both commands now resolve through a shared `resolveSkillDir(name)` helper that searches the same source set as `skill list` (project-local → community → bundled, first match wins), making discovery consistent across all `skill` subcommands.

--- a/packages/cli/src/commands/skill/info.ts
+++ b/packages/cli/src/commands/skill/info.ts
@@ -5,15 +5,14 @@ import { parse } from 'yaml';
 import { SkillMetadataSchema, type SkillMetadata } from '../../skill/schema';
 import { logger } from '../../output/logger';
 import { ExitCode } from '../../utils/errors';
-import { resolveSkillsDir } from '../../utils/paths';
+import { resolveSkillDir } from '../../utils/paths';
 
 type LoadResult = { ok: true; data: SkillMetadata } | { ok: false; exitCode: number };
 
 function loadSkillMetadata(name: string): LoadResult {
-  const skillsDir = resolveSkillsDir();
-  const skillDir = path.join(skillsDir, name);
+  const skillDir = resolveSkillDir(name);
 
-  if (!fs.existsSync(skillDir)) {
+  if (!skillDir) {
     logger.error(`Skill not found: ${name}`);
     return { ok: false, exitCode: ExitCode.ERROR };
   }

--- a/packages/cli/src/commands/skill/run.ts
+++ b/packages/cli/src/commands/skill/run.ts
@@ -7,7 +7,7 @@ import { detectComplexity, type Complexity } from '../../skill/complexity';
 import { buildPreamble } from './preamble';
 import { logger } from '../../output/logger';
 import { ExitCode } from '../../utils/errors';
-import { resolveSkillsDir } from '../../utils/paths';
+import { resolveSkillDir } from '../../utils/paths';
 
 type SkillMetadata = ReturnType<typeof SkillMetadataSchema.parse>;
 
@@ -100,10 +100,9 @@ async function runSkill(
   name: string,
   opts: { path?: string; complexity?: string; phase?: string; party?: boolean; backend?: string }
 ): Promise<void> {
-  const skillsDir = resolveSkillsDir();
-  const skillDir = path.join(skillsDir, name);
+  const skillDir = resolveSkillDir(name);
 
-  if (!fs.existsSync(skillDir)) {
+  if (!skillDir) {
     logger.error(`Skill not found: ${name}`);
     process.exit(ExitCode.ERROR);
     return;

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -168,3 +168,23 @@ export function resolveAllSkillsDirs(platform: string = 'claude-code'): string[]
 
   return dirs;
 }
+
+/**
+ * Resolve a single skill directory by name across all skill sources.
+ *
+ * Searches in priority order (project-local -> community -> bundled), returning
+ * the first `<dir>/<name>` that exists as a directory. This mirrors how
+ * `skill list` discovers skills, so `skill info`/`skill run` resolve the same
+ * project-local skills that `skill list --local` surfaces (issue #587).
+ *
+ * Returns null if no source contains the named skill.
+ */
+export function resolveSkillDir(name: string, platform: string = 'claude-code'): string | null {
+  for (const dir of resolveAllSkillsDirs(platform)) {
+    const candidate = path.join(dir, name);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/packages/cli/tests/commands/skill-info.test.ts
+++ b/packages/cli/tests/commands/skill-info.test.ts
@@ -9,7 +9,10 @@ const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
 
 let mockSkillsDir = '';
 vi.mock('../../src/utils/paths', () => ({
-  resolveSkillsDir: () => mockSkillsDir,
+  resolveSkillDir: (name: string) => {
+    const dir = path.join(mockSkillsDir, name);
+    return fs.existsSync(dir) && fs.statSync(dir).isDirectory() ? dir : null;
+  },
 }));
 
 import { createInfoCommand } from '../../src/commands/skill/info';

--- a/packages/cli/tests/commands/skill-local-resolution.test.ts
+++ b/packages/cli/tests/commands/skill-local-resolution.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { Command } from 'commander';
+
+// Regression test for issue #587:
+//   `skill info` / `skill run` must resolve project-local skills the same way
+//   `skill list --local` does. Before the fix, info/run resolved only from
+//   `resolveSkillsDir()` (compiled-module-location first), so a project-local
+//   skill under <cwd>/agents/skills/claude-code/<name>/ was listable but
+//   reported "Skill not found" by info/run.
+//
+// This suite intentionally does NOT mock src/utils/paths — it exercises the
+// real resolution chain so a revert to single-source resolution fails it.
+
+import { createInfoCommand } from '../../src/commands/skill/info';
+import { createRunCommand } from '../../src/commands/skill/run';
+
+const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+const mockStdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+const SKILL_NAME = 'demo-local-587';
+const skillYaml = `name: ${SKILL_NAME}
+version: "1.0.0"
+description: A project-local demo skill
+triggers: [manual]
+platforms: [claude-code]
+tools: [Read]
+type: flexible
+`;
+
+function infoProgram(): Command {
+  const program = new Command();
+  program.option('--json', 'JSON output');
+  program.addCommand(createInfoCommand());
+  return program;
+}
+
+function runProgram(): Command {
+  const program = new Command();
+  program.addCommand(createRunCommand());
+  return program;
+}
+
+describe('skill info/run resolve project-local skills (#587)', () => {
+  let projectDir: string;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-local-587-'));
+    const skillDir = path.join(projectDir, 'agents', 'skills', 'claude-code', SKILL_NAME);
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'skill.yaml'), skillYaml);
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${SKILL_NAME}\nlocal body\n`);
+    // Simulate running the CLI from the consuming project root.
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockStdoutWrite.mockClear();
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('skill info resolves a project-local skill by name', async () => {
+    await infoProgram().parseAsync(['node', 'test', 'info', SKILL_NAME]);
+
+    const output = mockConsoleLog.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain(SKILL_NAME);
+    expect(output).toContain('A project-local demo skill');
+    expect(mockExit).toHaveBeenCalledWith(0);
+    expect(mockExit).not.toHaveBeenCalledWith(2);
+  });
+
+  it('skill run resolves a project-local skill by name', async () => {
+    await runProgram().parseAsync(['node', 'test', 'run', SKILL_NAME]);
+
+    const output = mockStdoutWrite.mock.calls.map((c) => c[0]).join('');
+    expect(output).toContain(`# ${SKILL_NAME}`);
+    expect(output).toContain('local body');
+    expect(mockExit).toHaveBeenCalledWith(0);
+    expect(mockExit).not.toHaveBeenCalledWith(2);
+  });
+});

--- a/packages/cli/tests/commands/skill-run.test.ts
+++ b/packages/cli/tests/commands/skill-run.test.ts
@@ -10,10 +10,13 @@ const mockStdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() 
 const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
 const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-// Mock resolveSkillsDir to use our temp dir
+// Mock resolveSkillDir to resolve against our temp dir
 let mockSkillsDir = '';
 vi.mock('../../src/utils/paths', () => ({
-  resolveSkillsDir: () => mockSkillsDir,
+  resolveSkillDir: (name: string) => {
+    const dir = path.join(mockSkillsDir, name);
+    return fs.existsSync(dir) && fs.statSync(dir).isDirectory() ? dir : null;
+  },
 }));
 
 import { createRunCommand } from '../../src/commands/skill/run';

--- a/packages/cli/tests/utils/paths.test.ts
+++ b/packages/cli/tests/utils/paths.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import {
   resolveTemplatesDir,
   resolvePersonasDir,
   resolveSkillsDir,
   resolveAllSkillsDirs,
   resolveCommunitySkillsDir,
+  resolveSkillDir,
 } from '../../src/utils/paths';
 
 describe('resolveTemplatesDir', () => {
@@ -84,5 +88,35 @@ describe('resolveAllSkillsDirs', () => {
   it('accepts gemini-cli platform', () => {
     const result = resolveAllSkillsDirs('gemini-cli');
     result.forEach((dir) => expect(dir).toMatch(/gemini-cli$/));
+  });
+});
+
+describe('resolveSkillDir', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves a project-local skill discovered from cwd (#587)', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-resolve-skill-'));
+    const skillDir = path.join(projectDir, 'agents', 'skills', 'claude-code', 'local-only');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'skill.yaml'), 'name: local-only\n');
+
+    vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+    try {
+      expect(resolveSkillDir('local-only')).toBe(skillDir);
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when no source contains the named skill', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-resolve-skill-'));
+    vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+    try {
+      expect(resolveSkillDir('definitely-does-not-exist-xyz')).toBeNull();
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #587. `harness skill info <name>` and `harness skill run <name>` reported `Skill not found` for project-local skills that `harness skill list --local` discovered fine.

**Root cause:** `info`/`run` resolved a skill via `resolveSkillsDir()` + `path.join(name)` — a single source. `resolveSkillsDir()`'s `findUpDir('agents','skills')` walks up from the **compiled CLI module location first**, so in a consuming repo (CLI in `node_modules`) it resolved the CLI's *bundled* skills and never the project's own `agents/skills/claude-code/<name>/`. `skill list --local` used a different, cwd-based resolver (`resolveProjectSkillsDir`), producing the listable-but-not-runnable inconsistency.

**Fix:** Added a shared `resolveSkillDir(name, platform?)` helper in `utils/paths.ts` that iterates the existing `resolveAllSkillsDirs()` (project-local → community → bundled, first match wins) and returns the first existing `<dir>/<name>`. `info.ts` and `run.ts` now resolve through it, so discovery is consistent across all `skill` subcommands.

## Testing

- New end-to-end regression test `tests/commands/skill-local-resolution.test.ts` — does **not** mock `paths`; spies `process.cwd` at a temp project containing a local skill and asserts `info`/`run` resolve it. Verified it **fails** when `info`/`run` are reverted to `resolveSkillsDir`.
- Unit coverage for `resolveSkillDir` added to `tests/utils/paths.test.ts`.
- 96 skill/paths tests pass; `tsc --noEmit` clean.
- Verified against the built CLI run from a temp consuming-project: `info`/`run` now resolve a local skill; unknown skills still error correctly.

## Notes

- Patch changeset included (`@harness-engineering/cli`).
- Follow-up (out of scope): `skill validate` has the same single-source limitation — it scans only `resolveSkillsDir()`, so it won't validate project-local skills in a consuming repo. Worth a separate issue.