### PR TITLE
fix(ci): stop refresh-baselines PRs from conflicting on metric jitter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: node scripts/coverage-ratchet.mjs
 
+      # Guards the baseline-update gating that keeps refresh-baselines PRs from
+      # conflicting on coverage/benchmark jitter (see scripts + tests for context).
+      - name: Baseline-gating regression test
+        if: matrix.os == 'ubuntu-latest'
+        run: node --test 'tests/scripts/*.test.mjs'
+
       - name: Verify generated docs are fresh
         if: matrix.os == 'ubuntu-latest'
         run: pnpm run generate-docs --check
@@ -151,32 +157,51 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .harness/arch/baselines.json packages/cli/.harness/arch/baselines.json coverage-baselines.json benchmark-baselines.json
+          BASELINE_FILES=".harness/arch/baselines.json packages/cli/.harness/arch/baselines.json coverage-baselines.json benchmark-baselines.json"
+          git add $BASELINE_FILES
           if git diff --cached --quiet; then
             echo "No baseline changes to commit."
             exit 0
           fi
           git commit -m "chore: refresh baselines after merge [skip ci]"
+          OURS=$(git rev-parse HEAD)
           # Try direct push first; fall back to PR if branch protection blocks it
-          if ! git push 2>&1; then
-            echo "Direct push blocked by branch protection. Creating PR instead."
-            BRANCH="chore/refresh-baselines-$(date +%s)"
-            git checkout -b "$BRANCH"
-            git push -u origin "$BRANCH"
-            # Create the PR as github-actions[bot] so the PAT owner (a human) can approve it
-            # without hitting GitHub's self-approval block.
-            PR_URL=$(gh pr create \
-              --title "chore: refresh baselines after merge" \
-              --body "Auto-generated baseline refresh. This PR was created because direct pushes to main are blocked by branch protection rules." \
-              --base main \
-              --head "$BRANCH")
-            # Approve inline with the PAT. Events triggered by GITHUB_TOKEN do not start
-            # workflow runs, so a separate auto-approve workflow on pull_request_target
-            # would never fire for this PR.
-            GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
-              --body "Auto-approved: baseline refresh from github-actions[bot]."
-            gh pr merge "$PR_URL" --auto --squash --delete-branch
+          if git push 2>&1; then
+            exit 0
           fi
+          echo "Direct push blocked by branch protection. Creating PR instead."
+          # Fix B: base the PR branch on the CURRENT tip of origin/main, not the
+          # (possibly stale) event SHA this run checked out. Concurrent refresh runs
+          # otherwise branch from divergent commits and conflict on the same baseline
+          # lines; GitHub auto-merge cannot resolve content conflicts, so the loser
+          # sits open forever (this was the #671 failure mode).
+          git fetch origin main
+          BRANCH="chore/refresh-baselines-$(date +%s)"
+          git checkout -B "$BRANCH" origin/main
+          # Re-apply our freshly generated baselines on top of latest main. The files
+          # are regenerated wholesale, so "ours" is always the correct resolution and
+          # this re-apply can never conflict.
+          git checkout "$OURS" -- $BASELINE_FILES
+          git add $BASELINE_FILES
+          if git diff --cached --quiet; then
+            echo "Latest main already carries these baselines; nothing to PR."
+            exit 0
+          fi
+          git commit -m "chore: refresh baselines after merge [skip ci]"
+          git push -u origin "$BRANCH"
+          # Create the PR as github-actions[bot] so the PAT owner (a human) can approve it
+          # without hitting GitHub's self-approval block.
+          PR_URL=$(gh pr create \
+            --title "chore: refresh baselines after merge" \
+            --body "Auto-generated baseline refresh. Created because direct pushes to main are blocked by branch protection. Branch is based on the current tip of main to avoid concurrent-refresh conflicts." \
+            --base main \
+            --head "$BRANCH")
+          # Approve inline with the PAT. Events triggered by GITHUB_TOKEN do not start
+          # workflow runs, so a separate auto-approve workflow on pull_request_target
+          # would never fire for this PR.
+          GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
+            --body "Auto-approved: baseline refresh from github-actions[bot]."
+          gh pr merge "$PR_URL" --auto --squash --delete-branch
         env:
           HUSKY: '0'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/benchmark-check.mjs
