### PR TITLE
feat(cli): expand audit-anatomy ANAT-P* catalog to 10 patterns

### DIFF
--- a/.changeset/anatomy-patterns-catalog.md
+++ b/.changeset/anatomy-patterns-catalog.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Expand the audit-anatomy ANAT-P\* catalog from 2 to the proposal's target of 10 composition patterns, and refactor the catalog onto a shared `presencePattern` factory (trigger present AND no mitigating affordance in file → one `warn` finding). New patterns:
+
+- **P003 fetch-without-error** — async load with no error state.
+- **P004 conditional-render-without-fallback** — `{data && <…>}` with no else/empty branch.
+- **P005 form-without-submit-feedback** — submit with no pending/success/error signal.
+- **P006 modal-without-dismiss** — `Modal`/`Dialog`/`Drawer` with no `onClose`/`onDismiss`/`onOpenChange`.
+- **P007 async-action-without-pending** — async handler with no disabled/pending state.
+- **P008 list-without-key** — `.map(...)` rendering elements with no `key`.
+- **P009 router-without-not-found** — route table with no catch-all/404.
+- **P010 destructive-action-without-confirm** — delete/remove with no confirmation step.
+
+(P001 map-without-empty and P002 fetch-without-loading are unchanged.) Patterns deliberately avoid pure-accessibility checks (deferred to v2 per Decision #2) and stay conservative source-heuristics to keep false positives low. `full` mode runs all 10; `fast` mode is unchanged.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -419,7 +419,7 @@ Parse a git diff and check for forbidden patterns, oversized files, and missing 
 
 ### `audit_anatomy`
 
-Audit components for anatomy completeness. Emits ANAT-D* findings for component definitions missing required slots/states (e.g., Button missing `content`). In v1 vertical slice runs the component conventions, plus ANAT-P* composition patterns (map-without-empty, fetch-without-loading) in full mode.
+Audit components for anatomy completeness. Emits ANAT-D* findings for component definitions missing required slots/states (e.g., Button missing `content`). In v1 vertical slice runs the component conventions, plus 10 ANAT-P* composition patterns (missing empty/loading/error states, modal dismiss, submit feedback, list keys, route 404, destructive-action confirm, …) in full mode.
 
 **Parameters:**
 

--- a/packages/cli/src/audit/component-anatomy/catalog/patterns/index.ts
+++ b/packages/cli/src/audit/component-anatomy/catalog/patterns/index.ts
@@ -3,15 +3,19 @@
  *
  * Where conventions (ANAT-D*) check a component *definition* for required parts,
  * patterns (ANAT-P*) check *composition* sites for missing affordances: a list
- * rendered with no empty state, an async fetch with no loading boundary, etc.
- * (proposal.md Decision #2 — the "blue-ocean" finding class.)
+ * rendered with no empty state, an async fetch with no loading boundary, a modal
+ * with no dismiss, etc. (proposal.md Decision #2 — the "blue-ocean" finding
+ * class).
  *
- * v1 ships two flagship patterns via conservative source heuristics (no
- * tree-sitter dependency): a finding fires only when the triggering construct is
- * present AND no mitigating affordance appears anywhere in the file, which keeps
- * false positives low at the cost of missing intra-file edge cases. Each finding
- * is `warn` severity and carries a manual fix hint. The `PatternCheck` shape is
- * the extension point for the remaining catalog (P003+).
+ * Detection is conservative source-heuristic (no tree-sitter dependency): a
+ * finding fires only when a *trigger* construct is present in a file AND none of
+ * the *mitigating* affordances appear anywhere in that file. This keeps false
+ * positives low (proposal Success Criterion 6, ≤5% FP) at the cost of missing
+ * intra-file edge cases. Findings are `warn` severity with a manual fix hint.
+ *
+ * Patterns deliberately avoid pure accessibility checks (img-alt, input-label,
+ * etc.) — those overlap harness-accessibility and are deferred to v2 per
+ * Decision #2. These are state/affordance *completeness* checks.
  */
 
 import type { AnatomyFinding } from '../../findings/finding.js';
@@ -37,43 +41,66 @@ function lineAt(contents: string, index: number): number {
 
 const anyMatch = (contents: string, res: RegExp[]): boolean => res.some((re) => re.test(contents));
 
-function makeFinding(
-  pattern: PatternCheck,
-  file: string,
-  contents: string,
-  matchIndex: number,
-  componentType: string | null,
-  message: string,
-  fixDescription: string
-): AnatomyFinding {
-  const line = lineAt(contents, matchIndex);
-  const snippet = (contents.split('\n')[line - 1] ?? '').trim();
-  return {
-    code: pattern.code,
-    severity: 'warn',
-    file,
-    line,
-    componentType,
-    message,
-    evidence: { snippet },
-    rule: { id: pattern.code, source: pattern.source },
-    fix: { kind: 'manual', description: fixDescription },
-  };
+/** First match index across an ordered list of trigger patterns, or -1. */
+function firstTrigger(contents: string, triggers: RegExp[]): number {
+  let best = -1;
+  for (const re of triggers) {
+    const m = re.exec(contents);
+    if (m && (best === -1 || m.index < best)) best = m.index;
+  }
+  return best;
+}
+
+interface PatternSpec {
+  code: AnatomyFinding['code'];
+  id: string;
+  /** Constructs that, when present, indicate the pattern *could* apply. */
+  triggers: RegExp[];
+  /** Affordances whose presence anywhere in the file suppresses the finding. */
+  mitigations: RegExp[];
+  message: string;
+  fix: string;
 }
 
 /**
- * ANAT-P001 — a list is rendered with `.map(...)` but the file has no empty-state
- * branch (length-zero guard, `EmptyState`, "no results" copy). A list that can be
- * empty needs a designed empty state.
+ * Build a {@link PatternCheck} from the common "trigger present AND no mitigation
+ * in file" shape. Emits at most one finding per file, located at the first
+ * trigger. Every pattern in this catalog is expressed this way.
  */
-const mapWithoutEmpty: PatternCheck = {
-  code: 'ANAT-P001',
-  id: 'map-without-empty',
-  source: 'design-component-anatomy/pattern-map-without-empty',
-  detect(file, contents, componentType) {
-    const mapCall = /\.map\s*\(/.exec(contents);
-    if (!mapCall) return [];
-    const emptyGuards = [
+function presencePattern(spec: PatternSpec): PatternCheck {
+  return {
+    code: spec.code,
+    id: spec.id,
+    source: `design-component-anatomy/pattern-${spec.id}`,
+    detect(file, contents, componentType) {
+      const index = firstTrigger(contents, spec.triggers);
+      if (index === -1) return [];
+      if (anyMatch(contents, spec.mitigations)) return [];
+      const line = lineAt(contents, index);
+      const snippet = (contents.split('\n')[line - 1] ?? '').trim();
+      return [
+        {
+          code: spec.code,
+          severity: 'warn',
+          file,
+          line,
+          componentType,
+          message: spec.message,
+          evidence: { snippet },
+          rule: { id: spec.code, source: `design-component-anatomy/pattern-${spec.id}` },
+          fix: { kind: 'manual', description: spec.fix },
+        },
+      ];
+    },
+  };
+}
+
+const SPECS: PatternSpec[] = [
+  {
+    code: 'ANAT-P001',
+    id: 'map-without-empty',
+    triggers: [/\.map\s*\(/],
+    mitigations: [
       /\.length\s*===\s*0/,
       /\.length\s*<\s*1/,
       /\.length\s*>\s*0/,
@@ -83,42 +110,16 @@ const mapWithoutEmpty: PatternCheck = {
       /\bisEmpty\b/,
       /\bEmptyState\b/,
       /\bno\s+(results|items|data|entries)\b/i,
-    ];
-    if (anyMatch(contents, emptyGuards)) return [];
-    return [
-      makeFinding(
-        mapWithoutEmpty,
-        file,
-        contents,
-        mapCall.index,
-        componentType,
-        'List rendered with `.map(...)` but no empty state was found. An empty list ' +
-          'renders as a blank region — add a length-zero branch (e.g. an EmptyState).',
-        'Guard the list: `items.length === 0 ? <EmptyState/> : items.map(...)`.'
-      ),
-    ];
+    ],
+    message:
+      'List rendered with `.map(...)` but no empty state was found. An empty list renders as a blank region — add a length-zero branch (e.g. an EmptyState).',
+    fix: 'Guard the list: `items.length === 0 ? <EmptyState/> : items.map(...)`.',
   },
-};
-
-/**
- * ANAT-P002 — the file performs async data loading (fetch / query hook / awaited
- * effect) but renders no loading affordance (spinner, skeleton, Suspense,
- * `isLoading`). An async surface with no loading boundary flashes empty/janky.
- */
-const fetchWithoutLoading: PatternCheck = {
-  code: 'ANAT-P002',
-  id: 'fetch-without-loading',
-  source: 'design-component-anatomy/pattern-fetch-without-loading',
-  detect(file, contents, componentType) {
-    const asyncSignals = [
-      /\bfetch\s*\(/,
-      /\buse(Query|SWR|Swr|Mutation)\b/,
-      /\baxios\s*[.(]/,
-      /\bawait\s+/,
-    ];
-    const trigger = asyncSignals.map((re) => re.exec(contents)).find((m) => m !== null);
-    if (!trigger) return [];
-    const loadingSignals = [
+  {
+    code: 'ANAT-P002',
+    id: 'fetch-without-loading',
+    triggers: [/\bfetch\s*\(/, /\buse(Query|SWR|Swr|Mutation)\b/, /\baxios\s*[.(]/, /\bawait\s+/],
+    mitigations: [
       /\bis?Loading\b/i,
       /\bisPending\b/i,
       /\bpending\b/i,
@@ -126,23 +127,124 @@ const fetchWithoutLoading: PatternCheck = {
       /\bSpinner\b/,
       /<Suspense\b/,
       /\bplaceholder\b/i,
-    ];
-    if (anyMatch(contents, loadingSignals)) return [];
-    return [
-      makeFinding(
-        fetchWithoutLoading,
-        file,
-        contents,
-        trigger.index,
-        componentType,
-        'Async data loading found but no loading state. The surface renders empty ' +
-          'until data resolves — add a loading boundary (skeleton, spinner, or Suspense).',
-        'Render a loading affordance while the request is in flight ' +
-          '(e.g. `if (isLoading) return <Skeleton/>`).'
-      ),
-    ];
+    ],
+    message:
+      'Async data loading found but no loading state. The surface renders empty until data resolves — add a loading boundary (skeleton, spinner, or Suspense).',
+    fix: 'Render a loading affordance while the request is in flight (e.g. `if (isLoading) return <Skeleton/>`).',
   },
-};
+  {
+    code: 'ANAT-P003',
+    id: 'fetch-without-error',
+    triggers: [/\bfetch\s*\(/, /\buse(Query|SWR|Swr|Mutation)\b/, /\baxios\s*[.(]/, /\bawait\s+/],
+    mitigations: [
+      /\bis?Error\b/i,
+      /\berror\b/i,
+      /\bcatch\s*\(/,
+      /\.catch\s*\(/,
+      /\bErrorState\b/,
+      /\bErrorBoundary\b/,
+      /role=["']alert["']/,
+    ],
+    message:
+      'Async data loading found but no error state. A failed request renders nothing or throws — handle and display the error case.',
+    fix: 'Add an error branch (e.g. `if (isError) return <ErrorState/>`) or a try/catch around the request.',
+  },
+  {
+    code: 'ANAT-P004',
+    id: 'conditional-render-without-fallback',
+    triggers: [/\{\s*[\w.]*(data|items|list|results|rows|user|profile)[\w.]*\s*&&/i],
+    mitigations: [/\?\s*\(?</, /\?\?/, /\bEmptyState\b/, /:\s*null/, /:\s*</, /\.length\s*===\s*0/],
+    message:
+      'Data-driven `{value && <…>}` render with no fallback. When `value` is falsy the region collapses silently — provide an explicit empty/else branch.',
+    fix: 'Use a ternary with a fallback: `value ? <View/> : <EmptyState/>`.',
+  },
+  {
+    code: 'ANAT-P005',
+    id: 'form-without-submit-feedback',
+    triggers: [/<form\b/i, /\bonSubmit\b/, /\bhandleSubmit\b/],
+    mitigations: [
+      /\bisSubmitting\b/i,
+      /\bpending\b/i,
+      /\bsuccess\b/i,
+      /\berror\b/i,
+      /\bdisabled\b/,
+      /role=["']alert["']/,
+      /\btoast\b/i,
+    ],
+    message:
+      'Form submission found but no submit feedback (pending / success / error). The user gets no signal that submit worked or failed.',
+    fix: 'Disable the submit control while pending and surface a success/error state after submission.',
+  },
+  {
+    code: 'ANAT-P006',
+    id: 'modal-without-dismiss',
+    triggers: [/<(Modal|Dialog|Drawer|Sheet|Popover)\b/],
+    mitigations: [/\bonClose\b/, /\bonDismiss\b/, /\bonOpenChange\b/, /\bclose\b/i, /\bonCancel\b/],
+    message:
+      'Modal/Dialog/Drawer used with no dismiss affordance (`onClose` / `onDismiss` / `onOpenChange`). A modal the user cannot close is a trap.',
+    fix: 'Wire a dismiss handler (`onClose` / `onOpenChange`) and a visible close control.',
+  },
+  {
+    code: 'ANAT-P007',
+    id: 'async-action-without-pending',
+    triggers: [
+      /on[A-Z]\w*=\{?\s*async\b/,
+      /\bhandle\w*\s*=\s*async\b/,
+      /async\s+function\s+handle/i,
+    ],
+    mitigations: [
+      /\bdisabled\b/,
+      /\bis?Pending\b/i,
+      /\bis?Loading\b/i,
+      /\bis?Submitting\b/i,
+      /\bSpinner\b/,
+    ],
+    message:
+      'Async action handler with no pending state. Without disabling/feedback the user can double-submit and gets no progress signal.',
+    fix: 'Track a pending flag and disable the control (and show a spinner) while the action runs.',
+  },
+  {
+    code: 'ANAT-P008',
+    id: 'list-without-key',
+    triggers: [/\.map\s*\(\s*\(?[^)]*\)?\s*=>\s*</],
+    mitigations: [/\bkey=/],
+    message:
+      'Elements rendered from `.map(...)` with no `key` prop. Missing keys break reconciliation (lost state, mis-ordered DOM).',
+    fix: 'Add a stable `key` to the top-level mapped element: `items.map((i) => <Row key={i.id} />)`.',
+  },
+  {
+    code: 'ANAT-P009',
+    id: 'router-without-not-found',
+    triggers: [/<Routes\b/, /<Switch\b/, /\bcreateBrowserRouter\b/],
+    mitigations: [
+      /path=["']\*["']/,
+      /path=["']\/\*["']/,
+      /\bNotFound\b/,
+      /\bcatchAll\b/i,
+      /\b404\b/,
+    ],
+    message: 'Route table with no catch-all / not-found route. Unmatched URLs render a blank page.',
+    fix: 'Add a catch-all route (`<Route path="*" element={<NotFound/>} />`).',
+  },
+  {
+    code: 'ANAT-P010',
+    id: 'destructive-action-without-confirm',
+    triggers: [
+      /\b(onDelete|handleDelete|handleRemove|onRemove)\b/,
+      /\b(delete|remove|destroy)\w*\s*\(/i,
+    ],
+    mitigations: [
+      /\bconfirm\s*\(/i,
+      /\bAlertDialog\b/,
+      /\bConfirm(ation)?(Dialog|Modal)?\b/,
+      /\bareYouSure\b/i,
+      /\bwindow\.confirm\b/,
+    ],
+    message:
+      'Destructive action (delete/remove) with no confirmation step. A single click irreversibly destroys data.',
+    fix: 'Gate the action behind a confirmation (e.g. an AlertDialog) before performing it.',
+  },
+];
 
-/** The v1 ANAT-P* catalog, in stable order. */
-export const PATTERN_CHECKS: readonly PatternCheck[] = [mapWithoutEmpty, fetchWithoutLoading];
+/** The v1 ANAT-P* catalog (10 patterns), in stable order. */
+export const PATTERN_CHECKS: readonly PatternCheck[] = SPECS.map(presencePattern);

--- a/packages/cli/src/mcp/tools/audit-anatomy.ts
+++ b/packages/cli/src/mcp/tools/audit-anatomy.ts
@@ -56,7 +56,7 @@ export const auditAnatomyDefinition = {
   description:
     'Audit components for anatomy completeness. Emits ANAT-D* findings for component definitions ' +
     'missing required slots/states (e.g., Button missing `content`). In v1 vertical slice runs the ' +
-    'component conventions, plus ANAT-P* composition patterns (map-without-empty, fetch-without-loading) in full mode.',
+    'component conventions, plus 10 ANAT-P* composition patterns (missing empty/loading/error states, modal dismiss, submit feedback, list keys, route 404, destructive-action confirm, …) in full mode.',
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/cli/tests/audit/component-anatomy/unit/patterns.test.ts
+++ b/packages/cli/tests/audit/component-anatomy/unit/patterns.test.ts
@@ -10,6 +10,77 @@ function run(code: string, file: string, contents: string) {
   return pattern.detect(file, contents, null);
 }
 
+const fires = (code: string, src: string) => run(code, 'F.tsx', src).length === 1;
+
+describe('ANAT-P catalog completeness', () => {
+  it('ships at least 10 patterns with unique codes and slugs', () => {
+    expect(PATTERN_CHECKS.length).toBeGreaterThanOrEqual(10);
+    expect(new Set(PATTERN_CHECKS.map((p) => p.code)).size).toBe(PATTERN_CHECKS.length);
+    expect(new Set(PATTERN_CHECKS.map((p) => p.id)).size).toBe(PATTERN_CHECKS.length);
+    for (const p of PATTERN_CHECKS) expect(p.code).toMatch(/^ANAT-P\d{3}$/);
+  });
+});
+
+describe('ANAT-P003..P010 fire / suppress', () => {
+  it('P003 fetch-without-error: fires on fetch with no error handling, suppressed by catch', () => {
+    expect(fires('ANAT-P003', `useEffect(() => { fetch('/x').then(setData); }, []);`)).toBe(true);
+    expect(fires('ANAT-P003', `try { await fetch('/x'); } catch (e) { setError(e); }`)).toBe(false);
+  });
+
+  it('P004 conditional-render-without-fallback: fires on `{data && <…>}`, suppressed by ternary', () => {
+    expect(fires('ANAT-P004', `return <div>{data && <Profile user={data} />}</div>;`)).toBe(true);
+    expect(fires('ANAT-P004', `return <div>{data ? <Profile/> : <EmptyState/>}</div>;`)).toBe(
+      false
+    );
+  });
+
+  it('P005 form-without-submit-feedback: fires on onSubmit, suppressed by isSubmitting', () => {
+    expect(fires('ANAT-P005', `<form onSubmit={save}><button>Save</button></form>`)).toBe(true);
+    expect(
+      fires(
+        'ANAT-P005',
+        `<form onSubmit={save}><button disabled={isSubmitting}>Save</button></form>`
+      )
+    ).toBe(false);
+  });
+
+  it('P006 modal-without-dismiss: fires on <Modal> with no close, suppressed by onClose', () => {
+    expect(fires('ANAT-P006', `return <Modal><Body/></Modal>;`)).toBe(true);
+    expect(fires('ANAT-P006', `return <Modal onClose={hide}><Body/></Modal>;`)).toBe(false);
+  });
+
+  it('P007 async-action-without-pending: fires on async handler, suppressed by disabled', () => {
+    expect(fires('ANAT-P007', `<button onClick={async () => { await save(); }}>Go</button>`)).toBe(
+      true
+    );
+    expect(
+      fires(
+        'ANAT-P007',
+        `<button disabled={pending} onClick={async () => { await save(); }}>Go</button>`
+      )
+    ).toBe(false);
+  });
+
+  it('P008 list-without-key: fires on keyless map, suppressed by key=', () => {
+    expect(fires('ANAT-P008', `{items.map((i) => <Row data={i} />)}`)).toBe(true);
+    expect(fires('ANAT-P008', `{items.map((i) => <Row key={i.id} data={i} />)}`)).toBe(false);
+  });
+
+  it('P009 router-without-not-found: fires on <Routes> with no catch-all, suppressed by path="*"', () => {
+    expect(fires('ANAT-P009', `<Routes><Route path="/" element={<Home/>} /></Routes>`)).toBe(true);
+    expect(fires('ANAT-P009', `<Routes><Route path="*" element={<NotFound/>} /></Routes>`)).toBe(
+      false
+    );
+  });
+
+  it('P010 destructive-action-without-confirm: fires on delete handler, suppressed by confirm', () => {
+    expect(fires('ANAT-P010', `const onDelete = () => api.remove(id);`)).toBe(true);
+    expect(
+      fires('ANAT-P010', `const onDelete = () => { if (confirm('Sure?')) api.remove(id); };`)
+    ).toBe(false);
+  });
+});
+
 describe('ANAT-P001 map-without-empty', () => {
   it('flags a .map render with no empty-state branch', () => {
     const findings = run(


### PR DESCRIPTION
Ships the proposal's target of **10 ANAT-P\* composition patterns** (up from the 2 flagships), and refactors the catalog onto a shared `presencePattern` factory (trigger present in file AND no mitigating affordance → one `warn` finding at the trigger line).

## New patterns (P003–P010)
| Code | Pattern | Fires when… |
|---|---|---|
| P003 | fetch-without-error | async load, no error state/`catch`/`ErrorState` |
| P004 | conditional-render-without-fallback | `{data && <…>}` with no else/empty branch |
| P005 | form-without-submit-feedback | submit, no pending/success/error/disabled |
| P006 | modal-without-dismiss | `Modal`/`Dialog`/`Drawer`, no `onClose`/`onOpenChange` |
| P007 | async-action-without-pending | async handler, no disabled/pending |
| P008 | list-without-key | `.map(...)` → element with no `key` |
| P009 | router-without-not-found | `<Routes>`/`<Switch>`, no catch-all/404 |
| P010 | destructive-action-without-confirm | delete/remove, no confirmation |

P001/P002 unchanged.

## Scope notes
- Patterns deliberately **avoid pure-accessibility checks** (img-alt, input-label, link-href) — those overlap harness-accessibility and are v2-deferred per Decision #2. These are state/affordance **completeness** checks.
- Detection stays **conservative source-heuristic** (no tree-sitter): a finding fires only when the trigger is present and no mitigation appears in the file — trading recall for the proposal's ≤5% false-positive target.

## Tests
+9 (catalog-completeness invariant + fire/suppress for each of P003–P010); P001/P002 + runAudit-wiring tests unchanged. All 127 audit-anatomy tests pass. Regenerated MCP reference.