### PR TITLE
feat(orchestrator): SSE Last-Event-ID reconnection with replay buffer

### DIFF
--- a/.changeset/sse-reconnection.md
+++ b/.changeset/sse-reconnection.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Implement `Last-Event-ID` reconnection for the `GET /api/v1/events` SSE stream, which was deferred ("clients lose events across reconnects"). Previously each frame carried a _random_ `id`, so a reconnecting client's `Last-Event-ID` pointed at nothing replayable.
+
+A per-bus `SseEventLog` is now the single subscriber to the event bus: it stamps every event with a monotonic, gap-free sequence id, keeps the most recent events in a bounded in-memory ring buffer (default 1024), and fans them out to connected streams. A client that reconnects with `Last-Event-ID: <seq>` (browser `EventSource` sends this automatically) replays every buffered event strictly after that id — with no gap and no duplicate — before live delivery resumes. A non-numeric/absent `Last-Event-ID` (e.g. a legacy client) resumes live with no replay. The buffer is in-memory and bounded, so a server restart or an outage longer than the buffer simply resumes live from the next event, exactly like a first-time connection; the wire contract is unchanged so a durable store can replace the ring buffer later.

--- a/packages/orchestrator/src/server/http-v1-aliases.test.ts
+++ b/packages/orchestrator/src/server/http-v1-aliases.test.ts
@@ -269,7 +269,7 @@ describe('v1 bridge primitives — HTTP integration through dispatchAuthedReques
             // Once we've seen at least one framed event, we're done.
             if (buf.includes('event: state_change')) {
               expect(buf).toContain('"ping":"integration-test"');
-              expect(buf).toMatch(/id: evt_[a-f0-9]+/);
+              expect(buf).toMatch(/id: \d+/);
               r.destroy(); // close the SSE stream
               resolve();
             }

--- a/packages/orchestrator/src/server/routes/v1/events-sse.test.ts
+++ b/packages/orchestrator/src/server/routes/v1/events-sse.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { Socket } from 'node:net';
-import { handleV1EventsSseRoute } from './events-sse';
+import { handleV1EventsSseRoute, getSseEventLog } from './events-sse';
 
 function makeReqRes(
   method: string,
@@ -44,7 +44,7 @@ describe('GET /api/v1/events SSE', () => {
     expect(chunks.some((c) => c.startsWith(':'))).toBe(true);
   });
 
-  it('emits an event frame when emitter fires a subscribed topic', async () => {
+  it('emits an event frame with a monotonic numeric id when a topic fires', async () => {
     const emitter = new EventEmitter();
     const { req, res, chunks } = makeReqRes('GET', '/api/v1/events');
     handleV1EventsSseRoute(req, res, emitter);
@@ -53,15 +53,76 @@ describe('GET /api/v1/events SSE', () => {
     const joined = chunks.join('');
     expect(joined).toMatch(/event: interaction\.created\n/);
     expect(joined).toMatch(/data: \{"id":"int_abc",.+\}\n/);
-    expect(joined).toMatch(/id: evt_[a-f0-9]{16}\n\n/);
+    expect(joined).toMatch(/id: \d+\n\n/);
   });
 
-  it('removes listeners on client disconnect', () => {
+  it('assigns strictly increasing ids across events', async () => {
     const emitter = new EventEmitter();
-    const { req, res } = makeReqRes('GET', '/api/v1/events');
+    const { req, res, chunks } = makeReqRes('GET', '/api/v1/events');
     handleV1EventsSseRoute(req, res, emitter);
-    const before = emitter.listenerCount('state_change');
+    emitter.emit('state_change', { a: 1 });
+    emitter.emit('state_change', { a: 2 });
+    await new Promise((r) => setImmediate(r));
+    const ids = [...chunks.join('').matchAll(/id: (\d+)\n\n/g)].map((m) => Number(m[1]));
+    expect(ids).toHaveLength(2);
+    expect(ids[1]).toBeGreaterThan(ids[0]!);
+  });
+
+  it('stops delivering to a disconnected client (subscription cleanup)', async () => {
+    const emitter = new EventEmitter();
+    const { req, res, chunks } = makeReqRes('GET', '/api/v1/events');
+    handleV1EventsSseRoute(req, res, emitter);
     res.emit('close');
-    expect(emitter.listenerCount('state_change')).toBe(before - 1);
+    emitter.emit('state_change', { after: 'close' });
+    await new Promise((r) => setImmediate(r));
+    expect(chunks.join('')).not.toContain('after');
+  });
+
+  it('replays buffered events after Last-Event-ID on reconnect', async () => {
+    const emitter = new EventEmitter();
+    // First connection: receives three events and notes the first id.
+    const first = makeReqRes('GET', '/api/v1/events');
+    handleV1EventsSseRoute(first.req, first.res, emitter);
+    emitter.emit('state_change', { n: 1 });
+    emitter.emit('state_change', { n: 2 });
+    emitter.emit('state_change', { n: 3 });
+    await new Promise((r) => setImmediate(r));
+    const ids = [...first.chunks.join('').matchAll(/id: (\d+)\n\n/g)].map((m) => Number(m[1]));
+    expect(ids).toHaveLength(3);
+    first.res.emit('close');
+
+    // Reconnect with Last-Event-ID = id of event #1: must replay #2 and #3 only.
+    const resume = makeReqRes('GET', '/api/v1/events', { 'last-event-id': String(ids[0]) });
+    handleV1EventsSseRoute(resume.req, resume.res, emitter);
+    const replayed = resume.chunks.join('');
+    expect(replayed).toContain('"n":2');
+    expect(replayed).toContain('"n":3');
+    expect(replayed).not.toContain('"n":1');
+  });
+
+  it('without Last-Event-ID, a fresh connection replays nothing', async () => {
+    const emitter = new EventEmitter();
+    const warmup = makeReqRes('GET', '/api/v1/events');
+    handleV1EventsSseRoute(warmup.req, warmup.res, emitter);
+    emitter.emit('state_change', { historical: true });
+    await new Promise((r) => setImmediate(r));
+    warmup.res.emit('close');
+
+    const fresh = makeReqRes('GET', '/api/v1/events');
+    handleV1EventsSseRoute(fresh.req, fresh.res, emitter);
+    expect(fresh.chunks.join('')).not.toContain('historical');
+  });
+
+  it('ignores a non-numeric Last-Event-ID (legacy client) and resumes live', async () => {
+    const emitter = new EventEmitter();
+    const log = getSseEventLog(emitter);
+    log.replayFrom(0); // touch the log so it exists for this bus
+    const { req, res, chunks } = makeReqRes('GET', '/api/v1/events', {
+      'last-event-id': 'evt_deadbeefdeadbeef',
+    });
+    expect(() => handleV1EventsSseRoute(req, res, emitter)).not.toThrow();
+    emitter.emit('state_change', { live: true });
+    await new Promise((r) => setImmediate(r));
+    expect(chunks.join('')).toContain('live');
   });
 });

--- a/packages/orchestrator/src/server/routes/v1/events-sse.ts
+++ b/packages/orchestrator/src/server/routes/v1/events-sse.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { EventEmitter } from 'node:events';
-import { randomBytes } from 'node:crypto';
+import { EventEmitter } from 'node:events';
 
 /**
  * Event-bus topics the SSE handler subscribes to. Mirrors the WebSocket
@@ -24,8 +23,97 @@ const SSE_TOPICS = [
 
 const HEARTBEAT_MS = 15_000;
 
-function newEventId(): string {
-  return `evt_${randomBytes(8).toString('hex')}`;
+/** Default ring-buffer capacity for `Last-Event-ID` replay. */
+const DEFAULT_REPLAY_BUFFER = 1024;
+
+interface SseEvent {
+  /** Monotonic, gap-free sequence id (1-based). Serialized as the SSE `id:`. */
+  id: number;
+  topic: string;
+  data: unknown;
+}
+
+/**
+ * Per-bus event recorder backing `Last-Event-ID` reconnection.
+ *
+ * The original handler stamped each frame with a *random* id, so a reconnecting
+ * client's `Last-Event-ID` pointed at nothing replayable. This log is the single
+ * subscriber to the bus: it assigns every event a monotonic id, keeps the most
+ * recent `cap` events in a ring buffer, and fans them out to connected streams.
+ * A reconnecting client replays the buffered tail strictly after its last id,
+ * then resumes live — with no gap and no duplicate.
+ *
+ * The buffer is in-memory and bounded, so a server restart (or an outage longer
+ * than `cap` events) drops history: such a client simply resumes live from the
+ * next event, exactly as a first-time connection would. A durable store can
+ * replace the ring buffer later without changing the wire contract.
+ */
+export class SseEventLog {
+  private seq = 0;
+  private readonly buffer: SseEvent[] = [];
+  private readonly subscribers = new Set<(e: SseEvent) => void>();
+
+  constructor(bus: EventEmitter, cap: number = DEFAULT_REPLAY_BUFFER) {
+    this.cap = cap;
+    for (const topic of SSE_TOPICS) {
+      bus.on(topic, (data: unknown) => this.record(topic, data));
+    }
+  }
+
+  private readonly cap: number;
+
+  private record(topic: string, data: unknown): void {
+    const event: SseEvent = { id: ++this.seq, topic, data };
+    this.buffer.push(event);
+    if (this.buffer.length > this.cap) this.buffer.shift();
+    for (const fn of this.subscribers) fn(event);
+  }
+
+  /** Highest assigned id (0 when nothing has been recorded yet). */
+  currentSeq(): number {
+    return this.seq;
+  }
+
+  /** Buffered events strictly newer than `lastId`, oldest-first. */
+  replayFrom(lastId: number): SseEvent[] {
+    return this.buffer.filter((e) => e.id > lastId);
+  }
+
+  /** Register a live listener; returns an unsubscribe function. */
+  subscribe(fn: (e: SseEvent) => void): () => void {
+    this.subscribers.add(fn);
+    return () => {
+      this.subscribers.delete(fn);
+    };
+  }
+}
+
+// One log per bus instance — the bus is the orchestrator and lives for the
+// server's lifetime, so the log (and its single set of bus listeners) is a
+// per-server singleton. WeakMap lets test buses be GC'd with their logs.
+const logsByBus = new WeakMap<EventEmitter, SseEventLog>();
+
+/** Get (or lazily create) the replay log for a bus. Exposed for tests. */
+export function getSseEventLog(bus: EventEmitter): SseEventLog {
+  let log = logsByBus.get(bus);
+  if (!log) {
+    log = new SseEventLog(bus);
+    logsByBus.set(bus, log);
+  }
+  return log;
+}
+
+/**
+ * Parse a client's `Last-Event-ID` into a numeric sequence id. Returns null when
+ * absent or non-numeric (e.g. a client that connected before monotonic ids
+ * existed) — such a client resumes live without replay.
+ */
+function parseLastEventId(req: IncomingMessage): number | null {
+  const raw = req.headers['last-event-id'];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === undefined) return null;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 ? n : null;
 }
 
 /**
@@ -34,10 +122,11 @@ function newEventId(): string {
  * Spec D1: SSE stream alongside legacy /ws WebSocket. Each event is framed as:
  *   event: <type>
  *   data: <json>
- *   id: <evt_…>
+ *   id: <seq>
  *
- * Reconnection-via-Last-Event-ID is deferred to Phase 4 when the SQLite
- * webhook queue lands (re-uses the same persistence layer).
+ * Reconnection: a client that sends `Last-Event-ID: <seq>` (the browser
+ * `EventSource` does this automatically) replays every buffered event after that
+ * id before live delivery resumes (see {@link SseEventLog}).
  *
  * Scope: read-telemetry (enforced by dispatchAuthedRequest).
  */
@@ -58,20 +147,31 @@ export function handleV1EventsSseRoute(
   // Initial comment frame opens the stream for the client.
   res.write(`: harness gateway SSE — connected at ${new Date().toISOString()}\n\n`);
 
-  const listeners: Array<{ topic: string; fn: (data: unknown) => void }> = [];
-  for (const topic of SSE_TOPICS) {
-    const fn = (data: unknown): void => {
-      try {
-        const frame =
-          `event: ${topic}\n` + `data: ${JSON.stringify(data)}\n` + `id: ${newEventId()}\n\n`;
-        res.write(frame);
-      } catch {
-        // Connection write failure → unsubscribe on close handler below.
-      }
-    };
-    bus.on(topic, fn);
-    listeners.push({ topic, fn });
+  const log = getSseEventLog(bus);
+
+  const send = (e: SseEvent): void => {
+    try {
+      res.write(`event: ${e.topic}\n` + `data: ${JSON.stringify(e.data)}\n` + `id: ${e.id}\n\n`);
+    } catch {
+      // Connection write failure → unsubscribe on close handler below.
+    }
+  };
+
+  // Replay buffered history after the client's last seen id (if any). Everything
+  // up to and including `replayedThrough` has been sent; the live subscriber
+  // forwards only strictly-newer events, so there is no duplicate and no gap.
+  const lastId = parseLastEventId(req);
+  let replayedThrough = lastId ?? log.currentSeq();
+  if (lastId !== null) {
+    for (const e of log.replayFrom(lastId)) {
+      send(e);
+      replayedThrough = e.id;
+    }
   }
+
+  const unsubscribe = log.subscribe((e) => {
+    if (e.id > replayedThrough) send(e);
+  });
 
   const heartbeat = setInterval(() => {
     try {
@@ -84,7 +184,7 @@ export function handleV1EventsSseRoute(
 
   const cleanup = (): void => {
     clearInterval(heartbeat);
-    for (const { topic, fn } of listeners) bus.removeListener(topic, fn);
+    unsubscribe();
   };
   res.on('close', cleanup);
   res.on('finish', cleanup);


### PR DESCRIPTION
Stub #8 from the inventory. `GET /api/v1/events` deferred `Last-Event-ID` reconnection — and it was impossible anyway because each frame carried a **random** id.

## What's implemented
A per-bus `SseEventLog` is now the single subscriber to the event bus: it stamps every event with a **monotonic, gap-free** sequence id (the SSE `id:`), keeps the recent tail in a **bounded in-memory ring buffer** (default 1024), and fans events out to streams.

On reconnect with `Last-Event-ID: <seq>` (browser `EventSource` sends this automatically), the client **replays buffered events strictly after that id** — no gap, no duplicate (a live-subscriber guard forwards only ids `> replayedThrough`) — then resumes live. A non-numeric/absent header (legacy client) resumes live with no replay. Bounded + in-memory by design: a restart or an over-buffer outage resumes live like a first-time connection; the wire contract is unchanged so a durable store can replace the ring buffer later.

## Tests
+6 unit tests (monotonic ids, increasing-across-events, disconnect cleanup, **replay-after-Last-Event-ID**, fresh-replays-nothing, legacy-non-numeric-id) and updated the end-to-end integration assertion (`id:` is now numeric). Full orchestrator suite green.