### PR TITLE
fix(lmlm): panel number rounding + distinguish quant rows + dedup swap proposals

### DIFF
--- a/.changeset/lmlm-dedup-recs-and-proposals.md
+++ b/.changeset/lmlm-dedup-recs-and-proposals.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/dashboard': patch
+'@harness-engineering/local-models': patch
+---
+
+fix(lmlm): distinguish same-model quant rows + stop duplicate swap proposals
+
+Two "same item" confusions on the Local Models panel:
+
+- **Recommendations** listed the same `hfRepoId` at two quants (e.g. `Qwen3-32B`
+  Q4_K_M @ 21.5 GB and Q8_0 @ 35.1 GB) as visually identical rows because the quant
+  was never shown. The row now displays the quant, so the two options read as the
+  distinct VRAM/speed trade-offs they are.
+- **Pending proposals** could show the same install target twice (e.g. two
+  "Swap in llama3.3:70b" rows for different pool members). The diff engine's dedup
+  was per-`(target, replaces)` pair, so across ticks the same model accumulated
+  multiple pending proposals — all pulling the same blob. The engine now also
+  suppresses a candidate that is already the install target of an **open** proposal
+  (rejections stay pair-scoped, since declining one swap of a model does not veto a
+  different swap of it).

--- a/.changeset/lmlm-panel-number-rounding.md
+++ b/.changeset/lmlm-panel-number-rounding.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/dashboard': patch
+'@harness-engineering/local-models': patch
+---
+
+fix(lmlm): round numbers on the Local Models panel so raw floats stop leaking
+
+Disk usage, pool entry sizes/scores, hardware values, and the model-proposal
+justification text rendered raw floats (`75.65831765532494 GB`,
+`score 57.629999999999995`, `18.067657947540283GB VRAM est`). They now follow the
+panel's existing convention via a shared formatter: sizes/VRAM to one decimal,
+absolute scores as whole numbers. The server-side `buildJustification` rounds the
+score and VRAM values it embeds, so the stored proposal summary is clean too.

--- a/packages/dashboard/src/client/components/local-models/HardwareCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/HardwareCard.tsx
@@ -1,4 +1,5 @@
 import type { DashHardwareProfile } from '../../types/local-models';
+import { round1 } from './format';
 
 /**
  * Hardware card for the LMLM panel. Presentational, props-only (no fetch).
@@ -44,9 +45,13 @@ export function HardwareCard({ hardware, error, loading }: HardwareCardProps): J
       {hardware ? (
         <div className="space-y-1.5">
           <Row label="Platform" value={hardware.platform} testId="hw-platform" />
-          <Row label="VRAM" value={`${hardware.vramGb} GB`} testId="hw-vram" />
-          <Row label="RAM" value={`${hardware.ramGb} GB`} testId="hw-ram" />
-          <Row label="Bandwidth" value={`${hardware.bandwidthGbps} GB/s`} testId="hw-bandwidth" />
+          <Row label="VRAM" value={`${round1(hardware.vramGb)} GB`} testId="hw-vram" />
+          <Row label="RAM" value={`${round1(hardware.ramGb)} GB`} testId="hw-ram" />
+          <Row
+            label="Bandwidth"
+            value={`${round1(hardware.bandwidthGbps)} GB/s`}
+            testId="hw-bandwidth"
+          />
           <Row label="Chip" value={hardware.gpuName ?? hardware.cpuName} testId="hw-chip" />
           <p className="pt-1 text-xs text-neutral-muted">
             Detected {new Date(hardware.detectedAt).toLocaleString()}

--- a/packages/dashboard/src/client/components/local-models/PoolCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/PoolCard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import type { DashPoolEntryView, DashPoolStateView } from '../../types/local-models';
+import { round1, fmtScore } from './format';
 
 /**
  * Pool card for the LMLM panel. Renders entries, disk used-vs-budget, and
@@ -86,7 +87,7 @@ function PoolMemberRow({ entry, onMutated }: PoolMemberRowProps): JSX.Element {
       <div className="mt-0.5 flex items-center justify-between text-xs text-neutral-muted">
         <span className="font-mono">{entry.hfRepoId}</span>
         <span>
-          {entry.sizeOnDiskGb} GB · score {entry.currentScore}
+          {round1(entry.sizeOnDiskGb)} GB · score {fmtScore(entry.currentScore)}
         </span>
       </div>
       {note && (
@@ -124,7 +125,7 @@ export function PoolCard({ pool, error, loading, onMutated }: PoolCardProps): JS
             <div className="mb-1 flex items-center justify-between text-xs text-neutral-muted">
               <span>Disk usage</span>
               <span className="font-mono">
-                {pool.diskUsedGb} / {pool.diskBudgetGb} GB
+                {round1(pool.diskUsedGb)} / {round1(pool.diskBudgetGb)} GB
               </span>
             </div>
             <div className="h-2 w-full overflow-hidden rounded bg-white/10">

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -134,8 +134,8 @@ function RecommendationRow({
       </div>
       <div className="mt-0.5 flex items-center justify-between gap-2">
         <span className="text-xs text-neutral-muted">
-          {round1(rec.estimatedVramGb)} GB VRAM · ~{round1(rec.estimatedTokPerSec)} tok/s ·{' '}
-          {rec.fitsHardware ? 'fits' : "won't fit"}
+          {rec.quant} · {round1(rec.estimatedVramGb)} GB VRAM · ~{round1(rec.estimatedTokPerSec)}{' '}
+          tok/s · {rec.fitsHardware ? 'fits' : "won't fit"}
         </span>
         {installed ? (
           <span data-testid={`rec-installed-${rec.hfRepoId}`} className="text-xs text-green-400">

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ModelProposalRecord } from '@harness-engineering/types';
 import type { DashRankedModel, DashPoolStateView } from '../../types/local-models';
 import type { InstallProgressState } from '../../hooks/useLocalModelsPanel';
+import { round1, fmtScore } from './format';
 
 /**
  * Recommendations card for the LMLM panel. Two sections:
@@ -26,16 +27,6 @@ import type { InstallProgressState } from '../../hooks/useLocalModelsPanel';
  * Reuses the container/border/button classes from `pages/Proposals.tsx` —
  * introduces no new design tokens.
  */
