### PR TITLE
feat(cli): wire review-ci --comment PR poster + fix shadowed verdict-json output

### DIFF
--- a/.changeset/review-ci-comment-poster.md
+++ b/.changeset/review-ci-comment-poster.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Wire up `harness review-ci --comment` to actually post the verdict to the pull request (it previously logged a "not yet wired (Phase 3 stub)" warning). When `--comment` is set, the command now renders the verdict as a Markdown summary — assessment, finding counts, and a list of blocking + other findings — and posts it as a comment on the current branch's PR via `gh pr comment` (piped over stdin so long verdicts never hit the shell arg-length limit). A comment is used rather than a `--request-changes` review so it works in every context, including when the same actor authored the PR and in CI where the bot is not the author; the gate's exit code remains the authoritative merge blocker. If posting fails (no PR, no `gh`, auth error) the command warns and still exits with the verdict's code rather than crashing.
+
+Also fixes verdict-artifact output, which never worked: `review-ci`'s own `--json <path>` option was silently shadowed by the root program's global `--json` flag (commander routed the value to the parent, so the file was never written). The global `--json` now streams the verdict artifact to stdout (suppressing the human summary so the output stays valid, pipeable JSON), and a new `--out <path>` writes the artifact to a file.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -422,8 +422,8 @@ Run the tiered code-review gate (floor + optional LLM runner) for CI
 - `--runner` — claude | gemini | antigravity | codex | cursor | local (omit = floor-only)
 - `--block-on` — approve | comment | request-changes | none (default: "request-changes")
 - `--diff` — git range (default: origin/<base>...HEAD)
-- `--comment` — post verdict as a PR review (stubbed in this phase)
-- `--json` — write the verdict artifact to this path
+- `--comment` — post the verdict as a comment on the current branch's PR via gh
+- `--out` — write the verdict JSON artifact to a file (use the global --json to stream it to stdout instead)
 
 ### `harness scan [path]`
 

--- a/packages/cli/src/commands/review-ci.ts
+++ b/packages/cli/src/commands/review-ci.ts
@@ -194,27 +194,94 @@ export async function runReviewCi(opts: ReviewCiOptions): Promise<CiReviewResult
   return (opts.runCiReviewImpl ?? runCiReview)(callOpts);
 }
 
+/** A single validated finding as it appears on the verdict. */
+type ReviewFindingView = CiReviewResult['verdict']['findings'][number];
+
+/** Render a finding as a one-line Markdown bullet: severity, location, title. */
+function findingLine(f: ReviewFindingView): string {
+  const loc = f.lineRange ? `${f.file}:${f.lineRange[0]}` : f.file;
+  return `- \`${f.severity}\` **${loc}** — ${f.title}`;
+}
+
 /**
- * Emit the review result: print the terminal summary, optionally write the
- * verdict artifact, and (in this phase) warn that `--comment` is stubbed.
+ * Render the CI review verdict as a Markdown PR-comment body. Pure (no I/O), so
+ * it is unit-testable; the {@link PostReview} seam handles delivery.
+ */
+export function buildReviewBody(verdict: CiReviewResult['verdict']): string {
+  const findings = verdict.findings ?? [];
+  const blocking = verdict.blockingFindings ?? [];
+  const icon =
+    verdict.assessment === 'approve'
+      ? '✅'
+      : verdict.assessment === 'request-changes'
+        ? '🛑'
+        : '💬';
+  const out: string[] = [
+    `## ${icon} harness review-ci — ${verdict.assessment}`,
+    '',
+    `**Runner:** \`${verdict.runner}\`  •  **Findings:** ${findings.length} (blocking: ${blocking.length})`,
+  ];
+  if (verdict.skipped) out.push('', `> ⚠️ ${verdict.skipReason ?? 'A review tier was skipped.'}`);
+  if (blocking.length) out.push('', '### Blocking', ...blocking.map(findingLine));
+  const nonBlocking = findings.filter((f) => !blocking.some((b) => b.id === f.id));
+  if (nonBlocking.length) out.push('', '### Other findings', ...nonBlocking.map(findingLine));
+  if (!findings.length) out.push('', 'No findings. 🎉');
+  out.push('', '<sub>Posted by `harness review-ci`. The CI exit code is authoritative.</sub>');
+  return out.join('\n');
+}
+
+/** Seam for delivering the verdict to a PR — real impl shells out to `gh`. */
+export type PostReview = (verdict: CiReviewResult['verdict']) => void;
+
+/**
+ * Default poster: comment the verdict onto the current branch's PR via `gh`.
  *
- * Pure aside from the injected `writeFile`/`log` seams — contains NO
+ * Uses `gh pr comment` (not a `--request-changes` review) deliberately: a comment
+ * works in every context, including when the same actor authored the PR (GitHub
+ * forbids self-requesting-changes) and in CI where the bot is not the author. The
+ * gate's exit code — not this comment — is what blocks the merge, so an
+ * informational comment is the correct delivery. The body is piped via stdin
+ * (`--body-file -`) so long verdicts never hit the shell arg-length limit.
+ */
+const defaultPostReview: PostReview = (verdict) => {
+  execFileSync('gh', ['pr', 'comment', '--body-file', '-'], {
+    input: buildReviewBody(verdict),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  });
+};
+
+/**
+ * Emit the review result: print the terminal summary (or the JSON artifact to
+ * stdout when `--json` is given without a path), optionally write the artifact to
+ * a file, and optionally post it to the PR.
+ *
+ * Pure aside from the injected `writeFile`/`log`/`postReview` seams — contains NO
  * `process.exit`, so it stays unit-testable.
  */
 export function emitReviewCi(
   result: CiReviewResult,
-  opts: { jsonPath?: string | undefined; comment?: boolean | undefined },
+  opts: { jsonPath?: string | boolean | undefined; comment?: boolean | undefined },
   writeFile: (p: string, d: string) => void = (p, d) => writeFileSync(p, d),
-  log: (m: string) => void = (m) => process.stdout.write(m + '\n')
+  log: (m: string) => void = (m) => process.stdout.write(m + '\n'),
+  postReview: PostReview = defaultPostReview
 ): void {
-  log(result.terminalOutput);
-  if (opts.jsonPath) writeFile(opts.jsonPath, JSON.stringify(result.verdict, null, 2));
+  const serialized = JSON.stringify(result.verdict, null, 2);
+  // `--json` with no path => emit the artifact to stdout; suppress the human
+  // summary so the output stays valid, pipeable JSON.
+  const jsonToStdout = opts.jsonPath === true;
+  if (!jsonToStdout) log(result.terminalOutput);
+  if (typeof opts.jsonPath === 'string') writeFile(opts.jsonPath, serialized);
+  else if (jsonToStdout) log(serialized);
   if (opts.comment) {
-    logger.warn(
-      'review-ci: --comment posting is not yet wired (no gh PR poster; Phase 3 stub). ' +
-        'The verdict above is authoritative; use --json to capture the artifact. ' +
-        'PR-review posting lands in a later phase.'
-    );
+    try {
+      postReview(result.verdict);
+    } catch (err) {
+      logger.warn(
+        `review-ci: failed to post PR comment (${err instanceof Error ? err.message : String(err)}). ` +
+          'The verdict above is authoritative; the exit code still reflects the gate.'
+      );
+    }
   }
 }
 
