### PR TITLE
feat(orchestrator): wire maintenance AgentDispatcher to real agent session

### DIFF
--- a/.changeset/maintenance-agent-dispatcher.md
+++ b/.changeset/maintenance-agent-dispatcher.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Wire the maintenance `AgentDispatcher` to a real agent session. It was a stub that only logged "skill dispatch integration pending" and returned `{ producedCommits: false, fixed: 0 }`, so agent/skill-based maintenance tasks silently did nothing while the check/command runners worked.
+
+A new `createAgentDispatcher` (extracted to `maintenance/agent-dispatcher.ts` for unit-testability) resolves the named backend from `agent.backends` via `createBackend`, drives a multi-turn `AgentRunner` session over the skill prompt in the worktree, and measures the outcome by diffing `HEAD` before/after — commit count (`git rev-list --count`), not the agent's self-report, is the source of truth for `fixed`/`producedCommits`. An unknown/unconfigured backend name degrades to a logged no-op instead of crashing the scheduler.

--- a/packages/orchestrator/src/maintenance/agent-dispatcher.test.ts
+++ b/packages/orchestrator/src/maintenance/agent-dispatcher.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createAgentDispatcher } from './agent-dispatcher';
+import { MockBackend } from '../agent/backends/mock';
+
+const logger = { info: vi.fn(), warn: vi.fn() };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('createAgentDispatcher', () => {
+  it('no-ops (and never touches git) when the backend name is unknown', async () => {
+    const git = vi.fn();
+    const dispatcher = createAgentDispatcher({ resolveBackend: () => null, git, logger });
+
+    const result = await dispatcher.dispatch('harness-arch-fix', 'main', 'missing', '/repo');
+
+    expect(result).toEqual({ producedCommits: false, fixed: 0 });
+    expect(git).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('unknown backend "missing"'),
+      expect.objectContaining({ skill: 'harness-arch-fix' })
+    );
+  });
+
+  it('reports the commit count when HEAD advances during the session', async () => {
+    const revParse = ['sha-before', 'sha-after'];
+    const git = vi.fn((args: string[]) => {
+      if (args[0] === 'rev-parse') return revParse.shift()!;
+      if (args[0] === 'rev-list') return '3';
+      return '';
+    });
+    const dispatcher = createAgentDispatcher({
+      resolveBackend: () => new MockBackend(),
+      git,
+      logger,
+    });
+
+    const result = await dispatcher.dispatch('harness-arch-fix', 'fix/x', 'mock', '/repo');
+
+    expect(result).toEqual({ producedCommits: true, fixed: 3 });
+    expect(git).toHaveBeenCalledWith(['rev-parse', 'HEAD'], '/repo');
+    expect(git).toHaveBeenCalledWith(['rev-list', '--count', 'sha-before..sha-after'], '/repo');
+  });
+
+  it('reports no commits when HEAD is unchanged', async () => {
+    const git = vi.fn(() => 'sha-same'); // rev-parse returns the same sha both times
+    const dispatcher = createAgentDispatcher({
+      resolveBackend: () => new MockBackend(),
+      git,
+      logger,
+    });
+
+    const result = await dispatcher.dispatch('skill', 'b', 'mock', '/repo');
+
+    expect(result).toEqual({ producedCommits: false, fixed: 0 });
+    // rev-list is never needed when HEAD did not move.
+    expect(git).not.toHaveBeenCalledWith(expect.arrayContaining(['rev-list']), expect.anything());
+  });
+
+  it('counts the first commit when the repo had no prior HEAD', async () => {
+    let call = 0;
+    const git = vi.fn((args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        call += 1;
+        if (call === 1) throw new Error('fatal: no HEAD yet'); // empty repo before
+        return 'sha-new'; // a commit exists after
+      }
+      return '';
+    });
+    const dispatcher = createAgentDispatcher({
+      resolveBackend: () => new MockBackend(),
+      git,
+      logger,
+    });
+
+    const result = await dispatcher.dispatch('skill', 'b', 'mock', '/repo');
+
+    expect(result).toEqual({ producedCommits: true, fixed: 1 });
+  });
+});

