### PR TITLE
feat(core): add linear roadmap tracker kind (best-effort, unvalidated)

### DIFF
--- a/.changeset/linear-tracker-adapter.md
+++ b/.changeset/linear-tracker-adapter.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/core': minor
+---
+
+Add a `linear` roadmap tracker kind — a `LinearTrackerAdapter` implementing the full `RoadmapTrackerClient` interface over Linear's GraphQL API, wired into `createTrackerClient({ kind: 'linear', teamId, token })` (falls back to `LINEAR_API_KEY`). This builds on the standalone Linear GraphQL client added earlier; the adapter ships its own transport because `core` cannot depend on `orchestrator`.
+
+Mapping: `externalId` is `linear:<issue-uuid>`; `status` maps via Linear's fixed workflow-state **type** enum (`backlog|unstarted|started|completed`) rather than team-defined state names; `spec`/`plans`/`blockedBy`/`priority`/`milestone`/`summary` round-trip through the shared `<!-- harness-meta -->` body block (same encoding as the GitHub adapter); priority maps P0–P3 ↔ Linear 1–4; history events are stored as marked issue comments. Writes resolve the team's workflow states and assignee user ids on demand, and `update` supports optimistic-concurrency via `ifMatch` (→ `ConflictError`).
+
+⚠️ **Best-effort, not yet validated against a live Linear workspace.** Query/mutation shapes follow Linear's documented schema and the mapping is unit-tested with a mocked transport, but field-level behavior (custom workflow states, priority semantics, user resolution) should be verified against a real workspace before production use. `blocked`/`needs-human` statuses have no native Linear state type and are treated as `started` on write.

