### PR TITLE
fix(lmlm): Ollama inspect size fallback + system-page nav icons

### DIFF
--- a/.changeset/ollama-inspect-tags-fallback.md
+++ b/.changeset/ollama-inspect-tags-fallback.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/local-models': patch
+---
+
+fix(local-models): resolve model size from /api/tags when Ollama's /api/show omits it
+
+`OllamaInstallAdapter.inspect` required a size field from `/api/show`, but modern
+Ollama omits it there (the on-disk size lives in `/api/tags`). This made every
+install that relies on `inspect` — including the dashboard's Install button,
+which lets `PoolManager.install` resolve the size — fail with `parse_failed`.
+`inspect` now falls back to `/api/tags` for the size (keeping `/api/show`'s
+digest/metadata), and only fails when the model is absent from both.

--- a/.changeset/system-nav-icons.md
+++ b/.changeset/system-nav-icons.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/dashboard': patch
+---
+
+feat(dashboard): add sidebar icons for the remaining system pages
+
+`SystemNavItem` now maps icons for `signals`, `tokens`, `webhooks`,
+`insights-cache`, `proposals`, `routing`, and `local-models` (Brain) — pages
+that previously fell back to the default icon. Completes the Local Models panel's
+navigation affordance alongside the install/remove work.

--- a/packages/dashboard/src/client/components/sidebar/SystemNavItem.tsx
+++ b/packages/dashboard/src/client/components/sidebar/SystemNavItem.tsx
@@ -11,9 +11,17 @@ import {
   Map,
   BarChart3,
   KanbanSquare,
+  Signal,
+  Key,
+  Webhook,
+  Database,
+  GitPullRequest,
+  Route,
+  Brain,
 } from 'lucide-react';
 
 const PAGE_ICONS: Record<string, typeof Activity> = {
+  signals: Signal,
   health: Activity,
   graph: Share2,
   impact: Zap,
@@ -25,6 +33,12 @@ const PAGE_ICONS: Record<string, typeof Activity> = {
   streams: Radio,
   roadmap: Map,
   adoption: BarChart3,
+  tokens: Key,
+  webhooks: Webhook,
+  'insights-cache': Database,
+  proposals: GitPullRequest,
+  routing: Route,
+  'local-models': Brain,
 };
 
 interface Props {

--- a/packages/local-models/src/installer/ollama.ts
+++ b/packages/local-models/src/installer/ollama.ts
@@ -413,7 +413,32 @@ export class OllamaInstallAdapter implements InstallAdapter {
         { target: request.name, cause: err }
       );
     }
-    return parseShowBody(request.name, body);
+    const meta = parseShowMeta(request.name, body);
+    let sizeOnDiskGb = meta.sizeOnDiskGb;
+    let digest = meta.digest;
+    let modifiedAt = meta.modifiedAt;
+
+    // Modern Ollama `/api/show` omits the on-disk size; `/api/tags` reports it.
+    // Fall back there rather than failing the install (parse_failed).
+    if (sizeOnDiskGb === undefined) {
+      const listed = await this.list(request.signal ? { signal: request.signal } : {});
+      const match = listed.find((m) => m.ollamaName === request.name);
+      if (!match) {
+        throw new InstallError(
+          'parse_failed',
+          `ollama show omitted the size for ${request.name} and it is absent from /api/tags`,
+          { target: request.name }
+        );
+      }
+      sizeOnDiskGb = match.sizeOnDiskGb;
+      digest = digest ?? match.digest;
+      modifiedAt = modifiedAt ?? match.modifiedAt;
+    }
+
+    const info: RemoteModelInfo = { ollamaName: request.name, sizeOnDiskGb };
+    if (digest !== undefined) info.digest = digest;
+    if (modifiedAt !== undefined) info.modifiedAt = modifiedAt;
+    return info;
   }
 
   /**
@@ -529,7 +554,14 @@ function parseTagsBody(body: unknown, onWarn: (message: string) => void): Remote
   return result;
 }
 
-function parseShowBody(name: string, body: unknown): RemoteModelInfo {
+/** Metadata parsed from `/api/show`. `sizeOnDiskGb` is optional — modern Ollama omits it. */
+interface ShowMeta {
+  sizeOnDiskGb?: number;
+  digest?: string;
+  modifiedAt?: string;
+}
+
+function parseShowMeta(name: string, body: unknown): ShowMeta {
   if (typeof body !== 'object' || body === null) {
     throw new InstallError(
       'parse_failed',
@@ -540,23 +572,17 @@ function parseShowBody(name: string, body: unknown): RemoteModelInfo {
     );
   }
   const raw = body as Record<string, unknown>;
-  // Ollama variants ship either `size_bytes` (newer) or `size` (older); accept both.
+  // Ollama variants ship either `size_bytes` (newer) or `size` (older); many
+  // versions omit both from `/api/show` entirely (the size lives in `/api/tags`).
   const sizeBytes =
     typeof raw.size_bytes === 'number'
       ? raw.size_bytes
       : typeof raw.size === 'number'
         ? raw.size
         : undefined;
-  if (sizeBytes === undefined) {
-    throw new InstallError('parse_failed', `ollama show missing size field for ${name}`, {
-      target: name,
-    });
-  }
-  const info: RemoteModelInfo = {
-    ollamaName: name,
-    sizeOnDiskGb: bytesToGb(sizeBytes),
-  };
-  if (typeof raw.digest === 'string') info.digest = raw.digest;
-  if (typeof raw.modified_at === 'string') info.modifiedAt = raw.modified_at;
-  return info;
+  const meta: ShowMeta = {};
+  if (sizeBytes !== undefined) meta.sizeOnDiskGb = bytesToGb(sizeBytes);
+  if (typeof raw.digest === 'string') meta.digest = raw.digest;
+  if (typeof raw.modified_at === 'string') meta.modifiedAt = raw.modified_at;
+  return meta;
 }

--- a/packages/local-models/tests/installer/ollama.test.ts
+++ b/packages/local-models/tests/installer/ollama.test.ts
@@ -354,8 +354,31 @@ describe('OllamaInstallAdapter.inspect', () => {
     expect((err as InstallError).target).toBe('ghost:1b');
   });
 
-  it('throws InstallError(parse_failed) on missing size field', async () => {
-    const { fetcher } = makeFetcher(() => jsonResponse(200, { digest: 'sha256:x' }));
+  it('falls back to /api/tags for the size when /api/show omits it (modern Ollama)', async () => {
+    // Modern Ollama `/api/show` returns metadata but no size; the size lives in
+    // `/api/tags`. inspect must fall back there instead of failing.
+    const { fetcher, calls } = makeFetcher((call) =>
+      call.url.includes('/api/tags')
+        ? jsonResponse(200, { models: [{ name: 'qwen3:32b', size: 12 * 1024 ** 3 }] })
+        : jsonResponse(200, { digest: 'sha256:x' })
+    );
+    const adapter = new OllamaInstallAdapter({ fetcher });
+    const info = await adapter.inspect({ name: 'qwen3:32b' });
+    expect(info.sizeOnDiskGb).toBe(12);
+    // digest still comes from /api/show; the size from /api/tags.
+    expect(info.digest).toBe('sha256:x');
+    expect(calls.map((c) => c.url)).toEqual([
+      'http://localhost:11434/api/show',
+      'http://localhost:11434/api/tags',
+    ]);
+  });
+
+  it('throws InstallError(parse_failed) when size is absent from both /api/show and /api/tags', async () => {
+    const { fetcher } = makeFetcher((call) =>
+      call.url.includes('/api/tags')
+        ? jsonResponse(200, { models: [] })
+        : jsonResponse(200, { digest: 'sha256:x' })
+    );
     const adapter = new OllamaInstallAdapter({ fetcher });
     const err = await adapter.inspect({ name: 'qwen3:32b' }).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(InstallError);


### PR DESCRIPTION
## Summary

Two LMLM follow-ups that landed after #764 was merged (so they need their own PR):

### 1. Ollama `inspect` size fallback (`local-models`)
`OllamaInstallAdapter.inspect` required a size from `/api/show`, but modern Ollama omits it there (the on-disk size lives in `/api/tags`). This made **any install that resolves size via `inspect` fail with `parse_failed`** — including #764's dashboard **Install** button (which lets `PoolManager.install` resolve the size). `inspect` now falls back to `/api/tags`, keeps `/api/show`'s digest/metadata, and only fails when the model is absent from both. Verified against a live Ollama (0.31.1) while populating the pool.

### 2. System-page sidebar icons (`dashboard`)
`SystemNavItem` now maps icons for `signals`, `tokens`, `webhooks`, `insights-cache`, `proposals`, `routing`, and `local-models` (Brain) — pages that previously fell back to the default icon. Rounds out the Local Models panel's nav affordance.

## Testing
- `local-models`: replaced the stale "throws on missing size" test with a tags-fallback test + a both-empty case; full suite green (300).
- `dashboard`: typecheck + lint clean (no dedicated SystemNavItem test exists).
- Changesets: `local-models` patch, `dashboard` patch.

## Context
#764 (install/remove from the dashboard) merged before these two changes were ready — the inspect fix in particular is what makes #764's Install button actually work against a real Ollama, so it's worth landing promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)