### PR TITLE
fix(skills): ask the human in plain text, not via emit_interaction

### DIFF
--- a/.claude-plugin/agents/harness-adversarial-reviewer.md
+++ b/.claude-plugin/agents/harness-adversarial-reviewer.md
@@ -564,17 +564,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.claude-plugin/agents/harness-code-reviewer.md
+++ b/.claude-plugin/agents/harness-code-reviewer.md
@@ -567,17 +567,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.claude-plugin/agents/harness-frontend-races-reviewer.md
+++ b/.claude-plugin/agents/harness-frontend-races-reviewer.md
@@ -564,17 +564,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.claude-plugin/agents/harness-planner.md
+++ b/.claude-plugin/agents/harness-planner.md
@@ -120,44 +120,21 @@ Store the parsed skill list for use in Phase 2 task annotation.
 
    **Read-only constraint:** Steps 1-6 above are research and analysis. Do not propose task structure, file organization, or implementation approaches during SCOPE. Record what must be true (observable truths) and what you do not know (uncertainties). Solutions belong in DECOMPOSE.
 
-   When scope is ambiguous, use `emit_interaction`:
+   When scope is ambiguous, ask in plain text in your reply. **Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "The spec mentions X but does not define behavior for Y. Should we:",
-       options: [
-         {
-           label: "A) Include Y in this plan",
-           pros: ["Complete feature in one pass", "No follow-up coordination"],
-           cons: ["Increases scope and time", "May delay delivery"],
-           risk: "medium",
-           effort: "high"
-         },
-         {
-           label: "B) Defer Y to a follow-up plan",
-           pros: ["Keeps current plan focused", "Ship sooner"],
-           cons: ["Y remains unhandled", "May need rework when Y is added"],
-           risk: "low",
-           effort: "low"
-         },
-         {
-           label: "C) Update the spec first",
-           pros: ["Design is complete before planning", "No surprises during execution"],
-           cons: ["Blocks planning until spec is updated", "Extra round-trip"],
-           risk: "low",
-           effort: "medium"
-         }
-       ],
-       recommendation: {
-         optionIndex: 1,
-         reason: "Keeping the current plan focused reduces risk. Y can be addressed in a follow-up.",
-         confidence: "medium"
-       }
-     }
-   })
+   Present the choice as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: The spec mentions X but does not define behavior for Y. Should we:
+
+   |            | A) Include Y in this plan                               | B) Defer Y to a follow-up plan                       | C) Update the spec first                                          |
+   | ---------- | ------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+   | **Pros**   | Complete feature in one pass; no follow-up coordination | Keeps current plan focused; ship sooner              | Design is complete before planning; no surprises during execution |
+   | **Cons**   | Increases scope and time; may delay delivery            | Y remains unhandled; may need rework when Y is added | Blocks planning until spec is updated; extra round-trip           |
+   | **Risk**   | Medium                                                  | Low                                                  | Low                                                               |
+   | **Effort** | High                                                    | Low                                                  | Medium                                                            |
+
+   **Recommendation:** B) Defer Y to a follow-up plan (confidence: medium) — keeping the current plan focused reduces risk; Y can be addressed in a follow-up.
    ```
 
 #### EARS Requirement Patterns
@@ -248,7 +225,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
    **Estimated total:** 8 tasks, ~33 minutes
    ```
 
-   **Approval gate:** Present via `emit_interaction` (type: `confirmation`, text: "Approve skeleton direction?"). If approved, proceed to step 3. If rejected, revise and re-present.
+   **Approval gate:** Ask in plain text in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (they do not display to the human; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Ask directly: "Approve skeleton direction?" and wait. If approved, proceed to step 3. If rejected, revise and re-present.
 
 3. **Decompose into atomic tasks.** Each task must:
    - Be completable in 2-5 minutes, fit in a single context window
@@ -338,7 +315,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
 10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off in plain text.** Ask directly in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (the human will not see it; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Present the plan path, task count, and time estimate, then ask: "Proceed? (yes/no)" and wait for the reply.
 
 12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 

--- a/.claude-plugin/agents/harness-security-reviewer.md
+++ b/.claude-plugin/agents/harness-security-reviewer.md
@@ -839,17 +839,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.claude-plugin/agents/harness-task-executor.md
+++ b/.claude-plugin/agents/harness-task-executor.md
@@ -213,40 +213,37 @@ Three checkpoint types. Each requires pausing execution.
 
 **`[checkpoint:human-verify]` — Show and Confirm**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the confirmation in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Task N complete. Output: <summary>. Continue to Task N+1?",
-    context: "<test output or diff summary>",
-    impact: "Continuing proceeds to next task. Declining pauses for review.",
-    risk: "low"
-  }
-})
+```markdown
+Task N complete. Output: <summary>. Continue to Task N+1?
+
+Context: <test output or diff summary>
+Impact: Continuing proceeds to next task. Declining pauses for review.
+Risk: low
+
+Proceed? (yes/no)
 ```
 
 Wait for human confirmation.
 
 **`[checkpoint:decision]` — Present Options and Wait**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the decision in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "question",
-  question: {
-    text: "Task N requires a decision: <description>",
-    options: [
-      { label: "<option A>", pros: ["..."], cons: ["..."], risk: "low", effort: "low" },
-      { label: "<option B>", pros: ["..."], cons: ["..."], risk: "medium", effort: "medium" }
-    ],
-    recommendation: { optionIndex: 0, reason: "<why>", confidence: "medium" }
-  }
-})
+Present the options as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+```markdown
+### Decision needed: Task N requires a decision: <description>
+
+|            | A) <option A>   | B) <option B>   |
+| ---------- | --------------- | --------------- |
+| **Pros**   | <option A pros> | <option B pros> |
+| **Cons**   | <option A cons> | <option B cons> |
+| **Risk**   | low             | medium          |
+| **Effort** | low             | medium          |
+
+**Recommendation:** A) <option A> (confidence: medium) — <why>.
 ```
 
 Wait for human choice.

--- a/.claude-plugin/agents/harness-typescript-strict-reviewer.md
+++ b/.claude-plugin/agents/harness-typescript-strict-reviewer.md
@@ -564,17 +564,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.claude-plugin/agents/harness-verifier.md
+++ b/.claude-plugin/agents/harness-verifier.md
@@ -200,19 +200,16 @@ Use severity markers for critical findings: `**[CRITICAL]**` for blocking issues
 
 ### Verification Sign-Off
 
-After producing the report, request acceptance:
+After producing the report, request acceptance in plain text. Ask in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Verification report: <VERDICT>. Accept and proceed?",
-    context: "<N artifacts checked, N gaps found>",
-    impact: "Accepting proceeds to code review. Declining requires gap resolution.",
-    risk: "<low if PASS, high if gaps remain>"
-  }
-})
+```markdown
+Verification report: <VERDICT>. Accept and proceed?
+
+Context: <N artifacts checked, N gaps found>
+Impact: Accepting proceeds to code review. Declining requires gap resolution.
+Risk: <low if PASS, high if gaps remain>
+
+Proceed? (yes/no)
 ```
 
 ### Handoff and Transition

--- a/.cursor-plugin/agents/harness-adversarial-reviewer.md
+++ b/.cursor-plugin/agents/harness-adversarial-reviewer.md
@@ -563,17 +563,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.cursor-plugin/agents/harness-code-reviewer.md
+++ b/.cursor-plugin/agents/harness-code-reviewer.md
@@ -566,17 +566,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.cursor-plugin/agents/harness-frontend-races-reviewer.md
+++ b/.cursor-plugin/agents/harness-frontend-races-reviewer.md
@@ -563,17 +563,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.cursor-plugin/agents/harness-planner.md
+++ b/.cursor-plugin/agents/harness-planner.md
@@ -119,44 +119,21 @@ Store the parsed skill list for use in Phase 2 task annotation.
 
    **Read-only constraint:** Steps 1-6 above are research and analysis. Do not propose task structure, file organization, or implementation approaches during SCOPE. Record what must be true (observable truths) and what you do not know (uncertainties). Solutions belong in DECOMPOSE.
 
-   When scope is ambiguous, use `emit_interaction`:
+   When scope is ambiguous, ask in plain text in your reply. **Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "The spec mentions X but does not define behavior for Y. Should we:",
-       options: [
-         {
-           label: "A) Include Y in this plan",
-           pros: ["Complete feature in one pass", "No follow-up coordination"],
-           cons: ["Increases scope and time", "May delay delivery"],
-           risk: "medium",
-           effort: "high"
-         },
-         {
-           label: "B) Defer Y to a follow-up plan",
-           pros: ["Keeps current plan focused", "Ship sooner"],
-           cons: ["Y remains unhandled", "May need rework when Y is added"],
-           risk: "low",
-           effort: "low"
-         },
-         {
-           label: "C) Update the spec first",
-           pros: ["Design is complete before planning", "No surprises during execution"],
-           cons: ["Blocks planning until spec is updated", "Extra round-trip"],
-           risk: "low",
-           effort: "medium"
-         }
-       ],
-       recommendation: {
-         optionIndex: 1,
-         reason: "Keeping the current plan focused reduces risk. Y can be addressed in a follow-up.",
-         confidence: "medium"
-       }
-     }
-   })
+   Present the choice as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: The spec mentions X but does not define behavior for Y. Should we:
+
+   |            | A) Include Y in this plan                               | B) Defer Y to a follow-up plan                       | C) Update the spec first                                          |
+   | ---------- | ------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+   | **Pros**   | Complete feature in one pass; no follow-up coordination | Keeps current plan focused; ship sooner              | Design is complete before planning; no surprises during execution |
+   | **Cons**   | Increases scope and time; may delay delivery            | Y remains unhandled; may need rework when Y is added | Blocks planning until spec is updated; extra round-trip           |
+   | **Risk**   | Medium                                                  | Low                                                  | Low                                                               |
+   | **Effort** | High                                                    | Low                                                  | Medium                                                            |
+
+   **Recommendation:** B) Defer Y to a follow-up plan (confidence: medium) — keeping the current plan focused reduces risk; Y can be addressed in a follow-up.
    ```
 
 #### EARS Requirement Patterns
@@ -247,7 +224,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
    **Estimated total:** 8 tasks, ~33 minutes
    ```
 
