### PR TITLE
feat: design-craft capture command for the dashboard (deep mode)

### DIFF
--- a/docs/guides/design-craft-capture.md
+++ b/docs/guides/design-craft-capture.md
@@ -1,0 +1,63 @@
+# design-craft deep mode: capturing dashboard screenshots
+
+`harness design_craft --mode deep` critiques **rendered screenshots** of components
+through a vision model, instead of reading source code (`--mode fast`). The harness
+CLI ships no browser of its own — the project supplies the render+screenshot step
+via a `captureCommand`. This repo's capture command is
+[`scripts/design-capture.mjs`](../../scripts/design-capture.mjs), which screenshots
+the dashboard's pages with Playwright.
+
+## One-time setup
+
+Playwright is an **opt-in** dependency (it isn't installed by default, to keep
+installs and CI light):
+
+```bash
+pnpm add -Dw playwright
+npx playwright install chromium
+```
+
+## Running a deep-mode critique
+
+1. Start the dashboard dev server (client + API):
+
+   ```bash
+   pnpm --filter @harness-engineering/dashboard dev
+   ```
+
+   The client serves on `http://localhost:3700` by default
+   (`DASHBOARD_CLIENT_PORT` / `DASHBOARD_BASE_URL` override it).
+
+2. Invoke `design_craft` in deep mode with the dashboard page files and the
+   capture command:
+
+   ```jsonc
+   {
+     "mode": "deep",
+     "phases": ["critique"],
+     "autoCapture": "auto",
+     "captureCommand": "node scripts/design-capture.mjs",
+     "files": [
+       "packages/dashboard/src/client/pages/Signals.tsx",
+       "packages/dashboard/src/client/pages/Health.tsx",
+     ],
+   }
+   ```
+
+design-craft passes the `files` to the command via the
+`HARNESS_DESIGN_CRAFT_FILES` env var (a JSON array). The command navigates to
+each page's `/s/<slug>` route, screenshots it full-page, and prints a
+`[{ file, image, component }]` manifest on stdout, which deep mode then
+vision-critiques.
+
+## Notes & limits
+
+- **Pages only.** Only files under `pages/` map to a navigable route. Loose
+  components (`components/*.tsx`) have no standalone URL and are skipped — capture
+  the page that composes them. A Storybook (or a per-component render harness)
+  would lift this limit later without changing the manifest contract.
+- The route slug is the page filename lowercased, with a small override table
+  (e.g. `DecayTrends.tsx` → `/s/decay`).
+- If Playwright is missing, or a page fails to load, the command writes a clear
+  message to stderr; an empty/failed manifest surfaces as a normal design-craft
+  error.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docs:build": "pnpm --filter docs build",
     "docs:preview": "pnpm --filter docs preview",
     "generate-docs": "node scripts/generate-docs.mjs",
+    "design:capture": "node scripts/design-capture.mjs",
     "generate-barrel-exports": "node scripts/generate-barrel-exports.mjs",
     "generate:barrels": "node scripts/generate-barrel-exports.mjs && node scripts/generate-core-barrel.mjs",
     "generate:barrels:check": "node scripts/generate-barrel-exports.mjs --check && node scripts/generate-core-barrel.mjs --check",

