### PR TITLE
fix(sentinel): make sentinel-pre enforce-only (stop tainting on agent input)

### DIFF
--- a/.changeset/fix-sentinel-enforce-only.md
+++ b/.changeset/fix-sentinel-enforce-only.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(sentinel): make sentinel-pre enforce-only so it no longer taints on the agent's own tool inputs
+
+sentinel-pre previously ran injection detection and wrote taint on tool INPUTS,
+contradicting its documented enforce-only role. Legitimate agent activity — commit-bypass
+flags, base64/git-SHA tokens — tainted the 30-minute session window and then blocked the
+agent's own git push/commit as "destructive". Detection now lives solely in sentinel-post
+(which scans untrusted tool OUTPUT, the real prompt-injection vector); sentinel-pre only
+enforces existing taint. A genuinely tainted session still blocks destructive operations.

--- a/.harness/hooks/sentinel-pre.js
+++ b/.harness/hooks/sentinel-pre.js
@@ -1,17 +1,23 @@
 #!/usr/bin/env node
-/* global console */
 // sentinel-pre.js — PreToolUse:* hook
-// Sentinel prompt injection defense — scans tool inputs for injection patterns
-// and blocks destructive operations during tainted sessions.
+// Sentinel ENFORCEMENT: blocks destructive operations during an already-tainted
+// session. Taint is set exclusively by sentinel-post from untrusted tool OUTPUT
+// (the actual prompt-injection vector). This hook performs NO injection detection
+// on tool INPUTS — an agent's own tool inputs are its intent, not untrusted content,
+// and scanning them here falsely tainted legitimate work (e.g. an agent running
+// `git commit --no-verify`, or inputs containing base64/git-SHA tokens), then blocked
+// the agent's own `git push`. Detection lives in sentinel-post; pre only enforces.
 // Exit codes: 0 = allow, 2 = block
+//
+// Design contract: see packages/cli/src/hooks/profiles.ts — "sentinel-pre (exit-2
+// blocks a destructive op in an already-tainted session) and sentinel-post
+// (detection only)".
 
