### PR TITLE
fix(lmlm): async model install with download progress + Refresh button

### DIFF
--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -17,3 +17,7 @@ Error)` that a multi-GB pull triggered — the dashboard reverse-proxy's undici
 `headersTimeout` (~5 min) fired because no response headers were sent until the
 pull completed. The Recommendations panel now renders a live download progress bar
 and surfaces retryable install errors.
+
+The Recommendations panel also gains a **Refresh** button that triggers a
+force-refresh tick (`POST /api/v1/local-models/refresh`) to recompute
+recommendations on demand and refetch the panel.

--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -1,6 +1,7 @@
 ---
 '@harness-engineering/orchestrator': minor
 '@harness-engineering/dashboard': minor
+'@harness-engineering/local-models': patch
 '@harness-engineering/types': minor
 ---
 
@@ -27,3 +28,9 @@ times out. (`evict` approvals and rejects stay synchronous.)
 The Recommendations panel also gains a **Refresh** button that triggers a
 force-refresh tick (`POST /api/v1/local-models/refresh`) to recompute
 recommendations on demand and refetch the panel.
+
+Fixes a refresh-tick ordering bug where the pool was diffed against the ranking
+**before** the re-ranked scores were written back. A freshly-installed member
+enters the pool at `currentScore: 0` until its first re-rank, so diffing first
+produced phantom swap proposals justified as "replace a pool member scoring 0"
+(and inflated `scoreDelta`s). The tick now re-scores the pool before diffing.

--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -18,6 +18,12 @@ Error)` that a multi-GB pull triggered — the dashboard reverse-proxy's undici
 pull completed. The Recommendations panel now renders a live download progress bar
 and surfaces retryable install errors.
 
+Approving an `add`/`swap` model **proposal** (`POST /api/v1/proposals/:id/approve`)
+also installs the target, so it shares the same async treatment: it returns `202`
+and streams the download over `local-models:install`, and the Pending Proposals row
+shows the same progress bar instead of hanging the Approve button until the proxy
+times out. (`evict` approvals and rejects stay synchronous.)
+
 The Recommendations panel also gains a **Refresh** button that triggers a
 force-refresh tick (`POST /api/v1/local-models/refresh`) to recompute
 recommendations on demand and refetch the panel.

--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/dashboard': minor
+'@harness-engineering/types': minor
+---
+
+fix(lmlm): async model install with WebSocket download progress
+
+Operator model install (`POST /api/v1/local-models/pool/install`) now returns
+`202 { disposition: 'installing' }` as soon as the pull is accepted and streams
+byte-level download progress plus the terminal outcome over a new
+`local-models:install` WebSocket topic, instead of blocking the HTTP response for
+the entire `ollama pull`.
+
+This fixes the `502 Orchestrator proxy error: fetch failed (cause: Headers Timeout
+Error)` that a multi-GB pull triggered — the dashboard reverse-proxy's undici
+`headersTimeout` (~5 min) fired because no response headers were sent until the
+pull completed. The Recommendations panel now renders a live download progress bar
+and surfaces retryable install errors.

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ temp/
 **/.harness/dispatch-last-head.txt
 **/.harness/interactions/
 **/.harness/analyses/
+**/.harness/proposals/
 **/.harness/workspaces/
 **/.harness/metrics/
 # security/: track timeline.json (trend ledger), ignore everything else

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,6 +28,7 @@ docs/roadmap.d/**
 .harness/security/
 .harness/streams/
 .harness/sessions/
+.harness/proposals/
 **/.harness/graph/
 **/.harness/arch/
 **/fixtures/**/.harness/

