### PR TITLE
feat(cli): design-craft deep-mode auto-capture via capture command

### DIFF
--- a/.changeset/design-craft-auto-capture.md
+++ b/.changeset/design-craft-auto-capture.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Wire `design-craft` deep-mode auto-capture through a caller-configured capture command — finishing the `autoCapture` arg, which previously did nothing (`'prompt'`/`'auto'` behaved like `'skip'`). When `mode: 'deep'` needs captures and none are supplied, a new `captureCommand` is invoked (unless `autoCapture: 'skip'`) to render the components and produce screenshots; deep mode then vision-critiques them. This deliberately avoids a built-in headless browser: the project supplies its own render+screenshot step (Storybook, Playwright, etc.).
+
+Contract: the command receives the candidate files via the `HARNESS_DESIGN_CRAFT_FILES` env var (a JSON array) and prints a JSON array of `{ file, image, component? }` to stdout. A failed command, non-JSON output, or an empty manifest surfaces as a clear tool error. Explicit `captures` still take precedence, and `fast` mode is unaffected. `runCaptureCommand` is exported (with an executor seam) for testing.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -503,7 +503,8 @@ Run the harness-design-craft skill: CRITIQUE / POLISH / BENCHMARK phases over a 
 - `mode` (string, optional) — fast (code-only LLM critique) or deep (vision critique of rendered screenshots — requires `captures`).
 - `phases` (array, optional) — Subset of phases to run. Defaults to all three.
 - `files` (array, optional) — Optional file scoping. Each entry is a path relative to project root.
-- `autoCapture` (string, optional) — B' detect-and-offer behavior when preconditions are missing. MVP: only "skip" is fully implemented.
+- `autoCapture` (string, optional) — Deep-mode capture behavior when no `captures` are supplied. "skip" never runs the capture command; "prompt"/"auto" run `captureCommand` when one is configured.
+- `captureCommand` (string, optional) — Deep-mode render+screenshot command. Receives the candidate files via the HARNESS_DESIGN_CRAFT_FILES env var (JSON array) and must print a JSON array of { file, image, component? } to stdout. Used to obtain captures without a built-in browser.
 - `designStrictness` (string, optional) — Overall design strictness (passed through to harness-design when chained).
 - `benchmarkTargets` (array, optional) — BENCHMARK target descriptors. Each entry needs at minimum { file, component }; optional componentType narrows exemplar selection.
 - `captures` (array, optional) — Deep-mode (vision) captures: rendered component screenshots. Required when mode="deep" and the critique phase runs. Each entry: { file, image, component? }, where `image` is a path to a PNG/JPEG/WebP screenshot (the CLI does not render components itself).

--- a/packages/cli/src/mcp/tools/design-craft.ts
+++ b/packages/cli/src/mcp/tools/design-craft.ts
@@ -16,10 +16,9 @@
 //   - Mode 'fast' critiques source code; mode 'deep' critiques rendered
 //     screenshots (`captures`) via the provider's vision channel. The CLI
 //     does not render components itself — captures are caller-supplied.
-//   - autoCapture arg accepts 'prompt' | 'auto' | 'skip' but only 'skip'
-//     has fully defined behavior in this MVP (no detect-and-offer yet);
-//     'prompt' and 'auto' are accepted and currently behave like 'skip'
-//     with a TODO marker.
+//   - autoCapture 'prompt'/'auto' run a caller-configured `captureCommand`
+//     (render+screenshot step) to obtain deep-mode captures when none are
+//     supplied; 'skip' never runs it. The CLI ships no browser of its own.
 //
 // Honors:
 //   - ADR 0018: phase selection respected; cost surfaced in summary.
@@ -32,6 +31,7 @@
 //   section "MCP tool API" (lines ~205–221).
 
 import * as crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
 import { Ok, Err } from '@harness-engineering/core';
 import type { Result } from '@harness-engineering/core';
 import { resultToMcpResponse } from '../utils/result-adapter.js';