-   **Approval gate:** Present via `emit_interaction` (type: `confirmation`, text: "Approve skeleton direction?"). If approved, proceed to step 3. If rejected, revise and re-present.
+   **Approval gate:** Ask in plain text in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (they do not display to the human; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Ask directly: "Approve skeleton direction?" and wait. If approved, proceed to step 3. If rejected, revise and re-present.
 
 3. **Decompose into atomic tasks.** Each task must:
    - Be completable in 2-5 minutes, fit in a single context window
@@ -337,7 +314,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
 10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off in plain text.** Ask directly in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (the human will not see it; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Present the plan path, task count, and time estimate, then ask: "Proceed? (yes/no)" and wait for the reply.
 
 12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 

--- a/.cursor-plugin/agents/harness-security-reviewer.md
+++ b/.cursor-plugin/agents/harness-security-reviewer.md
@@ -838,17 +838,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.cursor-plugin/agents/harness-task-executor.md
+++ b/.cursor-plugin/agents/harness-task-executor.md
@@ -212,40 +212,37 @@ Three checkpoint types. Each requires pausing execution.
 
 **`[checkpoint:human-verify]` — Show and Confirm**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the confirmation in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Task N complete. Output: <summary>. Continue to Task N+1?",
-    context: "<test output or diff summary>",
-    impact: "Continuing proceeds to next task. Declining pauses for review.",
-    risk: "low"
-  }
-})
+```markdown
+Task N complete. Output: <summary>. Continue to Task N+1?
+
+Context: <test output or diff summary>
+Impact: Continuing proceeds to next task. Declining pauses for review.
+Risk: low
+
+Proceed? (yes/no)
 ```
 
 Wait for human confirmation.
 
 **`[checkpoint:decision]` — Present Options and Wait**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the decision in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "question",
-  question: {
-    text: "Task N requires a decision: <description>",
-    options: [
-      { label: "<option A>", pros: ["..."], cons: ["..."], risk: "low", effort: "low" },
-      { label: "<option B>", pros: ["..."], cons: ["..."], risk: "medium", effort: "medium" }
-    ],
-    recommendation: { optionIndex: 0, reason: "<why>", confidence: "medium" }
-  }
-})
+Present the options as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+```markdown
+### Decision needed: Task N requires a decision: <description>
+
+|            | A) <option A>   | B) <option B>   |
+| ---------- | --------------- | --------------- |
+| **Pros**   | <option A pros> | <option B pros> |
+| **Cons**   | <option A cons> | <option B cons> |
+| **Risk**   | low             | medium          |
+| **Effort** | low             | medium          |
+
+**Recommendation:** A) <option A> (confidence: medium) — <why>.
 ```
 
 Wait for human choice.

--- a/.cursor-plugin/agents/harness-typescript-strict-reviewer.md
+++ b/.cursor-plugin/agents/harness-typescript-strict-reviewer.md
@@ -563,17 +563,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.cursor-plugin/agents/harness-verifier.md
+++ b/.cursor-plugin/agents/harness-verifier.md
@@ -199,19 +199,16 @@ Use severity markers for critical findings: `**[CRITICAL]**` for blocking issues
 
 ### Verification Sign-Off
 
-After producing the report, request acceptance:
+After producing the report, request acceptance in plain text. Ask in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Verification report: <VERDICT>. Accept and proceed?",
-    context: "<N artifacts checked, N gaps found>",
-    impact: "Accepting proceeds to code review. Declining requires gap resolution.",
-    risk: "<low if PASS, high if gaps remain>"
-  }
-})
+```markdown
+Verification report: <VERDICT>. Accept and proceed?
+
+Context: <N artifacts checked, N gaps found>
+Impact: Accepting proceeds to code review. Declining requires gap resolution.
+Risk: <low if PASS, high if gaps remain>
+
+Proceed? (yes/no)
 ```
 
 ### Handoff and Transition

--- a/.gemini-extension/commands/brainstorming.toml
+++ b/.gemini-extension/commands/brainstorming.toml
@@ -84,22 +84,23 @@ When no arguments are provided (standalone invocation), the skill operates exact
 
 ### Phase 2: EVALUATE -- Ask Questions and Narrow
 
-1. **Ask ONE question at a time.** Ask the most important question first. Wait for the answer. Let it inform the next question. Use `emit_interaction` with `type: 'question'`:
+1. **Ask ONE question at a time, in plain text.** Ask the most important question first. Wait for the answer. Let it inform the next question.
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "For auth, which approach should we use?",
-       options: [
-         { "label": "A) Existing JWT middleware", "pros": ["Already in codebase"], "cons": ["No refresh tokens"], "risk": "low", "effort": "low" },
-         { "label": "B) OAuth2 via provider X", "pros": ["Industry standard"], "cons": ["New dependency"], "risk": "medium", "effort": "medium" },
-         { "label": "C) External auth service", "pros": ["Zero maintenance"], "cons": ["Vendor lock-in", "Cost"], "risk": "medium", "effort": "low" }
-       ],
-       recommendation: { "optionIndex": 0, "reason": "Sufficient for current requirements.", "confidence": "high" }
-     }
-   })
+   **Ask directly in your reply. Do NOT route the question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the question in state but does not display it to the human — the client collapses it to "Called harness" and the rendered prompt only returns to the model, so the human sees nothing and you end up narrating a question they cannot answer. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
+
+   Present the question as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: For auth, which approach should we use?
+
+   |            | A) Existing JWT middleware | B) OAuth2 via provider X | C) External auth service |
+   | ---------- | -------------------------- | ------------------------ | ------------------------ |
+   | **Pros**   | Already in codebase        | Industry standard        | Zero maintenance         |
+   | **Cons**   | No refresh tokens          | New dependency           | Vendor lock-in; cost     |
+   | **Risk**   | Low                        | Medium                   | Medium                   |
+   | **Effort** | Low                        | Medium                   | Low                      |
+
+   **Recommendation:** A) Existing JWT middleware (confidence: high) — sufficient for current requirements.
    ```
 
 2. **Prefer multiple choice over open-ended questions.** Give 2-4 concrete options with brief tradeoff notes.
@@ -189,22 +190,19 @@ These flow into `handoff.json` `contextKeywords` field. Select keywords that hel
 
 5. **Run `harness validate`** to verify proper placement and project health.
 
-6. **Request sign-off via `emit_interaction`:**
+6. **Request sign-off in plain text.** Ask directly in your reply — do NOT route the request through `emit_interaction` or `AskUserQuestion` (the human will not see it). Present it as:
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "confirmation",
-     confirmation: {
-       text: "Approve spec at <file-path>?",
-       context: "<one-paragraph summary>",
-       impact: "Spec approval unlocks implementation planning. No code changes yet.",
-       risk: "low"
-     }
-   })
+   ```markdown
+   Approve spec at <file-path>?
+
+   Context: <one-paragraph summary>
+   Impact: Spec approval unlocks implementation planning. No code changes yet.
+   Risk: low
+
+   Proceed? (yes/no)
    ```
 
-   The human must explicitly approve before this skill is complete.
+   The human must explicitly approve (a clear "yes") before this skill is complete.
 
 7. **Promote the roadmap row.** If `docs/roadmap.md` exists, transition the named row to `planned` and link the spec in a single structured call (steps 7 and 8 are intentionally ordered so the commit captures the roadmap mutation). Skip silently only when no roadmap exists.
    - Derive the lookup key from the slash-command `ARGUMENTS` string (D1). Derive the summary from the spec title (the H1 heading).

--- a/.gemini-extension/commands/code-review.toml
+++ b/.gemini-extension/commands/code-review.toml
@@ -553,17 +553,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/.gemini-extension/commands/execution.toml
+++ b/.gemini-extension/commands/execution.toml
@@ -207,40 +207,37 @@ Three checkpoint types. Each requires pausing execution.
 
 **`[checkpoint:human-verify]` — Show and Confirm**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the confirmation in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Task N complete. Output: <summary>. Continue to Task N+1?",
-    context: "<test output or diff summary>",
-    impact: "Continuing proceeds to next task. Declining pauses for review.",
-    risk: "low"
-  }
-})
+```markdown
+Task N complete. Output: <summary>. Continue to Task N+1?
+
+Context: <test output or diff summary>
+Impact: Continuing proceeds to next task. Declining pauses for review.
+Risk: low
+
+Proceed? (yes/no)
 ```
 
 Wait for human confirmation.
 
 **`[checkpoint:decision]` — Present Options and Wait**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the decision in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "question",
-  question: {
-    text: "Task N requires a decision: <description>",
-    options: [
-      { label: "<option A>", pros: ["..."], cons: ["..."], risk: "low", effort: "low" },
-      { label: "<option B>", pros: ["..."], cons: ["..."], risk: "medium", effort: "medium" }
-    ],
-    recommendation: { optionIndex: 0, reason: "<why>", confidence: "medium" }
-  }
-})
+Present the options as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+```markdown
+### Decision needed: Task N requires a decision: <description>
+
+|            | A) <option A>   | B) <option B>   |
+| ---------- | --------------- | --------------- |
+| **Pros**   | <option A pros> | <option B pros> |
+| **Cons**   | <option A cons> | <option B cons> |
+| **Risk**   | low             | medium          |
+| **Effort** | low             | medium          |
+
+**Recommendation:** A) <option A> (confidence: medium) — <why>.
 ```
 
 Wait for human choice.

--- a/.gemini-extension/commands/initialize-project.toml
+++ b/.gemini-extension/commands/initialize-project.toml
@@ -114,39 +114,21 @@ Detect plugin-only state by checking whether `harness` resolves on PATH (`comman
    - **No:** Set `i18n.enabled: false` in `harness.config.json`. The `harness-i18n-process` skill will still fire gentle prompts for unconfigured projects when features touch user-facing strings.
    - **Not sure:** Skip i18n configuration entirely. Do not set `i18n.enabled`. The project can enable i18n later by running `harness-i18n-workflow` directly.
 
-5b. **Configure design system (non-test-suite projects).** Ask: "Will this project have a UI requiring a design system?" Mirror the i18n step's three-way response shape. Use `emit_interaction`:
+5b. **Configure design system (non-test-suite projects).** Mirror the i18n step's three-way response shape.
 
-    ```json
-    emit_interaction({
-      type: "question",
-      question: {
-        text: "Will this project have a UI requiring a design system?",
-        options: [
-          {
-            label: "Yes — capture design intent now",
-            pros: ["Records platforms in harness.config.json", "harness-design-system fires automatically on first design-touching feature"],
-            cons: ["One extra follow-up question (which platforms)"],
-            risk: "low",
-            effort: "low"
-          },
-          {
-            label: "No — this project has no UI",
-            pros: ["No future design nudges", "Permanent decline recorded"],
-            cons: ["Re-running init is required if a UI is added later"],
-            risk: "low",
-            effort: "low"
-          },
-          {
-            label: "Not sure yet",
-            pros: ["Decision deferred without commitment", "Can run harness-design-system later"],
-            cons: ["No design.enabled flag set; on_new_feature will prompt later"],
-            risk: "low",
-            effort: "low"
-          }
-        ],
-        recommendation: { optionIndex: 0, reason: "Most product/service projects benefit from a centralized design system", confidence: "medium" }
-      }
-    })
+    **Ask directly in your reply. Do NOT route this question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model, so the human sees nothing. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). State your recommendation, then STOP and wait for the human's reply:
+
+    ```markdown
+    ### Will this project have a UI requiring a design system?
+
+    | | A) Yes — capture design intent now | B) No — this project has no UI | C) Not sure yet |
+    |---|---|---|---|
+    | **Pros** | Records platforms in harness.config.json; harness-design-system fires automatically on first design-touching feature | No future design nudges; permanent decline recorded | Decision deferred without commitment; can run harness-design-system later |
+    | **Cons** | One extra follow-up question (which platforms) | Re-running init is required if a UI is added later | No design.enabled flag set; on_new_feature will prompt later |
+    | **Risk** | Low | Low | Low |
+    | **Effort** | Low | Low | Low |
+
+    **Recommendation:** A) Yes — capture design intent now (confidence: medium) — most product/service projects benefit from a centralized design system.
     ```
 
     Based on the answer:
@@ -156,42 +138,21 @@ Detect plugin-only state by checking whether `harness` resolves on PATH (`comman
 
     **Skip this step entirely if Phase 1 step 5 classified the project as a test suite.** Test-suite projects will be dispatched at step 6 below to `initialize-test-suite-project` and have no UI to govern.
 