+++ b/scripts/benchmark-check.mjs
@@ -30,6 +30,37 @@ const PACKAGES = [
 const isUpdate = process.argv.includes('--update');
 
 /**
+ * Merge freshly measured benchmarks onto the committed baselines, keeping the
+ * existing entry for any benchmark whose mean moved less than the regression
+ * threshold (runner noise).
+ *
+ * This is Fix A for the refresh-baselines race: `--update` used to rewrite every
+ * mean/p99 on every run, so each push produced a diff of pure microsecond jitter.
+ * Concurrent refresh PRs then edited the same lines from divergent bases and
+ * conflicted — and auto-merge cannot resolve content conflicts. Gating the write
+ * to genuine movement makes jitter-only runs byte-identical (no diff, no PR).
+ *
+ * - mean within threshold -> keep the committed entry verbatim (no churn)
+ * - mean beyond threshold -> adopt the measured entry (real movement)
+ * - new benchmark / zero or missing baseline mean -> adopt
+ * - benchmark removed from code -> dropped (only fresh keys are written)
+ */
+export function mergeBenchmarkBaselines(existing = {}, fresh = {}, threshold = THRESHOLD) {
+  const merged = {};
+  for (const key of Object.keys(fresh)) {
+    const prev = existing[key];
+    const next = fresh[key];
+    if (!prev || typeof prev.mean !== 'number' || prev.mean === 0) {
+      merged[key] = next;
+      continue;
+    }
+    const delta = Math.abs(next.mean - prev.mean) / prev.mean;
+    merged[key] = delta <= threshold ? prev : next;
+  }
+  return merged;
+}
+
+/**
  * Run vitest bench for a package and return parsed JSON results.
  * Uses --outputJson to write structured output to a temp file.
  */
@@ -121,7 +152,14 @@ function main() {
   console.log(`\n  Found ${Object.keys(allResults).length} benchmarks.\n`);
 
   if (isUpdate) {
-    writeFileSync(BASELINES_PATH, JSON.stringify(allResults, null, 2) + '\n');
+    let existing = {};
+    try {
+      existing = JSON.parse(readFileSync(BASELINES_PATH, 'utf-8'));
+    } catch {
+      /* first run -- no committed baselines yet */
+    }
+    const merged = mergeBenchmarkBaselines(existing, allResults);
+    writeFileSync(BASELINES_PATH, JSON.stringify(merged, null, 2) + '\n');
     console.log(`Baselines updated: ${BASELINES_PATH}`);
     return;
   }
@@ -183,4 +221,9 @@ function main() {
   console.log('\nAll benchmarks within threshold.');
 }
 
-main();
+// Only run benchmarks when invoked directly, not when imported by tests.
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  main();
+}

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -10,6 +10,7 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const BASELINES_PATH = join(ROOT, 'coverage-baselines.json');
@@ -109,8 +110,57 @@ function check() {
   console.log('Coverage ratchet: all packages meet or exceed baselines.');
 }
 
+/**
+ * Merge freshly measured coverage onto the committed baselines, keeping the
+ * existing value for any metric whose change is within V8 noise tolerance.
+ *
+ * This is the heart of Fix A for the refresh-baselines race: `--update` used to
+ * rewrite the file with raw measurements every run, so each push produced a diff
+ * of pure jitter. When several pushes landed close together, their refresh PRs
+ * edited the same lines from divergent bases and conflicted — auto-merge cannot
+ * resolve content conflicts, so the losers sat open forever. Gating the write to
+ * meaningful movement makes jitter-only runs byte-identical (no diff, no PR).
+ *
+ * - within tolerance  -> keep the committed value (no churn)
+ * - beyond tolerance  -> adopt the measured value (real movement)
+ * - new package       -> adopt
+ * - package missing this run -> keep the committed value (transient gap, no churn)
+ */
+export function mergeCoverageBaselines(existing = {}, fresh = {}, tolerance = V8_VARIANCE_TOLERANCE) {
+  const merged = {};
+  const keys = [
+    ...Object.keys(existing),
+    ...Object.keys(fresh).filter((k) => !(k in existing)),
+  ];
+
+  for (const pkgKey of keys) {
+    const prev = existing[pkgKey];
+    const next = fresh[pkgKey];
+    if (!next) {
+      merged[pkgKey] = prev; // no coverage data this run -> preserve committed
+      continue;
+    }
+    if (!prev) {
+      merged[pkgKey] = next; // brand-new package
+      continue;
+    }
+    const out = {};
+    for (const metric of METRICS) {
+      const a = next[metric];
+      const b = prev[metric];
+      out[metric] =
+        typeof a === 'number' && typeof b === 'number' && Math.abs(a - b) <= tolerance
+          ? b
+          : a;
+    }
+    merged[pkgKey] = out;
+  }
+
+  return merged;
+}
+
 function update() {
-  const result = {};
+  const fresh = {};
 
   for (const pkgKey of Object.keys(PACKAGES)) {
     const actual = readCoverage(pkgKey);
@@ -118,20 +168,37 @@ function update() {
       console.warn(`  Skipping ${pkgKey} (no meaningful coverage data)`);
       continue;
     }
-    result[pkgKey] = actual;
-    console.log(`  ${pkgKey}: lines=${actual.lines}% branches=${actual.branches}% functions=${actual.functions}% statements=${actual.statements}%`);
+    fresh[pkgKey] = actual;
   }
 
-  writeFileSync(BASELINES_PATH, JSON.stringify(result, null, 2) + '\n');
+  let existing = {};
+  try {
+    existing = JSON.parse(readFileSync(BASELINES_PATH, 'utf8'));
+  } catch {
+    /* first run -- no committed baselines yet */
+  }
+
+  const merged = mergeCoverageBaselines(existing, fresh);
+  for (const pkgKey of Object.keys(merged)) {
+    const m = merged[pkgKey];
+    console.log(`  ${pkgKey}: lines=${m.lines}% branches=${m.branches}% functions=${m.functions}% statements=${m.statements}%`);
+  }
+
+  writeFileSync(BASELINES_PATH, JSON.stringify(merged, null, 2) + '\n');
   console.log(`\nBaselines written to ${BASELINES_PATH}`);
 }
 
-// --- main ---
-const args = process.argv.slice(2);
-if (args.includes('--update')) {
-  console.log('Updating coverage baselines...\n');
-  update();
-} else {
-  console.log('Checking coverage against baselines...\n');
-  check();
+// --- main (only when invoked directly, not when imported by tests) ---
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const args = process.argv.slice(2);
+  if (args.includes('--update')) {
+    console.log('Updating coverage baselines...\n');
+    update();
+  } else {
+    console.log('Checking coverage against baselines...\n');
+    check();
+  }
 }

--- a/tests/scripts/baseline-gating.test.mjs
+++ b/tests/scripts/baseline-gating.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Regression test for the refresh-baselines auto-merge race.
+ *
+ * Root cause (PR #671): the `--update` modes of coverage-ratchet and
+ * benchmark-check rewrote their baseline files with raw measurements on every
+ * run. Coverage percentages and benchmark mean/p99 timings jitter run-to-run, so
+ * every push produced a diff of pure noise. When pushes landed close together,
+ * the resulting refresh PRs edited the same lines from divergent bases and went
+ * CONFLICTING — and GitHub auto-merge cannot resolve content conflicts, so the
+ * losing PR sat open forever.
+ *
+ * The fix gates each `--update` write to *meaningful* movement so jitter-only
+ * runs produce a byte-identical file (no diff -> no PR -> no race). These tests
+ * assert that gate. Run with: node --test tests/scripts/
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mergeCoverageBaselines } from '../../scripts/coverage-ratchet.mjs';
+import { mergeBenchmarkBaselines } from '../../scripts/benchmark-check.mjs';
+
+test('coverage: sub-tolerance jitter keeps the committed file byte-identical', () => {
+  const committed = {
+    'packages/core': { lines: 91.61, branches: 76.8, functions: 92.98, statements: 89.23 },
+  };
+  // The exact jitter that conflicted in #671 (all moves < 0.5% V8 tolerance).
+  const measured = {
+    'packages/core': { lines: 91.78, branches: 76.93, functions: 93.24, statements: 89.41 },
+  };
+
+  const merged = mergeCoverageBaselines(committed, measured);
+
+  // Byte-identical serialization is what makes `git diff --cached --quiet` true.
+  assert.equal(JSON.stringify(merged), JSON.stringify(committed));
+});
+
+test('coverage: movement beyond tolerance is adopted', () => {
+  const committed = { 'packages/core': { lines: 80, branches: 70, functions: 80, statements: 80 } };
+  const measured = { 'packages/core': { lines: 85, branches: 70.2, functions: 80, statements: 80 } };
+
+  const merged = mergeCoverageBaselines(committed, measured);
+
+  assert.equal(merged['packages/core'].lines, 85); // real +5% gain locked in
+  assert.equal(merged['packages/core'].branches, 70); // +0.2% noise kept stable
+});
+
+test('coverage: a brand-new package is added; a package missing this run is preserved', () => {
+  const committed = { 'packages/core': { lines: 90, branches: 80, functions: 90, statements: 90 } };
+  const measured = {
+    'packages/core': { lines: 90.1, branches: 80, functions: 90, statements: 90 },
+    'packages/new': { lines: 50, branches: 40, functions: 60, statements: 55 },
+  };
+
+  const merged = mergeCoverageBaselines(committed, measured);
+
+  assert.deepEqual(merged['packages/core'], committed['packages/core']); // jitter ignored
+  assert.deepEqual(merged['packages/new'], measured['packages/new']); // new pkg adopted
+
+  // Missing-this-run package keeps its committed value rather than churning out.
+  const mergedMissing = mergeCoverageBaselines(committed, {});
+  assert.deepEqual(mergedMissing['packages/core'], committed['packages/core']);
+});
+
+test('benchmark: sub-threshold timing jitter keeps the committed file byte-identical', () => {
+  const committed = {
+    'core/validateConfig - valid config object': { mean: 0.001601108808008122, p99: 0.0032860000000027867 },
+  };
+  // The exact jitter that conflicted in #671 (mean move << 100% threshold).
+  const measured = {
+    'core/validateConfig - valid config object': { mean: 0.0018601312616490825, p99: 0.0030699999999797 },
+  };
+
+  const merged = mergeBenchmarkBaselines(committed, measured);
+
+  // p99 alone must not trigger a rewrite either — the whole entry is preserved.
+  assert.equal(JSON.stringify(merged), JSON.stringify(committed));
+});
+
+test('benchmark: a genuine regression beyond threshold is adopted', () => {
+  const committed = { 'core/op': { mean: 1.0, p99: 1.2 } };
+  const measured = { 'core/op': { mean: 3.0, p99: 3.5 } }; // 200% > 100% threshold
+
+  const merged = mergeBenchmarkBaselines(committed, measured);
+
+  assert.deepEqual(merged['core/op'], measured['core/op']);
+});
+
+test('benchmark: new and placeholder-zero baselines adopt fresh values', () => {
+  const merged = mergeBenchmarkBaselines(
+    { existing: { mean: 0, p99: 0 } },
+    { existing: { mean: 0.5, p99: 0.6 }, fresh: { mean: 0.1, p99: 0.2 } },
+  );
+
+  assert.deepEqual(merged.existing, { mean: 0.5, p99: 0.6 }); // zero placeholder -> adopt
+  assert.deepEqual(merged.fresh, { mean: 0.1, p99: 0.2 }); // new key -> adopt
+});


### PR DESCRIPTION
## Problem
The \`refresh-baselines\` CI job rewrote \`coverage-baselines.json\` and \`benchmark-baselines.json\` with **raw measurements on every push**. Those numbers jitter run-to-run (V8 coverage variance, microsecond benchmark timings), so every push produced a diff of pure noise. When pushes landed close together, the resulting refresh PRs edited the same lines from divergent bases and went \`CONFLICTING\` — and GitHub auto-merge **cannot resolve content conflicts**, so the loser sat open forever.

Most recent casualty: #671 (now closed; main already carried the equivalent baselines from #669).

## Root cause
Concurrent refresh runs branch from different main checkpoints and all rewrite the same non-deterministic baseline lines. First PR to merge wins; the rest are permanently \`DIRTY\`. Auto-merge fast-forwards *behind* branches but never merges conflicts.

## Fix A — stop committing jitter (\`scripts/coverage-ratchet.mjs\`, \`scripts/benchmark-check.mjs\`)
\`--update\` now **merges** measurements onto the committed baselines via new pure exports \`mergeCoverageBaselines()\` / \`mergeBenchmarkBaselines()\`. A value is rewritten only when it moves **beyond the script's existing noise tolerance** (coverage 0.5%, benchmark 100% mean). Jitter-only runs are byte-identical → \`git diff --cached --quiet\` → "No baseline changes to commit" → **no PR**. \`main()\` is guarded so the functions are importable by tests without running benchmarks. (Arch baselines are deterministic and still commit on real structural change.)

## Fix B — make the rare real refresh PR conflict-proof (\`.github/workflows/ci.yml\`)
The PR-fallback path now \`git fetch origin main\` + \`git checkout -B "\$BRANCH" origin/main\` and re-applies the regenerated files on top (ours wins, wholesale-regenerated → never a semantic conflict). The branch is based on the **current tip of main**, not the stale event SHA, so concurrent refreshes can't produce a conflicting branch.

## Test
Adds \`tests/scripts/baseline-gating.test.mjs\` (node:test, 6 cases), wired into CI as a "Baseline-gating regression test" step. Verified both ways: reverting the gate **and** mutating it back to the old \`return fresh\` behavior fail the byte-identical assertions.

No changeset required (changes are outside \`packages/<pkg>/src\`).