### PR TITLE
refactor(maintenance): share backend resolver across CLI and orchestrator

### DIFF
--- a/.changeset/share-maintenance-backend-resolver.md
+++ b/.changeset/share-maintenance-backend-resolver.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/orchestrator': patch
+'@harness-engineering/cli': patch
+---
+
+Extract a shared `makeBackendResolver` helper (orchestrator package) used by both the CLI's `harness maintenance run --fix` backend resolution and the orchestrator's `createMaintenanceTaskRunner`, removing the duplicated `name → createBackend(def) | null` resolve logic that could drift. Behavior is unchanged.

--- a/packages/cli/src/commands/maintenance-run.ts
+++ b/packages/cli/src/commands/maintenance-run.ts
@@ -20,7 +20,7 @@ import {
   selectTasks,
   runHarnessCheck,
   createAgentDispatcher,
-  createBackend,
+  makeBackendResolver,
   MAINTENANCE_CHECK_MAX_BUFFER,
   MAINTENANCE_CHECK_TIMEOUT_MS,
   type CheckCommandRunner,
@@ -47,12 +47,13 @@ export type ResolveBackend = (backendName: string) => AgentBackend | null;
 
 /** Build a {@link ResolveBackend} from a loaded `agent.backends` map. A `null`
  * or empty map yields a resolver that always returns `null` (nothing
- * configured) — the graceful-degradation case for a plain checkout. */
+ * configured) — the graceful-degradation case for a plain checkout.
+ *
+ * Delegates to the orchestrator's `makeBackendResolver` so the CLI's `--fix`
+ * dispatcher and the cron orchestrator (`createMaintenanceTaskRunner`) share
+ * ONE name → `createBackend` → `null` resolution and cannot drift. */
 export function makeResolveBackend(backends: Record<string, BackendDef> | null): ResolveBackend {
-  return (backendName: string) => {
-    const def = backends?.[backendName];
-    return def ? createBackend(def) : null;
-  };
+  return makeBackendResolver(backends);
 }
 
 /**

--- a/packages/orchestrator/src/agent/backend-resolver.test.ts
+++ b/packages/orchestrator/src/agent/backend-resolver.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import type { BackendDef } from '@harness-engineering/types';
+import { makeBackendResolver } from './backend-resolver.js';
+import { MockBackend } from './backends/mock.js';
+
+describe('makeBackendResolver', () => {
+  const backends: Record<string, BackendDef> = {
+    primary: { type: 'mock' },
+  };
+
+  it('resolves a known backend name to a live AgentBackend via createBackend', () => {
+    const resolve = makeBackendResolver(backends);
+    const backend = resolve('primary');
+    expect(backend).toBeInstanceOf(MockBackend);
+  });
+
+  it('returns null for an unknown backend name', () => {
+    const resolve = makeBackendResolver(backends);
+    expect(resolve('missing')).toBeNull();
+  });
+
+  it('returns an always-null resolver when the backends map is null', () => {
+    const resolve = makeBackendResolver(null);
+    expect(resolve('primary')).toBeNull();
+  });
+
+  it('returns an always-null resolver when the backends map is undefined', () => {
+    const resolve = makeBackendResolver(undefined);
+    expect(resolve('primary')).toBeNull();
+  });
+
+  it('returns null for any name when the backends map is empty', () => {
+    const resolve = makeBackendResolver({});
+    expect(resolve('primary')).toBeNull();
+  });
+});

--- a/packages/orchestrator/src/agent/backend-resolver.ts
+++ b/packages/orchestrator/src/agent/backend-resolver.ts
@@ -1,0 +1,34 @@
+import type { AgentBackend, BackendDef } from '@harness-engineering/types';
+import { createBackend } from './backend-factory.js';
+
+/**
+ * Maintenance backend resolver: map a configured backend NAME to a live
+ * {@link AgentBackend}, or `null` when the name is absent from the loaded
+ * `agent.backends` map. `null` lets the real agent dispatcher no-op honestly
+ * (graceful degradation on a plain checkout) instead of throwing.
+ */
+export type BackendResolver = (backendName: string) => AgentBackend | null;
+
+/**
+ * Build a {@link BackendResolver} from a synthesized `agent.backends` map.
+ *
+ * This is the ONE shared implementation of "resolve a backend name against a
+ * backends map via `createBackend`, else null". It is consumed by BOTH:
+ *   - the cron orchestrator (`createMaintenanceTaskRunner`), passing
+ *     `this.getBackends()`, and
+ *   - the on-demand CLI (`harness maintenance run --fix` →
+ *     `makeResolveBackend`), passing the config it loaded from
+ *     `harness.orchestrator.md`.
+ *
+ * Keeping it in the orchestrator package (next to `createBackend`) avoids the
+ * two call sites drifting. A `null`/`undefined`/empty map yields a resolver
+ * that always returns `null` — the nothing-configured degradation case.
+ */
+export function makeBackendResolver(
+  backends: Record<string, BackendDef> | null | undefined
+): BackendResolver {
+  return (backendName: string) => {
+    const def = backends?.[backendName];
+    return def ? createBackend(def) : null;
+  };
+}

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -34,6 +34,12 @@ export type { OrchestratorBackendFactoryOptions } from './agent/orchestrator-bac
 export { migrateAgentConfig } from './agent/config-migration';
 export type { MigrationResult } from './agent/config-migration';
 export { createBackend } from './agent/backend-factory';
