### PR TITLE
chore(roadmap): mark init-design-roadmap-polish-follow-ups done (delivered in #573)

### DIFF
--- a/docs/roadmap.d/init-design-roadmap-polish-follow-ups.md
+++ b/docs/roadmap.d/init-design-roadmap-polish-follow-ups.md
@@ -6,11 +6,11 @@ order: 0
 
 ### Init design + roadmap polish follow-ups
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/init-design-roadmap-polish/proposal.md
-- **Summary:** Carry-forward polish from init-design-roadmap-config: (S2) refresh proposal.md:146 stale Registrations bullet to reflect harness-roadmap skill invocation, (S3) add harness-roadmap to initialize-harness-project skill.yaml depends_on for symmetry with harness-design-system, plus FINAL-S1 helper extraction, FINAL-S2 'not sure' vocabulary homogenization, FINAL-S3 catalog-consistency test docstring clarification.
+- **Summary:** DELIVERED (PR #573, merged). Carry-forward polish from init-design-roadmap-config: (S2) refreshed proposal.md:146 stale Registrations bullet to reflect harness-roadmap skill invocation, (S3) added harness-roadmap to initialize-harness-project skill.yaml depends_on for symmetry with harness-design-system, plus FINAL-S1 helper extraction (`packages/cli/tests/integration/_helpers/init-fixture.ts`), FINAL-S2 'not sure' vocabulary homogenization, FINAL-S3 catalog-consistency test docstring clarification + D4/D5 vocabulary regression guards. All spec success criteria are satisfied by code already in main; the row was left `planned` after the merge and was re-dispatched — this flip records the delivery.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/init-design-roadmap-polish/plans/
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#257

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -620,11 +620,11 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Init design + roadmap polish follow-ups
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/init-design-roadmap-polish/proposal.md
-- **Summary:** Carry-forward polish from init-design-roadmap-config: (S2) refresh proposal.md:146 stale Registrations bullet to reflect harness-roadmap skill invocation, (S3) add harness-roadmap to initialize-harness-project skill.yaml depends_on for symmetry with harness-design-system, plus FINAL-S1 helper extraction, FINAL-S2 'not sure' vocabulary homogenization, FINAL-S3 catalog-consistency test docstring clarification.
+- **Summary:** DELIVERED (PR #573, merged). Carry-forward polish from init-design-roadmap-config: (S2) refreshed proposal.md:146 stale Registrations bullet to reflect harness-roadmap skill invocation, (S3) added harness-roadmap to initialize-harness-project skill.yaml depends_on for symmetry with harness-design-system, plus FINAL-S1 helper extraction (`packages/cli/tests/integration/_helpers/init-fixture.ts`), FINAL-S2 'not sure' vocabulary homogenization, FINAL-S3 catalog-consistency test docstring clarification + D4/D5 vocabulary regression guards. All spec success criteria are satisfied by code already in main; the row was left `planned` after the merge and was re-dispatched — this flip records the delivery.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/init-design-roadmap-polish/plans/
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#257


### PR DESCRIPTION
## Summary

The roadmap item **Init design + roadmap polish follow-ups** was still marked `planned`, so the orchestrator re-dispatched it — but every item in its spec was already **implemented and merged into `main` via PR #573** (`init-design-roadmap-polish`). This PR is a bookkeeping-only status flip so the completed item stops being re-picked. No source/skill/test changes.

### Verification that the work is already in main
All five spec items are present in the committed tree on `main` (HEAD):

- **S2** — `docs/changes/init-design-roadmap-config/proposal.md:146` Registrations bullet now reflects `harness-roadmap` skill invocation + post-create `manage_roadmap.add` (no longer the stale "manage_roadmap creates the roadmap" model).
- **S3** — `agents/skills/claude-code/initialize-harness-project/skill.yaml` `depends_on` includes `harness-roadmap` (symmetric with `harness-design-system`).
- **FINAL-S1** — `packages/cli/tests/integration/_helpers/init-fixture.ts` exists and exports `scaffoldInitFixture`; the matrix + e2e tests call it (no inline `mkdtemp`).
- **FINAL-S2** — `not-sure` (hyphenated) appears nowhere in user-facing copy; `Not sure yet` survives only as `C) …` option-label cells (whitelisted).
- **FINAL-S3** — `skill-catalog-consistency.test.ts` docstring cites each assert's regression motivation and adds the D4/D5 vocabulary guards.

Merge trail: commits `cd16bd8b0`, `0f627baca`, `4bbb93d3b`, `a7a6f2873`, `fcf6c4464` → PR #573 → `origin/main`.

## Changes
- `docs/roadmap.d/init-design-roadmap-polish-follow-ups.md` — `Status: planned → done`, `DELIVERED (PR #573, merged)` summary prefix, link the plans dir.
- `docs/roadmap.md` — regenerated aggregate (`harness roadmap regen`) to match the shard.

## Validation
- `harness roadmap regen` — aggregate rebuilt; `harness validate` no longer reports `roadmap.md is stale vs docs/roadmap.d/`.
- Remaining `harness validate` findings (dashboard design-token literals, arch baselines) are pre-existing and unrelated to this diff.
- Done-in-active-milestone is the established convention here (6 other `done` items sit in active milestones); the advisory is non-blocking.