### PR TITLE
feat(lmlm): make Local Models Pool + Recommendations cards functional

### DIFF
--- a/.changeset/lmlm-functional-wiring.md
+++ b/.changeset/lmlm-functional-wiring.md
@@ -1,0 +1,22 @@
+---
+'@harness-engineering/local-models': minor
+'@harness-engineering/orchestrator': minor
+---
+
+feat(lmlm): wire pool bounds seed + candidate source so the Local Models cards populate
+
+Completes the two deferred wiring gaps that left the dashboard's Pool and
+Recommendations cards permanently empty when LMLM is enabled.
+
+- **Pool bounds seed (Phase 1):** the orchestrator now applies the operator's
+  configured `localModels.pool` bounds (disk budget + org/family allowlist) to
+  the pool store on startup, after `PoolStateStore.load()` so declarative config
+  wins over stale persisted bounds. Previously `PoolManager.configurePool()` had
+  no caller and the pool defaulted to `diskBudgetGb: 0`, blocking every install.
+- **Candidate source (Phase 2):** a new `candidates` module in
+  `@harness-engineering/local-models` — a GGUF→`RankerCandidate` parser, a
+  bundled human-curated frozen candidate snapshot (offline-safe, deterministic),
+  and an allowlist-aware selector — feeds the recommender, which was previously
+  constructed with an empty candidate list. Live HuggingFace discovery runs in a
+  new on-demand `scripts/refresh-model-candidates.mjs` generator (fail-closed),
+  never in CI.

--- a/.changeset/lmlm-functional-wiring.md
+++ b/.changeset/lmlm-functional-wiring.md
@@ -1,6 +1,7 @@
 ---
 '@harness-engineering/local-models': minor
 '@harness-engineering/orchestrator': minor
+'@harness-engineering/dashboard': patch
 ---
 
 feat(lmlm): wire pool bounds seed + candidate source so the Local Models cards populate
@@ -20,3 +21,6 @@ Recommendations cards permanently empty when LMLM is enabled.
   constructed with an empty candidate list. Live HuggingFace discovery runs in a
   new on-demand `scripts/refresh-model-candidates.mjs` generator (fail-closed),
   never in CI.
+- **Recommendations card formatting:** VRAM and tok/s render to one decimal and
+  scores as whole numbers, instead of leaking full float precision (e.g.
+  `44.15923222899437 GB` → `44.2 GB`).

