### PR TITLE
feat(cli): audit-anatomy @anatomy-* + DESIGN.md anatomy-override resolvers

### DIFF
--- a/.changeset/audit-anatomy-overrides.md
+++ b/.changeset/audit-anatomy-overrides.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Implement the audit-anatomy source-of-truth override layers (follow-up to the component-type resolvers). The `resolveAnatomyRules` resolver previously stubbed Layers 1 and 2 to `null`, so anatomy rules always came from the built-in catalog with no project/author override path:
+
+- **Layer 1 — JSDoc `@anatomy-*`**: a file's leading doc block can declare its own anatomy via `@anatomy-slot content required`, `@anatomy-state disabled exclusive`, `@anatomy-variant primary|secondary|ghost`, `@anatomy-size sm|md|lg` (`parsers/anatomy-tags.ts`), producing a `ConventionRule` that overrides the catalog default.
+- **Layer 2 — DESIGN.md `## Component Anatomy Overrides`**: a tolerant parser (`parsers/design-overrides.ts`) reads per-component override blocks from the nearest DESIGN.md (list or inline `variants: a, b` styles, `(required)`/`(exclusive)` flags), memoized per DESIGN.md path.
+
+Resolution order is JSDoc → DESIGN.md → built-in catalog. Components with neither an `@anatomy-*` declaration nor a DESIGN.md override are unchanged (catalog default).

--- a/packages/cli/src/audit/component-anatomy/parsers/anatomy-tags.ts
+++ b/packages/cli/src/audit/component-anatomy/parsers/anatomy-tags.ts
@@ -1,0 +1,74 @@
+/**
+ * Build a {@link ConventionRule} override from `@anatomy-*` JSDoc tags.
+ *
+ * Tag grammar (docs/changes/design-pipeline/audit-component-anatomy/proposal.md
+ * → "JSDoc tag grammar"):
+ *
+ *   @anatomy-slot content required
+ *   @anatomy-slot icon-leading
+ *   @anatomy-state disabled exclusive
+ *   @anatomy-variant primary|secondary|ghost|danger
+ *   @anatomy-size sm|md|lg
+ *
+ * Slots/states are one part per tag with trailing `required` / `exclusive`
+ * flags; variants/sizes are a single pipe-delimited tag listing every value.
+ */
+
+import type { AnatomyPart, ConventionRule } from '../rules/convention-rule.js';
+import { readJsDocTag } from './jsdoc.js';
+
+/** Source ref stamped on JSDoc-authored overrides (citation only). */
+const JSDOC_SOURCE_REF = 'design-component-anatomy/jsdoc';
+
+function fixHint(name: string, axis: string): string {
+  return `Add the \`${name}\` ${axis} to this component, or drop the \`@anatomy-${axis} ${name}\` tag if it no longer applies.`;
+}
+
+/** Parse a `@anatomy-slot` / `@anatomy-state` value: `name [required] [exclusive]`. */
+function parseFlaggedPart(value: string, axis: 'slot' | 'state'): AnatomyPart | null {
+  const tokens = value.split(/\s+/).filter(Boolean);
+  const name = tokens[0];
+  if (!name) return null;
+  const flags = new Set(tokens.slice(1).map((t) => t.toLowerCase()));
+  return {
+    name,
+    required: flags.has('required'),
+    ...(flags.has('exclusive') ? { exclusive: true } : {}),
+    fixHint: fixHint(name, axis),
+  };
+}
+
+/** Parse a `@anatomy-variant` / `@anatomy-size` pipe-delimited value into parts. */
+function parsePipeList(value: string, axis: 'variant' | 'size'): AnatomyPart[] {
+  return value
+    .split('|')
+    .map((n) => n.trim())
+    .filter(Boolean)
+    .map((name) => ({ name, required: false, fixHint: fixHint(name, axis) }));
+}
+
+/**
+ * Construct a ConventionRule from a doc block's `@anatomy-*` tags, or `null`
+ * when the block declares no anatomy axes (so callers fall through to the next
+ * source-of-truth layer).
+ */
+export function buildAnatomyRuleFromJsDoc(
+  jsdoc: string,
+  componentType: string
+): ConventionRule | null {
+  const slots = readJsDocTag(jsdoc, 'anatomy-slot')
+    .map((v) => parseFlaggedPart(v, 'slot'))
+    .filter((p): p is AnatomyPart => p !== null);
+  const states = readJsDocTag(jsdoc, 'anatomy-state')
+    .map((v) => parseFlaggedPart(v, 'state'))
+    .filter((p): p is AnatomyPart => p !== null);
+  const variants = readJsDocTag(jsdoc, 'anatomy-variant').flatMap((v) =>
+    parsePipeList(v, 'variant')
+  );
+  const sizes = readJsDocTag(jsdoc, 'anatomy-size').flatMap((v) => parsePipeList(v, 'size'));
+
+  if (slots.length === 0 && states.length === 0 && variants.length === 0 && sizes.length === 0) {
+    return null;
+  }
+  return { componentType, slots, states, variants, sizes, source: { ref: JSDOC_SOURCE_REF } };
+}

