### PR TITLE
fix(cli): stop session-start skill-dispatch from hanging every command

### DIFF
--- a/.changeset/fix-session-dispatch-cached-only-hang.md
+++ b/.changeset/fix-session-dispatch-cached-only-hang.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix the session-start skill-dispatch advisory that could hang every `harness` command indefinitely. The banner fires only on a git HEAD delta — which is exactly what invalidates the health-snapshot cache — so `enrichSnapshotForDispatch` always ran a fresh, expensive full `captureHealthSnapshot` (deps/entropy/graph analysis) and `main()` awaited it unbounded, blocking the CLI after any commit on a large repo. The session-start path is now `cachedOnly`, honoring its documented "always uses cached health snapshot for speed" contract: it degrades to the stale cached snapshot (or a neutral all-clear one) instead of capturing fresh, so the banner never blocks command completion.

--- a/packages/cli/src/skill/dispatch-engine.ts
+++ b/packages/cli/src/skill/dispatch-engine.ts
@@ -153,9 +153,41 @@ export function buildDiffInfoFromGit(projectPath: string): DiffInfo | null {
  * Build an enriched DispatchContext by combining a health snapshot with
  * change-type and domain signals derived from git diff information.
  */
+/**
+ * A neutral, all-clear health snapshot with no active health signals. Used by the
+ * `cachedOnly` dispatch path when no cached snapshot exists, so the banner can still
+ * derive change-type/domain signals from the diff WITHOUT an expensive fresh capture.
+ */
+function neutralSnapshot(projectPath: string): HealthSnapshot {
+  return {
+    capturedAt: new Date().toISOString(),
+    gitHead: '',
+    projectPath,
+    checks: {
+      deps: { passed: true, issueCount: 0, circularDeps: 0, layerViolations: 0 },
+      entropy: { passed: true, deadExports: 0, deadFiles: 0, driftCount: 0 },
+      security: { passed: true, findingCount: 0, criticalCount: 0 },
+      perf: { passed: true, violationCount: 0 },
+      docs: { passed: true, undocumentedCount: 0 },
+      lint: { passed: true, issueCount: 0 },
+    },
+    metrics: {
+      avgFanOut: 0,
+      maxFanOut: 0,
+      avgCyclomaticComplexity: 0,
+      maxCyclomaticComplexity: 0,
+      avgCouplingRatio: 0,
+      testCoverage: null,
+      anomalyOutlierCount: 0,
+      articulationPointCount: 0,
+    },
+    signals: [],
+  };
+}
+
 export async function enrichSnapshotForDispatch(
   projectPath: string,
-  options: { files?: string[]; commitMessage?: string; fresh?: boolean }
+  options: { files?: string[]; commitMessage?: string; fresh?: boolean; cachedOnly?: boolean }
 ): Promise<DispatchContext> {
   // 1. Get snapshot (cached or fresh)
   let snapshot: HealthSnapshot | null = null;
@@ -164,6 +196,15 @@ export async function enrichSnapshotForDispatch(
   if (!options.fresh) {
     snapshot = loadCachedSnapshot(projectPath);
     if (snapshot && isSnapshotFresh(snapshot, projectPath)) {
+      snapshotFreshness = 'cached';
+    } else if (options.cachedOnly) {
+      // Advisory hot path (session-start banner): NEVER run a fresh full capture.
+      // captureHealthSnapshot is expensive, and this path only fires on a HEAD
+      // delta — which is exactly what invalidates the cache — so a fresh capture
+      // would run on EVERY command and block the CLI indefinitely. Degrade to the
+      // stale cached snapshot if present, else a neutral all-clear one; the banner
+      // still derives change-type/domain signals from the diff.
+      snapshot = snapshot ?? neutralSnapshot(projectPath);
       snapshotFreshness = 'cached';
     } else {
       snapshot = null; // stale, will recapture
@@ -333,6 +374,7 @@ export async function dispatchSkillsFromGit(
   projectPath: string,
   options: {
     fresh?: boolean;
+    cachedOnly?: boolean;
     limit?: number;
     trigger?: string;
     skillTriggers?: Map<string, string[]>;
@@ -363,9 +405,15 @@ export async function dispatchSkillsFromGit(
   const files = diffInfo.changedFiles;
 
   // Enrich and dispatch
-  const enrichOpts: { files?: string[]; commitMessage?: string; fresh?: boolean } = { files };
+  const enrichOpts: {
+    files?: string[];
+    commitMessage?: string;
+    fresh?: boolean;
+    cachedOnly?: boolean;
+  } = { files };
   if (commitMessage) enrichOpts.commitMessage = commitMessage;
   if (options.fresh) enrichOpts.fresh = options.fresh;
+  if (options.cachedOnly) enrichOpts.cachedOnly = true;
   const ctx = await enrichSnapshotForDispatch(projectPath, enrichOpts);
 
   const dispatchOpts: { limit?: number; trigger?: string; skillTriggers?: Map<string, string[]> } =

--- a/packages/cli/src/skill/dispatch-session.ts
+++ b/packages/cli/src/skill/dispatch-session.ts
@@ -113,7 +113,10 @@ export async function sessionStartDispatch(projectPath: string): Promise<Session
   }
 
   try {
-    const result = await dispatchSkillsFromGit(projectPath, {});
+    // cachedOnly: this advisory banner must never block the CLI. Because it fires
+    // only on a HEAD delta — which also invalidates the health-snapshot cache — a
+    // fresh capture would run on every command and hang. Degrade to cached/neutral.
+    const result = await dispatchSkillsFromGit(projectPath, { cachedOnly: true });
     writeLastHead(projectPath, currentHead);
     return { dispatched: true, result, currentHead };
   } catch {

--- a/packages/cli/tests/skill/dispatch-engine.test.ts
+++ b/packages/cli/tests/skill/dispatch-engine.test.ts
@@ -353,6 +353,41 @@ describe('enrichSnapshotForDispatch', () => {
     expect(mockCaptureHealthSnapshot).toHaveBeenCalled();
   });
 
+  // Regression: the session-start advisory dispatch (`cachedOnly: true`) must NEVER
+  // run a fresh capture. It fires only on a HEAD delta — which also invalidates the
+  // cache — so a fresh capture would run on every command and hang the CLI. See the
+  // roadmap-regen-hang debug session.
+  it('cachedOnly: does NOT capture fresh when the cached snapshot is stale', async () => {
+    vi.mocked(mockCaptureHealthSnapshot).mockClear();
+    vi.mocked(mockIsSnapshotFresh).mockReturnValue(false);
+    vi.mocked(mockCaptureHealthSnapshot).mockResolvedValue(STUB_SNAPSHOT);
+    const ctx = await enrichSnapshotForDispatch('/tmp/test', {
+      files: ['src/index.ts'],
+      commitMessage: 'refactor: cleanup',
+      cachedOnly: true,
+    });
+    expect(mockCaptureHealthSnapshot).not.toHaveBeenCalled();
+    expect(ctx.snapshotFreshness).toBe('cached');
+  });
+
+  it('cachedOnly: does NOT capture fresh when no cached snapshot exists (neutral fallback)', async () => {
+    vi.mocked(mockCaptureHealthSnapshot).mockClear();
+    vi.mocked(mockLoadCachedSnapshot).mockReturnValue(null);
+    vi.mocked(mockCaptureHealthSnapshot).mockResolvedValue(STUB_SNAPSHOT);
+    const ctx = await enrichSnapshotForDispatch('/tmp/test', {
+      files: ['migrations/001.sql'],
+      commitMessage: 'feat: add migration',
+      cachedOnly: true,
+    });
+    expect(mockCaptureHealthSnapshot).not.toHaveBeenCalled();
+    expect(ctx.snapshotFreshness).toBe('cached');
+    // Neutral snapshot carries no health signals — the banner still derives
+    // change-type/domain signals from the diff.
+    expect(ctx.allSignals).not.toContain('circular-deps');
+    expect(ctx.allSignals).toContain('change-feature');
+    expect(ctx.allSignals).toContain('domain-database');
+  });
+
   it('derives bugfix changeType from commit prefix', async () => {
     const ctx = await enrichSnapshotForDispatch('/tmp/test', {
       files: [],


### PR DESCRIPTION
## Fix: session-start skill-dispatch hangs every CLI command

Found via `/harness:debugging` while investigating why `harness roadmap regen` hung for >2 min (it worked earlier the same day). Root cause is **not** in roadmap code — that was a victim. Any `harness` command hangs after a commit.

### Root cause

`bin/harness.ts main()` fires a best-effort **session-start skill-dispatch banner** and then `await`s it before exiting, with no bound:

```js
const dispatchPromise = sessionStartDispatch(process.cwd()).catch(...)
await program.parseAsync(argv)          // the real command — fast
const dispatchResult = await dispatchPromise   // ← blocks here
```

`sessionStartDispatch` fires only on a git **HEAD delta** (vs `.harness/dispatch-last-head.txt`). It calls `dispatchSkillsFromGit(projectPath, {})`, and `enrichSnapshotForDispatch` runs a **fresh** `captureHealthSnapshot` (full deps/entropy/graph analysis) whenever the cached snapshot is stale. But `isSnapshotFresh` keys staleness on `gitHead` — so the dispatch-fires condition (HEAD moved) and the cache-stale condition (HEAD moved) are **perfectly correlated**. The path therefore *always* does the expensive capture, despite `sessionStartDispatch`'s own docstring: *"Always uses cached health snapshot for speed."* On a large repo that capture takes minutes (and hits catastrophic regex in entropy scanning), so after any commit every command blocks. `--version` escapes only because commander `process.exit`s before the `await`.

**Diagnosis evidence:** `sample` → catastrophic `RegExpPrototypeExec`; `--cpu-prof` → 85% `_pselect` with hot frames `captureHealthSnapshot`/`enrichSnapshotForDispatch`/`buildDiffInfoFromGit`; pure core `regenerate()` = 0 ms; raw `git diff` = 26 ms.

### Fix

Honor the documented contract: the session-start path is now **`cachedOnly`**. When the cache is stale/absent, it degrades to the stale cached snapshot (or a neutral all-clear one) and derives change-type/domain signals from the diff — instead of running a fresh full capture. Other callers (MCP `dispatch_skills`, `recommend`) are unchanged (they still capture fresh by default). Three small edits: `enrichSnapshotForDispatch` (+`cachedOnly` degrade branch + neutral snapshot), `dispatchSkillsFromGit` (thread the flag), `sessionStartDispatch` (opt in).

### Verification

- New regression tests in `dispatch-engine.test.ts` assert the cached-only path never calls `captureHealthSnapshot` (stale + absent-cache cases). They **fail on revert** (proven).
- 459 dispatch/recommend/mcp/integration tests pass; `tsc --noEmit` clean.
- End-to-end: `harness roadmap regen` went from **>2 min hang → 1 s**, and the advisory banner still prints.

Debug session: `.harness/debug/resolved/roadmap-regen-hang.md`.
