### PR TITLE
fix(lmlm): resilient model installs — resumable pulls, restart recovery, lineage scoring

### DIFF
--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -19,6 +19,14 @@ Error)` that a multi-GB pull triggered — the dashboard reverse-proxy's undici
 pull completed. The Recommendations panel now renders a live download progress bar
 and surfaces retryable install errors.
 
+Install now survives an orchestrator restart. A model add/swap approval marks its
+proposal `installing` (new `ModelProposalStatus`) for the duration of the pull; if
+the orchestrator goes down mid-download, startup finds the `installing` proposals
+and re-drives them — the `ollama pull` is idempotent, so it resumes from cached
+blobs (or no-ops if it already finished) and streams progress to a reconnecting
+dashboard. The status reverts to `open` on a retryable failure and the approve
+route rejects a re-approve while `installing`.
+
 Approving an `add`/`swap` model **proposal** (`POST /api/v1/proposals/:id/approve`)
 also installs the target, so it shares the same async treatment: it returns `202`
 and streams the download over `local-models:install`, and the Pending Proposals row

--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -35,6 +35,15 @@ enters the pool at `currentScore: 0` until its first re-rank, so diffing first
 produced phantom swap proposals justified as "replace a pool member scoring 0"
 (and inflated `scoreDelta`s). The tick now re-scores the pool before diffing.
 
+Wires the ranker's long-intended lineage interpolation: a candidate with no direct
+benchmark used to floor to `score: 0` while labelled `evidence: 'interpolated'` (a
+misnomer — nothing was interpolated), so real models like `Qwen/Qwen3-8B-GGUF`
+showed "score 0 · interpolated" and churned the pool once installed. The ranker now
+infers a score from same-series siblings by parameter count (linear in size, clamped
+to the measured range, dampened by `'low'` benchmark confidence so it never outranks
+a direct measurement of equal raw value); only a series with no measured sibling
+still scores 0.
+
 Adds resumable-pull resilience to `OllamaInstallAdapter` (new `maxPullRetries` /
 `pullRetryBackoffMs` / `pullRetryMaxBackoffMs` options; orchestrator opts in with
 5 retries). A multi-GB `ollama pull` that loses its `/api/pull` stream mid-download

--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -1,7 +1,7 @@
 ---
 '@harness-engineering/orchestrator': minor
 '@harness-engineering/dashboard': minor
-'@harness-engineering/local-models': patch
+'@harness-engineering/local-models': minor
 '@harness-engineering/types': minor
 ---
 
@@ -34,3 +34,12 @@ Fixes a refresh-tick ordering bug where the pool was diffed against the ranking
 enters the pool at `currentScore: 0` until its first re-rank, so diffing first
 produced phantom swap proposals justified as "replace a pool member scoring 0"
 (and inflated `scoreDelta`s). The tick now re-scores the pool before diffing.
+
+Adds resumable-pull resilience to `OllamaInstallAdapter` (new `maxPullRetries` /
+`pullRetryBackoffMs` / `pullRetryMaxBackoffMs` options; orchestrator opts in with
+5 retries). A multi-GB `ollama pull` that loses its `/api/pull` stream mid-download
+— most often the host sleeping mid-install — now re-issues the pull (ollama resumes
+from cached blobs) instead of dead-ending in an error. The failure budget is
+measured in consecutive non-progressing attempts, so any forward byte progress
+resets it and an install survives repeated sleep cycles as long as it keeps
+advancing; a canceled request or a genuinely-missing model still fails fast.

--- a/.changeset/lmlm-async-install-progress.md
+++ b/.changeset/lmlm-async-install-progress.md
@@ -1,7 +1,7 @@
 ---
 '@harness-engineering/orchestrator': minor
 '@harness-engineering/dashboard': minor
-'@harness-engineering/local-models': minor
+'@harness-engineering/local-models': patch
 '@harness-engineering/types': minor
 ---
 
@@ -19,14 +19,6 @@ Error)` that a multi-GB pull triggered — the dashboard reverse-proxy's undici
 pull completed. The Recommendations panel now renders a live download progress bar
 and surfaces retryable install errors.
 
-Install now survives an orchestrator restart. A model add/swap approval marks its
-proposal `installing` (new `ModelProposalStatus`) for the duration of the pull; if
-the orchestrator goes down mid-download, startup finds the `installing` proposals
-and re-drives them — the `ollama pull` is idempotent, so it resumes from cached
-blobs (or no-ops if it already finished) and streams progress to a reconnecting
-dashboard. The status reverts to `open` on a retryable failure and the approve
-route rejects a re-approve while `installing`.
-
 Approving an `add`/`swap` model **proposal** (`POST /api/v1/proposals/:id/approve`)
 also installs the target, so it shares the same async treatment: it returns `202`
 and streams the download over `local-models:install`, and the Pending Proposals row
@@ -42,21 +34,3 @@ Fixes a refresh-tick ordering bug where the pool was diffed against the ranking
 enters the pool at `currentScore: 0` until its first re-rank, so diffing first
 produced phantom swap proposals justified as "replace a pool member scoring 0"
 (and inflated `scoreDelta`s). The tick now re-scores the pool before diffing.
-
-Wires the ranker's long-intended lineage interpolation: a candidate with no direct
-benchmark used to floor to `score: 0` while labelled `evidence: 'interpolated'` (a
-misnomer — nothing was interpolated), so real models like `Qwen/Qwen3-8B-GGUF`
-showed "score 0 · interpolated" and churned the pool once installed. The ranker now
-infers a score from same-series siblings by parameter count (linear in size, clamped
-to the measured range, dampened by `'low'` benchmark confidence so it never outranks
-a direct measurement of equal raw value); only a series with no measured sibling
-still scores 0.
-
-Adds resumable-pull resilience to `OllamaInstallAdapter` (new `maxPullRetries` /
-`pullRetryBackoffMs` / `pullRetryMaxBackoffMs` options; orchestrator opts in with
-5 retries). A multi-GB `ollama pull` that loses its `/api/pull` stream mid-download
-— most often the host sleeping mid-install — now re-issues the pull (ollama resumes
-from cached blobs) instead of dead-ending in an error. The failure budget is
-measured in consecutive non-progressing attempts, so any forward byte progress
-resets it and an install survives repeated sleep cycles as long as it keeps
-advancing; a canceled request or a genuinely-missing model still fails fast.

