### PR TITLE
chore(roadmap): mark #528 and #640 done (completed work was stale as planned)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 project: harness-engineering
 version: 1
 created: 2026-03-21
-updated: 2026-06-25
+updated: 2026-06-26
 last_synced: 2026-06-23T18:05:08.357Z
 last_manual_edit: 2026-06-26T01:25:24.050Z
 ---
@@ -13,7 +13,7 @@ last_manual_edit: 2026-06-26T01:25:24.050Z
 
 ### Assignee means who is executing — set at execution, not selection
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/assignee-execution-lifecycle/proposal.md
 - **Summary:** Establish the invariant assignee ≠ null ⟺ in-progress via a centralized core authority: roadmap-pilot stops assigning at selection, harness-execution claims at execution start, machine claims never use the GitHub assignee field, inbound sync never clobbers a live machine claim, and RMH005 + groom enforce/migrate. Fixes the orchestrator silently skipping pilot-touched items.
 - **Blockers:** —
@@ -21,6 +21,7 @@ last_manual_edit: 2026-06-26T01:25:24.050Z
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#640
+- **Updated-At:** 2026-06-26T17:46:10.000Z
 
 ## v5.0 — Enforcement Hardening
 
@@ -49,7 +50,7 @@ last_manual_edit: 2026-06-26T01:25:24.050Z
 
 ### Reconcile health-snapshot.json passed flags with active signals
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/health-snapshot-signal-honesty/proposal.md
 - **Summary:** `.harness/health-snapshot.json` reports `entropy.passed: true` while listing "dead-code" in `signals[]`; same for docs (`passed: true`, `undocumentedCount: 27481`) and security (`passed: true`, `findingCount: 16`). The harness's own dogfooded output says all checks "passed" while listing seven active drift signals. Make `checks.X.passed` return `false` when `signals[]` includes the corresponding signal name. Source: Pass 1 #2.
 - **Blockers:** —
@@ -57,6 +58,7 @@ last_manual_edit: 2026-06-26T01:25:24.050Z
 - **Assignee:** —
 - **Priority:** P0
 - **External-ID:** github:Intense-Visions/harness-engineering#528
+- **Updated-At:** 2026-06-26T23:31:52.000Z
 
 ### Audit and cap the pre-commit --skip list
 


### PR DESCRIPTION
## What

Two roadmap items were still marked **`planned`** even though their work has shipped to `main`. Flip both to **`done`** and stamp `Updated-At` with the merge times.

| Item | Roadmap was | Shipped via | Status now |
|------|-------------|-------------|------------|
| #528 — Reconcile health-snapshot.json passed flags with active signals | planned | merged PR #648 | done |
| #640 — Assignee means who is executing — set at execution, not selection | planned | merged PR #643 | done |

## Why

Both issues were closed by their merged PRs, then reopened — a sync job reacting to the stale `planned` roadmap status keeps thrashing them closed→reopened. Both merge commits are confirmed on `main` and their spec dirs (`docs/changes/health-snapshot-signal-honesty/`, `docs/changes/assignee-execution-lifecycle/`) are present.

## How verified

- Cross-referenced every roadmap `External-ID` against GitHub issue state and against closing references on the last 200 merged PRs.
- Only these two items had a merged closing PR while the roadmap row was not `done`.

GitHub issues #528 and #640 are being closed with a comment linking the merged PRs.