### PR TITLE
chore(roadmap): auto-done #533 (rescue failed auto-done for PR 779)

### DIFF
--- a/docs/roadmap.d/build-harness-rollback-automated-revert-primitive.md
+++ b/docs/roadmap.d/build-harness-rollback-automated-revert-primitive.md
@@ -6,7 +6,7 @@ order: 6
 
 ### Build harness:rollback automated-revert primitive
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/harness-rollback/proposal.md
 - **Summary:** When a shipped PR fails post-merge eval (harness:outcome-eval) or triggers a defined signal threshold, automatically open a revert PR with full context. The article's "circuit breaker / automated rollback — a mechanism that physically stops the fall before it hits the ground." Currently the project has no automated rollback primitive — only human-mediated PR review. Needs a "revert ready" classification system and a trust model for auto-merging reverts. Source: Pass 2 #7.
 - **Blockers:** Build harness:outcome-eval skill

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,7 +81,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Build harness:rollback automated-revert primitive
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/harness-rollback/proposal.md
 - **Summary:** When a shipped PR fails post-merge eval (harness:outcome-eval) or triggers a defined signal threshold, automatically open a revert PR with full context. The article's "circuit breaker / automated rollback — a mechanism that physically stops the fall before it hits the ground." Currently the project has no automated rollback primitive — only human-mediated PR review. Needs a "revert ready" classification system and a trust model for auto-merging reverts. Source: Pass 2 #7.
 - **Blockers:** Build harness:outcome-eval skill


### PR DESCRIPTION
Rescues the roadmap-auto-done flip that the workflow computed correctly but could not land: its direct push to `main` was blocked by branch protection and its self-approved-PR fallback failed with `Resource not accessible by integration (createPullRequest)` (a token-permission gap in `.github/workflows/roadmap-auto-done.yml`).

Flips the #533 shard `planned → done` (issue #533 is already CLOSED/COMPLETED by the merge of #779) and regenerates the aggregate. Reuses the workflow's own commit `59ccbd430`.

Follow-up worth filing: the auto-done workflow's PAT lacks `pull-requests: write` for the fallback path, so every auto-done that can't direct-push will fail the same way.