@@ -95,6 +95,21 @@ export interface DesignCraftInput {
    */
   captures?: VisionCritiqueTarget[];
   /**
+   * Deep-mode auto-capture command. When `mode: 'deep'` needs captures and none
+   * are supplied, this command is invoked (unless `autoCapture: 'skip'`) to
+   * render the components and emit captures. The CLI has no browser of its own,
+   * so the caller supplies the render+screenshot step (Storybook, Playwright,
+   * etc.). Contract: the command receives the candidate file list via the
+   * `HARNESS_DESIGN_CRAFT_FILES` env var (a JSON array) and must print a JSON
+   * array of `{ file, image, component? }` to stdout.
+   */
+  captureCommand?: string;
+  /**
+   * Test seam — replace the capture-command executor. Receives `(command,
+   * files)` and returns the command's stdout. NOT in the MCP schema.
+   */
+  __runCapture?: (command: string, files: string[]) => string;
+  /**
    * Test seam — inject an LlmProvider directly (e.g. MockLlmProvider).
    * NOT documented in the MCP tool schema; used by integration tests so
    * deterministic CI works without touching the live provider factory.
@@ -140,7 +155,15 @@ export const designCraftToolDefinition = {
         type: 'string',
         enum: ['prompt', 'auto', 'skip'],
         description:
-          'B\' detect-and-offer behavior when preconditions are missing. MVP: only "skip" is fully implemented.',
+          'Deep-mode capture behavior when no `captures` are supplied. "skip" never runs the ' +
+          'capture command; "prompt"/"auto" run `captureCommand` when one is configured.',
+      },
+      captureCommand: {
+        type: 'string',
+        description:
+          'Deep-mode render+screenshot command. Receives the candidate files via the ' +
+          'HARNESS_DESIGN_CRAFT_FILES env var (JSON array) and must print a JSON array of ' +
+          '{ file, image, component? } to stdout. Used to obtain captures without a built-in browser.',
       },
       designStrictness: {
         type: 'string',
@@ -239,6 +262,70 @@ export async function runDesignCraft(
   return runPipeline(input);
 }
 
+/**
+ * Invoke the caller-configured capture command and parse its `{ file, image }`
+ * manifest. The command is the project's render+screenshot step (Storybook,
+ * Playwright, etc.) — it receives the candidate files via the
+ * `HARNESS_DESIGN_CRAFT_FILES` env var and prints a JSON array to stdout. This
+ * is how deep mode obtains screenshots without the CLI owning a browser.
+ */
+export function runCaptureCommand(
+  command: string,
+  files: string[],
+  exec?: (command: string, files: string[]) => string
+): Result<VisionCritiqueTarget[], { message: string }> {
+  let stdout: string;
+  try {
+    stdout = exec
+      ? exec(command, files)
+      : execSync(command, {
+          encoding: 'utf-8',
+          env: { ...process.env, HARNESS_DESIGN_CRAFT_FILES: JSON.stringify(files) },
+          maxBuffer: 16 * 1024 * 1024,
+        });
+  } catch (err) {
+    return Err({
+      message: `design-craft capture command failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return Err({
+      message:
+        'design-craft capture command did not emit valid JSON. Expected `[{ "file": "...", "image": "..." }]` on stdout.',
+    });
+  }
+  if (!Array.isArray(parsed)) {
+    return Err({
+      message: 'design-craft capture command output must be a JSON array of { file, image }.',
+    });
+  }
+
+  const captures: VisionCritiqueTarget[] = [];
+  for (const item of parsed) {
+    if (
+      item !== null &&
+      typeof item === 'object' &&
+      typeof (item as { file?: unknown }).file === 'string' &&
+      typeof (item as { image?: unknown }).image === 'string'
+    ) {
+      const entry = item as { file: string; image: string; component?: unknown };
+      const capture: VisionCritiqueTarget = { file: entry.file, image: entry.image };
+      if (typeof entry.component === 'string') capture.component = entry.component;
+      captures.push(capture);
+    }
+  }
+  if (captures.length === 0) {
+    return Err({
+      message: 'design-craft capture command produced no valid { file, image } entries.',
+    });
+  }
+  return Ok(captures);
+}
+
 async function runPipeline(
   input: DesignCraftInput
 ): Promise<Result<DesignCraftOutput, { message: string }>> {
@@ -246,22 +333,25 @@ async function runPipeline(
   const phases = selectPhases(input.phases);
 
   // Deep mode critiques rendered screenshots via the provider's vision channel.
-  // The CLI does not render components itself, so captures must be supplied by
-  // the caller; without them the critique phase cannot run in deep mode.
-  const captures = input.captures ?? [];
+  // The CLI does not render components itself, so captures are either supplied
+  // explicitly (`captures`) or produced by a caller-configured `captureCommand`.
+  const autoCapture: AutoCapture = input.autoCapture ?? 'prompt';
+  let captures = input.captures ?? [];
+  const needsCaptures = mode === 'deep' && phases.includes('critique') && captures.length === 0;
+
+  if (needsCaptures && input.captureCommand && autoCapture !== 'skip') {
+    const captured = runCaptureCommand(input.captureCommand, input.files ?? [], input.__runCapture);
+    if (!captured.ok) return captured;
+    captures = captured.value;
+  }
+
   if (mode === 'deep' && phases.includes('critique') && captures.length === 0) {
     return Err({
       message:
         'design-craft deep mode critiques rendered screenshots — supply `captures` ' +
-        '([{ file, image }]). The CLI does not render components itself; capture them ' +
-        '(e.g. via Storybook/Playwright) and pass the image paths, or use mode: "fast".',
+        '([{ file, image }]) or configure `captureCommand` to render them (the CLI does not ' +
+        'render components itself). Or use mode: "fast".',
     });
-  }
-  const autoCapture: AutoCapture = input.autoCapture ?? 'prompt';
-  if (autoCapture !== 'skip') {
-    // TODO (next task): implement resolvers/preconditions + resolvers/offer
-    // to populate `upgradeOffer`. For MVP we behave like 'skip' to avoid
-    // emitting a half-finished detect-and-offer payload.
   }
 
   const provider = input.__testProvider ?? getProvider();

--- a/packages/cli/tests/design-craft/capture-command.test.ts
+++ b/packages/cli/tests/design-craft/capture-command.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runCaptureCommand, handleDesignCraft } from '../../src/mcp/tools/design-craft';
+import { MockLlmProvider } from '../../src/design-craft/llm/provider';
+
+describe('runCaptureCommand', () => {
+  it('parses a { file, image, component? } manifest from stdout', () => {
+    const exec = () =>
+      JSON.stringify([
+        { file: 'src/A.tsx', image: '/tmp/a.png', component: 'A' },
+        { file: 'src/B.tsx', image: '/tmp/b.png' },
+        { nope: 1 }, // ignored — missing file/image
+      ]);
+    const r = runCaptureCommand('render', ['src/A.tsx'], exec);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value).toEqual([
+      { file: 'src/A.tsx', image: '/tmp/a.png', component: 'A' },
+      { file: 'src/B.tsx', image: '/tmp/b.png' },
+    ]);
+  });
+
+  it('passes the candidate files to the executor', () => {
+    let seen: string[] = [];
+    runCaptureCommand('render', ['x.tsx', 'y.tsx'], (_cmd, files) => {
+      seen = files;
+      return JSON.stringify([{ file: 'x.tsx', image: '/tmp/x.png' }]);
+    });
+    expect(seen).toEqual(['x.tsx', 'y.tsx']);
+  });
+
+  it('errors on non-JSON output', () => {
+    const r = runCaptureCommand('render', [], () => 'not json');
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/valid JSON/i);
+  });
+
+  it('errors when no valid entries are produced', () => {
+    const r = runCaptureCommand('render', [], () => JSON.stringify([{ nope: 1 }]));
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/no valid/i);
+  });
+
+  it('propagates a command failure', () => {
+    const r = runCaptureCommand('render', [], () => {
+      throw new Error('boom');
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/capture command failed.*boom/i);
+  });
+});
+
+describe('design-craft deep mode auto-capture', () => {
+  class VisionMockProvider extends MockLlmProvider {
+    async callVision(prompt: string): Promise<string> {
+      return this.callText(prompt);
+    }
+  }
+
+  it('runs the capture command to obtain captures, then vision-critiques them', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-autocap-'));
+    const img = path.join(dir, 'Hero.png');
+    fs.writeFileSync(img, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const result = await handleDesignCraft({
+      path: dir,
+      mode: 'deep',
+      phases: ['critique'],
+      autoCapture: 'auto',
+      captureCommand: 'render-screenshots',
+      __runCapture: () => JSON.stringify([{ file: 'src/Hero.tsx', component: 'Hero', image: img }]),
+      __testProvider: new VisionMockProvider(),
+      __recordMeasurement: false,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text) as {
+      findings: unknown[];
+      summary: { mode: string };
+    };
+    expect(payload.summary.mode).toBe('deep');
+    expect(payload.findings).toHaveLength(10); // 10 rubrics × 1 captured component
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('autoCapture:skip never runs the capture command (still errors without captures)', async () => {
+    let called = false;
+    const result = await handleDesignCraft({
+      path: '/tmp/fake',
+      mode: 'deep',
+      phases: ['critique'],
+      autoCapture: 'skip',
+      captureCommand: 'render',
+      __runCapture: () => {
+        called = true;
+        return '[]';
+      },
+    });
+    expect(called).toBe(false);
+    expect(result.isError).toBe(true);
+  });
+
+  it('surfaces a capture-command failure as a tool error', async () => {
+    const result = await handleDesignCraft({
+      path: '/tmp/fake',
+      mode: 'deep',
+      phases: ['critique'],
+      autoCapture: 'auto',
+      captureCommand: 'render',
+      __runCapture: () => {
+        throw new Error('render crashed');
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/capture command failed/i);
+  });
+});


### PR DESCRIPTION
Final follow-up — finishes the `autoCapture` arg, which did nothing (`'prompt'`/`'auto'` behaved like `'skip'`), and gives deep mode (#683) a way to *obtain* captures rather than only consuming caller-supplied ones.

## Approach (per the chosen "capture-command hook")
No headless-browser dependency. When `mode: 'deep'` needs captures and none are supplied, a caller-configured **`captureCommand`** is invoked (unless `autoCapture: 'skip'`) to render the components and produce screenshots; deep mode then vision-critiques them. The project owns the render step (Storybook, Playwright, etc.).

**Contract:** the command receives the candidate files via `HARNESS_DESIGN_CRAFT_FILES` (a JSON array env var) and prints a JSON array of `{ file, image, component? }` to stdout. A failed command, non-JSON output, or an empty manifest surfaces as a clear tool error. Explicit `captures` still take precedence; `fast` mode is unaffected.

## Why not a built-in renderer
Auto-rendering arbitrary `.tsx` reliably needs a browser + bundler/Storybook — a heavy dependency and architecture choice. The capture-command hook gets the same outcome (real screenshots → vision critique) while leaving the render mechanism to the project, which is the right seam.

## Tests
+8 tests: `runCaptureCommand` (manifest parse, files passed through, non-JSON/empty/failure errors) and end-to-end (`captureCommand` → vision findings; `autoCapture: 'skip'` never runs it; command failure → tool error). 57 design-craft tests pass. `runCaptureCommand` exported with an executor seam. Regenerated MCP reference.