### PR TITLE
chore(roadmap): mark roadmap-shard-store done (shipped in #684)

### DIFF
--- a/docs/roadmap.d/shard-the-roadmap-into-per-row-files-with-a-generated-aggregate-view.md
+++ b/docs/roadmap.d/shard-the-roadmap-into-per-row-files-with-a-generated-aggregate-view.md
@@ -6,12 +6,12 @@ order: 0
 
 ### Shard the roadmap into per-row files with a generated aggregate view
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/roadmap-shard-store/proposal.md
 - **Summary:** Shard docs/roadmap.md into per-row docs/roadmap.d/<slug>.md files (the sole authoritative source) with a generated merge=ours aggregate view, eliminating branch/worktree/PR contention by construction. A RoadmapStore abstraction lets sharded and monolith modes coexist (new projects sharded by default; existing adopters migrate via reversible `harness roadmap shard`). The conflict-free single-shard writeback unlocks auto-done on PR merge via a CI Action plus a `harness roadmap reconcile` fallback, keyed off the External-ID each row already carries. Invariant R: only the regenerator reads roadmap.md; all tools read the shard directory.
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** @chadjw
+- **Assignee:** —
 - **Priority:** —
 - **External-ID:** —
 - **Updated-At:** 2026-06-27T00:00:00.000Z

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,12 +13,12 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Shard the roadmap into per-row files with a generated aggregate view
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/roadmap-shard-store/proposal.md
 - **Summary:** Shard docs/roadmap.md into per-row docs/roadmap.d/<slug>.md files (the sole authoritative source) with a generated merge=ours aggregate view, eliminating branch/worktree/PR contention by construction. A RoadmapStore abstraction lets sharded and monolith modes coexist (new projects sharded by default; existing adopters migrate via reversible `harness roadmap shard`). The conflict-free single-shard writeback unlocks auto-done on PR merge via a CI Action plus a `harness roadmap reconcile` fallback, keyed off the External-ID each row already carries. Invariant R: only the regenerator reads roadmap.md; all tools read the shard directory.
 - **Blockers:** —
 - **Plan:** —
-- **Assignee:** @chadjw
+- **Assignee:** —
 - **Priority:** —
 - **External-ID:** —
 - **Updated-At:** 2026-06-27T00:00:00.000Z


### PR DESCRIPTION
Closes out the roadmap-shard-store work: flip its own Intake row to `done` and clear the assignee (assignee-lifecycle: assignee ⟺ in-progress).

The feature shipped in #684. The auto-done Action it introduced couldn't flip this row automatically — the row carries no `External-ID` issue, so there's no closing reference to map. A small manual close-out (one shard + the regenerated aggregate).

Follow-up tracked: #695 (archive `done` rows into `docs/roadmap.d/archive/`).

🤖 Generated with [Claude Code](https://claude.ai/code)