### PR TITLE
feat(lmlm): install & remove models from the dashboard panel

### DIFF
--- a/.changeset/lmlm-dashboard-pool-mutation.md
+++ b/.changeset/lmlm-dashboard-pool-mutation.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/dashboard': minor
+'@harness-engineering/types': minor
+---
+
+feat(lmlm): install & remove models directly from the dashboard panel
+
+Adds operator-initiated pool mutation to the LMLM dashboard — an **Install**
+action on Recommendations rows and a **Remove** action on Pool-card members — so
+the operator no longer has to hand-edit config or use the CLI.
+
+- **Backend:** two convenience routes, `POST /api/v1/local-models/pool/install`
+  and `POST /api/v1/local-models/pool/remove`, gated by the same
+  `manage-proposals` scope as approve/reject. Both are modeled as user-initiated
+  **auto-approved model proposals**, reusing the existing `onApproveModelProposal`
+  core — so the pool guards (`not_allowed`/`budget_exceeded` → `409`), the
+  in-use evict-deferral (`202 deferred`), and the audit trail all apply, and
+  proposals remain the single pool-mutation channel (ADR 0011).
+- **Dashboard:** an Install button per recommendation (an already-pooled model
+  shows "installed"), a Remove button per pool member (with a "removes after the
+  current run" note when the model is in use). Byte-level pull progress over WS
+  is a deferred enhancement; install shows an indeterminate "Installing…" state.
+- **Types:** `PoolInstallRequest`, `PoolRemoveRequest`, `PoolMutationDisposition`,
+  `PoolMutationResult`.

--- a/docs/knowledge/decisions/0011-operator-actions-as-auto-approved-proposals.md
+++ b/docs/knowledge/decisions/0011-operator-actions-as-auto-approved-proposals.md
@@ -1,0 +1,87 @@
+---
+number: 0011
+title: Operator-initiated pool mutation as auto-approved proposals
+date: 2026-07-08
+status: accepted
+tier: medium
+source: docs/changes/lmlm-dashboard-pool-mutation/proposal.md
+---
+
+## Context
+
+The LMLM dashboard needed direct **Install** and **Remove** actions so the
+operator can promote a recommended model into the pool and demote (evict) a pool
+member without hand-editing config or dropping to the CLI.
+
+The dashboard already had exactly one pool-mutation channel: the proposal
+approve/reject path (`onApproveModelProposal`), reached from the Recommendations
+card. That path is not a thin wrapper — it streams the `ollama pull`, enforces
+`PoolManager.canInstall()` (disk-budget + org allowlist), honors the
+`isModelInUse()` evict-deferral (an in-use model is marked `pendingEviction`,
+never evicted mid-request), persists an audit record, and broadcasts on the
+`local-models:pool` WebSocket topic.
+
+Two shapes were considered for the new actions:
+
+1. **Direct pool routes** — new endpoints call `PoolManager.install/evict`
+   directly. Conceptually simplest, but it re-implements progress, audit, and —
+   critically — the in-use eviction deferral, and it introduces a **second**
+   pool-mutation channel that future changes must keep in sync.
+2. **Auto-approved proposals** — the new endpoints build a `kind:'model'`
+   proposal (`add` for install, `evict` for remove), persist it via
+   `createModelProposal`, then run the exact same `onApproveModelProposal` core
+   the approve route uses.
+
+## Decision
+
+Operator-initiated Install and Remove are modeled as **user-initiated,
+auto-approved model proposals**. The convenience routes
+(`POST /api/v1/local-models/pool/install`, `.../pool/remove`) create a proposal
+and immediately approve it through `onApproveModelProposal`; they add no parallel
+mutation logic.
+
+Consequences of routing through the shared core:
+
+- The pool guards (`not_allowed`, `budget_exceeded`) are enforced once; the routes
+  map those codes to `409`.
+- The `isModelInUse` deferral is inherited: an in-use Remove returns a `deferred`
+  disposition (`202`) and the drain evicts it after the current run.
+- Every operator action writes the same proposal/audit record an autonomous
+  approval would, so the decision history is uniform.
+- Proposals remain the **single** pool-mutation mechanism on the dashboard
+  (preserving the D-P8-2 invariant); the convenience routes are a new _entry
+  point_ to that mechanism, not a new mechanism.
+
+Byte-level `ollama pull` progress is **not** wired to the WebSocket in this
+iteration (the approve core does not forward the installer's `onEvent`). Install
+awaits the pull synchronously — matching the existing approve-an-add flow — and
+the UI shows an indeterminate "Installing…" state until the pool refetches.
+Streaming progress is a deferred enhancement.
+
+## Consequences
+
+**Positive:**
+
+- No duplicated guard / deferral / audit logic; one code path governs both
+  autonomous and operator-initiated mutation.
+- The in-use safety property (never evict mid-request) holds automatically for
+  the dashboard Remove button.
+- Uniform audit trail across autonomous and manual actions.
+
+**Negative:**
+
+- A user-initiated action carries slight proposal ceremony (a proposal record is
+  created and immediately approved) rather than a bare mutation call.
+- Synchronous install holds the HTTP connection for the duration of the pull
+  (consistent with the existing approve flow, but a long-lived request for
+  multi-GB models). Async install + streamed progress is deferred.
+
+**Neutral:**
+
+- The convenience routes reuse the `manage-proposals` auth scope — identical to
+  approve/reject — so no new authorization surface is introduced.
+
+## Related
+
+- [`docs/changes/lmlm-dashboard-pool-mutation/proposal.md`](../../changes/lmlm-dashboard-pool-mutation/proposal.md)
+- [ADR 0004: Local availability disables rather than escalates](./0004-local-availability-disables-not-escalates.md)

--- a/packages/dashboard/src/client/components/local-models/PoolCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/PoolCard.tsx
@@ -1,21 +1,109 @@
-import type { DashPoolStateView } from '../../types/local-models';
+import { useCallback, useRef, useState } from 'react';
+import type { DashPoolEntryView, DashPoolStateView } from '../../types/local-models';
 
 /**
- * Pool card for the LMLM panel. READ-ONLY (D-P8-2): renders entries, disk
- * used-vs-budget, and `pendingEviction` badges. Exposes NO install/evict
- * controls — no HTTP install/evict route exists (Phase 7 D-Q2); pool mutation
- * flows through the Recommendations card's proposal approve/reject path.
+ * Pool card for the LMLM panel. Renders entries, disk used-vs-budget, and
+ * `pendingEviction` badges, and carries a **Remove** action per member. Remove
+ * POSTs to `POST /api/v1/local-models/pool/remove`, which — like the
+ * Recommendations card's approve/reject — is a proposals-backed pool mutation
+ * (an auto-approved `evict` proposal), so proposals remain the single
+ * pool-mutation mechanism (D-P8-2). An in-use member defers: the backend marks
+ * it `pendingEviction` and the row shows "removes after current run".
  *
- * Presentational, props-only. Reuses the container/border classes already in
- * `pages/Proposals.tsx` — introduces no new design tokens.
+ * Reuses the container/border classes already in `pages/Proposals.tsx` —
+ * introduces no new design tokens.
  */
 export interface PoolCardProps {
   pool: DashPoolStateView | null;
   error: string | null;
   loading: boolean;
+  /** Called after a successful remove so the page can refetch pool + recommendations. */
+  onMutated: () => void;
 }
 
-export function PoolCard({ pool, error, loading }: PoolCardProps): JSX.Element {
+interface PoolMemberRowProps {
+  entry: DashPoolEntryView;
+  onMutated: () => void;
+}
+
+function PoolMemberRow({ entry, onMutated }: PoolMemberRowProps): JSX.Element {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const busyRef = useRef(false);
+
+  const remove = useCallback(async (): Promise<void> => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    setNote(null);
+    try {
+      const res = await fetch('/api/v1/local-models/pool/remove', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ollamaName: entry.ollamaName }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+      const result = (await res.json().catch(() => ({}))) as { disposition?: string };
+      if (result.disposition === 'deferred') setNote('removes after current run');
+      onMutated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [entry.ollamaName, onMutated]);
+
+  return (
+    <li data-testid={`pool-row-${entry.ollamaName}`} className="rounded border border-white/10 p-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-sm">{entry.ollamaName}</span>
+        <div className="flex items-center gap-2">
+          {entry.pendingEviction && (
+            <span
+              data-testid={`pool-pending-${entry.ollamaName}`}
+              className="rounded bg-yellow-500/20 px-2 py-0.5 text-[10px] uppercase text-yellow-200"
+            >
+              pending eviction
+            </span>
+          )}
+          <button
+            type="button"
+            data-testid={`pool-remove-${entry.ollamaName}`}
+            disabled={busy || entry.pendingEviction === true}
+            onClick={() => void remove()}
+            className="rounded bg-red-600 px-3 py-1 text-xs disabled:opacity-50"
+          >
+            {busy ? 'Removing…' : 'Remove'}
+          </button>
+        </div>
+      </div>
+      <div className="mt-0.5 flex items-center justify-between text-xs text-neutral-muted">
+        <span className="font-mono">{entry.hfRepoId}</span>
+        <span>
+          {entry.sizeOnDiskGb} GB · score {entry.currentScore}
+        </span>
+      </div>
+      {note && (
+        <p data-testid={`pool-note-${entry.ollamaName}`} className="mt-1 text-xs text-yellow-200">
+          {note}
+        </p>
+      )}
+      {error && (
+        <p data-testid={`pool-error-${entry.ollamaName}`} className="mt-1 text-xs text-red-300">
+          {error}
+        </p>
+      )}
+    </li>
+  );
+}
+
+export function PoolCard({ pool, error, loading, onMutated }: PoolCardProps): JSX.Element {
   const pct =
     pool && pool.diskBudgetGb > 0
       ? Math.min(100, Math.round((pool.diskUsedGb / pool.diskBudgetGb) * 100))
@@ -26,7 +114,7 @@ export function PoolCard({ pool, error, loading }: PoolCardProps): JSX.Element {
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-base font-semibold">Pool</h2>
         <span className="text-xs text-neutral-muted">
-          Pool changes are approved on the Recommendations card.
+          Install models from the Recommendations card.
         </span>
       </div>
 
@@ -49,29 +137,7 @@ export function PoolCard({ pool, error, loading }: PoolCardProps): JSX.Element {
           ) : (
             <ul className="space-y-2">
               {pool.entries.map((e) => (
-                <li
-                  key={e.ollamaName}
-                  data-testid={`pool-row-${e.ollamaName}`}
-                  className="rounded border border-white/10 p-2"
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="font-mono text-sm">{e.ollamaName}</span>
-                    {e.pendingEviction && (
-                      <span
-                        data-testid={`pool-pending-${e.ollamaName}`}
-                        className="rounded bg-yellow-500/20 px-2 py-0.5 text-[10px] uppercase text-yellow-200"
-                      >
-                        pending eviction
-                      </span>
-                    )}
-                  </div>
-                  <div className="mt-0.5 flex items-center justify-between text-xs text-neutral-muted">
-                    <span className="font-mono">{e.hfRepoId}</span>
-                    <span>
-                      {e.sizeOnDiskGb} GB · score {e.currentScore}
-                    </span>
-                  </div>
-                </li>
+                <PoolMemberRow key={e.ollamaName} entry={e} onMutated={onMutated} />
               ))}
             </ul>
           )}

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import type { ModelProposalRecord } from '@harness-engineering/types';
-import type { DashRankedModel } from '../../types/local-models';
+import type { DashRankedModel, DashPoolStateView } from '../../types/local-models';
 
 /**
  * Recommendations card for the LMLM panel. Two sections:
@@ -15,9 +15,12 @@ import type { DashRankedModel } from '../../types/local-models';
  *     prior soundness-gate run, unlike skill proposals — proposals.ts:163), so
  *     the buttons are enabled immediately for open proposals.
  *
- * Approve/Reject POST to the SHARED `POST /api/v1/proposals/:id/{approve,reject}`
- * route (D-P8-2 — the only pool-mutation path on the dashboard). On success the
- * card calls `onDecided` so the page can refetch pool + recommendations.
+ * Each recommendation row also carries an **Install** button (an already-pooled
+ * model shows "installed" instead). Install POSTs to
+ * `POST /api/v1/local-models/pool/install`, which — like approve/reject — is a
+ * proposals-backed pool mutation (an auto-approved proposal), so proposals
+ * remain the single pool-mutation mechanism (D-P8-2). On success the card calls
+ * `onDecided` so the page refetches pool + recommendations.
  *
  * Reuses the container/border/button classes from `pages/Proposals.tsx` —
  * introduces no new design tokens.
@@ -36,9 +39,91 @@ export interface RecommendationsCardProps {
   recommendations: DashRankedModel[] | null;
   recommendationsError: string | null;
   proposals: ModelProposalRecord[] | null;
-  /** Called after a successful approve/reject so the page can refetch. */
+  /** Current pool, used to mark recommendations that are already installed. */
+  pool: DashPoolStateView | null;
+  /** Called after a successful approve/reject/install so the page can refetch. */
   onDecided: () => void;
   loading: boolean;
+}
+
+interface RecommendationRowProps {
+  rec: DashRankedModel;
+  installed: boolean;
+  onInstalled: () => void;
+}
+
+/**
+ * A single recommendation row with an Install action. An already-pooled model
+ * renders an "installed" badge instead of the button. Mirrors `ProposalRow`'s
+ * synchronous double-submit guard; install awaits the backend (which awaits the
+ * `ollama pull`) so the button shows an indeterminate "Installing…" state until
+ * the pool refetches.
+ */
+function RecommendationRow({ rec, installed, onInstalled }: RecommendationRowProps): JSX.Element {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const busyRef = useRef(false);
+
+  const install = useCallback(async (): Promise<void> => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/v1/local-models/pool/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hfRepoId: rec.hfRepoId, quant: rec.quant }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+      onInstalled();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [rec.hfRepoId, rec.quant, onInstalled]);
+
+  return (
+    <li data-testid={`rec-row-${rec.hfRepoId}`} className="rounded border border-white/10 p-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-sm">{rec.hfRepoId}</span>
+        <span className="text-xs text-neutral-muted">
+          score {fmtScore(rec.score)} · {rec.evidence}
+        </span>
+      </div>
+      <div className="mt-0.5 flex items-center justify-between gap-2">
+        <span className="text-xs text-neutral-muted">
+          {round1(rec.estimatedVramGb)} GB VRAM · ~{round1(rec.estimatedTokPerSec)} tok/s ·{' '}
+          {rec.fitsHardware ? 'fits' : "won't fit"}
+        </span>
+        {installed ? (
+          <span data-testid={`rec-installed-${rec.hfRepoId}`} className="text-xs text-green-400">
+            installed
+          </span>
+        ) : (
+          <button
+            type="button"
+            data-testid={`rec-install-${rec.hfRepoId}`}
+            disabled={busy}
+            onClick={() => void install()}
+            className="rounded bg-green-600 px-3 py-1 text-xs disabled:opacity-50"
+          >
+            {busy ? 'Installing…' : 'Install'}
+          </button>
+        )}
+      </div>
+      {error && (
+        <p data-testid={`rec-error-${rec.hfRepoId}`} className="mt-1 text-xs text-red-300">
+          {error}
+        </p>
+      )}
+    </li>
+  );
 }
 
 interface ProposalRowProps {
@@ -139,12 +224,18 @@ export function RecommendationsCard({
   recommendations,
   recommendationsError,
   proposals,
+  pool,
   onDecided,
   loading,
 }: RecommendationsCardProps): JSX.Element {
   const recs = recommendations ?? [];
   const props = proposals ?? [];
   const showEmptyRecs = recs.length === 0;
+  // Guard on Array.isArray, not `?? []`: a malformed pool payload (e.g. `[]`)
+  // would make `pool.entries` resolve to `Array.prototype.entries` (a function),
+  // which `?? []` would not catch.
+  const poolEntries = pool && Array.isArray(pool.entries) ? pool.entries : [];
+  const installedRepos = new Set(poolEntries.map((e) => e.hfRepoId));
 
   return (
     <div data-testid="rec-card" className="rounded-lg border border-white/10 p-4">
@@ -163,22 +254,12 @@ export function RecommendationsCard({
         ) : (
           <ul className="space-y-2">
             {recs.map((r) => (
-              <li
+              <RecommendationRow
                 key={r.hfRepoId}
-                data-testid={`rec-row-${r.hfRepoId}`}
-                className="rounded border border-white/10 p-2"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-mono text-sm">{r.hfRepoId}</span>
-                  <span className="text-xs text-neutral-muted">
-                    score {fmtScore(r.score)} · {r.evidence}
-                  </span>
-                </div>
-                <div className="mt-0.5 text-xs text-neutral-muted">
-                  {round1(r.estimatedVramGb)} GB VRAM · ~{round1(r.estimatedTokPerSec)} tok/s ·{' '}
-                  {r.fitsHardware ? 'fits' : "won't fit"}
-                </div>
-              </li>
+                rec={r}
+                installed={installedRepos.has(r.hfRepoId)}
+                onInstalled={onDecided}
+              />
             ))}
           </ul>
         )}

--- a/packages/dashboard/src/client/pages/LocalModels.tsx
+++ b/packages/dashboard/src/client/pages/LocalModels.tsx
@@ -50,13 +50,19 @@ export function LocalModels(): JSX.Element {
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <HardwareCard hardware={hardware.data} error={hardware.error} loading={hardware.loading} />
-        <PoolCard pool={pool.data} error={pool.error} loading={pool.loading} />
+        <PoolCard
+          pool={pool.data}
+          error={pool.error}
+          loading={pool.loading}
+          onMutated={refetchAll}
+        />
       </div>
 
       <RecommendationsCard
         recommendations={recommendations.data}
         recommendationsError={recommendations.error}
         proposals={proposals.data}
+        pool={pool.data}
         onDecided={refetchAll}
         loading={recommendations.loading}
       />

--- a/packages/dashboard/tests/client/components/local-models/PoolCard.test.tsx
+++ b/packages/dashboard/tests/client/components/local-models/PoolCard.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { PoolCard } from '../../../../src/client/components/local-models/PoolCard';
 import type { DashPoolStateView } from '../../../../src/client/types/local-models';
 
@@ -30,9 +30,24 @@ const POOL: DashPoolStateView = {
   lastRefreshAt: null,
 };
 
+function jsonRes(status: number, body: unknown): Response {
+  return { ok: status < 400, status, text: async () => '', json: async () => body } as Response;
+}
+
+function renderPool(over: Partial<React.ComponentProps<typeof PoolCard>> = {}) {
+  const onMutated = over.onMutated ?? vi.fn();
+  render(<PoolCard pool={POOL} error={null} loading={false} onMutated={onMutated} {...over} />);
+  return { onMutated };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
 describe('PoolCard', () => {
   it('renders one row per entry with its fields', () => {
-    render(<PoolCard pool={POOL} error={null} loading={false} />);
+    renderPool();
     expect(screen.getByTestId('pool-row-qwen3:32b').textContent).toContain('qwen3:32b');
     expect(screen.getByTestId('pool-row-qwen3:32b').textContent).toContain('Qwen/Qwen3-32B-GGUF');
     expect(screen.getByTestId('pool-row-qwen3:32b').textContent).toContain('18');
@@ -41,32 +56,70 @@ describe('PoolCard', () => {
   });
 
   it('renders a disk-usage indicator with used vs budget', () => {
-    render(<PoolCard pool={POOL} error={null} loading={false} />);
+    renderPool();
     expect(screen.getByTestId('pool-disk').textContent).toContain('40');
     expect(screen.getByTestId('pool-disk').textContent).toContain('100');
   });
 
   it('renders a pending-eviction badge for entries flagged pendingEviction', () => {
-    render(<PoolCard pool={POOL} error={null} loading={false} />);
+    renderPool();
     expect(screen.getByTestId('pool-pending-llama3:8b')).toBeDefined();
-    // The non-pending entry has no badge.
     expect(screen.queryByTestId('pool-pending-qwen3:32b')).toBeNull();
   });
 
   it('[O3] renders "No models in the pool" for an empty pool — no throw', () => {
-    render(
-      <PoolCard pool={{ ...POOL, entries: [], diskUsedGb: 0 }} error={null} loading={false} />
-    );
+    renderPool({ pool: { ...POOL, entries: [], diskUsedGb: 0 } });
     expect(screen.getByTestId('pool-card').textContent).toMatch(/no models in the pool/i);
   });
 
   it('renders the disabled state when LMLM is disabled', () => {
-    render(<PoolCard pool={null} error="LMLM disabled" loading={false} />);
+    render(<PoolCard pool={null} error="LMLM disabled" loading={false} onMutated={vi.fn()} />);
     expect(screen.getByTestId('pool-card').textContent).toMatch(/LMLM disabled/i);
   });
 
-  it('exposes no install/evict controls (D-P8-2 read-only)', () => {
-    render(<PoolCard pool={POOL} error={null} loading={false} />);
-    expect(screen.queryByRole('button', { name: /install|evict/i })).toBeNull();
+  it('Remove POSTs to /pool/remove and calls onMutated (SC7)', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonRes(200, { disposition: 'removed' })));
+    vi.stubGlobal('fetch', fetchMock);
+    const { onMutated } = renderPool();
+
+    fireEvent.click(screen.getByTestId('pool-remove-qwen3:32b'));
+
+    await waitFor(() => expect(onMutated).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('/api/v1/local-models/pool/remove');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(String((init as RequestInit).body)).toContain('qwen3:32b');
+  });
+
+  it('a deferred (202) remove renders "removes after current run" (SC7)', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonRes(202, { disposition: 'deferred' })));
+    vi.stubGlobal('fetch', fetchMock);
+    const { onMutated } = renderPool();
+
+    fireEvent.click(screen.getByTestId('pool-remove-qwen3:32b'));
+
+    await waitFor(() => expect(onMutated).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('pool-note-qwen3:32b').textContent).toMatch(
+      /after the current run|current run/i
+    );
+  });
+
+  it('disables Remove for a member already pending eviction', () => {
+    renderPool();
+    expect((screen.getByTestId('pool-remove-llama3:8b') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId('pool-remove-qwen3:32b') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('a failed remove surfaces an inline error and does not call onMutated', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 409, text: async () => 'conflict' } as Response)
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { onMutated } = renderPool();
+
+    fireEvent.click(screen.getByTestId('pool-remove-qwen3:32b'));
+
+    await waitFor(() => expect(screen.getByTestId('pool-error-qwen3:32b')).toBeDefined());
+    expect(onMutated).not.toHaveBeenCalled();
   });
 });

--- a/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
+++ b/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
@@ -2,7 +2,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import type { ModelProposalRecord } from '@harness-engineering/types';
 import { RecommendationsCard } from '../../../../src/client/components/local-models/RecommendationsCard';
-import type { DashRankedModel } from '../../../../src/client/types/local-models';
+import type { DashRankedModel, DashPoolStateView } from '../../../../src/client/types/local-models';
+
+const POOL_WITH_QWEN: DashPoolStateView = {
+  diskBudgetGb: 100,
+  diskUsedGb: 18,
+  entries: [
+    {
+      ollamaName: 'qwen3:32b',
+      hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      sizeOnDiskGb: 18,
+      installedAt: '2026-07-01T00:00:00.000Z',
+      lastUsedAt: null,
+      currentScore: 82,
+    },
+  ],
+  allowedOrgs: ['Qwen'],
+  allowedFamilies: [],
+  lastRefreshAt: null,
+};
 
 const RECS: DashRankedModel[] = [
   {
@@ -68,6 +86,69 @@ describe('RecommendationsCard', () => {
     expect(row.textContent).toContain('82');
     expect(row.textContent).toContain('direct');
     expect(row.textContent).toContain('20');
+  });
+
+  it('Install POSTs to /pool/install with hfRepoId + quant and calls onDecided (SC6)', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(okRes()));
+    vi.stubGlobal('fetch', fetchMock);
+    const onDecided = vi.fn();
+    render(
+      <RecommendationsCard
+        recommendations={RECS}
+        recommendationsError={null}
+        proposals={[]}
+        pool={null}
+        onDecided={onDecided}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('rec-install-Qwen/Qwen3-32B-GGUF'));
+
+    await waitFor(() => expect(onDecided).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('/api/v1/local-models/pool/install');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(String((init as RequestInit).body)).toContain('Qwen/Qwen3-32B-GGUF');
+    expect(String((init as RequestInit).body)).toContain('Q4_K_M');
+    vi.unstubAllGlobals();
+  });
+
+  it('shows "installed" instead of an Install button for a pooled model (SC6)', () => {
+    render(
+      <RecommendationsCard
+        recommendations={RECS}
+        recommendationsError={null}
+        proposals={[]}
+        pool={POOL_WITH_QWEN}
+        onDecided={vi.fn()}
+        loading={false}
+      />
+    );
+    expect(screen.getByTestId('rec-installed-Qwen/Qwen3-32B-GGUF')).toBeDefined();
+    expect(screen.queryByTestId('rec-install-Qwen/Qwen3-32B-GGUF')).toBeNull();
+  });
+
+  it('a failed install surfaces an inline error and does not call onDecided', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 409, text: async () => 'budget_exceeded' } as Response)
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const onDecided = vi.fn();
+    render(
+      <RecommendationsCard
+        recommendations={RECS}
+        recommendationsError={null}
+        proposals={[]}
+        pool={null}
+        onDecided={onDecided}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('rec-install-Qwen/Qwen3-32B-GGUF'));
+
+    await waitFor(() => expect(screen.getByTestId('rec-error-Qwen/Qwen3-32B-GGUF')).toBeDefined());
+    expect(onDecided).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
   });
 
   it('rounds long float metrics for display (score → whole, GB/tok-s → 1 decimal)', () => {

--- a/packages/orchestrator/src/server/http.ts
+++ b/packages/orchestrator/src/server/http.ts
@@ -21,6 +21,7 @@ import { handleV1WebhooksRoute } from './routes/v1/webhooks';
 import { handleV1TelemetryRoute } from './routes/v1/telemetry';
 import { handleV1ProposalsRoute } from './routes/v1/proposals';
 import { handleV1LocalModelsRoute } from './routes/v1/local-models';
+import { handleV1LocalModelsMutationRoute } from './routes/v1/local-models-pool-mutation';
 import type { RefreshSchedulerOps } from './routes/v1/local-models';
 import type { ModelPoolOps } from '../proposals/model-handlers';
 import { MODEL_PROPOSAL_TOPIC, MODEL_POOL_TOPIC } from '../proposals/model-handlers';
@@ -582,6 +583,18 @@ export class OrchestratorServer {
           ...(this.isModelInUseFn ? { isModelInUse: this.isModelInUseFn } : {}),
         });
       },
+      // LMLM dashboard pool mutation — POST /pool/install + /pool/remove.
+      // Operator-initiated install/remove via auto-approved proposals; reuses
+      // the same mutation pool + bus + in-use probe the proposals route uses.
+      // Registered before the read surface so /pool/install|remove match first.
+      (req, res) =>
+        handleV1LocalModelsMutationRoute(req, res, {
+          projectPath: this.projectPath,
+          bus: this.orchestrator as unknown as EventEmitter,
+          getModelPool: () => this.getModelPoolFn?.() ?? null,
+          ...(this.getRecommendationsFn ? { getRecommendations: this.getRecommendationsFn } : {}),
+          ...(this.isModelInUseFn ? { isModelInUse: this.isModelInUseFn } : {}),
+        }),
       // LMLM Phase 6/7 — POST /refresh + the GET read surface
       // (hardware/pool/recommendations/proposals). Registered before the
       // chat-proxy fallback so it owns the path. Each accessor is spread in

--- a/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
+++ b/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
@@ -1,0 +1,265 @@
+/**
+ * LMLM operator-initiated pool mutation routes (spec: lmlm-dashboard-pool-mutation).
+ *
+ *   POST /api/v1/local-models/pool/install  { hfRepoId, quant? }
+ *   POST /api/v1/local-models/pool/remove   { ollamaName }
+ *
+ * Both are modeled as **user-initiated, auto-approved model proposals** (D1):
+ * the handler builds a `kind:'model'` proposal (`add` for install, `evict` for
+ * remove), persists it via `createModelProposal`, then runs the exact same
+ * `onApproveModelProposal` core the approve route uses. This reuses the pool
+ * guards (`canInstall` → `not_allowed`/`budget_exceeded`), the `isModelInUse`
+ * evict-deferral, audit persistence, and the `local-models:pool` WS emit — so
+ * these routes add no parallel mutation logic and keep proposals the single
+ * pool-mutation channel (D-P8-2).
+ *
+ * Auth is enforced upstream by the bridge-route scope table (`manage-proposals`,
+ * identical to approve/reject). Install awaits the streamed `ollama pull`
+ * synchronously, matching the existing approve-an-add flow; byte-level progress
+ * over WS is a deferred enhancement (D3 note).
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { EventEmitter } from 'node:events';
+import { createModelProposal, updateProposal } from '@harness-engineering/core';
+import type { ModelProposalContent, PoolMutationResult } from '@harness-engineering/types';
+import type { RankedModel } from '@harness-engineering/local-models';
+import {
+  onApproveModelProposal,
+  type ModelHandlerDeps,
+  type ModelPoolOps,
+} from '../../../proposals/model-handlers.js';
+import { readBody } from '../../utils.js';
+
+const INSTALL_RE = /^\/api\/v1\/local-models\/pool\/install(?:\?.*)?$/;
+const REMOVE_RE = /^\/api\/v1\/local-models\/pool\/remove(?:\?.*)?$/;
+
+/** How many ranked candidates to scan when resolving an install target. */
+const RESOLVE_TOP = 50;
+
+export interface V1LocalModelsMutationDeps {
+  /** Project root where `.harness/proposals/` lives. */
+  projectPath: string;
+  /** Orchestrator event bus for `local-models:pool` emits. */
+  bus: EventEmitter;
+  /** Full mutation pool; null when LMLM is disabled → routes 503. */
+  getModelPool: () => ModelPoolOps | null;
+  /** Ranked candidates, used to resolve install-target `ollamaName` from `hfRepoId`. */
+  getRecommendations?: (opts: {
+    top: number;
+    profile: 'general' | 'coding' | 'reasoning';
+  }) => Promise<RankedModel[]>;
+  /** In-use probe: an approved evict of an in-use model is deferred, not applied. */
+  isModelInUse?: (ollamaName: string) => boolean;
+  /** Resolves the decision identity; defaults to the auth token id. */
+  getDecidedBy?: (req: IncomingMessage) => string;
+}
+
+function sendJSON(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function decidedByOf(deps: V1LocalModelsMutationDeps, req: IncomingMessage): string {
+  if (deps.getDecidedBy) return deps.getDecidedBy(req);
+  const token = (req as unknown as { _authToken?: { id: string } })._authToken;
+  return token?.id ?? 'operator';
+}
+
+function handlerDeps(
+  deps: V1LocalModelsMutationDeps,
+  req: IncomingMessage,
+  pool: ModelPoolOps
+): ModelHandlerDeps {
+  return {
+    pool,
+    bus: deps.bus,
+    updateProposal: (id, patch) =>
+      updateProposal(deps.projectPath, id, patch as Parameters<typeof updateProposal>[2]),
+    decidedBy: decidedByOf(deps, req),
+    ...(deps.isModelInUse ? { isModelInUse: deps.isModelInUse } : {}),
+  };
+}
+
+/** Parse a JSON body, returning `undefined` on malformed input (caller sends 400). */
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown> | undefined> {
+  try {
+    const raw = await readBody(req);
+    if (raw.length === 0) return {};
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function handleInstall(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: V1LocalModelsMutationDeps
+): Promise<void> {
+  const pool = deps.getModelPool();
+  if (pool === null) return sendJSON(res, 503, { error: 'LMLM disabled' });
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return sendJSON(res, 400, { error: 'invalid JSON body' });
+  const hfRepoId = typeof body.hfRepoId === 'string' ? body.hfRepoId : '';
+  if (hfRepoId.length === 0) return sendJSON(res, 400, { error: 'hfRepoId is required' });
+  const quant = typeof body.quant === 'string' ? body.quant : undefined;
+
+  if (!deps.getRecommendations) {
+    return sendJSON(res, 503, { error: 'recommendations unavailable' });
+  }
+  const ranked = await deps.getRecommendations({ top: RESOLVE_TOP, profile: 'general' });
+  const match = ranked.find(
+    (r) => r.hfRepoId === hfRepoId && (quant === undefined || r.quant === quant)
+  );
+  if (!match) {
+    return sendJSON(res, 404, {
+      error: `no recommendation for ${hfRepoId}${quant ? ` @ ${quant}` : ''}`,
+    });
+  }
+  if (!match.ollamaName) {
+    return sendJSON(res, 422, { error: `${hfRepoId} has no known Ollama mirror to install` });
+  }
+
+  const content: ModelProposalContent = {
+    action: 'add',
+    target: { hfRepoId: match.hfRepoId, ollamaName: match.ollamaName },
+    scoreDelta: match.score,
+    justification: {
+      summary: `Operator-initiated install of ${match.ollamaName} (${match.quant}).`,
+      benchmarkBasis: [],
+      hardwareFit: match.fitsHardware ? 'fits detected hardware' : 'may not fit detected hardware',
+      evidence: match.evidence,
+      freshness: `snapshot ${match.benchmarkSnapshot}`,
+    },
+    // 0 → the installer resolves the true on-disk size via `inspect` before the
+    // budget check, rather than trusting an estimate.
+    diskImpactGb: 0,
+  };
+
+  const record = await createModelProposal(deps.projectPath, content, {
+    proposedBy: decidedByOf(deps, req),
+  });
+  const outcome = await onApproveModelProposal(handlerDeps(deps, req, pool), record);
+
+  if (outcome.status === 'approved') {
+    const result: PoolMutationResult = {
+      disposition: 'installed',
+      proposalId: record.id,
+      evicted: outcome.evicted.map((e) => e.ollamaName),
+    };
+    return sendJSON(res, 200, result);
+  }
+  if (outcome.status === 'failed_target_missing') {
+    return sendJSON(res, 404, {
+      error: `${hfRepoId} is no longer available on HuggingFace`,
+      proposalId: record.id,
+    });
+  }
+  // `not_allowed` (org allowlist) / `budget_exceeded` (disk) are operator-fixable → 409.
+  const status = outcome.code === 'not_allowed' || outcome.code === 'budget_exceeded' ? 409 : 502;
+  return sendJSON(res, status, {
+    error: outcome.message,
+    code: outcome.code,
+    proposalId: record.id,
+  });
+}
+
+async function handleRemove(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: V1LocalModelsMutationDeps
+): Promise<void> {
+  const pool = deps.getModelPool();
+  if (pool === null) return sendJSON(res, 503, { error: 'LMLM disabled' });
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return sendJSON(res, 400, { error: 'invalid JSON body' });
+  const ollamaName = typeof body.ollamaName === 'string' ? body.ollamaName : '';
+  if (ollamaName.length === 0) return sendJSON(res, 400, { error: 'ollamaName is required' });
+
+  const entry = pool.snapshot().entries.find((e) => e.ollamaName === ollamaName);
+  if (!entry) return sendJSON(res, 404, { error: `${ollamaName} is not in the pool` });
+
+  const content: ModelProposalContent = {
+    action: 'evict',
+    target: { hfRepoId: entry.hfRepoId, ollamaName },
+    scoreDelta: 0,
+    justification: {
+      summary: `Operator-initiated removal of ${ollamaName}.`,
+      benchmarkBasis: [],
+      hardwareFit: '',
+      evidence: 'operator',
+      freshness: '',
+    },
+    diskImpactGb: entry.sizeOnDiskGb,
+  };
+
+  const record = await createModelProposal(deps.projectPath, content, {
+    proposedBy: decidedByOf(deps, req),
+  });
+  const outcome = await onApproveModelProposal(handlerDeps(deps, req, pool), record);
+
+  if (outcome.status === 'error') {
+    return sendJSON(res, 502, {
+      error: outcome.message,
+      code: outcome.code,
+      proposalId: record.id,
+    });
+  }
+  if (outcome.status === 'failed_target_missing') {
+    // An evict never produces this (only add/swap install can); stay exhaustive.
+    return sendJSON(res, 500, {
+      error: 'unexpected failed_target_missing on evict',
+      proposalId: record.id,
+    });
+  }
+  if (outcome.evicted.length > 0) {
+    const result: PoolMutationResult = {
+      disposition: 'removed',
+      proposalId: record.id,
+      evicted: outcome.evicted.map((e) => e.ollamaName),
+    };
+    return sendJSON(res, 200, result);
+  }
+  // No eviction recorded: either deferred (in use — still present, pendingEviction)
+  // or already absent (idempotent). Distinguish via the live snapshot.
+  const stillPresent = pool.snapshot().entries.some((e) => e.ollamaName === ollamaName);
+  if (stillPresent) {
+    const result: PoolMutationResult = {
+      disposition: 'deferred',
+      proposalId: record.id,
+      evicted: [],
+      message: 'model is in use; it will be removed after the current run',
+    };
+    return sendJSON(res, 202, result);
+  }
+  const result: PoolMutationResult = { disposition: 'removed', proposalId: record.id, evicted: [] };
+  return sendJSON(res, 200, result);
+}
+
+/**
+ * Dispatch the two POST mutation routes. Returns `true` when this module owns
+ * the request (halting the dispatch chain), `false` for pass-through.
+ */
+export function handleV1LocalModelsMutationRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: V1LocalModelsMutationDeps
+): boolean {
+  const url = req.url ?? '';
+  if ((req.method ?? 'GET') !== 'POST') return false;
+  if (INSTALL_RE.test(url)) {
+    void handleInstall(req, res, deps);
+    return true;
+  }
+  if (REMOVE_RE.test(url)) {
+    void handleRemove(req, res, deps);
+    return true;
+  }
+  return false;
+}

--- a/packages/orchestrator/src/server/v1-bridge-routes.ts
+++ b/packages/orchestrator/src/server/v1-bridge-routes.ts
@@ -118,6 +118,21 @@ export const V1_BRIDGE_ROUTES: ReadonlyArray<V1BridgeRoute> = [
     scope: 'manage-proposals',
     description: 'Force a background-scheduler refresh tick and return emitted proposals (O4).',
   },
+  // ── LMLM dashboard pool mutation — operator-initiated install/remove ──
+  // Modeled as auto-approved model proposals, so the same `manage-proposals`
+  // write scope that governs approve/reject governs these too.
+  {
+    method: 'POST',
+    pattern: /^\/api\/v1\/local-models\/pool\/install(?:\?.*)?$/,
+    scope: 'manage-proposals',
+    description: 'Install a recommended model into the local pool (auto-approved proposal).',
+  },
+  {
+    method: 'POST',
+    pattern: /^\/api\/v1\/local-models\/pool\/remove(?:\?.*)?$/,
+    scope: 'manage-proposals',
+    description: 'Remove a model from the local pool (auto-approved proposal).',
+  },
   // ── LMLM Phase 7 — read surface (hardware/pool/recommendations/proposals) ──
   // Load-bearing: `local-models` is in `V1_WRAPPABLE`, so without these entries
   // the `/api/v1` rewrite shim would rewrite `/api/v1/local-models/<name>` →

--- a/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
+++ b/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Socket } from 'node:net';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  EvictPoolRequest,
+  EvictPoolResult,
+  InstallPoolRequest,
+  InstallPoolResult,
+  PoolEntry,
+  PoolState,
+  RankedModel,
+} from '@harness-engineering/local-models';
+import { listProposals } from '@harness-engineering/core';
+import {
+  handleV1LocalModelsMutationRoute,
+  type V1LocalModelsMutationDeps,
+} from '../../../../src/server/routes/v1/local-models-pool-mutation';
+import { V1_BRIDGE_ROUTES } from '../../../../src/server/v1-bridge-routes';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lmlm-mutation-'));
+});
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+function makeReq(method: string, url: string, body?: unknown): IncomingMessage {
+  const r = new IncomingMessage(new Socket());
+  r.method = method;
+  r.url = url;
+  process.nextTick(() => {
+    if (body !== undefined) r.emit('data', Buffer.from(JSON.stringify(body)));
+    r.emit('end');
+  });
+  return r;
+}
+
+function makeRes(): {
+  res: ServerResponse;
+  chunks: string[];
+  statusCode: () => number;
+  body: () => unknown;
+  done: Promise<void>;
+} {
+  const r = new ServerResponse(new IncomingMessage(new Socket()));
+  const chunks: string[] = [];
+  let resolveDone!: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  r.write = ((c: string) => {
+    chunks.push(String(c));
+    return true;
+  }) as ServerResponse['write'];
+  r.end = ((c?: string) => {
+    if (c) chunks.push(String(c));
+    resolveDone();
+    return r;
+  }) as ServerResponse['end'];
+  return {
+    res: r,
+    chunks,
+    statusCode: () => r.statusCode,
+    body: () => JSON.parse(chunks.join('')),
+    done,
+  };
+}
+
+const ENTRY: PoolEntry = {
+  ollamaName: 'qwen3:32b',
+  hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+  sizeOnDiskGb: 20,
+  installedAt: '2026-01-01T00:00:00.000Z',
+  lastUsedAt: null,
+  currentScore: 71,
+};
+
+function poolState(entries: PoolEntry[]): PoolState {
+  return {
+    diskBudgetGb: 100,
+    diskUsedGb: entries.reduce((s, e) => s + e.sizeOnDiskGb, 0),
+    entries,
+    allowedOrgs: ['Qwen'],
+    allowedFamilies: [],
+    lastRefreshAt: null,
+  };
+}
+
+interface FakePool {
+  install: (r: InstallPoolRequest) => Promise<InstallPoolResult>;
+  evict: (r: EvictPoolRequest) => Promise<EvictPoolResult>;
+  snapshot: () => PoolState;
+  markPendingEviction: (n: string) => void;
+}
+
+function fakePool(over: Partial<FakePool> & { entries?: PoolEntry[] } = {}): FakePool {
+  const entries = over.entries ?? [];
+  return {
+    install:
+      over.install ??
+      (async (r) => ({
+        status: 'success',
+        entry: { ...ENTRY, ollamaName: r.ollamaName },
+        evicted: [],
+      })),
+    evict: over.evict ?? (async (r) => ({ status: 'success', name: r.ollamaName, removed: ENTRY })),
+    snapshot: over.snapshot ?? (() => poolState(entries)),
+    markPendingEviction: over.markPendingEviction ?? (() => {}),
+  };
+}
+
+const RANKED = {
+  hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+  ollamaName: 'qwen3:32b',
+  quant: 'Q4_K_M',
+  score: 71,
+  evidence: 'direct',
+  benchmarkSnapshot: '2026-05-28',
+  fitsHardware: true,
+} as unknown as RankedModel;
+
+function deps(over: Partial<V1LocalModelsMutationDeps> = {}): V1LocalModelsMutationDeps {
+  return {
+    projectPath: tmpDir,
+    bus: new EventEmitter(),
+    getModelPool: over.getModelPool ?? (() => fakePool()),
+    getRecommendations: over.getRecommendations ?? (async () => [RANKED]),
+    isModelInUse: over.isModelInUse,
+    ...over,
+  };
+}
+
+describe('POST /local-models/pool/install', () => {
+  it('installs an allow-listed recommendation and returns disposition:installed (SC1, SC8)', async () => {
+    const d = deps({ getModelPool: () => fakePool() });
+    const { res, body, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', {
+        hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(200);
+    expect(body()).toMatchObject({ disposition: 'installed' });
+    // SC8: an auto-approved proposal was persisted for audit.
+    const proposals = await listProposals(tmpDir, { kind: 'model' });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.status).toBe('approved');
+  });
+
+  it('maps a budget_exceeded / not_allowed pool veto to 409 (SC2)', async () => {
+    const d = deps({
+      getModelPool: () =>
+        fakePool({
+          install: async () => ({
+            status: 'error',
+            code: 'budget_exceeded',
+            message: 'no eviction plan fits',
+            evicted: [],
+          }),
+        }),
+    });
+    const { res, body, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', {
+        hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(409);
+    expect(body()).toMatchObject({ code: 'budget_exceeded' });
+  });
+
+  it('returns 404 when no recommendation matches the hfRepoId (SC2)', async () => {
+    const d = deps({ getRecommendations: async () => [] });
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', {
+        hfRepoId: 'unknown/model',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(404);
+  });
+
+  it('returns 400 when hfRepoId is missing', async () => {
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', {}),
+      res,
+      deps()
+    );
+    await done;
+    expect(statusCode()).toBe(400);
+  });
+
+  it('returns 503 when LMLM is disabled (SC5)', async () => {
+    const d = deps({ getModelPool: () => null });
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', {
+        hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(503);
+  });
+});
+
+describe('POST /local-models/pool/remove', () => {
+  it('removes an idle pool member and returns disposition:removed (SC3)', async () => {
+    const d = deps({
+      getModelPool: () => fakePool({ entries: [ENTRY] }),
+      isModelInUse: () => false,
+    });
+    const { res, body, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/remove', {
+        ollamaName: 'qwen3:32b',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(200);
+    expect(body()).toMatchObject({ disposition: 'removed', evicted: ['qwen3:32b'] });
+  });
+
+  it('defers removal of an in-use member (202 deferred, SC4)', async () => {
+    // In use → onApproveModelProposal marks pending instead of evicting; the
+    // static snapshot keeps the member present, so the route reports deferred.
+    const d = deps({
+      getModelPool: () => fakePool({ entries: [ENTRY] }),
+      isModelInUse: () => true,
+    });
+    const { res, body, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/remove', {
+        ollamaName: 'qwen3:32b',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(202);
+    expect(body()).toMatchObject({ disposition: 'deferred' });
+  });
+
+  it('returns 404 when the target is not in the pool', async () => {
+    const d = deps({ getModelPool: () => fakePool({ entries: [] }) });
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/remove', {
+        ollamaName: 'ghost:1b',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(404);
+  });
+
+  it('returns 503 when LMLM is disabled (SC5)', async () => {
+    const d = deps({ getModelPool: () => null });
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/remove', {
+        ollamaName: 'qwen3:32b',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(503);
+  });
+});
+
+describe('dispatch + auth registration', () => {
+  it('does not own non-mutation or GET requests', () => {
+    const { res } = makeRes();
+    expect(
+      handleV1LocalModelsMutationRoute(makeReq('GET', '/api/v1/local-models/pool'), res, deps())
+    ).toBe(false);
+    expect(
+      handleV1LocalModelsMutationRoute(makeReq('POST', '/api/v1/local-models/refresh'), res, deps())
+    ).toBe(false);
+  });
+
+  it('both routes require the manage-proposals scope (SC5)', () => {
+    const install = V1_BRIDGE_ROUTES.find(
+      (r) => r.method === 'POST' && r.pattern.test('/api/v1/local-models/pool/install')
+    );
+    const remove = V1_BRIDGE_ROUTES.find(
+      (r) => r.method === 'POST' && r.pattern.test('/api/v1/local-models/pool/remove')
+    );
+    expect(install?.scope).toBe('manage-proposals');
+    expect(remove?.scope).toBe('manage-proposals');
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -299,6 +299,10 @@ export type {
   LocalModelsRefreshConfig,
   LocalModelsInstallerConfig,
   LocalModelsConfig,
+  PoolInstallRequest,
+  PoolRemoveRequest,
+  PoolMutationDisposition,
+  PoolMutationResult,
 } from './local-models';
 
 // --- Plan task (parallel execution data model) ---

--- a/packages/types/src/local-models.ts
+++ b/packages/types/src/local-models.ts
@@ -83,3 +83,41 @@ export interface LocalModelsConfig {
     override?: LocalModelsHardwareOverride;
   };
 }
+
+/**
+ * Request body for `POST /api/v1/local-models/pool/install` — operator-initiated
+ * install of a recommended model. The server resolves `ollamaName` + disk size
+ * from the current recommendations for `hfRepoId`.
+ */
+export interface PoolInstallRequest {
+  /** HF repo id of the recommendation to install (e.g. `Qwen/Qwen3-32B-GGUF`). */
+  hfRepoId: string;
+  /** Optional quant to disambiguate when a repo has multiple ranked quants. */
+  quant?: string;
+}
+
+/** Request body for `POST /api/v1/local-models/pool/remove`. */
+export interface PoolRemoveRequest {
+  /** Ollama name of the installed pool member to remove. */
+  ollamaName: string;
+}
+
+/**
+ * Outcome of an operator-initiated pool mutation.
+ * - `installed` — the model was pulled into the pool.
+ * - `removed` — the member was evicted.
+ * - `deferred` — the member is in use; eviction is marked pending and drained
+ *   after the current run (never mid-request).
+ */
+export type PoolMutationDisposition = 'installed' | 'removed' | 'deferred';
+
+/** Response body for the install/remove convenience routes. */
+export interface PoolMutationResult {
+  disposition: PoolMutationDisposition;
+  /** The proposal id created + auto-approved for this action (audit trail). */
+  proposalId: string;
+  /** Ollama names evicted as part of the action (budget auto-evictions or the removed member). */
+  evicted: string[];
+  /** Human-readable note (e.g. the deferral explanation). */
+  message?: string;
+}


### PR DESCRIPTION
## Summary

Implements the merged spec (#762, `docs/changes/lmlm-dashboard-pool-mutation`): operator-initiated **Install** and **Remove** from the LMLM dashboard, so the operator can promote a recommendation into the pool or demote a pool member without hand-editing config or using the CLI.

## How it works
Both actions are modeled as **user-initiated, auto-approved model proposals** (ADR 0011). The convenience routes build a `kind:'model'` proposal (`add` for install, `evict` for remove) and run the exact `onApproveModelProposal` core the approve route already uses — so they inherit, rather than re-implement:
- **`canInstall` guards** → `not_allowed` / `budget_exceeded` map to **409**
- **`isModelInUse` evict-deferral** → an in-use Remove returns **202 `deferred`** and drains after the current run (never mid-request)
- **audit trail + `local-models:pool` WS emit**

Proposals stay the single pool-mutation channel; these routes are a new *entry point* to it, not a new mechanism.

## Changes
- **Backend** (`orchestrator`): `POST /api/v1/local-models/pool/install {hfRepoId, quant?}` and `.../pool/remove {ollamaName}`, gated by the `manage-proposals` scope (identical to approve/reject). Install resolves `ollamaName` from the current recommendations.
- **Dashboard**: Install button per recommendation row (an already-pooled model shows "installed"); Remove button per pool member (with a "removes after the current run" note when in use). Indeterminate "Installing…" state.
- **Types**: `PoolInstallRequest`, `PoolRemoveRequest`, `PoolMutationDisposition`, `PoolMutationResult`.

## Testing
- **11 backend** tests (dispositions, 409 guard mapping, 202 deferral, 404/400/503, auth-scope registration, audit-record persistence) + **6 dashboard** tests (install POST + installed badge + error; remove POST + deferred note + pending-disabled + error).
- Full suites green: **orchestrator 1618**, **dashboard 499**. Typecheck, lint, coverage ratchet, and `generate-docs --check` all pass.

## Deferred (called out in the spec / ADR)
Byte-level `ollama pull` progress over WebSocket — install awaits the pull synchronously (matching the existing approve-an-add flow), so the UI shows an indeterminate state rather than a percentage. Wiring the installer's `onEvent` through to a WS progress frame is a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)