### PR TITLE
feat(cli): implement design-craft deep mode via vision critique

### DIFF
--- a/.changeset/design-craft-deep-vision.md
+++ b/.changeset/design-craft-deep-vision.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Implement `design-craft` deep mode, which previously hard-errored ("deep mode (render + vision LLM) is not implemented in the Phase 1 MVP"). Deep mode now runs the CRITIQUE phase through the provider's **vision** channel (`callVision`, which was already part of the provider contract but unwired) over caller-supplied rendered screenshots:
+
+- a new `captures` input (`[{ file, image, component? }]`) carries the screenshots, and a new `runVisionCritique` phase critiques each capture × seed-rubric exactly like `runCritique` does for source code;
+- `mode: 'deep'` routes the critique phase to vision; POLISH and BENCHMARK are unaffected (they were already implemented — the stale module header claiming they "return []" is corrected);
+- when `mode: 'deep'` is requested for the critique phase without `captures`, the tool returns a clear, actionable error rather than the old blanket "not implemented".
+
+Auto-rendering components to screenshots remains out of scope (the CLI has no browser); captures are supplied by the caller (e.g. a Storybook/Playwright step). `fast` mode behavior is unchanged.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -500,12 +500,13 @@ Run the harness-design-craft skill: CRITIQUE / POLISH / BENCHMARK phases over a 
 **Parameters:**
 
 - `path` (string, required) — Project root path
-- `mode` (string, optional) — fast (code-only LLM critique) or deep (render + vision). MVP supports fast only.
+- `mode` (string, optional) — fast (code-only LLM critique) or deep (vision critique of rendered screenshots — requires `captures`).
 - `phases` (array, optional) — Subset of phases to run. Defaults to all three.
 - `files` (array, optional) — Optional file scoping. Each entry is a path relative to project root.
 - `autoCapture` (string, optional) — B' detect-and-offer behavior when preconditions are missing. MVP: only "skip" is fully implemented.
 - `designStrictness` (string, optional) — Overall design strictness (passed through to harness-design when chained).
 - `benchmarkTargets` (array, optional) — BENCHMARK target descriptors. Each entry needs at minimum { file, component }; optional componentType narrows exemplar selection.
+- `captures` (array, optional) — Deep-mode (vision) captures: rendered component screenshots. Required when mode="deep" and the critique phase runs. Each entry: { file, image, component? }, where `image` is a path to a PNG/JPEG/WebP screenshot (the CLI does not render components itself).
 
 ### `dispatch_skills`
 

--- a/packages/cli/src/design-craft/phases/critique.ts
+++ b/packages/cli/src/design-craft/phases/critique.ts
@@ -251,3 +251,59 @@ export async function runCritique(args: CritiqueArgs): Promise<CraftFinding[]> {
   }
   return findings;
 }
+
+/** A rendered component screenshot to critique in deep (vision) mode. */
+export interface VisionCritiqueTarget {
+  /** Path to the source file the screenshot renders (for finding attribution). */
+  file: string;
+  /** Optional component identifier (display name in the finding). */
+  component?: string;
+  /** Path to the rendered screenshot (PNG / JPEG / WebP). */
+  image: string;
+}
+
+export interface VisionCritiqueArgs {
+  targets: VisionCritiqueTarget[];
+  rubrics: RubricDefinition[];
+  provider: LlmProvider;
+}
+
+function readImage(imagePath: string): {
+  imageBuffer: Buffer;
+  mediaType: 'image/png' | 'image/jpeg' | 'image/webp';
+} {
+  const resolved = path.isAbsolute(imagePath) ? imagePath : path.resolve(process.cwd(), imagePath);
+  const imageBuffer = fs.readFileSync(resolved);
+  const ext = path.extname(resolved).toLowerCase();
+  const mediaType =
+    ext === '.jpg' || ext === '.jpeg' ? 'image/jpeg' : ext === '.webp' ? 'image/webp' : 'image/png';
+  return { imageBuffer, mediaType };
+}
+
+/**
+ * Run the CRITIQUE phase in deep (vision) mode over `targets × rubrics`. Mirrors
+ * {@link runCritique} but judges the *rendered screenshot* via the provider's
+ * vision channel instead of the source code — the difference that distinguishes
+ * `mode: 'deep'` from `mode: 'fast'`. Each (target, rubric) pair yields exactly
+ * one finding (real or low-confidence parse-failure sentinel), row-major stable.
+ */
+export async function runVisionCritique(args: VisionCritiqueArgs): Promise<CraftFinding[]> {
+  const findings: CraftFinding[] = [];
+  for (const target of args.targets) {
+    const image = readImage(target.image);
+    const targetId = target.component ?? target.file;
+    for (const rubric of args.rubrics) {
+      const prompt = formatPrompt(
+        rubric.prompt,
+        targetId,
+        '(the rendered component is attached as an image — judge the visual result, not source code)'
+      );
+      const raw = await args.provider.callVision(prompt, image);
+      const parsed = parseFindingResponse(raw);
+      findings.push(
+        parsed ? buildFinding(target, rubric, parsed) : buildSentinelFinding(target, rubric, raw)
+      );
+    }
+  }
+  return findings;
+}