--- a/packages/core/src/roadmap/tracker/adapters/linear.test.ts
+++ b/packages/core/src/roadmap/tracker/adapters/linear.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LinearTrackerAdapter } from './linear';
+import { serializeBodyBlock } from '../body-metadata';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * A fetch stub that routes each GraphQL operation to a canned response keyed by
+ * a substring of the query. Records the parsed request bodies for assertions.
+ */
+function routedFetch(routes: Array<{ match: string; data: unknown }>) {
+  const calls: Array<{ query: string; variables: Record<string, unknown> }> = [];
+  const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse((init?.body as string | undefined) ?? '{}') as {
+      query: string;
+      variables: Record<string, unknown>;
+    };
+    calls.push(body);
+    const route = routes.find((r) => body.query.includes(r.match));
+    return jsonResponse(route ? route.data : {});
+  });
+  return { fetchFn, calls };
+}
+
+function adapter(fetchFn: typeof fetch) {
+  return new LinearTrackerAdapter({ apiKey: 'lin_test', teamId: 'team_1', fetchFn });
+}
+
+const ISSUE = {
+  id: 'uuid-1',
+  title: 'Ship login',
+  description: serializeBodyBlock('A login flow', {
+    spec: 'docs/login.md',
+    plan: 'plans/login.md',
+    blocked_by: ['auth-service'],
+    priority: 'P1',
+    milestone: 'MVP',
+  }),
+  state: { type: 'started', name: 'In Progress' },
+  assignee: { displayName: 'Ada' },
+  priority: 2,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+};
+
+describe('LinearTrackerAdapter — reads', () => {
+  it('fetchAll maps a Linear issue to a TrackedFeature (status from state.type, body-meta)', async () => {
+    const { fetchFn } = routedFetch([
+      { match: 'team(id:$team)', data: { team: { issues: { nodes: [ISSUE] } } } },
+    ]);
+    const r = await adapter(fetchFn).fetchAll();
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.features).toHaveLength(1);
+    expect(r.value.features[0]).toMatchObject({
+      externalId: 'linear:uuid-1',
+      name: 'Ship login',
+      status: 'in-progress', // state.type 'started'
+      summary: 'A login flow',
+      spec: 'docs/login.md',
+      plans: ['plans/login.md'],
+      blockedBy: ['auth-service'],
+      assignee: 'Ada',
+      priority: 'P1',
+      milestone: 'MVP',
+    });
+  });
+
+  it('fetchByStatus filters by mapped status', async () => {
+    const { fetchFn } = routedFetch([
+      { match: 'team(id:$team)', data: { team: { issues: { nodes: [ISSUE] } } } },
+    ]);
+    const r = await adapter(fetchFn).fetchByStatus(['done']);
+    expect(r.ok && r.value).toEqual([]); // ISSUE is in-progress, not done
+  });
+
+  it('fetchById returns null when the issue is absent', async () => {
+    const { fetchFn } = routedFetch([{ match: 'issue(id:$id)', data: { issue: null } }]);
+    const r = await adapter(fetchFn).fetchById('linear:nope');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeNull();
+  });
+});
+
+describe('LinearTrackerAdapter — writes', () => {
+  it('create resolves a workflow state and posts issueCreate with a body-meta description', async () => {
+    const { fetchFn, calls } = routedFetch([
+      {
+        match: 'states { nodes',
+        data: { team: { states: { nodes: [{ id: 's-backlog', type: 'backlog' }] } } },
+      },
+      {
+        match: 'issueCreate',
+        data: { issueCreate: { issue: { ...ISSUE, id: 'new-1', title: 'New' } } },
+      },
+    ]);
+    const r = await adapter(fetchFn).create({ name: 'New', summary: 'sum', spec: 'docs/x.md' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.externalId).toBe('linear:new-1');
+
+    const createCall = calls.find((c) => c.query.includes('issueCreate'))!;
+    const input = createCall.variables.input as Record<string, unknown>;
+    expect(input.teamId).toBe('team_1');
+    expect(input.stateId).toBe('s-backlog');
+    expect(String(input.description)).toContain('harness-meta');
+    expect(String(input.description)).toContain('docs/x.md');
+  });
+
+  it('update raises ConflictError when ifMatch != server updatedAt', async () => {
+    const { fetchFn } = routedFetch([{ match: 'issue(id:$id)', data: { issue: ISSUE } }]);
+    const r = await adapter(fetchFn).update('linear:uuid-1', { name: 'X' }, 'STALE-ETAG');
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect((r.error as { code?: string }).code).toBe('TRACKER_CONFLICT');
+  });
+});
+
+describe('LinearTrackerAdapter — history round-trip', () => {
+  it('appendHistory posts a marked comment and fetchHistory parses it back', async () => {
+    const { fetchFn, calls } = routedFetch([
+      { match: 'commentCreate', data: { commentCreate: { success: true } } },
+    ]);
+    const a = adapter(fetchFn);
+    const append = await a.appendHistory('linear:uuid-1', {
+      type: 'claimed',
+      actor: 'Ada',
+      at: '2026-01-03T00:00:00Z',
+    });
+    expect(append.ok).toBe(true);
+    const body = String((calls[0]!.variables.input as Record<string, unknown>).body);
+
+    const { fetchFn: fetchFn2 } = routedFetch([
+      { match: 'comments(first', data: { issue: { comments: { nodes: [{ body }] } } } },
+    ]);
+    const hist = await adapter(fetchFn2).fetchHistory('linear:uuid-1');
+    expect(hist.ok).toBe(true);
+    if (!hist.ok) return;
+    expect(hist.value).toEqual([{ type: 'claimed', actor: 'Ada', at: '2026-01-03T00:00:00Z' }]);
+  });
+});
+
+describe('LinearTrackerAdapter — claim / release / complete / update body merge', () => {
+  const states = {
+    match: 'states { nodes',
+    data: {
+      team: {
+        states: {
+          nodes: [
+            { id: 's-backlog', type: 'backlog' },
+            { id: 's-started', type: 'started' },
+            { id: 's-done', type: 'completed' },
+          ],
+        },
+      },
+    },
+  };
+  const user = { match: 'users(filter', data: { users: { nodes: [{ id: 'u-ada' }] } } };
+  const updated = { match: 'issueUpdate', data: { issueUpdate: { issue: ISSUE } } };
+
+  it('claim resolves the user + started state and sets assignee', async () => {
+    const { fetchFn, calls } = routedFetch([states, user, updated]);
+    const r = await adapter(fetchFn).claim('linear:uuid-1', 'Ada');
+    expect(r.ok).toBe(true);
+    const input = calls.find((c) => c.query.includes('issueUpdate'))!.variables.input as Record<
+      string,
+      unknown
+    >;
+    expect(input.assigneeId).toBe('u-ada');
+    expect(input.stateId).toBe('s-started');
+  });
+
+  it('claim errors when the user cannot be resolved', async () => {
+    const { fetchFn } = routedFetch([{ match: 'users(filter', data: { users: { nodes: [] } } }]);
+    const r = await adapter(fetchFn).claim('linear:uuid-1', 'Ghost');
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/user not found/i);
+  });
+
+  it('release clears the assignee', async () => {
+    const { fetchFn, calls } = routedFetch([updated]);
+    const r = await adapter(fetchFn).release('linear:uuid-1');
+    expect(r.ok).toBe(true);
+    const input = calls[0]!.variables.input as Record<string, unknown>;
+    expect(input.assigneeId).toBeNull();
+  });
+
+  it('complete moves the issue to a completed-type state', async () => {
+    const { fetchFn, calls } = routedFetch([states, updated]);
+    const r = await adapter(fetchFn).complete('linear:uuid-1');
+    expect(r.ok).toBe(true);
+    const input = calls.find((c) => c.query.includes('issueUpdate'))!.variables.input as Record<
+      string,
+      unknown
+    >;
+    expect(input.stateId).toBe('s-done');
+  });
+
+  it('update merges body-backed fields into the existing harness-meta block', async () => {
+    const { fetchFn, calls } = routedFetch([
+      { match: 'issue(id:$id)', data: { issue: ISSUE } },
+      updated,
+    ]);
+    const r = await adapter(fetchFn).update('linear:uuid-1', { spec: 'docs/new-spec.md' });
+    expect(r.ok).toBe(true);
+    const input = calls.find((c) => c.query.includes('issueUpdate'))!.variables.input as Record<
+      string,
+      unknown
+    >;
+    const description = String(input.description);
+    expect(description).toContain('docs/new-spec.md');
+    // Untouched fields are preserved from the existing issue body.
+    expect(description).toContain('auth-service');
+  });
+});
+
+describe('LinearTrackerAdapter — status & priority mapping coverage', () => {
+  const cases: Array<{ type: string; priority: number; status: string; mapped: string | null }> = [
+    { type: 'backlog', priority: 1, status: 'backlog', mapped: 'P0' },
+    { type: 'triage', priority: 2, status: 'backlog', mapped: 'P1' },
+    { type: 'unstarted', priority: 3, status: 'planned', mapped: 'P2' },
+    { type: 'completed', priority: 4, status: 'done', mapped: 'P3' },
+    { type: 'canceled', priority: 0, status: 'done', mapped: null },
+    { type: 'weird-unknown', priority: 9, status: 'backlog', mapped: null },
+  ];
+
+  it.each(cases)('state.type=$type → $status, priority=$priority → $mapped', async (c) => {
+    const issue = {
+      id: 'x',
+      title: 'T',
+      description: 'no meta here',
+      state: { type: c.type },
+      priority: c.priority,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: null,
+    };
+    const { fetchFn } = routedFetch([
+      { match: 'team(id:$team)', data: { team: { issues: { nodes: [issue] } } } },
+    ]);
+    const r = await adapter(fetchFn).fetchAll();
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.features[0]!.status).toBe(c.status);
+    expect(r.value.features[0]!.priority).toBe(c.mapped);
+  });
+
+  it('fetchById returns the feature + etag on success', async () => {
+    const { fetchFn } = routedFetch([{ match: 'issue(id:$id)', data: { issue: ISSUE } }]);
+    const r = await adapter(fetchFn).fetchById('linear:uuid-1');
+    expect(r.ok).toBe(true);
+    if (!r.ok || !r.value) return;
+    expect(r.value.feature.externalId).toBe('linear:uuid-1');
+    expect(r.value.etag).toBe('2026-01-02T00:00:00Z');
+  });
+
+  it('create errors when the team has no workflow state of the wanted type', async () => {
+    const { fetchFn } = routedFetch([
+      { match: 'states { nodes', data: { team: { states: { nodes: [] } } } },
+    ]);
+    const r = await adapter(fetchFn).create({ name: 'N', summary: 's' });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/no workflow state/i);
+  });
+
+  it('fetchHistory skips comments without the marker or with malformed JSON', async () => {
+    const good = `${'<!-- harness-history -->'}\n\`\`\`json\n${JSON.stringify({ type: 'created', actor: 'x', at: '2026-01-01T00:00:00Z' })}\n\`\`\``;
+    const malformed = `${'<!-- harness-history -->'}\n\`\`\`json\nnot-json\n\`\`\``;
+    const { fetchFn } = routedFetch([
+      {
+        match: 'comments(first',
+        data: {
+          issue: { comments: { nodes: [{ body: 'plain' }, { body: malformed }, { body: good }] } },
+        },
+      },
+    ]);
+    const r = await adapter(fetchFn).fetchHistory('linear:uuid-1', 5);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toEqual([{ type: 'created', actor: 'x', at: '2026-01-01T00:00:00Z' }]);
+  });
+});
+
+describe('LinearTrackerAdapter — transport error mapping', () => {
+  it('maps a non-JSON 2xx response to Err', async () => {
+    const fetchFn = vi.fn(async () => new Response('<html>not json</html>', { status: 200 }));
+    const r = await adapter(fetchFn as unknown as typeof fetch).fetchAll();
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/not JSON/i);
+  });
+
+  it('maps a non-2xx HTTP response to Err', async () => {
+    const fetchFn = vi.fn(async () => new Response('forbidden', { status: 403 }));
+    const r = await adapter(fetchFn as unknown as typeof fetch).fetchAll();
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/HTTP 403/);
+  });
+
+  it('maps a GraphQL errors[] payload to Err', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(undefined as never));
+    // Re-stub to return an errors array (jsonResponse wraps under data).
+    const erroring = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ errors: [{ message: 'bad query' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    void fetchFn;
+    const r = await adapter(erroring as unknown as typeof fetch).fetchAll();
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/bad query/);
+  });
+
+  it('maps a transport throw to Err', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const r = await adapter(fetchFn as unknown as typeof fetch).fetchAll();
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/request failed.*ECONNREFUSED/);
+  });
+});
+
+describe('createTrackerClient (linear kind)', () => {
+  it('builds a Linear adapter from config', async () => {
+    const { createTrackerClient } = await import('../factory');
+    const r = createTrackerClient({ kind: 'linear', teamId: 't', token: 'k' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toBeInstanceOf(LinearTrackerAdapter);
+  });
+
+  it('errors when the Linear API key is missing', async () => {
+    const { createTrackerClient } = await import('../factory');
+    const prev = process.env.LINEAR_API_KEY;
+    delete process.env.LINEAR_API_KEY;
+    const r = createTrackerClient({ kind: 'linear', teamId: 't' });
+    if (prev !== undefined) process.env.LINEAR_API_KEY = prev;
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/missing Linear API key/);
+  });
+});

--- a/packages/core/src/roadmap/tracker/adapters/linear.ts
+++ b/packages/core/src/roadmap/tracker/adapters/linear.ts
@@ -1,0 +1,460 @@
+/**
+ * Linear tracker adapter — implements {@link RoadmapTrackerClient} over Linear's
+ * GraphQL API (https://linear.app/developers/graphql).
+ *
+ * ⚠️ Best-effort, NOT yet validated against a live Linear workspace. The query /
+ * mutation shapes follow Linear's documented schema and the mapping is unit-
+ * tested with a mocked transport, but field-level behavior (custom workflow
+ * states, priority semantics, user resolution) should be verified against a real
+ * workspace before production use. See the mapping notes inline.
+ *
+ * Mapping decisions:
+ *  - `externalId` is `linear:<issue-uuid>` (the stable id; mutations need it).
+ *  - `status` maps via Linear's fixed workflow-state *type* enum
+ *    (`backlog|unstarted|started|completed|canceled`), NOT state names (which are
+ *    team-defined). `blocked` / `needs-human` have no native state type and are
+ *    treated as `started` on write (best-effort).
+ *  - `spec` / `plans` / `blockedBy` / `priority` / `milestone` / `summary` are
+ *    stored in the shared `<!-- harness-meta -->` body block (same encoding as the
+ *    GitHub adapter), so roadmaps round-trip across trackers.
+ *  - `priority` maps P0–P3 ↔ Linear 1–4 (urgent/high/normal/low); Linear 0 (none)
+ *    ↔ null.
+ *  - History events are stored as issue comments carrying a `harness-history`
+ *    marker.
+ */
+
+import type { Result, FeatureStatus, Priority } from '@harness-engineering/types';
+import { Ok, Err } from '@harness-engineering/types';
+import type {
+  RoadmapTrackerClient,
+  TrackedFeature,
+  NewFeatureInput,
+  FeaturePatch,
+  HistoryEvent,
+  HistoryEventType,
+} from '../client';
+import { ConflictError } from '../client';
+import { parseBodyBlock, serializeBodyBlock, type BodyMeta } from '../body-metadata';
+
+const LINEAR_ENDPOINT = 'https://api.linear.app/graphql';
+const EXTERNAL_PREFIX = 'linear:';
+const HISTORY_MARKER = '<!-- harness-history -->';
+
+export interface LinearTrackerOptions {
+  apiKey: string;
+  /** Linear team id — required to create issues and resolve workflow states. */
+  teamId: string;
+  endpoint?: string;
+  fetchFn?: typeof fetch;
+}
+
+type LinearStateType = 'backlog' | 'unstarted' | 'started' | 'completed' | 'canceled' | 'triage';
+
+interface LinearIssue {
+  id: string;
+  title: string;
+  description?: string | null;
+  state?: { type?: string | null; name?: string | null } | null;
+  assignee?: { displayName?: string | null; name?: string | null } | null;
+  priority?: number | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+const ISSUE_FIELDS = `
+  id title description priority createdAt updatedAt
+  state { type name }
+  assignee { displayName name }
+`;
+
+function statusFromStateType(type: string | null | undefined): FeatureStatus {
+  switch (type) {
+    case 'backlog':
+    case 'triage':
+      return 'backlog';
+    case 'unstarted':
+      return 'planned';
+    case 'started':
+      return 'in-progress';
+    case 'completed':
+    case 'canceled':
+      return 'done';
+    default:
+      return 'backlog';
+  }
+}
+
+/** Desired Linear state *type* for a FeatureStatus (used to pick a team state). */
+function stateTypeForStatus(status: FeatureStatus): LinearStateType {
+  switch (status) {
+    case 'backlog':
+      return 'backlog';
+    case 'planned':
+      return 'unstarted';
+    case 'in-progress':
+    case 'blocked':
+    case 'needs-human':
+      return 'started';
+    case 'done':
+      return 'completed';
+    default:
+      return 'backlog';
+  }
+}
+
+function priorityFromLinear(p: number | null | undefined): Priority | null {
+  switch (p) {
+    case 1:
+      return 'P0';
+    case 2:
+      return 'P1';
+    case 3:
+      return 'P2';
+    case 4:
+      return 'P3';
+    default:
+      return null; // 0 / null = "no priority"
+  }
+}
+
+function linearFromPriority(p: Priority | null | undefined): number {
+  switch (p) {
+    case 'P0':
+      return 1;
+    case 'P1':
+      return 2;
+    case 'P2':
+      return 3;
+    case 'P3':
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+function metaFrom(feature: NewFeatureInput | FeaturePatch): BodyMeta {
+  const meta: BodyMeta = {};
+  if (feature.spec != null) meta.spec = feature.spec;
+  if (feature.plans && feature.plans.length > 0) meta.plan = feature.plans[0]!;
+  if (feature.blockedBy && feature.blockedBy.length > 0) meta.blocked_by = feature.blockedBy;
+  if (feature.priority != null) meta.priority = feature.priority;
+  if (feature.milestone != null) meta.milestone = feature.milestone;
+  return meta;
+}
+
+export class LinearTrackerAdapter implements RoadmapTrackerClient {
+  private readonly apiKey: string;
+  private readonly teamId: string;
+  private readonly endpoint: string;
+  private readonly fetchFn: typeof fetch;
+  /** Lazily-resolved `stateType → stateId` for the team. */
+  private stateCache: Map<string, string> | null = null;
+
+  constructor(opts: LinearTrackerOptions) {
+    this.apiKey = opts.apiKey;
+    this.teamId = opts.teamId;
+    this.endpoint = opts.endpoint ?? LINEAR_ENDPOINT;
+    this.fetchFn = opts.fetchFn ?? globalThis.fetch;
+  }
+
+  private async gql<T = unknown>(
+    query: string,
+    variables?: Record<string, unknown>
+  ): Promise<Result<T, Error>> {
+    let res: Response;
+    try {
+      res = await this.fetchFn(this.endpoint, {
+        method: 'POST',
+        headers: { Authorization: this.apiKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables: variables ?? {} }),
+      });
+    } catch (err) {
+      return Err(
+        new Error(`Linear request failed: ${err instanceof Error ? err.message : String(err)}`)
+      );
+    }
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      return Err(new Error(`Linear HTTP ${res.status}${body ? `: ${body.slice(0, 300)}` : ''}`));
+    }
+    let json: { data?: T; errors?: Array<{ message?: string }> };
+    try {
+      json = (await res.json()) as typeof json;
+    } catch (err) {
+      return Err(
+        new Error(`Linear response not JSON: ${err instanceof Error ? err.message : String(err)}`)
+      );
+    }
+    if (json.errors && json.errors.length > 0) {
+      return Err(
+        new Error(`Linear GraphQL error: ${json.errors.map((e) => e.message ?? '?').join('; ')}`)
+      );
+    }
+    return Ok((json.data ?? {}) as T);
+  }
+
+  private toExternalId(id: string): string {
+    return `${EXTERNAL_PREFIX}${id}`;
+  }
+
+  private toIssueId(externalId: string): string {
+    return externalId.startsWith(EXTERNAL_PREFIX)
+      ? externalId.slice(EXTERNAL_PREFIX.length)
+      : externalId;
+  }
+
+  private featureFromIssue(issue: LinearIssue): TrackedFeature {
+    const { summary, meta } = parseBodyBlock(issue.description ?? '');
+    return {
+      externalId: this.toExternalId(issue.id),
+      name: issue.title,
+      status: statusFromStateType(issue.state?.type),
+      summary,
+      spec: meta.spec ?? null,
+      plans: meta.plan ? [meta.plan] : [],
+      blockedBy: meta.blocked_by ?? [],
+      assignee: issue.assignee?.displayName ?? issue.assignee?.name ?? null,
+      priority: meta.priority ?? priorityFromLinear(issue.priority),
+      milestone: meta.milestone ?? null,
+      createdAt: issue.createdAt ?? new Date(0).toISOString(),
+      updatedAt: issue.updatedAt ?? null,
+    };
+  }
+
+  /** Resolve (and cache) the team's first state id of each workflow type. */
+  private async resolveStateId(status: FeatureStatus): Promise<Result<string, Error>> {
+    if (!this.stateCache) {
+      const r = await this.gql<{
+        team?: { states?: { nodes?: Array<{ id: string; type: string }> } };
+      }>(`query($team:String!){ team(id:$team){ states { nodes { id type } } } }`, {
+        team: this.teamId,
+      });
+      if (!r.ok) return r;
+      const cache = new Map<string, string>();
+      for (const s of r.value.team?.states?.nodes ?? []) {
+        if (!cache.has(s.type)) cache.set(s.type, s.id);
+      }
+      this.stateCache = cache;
+    }
+    const wanted = stateTypeForStatus(status);
+    const id = this.stateCache.get(wanted) ?? this.stateCache.get('backlog');
+    return id ? Ok(id) : Err(new Error(`Linear team has no workflow state of type "${wanted}"`));
+  }
+
+  private async resolveUserId(assignee: string): Promise<Result<string | null, Error>> {
+    const r = await this.gql<{ users?: { nodes?: Array<{ id: string }> } }>(
+      `query($q:String!){ users(filter:{ or:[{ displayName:{ eq:$q } },{ email:{ eq:$q } }] }){ nodes { id } } }`,
+      { q: assignee }
+    );
+    if (!r.ok) return r;
+    return Ok(r.value.users?.nodes?.[0]?.id ?? null);
+  }
+
+  // ── Reads ──────────────────────────────────────────────────────────────
+
+  async fetchAll(): Promise<Result<{ features: TrackedFeature[]; etag: string | null }, Error>> {
+    const r = await this.gql<{ team?: { issues?: { nodes?: LinearIssue[] } } }>(
+      `query($team:String!){ team(id:$team){ issues(first:250){ nodes { ${ISSUE_FIELDS} } } } }`,
+      { team: this.teamId }
+    );
+    if (!r.ok) return r;
+    const features = (r.value.team?.issues?.nodes ?? []).map((i) => this.featureFromIssue(i));
+    return Ok({ features, etag: null });
+  }
+
+  async fetchById(
+    externalId: string
+  ): Promise<Result<{ feature: TrackedFeature; etag: string } | null, Error>> {
+    const r = await this.gql<{ issue?: LinearIssue | null }>(
+      `query($id:String!){ issue(id:$id){ ${ISSUE_FIELDS} } }`,
+      { id: this.toIssueId(externalId) }
+    );
+    if (!r.ok) return r;
+    if (!r.value.issue) return Ok(null);
+    const feature = this.featureFromIssue(r.value.issue);
+    return Ok({ feature, etag: feature.updatedAt ?? '' });
+  }
+
+  async fetchByStatus(statuses: FeatureStatus[]): Promise<Result<TrackedFeature[], Error>> {
+    const all = await this.fetchAll();
+    if (!all.ok) return all;
+    const wanted = new Set(statuses);
+    return Ok(all.value.features.filter((f) => wanted.has(f.status)));
+  }
+
+  // ── Writes ─────────────────────────────────────────────────────────────
+
+  async create(feature: NewFeatureInput): Promise<Result<TrackedFeature, Error>> {
+    const stateR = await this.resolveStateId(feature.status ?? 'backlog');
+    if (!stateR.ok) return stateR;
+    const body = serializeBodyBlock(feature.summary ?? '', metaFrom(feature));
+    const input: Record<string, unknown> = {
+      teamId: this.teamId,
+      title: feature.name,
+      description: body,
+      stateId: stateR.value,
+      priority: linearFromPriority(feature.priority),
+    };
+    if (feature.assignee) {
+      const userR = await this.resolveUserId(feature.assignee);
+      if (userR.ok && userR.value) input.assigneeId = userR.value;
+    }
+    const r = await this.gql<{ issueCreate?: { issue?: LinearIssue } }>(
+      `mutation($input:IssueCreateInput!){ issueCreate(input:$input){ issue { ${ISSUE_FIELDS} } } }`,
+      { input }
+    );
+    if (!r.ok) return r;
+    const issue = r.value.issueCreate?.issue;
+    if (!issue) return Err(new Error('Linear issueCreate returned no issue'));
+    return Ok(this.featureFromIssue(issue));
+  }
+
+  /** Shared issueUpdate with optional optimistic-concurrency check on updatedAt. */
+  private async issueUpdate(
+    externalId: string,
+    input: Record<string, unknown>,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    const id = this.toIssueId(externalId);
+    if (ifMatch !== undefined) {
+      const cur = await this.fetchById(externalId);
+      if (!cur.ok) return cur;
+      const serverUpdatedAt = cur.value?.feature.updatedAt ?? null;
+      if (serverUpdatedAt !== ifMatch) {
+        return Err(
+          new ConflictError(
+            externalId,
+            { updatedAt: { ours: ifMatch, theirs: serverUpdatedAt } },
+            serverUpdatedAt
+          )
+        );
+      }
+    }
+    const r = await this.gql<{ issueUpdate?: { issue?: LinearIssue } }>(
+      `mutation($id:String!,$input:IssueUpdateInput!){ issueUpdate(id:$id,input:$input){ issue { ${ISSUE_FIELDS} } } }`,
+      { id, input }
+    );
+    if (!r.ok) return r;
+    const issue = r.value.issueUpdate?.issue;
+    if (!issue) return Err(new Error('Linear issueUpdate returned no issue'));
+    return Ok(this.featureFromIssue(issue));
+  }
+
+  async update(
+    externalId: string,
+    patch: FeaturePatch,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    const input: Record<string, unknown> = {};
+    if (patch.name !== undefined) input.title = patch.name;
+    if (patch.priority !== undefined) input.priority = linearFromPriority(patch.priority);
+    if (patch.status !== undefined) {
+      const stateR = await this.resolveStateId(patch.status);
+      if (!stateR.ok) return stateR;
+      input.stateId = stateR.value;
+    }
+    // Body-backed fields (summary/spec/plans/blockedBy/priority/milestone) must be
+    // merged into the existing description so we don't clobber the harness-meta block.
+    const bodyFields: Array<keyof FeaturePatch> = [
+      'summary',
+      'spec',
+      'plans',
+      'blockedBy',
+      'priority',
+      'milestone',
+    ];
+    if (bodyFields.some((k) => patch[k] !== undefined)) {
+      const cur = await this.fetchById(externalId);
+      if (!cur.ok) return cur;
+      if (!cur.value) return Err(new Error(`Linear issue not found: ${externalId}`));
+      const f = cur.value.feature;
+      const merged: NewFeatureInput = {
+        name: patch.name ?? f.name,
+        summary: patch.summary ?? f.summary,
+        spec: patch.spec !== undefined ? patch.spec : f.spec,
+        plans: patch.plans !== undefined ? patch.plans : f.plans,
+        blockedBy: patch.blockedBy !== undefined ? patch.blockedBy : f.blockedBy,
+        priority: patch.priority !== undefined ? patch.priority : f.priority,
+        milestone: patch.milestone !== undefined ? patch.milestone : f.milestone,
+      };
+      input.description = serializeBodyBlock(merged.summary ?? '', metaFrom(merged));
+    }
+    if (patch.assignee !== undefined) {
+      if (patch.assignee === null) {
+        input.assigneeId = null;
+      } else {
+        const userR = await this.resolveUserId(patch.assignee);
+        if (userR.ok && userR.value) input.assigneeId = userR.value;
+      }
+    }
+    return this.issueUpdate(externalId, input, ifMatch);
+  }
+
+  async claim(
+    externalId: string,
+    assignee: string,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    const userR = await this.resolveUserId(assignee);
+    if (!userR.ok) return userR;
+    if (!userR.value) return Err(new Error(`Linear user not found: ${assignee}`));
+    const stateR = await this.resolveStateId('in-progress');
+    if (!stateR.ok) return stateR;
+    return this.issueUpdate(
+      externalId,
+      { assigneeId: userR.value, stateId: stateR.value },
+      ifMatch
+    );
+  }
+
+  async release(
+    externalId: string,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    return this.issueUpdate(externalId, { assigneeId: null }, ifMatch);
+  }
+
+  async complete(
+    externalId: string,
+    ifMatch?: string
+  ): Promise<Result<TrackedFeature, ConflictError | Error>> {
+    const stateR = await this.resolveStateId('done');
+    if (!stateR.ok) return stateR;
+    return this.issueUpdate(externalId, { stateId: stateR.value }, ifMatch);
+  }
+
+  // ── History (stored as issue comments) ──────────────────────────────────
+
+  async appendHistory(externalId: string, event: HistoryEvent): Promise<Result<void, Error>> {
+    const body = `${HISTORY_MARKER}\n\`\`\`json\n${JSON.stringify(event)}\n\`\`\``;
+    const r = await this.gql<{ commentCreate?: { success?: boolean } }>(
+      `mutation($input:CommentCreateInput!){ commentCreate(input:$input){ success } }`,
+      { input: { issueId: this.toIssueId(externalId), body } }
+    );
+    if (!r.ok) return r;
+    return Ok(undefined);
+  }
+
+  async fetchHistory(externalId: string, limit?: number): Promise<Result<HistoryEvent[], Error>> {
+    const r = await this.gql<{ issue?: { comments?: { nodes?: Array<{ body?: string }> } } }>(
+      `query($id:String!){ issue(id:$id){ comments(first:250){ nodes { body } } } }`,
+      { id: this.toIssueId(externalId) }
+    );
+    if (!r.ok) return r;
+    const events: HistoryEvent[] = [];
+    for (const c of r.value.issue?.comments?.nodes ?? []) {
+      if (!c.body || !c.body.includes(HISTORY_MARKER)) continue;
+      const m = /```json\s*([\s\S]*?)\s*```/.exec(c.body);
+      if (!m?.[1]) continue;
+      try {
+        const parsed = JSON.parse(m[1]) as HistoryEvent;
+        if (parsed && typeof parsed.type === 'string') events.push(parsed);
+      } catch {
+        // skip malformed history comment
+      }
+    }
+    return Ok(typeof limit === 'number' ? events.slice(0, limit) : events);
+  }
+}
+
+export type { HistoryEventType };

--- a/packages/core/src/roadmap/tracker/factory.ts
+++ b/packages/core/src/roadmap/tracker/factory.ts
@@ -5,9 +5,10 @@ import {
   GitHubIssuesTrackerAdapter,
   type GitHubIssuesTrackerOptions,
 } from './adapters/github-issues';
+import { LinearTrackerAdapter, type LinearTrackerOptions } from './adapters/linear';
 import { ETagStore } from './etag-store';
 
-export interface TrackerClientConfig {
+export interface GitHubTrackerClientConfig {
   kind: 'github-issues';
   repo: string;
   token?: string;
@@ -16,22 +17,49 @@ export interface TrackerClientConfig {
   etagStore?: ETagStore;
 }
 
+export interface LinearTrackerClientConfig {
+  kind: 'linear';
+  /** Linear team id (resolves workflow states + scopes issues). */
+  teamId: string;
+  /** Linear API key; falls back to the LINEAR_API_KEY env var. */
+  token?: string;
+  /** GraphQL endpoint override. */
+  apiBase?: string;
+}
+
+export type TrackerClientConfig = GitHubTrackerClientConfig | LinearTrackerClientConfig;
+
 export function createTrackerClient(
   config: TrackerClientConfig
 ): Result<RoadmapTrackerClient, Error> {
-  if (config.kind !== 'github-issues') {
-    return Err(new Error(`Unsupported tracker kind: "${String(config.kind)}"`));
+  if (config.kind === 'github-issues') {
+    const token = config.token ?? process.env.GITHUB_TOKEN;
+    if (!token) {
+      return Err(
+        new Error('createTrackerClient: missing GitHub token (config.token or GITHUB_TOKEN env)')
+      );
+    }
+    // Build options without spreading undefined values (exactOptionalPropertyTypes).
+    const opts: GitHubIssuesTrackerOptions = { token, repo: config.repo };
+    if (config.apiBase !== undefined) opts.apiBase = config.apiBase;
+    if (config.selectorLabel !== undefined) opts.selectorLabel = config.selectorLabel;
+    if (config.etagStore !== undefined) opts.etagStore = config.etagStore;
+    return Ok(new GitHubIssuesTrackerAdapter(opts));
   }
-  const token = config.token ?? process.env.GITHUB_TOKEN;
-  if (!token) {
-    return Err(
-      new Error('createTrackerClient: missing GitHub token (config.token or GITHUB_TOKEN env)')
-    );
+
+  if (config.kind === 'linear') {
+    const token = config.token ?? process.env.LINEAR_API_KEY;
+    if (!token) {
+      return Err(
+        new Error(
+          'createTrackerClient: missing Linear API key (config.token or LINEAR_API_KEY env)'
+        )
+      );
+    }
+    const opts: LinearTrackerOptions = { apiKey: token, teamId: config.teamId };
+    if (config.apiBase !== undefined) opts.endpoint = config.apiBase;
+    return Ok(new LinearTrackerAdapter(opts));
   }
-  // Build options object without spreading undefined values (exactOptionalPropertyTypes).
-  const opts: GitHubIssuesTrackerOptions = { token, repo: config.repo };
-  if (config.apiBase !== undefined) opts.apiBase = config.apiBase;
-  if (config.selectorLabel !== undefined) opts.selectorLabel = config.selectorLabel;
-  if (config.etagStore !== undefined) opts.etagStore = config.etagStore;
-  return Ok(new GitHubIssuesTrackerAdapter(opts));
+
+  return Err(new Error(`Unsupported tracker kind: "${String((config as { kind: string }).kind)}"`));
 }

--- a/packages/core/src/roadmap/tracker/index.ts
+++ b/packages/core/src/roadmap/tracker/index.ts
@@ -20,7 +20,13 @@ export type {
 } from './client';
 export { ConflictError } from './client';
 export { createTrackerClient } from './factory';
-export type { TrackerClientConfig } from './factory';
+export type {
+  TrackerClientConfig,
+  GitHubTrackerClientConfig,
+  LinearTrackerClientConfig,
+} from './factory';
+export { LinearTrackerAdapter } from './adapters/linear';
+export type { LinearTrackerOptions } from './adapters/linear';
 export { ETagStore } from './etag-store';
 export { makeTrackerConflictBody } from './conflict-body';
 export type { TrackerConflictBody, MakeTrackerConflictBodyOptions } from './conflict-body';


### PR DESCRIPTION
Follow-up to #682 — the full Linear tracker *kind*. A `LinearTrackerAdapter` implements the complete `RoadmapTrackerClient` (3 reads, 5 writes, 2 history) over Linear's GraphQL API, wired into `createTrackerClient({ kind: 'linear', teamId, token })` (falls back to `LINEAR_API_KEY`). It ships its own GraphQL transport because `core` can't depend on `orchestrator` (where #682's client lives).

## Mapping
- `externalId` = `linear:<issue-uuid>`.
- **`status` via Linear's fixed workflow-state `type` enum** (`backlog|unstarted|started|completed`), not team-defined state names — the principled mapping that makes this buildable.
- `spec`/`plans`/`blockedBy`/`priority`/`milestone`/`summary` round-trip through the shared `<!-- harness-meta -->` body block (same encoding as the GitHub adapter, so roadmaps move across trackers).
- priority P0–P3 ↔ Linear 1–4; history events = marked issue comments.
- Writes resolve the team's workflow states + assignee user ids on demand; `update` supports optimistic concurrency via `ifMatch` → `ConflictError`.

## ⚠️ Caveat (per the agreed best-effort posture)
**Not yet validated against a live Linear workspace.** Query/mutation shapes follow Linear's documented schema; the mapping is unit-tested with a **mocked transport** (26 tests, ~90% line coverage), but field-level behavior — custom workflow states, priority semantics, user resolution — should be verified against a real workspace before production use. `blocked`/`needs-human` have no native Linear state type and are treated as `started` on write.