### PR TITLE
feat(orchestrator): real Linear GraphQL client (replace console.log stub)

### DIFF
--- a/.changeset/linear-graphql-client.md
+++ b/.changeset/linear-graphql-client.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Add a real `LinearGraphQLClient`, replacing the `LinearGraphQLStub` that only `console.log`ged the query and returned an empty object. The client POSTs the operation to Linear's GraphQL endpoint (`https://api.linear.app/graphql`, overridable) with the API key in the `Authorization` header, and normalizes all three failure modes — transport throw, non-2xx HTTP (with a truncated body), and a GraphQL `errors` array — into a single `Err`, returning `Ok(data)` on success. `fetch` is injectable for testing. `LinearGraphQLStub` is retained but `@deprecated`.
+
+Scope note: this is the authenticated GraphQL transport. Wiring a full `linear` tracker _kind_ (mapping Linear issues to `TrackedFeature` and implementing the tracker-client interface) is a larger follow-up that builds on this client.

--- a/packages/orchestrator/src/tracker/extensions/linear.test.ts
+++ b/packages/orchestrator/src/tracker/extensions/linear.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LinearGraphQLClient } from './linear';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('LinearGraphQLClient', () => {
+  it('POSTs the query + variables with the API key and returns data', async () => {
+    const fetchFn = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      jsonResponse({ data: { viewer: { id: 'u1' } } })
+    );
+    const client = new LinearGraphQLClient({ apiKey: 'lin_api_test', fetchFn });
+
+    const result = await client.query('query { viewer { id } }', { x: 1 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({ viewer: { id: 'u1' } });
+
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe('https://api.linear.app/graphql');
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('lin_api_test');
+    expect(JSON.parse(init?.body as string)).toEqual({
+      query: 'query { viewer { id } }',
+      variables: { x: 1 },
+    });
+  });
+
+  it('returns Err on a non-2xx HTTP status with a truncated body', async () => {
+    const fetchFn = vi.fn(async () => new Response('unauthorized', { status: 401 }));
+    const client = new LinearGraphQLClient({ apiKey: 'bad', fetchFn });
+
+    const result = await client.query('query { viewer { id } }');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/HTTP 401/);
+    expect(result.error.message).toMatch(/unauthorized/);
+  });
+
+  it('returns Err when the GraphQL envelope carries errors', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ errors: [{ message: 'Field "nope" not found' }] })
+    );
+    const client = new LinearGraphQLClient({ apiKey: 'k', fetchFn });
+
+    const result = await client.query('query { nope }');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/Field "nope" not found/);
+  });
+
+  it('returns Err when fetch throws (transport failure)', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const client = new LinearGraphQLClient({ apiKey: 'k', fetchFn });
+
+    const result = await client.query('query { viewer { id } }');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toMatch(/request failed.*ECONNREFUSED/);
+  });
+
+  it('honors a custom endpoint', async () => {
+    const fetchFn = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) =>
+      jsonResponse({ data: {} })
+    );
+    const client = new LinearGraphQLClient({
+      apiKey: 'k',
+      endpoint: 'https://proxy.example/graphql',
+      fetchFn,
+    });
+    await client.query('query { __typename }');
+    expect(fetchFn.mock.calls[0]![0]).toBe('https://proxy.example/graphql');
+  });
+});

--- a/packages/orchestrator/src/tracker/extensions/linear.ts
+++ b/packages/orchestrator/src/tracker/extensions/linear.ts
@@ -1,13 +1,107 @@
-import { Result, Ok } from '@harness-engineering/types';
+import { Result, Ok, Err } from '@harness-engineering/types';
 
 /**
- * Interface for Linear GraphQL tool extension.
- * This is a stub implementation for Phase 4.
+ * Interface for a Linear GraphQL tool extension — a thin authenticated client
+ * over Linear's GraphQL API (https://linear.app/developers/graphql).
  */
 export interface LinearGraphQLExtension {
+  /**
+   * Execute a GraphQL operation. Resolves to `Ok(data)` (the `data` object of
+   * the GraphQL envelope) on success, or `Err` on a transport failure, a non-2xx
+   * HTTP status, or a GraphQL `errors` array.
+   */
   query(query: string, variables?: Record<string, unknown>): Promise<Result<unknown, Error>>;
 }
 