--- a/packages/cli/src/audit/component-anatomy/parsers/design-overrides.ts
+++ b/packages/cli/src/audit/component-anatomy/parsers/design-overrides.ts
@@ -1,0 +1,109 @@
+/**
+ * Parser for the optional `## Component Anatomy Overrides` section of DESIGN.md.
+ *
+ * Per-component overrides of the convention library (source-of-truth Layer 2,
+ * Decision #1). See docs/changes/design-pipeline/audit-component-anatomy/
+ * proposal.md → "DESIGN.md schema additions":
+ *
+ *   ## Component Anatomy Overrides
+ *
+ *   ### Button
+ *
+ *   slots:
+ *   - content (required)
+ *   - icon-leading
+ *   states:
+ *   - disabled (exclusive)
+ *   variants: primary, secondary, ghost
+ *   sizes: sm, md, lg
+ *
+ * Tolerant of indentation, inline (`variants: a, b`) vs. list (`- a`) value
+ * styles, and `(required)` / `(exclusive)` flags.
+ */
+
+import type { AnatomyPart, ConventionRule } from '../rules/convention-rule.js';
+
+const SINGULAR = { slots: 'slot', states: 'state', variants: 'variant', sizes: 'size' } as const;
+type Axis = keyof typeof SINGULAR;
+
+const SOURCE_REF = 'design-component-anatomy/design-md';
+
+function partFrom(raw: string, axis: Axis): AnatomyPart | null {
+  const m = /^([A-Za-z0-9][A-Za-z0-9-]*)\s*(?:\(([^)]*)\))?/.exec(raw.trim());
+  const name = m?.[1];
+  if (!name) return null;
+  const flags = (m?.[2] ?? '').toLowerCase();
+  return {
+    name,
+    required: /\brequired\b/.test(flags),
+    ...(/\bexclusive\b/.test(flags) ? { exclusive: true } : {}),
+    fixHint: `Add the \`${name}\` ${SINGULAR[axis]} to this component (declared in the DESIGN.md anatomy override).`,
+  };
+}
+
+/**
+ * Parse the overrides section into a `componentType → ConventionRule` map.
+ * Returns an empty map when the section is absent.
+ */
+export function parseAnatomyOverrides(designMd: string): Map<string, ConventionRule> {
+  const lines = designMd.split('\n');
+  const out = new Map<string, ConventionRule>();
+
+  let i = lines.findIndex((l) => /^#{1,6}\s+Component Anatomy Overrides\b/i.test(l));
+  if (i === -1) return out;
+
+  let current: { type: string; axes: Record<Axis, AnatomyPart[]> } | null = null;
+  let currentAxis: Axis | null = null;
+
+  const flush = (): void => {
+    if (!current) return;
+    out.set(current.type, {
+      componentType: current.type,
+      slots: current.axes.slots,
+      states: current.axes.states,
+      variants: current.axes.variants,
+      sizes: current.axes.sizes,
+      source: { ref: SOURCE_REF },
+    });
+  };
+
+  for (i += 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    // A new h1/h2 ends the overrides section (component headings are h3+).
+    if (/^#{1,2}\s/.test(line)) break;
+
+    const compHeading = /^#{3,6}\s+(.+?)\s*$/.exec(line);
+    if (compHeading) {
+      flush();
+      current = {
+        type: compHeading[1]!.trim(),
+        axes: { slots: [], states: [], variants: [], sizes: [] },
+      };
+      currentAxis = null;
+      continue;
+    }
+    if (!current) continue;
+
+    const axisMatch = /^\s*(slots|states|variants|sizes)\s*:\s*(.*)$/i.exec(line);
+    if (axisMatch) {
+      currentAxis = axisMatch[1]!.toLowerCase() as Axis;
+      const inline = axisMatch[2]!.trim();
+      if (inline) {
+        for (const tok of inline.split(',')) {
+          const part = partFrom(tok, currentAxis);
+          if (part) current.axes[currentAxis].push(part);
+        }
+        currentAxis = null; // inline form is self-contained
+      }
+      continue;
+    }
+
+    const listItem = /^\s*[-*]\s+(.*)$/.exec(line);
+    if (listItem && currentAxis) {
+      const part = partFrom(listItem[1]!, currentAxis);
+      if (part) current.axes[currentAxis].push(part);
+    }
+  }
+  flush();
+  return out;
+}

--- a/packages/cli/src/audit/component-anatomy/resolvers/source-of-truth.ts
+++ b/packages/cli/src/audit/component-anatomy/resolvers/source-of-truth.ts
@@ -2,17 +2,21 @@
  * Source-of-truth resolver — implements Decision #1 (proposal.md).
  *
  * Three-layer stack (mirrors component-type resolver — Decision #3):
- *   1. JSDoc `@anatomy-*` self-declaration tags. STUB pending JSDoc parser.
+ *   1. JSDoc `@anatomy-*` self-declaration tags.
  *   2. DESIGN.md `## Component Anatomy Overrides` per-component override.
- *      STUB pending DESIGN.md parser.
  *   3. Built-in convention catalog lookup.
  *
  * Returns the resolved ConventionRule (or null when no convention is
  * available for the type — silent skip per Decision #1).
  */
 
+import * as fs from 'node:fs';
 import type { ConventionRule } from '../rules/convention-rule.js';
 import { lookupConvention } from '../catalog/index.js';
+import { extractLeadingJsDoc } from '../parsers/jsdoc.js';
+import { buildAnatomyRuleFromJsDoc } from '../parsers/anatomy-tags.js';
+import { findDesignMd } from '../parsers/design-registry.js';
+import { parseAnatomyOverrides } from '../parsers/design-overrides.js';
 
 /**
  * Resolve the active anatomy rules for a component.
@@ -30,11 +34,11 @@ export function resolveAnatomyRules(
 ): ConventionRule | null {
   if (componentType === null) return null;
 
-  // Layer 1: JSDoc @anatomy-* tags (STUB — pending JSDoc parser task).
-  const jsdocRule = resolveFromJSDoc(filePath, fileContents, componentType);
+  // Layer 1: the file's own `@anatomy-*` JSDoc self-declaration.
+  const jsdocRule = resolveFromJSDoc(fileContents, componentType);
   if (jsdocRule !== null) return jsdocRule;
 
-  // Layer 2: DESIGN.md overrides (STUB — pending DESIGN.md parser task).
+  // Layer 2: DESIGN.md `## Component Anatomy Overrides` for this type.
   const overrideRule = resolveFromDesignOverrides(filePath, componentType);
   if (overrideRule !== null) return overrideRule;
 
@@ -42,19 +46,35 @@ export function resolveAnatomyRules(
   return lookupConvention(componentType);
 }
 
-/** STUB. Returns null until the JSDoc parser task lands. */
-function resolveFromJSDoc(
-  _filePath: string,
-  _fileContents: string,
-  _componentType: string
-): ConventionRule | null {
-  return null;
+/** Layer 1: build a rule from the leading JSDoc block's `@anatomy-*` tags. */
+function resolveFromJSDoc(fileContents: string, componentType: string): ConventionRule | null {
+  const jsdoc = extractLeadingJsDoc(fileContents);
+  if (jsdoc === null) return null;
+  return buildAnatomyRuleFromJsDoc(jsdoc, componentType);
 }
 
-/** STUB. Returns null until the DESIGN.md parser task lands. */
+// Parsed `## Component Anatomy Overrides` keyed by DESIGN.md path — DESIGN.md is
+// static for a process, so memoizing avoids re-reading it for every file.
+const overridesCache = new Map<string, Map<string, ConventionRule>>();
+
+/** Layer 2: look the component type up in the nearest DESIGN.md overrides. */
 function resolveFromDesignOverrides(
-  _filePath: string,
-  _componentType: string
+  filePath: string,
+  componentType: string
 ): ConventionRule | null {
-  return null;
+  const designPath = findDesignMd(filePath);
+  if (designPath === null) return null;
+
+  let byType = overridesCache.get(designPath);
+  if (!byType) {
+    let contents: string;
+    try {
+      contents = fs.readFileSync(designPath, 'utf8');
+    } catch {
+      contents = '';
+    }
+    byType = parseAnatomyOverrides(contents);
+    overridesCache.set(designPath, byType);
+  }
+  return byType.get(componentType) ?? null;
 }

--- a/packages/cli/tests/audit/component-anatomy/unit/anatomy-overrides.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/anatomy-overrides.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { extractLeadingJsDoc } from '../../../../src/audit/component-anatomy/parsers/jsdoc';
+import { buildAnatomyRuleFromJsDoc } from '../../../../src/audit/component-anatomy/parsers/anatomy-tags';
+import { parseAnatomyOverrides } from '../../../../src/audit/component-anatomy/parsers/design-overrides';
+import { resolveAnatomyRules } from '../../../../src/audit/component-anatomy/resolvers/source-of-truth';
+
+const TAGGED_SOURCE = `/**
+ * @component-type Button
+ * @anatomy-slot content required
+ * @anatomy-slot icon-leading
+ * @anatomy-state disabled exclusive
+ * @anatomy-variant primary|secondary|ghost
+ * @anatomy-size sm|md|lg
+ */
+export const Button = () => null;
+`;
+
+describe('buildAnatomyRuleFromJsDoc', () => {
+  it('builds a ConventionRule from @anatomy-* tags with flags', () => {
+    const rule = buildAnatomyRuleFromJsDoc(extractLeadingJsDoc(TAGGED_SOURCE)!, 'Button')!;
+    expect(rule.componentType).toBe('Button');
+    expect(rule.slots).toEqual([
+      expect.objectContaining({ name: 'content', required: true }),
+      expect.objectContaining({ name: 'icon-leading', required: false }),
+    ]);
+    expect(rule.states).toEqual([
+      expect.objectContaining({ name: 'disabled', required: false, exclusive: true }),
+    ]);
+    expect(rule.variants.map((v) => v.name)).toEqual(['primary', 'secondary', 'ghost']);
+    expect(rule.sizes.map((s) => s.name)).toEqual(['sm', 'md', 'lg']);
+    expect(rule.source.ref).toMatch(/jsdoc/);
+  });
+
+  it('returns null when no @anatomy-* tags are present', () => {
+    const jsdoc = extractLeadingJsDoc(
+      '/**\n * @component-type Button\n */\nexport const Button = 1;'
+    )!;
+    expect(buildAnatomyRuleFromJsDoc(jsdoc, 'Button')).toBeNull();
+  });
+});
+
+const DESIGN = `# Design
+
+## Component Anatomy Overrides
+
+### Button
+
+slots:
+- content (required)
+- icon-leading
+states:
+- disabled (exclusive)
+variants: primary, secondary, ghost
+sizes: sm, md, lg
+
+### Input
+
+slots:
+- label (required)
+`;
+
+describe('parseAnatomyOverrides', () => {
+  it('parses per-component overrides with list + inline axis styles', () => {
+    const byType = parseAnatomyOverrides(DESIGN);
+    const button = byType.get('Button')!;
+    expect(button.slots).toEqual([
+      expect.objectContaining({ name: 'content', required: true }),
+      expect.objectContaining({ name: 'icon-leading', required: false }),
+    ]);
+    expect(button.states[0]).toMatchObject({ name: 'disabled', exclusive: true });
+    expect(button.variants.map((v) => v.name)).toEqual(['primary', 'secondary', 'ghost']);
+    expect(byType.get('Input')!.slots[0]).toMatchObject({ name: 'label', required: true });
+  });
+
+  it('returns an empty map when the section is absent', () => {
+    expect(parseAnatomyOverrides('# Design\n\nnothing here').size).toBe(0);
+  });
+});
+
+describe('resolveAnatomyRules layering', () => {
+  let dir = '';
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = '';
+  });
+
+  it('Layer 1: JSDoc @anatomy-* wins over the catalog default', () => {
+    const rule = resolveAnatomyRules('/abs/Button.tsx', TAGGED_SOURCE, 'Button')!;
+    expect(rule.source.ref).toMatch(/jsdoc/);
+    expect(rule.slots.map((s) => s.name)).toEqual(['content', 'icon-leading']);
+  });
+
+  it('Layer 2: DESIGN.md overrides apply when there is no JSDoc declaration', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anat-ovr-'));
+    fs.writeFileSync(path.join(dir, 'DESIGN.md'), DESIGN);
+    const file = path.join(dir, 'src', 'Button.tsx');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const rule = resolveAnatomyRules(file, 'export const Button = () => null;', 'Button')!;
+    expect(rule.source.ref).toMatch(/design-md/);
+    expect(rule.variants.map((v) => v.name)).toEqual(['primary', 'secondary', 'ghost']);
+  });
+
+  it('returns null component type → null rule', () => {
+    expect(resolveAnatomyRules('/abs/x.tsx', 'x', null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #681 (now merged). Implements the source-of-truth resolver's two override layers, which were stubs returning `null` (anatomy rules always came from the built-in catalog):

- **Layer 1 — JSDoc `@anatomy-*`** (`parsers/anatomy-tags.ts`): a file's leading doc block declares its anatomy — `@anatomy-slot content required`, `@anatomy-state disabled exclusive`, `@anatomy-variant primary|secondary|ghost`, `@anatomy-size sm|md|lg` — producing a `ConventionRule` overriding the catalog default.
- **Layer 2 — DESIGN.md `## Component Anatomy Overrides`** (`parsers/design-overrides.ts`): tolerant per-component parser (list `- name (required)` + inline `variants: a, b` styles, `(required)`/`(exclusive)` flags), nearest DESIGN.md, memoized per path.

Resolution order: JSDoc → DESIGN.md → built-in catalog. Components with neither are unchanged.

+7 unit tests; all 111 audit-anatomy tests pass. The remaining audit-anatomy piece is the ANAT-P* pattern engine (separate PR).