--- a/packages/cli/src/mcp/tools/design-craft.ts
+++ b/packages/cli/src/mcp/tools/design-craft.ts
@@ -11,10 +11,11 @@
 //     called out as a separate coordination commit by the user's scope
 //     statement, mirroring the same posture the user took for
 //     harness.config.json schema extension and DesignConstraintAdapter.
-//   - CRITIQUE phase invoked end-to-end against the one seeded rubric
-//     (hierarchy-clarity). POLISH and BENCHMARK are stubs returning [].
-//   - Mode arg accepts 'fast' | 'deep' but only 'fast' is implemented;
-//     'deep' returns a friendly "unimplemented in MVP" error.
+//   - CRITIQUE / POLISH / BENCHMARK phases all run end-to-end over the
+//     seeded rubrics / patterns / exemplars.
+//   - Mode 'fast' critiques source code; mode 'deep' critiques rendered
+//     screenshots (`captures`) via the provider's vision channel. The CLI
+//     does not render components itself — captures are caller-supplied.
 //   - autoCapture arg accepts 'prompt' | 'auto' | 'skip' but only 'skip'
 //     has fully defined behavior in this MVP (no detect-and-offer yet);
 //     'prompt' and 'auto' are accepted and currently behave like 'skip'
@@ -35,8 +36,8 @@ import { Ok, Err } from '@harness-engineering/core';
 import type { Result } from '@harness-engineering/core';
 import { resultToMcpResponse } from '../utils/result-adapter.js';
 import type { McpToolResponse } from '../utils/result-adapter.js';
-import { runCritique } from '../../design-craft/phases/critique.js';
-import type { CritiqueTarget } from '../../design-craft/phases/critique.js';
+import { runCritique, runVisionCritique } from '../../design-craft/phases/critique.js';
+import type { CritiqueTarget, VisionCritiqueTarget } from '../../design-craft/phases/critique.js';
 import { runPolish } from '../../design-craft/phases/polish.js';
 import type { PolishTarget } from '../../design-craft/phases/polish.js';
 import { runBenchmark } from '../../design-craft/phases/benchmark.js';
