### PR TITLE
test(cli): fix Windows-flaky check-arch baseline test + mark protect-config done

### DIFF
--- a/.harness/learnings.md
+++ b/.harness/learnings.md
@@ -1,3 +1,13 @@
+## 2026-06-27: protect-config fail-closed — hook fail-open is load-bearing under issue #619
+
+Hardening a harness hook to "fail closed" on malformed input is NOT a blanket win — it interacts with a documented stability fix:
+
+1. **All harness hooks fail OPEN on absent/partial stdin on purpose.** `protect-config.test.ts:8-10` records issue #619: under v8 coverage the `cat <file> | node` pipe intermittently delivers empty/truncated stdin, which trips the fail-open path. Every sibling hook (including the security hook `sentinel-pre.js:107,112,119`) exits 0 on unreadable/empty/unparseable stdin. A naive "make the security hook fail closed" would turn that coverage glitch into BLOCKED legitimate Write/Edit calls — a self-DoS. The fix that ships: fail closed only on a _well-formed-but-unresolvable_ request (valid JSON, missing/non-string `file_path`, or an unexpected post-parse throw); keep absent/partial stdin fail-open. The #619 glitch lands in the still-open branches, so stability is preserved.
+
+2. **A PreToolUse Write|Edit hook flipping to exit 2 is near-zero false-positive risk for the missing-file_path branch** because Write/Edit always carry `file_path` by schema (matcher is `Write|Edit`, not `*` — `profiles.ts:29`). But pin it with tests (null / number / empty-string) since the branch now BLOCKS instead of allows.
+
+3. **Behavior-only hook changes do NOT trigger the profiles.ts/plugin-config.mjs dual-source concern** — that only applies to hook-profile _membership_ changes. This change kept protect-config in the standard profile, so no STANDARD_HOOKS mirror edit was needed.
+
 ## 2026-06-04: init-design-roadmap-polish — autopilot resume and pre-push hook interactions
 
 Three reusable observations from resuming a session at FINAL_REVIEW and shipping the PR:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,7 +39,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Make protect-config fail-closed in ambiguous cases
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/protect-config-fail-closed/proposal.md
 - **Summary:** `packages/cli/src/hooks/protect-config.js:36,41,49` — three branches currently fail-open (parse error → allow, empty stdin → allow, missing `file_path` → allow). The security-flavored hook that protects config silently yields whenever its input is malformed. Change to fail-closed with a clear error message. Defense-in-depth. Source: Pass 5 #2.
 - **Blockers:** —

--- a/packages/cli/tests/commands/check-arch.test.ts
+++ b/packages/cli/tests/commands/check-arch.test.ts
@@ -378,7 +378,7 @@ describe('check-arch command', () => {
       fsSync.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('handles --update-baseline with JSON output', async () => {
+    it('handles --update-baseline with JSON output', { timeout: 60_000 }, async () => {
       const fsSync = await import('node:fs');
       const osModule = await import('node:os');
       const tmpDir = fsSync.mkdtempSync(path.join(osModule.tmpdir(), 'check-arch-json-'));


### PR DESCRIPTION
## Summary

Two small wrap-up changes following #665:

### 1. Fix the pre-existing Windows CI failure (the substantive change)
`build-and-test (windows-latest, 22)` has been failing **deterministically on `main`** — independent of any one PR — on:

```
FAIL tests/commands/check-arch.test.ts > ... > handles --update-baseline with JSON output
Error: Test timed out in 30000ms.  (check-arch.test.ts:381)
```

**Root cause:** that test runs a real architecture-baseline scan but used vitest's default 30s timeout, while its sibling `handles --update-baseline and exits with SUCCESS` (`:356`) was already bumped to `{ timeout: 60_000 }`. The scan exceeds 30s on the slower `windows-latest` runner, so it times out. ubuntu/macOS pass.

**Fix:** give `:381` the same 60s budget as `:356`. One line.

This unblocks the Windows required check for **all** open PRs, not just this one.

### 2. Mark the roadmap row done
`protect-config fail-closed` shipped in #665 (issue #527 closed), so its roadmap row flips `planned → done`. Surgical one-line edit (deliberately **not** via `manage_roadmap update`, which re-serialized the whole file and cascaded unrelated rows' statuses + dropped the Assignment History table).

## Test plan
- `:381` now completes within 60s on Windows like its sibling.
- No behavioral/source change — test-timeout + docs only.

## Note
This PR also lands a `.harness/learnings.md` entry (the issue-#619 / hook fail-open note from the #665 session) that was a pre-staged working-tree artifact — harmless to land here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)