-5c. **Capture strategic anchor (all levels).** Offer a three-way prompt for `STRATEGY.md` — the durable upstream product anchor read by `harness-brainstorming`, `harness-ideate`, and `harness-roadmap-pilot`. Use `emit_interaction`:
+5c. **Capture strategic anchor (all levels).** Offer a three-way prompt for `STRATEGY.md` — the durable upstream product anchor read by `harness-brainstorming`, `harness-ideate`, and `harness-roadmap-pilot`.
 
-    ```json
-    emit_interaction({
-      type: "question",
-      question: {
-        text: "Capture strategic anchor (STRATEGY.md) now?",
-        options: [
-          {
-            label: "Yes — run the strategy interview",
-            pros: [
-              "Grounds brainstorm/ideate/roadmap-pilot in product-level context",
-              "Durable across milestones and phases (peer of README.md)"
-            ],
-            cons: ["Adds an interview (10-20 minutes) to init"],
-            risk: "low",
-            effort: "medium"
-          },
-          {
-            label: "No — this project does not need a strategy doc",
-            pros: ["Permanent decline recorded; init does not re-ask on rerun"],
-            cons: ["Re-running init will not re-offer; user must run /harness:strategy manually"],
-            risk: "low",
-            effort: "low"
-          },
-          {
-            label: "Not sure yet",
-            pros: ["Decision deferred without commitment", "Can run /harness:strategy later"],
-            cons: ["No decline flag set; init may re-offer on rerun"],
-            risk: "low",
-            effort: "low"
-          }
-        ],
-        recommendation: { optionIndex: 0, reason: "Strategy grounds brainstorm/ideate/roadmap-pilot — value compounds as the project grows", confidence: "medium" }
-      }
-    })
+    **Ask in plain text in your reply, same as step 5b — never via `emit_interaction`, `AskUserQuestion`, or any tool (the human won't see a tool-routed prompt; only plain text reaches them across Claude Code, Cursor, Codex, and Gemini CLI).** State your recommendation, then STOP and wait for the human's reply:
+
+    ```markdown
+    ### Capture strategic anchor (STRATEGY.md) now?
+
+    | | A) Yes — run the strategy interview | B) No — this project does not need a strategy doc | C) Not sure yet |
+    |---|---|---|---|
+    | **Pros** | Grounds brainstorm/ideate/roadmap-pilot in product-level context; durable across milestones and phases (peer of README.md) | Permanent decline recorded; init does not re-ask on rerun | Decision deferred without commitment; can run /harness:strategy later |
+    | **Cons** | Adds an interview (10-20 minutes) to init | Re-running init will not re-offer; user must run /harness:strategy manually | No decline flag set; init may re-offer on rerun |
+    | **Risk** | Low | Low | Low |
+    | **Effort** | Medium | Low | Low |
+
+    **Recommendation:** A) Yes — run the strategy interview (confidence: medium) — strategy grounds brainstorm/ideate/roadmap-pilot; value compounds as the project grows.
     ```
 
     Before prompting, check whether `STRATEGY.md` already exists at repo root. Three cases:
@@ -289,32 +250,21 @@ This phase closes the parity gap that the marketplace plugin install does not co
 
 ### Phase 6: FINALIZE — Roadmap and Commit
 
-1. **Set up project roadmap.** Ask: "Set up a project roadmap now? `docs/roadmap.md` tracks features, milestones, and status across your specs and plans." Use `emit_interaction`:
+1. **Set up project roadmap.** `docs/roadmap.md` tracks features, milestones, and status across your specs and plans.
 
-   ```json
-   emit_interaction({
-     type: "question",
-     question: {
-       text: "Set up a project roadmap now?",
-       options: [
-         {
-           label: "Yes — create docs/roadmap.md now",
-           pros: ["Roadmap visible from day one", "Future specs auto-discovered on next sync"],
-           cons: ["Adds one file to the initial commit"],
-           risk: "low",
-           effort: "low"
-         },
-         {
-           label: "No — skip for now",
-           pros: ["Smaller initial footprint"],
-           cons: ["Run `/harness:roadmap --create` later when ready"],
-           risk: "low",
-           effort: "low"
-         }
-       ],
-       recommendation: { optionIndex: 0, reason: "Validation has just passed — a tangible 'project works' signal is the right moment to introduce planning artifacts", confidence: "medium" }
-     }
-   })
+   **Ask in plain text in your reply, same as Phase 3 steps 5b/5c — never via `emit_interaction`, `AskUserQuestion`, or any tool (the human won't see a tool-routed prompt; only plain text reaches them across Claude Code, Cursor, Codex, and Gemini CLI).** State your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Set up a project roadmap now?
+
+   |            | A) Yes — create docs/roadmap.md now                                     | B) No — skip for now                             |
+   | ---------- | ----------------------------------------------------------------------- | ------------------------------------------------ |
+   | **Pros**   | Roadmap visible from day one; future specs auto-discovered on next sync | Smaller initial footprint                        |
+   | **Cons**   | Adds one file to the initial commit                                     | Run `/harness:roadmap --create` later when ready |
+   | **Risk**   | Low                                                                     | Low                                              |
+   | **Effort** | Low                                                                     | Low                                              |
+
+   **Recommendation:** A) Yes — create docs/roadmap.md now (confidence: medium) — validation has just passed; a tangible "project works" signal is the right moment to introduce planning artifacts.
    ```
 
    Based on the answer:

--- a/.gemini-extension/commands/integration.toml
+++ b/.gemini-extension/commands/integration.toml
@@ -86,7 +86,7 @@ Before running sub-phases, resolve the effective integration tier:
    Tier escalated from `small` to `medium`: 8 new exports detected.
    ```
 
-   Use `emit_interaction` with type `confirmation` to inform and get acknowledgment.
+   Inform the human and get acknowledgment in plain text in your reply (do NOT route this through `emit_interaction` or `AskUserQuestion` — they record the prompt but do not display it to the human, so they won't see it).
 
 ---
 
@@ -233,7 +233,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
    <What follows from this decision -- positive, negative, and neutral?>
    ```
 
-   d. **Present for review.** In `thorough` rigor, present each ADR draft via `emit_interaction` (type: `confirmation`) and wait for human approval. In `standard` rigor, auto-approve but log the draft for review.
+   d. **Present for review.** In `thorough` rigor, present each ADR draft in plain text in your reply and wait for human approval — do NOT route it through `emit_interaction` or `AskUserQuestion`, which record the prompt but do not display it to the human (the client collapses the call to "Called harness" and the text only returns to the model). In `standard` rigor, auto-approve but log the draft for review.
 
 #### Knowledge Graph Enrichment (medium + large tiers)
 
@@ -286,7 +286,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
 
 ---
 
-### Sub-Phase 3: UPDATE (medium + large tiers)
+### Sub-Phase 3: UPDATE (medium and large tiers)
 
 Report progress: `**[UPDATE]** Checking project metadata updates`
 
@@ -384,22 +384,24 @@ After all applicable sub-phases complete, produce the combined integration repor
 
    Immediately invoke harness-code-review without waiting for user input.
 
-4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions. Present options via `emit_interaction`:
+4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions, then ask the human how to proceed in plain text.
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "Integration failed. <N> items incomplete. How to proceed?",
-       options: [
-         { "label": "fix -- Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE", "risk": "low", "effort": "medium" },
-         { "label": "skip -- Record decision and proceed to REVIEW (human override)", "risk": "medium", "effort": "low" },
-         { "label": "stop -- Save state and exit", "risk": "low", "effort": "low" }
-       ],
-       recommendation: { "optionIndex": 0, "reason": "Fixing integration gaps now prevents review rework.", "confidence": "high" }
-     }
-   })
+   **Ask directly in your reply. Do NOT route the question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model, so the human sees nothing and you end up narrating a question they cannot answer. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
+
+   Present the options as a markdown table, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: Integration failed. <N> items incomplete. How to proceed?
+
+   |            | fix                                                                                | skip                                                   | stop                      |
+   | ---------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------- |
+   | **What**   | Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE | Record decision and proceed to REVIEW (human override) | Save state and exit       |
+   | **Pros**   | Closes gaps before review                                                          | Unblocks progress immediately                          | Preserves state for later |
+   | **Cons**   | Another execute/verify cycle                                                       | Ships with known gaps                                  | No forward progress       |
+   | **Risk**   | Low                                                                                | Medium                                                 | Low                       |
+   | **Effort** | Medium                                                                             | Low                                                    | Low                       |
+
+   **Recommendation:** fix (confidence: high) — fixing integration gaps now prevents review rework.
    ```
 
    - **fix:** Record fix tasks in handoff. The autopilot re-enters EXECUTE with those tasks.
@@ -469,7 +471,7 @@ Every pass/fail assertion in the integration report MUST include concrete eviden
 - **`harness check-deps`** -- Run during WIRE if new modules were added.
 - **`ingest_source`** -- Run during MATERIALIZE to enrich knowledge graph with decision nodes.
 - **`manage_roadmap`** -- Run during UPDATE to sync roadmap status. Use `sync` with `apply: true`.
-- **`emit_interaction`** -- Tier escalation notification, ADR review (thorough mode), fail/skip/stop decision, transition to REVIEW on pass.
+- **`emit_interaction`** -- Used only for the transition to REVIEW on pass. Tier escalation, ADR review (thorough mode), and fail/skip/stop decisions are asked in plain text in your reply.
 - **Session directory** -- `.harness/sessions/<slug>/` contains all report files. Do not write to global `.harness/` when session slug is known.
 
 ## Success Criteria

--- a/.gemini-extension/commands/planning.toml
+++ b/.gemini-extension/commands/planning.toml
@@ -115,44 +115,21 @@ Store the parsed skill list for use in Phase 2 task annotation.
 
    **Read-only constraint:** Steps 1-6 above are research and analysis. Do not propose task structure, file organization, or implementation approaches during SCOPE. Record what must be true (observable truths) and what you do not know (uncertainties). Solutions belong in DECOMPOSE.
 
-   When scope is ambiguous, use `emit_interaction`:
+   When scope is ambiguous, ask in plain text in your reply. **Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "The spec mentions X but does not define behavior for Y. Should we:",
-       options: [
-         {
-           label: "A) Include Y in this plan",
-           pros: ["Complete feature in one pass", "No follow-up coordination"],
-           cons: ["Increases scope and time", "May delay delivery"],
-           risk: "medium",
-           effort: "high"
-         },
-         {
-           label: "B) Defer Y to a follow-up plan",
-           pros: ["Keeps current plan focused", "Ship sooner"],
-           cons: ["Y remains unhandled", "May need rework when Y is added"],
-           risk: "low",
-           effort: "low"
-         },
-         {
-           label: "C) Update the spec first",
-           pros: ["Design is complete before planning", "No surprises during execution"],
-           cons: ["Blocks planning until spec is updated", "Extra round-trip"],
-           risk: "low",
-           effort: "medium"
-         }
-       ],
-       recommendation: {
-         optionIndex: 1,
-         reason: "Keeping the current plan focused reduces risk. Y can be addressed in a follow-up.",
-         confidence: "medium"
-       }
-     }
-   })
+   Present the choice as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: The spec mentions X but does not define behavior for Y. Should we:
+
+   |            | A) Include Y in this plan                               | B) Defer Y to a follow-up plan                       | C) Update the spec first                                          |
+   | ---------- | ------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+   | **Pros**   | Complete feature in one pass; no follow-up coordination | Keeps current plan focused; ship sooner              | Design is complete before planning; no surprises during execution |
+   | **Cons**   | Increases scope and time; may delay delivery            | Y remains unhandled; may need rework when Y is added | Blocks planning until spec is updated; extra round-trip           |
+   | **Risk**   | Medium                                                  | Low                                                  | Low                                                               |
+   | **Effort** | High                                                    | Low                                                  | Medium                                                            |
+
+   **Recommendation:** B) Defer Y to a follow-up plan (confidence: medium) — keeping the current plan focused reduces risk; Y can be addressed in a follow-up.
    ```
 
 #### EARS Requirement Patterns
@@ -243,7 +220,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
    **Estimated total:** 8 tasks, ~33 minutes
    ```
 
