### PR TITLE
feat(cli): generate GitLab CI for personas + wire --platform flag

### DIFF
--- a/.changeset/persona-gitlab-ci.md
+++ b/.changeset/persona-gitlab-ci.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Implement GitLab CI generation for personas (`generateCIWorkflow(persona, 'gitlab')`), which previously returned `Err('GitLab CI generation is not yet supported')`. The generator emits a `.gitlab-ci.yml` pipeline fragment with an `enforce` job (`image: node:20`, `corepack`/`pnpm` setup, one `npx harness <command>` script line per command step) and translates persona triggers into GitLab `rules:` — merge-request pipelines (with `changes:` from path globs), per-branch `$CI_COMMIT_BRANCH` matches, and schedule pipelines (the cron lives in GitLab's pipeline-schedule settings, not the YAML, so it is intentionally omitted). Skill steps are skipped (CI cannot run an AI agent); a persona with only skill steps gets a no-op script so the YAML stays valid.
+
+Also wires the previously-unreachable platform parameter to a user-facing flag: `harness persona generate <name> --platform gitlab` now writes `<slug>.gitlab-ci.yml` (include it from `.gitlab-ci.yml`), while `--platform github` (the default) continues to write `.github/workflows/<slug>.yml`.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1000,6 +1000,7 @@ Generate artifacts from a persona config
 
 - `--output-dir` — Output directory (default: ".")
 - `--only` — Generate only: ci, agents-md, runtime
+- `--platform` — CI platform for the ci artifact (default: "github")
 
 ### `harness persona list`
 

--- a/packages/cli/src/commands/persona/generate.ts
+++ b/packages/cli/src/commands/persona/generate.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
 import { loadPersona } from '../../persona/loader';
@@ -14,7 +14,8 @@ import type { Persona } from '../../persona/schema';
 function generatePersonaArtifacts(
   persona: Persona,
   outputDir: string,
-  only: string | undefined
+  only: string | undefined,
+  platform: 'github' | 'gitlab'
 ): string[] {
   const slug = toKebabCase(persona.name);
   const generated: string[] = [];
@@ -37,9 +38,15 @@ function generatePersonaArtifacts(
     }
   }
   if (!only || only === 'ci') {
-    const result = generateCIWorkflow(persona, 'github');
+    const result = generateCIWorkflow(persona, platform);
     if (result.ok) {
-      const outPath = path.join(outputDir, '.github', 'workflows', `${slug}.yml`);
+      // GitHub Actions wants one workflow file under .github/workflows/; GitLab
+      // wants an includable pipeline fragment (the user references it from
+      // .gitlab-ci.yml via `include:`).
+      const outPath =
+        platform === 'gitlab'
+          ? path.join(outputDir, `${slug}.gitlab-ci.yml`)
+          : path.join(outputDir, '.github', 'workflows', `${slug}.yml`);
       fs.mkdirSync(path.dirname(outPath), { recursive: true });
       fs.writeFileSync(outPath, result.value);
       generated.push(outPath);
@@ -54,6 +61,11 @@ export function createGenerateCommand(): Command {
     .argument('<name>', 'Persona name (e.g., architecture-enforcer)')
     .option('--output-dir <dir>', 'Output directory', '.')
     .option('--only <type>', 'Generate only: ci, agents-md, runtime')
+    .addOption(
+      new Option('--platform <platform>', 'CI platform for the ci artifact')
+        .choices(['github', 'gitlab'])
+        .default('github')
+    )
     .action(async (name, opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const personaResult = loadPersona(path.join(resolvePersonasDir(), `${name}.yaml`));
@@ -64,7 +76,8 @@ export function createGenerateCommand(): Command {
       const generated = generatePersonaArtifacts(
         personaResult.value,
         path.resolve(opts.outputDir),
-        opts.only as string | undefined
+        opts.only as string | undefined,
+        opts.platform as 'github' | 'gitlab'
       );
       if (!globalOpts.quiet) {
         logger.success(`Generated ${generated.length} artifacts for ${personaResult.value.name}:`);

--- a/packages/cli/src/persona/generators/ci-workflow.ts
+++ b/packages/cli/src/persona/generators/ci-workflow.ts
@@ -27,25 +27,83 @@ function buildGitHubTriggers(triggers: PersonaTrigger[]): Record<string, unknown
   return on;
 }
 
+/**
+ * Translate persona triggers into GitLab CI `rules:` entries.
+ *
+ * GitLab has no `on:` block — pipeline filtering lives on each job's `rules`,
+ * gated by predefined variables:
+ *  - `on_pr`      -> merge-request pipelines (`CI_PIPELINE_SOURCE`), with the
+ *                    persona's path globs mapped to `changes:`.
+ *  - `on_commit`  -> branch pipelines; one rule per configured branch (matched on
+ *                    `CI_COMMIT_BRANCH`), or any push when no branches are given.
+ *  - `scheduled`  -> schedule pipelines. GitLab cron lives in the project's
+ *                    pipeline-schedule settings (UI/API), not the YAML, so the
+ *                    rule only gates on the schedule source; the cron is dropped
+ *                    intentionally (there is nowhere valid to put it in the file).
+ */
+function buildGitLabRules(triggers: PersonaTrigger[]): Record<string, unknown>[] {
+  const rules: Record<string, unknown>[] = [];
+  for (const trigger of triggers) {
+    switch (trigger.event) {
+      case 'on_pr': {
+        const rule: Record<string, unknown> = {
+          if: '$CI_PIPELINE_SOURCE == "merge_request_event"',
+        };
+        if (trigger.conditions?.paths) rule.changes = trigger.conditions.paths;
+        rules.push(rule);
+        break;
+      }
+      case 'on_commit': {
+        const branches = trigger.conditions?.branches;
+        if (branches?.length) {
+          for (const branch of branches) rules.push({ if: `$CI_COMMIT_BRANCH == "${branch}"` });
+        } else {
+          rules.push({ if: '$CI_PIPELINE_SOURCE == "push"' });
+        }
+        break;
+      }
+      case 'scheduled':
+        rules.push({ if: '$CI_PIPELINE_SOURCE == "schedule"' });
+        break;
+    }
+  }
+  return rules;
+}
+
 export function generateCIWorkflow(
   persona: Persona,
   platform: 'github' | 'gitlab'
 ): Result<string, Error> {
   try {
-    if (platform === 'gitlab') return Err(new Error('GitLab CI generation is not yet supported'));
-
     const severity = persona.config.severity;
+    const severityFlag = severity ? ` --severity ${severity}` : '';
+    // Only emit command steps in CI (skill steps require AI agent runtime).
+    const commandSteps = persona.steps.filter((s): s is CommandStep => 'command' in s);
+
+    if (platform === 'gitlab') {
+      const script = commandSteps.map((step) => `npx harness ${step.command}${severityFlag}`);
+      const rules = buildGitLabRules(persona.triggers);
+      const enforce: Record<string, unknown> = {
+        image: 'node:20',
+        ...(rules.length ? { rules } : {}),
+        before_script: ['corepack enable', 'pnpm install --frozen-lockfile'],
+        // GitLab requires a non-empty `script`; fall back to a no-op when a
+        // persona has only skill steps (which CI cannot run).
+        script: script.length ? script : ['echo "No command steps to run in CI"'],
+      };
+      const pipeline = {
+        workflow: { name: persona.name },
+        enforce,
+      };
+      return Ok(YAML.stringify(pipeline, { lineWidth: 0 }));
+    }
+
     const steps: Record<string, unknown>[] = [
       { uses: 'actions/checkout@v4' },
       { uses: 'actions/setup-node@v4', with: { 'node-version': '20' } },
       { uses: 'pnpm/action-setup@v4', with: { run_install: 'frozen' } },
     ];
-
-    // Only emit command steps in CI (skill steps require AI agent runtime)
-    const commandSteps = persona.steps.filter((s): s is CommandStep => 'command' in s);
-
     for (const step of commandSteps) {
-      const severityFlag = severity ? ` --severity ${severity}` : '';
       steps.push({ run: `npx harness ${step.command}${severityFlag}` });
     }
 

--- a/packages/cli/tests/commands/persona/generate.test.ts
+++ b/packages/cli/tests/commands/persona/generate.test.ts
@@ -94,6 +94,14 @@ describe('persona generate command', () => {
       const opt = cmd.options.find((o) => o.long === '--only');
       expect(opt).toBeDefined();
     });
+
+    it('has --platform option defaulting to github', () => {
+      const cmd = createGenerateCommand();
+      const opt = cmd.options.find((o) => o.long === '--platform');
+      expect(opt).toBeDefined();
+      expect(opt?.defaultValue).toBe('github');
+      expect(opt?.argChoices).toEqual(['github', 'gitlab']);
+    });
   });
 
   describe('action handler', () => {
@@ -190,6 +198,35 @@ describe('persona generate command', () => {
       expect(mockedGenerateRuntime).not.toHaveBeenCalled();
       expect(mockedGenerateAgentsMd).not.toHaveBeenCalled();
       expect(mockedGenerateCIWorkflow).toHaveBeenCalled();
+    });
+
+    it('passes --platform gitlab through and writes a .gitlab-ci.yml fragment', async () => {
+      mockedLoadPersona.mockReturnValue({ ok: true, value: mockPersona } as any);
+      mockedGenerateCIWorkflow.mockReturnValue({ ok: true, value: 'enforce: {}' } as any);
+      const { writeFileSync } = await import('fs');
+
+      const program = createProgram();
+      await expect(
+        program.parseAsync([
+          'node',
+          'test',
+          'persona',
+          'generate',
+          'arch-enforcer',
+          '--only',
+          'ci',
+          '--platform',
+          'gitlab',
+        ])
+      ).rejects.toThrow('process.exit');
+
+      expect(mockExit).toHaveBeenCalledWith(0);
+      expect(mockedGenerateCIWorkflow).toHaveBeenCalledWith(mockPersona, 'gitlab');
+      const writtenPaths = vi.mocked(writeFileSync).mock.calls.map((c) => String(c[0]));
+      expect(writtenPaths.some((p) => p.endsWith('architecture-enforcer.gitlab-ci.yml'))).toBe(
+        true
+      );
+      expect(writtenPaths.some((p) => p.includes('.github/workflows'))).toBe(false);
     });
 
     it('suppresses output when --quiet is set', async () => {

--- a/packages/cli/tests/persona/generators/ci-workflow.test.ts
+++ b/packages/cli/tests/persona/generators/ci-workflow.test.ts
@@ -92,3 +92,51 @@ describe('generateCIWorkflow', () => {
     expect(runSteps.length).toBe(3); // validate, check-deps, check-docs (no skill)
   });
 });
+
+describe('generateCIWorkflow (gitlab)', () => {
+  it('generates valid GitLab CI YAML with an enforce job', () => {
+    const result = generateCIWorkflow(mockPersona, 'gitlab');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const pipeline = YAML.parse(result.value);
+    expect(pipeline.workflow.name).toBe('Architecture Enforcer');
+    expect(pipeline.enforce.image).toBe('node:20');
+    expect(pipeline.enforce.before_script).toContain('pnpm install --frozen-lockfile');
+  });
+
+  it('maps each command step to a harness script line (skips skill steps)', () => {
+    const result = generateCIWorkflow(mockPersona, 'gitlab');
+    if (!result.ok) return;
+    const pipeline = YAML.parse(result.value);
+    expect(pipeline.enforce.script).toEqual([
+      'npx harness check-deps --severity error',
+      'npx harness validate --severity error',
+    ]);
+  });
+
+  it('translates triggers into rules (MR source, branch match, schedule)', () => {
+    const result = generateCIWorkflow(mockPersona, 'gitlab');
+    if (!result.ok) return;
+    const pipeline = YAML.parse(result.value);
+    const rules = pipeline.enforce.rules as Array<Record<string, unknown>>;
+    expect(rules).toContainEqual({
+      if: '$CI_PIPELINE_SOURCE == "merge_request_event"',
+      changes: ['src/**'],
+    });
+    expect(rules).toContainEqual({ if: '$CI_COMMIT_BRANCH == "main"' });
+    expect(rules).toContainEqual({ if: '$CI_PIPELINE_SOURCE == "schedule"' });
+  });
+
+  it('falls back to a no-op script when a persona has only skill steps', () => {
+    const skillOnly: Persona = {
+      ...mockPersona,
+      version: 2,
+      steps: [{ skill: 'harness-code-review', when: 'on_pr', output: 'auto' }],
+    };
+    const result = generateCIWorkflow(skillOnly, 'gitlab');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const pipeline = YAML.parse(result.value);
+    expect(pipeline.enforce.script).toEqual(['echo "No command steps to run in CI"']);
+  });
+});


### PR DESCRIPTION
Stub #6 from the inventory. `generateCIWorkflow(persona, 'gitlab')` returned `Err('GitLab CI generation is not yet supported')`, and the `platform` parameter was unreachable anyway (every caller hardcoded `'github'`).

## What's implemented
- **GitLab generator** — emits a `.gitlab-ci.yml` fragment: an `enforce` job (`image: node:20`, `corepack enable` + `pnpm install --frozen-lockfile`, one `npx harness <command>` script line per command step). Persona triggers map to GitLab `rules:`:
  - `on_pr` → `$CI_PIPELINE_SOURCE == "merge_request_event"` (+ `changes:` from path globs)
  - `on_commit` → one `$CI_COMMIT_BRANCH == "<branch>"` rule per branch, or `"push"` source when none
  - `scheduled` → `$CI_PIPELINE_SOURCE == "schedule"` (GitLab cron lives in pipeline-schedule settings, not the YAML, so it's intentionally omitted)
  - Skill steps are skipped; a skill-only persona gets a no-op script so the YAML stays valid.
- **Wired it** — `harness persona generate <name> --platform gitlab` writes `<slug>.gitlab-ci.yml`; `--platform github` (default) unchanged.

+4 generator tests, +2 command tests (23 persona tests pass). Changeset + regenerated CLI reference included.