+const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql';
+
+export interface LinearGraphQLClientOptions {
+  /**
+   * Linear authentication token. A personal API key is sent verbatim in the
+   * `Authorization` header; an OAuth access token must be passed already prefixed
+   * with `Bearer ` (Linear's two supported schemes).
+   */
+  apiKey: string;
+  /** Override the GraphQL endpoint (e.g. a proxy). Defaults to Linear's API. */
+  endpoint?: string;
+  /** Injectable fetch for tests; defaults to the global `fetch`. */
+  fetchFn?: typeof fetch;
+}
+
+interface GraphQLEnvelope {
+  data?: unknown;
+  errors?: Array<{ message?: string }>;
+}
+
+/**
+ * Real Linear GraphQL client. Replaces {@link LinearGraphQLStub}, which only
+ * logged the query and returned an empty object. POSTs the operation to Linear's
+ * GraphQL endpoint with the API key, and normalizes the three failure modes
+ * (transport throw, non-2xx HTTP, GraphQL `errors`) into a single `Err`.
+ */
+export class LinearGraphQLClient implements LinearGraphQLExtension {
+  private readonly apiKey: string;
+  private readonly endpoint: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(opts: LinearGraphQLClientOptions) {
+    this.apiKey = opts.apiKey;
+    this.endpoint = opts.endpoint ?? LINEAR_GRAPHQL_ENDPOINT;
+    this.fetchFn = opts.fetchFn ?? globalThis.fetch;
+  }
+
+  async query(query: string, variables?: Record<string, unknown>): Promise<Result<unknown, Error>> {
+    let res: Response;
+    try {
+      res = await this.fetchFn(this.endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: this.apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables: variables ?? {} }),
+      });
+    } catch (err) {
+      return Err(
+        new Error(
+          `Linear GraphQL request failed: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      const detail = body ? `: ${body.slice(0, 500)}` : '';
+      return Err(new Error(`Linear GraphQL HTTP ${res.status}${detail}`));
+    }
+
+    let envelope: GraphQLEnvelope;
+    try {
+      envelope = (await res.json()) as GraphQLEnvelope;
+    } catch (err) {
+      return Err(
+        new Error(
+          `Linear GraphQL response was not valid JSON: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        )
+      );
+    }
+
+    if (envelope.errors && envelope.errors.length > 0) {
+      const message = envelope.errors.map((e) => e.message ?? 'unknown error').join('; ');
+      return Err(new Error(`Linear GraphQL error: ${message}`));
+    }
+
+    return Ok(envelope.data ?? {});
+  }
+}
+
+/**
+ * @deprecated Phase-4 placeholder retained for backward compatibility. It logs
+ * the query and returns an empty object; use {@link LinearGraphQLClient} for a
+ * real authenticated client.
+ */
 export class LinearGraphQLStub implements LinearGraphQLExtension {
   async query(
     query: string,


### PR DESCRIPTION
Stub #7 from the inventory. `LinearGraphQLStub` only `console.log`ged the query and returned `{ data: {} }`.

## What's implemented
`LinearGraphQLClient` POSTs the operation to Linear's GraphQL endpoint (`https://api.linear.app/graphql`, overridable) with the API key in the `Authorization` header (Linear's personal-API-key scheme; pass `Bearer …` for OAuth), and normalizes all three failure modes into a single `Err`:
- transport throw → `Linear GraphQL request failed: …`
- non-2xx HTTP → `Linear GraphQL HTTP <status>: <truncated body>`
- GraphQL `errors[]` → `Linear GraphQL error: <messages>`

On success it returns `Ok(data)` (the envelope's `data`). `fetch` is injected for testing; `LinearGraphQLStub` is kept but `@deprecated`.

## Scope note
This is the authenticated **transport**. A full `linear` tracker *kind* (Linear issue → `TrackedFeature` mapping + the tracker-client interface) is a larger follow-up that builds on this client — it needs a real Linear workspace to validate against, so it's intentionally out of scope here.

## Tests
+5 tests with an injected fake fetch: request shape (URL/method/auth/body), HTTP-error→Err, GraphQL-errors→Err, transport-throw→Err, custom endpoint.