-   **Approval gate:** Present via `emit_interaction` (type: `confirmation`, text: "Approve skeleton direction?"). If approved, proceed to step 3. If rejected, revise and re-present.
+   **Approval gate:** Ask in plain text in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (they do not display to the human; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Ask directly: "Approve skeleton direction?" and wait. If approved, proceed to step 3. If rejected, revise and re-present.
 
 3. **Decompose into atomic tasks.** Each task must:
    - Be completable in 2-5 minutes, fit in a single context window
@@ -333,7 +310,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
 10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off in plain text.** Ask directly in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (the human will not see it; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Present the plan path, task count, and time estimate, then ask: "Proceed? (yes/no)" and wait for the reply.
 
 12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 

--- a/.gemini-extension/commands/pulse.toml
+++ b/.gemini-extension/commands/pulse.toml
@@ -57,7 +57,7 @@ Read `references/interview.md` for the SMART pushback rules and the READ-WRITE-D
    - If `name` is non-null, confirm it as the product name; otherwise prompt.
    - For each `keyMetric`, walk it through the SMART bar in step 4.
 
-2. **Pick the lookback default.** Use `emit_interaction` (type: `question`) when in MCP mode; otherwise present numbered options in chat: `["24h", "7d", "30d", "custom"]`. Default `24h` per spec.
+2. **Pick the lookback default.** Ask in plain text — present numbered options `["24h", "7d", "30d", "custom"]` and wait (do NOT use `emit_interaction`/`AskUserQuestion`; the human won't see it — it renders only to the model and the client collapses the call to "Called harness"). Default `24h` per spec.
 
 3. **Identify the primary engagement event** (e.g. `session_started`). Apply the SMART bar. If the user can't name one, set `null` and add a pending entry. Record the event name in `primaryEvent`.
 

--- a/.gemini-extension/commands/verification.toml
+++ b/.gemini-extension/commands/verification.toml
@@ -193,19 +193,16 @@ Use severity markers for critical findings: `**[CRITICAL]**` for blocking issues
 
 ### Verification Sign-Off
 
-After producing the report, request acceptance:
+After producing the report, request acceptance in plain text. Ask in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Verification report: <VERDICT>. Accept and proceed?",
-    context: "<N artifacts checked, N gaps found>",
-    impact: "Accepting proceeds to code review. Declining requires gap resolution.",
-    risk: "<low if PASS, high if gaps remain>"
-  }
-})
+```markdown
+Verification report: <VERDICT>. Accept and proceed?
+
+Context: <N artifacts checked, N gaps found>
+Impact: Accepting proceeds to code review. Declining requires gap resolution.
+Risk: <low if PASS, high if gaps remain>
+
+Proceed? (yes/no)
 ```
 
 ### Handoff and Transition

--- a/agents/skills/claude-code/harness-brainstorming/SKILL.md
+++ b/agents/skills/claude-code/harness-brainstorming/SKILL.md
@@ -64,22 +64,23 @@ When no arguments are provided (standalone invocation), the skill operates exact
 
 ### Phase 2: EVALUATE -- Ask Questions and Narrow
 
-1. **Ask ONE question at a time.** Ask the most important question first. Wait for the answer. Let it inform the next question. Use `emit_interaction` with `type: 'question'`:
+1. **Ask ONE question at a time, in plain text.** Ask the most important question first. Wait for the answer. Let it inform the next question.
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "For auth, which approach should we use?",
-       options: [
-         { "label": "A) Existing JWT middleware", "pros": ["Already in codebase"], "cons": ["No refresh tokens"], "risk": "low", "effort": "low" },
-         { "label": "B) OAuth2 via provider X", "pros": ["Industry standard"], "cons": ["New dependency"], "risk": "medium", "effort": "medium" },
-         { "label": "C) External auth service", "pros": ["Zero maintenance"], "cons": ["Vendor lock-in", "Cost"], "risk": "medium", "effort": "low" }
-       ],
-       recommendation: { "optionIndex": 0, "reason": "Sufficient for current requirements.", "confidence": "high" }
-     }
-   })
+   **Ask directly in your reply. Do NOT route the question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the question in state but does not display it to the human — the client collapses it to "Called harness" and the rendered prompt only returns to the model, so the human sees nothing and you end up narrating a question they cannot answer. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
+
+   Present the question as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: For auth, which approach should we use?
+
+   |            | A) Existing JWT middleware | B) OAuth2 via provider X | C) External auth service |
+   | ---------- | -------------------------- | ------------------------ | ------------------------ |
+   | **Pros**   | Already in codebase        | Industry standard        | Zero maintenance         |
+   | **Cons**   | No refresh tokens          | New dependency           | Vendor lock-in; cost     |
+   | **Risk**   | Low                        | Medium                   | Medium                   |
+   | **Effort** | Low                        | Medium                   | Low                      |
+
+   **Recommendation:** A) Existing JWT middleware (confidence: high) — sufficient for current requirements.
    ```
 
 2. **Prefer multiple choice over open-ended questions.** Give 2-4 concrete options with brief tradeoff notes.
@@ -169,22 +170,19 @@ These flow into `handoff.json` `contextKeywords` field. Select keywords that hel
 
 5. **Run `harness validate`** to verify proper placement and project health.
 
-6. **Request sign-off via `emit_interaction`:**
+6. **Request sign-off in plain text.** Ask directly in your reply — do NOT route the request through `emit_interaction` or `AskUserQuestion` (the human will not see it). Present it as:
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "confirmation",
-     confirmation: {
-       text: "Approve spec at <file-path>?",
-       context: "<one-paragraph summary>",
-       impact: "Spec approval unlocks implementation planning. No code changes yet.",
-       risk: "low"
-     }
-   })
+   ```markdown
+   Approve spec at <file-path>?
+
+   Context: <one-paragraph summary>
+   Impact: Spec approval unlocks implementation planning. No code changes yet.
+   Risk: low
+
+   Proceed? (yes/no)
    ```
 
-   The human must explicitly approve before this skill is complete.
+   The human must explicitly approve (a clear "yes") before this skill is complete.
 
 7. **Promote the roadmap row.** If `docs/roadmap.md` exists, transition the named row to `planned` and link the spec in a single structured call (steps 7 and 8 are intentionally ordered so the commit captures the roadmap mutation). Skip silently only when no roadmap exists.
    - Derive the lookup key from the slash-command `ARGUMENTS` string (D1). Derive the summary from the spec title (the H1 heading).

--- a/agents/skills/claude-code/harness-code-review/SKILL.md
+++ b/agents/skills/claude-code/harness-code-review/SKILL.md
@@ -539,17 +539,16 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 
 ### Review Acceptance
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Review complete: <Assessment>. Accept review?",
-    context: "<N critical, N important, N suggestion findings>",
-    impact: "Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.",
-    risk: "<low if approve, high if critical>"
-  }
-})
+Ask for acceptance directly in your reply. Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
+
+```markdown
+Review complete: <Assessment>. Accept review?
+
+Context: <N critical, N important, N suggestion findings>
+Impact: Accepting finalizes findings. Approve = ready for merge. Request-changes = fixes needed.
+Risk: <low if approve, high if critical>
+
+Proceed? (yes/no)
 ```
 
 #### Handoff and Transition

--- a/agents/skills/claude-code/harness-execution/SKILL.md
+++ b/agents/skills/claude-code/harness-execution/SKILL.md
@@ -186,40 +186,37 @@ Three checkpoint types. Each requires pausing execution.
 
 **`[checkpoint:human-verify]` — Show and Confirm**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the confirmation in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Task N complete. Output: <summary>. Continue to Task N+1?",
-    context: "<test output or diff summary>",
-    impact: "Continuing proceeds to next task. Declining pauses for review.",
-    risk: "low"
-  }
-})
+```markdown
+Task N complete. Output: <summary>. Continue to Task N+1?
+
+Context: <test output or diff summary>
+Impact: Continuing proceeds to next task. Declining pauses for review.
+Risk: low
+
+Proceed? (yes/no)
 ```
 
 Wait for human confirmation.
 
 **`[checkpoint:decision]` — Present Options and Wait**
 
-Stop. Present via `emit_interaction`:
+Stop. Present the decision in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "question",
-  question: {
-    text: "Task N requires a decision: <description>",
-    options: [
-      { label: "<option A>", pros: ["..."], cons: ["..."], risk: "low", effort: "low" },
-      { label: "<option B>", pros: ["..."], cons: ["..."], risk: "medium", effort: "medium" }
-    ],
-    recommendation: { optionIndex: 0, reason: "<why>", confidence: "medium" }
-  }
-})
+Present the options as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+```markdown
+### Decision needed: Task N requires a decision: <description>
+
+|            | A) <option A>   | B) <option B>   |
+| ---------- | --------------- | --------------- |
+| **Pros**   | <option A pros> | <option B pros> |
+| **Cons**   | <option A cons> | <option B cons> |
+| **Risk**   | low             | medium          |
+| **Effort** | low             | medium          |
+
+**Recommendation:** A) <option A> (confidence: medium) — <why>.
 ```
 
 Wait for human choice.

--- a/agents/skills/claude-code/harness-integration/SKILL.md
+++ b/agents/skills/claude-code/harness-integration/SKILL.md
@@ -66,7 +66,7 @@ Before running sub-phases, resolve the effective integration tier:
    Tier escalated from `small` to `medium`: 8 new exports detected.
    ```
 
