### PR TITLE
feat(core): wire pulse qualityScoring runtime path

### DIFF
--- a/.changeset/pulse-quality-scoring.md
+++ b/.changeset/pulse-quality-scoring.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': patch
+---
+
+Wire the `pulse.qualityScoring` runtime path, which was accepted in config but silently ignored (a `TODO(phase-4.5)` no-op in the orchestrator). When `qualityScoring` is enabled and `qualityDimension` is set, `runPulse` now aggregates that dimension's distribution across every successfully-queried source into a `QualitySummary` (`dimension`, merged bucket→count `distribution`, `total`, contributing `sources`) on the orchestrator result, and the pulse report adds a `quality[<dimension>]: <total> sampled across <n> source(s)` headline. When no source reports the dimension the summary is empty (`total: 0, sources: 0`) rather than crashing. The aggregation deliberately surfaces what the data says about the dimension without imposing a good/bad verdict — the consuming skill or human interprets the distribution. When `qualityScoring` is off, behavior is unchanged (`quality` is absent). Exposes `computeQuality` and the `QualitySummary` type.

--- a/packages/core/src/pulse/index.ts
+++ b/packages/core/src/pulse/index.ts
@@ -21,7 +21,8 @@ export {
   MOCK_ADAPTER_NAME,
 } from './adapters';
 export { runPulse, computeWindow, parseLookback, assembleReport, extractHeadlines } from './run';
-export type { OrchestratorResult } from './run/orchestrator';
+export type { OrchestratorResult, QualitySummary } from './run/orchestrator';
+export { computeQuality } from './run/orchestrator';
 export type {
   PulseConfig,
   PulseSources,

--- a/packages/core/src/pulse/run/orchestrator.test.ts
+++ b/packages/core/src/pulse/run/orchestrator.test.ts
@@ -142,4 +142,64 @@ describe('runPulse orchestrator', () => {
     expect(order.indexOf('d-start')).toBeGreaterThan(order.indexOf('a-end'));
     expect(order.indexOf('d-start')).toBeGreaterThan(order.indexOf('t-end'));
   });
+
+  const withDist = (event: string, dist: SanitizedResult['distributions']): SanitizedResult => ({
+    fields: { event_name: event, count: 1 },
+    distributions: dist,
+  });
+
+  it('omits quality when qualityScoring is disabled', async () => {
+    registerPulseAdapter('mock', {
+      query: async () => ({}),
+      sanitize: () => withDist('x', { sentiment: { good: 3 } }),
+    });
+    const result = await runPulse(
+      { ...baseConfig, qualityScoring: false, qualityDimension: 'sentiment' },
+      computeWindow(new Date(), '24h')
+    );
+    expect(result.quality).toBeUndefined();
+  });
+
+  it('aggregates the configured dimension distribution across sources when enabled', async () => {
+    registerPulseAdapter('a', {
+      query: async () => ({}),
+      sanitize: () => withDist('a', { sentiment: { good: 3, bad: 1 } }),
+    });
+    registerPulseAdapter('t', {
+      query: async () => ({}),
+      sanitize: () => withDist('t', { sentiment: { good: 2 }, other: { x: 9 } }),
+    });
+    const result = await runPulse(
+      {
+        ...baseConfig,
+        qualityScoring: true,
+        qualityDimension: 'sentiment',
+        sources: { analytics: 'a', tracing: 't', payments: null, db: { enabled: false } },
+      },
+      computeWindow(new Date(), '24h')
+    );
+    expect(result.quality).toEqual({
+      dimension: 'sentiment',
+      distribution: { good: 5, bad: 1 },
+      total: 6,
+      sources: 2,
+    });
+  });
+
+  it('returns an empty quality summary when no source reports the dimension', async () => {
+    registerPulseAdapter('mock', {
+      query: async () => ({}),
+      sanitize: () => withDist('x', { other: { x: 1 } }),
+    });
+    const result = await runPulse(
+      { ...baseConfig, qualityScoring: true, qualityDimension: 'sentiment' },
+      computeWindow(new Date(), '24h')
+    );
+    expect(result.quality).toEqual({
+      dimension: 'sentiment',
+      distribution: {},
+      total: 0,
+      sources: 0,
+    });
+  });
 });

--- a/packages/core/src/pulse/run/orchestrator.ts
+++ b/packages/core/src/pulse/run/orchestrator.ts
@@ -28,11 +28,53 @@ export interface SkipRecord {
   reason: string;
 }
 
