### PR TITLE
docs(roadmap): mark LMLM Phases 4–9 done (delivered in #753)

### DIFF
--- a/docs/roadmap.d/lmlm-wire-engine-to-operator-surfaces.md
+++ b/docs/roadmap.d/lmlm-wire-engine-to-operator-surfaces.md
@@ -6,11 +6,11 @@ order: 1
 
 ### LMLM Phases 4–9: wire the engine to operator surfaces
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/local-model-lifecycle-manager/proposal.md
-- **Summary:** The `@harness-engineering/local-models` package (v0.2.2, published) implements the LMLM engine — hardware detection, benchmark-ranked recommendation, Ollama install adapter, pool manager + eviction — but has ZERO consumers: no package imports it, the `localModels` config block is inert (type-only, read by no runtime code), and the only shipped CLI is `harness models probe` (which uses the orchestrator's `/v1/models` probe, not the package). Roadmap #386 was marked `done` after Phase 3c (last feature commit `feat(local-models): LMLM Phase 3c`; `done` applied during a bulk roadmap archive-split, not a completion). Phases 4–9 never landed: (4) `LocalModelResolver` consuming pool state [D5], (5) `ProposalSchema` generalization `proposalKind: skill|model` [D11], (6) background scheduler + drift reconciliation [D9/D12], (7) HTTP/WS/notification sinks [D6], (8) dashboard panel, (9) docs/ADRs. The `harness models` command header itself lists these as "future LMLM phases." Spec predates codebase drift (a `LocalModelResolver` now exists via #296/#297 but only probes `/v1/models`), so revalidate the spec (soundness-review) before building. Corrects the accidental `done` on #386.
+- **Summary:** DELIVERED (PR #753, merged + released). Wired the previously-dormant `@harness-engineering/local-models` engine to operator surfaces across CLI, orchestrator, and dashboard — Phases 4–9: (4) `LocalModelResolver` consumes pool state, (5) discriminated `ProposalSchema` (`kind: skill|model`) + model-proposal engine/handlers/CLI, (6) background scheduler + drift reconciliation, (7) HTTP routes + WS topics + notification sinks + S1 dispatch-safe eviction, (8) read-only dashboard panel, (9) ADRs 0058–0062 + operator guide. Corrects the accidental `done` on #386 (which was flipped during a bulk archive-split after only Phase 3c). Known limitation: the autonomous swap-proposal loop is inert until the live-HF candidate parser lands — see follow-up `lmlm-live-hf-candidate-discovery`; manual `harness models`, resolver-from-pool, and drift reconciliation all work today.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/local-model-lifecycle-manager/plans/
 - **Assignee:** —
 - **Priority:** P2
 - **External-ID:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,11 +13,11 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### LMLM Phases 4–9: wire the engine to operator surfaces
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/local-model-lifecycle-manager/proposal.md
-- **Summary:** The `@harness-engineering/local-models` package (v0.2.2, published) implements the LMLM engine — hardware detection, benchmark-ranked recommendation, Ollama install adapter, pool manager + eviction — but has ZERO consumers: no package imports it, the `localModels` config block is inert (type-only, read by no runtime code), and the only shipped CLI is `harness models probe` (which uses the orchestrator's `/v1/models` probe, not the package). Roadmap #386 was marked `done` after Phase 3c (last feature commit `feat(local-models): LMLM Phase 3c`; `done` applied during a bulk roadmap archive-split, not a completion). Phases 4–9 never landed: (4) `LocalModelResolver` consuming pool state [D5], (5) `ProposalSchema` generalization `proposalKind: skill|model` [D11], (6) background scheduler + drift reconciliation [D9/D12], (7) HTTP/WS/notification sinks [D6], (8) dashboard panel, (9) docs/ADRs. The `harness models` command header itself lists these as "future LMLM phases." Spec predates codebase drift (a `LocalModelResolver` now exists via #296/#297 but only probes `/v1/models`), so revalidate the spec (soundness-review) before building. Corrects the accidental `done` on #386.
+- **Summary:** DELIVERED (PR #753, merged + released). Wired the previously-dormant `@harness-engineering/local-models` engine to operator surfaces across CLI, orchestrator, and dashboard — Phases 4–9: (4) `LocalModelResolver` consumes pool state, (5) discriminated `ProposalSchema` (`kind: skill|model`) + model-proposal engine/handlers/CLI, (6) background scheduler + drift reconciliation, (7) HTTP routes + WS topics + notification sinks + S1 dispatch-safe eviction, (8) read-only dashboard panel, (9) ADRs 0058–0062 + operator guide. Corrects the accidental `done` on #386 (which was flipped during a bulk archive-split after only Phase 3c). Known limitation: the autonomous swap-proposal loop is inert until the live-HF candidate parser lands — see follow-up `lmlm-live-hf-candidate-discovery`; manual `harness models`, resolver-from-pool, and drift reconciliation all work today.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/local-model-lifecycle-manager/plans/
 - **Assignee:** —
 - **Priority:** P2
 - **External-ID:** —


### PR DESCRIPTION
The LMLM Phases 4–9 wiring shipped in #753 (merged + released), but its roadmap tracking row (`lmlm-wire-engine-to-operator-surfaces`) stayed `planned` — roadmap-auto-done keys on a `Closes #<issue>` link, and #753 didn't have one (#386 was already archived-closed). This flips the row to `done` with a delivered-state summary + plan pointer, and calls out the `lmlm-live-hf-candidate-discovery` follow-up. The two Intake follow-up shards stay `planned`. Docs-only.