-import { readFileSync, writeFileSync, mkdirSync, unlinkSync, realpathSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { readFileSync, unlinkSync, realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
 import process from 'node:process';
 
 // Destructive tool patterns blocked during taint.
-// These are intentionally inline — this check runs before the @harness-engineering/core
-// import attempt to ensure enforcement even when core is unavailable.
 // Keep in sync with DESTRUCTIVE_BASH exported from @harness-engineering/core injection-patterns.ts.
 const DESTRUCTIVE_BASH = [
   /\bgit\s+push\b/,
@@ -31,73 +37,6 @@ function isOutsideWorkspace(filePath, workspaceRoot) {
   let realResolved = resolved;
   try { realResolved = realpathSync(resolved); } catch { /* path doesn't exist yet — use resolved */ }
   return !realResolved.startsWith(workspaceRoot);
-}
-
-// Minimal inline patterns for when @harness-engineering/core isn't available.
-// Keep in sync with @harness-engineering/core injection-patterns.ts ALL_PATTERNS.
-// Covers all HIGH-severity patterns and key MEDIUM patterns for degraded-mode safety.
-function inlineScan(text) {
-  console.error('[sentinel] Running in degraded mode: core import failed, using inline patterns');
-  const findings = [];
-  const lines = text.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // HIGH: INJ-UNI-001 — Zero-width characters
-    // eslint-disable-next-line no-misleading-character-class -- intentional: detects zero-width chars for security
-    if (/[\u200B\u200C\u200D\uFEFF\u2060]/.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-UNI-001', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-UNI-002 — RTL/LTR override characters
-    if (/[\u202A-\u202E\u2066-\u2069]/.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-UNI-002', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-REROL-001 — Ignore previous instructions
-    if (/(?:ignore|disregard|forget)\s+(?:all\s+)?(?:previous|prior|above|earlier)\s+(?:instructions?|prompts?|context|rules?|guidelines?)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-REROL-001', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-REROL-002 — Role reassignment
-    if (/you\s+are\s+now\s+(?:a\s+|an\s+)?(?:new\s+)?(?:helpful\s+)?(?:my\s+)?(?:\w+\s+)?(?:assistant|agent|AI|bot|chatbot|system|persona)\b/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-REROL-002', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-REROL-003 — Direct instruction override
-    if (/(?:new\s+)?(?:system\s+)?(?:instruction|directive|role|persona)\s*[:=]\s*/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-REROL-003', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-PERM-001 — Enable all tools/permissions
-    if (/(?:allow|enable|grant)\s+all\s+(?:tools?|permissions?|access)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-PERM-001', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-PERM-002 — Disable safety/security
-    if (/(?:disable|turn\s+off|remove|bypass)\s+(?:all\s+)?(?:safety|security|restrictions?|guardrails?|protections?|checks?)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-PERM-002', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-PERM-003 — Auto-approve directive
-    if (/(?:auto[- ]?approve|--no-verify|--dangerously-skip-permissions)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-PERM-003', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-ENC-001 — Suspicious base64 (skip lines that look like file paths or CLI commands)
-    if (!/^[\s]*(?:cd |git |node |pnpm |npm |\/|packages\/|agents\/|src\/)/.test(line) &&
-        /(?<!Bearer\s)(?<![:])(?<![A-Za-z0-9/])(?!eyJ)(?:[A-Za-z0-9+/]{4}){7,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?(?![A-Za-z0-9/])/.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-ENC-001', match: line.trim(), line: i + 1 });
-    }
-    // MEDIUM: INJ-CTX-001 — System prompt claims
-    if (/(?:the\s+)?(?:system\s+prompt|system\s+message|hidden\s+instructions?)\s+(?:says?|tells?|instructs?|contains?|is)/i.test(line)) {
-      findings.push({ severity: 'medium', ruleId: 'INJ-CTX-001', match: line.trim(), line: i + 1 });
-    }
-  }
-  return findings;
-}
-
-function extractText(toolName, toolInput) {
-  if (toolName === 'Bash') return toolInput?.command ?? '';
-  if (toolName === 'Write') return toolInput?.content ?? '';
-  if (toolName === 'Edit') return `${toolInput?.old_string ?? ''}\n${toolInput?.new_string ?? ''}`;
-  if (toolName === 'Read') return toolInput?.file_path ?? '';
-  const parts = [];
-  for (const value of Object.values(toolInput || {})) {
-    if (typeof value === 'string') parts.push(value);
-  }
-  return parts.join('\n') || null;
 }
 
 async function main() {
@@ -125,7 +64,8 @@ async function main() {
     const sessionId = input?.session_id;
     const workspaceRoot = process.cwd();
 
-    // Step 1: Check taint state — block destructive ops if tainted
+    // Check taint state — block destructive ops if the session is already tainted.
+    // Taint is written only by sentinel-post (from untrusted tool OUTPUT).
     let tainted = false;
     try {
       const taintPath = resolve(
@@ -170,69 +110,6 @@ async function main() {
           );
           process.exit(2);
         }
-      }
-    }
-
-    // Step 2: Scan tool inputs for injection patterns
-    const textToScan = extractText(toolName, toolInput);
-    if (textToScan) {
-      let findings;
-      try {
-        const core = await import('@harness-engineering/core');
-        findings = core.scanForInjection(textToScan);
-      } catch {
-        findings = inlineScan(textToScan);
-      }
-
-      const actionable = findings.filter((f) => f.severity === 'high' || f.severity === 'medium');
-
-      if (actionable.length > 0) {
-        try {
-          const core = await import('@harness-engineering/core');
-          core.writeTaint(
-            workspaceRoot,
-            sessionId,
-            `Injection pattern detected in PreToolUse:${toolName} input`,
-            actionable,
-            `PreToolUse:${toolName}`
-          );
-        } catch {
-          // Fallback inline taint writer — merges with existing taint state
-          try {
-            const id = sessionId || 'default';
-            const taintPath = resolve(workspaceRoot, '.harness', `session-taint-${id}.json`);
-            mkdirSync(dirname(taintPath), { recursive: true });
-            const now = new Date().toISOString();
-            const maxSev = actionable.some((f) => f.severity === 'high') ? 'high' : 'medium';
-            const newFindings = actionable.map((f) => ({
-              ruleId: f.ruleId, severity: f.severity, match: f.match,
-              source: `PreToolUse:${toolName}`, detectedAt: now,
-            }));
-            // Read and merge existing taint state to preserve earlier taintedAt and findings
-            let existing = null;
-            try { existing = JSON.parse(readFileSync(taintPath, 'utf-8')); } catch { /* no existing */ }
-            const state = {
-              sessionId: id,
-              taintedAt: existing?.taintedAt ?? now,
-              expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
-              reason: existing?.reason ?? `Injection pattern detected in PreToolUse:${toolName} input`,
-              severity: maxSev,
-              findings: [...(existing?.findings ?? []), ...newFindings],
-            };
-            writeFileSync(taintPath, JSON.stringify(state, null, 2) + '\n');
-          } catch { /* best-effort */ }
-        }
-
-        for (const f of actionable) {
-          process.stderr.write(
-            `Sentinel [${f.severity}] ${f.ruleId}: detected in ${toolName} input\n`
-          );
-        }
-      }
-
-      const low = findings.filter((f) => f.severity === 'low');
-      for (const f of low) {
-        process.stderr.write(`Sentinel [low] ${f.ruleId}: ${f.match.slice(0, 80)}\n`);
       }
     }
 

--- a/packages/cli/src/hooks/sentinel-pre.js
+++ b/packages/cli/src/hooks/sentinel-pre.js
@@ -1,17 +1,23 @@
 #!/usr/bin/env node
-/* global console */
 // sentinel-pre.js — PreToolUse:* hook
-// Sentinel prompt injection defense — scans tool inputs for injection patterns
-// and blocks destructive operations during tainted sessions.
+// Sentinel ENFORCEMENT: blocks destructive operations during an already-tainted
+// session. Taint is set exclusively by sentinel-post from untrusted tool OUTPUT
+// (the actual prompt-injection vector). This hook performs NO injection detection
+// on tool INPUTS — an agent's own tool inputs are its intent, not untrusted content,
+// and scanning them here falsely tainted legitimate work (e.g. an agent running
+// `git commit --no-verify`, or inputs containing base64/git-SHA tokens), then blocked
+// the agent's own `git push`. Detection lives in sentinel-post; pre only enforces.
 // Exit codes: 0 = allow, 2 = block
+//
+// Design contract: see packages/cli/src/hooks/profiles.ts — "sentinel-pre (exit-2
+// blocks a destructive op in an already-tainted session) and sentinel-post
+// (detection only)".
 
-import { readFileSync, writeFileSync, mkdirSync, unlinkSync, realpathSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { readFileSync, unlinkSync, realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
 import process from 'node:process';
 
 // Destructive tool patterns blocked during taint.
-// These are intentionally inline — this check runs before the @harness-engineering/core
-// import attempt to ensure enforcement even when core is unavailable.
 // Keep in sync with DESTRUCTIVE_BASH exported from @harness-engineering/core injection-patterns.ts.
 const DESTRUCTIVE_BASH = [
   /\bgit\s+push\b/,
@@ -31,73 +37,6 @@ function isOutsideWorkspace(filePath, workspaceRoot) {
   let realResolved = resolved;
   try { realResolved = realpathSync(resolved); } catch { /* path doesn't exist yet — use resolved */ }
   return !realResolved.startsWith(workspaceRoot);
-}
-
-// Minimal inline patterns for when @harness-engineering/core isn't available.
-// Keep in sync with @harness-engineering/core injection-patterns.ts ALL_PATTERNS.
-// Covers all HIGH-severity patterns and key MEDIUM patterns for degraded-mode safety.
-function inlineScan(text) {
-  console.error('[sentinel] Running in degraded mode: core import failed, using inline patterns');
-  const findings = [];
-  const lines = text.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // HIGH: INJ-UNI-001 — Zero-width characters
-    // eslint-disable-next-line no-misleading-character-class -- intentional: detects zero-width chars for security
-    if (/[\u200B\u200C\u200D\uFEFF\u2060]/.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-UNI-001', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-UNI-002 — RTL/LTR override characters
-    if (/[\u202A-\u202E\u2066-\u2069]/.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-UNI-002', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-REROL-001 — Ignore previous instructions
-    if (/(?:ignore|disregard|forget)\s+(?:all\s+)?(?:previous|prior|above|earlier)\s+(?:instructions?|prompts?|context|rules?|guidelines?)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-REROL-001', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-REROL-002 — Role reassignment
-    if (/you\s+are\s+now\s+(?:a\s+|an\s+)?(?:new\s+)?(?:helpful\s+)?(?:my\s+)?(?:\w+\s+)?(?:assistant|agent|AI|bot|chatbot|system|persona)\b/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-REROL-002', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-REROL-003 — Direct instruction override
-    if (/(?:new\s+)?(?:system\s+)?(?:instruction|directive|role|persona)\s*[:=]\s*/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-REROL-003', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-PERM-001 — Enable all tools/permissions
-    if (/(?:allow|enable|grant)\s+all\s+(?:tools?|permissions?|access)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-PERM-001', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-PERM-002 — Disable safety/security
-    if (/(?:disable|turn\s+off|remove|bypass)\s+(?:all\s+)?(?:safety|security|restrictions?|guardrails?|protections?|checks?)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-PERM-002', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-PERM-003 — Auto-approve directive
-    if (/(?:auto[- ]?approve|--no-verify|--dangerously-skip-permissions)/i.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-PERM-003', match: line.trim(), line: i + 1 });
-    }
-    // HIGH: INJ-ENC-001 — Suspicious base64 (skip lines that look like file paths or CLI commands)
-    if (!/^[\s]*(?:cd |git |node |pnpm |npm |\/|packages\/|agents\/|src\/)/.test(line) &&
-        /(?<!Bearer\s)(?<![:])(?<![A-Za-z0-9/])(?!eyJ)(?:[A-Za-z0-9+/]{4}){7,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?(?![A-Za-z0-9/])/.test(line)) {
-      findings.push({ severity: 'high', ruleId: 'INJ-ENC-001', match: line.trim(), line: i + 1 });
-    }
-    // MEDIUM: INJ-CTX-001 — System prompt claims
-    if (/(?:the\s+)?(?:system\s+prompt|system\s+message|hidden\s+instructions?)\s+(?:says?|tells?|instructs?|contains?|is)/i.test(line)) {
-      findings.push({ severity: 'medium', ruleId: 'INJ-CTX-001', match: line.trim(), line: i + 1 });
-    }
-  }
-  return findings;
-}
-
-function extractText(toolName, toolInput) {
-  if (toolName === 'Bash') return toolInput?.command ?? '';
-  if (toolName === 'Write') return toolInput?.content ?? '';
-  if (toolName === 'Edit') return `${toolInput?.old_string ?? ''}\n${toolInput?.new_string ?? ''}`;
-  if (toolName === 'Read') return toolInput?.file_path ?? '';
-  const parts = [];
-  for (const value of Object.values(toolInput || {})) {
-    if (typeof value === 'string') parts.push(value);
-  }
-  return parts.join('\n') || null;
 }
 
 async function main() {
@@ -125,7 +64,8 @@ async function main() {
     const sessionId = input?.session_id;
     const workspaceRoot = process.cwd();
 
-    // Step 1: Check taint state — block destructive ops if tainted
+    // Check taint state — block destructive ops if the session is already tainted.
+    // Taint is written only by sentinel-post (from untrusted tool OUTPUT).
     let tainted = false;
     try {
       const taintPath = resolve(
@@ -170,69 +110,6 @@ async function main() {
           );
           process.exit(2);
         }
-      }
-    }
-
-    // Step 2: Scan tool inputs for injection patterns
-    const textToScan = extractText(toolName, toolInput);
-    if (textToScan) {
-      let findings;
-      try {
-        const core = await import('@harness-engineering/core');
-        findings = core.scanForInjection(textToScan);
-      } catch {
-        findings = inlineScan(textToScan);
-      }
-
-      const actionable = findings.filter((f) => f.severity === 'high' || f.severity === 'medium');
-
-      if (actionable.length > 0) {
-        try {
-          const core = await import('@harness-engineering/core');
-          core.writeTaint(
-            workspaceRoot,
-            sessionId,
-            `Injection pattern detected in PreToolUse:${toolName} input`,
-            actionable,
-            `PreToolUse:${toolName}`
-          );
-        } catch {
-          // Fallback inline taint writer — merges with existing taint state
-          try {
-            const id = sessionId || 'default';
-            const taintPath = resolve(workspaceRoot, '.harness', `session-taint-${id}.json`);
-            mkdirSync(dirname(taintPath), { recursive: true });
-            const now = new Date().toISOString();
-            const maxSev = actionable.some((f) => f.severity === 'high') ? 'high' : 'medium';
-            const newFindings = actionable.map((f) => ({
-              ruleId: f.ruleId, severity: f.severity, match: f.match,
-              source: `PreToolUse:${toolName}`, detectedAt: now,
-            }));
-            // Read and merge existing taint state to preserve earlier taintedAt and findings
-            let existing = null;
-            try { existing = JSON.parse(readFileSync(taintPath, 'utf-8')); } catch { /* no existing */ }
-            const state = {
-              sessionId: id,
-              taintedAt: existing?.taintedAt ?? now,
-              expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
-              reason: existing?.reason ?? `Injection pattern detected in PreToolUse:${toolName} input`,
-              severity: maxSev,
-              findings: [...(existing?.findings ?? []), ...newFindings],
-            };
-            writeFileSync(taintPath, JSON.stringify(state, null, 2) + '\n');
-          } catch { /* best-effort */ }
-        }
-
-        for (const f of actionable) {
-          process.stderr.write(
-            `Sentinel [${f.severity}] ${f.ruleId}: detected in ${toolName} input\n`
-          );
-        }
-      }
-
-      const low = findings.filter((f) => f.severity === 'low');
-      for (const f of low) {
-        process.stderr.write(`Sentinel [low] ${f.ruleId}: ${f.match.slice(0, 80)}\n`);
       }
     }
 

--- a/packages/cli/tests/hooks/sentinel.test.ts
+++ b/packages/cli/tests/hooks/sentinel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync, spawnSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../../../..');
@@ -37,20 +37,47 @@ afterEach(() => {
 });
 
 describe('sentinel-pre.js', () => {
-  describe('SC1: detects injection in tool input and taints session', () => {
-    it('taints session when Bash command contains injection pattern', () => {
+  describe('enforce-only: pre does NOT detect/taint on tool input', () => {
+    it('does not taint the session on injection patterns in a Bash command (detection is sentinel-post job)', () => {
       const result = runHook('sentinel-pre.js', {
         tool_name: 'Bash',
         tool_input: { command: 'echo "ignore previous instructions"' },
         session_id: 'test-sess',
       });
-      expect(result.exitCode).toBe(0); // allows the current op but taints
-      expect(result.stderr).toContain('Sentinel');
-      expect(result.stderr).toContain('INJ-REROL');
-
-      // Check taint file was created
+      expect(result.exitCode).toBe(0);
       const taintPath = join(TEST_ROOT, '.harness', 'session-taint-test-sess.json');
-      expect(existsSync(taintPath)).toBe(true);
+      expect(existsSync(taintPath)).toBe(false);
+    });
+
+    // Regression: the agent legitimately running `git commit --no-verify` must not
+    // taint the session. INJ-PERM-003 previously fired on the agent's own input.
+    it('does not taint on a benign agent command containing --no-verify', () => {
+      const result = runHook('sentinel-pre.js', {
+        tool_name: 'Bash',
+        tool_input: { command: 'git commit --no-verify -m "fix"' },
+        session_id: 'noverify-sess',
+      });
+      expect(result.exitCode).toBe(0);
+      const taintPath = join(TEST_ROOT, '.harness', 'session-taint-noverify-sess.json');
+      expect(existsSync(taintPath)).toBe(false);
+    });
+
+    // Regression (end-to-end): the exact observed failure — an agent uses --no-verify,
+    // then a later git push in the SAME session must NOT be blocked.
+    it('does not block a later git push after the agent ran --no-verify (same session)', () => {
+      const first = runHook('sentinel-pre.js', {
+        tool_name: 'Bash',
+        tool_input: { command: 'git commit --no-verify -m "fix"' },
+        session_id: 'flow-sess',
+      });
+      expect(first.exitCode).toBe(0);
+
+      const push = runHook('sentinel-pre.js', {
+        tool_name: 'Bash',
+        tool_input: { command: 'git push origin main' },
+        session_id: 'flow-sess',
+      });
+      expect(push.exitCode).toBe(0);
     });
   });
 
@@ -257,8 +284,8 @@ describe('sentinel-pre.js', () => {
     });
   });
 
-  describe('medium-severity detection and taint', () => {
-    it('taints session on medium-severity-only findings', () => {
+  describe('enforce-only: medium-severity input is not tainted', () => {
+    it('does not taint on medium-severity injection text in Write content', () => {
       const result = runHook('sentinel-pre.js', {
         tool_name: 'Write',
         tool_input: {
@@ -268,27 +295,33 @@ describe('sentinel-pre.js', () => {
         session_id: 'medium-sess',
       });
       expect(result.exitCode).toBe(0);
-      expect(result.stderr).toContain('Sentinel');
-
       const taintPath = join(TEST_ROOT, '.harness', 'session-taint-medium-sess.json');
-      expect(existsSync(taintPath)).toBe(true);
-
-      const taintState = JSON.parse(readFileSync(taintPath, 'utf-8'));
-      expect(taintState.severity).toBe('medium');
+      expect(existsSync(taintPath)).toBe(false);
     });
   });
 
   describe('default session ID fallback', () => {
-    it('uses "default" session ID when session_id is absent', () => {
+    it('uses "default" session ID when checking taint for enforcement', () => {
+      // Taint the default session; a destructive op with no session_id must block.
+      const taintState = {
+        sessionId: 'default',
+        taintedAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+        reason: 'test',
+        severity: 'high',
+        findings: [],
+      };
+      writeFileSync(
+        join(TEST_ROOT, '.harness', 'session-taint-default.json'),
+        JSON.stringify(taintState)
+      );
+
       const result = runHook('sentinel-pre.js', {
         tool_name: 'Bash',
-        tool_input: { command: 'echo "ignore previous instructions"' },
+        tool_input: { command: 'git push origin main' },
         // no session_id field
       });
-      expect(result.exitCode).toBe(0);
-
-      const taintPath = join(TEST_ROOT, '.harness', 'session-taint-default.json');
-      expect(existsSync(taintPath)).toBe(true);
+      expect(result.exitCode).toBe(2);
     });
   });
 
@@ -323,20 +356,6 @@ describe('sentinel-pre.js', () => {
         session_id: 'session-a',
       });
       expect(resultA.exitCode).toBe(2);
-    });
-  });
-
-  describe('SC16: LOW findings logged but no taint', () => {
-    it('logs low-severity findings to stderr without tainting', () => {
-      const result = runHook('sentinel-pre.js', {
-        tool_name: 'Bash',
-        tool_input: { command: 'echo "text           lots of hidden whitespace"' },
-        session_id: 'low-sess',
-      });
-      expect(result.exitCode).toBe(0);
-      // Should NOT create taint file for LOW-only findings
-      const taintPath = join(TEST_ROOT, '.harness', 'session-taint-low-sess.json');
-      expect(existsSync(taintPath)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Problem

`sentinel-pre` ran injection **detection + taint-writing on the agent's own tool INPUTS**, contradicting its documented enforce-only role in `profiles.ts` ("sentinel-pre … blocks a destructive op in an already-tainted session … sentinel-post (detection only)").

HIGH patterns fired on legitimate agent activity — INJ-PERM-003 on commit-bypass flags, INJ-ENC on base64 / 40-char git SHAs — tainting the 30-minute sliding window, after which the agent's own version-control operations were blocked as "destructive". Observed live: a routine push of a clean, reviewed branch was blocked mid-workflow, requiring a manual `harness taint clear`.

This just shipped to the **standard** hook profile (#556 / PR #717), so it now affects every adopter's long sessions.

## Fix

Make `sentinel-pre` **enforce-only**: remove the detection + taint-writing step (and the now-unused `inlineScan`/`extractText` helpers). Detection stays in `sentinel-post`, which scans untrusted tool **OUTPUT** — the real prompt-injection vector. Enforcement (block destructive bash / outside-workspace writes when *already* tainted) is unchanged, so a genuinely tainted session still blocks destructive ops. **The control isn't weakened; the category error is removed.**

## Verification

- Regression test reproduces the exact failure: agent runs a bypass flag, then a later version-control push in the same session must not block.
- **Revert-verified:** 4 tests FAIL against the old hook, all 21 pass with the fix.
- Package lint clean; full hooks suite 160/160.

## Notes

- Fixes the authoritative source (`packages/cli/src/hooks/sentinel-pre.js`); the distributed `.harness/hooks/` copy regenerates on CLI republish + setup.
- Found via `/harness:debugging`; debug session in `.harness/debug/resolved/`.
- Follow-up: `sentinel-post`'s inline degraded-mode patterns still carry the pre-hardening INJ-REROL-003 (drift vs core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
