### PR TITLE
chore(roadmap): reconcile sentinel-standard-profile (#556) + close stale issues

### DIFF
--- a/docs/roadmap.d/move-sentinel-pre-post-to-standard-hook-profile.md
+++ b/docs/roadmap.d/move-sentinel-pre-post-to-standard-hook-profile.md
@@ -6,7 +6,7 @@ order: 0
 
 ### Move sentinel-pre/post to standard hook profile
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/sentinel-standard-profile/proposal.md
 - **Summary:** `packages/cli/src/hooks/profiles.ts:31-32` — `sentinel-pre` and `sentinel-post` (prompt-injection defense covering zero-width chars, RTL/LTR overrides, role-reassignment, permission-escalation, base64 exfiltration, destructive-bash in tainted sessions) currently ship at STRICT profile only. Default-profile adopters get NONE of this defense. Move to standard. Cost-tracker can remain strict-only as a separate concern. Source: Pass 6 #1.
 - **Blockers:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -241,7 +241,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Move sentinel-pre/post to standard hook profile
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/sentinel-standard-profile/proposal.md
 - **Summary:** `packages/cli/src/hooks/profiles.ts:31-32` — `sentinel-pre` and `sentinel-post` (prompt-injection defense covering zero-width chars, RTL/LTR overrides, role-reassignment, permission-escalation, base64 exfiltration, destructive-bash in tainted sessions) currently ship at STRICT profile only. Default-profile adopters get NONE of this defense. Move to standard. Cost-tracker can remain strict-only as a separate concern. Source: Pass 6 #1.
 - **Blockers:** —


### PR DESCRIPTION
## What

Marks the roadmap row **Move sentinel-pre/post to standard hook profile** (`#556`) as `done` and regenerates the aggregate.

## Why

PR #646 promoted `sentinel-pre`/`sentinel-post` to the `standard` hook profile and merged to `main` on 2026-06-26 — but the roadmap row stayed `planned` and issue #556 stayed open. The merge-triggered auto-done never fired because PR #646 carried no `Closes #556` reference. This surfaced when `roadmap-pilot` recommended #556 as the top unblocked P0, and a pre-flight check found the work already merged (code, tests, and ADR-0046 all present).

## Reconciliation sweep

While confirming, an audit (open issues × archived-done roadmap rows, matched by `External-ID`) found the same drift on 6 more issues. All verified against a delivering PR and closed:

| Issue | Delivered by |
|---|---|
| #556 | PR #646 (this row) |
| #574 | PR #630 |
| #541 | PR #624 |
| #535 | PR #618 |
| #534 | PR #595 |
| #532 | PR #618 |
| #525 | PR #611 |

(One issue, #124 "Dashboard v3", was closed then reopened — a false match against the kanban entry; not actually done.)

## Scope

Documentation/bookkeeping only — 2 files, `planned`→`done` + aggregate regen. No code change.

## Root cause / follow-up

Merge-triggered auto-done depends on a `Closes #NNN` reference that PRs are frequently omitting, so roadmap-done and GitHub-issue-open drift apart. Worth a follow-up to make the reconciler match on `External-ID` rather than relying on closing keywords.