### PR TITLE
fix(assess): honor tooling.linter in lint check (#702)

### DIFF
--- a/.changeset/fix-lint-honor-tooling-linter.md
+++ b/.changeset/fix-lint-honor-tooling-linter.md
@@ -1,0 +1,17 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(assess): honor `tooling.linter` in the lint check (#702)
+
+The `assess_project` lint check hardcoded `npx turbo run lint --force`, so every
+non-npm project (Python, Go, Rust) got a spurious lint failure (`healthy: false`)
+regardless of its configured linter — breaking the health gate and
+`harness-release-readiness`.
+
+The lint check now resolves its command from `harness.config.json`
+`tooling.linter`: `ruff` → `ruff check .`, `golangci-lint` → `golangci-lint run`,
+`clippy` → `cargo clippy`. npm/typescript, unconfigured, and unknown-linter
+projects fall back to `turbo run lint`. The config is read as raw JSON because
+`HarnessConfigSchema` declares `tooling` only under `template`, so `loadConfig`
+strips the top-level `tooling` block that `harness init` actually writes.

--- a/packages/cli/src/mcp/tools/assess-project.ts
+++ b/packages/cli/src/mcp/tools/assess-project.ts
@@ -1,7 +1,54 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { sanitizePath } from '../utils/sanitize-path.js';
 import { bigIntSafeReplacer } from '../utils/result-adapter.js';
 
 type CheckName = 'validate' | 'deps' | 'docs' | 'entropy' | 'security' | 'perf' | 'lint';
+
+/** Command + args pair for spawning the lint runner. */
+interface LintCommand {
+  command: string;
+  args: string[];
+}
+
+/** npm/turbo fallback used when no non-npm linter is configured. */
+const TURBO_LINT: LintCommand = { command: 'npx', args: ['turbo', 'run', 'lint', '--force'] };
+
+/**
+ * Resolve the lint command for a project by honoring `tooling.linter` from
+ * harness.config.json, instead of always running turbo. Non-npm linters map to
+ * their native check invocations (mirroring `stepsForLanguage` in
+ * `commands/ci/init.ts`); npm/turbo projects, unconfigured projects, and linters
+ * without a standalone runner fall back to `turbo run lint`.
+ *
+ * The raw config JSON is read directly because `HarnessConfigSchema` declares
+ * `tooling` only under `template`, so `loadConfig` strips the top-level
+ * `tooling` block that `harness init` actually writes.
+ */
+export function resolveLintCommand(projectPath: string): LintCommand {
+  let linter: string | undefined;
+  try {
+    const raw = fs.readFileSync(path.join(projectPath, 'harness.config.json'), 'utf-8');
+    const config = JSON.parse(raw) as {
+      tooling?: { linter?: string };
+      template?: { tooling?: { linter?: string } };
+    };
+    linter = config.tooling?.linter ?? config.template?.tooling?.linter;
+  } catch {
+    return TURBO_LINT;
+  }
+
+  switch (linter) {
+    case 'ruff':
+      return { command: 'ruff', args: ['check', '.'] };
+    case 'golangci-lint':
+      return { command: 'golangci-lint', args: ['run'] };
+    case 'clippy':
+      return { command: 'cargo', args: ['clippy'] };
+    default:
+      return TURBO_LINT;
+  }
+}
 
 export const assessProjectDefinition = {
   name: 'assess_project',
@@ -334,7 +381,8 @@ export async function handleAssessProject(input: {
       (async (): Promise<CheckResult> => {
         try {
           const { execFileSync } = await import('child_process');
-          const output = execFileSync('npx', ['turbo', 'run', 'lint', '--force'], {
+          const { command, args } = resolveLintCommand(projectPath);
+          const output = execFileSync(command, args, {
             cwd: projectPath,
             encoding: 'utf-8',
             timeout: 60_000,

--- a/packages/cli/tests/mcp/tools/assess-project.test.ts
+++ b/packages/cli/tests/mcp/tools/assess-project.test.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import {
   assessProjectDefinition,
   handleAssessProject,
+  resolveLintCommand,
 } from '../../../src/mcp/tools/assess-project';
 
 describe('assess_project tool', () => {
@@ -136,6 +137,74 @@ describe('assess_project tool', () => {
       });
       const parsed = JSON.parse(response.content[0].text);
       expect(parsed.checks[0]).not.toHaveProperty('detailed');
+    });
+  });
+
+  // Regression: #702 — lint check hardcoded `turbo run lint`, ignoring
+  // `tooling.linter`, so every non-npm project got a spurious lint failure.
+  describe('resolveLintCommand honors tooling.linter (#702)', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ap-lint-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeConfig(config: unknown): void {
+      fs.writeFileSync(path.join(tmpDir, 'harness.config.json'), JSON.stringify(config));
+    }
+
+    it('runs ruff for a Python project instead of turbo', () => {
+      writeConfig({
+        version: 1,
+        template: { language: 'python', version: 1 },
+        tooling: { linter: 'ruff', formatter: 'ruff', testRunner: 'pytest' },
+      });
+      const resolved = resolveLintCommand(tmpDir);
+      expect(resolved).toEqual({ command: 'ruff', args: ['check', '.'] });
+      // The reported bug: it must NOT fall through to turbo.
+      expect(resolved.args).not.toContain('turbo');
+    });
+
+    it('runs golangci-lint for a Go project', () => {
+      writeConfig({ version: 1, tooling: { linter: 'golangci-lint' } });
+      expect(resolveLintCommand(tmpDir)).toEqual({ command: 'golangci-lint', args: ['run'] });
+    });
+
+    it('runs cargo clippy for a Rust project', () => {
+      writeConfig({ version: 1, tooling: { linter: 'clippy' } });
+      expect(resolveLintCommand(tmpDir)).toEqual({ command: 'cargo', args: ['clippy'] });
+    });
+
+    it('reads tooling.linter nested under template as a fallback', () => {
+      writeConfig({ version: 1, template: { tooling: { linter: 'ruff' } } });
+      expect(resolveLintCommand(tmpDir)).toEqual({ command: 'ruff', args: ['check', '.'] });
+    });
+
+    it('falls back to turbo when no linter is configured', () => {
+      writeConfig({ version: 1, name: 'ts-project' });
+      expect(resolveLintCommand(tmpDir)).toEqual({
+        command: 'npx',
+        args: ['turbo', 'run', 'lint', '--force'],
+      });
+    });
+
+    it('falls back to turbo for unknown/npm linters', () => {
+      writeConfig({ version: 1, tooling: { linter: 'eslint' } });
+      expect(resolveLintCommand(tmpDir)).toEqual({
+        command: 'npx',
+        args: ['turbo', 'run', 'lint', '--force'],
+      });
+    });
+
+    it('falls back to turbo when harness.config.json is missing', () => {
+      expect(resolveLintCommand(tmpDir)).toEqual({
+        command: 'npx',
+        args: ['turbo', 'run', 'lint', '--force'],
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #702. The `assess_project` lint check hardcoded `npx turbo run lint --force`, so every non-npm project (Python, Go, Rust) got a spurious lint failure (`healthy: false`) regardless of its configured linter — breaking the health gate and `harness-release-readiness`.

## Root cause

`packages/cli/src/mcp/tools/assess-project.ts` ran `turbo run lint` unconditionally, ignoring `harness.config.json` `tooling.linter`.

A related trap surfaced during investigation: `harness init` writes `tooling` at the **top level** of `harness.config.json`, but `HarnessConfigSchema` only declares `tooling` under `template`. Since `z.object()` strips unknown keys, `loadConfig` never surfaces `tooling.linter` — so the fix reads the raw config JSON directly.

## Fix

Extracted an exported, testable `resolveLintCommand(projectPath)` that maps the configured linter to its native command, mirroring `stepsForLanguage` in `commands/ci/init.ts`:

| Configured linter | Command |
|---|---|
| `ruff` | `ruff check .` |
| `golangci-lint` | `golangci-lint run` |
| `clippy` | `cargo clippy` |
| unset / `eslint` / unknown / missing config | `npx turbo run lint --force` (fallback) |

## Testing

- 7 new regression tests + 13 existing → 20/20 pass.
- **Revert check:** forcing the resolver to always return turbo fails the ruff/go/rust/template-nested cases and passes the fallback cases — proving the tests guard the bug.
- `tsc --noEmit` clean; eslint clean on source.

## Follow-up (not in this PR)

- The `post-write.ts` (top-level `tooling`) vs `schema.ts` (`template.tooling`) mismatch is a broader inconsistency worth reconciling so other config consumers can read tooling.
- Java/`checkstyle` has no clean standalone CLI, so it stays on the turbo fallback (behavior unchanged — pre-existing limitation, not a regression).