### PR TITLE
chore(roadmap): mark Event-Sourced State Model (#598) done

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -591,7 +591,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Event-Sourced State Model with Deterministic Reducer
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/event-sourced-state-model/proposal.md
 - **Summary:** Replace harness's mutated .harness/state.json with an append-only event log + pure deterministic reducer + materialized snapshot, plus an explicit guarded state machine for autopilot/orchestrator task lanes (forced-transition rules, dependency guards, mandatory evidence to reach terminal states). Highest-leverage hardening of harness's weakest subsystem (state/provenance); subsumes and complements the Append-Only Session Audit Trail (#580). Modeled on Spec Kitty's status/{emit,store,reducer,transitions}.py. Adoption #1 from docs/research/spec-kitty-comparison-analysis.md [SPECKITTY-1]
 - **Blockers:** —


### PR DESCRIPTION
Marks the **Event-Sourced State Model with Deterministic Reducer** roadmap row `done` — its implementation shipped in #667 (merged `854b1421d`). Single-line status flip; no cascade.

GH-580 (subsumed) is already `done` on main. This closes the bookkeeping for #598.