@@ -87,6 +88,13 @@ export interface DesignCraftInput {
     componentType?: string;
   }>;
   /**
+   * Deep-mode (vision) captures: rendered screenshots of components to critique
+   * visually. Required when `mode: 'deep'` and the critique phase runs — the CLI
+   * does not render components itself (no browser), so the screenshots are
+   * supplied by the caller (e.g. a Storybook/Playwright capture step).
+   */
+  captures?: VisionCritiqueTarget[];
+  /**
    * Test seam — inject an LlmProvider directly (e.g. MockLlmProvider).
    * NOT documented in the MCP tool schema; used by integration tests so
    * deterministic CI works without touching the live provider factory.
@@ -115,7 +123,8 @@ export const designCraftToolDefinition = {
         type: 'string',
         enum: ['fast', 'deep'],
         description:
-          'fast (code-only LLM critique) or deep (render + vision). MVP supports fast only.',
+          'fast (code-only LLM critique) or deep (vision critique of rendered screenshots — ' +
+          'requires `captures`).',
       },
       phases: {
         type: 'array',
@@ -150,6 +159,22 @@ export const designCraftToolDefinition = {
             componentType: { type: 'string' },
           },
           required: ['file', 'component'],
+        },
+      },
+      captures: {
+        type: 'array',
+        description:
+          'Deep-mode (vision) captures: rendered component screenshots. Required when mode="deep" ' +
+          'and the critique phase runs. Each entry: { file, image, component? }, where `image` is a ' +
+          'path to a PNG/JPEG/WebP screenshot (the CLI does not render components itself).',
+        items: {
+          type: 'object',
+          properties: {
+            file: { type: 'string' },
+            image: { type: 'string' },
+            component: { type: 'string' },
+          },
+          required: ['file', 'image'],
         },
       },
     },
@@ -218,14 +243,20 @@ async function runPipeline(
   input: DesignCraftInput
 ): Promise<Result<DesignCraftOutput, { message: string }>> {
   const mode: Mode = input.mode ?? 'fast';
-  if (mode === 'deep') {
+  const phases = selectPhases(input.phases);
+
+  // Deep mode critiques rendered screenshots via the provider's vision channel.
+  // The CLI does not render components itself, so captures must be supplied by
+  // the caller; without them the critique phase cannot run in deep mode.
+  const captures = input.captures ?? [];
+  if (mode === 'deep' && phases.includes('critique') && captures.length === 0) {
     return Err({
       message:
-        'design-craft deep mode (render + vision LLM) is not implemented in the Phase 1 MVP. Use mode: "fast".',
+        'design-craft deep mode critiques rendered screenshots — supply `captures` ' +
+        '([{ file, image }]). The CLI does not render components itself; capture them ' +
+        '(e.g. via Storybook/Playwright) and pass the image paths, or use mode: "fast".',
     });
   }
-
-  const phases = selectPhases(input.phases);
   const autoCapture: AutoCapture = input.autoCapture ?? 'prompt';
   if (autoCapture !== 'skip') {
     // TODO (next task): implement resolvers/preconditions + resolvers/offer
@@ -245,12 +276,21 @@ async function runPipeline(
   const scores: BenchmarkScore[] = [];
 
   let rubricsApplied: string[] = [];
-  if (phases.includes('critique') && critiqueTargets.length > 0) {
+  if (phases.includes('critique')) {
     const rubrics = [...SEED_RUBRICS];
-    rubricsApplied = rubrics.map((r) => r.id);
-    const critiqueFindings = await runCritique({ targets: critiqueTargets, rubrics, provider });
+    // Deep mode → vision critique over the rendered captures; fast mode → the
+    // code-only critique over the source files.
+    const critiqueFindings =
+      mode === 'deep'
+        ? await runVisionCritique({ targets: captures, rubrics, provider })
+        : critiqueTargets.length > 0
+          ? await runCritique({ targets: critiqueTargets, rubrics, provider })
+          : [];
+    if (critiqueFindings.length > 0 || mode === 'deep') {
+      rubricsApplied = rubrics.map((r) => r.id);
+    }
     findings.push(...critiqueFindings);
-    if (recordMeasurement) {
+    if (recordMeasurement && critiqueFindings.length > 0) {
       for (const rubric of rubrics) recordTrigger(rubric.id, measurementRoot);
       for (const f of critiqueFindings) recordSignalEvent(f, measurementRoot, measurementRoot);
     }

--- a/packages/cli/tests/design-craft/integration/critique-mvp.test.ts
+++ b/packages/cli/tests/design-craft/integration/critique-mvp.test.ts
@@ -203,13 +203,47 @@ describe('design-craft MCP handler (MVP)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('rejects deep mode in MVP with a clear error', async () => {
+  it('deep mode without captures returns a clear error', async () => {
     const result = await handleDesignCraft({
       path: '/tmp/fake-project',
       mode: 'deep',
     });
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toMatch(/deep mode .* not implemented/i);
+    expect(result.content[0].text).toMatch(/deep mode critiques rendered screenshots/i);
+  });
+
+  it('deep mode critiques provided captures via the vision channel', async () => {
+    // A provider that answers vision calls (the base mock throws on callVision).
+    class VisionMockProvider extends MockLlmProvider {
+      async callVision(prompt: string): Promise<string> {
+        return this.callText(prompt);
+      }
+    }
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'design-craft-vision-'));
+    const imagePath = path.join(tmpDir, 'Hero.png');
+    fs.writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47])); // minimal PNG magic
+
+    const result = await handleDesignCraft({
+      path: tmpDir,
+      mode: 'deep',
+      phases: ['critique'],
+      captures: [{ file: 'src/Hero.tsx', component: 'Hero', image: imagePath }],
+      __testProvider: new VisionMockProvider(),
+      __recordMeasurement: false,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text) as {
+      findings: unknown[];
+      summary: { mode: string; phaseRun: string[]; catalog: { rubricsApplied: string[] } };
+    };
+    expect(payload.summary.mode).toBe('deep');
+    // 10 seed rubrics × 1 capture, judged through the vision channel.
+    expect(payload.findings).toHaveLength(10);
+    expect(payload.summary.catalog.rubricsApplied).toHaveLength(10);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it('rejects missing path argument', async () => {


### PR DESCRIPTION
Stub #2 from the inventory (the largest). `design-craft` deep mode hard-errored: *"deep mode (render + vision LLM) is not implemented in the Phase 1 MVP."*

## What's implemented
Deep mode now runs the CRITIQUE phase through the provider's **vision** channel — `callVision` was already part of the `LlmProvider` contract (the mock threw) but nothing wired it:
- a new `captures` input (`[{ file, image, component? }]`) carries rendered component screenshots;
- a new `runVisionCritique` phase critiques each `capture × seed-rubric` exactly like `runCritique` does for source code, but judges the image via `callVision`;
- `mode: 'deep'` routes the critique phase to vision; POLISH/BENCHMARK are unaffected (they were already implemented — the stale module header claiming they "return []" is corrected here too);
- `mode: 'deep'` for the critique phase **without** `captures` returns a clear, actionable error instead of the old blanket "not implemented".

## Scope note
Auto-**rendering** components to screenshots stays out of scope — the CLI has no headless browser, so captures are caller-supplied (e.g. a Storybook/Playwright step). `fast` mode is unchanged.

## Tests
Updated the obsolete "deep mode not implemented" assertion and added an end-to-end deep-mode test (captures + a vision-capable mock provider → 10 rubric findings through the vision channel). 49 design-craft + 16 check-design tests pass. Changeset + regenerated MCP reference included.