--- a/docs/changes/lmlm-functional-wiring/proposal.md
+++ b/docs/changes/lmlm-functional-wiring/proposal.md
@@ -1,0 +1,192 @@
+---
+title: LMLM Functional Wiring — Pool Bounds Seed + Live Candidate Source
+status: planned
+keywords:
+  - local-models
+  - lmlm
+  - pool-bounds
+  - configurePool
+  - recommender
+  - huggingface
+  - ranker-candidate
+  - gguf
+  - frozen-snapshot
+---
+
+# LMLM Functional Wiring — Pool Bounds Seed + Live Candidate Source
+
+## Overview & Goals
+
+The Local Model Lifecycle Manager (LMLM) shipped its engine and operator surfaces
+in #753 (Phases 4–9). When enabled (`localModels.enabled: true`), hardware
+detection works and all four `/api/v1/local-models/*` routes return `200`. But
+two dashboard cards render permanently empty because two primitives that already
+exist in the codebase are **never called**:
+
+1. **Pool card shows `0 / 0 GB`, "No models in the pool."** The pool state
+   defaults to `diskBudgetGb: 0, allowedOrgs: []` (`packages/local-models/src/pool/types.ts:88`).
+   `PoolManager.configurePool()` — which correctly updates and persists bounds
+   (`packages/local-models/src/pool/manager.ts:585`) — has **zero callers**. The
+   operator's configured `localModels.pool` bounds are never applied. With a
+   `0` budget, no model ever fits, so both auto-install and manual pulls are
+   effectively blocked.
+
+2. **Recommendations card shows "No recommendations yet."** The recommender is
+   constructed with an empty candidate set:
+   `createNativeRecommender({ candidates: [] })` (`packages/orchestrator/src/orchestrator.ts:2120`).
+   The seam's own header explains why: _"Phase 2's live-HF candidate parser
+   (arbitrary HF model → `RankerCandidate` with `sizeB`/`quant` extracted from the
+   GGUF manifest) was never built"_ (`packages/local-models/src/recommender/native.ts:5`).
+   Zero candidates in → zero recommendations out, regardless of detected hardware.
+
+**Goal:** close both gaps so the Pool and Recommendations cards become functional
+using the primitives that already exist (`configurePool`, `HuggingFaceClient`,
+`rankModels`, `loadFrozenSnapshot`). This is completion of the original LMLM
+spec's deferred Phase 2 (candidate source, D8) and Phase 7 (pool bounds), not
+net-new design.
+
+**Non-goals (YAGNI):**
+
+- The full `harness models pool set-budget/allow-org/allow-family` CLI group
+  (proposal.md:250) — deferred; config-seed makes the bounds functional without it.
+- Autonomous discovery of brand-new HF models beyond the allow-listed orgs.
+- Release-coupled auto-refresh of the frozen fallback (see Decision D5).
+- Dashboard mutation UX, notification sinks — these already consume pool/proposal
+  state once it is populated.
+
+**Grounding:** `STRATEGY.md` present; advances the local-inference-autonomy
+thread (LMLM proposal D1/D3/D8). No contradiction with strategy.
+
+## Decisions Made
+
+| #      | Decision                                                                                                                                                                                                                                                                                                                                                     | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **D1** | **Pool bounds are seeded from config at orchestrator startup**, by calling the existing `PoolManager.configurePool(config.localModels.pool)`. The `harness models pool` CLI subcommands are deferred.                                                                                                                                                        | Makes the already-written `localModels.pool` config functional with the smallest surface. Matches LMLM D1 ("operator pre-approves disk budget + allowed orgs"). The CLI group is a separable, larger effort not needed to make the cards work.                                                                                                                                                                                                         |
+| **D2** | **Config wins over the persisted store on startup.** Each startup applies the config bounds after `store.load()`, overwriting persisted `diskBudgetGb`/`allowedOrgs`/`allowedFamilies`.                                                                                                                                                                      | Declarative, idempotent, least-surprising while bounds live only in config. Config is the single source of truth. (Revisit with a `source` marker if/when CLI runtime edits land.)                                                                                                                                                                                                                                                                     |
+| **D3** | **Candidate source is hybrid (live HF + frozen fallback), built parser-first.** The keystone is a `HuggingFaceModel` (+ GGUF `siblings`) → `RankerCandidate` parser that extracts `sizeB`/`quant`. Live HF `listModels` filtered by `allowedOrgs` is the primary source; a bundled frozen candidate snapshot is the offline/rate-limited fallback (LMLM D8). | The parser is required for any source and is the real work; source-switching is a thin wrapper over it. Live matches D3/D8 freshness intent; frozen satisfies D8 graceful degradation.                                                                                                                                                                                                                                                                 |
+| **D4** | **One spec, two phases.** Phase 1 = pool-bounds seed (D1/D2). Phase 2 = candidate parser + source (D3).                                                                                                                                                                                                                                                      | Phase 1 ships value immediately (pool becomes usable) and is a trivial wiring change; Phase 2 is the meatier parser. Shared LMLM context makes one spec cheaper than two.                                                                                                                                                                                                                                                                              |
+| **D5** | **The frozen fallback is refreshed by an on-demand generation script, never by release-coupled CI auto-commit.** `scripts/refresh-model-candidates.mjs` regenerates it (fail-closed, sorted output) for a human to review and commit. An optional scheduled workflow that opens a PR is a deferred follow-up.                                                | The frozen candidates steer which models get recommended/installed — a data file that must stay reviewed and deterministic (mirrors the hand-seeded benchmark `snapshot.json`, `"source": "seed"`). Its freshness need tracks the HF ecosystem (~monthly), not our release cadence; coupling to releases invites non-deterministic builds and outage-at-release-time fragility. It is a fallback path, not the primary — over-automation is premature. |
+
+## Technical Design
+
+> The precise signatures / insertion points below are being confirmed against the
+> code and will be finalized in the section-by-section review before
+> implementation. File:line anchors are current as of this draft.
+
+### Phase 1 — Pool bounds seed (Gap 1)
+
+- **Where:** the orchestrator startup path that awaits `PoolStateStore.load()`
+  (in `initLocalModelAndPipeline`, `packages/orchestrator/src/orchestrator.ts`).
+  Immediately after `load()` resolves — and only when `this.modelPool` is
+  non-null and `this.config.localModels?.pool` is defined — call
+  `await this.modelPool.configurePool({ diskBudgetGb, allowedOrgs, allowedFamilies })`
+  from the config block (D2: config wins because it runs _after_ load).
+- **Guards:** no-op when `localModels` is disabled (`modelPool` null) or when
+  `localModels.pool` is undefined, matching the existing disabled-path style.
+- **No new types.** `ConfigurePoolRequest` already accepts exactly
+  `{ diskBudgetGb?, allowedOrgs?, allowedFamilies? }`; `LocalModelsPoolConfig`
+  provides all three.
+- **Effect:** the Pool card renders the configured budget (`100 GB`) and the
+  allow-list; auto-install and manual-pull fit checks operate against real bounds.
+
+### Phase 2 — Candidate parser + source (Gap 2)
+
+New module(s) in `packages/local-models/src/recommender/` (or a sibling
+`candidates/` dir — finalized during review):
+
+1. **GGUF → RankerCandidate parser.** Given a `HuggingFaceModel` /
+   `HuggingFaceModelDetail`, produce zero-or-more `RankerCandidate`:
+   - `hfRepoId` = model id.
+   - `sizeB` = parameter count in billions, extracted from repo id / filename
+     (e.g. `Qwen3-32B` → `32`), falling back to any HF metadata.
+   - `quant` = extracted from each GGUF `siblings[].rfilename` (e.g.
+     `...-Q4_K_M.gguf` → the string `normalizeQuantId` accepts), one candidate
+     per recognized quant file.
+   - `ollamaName` = mapped when a known mirror exists (best-effort).
+   - Files that don't parse to a recognized quant are skipped (logged, not fatal).
+
+2. **Candidate source.** A function that returns `RankerCandidate[]`:
+   - **Live:** `HuggingFaceClient.listModels({ author: org })` for each
+     `allowedOrgs` entry (respecting `allowedFamilies` when non-empty), then fetch
+     model detail for `siblings`, then run the parser. Cached via the existing
+     `huggingface/cache.ts` TTL layer (24h, matching refresh cadence).
+   - **Frozen fallback (D8):** a bundled `candidates.json` loaded via the same
+     `import ... with { type: 'json' }` static-inline pattern as the benchmark
+     snapshot. Used when HF is unreachable/rate-limited; the recommender is
+     already degradation-first (`native.ts`).
+
+3. **Wiring.** Replace `createNativeRecommender({ candidates: [] })`
+   (`orchestrator.ts:2120`) with the sourced candidate list. The on-demand
+   recommendations route and the background refresh tick share the one
+   recommender, so both light up from a single change.
+
+4. **Frozen snapshot + refresh script (D5).**
+   `scripts/refresh-model-candidates.mjs` runs the live source against the allow-list,
+   writes a sorted `candidates.json`, and **fails closed** (never overwrites on HF
+   error). Human reviews the diff and commits.
+
+## Integration Points
+
+- **Entry Points:** No new CLI command / MCP tool / route. Touches the
+  orchestrator startup path (Phase 1) and the recommender candidate seam (Phase 2).
+  New package-internal modules in `@harness-engineering/local-models`; a new
+  `scripts/refresh-model-candidates.mjs`.
+- **Registrations Required:** If new public symbols are exported from
+  `packages/local-models/src/index.ts` (parser / candidate-source / frozen loader),
+  regenerate the barrel if applicable. No skill/route/tier registration.
+- **Documentation Updates:** Note in the LMLM proposal / any LMLM guide that Phase 2
+  candidate sourcing and Phase 7 pool-bounds seed are now delivered. Document the
+  `refresh-model-candidates` script (how/when to run it). Update reference docs only
+  if a CLI command changes — none does here.
+- **Architectural Decisions:** D2 (config-wins precedence) and D5 (no
+  release-coupled snapshot refresh) are the two candidates for a short ADR — both
+  encode a non-obvious policy future changes must respect. D1/D3/D4 are wiring
+  choices that don't warrant standalone ADRs.
+- **Knowledge Impact:** Reinforce the "Model Recommendation Lifecycle" business
+  process node (hardware detect → HF fetch → parse → rank → propose). Add the
+  fact that pool bounds are declarative-from-config (D2) and the frozen candidate
+  fallback is human-curated (D5).
+
+## Success Criteria
+
+Observable, testable outcomes:
+
+- **SC1** — With `localModels.enabled: true` and `localModels.pool.diskBudgetGb: 100`,
+  after orchestrator start, `GET /api/v1/local-models/pool` returns
+  `diskBudgetGb: 100` and the configured `allowedOrgs` (not `0` / `[]`).
+- **SC2** — When config and a pre-existing persisted store disagree, the config
+  value wins after restart (D2), verified by a test that loads a store with
+  `diskBudgetGb: 5` and config `100`, then asserts `100`.
+- **SC3** — Phase-1 seed is a no-op when `localModels` is disabled or
+  `localModels.pool` is absent (no throw, `modelPool` stays null / bounds untouched).
+- **SC4** — The GGUF parser turns a representative `HuggingFaceModelDetail`
+  (e.g. `Qwen/Qwen3-32B-GGUF` with `Q4_K_M` + `Q8_0` siblings) into the expected
+  `RankerCandidate[]` with correct `sizeB` and `normalizeQuantId`-valid `quant`;
+  unrecognized files are skipped.
+- **SC5** — With a non-empty candidate source,
+  `GET /api/v1/local-models/recommendations?top=5` returns a non-empty ranked list
+  for the detected hardware, each entry `fitsHardware`-consistent (mirrors LMLM F3).
+- **SC6** — When the HF client throws / is unreachable, the candidate source falls
+  back to the bundled frozen snapshot and recommendations are still non-empty
+  (LMLM S4 degradation), surfaced as a warning, not a 503.
+- **SC7** — `scripts/refresh-model-candidates.mjs` fails closed on HF error (exits
+  non-zero, leaves `candidates.json` unchanged) and produces stable, sorted output
+  on success (re-running with unchanged input yields no diff).
+- **SC8** — `pnpm build`, typecheck, lint, and the local-models + orchestrator test
+  suites pass; a changeset is present.
+
+## Implementation Order
+
+**Phase 1 — Pool bounds seed (small):**
+
+1. Add the post-`load()` `configurePool` seed in the orchestrator startup path,
+   guarded on enabled + `localModels.pool` present.
+2. Tests: SC1, SC2, SC3 (config-wins, disabled no-op).
+
+**Phase 2 — Candidate parser + source (medium):** 3. Build the GGUF→`RankerCandidate` parser with unit tests (SC4), reusing any
+existing quant/size parsing prior art. 4. Build the candidate source (live HF via `listModels` + detail/`siblings`,
+filtered by allow-list, cached) with the frozen-snapshot fallback. 5. Add the bundled `candidates.json` (curated seed) + `loadFrozenCandidates`
+loader (static-inline pattern) + `scripts/refresh-model-candidates.mjs` (D5, SC7). 6. Wire the source into `createNativeRecommender` at `orchestrator.ts:2120`;
+integration tests for SC5, SC6. 7. Export any new public symbols; regenerate barrel if needed.
+
+**Wrap-up:** 8. Changeset, full local validation (SC8), PR for human review.

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -22,6 +22,16 @@ import type { DashRankedModel } from '../../types/local-models';
  * Reuses the container/border/button classes from `pages/Proposals.tsx` —
  * introduces no new design tokens.
  */