-/** Round to at most one decimal, dropping a trailing `.0` (e.g. 44.159 → "44.2", 20 → "20"). */
-function round1(n: number): string {
-  return (Math.round(n * 10) / 10).toString();
-}
-
-/** Ranking scores render as whole numbers (they are a 0–100 index, not a measurement). */
-function fmtScore(n: number): string {
-  return Math.round(n).toString();
-}
-
 /** Human-readable byte count for the download bar (e.g. 12.3 GB, 512 MB). */
 function fmtBytes(n: number): string {
   if (n >= 1e9) return `${round1(n / 1e9)} GB`;

--- a/packages/dashboard/src/client/components/local-models/format.ts
+++ b/packages/dashboard/src/client/components/local-models/format.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared number formatting for the LMLM panel so raw floats never leak into the
+ * DOM (e.g. `75.65831765532494 GB`, `score 57.629999999999995`). The convention,
+ * consistent across the Recommendations and Pool cards:
+ *   - sizes / VRAM (GB)  → one decimal, trailing `.0` dropped (`44.2`, `18.1`, `100`)
+ *   - absolute scores    → whole number (`71`, `58`, `55`) — a 0–100 index, not a measurement
+ * (Score *deltas* stay one-decimal at their call sites via {@link round1}.)
+ */
+
+/** Round to at most one decimal, dropping a trailing `.0` (e.g. 44.159 → "44.2", 20 → "20"). */
+export function round1(n: number): string {
+  return (Math.round(n * 10) / 10).toString();
+}
+
+/** Absolute ranking scores render as whole numbers (a 0–100 index, not a measurement). */
+export function fmtScore(n: number): string {
+  return Math.round(n).toString();
+}

--- a/packages/dashboard/tests/client/components/local-models/PoolCard.test.tsx
+++ b/packages/dashboard/tests/client/components/local-models/PoolCard.test.tsx
@@ -61,6 +61,33 @@ describe('PoolCard', () => {
     expect(screen.getByTestId('pool-disk').textContent).toContain('100');
   });
 
+  it('rounds raw float sizes/scores so they never leak into the DOM', () => {
+    renderPool({
+      pool: {
+        ...POOL,
+        diskUsedGb: 75.65831765532494,
+        entries: [
+          {
+            ollamaName: 'deepseek-r1:32b',
+            hfRepoId: 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-GGUF',
+            sizeOnDiskGb: 18.067657947540283,
+            installedAt: '2026-07-01T00:00:00.000Z',
+            lastUsedAt: null,
+            currentScore: 57.629999999999995,
+          },
+        ],
+      },
+    });
+    const disk = screen.getByTestId('pool-disk').textContent ?? '';
+    const row = screen.getByTestId('pool-row-deepseek-r1:32b').textContent ?? '';
+    expect(disk).toContain('75.7'); // one decimal, not 75.65831765532494
+    expect(row).toContain('18.1 GB'); // size to one decimal
+    expect(row).toContain('score 58'); // absolute score as a whole number
+    // No long float anywhere on the card.
+    expect(disk).not.toMatch(/\d\.\d{3,}/);
+    expect(row).not.toMatch(/\d\.\d{3,}/);
+  });
+
   it('renders a pending-eviction badge for entries flagged pendingEviction', () => {
     renderPool();
     expect(screen.getByTestId('pool-pending-llama3:8b')).toBeDefined();

--- a/packages/local-models/src/proposals/engine.ts
+++ b/packages/local-models/src/proposals/engine.ts
@@ -66,6 +66,16 @@ export function diffPoolAgainstRanking(input: DiffInput): ModelProposalContent[]
   for (const p of input.pending ?? []) suppressed.add(pairKey(p.target, p.replaces));
   for (const r of input.rejected ?? []) suppressed.add(pairKey(r.target, r.replaces));
 
+  // Target-level suppression for PENDING proposals: if a model is already the
+  // install target of an open proposal, do not propose installing it AGAIN to
+  // replace a different member. The per-pair `suppressed` set above only blocks
+  // the exact (target, replaces) pair, so across ticks the same model would
+  // otherwise accumulate multiple pending proposals — two "Swap in llama3.3:70b"
+  // rows for different members, all pulling the same blob. Rejected pairs stay
+  // pair-level: declining one swap of a model does not veto a different swap of it.
+  const pendingTargets = new Set<string>();
+  for (const p of input.pending ?? []) pendingTargets.add(p.target);
+
   const claimed = new Set<string>();
   const proposals: ModelProposalContent[] = [];
 
@@ -80,6 +90,7 @@ export function diffPoolAgainstRanking(input: DiffInput): ModelProposalContent[]
       pooledNames,
       claimed,
       suppressed,
+      pendingTargets,
     });
     if (candidate === undefined || candidate.ollamaName === undefined) continue;
 
@@ -136,6 +147,7 @@ function bestCandidateFor(
     pooledNames: Set<string>;
     claimed: Set<string>;
     suppressed: Set<string>;
+    pendingTargets: Set<string>;
   }
 ): RankedModel | undefined {
   let best: RankedModel | undefined;
@@ -144,6 +156,7 @@ function bestCandidateFor(
     if (c.ollamaName === undefined) continue;
     if (ctx.pooledNames.has(c.ollamaName)) continue;
     if (ctx.claimed.has(c.ollamaName)) continue;
+    if (ctx.pendingTargets.has(c.ollamaName)) continue; // already a pending install target
     if (ctx.suppressed.has(pairKey(c.ollamaName, entry.ollamaName))) continue;
     if (c.score - entry.currentScore < ctx.proposalThreshold) continue;
     if (best === undefined || c.score > best.score) best = c;

--- a/packages/local-models/src/proposals/justification.ts
+++ b/packages/local-models/src/proposals/justification.ts
@@ -36,19 +36,30 @@ export function buildJustification(
 ): ModelProposalContent['justification'] {
   const { target, currentScore, vramGb } = input;
   const name = target.ollamaName ?? target.hfRepoId;
+  const targetScore = score(target.score);
   const summary =
     currentScore !== undefined
-      ? `Swap in ${name} (score ${target.score}) to replace a pool member scoring ${currentScore}.`
-      : `Add ${name} (score ${target.score}) to the pool.`;
+      ? `Swap in ${name} (score ${targetScore}) to replace a pool member scoring ${score(currentScore)}.`
+      : `Add ${name} (score ${targetScore}) to the pool.`;
   const benchmarkBasis =
     currentScore !== undefined
-      ? [`Composite score ${target.score} vs current ${currentScore}`]
-      : [`Composite score ${target.score}`];
+      ? [`Composite score ${targetScore} vs current ${score(currentScore)}`]
+      : [`Composite score ${targetScore}`];
   return {
     summary,
     benchmarkBasis,
-    hardwareFit: `${target.estimatedVramGb}GB VRAM est; you have ${vramGb}GB`,
+    hardwareFit: `${gb(target.estimatedVramGb)}GB VRAM est; you have ${gb(vramGb)}GB`,
     evidence: String(target.evidence),
     freshness: `Benchmark snapshot ${target.benchmarkSnapshot}`,
   };
+}
+
+/** Absolute scores render as whole numbers so raw floats never reach the operator. */
+function score(n: number): number {
+  return Math.round(n);
+}
+
+/** GB values render to at most one decimal (trailing `.0` dropped). */
+function gb(n: number): number {
+  return Math.round(n * 10) / 10;
 }

--- a/packages/local-models/tests/proposals/engine.test.ts
+++ b/packages/local-models/tests/proposals/engine.test.ts
@@ -133,6 +133,40 @@ describe('diffPoolAgainstRanking (F7: rejected/pending dedup)', () => {
     expect(out).toHaveLength(1);
     expect(out[0]!.target.ollamaName).toBe('newmodel');
   });
+
+  const twoMembers = poolOf([
+    pe({ ollamaName: 'oldA', hfRepoId: 'org/a', currentScore: 60 }),
+    pe({ ollamaName: 'oldB', hfRepoId: 'org/b', currentScore: 61 }),
+  ]);
+  const oneWinner = [rm({ ollamaName: 'newmodel', hfRepoId: 'Org/New', score: 85 })];
+
+  it('does not stack a SECOND pending proposal for the same install target (target-level dedup)', () => {
+    // A prior tick already proposed installing `newmodel` (to replace oldA). It
+    // must NOT be proposed again to replace oldB — otherwise the operator sees
+    // two "Swap in newmodel" rows, both pulling the same blob.
+    const out = diffPoolAgainstRanking({
+      pool: twoMembers,
+      ranked: oneWinner,
+      proposalThreshold: 5,
+      vramGb: 32,
+      pending: [{ target: 'newmodel', replaces: 'oldA' }],
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it('a REJECTED swap does not veto proposing that model for a DIFFERENT member', () => {
+    // Rejection stays pair-scoped: declining (newmodel → oldA) does not block
+    // proposing (newmodel → oldB), which is a genuinely new decision.
+    const out = diffPoolAgainstRanking({
+      pool: twoMembers,
+      ranked: oneWinner,
+      proposalThreshold: 5,
+      vramGb: 32,
+      rejected: [{ target: 'newmodel', replaces: 'oldA' }],
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.replaces?.ollamaName).toBe('oldB');
+  });
 });
 
 describe('diffPoolAgainstRanking (P5-SUG-EVICT-a: real diskImpactGb)', () => {

--- a/packages/local-models/tests/proposals/justification.test.ts
+++ b/packages/local-models/tests/proposals/justification.test.ts
@@ -16,10 +16,27 @@ describe('buildJustification', () => {
   it('renders a swap rationale with benchmark basis + hardware fit', () => {
     const j = buildJustification({ target, currentScore: 71.4, vramGb: 32 });
     expect(j.summary).toMatch(/qwen3:32b/);
-    expect(j.benchmarkBasis[0]).toMatch(/82.*71\.4|71\.4.*82/);
+    // Scores render as whole numbers — 71.4 → 71.
+    expect(j.benchmarkBasis[0]).toMatch(/82.*\b71\b|\b71\b.*82/);
     expect(j.hardwareFit).toMatch(/27.*32/);
     expect(j.evidence).toBe('direct');
     expect(j.freshness).toMatch(/2026-05-21/);
+  });
+
+  it('rounds raw score/VRAM floats so they never leak into the rationale', () => {
+    const noisy = {
+      ...target,
+      score: 57.629999999999995,
+      estimatedVramGb: 18.067657947540283,
+    } as unknown as RankedModel;
+    const j = buildJustification({ target: noisy, currentScore: 54.57, vramGb: 63.9999 });
+    // Absolute scores → whole; GB → at most one decimal.
+    expect(j.summary).toContain('score 58');
+    expect(j.summary).toContain('scoring 55');
+    expect(j.hardwareFit).toBe('18.1GB VRAM est; you have 64GB');
+    // No long float ever reaches the operator.
+    expect(j.summary).not.toMatch(/\d\.\d{3,}/);
+    expect(j.benchmarkBasis.join(' ')).not.toMatch(/\d\.\d{3,}/);
   });
 
   it('renders an add rationale (no current member) without a comparison', () => {


### PR DESCRIPTION
Three fixes to the Local Models panel, all surfaced during manual testing.

## 1. Number rounding
Disk usage, pool entry sizes/scores, hardware values, and the server-side model-proposal justification rendered raw floats (`75.65831765532494 GB`, `score 57.629999999999995`, `18.067657947540283GB VRAM est`). A shared `format.ts` util applies the panel's existing convention — **sizes/VRAM → one decimal, absolute scores → whole** — across HardwareCard, PoolCard, and RecommendationsCard, and `buildJustification` rounds the values it embeds so the stored proposal summary is clean.

## 2. Duplicate-looking recommendations
The bundled candidate list has `Qwen3-32B` at two quants (Q4_K_M @ 21.5 GB, Q8_0 @ 35.1 GB); the row never showed the quant, so they looked identical. The row now displays the quant.

## 3. Duplicate swap proposals
The diff engine deduped only by `(target, replaces)` pair, so across ticks the same model could become the install target of multiple pending proposals (two "Swap in llama3.3:70b" rows, all pulling the same blob). The engine now also suppresses a candidate that's already the install target of an **open** proposal; rejections stay pair-scoped.

## Testing
Engine 12/12 (incl. 2 new dedup tests), dashboard LMLM components 33/33 (incl. PoolCard rounding regression), justification rounding regression. Typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)