### PR TITLE
feat(cli): implement audit-anatomy JSDoc + DESIGN.md component-type resolvers

### DIFF
--- a/.changeset/audit-anatomy-resolvers.md
+++ b/.changeset/audit-anatomy-resolvers.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Implement the component-type resolver's two explicit-declaration layers for `audit_anatomy`, which were stubbed (`return null` "pending the JSDoc/DESIGN.md parser task") so only the export-name heuristic resolved component types:
+
+- **Layer 1 — JSDoc `@component-type`**: a new dependency-free JSDoc reader (`parsers/jsdoc.ts`) extracts the file's leading doc block (skipping a `use client` banner) and reads the authoritative `@component-type <Type>` self-declaration.
+- **Layer 2 — DESIGN.md `## Component Registry`**: a new parser (`parsers/design-registry.ts`) finds the nearest `DESIGN.md` up the tree and parses its `| Type | File |` registry table, mapping the audited file to its declared type (parsed registries are memoized per DESIGN.md path).
+
+Resolution order is JSDoc → registry → export-name → silent skip (Decision #3). The JSDoc reader also exposes `readJsDocTag` for the repeated `@anatomy-*` tags, groundwork for the anatomy-override and ANAT-P\* pattern layers (still pending). No behavior change for files that rely on the export-name layer.

--- a/packages/cli/src/audit/component-anatomy/parsers/design-registry.ts
+++ b/packages/cli/src/audit/component-anatomy/parsers/design-registry.ts
@@ -1,0 +1,75 @@
+/**
+ * Parser for the optional `## Component Registry` section of DESIGN.md.
+ *
+ * The registry is a markdown table mapping a component Type to the File that
+ * implements it — the component-type resolver's Layer 2 (Decision #3). See
+ * docs/changes/design-pipeline/audit-component-anatomy/proposal.md → "DESIGN.md
+ * schema additions".
+ *
+ *   ## Component Registry
+ *
+ *   | Type   | File                            | Notes    |
+ *   | ------ | ------------------------------- | -------- |
+ *   | Button | packages/ui/src/Button.tsx      |          |
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface RegistryEntry {
+  type: string;
+  /** File path exactly as written in the table (project-relative). */
+  file: string;
+}
+
+/**
+ * Extract the `Type`/`File` rows from a DESIGN.md `## Component Registry` table.
+ * Tolerates extra columns (e.g. Notes), arbitrary heading depth, and the
+ * separator row. Returns `[]` when the section is absent or has no data rows.
+ */
+export function parseComponentRegistry(designMd: string): RegistryEntry[] {
+  const lines = designMd.split('\n');
+  const headingIdx = lines.findIndex((l) => /^#{1,6}\s+Component Registry\b/i.test(l));
+  if (headingIdx === -1) return [];
+
+  const entries: RegistryEntry[] = [];
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    // Stop at the next heading — the section is over.
+    if (/^#{1,6}\s+/.test(line)) break;
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|')) continue;
+    const cells = trimmed
+      .slice(1, trimmed.endsWith('|') ? -1 : undefined)
+      .split('|')
+      .map((c) => c.trim());
+    const [type, file] = cells;
+    if (!type || !file) continue;
+    // Skip the header row and the `---` separator row.
+    if (/^type$/i.test(type) || /^:?-{2,}:?$/.test(type)) continue;
+    entries.push({ type, file });
+  }
+  return entries;
+}
+
+/**
+ * Walk up from `fromPath`'s directory looking for a `DESIGN.md` (case-insensitive
+ * filename). Returns the absolute path of the nearest one, or null. Bounded by
+ * the filesystem root.
+ */
+export function findDesignMd(fromPath: string): string | null {
+  let dir = path.dirname(path.resolve(fromPath));
+  for (;;) {
+    let names: string[];
+    try {
+      names = fs.readdirSync(dir);
+    } catch {
+      names = [];
+    }
+    const hit = names.find((n) => n.toLowerCase() === 'design.md');
+    if (hit) return path.join(dir, hit);
+    const parent = path.dirname(dir);
+    if (parent === dir) return null; // reached filesystem root
+    dir = parent;
+  }
+}

--- a/packages/cli/src/audit/component-anatomy/parsers/jsdoc.ts
+++ b/packages/cli/src/audit/component-anatomy/parsers/jsdoc.ts
@@ -1,0 +1,53 @@
+/**
+ * Minimal JSDoc tag reader for the anatomy resolvers.
+ *
+ * The audit only needs to read a handful of `@anatomy-*` / `@component-type`
+ * tags from the *leading* documentation block of a component file — it does not
+ * need a full JSDoc AST. This extracts that block and reads its tags with small,
+ * dependency-free regexes (the tag grammar is one tag per line; see
+ * docs/changes/design-pipeline/audit-component-anatomy/proposal.md → "JSDoc tag
+ * grammar").
+ */
+
+/**
+ * Return the text inside the first leading `/** ... *\/` block comment, with the
+ * leading ` * ` decoration stripped from each line. Returns null when the file
+ * does not open with a block comment (ignoring a shebang / `use client` banner
+ * and surrounding whitespace).
+ */
+export function extractLeadingJsDoc(source: string): string | null {
+  // Skip an optional shebang, a leading "use client"/"use server" directive,
+  // and whitespace, then require a /** block comment.
+  const re = /^\s*(?:#![^\n]*\n)?\s*(?:['"]use (?:client|server)['"];?\s*)?\s*\/\*\*([\s\S]*?)\*\//;
+  const match = re.exec(source);
+  if (!match) return null;
+  return match[1]!
+    .split('\n')
+    .map((line) => line.replace(/^\s*\*?\s?/, ''))
+    .join('\n')
+    .trim();
+}
+
+/**
+ * Read every value of a JSDoc tag from a doc block, in document order. Each match
+ * is the remainder of the tag's line, trimmed. e.g. for `@anatomy-slot content
+ * required` the value is `content required`.
+ */
+export function readJsDocTag(jsdoc: string, tag: string): string[] {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`@${escaped}\\b[ \\t]*(.*)$`, 'gm');
+  const values: string[] = [];
+  for (const m of jsdoc.matchAll(re)) {
+    values.push((m[1] ?? '').trim());
+  }
+  return values;
+}
+
+/**
+ * Read a single-value tag (the first occurrence), or null when absent/empty.
+ * Used for `@component-type <Type>`.
+ */
+export function readJsDocTagValue(jsdoc: string, tag: string): string | null {
+  const [first] = readJsDocTag(jsdoc, tag);
+  return first ? first : null;
+}

--- a/packages/cli/src/audit/component-anatomy/resolvers/component-type.ts
+++ b/packages/cli/src/audit/component-anatomy/resolvers/component-type.ts
@@ -3,21 +3,22 @@
  *
  * Three-layer stack:
  *   1. JSDoc `@component-type` tag (top of the file) — authoritative
- *      self-declaration. STUB in this MVP — returns null pending the
- *      JSDoc parser task.
+ *      self-declaration, read from the leading doc block.
  *   2. DESIGN.md `## Component Registry` section — explicit
- *      project-level mapping. STUB in this MVP — returns null pending
- *      the DESIGN.md parser task.
+ *      project-level Type→File mapping (nearest DESIGN.md up the tree).
  *   3. Top-level export-name catalog match — `export const Button = ...`
- *      where `Button` is a key in the convention catalog. This is the
- *      implemented layer for the vertical slice; per Decision #3 it
- *      covers ~80% of well-organized React codebases.
+ *      where `Button` is a key in the convention catalog. Per Decision #3
+ *      it covers ~80% of well-organized React codebases.
  *
  * Resolution returns `null` (silent skip) when no layer matches — per
  * Decision #3 the audit deliberately does NOT guess.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { getCatalogTypes } from '../catalog/index.js';
+import { extractLeadingJsDoc, readJsDocTagValue } from '../parsers/jsdoc.js';
+import { parseComponentRegistry, findDesignMd } from '../parsers/design-registry.js';
 
 /**
  * Catalog of recognised component types, lazily materialised from the
@@ -49,14 +50,47 @@ export function resolveComponentType(filePath: string, fileContents: string): st
   return resolveFromExportName(fileContents);
 }
 
-/** STUB. Returns null until the JSDoc parser task lands. */
-function resolveFromJSDoc(_filePath: string, _fileContents: string): string | null {
-  return null;
+/**
+ * Layer 1: the file's leading JSDoc `@component-type <Type>` self-declaration.
+ * Authoritative when present — returned verbatim (the author owns it); if the
+ * declared type has no convention, the downstream rule resolver skips silently.
+ */
+function resolveFromJSDoc(_filePath: string, fileContents: string): string | null {
+  const jsdoc = extractLeadingJsDoc(fileContents);
+  if (jsdoc === null) return null;
+  return readJsDocTagValue(jsdoc, 'component-type');
 }
 
-/** STUB. Returns null until the DESIGN.md parser task lands. */
-function resolveFromDesignRegistry(_filePath: string): string | null {
-  return null;
+// Parsed `## Component Registry` rows keyed by the DESIGN.md path that produced
+// them — DESIGN.md is static for a process, so memoizing avoids re-reading and
+// re-parsing it on every audited file.
+const registryCache = new Map<string, Map<string, string>>();
+
+/**
+ * Layer 2: the nearest DESIGN.md `## Component Registry` table. Maps the audited
+ * file (matched by its registry `File` path, resolved relative to DESIGN.md's
+ * directory) to its declared `Type`.
+ */
+function resolveFromDesignRegistry(filePath: string): string | null {
+  const designPath = findDesignMd(filePath);
+  if (designPath === null) return null;
+
+  let byFile = registryCache.get(designPath);
+  if (!byFile) {
+    byFile = new Map();
+    let contents: string;
+    try {
+      contents = fs.readFileSync(designPath, 'utf8');
+    } catch {
+      contents = '';
+    }
+    const designDir = path.dirname(designPath);
+    for (const entry of parseComponentRegistry(contents)) {
+      byFile.set(path.resolve(designDir, entry.file), entry.type);
+    }
+    registryCache.set(designPath, byFile);
+  }
+  return byFile.get(path.resolve(filePath)) ?? null;
 }
 
 /**

--- a/packages/cli/tests/audit/component-anatomy/unit/component-type-resolver.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/component-type-resolver.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolveComponentType } from '../../../../src/audit/component-anatomy/resolvers/component-type';
+
+describe('resolveComponentType — JSDoc @component-type (Layer 1)', () => {
+  it('returns the self-declared type from the leading JSDoc', () => {
+    const source = `/**\n * @component-type Button\n */\nexport const Whatever = () => null;\n`;
+    expect(resolveComponentType('/abs/Whatever.tsx', source)).toBe('Button');
+  });
+
+  it('JSDoc wins over the export-name fallback', () => {
+    // Export name would resolve to nothing useful, but the tag is authoritative.
+    const source = `/**\n * @component-type Input\n */\nexport const NotInput = () => null;\n`;
+    expect(resolveComponentType('/abs/NotInput.tsx', source)).toBe('Input');
+  });
+});
+
+describe('resolveComponentType — DESIGN.md Component Registry (Layer 2)', () => {
+  let dir = '';
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = '';
+  });
+
+  it('resolves the type by matching the audited file against the registry', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anat-ct-'));
+    fs.writeFileSync(
+      path.join(dir, 'DESIGN.md'),
+      `## Component Registry\n\n| Type | File | \n| --- | --- |\n| Button | src/widgets/Thing.tsx |\n`
+    );
+    const file = path.join(dir, 'src', 'widgets', 'Thing.tsx');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    // No JSDoc tag and an export name that is not in the catalog → only the
+    // registry can resolve it.
+    fs.writeFileSync(file, 'export const Thing = () => null;\n');
+    expect(resolveComponentType(file, fs.readFileSync(file, 'utf8'))).toBe('Button');
+  });
+
+  it('returns null when neither JSDoc, registry, nor export-name match', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anat-ct-none-'));
+    const file = path.join(dir, 'Mystery.tsx');
+    fs.writeFileSync(file, 'export const Mystery = () => null;\n');
+    expect(resolveComponentType(file, fs.readFileSync(file, 'utf8'))).toBeNull();
+  });
+});

