### PR TITLE
feat(cli): implement audit-anatomy ANAT-P* pattern engine

### DIFF
--- a/.changeset/audit-anatomy-patterns.md
+++ b/.changeset/audit-anatomy-patterns.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Implement the audit-anatomy ANAT-P\* pattern engine, which was a no-op (`void mode`) — `full` mode behaved identically to `fast` and `patternsApplied` was always empty. A new, extensible pattern catalog (`catalog/patterns/`) ships the two flagship composition patterns:
+
+- **ANAT-P001 map-without-empty** — a list rendered with `.map(...)` but no empty-state branch (length-zero guard, `EmptyState`, "no results" copy).
+- **ANAT-P002 fetch-without-loading** — async data loading (`fetch` / query hook / awaited effect) with no loading affordance (skeleton, spinner, Suspense, `isLoading`).
+
+`full` mode now runs these over every audited file (composition patterns aren't bound to a resolved component type), emits `warn`-severity findings with manual fix hints, and reports the applied pattern ids in `summary.catalog.patternsApplied`; `fast` mode is unchanged (conventions only). Detection uses conservative source heuristics (a finding fires only when the triggering construct is present and no mitigating affordance appears in the file) — no tree-sitter dependency. The `PatternCheck` interface is the extension point for the rest of the catalog (P003+).

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -419,12 +419,12 @@ Parse a git diff and check for forbidden patterns, oversized files, and missing 
 
 ### `audit_anatomy`
 
-Audit components for anatomy completeness. Emits ANAT-D* findings for component definitions missing required slots/states (e.g., Button missing `content`). In v1 vertical slice runs the Button convention only; pattern-presence checks (ANAT-P*) return empty pending follow-up.
+Audit components for anatomy completeness. Emits ANAT-D* findings for component definitions missing required slots/states (e.g., Button missing `content`). In v1 vertical slice runs the component conventions, plus ANAT-P* composition patterns (map-without-empty, fetch-without-loading) in full mode.
 
 **Parameters:**
 
 - `path` (string, required) — Project root path
-- `mode` (string, optional) — fast = conventions only (cheap AST scan). full = conventions + patterns. In v1 both modes run conventions only because pattern engine is not yet wired.
+- `mode` (string, optional) — fast = conventions only (cheap AST scan); full additionally runs the ANAT-P\* composition patterns.
 - `files` (array, optional) — Optional explicit file list (paths or globs) to scope the audit.
 - `designStrictness` (string, optional) — Overrides design.strictness from harness.config.json.
 - `catalog` (array, optional) — Optional subset of catalog entries to run.

--- a/packages/cli/src/audit/component-anatomy/catalog/patterns/index.ts
+++ b/packages/cli/src/audit/component-anatomy/catalog/patterns/index.ts
@@ -1,0 +1,148 @@
+/**
+ * ANAT-P* pattern catalog — "missing-anatomy-component" composition patterns.
+ *
+ * Where conventions (ANAT-D*) check a component *definition* for required parts,
+ * patterns (ANAT-P*) check *composition* sites for missing affordances: a list
+ * rendered with no empty state, an async fetch with no loading boundary, etc.
+ * (proposal.md Decision #2 — the "blue-ocean" finding class.)
+ *
+ * v1 ships two flagship patterns via conservative source heuristics (no
+ * tree-sitter dependency): a finding fires only when the triggering construct is
+ * present AND no mitigating affordance appears anywhere in the file, which keeps
+ * false positives low at the cost of missing intra-file edge cases. Each finding
+ * is `warn` severity and carries a manual fix hint. The `PatternCheck` shape is
+ * the extension point for the remaining catalog (P003+).
+ */
+
+import type { AnatomyFinding } from '../../findings/finding.js';
+
+export interface PatternCheck {
+  code: AnatomyFinding['code'];
+  /** Stable slug surfaced in `summary.catalog.patternsApplied`. */
+  id: string;
+  /** Authoritative citation written into `finding.rule.source`. */
+  source: string;
+  /** Scan a file's source; return zero or more findings (file path pre-resolved). */
+  detect(file: string, contents: string, componentType: string | null): AnatomyFinding[];
+}
+
+/** 1-indexed line number of a character offset. */
+function lineAt(contents: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index && i < contents.length; i++) {
+    if (contents[i] === '\n') line += 1;
+  }
+  return line;
+}
+
+const anyMatch = (contents: string, res: RegExp[]): boolean => res.some((re) => re.test(contents));
+
+function makeFinding(
+  pattern: PatternCheck,
+  file: string,
+  contents: string,
+  matchIndex: number,
+  componentType: string | null,
+  message: string,
+  fixDescription: string
+): AnatomyFinding {
+  const line = lineAt(contents, matchIndex);
+  const snippet = (contents.split('\n')[line - 1] ?? '').trim();
+  return {
+    code: pattern.code,
+    severity: 'warn',
+    file,
+    line,
+    componentType,
+    message,
+    evidence: { snippet },
+    rule: { id: pattern.code, source: pattern.source },
+    fix: { kind: 'manual', description: fixDescription },
+  };
+}
+
+/**
+ * ANAT-P001 — a list is rendered with `.map(...)` but the file has no empty-state
+ * branch (length-zero guard, `EmptyState`, "no results" copy). A list that can be
+ * empty needs a designed empty state.
+ */
+const mapWithoutEmpty: PatternCheck = {
+  code: 'ANAT-P001',
+  id: 'map-without-empty',
+  source: 'design-component-anatomy/pattern-map-without-empty',
+  detect(file, contents, componentType) {
+    const mapCall = /\.map\s*\(/.exec(contents);
+    if (!mapCall) return [];
+    const emptyGuards = [
+      /\.length\s*===\s*0/,
+      /\.length\s*<\s*1/,
+      /\.length\s*>\s*0/,
+      /\.length\s*\?/,
+      /\blength\s*&&/,
+      /\?\.length\b/,
+      /\bisEmpty\b/,
+      /\bEmptyState\b/,
+      /\bno\s+(results|items|data|entries)\b/i,
+    ];
+    if (anyMatch(contents, emptyGuards)) return [];
+    return [
+      makeFinding(
+        mapWithoutEmpty,
+        file,
+        contents,
+        mapCall.index,
+        componentType,
+        'List rendered with `.map(...)` but no empty state was found. An empty list ' +
+          'renders as a blank region — add a length-zero branch (e.g. an EmptyState).',
+        'Guard the list: `items.length === 0 ? <EmptyState/> : items.map(...)`.'
+      ),
+    ];
+  },
+};
+
+/**
+ * ANAT-P002 — the file performs async data loading (fetch / query hook / awaited
+ * effect) but renders no loading affordance (spinner, skeleton, Suspense,
+ * `isLoading`). An async surface with no loading boundary flashes empty/janky.
+ */
+const fetchWithoutLoading: PatternCheck = {
+  code: 'ANAT-P002',
+  id: 'fetch-without-loading',
+  source: 'design-component-anatomy/pattern-fetch-without-loading',
+  detect(file, contents, componentType) {
+    const asyncSignals = [
+      /\bfetch\s*\(/,
+      /\buse(Query|SWR|Swr|Mutation)\b/,
+      /\baxios\s*[.(]/,
+      /\bawait\s+/,
+    ];
+    const trigger = asyncSignals.map((re) => re.exec(contents)).find((m) => m !== null);
+    if (!trigger) return [];
+    const loadingSignals = [
+      /\bis?Loading\b/i,
+      /\bisPending\b/i,
+      /\bpending\b/i,
+      /\bSkeleton\b/,
+      /\bSpinner\b/,
+      /<Suspense\b/,
+      /\bplaceholder\b/i,
+    ];
+    if (anyMatch(contents, loadingSignals)) return [];
+    return [
+      makeFinding(
+        fetchWithoutLoading,
+        file,
+        contents,
+        trigger.index,
+        componentType,
+        'Async data loading found but no loading state. The surface renders empty ' +
+          'until data resolves — add a loading boundary (skeleton, spinner, or Suspense).',
+        'Render a loading affordance while the request is in flight ' +
+          '(e.g. `if (isLoading) return <Skeleton/>`).'
+      ),
+    ];
+  },
+};
+
+/** The v1 ANAT-P* catalog, in stable order. */
+export const PATTERN_CHECKS: readonly PatternCheck[] = [mapWithoutEmpty, fetchWithoutLoading];

--- a/packages/cli/src/mcp/tools/audit-anatomy.ts
+++ b/packages/cli/src/mcp/tools/audit-anatomy.ts
@@ -4,7 +4,7 @@
  * Entry point for the audit-component-anatomy skill (design-pipeline
  * sub-project #2). Phase 1 vertical-slice scope:
  *   - Convention catalog: Button only (one rule)
- *   - Pattern catalog: stubbed — patterns return empty
+ *   - Pattern catalog: ANAT-P* composition patterns run in `full` mode
  *   - Mode handling: fast/full both run conventions only in MVP
  *
  * Tool registration into `mcp/server.ts` is a separate coordination
@@ -26,6 +26,7 @@ import {
 import { resolveComponentType } from '../../audit/component-anatomy/resolvers/component-type.js';
 import { resolveAnatomyRules } from '../../audit/component-anatomy/resolvers/source-of-truth.js';
 import { runConventionRule } from '../../audit/component-anatomy/rules/convention-runner.js';
+import { PATTERN_CHECKS } from '../../audit/component-anatomy/catalog/patterns/index.js';
 import type { AnatomyFinding, Severity } from '../../audit/component-anatomy/findings/finding.js';
 
 type AuditMode = 'fast' | 'full';
@@ -55,7 +56,7 @@ export const auditAnatomyDefinition = {
   description:
     'Audit components for anatomy completeness. Emits ANAT-D* findings for component definitions ' +
     'missing required slots/states (e.g., Button missing `content`). In v1 vertical slice runs the ' +
-    'Button convention only; pattern-presence checks (ANAT-P*) return empty pending follow-up.',
+    'component conventions, plus ANAT-P* composition patterns (map-without-empty, fetch-without-loading) in full mode.',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -64,8 +65,7 @@ export const auditAnatomyDefinition = {
         type: 'string',
         enum: ['fast', 'full'],
         description:
-          'fast = conventions only (cheap AST scan). full = conventions + patterns. ' +
-          'In v1 both modes run conventions only because pattern engine is not yet wired.',
+          'fast = conventions only (cheap AST scan); full additionally runs the ANAT-P* composition patterns.',
       },
       files: {
         type: 'array',
@@ -105,6 +105,7 @@ export async function runAudit(input: AuditAnatomyInput): Promise<AuditAnatomyOu
   const candidateFiles = input.files ?? [];
 
   const conventionsApplied = new Set<string>();
+  const patternsApplied = new Set<string>();
   let totalFiles = 0;
 
   for (const candidatePath of candidateFiles) {
@@ -119,7 +120,22 @@ export async function runAudit(input: AuditAnatomyInput): Promise<AuditAnatomyOu
     }
     totalFiles += 1;
 
+    const fileRelative = path.relative(projectRoot, absolute).replaceAll('\\', '/') || absolute;
     const componentType = resolveComponentType(absolute, contents);
+
+    // ANAT-P* pattern checks (full mode only — they are the more expensive,
+    // composition-level scans). They run on EVERY file regardless of whether a
+    // component type resolved, since composition patterns are not bound to a
+    // component definition.
+    if (mode === 'full') {
+      for (const pattern of PATTERN_CHECKS) {
+        const patternFindings = pattern.detect(fileRelative, contents, componentType);
+        if (patternFindings.length > 0) patternsApplied.add(pattern.id);
+        findings.push(...patternFindings);
+      }
+    }
+
+    // ANAT-D* convention checks require a resolved type, a rule, and a parse.
     if (componentType === null) continue;
 
     const rule = resolveAnatomyRules(absolute, contents, componentType);
@@ -130,17 +146,12 @@ export async function runAudit(input: AuditAnatomyInput): Promise<AuditAnatomyOu
 
     conventionsApplied.add(rule.componentType);
 
-    const fileRelative = path.relative(projectRoot, absolute).replaceAll('\\', '/') || absolute;
     const runnerOptions: Parameters<typeof runConventionRule>[2] = { filePath: fileRelative };
     if (input.designStrictness !== undefined) {
       runnerOptions.strictness = input.designStrictness;
     }
     const fileFindings = runConventionRule(rule, parsed, runnerOptions);
     findings.push(...fileFindings);
-
-    // Pattern catalog is stubbed for the MVP — patterns return empty in
-    // both fast and full mode until the tree-sitter wrapper lands.
-    void mode;
   }
 
   const summary = buildSummary(findings, totalFiles, Date.now() - start);
@@ -150,7 +161,7 @@ export async function runAudit(input: AuditAnatomyInput): Promise<AuditAnatomyOu
     summary,
     catalog: {
       conventionsApplied: [...conventionsApplied].sort(),
-      patternsApplied: [],
+      patternsApplied: [...patternsApplied].sort(),
     },
     meta: { mode, deferredToA11y: 0 },
   };

--- a/packages/cli/tests/audit/component-anatomy/unit/patterns.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/patterns.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PATTERN_CHECKS } from '../../../../src/audit/component-anatomy/catalog/patterns/index';
+import { runAudit } from '../../../../src/mcp/tools/audit-anatomy';
+
+function run(code: string, file: string, contents: string) {
+  const pattern = PATTERN_CHECKS.find((p) => p.code === code)!;
+  return pattern.detect(file, contents, null);
+}
+
+describe('ANAT-P001 map-without-empty', () => {
+  it('flags a .map render with no empty-state branch', () => {
+    const findings = run(
+      'ANAT-P001',
+      'List.tsx',
+      `export const List = ({ items }) => <ul>{items.map((i) => <li key={i.id}>{i.name}</li>)}</ul>;`
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.code).toBe('ANAT-P001');
+    expect(findings[0]!.severity).toBe('warn');
+    expect(findings[0]!.line).toBe(1);
+  });
+
+  it('does not flag when a length-zero guard is present', () => {
+    expect(
+      run(
+        'ANAT-P001',
+        'List.tsx',
+        `export const List = ({ items }) =>
+           items.length === 0 ? <EmptyState/> : <ul>{items.map((i) => <li>{i}</li>)}</ul>;`
+      )
+    ).toEqual([]);
+  });
+
+  it('does not flag a file with no .map', () => {
+    expect(run('ANAT-P001', 'X.tsx', 'export const X = () => <div/>;')).toEqual([]);
+  });
+});
+
+describe('ANAT-P002 fetch-without-loading', () => {
+  it('flags async fetching with no loading affordance', () => {
+    const findings = run(
+      'ANAT-P002',
+      'Users.tsx',
+      `export function Users() {
+         const [data, setData] = useState(null);
+         useEffect(() => { fetch('/api/users').then((r) => r.json()).then(setData); }, []);
+         return <div>{data?.length}</div>;
+       }`
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.code).toBe('ANAT-P002');
+  });
+
+  it('does not flag when a loading state is present', () => {
+    expect(
+      run(
+        'ANAT-P002',
+        'Users.tsx',
+        `export function Users() {
+           const { data, isLoading } = useQuery('users');
+           if (isLoading) return <Skeleton/>;
+           return <div>{data}</div>;
+         }`
+      )
+    ).toEqual([]);
+  });
+
+  it('does not flag a file with no async loading', () => {
+    expect(run('ANAT-P002', 'Static.tsx', 'export const Static = () => <p>hi</p>;')).toEqual([]);
+  });
+});
+
+describe('runAudit pattern wiring', () => {
+  let dir = '';
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    dir = '';
+  });
+
+  it('full mode emits ANAT-P findings + patternsApplied; fast mode does not', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'anat-pat-'));
+    const file = path.join(dir, 'List.tsx');
+    fs.writeFileSync(
+      file,
+      `export const List = ({ items }) => <ul>{items.map((i) => <li>{i}</li>)}</ul>;`
+    );
+
+    const full = await runAudit({ path: dir, mode: 'full', files: [file] });
+    const pCodes = full.findings.filter((f) => f.code.startsWith('ANAT-P')).map((f) => f.code);
+    expect(pCodes).toContain('ANAT-P001');
+    expect(full.catalog.patternsApplied).toContain('map-without-empty');
+
+    const fast = await runAudit({ path: dir, mode: 'fast', files: [file] });
+    expect(fast.findings.some((f) => f.code.startsWith('ANAT-P'))).toBe(false);
+    expect(fast.catalog.patternsApplied).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-up to #681/#685 — the third audit-anatomy stub. The pattern path was a literal no-op (`void mode`), so `full` mode behaved identically to `fast` and `summary.catalog.patternsApplied` was always empty.

## What's implemented
A new extensible pattern catalog (`catalog/patterns/`) with the two flagship composition patterns ("missing-anatomy-component" — proposal Decision #2's blue-ocean finding class):
- **ANAT-P001 map-without-empty** — a `.map(...)` list render with no empty-state branch (length-zero guard, `EmptyState`, "no results" copy).
- **ANAT-P002 fetch-without-loading** — async data loading (`fetch` / query hook / awaited effect) with no loading affordance (skeleton, spinner, Suspense, `isLoading`).

`full` mode now runs these over **every** audited file (composition patterns aren't bound to a resolved component type), emits `warn` findings with manual fix hints, and reports `patternsApplied`. `fast` mode is unchanged (conventions only).

## Approach note
The proposal envisioned tree-sitter S-expression queries; this ships **conservative source heuristics** instead (no new dependency) — a finding fires only when the triggering construct is present **and** no mitigating affordance appears in the file, trading some recall for low false positives. `PatternCheck` is the extension point for the rest of the catalog (P003–P010).

## Tests
+7 tests (each pattern: fires / suppressed-by-affordance / absent-construct, plus a `runAudit` full-vs-fast wiring test). All audit-anatomy tests pass. Regenerated MCP reference.