-   Use `emit_interaction` with type `confirmation` to inform and get acknowledgment.
+   Inform the human and get acknowledgment in plain text in your reply (do NOT route this through `emit_interaction` or `AskUserQuestion` — they record the prompt but do not display it to the human, so they won't see it).
 
 ---
 
@@ -213,7 +213,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
    <What follows from this decision -- positive, negative, and neutral?>
    ```
 
-   d. **Present for review.** In `thorough` rigor, present each ADR draft via `emit_interaction` (type: `confirmation`) and wait for human approval. In `standard` rigor, auto-approve but log the draft for review.
+   d. **Present for review.** In `thorough` rigor, present each ADR draft in plain text in your reply and wait for human approval — do NOT route it through `emit_interaction` or `AskUserQuestion`, which record the prompt but do not display it to the human (the client collapses the call to "Called harness" and the text only returns to the model). In `standard` rigor, auto-approve but log the draft for review.
 
 #### Knowledge Graph Enrichment (medium + large tiers)
 
@@ -266,7 +266,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
 
 ---
 
-### Sub-Phase 3: UPDATE (medium + large tiers)
+### Sub-Phase 3: UPDATE (medium and large tiers)
 
 Report progress: `**[UPDATE]** Checking project metadata updates`
 
@@ -364,22 +364,24 @@ After all applicable sub-phases complete, produce the combined integration repor
 
    Immediately invoke harness-code-review without waiting for user input.
 
-4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions. Present options via `emit_interaction`:
+4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions, then ask the human how to proceed in plain text.
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "Integration failed. <N> items incomplete. How to proceed?",
-       options: [
-         { "label": "fix -- Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE", "risk": "low", "effort": "medium" },
-         { "label": "skip -- Record decision and proceed to REVIEW (human override)", "risk": "medium", "effort": "low" },
-         { "label": "stop -- Save state and exit", "risk": "low", "effort": "low" }
-       ],
-       recommendation: { "optionIndex": 0, "reason": "Fixing integration gaps now prevents review rework.", "confidence": "high" }
-     }
-   })
+   **Ask directly in your reply. Do NOT route the question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model, so the human sees nothing and you end up narrating a question they cannot answer. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
+
+   Present the options as a markdown table, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: Integration failed. <N> items incomplete. How to proceed?
+
+   |            | fix                                                                                | skip                                                   | stop                      |
+   | ---------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------- |
+   | **What**   | Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE | Record decision and proceed to REVIEW (human override) | Save state and exit       |
+   | **Pros**   | Closes gaps before review                                                          | Unblocks progress immediately                          | Preserves state for later |
+   | **Cons**   | Another execute/verify cycle                                                       | Ships with known gaps                                  | No forward progress       |
+   | **Risk**   | Low                                                                                | Medium                                                 | Low                       |
+   | **Effort** | Medium                                                                             | Low                                                    | Low                       |
+
+   **Recommendation:** fix (confidence: high) — fixing integration gaps now prevents review rework.
    ```
 
    - **fix:** Record fix tasks in handoff. The autopilot re-enters EXECUTE with those tasks.
@@ -449,7 +451,7 @@ Every pass/fail assertion in the integration report MUST include concrete eviden
 - **`harness check-deps`** -- Run during WIRE if new modules were added.
 - **`ingest_source`** -- Run during MATERIALIZE to enrich knowledge graph with decision nodes.
 - **`manage_roadmap`** -- Run during UPDATE to sync roadmap status. Use `sync` with `apply: true`.
-- **`emit_interaction`** -- Tier escalation notification, ADR review (thorough mode), fail/skip/stop decision, transition to REVIEW on pass.
+- **`emit_interaction`** -- Used only for the transition to REVIEW on pass. Tier escalation, ADR review (thorough mode), and fail/skip/stop decisions are asked in plain text in your reply.
 - **Session directory** -- `.harness/sessions/<slug>/` contains all report files. Do not write to global `.harness/` when session slug is known.
 
 ## Success Criteria

--- a/agents/skills/claude-code/harness-planning/SKILL.md
+++ b/agents/skills/claude-code/harness-planning/SKILL.md
@@ -95,44 +95,21 @@ Store the parsed skill list for use in Phase 2 task annotation.
 
    **Read-only constraint:** Steps 1-6 above are research and analysis. Do not propose task structure, file organization, or implementation approaches during SCOPE. Record what must be true (observable truths) and what you do not know (uncertainties). Solutions belong in DECOMPOSE.
 
-   When scope is ambiguous, use `emit_interaction`:
+   When scope is ambiguous, ask in plain text in your reply. **Do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "The spec mentions X but does not define behavior for Y. Should we:",
-       options: [
-         {
-           label: "A) Include Y in this plan",
-           pros: ["Complete feature in one pass", "No follow-up coordination"],
-           cons: ["Increases scope and time", "May delay delivery"],
-           risk: "medium",
-           effort: "high"
-         },
-         {
-           label: "B) Defer Y to a follow-up plan",
-           pros: ["Keeps current plan focused", "Ship sooner"],
-           cons: ["Y remains unhandled", "May need rework when Y is added"],
-           risk: "low",
-           effort: "low"
-         },
-         {
-           label: "C) Update the spec first",
-           pros: ["Design is complete before planning", "No surprises during execution"],
-           cons: ["Blocks planning until spec is updated", "Extra round-trip"],
-           risk: "low",
-           effort: "medium"
-         }
-       ],
-       recommendation: {
-         optionIndex: 1,
-         reason: "Keeping the current plan focused reduces risk. Y can be addressed in a follow-up.",
-         confidence: "medium"
-       }
-     }
-   })
+   Present the choice as a markdown table so tradeoffs are scannable, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: The spec mentions X but does not define behavior for Y. Should we:
+
+   |            | A) Include Y in this plan                               | B) Defer Y to a follow-up plan                       | C) Update the spec first                                          |
+   | ---------- | ------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+   | **Pros**   | Complete feature in one pass; no follow-up coordination | Keeps current plan focused; ship sooner              | Design is complete before planning; no surprises during execution |
+   | **Cons**   | Increases scope and time; may delay delivery            | Y remains unhandled; may need rework when Y is added | Blocks planning until spec is updated; extra round-trip           |
+   | **Risk**   | Medium                                                  | Low                                                  | Low                                                               |
+   | **Effort** | High                                                    | Low                                                  | Medium                                                            |
+
+   **Recommendation:** B) Defer Y to a follow-up plan (confidence: medium) — keeping the current plan focused reduces risk; Y can be addressed in a follow-up.
    ```
 
 #### EARS Requirement Patterns
@@ -223,7 +200,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
    **Estimated total:** 8 tasks, ~33 minutes
    ```
 
