### PR TITLE
feat(cli): implement roadmap migrate --to=file-backed (reverse migration)

### DIFF
--- a/.changeset/roadmap-reverse-migration.md
+++ b/.changeset/roadmap-reverse-migration.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Implement `harness roadmap migrate --to=file-backed` (reverse migration), which previously errored `--to=file-backed reverse migration is not yet implemented`. It is the inverse of the forward (file-backed → file-less) migration: it fetches every feature from the configured tracker, reconstructs a `docs/roadmap.md` (grouping features by milestone, with un-milestoned features in a Backlog section), and flips `roadmap.mode` back to `file-backed` after taking a byte-identical `harness.config.json.pre-migration` backup — mirroring the forward path's config rewrite.
+
+Safety: it short-circuits to `already-migrated` when the project is already file-backed, refuses to overwrite an existing `docs/roadmap.md` (the file-less invariant is that the file must not exist), and honors `--dry-run` (prints the plan, writes nothing) and `--format=json`. Exposes `featuresToRoadmap` for reuse/testing.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1059,7 +1059,7 @@ Migrate the project roadmap to a different storage mode
 
 **Options:**
 
-- `--to` — Migration target (only "file-less" supported today)
+- `--to` — Migration target: "file-less" or "file-backed"
 - `--dry-run` — Print the migration plan without making any changes
 - `--format` — Output format: "human" (default) or "json" (single JSON object for CI consumers) (default: "human")
 

--- a/packages/cli/src/commands/roadmap/migrate.ts
+++ b/packages/cli/src/commands/roadmap/migrate.ts
@@ -6,12 +6,19 @@ import {
   Ok,
   Err,
   parseRoadmap,
+  serializeRoadmap,
   loadProjectRoadmapMode,
   loadTrackerClientConfigFromProject,
   createTrackerClient,
   migrate,
 } from '@harness-engineering/core';
-import type { Result, RoadmapTrackerClient, TrackedFeature } from '@harness-engineering/core';
+import type {
+  Result,
+  RoadmapTrackerClient,
+  TrackedFeature,
+  Roadmap,
+  RoadmapFeature,
+} from '@harness-engineering/core';
 import { logger } from '../../output/logger';
 import { CLIError, ExitCode } from '../../utils/errors';
 import { acquireMigrateLock, isRefusal } from './migrate-lock';