@@ -233,16 +300,24 @@ export function createReviewCiCommand(): Command {
         .default('request-changes')
     )
     .option('--diff <range>', 'git range (default: origin/<base>...HEAD)')
-    .option('--comment', 'post verdict as a PR review (stubbed in this phase)')
-    .option('--json <path>', 'write the verdict artifact to this path')
-    .action(async (opts: Record<string, unknown>) => {
+    .option('--comment', "post the verdict as a comment on the current branch's PR via gh")
+    .option(
+      '--out <path>',
+      'write the verdict JSON artifact to a file (use the global --json to stream it to stdout instead)'
+    )
+    .action(async (opts: Record<string, unknown>, cmd: Command) => {
       const result = await runReviewCi({
         runner: opts.runner as string | undefined,
         blockOn: opts.blockOn as CiBlockOn | undefined,
         diffRange: opts.diff as string | undefined,
       });
+      // The root program owns a global `--json` (boolean); a subcommand cannot
+      // redeclare `--json` (commander routes the value to the parent program), so
+      // we read the global to mean "stream the verdict JSON to stdout" and use
+      // `--out <path>` to write the artifact to a file.
+      const streamJson = cmd.optsWithGlobals().json === true;
       emitReviewCi(result, {
-        jsonPath: opts.json as string | undefined,
+        jsonPath: typeof opts.out === 'string' ? opts.out : streamJson ? true : undefined,
         comment: opts.comment as boolean | undefined,
       });
       // process.exit is confined to the commander action so the pure functions

--- a/packages/cli/tests/commands/review-ci.test.ts
+++ b/packages/cli/tests/commands/review-ci.test.ts
@@ -11,6 +11,7 @@ import {
   buildDiffInfo,
   runReviewCi,
   emitReviewCi,
+  buildReviewBody,
   createReviewCiCommand,
   assertKnownRunner,
 } from '../../src/commands/review-ci';
@@ -258,19 +259,78 @@ describe('emitReviewCi', () => {
     expect(writeFile).not.toHaveBeenCalled();
   });
 
-  it('warns the documented stub when --comment is set', () => {
+  it('emits the JSON artifact to stdout (not a file) when jsonPath is true', () => {
+    const writeFile = vi.fn();
+    const log = vi.fn();
+    emitReviewCi(result, { jsonPath: true }, writeFile, log);
+    expect(writeFile).not.toHaveBeenCalled();
+    // Human summary is suppressed so stdout stays valid, pipeable JSON.
+    expect(log).not.toHaveBeenCalledWith('TERMINAL_SUMMARY');
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(log.mock.calls[0]![0] as string)).toMatchObject({
+      assessment: 'request-changes',
+    });
+  });
+
+  it('posts the verdict via the PR poster when --comment is set', () => {
+    const postReview = vi.fn();
+    emitReviewCi(result, { comment: true }, vi.fn(), vi.fn(), postReview);
+    expect(postReview).toHaveBeenCalledTimes(1);
+    expect(postReview.mock.calls[0]![0]).toMatchObject({ assessment: 'request-changes' });
+  });
+
+  it('warns (does not throw) when the PR poster fails', () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    emitReviewCi(result, { comment: true }, vi.fn(), vi.fn());
+    const postReview = vi.fn(() => {
+      throw new Error('gh: no PR found');
+    });
+    expect(() =>
+      emitReviewCi(result, { comment: true }, vi.fn(), vi.fn(), postReview)
+    ).not.toThrow();
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0]![0]).toContain('comment posting is not yet wired');
+    expect(warn.mock.calls[0]![0]).toContain('failed to post PR comment');
     warn.mockRestore();
   });
 
-  it('does not warn when --comment is absent', () => {
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    emitReviewCi(result, {}, vi.fn(), vi.fn());
-    expect(warn).not.toHaveBeenCalled();
-    warn.mockRestore();
+  it('does not post when --comment is absent', () => {
+    const postReview = vi.fn();
+    emitReviewCi(result, {}, vi.fn(), vi.fn(), postReview);
+    expect(postReview).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildReviewBody', () => {
+  it('renders assessment, counts, and blocking findings as Markdown', () => {
+    const verdict = {
+      assessment: 'request-changes',
+      runner: 'claude',
+      findings: [
+        { id: 'a', file: 'src/a.ts', lineRange: [10, 10], severity: 'critical', title: 'Boom' },
+        { id: 'b', file: 'src/b.ts', lineRange: [3, 3], severity: 'info', title: 'Nit' },
+      ],
+      blockingFindings: [
+        { id: 'a', file: 'src/a.ts', lineRange: [10, 10], severity: 'critical', title: 'Boom' },
+      ],
+    } as unknown as CiReviewResult['verdict'];
+
+    const body = buildReviewBody(verdict);
+
+    expect(body).toContain('harness review-ci — request-changes');
+    expect(body).toContain('Findings:** 2 (blocking: 1)');
+    expect(body).toContain('### Blocking');
+    expect(body).toContain('`critical` **src/a.ts:10** — Boom');
+    expect(body).toContain('### Other findings');
+    expect(body).toContain('`info` **src/b.ts:3** — Nit');
+  });
+
+  it('renders a clean verdict when there are no findings', () => {
+    const verdict = {
+      assessment: 'approve',
+      runner: 'floor-only',
+      findings: [],
+      blockingFindings: [],
+    } as unknown as CiReviewResult['verdict'];
+    expect(buildReviewBody(verdict)).toContain('No findings.');
   });
 });
 
@@ -280,7 +340,7 @@ describe('createReviewCiCommand', () => {
     expect(cmd.name()).toBe('review-ci');
     const flags = cmd.options.map((o) => o.long);
     expect(flags).toEqual(
-      expect.arrayContaining(['--runner', '--block-on', '--diff', '--comment', '--json'])
+      expect.arrayContaining(['--runner', '--block-on', '--diff', '--comment', '--out'])
     );
   });
 


### PR DESCRIPTION
Follow-up to #672. Finishes two unbuilt pieces of `harness review-ci`.

## `--comment` was a Phase 3 stub
It only logged *"--comment posting is not yet wired (no gh PR poster; Phase 3 stub)"*. It now:
- renders the verdict as a Markdown summary (assessment, finding counts, blocking + other findings) via a new pure, unit-tested `buildReviewBody()`;
- posts it to the current branch's PR with `gh pr comment` (body piped over stdin so long verdicts never hit the shell arg-length limit);
- uses a **comment** rather than a `--request-changes` review, so it works when the same actor authored the PR and in CI where the bot is not the author — the gate's **exit code** remains the authoritative merge blocker;
- on failure (no PR / no `gh` / auth) **warns and still exits with the verdict code** instead of crashing.

## `--json <path>` never actually worked
review-ci's own `--json <path>` was silently **shadowed by the root program's global `--json`** (commander routes the value to the parent program), so the artifact file was never written — even though the old stub told users to "use --json to capture the artifact."
- The global `--json` now **streams the verdict JSON to stdout** (human summary suppressed so the output stays valid, pipeable JSON).
- New `--out <path>` **writes the artifact to a file**.

Adds 9 tests (poster invocation, failure-warns-not-throws, stdout-JSON, `buildReviewBody`), updates the stub-pinning test, regenerates the CLI reference, and includes a changeset.

Verified end-to-end against this repo's diff: `--json` emits clean JSON, `--out` writes the file, default prints the human summary.