--- a/.changeset/lmlm-install-resilience.md
+++ b/.changeset/lmlm-install-resilience.md
@@ -1,0 +1,33 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/local-models': minor
+'@harness-engineering/types': minor
+---
+
+fix(lmlm): resilient model installs — resumable pulls, restart recovery, and lineage scoring
+
+Three follow-ups to the async operator install (#775):
+
+- **Resumable pulls.** `OllamaInstallAdapter` gains opt-in retry-with-resume
+  (`maxPullRetries` / `pullRetryBackoffMs` / `pullRetryMaxBackoffMs`; the
+  orchestrator enables 5). A multi-GB `ollama pull` that loses its `/api/pull`
+  stream mid-download — most often the host sleeping mid-install — re-issues the
+  pull (ollama resumes from cached blobs) instead of dead-ending in an error. The
+  budget counts consecutive non-progressing attempts, so any forward byte progress
+  resets it; a canceled request or a missing model still fails fast.
+
+- **Restart recovery.** A model add/swap approval marks its proposal `installing`
+  (new `ModelProposalStatus`) for the duration of the pull. If the orchestrator
+  restarts mid-download, startup finds the `installing` proposals and re-drives them
+  — `onApproveModelProposal` is idempotent, so ollama resumes the pull (or no-ops if
+  it already finished) and progress streams to a reconnecting dashboard. The status
+  reverts to `open` on a retryable failure, and the approve route rejects a
+  re-approve while `installing`.
+
+- **Lineage score interpolation.** A candidate with no direct benchmark used to
+  floor to `score: 0` while labelled `evidence: 'interpolated'` (a misnomer), so real
+  models like `Qwen/Qwen3-8B-GGUF` showed "score 0 · interpolated" and churned the
+  pool once installed. The ranker now infers a score from same-series siblings by
+  parameter count (linear in size, clamped to the measured range, dampened by `'low'`
+  benchmark confidence so it never outranks a direct measurement); only a series with
+  no measured sibling still scores 0.

--- a/packages/local-models/src/installer/ollama.ts
+++ b/packages/local-models/src/installer/ollama.ts
@@ -52,6 +52,26 @@ export interface OllamaInstallAdapterOptions {
   timeoutMs?: number;
   /** Optional structured logger; defaults to a silent no-op. */
   onWarn?: (message: string, cause?: unknown) => void;
+  /**
+   * Resumable-pull resilience. A multi-GB `ollama pull` can lose its `/api/pull`
+   * stream mid-download (most commonly a laptop sleeping mid-install). Ollama
+   * caches partial blobs, so re-issuing `/api/pull` RESUMES rather than restarts.
+   * This is the number of consecutive **non-progressing** pull failures to retry
+   * before giving up. An attempt that advances the byte count resets the counter,
+   * so a pull survives arbitrarily many transient drops as long as it keeps making
+   * progress — a stall that never advances still terminates after this many tries.
+   * Defaults to `0` (no retries); the orchestrator opts in.
+   */
+  maxPullRetries?: number;
+  /**
+   * Base backoff before the first retry, doubled per consecutive failure and
+   * capped at {@link OllamaInstallAdapterOptions.pullRetryMaxBackoffMs}. Defaults
+   * to 1000ms. (While the host is asleep the timer is frozen, so the retry fires
+   * on wake and resumes.)
+   */
+  pullRetryBackoffMs?: number;
+  /** Upper bound on the exponential retry backoff. Defaults to 30000ms. */
+  pullRetryMaxBackoffMs?: number;
 }
 
 /**
@@ -183,15 +203,77 @@ export class OllamaInstallAdapter implements InstallAdapter {
   private readonly fetcher: InstallerFetcher;
   private readonly timeoutMs: number;
   private readonly onWarn: (message: string, cause?: unknown) => void;
+  private readonly maxPullRetries: number;
+  private readonly pullRetryBackoffMs: number;
+  private readonly pullRetryMaxBackoffMs: number;
 
   constructor(options: OllamaInstallAdapterOptions = {}) {
     this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
     this.fetcher = options.fetcher ?? defaultFetcher();
     this.timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.onWarn = options.onWarn ?? (() => undefined);
+    this.maxPullRetries = Math.max(0, options.maxPullRetries ?? 0);
+    this.pullRetryBackoffMs = options.pullRetryBackoffMs ?? 1000;
+    this.pullRetryMaxBackoffMs = options.pullRetryMaxBackoffMs ?? 30_000;
   }
 
+  /**
+   * Install with resumable-pull resilience. Delegates to {@link attemptPull} and,
+   * when `maxPullRetries > 0`, re-issues `/api/pull` on a transient failure —
+   * ollama resumes from cached blobs. The failure budget is measured in
+   * CONSECUTIVE NON-PROGRESSING attempts: any forward byte progress resets it, so
+   * an install being nibbled through by repeated sleep-drops keeps going, while a
+   * genuinely stuck pull still terminates. A canceled request (`signal`) and a
+   * `failed_target_missing` (the model does not exist upstream) are terminal — no
+   * retry.
+   */
   async install(request: InstallRequest): Promise<InstallResult> {
+    if (this.maxPullRetries <= 0) return this.attemptPull(request);
+
+    // Track the high-water byte mark across attempts (forwarding every event to
+    // the caller unchanged). An attempt that pushes it higher "made progress".
+    let maxCompleted = 0;
+    const tracked: InstallRequest = {
+      ...request,
+      onEvent: (event) => {
+        if (event.kind === 'progress' && event.completedBytes > maxCompleted) {
+          maxCompleted = event.completedBytes;
+        }
+        request.onEvent?.(event);
+      },
+    };
+
+    let failuresSinceProgress = 0;
+    for (let attempt = 1; ; attempt++) {
+      const completedBefore = maxCompleted;
+      const result = await this.attemptPull(tracked);
+      if (result.status === 'success') return result;
+      // Terminal, non-resumable outcomes.
+      if (request.signal?.aborted) return result;
+      if (result.code === 'failed_target_missing') return result;
+
+      const madeProgress = maxCompleted > completedBefore;
+      failuresSinceProgress = madeProgress ? 0 : failuresSinceProgress + 1;
+      if (failuresSinceProgress > this.maxPullRetries) return result;
+
+      const backoffMs = Math.min(
+        this.pullRetryBackoffMs * 2 ** (failuresSinceProgress - 1),
+        this.pullRetryMaxBackoffMs
+      );
+      safeEmit(
+        request.onEvent,
+        {
+          kind: 'pulling',
+          message: `pull interrupted (${result.message}); resuming (retry ${attempt})`,
+        },
+        this.onWarn
+      );
+      if (await this.abortableDelay(backoffMs, request.signal)) return result;
+    }
+  }
+
+  /** One `/api/pull` attempt: open the stream, drive it to success or a stable error. */
+  private async attemptPull(request: InstallRequest): Promise<InstallResult> {
     const url = `${this.baseUrl}/api/pull`;
     let response: InstallerFetchResponse;
     try {
@@ -463,6 +545,26 @@ export class OllamaInstallAdapter implements InstallAdapter {
       clearTimeout(timer);
       if (externalSignal) externalSignal.removeEventListener('abort', onAbort);
     }
+  }
+
+  /**
+   * Sleep `ms`, resolving `true` if `signal` aborts during the wait (so the retry
+   * loop bails instead of resuming a canceled install) and `false` if the delay
+   * elapses. On a sleeping host the timer is frozen and fires on wake.
+   */
+  private abortableDelay(ms: number, signal?: AbortSignal): Promise<boolean> {
+    if (signal?.aborted) return Promise.resolve(true);
+    return new Promise<boolean>((resolve) => {
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve(true);
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve(false);
+      }, ms);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 }
 

--- a/packages/local-models/src/ranker/algorithm.ts
+++ b/packages/local-models/src/ranker/algorithm.ts
@@ -37,6 +37,12 @@
 
 import { mergeBenchmarks } from './benchmarks/merge.js';
 import type { BenchmarkEvidence, BenchmarkObservation } from './benchmarks/types.js';
+import {
+  buildSeriesScores,
+  interpolateBySize,
+  seriesKey,
+  type SeriesPoint,
+} from './interpolate.js';
 import { estimateSpeed, type SpeedEstimate } from './speed.js';
 import { estimateVram, type VramEstimate } from './vram.js';
 import type {
@@ -114,9 +120,12 @@ export function rankModels(input: RankInput): RankResult {
   }
 
   const observationsByRepo = indexObservationsByRepo(input);
+  // Group measured siblings by model series so an un-benchmarked candidate can
+  // borrow a size-interpolated score instead of flooring to 0 (see interpolate.ts).
+  const seriesScores = buildSeriesScores(input.snapshot, snapshotDate);
 
   const scored = input.candidates.map((candidate) =>
-    scoreCandidate(candidate, input, observationsByRepo, snapshotDate)
+    scoreCandidate(candidate, input, observationsByRepo, snapshotDate, seriesScores)
   );
 
   const filtered = input.options?.includeUnfit ? scored : scored.filter((m) => m.fitsHardware);
@@ -170,7 +179,8 @@ function scoreCandidate(
   candidate: RankerCandidate,
   input: RankInput,
   observationsByRepo: Map<string, BenchmarkObservation[]>,
-  snapshotDate: string
+  snapshotDate: string,
+  seriesScores: Map<string, SeriesPoint[]>
 ): RankedModel {
   const vramEstimate = computeVram(candidate, input);
   const speedEstimate = computeSpeed(candidate, input, vramEstimate);
@@ -182,12 +192,31 @@ function scoreCandidate(
   });
 
   const fitsHardware = vramEstimate.totalGb <= input.hardware.vramGb;
-  const evidence = weakestEvidence(benchmarkScore.contributions.map((c) => c.observation.evidence));
+
+  // Direct evidence when the model was measured; otherwise try to infer a score
+  // from same-series siblings (marked `interpolated` + `low` confidence so the
+  // ×0.6 multiplier keeps it below a real measurement of equal raw value). Only
+  // when no sibling exists does the score honestly stay 0.
+  let mergedScore = benchmarkScore.score;
+  let benchmarkConfidence = benchmarkScore.confidence;
+  let evidence = weakestEvidence(benchmarkScore.contributions.map((c) => c.observation.evidence));
+  if (observations.length === 0) {
+    const inferred = interpolateBySize(
+      seriesScores.get(seriesKey(candidate.hfRepoId)) ?? [],
+      candidate.sizeB
+    );
+    if (inferred !== undefined) {
+      mergedScore = inferred;
+      benchmarkConfidence = 'low';
+      evidence = 'interpolated';
+    }
+  }
+
   const score = scaleScore({
-    mergedScore: benchmarkScore.score,
+    mergedScore,
     fitsHardware,
     speedConfidence: speedEstimate.confidence,
-    benchmarkConfidence: benchmarkScore.confidence,
+    benchmarkConfidence,
   });
 
   return assembleRankedModel({

--- a/packages/local-models/src/ranker/interpolate.ts
+++ b/packages/local-models/src/ranker/interpolate.ts
@@ -1,0 +1,111 @@
+/**
+ * Lineage score interpolation (finishes the `interpolated` evidence grade).
+ *
+ * A candidate with NO direct benchmark observation for its exact `hfRepoId` used
+ * to merge to `score: 0` and floor to `evidence: 'interpolated'` — a misnomer,
+ * since nothing was actually interpolated. The result was real models (e.g.
+ * `Qwen/Qwen3-8B-GGUF`) shown as "score 0 · interpolated" and, once pooled,
+ * churned by the diff engine (any candidate "beats" a 0).
+ *
+ * This module supplies the missing interpolation: it groups the benchmark
+ * snapshot by model *series* (family, size-agnostic) and, for an un-benchmarked
+ * candidate, infers a merged score from same-series siblings by parameter count.
+ * Interpolated scores are marked `evidence: 'interpolated'` and carry `'low'`
+ * benchmark confidence, so the ×0.6 confidence multiplier dampens them — an
+ * inferred score never outranks a directly-measured one of equal raw value.
+ *
+ * The curve is deliberately simple and data-bounded (no magic exponents): linear
+ * in `sizeB` between the two bracketing siblings, clamped to the known score
+ * range outside it (never invents a score higher than any measured sibling). A
+ * single sibling is scaled down linearly for a smaller target and held for a
+ * larger one. When a series has no benchmarked sibling at all, the score stays 0
+ * (honestly unknown) rather than fabricated.
+ */
+
+import { mergeBenchmarks } from './benchmarks/merge.js';
+import type { BenchmarkSnapshot } from './benchmarks/types.js';
+
+/** One known (size, score) point within a model series. */
+export interface SeriesPoint {
+  sizeB: number;
+  score: number;
+}
+
+/**
+ * Normalize an `hfRepoId` to a size-agnostic series key so every size of one
+ * model line collapses together (`Qwen/Qwen3-8B-GGUF` and `Qwen/Qwen3-32B-GGUF`
+ * → `qwen-qwen3`). Deriving the key the same way for candidates and snapshot
+ * models keeps the two sides consistent without the candidate needing a `family`.
+ */
+export function seriesKey(hfRepoId: string): string {
+  return hfRepoId
+    .toLowerCase()
+    .replace(/[-_/]?\d+(?:\.\d+)?b\b/g, '') // drop parameter-size tokens: -8b, 70b, 1.5b
+    .replace(/[-_]?gguf\b/g, '') // drop the GGUF format suffix
+    .replace(/[-_/\s]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Merged benchmark score per known model, grouped by {@link seriesKey} and sorted
+ * ascending by `sizeB`. Models with no observations (or a non-positive merged
+ * score) are skipped — only real, measured siblings anchor the interpolation.
+ */
+export function buildSeriesScores(
+  snapshot: BenchmarkSnapshot,
+  snapshotDate: string
+): Map<string, SeriesPoint[]> {
+  const bySeries = new Map<string, SeriesPoint[]>();
+  for (const model of snapshot.models) {
+    if (model.observations.length === 0) continue;
+    const merged = mergeBenchmarks({
+      observations: [...model.observations],
+      target: { model: model.hfRepoId, quant: '' },
+      snapshotDate,
+    });
+    if (merged.score <= 0) continue;
+    const key = seriesKey(model.hfRepoId);
+    const points = bySeries.get(key) ?? [];
+    points.push({ sizeB: model.sizeB, score: merged.score });
+    bySeries.set(key, points);
+  }
+  for (const points of bySeries.values()) points.sort((a, b) => a.sizeB - b.sizeB);
+  return bySeries;
+}
+
+/** Linear interpolation of score between two points at parameter count `x`. */
+function lerp(a: SeriesPoint, b: SeriesPoint, x: number): number {
+  if (b.sizeB === a.sizeB) return (a.score + b.score) / 2;
+  const t = (x - a.sizeB) / (b.sizeB - a.sizeB);
+  return a.score + t * (b.score - a.score);
+}
+
+/**
+ * Infer a benchmark score for `targetSizeB` from same-series known points.
+ * Returns `undefined` when the series has no measured sibling (score stays 0 /
+ * unknown upstream). See the module header for the (deliberately simple) curve.
+ */
+export function interpolateBySize(
+  points: readonly SeriesPoint[],
+  targetSizeB: number
+): number | undefined {
+  if (points.length === 0) return undefined;
+  if (points.length === 1) {
+    const only = points[0]!;
+    // No trend from a single point: hold the score for an equal-or-larger target,
+    // scale down proportionally for a smaller one (bigger models score higher).
+    return targetSizeB >= only.sizeB ? only.score : only.score * (targetSizeB / only.sizeB);
+  }
+  const first = points[0]!;
+  const last = points[points.length - 1]!;
+  // Below the smallest measured size: extrapolate down the first segment (floored
+  // at 0). Above the largest: clamp — never invent a score above a real sibling.
+  if (targetSizeB <= first.sizeB) return Math.max(0, lerp(first, points[1]!, targetSizeB));
+  if (targetSizeB >= last.sizeB) return last.score;
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i]!;
+    const b = points[i + 1]!;
+    if (targetSizeB >= a.sizeB && targetSizeB <= b.sizeB) return lerp(a, b, targetSizeB);
+  }
+  return last.score; // unreachable given the bounds above
+}

--- a/packages/local-models/tests/installer/ollama.test.ts
+++ b/packages/local-models/tests/installer/ollama.test.ts
@@ -208,6 +208,113 @@ describe('OllamaInstallAdapter.install', () => {
   });
 });
 
+describe('OllamaInstallAdapter.install (resumable retries)', () => {
+  /** A stream that yields `lines` then throws mid-iteration (a dropped socket). */
+  function droppingResponse(lines: string[]): InstallerFetchResponse {
+    return {
+      status: 200,
+      json: async () => {
+        throw new Error('streaming');
+      },
+      text: async () => lines.join('\n'),
+      body: {
+        async *[Symbol.asyncIterator]() {
+          for (const line of lines) yield line;
+          throw new Error('socket hang up');
+        },
+      },
+    };
+  }
+
+  it('resumes after a mid-stream drop and succeeds (re-issues /api/pull)', async () => {
+    let call = 0;
+    const { fetcher, calls } = makeFetcher(() => {
+      call += 1;
+      // Attempt 1 makes progress then drops; attempt 2 resumes to success.
+      return call === 1
+        ? droppingResponse(['{"status":"downloading","completed":50,"total":100}'])
+        : streamingResponse(200, [
+            '{"status":"downloading","completed":100,"total":100}',
+            '{"status":"success"}',
+          ]);
+    });
+    const adapter = new OllamaInstallAdapter({ fetcher, maxPullRetries: 3, pullRetryBackoffMs: 0 });
+
+    const events: InstallEvent[] = [];
+    const result = await adapter.install({ name: 'qwen3:32b', onEvent: (e) => events.push(e) });
+
+    expect(result).toEqual({ status: 'success', name: 'qwen3:32b' });
+    expect(calls).toHaveLength(2); // one resume
+    // The operator sees a "resuming" pulling event between the two attempts.
+    expect(events.some((e) => e.kind === 'pulling' && /resuming/.test(e.message))).toBe(true);
+  });
+
+  it('forward progress resets the failure budget → survives more drops than maxPullRetries', async () => {
+    let call = 0;
+    const { fetcher, calls } = makeFetcher(() => {
+      call += 1;
+      // Each attempt advances by 20 bytes then drops, until the 5th reaches success.
+      if (call < 5) {
+        return droppingResponse([`{"status":"downloading","completed":${call * 20},"total":100}`]);
+      }
+      return streamingResponse(200, [
+        '{"status":"downloading","completed":100,"total":100}',
+        '{"status":"success"}',
+      ]);
+    });
+    // maxPullRetries=2 would cap at 3 attempts WITHOUT the progress reset; because
+    // each attempt advances the byte count, the budget keeps resetting.
+    const adapter = new OllamaInstallAdapter({ fetcher, maxPullRetries: 2, pullRetryBackoffMs: 0 });
+
+    const result = await adapter.install({ name: 'qwen3:32b' });
+
+    expect(result.status).toBe('success');
+    expect(calls).toHaveLength(5);
+  });
+
+  it('gives up after maxPullRetries consecutive NON-progressing failures', async () => {
+    // Every attempt drops immediately with no byte progress → the budget is never
+    // reset, so it terminates after 1 + maxPullRetries attempts.
+    const { fetcher, calls } = makeFetcher(() =>
+      droppingResponse(['{"status":"pulling manifest"}'])
+    );
+    const adapter = new OllamaInstallAdapter({ fetcher, maxPullRetries: 2, pullRetryBackoffMs: 0 });
+
+    const result = await adapter.install({ name: 'qwen3:32b' });
+
+    expect(result.status).toBe('error');
+    if (result.status === 'error') expect(result.code).toBe('install_failed');
+    expect(calls).toHaveLength(3); // initial + 2 retries
+  });
+
+  it('does not retry a failed_target_missing (the model does not exist upstream)', async () => {
+    const { fetcher, calls } = makeFetcher(() => textResponse(404, 'not found'));
+    const adapter = new OllamaInstallAdapter({ fetcher, maxPullRetries: 3, pullRetryBackoffMs: 0 });
+
+    const result = await adapter.install({ name: 'ghost:1b' });
+
+    expect(result.status).toBe('error');
+    if (result.status === 'error') expect(result.code).toBe('failed_target_missing');
+    expect(calls).toHaveLength(1); // no retry
+  });
+
+  it('does not retry once the caller aborts', async () => {
+    const controller = new AbortController();
+    let call = 0;
+    const { fetcher, calls } = makeFetcher(() => {
+      call += 1;
+      controller.abort(); // cancel as soon as the first attempt starts
+      return droppingResponse(['{"status":"downloading","completed":10,"total":100}']);
+    });
+    const adapter = new OllamaInstallAdapter({ fetcher, maxPullRetries: 3, pullRetryBackoffMs: 0 });
+
+    const result = await adapter.install({ name: 'qwen3:32b', signal: controller.signal });
+
+    expect(result.status).toBe('error');
+    expect(calls).toHaveLength(1); // aborted → no resume
+  });
+});
+
 describe('OllamaInstallAdapter.evict', () => {
   it('issues DELETE /api/delete and resolves success on 200', async () => {
     const { fetcher, calls } = makeFetcher(() => jsonResponse(200, {}));

--- a/packages/local-models/tests/ranker/algorithm.test.ts
+++ b/packages/local-models/tests/ranker/algorithm.test.ts
@@ -356,6 +356,35 @@ describe('rankModels — empty input (OT6)', () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]?.code).toBe('snapshot_unavailable');
   });
+
+  it('interpolates a score for an un-benchmarked candidate from a same-series sibling', () => {
+    // The reported bug: Qwen3-8B (no direct benchmark) showed "score 0 · interpolated".
+    // With a measured Qwen3-32B sibling it now gets a real, size-scaled score below
+    // the 32B's — never a bogus 0 — and is honestly labelled `interpolated`.
+    const qwen8b: RankerCandidate = {
+      hfRepoId: 'Qwen/Qwen3-8B-GGUF',
+      ollamaName: 'qwen3:8b',
+      sizeB: 8,
+      quant: 'Q4_K_M',
+    };
+    const snapshot = buildSnapshot([
+      {
+        hfRepoId: QWEN_32B.hfRepoId,
+        family: 'qwen3',
+        sizeB: QWEN_32B.sizeB,
+        observations: [freshDirectObservation(80)],
+      },
+    ]);
+    const result = rankModels({ candidates: [QWEN_32B, qwen8b], hardware: M3_MAX_36GB, snapshot });
+
+    const big = result.ranked.find((r) => r.hfRepoId === QWEN_32B.hfRepoId);
+    const small = result.ranked.find((r) => r.hfRepoId === qwen8b.hfRepoId);
+    expect(small?.evidence).toBe('interpolated');
+    expect(small?.score).toBeGreaterThan(0); // no longer a phantom 0
+    expect(big?.evidence).toBe('direct');
+    // A dampened, size-scaled inference stays below the directly-measured sibling.
+    expect(small?.score).toBeLessThan(big?.score ?? Infinity);
+  });
 });
 
 describe('rankModels — deterministic tie-break (OT7)', () => {

--- a/packages/local-models/tests/ranker/interpolate.test.ts
+++ b/packages/local-models/tests/ranker/interpolate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSeriesScores,
+  interpolateBySize,
+  seriesKey,
+  type SeriesPoint,
+} from '../../src/ranker/interpolate.js';
+import type { BenchmarkSnapshot } from '../../src/ranker/benchmarks/types.js';
+
+describe('seriesKey', () => {
+  it('collapses every size of a model line to one key', () => {
+    expect(seriesKey('Qwen/Qwen3-8B-GGUF')).toBe(seriesKey('Qwen/Qwen3-32B-GGUF'));
+    expect(seriesKey('deepseek-ai/DeepSeek-R1-Distill-Qwen-14B-GGUF')).toBe(
+      seriesKey('deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-GGUF')
+    );
+  });
+
+  it('keeps distinct model lines apart', () => {
+    expect(seriesKey('Qwen/Qwen3-8B-GGUF')).not.toBe(
+      seriesKey('deepseek-ai/DeepSeek-R1-Distill-Qwen-8B-GGUF')
+    );
+  });
+
+  it('does not strip a non-parameter numeric like the "3" in Qwen3 or "R1"', () => {
+    expect(seriesKey('Qwen/Qwen3-8B-GGUF')).toContain('qwen3');
+    expect(seriesKey('deepseek-ai/DeepSeek-R1-Distill-Qwen-14B-GGUF')).toContain('r1');
+  });
+});
+
+describe('interpolateBySize', () => {
+  const points: SeriesPoint[] = [
+    { sizeB: 8, score: 40 },
+    { sizeB: 32, score: 60 },
+    { sizeB: 70, score: 72 },
+  ];
+
+  it('returns undefined when there is no sibling', () => {
+    expect(interpolateBySize([], 8)).toBeUndefined();
+  });
+
+  it('linearly interpolates between bracketing siblings', () => {
+    // Halfway (in size) between 8→32 is 20 → halfway between 40 and 60 = 50.
+    expect(interpolateBySize(points, 20)).toBe(50);
+  });
+
+  it('clamps to the largest measured score above the range (never invents higher)', () => {
+    expect(interpolateBySize(points, 200)).toBe(72);
+  });
+
+  it('extrapolates downward below the smallest size, floored at 0', () => {
+    const two: SeriesPoint[] = [
+      { sizeB: 8, score: 40 },
+      { sizeB: 32, score: 60 },
+    ];
+    // Slope 20/24 per B; at size 2 → 40 - 6*(20/24) = 35.
+    expect(interpolateBySize(two, 2)).toBeCloseTo(35, 5);
+    expect(interpolateBySize(two, 0)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('scales a single sibling down for a smaller target and holds it for a larger one', () => {
+    const one: SeriesPoint[] = [{ sizeB: 32, score: 60 }];
+    expect(interpolateBySize(one, 8)).toBeCloseTo(60 * (8 / 32), 5); // 15
+    expect(interpolateBySize(one, 70)).toBe(60); // no upward invention
+  });
+});
+
+describe('buildSeriesScores', () => {
+  function snapshot(models: BenchmarkSnapshot['models']): BenchmarkSnapshot {
+    return { version: 1, generatedAt: '2026-05-28', source: 'seed', models };
+  }
+  const obs = (value: number) => ({
+    source: 'open-llm-leaderboard',
+    benchmark: 'mmlu-pro',
+    value,
+    evidence: 'direct' as const,
+    observedAt: '2026-05-01',
+  });
+
+  it('groups measured models by series, sorted by size, skipping unobserved ones', () => {
+    const map = buildSeriesScores(
+      snapshot([
+        { hfRepoId: 'Qwen/Qwen3-32B-GGUF', family: 'qwen3', sizeB: 32, observations: [obs(60)] },
+        { hfRepoId: 'Qwen/Qwen3-8B-GGUF', family: 'qwen3', sizeB: 8, observations: [obs(40)] },
+        { hfRepoId: 'Qwen/Qwen3-14B-GGUF', family: 'qwen3', sizeB: 14, observations: [] }, // skipped
+      ]),
+      '2026-05-28'
+    );
+    const qwen = map.get(seriesKey('Qwen/Qwen3-8B-GGUF'));
+    expect(qwen?.map((p) => p.sizeB)).toEqual([8, 32]); // sorted, 14B (no obs) omitted
+    expect(qwen?.[0]?.score).toBeGreaterThan(0);
+  });
+});

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2099,6 +2099,11 @@ export class Orchestrator extends EventEmitter {
     this.modelInstaller = new OllamaInstallAdapter({
       baseUrl: installerCfg?.ollamaEndpoint ?? 'http://localhost:11434',
       onWarn,
+      // Survive transient `/api/pull` drops (most often the host sleeping mid
+      // multi-GB download): ollama resumes from cached blobs, and any forward
+      // progress resets the budget, so an install nibbled through across several
+      // sleep cycles still completes instead of dead-ending in an error.
+      maxPullRetries: 5,
     });
     this.modelPool = new PoolManager({ store, installer: this.modelInstaller, onWarn });
   }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -52,7 +52,9 @@ import type {
   HardwareProfile,
   SchedulerTimerHandle,
 } from '@harness-engineering/local-models';
-import { createModelProposal, listProposals } from '@harness-engineering/core';
+import { createModelProposal, listProposals, updateProposal } from '@harness-engineering/core';
+import { redriveInstallingProposals } from './proposals/model-handlers';
+import type { ModelProposalRecord } from '@harness-engineering/types';
 import { migrateAgentConfig } from './agent/config-migration';
 import { OrchestratorBackendFactory } from './agent/orchestrator-backend-factory';
 import { makeBackendResolver } from './agent/backend-resolver';
@@ -2109,6 +2111,47 @@ export class Orchestrator extends EventEmitter {
   }
 
   /**
+   * Resume installs interrupted by a restart. A proposal left `installing` had
+   * its background `ollama pull` cut short when the orchestrator went down; the
+   * pull is idempotent (ollama resumes from cached blobs), so we re-drive it.
+   * Fire-and-forget with its own error isolation — a resumed multi-GB download
+   * must not block startup, and a re-drive failure only logs.
+   */
+  private redriveInterruptedInstalls(): void {
+    const pool = this.modelPool;
+    if (pool === null) return;
+    void (async () => {
+      try {
+        // `listProposals` only filters on the shared skill-status enum, so filter
+        // the model-only `installing` status here.
+        const modelProposals = (await listProposals(this.projectRoot, {
+          kind: 'model',
+        })) as ModelProposalRecord[];
+        const installing = modelProposals.filter((p) => p.status === 'installing');
+        if (installing.length === 0) return;
+        this.logger.info(`Resuming ${installing.length} model install(s) interrupted by a restart`);
+        await redriveInstallingProposals(
+          {
+            pool,
+            bus: this,
+            updateProposal: (id, patch) =>
+              updateProposal(this.projectRoot, id, patch as Parameters<typeof updateProposal>[2]),
+            decidedBy: 'orchestrator',
+            isModelInUse: (name) => this.isLocalModelInUse(name),
+          },
+          installing,
+          {
+            onWarn: (message, cause) =>
+              this.logger.warn(message, cause !== undefined ? { cause } : undefined),
+          }
+        );
+      } catch (err) {
+        this.logger.warn('interrupted-install re-drive failed', { cause: err });
+      }
+    })();
+  }
+
+  /**
    * LMLM Phase 7 wiring: apply the operator's configured pool bounds (disk
    * budget + org/family allowlist) from `localModels.pool` to the live pool.
    * Called after `PoolStateStore.load()` so config wins over persisted bounds
@@ -2282,6 +2325,10 @@ export class Orchestrator extends EventEmitter {
         // is `diskBudgetGb: 0, allowedOrgs: []`, which would otherwise block
         // every install and leave the dashboard pool card at "0 / 0 GB".
         await this.applyConfiguredPoolBounds();
+        // Resume any install whose background pull was cut short by a restart
+        // (proposal left `installing`). Fire-and-forget — a large resumed pull
+        // must not block startup.
+        this.redriveInterruptedInstalls();
       }
       for (const resolver of this.localResolvers.values()) {
         await resolver.start();

--- a/packages/orchestrator/src/proposals/model-handlers.ts
+++ b/packages/orchestrator/src/proposals/model-handlers.ts
@@ -228,6 +228,12 @@ export async function onApproveModelProposal(
   }
 
   // `add` and `swap` both install the target first.
+  // Mark the proposal `installing` BEFORE the pull so the intent is durable: if
+  // the orchestrator restarts mid-`ollama pull`, startup finds this record and
+  // re-drives the (idempotent) install instead of losing it. Cleared to
+  // `approved` on success or reverted to `open` on a retryable failure below.
+  await deps.updateProposal(proposal.id, { status: 'installing' });
+
   // The proposal carries only a score *delta*, not an absolute score; the new
   // pool entry starts at 0 and the scheduler's next re-rank sets its real score.
   const installResult = await deps.pool.install({
@@ -253,7 +259,9 @@ export async function onApproveModelProposal(
       return { status: 'failed_target_missing', proposal: updated as ModelProposalRecord };
     }
     // budget_exceeded / not_allowed / installer_unavailable / install_failed:
-    // structured error, pool unchanged, proposal left pending for a retry.
+    // structured error, pool unchanged. Revert `installing` → `open` so the
+    // proposal is retryable and startup does not re-drive a known failure.
+    await deps.updateProposal(proposal.id, { status: 'open' });
     return { status: 'error', code: installResult.code, message: installResult.message };
   }
 
@@ -308,6 +316,9 @@ export async function onApproveModelProposal(
         installed: model.target.ollamaName,
         phase: 'swap_evict_failed',
       });
+      // Revert `installing` → `open`: the target is in, but the swap is
+      // incomplete and a later re-approve retries only the failed evict.
+      await deps.updateProposal(proposal.id, { status: 'open' });
       return { status: 'error', code: evictResult.code, message: evictResult.message };
     }
     if (evictResult.removed !== null) {
@@ -400,4 +411,48 @@ export async function onRejectModelProposal(
     reason,
   });
   return updated as ModelProposalRecord;
+}
+
+/**
+ * Re-drive installs interrupted by an orchestrator restart. A proposal left in
+ * `installing` had its background `ollama pull` cut short (the process died
+ * mid-download); on startup we re-run {@link onApproveModelProposal}, which is
+ * idempotent — `PoolManager.install` returns `alreadyInstalled` if ollama
+ * finished the pull, or resumes from cached blobs if it was partial. Each re-drive
+ * streams progress + a terminal frame on `local-models:install` exactly like the
+ * original request, so a reconnecting dashboard shows the resumed download. Runs
+ * sequentially (one heavy pull at a time) and never throws — a failed re-drive is
+ * logged and the proposal is left for the operator, not retried in a tight loop.
+ */
+export async function redriveInstallingProposals(
+  deps: Omit<ModelHandlerDeps, 'onInstallEvent'>,
+  proposals: readonly ModelProposalRecord[],
+  opts: { onWarn?: (message: string, cause?: unknown) => void } = {}
+): Promise<void> {
+  for (const proposal of proposals) {
+    if (proposal.status !== 'installing') continue;
+    if (proposal.model.action === 'evict') continue; // evict has no pull to resume
+    const { emit, onInstallEvent } = makeInstallProgressForwarder(deps.bus, {
+      proposalId: proposal.id,
+      hfRepoId: proposal.model.target.hfRepoId,
+      ollamaName: proposal.model.target.ollamaName,
+    });
+    emit('started');
+    try {
+      const outcome = await onApproveModelProposal({ ...deps, onInstallEvent }, proposal);
+      if (outcome.status === 'approved') {
+        emit('complete');
+      } else if (outcome.status === 'failed_target_missing') {
+        emit('error', {
+          code: 'failed_target_missing',
+          message: `${proposal.model.target.hfRepoId} is no longer available on HuggingFace`,
+        });
+      } else {
+        emit('error', { code: outcome.code, message: outcome.message });
+      }
+    } catch (err) {
+      opts.onWarn?.('re-drive of interrupted install failed', err);
+      emit('error', { message: err instanceof Error ? err.message : String(err) });
+    }
+  }
 }

--- a/packages/orchestrator/src/server/routes/v1/proposals.ts
+++ b/packages/orchestrator/src/server/routes/v1/proposals.ts
@@ -174,7 +174,8 @@ async function handleApprove(
     if (
       existing.status === 'approved' ||
       existing.status === 'rejected' ||
-      existing.status === 'failed_target_missing'
+      existing.status === 'failed_target_missing' ||
+      existing.status === 'installing'
     ) {
       sendJSON(res, 409, {
         error: `proposal already ${existing.status}; cannot approve`,

--- a/packages/orchestrator/tests/proposals/model-handlers.test.ts
+++ b/packages/orchestrator/tests/proposals/model-handlers.test.ts
@@ -12,6 +12,8 @@ import type {
 import {
   onApproveModelProposal,
   onRejectModelProposal,
+  redriveInstallingProposals,
+  MODEL_INSTALL_TOPIC,
   type ModelHandlerDeps,
 } from '../../src/proposals/model-handlers';
 
@@ -142,9 +144,10 @@ describe('onApproveModelProposal (F11 stale-target cancellation)', () => {
     const outcome = await onApproveModelProposal(h.deps, proposal);
 
     expect(outcome.status).toBe('failed_target_missing');
-    // proposal transitioned
-    expect(h.updateCalls).toHaveLength(1);
-    expect(h.updateCalls[0]!.patch.status).toBe('failed_target_missing');
+    // proposal transitioned: `installing` marker first, then the terminal status.
+    expect(h.updateCalls).toHaveLength(2);
+    expect(h.updateCalls[0]!.patch.status).toBe('installing');
+    expect(h.updateCalls.at(-1)!.patch.status).toBe('failed_target_missing');
     // bus event on the proposal topic
     const evt = h.events.find((e) => e.topic === 'local-models:proposal');
     expect(evt).toBeDefined();
@@ -167,8 +170,10 @@ describe('onApproveModelProposal (F11 stale-target cancellation)', () => {
     expect(outcome.status).toBe('approved');
     expect(pool.installCalls[0]!.ollamaName).toBe('qwen3:32b');
     expect(pool.evictCalls[0]!.ollamaName).toBe('qwen2.5:32b');
-    expect(h.updateCalls[0]!.patch.status).toBe('approved');
-    expect(h.updateCalls[0]!.patch.decision?.action).toBe('approved');
+    // `installing` marker precedes the terminal `approved`.
+    expect(h.updateCalls[0]!.patch.status).toBe('installing');
+    expect(h.updateCalls.at(-1)!.patch.status).toBe('approved');
+    expect(h.updateCalls.at(-1)!.patch.decision?.action).toBe('approved');
     expect(h.events.some((e) => e.topic === 'local-models:pool')).toBe(true);
   });
 
@@ -239,8 +244,9 @@ describe('onApproveModelProposal (F11 stale-target cancellation)', () => {
     // Truthful failure surfaced (not a false 'approved').
     expect(outcome.status).toBe('error');
     expect(outcome).toMatchObject({ code: 'installer_unavailable' });
-    // Proposal NOT marked approved (left pending for a retry of the failed evict).
-    expect(h.updateCalls).toHaveLength(0);
+    // Proposal NOT approved: `installing` marker set, then reverted to `open`
+    // (retryable) — a later re-approve retries only the failed evict.
+    expect(h.updateCalls.map((c) => c.patch.status)).toEqual(['installing', 'open']);
     // The install still ran and mutated the pool, so a pool event fires — but it
     // reflects ACTUAL state: target installed, replaces NOT evicted.
     const poolEvt = h.events.find((e) => e.topic === 'local-models:pool');
@@ -264,7 +270,8 @@ describe('onApproveModelProposal (F11 stale-target cancellation)', () => {
     expect(outcome.status).toBe('error');
     expect(outcome).toMatchObject({ code: 'budget_exceeded' });
     expect(pool.evictCalls).toHaveLength(0);
-    expect(h.updateCalls).toHaveLength(0); // proposal left pending
+    // `installing` marker set, then reverted to `open` (retryable).
+    expect(h.updateCalls.map((c) => c.patch.status)).toEqual(['installing', 'open']);
     expect(h.events).toHaveLength(0);
   });
 });
@@ -308,8 +315,9 @@ describe('onApproveModelProposal — S1 no-mid-dispatch-swap deferral', () => {
     expect(pool.evictCalls).toHaveLength(0);
     // pendingEviction flag set on the in-use model.
     expect(pool.markCalls).toEqual(['qwen2.5:32b']);
-    // proposal recorded approved.
-    expect(h.updateCalls[0]!.patch.status).toBe('approved');
+    // proposal recorded approved (after the `installing` marker).
+    expect(h.updateCalls[0]!.patch.status).toBe('installing');
+    expect(h.updateCalls.at(-1)!.patch.status).toBe('approved');
     // evict_deferred pool event surfaces the deferred name.
     const poolEvt = h.events.find((e) => e.topic === 'local-models:pool');
     expect(poolEvt).toBeDefined();
@@ -393,5 +401,56 @@ describe('onRejectModelProposal (F7 linkage)', () => {
       target: 'qwen3:32b',
       replaces: 'qwen2.5:32b',
     });
+  });
+});
+
+describe('redriveInstallingProposals (restart recovery)', () => {
+  function installFrames(bus: EventEmitter): Array<{ phase: string; code?: string }> {
+    const frames: Array<{ phase: string; code?: string }> = [];
+    bus.on(MODEL_INSTALL_TOPIC, (f) => frames.push(f as { phase: string }));
+    return frames;
+  }
+
+  it('re-drives an `installing` proposal to completion (idempotent pull resumes)', async () => {
+    const pool = fakePool({ install: { status: 'success', entry: REPLACED, evicted: [] } });
+    const proposal = { ...modelProposal(), status: 'installing' as const };
+    const h = harness(pool, proposal);
+    const frames = installFrames(h.bus);
+
+    await redriveInstallingProposals(h.deps, [proposal]);
+
+    // The pull was re-issued and the proposal reached `approved`.
+    expect(pool.installCalls).toHaveLength(1);
+    expect(h.updateCalls.at(-1)!.patch.status).toBe('approved');
+    // Progress streamed: a started frame and a terminal complete frame.
+    expect(frames[0]?.phase).toBe('started');
+    expect(frames.at(-1)?.phase).toBe('complete');
+  });
+
+  it('skips proposals that are not `installing`', async () => {
+    const pool = fakePool({});
+    const openProposal = modelProposal(); // status 'open'
+    const h = harness(pool, openProposal);
+
+    await redriveInstallingProposals(h.deps, [openProposal]);
+
+    expect(pool.installCalls).toHaveLength(0);
+    expect(h.updateCalls).toHaveLength(0);
+  });
+
+  it('isolates a re-drive failure: logs, emits an error frame, does not throw', async () => {
+    const pool = fakePool({});
+    pool.install = () => Promise.reject(new Error('ollama exploded'));
+    const proposal = { ...modelProposal(), status: 'installing' as const };
+    const h = harness(pool, proposal);
+    const frames = installFrames(h.bus);
+    const warnings: string[] = [];
+
+    await expect(
+      redriveInstallingProposals(h.deps, [proposal], { onWarn: (m) => warnings.push(m) })
+    ).resolves.toBeUndefined();
+
+    expect(frames.at(-1)?.phase).toBe('error');
+    expect(warnings.some((m) => /re-drive/i.test(m))).toBe(true);
   });
 });

--- a/packages/types/src/proposals.ts
+++ b/packages/types/src/proposals.ts
@@ -136,6 +136,12 @@ export const ModelProposalStatusSchema = z.enum([
   'open',
   'gate-running',
   'gate-failed',
+  // Durable marker that a background `ollama pull` for this approved add/swap is
+  // in flight. Set when the pull starts, cleared to `approved` on success or back
+  // to `open` on a (retryable) failure. On orchestrator startup, `installing`
+  // proposals are re-driven so an install interrupted by a restart resumes rather
+  // than being lost (the pull is idempotent — ollama resumes from cached blobs).
+  'installing',
   'approved',
   'rejected',
   'failed_target_missing',


### PR DESCRIPTION
## Summary

Follow-ups to the async operator install shipped in #775, hardening model installs against real-world failure modes and fixing a scoring bug. Three independent changes:

### 1. Resumable pulls — a sleep-dropped install self-heals

A multi-GB `ollama pull` runs as a background task and loses its `/api/pull` stream when the host sleeps mid-download, dead-ending in an error. Ollama caches partial blobs, so re-issuing `/api/pull` **resumes** rather than restarts.

`OllamaInstallAdapter` gains opt-in retry-with-resume (`maxPullRetries` / `pullRetryBackoffMs` / `pullRetryMaxBackoffMs`; the orchestrator enables **5**). The budget counts **consecutive non-progressing attempts** — any forward byte progress resets it — so a pull nibbled through across several sleep cycles still completes, while a canceled request or a missing model fails fast.

### 2. Restart recovery — installs survive an orchestrator restart

Retry-with-resume heals drops *within* a running process; a full restart mid-pull previously lost the in-flight install (the background promise was gone; the proposal sat `open`).

A model add/swap approval now marks its proposal **`installing`** (new `ModelProposalStatus`) for the duration of the pull. On startup the orchestrator finds any `installing` proposals and **re-drives** them — `onApproveModelProposal` is idempotent, so ollama resumes the pull (or no-ops if it already finished) and progress streams to a reconnecting dashboard. The status reverts to `open` on a retryable failure, and the approve route `409`s a re-approve while `installing`.

### 3. Lineage score interpolation — no more "score 0 · interpolated"

`scoreCandidate` looked up benchmarks by **exact `hfRepoId`** only, so a model absent from the snapshot got zero contributions → merged score `0`, then floored to the `interpolated` label — a misnomer, since nothing was interpolated. Real models (e.g. `Qwen/Qwen3-8B-GGUF`) showed "score 0 · interpolated" and, once pooled, were churned by the diff engine (any candidate beats a `0`).

The ranker now infers a score from same-series siblings by parameter count (linear in size, clamped to the measured range, dampened by `'low'` benchmark confidence so it never outranks a direct measurement). The `interpolated` grade and the snapshot's `family`/`sizeB` fields existed for exactly this but were never wired. Only a series with no measured sibling still scores `0`.

## Testing

- **Resumable pulls**: resume-succeeds, progress-resets-budget-across-5-drops, exhaustion, no-retry-on-404, no-retry-on-abort.
- **Restart recovery**: re-drive to completion, skips non-`installing`, failure isolation; plus updated status-transition assertions (`installing` → terminal).
- **Interpolation**: `seriesKey` grouping, the interpolation curve (bracketed / clamped / single-sibling), and an end-to-end case (Qwen3-8B interpolating from a measured Qwen3-32B). Parity fixtures unchanged.
- Verified on the post-#775 base: local-models 316/316, orchestrator suite green (bar the repo's known parallel-run flake), typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