+/**
+ * Quality sampling on a single configured dimension (`pulse.qualityDimension`),
+ * produced only when `pulse.qualityScoring` is enabled. The named dimension's
+ * per-source distributions are merged into one bucket→count map. This surfaces
+ * *what the data says* about the dimension; it deliberately does not impose a
+ * good/bad verdict — the consuming skill or human interprets the distribution.
+ */
+export interface QualitySummary {
+  /** The configured `qualityDimension` this summary aggregates. */
+  dimension: string;
+  /** Merged bucket→count across every source that reported the dimension. */
+  distribution: Record<string, number>;
+  /** Sum of all bucket counts. */
+  total: number;
+  /** How many queried sources contributed a distribution for the dimension. */
+  sources: number;
+}
+
 export interface OrchestratorResult {
   sources: SourceResult[];
   sourcesQueried: string[];
   sourcesSkipped: SkipRecord[];
   durationMs: number;
+  /** Present only when `pulse.qualityScoring` is enabled (see {@link QualitySummary}). */
+  quality?: QualitySummary;
+}
+
+/**
+ * Merge the named dimension's distribution across all successfully-queried
+ * sources. A source contributes when its sanitized result carries a
+ * `distributions[dimension]` map. When no source reports the dimension the
+ * summary is empty (`total: 0, sources: 0`) so callers can say "no quality data
+ * for <dimension>" rather than crashing.
+ */
+export function computeQuality(dimension: string, sources: SourceResult[]): QualitySummary {
+  const distribution: Record<string, number> = {};
+  let contributing = 0;
+  for (const s of sources) {
+    const dist = s.result.distributions[dimension];
+    if (!dist) continue;
+    contributing++;
+    for (const [bucket, count] of Object.entries(dist)) {
+      distribution[bucket] = (distribution[bucket] ?? 0) + count;
+    }
+  }
+  const total = Object.values(distribution).reduce((sum, n) => sum + n, 0);
+  return { dimension, distribution, total, sources: contributing };
 }
 
 type QueryOutcome =
@@ -127,8 +169,18 @@ export async function runPulse(
     }
   }
 
-  // pulse.qualityScoring runtime path is deferred to a follow-up phase.
-  // TODO(phase-4.5): wire qualityScoring + qualityDimension into orchestrator.
+  // Quality sampling: when enabled with a dimension, aggregate that dimension's
+  // distribution across the queried sources (see computeQuality).
+  const quality =
+    config.qualityScoring && config.qualityDimension
+      ? computeQuality(config.qualityDimension, sources)
+      : undefined;
 
-  return { sources, sourcesQueried, sourcesSkipped, durationMs: Date.now() - startedAt };
+  return {
+    sources,
+    sourcesQueried,
+    sourcesSkipped,
+    durationMs: Date.now() - startedAt,
+    ...(quality ? { quality } : {}),
+  };
 }

--- a/packages/core/src/pulse/run/report.test.ts
+++ b/packages/core/src/pulse/run/report.test.ts
@@ -45,6 +45,20 @@ describe('extractHeadlines', () => {
     // Must NOT include the next section's content.
     expect(headlines).not.toContain('## Usage');
   });
+
+  it('adds a quality headline when a QualitySummary is present', () => {
+    const withQuality: OrchestratorResult = {
+      ...baseResult,
+      quality: { dimension: 'sentiment', distribution: { good: 5, bad: 1 }, total: 6, sources: 2 },
+    };
+    const headlines = extractHeadlines(assembleReport(withQuality, 'TestProduct', '24h'));
+    expect(headlines).toContain('quality[sentiment]: 6 sampled across 2 source(s)');
+  });
+
+  it('omits the quality headline when no QualitySummary is present', () => {
+    const headlines = extractHeadlines(assembleReport(baseResult, 'TestProduct', '24h'));
+    expect(headlines).not.toContain('quality[');
+  });
 });
 
 describe('assembleReport', () => {

--- a/packages/core/src/pulse/run/report.ts
+++ b/packages/core/src/pulse/run/report.ts
@@ -57,11 +57,17 @@ function totalCount(s: SanitizedResult): number {
 
 function buildHeadlines(r: OrchestratorResult): string {
   const total = r.sources.reduce((sum, s) => sum + totalCount(s.result), 0);
-  return [
+  const lines = [
     `- ${r.sourcesQueried.length} source(s) queried in ${r.durationMs}ms`,
     `- ${total} total events recorded`,
     `- ${r.sourcesSkipped.length} source(s) skipped`,
-  ].join('\n');
+  ];
+  if (r.quality) {
+    lines.push(
+      `- quality[${r.quality.dimension}]: ${r.quality.total} sampled across ${r.quality.sources} source(s)`
+    );
+  }
+  return lines.join('\n');
 }
 
 function buildUsage(r: OrchestratorResult): string {


### PR DESCRIPTION
Stub #9 from the inventory. `pulse.qualityScoring` / `qualityDimension` were validated into config but the runtime path was a `TODO(phase-4.5)` no-op — the orchestrator accepted the fields and silently ignored them.

## What's implemented
When `qualityScoring` is enabled with a `qualityDimension`, `runPulse` aggregates that dimension's distribution across every successfully-queried source into a `QualitySummary`:
- `dimension`, merged bucket→count `distribution`, `total`, and contributing `sources` count.
- The pulse report adds a headline: `quality[<dimension>]: <total> sampled across <n> source(s)`.
- No source reports the dimension → empty summary (`total: 0, sources: 0`), not a crash.
- `qualityScoring` off → `quality` absent; behavior unchanged.

The aggregation faithfully implements the phase-3 plan's *"quality sampling on a single dimension"* — it surfaces what the data says about the dimension and leaves good/bad interpretation to the consuming skill/human (the dimension is free-text by design), rather than fabricating a verdict semantics that isn't specified.

## Tests
+3 orchestrator tests (disabled→absent, multi-source aggregation, dimension-absent→empty) and +2 report tests (headline present/absent). All 18 pulse tests pass. Exposes `computeQuality` + `QualitySummary`. Changeset included.