### PR TITLE
fix(cli): stop manage_roadmap update re-blocking unrelated features (#610)

### DIFF
--- a/.changeset/roadmap-update-cascade-unblock-only.md
+++ b/.changeset/roadmap-update-cascade-unblock-only.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Stop `manage_roadmap update` from re-blocking unrelated features (#610). The post-update cascade re-ran `syncRoadmap`, whose `inferStatus` re-derives `blocked` for any `planned` feature with an unfinished blocker. Because `planned` and `blocked` are lateral in `STATUS_RANK`, that move was not treated as a regression and got applied verbatim — so editing one feature (e.g. setting an assignee) silently flipped every unrelated `planned`-with-pending-blocker row to `blocked`. The cascade is now unblock-only: it drops any transition _into_ `blocked`, matching its documented intent ("flip dependents from `blocked → planned`"). Re-deriving `blocked` remains the explicit `sync` action's job. (Symptoms 1 & 2 from the issue — inline assignee not written and a bystander assignee wiped — were already resolved by the assignee-lifecycle chokepoint, ADR-0045.)

--- a/packages/cli/src/mcp/tools/roadmap.ts
+++ b/packages/cli/src/mcp/tools/roadmap.ts
@@ -397,9 +397,19 @@ function handleUpdate(
 
   // Cascade: when this update marks a feature done (or otherwise resolves a
   // blocker), flip dependents from blocked → planned in the same write.
+  //
+  // This is an unblock-only cascade. syncRoadmap also re-derives `blocked` for
+  // any planned feature with an unfinished blocker (sync.ts inferStatus); since
+  // planned/blocked are lateral in STATUS_RANK that move is not a regression, so
+  // applying it verbatim re-blocks unrelated bystanders on every single update
+  // (#610). Drop any transition *into* blocked here — re-blocking is the explicit
+  // `sync` action's job, not a side-effect of editing one feature.
   const cascade = syncRoadmap({ projectPath, roadmap });
-  if (cascade.ok && cascade.value.length > 0) {
-    applySyncChanges(roadmap, cascade.value);
+  if (cascade.ok) {
+    const unblocking = cascade.value.filter((change) => change.to !== 'blocked');
+    if (unblocking.length > 0) {
+      applySyncChanges(roadmap, unblocking);
+    }
   }
 
   roadmap.frontmatter.lastManualEdit = new Date().toISOString();

--- a/packages/cli/tests/mcp/tools/roadmap.test.ts
+++ b/packages/cli/tests/mcp/tools/roadmap.test.ts
@@ -262,6 +262,23 @@ describe('manage_roadmap update action', () => {
     expect(auth.status).toBe('done');
   });
 
+  it('does not re-block unrelated features when updating one feature (#610)', async () => {
+    // User Dashboard is `planned` and blocked by Auth System (in-progress, not done).
+    // Updating an UNRELATED feature must not flip it `planned` -> `blocked`: the
+    // post-update cascade is for unblocking dependents, not re-blocking bystanders.
+    const response = await handleManageRoadmap({
+      path: tmpDir,
+      action: 'update',
+      feature: 'Dark Mode',
+      summary: 'unrelated edit',
+    });
+    expect(response.isError).toBeFalsy();
+    const parsed = JSON.parse(response.content[0].text);
+    const mvp = parsed.milestones.find((m: { name: string }) => m.name === 'MVP Release');
+    const dash = mvp.features.find((f: { name: string }) => f.name === 'User Dashboard');
+    expect(dash.status).toBe('planned');
+  });
+
   it('updates feature summary and spec', async () => {
     const response = await handleManageRoadmap({
       path: tmpDir,


### PR DESCRIPTION
## Summary

Fixes the remaining corruption from #610: `manage_roadmap update` flipping ~13 unrelated features `planned → blocked` on a single feature edit.

**Root cause.** `handleUpdate` re-runs the `syncRoadmap` cascade on every update. `inferStatus` re-derives `blocked` for any `planned` feature with an unfinished blocker, and since `planned`/`blocked` are lateral in `STATUS_RANK`, that move is not a regression — so `applySyncChanges` applied it verbatim, re-blocking every unrelated bystander row.

**Fix.** Make the update cascade **unblock-only**: drop any transition *into* `blocked`, matching its documented intent ("flip dependents from `blocked → planned`"). Re-deriving `blocked` stays the explicit `sync` action's job, so `handleSync`/`syncRoadmap` are untouched.

## Issue triage (3 symptoms)

The issue was filed 2026-06-23; the assignee-lifecycle refactor (ADR-0045) landed 3 days later. Reproduced against current code:

| Symptom | Status |
|---|---|
| 1. Inline `**Assignee:**` not written, only history row | ✅ already fixed by `claim`/`release` chokepoint |
| 2. Unrelated feature's assignee silently wiped | ✅ already fixed |
| 3. ~13 features flipped `planned → blocked` | ✅ **fixed here** |

## Testing

- New regression test `roadmap.test.ts` → "does not re-block unrelated features when updating one feature (#610)" — **fails before** (`expected 'blocked' to be 'planned'`), passes after.
- roadmap suite 53/53; file-backed-regression + groom 10/10; core sync 17/17; `tsc` clean.

Closes #610