--- a/scripts/design-capture.mjs
+++ b/scripts/design-capture.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * design-craft capture command for the dashboard.
+ *
+ * Renders dashboard *pages* via a headless browser and prints a
+ * `[{ file, image, component }]` manifest on stdout — the contract
+ * `harness design_craft --mode deep` expects from a `captureCommand`. The
+ * harness CLI ships no browser of its own (by design); this project-side script
+ * supplies the render+screenshot step.
+ *
+ * Playwright is an OPT-IN, lazily-imported dependency so it is NOT forced on
+ * every install / CI run. To use deep-mode capture:
+ *
+ *   1. pnpm add -Dw playwright && npx playwright install chromium
+ *   2. Run the dashboard:  pnpm --filter @harness-engineering/dashboard dev
+ *   3. Invoke design-craft with:
+ *        captureCommand = "node scripts/design-capture.mjs"
+ *      and `files` set to dashboard page paths
+ *      (packages/dashboard/src/client/pages/*.tsx).
+ *
+ * Input: the candidate files arrive as a JSON array in the
+ * `HARNESS_DESIGN_CRAFT_FILES` env var (set by design-craft). The dashboard
+ * dev-server URL is `DASHBOARD_BASE_URL` (default `http://localhost:3700`,
+ * overridable via `DASHBOARD_CLIENT_PORT`).
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Pages whose route slug differs from their lowercased filename. */
+const SLUG_OVERRIDES = { decaytrends: 'decay' };
+
+/** Map a page file path to its `/s/<slug>` route slug. */
+export function slugForFile(file) {
+  const name = basename(file, extname(file)).toLowerCase();
+  return SLUG_OVERRIDES[name] ?? name;
+}
+
+/** Parse the `HARNESS_DESIGN_CRAFT_FILES` env var into a string[] (tolerant). */
+export function parseTargetFiles(raw) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((f) => typeof f === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Keep only dashboard *page* files — only routes can be navigated to and
+ * screenshotted; loose components have no standalone URL without a render
+ * harness, so they are skipped.
+ */
+export function pageFiles(files) {
+  return files.filter((f) => f.includes('/pages/') && f.endsWith('.tsx'));
+}
+
+/** Build the base dashboard URL from env. */
+export function baseUrl(env = process.env) {
+  if (env.DASHBOARD_BASE_URL) return env.DASHBOARD_BASE_URL;
+  return `http://localhost:${env.DASHBOARD_CLIENT_PORT ?? '3700'}`;
+}
+
+async function main() {
+  const targets = pageFiles(parseTargetFiles(process.env.HARNESS_DESIGN_CRAFT_FILES));
+  if (targets.length === 0) {
+    process.stderr.write(
+      'design-capture: no dashboard page files in HARNESS_DESIGN_CRAFT_FILES ' +
+        '(expected packages/dashboard/src/client/pages/*.tsx).\n'
+    );
+    process.stdout.write('[]\n');
+    return;
+  }
+
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch {
+    process.stderr.write(
+      'design-capture: playwright is not installed. Run ' +
+        '`pnpm add -Dw playwright && npx playwright install chromium`.\n'
+    );
+    process.exit(1);
+  }
+
+  const base = baseUrl();
+  const outDir = mkdtempSync(join(tmpdir(), 'design-capture-'));
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const manifest = [];
+  try {
+    for (const file of targets) {
+      const slug = slugForFile(file);
+      const url = `${base}/s/${slug}`;
+      try {
+        await page.goto(url, { waitUntil: 'networkidle', timeout: 15_000 });
+        await page.waitForTimeout(500);
+      } catch (err) {
+        process.stderr.write(`design-capture: failed to load ${url}: ${err.message}\n`);
+        continue;
+      }
+      const image = join(outDir, `${slug}.png`);
+      await page.screenshot({ path: image, fullPage: true });
+      manifest.push({ file, image, component: basename(file, extname(file)) });
+    }
+  } finally {
+    await browser.close();
+  }
+  process.stdout.write(JSON.stringify(manifest) + '\n');
+}
+
+// Only run when invoked directly (not when imported by tests).
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedDirectly) {
+  main().catch((err) => {
+    process.stderr.write(`design-capture: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/tests/scripts/design-capture.test.mjs
+++ b/tests/scripts/design-capture.test.mjs
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the pure helpers in scripts/design-capture.mjs (the design-craft
+ * capture command). The Playwright/render path needs a browser + a running
+ * dashboard and is exercised manually; here we lock the file→route mapping and
+ * input parsing that decide what gets captured. Run with: node --test tests/scripts/
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  slugForFile,
+  parseTargetFiles,
+  pageFiles,
+  baseUrl,
+} from '../../scripts/design-capture.mjs';
+
+test('slugForFile lowercases the page basename', () => {
+  assert.equal(slugForFile('packages/dashboard/src/client/pages/Signals.tsx'), 'signals');
+  assert.equal(slugForFile('pages/Kanban.tsx'), 'kanban');
+});
+
+test('slugForFile honors known route-slug overrides', () => {
+  assert.equal(slugForFile('pages/DecayTrends.tsx'), 'decay');
+});
+
+test('parseTargetFiles reads a JSON array and tolerates junk', () => {
+  assert.deepEqual(parseTargetFiles('["a.tsx","b.tsx"]'), ['a.tsx', 'b.tsx']);
+  assert.deepEqual(parseTargetFiles('["a.tsx", 1, null]'), ['a.tsx']); // non-strings dropped
+  assert.deepEqual(parseTargetFiles(undefined), []);
+  assert.deepEqual(parseTargetFiles('not json'), []);
+  assert.deepEqual(parseTargetFiles('{"not":"array"}'), []);
+});
+
+test('pageFiles keeps only dashboard page .tsx files', () => {
+  const input = [
+    'packages/dashboard/src/client/pages/Health.tsx',
+    'packages/dashboard/src/client/components/KpiCard.tsx', // not a page
+    'packages/dashboard/src/client/pages/Roadmap.ts', // not .tsx
+    'src/pages/Other.tsx',
+  ];
+  assert.deepEqual(pageFiles(input), [
+    'packages/dashboard/src/client/pages/Health.tsx',
+    'src/pages/Other.tsx',
+  ]);
+});
+
+test('baseUrl resolves from DASHBOARD_BASE_URL, then port, then default', () => {
+  assert.equal(baseUrl({ DASHBOARD_BASE_URL: 'http://x:9' }), 'http://x:9');
+  assert.equal(baseUrl({ DASHBOARD_CLIENT_PORT: '4000' }), 'http://localhost:4000');
+  assert.equal(baseUrl({}), 'http://localhost:3700');
+});


### PR DESCRIPTION
Sets up **this repo's** `captureCommand` so `design_craft --mode deep` works against the dashboard — the project-side render+screenshot step the capture-command hook (#694) expects.

## What's here
- **`scripts/design-capture.mjs`** — reads the target files from `HARNESS_DESIGN_CRAFT_FILES`, maps each dashboard page to its `/s/<slug>` route, screenshots the running dev server full-page with Playwright, and prints the `[{ file, image, component }]` manifest deep mode consumes.
- **`design:capture`** root script + **`docs/guides/design-craft-capture.md`** usage guide.
- **node:test** coverage for the pure helpers (slug mapping, env parsing, page-file filter, base-URL resolution), auto-run by the existing `tests/scripts/*.test.mjs` CI step.

## Why Playwright is opt-in
A real screenshot needs a browser, but forcing Playwright (+ ~hundreds of MB of browser binaries) on every install/CI is heavy. So it's **lazily imported**: the script runs only when the user has installed it (`pnpm add -Dw playwright && npx playwright install chromium`) and the dashboard dev server is up; otherwise it fails with a clear instruction. This keeps the default install/CI light while making deep capture a one-command opt-in — consistent with #694's "the project owns the render mechanism" design.

## Limits (documented)
- **Pages only** — loose `components/*.tsx` have no standalone URL and are skipped; a Storybook/per-component harness would lift this later without changing the manifest contract.
- Slug = page filename lowercased + a small override table (`DecayTrends` → `decay`).