--- a/packages/cli/tests/audit/component-anatomy/unit/design-registry.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/design-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  parseComponentRegistry,
+  findDesignMd,
+} from '../../../../src/audit/component-anatomy/parsers/design-registry';
+
+const DESIGN = `# Design
+
+## Component Registry
+
+| Type   | File                            | Notes    |
+| ------ | ------------------------------- | -------- |
+| Button | packages/ui/src/Button.tsx      |          |
+| Input  | packages/ui/src/Input/index.tsx | compound |
+
+## Something Else
+
+| Type | File |
+| ---- | ---- |
+| Nope | x.ts |
+`;
+
+describe('parseComponentRegistry', () => {
+  it('parses Type/File rows, skipping the header and separator', () => {
+    expect(parseComponentRegistry(DESIGN)).toEqual([
+      { type: 'Button', file: 'packages/ui/src/Button.tsx' },
+      { type: 'Input', file: 'packages/ui/src/Input/index.tsx' },
+    ]);
+  });
+
+  it('stops at the next heading (does not bleed into other tables)', () => {
+    expect(parseComponentRegistry(DESIGN).some((e) => e.type === 'Nope')).toBe(false);
+  });
+
+  it('returns [] when the section is absent', () => {
+    expect(parseComponentRegistry('# Design\n\nNo registry here.')).toEqual([]);
+  });
+});
+
+describe('findDesignMd', () => {
+  let dir = '';
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = '';
+  });
+
+  it('walks up to find the nearest DESIGN.md (case-insensitive)', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anat-reg-'));
+    fs.writeFileSync(path.join(dir, 'DESIGN.md'), DESIGN);
+    const nested = path.join(dir, 'packages', 'ui', 'src');
+    fs.mkdirSync(nested, { recursive: true });
+    const found = findDesignMd(path.join(nested, 'Button.tsx'));
+    expect(found).toBe(path.join(dir, 'DESIGN.md'));
+  });
+
+  it('returns null when no DESIGN.md exists up the tree', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anat-noreg-'));
+    expect(findDesignMd(path.join(dir, 'Button.tsx'))).toBeNull();
+  });
+});