@@ -230,15 +237,10 @@ export async function runRoadmapMigrate(
   if (!opts.to) {
     return Err(new CLIError('missing required argument: --to <target>', ExitCode.ERROR));
   }
-  // REV-P5-S5: accept --to=file-backed as a recognized-but-not-yet-implemented
-  // target so the flag validator does not bury the failure as "unsupported
-  // target". Reverse migration (file-less -> file-backed) is a future spec.
+  // Reverse migration: file-less -> file-backed (reconstruct docs/roadmap.md
+  // from the tracker and flip the config mode back).
   if (opts.to === 'file-backed') {
-    return Err(
-      new CLIError(
-        '--to=file-backed reverse migration is not yet implemented; track in a future spec'
-      )
-    );
+    return runReverseMigrate(opts);
   }
   if (opts.to !== 'file-less') {
     return Err(
@@ -348,10 +350,204 @@ export async function runRoadmapMigrate(
   }
 }
 
+/**
+ * Reconstruct a file-backed Roadmap from tracker features. `TrackedFeature` is
+ * nearly a superset of `RoadmapFeature`; the only structural work is grouping by
+ * milestone (a null milestone becomes the special Backlog section) in first-seen
+ * order, with Backlog sorted last for a conventional layout.
+ */
+export function featuresToRoadmap(
+  features: TrackedFeature[],
+  project: string,
+  nowIso: string
+): Roadmap {
+  const order: string[] = [];
+  const byMilestone = new Map<string, RoadmapFeature[]>();
+  for (const f of features) {
+    const key = f.milestone ?? 'Backlog';
+    let bucket = byMilestone.get(key);
+    if (!bucket) {
+      bucket = [];
+      byMilestone.set(key, bucket);
+      order.push(key);
+    }
+    bucket.push({
+      name: f.name,
+      status: f.status,
+      spec: f.spec,
+      plans: f.plans,
+      blockedBy: f.blockedBy,
+      summary: f.summary,
+      assignee: f.assignee,
+      priority: f.priority,
+      externalId: f.externalId,
+      updatedAt: f.updatedAt,
+    });
+  }
+  // Array.sort is stable in V8, so non-Backlog milestones keep first-seen order
+  // while Backlog is pushed to the end.
+  order.sort((a, b) => (a === 'Backlog' ? 1 : b === 'Backlog' ? -1 : 0));
+  const milestones = order.map((name) => ({
+    name,
+    isBacklog: name === 'Backlog',
+    features: byMilestone.get(name) ?? [],
+  }));
+  return {
+    frontmatter: { project, version: 1, lastSynced: nowIso, lastManualEdit: nowIso },
+    milestones,
+    assignmentHistory: [],
+  };
+}
+
+/** Read the project name from harness.config.json (`name`), defaulting to "Roadmap". */
+function readProjectName(configPath: string): string {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as { name?: unknown };
+    return typeof parsed.name === 'string' && parsed.name.length > 0 ? parsed.name : 'Roadmap';
+  } catch {
+    return 'Roadmap';
+  }
+}
+
+function emitReverseReport(
+  report: migrate.MigrationReport,
+  count: number,
+  isJson: boolean,
+  dryRun: boolean
+): void {
+  if (isJson) {
+    console.log(
+      JSON.stringify(buildJsonOutput(undefined, report, undefined, MigrateExitCode.SUCCESS))
+    );
+    return;
+  }
+  if (dryRun) {
+    console.log(`${chalk.cyan('DRY RUN ')}Reverse migration plan:`);
+    console.log(`  Would write docs/roadmap.md with ${count} feature(s)`);
+    console.log('  Would set roadmap.mode = "file-backed"');
+    return;
+  }
+  printReport(report);
+}
+
+/**
+ * Reverse migration: file-less -> file-backed.
+ *
+ * Inverse of the forward migration — instead of pushing roadmap.md into the
+ * tracker, it pulls the tracker's features back into a freshly serialized
+ * `docs/roadmap.md` and flips `roadmap.mode` to `file-backed` (byte-identical
+ * config backup first, mirroring the forward path). Refuses to clobber an
+ * existing roadmap.md (the file-less invariant is that it must not exist).
+ */
+export async function runReverseMigrate(
+  opts: RoadmapMigrateOptions
+): Promise<Result<migrate.MigrationReport, CLIError>> {
+  const cwd = opts.cwd ?? process.cwd();
+  const isJson = (opts.format ?? 'human') === 'json';
+
+  // Already file-backed -> nothing to reverse.
+  if (loadProjectRoadmapMode(cwd) === 'file-backed') {
+    const report: migrate.MigrationReport = {
+      created: 0,
+      updated: 0,
+      unchanged: 0,
+      historyAppended: 0,
+      archivedFrom: null,
+      archivedTo: null,
+      configBackup: null,
+      mode: 'already-migrated',
+    };
+    if (isJson) {
+      console.log(
+        JSON.stringify(buildJsonOutput(undefined, report, undefined, MigrateExitCode.SUCCESS))
+      );
+    } else {
+      logger.success('Already file-backed; nothing to do.');
+    }
+    return Ok(report);
+  }
+
+  const lockResult = acquireMigrateLock(cwd);
+  if (isRefusal(lockResult)) return Err(new CLIError(lockResult.message));
+  try {
+    // The file-less invariant is that docs/roadmap.md does not exist; refuse to
+    // overwrite a stray one rather than silently clobbering manual edits.
+    const roadmapPath = path.join(cwd, 'docs', 'roadmap.md');
+    if (fs.existsSync(roadmapPath)) {
+      return Err(
+        new CLIError(`docs/roadmap.md already exists; refusing to overwrite (${roadmapPath})`)
+      );
+    }
+
+    // Tracker client (injected for tests, else built from project config).
+    let client: RoadmapTrackerClient;
+    if (opts.client) {
+      client = opts.client;
+    } else {
+      const cfgR = loadTrackerClientConfigFromProject(cwd);
+      if (!cfgR.ok) return Err(new CLIError(cfgR.error.message));
+      const clientR = createTrackerClient(cfgR.value);
+      if (!clientR.ok) return Err(new CLIError(clientR.error.message));
+      client = clientR.value;
+    }
+
+    const fetchR = await client.fetchAll();
+    if (!fetchR.ok) {
+      return Err(new CLIError(`failed to fetch tracker features: ${fetchR.error.message}`));
+    }
+    const features = fetchR.value.features;
+
+    const configPath = path.join(cwd, 'harness.config.json');
+    const project = readProjectName(configPath);
+    const nowIso = new Date().toISOString();
+    const markdown = serializeRoadmap(featuresToRoadmap(features, project, nowIso));
+
+    const report: migrate.MigrationReport = {
+      created: features.length,
+      updated: 0,
+      unchanged: 0,
+      historyAppended: 0,
+      archivedFrom: null,
+      archivedTo: null,
+      configBackup: null,
+      mode: opts.dryRun ? 'dry-run' : 'applied',
+    };
+
+    if (opts.dryRun) {
+      emitReverseReport(report, features.length, isJson, true);
+      return Ok(report);
+    }
+
+    // Write the reconstructed roadmap.
+    fs.mkdirSync(path.dirname(roadmapPath), { recursive: true });
+    fs.writeFileSync(roadmapPath, markdown);
+    report.archivedTo = roadmapPath;
+
+    // Config: backup, then flip roadmap.mode -> file-backed (mirrors forward).
+    if (fs.existsSync(configPath)) {
+      const original = fs.readFileSync(configPath, 'utf-8');
+      const configBackupPath = path.join(cwd, 'harness.config.json.pre-migration');
+      fs.writeFileSync(configBackupPath, original);
+      report.configBackup = configBackupPath;
+      const parsed = JSON.parse(original) as Record<string, unknown>;
+      const roadmapSection: Record<string, unknown> =
+        (parsed.roadmap as Record<string, unknown> | undefined) ?? {};
+      roadmapSection.mode = 'file-backed';
+      parsed.roadmap = roadmapSection;
+      fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n');
+    }
+
+    emitReverseReport(report, features.length, isJson, false);
+    return Ok(report);
+  } finally {
+    lockResult.release();
+  }
+}
+
 export function createRoadmapMigrateCommand(): Command {
   return new Command('migrate')
     .description('Migrate the project roadmap to a different storage mode')
-    .requiredOption('--to <target>', 'Migration target (only "file-less" supported today)')
+    .requiredOption('--to <target>', 'Migration target: "file-less" or "file-backed"')
     .option('--dry-run', 'Print the migration plan without making any changes', false)
     .option(
       '--format <fmt>',

--- a/packages/cli/tests/commands/roadmap/migrate.test.ts
+++ b/packages/cli/tests/commands/roadmap/migrate.test.ts
@@ -12,6 +12,7 @@ import {
   runRoadmapMigrate,
   reportToExitCode,
   MigrateExitCode,
+  featuresToRoadmap,
 } from '../../../src/commands/roadmap/migrate';
 
 function baseFeature(name: string, externalId: string): TrackedFeature {
@@ -48,6 +49,10 @@ function happyClient(): RoadmapTrackerClient {
     appendHistory: async () => Ok(undefined),
     fetchHistory: async () => Ok([]),
   };
+}
+
+function featureClient(features: TrackedFeature[]): RoadmapTrackerClient {
+  return { ...happyClient(), fetchAll: async () => Ok({ features, etag: null }) };
 }
 
 function throwingClient(): RoadmapTrackerClient {
@@ -485,21 +490,104 @@ describe('runRoadmapMigrate', () => {
     expect(result.ok).toBe(true);
     expect(fs.existsSync(path.join(cwd, '.harness', 'migrate.lock'))).toBe(false);
   });
+});
 
-  it('REV-P5-S5: --to=file-backed → recognized but not-yet-implemented error', async () => {
-    // Future-proofing: reverse migration is a recognized direction but not
-    // implemented in this release. The error must be specific (not the
-    // generic "unsupported target") so operators can find tracking docs.
-    cwd = makeProject();
+describe('runRoadmapMigrate --to=file-backed (reverse)', () => {
+  let cwd: string;
+  afterEach(() => {
+    if (cwd) fs.rmSync(cwd, { recursive: true, force: true });
+    cwd = '';
+  });
+
+  const feats = (): TrackedFeature[] => [
+    { ...baseFeature('Alpha', 'github:o/r#1'), milestone: 'MVP', status: 'in-progress' },
+    { ...baseFeature('Beta', 'github:o/r#2'), milestone: null },
+  ];
+
+  it('--dry-run reports dry-run and writes nothing (config stays file-less)', async () => {
+    cwd = makeProject({ mode: 'file-less', withRoadmap: false });
+    const result = await runRoadmapMigrate({
+      to: 'file-backed',
+      dryRun: true,
+      cwd,
+      client: featureClient(feats()),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.mode).toBe('dry-run');
+    expect(fs.existsSync(path.join(cwd, 'docs', 'roadmap.md'))).toBe(false);
+    const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'harness.config.json'), 'utf-8'));
+    expect(cfg.roadmap.mode).toBe('file-less');
+  });
+
+  it('applied: writes a round-trippable roadmap.md, flips mode, backs up config', async () => {
+    cwd = makeProject({ mode: 'file-less', withRoadmap: false });
     const result = await runRoadmapMigrate({
       to: 'file-backed',
       dryRun: false,
       cwd,
-      client: happyClient(),
+      client: featureClient(feats()),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.mode).toBe('applied');
+    expect(result.value.created).toBe(2);
+
+    const md = fs.readFileSync(path.join(cwd, 'docs', 'roadmap.md'), 'utf-8');
+    expect(md).toContain('### Alpha');
+    expect(md).toContain('### Beta');
+    expect(md).toContain('## MVP');
+    expect(md).toContain('## Backlog');
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(cwd, 'harness.config.json'), 'utf-8'));
+    expect(cfg.roadmap.mode).toBe('file-backed');
+    expect(fs.existsSync(path.join(cwd, 'harness.config.json.pre-migration'))).toBe(true);
+    expect(result.value.configBackup).toContain('pre-migration');
+  });
+
+  it('already file-backed → already-migrated, no roadmap.md written', async () => {
+    cwd = makeProject({ mode: 'file-backed', withRoadmap: false });
+    const result = await runRoadmapMigrate({
+      to: 'file-backed',
+      dryRun: false,
+      cwd,
+      client: featureClient(feats()),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.mode).toBe('already-migrated');
+    expect(fs.existsSync(path.join(cwd, 'docs', 'roadmap.md'))).toBe(false);
+  });
+
+  it('refuses to overwrite an existing docs/roadmap.md', async () => {
+    cwd = makeProject({ mode: 'file-less', withRoadmap: true });
+    const result = await runRoadmapMigrate({
+      to: 'file-backed',
+      dryRun: false,
+      cwd,
+      client: featureClient(feats()),
     });
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.message).toMatch(/reverse migration is not yet implemented/i);
-    expect(result.error.message).not.toMatch(/unsupported (migration )?target/i);
+    expect(result.error.message).toMatch(/already exists; refusing to overwrite/i);
+  });
+});
+
+describe('featuresToRoadmap', () => {
+  it('groups features by milestone with Backlog last and preserves data', () => {
+    const rm = featuresToRoadmap(
+      [
+        { ...baseFeature('Alpha', 'x#1'), milestone: 'MVP' },
+        { ...baseFeature('Beta', 'x#2'), milestone: null },
+        { ...baseFeature('Gamma', 'x#3'), milestone: 'MVP' },
+      ],
+      'Proj',
+      '2026-06-28T00:00:00Z'
+    );
+    expect(rm.milestones.map((m) => m.name)).toEqual(['MVP', 'Backlog']);
+    expect(rm.milestones[0]?.features.map((f) => f.name)).toEqual(['Alpha', 'Gamma']);
+    expect(rm.milestones[1]?.isBacklog).toBe(true);
+    expect(rm.frontmatter.project).toBe('Proj');
+    expect(rm.milestones[0]?.features[0]?.externalId).toBe('x#1');
   });
 });


### PR DESCRIPTION
Stub #4 from the inventory. `harness roadmap migrate --to=file-backed` errored `reverse migration is not yet implemented; track in a future spec`.

## What's implemented
It's the inverse of the forward (file-backed → file-less) migration:
1. Fetches every feature from the configured tracker (`client.fetchAll()`).
2. Reconstructs `docs/roadmap.md` via `featuresToRoadmap` → `serializeRoadmap` — features grouped by `milestone` (first-seen order; un-milestoned features land in a **Backlog** section sorted last). `TrackedFeature` is ~1:1 with `RoadmapFeature`.
3. Flips `roadmap.mode` back to `file-backed` after a byte-identical `harness.config.json.pre-migration` backup — mirroring the forward path's config rewrite.

## Safety
- Short-circuits to `already-migrated` when the project is already file-backed.
- Refuses to overwrite an existing `docs/roadmap.md` (the file-less invariant is that the file must not exist).
- Honors `--dry-run` (prints the plan, writes nothing) and `--format=json`.

## Tests
+5 command tests (dry-run, applied+config-flip+backup, already-migrated, refuse-overwrite) and a `featuresToRoadmap` unit test (milestone grouping, Backlog last, data preserved). All 40 roadmap tests pass. Changeset + regenerated CLI reference included.