--- a/docs/changes/local-model-lifecycle-manager/plans/2026-07-08-phase10-async-install-progress-plan.md
+++ b/docs/changes/local-model-lifecycle-manager/plans/2026-07-08-phase10-async-install-progress-plan.md
@@ -1,0 +1,72 @@
+# Phase 10 — Async operator install + WebSocket download progress
+
+**Spec:** local-model-lifecycle-manager (resolves the D3 note deferred in Phase 8)
+**Date:** 2026-07-08
+
+## Problem
+
+Clicking **Install** on a recommended model POSTs `/api/v1/local-models/pool/install`,
+which the dashboard reverse-proxies to the orchestrator. `handleInstall` awaits the
+entire `ollama pull` **synchronously** before writing any HTTP response
+(`local-models-pool-mutation.ts` — "Install awaits the streamed `ollama pull`
+synchronously ... byte-level progress over WS is a deferred enhancement (D3 note)").
+
+For a multi-GB model the pull exceeds the dashboard proxy's undici default
+`headersTimeout` (~5 min), so the proxied `fetch()` aborts with
+`UND_ERR_HEADERS_TIMEOUT` and the middleware returns
+`502 Orchestrator proxy error: fetch failed (cause: Headers Timeout Error)`.
+
+The same synchronous design is why there is **no progress feedback**: the Ollama
+installer already emits `{ kind:'progress', completedBytes, totalBytes }` per
+`/api/pull` NDJSON line, `PoolManager.install` already forwards an `onEvent`
+callback, but `onApproveModelProposal` calls `pool.install()` **without** one, so
+every progress event is dropped and no bytes reach the client until completion.
+
+Both reported symptoms (the 502 and the missing progress bar) are one root cause.
+
+## Fix — make install asynchronous, stream progress over a dedicated WS topic
+
+The install returns `202 Accepted` as soon as the proposal is created and the pull
+is kicked off (well under the proxy timeout), then streams progress + terminal
+status over a **new** WS topic `local-models:install`. A separate topic (not the
+existing `local-models:pool` refetch-delta) avoids a per-byte refetch storm.
+
+### Tasks
+
+1. **Types (`packages/types/src/local-models.ts`)** — add `ModelInstallEvent`
+   `{ proposalId, hfRepoId, ollamaName, phase: 'started'|'progress'|'complete'|'error',
+completedBytes?, totalBytes?, message?, code? }`; add `'installing'` to
+   `PoolMutationDisposition`. Export both from `index.ts`.
+2. **`model-handlers.ts`** — add `MODEL_INSTALL_TOPIC = 'local-models:install'`;
+   add optional `onInstallEvent?: (e: InstallEvent) => void` to `ModelHandlerDeps`;
+   pass `onEvent: deps.onInstallEvent` into `deps.pool.install(...)`.
+3. **`local-models-pool-mutation.ts` `handleInstall`** — keep synchronous validation
+   (400/404/422/503) and proposal creation; emit a `started` frame; call
+   `onApproveModelProposal` **without awaiting**, passing an `onInstallEvent` that
+   translates each `InstallEvent` into a `ModelInstallEvent` on `MODEL_INSTALL_TOPIC`;
+   respond `202 { disposition:'installing', proposalId, ollamaName, evicted:[] }`;
+   on the background promise resolution emit `complete` (approved) or `error`
+   (failed_target_missing / not_allowed / budget_exceeded / install_failed) frames.
+   `.catch` guards against unhandled rejection.
+4. **`http.ts`** — subscribe the orchestrator emitter on `MODEL_INSTALL_TOPIC` and
+   broadcast to WS clients; detach in `stop()` (mirror `modelPoolListener`).
+5. **Client types + hook** — add `LocalModelsInstallEvent` mirror +
+   `{ type:'local-models:install' }` to `WebSocketMessage`; in `useLocalModelsPanel`
+   consume install frames into an `installProgress` map keyed by `hfRepoId`
+   (progress → bytes; complete → clear + refetch pool/recommendations; error → keep
+   message). Expose `installProgress`; thread through `LocalModels.tsx`.
+6. **`RecommendationsCard`** — `RecommendationRow` accepts a `progress` prop, treats
+   `202` as success-of-request (not completion), renders a progress bar from
+   `completedBytes/totalBytes`, stays in "Installing…" until a terminal frame, and
+   surfaces a WS `error` frame on the row.
+
+### Consequence / contract change
+
+Install outcomes that require running the pull (approved, budget_exceeded,
+not_allowed, install_failed, failed_target_missing) move from the synchronous HTTP
+response to `local-models:install` WS frames. The HTTP response now only reports
+**pre-pull** validation failures (invalid body, unknown repo, no Ollama mirror,
+LMLM disabled) and otherwise `202`. `/pool/remove` is unchanged (eviction is fast,
+no pull). Existing `local-models-pool-mutation.test.ts` install assertions updated
+accordingly; a regression test asserts the route responds without awaiting the pull
+and that progress frames are emitted.

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -196,10 +196,24 @@ function RecommendationRow({
 interface ProposalRowProps {
   proposal: ModelProposalRecord;
   onDecided: () => void;
+  /** WS-driven install progress / terminal error for this proposal's target. */
+  progress?: InstallProgressState | undefined;
+  /** Clear this proposal's settled install error (before a retry / on dismiss). */
+  onDismiss: () => void;
 }
 
-function ProposalRow({ proposal, onDecided }: ProposalRowProps): JSX.Element {
+/**
+ * A pending model proposal with Approve/Reject. Approving an `add`/`swap`
+ * installs the target — a multi-GB `ollama pull` — so, like the direct Install
+ * action, the approve route returns `202` and streams the download over the
+ * `local-models:install` WS topic (the `progress` prop). The row stays
+ * "Installing…" with a live bar until a terminal frame instead of hanging the
+ * button until the proxy times out. Reject and `evict` approvals are fast and
+ * stay synchronous (they refetch via `onDecided`).
+ */
+function ProposalRow({ proposal, onDecided, progress, onDismiss }: ProposalRowProps): JSX.Element {
   const [busy, setBusy] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');
   // Synchronous double-submit guard: `disabled={busy}` only takes effect after
@@ -207,35 +221,70 @@ function ProposalRow({ proposal, onDecided }: ProposalRowProps): JSX.Element {
   // second POST before React flushes. The ref blocks that sub-frame window.
   const busyRef = useRef(false);
 
-  const post = useCallback(
-    async (suffix: string, body?: object): Promise<void> => {
-      if (busyRef.current) return;
-      busyRef.current = true;
-      setBusy(true);
-      setError(null);
-      try {
-        const init: RequestInit = {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        };
-        if (body) init.body = JSON.stringify(body);
-        const res = await fetch(`/api/v1/proposals/${proposal.id}${suffix}`, init);
-        if (!res.ok) {
-          const text = await res.text();
-          throw new Error(`HTTP ${res.status}: ${text}`);
-        }
-        onDecided();
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-      } finally {
-        busyRef.current = false;
-        setBusy(false);
+  // A terminal WS error ends the in-flight install so the operator can retry.
+  useEffect(() => {
+    if (progress?.phase === 'error') setSubmitted(false);
+  }, [progress?.phase]);
+
+  const streaming = progress?.phase === 'started' || progress?.phase === 'progress';
+  const installing = streaming || (submitted && progress === undefined);
+  const errorMsg = progress?.phase === 'error' ? (progress.message ?? 'Install failed') : error;
+
+  const approve = useCallback(async (): Promise<void> => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    onDismiss(); // clear any prior WS error for this target before retrying
+    try {
+      // Approve sends NO body: the route derives decidedBy from the auth token.
+      const res = await fetch(`/api/v1/proposals/${proposal.id}/approve`, { method: 'POST' });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text}`);
       }
-    },
-    [proposal.id, onDecided]
-  );
+      // 202 = install kicked off in the background (add/swap); keep "Installing…"
+      // until a WS terminal frame. 200 = a synchronous approval (evict) → refetch.
+      if (res.status === 202) setSubmitted(true);
+      else onDecided();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [proposal.id, onDecided, onDismiss]);
+
+  const reject = useCallback(async (): Promise<void> => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/proposals/${proposal.id}/reject`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: rejectReason.trim() || 'rejected' }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+      onDecided();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [proposal.id, rejectReason, onDecided]);
 
   const { model } = proposal;
+  const pct =
+    progress?.totalBytes && progress.totalBytes > 0
+      ? Math.min(100, Math.round(((progress.completedBytes ?? 0) / progress.totalBytes) * 100))
+      : null;
+  const disabled = busy || installing;
 
   return (
     <li data-testid={`proposal-${proposal.id}`} className="rounded border border-white/10 p-3">
@@ -252,15 +301,12 @@ function ProposalRow({ proposal, onDecided }: ProposalRowProps): JSX.Element {
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <button
           type="button"
-          disabled={busy}
-          // Approve sends NO body: the proposals route derives decidedBy from the
-          // auth token via getDecidedBy and never reads a body field, so a
-          // { decidedBy } payload was dead. Symmetric with reject, which sends
-          // only the { reason } the route actually consumes (XP-4).
-          onClick={() => void post('/approve')}
-          className="rounded bg-green-600 px-3 py-1 text-xs"
+          data-testid={`proposal-approve-${proposal.id}`}
+          disabled={disabled}
+          onClick={() => void approve()}
+          className="rounded bg-green-600 px-3 py-1 text-xs disabled:opacity-50"
         >
-          Approve
+          {installing ? 'Installing…' : busy ? 'Approving…' : 'Approve'}
         </button>
         <input
           data-testid={`reject-reason-${proposal.id}`}
@@ -271,16 +317,38 @@ function ProposalRow({ proposal, onDecided }: ProposalRowProps): JSX.Element {
         />
         <button
           type="button"
-          disabled={busy}
-          onClick={() => void post('/reject', { reason: rejectReason.trim() || 'rejected' })}
-          className="rounded bg-red-600 px-3 py-1 text-xs"
+          disabled={disabled}
+          onClick={() => void reject()}
+          className="rounded bg-red-600 px-3 py-1 text-xs disabled:opacity-50"
         >
           Reject
         </button>
       </div>
-      {error && (
+      {streaming && (
+        <div data-testid={`proposal-progress-${proposal.id}`} className="mt-2">
+          <div
+            className="h-1.5 w-full overflow-hidden rounded bg-white/10"
+            role="progressbar"
+            {...(pct !== null
+              ? { 'aria-valuenow': pct, 'aria-valuemin': 0, 'aria-valuemax': 100 }
+              : {})}
+          >
+            <div
+              className={`h-full bg-green-500 transition-all ${pct === null ? 'animate-pulse' : ''}`}
+              style={{ width: pct !== null ? `${pct}%` : '100%' }}
+            />
+          </div>
+          <p className="mt-0.5 text-xs text-neutral-muted">
+            {progress?.message ?? 'Downloading…'}
+            {pct !== null && progress?.totalBytes
+              ? ` — ${pct}% (${fmtBytes(progress.completedBytes ?? 0)} / ${fmtBytes(progress.totalBytes)})`
+              : ''}
+          </p>
+        </div>
+      )}
+      {errorMsg && (
         <p data-testid={`proposal-error-${proposal.id}`} className="mt-1 text-xs text-red-300">
-          {error}
+          {errorMsg}
         </p>
       )}
     </li>
@@ -388,7 +456,13 @@ export function RecommendationsCard({
           </h3>
           <ul className="space-y-2">
             {props.map((p) => (
-              <ProposalRow key={p.id} proposal={p} onDecided={onDecided} />
+              <ProposalRow
+                key={p.id}
+                proposal={p}
+                onDecided={onDecided}
+                progress={installProgress?.[p.model.target.hfRepoId]}
+                onDismiss={() => onDismissInstall?.(p.model.target.hfRepoId)}
+              />
             ))}
           </ul>
         </section>

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ModelProposalRecord } from '@harness-engineering/types';
 import type { DashRankedModel, DashPoolStateView } from '../../types/local-models';
+import type { InstallProgressState } from '../../hooks/useLocalModelsPanel';
 
 /**
  * Recommendations card for the LMLM panel. Two sections:
@@ -35,40 +36,77 @@ function fmtScore(n: number): string {
   return Math.round(n).toString();
 }
 
+/** Human-readable byte count for the download bar (e.g. 12.3 GB, 512 MB). */
+function fmtBytes(n: number): string {
+  if (n >= 1e9) return `${round1(n / 1e9)} GB`;
+  if (n >= 1e6) return `${round1(n / 1e6)} MB`;
+  if (n >= 1e3) return `${round1(n / 1e3)} KB`;
+  return `${Math.round(n)} B`;
+}
+
 export interface RecommendationsCardProps {
   recommendations: DashRankedModel[] | null;
   recommendationsError: string | null;
   proposals: ModelProposalRecord[] | null;
   /** Current pool, used to mark recommendations that are already installed. */
   pool: DashPoolStateView | null;
-  /** Called after a successful approve/reject/install so the page can refetch. */
+  /** Called after a successful approve/reject so the page can refetch. */
   onDecided: () => void;
   loading: boolean;
+  /** Live install progress/error keyed by `hfRepoId` (from `local-models:install` frames). */
+  installProgress?: Record<string, InstallProgressState>;
+  /** Clear a settled install error so its row message dismisses. */
+  onDismissInstall?: (hfRepoId: string) => void;
 }
 
 interface RecommendationRowProps {
   rec: DashRankedModel;
   installed: boolean;
-  onInstalled: () => void;
+  /** WS-driven download progress / terminal error for this row, if any. */
+  progress?: InstallProgressState | undefined;
+  /** Clear this row's settled install error (before a retry / on dismiss). */
+  onDismiss: () => void;
 }
 
 /**
  * A single recommendation row with an Install action. An already-pooled model
- * renders an "installed" badge instead of the button. Mirrors `ProposalRow`'s
- * synchronous double-submit guard; install awaits the backend (which awaits the
- * `ollama pull`) so the button shows an indeterminate "Installing…" state until
- * the pool refetches.
+ * renders an "installed" badge instead of the button.
+ *
+ * Install is asynchronous (D3): the POST returns `202` as soon as the pull is
+ * accepted server-side, then byte-level progress + the terminal outcome stream in
+ * over the `local-models:install` WS topic (the `progress` prop). The row stays in
+ * an "Installing…" state — showing a live download bar — from the POST until a
+ * terminal frame: `complete` flips it to the "installed" badge (via the pool
+ * refetch), `error` re-enables the button and surfaces the failure for a retry.
  */
-function RecommendationRow({ rec, installed, onInstalled }: RecommendationRowProps): JSX.Element {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const busyRef = useRef(false);
+function RecommendationRow({
+  rec,
+  installed,
+  progress,
+  onDismiss,
+}: RecommendationRowProps): JSX.Element {
+  // `pending` guards the (now fast) POST; `submitted` bridges the gap between a
+  // 202 and the first WS frame so the button cannot be re-clicked in between.
+  const [pending, setPending] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [postError, setPostError] = useState<string | null>(null);
+  const pendingRef = useRef(false);
+
+  // A terminal WS error ends the in-flight state so the operator can retry.
+  useEffect(() => {
+    if (progress?.phase === 'error') setSubmitted(false);
+  }, [progress?.phase]);
+
+  const streaming = progress?.phase === 'started' || progress?.phase === 'progress';
+  const installing = pending || streaming || (submitted && progress === undefined);
+  const errorMsg = progress?.phase === 'error' ? (progress.message ?? 'Install failed') : postError;
 
   const install = useCallback(async (): Promise<void> => {
-    if (busyRef.current) return;
-    busyRef.current = true;
-    setBusy(true);
-    setError(null);
+    if (pendingRef.current) return;
+    pendingRef.current = true;
+    setPending(true);
+    setPostError(null);
+    onDismiss(); // clear any prior WS error for this repo before retrying
     try {
       const res = await fetch('/api/v1/local-models/pool/install', {
         method: 'POST',
@@ -79,14 +117,21 @@ function RecommendationRow({ rec, installed, onInstalled }: RecommendationRowPro
         const text = await res.text();
         throw new Error(`HTTP ${res.status}: ${text}`);
       }
-      onInstalled();
+      // 202 Accepted — the pull runs server-side; do NOT refetch yet. The
+      // progress bar and completion arrive over the WS `progress` prop.
+      setSubmitted(true);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setPostError(e instanceof Error ? e.message : String(e));
     } finally {
-      busyRef.current = false;
-      setBusy(false);
+      pendingRef.current = false;
+      setPending(false);
     }
-  }, [rec.hfRepoId, rec.quant, onInstalled]);
+  }, [rec.hfRepoId, rec.quant, onDismiss]);
+
+  const pct =
+    progress?.totalBytes && progress.totalBytes > 0
+      ? Math.min(100, Math.round(((progress.completedBytes ?? 0) / progress.totalBytes) * 100))
+      : null;
 
   return (
     <li data-testid={`rec-row-${rec.hfRepoId}`} className="rounded border border-white/10 p-2">
@@ -109,17 +154,39 @@ function RecommendationRow({ rec, installed, onInstalled }: RecommendationRowPro
           <button
             type="button"
             data-testid={`rec-install-${rec.hfRepoId}`}
-            disabled={busy}
+            disabled={installing}
             onClick={() => void install()}
             className="rounded bg-green-600 px-3 py-1 text-xs disabled:opacity-50"
           >
-            {busy ? 'Installing…' : 'Install'}
+            {installing ? 'Installing…' : 'Install'}
           </button>
         )}
       </div>
-      {error && (
+      {streaming && (
+        <div data-testid={`rec-progress-${rec.hfRepoId}`} className="mt-1.5">
+          <div
+            className="h-1.5 w-full overflow-hidden rounded bg-white/10"
+            role="progressbar"
+            {...(pct !== null
+              ? { 'aria-valuenow': pct, 'aria-valuemin': 0, 'aria-valuemax': 100 }
+              : {})}
+          >
+            <div
+              className={`h-full bg-green-500 transition-all ${pct === null ? 'animate-pulse' : ''}`}
+              style={{ width: pct !== null ? `${pct}%` : '100%' }}
+            />
+          </div>
+          <p className="mt-0.5 text-xs text-neutral-muted">
+            {progress?.message ?? 'Downloading…'}
+            {pct !== null && progress?.totalBytes
+              ? ` — ${pct}% (${fmtBytes(progress.completedBytes ?? 0)} / ${fmtBytes(progress.totalBytes)})`
+              : ''}
+          </p>
+        </div>
+      )}
+      {errorMsg && (
         <p data-testid={`rec-error-${rec.hfRepoId}`} className="mt-1 text-xs text-red-300">
-          {error}
+          {errorMsg}
         </p>
       )}
     </li>
@@ -227,6 +294,8 @@ export function RecommendationsCard({
   pool,
   onDecided,
   loading,
+  installProgress,
+  onDismissInstall,
 }: RecommendationsCardProps): JSX.Element {
   const recs = recommendations ?? [];
   const props = proposals ?? [];
@@ -258,7 +327,8 @@ export function RecommendationsCard({
                 key={r.hfRepoId}
                 rec={r}
                 installed={installedRepos.has(r.hfRepoId)}
-                onInstalled={onDecided}
+                progress={installProgress?.[r.hfRepoId]}
+                onDismiss={() => onDismissInstall?.(r.hfRepoId)}
               />
             ))}
           </ul>

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -306,14 +306,60 @@ export function RecommendationsCard({
   const poolEntries = pool && Array.isArray(pool.entries) ? pool.entries : [];
   const installedRepos = new Set(poolEntries.map((e) => e.hfRepoId));
 
+  // Manual "Refresh" triggers a force-refresh tick (re-fetch HF + re-rank +
+  // reconcile), then refetches so new recommendations/proposals render. Unlike
+  // install, this is a fast synchronous recompute — no `ollama pull`, no 202.
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+  const refreshingRef = useRef(false);
+  const lmlmDisabled = recommendationsError === 'LMLM disabled';
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const res = await fetch('/api/v1/local-models/refresh', { method: 'POST' });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+      onDecided();
+    } catch (e) {
+      setRefreshError(e instanceof Error ? e.message : String(e));
+    } finally {
+      refreshingRef.current = false;
+      setRefreshing(false);
+    }
+  }, [onDecided]);
+
   return (
     <div data-testid="rec-card" className="rounded-lg border border-white/10 p-4">
       <h2 className="mb-3 text-base font-semibold">Recommendations</h2>
 
       <section>
-        <h3 className="mb-2 text-xs font-semibold uppercase text-neutral-muted">
-          Recommended for your hardware
-        </h3>
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h3 className="text-xs font-semibold uppercase text-neutral-muted">
+            Recommended for your hardware
+          </h3>
+          {!lmlmDisabled && (
+            <button
+              type="button"
+              data-testid="rec-refresh"
+              disabled={refreshing}
+              onClick={() => void refresh()}
+              className="rounded border border-white/10 px-2 py-0.5 text-xs text-neutral-muted hover:bg-white/5 disabled:opacity-50"
+            >
+              {refreshing ? 'Refreshing…' : 'Refresh'}
+            </button>
+          )}
+        </div>
+        {refreshError && (
+          <p data-testid="rec-refresh-error" className="mb-2 text-xs text-red-300">
+            {refreshError}
+          </p>
+        )}
         {loading && showEmptyRecs && !recommendationsError ? (
           <p className="text-sm text-neutral-muted">Loading recommendations…</p>
         ) : showEmptyRecs ? (

--- a/packages/dashboard/src/client/hooks/useLocalModelsPanel.ts
+++ b/packages/dashboard/src/client/hooks/useLocalModelsPanel.ts
@@ -33,6 +33,20 @@ export interface Resource<T> {
   loading: boolean;
 }
 
+/**
+ * In-flight (or just-failed) state of one operator install, keyed by `hfRepoId`
+ * and driven by `local-models:install` WS frames. A `complete` frame REMOVES the
+ * entry (the row flips to "installed" off the pool refetch); an `error` frame
+ * keeps it so the row can surface the failure until dismissed.
+ */
+export interface InstallProgressState {
+  phase: 'started' | 'progress' | 'error';
+  completedBytes?: number;
+  totalBytes?: number;
+  message?: string;
+  code?: string;
+}
+
 export interface UseLocalModelsPanelResult {
   hardware: Resource<DashHardwareProfile>;
   pool: Resource<DashPoolStateView>;
@@ -42,6 +56,10 @@ export interface UseLocalModelsPanelResult {
   allDisabled: boolean;
   /** Re-issue all four GETs. Used by card action handlers after an approve/reject. */
   refetchAll: () => void;
+  /** Live install progress/error keyed by `hfRepoId` (from `local-models:install` WS frames). */
+  installProgress: Record<string, InstallProgressState>;
+  /** Clear a settled `error` entry so the row's failure message dismisses. */
+  dismissInstall: (hfRepoId: string) => void;
 }
 
 const INITIAL = <T>(): Resource<T> => ({ data: null, error: null, loading: true });
@@ -169,6 +187,7 @@ export function useLocalModelsPanel(): UseLocalModelsPanelResult {
   const [pool, setPool] = useState<Resource<DashPoolStateView>>(INITIAL);
   const [recommendations, setRecommendations] = useState<Resource<DashRankedModel[]>>(INITIAL);
   const [proposals, setProposals] = useState<Resource<ModelProposalRecord[]>>(INITIAL);
+  const [installProgress, setInstallProgress] = useState<Record<string, InstallProgressState>>({});
 
   const mountedRef = useRef(true);
   const controllersRef = useRef<Set<AbortController>>(new Set());
@@ -216,6 +235,15 @@ export function useLocalModelsPanel(): UseLocalModelsPanelResult {
     void fetchProposals();
   }, [fetchHardware, fetchPool, fetchRecommendations, fetchProposals]);
 
+  const dismissInstall = useCallback((hfRepoId: string) => {
+    setInstallProgress((prev) => {
+      if (!(hfRepoId in prev)) return prev;
+      const next = { ...prev };
+      delete next[hfRepoId];
+      return next;
+    });
+  }, []);
+
   // Coalesce delta-driven refetches so a burst of WS frames collapses into a
   // single refetch per affected resource (see useCoalescedRefetch).
   const scheduleRefetch = useCoalescedRefetch({
@@ -256,6 +284,26 @@ export function useLocalModelsPanel(): UseLocalModelsPanelResult {
             scheduleRefetch(['pool', 'recommendations']);
           } else if (msg.type === 'local-models:proposal') {
             scheduleRefetch(['proposals', 'recommendations']);
+          } else if (msg.type === 'local-models:install') {
+            const ev = msg.data;
+            if (ev.phase === 'complete') {
+              // Pool now holds the model; drop the progress row and refetch so it
+              // renders as "installed" (the paired `local-models:pool` frame also
+              // schedules this — coalesced into one refetch).
+              dismissInstall(ev.hfRepoId);
+              scheduleRefetch(['pool', 'recommendations']);
+            } else {
+              // 'started' | 'progress' (byte updates) or 'error' (retained so the
+              // row can surface the failure until retried/dismissed).
+              const entry: InstallProgressState = {
+                phase: ev.phase,
+                ...(ev.completedBytes !== undefined ? { completedBytes: ev.completedBytes } : {}),
+                ...(ev.totalBytes !== undefined ? { totalBytes: ev.totalBytes } : {}),
+                ...(ev.message !== undefined ? { message: ev.message } : {}),
+                ...(ev.code !== undefined ? { code: ev.code } : {}),
+              };
+              setInstallProgress((prev) => ({ ...prev, [ev.hfRepoId]: entry }));
+            }
           }
         } catch {
           // ignore malformed messages
@@ -280,7 +328,7 @@ export function useLocalModelsPanel(): UseLocalModelsPanelResult {
       wsRef.current?.close();
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
     };
-  }, [scheduleRefetch]);
+  }, [scheduleRefetch, dismissInstall]);
 
   const allDisabled =
     hardware.error === 'LMLM disabled' &&
@@ -288,5 +336,14 @@ export function useLocalModelsPanel(): UseLocalModelsPanelResult {
     recommendations.error === 'LMLM disabled' &&
     proposals.error === 'LMLM disabled';
 
-  return { hardware, pool, recommendations, proposals, allDisabled, refetchAll };
+  return {
+    hardware,
+    pool,
+    recommendations,
+    proposals,
+    allDisabled,
+    refetchAll,
+    installProgress,
+    dismissInstall,
+  };
 }

--- a/packages/dashboard/src/client/pages/LocalModels.tsx
+++ b/packages/dashboard/src/client/pages/LocalModels.tsx
@@ -20,8 +20,16 @@ import { RecommendationsCard } from '../components/local-models/RecommendationsC
  * this tree (bundle/WS-double-connection note in the plan).
  */
 export function LocalModels(): JSX.Element {
-  const { hardware, pool, recommendations, proposals, allDisabled, refetchAll } =
-    useLocalModelsPanel();
+  const {
+    hardware,
+    pool,
+    recommendations,
+    proposals,
+    allDisabled,
+    refetchAll,
+    installProgress,
+    dismissInstall,
+  } = useLocalModelsPanel();
 
   if (allDisabled) {
     return (
@@ -65,6 +73,8 @@ export function LocalModels(): JSX.Element {
         pool={pool.data}
         onDecided={refetchAll}
         loading={recommendations.loading}
+        installProgress={installProgress}
+        onDismissInstall={dismissInstall}
       />
     </div>
   );

--- a/packages/dashboard/src/client/types/local-models.ts
+++ b/packages/dashboard/src/client/types/local-models.ts
@@ -116,3 +116,21 @@ export interface LocalModelsProposalEvent {
   action?: string;
   target?: string;
 }
+
+/**
+ * Mirror of `ModelInstallEvent` (`packages/types/src/local-models.ts`), broadcast
+ * on `local-models:install`. Unlike the two delta topics above, this one carries
+ * STATE the panel renders directly (the download progress bar) — an operator
+ * install returns `202` before the pull finishes (D3 async install), so its
+ * progress and terminal outcome arrive here, keyed by `hfRepoId`.
+ */
+export interface LocalModelsInstallEvent {
+  proposalId: string;
+  hfRepoId: string;
+  ollamaName: string;
+  phase: 'started' | 'progress' | 'complete' | 'error';
+  completedBytes?: number;
+  totalBytes?: number;
+  message?: string;
+  code?: string;
+}

--- a/packages/dashboard/src/client/types/orchestrator.ts
+++ b/packages/dashboard/src/client/types/orchestrator.ts
@@ -4,7 +4,11 @@ import type {
   RoutingDecision,
   BlockerRef,
 } from '@harness-engineering/types';
-import type { LocalModelsPoolEvent, LocalModelsProposalEvent } from './local-models';
+import type {
+  LocalModelsPoolEvent,
+  LocalModelsProposalEvent,
+  LocalModelsInstallEvent,
+} from './local-models';
 
 export type { LocalModelStatus, NamedLocalModelStatus };
 
@@ -222,7 +226,9 @@ export type WebSocketMessage =
   | { type: 'routing:decision'; data: RoutingDecision }
   // LMLM Phase 8 — pool/proposal delta signals (refetch triggers, D-P8-3).
   | { type: 'local-models:pool'; data: LocalModelsPoolEvent }
-  | { type: 'local-models:proposal'; data: LocalModelsProposalEvent };
+  | { type: 'local-models:proposal'; data: LocalModelsProposalEvent }
+  // LMLM Phase 10 — byte-level download progress for an in-flight operator install.
+  | { type: 'local-models:install'; data: LocalModelsInstallEvent };
 
 /** SSE event types from the chat proxy endpoint. */
 export type ChatSSEEvent =

--- a/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
+++ b/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
@@ -174,6 +174,66 @@ describe('RecommendationsCard', () => {
     ).toBe(false);
   });
 
+  it('Refresh POSTs to /refresh and refetches (onDecided) on success', async () => {
+    const accepted = { ok: true, status: 200, text: async () => 'ok' } as Response;
+    const fetchMock = vi.fn(() => Promise.resolve(accepted));
+    vi.stubGlobal('fetch', fetchMock);
+    const onDecided = vi.fn();
+    render(
+      <RecommendationsCard
+        recommendations={RECS}
+        recommendationsError={null}
+        proposals={[]}
+        pool={null}
+        onDecided={onDecided}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('rec-refresh'));
+
+    await waitFor(() => expect(onDecided).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('/api/v1/local-models/refresh');
+    expect((init as RequestInit).method).toBe('POST');
+    vi.unstubAllGlobals();
+  });
+
+  it('hides the Refresh button when recommendations are LMLM-disabled', () => {
+    render(
+      <RecommendationsCard
+        recommendations={null}
+        recommendationsError="LMLM disabled"
+        proposals={[]}
+        onDecided={() => {}}
+        loading={false}
+      />
+    );
+    expect(screen.queryByTestId('rec-refresh')).toBeNull();
+  });
+
+  it('a failed Refresh surfaces an inline error and does not call onDecided', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 503, text: async () => 'LMLM disabled' } as Response)
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const onDecided = vi.fn();
+    render(
+      <RecommendationsCard
+        recommendations={RECS}
+        recommendationsError={null}
+        proposals={[]}
+        pool={null}
+        onDecided={onDecided}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('rec-refresh'));
+
+    await waitFor(() => expect(screen.getByTestId('rec-refresh-error')).toBeDefined());
+    expect(onDecided).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
   it('shows "installed" instead of an Install button for a pooled model (SC6)', () => {
     render(
       <RecommendationsCard

--- a/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
+++ b/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
@@ -88,8 +88,12 @@ describe('RecommendationsCard', () => {
     expect(row.textContent).toContain('20');
   });
 
-  it('Install POSTs to /pool/install with hfRepoId + quant and calls onDecided (SC6)', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve(okRes()));
+  it('Install POSTs to /pool/install with hfRepoId + quant; 202 keeps it "Installing…" without onDecided (SC6)', async () => {
+    // Install is async (D3): the POST returns 202 and completion arrives over the
+    // `local-models:install` WS topic — so the row must NOT fire the onDecided
+    // refetch here (that would race a not-yet-pulled model) and must stay busy.
+    const accepted = { ok: true, status: 202, text: async () => 'accepted' } as Response;
+    const fetchMock = vi.fn(() => Promise.resolve(accepted));
     vi.stubGlobal('fetch', fetchMock);
     const onDecided = vi.fn();
     render(
@@ -104,13 +108,70 @@ describe('RecommendationsCard', () => {
     );
     fireEvent.click(screen.getByTestId('rec-install-Qwen/Qwen3-32B-GGUF'));
 
-    await waitFor(() => expect(onDecided).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('rec-install-Qwen/Qwen3-32B-GGUF').textContent).toContain(
+        'Installing'
+      )
+    );
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(String(url)).toBe('/api/v1/local-models/pool/install');
     expect((init as RequestInit).method).toBe('POST');
     expect(String((init as RequestInit).body)).toContain('Qwen/Qwen3-32B-GGUF');
     expect(String((init as RequestInit).body)).toContain('Q4_K_M');
+    expect(onDecided).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
+  });
+
+  it('renders a download progress bar from install progress frames', () => {
+    render(
+      <RecommendationsCard
+        recommendations={RECS}
+        recommendationsError={null}
+        proposals={[]}
+        pool={null}
+        onDecided={vi.fn()}
+        loading={false}
+        installProgress={{
+          'Qwen/Qwen3-32B-GGUF': { phase: 'progress', completedBytes: 5e9, totalBytes: 1e10 },
+        }}
+        onDismissInstall={vi.fn()}
+      />
+    );
+    const bar = screen.getByTestId('rec-progress-Qwen/Qwen3-32B-GGUF');
+    expect(bar.textContent).toContain('50%');
+    expect(bar.querySelector('[role="progressbar"]')?.getAttribute('aria-valuenow')).toBe('50');
+    // The row reflects the in-flight install.
+    expect(screen.getByTestId('rec-install-Qwen/Qwen3-32B-GGUF').textContent).toContain(
+      'Installing'
+    );
+  });
+
+  it('surfaces a WS install error frame on the row and re-enables retry', () => {
+    render(
+      <RecommendationsCard
+        recommendations={RECS}
+        recommendationsError={null}
+        proposals={[]}
+        pool={null}
+        onDecided={vi.fn()}
+        loading={false}
+        installProgress={{
+          'Qwen/Qwen3-32B-GGUF': {
+            phase: 'error',
+            message: 'no eviction plan fits',
+            code: 'budget_exceeded',
+          },
+        }}
+        onDismissInstall={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('rec-error-Qwen/Qwen3-32B-GGUF').textContent).toContain(
+      'no eviction plan fits'
+    );
+    // A terminal error re-enables the button so the operator can retry.
+    expect(
+      (screen.getByTestId('rec-install-Qwen/Qwen3-32B-GGUF') as HTMLButtonElement).disabled
+    ).toBe(false);
   });
 
   it('shows "installed" instead of an Install button for a pooled model (SC6)', () => {

--- a/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
+++ b/packages/dashboard/tests/client/components/local-models/RecommendationsCard.test.tsx
@@ -369,6 +369,71 @@ describe('RecommendationsCard', () => {
     vi.unstubAllGlobals();
   });
 
+  it('Approve of an add/swap: 202 keeps it "Installing…" without onDecided', async () => {
+    // Approving an add/swap installs the target (ollama pull); the route returns
+    // 202 and streams over WS, so the row must stay busy and NOT refetch here.
+    const accepted = { ok: true, status: 202, text: async () => 'accepted' } as Response;
+    const fetchMock = vi.fn(() => Promise.resolve(accepted));
+    vi.stubGlobal('fetch', fetchMock);
+    const onDecided = vi.fn();
+    render(
+      <RecommendationsCard
+        recommendations={[]}
+        recommendationsError={null}
+        proposals={[PROPOSAL]}
+        onDecided={onDecided}
+        loading={false}
+      />
+    );
+    fireEvent.click(screen.getByTestId('proposal-approve-mp-1'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('proposal-approve-mp-1').textContent).toContain('Installing')
+    );
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('/api/v1/proposals/mp-1/approve');
+    expect(onDecided).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders a download progress bar while a proposal is installing', () => {
+    render(
+      <RecommendationsCard
+        recommendations={[]}
+        recommendationsError={null}
+        proposals={[PROPOSAL]}
+        onDecided={vi.fn()}
+        loading={false}
+        installProgress={{
+          'Qwen/Qwen3-32B-GGUF': { phase: 'progress', completedBytes: 3e9, totalBytes: 4e9 },
+        }}
+        onDismissInstall={vi.fn()}
+      />
+    );
+    const bar = screen.getByTestId('proposal-progress-mp-1');
+    expect(bar.textContent).toContain('75%');
+    expect(screen.getByTestId('proposal-approve-mp-1').textContent).toContain('Installing');
+  });
+
+  it('surfaces a WS install error on the proposal row and re-enables Approve', () => {
+    render(
+      <RecommendationsCard
+        recommendations={[]}
+        recommendationsError={null}
+        proposals={[PROPOSAL]}
+        onDecided={vi.fn()}
+        loading={false}
+        installProgress={{
+          'Qwen/Qwen3-32B-GGUF': { phase: 'error', message: 'no eviction plan fits' },
+        }}
+        onDismissInstall={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('proposal-error-mp-1').textContent).toContain(
+      'no eviction plan fits'
+    );
+    expect((screen.getByTestId('proposal-approve-mp-1') as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it('Reject with a reason POSTs to /reject and calls onDecided', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(okRes()));
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/dashboard/tests/client/hooks/useLocalModelsPanel.test.ts
+++ b/packages/dashboard/tests/client/hooks/useLocalModelsPanel.test.ts
@@ -376,6 +376,68 @@ describe('useLocalModelsPanel', () => {
     vi.unstubAllGlobals();
   });
 
+  it('tracks a local-models:install lifecycle in installProgress (progress → error → complete)', async () => {
+    const fetchMock = branchingFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useLocalModelsPanel());
+    await waitFor(() => expect(FakeWebSocket.instance).not.toBeNull());
+    const ws = FakeWebSocket.instance!;
+    const repo = 'Qwen/Qwen3-32B-GGUF';
+
+    // progress frame → byte-tracked entry keyed by hfRepoId
+    act(() => {
+      ws.simulateMessage({
+        type: 'local-models:install',
+        data: {
+          proposalId: 'mp-1',
+          hfRepoId: repo,
+          ollamaName: 'qwen3:32b',
+          phase: 'progress',
+          completedBytes: 500,
+          totalBytes: 1000,
+        },
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.installProgress[repo]).toMatchObject({
+        phase: 'progress',
+        completedBytes: 500,
+        totalBytes: 1000,
+      })
+    );
+
+    // error frame → retained with message/code so the row can surface it
+    act(() => {
+      ws.simulateMessage({
+        type: 'local-models:install',
+        data: {
+          proposalId: 'mp-1',
+          hfRepoId: repo,
+          ollamaName: 'qwen3:32b',
+          phase: 'error',
+          message: 'no eviction plan fits',
+          code: 'budget_exceeded',
+        },
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.installProgress[repo]).toMatchObject({
+        phase: 'error',
+        code: 'budget_exceeded',
+      })
+    );
+
+    // complete frame → entry cleared (row flips to "installed" off the pool refetch)
+    act(() => {
+      ws.simulateMessage({
+        type: 'local-models:install',
+        data: { proposalId: 'mp-1', hfRepoId: repo, ollamaName: 'qwen3:32b', phase: 'complete' },
+      });
+    });
+    await waitFor(() => expect(result.current.installProgress[repo]).toBeUndefined());
+  });
+
   it('closes the socket on unmount', async () => {
     const fetchMock = branchingFetch();
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/local-models/src/scheduler/refresh.ts
+++ b/packages/local-models/src/scheduler/refresh.ts
@@ -8,10 +8,15 @@
  *   2. recommend (HF, cache TTL, frozen-snapshot fallback) → ranking
  *   3. DRIFT RECONCILE (D12/F10): prune pool entries the installer no longer
  *      reports, freeing their disk budget — done inside `PoolManager.reconcile`
- *   4. diff the reconciled pool against the ranking via the Phase 5b engine
- *   5. emit a `ModelProposal` for each diff over threshold not already
+ *   4. rewrite pool entry scores from the re-rank — BEFORE the diff, so a
+ *      freshly-installed member (which enters the pool at `currentScore: 0` until
+ *      its first re-rank) is diffed against its real score, not the uninitialized
+ *      0. Diffing first produced phantom swaps ("replace a pool member scoring 0")
+ *      and inflated `scoreDelta`s on the tick right after an install/swap.
+ *   5. diff the reconciled, re-scored pool against the ranking via the Phase 5b
+ *      engine
+ *   6. emit a `ModelProposal` for each diff over threshold not already
  *      pending/rejected
- *   6. rewrite pool entry scores from the re-rank
  *
  * The pipeline is degradation-first: every stage is wrapped so a failure is
  * recorded on `TickResult.errors` and, where safe, later stages still run. A
@@ -114,8 +119,12 @@ export async function runRefreshTick(deps: RefreshTickDeps): Promise<TickResult>
   const reconcile = await tryStage('reconcile', errors, () => deps.poolManager.reconcile());
   const reconciledRemoved = (reconcile?.removed ?? []).map((e) => e.ollamaName);
 
-  const proposalsEmitted = await emitDiff(deps, hardware, ranked, errors);
+  // Re-score the pool from this tick's ranking BEFORE diffing, so the diff (and
+  // the "replace a pool member scoring N" justification) uses each member's real
+  // score rather than the 0 a just-installed member carries until its first
+  // re-rank. Diffing first churned the pool with phantom swaps against that 0.
   await writeBackScores(deps, ranked, errors);
+  const proposalsEmitted = await emitDiff(deps, hardware, ranked, errors);
 
   return {
     candidatesEvaluated: ranked.length,

--- a/packages/local-models/tests/scheduler/refresh.test.ts
+++ b/packages/local-models/tests/scheduler/refresh.test.ts
@@ -106,7 +106,7 @@ function recommendResult(ranked: RankedModel[]): RecommendResult {
   return { ranked, snapshotLoaded: true, hfReachable: true, warnings: [] };
 }
 
-describe('runRefreshTick (reconcile → rank → diff → emit)', () => {
+describe('runRefreshTick (reconcile → rescore → diff → emit)', () => {
   it('reconciles before diffing, emits one proposal per diff, updates scores, returns metrics', async () => {
     const pool = await seededPool(baseState(), [{ ollamaName: 'old:8b', sizeOnDiskGb: 20 }]);
     const order: string[] = [];
@@ -148,6 +148,66 @@ describe('runRefreshTick (reconcile → rank → diff → emit)', () => {
     expect(result.candidatesEvaluated).toBe(2);
     expect(result.reconciledRemoved).toEqual([]);
     expect(result.errors).toEqual([]);
+  });
+
+  it('re-scores the pool BEFORE diffing → no phantom swap against a freshly-installed member scoring 0', async () => {
+    // Regression: a just-installed/swapped-in member enters the pool at
+    // currentScore 0 until its first re-rank. If the diff runs before the
+    // score write-back, it sees 0, so ANY candidate over threshold "beats" it →
+    // a phantom swap proposal justified as "replace a pool member scoring 0".
+    // Writing scores back first makes the diff use the member's real score.
+    const fresh: PoolState = {
+      ...baseState(),
+      entries: [
+        {
+          ollamaName: 'fresh:32b',
+          hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+          sizeOnDiskGb: 20,
+          installedAt: '2026-07-08T00:00:00.000Z',
+          lastUsedAt: null,
+          currentScore: 0, // never re-ranked yet
+        },
+      ],
+    };
+    const pool = await seededPool(fresh, [{ ollamaName: 'fresh:32b', sizeOnDiskGb: 20 }]);
+    // This tick's ranking scores fresh:32b at 80. A rival scores 83 — enough to
+    // "beat" a stale 0 by the threshold (5), but only +3 over the real 80, so NO
+    // swap should be proposed once the real score is used.
+    const ranked = [
+      rankedModel({
+        ollamaName: 'fresh:32b',
+        hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+        sizeB: 32,
+        score: 80,
+      }),
+      rankedModel({
+        ollamaName: 'rival:32b',
+        hfRepoId: 'Org/Rival-32B-GGUF',
+        sizeB: 32,
+        score: 83,
+      }),
+    ];
+    const emitted: string[] = [];
+    const deps: RefreshTickDeps = {
+      detectHardware: async () => HARDWARE,
+      recommend: async () => recommendResult(ranked),
+      poolManager: pool,
+      dedupSource: async () => ({ pending: [], rejected: [] }),
+      emitProposal: async (c) => {
+        emitted.push(c.target.ollamaName);
+      },
+      proposalThreshold: 5,
+    };
+
+    const result = await runRefreshTick(deps);
+
+    // No phantom swap: rival (83) does not beat the member's REAL score (80) by 5.
+    expect(emitted).toEqual([]);
+    expect(result.proposalsEmitted).toBe(0);
+    // The member's score was written back from the re-rank before the diff.
+    expect(pool.snapshot().entries.find((e) => e.ollamaName === 'fresh:32b')?.currentScore).toBe(
+      80
+    );
   });
 
   it('collects per-stage errors without aborting the tick (emit failure is isolated)', async () => {

--- a/packages/orchestrator/src/proposals/model-handlers.ts
+++ b/packages/orchestrator/src/proposals/model-handlers.ts
@@ -3,6 +3,7 @@ import type { ModelProposalRecord, Proposal, ProposalDecision } from '@harness-e
 import type {
   EvictPoolRequest,
   EvictPoolResult,
+  InstallEvent,
   InstallPoolRequest,
   InstallPoolResult,
   PoolEntry,
@@ -72,6 +73,14 @@ export interface ModelHandlerDeps {
    * agent-run-coarse and may over-defer — a safe failure (see ADR 0060).
    */
   isModelInUse?: (ollamaName: string) => boolean;
+  /**
+   * Streaming install-progress sink, forwarded verbatim to `pool.install` as its
+   * `onEvent`. The install route translates each {@link InstallEvent} into a
+   * `local-models:install` WS frame so the dashboard can render a download
+   * progress bar. Absent in the automated proposal-engine path (no operator
+   * watching) — the pull still runs, its progress is simply not broadcast.
+   */
+  onInstallEvent?: (event: InstallEvent) => void;
 }
 
 /** True when the probe (if supplied) reports the model might be mid-request. */
@@ -83,6 +92,14 @@ function isInUse(deps: ModelHandlerDeps, ollamaName: string): boolean {
 export const MODEL_PROPOSAL_TOPIC = 'local-models:proposal';
 /** Bus topic for pool mutations (install / evict applied). */
 export const MODEL_POOL_TOPIC = 'local-models:pool';
+/**
+ * Bus topic for byte-level install progress + terminal status of an in-flight
+ * operator install (D3 async install). Distinct from {@link MODEL_POOL_TOPIC},
+ * which is a coarse refetch-delta: streaming per-byte progress there would make
+ * the dashboard refetch the pool on every frame. Consumers render a progress bar
+ * off this topic and only refetch on the completing `local-models:pool` frame.
+ */
+export const MODEL_INSTALL_TOPIC = 'local-models:install';
 
 /** Outcome of {@link onApproveModelProposal}. */
 export type ModelApproveOutcome =
@@ -170,6 +187,7 @@ export async function onApproveModelProposal(
     ollamaName: model.target.ollamaName,
     ...(model.replaces !== undefined ? { replaces: model.replaces.ollamaName } : {}),
     ...(model.diskImpactGb > 0 ? { sizeOnDiskGb: model.diskImpactGb } : {}),
+    ...(deps.onInstallEvent ? { onEvent: deps.onInstallEvent } : {}),
   });
 
   if (installResult.status === 'error') {

--- a/packages/orchestrator/src/proposals/model-handlers.ts
+++ b/packages/orchestrator/src/proposals/model-handlers.ts
@@ -1,5 +1,10 @@
 import type { EventEmitter } from 'node:events';
-import type { ModelProposalRecord, Proposal, ProposalDecision } from '@harness-engineering/types';
+import type {
+  ModelInstallEvent,
+  ModelProposalRecord,
+  Proposal,
+  ProposalDecision,
+} from '@harness-engineering/types';
 import type {
   EvictPoolRequest,
   EvictPoolResult,
@@ -100,6 +105,49 @@ export const MODEL_POOL_TOPIC = 'local-models:pool';
  * off this topic and only refetch on the completing `local-models:pool` frame.
  */
 export const MODEL_INSTALL_TOPIC = 'local-models:install';
+
+/** Streaming + lifecycle emitter for one install, bound to its correlation fields. */
+export interface InstallProgressForwarder {
+  /**
+   * Pass as {@link ModelHandlerDeps.onInstallEvent}: forwards the installer's
+   * byte stream as `progress` frames on {@link MODEL_INSTALL_TOPIC}. Terminal
+   * frames are NOT emitted here — the caller derives `complete`/`error` from the
+   * resolved approve outcome so the pool state is already committed.
+   */
+  onInstallEvent: (event: InstallEvent) => void;
+  /** Emit a lifecycle frame (`started` / `complete` / `error`) for this install. */
+  emit: (phase: ModelInstallEvent['phase'], patch?: Partial<ModelInstallEvent>) => void;
+}
+
+/**
+ * Build the shared `local-models:install` progress emitter used by BOTH pull
+ * entry points — the operator install route and the model-proposal approve route
+ * — so a `swap`/`add` approval streams a download bar exactly like a direct
+ * install (and, crucially, returns before the multi-GB pull blows the dashboard
+ * proxy's `headersTimeout`). Closes over the invariant correlation fields so each
+ * call site supplies only the phase-specific delta.
+ */
+export function makeInstallProgressForwarder(
+  bus: EventEmitter,
+  base: Pick<ModelInstallEvent, 'proposalId' | 'hfRepoId' | 'ollamaName'>
+): InstallProgressForwarder {
+  const emit: InstallProgressForwarder['emit'] = (phase, patch = {}) => {
+    const frame: ModelInstallEvent = { ...base, ...patch, phase };
+    bus.emit(MODEL_INSTALL_TOPIC, frame);
+  };
+  const onInstallEvent = (event: InstallEvent): void => {
+    if (event.kind === 'progress') {
+      emit('progress', {
+        completedBytes: event.completedBytes,
+        totalBytes: event.totalBytes,
+        ...(event.message !== undefined ? { message: event.message } : {}),
+      });
+    } else if (event.kind === 'pulling') {
+      emit('progress', { message: event.message });
+    }
+  };
+  return { emit, onInstallEvent };
+}
 
 /** Outcome of {@link onApproveModelProposal}. */
 export type ModelApproveOutcome =

--- a/packages/orchestrator/src/server/http.ts
+++ b/packages/orchestrator/src/server/http.ts
@@ -24,7 +24,11 @@ import { handleV1LocalModelsRoute } from './routes/v1/local-models';
 import { handleV1LocalModelsMutationRoute } from './routes/v1/local-models-pool-mutation';
 import type { RefreshSchedulerOps } from './routes/v1/local-models';
 import type { ModelPoolOps } from '../proposals/model-handlers';
-import { MODEL_PROPOSAL_TOPIC, MODEL_POOL_TOPIC } from '../proposals/model-handlers';
+import {
+  MODEL_PROPOSAL_TOPIC,
+  MODEL_POOL_TOPIC,
+  MODEL_INSTALL_TOPIC,
+} from '../proposals/model-handlers';
 import type { HardwareProfile, RankedModel } from '@harness-engineering/local-models';
 import { handleV1RoutingRoute } from './routes/v1/routing';
 import type { BackendRouter } from '../agent/backend-router';
@@ -266,6 +270,8 @@ export class OrchestratorServer {
   // LMLM Phase 7 — bus→WS fan-out listeners for the model proposal/pool topics.
   private modelProposalListener: ((data: unknown) => void) | null = null;
   private modelPoolListener: ((data: unknown) => void) | null = null;
+  // LMLM Phase 10 — bus→WS fan-out for byte-level install progress (D3 async install).
+  private modelInstallListener: ((data: unknown) => void) | null = null;
   private recorder: StreamRecorder | null = null;
   private planWatcher: PlanWatcher | null = null;
   private tokenStore!: TokenStore;
@@ -361,8 +367,13 @@ export class OrchestratorServer {
     this.modelProposalListener = (data: unknown) =>
       this.broadcaster.broadcast(MODEL_PROPOSAL_TOPIC, data);
     this.modelPoolListener = (data: unknown) => this.broadcaster.broadcast(MODEL_POOL_TOPIC, data);
+    // Phase 10: byte-level install progress rides its own topic so per-frame
+    // broadcasts do not trigger the pool refetch the `local-models:pool` topic drives.
+    this.modelInstallListener = (data: unknown) =>
+      this.broadcaster.broadcast(MODEL_INSTALL_TOPIC, data);
     this.orchestrator.on(MODEL_PROPOSAL_TOPIC, this.modelProposalListener);
     this.orchestrator.on(MODEL_POOL_TOPIC, this.modelPoolListener);
+    this.orchestrator.on(MODEL_INSTALL_TOPIC, this.modelInstallListener);
   }
 
   /**
@@ -801,6 +812,10 @@ export class OrchestratorServer {
     if (this.modelPoolListener) {
       this.orchestrator.removeListener(MODEL_POOL_TOPIC, this.modelPoolListener);
       this.modelPoolListener = null;
+    }
+    if (this.modelInstallListener) {
+      this.orchestrator.removeListener(MODEL_INSTALL_TOPIC, this.modelInstallListener);
+      this.modelInstallListener = null;
     }
     if (this.planWatcher) {
       this.planWatcher.stop();

--- a/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
+++ b/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
@@ -30,19 +30,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { EventEmitter } from 'node:events';
 import { createModelProposal, updateProposal } from '@harness-engineering/core';
-import type {
-  ModelInstallEvent,
-  ModelProposalContent,
-  PoolMutationResult,
-} from '@harness-engineering/types';
-import {
-  estimateDiskGb,
-  type InstallEvent,
-  type RankedModel,
-} from '@harness-engineering/local-models';
+import type { ModelProposalContent, PoolMutationResult } from '@harness-engineering/types';
+import { estimateDiskGb, type RankedModel } from '@harness-engineering/local-models';
 import {
   onApproveModelProposal,
-  MODEL_INSTALL_TOPIC,
+  makeInstallProgressForwarder,
   type ModelHandlerDeps,
   type ModelPoolOps,
 } from '../../../proposals/model-handlers.js';
@@ -171,31 +163,17 @@ async function handleInstall(
   });
 
   const ollamaName = match.ollamaName;
-  const emit = installFrameEmitter(deps.bus, {
+  // Shared `local-models:install` progress emitter (also used by the proposal
+  // approve route, so a swap/add approval streams the same download bar).
+  const { emit, onInstallEvent } = makeInstallProgressForwarder(deps.bus, {
     proposalId: record.id,
     hfRepoId: match.hfRepoId,
     ollamaName,
   });
 
-  // Forward the installer's byte-level stream as `progress` frames. Terminal
-  // outcomes (`success`/`error`) are NOT emitted here — they are derived from the
-  // resolved `onApproveModelProposal` outcome below so the pool state is already
-  // committed and there is a single source of terminal truth.
-  const onInstallEvent = (event: InstallEvent): void => {
-    if (event.kind === 'progress') {
-      emit('progress', {
-        completedBytes: event.completedBytes,
-        totalBytes: event.totalBytes,
-        ...(event.message !== undefined ? { message: event.message } : {}),
-      });
-    } else if (event.kind === 'pulling') {
-      emit('progress', { message: event.message });
-    }
-  };
-
   const handler: ModelHandlerDeps = { ...handlerDeps(deps, req, pool), onInstallEvent };
 
-  emit('started', {});
+  emit('started');
 
   // Kick off the pull WITHOUT awaiting — the response returns before the multi-GB
   // download completes (avoiding the proxy `headersTimeout` 502). The terminal
@@ -229,21 +207,6 @@ async function handleInstall(
     message: `installing ${ollamaName} — progress streams on the local-models:install channel`,
   };
   return sendJSON(res, 202, result);
-}
-
-/**
- * Build an emitter that broadcasts `local-models:install` frames for one install,
- * closing over the invariant correlation fields (`proposalId`/`hfRepoId`/
- * `ollamaName`) so each call site only supplies the phase-specific delta.
- */
-function installFrameEmitter(
-  bus: EventEmitter,
-  base: Pick<ModelInstallEvent, 'proposalId' | 'hfRepoId' | 'ollamaName'>
-): (phase: ModelInstallEvent['phase'], patch: Partial<ModelInstallEvent>) => void {
-  return (phase, patch) => {
-    const frame: ModelInstallEvent = { ...base, ...patch, phase };
-    bus.emit(MODEL_INSTALL_TOPIC, frame);
-  };
 }
 
 async function handleRemove(

--- a/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
+++ b/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
@@ -14,18 +14,35 @@
  * pool-mutation channel (D-P8-2).
  *
  * Auth is enforced upstream by the bridge-route scope table (`manage-proposals`,
- * identical to approve/reject). Install awaits the streamed `ollama pull`
- * synchronously, matching the existing approve-an-add flow; byte-level progress
- * over WS is a deferred enhancement (D3 note).
+ * identical to approve/reject).
+ *
+ * **Install is asynchronous (D3).** A multi-GB `ollama pull` far exceeds the
+ * dashboard proxy's undici `headersTimeout` (~5 min), so awaiting it inline made
+ * the proxied `fetch()` abort with `UND_ERR_HEADERS_TIMEOUT` → a 502. Instead the
+ * route validates + creates the proposal synchronously, kicks off the pull in the
+ * background, and returns `202 { disposition: 'installing' }` immediately. Byte
+ * progress and the terminal outcome (approved / budget / allowlist / failure) are
+ * streamed on the `local-models:install` WS topic — NOT in the HTTP response — so
+ * the dashboard renders a download progress bar. `/pool/remove` stays synchronous
+ * (eviction is fast; no pull).
  */
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { EventEmitter } from 'node:events';
 import { createModelProposal, updateProposal } from '@harness-engineering/core';
-import type { ModelProposalContent, PoolMutationResult } from '@harness-engineering/types';
-import { estimateDiskGb, type RankedModel } from '@harness-engineering/local-models';
+import type {
+  ModelInstallEvent,
+  ModelProposalContent,
+  PoolMutationResult,
+} from '@harness-engineering/types';
+import {
+  estimateDiskGb,
+  type InstallEvent,
+  type RankedModel,
+} from '@harness-engineering/local-models';
 import {
   onApproveModelProposal,
+  MODEL_INSTALL_TOPIC,
   type ModelHandlerDeps,
   type ModelPoolOps,
 } from '../../../proposals/model-handlers.js';
@@ -152,29 +169,81 @@ async function handleInstall(
   const record = await createModelProposal(deps.projectPath, content, {
     proposedBy: decidedByOf(deps, req),
   });
-  const outcome = await onApproveModelProposal(handlerDeps(deps, req, pool), record);
 
-  if (outcome.status === 'approved') {
-    const result: PoolMutationResult = {
-      disposition: 'installed',
-      proposalId: record.id,
-      evicted: outcome.evicted.map((e) => e.ollamaName),
-    };
-    return sendJSON(res, 200, result);
-  }
-  if (outcome.status === 'failed_target_missing') {
-    return sendJSON(res, 404, {
-      error: `${hfRepoId} is no longer available on HuggingFace`,
-      proposalId: record.id,
-    });
-  }
-  // `not_allowed` (org allowlist) / `budget_exceeded` (disk) are operator-fixable → 409.
-  const status = outcome.code === 'not_allowed' || outcome.code === 'budget_exceeded' ? 409 : 502;
-  return sendJSON(res, status, {
-    error: outcome.message,
-    code: outcome.code,
+  const ollamaName = match.ollamaName;
+  const emit = installFrameEmitter(deps.bus, {
     proposalId: record.id,
+    hfRepoId: match.hfRepoId,
+    ollamaName,
   });
+
+  // Forward the installer's byte-level stream as `progress` frames. Terminal
+  // outcomes (`success`/`error`) are NOT emitted here — they are derived from the
+  // resolved `onApproveModelProposal` outcome below so the pool state is already
+  // committed and there is a single source of terminal truth.
+  const onInstallEvent = (event: InstallEvent): void => {
+    if (event.kind === 'progress') {
+      emit('progress', {
+        completedBytes: event.completedBytes,
+        totalBytes: event.totalBytes,
+        ...(event.message !== undefined ? { message: event.message } : {}),
+      });
+    } else if (event.kind === 'pulling') {
+      emit('progress', { message: event.message });
+    }
+  };
+
+  const handler: ModelHandlerDeps = { ...handlerDeps(deps, req, pool), onInstallEvent };
+
+  emit('started', {});
+
+  // Kick off the pull WITHOUT awaiting — the response returns before the multi-GB
+  // download completes (avoiding the proxy `headersTimeout` 502). The terminal
+  // outcome reaches the operator over the `local-models:install` WS topic.
+  void onApproveModelProposal(handler, record)
+    .then((outcome) => {
+      if (outcome.status === 'approved') {
+        // `onApproveModelProposal` already emitted the `local-models:pool` frame
+        // that drives the dashboard's pool refetch (row flips to "installed").
+        emit('complete', {});
+        return;
+      }
+      if (outcome.status === 'failed_target_missing') {
+        emit('error', {
+          code: 'failed_target_missing',
+          message: `${hfRepoId} is no longer available on HuggingFace`,
+        });
+        return;
+      }
+      // budget_exceeded / not_allowed / installer_unavailable / install_failed.
+      emit('error', { code: outcome.code, message: outcome.message });
+    })
+    .catch((err: unknown) => {
+      emit('error', { message: err instanceof Error ? err.message : String(err) });
+    });
+
+  const result: PoolMutationResult = {
+    disposition: 'installing',
+    proposalId: record.id,
+    evicted: [],
+    message: `installing ${ollamaName} — progress streams on the local-models:install channel`,
+  };
+  return sendJSON(res, 202, result);
+}
+
+/**
+ * Build an emitter that broadcasts `local-models:install` frames for one install,
+ * closing over the invariant correlation fields (`proposalId`/`hfRepoId`/
+ * `ollamaName`) so each call site only supplies the phase-specific delta.
+ */
+function installFrameEmitter(
+  bus: EventEmitter,
+  base: Pick<ModelInstallEvent, 'proposalId' | 'hfRepoId' | 'ollamaName'>
+): (phase: ModelInstallEvent['phase'], patch: Partial<ModelInstallEvent>) => void {
+  return (phase, patch) => {
+    const frame: ModelInstallEvent = { ...base, ...patch, phase };
+    bus.emit(MODEL_INSTALL_TOPIC, frame);
+  };
 }
 
 async function handleRemove(

--- a/packages/orchestrator/src/server/routes/v1/proposals.test.ts
+++ b/packages/orchestrator/src/server/routes/v1/proposals.test.ts
@@ -14,7 +14,20 @@ import type {
 } from '@harness-engineering/local-models';
 import { handleV1ProposalsRoute } from './proposals';
 import { runGate } from '../../../proposals/gate';
-import type { ModelPoolOps } from '../../../proposals/model-handlers';
+import { MODEL_INSTALL_TOPIC, type ModelPoolOps } from '../../../proposals/model-handlers';
+
+/**
+ * Approving an `add`/`swap` model proposal is asynchronous (the route returns 202
+ * and streams the pull on `local-models:install`). Resolve on the terminal frame
+ * so tests observe the eventual outcome that now rides the WS topic.
+ */
+function waitInstallTerminal(bus: EventEmitter): Promise<{ phase: string; code?: string }> {
+  return new Promise((resolve) => {
+    bus.on(MODEL_INSTALL_TOPIC, (f: { phase: string; code?: string }) => {
+      if (f.phase === 'complete' || f.phase === 'error') resolve(f);
+    });
+  });
+}
 
 function makeReqRes(
   method: string,
@@ -272,19 +285,22 @@ function fakePool(opts: { install?: InstallPoolResult; evict?: EvictPoolResult }
 }
 
 describe('POST /api/v1/proposals/:id/approve (model kind)', () => {
-  it('stale target (HF 404) → failed_target_missing, pool snapshot unchanged', async () => {
+  it('swap approve is async: 202 immediately, then a stale target (HF 404) → failed_target_missing over WS, pool unchanged', async () => {
     writeModelProposal(tmpDir, 'proposal_model1');
     const pool = fakePool({
       install: { status: 'error', code: 'failed_target_missing', message: 'HF 404', evicted: [] },
     });
     const before = pool.ops.snapshot().entries.slice();
+    const terminal = waitInstallTerminal(bus);
     const { req, res, sent } = makeReqRes('POST', '/api/v1/proposals/proposal_model1/approve');
     handleV1ProposalsRoute(req, res, { projectPath: tmpDir, bus, modelPool: pool.ops });
     await settle();
 
-    expect(sent().status).toBe(200);
-    const out = JSON.parse(sent().body) as { status: string };
-    expect(out.status).toBe('failed_target_missing');
+    // Returns 202 without awaiting the pull (no proxy headersTimeout 502).
+    expect(sent().status).toBe(202);
+    expect(JSON.parse(sent().body)).toMatchObject({ disposition: 'installing' });
+    // The stale-target outcome now arrives on the install WS topic.
+    expect(await terminal).toMatchObject({ phase: 'error', code: 'failed_target_missing' });
     // Persisted transition
     const stored = await getProposal(tmpDir, 'proposal_model1');
     expect(stored?.status).toBe('failed_target_missing');
@@ -298,6 +314,7 @@ describe('POST /api/v1/proposals/:id/approve (model kind)', () => {
     const pool = fakePool({ install: { status: 'success', entry: POOLED, evicted: [] } });
     const poolEvents: Array<{ phase?: string; deferred?: string }> = [];
     bus.on('local-models:pool', (d) => poolEvents.push(d as { phase?: string; deferred?: string }));
+    const terminal = waitInstallTerminal(bus);
     const { req, res, sent } = makeReqRes('POST', '/api/v1/proposals/proposal_model_defer/approve');
     handleV1ProposalsRoute(req, res, {
       projectPath: tmpDir,
@@ -307,7 +324,8 @@ describe('POST /api/v1/proposals/:id/approve (model kind)', () => {
     });
     await settle();
 
-    expect(sent().status).toBe(200);
+    expect(sent().status).toBe(202);
+    await terminal;
     // Install applied; the in-use `replaces` was deferred, not evicted.
     expect(pool.installCalls).toBe(1);
     expect(pool.evictCalls).toBe(0);

--- a/packages/orchestrator/src/server/routes/v1/proposals.ts
+++ b/packages/orchestrator/src/server/routes/v1/proposals.ts
@@ -20,6 +20,7 @@ import { emitProposalApproved, emitProposalRejected } from '../../../proposals/e
 import {
   onApproveModelProposal,
   onRejectModelProposal,
+  makeInstallProgressForwarder,
   type ModelHandlerDeps,
   type ModelPoolOps,
 } from '../../../proposals/model-handlers';
@@ -180,6 +181,42 @@ async function handleApprove(
       });
       return;
     }
+    // `add`/`swap` approvals install the target — a multi-GB `ollama pull` that,
+    // awaited inline, blocks the response past the dashboard proxy's undici
+    // `headersTimeout` (~5 min) → a 502 and a permanently "Approving…" button
+    // (same root cause as the operator install route). Kick the pull off in the
+    // background, stream progress on `local-models:install`, and return
+    // `202 { disposition: 'installing' }` immediately. `evict` has no pull, so it
+    // stays synchronous.
+    const action = existing.model.action;
+    if (action === 'add' || action === 'swap') {
+      const { emit, onInstallEvent } = makeInstallProgressForwarder(deps.bus, {
+        proposalId: existing.id,
+        hfRepoId: existing.model.target.hfRepoId,
+        ollamaName: existing.model.target.ollamaName,
+      });
+      const handler: ModelHandlerDeps = { ...modelHandlerDeps(deps, req), onInstallEvent };
+      emit('started');
+      void onApproveModelProposal(handler, existing)
+        .then((outcome) => {
+          if (outcome.status === 'approved') {
+            emit('complete');
+          } else if (outcome.status === 'failed_target_missing') {
+            emit('error', {
+              code: 'failed_target_missing',
+              message: `${existing.model.target.hfRepoId} is no longer available on HuggingFace`,
+            });
+          } else {
+            emit('error', { code: outcome.code, message: outcome.message });
+          }
+        })
+        .catch((err: unknown) => {
+          emit('error', { message: err instanceof Error ? err.message : String(err) });
+        });
+      sendJSON(res, 202, { disposition: 'installing', proposalId: existing.id });
+      return;
+    }
+
     const outcome = await onApproveModelProposal(modelHandlerDeps(deps, req), existing);
     sendJSON(res, outcome.status === 'error' ? 422 : 200, outcome);
     return;

--- a/packages/orchestrator/tests/server/http.test.ts
+++ b/packages/orchestrator/tests/server/http.test.ts
@@ -256,10 +256,13 @@ describe('OrchestratorServer LMLM Phase 6 wiring', () => {
     await server.start();
 
     const res = await post(port, '/api/v1/proposals/proposal_model_live/approve');
-    // The 501 stub is retired: the request now reaches the pool handler (200 approved).
+    // The 501 stub is retired: the request reaches the pool handler. A swap/add
+    // approval installs the target asynchronously (the pull would otherwise block
+    // past the proxy headersTimeout), so it returns 202 { disposition:'installing' }
+    // and streams the outcome over the local-models:install WS topic.
     expect(res.statusCode).not.toBe(501);
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).status).toBe('approved');
+    expect(res.statusCode).toBe(202);
+    expect(JSON.parse(res.body).disposition).toBe('installing');
   });
 
   it('getModelPool absent → model approve still returns 501 (LMLM disabled)', async () => {

--- a/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
+++ b/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
@@ -14,11 +14,13 @@ import type {
   PoolState,
   RankedModel,
 } from '@harness-engineering/local-models';
+import type { ModelInstallEvent } from '@harness-engineering/types';
 import { listProposals } from '@harness-engineering/core';
 import {
   handleV1LocalModelsMutationRoute,
   type V1LocalModelsMutationDeps,
 } from '../../../../src/server/routes/v1/local-models-pool-mutation';
+import { MODEL_INSTALL_TOPIC } from '../../../../src/proposals/model-handlers';
 import { V1_BRIDGE_ROUTES } from '../../../../src/server/v1-bridge-routes';
 
 let tmpDir: string;
@@ -141,9 +143,33 @@ function deps(over: Partial<V1LocalModelsMutationDeps> = {}): V1LocalModelsMutat
   };
 }
 
+/**
+ * Collect the `local-models:install` frames a bus emits, exposing a promise that
+ * resolves on the terminal (`complete`/`error`) frame. Install is asynchronous —
+ * the route returns 202 before the background pull finishes — so tests await this
+ * to observe the eventual outcome that now rides the WS topic, not the response.
+ */
+function installFrames(bus: EventEmitter): {
+  frames: ModelInstallEvent[];
+  waitTerminal: () => Promise<ModelInstallEvent>;
+} {
+  const frames: ModelInstallEvent[] = [];
+  let resolve!: (f: ModelInstallEvent) => void;
+  const terminal = new Promise<ModelInstallEvent>((r) => {
+    resolve = r;
+  });
+  bus.on(MODEL_INSTALL_TOPIC, (f: ModelInstallEvent) => {
+    frames.push(f);
+    if (f.phase === 'complete' || f.phase === 'error') resolve(f);
+  });
+  return { frames, waitTerminal: () => terminal };
+}
+
 describe('POST /local-models/pool/install', () => {
-  it('installs an allow-listed recommendation and returns disposition:installed (SC1, SC8)', async () => {
-    const d = deps({ getModelPool: () => fakePool() });
+  it('returns 202 installing immediately, streams started→complete, and auto-approves the proposal (SC1, SC8)', async () => {
+    const bus = new EventEmitter();
+    const { frames, waitTerminal } = installFrames(bus);
+    const d = deps({ bus, getModelPool: () => fakePool() });
     const { res, body, statusCode, done } = makeRes();
     handleV1LocalModelsMutationRoute(
       makeReq('POST', '/api/v1/local-models/pool/install', {
@@ -153,12 +179,101 @@ describe('POST /local-models/pool/install', () => {
       d
     );
     await done;
-    expect(statusCode()).toBe(200);
-    expect(body()).toMatchObject({ disposition: 'installed' });
+    expect(statusCode()).toBe(202);
+    expect(body()).toMatchObject({ disposition: 'installing', evicted: [] });
+    const terminal = await waitTerminal();
+    expect(frames[0]).toMatchObject({
+      phase: 'started',
+      hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      ollamaName: 'qwen3:32b',
+    });
+    expect(terminal.phase).toBe('complete');
     // SC8: an auto-approved proposal was persisted for audit.
     const proposals = await listProposals(tmpDir, { kind: 'model' });
     expect(proposals).toHaveLength(1);
     expect(proposals[0]!.status).toBe('approved');
+  });
+
+  it('responds 202 WITHOUT awaiting the pull (regression: proxy headersTimeout 502)', async () => {
+    // The root cause of the observed `502 ... (cause: Headers Timeout Error)`:
+    // the route used to await the full multi-GB `ollama pull` before sending any
+    // response, so the dashboard proxy's undici `headersTimeout` (~5 min) fired.
+    // The route must now return before the pull resolves.
+    let releasePull!: () => void;
+    const pullGate = new Promise<void>((r) => {
+      releasePull = r;
+    });
+    let pullResolved = false;
+    const bus = new EventEmitter();
+    const { waitTerminal } = installFrames(bus);
+    const d = deps({
+      bus,
+      getModelPool: () =>
+        fakePool({
+          install: async (r) => {
+            await pullGate; // a long download that has NOT finished when we assert
+            pullResolved = true;
+            return {
+              status: 'success',
+              entry: { ...ENTRY, ollamaName: r.ollamaName },
+              evicted: [],
+            };
+          },
+        }),
+    });
+    const { res, body, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', { hfRepoId: 'Qwen/Qwen3-32B-GGUF' }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(202);
+    expect(body()).toMatchObject({ disposition: 'installing' });
+    expect(pullResolved).toBe(false); // response returned mid-pull — no headers timeout
+    releasePull();
+    await waitTerminal();
+    expect(pullResolved).toBe(true);
+  });
+
+  it('forwards installer byte progress as local-models:install progress frames (download bar)', async () => {
+    const bus = new EventEmitter();
+    const { frames, waitTerminal } = installFrames(bus);
+    const d = deps({
+      bus,
+      getModelPool: () =>
+        fakePool({
+          install: async (r) => {
+            r.onEvent?.({
+              kind: 'progress',
+              completedBytes: 500,
+              totalBytes: 1000,
+              message: 'pull',
+            });
+            return {
+              status: 'success',
+              entry: { ...ENTRY, ollamaName: r.ollamaName },
+              evicted: [],
+            };
+          },
+        }),
+    });
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', { hfRepoId: 'Qwen/Qwen3-32B-GGUF' }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(202);
+    await waitTerminal();
+    const progress = frames.find((f) => f.phase === 'progress');
+    expect(progress).toMatchObject({
+      completedBytes: 500,
+      totalBytes: 1000,
+      hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      ollamaName: 'qwen3:32b',
+    });
   });
 
   it('sizes the install from an estimate, never a pre-pull inspect (regression: install 404 target-missing)', async () => {
@@ -169,7 +284,10 @@ describe('POST /local-models/pool/install', () => {
     // fix hands the pool an estimated on-disk size so `install` is given a
     // concrete `sizeOnDiskGb` and the impossible pre-pull inspect never runs.
     let received: InstallPoolRequest | undefined;
+    const bus = new EventEmitter();
+    const { waitTerminal } = installFrames(bus);
     const d = deps({
+      bus,
       getModelPool: () =>
         fakePool({
           install: async (r) => {
@@ -191,12 +309,16 @@ describe('POST /local-models/pool/install', () => {
       d
     );
     await done;
-    expect(statusCode()).toBe(200);
+    expect(statusCode()).toBe(202);
+    await waitTerminal();
     expect(received?.sizeOnDiskGb).toBeGreaterThan(0);
   });
 
-  it('maps a budget_exceeded / not_allowed pool veto to 409 (SC2)', async () => {
+  it('streams an error frame carrying the pool veto code (budget_exceeded / not_allowed) (SC2)', async () => {
+    const bus = new EventEmitter();
+    const { waitTerminal } = installFrames(bus);
     const d = deps({
+      bus,
       getModelPool: () =>
         fakePool({
           install: async () => ({
@@ -207,7 +329,7 @@ describe('POST /local-models/pool/install', () => {
           }),
         }),
     });
-    const { res, body, statusCode, done } = makeRes();
+    const { res, statusCode, done } = makeRes();
     handleV1LocalModelsMutationRoute(
       makeReq('POST', '/api/v1/local-models/pool/install', {
         hfRepoId: 'Qwen/Qwen3-32B-GGUF',
@@ -216,8 +338,10 @@ describe('POST /local-models/pool/install', () => {
       d
     );
     await done;
-    expect(statusCode()).toBe(409);
-    expect(body()).toMatchObject({ code: 'budget_exceeded' });
+    // The pre-pull veto now surfaces over WS, not in the (already-sent 202) body.
+    expect(statusCode()).toBe(202);
+    const terminal = await waitTerminal();
+    expect(terminal).toMatchObject({ phase: 'error', code: 'budget_exceeded' });
   });
 
   it('returns 404 when no recommendation matches the hfRepoId (SC2)', async () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -303,6 +303,7 @@ export type {
   PoolRemoveRequest,
   PoolMutationDisposition,
   PoolMutationResult,
+  ModelInstallEvent,
 } from './local-models';
 
 // --- Plan task (parallel execution data model) ---

--- a/packages/types/src/local-models.ts
+++ b/packages/types/src/local-models.ts
@@ -108,8 +108,12 @@ export interface PoolRemoveRequest {
  * - `removed` — the member was evicted.
  * - `deferred` — the member is in use; eviction is marked pending and drained
  *   after the current run (never mid-request).
+ * - `installing` — the pull was kicked off in the background; the pool is not yet
+ *   mutated. Progress + the terminal outcome arrive on the `local-models:install`
+ *   WS topic (never in the HTTP response) so the request returns before undici's
+ *   proxy `headersTimeout` fires on a multi-GB download.
  */
-export type PoolMutationDisposition = 'installed' | 'removed' | 'deferred';
+export type PoolMutationDisposition = 'installed' | 'removed' | 'deferred' | 'installing';
 
 /** Response body for the install/remove convenience routes. */
 export interface PoolMutationResult {
@@ -120,4 +124,39 @@ export interface PoolMutationResult {
   evicted: string[];
   /** Human-readable note (e.g. the deferral explanation). */
   message?: string;
+}
+
+/**
+ * A single frame on the `local-models:install` WS topic, tracking one operator
+ * install from kickoff to terminal outcome. Because the install route returns
+ * `202` before the `ollama pull` finishes (D3 / async install), ALL install
+ * progress and the final result reach the dashboard here rather than in the HTTP
+ * response:
+ *
+ * - `started`  — the pull was accepted and kicked off (proposal created).
+ * - `progress` — a byte-count update from the installer's `/api/pull` stream;
+ *   `completedBytes`/`totalBytes` drive the progress bar.
+ * - `complete` — the pull succeeded and the pool now holds the model (a
+ *   `local-models:pool` refetch-delta fires alongside so the row flips to
+ *   "installed").
+ * - `error`    — the install failed (budget/allowlist/installer); `message` +
+ *   `code` explain why and the row surfaces them.
+ *
+ * `hfRepoId` is the client-facing correlation key (the Recommendations row keys on
+ * it); `ollamaName` is the resolved install target; `proposalId` ties back to the
+ * audit trail.
+ */
+export interface ModelInstallEvent {
+  proposalId: string;
+  hfRepoId: string;
+  ollamaName: string;
+  phase: 'started' | 'progress' | 'complete' | 'error';
+  /** Bytes pulled so far (`progress` frames only). */
+  completedBytes?: number;
+  /** Total bytes to pull, when the installer reports it (`progress` frames only). */
+  totalBytes?: number;
+  /** Installer status line (`progress`) or failure explanation (`error`). */
+  message?: string;
+  /** Stable failure code on `error` frames (e.g. `budget_exceeded`, `not_allowed`). */
+  code?: string;
 }


### PR DESCRIPTION
## Summary

Fixes the `502 Orchestrator proxy error: fetch failed (cause: Headers Timeout Error)` when installing a local model from the Recommendations panel, and adds the download **progress bar** + a **Refresh** button that were missing.

### Root cause (one cause, both symptoms)

`handleInstall` awaited the entire `ollama pull` **synchronously** before sending any HTTP response. A multi-GB pull far exceeds the dashboard reverse-proxy's undici default `headersTimeout` (~5 min), so the proxied `fetch()` aborted with `UND_ERR_HEADERS_TIMEOUT` → the observed 502. The same blocking design dropped the installer's already-emitted byte-progress events (`InstallEvent` / `onEvent` existed since Phase 3c but were never wired), so there was no download feedback.

### Fix — async install + WebSocket progress

- Install now validates + creates the proposal synchronously, kicks off the pull in the background, and returns **`202 { disposition: 'installing' }`** immediately (well under the proxy timeout).
- Byte progress + the terminal outcome stream on a **new `local-models:install` WS topic**, kept separate from the `local-models:pool` refetch-delta so per-byte frames don't trigger a refetch storm.
- The dashboard consumes them into `installProgress` (keyed by `hfRepoId`); the Recommendations row renders a **live download bar**, flips to "installed" on the pool refetch, or surfaces a **retryable error**.

### Also: Refresh button

The Recommendations panel gains a **Refresh** control that triggers a force-refresh tick (`POST /api/v1/local-models/refresh` → re-fetch HF + re-rank + reconcile) and refetches the panel. Hidden when LMLM is disabled; inline error on failure. Fast synchronous recompute — no `ollama pull`, so no async/202 needed.

### Contract change

Install outcomes that require running the pull (approved / budget / allowlist / failure) moved from the HTTP response to the `local-models:install` WS topic. The HTTP response now reports only **pre-pull** validation (400/404/422/503) and otherwise `202`. `/pool/remove` is unchanged.

## Testing

- **Regression test** (`local-models-pool-mutation.test.ts` → "responds 202 WITHOUT awaiting the pull"): gates an unresolved pull and asserts the 202 lands while it's still in flight — under the old synchronous model the test deadlocks. Plus progress-frame forwarding, error-frame, and the install-lifecycle/progress-bar/refresh tests on the hook and card.
- Verified locally: orchestrator server suite 258/258, dashboard 502/502 (+ new cases), typecheck + lint + build green across `types` / `orchestrator` / `dashboard`.

## Notes

- Plan doc: `docs/changes/local-model-lifecycle-manager/plans/2026-07-08-phase10-async-install-progress-plan.md` (resolves the Phase 8 D3 deferral).
- A pre-commit arch check flagged a small `module-size` baseline delta (+286 B on orchestrator) from the added feature code — baseline-relative, refreshed by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
