### PR TITLE
fix(lmlm): estimate on-disk size for operator install instead of pre-pull inspect

### DIFF
--- a/.changeset/lmlm-install-prepull-inspect.md
+++ b/.changeset/lmlm-install-prepull-inspect.md
@@ -1,0 +1,7 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(lmlm): estimate on-disk size for operator install instead of a pre-pull inspect
+
+The Recommendations "Install" action 404'd on every model with a misleading "no longer available on HuggingFace" error. The route built the install proposal with `diskImpactGb: 0`, which drove the pool to resolve the on-disk size via `installer.inspect` (ollama `/api/show`) — a call that only succeeds for models already pulled locally, so a fresh install target always 404'd into `failed_target_missing` before the download began. The route now sizes the proposal via `estimateDiskGb` from the matched candidate (params + quant), matching the automated proposal engine, so the install proceeds to the pull.

--- a/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
+++ b/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
@@ -23,7 +23,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { EventEmitter } from 'node:events';
 import { createModelProposal, updateProposal } from '@harness-engineering/core';
 import type { ModelProposalContent, PoolMutationResult } from '@harness-engineering/types';
-import type { RankedModel } from '@harness-engineering/local-models';
+import { estimateDiskGb, type RankedModel } from '@harness-engineering/local-models';
 import {
   onApproveModelProposal,
   type ModelHandlerDeps,
@@ -136,9 +136,17 @@ async function handleInstall(
       evidence: match.evidence,
       freshness: `snapshot ${match.benchmarkSnapshot}`,
     },
-    // 0 → the installer resolves the true on-disk size via `inspect` before the
-    // budget check, rather than trusting an estimate.
-    diskImpactGb: 0,
+    // Estimate the on-disk size from the candidate's params + quant (the same
+    // `estimateDiskGb` the automated proposal engine uses). The pool needs a
+    // size for its pre-commit budget check *before* the pull; it cannot inspect
+    // the target first, because ollama `/api/show` 404s for a model that is not
+    // yet pulled locally — which would surface as a spurious "no longer
+    // available on HuggingFace" 404 on every operator install.
+    diskImpactGb: estimateDiskGb({
+      sizeB: match.sizeB,
+      quant: match.quant,
+      ...(match.activeB !== undefined ? { activeB: match.activeB } : {}),
+    }),
   };
 
   const record = await createModelProposal(deps.projectPath, content, {

--- a/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
+++ b/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
@@ -122,6 +122,7 @@ function fakePool(over: Partial<FakePool> & { entries?: PoolEntry[] } = {}): Fak
 const RANKED = {
   hfRepoId: 'Qwen/Qwen3-32B-GGUF',
   ollamaName: 'qwen3:32b',
+  sizeB: 32,
   quant: 'Q4_K_M',
   score: 71,
   evidence: 'direct',
@@ -158,6 +159,40 @@ describe('POST /local-models/pool/install', () => {
     const proposals = await listProposals(tmpDir, { kind: 'model' });
     expect(proposals).toHaveLength(1);
     expect(proposals[0]!.status).toBe('approved');
+  });
+
+  it('sizes the install from an estimate, never a pre-pull inspect (regression: install 404 target-missing)', async () => {
+    // Regression for the LMLM Recommendations "Install" 404 bug. The route used
+    // to send diskImpactGb:0 so the pool would resolve the size via an ollama
+    // `/api/show` inspect — which 404s for a not-yet-pulled model, surfacing as
+    // `failed_target_missing` → bogus "no longer available on HuggingFace". The
+    // fix hands the pool an estimated on-disk size so `install` is given a
+    // concrete `sizeOnDiskGb` and the impossible pre-pull inspect never runs.
+    let received: InstallPoolRequest | undefined;
+    const d = deps({
+      getModelPool: () =>
+        fakePool({
+          install: async (r) => {
+            received = r;
+            return {
+              status: 'success',
+              entry: { ...ENTRY, ollamaName: r.ollamaName },
+              evicted: [],
+            };
+          },
+        }),
+    });
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', {
+        hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(200);
+    expect(received?.sizeOnDiskGb).toBeGreaterThan(0);
   });
 
   it('maps a budget_exceeded / not_allowed pool veto to 409 (SC2)', async () => {


### PR DESCRIPTION
## Problem

Every **Install** on the Local Models Recommendations card returned `HTTP 404 {"error":"<model> is no longer available on HuggingFace"}` — for models that are perfectly available (Llama-3.3-70B-Instruct-GGUF, Qwen3-32B-GGUF, DeepSeek-R1-Distill-*, …). The install never reached the download step, and the error message was misleading: **there is no HuggingFace check involved.**

## Root cause

`handleInstall` built the `add` proposal with `diskImpactGb: 0`, intending the pool to resolve the true on-disk size via `installer.inspect` *before* the budget check. But:

- `inspect()` calls ollama's `/api/show`, which **only returns data for models already pulled locally**.
- An install target is by definition *not yet* local → `/api/show` returns **404** → `failed_target_missing`.
- The route maps `failed_target_missing` → `404 "no longer available on HuggingFace"`.

The pre-pull budget check was trying to measure a file that hadn't been downloaded yet — impossible via inspect. The `ollama pull` that would actually succeed was never reached.

## Fix

The route now sizes the proposal with `estimateDiskGb({ sizeB, quant, activeB })` from the matched `RankedModel` — the same helper the **automated** proposal engine already uses. A non-zero `diskImpactGb` makes `onApproveModelProposal` pass `sizeOnDiskGb` to `pool.install`, so `resolveSizeOnDisk` uses the estimate and skips the impossible pre-pull inspect; the pull then proceeds.

## Why it shipped

The route's unit tests stub `pool.install`, so the real `resolveSizeOnDisk → inspect` chain was never exercised end-to-end.

## Testing

- Added regression test "sizes the install from an estimate, never a pre-pull inspect" asserting `pool.install` receives a positive `sizeOnDiskGb`.
- **Revert-and-fail verified:** fails with `diskImpactGb: 0`, passes with the estimate.
- Full route test file: 12/12 pass. `tsc --noEmit` clean.

## Notes / out of scope

- Recorded pool size is now an estimate, matching the automated path.
- The manager's `resolveSizeOnDisk → inspect` fallback remains a latent trap for any future caller that omits the size (no current caller hits it) — candidate for a follow-up defense-in-depth hardening.