-   **Approval gate:** Present via `emit_interaction` (type: `confirmation`, text: "Approve skeleton direction?"). If approved, proceed to step 3. If rejected, revise and re-present.
+   **Approval gate:** Ask in plain text in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (they do not display to the human; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Ask directly: "Approve skeleton direction?" and wait. If approved, proceed to step 3. If rejected, revise and re-present.
 
 3. **Decompose into atomic tasks.** Each task must:
    - Be completable in 2-5 minutes, fit in a single context window
@@ -313,7 +290,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 
 10. **Write session summary (if session is known).** Call `writeSessionSummary` with skill, status, plan path, keyContext, nextStep. Skip if no session slug.
 
-11. **Request plan sign-off:** Use `emit_interaction` (type: `confirmation`) with plan path, task count, and time estimate.
+11. **Request plan sign-off in plain text.** Ask directly in your reply — do NOT route this through `emit_interaction` or `AskUserQuestion` (the human will not see it; `emit_interaction` collapses to "Called harness" and `AskUserQuestion` is Claude-Code-only). Present the plan path, task count, and time estimate, then ask: "Proceed? (yes/no)" and wait for the reply.
 
 12. **Suggest transition to execution.** After approval, call `emit_interaction` with type: `transition`, `completedPhase: "planning"`, `suggestedNext: "execution"`, `requiresConfirmation: true`. Include `qualityGate` with checks: plan-written, harness-validate, observable-truths-traced, human-approved. If confirmed: invoke harness-execution. If declined: stop (handoff already written).
 

--- a/agents/skills/claude-code/harness-pulse/SKILL.md
+++ b/agents/skills/claude-code/harness-pulse/SKILL.md
@@ -35,7 +35,7 @@ Read `references/interview.md` for the SMART pushback rules and the READ-WRITE-D
    - If `name` is non-null, confirm it as the product name; otherwise prompt.
    - For each `keyMetric`, walk it through the SMART bar in step 4.
 
-2. **Pick the lookback default.** Use `emit_interaction` (type: `question`) when in MCP mode; otherwise present numbered options in chat: `["24h", "7d", "30d", "custom"]`. Default `24h` per spec.
+2. **Pick the lookback default.** Ask in plain text — present numbered options `["24h", "7d", "30d", "custom"]` and wait (do NOT use `emit_interaction`/`AskUserQuestion`; the human won't see it — it renders only to the model and the client collapses the call to "Called harness"). Default `24h` per spec.
 
 3. **Identify the primary engagement event** (e.g. `session_started`). Apply the SMART bar. If the user can't name one, set `null` and add a pending entry. Record the event name in `primaryEvent`.
 

--- a/agents/skills/claude-code/harness-verification/SKILL.md
+++ b/agents/skills/claude-code/harness-verification/SKILL.md
@@ -174,19 +174,16 @@ Use severity markers for critical findings: `**[CRITICAL]**` for blocking issues
 
 ### Verification Sign-Off
 
-After producing the report, request acceptance:
+After producing the report, request acceptance in plain text. Ask in plain text in your reply — do NOT route this through `emit_interaction`, `AskUserQuestion`, or any tool. `emit_interaction` records the prompt but does not display it to the human (the client collapses the call to "Called harness" and the rendered text only returns to the model); `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). Present it as:
 
-```json
-emit_interaction({
-  path: "<project-root>",
-  type: "confirmation",
-  confirmation: {
-    text: "Verification report: <VERDICT>. Accept and proceed?",
-    context: "<N artifacts checked, N gaps found>",
-    impact: "Accepting proceeds to code review. Declining requires gap resolution.",
-    risk: "<low if PASS, high if gaps remain>"
-  }
-})
+```markdown
+Verification report: <VERDICT>. Accept and proceed?
+
+Context: <N artifacts checked, N gaps found>
+Impact: Accepting proceeds to code review. Declining requires gap resolution.
+Risk: <low if PASS, high if gaps remain>
+
+Proceed? (yes/no)
 ```
 
 ### Handoff and Transition

--- a/agents/skills/claude-code/initialize-harness-project/SKILL.md
+++ b/agents/skills/claude-code/initialize-harness-project/SKILL.md
@@ -100,39 +100,21 @@ Detect plugin-only state by checking whether `harness` resolves on PATH (`comman
    - **No:** Set `i18n.enabled: false` in `harness.config.json`. The `harness-i18n-process` skill will still fire gentle prompts for unconfigured projects when features touch user-facing strings.
    - **Not sure:** Skip i18n configuration entirely. Do not set `i18n.enabled`. The project can enable i18n later by running `harness-i18n-workflow` directly.
 
-5b. **Configure design system (non-test-suite projects).** Ask: "Will this project have a UI requiring a design system?" Mirror the i18n step's three-way response shape. Use `emit_interaction`:
+5b. **Configure design system (non-test-suite projects).** Mirror the i18n step's three-way response shape.
 
-    ```json
-    emit_interaction({
-      type: "question",
-      question: {
-        text: "Will this project have a UI requiring a design system?",
-        options: [
-          {
-            label: "Yes — capture design intent now",
-            pros: ["Records platforms in harness.config.json", "harness-design-system fires automatically on first design-touching feature"],
-            cons: ["One extra follow-up question (which platforms)"],
-            risk: "low",
-            effort: "low"
-          },
-          {
-            label: "No — this project has no UI",
-            pros: ["No future design nudges", "Permanent decline recorded"],
-            cons: ["Re-running init is required if a UI is added later"],
-            risk: "low",
-            effort: "low"
-          },
-          {
-            label: "Not sure yet",
-            pros: ["Decision deferred without commitment", "Can run harness-design-system later"],
-            cons: ["No design.enabled flag set; on_new_feature will prompt later"],
-            risk: "low",
-            effort: "low"
-          }
-        ],
-        recommendation: { optionIndex: 0, reason: "Most product/service projects benefit from a centralized design system", confidence: "medium" }
-      }
-    })
+    **Ask directly in your reply. Do NOT route this question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model, so the human sees nothing. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI). State your recommendation, then STOP and wait for the human's reply:
+
+    ```markdown
+    ### Will this project have a UI requiring a design system?
+
+    | | A) Yes — capture design intent now | B) No — this project has no UI | C) Not sure yet |
+    |---|---|---|---|
+    | **Pros** | Records platforms in harness.config.json; harness-design-system fires automatically on first design-touching feature | No future design nudges; permanent decline recorded | Decision deferred without commitment; can run harness-design-system later |
+    | **Cons** | One extra follow-up question (which platforms) | Re-running init is required if a UI is added later | No design.enabled flag set; on_new_feature will prompt later |
+    | **Risk** | Low | Low | Low |
+    | **Effort** | Low | Low | Low |
+
+    **Recommendation:** A) Yes — capture design intent now (confidence: medium) — most product/service projects benefit from a centralized design system.
     ```
 
     Based on the answer:
@@ -142,42 +124,21 @@ Detect plugin-only state by checking whether `harness` resolves on PATH (`comman
 
     **Skip this step entirely if Phase 1 step 5 classified the project as a test suite.** Test-suite projects will be dispatched at step 6 below to `initialize-test-suite-project` and have no UI to govern.
 
-5c. **Capture strategic anchor (all levels).** Offer a three-way prompt for `STRATEGY.md` — the durable upstream product anchor read by `harness-brainstorming`, `harness-ideate`, and `harness-roadmap-pilot`. Use `emit_interaction`:
+5c. **Capture strategic anchor (all levels).** Offer a three-way prompt for `STRATEGY.md` — the durable upstream product anchor read by `harness-brainstorming`, `harness-ideate`, and `harness-roadmap-pilot`.
 
-    ```json
-    emit_interaction({
-      type: "question",
-      question: {
-        text: "Capture strategic anchor (STRATEGY.md) now?",
-        options: [
-          {
-            label: "Yes — run the strategy interview",
-            pros: [
-              "Grounds brainstorm/ideate/roadmap-pilot in product-level context",
-              "Durable across milestones and phases (peer of README.md)"
-            ],
-            cons: ["Adds an interview (10-20 minutes) to init"],
-            risk: "low",
-            effort: "medium"
-          },
-          {
-            label: "No — this project does not need a strategy doc",
-            pros: ["Permanent decline recorded; init does not re-ask on rerun"],
-            cons: ["Re-running init will not re-offer; user must run /harness:strategy manually"],
-            risk: "low",
-            effort: "low"
-          },
-          {
-            label: "Not sure yet",
-            pros: ["Decision deferred without commitment", "Can run /harness:strategy later"],
-            cons: ["No decline flag set; init may re-offer on rerun"],
-            risk: "low",
-            effort: "low"
-          }
-        ],
-        recommendation: { optionIndex: 0, reason: "Strategy grounds brainstorm/ideate/roadmap-pilot — value compounds as the project grows", confidence: "medium" }
-      }
-    })
+    **Ask in plain text in your reply, same as step 5b — never via `emit_interaction`, `AskUserQuestion`, or any tool (the human won't see a tool-routed prompt; only plain text reaches them across Claude Code, Cursor, Codex, and Gemini CLI).** State your recommendation, then STOP and wait for the human's reply:
+
+    ```markdown
+    ### Capture strategic anchor (STRATEGY.md) now?
+
+    | | A) Yes — run the strategy interview | B) No — this project does not need a strategy doc | C) Not sure yet |
+    |---|---|---|---|
+    | **Pros** | Grounds brainstorm/ideate/roadmap-pilot in product-level context; durable across milestones and phases (peer of README.md) | Permanent decline recorded; init does not re-ask on rerun | Decision deferred without commitment; can run /harness:strategy later |
+    | **Cons** | Adds an interview (10-20 minutes) to init | Re-running init will not re-offer; user must run /harness:strategy manually | No decline flag set; init may re-offer on rerun |
+    | **Risk** | Low | Low | Low |
+    | **Effort** | Medium | Low | Low |
+
+    **Recommendation:** A) Yes — run the strategy interview (confidence: medium) — strategy grounds brainstorm/ideate/roadmap-pilot; value compounds as the project grows.
     ```
 
     Before prompting, check whether `STRATEGY.md` already exists at repo root. Three cases:
@@ -275,32 +236,21 @@ This phase closes the parity gap that the marketplace plugin install does not co
 
 ### Phase 6: FINALIZE — Roadmap and Commit
 
-1. **Set up project roadmap.** Ask: "Set up a project roadmap now? `docs/roadmap.md` tracks features, milestones, and status across your specs and plans." Use `emit_interaction`:
+1. **Set up project roadmap.** `docs/roadmap.md` tracks features, milestones, and status across your specs and plans.
 
-   ```json
-   emit_interaction({
-     type: "question",
-     question: {
-       text: "Set up a project roadmap now?",
-       options: [
-         {
-           label: "Yes — create docs/roadmap.md now",
-           pros: ["Roadmap visible from day one", "Future specs auto-discovered on next sync"],
-           cons: ["Adds one file to the initial commit"],
-           risk: "low",
-           effort: "low"
-         },
-         {
-           label: "No — skip for now",
-           pros: ["Smaller initial footprint"],
-           cons: ["Run `/harness:roadmap --create` later when ready"],
-           risk: "low",
-           effort: "low"
-         }
-       ],
-       recommendation: { optionIndex: 0, reason: "Validation has just passed — a tangible 'project works' signal is the right moment to introduce planning artifacts", confidence: "medium" }
-     }
-   })
+   **Ask in plain text in your reply, same as Phase 3 steps 5b/5c — never via `emit_interaction`, `AskUserQuestion`, or any tool (the human won't see a tool-routed prompt; only plain text reaches them across Claude Code, Cursor, Codex, and Gemini CLI).** State your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Set up a project roadmap now?
+
+   |            | A) Yes — create docs/roadmap.md now                                     | B) No — skip for now                             |
+   | ---------- | ----------------------------------------------------------------------- | ------------------------------------------------ |
+   | **Pros**   | Roadmap visible from day one; future specs auto-discovered on next sync | Smaller initial footprint                        |
+   | **Cons**   | Adds one file to the initial commit                                     | Run `/harness:roadmap --create` later when ready |
+   | **Risk**   | Low                                                                     | Low                                              |
+   | **Effort** | Low                                                                     | Low                                              |
+
+   **Recommendation:** A) Yes — create docs/roadmap.md now (confidence: medium) — validation has just passed; a tangible "project works" signal is the right moment to introduce planning artifacts.
    ```
 
    Based on the answer:

--- a/agents/skills/codex/harness-integration/SKILL.md
+++ b/agents/skills/codex/harness-integration/SKILL.md
@@ -66,7 +66,7 @@ Before running sub-phases, resolve the effective integration tier:
    Tier escalated from `small` to `medium`: 8 new exports detected.
    ```
 
-   Use `emit_interaction` with type `confirmation` to inform and get acknowledgment.
+   Inform the human and get acknowledgment in plain text in your reply (do NOT route this through `emit_interaction` or `AskUserQuestion` — they record the prompt but do not display it to the human, so they won't see it).
 
 ---
 
@@ -213,7 +213,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
    <What follows from this decision -- positive, negative, and neutral?>
    ```
 
-   d. **Present for review.** In `thorough` rigor, present each ADR draft via `emit_interaction` (type: `confirmation`) and wait for human approval. In `standard` rigor, auto-approve but log the draft for review.
+   d. **Present for review.** In `thorough` rigor, present each ADR draft in plain text in your reply and wait for human approval — do NOT route it through `emit_interaction` or `AskUserQuestion`, which record the prompt but do not display it to the human (the client collapses the call to "Called harness" and the text only returns to the model). In `standard` rigor, auto-approve but log the draft for review.
 
 #### Knowledge Graph Enrichment (medium + large tiers)
 
@@ -266,7 +266,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
 
 ---
 
-### Sub-Phase 3: UPDATE (medium + large tiers)
+### Sub-Phase 3: UPDATE (medium and large tiers)
 
 Report progress: `**[UPDATE]** Checking project metadata updates`
 
@@ -364,22 +364,24 @@ After all applicable sub-phases complete, produce the combined integration repor
 
    Immediately invoke harness-code-review without waiting for user input.
 
-4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions. Present options via `emit_interaction`:
+4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions, then ask the human how to proceed in plain text.
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "Integration failed. <N> items incomplete. How to proceed?",
-       options: [
-         { "label": "fix -- Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE", "risk": "low", "effort": "medium" },
-         { "label": "skip -- Record decision and proceed to REVIEW (human override)", "risk": "medium", "effort": "low" },
-         { "label": "stop -- Save state and exit", "risk": "low", "effort": "low" }
-       ],
-       recommendation: { "optionIndex": 0, "reason": "Fixing integration gaps now prevents review rework.", "confidence": "high" }
-     }
-   })
+   **Ask directly in your reply. Do NOT route the question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model, so the human sees nothing and you end up narrating a question they cannot answer. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
+
+   Present the options as a markdown table, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: Integration failed. <N> items incomplete. How to proceed?
+
+   |            | fix                                                                                | skip                                                   | stop                      |
+   | ---------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------- |
+   | **What**   | Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE | Record decision and proceed to REVIEW (human override) | Save state and exit       |
+   | **Pros**   | Closes gaps before review                                                          | Unblocks progress immediately                          | Preserves state for later |
+   | **Cons**   | Another execute/verify cycle                                                       | Ships with known gaps                                  | No forward progress       |
+   | **Risk**   | Low                                                                                | Medium                                                 | Low                       |
+   | **Effort** | Medium                                                                             | Low                                                    | Low                       |
+
+   **Recommendation:** fix (confidence: high) — fixing integration gaps now prevents review rework.
    ```
 
    - **fix:** Record fix tasks in handoff. The autopilot re-enters EXECUTE with those tasks.
@@ -449,7 +451,7 @@ Every pass/fail assertion in the integration report MUST include concrete eviden
 - **`harness check-deps`** -- Run during WIRE if new modules were added.
 - **`ingest_source`** -- Run during MATERIALIZE to enrich knowledge graph with decision nodes.
 - **`manage_roadmap`** -- Run during UPDATE to sync roadmap status. Use `sync` with `apply: true`.
-- **`emit_interaction`** -- Tier escalation notification, ADR review (thorough mode), fail/skip/stop decision, transition to REVIEW on pass.
+- **`emit_interaction`** -- Used only for the transition to REVIEW on pass. Tier escalation, ADR review (thorough mode), and fail/skip/stop decisions are asked in plain text in your reply.
 - **Session directory** -- `.harness/sessions/<slug>/` contains all report files. Do not write to global `.harness/` when session slug is known.
 
 ## Success Criteria

--- a/agents/skills/codex/harness-pulse/SKILL.md
+++ b/agents/skills/codex/harness-pulse/SKILL.md
@@ -35,7 +35,7 @@ Read `references/interview.md` for the SMART pushback rules and the READ-WRITE-D
    - If `name` is non-null, confirm it as the product name; otherwise prompt.
    - For each `keyMetric`, walk it through the SMART bar in step 4.
 
-2. **Pick the lookback default.** Use `emit_interaction` (type: `question`) when in MCP mode; otherwise present numbered options in chat: `["24h", "7d", "30d", "custom"]`. Default `24h` per spec.
+2. **Pick the lookback default.** Ask in plain text — present numbered options `["24h", "7d", "30d", "custom"]` and wait (do NOT use `emit_interaction`/`AskUserQuestion`; the human won't see it — it renders only to the model and the client collapses the call to "Called harness"). Default `24h` per spec.
 
 3. **Identify the primary engagement event** (e.g. `session_started`). Apply the SMART bar. If the user can't name one, set `null` and add a pending entry. Record the event name in `primaryEvent`.
 

--- a/agents/skills/cursor/harness-integration/SKILL.md
+++ b/agents/skills/cursor/harness-integration/SKILL.md
@@ -66,7 +66,7 @@ Before running sub-phases, resolve the effective integration tier:
    Tier escalated from `small` to `medium`: 8 new exports detected.
    ```
 
-   Use `emit_interaction` with type `confirmation` to inform and get acknowledgment.
+   Inform the human and get acknowledgment in plain text in your reply (do NOT route this through `emit_interaction` or `AskUserQuestion` — they record the prompt but do not display it to the human, so they won't see it).
 
 ---
 
@@ -213,7 +213,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
    <What follows from this decision -- positive, negative, and neutral?>
    ```
 
-   d. **Present for review.** In `thorough` rigor, present each ADR draft via `emit_interaction` (type: `confirmation`) and wait for human approval. In `standard` rigor, auto-approve but log the draft for review.
+   d. **Present for review.** In `thorough` rigor, present each ADR draft in plain text in your reply and wait for human approval — do NOT route it through `emit_interaction` or `AskUserQuestion`, which record the prompt but do not display it to the human (the client collapses the call to "Called harness" and the text only returns to the model). In `standard` rigor, auto-approve but log the draft for review.
 
 #### Knowledge Graph Enrichment (medium + large tiers)
 
@@ -266,7 +266,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
 
 ---
 
-### Sub-Phase 3: UPDATE (medium + large tiers)
+### Sub-Phase 3: UPDATE (medium and large tiers)
 
 Report progress: `**[UPDATE]** Checking project metadata updates`
 
@@ -364,22 +364,24 @@ After all applicable sub-phases complete, produce the combined integration repor
 
    Immediately invoke harness-code-review without waiting for user input.
 
-4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions. Present options via `emit_interaction`:
+4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions, then ask the human how to proceed in plain text.
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "Integration failed. <N> items incomplete. How to proceed?",
-       options: [
-         { "label": "fix -- Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE", "risk": "low", "effort": "medium" },
-         { "label": "skip -- Record decision and proceed to REVIEW (human override)", "risk": "medium", "effort": "low" },
-         { "label": "stop -- Save state and exit", "risk": "low", "effort": "low" }
-       ],
-       recommendation: { "optionIndex": 0, "reason": "Fixing integration gaps now prevents review rework.", "confidence": "high" }
-     }
-   })
+   **Ask directly in your reply. Do NOT route the question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model, so the human sees nothing and you end up narrating a question they cannot answer. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
+
+   Present the options as a markdown table, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: Integration failed. <N> items incomplete. How to proceed?
+
+   |            | fix                                                                                | skip                                                   | stop                      |
+   | ---------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------- |
+   | **What**   | Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE | Record decision and proceed to REVIEW (human override) | Save state and exit       |
+   | **Pros**   | Closes gaps before review                                                          | Unblocks progress immediately                          | Preserves state for later |
+   | **Cons**   | Another execute/verify cycle                                                       | Ships with known gaps                                  | No forward progress       |
+   | **Risk**   | Low                                                                                | Medium                                                 | Low                       |
+   | **Effort** | Medium                                                                             | Low                                                    | Low                       |
+
+   **Recommendation:** fix (confidence: high) — fixing integration gaps now prevents review rework.
    ```
 
    - **fix:** Record fix tasks in handoff. The autopilot re-enters EXECUTE with those tasks.
@@ -449,7 +451,7 @@ Every pass/fail assertion in the integration report MUST include concrete eviden
 - **`harness check-deps`** -- Run during WIRE if new modules were added.
 - **`ingest_source`** -- Run during MATERIALIZE to enrich knowledge graph with decision nodes.
 - **`manage_roadmap`** -- Run during UPDATE to sync roadmap status. Use `sync` with `apply: true`.
-- **`emit_interaction`** -- Tier escalation notification, ADR review (thorough mode), fail/skip/stop decision, transition to REVIEW on pass.
+- **`emit_interaction`** -- Used only for the transition to REVIEW on pass. Tier escalation, ADR review (thorough mode), and fail/skip/stop decisions are asked in plain text in your reply.
 - **Session directory** -- `.harness/sessions/<slug>/` contains all report files. Do not write to global `.harness/` when session slug is known.
 
 ## Success Criteria

--- a/agents/skills/cursor/harness-pulse/SKILL.md
+++ b/agents/skills/cursor/harness-pulse/SKILL.md
@@ -35,7 +35,7 @@ Read `references/interview.md` for the SMART pushback rules and the READ-WRITE-D
    - If `name` is non-null, confirm it as the product name; otherwise prompt.
    - For each `keyMetric`, walk it through the SMART bar in step 4.
 
-2. **Pick the lookback default.** Use `emit_interaction` (type: `question`) when in MCP mode; otherwise present numbered options in chat: `["24h", "7d", "30d", "custom"]`. Default `24h` per spec.
+2. **Pick the lookback default.** Ask in plain text — present numbered options `["24h", "7d", "30d", "custom"]` and wait (do NOT use `emit_interaction`/`AskUserQuestion`; the human won't see it — it renders only to the model and the client collapses the call to "Called harness"). Default `24h` per spec.
 
 3. **Identify the primary engagement event** (e.g. `session_started`). Apply the SMART bar. If the user can't name one, set `null` and add a pending entry. Record the event name in `primaryEvent`.
 

--- a/agents/skills/gemini-cli/harness-integration/SKILL.md
+++ b/agents/skills/gemini-cli/harness-integration/SKILL.md
@@ -66,7 +66,7 @@ Before running sub-phases, resolve the effective integration tier:
    Tier escalated from `small` to `medium`: 8 new exports detected.
    ```
 
-   Use `emit_interaction` with type `confirmation` to inform and get acknowledgment.
+   Inform the human and get acknowledgment in plain text in your reply (do NOT route this through `emit_interaction` or `AskUserQuestion` — they record the prompt but do not display it to the human, so they won't see it).
 
 ---
 
@@ -213,7 +213,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
    <What follows from this decision -- positive, negative, and neutral?>
    ```
 
-   d. **Present for review.** In `thorough` rigor, present each ADR draft via `emit_interaction` (type: `confirmation`) and wait for human approval. In `standard` rigor, auto-approve but log the draft for review.
+   d. **Present for review.** In `thorough` rigor, present each ADR draft in plain text in your reply and wait for human approval — do NOT route it through `emit_interaction` or `AskUserQuestion`, which record the prompt but do not display it to the human (the client collapses the call to "Called harness" and the text only returns to the model). In `standard` rigor, auto-approve but log the draft for review.
 
 #### Knowledge Graph Enrichment (medium + large tiers)
 
@@ -266,7 +266,7 @@ Skip this sub-phase for `small` tier or `fast` rigor. For medium and large tiers
 
 ---
 
-### Sub-Phase 3: UPDATE (medium + large tiers)
+### Sub-Phase 3: UPDATE (medium and large tiers)
 
 Report progress: `**[UPDATE]** Checking project metadata updates`
 
@@ -364,22 +364,24 @@ After all applicable sub-phases complete, produce the combined integration repor
 
    Immediately invoke harness-code-review without waiting for user input.
 
-4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions. Present options via `emit_interaction`:
+4. **On FAIL:** Do NOT emit a transition. Report incomplete items with fix instructions, then ask the human how to proceed in plain text.
 
-   ```json
-   emit_interaction({
-     path: "<project-root>",
-     type: "question",
-     question: {
-       text: "Integration failed. <N> items incomplete. How to proceed?",
-       options: [
-         { "label": "fix -- Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE", "risk": "low", "effort": "medium" },
-         { "label": "skip -- Record decision and proceed to REVIEW (human override)", "risk": "medium", "effort": "low" },
-         { "label": "stop -- Save state and exit", "risk": "low", "effort": "low" }
-       ],
-       recommendation: { "optionIndex": 0, "reason": "Fixing integration gaps now prevents review rework.", "confidence": "high" }
-     }
-   })
+   **Ask directly in your reply. Do NOT route the question through `emit_interaction`, `AskUserQuestion`, or any tool.** `emit_interaction` records the prompt but does not display it to the human — the client collapses the call to "Called harness" and the rendered text only returns to the model, so the human sees nothing and you end up narrating a question they cannot answer. `AskUserQuestion` is Claude-Code-only and caps headers at 12 chars / 4 options. Plain text in your own message is the only channel that reliably reaches the human across every tool (Claude Code, Cursor, Codex, Gemini CLI).
+
+   Present the options as a markdown table, state your recommendation, then STOP and wait for the human's reply:
+
+   ```markdown
+   ### Decision needed: Integration failed. <N> items incomplete. How to proceed?
+
+   |            | fix                                                                                | skip                                                   | stop                      |
+   | ---------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------- |
+   | **What**   | Re-enter EXECUTE with integration-specific fix tasks, then re-VERIFY, re-INTEGRATE | Record decision and proceed to REVIEW (human override) | Save state and exit       |
+   | **Pros**   | Closes gaps before review                                                          | Unblocks progress immediately                          | Preserves state for later |
+   | **Cons**   | Another execute/verify cycle                                                       | Ships with known gaps                                  | No forward progress       |
+   | **Risk**   | Low                                                                                | Medium                                                 | Low                       |
+   | **Effort** | Medium                                                                             | Low                                                    | Low                       |
+
+   **Recommendation:** fix (confidence: high) — fixing integration gaps now prevents review rework.
    ```
 
    - **fix:** Record fix tasks in handoff. The autopilot re-enters EXECUTE with those tasks.
@@ -449,7 +451,7 @@ Every pass/fail assertion in the integration report MUST include concrete eviden
 - **`harness check-deps`** -- Run during WIRE if new modules were added.
 - **`ingest_source`** -- Run during MATERIALIZE to enrich knowledge graph with decision nodes.
 - **`manage_roadmap`** -- Run during UPDATE to sync roadmap status. Use `sync` with `apply: true`.
-- **`emit_interaction`** -- Tier escalation notification, ADR review (thorough mode), fail/skip/stop decision, transition to REVIEW on pass.
+- **`emit_interaction`** -- Used only for the transition to REVIEW on pass. Tier escalation, ADR review (thorough mode), and fail/skip/stop decisions are asked in plain text in your reply.
 - **Session directory** -- `.harness/sessions/<slug>/` contains all report files. Do not write to global `.harness/` when session slug is known.
 
 ## Success Criteria

--- a/agents/skills/gemini-cli/harness-pulse/SKILL.md
+++ b/agents/skills/gemini-cli/harness-pulse/SKILL.md
@@ -35,7 +35,7 @@ Read `references/interview.md` for the SMART pushback rules and the READ-WRITE-D
    - If `name` is non-null, confirm it as the product name; otherwise prompt.
    - For each `keyMetric`, walk it through the SMART bar in step 4.
 
-2. **Pick the lookback default.** Use `emit_interaction` (type: `question`) when in MCP mode; otherwise present numbered options in chat: `["24h", "7d", "30d", "custom"]`. Default `24h` per spec.
+2. **Pick the lookback default.** Ask in plain text — present numbered options `["24h", "7d", "30d", "custom"]` and wait (do NOT use `emit_interaction`/`AskUserQuestion`; the human won't see it — it renders only to the model and the client collapses the call to "Called harness"). Default `24h` per spec.
 
 3. **Identify the primary engagement event** (e.g. `session_started`). Apply the SMART bar. If the user can't name one, set `null` and add a pending entry. Record the event name in `primaryEvent`.
 

--- a/agents/skills/tests/interaction-channel.test.ts
+++ b/agents/skills/tests/interaction-channel.test.ts
@@ -1,0 +1,64 @@
+// agents/skills/tests/interaction-channel.test.ts
+//
+// Guards the UX-channel invariant for skill prompts.
+//
+// `emit_interaction` with `type: 'question'` or `type: 'confirmation'` renders and
+// records a prompt but does NOT display it to the human: the client collapses the
+// call to "Called harness" and the rendered text only returns to the model. A skill
+// that routes a user-facing ask through it leaves the human staring at "Called
+// harness" while the agent narrates a question they cannot answer.
+//
+// User-facing asks must be made in PLAIN TEXT in the agent's own reply — the only
+// channel that reliably reaches the human across every platform (Claude Code,
+// Cursor, Codex, Gemini CLI). `AskUserQuestion` is Claude-Code-only and caps headers
+// at 12 chars / 4 options, so it is not a portable substitute either.
+//
+// `type: 'transition'` is exempt: it does real work (saveHandoff + telemetry) and is
+// not a question posed to the human.
+
+import { describe, it, expect } from 'vitest';
+import { glob } from 'glob';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = resolve(__dirname, '..');
+
+// Matches `type: "question"`, `type: 'confirmation'`, and inline `type: \`question\``
+// forms — i.e. an emit_interaction ask aimed at the human. Does NOT match the prose
+// rationale that names the tool ("do NOT route this through `emit_interaction`"),
+// which never writes `type: question`.
+const FORBIDDEN_ASK = /type:\s*["'`](question|confirmation)["'`]/;
+
+describe('skill prompts use a human-visible channel', () => {
+  const skillMdFiles = glob.sync('**/SKILL.md', {
+    cwd: SKILLS_DIR,
+    ignore: ['**/node_modules/**', '**/tests/**'],
+  });
+
+  if (skillMdFiles.length === 0) {
+    it.skip('no SKILL.md files found yet', () => {});
+    return;
+  }
+
+  it.each(skillMdFiles)(
+    '%s does not route a user-facing ask through emit_interaction (question/confirmation)',
+    (file) => {
+      const content = readFileSync(resolve(SKILLS_DIR, file), 'utf-8');
+      const offending = content
+        .split('\n')
+        .map((line, i) => ({ line, n: i + 1 }))
+        .filter(({ line }) => FORBIDDEN_ASK.test(line));
+
+      expect(
+        offending,
+        `${file} asks the human via emit_interaction at line(s) ` +
+          `${offending.map((o) => o.n).join(', ')}. ` +
+          `Ask in plain text in the reply instead — emit_interaction does not display ` +
+          `the prompt to the human (it collapses to "Called harness"). ` +
+          `type: 'transition' is exempt and uses a different type literal.`
+      ).toHaveLength(0);
+    }
+  );
+});

--- a/packages/cli/tests/integration/skill-catalog-consistency.test.ts
+++ b/packages/cli/tests/integration/skill-catalog-consistency.test.ts
@@ -31,15 +31,16 @@
 //     prevents the old wording from sneaking back via a careless edit or
 //     a merge from an old branch.
 //
-// (d) `Not sure yet` outside `emit_interaction` button labels fails
+// (d) `Not sure yet` outside an explicit option label fails
 //     REGRESSION GUARDED: init-design-roadmap-polish FINAL-S2 normalized
 //     narrative copy to lowercase `not sure` (no "yet", no hyphen), but
-//     the literal "Not sure yet" survives as a verbatim button-label
-//     string inside `emit_interaction` options (carries the
-//     "you-can-decide-later" UX affordance). Per D5, this assert tightens
-//     the window so any non-button "Not sure yet" — narrative prose,
-//     headings, table cells — fails the suite. Without this guard, the
-//     vocabulary drift FINAL-S2 closed would re-open on the next edit.
+//     the literal "Not sure yet" survives as a verbatim option-label string
+//     (carries the "you-can-decide-later" UX affordance). Since user-facing
+//     asks moved to plain text, the option label is a markdown table cell
+//     (`C) Not sure yet`) rather than an `emit_interaction` JSON `label:`;
+//     the assert accepts either option-label form. Any "Not sure yet" in
+//     narrative prose or headings still fails the suite. Without this guard,
+//     the vocabulary drift FINAL-S2 closed would re-open on the next edit.
 //
 // (e) hyphenated `not-sure` appears nowhere in user-facing copy
 //     REGRESSION GUARDED: the hyphenated form reads as an identifier
@@ -115,12 +116,17 @@ describe('skill catalog ↔ SKILL.md consistency (spec #15)', () => {
     expect(md).not.toMatch(/created via manage_roadmap/);
   });
 
-  it('forbids "Not sure yet" outside emit_interaction button labels', () => {
+  it('forbids "Not sure yet" outside an explicit option label', () => {
+    // User-facing asks are now plain text (not emit_interaction) — the
+    // "you-can-decide-later" affordance survives as an option label rendered
+    // as a markdown table cell (`C) Not sure yet`) rather than a JSON
+    // `label: "Not sure yet"`. Either form is an explicit option label;
+    // narrative prose must still use lowercase `not sure` (assert intent d).
     const skillMd = fs.readFileSync(SKILL_MD, 'utf-8');
     const occurrences = [...skillMd.matchAll(/Not sure yet/g)];
     for (const m of occurrences) {
       const window = skillMd.slice(Math.max(0, m.index! - 32), m.index! + 16);
-      expect(window).toMatch(/label:\s*["']Not sure yet/);
+      expect(window).toMatch(/(?:label:\s*["']|[A-Z]\)\s*)Not sure yet/);
     }
   });
 


### PR DESCRIPTION
## Problem

During brainstorming (and 7 peer skills), the agent narrates *"I've asked the scope question (A/B/C)"* but the human never sees an interactive prompt — only `Called harness`.

**Root cause:** these skills route user-facing questions/confirmations through `emit_interaction({type:'question'|'confirmation'})`. That MCP tool (`packages/cli/src/mcp/tools/interaction.ts:199` → `interaction-renderer.ts:13`) **renders** the prompt, **records** it in state as "pending user response", and **returns** it as tool-result content — it does *not* open an interactive prompt. The client collapses the call to `Called harness` and the rendered question only flows back to the model. So the agent "asks" via the tool, the tool succeeds, and the agent narrates a question the human cannot answer.

No code consumes the recorded ask state (write-only telemetry), and sibling skills `harness-ideate` / `harness-roadmap-pilot` already ask in plain text and surface correctly — confirming this is a skill-authoring defect, not a client bug.

## Fix

Convert every user-facing ask to **plain text in the agent's own reply** — the only channel that reaches the human across Claude Code, Cursor, Codex, and Gemini CLI. (`AskUserQuestion` is Claude-Code-only with a 12-char header / 4-option cap; relaying `emit_interaction` keeps the same fragility.) The rich comparison table the old renderer produced is preserved as a markdown table. `emit_interaction` `type:'transition'` is **untouched** — it does real work (`saveHandoff` + telemetry).

**8 skills:** `harness-brainstorming`, `harness-code-review`, `harness-execution`, `harness-planning`, `harness-verification`, `initialize-harness-project` (symlinked → edited `claude-code` source), plus `harness-integration` and `harness-pulse` (real per-platform copies → all 4 platforms kept byte-identical for `platform-parity`).

Regenerated plugin artifacts (gemini command TOML + claude/cursor persona-agent definitions that embed these skills' content).

## Regression guard

New `agents/skills/tests/interaction-channel.test.ts` fails if any SKILL.md reintroduces an `emit_interaction` question/confirmation ask. **Proven** to fail on the pre-fix `harness-brainstorming` (lines 67/72/177) and pass after.

Also updated `skill-catalog-consistency.test.ts` assert (d): the `"Not sure yet"` option label now lives in a plain-text table cell (`C) Not sure yet`) instead of an `emit_interaction` `label:`; the guard accepts either option-label form while still forbidding it in narrative prose.

## Verification

- `agents/skills` suite: `interaction-channel`, `platform-parity`, `structure`, `references`, `schema` all green.
- Full CLI test suite green (the previously-failing `skill-catalog-consistency` now passes).
- No changeset required (`check:changesets`: "No publishable package changes detected").