+/** Round to at most one decimal, dropping a trailing `.0` (e.g. 44.159 → "44.2", 20 → "20"). */
+function round1(n: number): string {
+  return (Math.round(n * 10) / 10).toString();
+}
+
+/** Ranking scores render as whole numbers (they are a 0–100 index, not a measurement). */
+function fmtScore(n: number): string {
+  return Math.round(n).toString();
+}
+
 export interface RecommendationsCardProps {
   recommendations: DashRankedModel[] | null;
   recommendationsError: string | null;
@@ -83,7 +93,7 @@ function ProposalRow({ proposal, onDecided }: ProposalRowProps): JSX.Element {
           {model.target.ollamaName}
         </span>
         <span className="text-xs text-neutral-muted">
-          Δ{model.scoreDelta} · {model.diskImpactGb} GB
+          Δ{round1(model.scoreDelta)} · {round1(model.diskImpactGb)} GB
         </span>
       </div>
       <p className="mt-1 text-sm">{model.justification.summary}</p>
@@ -161,11 +171,11 @@ export function RecommendationsCard({
                 <div className="flex items-center justify-between gap-2">
                   <span className="font-mono text-sm">{r.hfRepoId}</span>
                   <span className="text-xs text-neutral-muted">
-                    score {r.score} · {r.evidence}
+                    score {fmtScore(r.score)} · {r.evidence}
                   </span>
                 </div>
                 <div className="mt-0.5 text-xs text-neutral-muted">
-                  {r.estimatedVramGb} GB VRAM · ~{r.estimatedTokPerSec} tok/s ·{' '}
+                  {round1(r.estimatedVramGb)} GB VRAM · ~{round1(r.estimatedTokPerSec)} tok/s ·{' '}
                   {r.fitsHardware ? 'fits' : "won't fit"}
                 </div>
               </li>

--- a/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
+++ b/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
@@ -70,6 +70,34 @@ describe('RecommendationsCard', () => {
     expect(row.textContent).toContain('20');
   });
 
+  it('rounds long float metrics for display (score → whole, GB/tok-s → 1 decimal)', () => {
+    const noisy: DashRankedModel[] = [
+      {
+        ...RECS[0]!,
+        estimatedVramGb: 44.15923222899437,
+        estimatedTokPerSec: 1.7711205344329897,
+        score: 57.629999999999995,
+      },
+    ];
+    render(
+      <RecommendationsCard
+        recommendations={noisy}
+        recommendationsError={null}
+        proposals={[]}
+        onDecided={() => {}}
+        loading={false}
+      />
+    );
+    const row = screen.getByTestId('rec-row-Qwen/Qwen3-32B-GGUF');
+    expect(row.textContent).toContain('44.2 GB VRAM');
+    expect(row.textContent).toContain('~1.8 tok/s');
+    expect(row.textContent).toContain('score 58');
+    // The raw, unrounded floats must not leak into the DOM.
+    expect(row.textContent).not.toContain('44.15923222899437');
+    expect(row.textContent).not.toContain('1.7711205344329897');
+    expect(row.textContent).not.toContain('57.629999999999995');
+  });
+
   it('[O3 / known limitation] renders "No recommendations yet" for an empty ranked set', () => {
     render(
       <RecommendationsCard

--- a/packages/local-models/src/candidates/candidates.json
+++ b/packages/local-models/src/candidates/candidates.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "generatedAt": "2026-07-08",
+  "source": "seed",
+  "candidates": [
+    {
+      "hfRepoId": "Qwen/Qwen3-32B-GGUF",
+      "ollamaName": "qwen3:32b",
+      "family": "qwen3",
+      "sizeB": 32,
+      "quant": "Q4_K_M"
+    },
+    {
+      "hfRepoId": "Qwen/Qwen3-32B-GGUF",
+      "ollamaName": "qwen3:32b",
+      "family": "qwen3",
+      "sizeB": 32,
+      "quant": "Q8_0"
+    },
+    {
+      "hfRepoId": "Qwen/Qwen3-14B-GGUF",
+      "ollamaName": "qwen3:14b",
+      "family": "qwen3",
+      "sizeB": 14,
+      "quant": "Q4_K_M"
+    },
+    {
+      "hfRepoId": "Qwen/Qwen3-8B-GGUF",
+      "ollamaName": "qwen3:8b",
+      "family": "qwen3",
+      "sizeB": 8,
+      "quant": "Q4_K_M"
+    },
+    {
+      "hfRepoId": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+      "ollamaName": "deepseek-r1:32b",
+      "family": "deepseek-r1",
+      "sizeB": 32,
+      "quant": "Q4_K_M"
+    },
+    {
+      "hfRepoId": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+      "ollamaName": "deepseek-r1:14b",
+      "family": "deepseek-r1",
+      "sizeB": 14,
+      "quant": "Q4_K_M"
+    },
+    {
+      "hfRepoId": "meta-llama/Llama-3.3-70B-Instruct-GGUF",
+      "ollamaName": "llama3.3:70b",
+      "family": "llama-3",
+      "sizeB": 70,
+      "quant": "Q4_K_M"
+    }
+  ]
+}

--- a/packages/local-models/src/candidates/frozen.ts
+++ b/packages/local-models/src/candidates/frozen.ts
@@ -1,0 +1,82 @@
+/**
+ * Frozen candidate snapshot loader (LMLM Phase 2, D3/D8).
+ *
+ * The bundled `candidates.json` is imported statically so esbuild (tsup)
+ * inlines it into the package output — no runtime file I/O, works offline,
+ * and stays deterministic. This mirrors the benchmark snapshot loader
+ * (`ranker/benchmarks/snapshot.ts`). Regenerate the JSON on demand with
+ * `scripts/refresh-model-candidates.mjs`; never auto-commit it from CI (D5).
+ *
+ * @see docs/changes/lmlm-functional-wiring/proposal.md (Phase 2, D5)
+ */
+
+import bundledCandidates from './candidates.json' with { type: 'json' };
+import { normalizeQuantId } from '../ranker/index.js';
+import type { FrozenCandidate, FrozenCandidatesFile, LoadFrozenCandidatesResult } from './types.js';
+
+/** Current supported schema version of the frozen candidate file. */
+export const FROZEN_CANDIDATES_VERSION = 1;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Validate one raw entry into a `FrozenCandidate`, or return a reason string. */
+function validateCandidate(raw: unknown, index: number): FrozenCandidate | string {
+  if (!isRecord(raw)) return `candidate[${index}] is not an object`;
+  if (typeof raw.hfRepoId !== 'string' || raw.hfRepoId.length === 0) {
+    return `candidate[${index}] has no hfRepoId`;
+  }
+  if (typeof raw.sizeB !== 'number' || !Number.isFinite(raw.sizeB) || raw.sizeB <= 0) {
+    return `candidate[${index}] (${raw.hfRepoId}) has invalid sizeB`;
+  }
+  if (typeof raw.quant !== 'string' || !normalizeQuantId(raw.quant).known) {
+    return `candidate[${index}] (${raw.hfRepoId}) has unrecognised quant '${String(raw.quant)}'`;
+  }
+  const candidate: FrozenCandidate = {
+    hfRepoId: raw.hfRepoId,
+    sizeB: raw.sizeB,
+    quant: normalizeQuantId(raw.quant).canonical,
+  };
+  if (typeof raw.activeB === 'number' && raw.activeB > 0) candidate.activeB = raw.activeB;
+  if (typeof raw.ollamaName === 'string' && raw.ollamaName.length > 0) {
+    candidate.ollamaName = raw.ollamaName;
+  }
+  if (typeof raw.family === 'string' && raw.family.length > 0) candidate.family = raw.family;
+  return candidate;
+}
+
+/** Validate a raw frozen-candidates document. Returns candidates or a reason. */
+export function validateFrozenCandidates(
+  data: unknown
+): { ok: true; candidates: FrozenCandidate[] } | { ok: false; reason: string } {
+  if (!isRecord(data)) return { ok: false, reason: 'frozen candidates file is not an object' };
+  if (data.version !== FROZEN_CANDIDATES_VERSION) {
+    return { ok: false, reason: `unsupported version ${String(data.version)}` };
+  }
+  if (!Array.isArray(data.candidates)) {
+    return { ok: false, reason: 'frozen candidates file has no candidates array' };
+  }
+  const candidates: FrozenCandidate[] = [];
+  for (let i = 0; i < data.candidates.length; i++) {
+    const result = validateCandidate(data.candidates[i], i);
+    if (typeof result === 'string') return { ok: false, reason: result };
+    candidates.push(result);
+  }
+  return { ok: true, candidates };
+}
+
+/**
+ * Load the bundled frozen candidate snapshot. Degradation-first: a
+ * schema-invalid snapshot returns an empty list plus a warning (never throws),
+ * so the recommender surfaces "no recommendations" rather than crashing.
+ * Tests inject `override` to exercise the fallback path.
+ */
+export function loadFrozenCandidates(override?: unknown): LoadFrozenCandidatesResult {
+  const data: unknown = override ?? (bundledCandidates as FrozenCandidatesFile);
+  const validation = validateFrozenCandidates(data);
+  if (!validation.ok) {
+    return { candidates: [], source: 'fallback', warnings: [validation.reason] };
+  }
+  return { candidates: validation.candidates, source: 'frozen', warnings: [] };
+}

--- a/packages/local-models/src/candidates/index.ts
+++ b/packages/local-models/src/candidates/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Candidates — public barrel (LMLM Phase 2).
+ *
+ * The GGUF→candidate parser (shared with the refresh script), the frozen
+ * snapshot loader (offline-safe runtime source), and the allowlist-aware
+ * selector the orchestrator feeds into the recommender.
+ *
+ * @see docs/changes/lmlm-functional-wiring/proposal.md (Phase 2)
+ */
+
+export { extractSizeB, extractQuantFromFilename, parseHfModelToCandidates } from './parse.js';
+export type { ExtractedSize, ParseCandidateOptions } from './parse.js';
+
+export {
+  loadFrozenCandidates,
+  validateFrozenCandidates,
+  FROZEN_CANDIDATES_VERSION,
+} from './frozen.js';
+
+export { selectCandidates } from './select.js';
+export type { CandidateSelectionBounds } from './select.js';
+
+export type { FrozenCandidate, FrozenCandidatesFile, LoadFrozenCandidatesResult } from './types.js';

--- a/packages/local-models/src/candidates/parse.ts
+++ b/packages/local-models/src/candidates/parse.ts
@@ -1,0 +1,114 @@
+/**
+ * GGUF → `RankerCandidate` parser (LMLM Phase 2 completion).
+ *
+ * Turns a HuggingFace model (repo id + GGUF file manifest) into zero-or-more
+ * `RankerCandidate`s — one per recognised quant — with `sizeB` extracted from
+ * the repo id and `quant` extracted from each `.gguf` sibling filename.
+ *
+ * Best-effort by design: models whose parameter count can't be read from the
+ * name, and files that don't carry a `normalizeQuantId`-recognised quant, are
+ * skipped rather than guessed. The runtime consumes a curated frozen snapshot
+ * (see `./frozen.ts`); this parser is the shared core used by the on-demand
+ * `scripts/refresh-model-candidates.mjs` generator, whose output a human
+ * reviews before committing.
+ *
+ * @see docs/changes/lmlm-functional-wiring/proposal.md (Phase 2, D3)
+ */
+
+import type { HuggingFaceModelDetail } from '../huggingface/index.js';
+import { normalizeQuantId } from '../ranker/index.js';
+import type { RankerCandidate } from '../ranker/index.js';
+
+/** Mixture-of-Experts naming like `8x7B` — `experts × per-expert-B`. */
+const MOE_SIZE_RE = /(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)\s*b\b/i;
+/** Dense parameter-count token like `32B`, `1.5B`, `70b`. Global for `matchAll`. */
+const DENSE_SIZE_RE = /(\d+(?:\.\d+)?)\s*b\b/gi;
+/**
+ * A quant token embedded in a GGUF filename: GGUF K-quants (`Q4_K_M`, `Q8_0`),
+ * importance-quants (`IQ4_XS`), or plain float formats (`F16`, `BF16`). The
+ * captured group is handed to `normalizeQuantId`, which owns aliasing/casing.
+ */
+const QUANT_RE =
+  /(?:^|[-_. ])((?:iq|q)\d+(?:_[a-z0-9]+)*|bf16|fp16|f16|f32|mxfp4|mlx-\d+bit)(?=[-_. ]|\.gguf$|$)/i;
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/** Extracted parameter counts in billions. `activeB` is set only for MoE. */
+export interface ExtractedSize {
+  sizeB: number;
+  activeB?: number;
+}
+
+/**
+ * Read the parameter count (in billions) from a model name / repo id. MoE
+ * `AxB` naming yields `sizeB = A×B` (approximate total) and `activeB = B`.
+ * Dense names yield the largest `<n>B` token (repo ids embed version numbers
+ * like `Llama-3.3-70B` — `70` is the size, `3.3` carries no `B`). Returns
+ * `null` when no size token is present.
+ */
+export function extractSizeB(name: string): ExtractedSize | null {
+  const moe = MOE_SIZE_RE.exec(name);
+  if (moe) {
+    const experts = Number(moe[1]);
+    const per = Number(moe[2]);
+    if (experts > 0 && per > 0) return { sizeB: round1(experts * per), activeB: per };
+  }
+  let best: number | null = null;
+  for (const m of name.matchAll(DENSE_SIZE_RE)) {
+    const v = Number(m[1]);
+    if (Number.isFinite(v) && v > 0 && (best === null || v > best)) best = v;
+  }
+  return best === null ? null : { sizeB: best };
+}
+
+/**
+ * Extract the quant token from a GGUF filename (e.g. `Qwen3-32B-Q4_K_M.gguf`
+ * → `Q4_K_M`). Returns `null` for non-`.gguf` files or files with no
+ * recognisable quant token. Normalisation/validation is left to the caller.
+ */
+export function extractQuantFromFilename(rfilename: string): string | null {
+  if (!/\.gguf$/i.test(rfilename)) return null;
+  const m = QUANT_RE.exec(rfilename);
+  return m ? (m[1] as string) : null;
+}
+
+/** Options for {@link parseHfModelToCandidates}. */
+export interface ParseCandidateOptions {
+  /** Override the name-derived size when the caller knows the true param count. */
+  sizeOverride?: number;
+}
+
+/**
+ * Parse a HuggingFace model detail into `RankerCandidate`s — one per distinct,
+ * recognised quant among its `.gguf` siblings. Deduplicates quants (sharded
+ * files repeat a quant across `-00001-of-000NN.gguf` parts). Returns `[]` when
+ * the size can't be determined or no recognised GGUF quant is present.
+ */
+export function parseHfModelToCandidates(
+  model: HuggingFaceModelDetail,
+  opts: ParseCandidateOptions = {}
+): RankerCandidate[] {
+  const size =
+    opts.sizeOverride !== undefined ? { sizeB: opts.sizeOverride } : extractSizeB(model.id);
+  if (!size || size.sizeB <= 0) return [];
+
+  const seen = new Set<string>();
+  const out: RankerCandidate[] = [];
+  for (const sibling of model.siblings ?? []) {
+    const raw = extractQuantFromFilename(sibling.rfilename);
+    if (raw === null) continue;
+    const norm = normalizeQuantId(raw);
+    if (!norm.known || seen.has(norm.canonical)) continue;
+    seen.add(norm.canonical);
+    const candidate: RankerCandidate = {
+      hfRepoId: model.id,
+      sizeB: size.sizeB,
+      quant: norm.canonical,
+    };
+    if (size.activeB !== undefined) candidate.activeB = size.activeB;
+    out.push(candidate);
+  }
+  return out;
+}

--- a/packages/local-models/src/candidates/select.ts
+++ b/packages/local-models/src/candidates/select.ts
@@ -1,0 +1,59 @@
+/**
+ * Candidate selection (LMLM Phase 2, D3).
+ *
+ * Filters a candidate list to the operator's approved trust line — the same
+ * `allowedOrgs` / `allowedFamilies` bounds the pool enforces at install time
+ * — so the Recommendations card never surfaces a model the operator could not
+ * actually install. Org is derived from the `hfRepoId` prefix; family from the
+ * optional `family` tag.
+ *
+ * @see docs/changes/lmlm-functional-wiring/proposal.md (Phase 2, D3)
+ */
+
+import type { RankerCandidate } from '../ranker/index.js';
+import type { FrozenCandidate } from './types.js';
+
+/** The subset of pool bounds relevant to candidate selection. */
+export interface CandidateSelectionBounds {
+  allowedOrgs: readonly string[];
+  allowedFamilies: readonly string[];
+}
+
+/** Derive the HF org from a repo id (`Qwen/Qwen3-32B-GGUF` → `Qwen`). */
+function orgOf(hfRepoId: string): string {
+  const slash = hfRepoId.indexOf('/');
+  return slash === -1 ? hfRepoId : hfRepoId.slice(0, slash);
+}
+
+/**
+ * Keep only candidates whose org is in `allowedOrgs` and (when `allowedFamilies`
+ * is non-empty) whose `family` is in `allowedFamilies`. An **empty**
+ * `allowedOrgs` means "nothing is approved" and yields `[]` — matching the
+ * pool's install semantics, where an empty allowlist blocks every install.
+ * The returned objects are plain `RankerCandidate`s (the `family` tag is
+ * dropped) ready to hand to the recommender.
+ */
+export function selectCandidates(
+  candidates: readonly FrozenCandidate[],
+  bounds: CandidateSelectionBounds | undefined
+): RankerCandidate[] {
+  const allowedOrgs = bounds?.allowedOrgs ?? [];
+  const allowedFamilies = bounds?.allowedFamilies ?? [];
+  if (allowedOrgs.length === 0) return [];
+
+  const out: RankerCandidate[] = [];
+  for (const c of candidates) {
+    if (!allowedOrgs.includes(orgOf(c.hfRepoId))) continue;
+    if (
+      allowedFamilies.length > 0 &&
+      (c.family === undefined || !allowedFamilies.includes(c.family))
+    ) {
+      continue;
+    }
+    const candidate: RankerCandidate = { hfRepoId: c.hfRepoId, sizeB: c.sizeB, quant: c.quant };
+    if (c.activeB !== undefined) candidate.activeB = c.activeB;
+    if (c.ollamaName !== undefined) candidate.ollamaName = c.ollamaName;
+    out.push(candidate);
+  }
+  return out;
+}

--- a/packages/local-models/src/candidates/types.ts
+++ b/packages/local-models/src/candidates/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Frozen candidate snapshot types (LMLM Phase 2, D3/D8).
+ *
+ * The runtime recommender consumes a bundled, human-curated candidate list as
+ * its offline-safe, deterministic source (mirroring the benchmark snapshot).
+ * A `FrozenCandidate` is a `RankerCandidate` plus an optional `family` tag so
+ * the operator's `allowedFamilies` allowlist can filter it.
+ *
+ * @see docs/changes/lmlm-functional-wiring/proposal.md (Phase 2, D5)
+ */
+
+import type { RankerCandidate } from '../ranker/index.js';
+
+/** A ranker candidate augmented with the family tag used for allowlist filtering. */
+export interface FrozenCandidate extends RankerCandidate {
+  /** Model family (e.g. `qwen3`, `deepseek-r1`) for `allowedFamilies` filtering. */
+  family?: string;
+}
+
+/** On-disk / bundled frozen candidate file. */
+export interface FrozenCandidatesFile {
+  /** Schema version. Bumped when the shape changes. */
+  version: number;
+  /** ISO date the snapshot was generated (provenance). */
+  generatedAt: string;
+  /** How the snapshot was produced (`seed` = hand-curated, `hf-refresh` = script). */
+  source: string;
+  /** The candidate list. */
+  candidates: FrozenCandidate[];
+}
+
+/** Result of loading the frozen candidate snapshot. Never throws. */
+export interface LoadFrozenCandidatesResult {
+  candidates: FrozenCandidate[];
+  /** `frozen` when the bundled snapshot loaded; `fallback` on validation failure. */
+  source: 'frozen' | 'fallback';
+  /** Human-readable warnings (schema failure detail) — advisory, never fatal. */
+  warnings: string[];
+}

--- a/packages/local-models/src/index.ts
+++ b/packages/local-models/src/index.ts
@@ -26,6 +26,7 @@
 export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const;
 export const LOCAL_MODELS_VERSION = '0.1.0' as const;
 
+export * from './candidates/index.js';
 export * from './hardware/index.js';
 export * from './huggingface/index.js';
 export * from './installer/index.js';

--- a/packages/local-models/tests/candidates/frozen.test.ts
+++ b/packages/local-models/tests/candidates/frozen.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { loadFrozenCandidates, validateFrozenCandidates } from '../../src/candidates/frozen.js';
+import { normalizeQuantId } from '../../src/ranker/index.js';
+
+describe('loadFrozenCandidates (bundled snapshot)', () => {
+  it('loads the bundled snapshot with no warnings', () => {
+    const result = loadFrozenCandidates();
+    expect(result.source).toBe('frozen');
+    expect(result.warnings).toEqual([]);
+    expect(result.candidates.length).toBeGreaterThan(0);
+  });
+
+  it('every bundled candidate has a valid size and a recognised quant', () => {
+    for (const c of loadFrozenCandidates().candidates) {
+      expect(c.sizeB).toBeGreaterThan(0);
+      expect(normalizeQuantId(c.quant).known).toBe(true);
+      expect(c.hfRepoId).toContain('/');
+    }
+  });
+
+  it('covers the three allow-listed orgs so the default config is non-empty', () => {
+    const orgs = new Set(loadFrozenCandidates().candidates.map((c) => c.hfRepoId.split('/')[0]));
+    expect(orgs).toContain('Qwen');
+    expect(orgs).toContain('deepseek-ai');
+    expect(orgs).toContain('meta-llama');
+  });
+});
+
+describe('loadFrozenCandidates (degradation)', () => {
+  it('falls back to an empty list with a warning on a schema-invalid override', () => {
+    const result = loadFrozenCandidates({ version: 99, candidates: [] });
+    expect(result.source).toBe('fallback');
+    expect(result.candidates).toEqual([]);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+describe('validateFrozenCandidates', () => {
+  it('accepts a well-formed document', () => {
+    const parsed = validateFrozenCandidates({
+      version: 1,
+      generatedAt: '2026-07-08',
+      source: 'seed',
+      candidates: [{ hfRepoId: 'Qwen/Qwen3-8B-GGUF', sizeB: 8, quant: 'q4' }],
+    });
+    expect(parsed.ok).toBe(true);
+    // 'q4' is aliased to the canonical 'Q4_K_M'.
+    if (parsed.ok) expect(parsed.candidates[0]!.quant).toBe('Q4_K_M');
+  });
+
+  it('rejects an unsupported version', () => {
+    const parsed = validateFrozenCandidates({ version: 2, candidates: [] });
+    expect(parsed.ok).toBe(false);
+  });
+
+  it('rejects a candidate with an unrecognised quant', () => {
+    const parsed = validateFrozenCandidates({
+      version: 1,
+      candidates: [{ hfRepoId: 'Qwen/X', sizeB: 8, quant: 'totally-made-up' }],
+    });
+    expect(parsed.ok).toBe(false);
+  });
+
+  it('rejects a candidate with a non-positive size', () => {
+    const parsed = validateFrozenCandidates({
+      version: 1,
+      candidates: [{ hfRepoId: 'Qwen/X', sizeB: 0, quant: 'Q4_K_M' }],
+    });
+    expect(parsed.ok).toBe(false);
+  });
+});

--- a/packages/local-models/tests/candidates/parse.test.ts
+++ b/packages/local-models/tests/candidates/parse.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractSizeB,
+  extractQuantFromFilename,
+  parseHfModelToCandidates,
+} from '../../src/candidates/parse.js';
+import type { HuggingFaceModelDetail } from '../../src/huggingface/index.js';
+
+function model(id: string, rfilenames: string[]): HuggingFaceModelDetail {
+  return {
+    id,
+    downloads: 0,
+    likes: 0,
+    tags: ['gguf'],
+    siblings: rfilenames.map((rfilename) => ({ rfilename })),
+  };
+}
+
+describe('extractSizeB', () => {
+  it('reads a dense parameter count from the repo id', () => {
+    expect(extractSizeB('Qwen/Qwen3-32B-GGUF')).toEqual({ sizeB: 32 });
+    expect(extractSizeB('Qwen/Qwen3-8B')).toEqual({ sizeB: 8 });
+  });
+
+  it('ignores version numbers that carry no B suffix (picks the largest B token)', () => {
+    expect(extractSizeB('meta-llama/Llama-3.3-70B-Instruct-GGUF')).toEqual({ sizeB: 70 });
+    expect(extractSizeB('meta-llama/Llama-3.1-405B')).toEqual({ sizeB: 405 });
+  });
+
+  it('reads fractional sizes', () => {
+    expect(extractSizeB('Qwen/Qwen2.5-1.5B-Instruct')).toEqual({ sizeB: 1.5 });
+  });
+
+  it('reads MoE naming as total + active', () => {
+    expect(extractSizeB('mistralai/Mixtral-8x7B-v0.1')).toEqual({ sizeB: 56, activeB: 7 });
+  });
+
+  it('returns null when there is no size token', () => {
+    expect(extractSizeB('deepseek-ai/DeepSeek-V2.5')).toBeNull();
+    expect(extractSizeB('some/random-model')).toBeNull();
+  });
+});
+
+describe('extractQuantFromFilename', () => {
+  it('extracts K-quants from GGUF filenames', () => {
+    expect(extractQuantFromFilename('Qwen3-32B-Q4_K_M.gguf')).toBe('Q4_K_M');
+    expect(extractQuantFromFilename('model.Q8_0.gguf')).toBe('Q8_0');
+    expect(extractQuantFromFilename('model-Q4_0.gguf')).toBe('Q4_0');
+  });
+
+  it('extracts importance-quants and float formats', () => {
+    expect(extractQuantFromFilename('model-IQ4_XS.gguf')).toBe('IQ4_XS');
+    expect(extractQuantFromFilename('model-f16.gguf')).toBe('f16');
+    expect(extractQuantFromFilename('model.BF16.gguf')).toBe('BF16');
+  });
+
+  it('extracts the quant from a sharded filename', () => {
+    expect(extractQuantFromFilename('Qwen3-32B-Q4_K_M-00001-of-00002.gguf')).toBe('Q4_K_M');
+  });
+
+  it('returns null for non-gguf files and quant-less names', () => {
+    expect(extractQuantFromFilename('README.md')).toBeNull();
+    expect(extractQuantFromFilename('model.safetensors')).toBeNull();
+    expect(extractQuantFromFilename('config.json')).toBeNull();
+    expect(extractQuantFromFilename('model-nonsense.gguf')).toBeNull();
+  });
+});
+
+describe('parseHfModelToCandidates', () => {
+  it('produces one candidate per recognised quant, with size from the repo id', () => {
+    const detail = model('Qwen/Qwen3-32B-GGUF', [
+      'Qwen3-32B-Q4_K_M.gguf',
+      'Qwen3-32B-Q8_0.gguf',
+      'README.md',
+    ]);
+    const candidates = parseHfModelToCandidates(detail);
+    expect(candidates).toEqual([
+      { hfRepoId: 'Qwen/Qwen3-32B-GGUF', sizeB: 32, quant: 'Q4_K_M' },
+      { hfRepoId: 'Qwen/Qwen3-32B-GGUF', sizeB: 32, quant: 'Q8_0' },
+    ]);
+  });
+
+  it('deduplicates a quant repeated across shards', () => {
+    const detail = model('Qwen/Qwen3-32B-GGUF', [
+      'Qwen3-32B-Q4_K_M-00001-of-00002.gguf',
+      'Qwen3-32B-Q4_K_M-00002-of-00002.gguf',
+    ]);
+    expect(parseHfModelToCandidates(detail)).toEqual([
+      { hfRepoId: 'Qwen/Qwen3-32B-GGUF', sizeB: 32, quant: 'Q4_K_M' },
+    ]);
+  });
+
+  it('returns [] when the size cannot be determined', () => {
+    expect(parseHfModelToCandidates(model('some/no-size-model', ['x-Q4_K_M.gguf']))).toEqual([]);
+  });
+
+  it('returns [] when no GGUF quant is recognised', () => {
+    expect(parseHfModelToCandidates(model('Qwen/Qwen3-32B-GGUF', ['model.safetensors']))).toEqual(
+      []
+    );
+  });
+
+  it('honors a size override for models whose name lacks a param count', () => {
+    const detail = model('some/custom-model', ['custom-Q4_K_M.gguf']);
+    expect(parseHfModelToCandidates(detail, { sizeOverride: 12 })).toEqual([
+      { hfRepoId: 'some/custom-model', sizeB: 12, quant: 'Q4_K_M' },
+    ]);
+  });
+
+  it('carries MoE active params through to the candidate', () => {
+    const detail = model('mistralai/Mixtral-8x7B-v0.1', ['mixtral-8x7b-Q4_K_M.gguf']);
+    expect(parseHfModelToCandidates(detail)).toEqual([
+      { hfRepoId: 'mistralai/Mixtral-8x7B-v0.1', sizeB: 56, activeB: 7, quant: 'Q4_K_M' },
+    ]);
+  });
+});

--- a/packages/local-models/tests/candidates/select.test.ts
+++ b/packages/local-models/tests/candidates/select.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { selectCandidates } from '../../src/candidates/select.js';
+import type { FrozenCandidate } from '../../src/candidates/types.js';
+
+const CANDIDATES: FrozenCandidate[] = [
+  {
+    hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+    ollamaName: 'qwen3:32b',
+    family: 'qwen3',
+    sizeB: 32,
+    quant: 'Q4_K_M',
+  },
+  {
+    hfRepoId: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-GGUF',
+    family: 'deepseek-r1',
+    sizeB: 32,
+    quant: 'Q4_K_M',
+  },
+  {
+    hfRepoId: 'meta-llama/Llama-3.3-70B-Instruct-GGUF',
+    family: 'llama-3',
+    sizeB: 70,
+    quant: 'Q4_K_M',
+  },
+];
+
+describe('selectCandidates', () => {
+  it('keeps only candidates whose org is allow-listed', () => {
+    const result = selectCandidates(CANDIDATES, { allowedOrgs: ['Qwen'], allowedFamilies: [] });
+    expect(result.map((c) => c.hfRepoId)).toEqual(['Qwen/Qwen3-32B-GGUF']);
+  });
+
+  it('narrows further by allowedFamilies when non-empty', () => {
+    const result = selectCandidates(
+      [
+        ...CANDIDATES,
+        { hfRepoId: 'Qwen/Qwen2.5-32B-GGUF', family: 'qwen2.5', sizeB: 32, quant: 'Q4_K_M' },
+      ],
+      { allowedOrgs: ['Qwen'], allowedFamilies: ['qwen3'] }
+    );
+    expect(result.map((c) => c.hfRepoId)).toEqual(['Qwen/Qwen3-32B-GGUF']);
+  });
+
+  it('returns [] when the org allowlist is empty (nothing approved)', () => {
+    expect(selectCandidates(CANDIDATES, { allowedOrgs: [], allowedFamilies: [] })).toEqual([]);
+    expect(selectCandidates(CANDIDATES, undefined)).toEqual([]);
+  });
+
+  it('strips the family tag and preserves ollamaName on the returned candidate', () => {
+    const [first] = selectCandidates(CANDIDATES, {
+      allowedOrgs: ['Qwen'],
+      allowedFamilies: [],
+    });
+    expect(first).toEqual({
+      hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      ollamaName: 'qwen3:32b',
+      sizeB: 32,
+      quant: 'Q4_K_M',
+    });
+    expect('family' in first!).toBe(false);
+  });
+});

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -41,6 +41,8 @@ import {
   RefreshScheduler,
   runRefreshTick,
   createNativeRecommender,
+  loadFrozenCandidates,
+  selectCandidates,
 } from '@harness-engineering/local-models';
 import type {
   PoolStateProvider,
@@ -2102,6 +2104,25 @@ export class Orchestrator extends EventEmitter {
   }
 
   /**
+   * LMLM Phase 7 wiring: apply the operator's configured pool bounds (disk
+   * budget + org/family allowlist) from `localModels.pool` to the live pool.
+   * Called after `PoolStateStore.load()` so config wins over persisted bounds
+   * (D2, declarative precedence). No-op when the pool is null (LMLM disabled)
+   * or no `pool` block is configured, so it is safe to call unconditionally
+   * on the startup path.
+   */
+  private async applyConfiguredPoolBounds(): Promise<void> {
+    const pool = this.modelPool;
+    const bounds = this.config.localModels?.pool;
+    if (pool === null || !bounds) return;
+    await pool.configurePool({
+      diskBudgetGb: bounds.diskBudgetGb,
+      allowedOrgs: bounds.allowedOrgs,
+      allowedFamilies: bounds.allowedFamilies,
+    });
+  }
+
+  /**
    * LMLM Phase 6: arm the single background refresh scheduler over the live
    * pool. No-op when LMLM is disabled (`modelPool` null). Each tick runs
    * hardware→recommend→reconcile(D12 drift)→diff→emit→score-writeback.
@@ -2117,7 +2138,25 @@ export class Orchestrator extends EventEmitter {
     if (this.modelPool === null) return;
     const pool = this.modelPool;
     const refreshCfg = this.config.localModels?.refresh;
-    const recommend = createNativeRecommender({ candidates: [] });
+    // LMLM Phase 2 completion: source ranking candidates from the bundled,
+    // human-curated frozen snapshot (offline-safe, deterministic — the same
+    // pattern as the benchmark snapshot), filtered to the operator's approved
+    // org/family allowlist so we never recommend a model the pool can't
+    // install. Live HF discovery runs in the on-demand
+    // `scripts/refresh-model-candidates.mjs` generator (D3/D5), keeping the
+    // interactive recommendations route free of per-request network calls.
+    const frozen = loadFrozenCandidates();
+    const candidates = selectCandidates(frozen.candidates, this.config.localModels?.pool);
+    for (const warning of frozen.warnings) {
+      this.logger.warn('LMLM frozen candidate snapshot degraded', { warning });
+    }
+    if (candidates.length === 0) {
+      this.logger.warn('LMLM recommender has no candidates', {
+        frozenCount: frozen.candidates.length,
+        allowedOrgs: this.config.localModels?.pool?.allowedOrgs ?? [],
+      });
+    }
+    const recommend = createNativeRecommender({ candidates });
     // Phase 7: reuse this same recommender for the on-demand recommendations
     // route so the HTTP surface and the background tick share one ranking path.
     this.modelRecommender = recommend;
@@ -2232,6 +2271,12 @@ export class Orchestrator extends EventEmitter {
       // test override or LMLM is disabled (poolStateStore is null).
       if (this.poolStateStore !== null) {
         await this.poolStateStore.load();
+        // LMLM Phase 7 wiring: seed the operator's configured pool bounds over
+        // the just-loaded persisted state. Runs AFTER load() so declarative
+        // config wins over stale on-disk bounds — the default persisted state
+        // is `diskBudgetGb: 0, allowedOrgs: []`, which would otherwise block
+        // every install and leave the dashboard pool card at "0 / 0 GB".
+        await this.applyConfiguredPoolBounds();
       }
       for (const resolver of this.localResolvers.values()) {
         await resolver.start();

--- a/packages/orchestrator/tests/integration/orchestrator-model-pool.test.ts
+++ b/packages/orchestrator/tests/integration/orchestrator-model-pool.test.ts
@@ -396,6 +396,131 @@ describe('Orchestrator LMLM Phase 7 — drain re-entrancy guard (P7-SUG-DRAIN-RE
   });
 });
 
+/** Structural access to the private `applyConfiguredPoolBounds`, bound to `orch`. */
+function applyBoundsOf(orch: Orchestrator): () => Promise<void> {
+  return (
+    orch as unknown as { applyConfiguredPoolBounds(): Promise<void> }
+  ).applyConfiguredPoolBounds.bind(orch);
+}
+
+/** A PoolManager over an isolated in-memory fs seeded with the given state. */
+async function makePoolWithState(state: PoolState): Promise<PoolManager> {
+  const poolPath = '/tmp/lmlm-seed-test/pool.json';
+  const fs = makeFs({ [poolPath]: JSON.stringify({ version: 1, state }, null, 2) });
+  const store = new PoolStateStore({ path: poolPath, fs });
+  await store.load();
+  const installer = stubInstaller(state.entries);
+  return new PoolManager({ store, installer: installer.adapter });
+}
+
+/** Structural access to the private `modelRecommender`. */
+function recommenderOf(
+  orch: Orchestrator
+): ((hw: unknown) => Promise<{ ranked: unknown[] }>) | null {
+  return (
+    orch as unknown as {
+      modelRecommender: ((hw: unknown) => Promise<{ ranked: unknown[] }>) | null;
+    }
+  ).modelRecommender;
+}
+
+/** Structural access to the private `detectLmlmHardware`, bound to `orch`. */
+function detectHardwareOf(orch: Orchestrator): () => Promise<unknown> {
+  return (orch as unknown as { detectLmlmHardware(): Promise<unknown> }).detectLmlmHardware.bind(
+    orch
+  );
+}
+
+describe('Orchestrator LMLM Phase 2 — recommender candidate sourcing (SC5)', () => {
+  it('ranks non-empty candidates for the allow-listed org from the frozen snapshot', async () => {
+    // localModelsWithHardware() allow-lists org 'Qwen'; the bundled frozen
+    // snapshot ships Qwen candidates, so the recommender must return a ranking.
+    const orch = new Orchestrator(makeConfig(localModelsWithHardware()), 'Prompt', {
+      tracker: makeMockTracker(),
+      backend: new MockBackend(),
+      execFileFn: noopExecFile,
+      schedulerTimer: noopTimer,
+    });
+    await initPipeline(orch);
+
+    const recommend = recommenderOf(orch);
+    expect(recommend).not.toBeNull();
+
+    const hardware = await detectHardwareOf(orch)();
+    const result = await recommend!(hardware);
+    expect(result.ranked.length).toBeGreaterThan(0);
+
+    await orch.stop();
+  });
+});
+
+describe('Orchestrator LMLM Phase 7 — pool bounds seed from config (D1/D2)', () => {
+  it('overwrites persisted bounds with configured bounds — config wins (SC2)', async () => {
+    const orch = makeOrchestrator(
+      makeConfig({
+        ...localModelsConfig(),
+        pool: {
+          diskBudgetGb: 100,
+          allowedOrgs: ['Qwen', 'deepseek-ai'],
+          allowedFamilies: ['qwen3'],
+        },
+      })
+    );
+    // Persisted state disagrees with config: smaller budget, no allowlist.
+    const manager = await makePoolWithState({
+      diskBudgetGb: 5,
+      diskUsedGb: 0,
+      entries: [],
+      allowedOrgs: [],
+      allowedFamilies: [],
+      lastRefreshAt: null,
+    });
+    setModelPool(orch, manager);
+
+    await applyBoundsOf(orch)();
+
+    const snap = manager.snapshot();
+    expect(snap.diskBudgetGb).toBe(100);
+    expect(snap.allowedOrgs).toEqual(['Qwen', 'deepseek-ai']);
+    expect(snap.allowedFamilies).toEqual(['qwen3']);
+
+    await orch.stop();
+  });
+
+  it('seeds an empty default store so the pool card leaves "0 / 0 GB" (SC1)', async () => {
+    const orch = makeOrchestrator(
+      makeConfig({
+        ...localModelsConfig(),
+        pool: { diskBudgetGb: 100, allowedOrgs: ['Qwen'], allowedFamilies: [] },
+      })
+    );
+    // Fresh default store: diskBudgetGb 0, empty allowlist (the shipped default).
+    const manager = await makePoolWithState({
+      diskBudgetGb: 0,
+      diskUsedGb: 0,
+      entries: [],
+      allowedOrgs: [],
+      allowedFamilies: [],
+      lastRefreshAt: null,
+    });
+    setModelPool(orch, manager);
+
+    await applyBoundsOf(orch)();
+
+    expect(manager.snapshot().diskBudgetGb).toBe(100);
+    expect(manager.snapshot().allowedOrgs).toEqual(['Qwen']);
+
+    await orch.stop();
+  });
+
+  it('is a no-op when LMLM is disabled (modelPool null) — no throw (SC3)', async () => {
+    const orch = makeOrchestrator(makeConfig()); // no localModels → disabled
+    expect(modelPoolOf(orch)).toBeNull();
+    await expect(applyBoundsOf(orch)()).resolves.toBeUndefined();
+    await orch.stop();
+  });
+});
+
 describe('Orchestrator LMLM Phase 7 — drain liveness on refresh tick (P7-SUG-DRAIN-LIVENESS)', () => {
   it('evicts a model left pendingEviction (failed drain) on the next scheduler tick', async () => {
     const orch = new Orchestrator(makeConfig(localModelsWithHardware()), 'Prompt', {

--- a/scripts/refresh-model-candidates.mjs
+++ b/scripts/refresh-model-candidates.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Regenerate the frozen LMLM candidate snapshot from the live HuggingFace API.
+ *
+ * ON-DEMAND ONLY. This is deliberately NOT wired into CI or release (LMLM
+ * wiring spec, D5): the frozen candidate list steers which models the
+ * orchestrator recommends and installs, so it must stay human-reviewed and
+ * deterministic. Run it by hand, review the diff, and commit.
+ *
+ * Fail-closed: any fetch error — or an empty parse result — aborts WITHOUT
+ * overwriting the committed snapshot, so a HuggingFace outage can never land a
+ * degraded file.
+ *
+ * Usage:
+ *   pnpm --filter @harness-engineering/local-models build   # build dist first
+ *   node scripts/refresh-model-candidates.mjs [org ...]
+ *
+ * Defaults to the standard allow-listed orgs. Honours HF_TOKEN when set.
+ *
+ * @see docs/changes/lmlm-functional-wiring/proposal.md (Phase 2, D5)
+ */
+
+import { writeFileSync, readFileSync } from 'node:fs';
+
+const OUT = new URL('../packages/local-models/src/candidates/candidates.json', import.meta.url);
+const DIST = new URL('../packages/local-models/dist/index.mjs', import.meta.url);
+const DEFAULT_ORGS = ['Qwen', 'deepseek-ai', 'meta-llama'];
+const PER_ORG_LIMIT = 25;
+
+const { HuggingFaceClient, parseHfModelToCandidates } = await import(DIST.href).catch((err) => {
+  console.error(
+    '[refresh] could not load @harness-engineering/local-models dist — build it first ' +
+      '(`pnpm --filter @harness-engineering/local-models build`).'
+  );
+  throw err;
+});
+
+/** Re-emit a candidate with a stable key order so diffs stay minimal. */
+function normalize(candidate, tags) {
+  const out = { hfRepoId: candidate.hfRepoId };
+  const ollamaName = candidate.ollamaName ?? tags?.ollamaName;
+  const family = candidate.family ?? tags?.family;
+  if (ollamaName) out.ollamaName = ollamaName;
+  if (family) out.family = family;
+  out.sizeB = candidate.sizeB;
+  if (candidate.activeB !== undefined) out.activeB = candidate.activeB;
+  out.quant = candidate.quant;
+  return out;
+}
+
+async function main() {
+  const orgs = process.argv.slice(2).length > 0 ? process.argv.slice(2) : DEFAULT_ORGS;
+  const client = new HuggingFaceClient();
+  const collected = new Map(); // `${hfRepoId}||${quant}` -> candidate
+
+  for (const org of orgs) {
+    console.error(`[refresh] listing GGUF models for ${org} ...`);
+    const models = await client.listModels({
+      author: org,
+      search: 'gguf',
+      sort: 'downloads',
+      limit: PER_ORG_LIMIT,
+    });
+    for (const model of models) {
+      if (!model.tags?.includes('gguf')) continue;
+      const detail = await client.getModel(model.id);
+      for (const candidate of parseHfModelToCandidates(detail)) {
+        collected.set(`${candidate.hfRepoId}||${candidate.quant}`, candidate);
+      }
+    }
+  }
+
+  if (collected.size === 0) {
+    console.error(
+      '[refresh] no candidates parsed — refusing to overwrite the committed snapshot (fail closed).'
+    );
+    process.exit(1);
+  }
+
+  // The HF API does not carry our `family` / `ollamaName` curation tags —
+  // preserve them from the existing snapshot, keyed by repo id.
+  const tagByRepo = new Map();
+  try {
+    const existing = JSON.parse(readFileSync(OUT, 'utf-8'));
+    for (const candidate of existing.candidates ?? []) {
+      if (!tagByRepo.has(candidate.hfRepoId)) {
+        tagByRepo.set(candidate.hfRepoId, {
+          family: candidate.family,
+          ollamaName: candidate.ollamaName,
+        });
+      }
+    }
+  } catch {
+    // First run / missing file — no tags to preserve.
+  }
+
+  const candidates = [...collected.values()]
+    .map((candidate) => normalize(candidate, tagByRepo.get(candidate.hfRepoId)))
+    .sort((a, b) =>
+      a.hfRepoId === b.hfRepoId
+        ? a.quant.localeCompare(b.quant)
+        : a.hfRepoId.localeCompare(b.hfRepoId)
+    );
+
+  const doc = {
+    version: 1,
+    generatedAt: new Date().toISOString().slice(0, 10),
+    source: 'hf-refresh',
+    candidates,
+  };
+  writeFileSync(OUT, `${JSON.stringify(doc, null, 2)}\n`);
+  console.error(`[refresh] wrote ${candidates.length} candidates to ${OUT.pathname}`);
+}
+
+main().catch((err) => {
+  console.error('[refresh] failed — committed snapshot left unchanged:', err?.message ?? err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

When LMLM is enabled (`localModels.enabled: true`), hardware detection works but the dashboard **Pool** and **Recommendations** cards render permanently empty — not from misconfiguration, but because two primitives that already exist in the codebase were **never called**. This PR wires them up. Both are completions of the original LMLM spec's deferred **Phase 2 (candidate source)** and **Phase 7 (pool bounds)**.

Spec: `docs/changes/lmlm-functional-wiring/proposal.md`

## Gap 1 → Phase 1: pool bounds seed
- The pool defaulted to `diskBudgetGb: 0, allowedOrgs: []`, so no model ever fit and the Pool card showed `0 / 0 GB`. `PoolManager.configurePool()` (which correctly persists bounds) had **zero callers**.
- The orchestrator now applies the operator's configured `localModels.pool` bounds after `PoolStateStore.load()` — **config wins over stale persisted bounds** (declarative precedence). Extracted as a testable `applyConfiguredPoolBounds()`.

## Gap 2 → Phase 2: candidate source
- The recommender was built with `createNativeRecommender({ candidates: [] })` — zero candidates in, zero recommendations out.
- New `candidates` module in `@harness-engineering/local-models`:
  - **`parse.ts`** — the GGUF→`RankerCandidate` parser the spec called out as never-built (extracts `sizeB` from the repo id, `quant` from each `.gguf` sibling via `normalizeQuantId`).
  - **`candidates.json` + `frozen.ts`** — a bundled, human-curated frozen snapshot (statically inlined like the benchmark snapshot), loaded at runtime.
  - **`select.ts`** — filters candidates to the pool's `allowedOrgs`/`allowedFamilies` so we never recommend an uninstallable model.
- The orchestrator now sources the recommender from the frozen snapshot filtered to the allowlist.

### Design note: frozen-at-runtime, live-in-script
`createNativeRecommender` takes a **static** candidate list and `startRefreshScheduler` runs once, synchronously. Doing live-HF discovery on the interactive recommendations route would mean many network calls per card load (slow, rate-limit-prone). So the runtime uses the deterministic bundled snapshot, and **live HuggingFace discovery runs in a new on-demand generator** — `scripts/refresh-model-candidates.mjs` (fail-closed; **never CI/release-coupled**, per decision D5, because the snapshot steers installs and must stay human-reviewed). The GGUF parser is the shared keystone used by that script.

## Testing
- **31 new tests** (27 local-models: parser/frozen/select; 4 orchestrator: seed config-wins/no-op + recommender non-empty).
- Full suites green: **local-models 299**, **orchestrator 1607** (1 pre-existing skip). Typecheck, lint, prettier, coverage ratchet, and `generate-docs --check` all pass.

## Reviewer notes
- No new CLI command / MCP tool / API route — internal wiring + one package module + one utility script.
- Deferred (YAGNI, called out in the spec): the `harness models pool set-budget/allow-org/allow-family` CLI group, and a scheduled PR-opening refresh workflow.
- Enabling LMLM itself (the `localModels` block in `harness.orchestrator.md`) is intentionally **not** in this PR — that's a local operational choice; this PR only makes the feature work when enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)