--- a/packages/orchestrator/src/maintenance/agent-dispatcher.ts
+++ b/packages/orchestrator/src/maintenance/agent-dispatcher.ts
@@ -1,0 +1,137 @@
+import type { AgentBackend, Issue } from '@harness-engineering/types';
+import { AgentRunner } from '../agent/runner';
+import type { AgentDispatcher, AgentDispatchResult } from './task-runner';
+
+/**
+ * Dependencies for {@link createAgentDispatcher}. All side-effecting collaborators
+ * are injected so the dispatcher is unit-testable with a MockBackend and a fake
+ * git seam (no real agent process, no real repository).
+ */
+export interface AgentDispatcherDeps {
+  /**
+   * Resolve a configured backend by name (e.g. `'local'`, `'claude'`). Returns
+   * `null` when the name is unknown/unconfigured — the dispatcher then no-ops
+   * rather than throwing, so a misconfigured maintenance task degrades to
+   * "produced nothing" instead of crashing the scheduler.
+   */
+  resolveBackend: (backendName: string) => AgentBackend | null;
+  /** Run `git <args>` in `cwd`, returning trimmed stdout (throws on failure). */
+  git: (args: string[], cwd: string) => string;
+  /** Max agent turns per dispatch. Defaults to 10. */
+  maxTurns?: number;
+  logger: {
+    info: (message: string, meta?: Record<string, unknown>) => void;
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+/**
+ * A throwaway Issue for the maintenance session. `AgentRunner.runSession` takes an
+ * Issue for telemetry/labelling only (the parameter is otherwise unused), so the
+ * maintenance run synthesizes a minimal one keyed on the branch.
+ */
+function syntheticIssue(branch: string, skill: string): Issue {
+  return {
+    id: `maintenance:${branch}`,
+    identifier: branch,
+    title: `Maintenance: ${skill}`,
+    description: null,
+    priority: null,
+    state: 'in_progress',
+    branchName: branch,
+    url: null,
+    labels: ['maintenance'],
+    blockedBy: [],
+    spec: null,
+    plans: [],
+    createdAt: null,
+    updatedAt: null,
+    externalId: null,
+  };
+}
+
+function buildPrompt(skill: string, promptContext?: string): string {
+  const instruction =
+    `Run the \`${skill}\` skill to detect and fix issues in this repository. ` +
+    `Apply the fixes and commit each logical change. If there is nothing to fix, make no commits.`;
+  return promptContext ? `${promptContext}\n\n${instruction}` : instruction;
+}
+
+/** `git rev-parse HEAD` in cwd, or `null` when there is no commit yet. */
+function headOf(git: AgentDispatcherDeps['git'], cwd: string): string | null {
+  try {
+    return git(['rev-parse', 'HEAD'], cwd) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wire the maintenance {@link AgentDispatcher} to a real agent session.
+ *
+ * Replaces the previous stub (which only logged and returned `producedCommits:
+ * false`). Resolves the named backend, drives a multi-turn {@link AgentRunner}
+ * session over the skill prompt in the worktree, then measures whether the agent
+ * actually committed anything by diffing `HEAD` before/after. Commit count — not
+ * the agent's self-report — is the source of truth for `fixed`.
+ */
+export function createAgentDispatcher(deps: AgentDispatcherDeps): AgentDispatcher {
+  const maxTurns = deps.maxTurns ?? 10;
+
+  const dispatch = async (
+    skill: string,
+    branch: string,
+    backendName: string,
+    cwd: string,
+    options?: { promptContext?: string }
+  ): Promise<AgentDispatchResult> => {
+    const backend = deps.resolveBackend(backendName);
+    if (!backend) {
+      deps.logger.warn(`Maintenance agent dispatch skipped: unknown backend "${backendName}"`, {
+        skill,
+        branch,
+      });
+      return { producedCommits: false, fixed: 0 };
+    }
+
+    const before = headOf(deps.git, cwd);
+
+    const runner = new AgentRunner(backend, { maxTurns });
+    const session = runner.runSession(
+      syntheticIssue(branch, skill),
+      cwd,
+      buildPrompt(skill, options?.promptContext)
+    );
+    // Drain the session to completion. Per-turn AgentEvents are not surfaced
+    // here (the maintenance reporter observes the commit outcome, not the
+    // streaming transcript); we only need the run to finish.
+    let step = await session.next();
+    while (!step.done) step = await session.next();
+
+    const after = headOf(deps.git, cwd);
+    let fixed = 0;
+    if (after && after !== before) {
+      if (before) {
+        try {
+          fixed = parseInt(deps.git(['rev-list', '--count', `${before}..${after}`], cwd), 10) || 0;
+        } catch {
+          fixed = 1; // HEAD moved but the count failed — at least one commit landed.
+        }
+      } else {
+        fixed = 1; // No prior HEAD (empty repo) and now there is one.
+      }
+    }
+
+    const producedCommits = fixed > 0;
+    deps.logger.info('Maintenance agent dispatch complete', {
+      skill,
+      branch,
+      backendName,
+      producedCommits,
+      fixed,
+    });
+    return { producedCommits, fixed };
+  };
+
+  return { dispatch };
+}

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -35,6 +35,9 @@ import { PromptRenderer } from './prompt/renderer';
 import { LocalModelResolver } from './agent/local-model-resolver';
 import { migrateAgentConfig } from './agent/config-migration';
 import { OrchestratorBackendFactory } from './agent/orchestrator-backend-factory';
+import { createBackend } from './agent/backend-factory';
+import { createAgentDispatcher } from './maintenance/agent-dispatcher';
+import { execFileSync } from 'node:child_process';
 import { buildIntelligencePipeline } from './agent/intelligence-factory';
 import { toArray } from './agent/backend-router';
 import { RoutingDecisionBus } from './routing/decision-bus.js';
@@ -694,20 +697,17 @@ export class Orchestrator extends EventEmitter {
       },
     };
 
-    const agentDispatcher: AgentDispatcher = {
-      dispatch: async (skill: string, branch: string, backendName: string, cwd: string) => {
-        logger.info(
-          'Maintenance agent dispatcher invoked (stub — skill dispatch integration pending)',
-          {
-            skill,
-            branch,
-            backendName,
-            cwd,
-          }
-        );
-        return { producedCommits: false, fixed: 0 };
-      },
+    // Resolve a configured backend by name into a live AgentBackend; null when
+    // the maintenance task references a backend that isn't in agent.backends.
+    const resolveBackend = (backendName: string) => {
+      const def = this.getBackends()?.[backendName];
+      return def ? createBackend(def) : null;
     };
+    const agentDispatcher: AgentDispatcher = createAgentDispatcher({
+      resolveBackend,
+      git: (args, cwd) => execFileSync('git', args, { cwd, encoding: 'utf-8' }).toString().trim(),
+      logger,
+    });
 
     const commandExecutor: CommandExecutor = {
       exec: async (command: string[], cwd: string) => {


### PR DESCRIPTION
Stub #5 from the inventory. The maintenance `AgentDispatcher.dispatch` only logged *"skill dispatch integration pending"* and returned `{ producedCommits: false, fixed: 0 }` — so agent/skill-based maintenance tasks silently did nothing (the check/command runners were real; only the agent path no-opped, and it was untested because the task-runner tests inject a mock dispatcher).

## What's implemented
`createAgentDispatcher` (extracted to `maintenance/agent-dispatcher.ts` so it's unit-testable without the whole orchestrator):
- resolves the named backend from `agent.backends` via `createBackend`,
- drives a multi-turn `AgentRunner` session over the skill prompt in the worktree (`cwd`),
- measures the outcome by diffing `HEAD` before/after — **commit count (`git rev-list --count`), not the agent's self-report**, is the source of truth for `fixed`/`producedCommits`.

An unknown/unconfigured backend name degrades to a **logged no-op** instead of crashing the scheduler. All collaborators (backend resolution, git) are injected seams.

## Tests
+4 unit tests (unknown-backend no-op, HEAD-advances→count, HEAD-unchanged→0, empty-repo→first commit) driving a real `AgentRunner` + `MockBackend` with a fake git seam. All 227 maintenance tests pass.