+// Shared maintenance backend resolver. The ONE implementation of "backend
+// name → live AgentBackend via createBackend, else null", consumed by both
+// the cron orchestrator (createMaintenanceTaskRunner) and the on-demand CLI
+// (`harness maintenance run --fix`) so the two resolution sites cannot drift.
+export { makeBackendResolver } from './agent/backend-resolver';
+export type { BackendResolver } from './agent/backend-resolver';
 
 // Re-export the workflow Zod schemas so other packages (cli config, tests)
 // can validate `agent.backends` / `agent.routing` against the same source

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -35,7 +35,7 @@ import { PromptRenderer } from './prompt/renderer';
 import { LocalModelResolver } from './agent/local-model-resolver';
 import { migrateAgentConfig } from './agent/config-migration';
 import { OrchestratorBackendFactory } from './agent/orchestrator-backend-factory';
-import { createBackend } from './agent/backend-factory';
+import { makeBackendResolver } from './agent/backend-resolver';
 import { createAgentDispatcher } from './maintenance/agent-dispatcher';
 import { execFileSync } from 'node:child_process';
 import { buildIntelligencePipeline } from './agent/intelligence-factory';
@@ -716,10 +716,11 @@ export class Orchestrator extends EventEmitter {
 
     // Resolve a configured backend by name into a live AgentBackend; null when
     // the maintenance task references a backend that isn't in agent.backends.
-    const resolveBackend = (backendName: string) => {
-      const def = this.getBackends()?.[backendName];
-      return def ? createBackend(def) : null;
-    };
+    // Shared with the on-demand CLI (`harness maintenance run --fix` →
+    // makeResolveBackend) via `makeBackendResolver` so the two sites can't
+    // drift. `getBackends()` returns the immutable synthesized map set in the
+    // constructor, so capturing it once here matches the prior per-call read.
+    const resolveBackend = makeBackendResolver(this.getBackends());
     const agentDispatcher: AgentDispatcher = createAgentDispatcher({
       resolveBackend,
       git: (args, cwd) => execFileSync('git', args, { cwd, encoding: 'utf-8' }).toString().trim(),


### PR DESCRIPTION
Follow-up to #687 (on-demand maintenance pipeline). The final review flagged that the CLI's `--fix` backend resolution and the orchestrator's `createMaintenanceTaskRunner` each carried the same `name → createBackend(def) | null` logic, which could drift.

Extracts a shared `makeBackendResolver` helper into the orchestrator package, consumed by both sites. Behavior unchanged; only the resolve core is shared (the orchestrator's richer constructor-time backend synthesis is intentionally left separate). New helper is unit-tested; orchestrator function coverage nudges up (84.09% vs 83.99 baseline).

Single commit, +89/−11.