### PR TITLE
chore(roadmap): mark standardize-parallel-execution (#743) done

### DIFF
--- a/docs/roadmap.d/standardize-parallel-execution.md
+++ b/docs/roadmap.d/standardize-parallel-execution.md
@@ -6,7 +6,7 @@ order: 7
 
 ### Standardize Parallel Execution
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/standardize-parallel-execution/proposal.md
 - **Summary:** Compose the harness's existing parallelism primitives (findParallelGroups wave-grouper, predict_conflicts, worktree isolation) into the standard execution path so sound parallel execution fires automatically instead of only when a human asks. Adds a shared parallelization-planner sub-protocol emitting a ParallelizationPlan (waves + severity + per-wave firing decision), a `dependsOn` task-schema field, and risk-tiered non-blocking dispatch (clean waves announce-and-go, medium/graph-unavailable confirm once, high-severity auto-serialize) wired into harness-autopilot EXECUTE. Execution-first; parallel planning/research and smart-merge (#600) are named follow-ons.
 - **Blockers:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -577,7 +577,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Standardize Parallel Execution
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/standardize-parallel-execution/proposal.md
 - **Summary:** Compose the harness's existing parallelism primitives (findParallelGroups wave-grouper, predict_conflicts, worktree isolation) into the standard execution path so sound parallel execution fires automatically instead of only when a human asks. Adds a shared parallelization-planner sub-protocol emitting a ParallelizationPlan (waves + severity + per-wave firing decision), a `dependsOn` task-schema field, and risk-tiered non-blocking dispatch (clean waves announce-and-go, medium/graph-unavailable confirm once, high-severity auto-serialize) wired into harness-autopilot EXECUTE. Execution-first; parallel planning/research and smart-merge (#600) are named follow-ons.
 - **Blockers:** —


### PR DESCRIPTION
Marks the `standardize-parallel-execution` roadmap row `done` now that #743 is squash-merged. The merge-triggered Roadmap Auto-Done workflow ran green but was a no-op (the row has no linked closing issue, so `closingIssuesReferences` was empty and the body-parse fallback found no closed-completed issue) — so the flip is manual, matching the repo convention (e.g. #730, #734). Shard status `planned → done`; aggregate regenerated.