--- a/packages/cli/tests/audit/component-anatomy/unit/jsdoc-parser.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/jsdoc-parser.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractLeadingJsDoc,
+  readJsDocTag,
+  readJsDocTagValue,
+} from '../../../../src/audit/component-anatomy/parsers/jsdoc';
+
+const SOURCE = `/**
+ * Button component.
+ *
+ * @component-type Button
+ * @anatomy-slot content required
+ * @anatomy-slot icon-leading
+ * @anatomy-state disabled exclusive
+ */
+export const Button = () => null;
+`;
+
+describe('extractLeadingJsDoc', () => {
+  it('extracts and de-decorates the leading block comment', () => {
+    const jsdoc = extractLeadingJsDoc(SOURCE);
+    expect(jsdoc).toContain('@component-type Button');
+    expect(jsdoc).toContain('@anatomy-slot content required');
+    expect(jsdoc).not.toContain('*'); // decoration stripped
+  });
+
+  it('skips a leading "use client" directive before the block', () => {
+    const jsdoc = extractLeadingJsDoc(`'use client';\n/**\n * @component-type Input\n */\n`);
+    expect(jsdoc).toContain('@component-type Input');
+  });
+
+  it('returns null when the file does not open with a block comment', () => {
+    expect(extractLeadingJsDoc('export const Button = () => null;')).toBeNull();
+    // A line comment is not a JSDoc block.
+    expect(extractLeadingJsDoc('// @component-type Button\nexport const X = 1;')).toBeNull();
+  });
+});
+
+describe('readJsDocTag / readJsDocTagValue', () => {
+  it('reads all values of a repeated tag in document order', () => {
+    const jsdoc = extractLeadingJsDoc(SOURCE)!;
+    expect(readJsDocTag(jsdoc, 'anatomy-slot')).toEqual(['content required', 'icon-leading']);
+  });
+
+  it('reads the first value of a single-value tag', () => {
+    const jsdoc = extractLeadingJsDoc(SOURCE)!;
+    expect(readJsDocTagValue(jsdoc, 'component-type')).toBe('Button');
+  });
+
+  it('returns [] / null for an absent tag', () => {
+    const jsdoc = extractLeadingJsDoc(SOURCE)!;
+    expect(readJsDocTag(jsdoc, 'anatomy-variant')).toEqual([]);
+    expect(readJsDocTagValue(jsdoc, 'anatomy-variant')).toBeNull();
+  });
+
+  it('does not partial-match a longer tag name', () => {
+    const jsdoc = extractLeadingJsDoc(SOURCE)!;
+    // `anatomy-state` must not be matched when querying `anatomy-st`.
+    expect(readJsDocTag(jsdoc, 'anatomy-st')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Part of stub #3 from the inventory (audit-anatomy). The component-type resolver's two explicit-declaration layers were stubs (`return null` "pending the JSDoc/DESIGN.md parser task"), so only the export-name heuristic resolved component types.

## What's implemented
- **Layer 1 — JSDoc `@component-type`**: a dependency-free JSDoc reader (`parsers/jsdoc.ts`) extracts the file's leading doc block (skipping a `use client` banner) and reads the authoritative `@component-type <Type>` self-declaration.
- **Layer 2 — DESIGN.md `## Component Registry`**: a parser (`parsers/design-registry.ts`) finds the nearest `DESIGN.md` up the tree and parses its `| Type | File |` table, mapping the audited file to its declared type (memoized per DESIGN.md path).

Resolution order is JSDoc → registry → export-name → silent skip (Decision #3). No behavior change for files relying on the export-name layer.

## Scope note
This lands the two component-**type** resolver layers. The `@anatomy-*` JSDoc override resolver, DESIGN.md Anatomy Overrides, and the full **ANAT-P\*** pattern engine remain pending — `readJsDocTag` (which reads the repeated `@anatomy-*` tags) is included here as groundwork for them.

## Tests
+16 unit tests across the JSDoc reader, the registry parser/finder, and the resolver layers (JSDoc-wins, registry-match, none-match→null). All 104 audit-anatomy tests pass.