### PR TITLE
feat(lmlm): task-aware, self-correcting consumption of pooled local models

### DIFF
--- a/.changeset/lmlm-pool-consumption.md
+++ b/.changeset/lmlm-pool-consumption.md
@@ -1,4 +1,5 @@
 ---
+'@harness-engineering/types': minor
 '@harness-engineering/intelligence': minor
 '@harness-engineering/local-models': minor
 '@harness-engineering/orchestrator': minor

--- a/.changeset/lmlm-pool-consumption.md
+++ b/.changeset/lmlm-pool-consumption.md
@@ -1,0 +1,31 @@
+---
+'@harness-engineering/intelligence': minor
+'@harness-engineering/local-models': minor
+'@harness-engineering/orchestrator': minor
+---
+
+feat(lmlm): consume pooled models freshly — event-driven refresh, live analysis model, score-seed, runtime feedback, task-aware selection, warming
+
+The pool install side was fast, but consumption was pull-based and static: a
+newly installed model wasn't used by agents for up to a poll cycle and by the
+analysis pipeline never (until restart), a fresh entry sat at `currentScore: 0`,
+runtime outcomes didn't feed back, and selection ignored the ranker's per-task
+profiles. This wires the pool through to inference.
+
+- **Freshness loop** — `LocalModelResolver.refresh()` debounce-re-probes on a
+  `local-models:pool` mutation, so an install/swap is resolvable in seconds. The
+  analysis provider reads its model live per request (`getModel` seam) instead of
+  snapshotting once at construction, unless the operator pinned a layer model.
+- **Score-seed** — an installed pool entry seeds `currentScore` from its ranked
+  score rather than `0`, so an explicitly-installed model isn't buried until the
+  next re-rank.
+- **Runtime feedback** — `lastUsedAt` is stamped on real inference; a model that
+  fails N consecutive inferences is deprioritized until it recovers.
+- **Task-aware selection** — per-profile pool scoring (general/coding/reasoning)
+  routes each use-case to its best-fit pooled model, degrading to composite score
+  when the benchmark snapshot lacks profile tags.
+- **Warming** — the resolver best-effort warms a newly selected model
+  (`keep_alive`) so the next dispatch isn't a cold start.
+
+See `docs/changes/lmlm-pool-consumption/proposal.md` and the task-aware selection
+ADR under `docs/knowledge/decisions/`.

--- a/docs/changes/lmlm-pool-consumption/plans/2026-07-09-lmlm-pool-consumption-plan.md
+++ b/docs/changes/lmlm-pool-consumption/plans/2026-07-09-lmlm-pool-consumption-plan.md
@@ -1,0 +1,93 @@
+# Plan: LMLM Pool Consumption Improvements
+
+**Date:** 2026-07-09 | **Spec:** docs/changes/lmlm-pool-consumption/proposal.md | **Tasks:** 21 | **Time:** ~94 min | **Integration Tier:** large
+
+## Goal
+
+The pooled model used for inference reflects the current pool freshly, respects operator intent (no score-0 burial), self-corrects on runtime failure, and matches the task at hand.
+
+## Observable Truths (Acceptance Criteria)
+
+1. When a `local-models:pool` event fires, the resolver re-probes (installed model usable in seconds, not ≤30s).
+2. When an analysis request runs, the provider uses the resolver's current model without a restart.
+3. When a model is installed, its pool `currentScore` equals its ranked score, never `0`.
+4. When an inference session first succeeds, `lastUsedAt` advances; a model failing N consecutive inferences is deprioritized until recovery.
+5. When a coding-tagged task dispatches, the resolver selects the available pooled model with the highest coding-profile score.
+6. When the resolver selects a new model, it warms it before the next dispatch.
+
+## File Map
+
+- MODIFY `packages/orchestrator/src/agent/local-model-resolver.ts` (event refresh, circuit-breaker, use-case-aware resolve, warming hook)
+- MODIFY `packages/orchestrator/src/orchestrator.ts` (subscribe resolvers to `local-models:pool`; thread use-case)
+- MODIFY `packages/orchestrator/src/agent/analysis-provider-factory.ts` + the analysis provider (`getModel()` seam)
+- MODIFY `packages/local-models/src/pool/manager.ts` (`initialScore` seed, `markUsed`)
+- MODIFY `packages/local-models/src/pool/types.ts` (`scoresByProfile`)
+- MODIFY `packages/local-models/src/pool/provider.ts` (`poolStateToCandidates(state, profile?)`)
+- MODIFY `packages/local-models/src/scheduler/refresh.ts` (per-profile score writeback)
+- MODIFY `packages/local-models/src/ranker/*` (per-profile scoring)
+- MODIFY `packages/orchestrator/src/proposals/model-handlers.ts`, `.../routes/v1/local-models-pool-mutation.ts`, `packages/types/src/proposals.ts` (absolute score for seeding)
+- MODIFY `packages/orchestrator/src/agent/backends/local.ts` (`onModelUsed`, warming)
+- MODIFY `packages/orchestrator/src/agent/orchestrator-backend-factory.ts` (thread use-case → resolve)
+- CREATE `docs/knowledge/decisions/NNNN-lmlm-task-aware-selection.md` (ADR)
+- MODIFY operator guide docs
+
+## Skeleton
+
+1. Freshness loop (~4 tasks) — _approved_
+2. Score-seed (~3 tasks) — _approved_
+3. Runtime feedback (~4 tasks) — _approved_
+4. Task-aware selection + ADR (~6 tasks) — _approved_
+5. Warming (~2 tasks) — _approved_
+6. Integration: ADR + docs (~2 tasks) — _approved_
+
+## Tasks (milestone-sequenced; TDD; `harness validate` per code task)
+
+**Milestone 1 — Freshness loop**
+
+- T1: `LocalModelResolver.refresh()` — debounced immediate re-probe. Test: refresh triggers probe.
+- T2: Orchestrator subscribes each local/pi resolver to `local-models:pool` → `resolver.refresh()`. Test: emit event → resolver re-probes.
+- T3: Add `getModel?()` seam to `OpenAICompatibleAnalysisProvider`; read at request time. Test: provider uses getModel over defaultModel.
+- T4: `analysis-provider-factory` passes `getModel: () => resolver.getStatus().resolved`. Test: factory wires getModel.
+
+**Milestone 2 — Score-seed**
+
+- T5: `[MODIFIED]` `pool.install` seeds `currentScore` from `initialScore`. Test: installed entry carries the score.
+- T6: Add absolute `targetScore` to `ModelProposalContent` (additive schema). Test: schema accepts + round-trips.
+- T7: Install/approve pass the ranked score as `initialScore`. Test: install route seeds non-zero score.
+
+**Milestone 3 — Runtime feedback**
+
+- T8: `pool.markUsed(ollamaName)` stamps `lastUsedAt`. Test: markUsed advances lastUsedAt.
+- T9: `LocalBackend` `onModelUsed` seam, called on first successful turn; orchestrator binds to `pool.markUsed`. Test: successful turn calls onModelUsed once.
+- T10: Circuit-breaker overlay in resolver: N consecutive failures → deprioritize; success/cooldown clears. Test: tripped model deprioritized.
+- T11: Wire backend inference failures → resolver circuit-breaker. Test: failure increments; recovery clears.
+
+**Milestone 4 — Task-aware selection + ADR**
+
+- T12: Ranker per-profile score API (`general`/`coding`/`reasoning`) weighting profile-relevant benchmarks. Test: profiles differ where data supports it; fall back to composite.
+- T13: `scoresByProfile` on `PoolEntry` (additive). Test: schema + serialize round-trip.
+- T14: `scheduler/refresh.ts` writes `scoresByProfile` in the re-score step. Test: writeback populates profiles.
+- T15: `poolStateToCandidates(state, profile?)` sorts by `scoresByProfile[profile]` (fallback `currentScore`). Test: profile ordering.
+- T16: `resolveModel(useCase?)` + `RoutingUseCase → profile` map; resolver picks best profile-scored loaded model. Test: coding use-case → coding best-fit.
+- T17: Thread use-case through `getResolverModelFor`/backend factory to `resolveModel`. Test: dispatch passes use-case.
+- T18: ADR `docs/knowledge/decisions/NNNN-lmlm-task-aware-selection.md`. **Category:** integration.
+
+**Milestone 5 — Warming**
+
+- T19: `warmModel(ollamaName)` via Ollama `keep_alive` (best-effort, debounced). Test: warm request issued on selection change.
+- T20: Trigger warm on resolver selection change. Test: selection change → warm.
+
+**Integration**
+
+- T21: Operator guide docs — selection model, task-aware routing, circuit-breaker, warming. **Category:** integration.
+
+## Change Specifications
+
+- [ADDED] Event-driven resolver refresh; analysis lazy model; runtime circuit-breaker; per-profile pool scoring; use-case-aware selection; model warming.
+- [MODIFIED] Install seeds `currentScore` from the ranked score (was `0`); `lastUsedAt` stamped on real inference (was install-time/never).
+- [ADDED] `PoolEntry.scoresByProfile`, `ModelProposalContent.targetScore` (additive schema).
+
+## Notes / Risk
+
+- **Phase 4 depends on benchmark categorization.** If the snapshot's benchmarks aren't tagged by profile, per-profile scores collapse to the composite — the feature still ships (task-awareness degrades gracefully to score-order). Verified during T12.
+- Executed milestone-by-milestone with a commit per task/phase.

--- a/docs/guides/local-model-lifecycle.md
+++ b/docs/guides/local-model-lifecycle.md
@@ -95,7 +95,43 @@ Model proposals get a single approve/reject decision, from either surface:
 - The **Pool** card is **read-only** — see [Known limitations](#known-limitations-read-before-relying-on-autonomy).
 
 Approving a proposal installs (or swaps/evicts) via the configured backend, updates
-pool state, and the `LocalModelResolver` picks up the new member on its next probe.
+pool state, and the `LocalModelResolver` picks up the new member within a debounce
+window (see [How pooled models are consumed](#how-pooled-models-are-consumed)), not
+only on its next scheduled probe.
+
+## How pooled models are consumed
+
+Installing a model is only half the story — this is how a pooled model actually
+reaches inference. See [ADR 0064](../knowledge/decisions/0064-lmlm-task-aware-pool-consumption.md)
+for the rationale.
+
+- **Event-driven freshness.** A pool mutation (install / swap / eviction) emits a
+  `local-models:pool` event that debounce-triggers a resolver re-probe, so a
+  just-installed or swapped model becomes dispatchable in **seconds**, not up to a
+  full poll cycle (`localModel.probeIntervalMs`, default ~30s). The intelligence
+  (analysis) pipeline reads its model **live per request**, so a swap is consumed
+  without an orchestrator restart — unless you pinned a layer model
+  (`intelligence.models.sel` / `.pesl`), which stays fixed by design.
+- **Score seeding.** A freshly installed model enters the pool at its **real ranked
+  score**, not `0`, so it is selectable immediately instead of sitting at the bottom
+  until the next re-rank. (This is why an approved install no longer shows a
+  "pool member scoring 0" justification.)
+- **Task-aware selection.** Within a local backend, the resolver orders pooled
+  candidates by a **task profile** derived from the routed use-case:
+  code-editing tiers (`quick-fix`, `guided-change`, `full-exploration`) → **coding**,
+  the `diagnostic` tier → **reasoning**, everything else → **general** (the composite
+  score). Profiles come from the ranker weighting profile-relevant benchmarks; when
+  the benchmark data can't distinguish a profile, selection **degrades gracefully to
+  composite score-order**, so task-awareness never buries a well-scored model.
+- **Runtime self-correction.** A completed turn stamps `lastUsedAt` (so LRU eviction
+  reflects real usage) and clears a per-model **circuit breaker**. A model that fails
+  several consecutive inferences is **deprioritized** — the resolver rolls to a healthy
+  pooled alternative — until it succeeds again or a cooldown elapses. If the failing
+  model is the _only_ one loaded, it is still used (a flaky model beats none).
+- **Warming.** When the resolver's selection changes, it best-effort **warms** the new
+  model into VRAM via Ollama's `keep_alive`, so the next dispatch isn't a cold start.
+  Warming is Ollama-only and never blocks a dispatch; a warm failure just means the
+  first request pays the load cost.
 
 ## Known limitations (read before relying on autonomy)
 
@@ -132,6 +168,7 @@ workflow; they scope what "autonomy" means today.
 
 - [ADR 0061: LMLM as a standalone package with a native TS ranking port](../knowledge/decisions/0061-lmlm-package-boundary-and-native-ranking-port.md)
 - [ADR 0062: Pool-bounded autonomy with Ollama-first installation](../knowledge/decisions/0062-pool-bounded-autonomy-and-ollama-first-install.md)
+- [ADR 0064: Task-aware, self-correcting consumption of pooled local models](../knowledge/decisions/0064-lmlm-task-aware-pool-consumption.md)
 - [ADR 0058: Generalize SkillProposalSchema into a discriminated ProposalSchema](../knowledge/decisions/0058-generalize-skill-proposal-into-discriminated-proposal.md)
 - [ADR 0059: Background refresh scheduler and silent drift reconciliation](../knowledge/decisions/0059-background-scheduler-and-silent-drift-reconciliation.md)
 - [ADR 0060: LMLM operator surfaces and dispatch-safe eviction](../knowledge/decisions/0060-lmlm-operator-surfaces-and-dispatch-safe-eviction.md)

--- a/docs/knowledge/decisions/0064-lmlm-task-aware-pool-consumption.md
+++ b/docs/knowledge/decisions/0064-lmlm-task-aware-pool-consumption.md
@@ -1,0 +1,78 @@
+---
+number: 0064
+title: Task-aware, self-correcting consumption of pooled local models
+date: 2026-07-09
+status: accepted
+tier: large
+source: docs/changes/lmlm-pool-consumption/proposal.md
+---
+
+## Context
+
+LMLM's install side is fast and unattended (ADR 0062), but the **consumption** path —
+how a pooled model actually reaches inference — was pull-based and static:
+
+- The `LocalModelResolver` only polled (`probeIntervalMs` ~30s) and ignored the
+  `local-models:pool` event the orchestrator already emits, so a just-installed model
+  wasn't dispatched for up to a poll cycle. The analysis pipeline snapshotted its model
+  once at construction and never updated — a swap wasn't consumed until a restart.
+- A freshly installed pool entry started at `currentScore: 0`, and the resolver picks
+  the highest-scored **loaded** model, so an explicitly-installed model sat at the
+  bottom until the next re-rank ("pool member scoring 0" in a proposal).
+- Runtime outcomes didn't feed back: `lastUsedAt` wasn't stamped on real inference (so
+  LRU eviction ran on stale data), and a model failing every request kept being picked.
+- Within a local backend the model was just the top **composite**-scored pool entry;
+  the ranker computes per-benchmark data but no task profile was consulted at dispatch,
+  so a coding task and a math-reasoning task got the same model.
+
+## Decision
+
+Make pooled-model consumption **event-driven, operator-honest, self-correcting, and
+task-aware**, degrading gracefully when data is thin.
+
+- **Event-driven freshness.** `LocalModelResolver.refresh()` debounce-re-probes on a
+  `local-models:pool` mutation, and the analysis provider reads its model live per
+  request (`getModel` seam) rather than snapshotting once — unless the operator pinned
+  a layer model, which stays static.
+- **Seed the score on install.** A model proposal carries the target's absolute
+  `targetScore`; approval seeds the new pool entry's `currentScore` from it, so an
+  explicitly-installed model enters at its real rank, never `0`.
+- **Runtime feedback.** A completed turn stamps `lastUsedAt` (LRU) and clears a
+  per-model **circuit breaker**; N consecutive inference failures deprioritize a model
+  during resolution (it sinks below healthy peers but remains a last resort if it is the
+  only loaded candidate) until a success or an elapsed cooldown clears it.
+- **Task-aware selection.** The ranker computes `scoresByProfile`
+  (`general`/`coding`/`reasoning`) by weighting only profile-relevant benchmarks; the
+  scheduler writes these onto pool entries; `poolStateToCandidates(state, profile)`
+  orders by the profile score; and `resolveModel(useCase)` maps the routed use-case to a
+  profile (**code-editing tiers → coding, the diagnostic tier → reasoning, everything
+  else → general**) and picks the best profile-scored loaded model.
+- **Degrade, don't bury.** Where the data doesn't support a distinction, the feature
+  collapses to the prior behavior: `scoresByProfile.general` always equals the composite;
+  a profile with no relevant benchmark falls back to the composite; a pool entry without
+  a profile score falls back to `currentScore`; a `general`-mapped use-case returns the
+  cached composite resolution. `targetScore`, `scoresByProfile`, and the use-case
+  parameter are all **additive and optional**, so older persisted proposals/pool entries
+  and existing call sites keep working unchanged.
+
+The use-case→profile map is a deliberately **conservative heuristic**, not a learned
+policy. It lives in one function (`useCaseToProfile`) and is the intended extension
+point as more signal becomes available (e.g. `cognitiveMode` on `skill`/`mode`
+use-cases).
+
+## Consequences
+
+- **Positive.** A newly installed/swapped model is dispatched within seconds, at its
+  real rank; a flaky model is routed around automatically and recovers on its own; a
+  coding task prefers the coding specialist in the pool. LRU eviction reflects real
+  usage.
+- **Negative / limits.** Per-profile scores are only as good as the snapshot's benchmark
+  tagging; when benchmarks aren't profile-classifiable the task-awareness silently
+  degrades to composite score-order. The `tier`-based mapping assumes the routing tier
+  approximates task type — a mismatched routing config would mis-map. Runtime feedback is
+  a binary circuit breaker, not a full latency/quality signal into scoring (a deliberate
+  scope cut — full runtime scoring is deferred). The `pi` backend wires freshness but not
+  the usage/failure hooks yet (its streaming turn path is a follow-up).
+- **Neutral.** Adds a small amount of per-model state to the resolver (failure counts +
+  trip timestamps) and one extra map on `PoolEntry`. The circuit-breaker thresholds and
+  cooldown are constants with injectable seams for tests.

--- a/packages/intelligence/src/analysis-provider/openai-compatible.ts
+++ b/packages/intelligence/src/analysis-provider/openai-compatible.ts
@@ -9,6 +9,14 @@ export interface OpenAICompatibleProviderOptions {
   baseUrl: string;
   /** Default model name (e.g., 'deepseek-coder-v2'). */
   defaultModel?: string;
+  /**
+   * Consumption Phase 1 (T3): live model resolver, read at request time. When
+   * provided and it returns a non-empty name, that name is used in preference to
+   * `defaultModel` so a pool install/swap is consumed by analysis without a
+   * restart. `request.model` (an explicit per-call override) still wins; a
+   * null/undefined/empty return falls through to `defaultModel`.
+   */
+  getModel?: () => string | null | undefined;
   /** Request timeout in ms (default: 90000). */
   timeoutMs?: number;
   /**
@@ -38,6 +46,7 @@ const DEFAULT_TIMEOUT_MS = 90_000;
 export class OpenAICompatibleAnalysisProvider implements AnalysisProvider {
   private readonly client: OpenAI;
   private readonly defaultModel: string;
+  private readonly getModel?: () => string | null | undefined;
   private readonly promptSuffix: string | null;
   private readonly jsonMode: boolean;
 
@@ -48,12 +57,19 @@ export class OpenAICompatibleAnalysisProvider implements AnalysisProvider {
       timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     });
     this.defaultModel = options.defaultModel ?? DEFAULT_MODEL;
+    if (options.getModel !== undefined) {
+      this.getModel = options.getModel;
+    }
     this.promptSuffix = options.promptSuffix ?? null;
     this.jsonMode = options.jsonMode ?? true;
   }
 
   async analyze<T>(request: AnalysisRequest): Promise<AnalysisResponse<T>> {
-    const model = request.model ?? this.defaultModel;
+    // Model precedence: explicit per-request override → live resolver
+    // (getModel, read fresh each call) → static defaultModel.
+    const resolved = this.getModel?.();
+    const model =
+      request.model ?? (resolved != null && resolved !== '' ? resolved : this.defaultModel);
     const maxTokens = request.maxTokens ?? DEFAULT_MAX_TOKENS;
     const jsonSchema = zodToJsonSchema(request.responseSchema);
 

--- a/packages/intelligence/tests/analysis-provider/openai-compatible.test.ts
+++ b/packages/intelligence/tests/analysis-provider/openai-compatible.test.ts
@@ -98,6 +98,69 @@ describe('OpenAICompatibleAnalysisProvider', () => {
       expect(response.model).toBe('qwen3-72b');
     });
 
+    it('uses getModel() over defaultModel, read fresh each call (T3)', async () => {
+      let live = 'model-a';
+      const liveProvider = new OpenAICompatibleAnalysisProvider({
+        apiKey: 'key',
+        baseUrl: 'http://localhost:1234/v1',
+        defaultModel: 'static-fallback',
+        getModel: () => live,
+      });
+      mockCreate.mockResolvedValue(
+        makeCompletionResponse(JSON.stringify({ summary: 'ok', score: 1 }))
+      );
+
+      const first = await liveProvider.analyze({ prompt: 'test', responseSchema: testSchema });
+      expect(mockCreate).toHaveBeenLastCalledWith(expect.objectContaining({ model: 'model-a' }));
+      expect(first.model).toBe('model-a');
+
+      // A pool swap changes what the resolver returns; the very next call
+      // picks it up without reconstructing the provider.
+      live = 'model-b';
+      const second = await liveProvider.analyze({ prompt: 'test', responseSchema: testSchema });
+      expect(mockCreate).toHaveBeenLastCalledWith(expect.objectContaining({ model: 'model-b' }));
+      expect(second.model).toBe('model-b');
+    });
+
+    it('falls back to defaultModel when getModel() returns null/empty (T3)', async () => {
+      const nullProvider = new OpenAICompatibleAnalysisProvider({
+        apiKey: 'key',
+        baseUrl: 'http://localhost:1234/v1',
+        defaultModel: 'static-fallback',
+        getModel: () => null,
+      });
+      mockCreate.mockResolvedValueOnce(
+        makeCompletionResponse(JSON.stringify({ summary: 'ok', score: 1 }))
+      );
+
+      const response = await nullProvider.analyze({ prompt: 'test', responseSchema: testSchema });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'static-fallback' })
+      );
+      expect(response.model).toBe('static-fallback');
+    });
+
+    it('request.model overrides getModel() (T3)', async () => {
+      const liveProvider = new OpenAICompatibleAnalysisProvider({
+        apiKey: 'key',
+        baseUrl: 'http://localhost:1234/v1',
+        defaultModel: 'static-fallback',
+        getModel: () => 'resolver-model',
+      });
+      mockCreate.mockResolvedValueOnce(
+        makeCompletionResponse(JSON.stringify({ summary: 'ok', score: 1 }))
+      );
+
+      await liveProvider.analyze({
+        prompt: 'test',
+        responseSchema: testSchema,
+        model: 'explicit-override',
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'explicit-override' })
+      );
+    });
+
     it('handles missing usage gracefully (defaults to 0)', async () => {
       mockCreate.mockResolvedValueOnce({
         choices: [

--- a/packages/local-models/src/pool/manager.ts
+++ b/packages/local-models/src/pool/manager.ts
@@ -38,6 +38,7 @@ import { isInstallError } from '../installer/index.js';
 import { planEviction } from './eviction.js';
 import type { PoolStateStore } from './state.js';
 import type { PoolEntry, PoolState, PoolStateView } from './types.js';
+import type { RankProfile } from '../ranker/profiles.js';
 
 /**
  * Stable error codes the manager surfaces. Extends Phase 3b's `InstallErrorCode`
@@ -149,6 +150,13 @@ export interface ConfigurePoolRequest {
 export interface ScoreUpdate {
   ollamaName: string;
   currentScore: number;
+  /**
+   * Consumption Phase 4 (T14): per-profile scores written alongside
+   * `currentScore` in the scheduler's re-score step. Optional so callers that
+   * don't compute profiles (or older call sites) leave the entry's existing
+   * `scoresByProfile` untouched.
+   */
+  scoresByProfile?: Partial<Record<RankProfile, number>>;
 }
 
 export interface AllowCheckRequest {
@@ -566,17 +574,25 @@ export class PoolManager {
   /** Batched score rewrite. Persists once. Ignores unknown names. */
   async updateScores(updates: ScoreUpdate[]): Promise<void> {
     if (updates.length === 0) return;
-    const lookup = new Map(updates.map((u) => [u.ollamaName, u.currentScore]));
+    const lookup = new Map(updates.map((u) => [u.ollamaName, u]));
     const state = this.store.snapshot();
     const anyMatch = state.entries.some((entry) => lookup.has(entry.ollamaName));
     if (!anyMatch) return;
     this.store.update((draft) => ({
       ...draft,
-      entries: draft.entries.map((entry) =>
-        lookup.has(entry.ollamaName)
-          ? { ...entry, currentScore: lookup.get(entry.ollamaName) as number }
-          : entry
-      ),
+      entries: draft.entries.map((entry) => {
+        const update = lookup.get(entry.ollamaName);
+        if (update === undefined) return entry;
+        // T14: write per-profile scores alongside currentScore when the caller
+        // supplied them; otherwise leave the entry's existing map untouched.
+        return {
+          ...entry,
+          currentScore: update.currentScore,
+          ...(update.scoresByProfile !== undefined
+            ? { scoresByProfile: update.scoresByProfile }
+            : {}),
+        };
+      }),
     }));
     await this.store.persist();
   }

--- a/packages/local-models/src/pool/provider.ts
+++ b/packages/local-models/src/pool/provider.ts
@@ -6,7 +6,8 @@
  *
  * @see docs/changes/local-model-lifecycle-manager/proposal.md Phase 4; D5
  */
-import type { PoolState } from './types.js';
+import type { PoolState, PoolEntry } from './types.js';
+import type { RankProfile } from '../ranker/profiles.js';
 
 /** Read-only view over current pool state. Satisfied by PoolManager + PoolStateStore. */
 export interface PoolStateProvider {
@@ -15,12 +16,32 @@ export interface PoolStateProvider {
 }
 
 /**
- * Derive the resolver candidate list from pool state: entries ordered by
- * `currentScore` descending, mapped to `ollamaName`. Pure; does not mutate
- * the input.
+ * The score an entry sorts by for `profile`. Consumption Phase 4 (T15): when a
+ * task profile is requested, prefer that profile's score from `scoresByProfile`;
+ * fall back to `currentScore` when the entry lacks a profile score (older entry,
+ * or a profile the re-rank couldn't compute). With no profile, `currentScore`.
  */
-export function poolStateToCandidates(state: PoolState): string[] {
+function scoreForProfile(entry: PoolEntry, profile?: RankProfile): number {
+  if (profile !== undefined) {
+    const byProfile = entry.scoresByProfile?.[profile];
+    if (byProfile !== undefined) return byProfile;
+  }
+  return entry.currentScore;
+}
+
+/**
+ * Derive the resolver candidate list from pool state: entries ordered by score
+ * descending, mapped to `ollamaName`. When `profile` is given, entries order by
+ * their per-profile score (falling back to `currentScore`) so a task-tagged
+ * dispatch prefers the profile's best-fit model; `ollamaName` breaks ties for a
+ * stable order. Pure; does not mutate the input.
+ */
+export function poolStateToCandidates(state: PoolState, profile?: RankProfile): string[] {
   return [...state.entries]
-    .sort((a, b) => b.currentScore - a.currentScore)
+    .sort((a, b) => {
+      const diff = scoreForProfile(b, profile) - scoreForProfile(a, profile);
+      if (diff !== 0) return diff;
+      return a.ollamaName < b.ollamaName ? -1 : a.ollamaName > b.ollamaName ? 1 : 0;
+    })
     .map((entry) => entry.ollamaName);
 }

--- a/packages/local-models/src/pool/types.ts
+++ b/packages/local-models/src/pool/types.ts
@@ -15,6 +15,8 @@
  * @see docs/changes/local-model-lifecycle-manager/proposal.md (Phase 3, lines 431–443)
  */
 
+import type { RankProfile } from '../ranker/profiles.js';
+
 /**
  * A single installed Ollama model whose lifecycle the orchestrator is
  * managing. Steady-state shape only — transient install/evict status is
@@ -38,6 +40,15 @@ export interface PoolEntry {
   lastUsedAt: string | null;
   /** Most-recent ranker score (0–100). Eviction's primary sort key. */
   currentScore: number;
+  /**
+   * Consumption Phase 4 (T13): most-recent per-task-profile scores (0–100),
+   * written back by the scheduler's re-score step. Optional + additive so
+   * entries persisted before this field round-trip unchanged (the loader
+   * tolerates its absence; `cloneEntry` spreads it when present). Consumed by
+   * `poolStateToCandidates(state, profile)` to order candidates for a
+   * task-tagged dispatch. Absent ⇒ selection falls back to `currentScore`.
+   */
+  scoresByProfile?: Partial<Record<RankProfile, number>>;
 }
 
 /**

--- a/packages/local-models/src/proposals/engine.ts
+++ b/packages/local-models/src/proposals/engine.ts
@@ -116,6 +116,10 @@ function buildSwapProposal(
     target: { hfRepoId: candidate.hfRepoId, ollamaName: candidate.ollamaName! },
     replaces: { ollamaName: entry.ollamaName },
     scoreDelta: candidate.score - entry.currentScore,
+    // Consumption Phase 2 (T7): the target's absolute ranked score. Seeds the
+    // swapped-in entry's `currentScore` on approval so it enters the pool at its
+    // real rank rather than 0.
+    targetScore: candidate.score,
     justification: buildJustification({
       target: candidate,
       currentScore: entry.currentScore,

--- a/packages/local-models/src/ranker/algorithm.ts
+++ b/packages/local-models/src/ranker/algorithm.ts
@@ -37,6 +37,7 @@
 
 import { mergeBenchmarks } from './benchmarks/merge.js';
 import type { BenchmarkEvidence, BenchmarkObservation } from './benchmarks/types.js';
+import { RANK_PROFILES, classifyBenchmark, type RankProfile } from './profiles.js';
 import {
   buildSeriesScores,
   interpolateBySize,
@@ -219,6 +220,19 @@ function scoreCandidate(
     benchmarkConfidence,
   });
 
+  // T12: per-profile scores. `general` is the composite; `coding`/`reasoning`
+  // re-merge only their profile-relevant observations (falling back to the
+  // composite when the model has none) so a task-tagged dispatch can prefer a
+  // specialist. Unfit rows collapse to 0 across all profiles (scaleScore floors).
+  const scoresByProfile = computeProfileScores({
+    observations,
+    target: candidateTarget(candidate),
+    snapshotDate,
+    compositeScore: score,
+    fitsHardware,
+    speedConfidence: speedEstimate.confidence,
+  });
+
   return assembleRankedModel({
     candidate,
     vramEstimate,
@@ -227,8 +241,51 @@ function scoreCandidate(
     evidence,
     fitsHardware,
     score,
+    scoresByProfile,
     benchmarkSnapshot: snapshotDate,
   });
+}
+
+/**
+ * T12: compute the per-profile score map. `general` mirrors the composite. For
+ * each specialized profile, merge only observations whose benchmark classifies
+ * to it and scale with the same multipliers; when a profile has no relevant
+ * observation the composite is used so the model isn't buried for lacking a tag.
+ */
+function computeProfileScores(args: {
+  observations: readonly BenchmarkObservation[];
+  target: { model: string; quant: string };
+  snapshotDate: string;
+  compositeScore: number;
+  fitsHardware: boolean;
+  speedConfidence: SpeedEstimate['confidence'];
+}): Record<RankProfile, number> {
+  const out = {} as Record<RankProfile, number>;
+  for (const profile of RANK_PROFILES) {
+    if (profile === 'general' || !args.fitsHardware) {
+      out[profile] = args.compositeScore;
+      continue;
+    }
+    const relevant = args.observations.filter((o) => classifyBenchmark(o.benchmark) === profile);
+    if (relevant.length === 0) {
+      // No profile-specific signal — fall back to the composite (degrade to
+      // score-order rather than penalize an un-tagged model).
+      out[profile] = args.compositeScore;
+      continue;
+    }
+    const merged = mergeBenchmarks({
+      observations: relevant,
+      target: args.target,
+      snapshotDate: args.snapshotDate,
+    });
+    out[profile] = scaleScore({
+      mergedScore: merged.score,
+      fitsHardware: args.fitsHardware,
+      speedConfidence: args.speedConfidence,
+      benchmarkConfidence: merged.confidence,
+    });
+  }
+  return out;
 }
 
 /** Build the `MergeTarget` shape from a candidate. */
@@ -245,6 +302,7 @@ function assembleRankedModel(args: {
   evidence: BenchmarkEvidence;
   fitsHardware: boolean;
   score: number;
+  scoresByProfile: Record<RankProfile, number>;
   benchmarkSnapshot: string;
 }): RankedModel {
   const { candidate, vramEstimate, speedEstimate, benchmarkScore } = args;
@@ -256,6 +314,7 @@ function assembleRankedModel(args: {
     estimatedTokPerSec: speedEstimate.tokPerSec,
     speedConfidence: speedEstimate.confidence,
     score: args.score,
+    scoresByProfile: args.scoresByProfile,
     evidence: args.evidence,
     benchmarkSnapshot: args.benchmarkSnapshot,
     fitsHardware: args.fitsHardware,

--- a/packages/local-models/src/ranker/index.ts
+++ b/packages/local-models/src/ranker/index.ts
@@ -18,4 +18,5 @@ export * from './speed.js';
 export * from './evidence.js';
 export * from './recency.js';
 export * from './algorithm.js';
+export * from './profiles.js';
 export * from './types.js';

--- a/packages/local-models/src/ranker/profiles.ts
+++ b/packages/local-models/src/ranker/profiles.ts
@@ -1,0 +1,52 @@
+/**
+ * Task-aware ranking profiles (Consumption Phase 4 / T12).
+ *
+ * The composite `RankedModel.score` blends every benchmark a model has. But a
+ * coding task and a math-reasoning task are not served equally well by the same
+ * model, and the snapshot already carries per-benchmark slugs (`humaneval`,
+ * `gsm8k`, `livebench-coding`, …). This module classifies each benchmark slug
+ * into a task profile and computes a per-profile score by merging only the
+ * profile-relevant observations.
+ *
+ * Design (matches the plan's degradation note): when a model has no observation
+ * relevant to a profile, that profile's score falls back to the composite — the
+ * feature degrades to plain score-order rather than burying an un-tagged model.
+ * So `scoresByProfile.general` always equals the composite, and `coding` /
+ * `reasoning` differ only where the data supports it.
+ *
+ * @see docs/changes/lmlm-pool-consumption/proposal.md (D5)
+ */
+
+/** Task profiles the resolver routes use-cases to. `general` is the composite. */
+export const RANK_PROFILES = ['general', 'coding', 'reasoning'] as const;
+export type RankProfile = (typeof RANK_PROFILES)[number];
+
+/** Narrow an arbitrary string to a {@link RankProfile}. */
+export function isRankProfile(value: string): value is RankProfile {
+  return (RANK_PROFILES as readonly string[]).includes(value);
+}
+
+/**
+ * Classify a benchmark slug into the specialized profile it measures, or `null`
+ * when it's a general-knowledge benchmark (or unrecognized). Matching is
+ * substring/keyword based and case-insensitive so new leaderboard slugs on the
+ * same theme (`livecodebench`, `swe-bench`, `math-500`, …) map without a code
+ * change. Coding is checked before reasoning because some coding benchmarks
+ * ("code reasoning") contain reasoning keywords.
+ */
+export function classifyBenchmark(benchmark: string): Exclude<RankProfile, 'general'> | null {
+  const b = benchmark.toLowerCase();
+  if (
+    /(cod|humaneval|mbpp|swe[-_ ]?bench|repobench|bigcode|leetcode|program|polyglot|apps)/.test(b)
+  ) {
+    return 'coding';
+  }
+  if (
+    /(reason|math|gsm|gpqa|\barc\b|aqua|\bbbh\b|theorem|aime|logic|proof|drop|\bmath[-_]?500\b)/.test(
+      b
+    )
+  ) {
+    return 'reasoning';
+  }
+  return null;
+}

--- a/packages/local-models/src/ranker/types.ts
+++ b/packages/local-models/src/ranker/types.ts
@@ -25,6 +25,7 @@ import type {
 import type { MergedScore } from './benchmarks/merge.js';
 import type { KvCacheQuant, VramEstimate } from './vram.js';
 import type { SpeedBackend, SpeedEstimate } from './speed.js';
+import type { RankProfile } from './profiles.js';
 
 /**
  * Per-candidate input the orchestrator consumes. Identifiers and the
@@ -140,6 +141,15 @@ export interface RankedModel {
   speedEstimate: SpeedEstimate;
   /** Merged benchmark score plus per-observation contributions. */
   benchmarkScore: MergedScore;
+  /**
+   * Consumption Phase 4 (T12): per-task-profile scores on the same `[0, 100]`
+   * scale as `score`. `general` always equals the composite `score`; `coding`
+   * and `reasoning` weight only their profile-relevant benchmarks and fall back
+   * to the composite when the model has no relevant observations. Consumed by
+   * the pool's per-profile scoring so a coding-tagged dispatch picks the
+   * coding-best-fit pooled model. Always populated by `rankModels`.
+   */
+  scoresByProfile: Record<RankProfile, number>;
 }
 
 /** Stable warning codes the ranker surfaces alongside the ranking. */

--- a/packages/local-models/src/scheduler/refresh.ts
+++ b/packages/local-models/src/scheduler/refresh.ts
@@ -213,11 +213,20 @@ async function writeBackScores(
   ranked: RecommendResult['ranked'],
   errors: string[]
 ): Promise<void> {
-  const byName = new Map(ranked.map((m) => [m.ollamaName, m.score]));
+  // T14: carry the composite score AND the per-profile score map so a pooled
+  // model's task-aware ordering (poolStateToCandidates(state, profile)) reflects
+  // the latest re-rank, not a stale/absent profile map.
+  const byName = new Map(ranked.map((m) => [m.ollamaName, m]));
   const updates: ScoreUpdate[] = [];
   for (const entry of deps.poolManager.snapshot().entries) {
-    const score = byName.get(entry.ollamaName);
-    if (score !== undefined) updates.push({ ollamaName: entry.ollamaName, currentScore: score });
+    const model = byName.get(entry.ollamaName);
+    if (model !== undefined) {
+      updates.push({
+        ollamaName: entry.ollamaName,
+        currentScore: model.score,
+        scoresByProfile: { ...model.scoresByProfile },
+      });
+    }
   }
   if (updates.length === 0) return;
   await tryStage('updateScores', errors, () => deps.poolManager.updateScores(updates));

--- a/packages/local-models/tests/pool/provider.test.ts
+++ b/packages/local-models/tests/pool/provider.test.ts
@@ -33,6 +33,38 @@ describe('poolStateToCandidates', () => {
     poolStateToCandidates(state);
     expect(entries.map((e) => e.ollamaName)).toEqual(['a', 'b']);
   });
+
+  it('T15: orders by the requested profile score, not currentScore', () => {
+    // 'coder' has the lower composite score but the higher CODING profile score.
+    const coder: PoolEntry = {
+      ...entry('coder:7b', 60),
+      scoresByProfile: { coding: 95, reasoning: 30 },
+    };
+    const generalist: PoolEntry = {
+      ...entry('generalist:32b', 85),
+      scoresByProfile: { coding: 50, reasoning: 88 },
+    };
+    const state: PoolState = { ...EmptyPoolState(), entries: [coder, generalist] };
+
+    // No profile → composite order (generalist first).
+    expect(poolStateToCandidates(state)).toEqual(['generalist:32b', 'coder:7b']);
+    // Coding profile → the coding specialist wins.
+    expect(poolStateToCandidates(state, 'coding')).toEqual(['coder:7b', 'generalist:32b']);
+    // Reasoning profile → the generalist wins.
+    expect(poolStateToCandidates(state, 'reasoning')).toEqual(['generalist:32b', 'coder:7b']);
+  });
+
+  it('T15: falls back to currentScore when an entry lacks the requested profile score', () => {
+    const withProfile: PoolEntry = {
+      ...entry('a:7b', 40),
+      scoresByProfile: { coding: 90 },
+    };
+    const withoutProfile = entry('b:7b', 70); // no scoresByProfile → uses 70
+    const state: PoolState = { ...EmptyPoolState(), entries: [withProfile, withoutProfile] };
+
+    // For coding: a=90 (profile) vs b=70 (fallback currentScore) → a first.
+    expect(poolStateToCandidates(state, 'coding')).toEqual(['a:7b', 'b:7b']);
+  });
 });
 
 describe('PoolStateProvider structural conformance', () => {

--- a/packages/local-models/tests/proposals/engine.test.ts
+++ b/packages/local-models/tests/proposals/engine.test.ts
@@ -69,6 +69,12 @@ describe('diffPoolAgainstRanking (F6: at most one proposal per pool entry)', () 
     expect(p0.action).toBe('swap');
     expect(p0.justification.summary).toMatch(new RegExp(p0.target.ollamaName));
     expect(p0.scoreDelta).toBeGreaterThanOrEqual(5);
+    // T7: the swap proposal carries the target's absolute ranked score so the
+    // swapped-in entry seeds `currentScore` at its real rank — it equals the
+    // chosen candidate's score, not the delta.
+    const chosen = ranked.find((r) => r.ollamaName === p0.target.ollamaName)!;
+    expect(p0.targetScore).toBe(chosen.score);
+    expect(p0.targetScore).toBe(p0.scoreDelta + 60); // old-a's currentScore was 60
   });
 
   it('emits nothing when candidates beat by less than the threshold (ties included)', () => {

--- a/packages/local-models/tests/ranker/algorithm.test.ts
+++ b/packages/local-models/tests/ranker/algorithm.test.ts
@@ -574,3 +574,88 @@ describe('scaleScore helper', () => {
     expect(medium).toBeGreaterThanOrEqual(low);
   });
 });
+
+describe('rankModels — per-profile scores (T12)', () => {
+  function obs(benchmark: string, value: number): BenchmarkObservation {
+    return {
+      source: 'open-llm-leaderboard',
+      benchmark,
+      value,
+      evidence: 'direct',
+      observedAt: SNAPSHOT_DATE,
+    };
+  }
+
+  it('every ranked model carries a full scoresByProfile map; general equals composite', () => {
+    const snapshot = buildSnapshot([
+      {
+        hfRepoId: QWEN_32B.hfRepoId,
+        family: 'qwen3',
+        sizeB: QWEN_32B.sizeB,
+        observations: [freshDirectObservation(80)],
+      },
+    ]);
+    const [top] = rankModels({ candidates: [QWEN_32B], hardware: M3_MAX_36GB, snapshot }).ranked;
+    expect(top).toBeDefined();
+    if (!top) return;
+    expect(Object.keys(top.scoresByProfile).sort()).toEqual(['coding', 'general', 'reasoning']);
+    expect(top.scoresByProfile.general).toBeCloseTo(top.score, 6);
+  });
+
+  it('a coding-strong / reasoning-weak model scores higher on the coding profile', () => {
+    const snapshot = buildSnapshot([
+      {
+        hfRepoId: QWEN_32B.hfRepoId,
+        family: 'qwen3',
+        sizeB: QWEN_32B.sizeB,
+        // Strong coding, weak reasoning — the profiles must diverge.
+        observations: [obs('humaneval', 95), obs('gsm8k', 40)],
+      },
+    ]);
+    const [top] = rankModels({ candidates: [QWEN_32B], hardware: M3_MAX_36GB, snapshot }).ranked;
+    expect(top).toBeDefined();
+    if (!top) return;
+    expect(top.scoresByProfile.coding).toBeGreaterThan(top.scoresByProfile.reasoning);
+  });
+
+  it('falls back to the composite for a profile with no relevant benchmark', () => {
+    const snapshot = buildSnapshot([
+      {
+        hfRepoId: QWEN_32B.hfRepoId,
+        family: 'qwen3',
+        sizeB: QWEN_32B.sizeB,
+        // Only a general benchmark — coding/reasoning have no signal.
+        observations: [freshDirectObservation(80)],
+      },
+    ]);
+    const [top] = rankModels({ candidates: [QWEN_32B], hardware: M3_MAX_36GB, snapshot }).ranked;
+    expect(top).toBeDefined();
+    if (!top) return;
+    expect(top.scoresByProfile.coding).toBeCloseTo(top.score, 6);
+    expect(top.scoresByProfile.reasoning).toBeCloseTo(top.score, 6);
+  });
+
+  it('an unfit model scores 0 across all profiles', () => {
+    const snapshot = buildSnapshot([
+      {
+        hfRepoId: LLAMA_70B.hfRepoId,
+        family: 'llama-3',
+        sizeB: LLAMA_70B.sizeB,
+        observations: [obs('humaneval', 90)],
+      },
+    ]);
+    const result = rankModels({
+      candidates: [LLAMA_70B],
+      hardware: CPU_ONLY,
+      snapshot,
+      options: { includeUnfit: true },
+    });
+    const [top] = result.ranked;
+    expect(top).toBeDefined();
+    if (!top) return;
+    expect(top.fitsHardware).toBe(false);
+    expect(top.scoresByProfile.general).toBe(0);
+    expect(top.scoresByProfile.coding).toBe(0);
+    expect(top.scoresByProfile.reasoning).toBe(0);
+  });
+});

--- a/packages/local-models/tests/scheduler/refresh.test.ts
+++ b/packages/local-models/tests/scheduler/refresh.test.ts
@@ -150,6 +150,33 @@ describe('runRefreshTick (reconcile → rescore → diff → emit)', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('T14: writes per-profile scores back onto the pooled entry', async () => {
+    const pool = await seededPool(baseState(), [{ ollamaName: 'old:8b', sizeOnDiskGb: 20 }]);
+    const ranked = [
+      rankedModel({
+        ollamaName: 'old:8b',
+        hfRepoId: 'Qwen/Qwen3-8B-GGUF',
+        sizeB: 8,
+        score: 62,
+        scoresByProfile: { general: 62, coding: 75, reasoning: 40 },
+      }),
+    ];
+    const deps: RefreshTickDeps = {
+      detectHardware: async () => HARDWARE,
+      recommend: async () => recommendResult(ranked),
+      poolManager: pool,
+      dedupSource: async () => ({ pending: [], rejected: [] }),
+      emitProposal: async () => {},
+      proposalThreshold: 5,
+    };
+
+    await runRefreshTick(deps);
+
+    const entry = pool.snapshot().entries.find((e) => e.ollamaName === 'old:8b');
+    expect(entry?.currentScore).toBe(62);
+    expect(entry?.scoresByProfile).toEqual({ general: 62, coding: 75, reasoning: 40 });
+  });
+
   it('re-scores the pool BEFORE diffing → no phantom swap against a freshly-installed member scoring 0', async () => {
     // Regression: a just-installed/swapped-in member enters the pool at
     // currentScore 0 until its first re-rank. If the diff runs before the

--- a/packages/orchestrator/src/agent/analysis-provider-factory.ts
+++ b/packages/orchestrator/src/agent/analysis-provider-factory.ts
@@ -141,10 +141,19 @@ function buildLocalLikeProvider(
   logger.info(
     `Intelligence pipeline using backend '${backendName}' (${def.type}) at ${def.endpoint} (model: ${model ?? '(default)'})`
   );
+  // Consumption Phase 1 (T4): unless the operator pinned a layer model, read
+  // the resolver's current `resolved` fresh on every analysis request so a pool
+  // install/swap is consumed without reconstructing the pipeline. `defaultModel`
+  // (the construction-time snapshot) remains the fallback when the resolver
+  // transiently reports null. A pinned `layerModel` stays static — the operator
+  // asked for that specific model, so we don't let pool churn override it.
   return new OpenAICompatibleAnalysisProvider({
     apiKey,
     baseUrl: def.endpoint,
     ...(model !== undefined && { defaultModel: model }),
+    ...(layerModel === undefined && {
+      getModel: () => getResolverStatusSnapshot()?.resolved ?? undefined,
+    }),
     ...(intelligence?.requestTimeoutMs !== undefined && {
       timeoutMs: intelligence.requestTimeoutMs,
     }),

--- a/packages/orchestrator/src/agent/backends/local.ts
+++ b/packages/orchestrator/src/agent/backends/local.ts
@@ -23,6 +23,20 @@ export interface LocalBackendConfig {
   apiKey?: string;
   /** Request timeout in ms (default: 90000). */
   timeoutMs?: number;
+  /**
+   * Consumption Phase 3 (T9): called with the resolved model name after a turn
+   * completes successfully. The orchestrator binds this to `pool.markUsed`
+   * (stamps `lastUsedAt` so LRU eviction reflects real usage) and the resolver's
+   * circuit-breaker success path. Best-effort — thrown errors are swallowed so a
+   * telemetry hook never breaks a good turn.
+   */
+  onModelUsed?: (model: string) => void;
+  /**
+   * Consumption Phase 3 (T11): called with the resolved model name when a turn
+   * fails at the inference layer. Bound to the resolver's circuit breaker so a
+   * repeatedly-failing model is deprioritized. Best-effort.
+   */
+  onModelFailed?: (model: string) => void;
 }
 
 const DEFAULT_TIMEOUT_MS = 90_000;
@@ -35,8 +49,10 @@ export interface LocalSession extends AgentSession {
 
 export class LocalBackend implements AgentBackend {
   readonly name = 'local';
-  private config: Required<Omit<LocalBackendConfig, 'getModel'>>;
+  private config: Required<Omit<LocalBackendConfig, 'getModel' | 'onModelUsed' | 'onModelFailed'>>;
   private getModel: (() => string | null) | undefined;
+  private onModelUsed: ((model: string) => void) | undefined;
+  private onModelFailed: ((model: string) => void) | undefined;
   private client: OpenAI;
 
   constructor(config: LocalBackendConfig = {}) {
@@ -47,6 +63,8 @@ export class LocalBackend implements AgentBackend {
       timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     };
     this.getModel = config.getModel;
+    this.onModelUsed = config.onModelUsed;
+    this.onModelFailed = config.onModelFailed;
     this.client = new OpenAI({
       apiKey: this.config.apiKey,
       baseURL: this.config.endpoint,
@@ -127,6 +145,8 @@ export class LocalBackend implements AgentBackend {
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Local backend request failed';
+      // T11: feed the inference failure to the resolver's circuit breaker.
+      this.notify(this.onModelFailed, localSession.resolvedModel);
       yield {
         type: 'error',
         timestamp: new Date().toISOString(),
@@ -140,6 +160,10 @@ export class LocalBackend implements AgentBackend {
         error: errorMessage,
       };
     }
+
+    // T9: a turn completed against `resolvedModel` — stamp real usage (LRU) and
+    // clear the circuit breaker via the orchestrator-bound hook.
+    this.notify(this.onModelUsed, localSession.resolvedModel);
 
     const usage = { inputTokens, outputTokens, totalTokens };
 
@@ -158,6 +182,16 @@ export class LocalBackend implements AgentBackend {
       sessionId: session.sessionId,
       usage,
     };
+  }
+
+  /** Best-effort telemetry hook invocation — a throwing hook never breaks a turn. */
+  private notify(hook: ((model: string) => void) | undefined, model: string): void {
+    if (!hook) return;
+    try {
+      hook(model);
+    } catch {
+      // Swallow — usage/failure telemetry is advisory, not turn-critical.
+    }
   }
 
   async stopSession(_session: AgentSession): Promise<Result<void, AgentError>> {

--- a/packages/orchestrator/src/agent/local-model-resolver.ts
+++ b/packages/orchestrator/src/agent/local-model-resolver.ts
@@ -57,6 +57,15 @@ export interface LocalModelResolverOptions {
   /** Debounce window for event-driven {@link LocalModelResolver.refresh}; default 250ms. */
   refreshDebounceMs?: number;
   /**
+   * Consumption Phase 5 (T19/T20): called with the newly-resolved model name
+   * whenever the resolver's composite selection changes (and is non-null), so
+   * the orchestrator can warm it into VRAM before the next dispatch. Naturally
+   * debounced — it fires only on an actual selection change, not every probe.
+   * Best-effort: a throwing hook is swallowed. Injected in tests; wired to
+   * {@link defaultWarmModel} in production.
+   */
+  warmModel?: (ollamaName: string) => void;
+  /**
    * Consumption Phase 3 (T10): consecutive inference failures before a model is
    * deprioritized by the circuit breaker. Default 3.
    */
@@ -145,6 +154,42 @@ export async function defaultFetchModels(
   return ids;
 }
 
+/**
+ * Consumption Phase 5 (T19): warm `ollamaName` into VRAM via Ollama's native
+ * `keep_alive`. Derives the native `/api/generate` endpoint from the
+ * OpenAI-compatible `endpoint` (`…/v1` → `…`), then POSTs an empty-prompt
+ * request with `keep_alive` so Ollama loads (and pins) the model without
+ * generating tokens. Best-effort and Ollama-specific (LMLM is Ollama-first):
+ * a non-Ollama server or any failure resolves quietly — warming is an
+ * optimization, never a correctness requirement. Fire-and-forget: the returned
+ * promise is swallowed by callers.
+ */
+export async function defaultWarmModel(
+  endpoint: string,
+  ollamaName: string,
+  apiKey?: string,
+  keepAlive: string = '10m',
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS
+): Promise<void> {
+  // `http://host:11434/v1` → `http://host:11434/api/generate`.
+  const base = endpoint.replace(/\/v1\/?$/, '').replace(/\/$/, '');
+  const url = `${base}/api/generate`;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey ?? DEFAULT_API_KEY}`,
+      },
+      // Empty prompt + keep_alive loads the model into VRAM without generating.
+      body: JSON.stringify({ model: ollamaName, prompt: '', keep_alive: keepAlive }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch {
+    // Best-effort — a cold model just costs the next dispatch a load. Swallow.
+  }
+}
+
 export class LocalModelResolver {
   private readonly endpoint: string;
   private readonly apiKey?: string;
@@ -152,6 +197,7 @@ export class LocalModelResolver {
   private readonly poolState?: PoolStateProvider;
   private readonly probeIntervalMs: number;
   private readonly fetchModels: (endpoint: string, apiKey?: string) => Promise<string[]>;
+  private readonly warmModel?: (ollamaName: string) => void;
   private readonly logger: ResolverLogger;
 
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -209,6 +255,7 @@ export class LocalModelResolver {
     this.fetchModels =
       opts.fetchModels ??
       ((endpoint: string, apiKey?: string) => defaultFetchModels(endpoint, apiKey, timeoutMs));
+    if (opts.warmModel !== undefined) this.warmModel = opts.warmModel;
     this.logger = opts.logger ?? noopLogger;
   }
 
@@ -276,6 +323,7 @@ export class LocalModelResolver {
 
   private async runProbe(): Promise<LocalModelStatus> {
     const before = this.snapshotForDiff();
+    const prevResolved = this.resolved;
     try {
       const detected = await this.fetchModels(this.endpoint, this.apiKey);
       this.detected = [...detected];
@@ -315,7 +363,25 @@ export class LocalModelResolver {
         }
       }
     }
+    // T20: warm the newly-selected model on a selection change so the next
+    // dispatch isn't a cold start. Fires only when the composite resolution
+    // actually changed to a non-null model — a natural debounce.
+    if (this.resolved !== null && this.resolved !== prevResolved) {
+      this.warm(this.resolved);
+    }
     return status;
+  }
+
+  /** Best-effort warm-hook invocation — a throwing warm never breaks a probe. */
+  private warm(ollamaName: string): void {
+    if (!this.warmModel) return;
+    try {
+      this.warmModel(ollamaName);
+    } catch (err) {
+      this.logger.warn('local-model-resolver warm hook threw', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**

--- a/packages/orchestrator/src/agent/local-model-resolver.ts
+++ b/packages/orchestrator/src/agent/local-model-resolver.ts
@@ -1,6 +1,24 @@
-import type { LocalModelStatus } from '@harness-engineering/types';
-import type { PoolStateProvider } from '@harness-engineering/local-models';
+import type { LocalModelStatus, RoutingUseCase } from '@harness-engineering/types';
+import type { PoolStateProvider, RankProfile } from '@harness-engineering/local-models';
 import { poolStateToCandidates } from '@harness-engineering/local-models';
+
+/**
+ * Consumption Phase 4 (T16): map a routing use-case to the task profile whose
+ * per-model scores the resolver should order pooled candidates by. Code-editing
+ * tiers → `coding`; the diagnostic tier (debugging/investigation) → `reasoning`;
+ * everything else (analysis layers, chat, maintenance, sandboxing, skills/modes)
+ * → `general`, i.e. the composite score. Heuristic + intentionally conservative
+ * — see the task-aware-selection ADR. Extend here as more signal is available
+ * (e.g. cognitiveMode on `skill`/`mode`).
+ */
+export function useCaseToProfile(useCase: RoutingUseCase): RankProfile {
+  switch (useCase.kind) {
+    case 'tier':
+      return useCase.tier === 'diagnostic' ? 'reasoning' : 'coding';
+    default:
+      return 'general';
+  }
+}
 
 const DEFAULT_PROBE_INTERVAL_MS = 30_000;
 const MIN_PROBE_INTERVAL_MS = 1_000;
@@ -194,8 +212,21 @@ export class LocalModelResolver {
     this.logger = opts.logger ?? noopLogger;
   }
 
-  resolveModel(): string | null {
-    return this.resolved;
+  /**
+   * The model to dispatch to. With no `useCase`, returns the cached composite
+   * resolution from the last probe (byte-identical to the pre-Phase-4 resolver).
+   * With a `useCase`, orders the (pool-derived) candidates by that use-case's
+   * task profile and picks the best loaded, breaker-healthy one — so a
+   * coding-tagged dispatch prefers the coding specialist. A `general`-mapped
+   * use-case returns the cached composite resolution unchanged.
+   */
+  resolveModel(useCase?: RoutingUseCase): string | null {
+    if (useCase === undefined) return this.resolved;
+    const profile = useCaseToProfile(useCase);
+    if (profile === 'general') return this.resolved;
+    // Re-select from the last-probed detected set ordered by the profile score.
+    // No re-probe: `this.detected` reflects the most recent poll/refresh.
+    return this.selectMatch(this.candidates(profile), this.detected);
   }
 
   getStatus(): LocalModelStatus {
@@ -215,8 +246,10 @@ export class LocalModelResolver {
    * from pool entries (currentScore desc → ollamaName); otherwise the static
    * `configured` list is returned unchanged (byte-identical to pre-Phase-4).
    */
-  private candidates(): string[] {
-    return this.poolState ? poolStateToCandidates(this.poolState.snapshot()) : [...this.configured];
+  private candidates(profile?: RankProfile): string[] {
+    return this.poolState
+      ? poolStateToCandidates(this.poolState.snapshot(), profile)
+      : [...this.configured];
   }
 
   onStatusChange(handler: (status: LocalModelStatus) => void): () => void {

--- a/packages/orchestrator/src/agent/local-model-resolver.ts
+++ b/packages/orchestrator/src/agent/local-model-resolver.ts
@@ -4,6 +4,8 @@ import { poolStateToCandidates } from '@harness-engineering/local-models';
 
 const DEFAULT_PROBE_INTERVAL_MS = 30_000;
 const MIN_PROBE_INTERVAL_MS = 1_000;
+/** Coalescing window for event-driven `refresh()` so a burst of pool frames → one probe. */
+const REFRESH_DEBOUNCE_MS = 250;
 const DEFAULT_API_KEY = 'lm-studio'; // harness-ignore SEC-SEC-002: LM Studio documented no-auth placeholder, not a real secret
 const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
@@ -26,6 +28,8 @@ export interface LocalModelResolverOptions {
   poolState?: PoolStateProvider;
   /** Probe cadence in ms; default 30_000, minimum 1_000. */
   probeIntervalMs?: number;
+  /** Debounce window for event-driven {@link LocalModelResolver.refresh}; default 250ms. */
+  refreshDebounceMs?: number;
   /**
    * Per-request timeout for the default fetch implementation, in ms.
    * Default: 5_000. Ignored when a custom `fetchModels` is provided
@@ -116,6 +120,10 @@ export class LocalModelResolver {
   private readonly logger: ResolverLogger;
 
   private timer: ReturnType<typeof setInterval> | null = null;
+  /** Debounce handle for event-driven {@link refresh}; coalesces a burst into one probe. */
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Test seam for the refresh debounce delay (0 in tests → next-tick probe). */
+  private readonly refreshDebounceMs: number;
   private listeners = new Set<(status: LocalModelStatus) => void>();
   /**
    * Tracks an in-flight probe so concurrent invocations (interval tick while a
@@ -147,6 +155,7 @@ export class LocalModelResolver {
     }
     const interval = opts.probeIntervalMs ?? DEFAULT_PROBE_INTERVAL_MS;
     this.probeIntervalMs = Math.max(MIN_PROBE_INTERVAL_MS, interval);
+    this.refreshDebounceMs = Math.max(0, opts.refreshDebounceMs ?? REFRESH_DEBOUNCE_MS);
     const timeoutMs = opts.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
     // Bind timeout into the default impl. Custom `fetchModels` injections own
     // their own timeout policy (typically the test harness), so we leave them
@@ -248,6 +257,22 @@ export class LocalModelResolver {
     return status;
   }
 
+  /**
+   * Event-driven refresh: schedule a debounced re-probe. Called when a
+   * `local-models:pool` mutation fires so a just-installed/swapped model becomes
+   * usable within a debounce window instead of waiting up to `probeIntervalMs`.
+   * A burst of frames coalesces into one probe (the timer is only armed once).
+   */
+  refresh(): void {
+    if (this.refreshTimer !== null) return;
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = null;
+      void this.probe();
+    }, this.refreshDebounceMs);
+    const handle = this.refreshTimer as unknown as { unref?: () => void };
+    handle.unref?.();
+  }
+
   async start(): Promise<void> {
     if (this.timer !== null) {
       // Idempotent: already running.
@@ -269,6 +294,10 @@ export class LocalModelResolver {
     if (this.timer !== null) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    if (this.refreshTimer !== null) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
     }
   }
 

--- a/packages/orchestrator/src/agent/local-model-resolver.ts
+++ b/packages/orchestrator/src/agent/local-model-resolver.ts
@@ -6,6 +6,14 @@ const DEFAULT_PROBE_INTERVAL_MS = 30_000;
 const MIN_PROBE_INTERVAL_MS = 1_000;
 /** Coalescing window for event-driven `refresh()` so a burst of pool frames → one probe. */
 const REFRESH_DEBOUNCE_MS = 250;
+/**
+ * Consumption Phase 3 (T10): consecutive inference failures that trip a model's
+ * circuit breaker (deprioritizing it during resolution). A success or an elapsed
+ * cooldown clears the count.
+ */
+const DEFAULT_BREAKER_THRESHOLD = 3;
+/** How long a tripped model stays deprioritized before it's eligible again. */
+const DEFAULT_BREAKER_COOLDOWN_MS = 60_000;
 const DEFAULT_API_KEY = 'lm-studio'; // harness-ignore SEC-SEC-002: LM Studio documented no-auth placeholder, not a real secret
 const DEFAULT_FETCH_TIMEOUT_MS = 5_000;
 
@@ -30,6 +38,15 @@ export interface LocalModelResolverOptions {
   probeIntervalMs?: number;
   /** Debounce window for event-driven {@link LocalModelResolver.refresh}; default 250ms. */
   refreshDebounceMs?: number;
+  /**
+   * Consumption Phase 3 (T10): consecutive inference failures before a model is
+   * deprioritized by the circuit breaker. Default 3.
+   */
+  breakerThreshold?: number;
+  /** Cooldown (ms) after which a tripped model is eligible again. Default 60_000. */
+  breakerCooldownMs?: number;
+  /** Injectable clock (ms since epoch) for the circuit-breaker cooldown; default `Date.now`. Test seam. */
+  now?: () => number;
   /**
    * Per-request timeout for the default fetch implementation, in ms.
    * Default: 5_000. Ignored when a custom `fetchModels` is provided
@@ -124,6 +141,14 @@ export class LocalModelResolver {
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
   /** Test seam for the refresh debounce delay (0 in tests → next-tick probe). */
   private readonly refreshDebounceMs: number;
+  /** Consumption Phase 3 (T10): circuit-breaker config + per-model failure/trip state. */
+  private readonly breakerThreshold: number;
+  private readonly breakerCooldownMs: number;
+  private readonly now: () => number;
+  /** Consecutive inference failures per model since its last success. */
+  private consecutiveFailures = new Map<string, number>();
+  /** Epoch-ms at which a tripped model becomes eligible again (cooldown expiry). */
+  private trippedUntil = new Map<string, number>();
   private listeners = new Set<(status: LocalModelStatus) => void>();
   /**
    * Tracks an in-flight probe so concurrent invocations (interval tick while a
@@ -156,6 +181,9 @@ export class LocalModelResolver {
     const interval = opts.probeIntervalMs ?? DEFAULT_PROBE_INTERVAL_MS;
     this.probeIntervalMs = Math.max(MIN_PROBE_INTERVAL_MS, interval);
     this.refreshDebounceMs = Math.max(0, opts.refreshDebounceMs ?? REFRESH_DEBOUNCE_MS);
+    this.breakerThreshold = Math.max(1, opts.breakerThreshold ?? DEFAULT_BREAKER_THRESHOLD);
+    this.breakerCooldownMs = Math.max(0, opts.breakerCooldownMs ?? DEFAULT_BREAKER_COOLDOWN_MS);
+    this.now = opts.now ?? (() => Date.now());
     const timeoutMs = opts.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
     // Bind timeout into the default impl. Custom `fetchModels` injections own
     // their own timeout policy (typically the test harness), so we leave them
@@ -221,7 +249,7 @@ export class LocalModelResolver {
       this.lastError = null;
       this.lastProbeAt = new Date().toISOString();
       const candidates = this.candidates();
-      const match = candidates.find((id) => detected.includes(id)) ?? null;
+      const match = this.selectMatch(candidates, detected);
       this.resolved = match;
       this.available = match !== null;
       this.warnings = match
@@ -255,6 +283,67 @@ export class LocalModelResolver {
       }
     }
     return status;
+  }
+
+  /**
+   * Consumption Phase 3 (T10): pick the resolved model from the candidates that
+   * are actually loaded, preferring ones whose circuit breaker is not tripped.
+   * Candidate order (score-desc from the pool) is preserved within each tier, so
+   * a tripped top pick sinks below a healthy lower pick but still resolves as a
+   * last resort when every loaded candidate is tripped (better a flaky model than
+   * none). Returns null when no candidate is loaded.
+   */
+  private selectMatch(candidates: string[], detected: string[]): string | null {
+    const detectedSet = new Set(detected);
+    const available = candidates.filter((id) => detectedSet.has(id));
+    if (available.length === 0) return null;
+    const healthy = available.filter((id) => !this.isTripped(id));
+    return healthy[0] ?? available[0] ?? null;
+  }
+
+  /**
+   * Whether `model`'s circuit breaker is currently tripped. Lazily clears the
+   * trip once its cooldown has elapsed so the model becomes eligible again on the
+   * next resolution without needing a separate timer.
+   */
+  private isTripped(model: string): boolean {
+    const until = this.trippedUntil.get(model);
+    if (until === undefined) return false;
+    if (this.now() >= until) {
+      this.trippedUntil.delete(model);
+      this.consecutiveFailures.delete(model);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Record a successful inference on `model`: clears its failure count and any
+   * active trip so a recovered model is immediately re-preferred.
+   */
+  recordSuccess(model: string): void {
+    if (!model) return;
+    const hadState = this.consecutiveFailures.has(model) || this.trippedUntil.has(model);
+    this.consecutiveFailures.delete(model);
+    this.trippedUntil.delete(model);
+    // A recovery may change which model is preferred — re-resolve promptly.
+    if (hadState) this.refresh();
+  }
+
+  /**
+   * Record a failed inference on `model`. On the Nth consecutive failure the
+   * breaker trips (deprioritizing the model for `breakerCooldownMs`) and a
+   * re-probe is scheduled so the resolver rolls to a healthy alternative.
+   */
+  recordFailure(model: string): void {
+    if (!model) return;
+    const next = (this.consecutiveFailures.get(model) ?? 0) + 1;
+    this.consecutiveFailures.set(model, next);
+    if (next >= this.breakerThreshold) {
+      this.trippedUntil.set(model, this.now() + this.breakerCooldownMs);
+      // The currently-resolved model just tripped — re-resolve to a healthy one.
+      this.refresh();
+    }
   }
 
   /**

--- a/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
+++ b/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
@@ -25,6 +25,17 @@ import { PiBackend } from './backends/pi.js';
  * `LocalModelResolver` (so multi-resolver array-fallback works without
  * leaking resolver lifetimes into the factory).
  */
+/**
+ * Runtime-feedback callbacks a `local`/`pi` backend fires as turns complete.
+ * See {@link OrchestratorBackendFactoryOptions.getModelUsageHooksFor}.
+ */
+export interface LocalModelUsageHooks {
+  /** Fired with the resolved model after a successful turn (LRU + breaker clear). */
+  onModelUsed?: (model: string) => void;
+  /** Fired with the resolved model after a failed turn (breaker increment). */
+  onModelFailed?: (model: string) => void;
+}
+
 export interface OrchestratorBackendFactoryOptions {
   backends: Record<string, BackendDef>;
   routing: RoutingConfig;
@@ -44,6 +55,16 @@ export interface OrchestratorBackendFactoryOptions {
    * route through the resolver Map.
    */
   getResolverModelFor?: (backendName: string) => (() => string | null) | undefined;
+  /**
+   * Consumption Phase 3 (T11): per-`local`/`pi` backend hook returning the
+   * runtime-feedback callbacks bound to that backend's resolver + pool. The
+   * factory forwards them to the constructed `LocalBackend` so a completed turn
+   * stamps `lastUsedAt` (LRU) + clears the circuit breaker, and a failed turn
+   * feeds the breaker. Returning `undefined` means "no feedback wiring" (the
+   * backend runs exactly as before). Kept parallel to `getResolverModelFor` so
+   * the factory stays ignorant of resolver/pool lifecycles.
+   */
+  getModelUsageHooksFor?: (backendName: string) => LocalModelUsageHooks | undefined;
   /**
    * Phase 5: prompt-cache recorder forwarded to Anthropic-capable backends.
    * Other backends accept-but-ignore. Shared across dispatches so the
@@ -124,8 +145,9 @@ export class OrchestratorBackendFactory {
 
     if ((def.type === 'local' || def.type === 'pi') && this.opts.getResolverModelFor) {
       const getModel = this.opts.getResolverModelFor(name);
+      const usageHooks = this.opts.getModelUsageHooksFor?.(name);
       backend = getModel
-        ? this.buildLocalLikeWithResolver(def, getModel)
+        ? this.buildLocalLikeWithResolver(def, getModel, usageHooks)
         : createBackend(def, createOpts);
     } else {
       backend = createBackend(def, createOpts);
@@ -143,16 +165,27 @@ export class OrchestratorBackendFactory {
    * mirroring `createBackend`'s local/pi branches but substituting the
    * head-of-array placeholder with the orchestrator-owned resolver.
    */
-  private buildLocalLikeWithResolver(def: BackendDef, getModel: () => string | null): AgentBackend {
+  private buildLocalLikeWithResolver(
+    def: BackendDef,
+    getModel: () => string | null,
+    usageHooks?: LocalModelUsageHooks
+  ): AgentBackend {
     if (def.type === 'local') {
       return new LocalBackend({
         endpoint: def.endpoint,
         getModel,
         ...(def.apiKey !== undefined ? { apiKey: def.apiKey } : {}),
         ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
+        ...(usageHooks?.onModelUsed !== undefined ? { onModelUsed: usageHooks.onModelUsed } : {}),
+        ...(usageHooks?.onModelFailed !== undefined
+          ? { onModelFailed: usageHooks.onModelFailed }
+          : {}),
       });
     }
     if (def.type === 'pi') {
+      // T11: PiBackend's streaming pi-session turn path doesn't yet surface the
+      // usage/failure hooks; runtime feedback is wired for `local` only. `getModel`
+      // (freshness) still applies. Extending pi is a follow-up.
       return new PiBackend({
         endpoint: def.endpoint,
         getModel,

--- a/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
+++ b/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
@@ -54,7 +54,10 @@ export interface OrchestratorBackendFactoryOptions {
    * existence and lifecycle while still letting it produce backends that
    * route through the resolver Map.
    */
-  getResolverModelFor?: (backendName: string) => (() => string | null) | undefined;
+  getResolverModelFor?: (
+    backendName: string,
+    useCase: RoutingUseCase
+  ) => (() => string | null) | undefined;
   /**
    * Consumption Phase 3 (T11): per-`local`/`pi` backend hook returning the
    * runtime-feedback callbacks bound to that backend's resolver + pool. The
@@ -144,7 +147,9 @@ export class OrchestratorBackendFactory {
     const createOpts = this.opts.cacheMetrics ? { cacheMetrics: this.opts.cacheMetrics } : {};
 
     if ((def.type === 'local' || def.type === 'pi') && this.opts.getResolverModelFor) {
-      const getModel = this.opts.getResolverModelFor(name);
+      // T17: thread the routed use-case so the resolver can order pooled
+      // candidates by the use-case's task profile (coding/reasoning/general).
+      const getModel = this.opts.getResolverModelFor(name, useCase);
       const usageHooks = this.opts.getModelUsageHooksFor?.(name);
       backend = getModel
         ? this.buildLocalLikeWithResolver(def, getModel, usageHooks)

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -620,6 +620,24 @@ export class Orchestrator extends EventEmitter {
           const resolver = this.localResolvers.get(name);
           return resolver ? () => resolver.resolveModel() : undefined;
         },
+        // Consumption Phase 3 (T11): bind per-backend runtime feedback. A
+        // successful turn stamps `lastUsedAt` (LRU) via the pool and clears the
+        // resolver's circuit breaker; a failed turn feeds the breaker so a
+        // repeatedly-failing model is deprioritized. `modelPool` is read lazily
+        // (per dispatch) because it loads in start(), after this constructor.
+        getModelUsageHooksFor: (name) => {
+          const resolver = this.localResolvers.get(name);
+          if (!resolver) return undefined;
+          return {
+            onModelUsed: (model: string) => {
+              resolver.recordSuccess(model);
+              void this.modelPool?.markUsed(model);
+            },
+            onModelFailed: (model: string) => {
+              resolver.recordFailure(model);
+            },
+          };
+        },
       });
     } else {
       this.backendFactory = null;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -32,7 +32,7 @@ import { PromptRenderer } from './prompt/renderer';
 // `OrchestratorBackendFactory` + `createBackend` (factory module). The
 // orchestrator no longer constructs backends directly — factory handles
 // dispatch-time materialization.
-import { LocalModelResolver } from './agent/local-model-resolver';
+import { LocalModelResolver, defaultWarmModel } from './agent/local-model-resolver';
 import {
   PoolStateStore,
   PoolManager,
@@ -553,6 +553,16 @@ export class Orchestrator extends EventEmitter {
         if (def.apiKey !== undefined) resolverOpts.apiKey = def.apiKey;
         if (def.probeIntervalMs !== undefined) resolverOpts.probeIntervalMs = def.probeIntervalMs;
         if (this.poolStateProvider !== null) resolverOpts.poolState = this.poolStateProvider;
+        // T20: warm a newly-selected model into VRAM (Ollama keep_alive) so the
+        // next dispatch isn't a cold start. Only for the Ollama-first `local`
+        // backend; `pi` (LM Studio) has no equivalent keep_alive primitive.
+        if (def.type === 'local') {
+          const endpoint = def.endpoint;
+          const apiKey = def.apiKey;
+          resolverOpts.warmModel = (ollamaName) => {
+            void defaultWarmModel(endpoint, ollamaName, apiKey);
+          };
+        }
         this.localResolvers.set(name, new LocalModelResolver(resolverOpts));
       }
     }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -222,6 +222,13 @@ export class Orchestrator extends EventEmitter {
    * so this map is the single source of truth post-migration.
    */
   private localResolvers = new Map<string, LocalModelResolver>();
+  /**
+   * Consumption Phase 1 (T2): bus listener that debounce-refreshes every local
+   * resolver when a `local-models:pool` mutation fires, so a just-installed or
+   * swapped model becomes usable within the refresh window instead of waiting up
+   * to `probeIntervalMs` for the next poll. Held for removal in {@link stop}.
+   */
+  private poolRefreshListener: (() => void) | null = null;
   /** Phase 4 (D5): pool-state port shared by all local/pi resolvers. Null when LMLM disabled. */
   private poolStateProvider: PoolStateProvider | null = null;
   private poolStateStore: PoolStateStore | null = null;
@@ -2416,6 +2423,19 @@ export class Orchestrator extends EventEmitter {
       for (const resolver of this.localResolvers.values()) {
         await resolver.start();
       }
+      // Consumption Phase 1 (T2): event-driven freshness. A `local-models:pool`
+      // mutation (install / swap / eviction) debounce-refreshes every resolver
+      // so the new pool member is resolvable in seconds, not up to a poll cycle.
+      // Registered once, after resolvers are running, and removed in stop().
+      if (this.poolRefreshListener === null && this.localResolvers.size > 0) {
+        const listener = (): void => {
+          for (const resolver of this.localResolvers.values()) {
+            resolver.refresh();
+          }
+        };
+        this.poolRefreshListener = listener;
+        this.on('local-models:pool', listener);
+      }
     }
     // LMLM Phase 6: start the background refresh scheduler once the pool state
     // is loaded. Guarded on modelPool so LMLM-disabled configs never arm it.
@@ -2531,6 +2551,12 @@ export class Orchestrator extends EventEmitter {
     // Null out the bus reference; ring buffer + listener set are
     // eligible for GC once no external references remain.
     this.routingDecisionBus = null;
+    // Consumption Phase 1 (T2): detach the pool-refresh bus listener before
+    // stopping resolvers so a late emit can't re-arm a stopped resolver's timer.
+    if (this.poolRefreshListener !== null) {
+      this.removeListener('local-models:pool', this.poolRefreshListener);
+      this.poolRefreshListener = null;
+    }
     for (const resolver of this.localResolvers.values()) {
       resolver.stop();
     }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -616,9 +616,11 @@ export class Orchestrator extends EventEmitter {
         ...(this.config.agent.secrets !== undefined ? { secrets: this.config.agent.secrets } : {}),
         cacheMetrics: this.cacheMetrics,
         decisionBus: this.routingDecisionBus,
-        getResolverModelFor: (name) => {
+        getResolverModelFor: (name, useCase) => {
           const resolver = this.localResolvers.get(name);
-          return resolver ? () => resolver.resolveModel() : undefined;
+          // T17: bind the routed use-case so resolveModel orders candidates by
+          // its task profile (coding/reasoning/general).
+          return resolver ? () => resolver.resolveModel(useCase) : undefined;
         },
         // Consumption Phase 3 (T11): bind per-backend runtime feedback. A
         // successful turn stamps `lastUsedAt` (LRU) via the pool and clears the

--- a/packages/orchestrator/src/proposals/model-handlers.ts
+++ b/packages/orchestrator/src/proposals/model-handlers.ts
@@ -234,13 +234,17 @@ export async function onApproveModelProposal(
   // `approved` on success or reverted to `open` on a retryable failure below.
   await deps.updateProposal(proposal.id, { status: 'installing' });
 
-  // The proposal carries only a score *delta*, not an absolute score; the new
-  // pool entry starts at 0 and the scheduler's next re-rank sets its real score.
+  // Consumption Phase 2 (T7): seed the new entry's score from the proposal's
+  // absolute `targetScore` (the ranker's composite for the target) so an
+  // explicitly-installed model is immediately resolvable at its real rank
+  // instead of sitting at 0 until the scheduler's next re-rank. Older proposals
+  // without `targetScore` fall back to 0 (legacy behavior).
   const installResult = await deps.pool.install({
     hfRepoId: model.target.hfRepoId,
     ollamaName: model.target.ollamaName,
     ...(model.replaces !== undefined ? { replaces: model.replaces.ollamaName } : {}),
     ...(model.diskImpactGb > 0 ? { sizeOnDiskGb: model.diskImpactGb } : {}),
+    ...(model.targetScore !== undefined ? { initialScore: model.targetScore } : {}),
     ...(deps.onInstallEvent ? { onEvent: deps.onInstallEvent } : {}),
   });
 

--- a/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
+++ b/packages/orchestrator/src/server/routes/v1/local-models-pool-mutation.ts
@@ -138,6 +138,11 @@ async function handleInstall(
     action: 'add',
     target: { hfRepoId: match.hfRepoId, ollamaName: match.ollamaName },
     scoreDelta: match.score,
+    // Consumption Phase 2 (T7): carry the absolute ranked score so the new pool
+    // entry seeds `currentScore` at its real rank instead of 0 — an
+    // operator-initiated install is usable immediately, not buried until the
+    // scheduler's next re-rank.
+    targetScore: match.score,
     justification: {
       summary: `Operator-initiated install of ${match.ollamaName} (${match.quant}).`,
       benchmarkBasis: [],

--- a/packages/orchestrator/tests/agent/analysis-provider-factory.test.ts
+++ b/packages/orchestrator/tests/agent/analysis-provider-factory.test.ts
@@ -58,6 +58,60 @@ describe('buildAnalysisProvider — BackendDef → AnalysisProvider translation'
     expect(result).toBeInstanceOf(OpenAICompatibleAnalysisProvider);
   });
 
+  it('T4: wires getModel to read the resolver snapshot live (no pinned layer model)', () => {
+    let resolved: string | null = 'model-a';
+    const def: BackendDef = {
+      type: 'local',
+      endpoint: 'http://localhost:11434/v1',
+      model: 'model-a',
+      apiKey: 'ollama',
+    };
+    const result = buildAnalysisProvider({
+      def,
+      backendName: 'local',
+      layer: 'sel',
+      getResolverStatusSnapshot: () => ({
+        available: true,
+        resolved,
+        configured: ['model-a'],
+        detected: ['model-a'],
+      }),
+      intelligence: { enabled: true },
+      logger: noopLogger,
+    });
+    const getModel = (result as unknown as { getModel?: () => string | null | undefined }).getModel;
+    expect(getModel).toBeTypeOf('function');
+    expect(getModel!()).toBe('model-a');
+    // A pool swap changes the resolver; getModel reflects it without rebuild.
+    resolved = 'model-b';
+    expect(getModel!()).toBe('model-b');
+  });
+
+  it('T4: does NOT wire getModel when an operator pinned a layer model', () => {
+    const def: BackendDef = {
+      type: 'local',
+      endpoint: 'http://localhost:11434/v1',
+      model: 'model-a',
+      apiKey: 'ollama',
+    };
+    const result = buildAnalysisProvider({
+      def,
+      backendName: 'local',
+      layer: 'sel',
+      getResolverStatusSnapshot: () => ({
+        available: true,
+        resolved: 'model-a',
+        configured: ['model-a'],
+        detected: ['model-a'],
+      }),
+      // Operator pinned the SEL layer model — pool churn must not override it.
+      intelligence: { enabled: true, models: { sel: 'pinned-model' } },
+      logger: noopLogger,
+    });
+    const getModel = (result as unknown as { getModel?: () => string | null | undefined }).getModel;
+    expect(getModel).toBeUndefined();
+  });
+
   it('SC31: type=local with unavailable resolver returns null and warns', () => {
     const warnSpy = vi.fn();
     const def: BackendDef = {

--- a/packages/orchestrator/tests/agent/backends/local.test.ts
+++ b/packages/orchestrator/tests/agent/backends/local.test.ts
@@ -271,4 +271,112 @@ describe('LocalBackend', () => {
       );
     });
   });
+
+  describe('model-usage hooks (T9/T11)', () => {
+    async function drain(gen: AsyncGenerator<unknown, unknown, void>): Promise<void> {
+      let next = await gen.next();
+      while (!next.done) next = await gen.next();
+    }
+
+    it('T9: calls onModelUsed once with the resolved model on a successful turn', async () => {
+      const openaiModule = await import('openai');
+      const mockChatCreate = (
+        openaiModule as unknown as { __mockChatCreate: ReturnType<typeof vi.fn> }
+      ).__mockChatCreate;
+      mockChatCreate.mockClear();
+
+      const onModelUsed = vi.fn();
+      const onModelFailed = vi.fn();
+      const localBackend = new LocalBackend({
+        endpoint: 'http://localhost:11434/v1',
+        getModel: () => 'qwen3:8b',
+        onModelUsed,
+        onModelFailed,
+      });
+      const sessionResult = await localBackend.startSession({
+        workspacePath: '/tmp/workspace',
+        permissionMode: 'full',
+      });
+      if (!sessionResult.ok) return;
+
+      await drain(
+        localBackend.runTurn(sessionResult.value, {
+          sessionId: sessionResult.value.sessionId,
+          prompt: 'Hi',
+          isContinuation: false,
+        })
+      );
+
+      expect(onModelUsed).toHaveBeenCalledTimes(1);
+      expect(onModelUsed).toHaveBeenCalledWith('qwen3:8b');
+      expect(onModelFailed).not.toHaveBeenCalled();
+    });
+
+    it('T11: calls onModelFailed (not onModelUsed) when the inference call throws', async () => {
+      const openaiModule = await import('openai');
+      const mockChatCreate = (
+        openaiModule as unknown as { __mockChatCreate: ReturnType<typeof vi.fn> }
+      ).__mockChatCreate;
+      mockChatCreate.mockClear();
+      mockChatCreate.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      const onModelUsed = vi.fn();
+      const onModelFailed = vi.fn();
+      const localBackend = new LocalBackend({
+        endpoint: 'http://localhost:11434/v1',
+        getModel: () => 'qwen3:8b',
+        onModelUsed,
+        onModelFailed,
+      });
+      const sessionResult = await localBackend.startSession({
+        workspacePath: '/tmp/workspace',
+        permissionMode: 'full',
+      });
+      if (!sessionResult.ok) return;
+
+      await drain(
+        localBackend.runTurn(sessionResult.value, {
+          sessionId: sessionResult.value.sessionId,
+          prompt: 'Hi',
+          isContinuation: false,
+        })
+      );
+
+      expect(onModelFailed).toHaveBeenCalledTimes(1);
+      expect(onModelFailed).toHaveBeenCalledWith('qwen3:8b');
+      expect(onModelUsed).not.toHaveBeenCalled();
+    });
+
+    it('swallows a throwing hook so telemetry never breaks a turn', async () => {
+      const openaiModule = await import('openai');
+      const mockChatCreate = (
+        openaiModule as unknown as { __mockChatCreate: ReturnType<typeof vi.fn> }
+      ).__mockChatCreate;
+      mockChatCreate.mockClear();
+
+      const localBackend = new LocalBackend({
+        endpoint: 'http://localhost:11434/v1',
+        getModel: () => 'qwen3:8b',
+        onModelUsed: () => {
+          throw new Error('hook boom');
+        },
+      });
+      const sessionResult = await localBackend.startSession({
+        workspacePath: '/tmp/workspace',
+        permissionMode: 'full',
+      });
+      if (!sessionResult.ok) return;
+
+      const gen = localBackend.runTurn(sessionResult.value, {
+        sessionId: sessionResult.value.sessionId,
+        prompt: 'Hi',
+        isContinuation: false,
+      });
+      let next = await gen.next();
+      let result: import('@harness-engineering/types').TurnResult | undefined;
+      while (!next.done) next = await gen.next();
+      result = next.value as import('@harness-engineering/types').TurnResult;
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/packages/orchestrator/tests/agent/local-model-resolver.test.ts
+++ b/packages/orchestrator/tests/agent/local-model-resolver.test.ts
@@ -889,3 +889,80 @@ describe('LocalModelResolver — circuit breaker (T10)', () => {
     expect((await resolver.probe()).resolved).toBe('a');
   });
 });
+
+describe('LocalModelResolver — task-aware resolveModel (T16)', () => {
+  // A pool provider whose entries carry per-profile scores.
+  const profiledProvider = (
+    rows: Array<{
+      name: string;
+      currentScore: number;
+      scoresByProfile: Partial<Record<'general' | 'coding' | 'reasoning', number>>;
+    }>
+  ): PoolStateProvider => ({
+    snapshot: () => ({
+      ...EmptyPoolState(),
+      entries: rows.map((r) => ({
+        ollamaName: r.name,
+        hfRepoId: `Org/${r.name}`,
+        sizeOnDiskGb: 1,
+        installedAt: '2026-07-07T00:00:00.000Z',
+        lastUsedAt: null,
+        currentScore: r.currentScore,
+        scoresByProfile: r.scoresByProfile,
+      })),
+    }),
+  });
+
+  it('a coding use-case selects the coding-best loaded model, not the composite-best', async () => {
+    const poolState = profiledProvider([
+      { name: 'generalist:32b', currentScore: 85, scoresByProfile: { coding: 50, reasoning: 88 } },
+      { name: 'coder:7b', currentScore: 60, scoresByProfile: { coding: 95, reasoning: 30 } },
+    ]);
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: [],
+      poolState,
+      fetchModels: async () => ['generalist:32b', 'coder:7b'], // both loaded
+    });
+    await resolver.probe();
+
+    // No use-case → composite (generalist wins on currentScore).
+    expect(resolver.resolveModel()).toBe('generalist:32b');
+    // Coding tier → the coding specialist.
+    expect(resolver.resolveModel({ kind: 'tier', tier: 'quick-fix' })).toBe('coder:7b');
+    // Diagnostic tier maps to reasoning → the generalist (reasoning 88 > 30).
+    expect(resolver.resolveModel({ kind: 'tier', tier: 'diagnostic' })).toBe('generalist:32b');
+  });
+
+  it('only considers loaded models for the profile selection', async () => {
+    const poolState = profiledProvider([
+      { name: 'coder:7b', currentScore: 60, scoresByProfile: { coding: 95 } },
+      { name: 'generalist:32b', currentScore: 85, scoresByProfile: { coding: 50 } },
+    ]);
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: [],
+      poolState,
+      fetchModels: async () => ['generalist:32b'], // coder NOT loaded
+    });
+    await resolver.probe();
+    // Coding-best is coder:7b but it isn't loaded → fall to the loaded generalist.
+    expect(resolver.resolveModel({ kind: 'tier', tier: 'guided-change' })).toBe('generalist:32b');
+  });
+
+  it('non-tier use-cases map to general (composite resolution)', async () => {
+    const poolState = profiledProvider([
+      { name: 'coder:7b', currentScore: 60, scoresByProfile: { coding: 95 } },
+      { name: 'generalist:32b', currentScore: 85, scoresByProfile: { coding: 50 } },
+    ]);
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: [],
+      poolState,
+      fetchModels: async () => ['generalist:32b', 'coder:7b'],
+    });
+    await resolver.probe();
+    expect(resolver.resolveModel({ kind: 'chat' })).toBe('generalist:32b');
+    expect(resolver.resolveModel({ kind: 'maintenance' })).toBe('generalist:32b');
+  });
+});

--- a/packages/orchestrator/tests/agent/local-model-resolver.test.ts
+++ b/packages/orchestrator/tests/agent/local-model-resolver.test.ts
@@ -243,6 +243,67 @@ describe('LocalModelResolver — lifecycle (fake timers)', () => {
 
     resolver.stop();
   });
+
+  it('refresh() triggers a debounced re-probe (T1)', async () => {
+    const fetchModels = vi.fn().mockResolvedValue(['a']);
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a'],
+      probeIntervalMs: 30_000,
+      refreshDebounceMs: 250,
+      fetchModels,
+    });
+    await resolver.start();
+    expect(fetchModels).toHaveBeenCalledTimes(1); // start() probe
+
+    resolver.refresh();
+    // Not yet — still inside the debounce window.
+    expect(fetchModels).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(fetchModels).toHaveBeenCalledTimes(2); // debounced re-probe fired
+
+    resolver.stop();
+  });
+
+  it('refresh() coalesces a burst into a single probe (T1)', async () => {
+    const fetchModels = vi.fn().mockResolvedValue(['a']);
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a'],
+      probeIntervalMs: 30_000,
+      refreshDebounceMs: 250,
+      fetchModels,
+    });
+    await resolver.start();
+    expect(fetchModels).toHaveBeenCalledTimes(1);
+
+    // A burst of pool frames all arm the same single timer.
+    resolver.refresh();
+    resolver.refresh();
+    resolver.refresh();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(fetchModels).toHaveBeenCalledTimes(2); // one coalesced probe, not three
+
+    resolver.stop();
+  });
+
+  it('stop() cancels a pending refresh (T1)', async () => {
+    const fetchModels = vi.fn().mockResolvedValue(['a']);
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a'],
+      probeIntervalMs: 30_000,
+      refreshDebounceMs: 250,
+      fetchModels,
+    });
+    await resolver.start();
+    resolver.refresh();
+    resolver.stop();
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(fetchModels).toHaveBeenCalledTimes(1); // only the start() probe; refresh cancelled
+  });
 });
 
 describe('LocalModelResolver — onStatusChange semantics (SC10)', () => {

--- a/packages/orchestrator/tests/agent/local-model-resolver.test.ts
+++ b/packages/orchestrator/tests/agent/local-model-resolver.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeLocalModel,
   LocalModelResolver,
   defaultFetchModels,
+  defaultWarmModel,
 } from '../../src/agent/local-model-resolver';
 import type { PoolStateProvider } from '@harness-engineering/local-models';
 import { EmptyPoolState } from '@harness-engineering/local-models';
@@ -964,5 +965,100 @@ describe('LocalModelResolver — task-aware resolveModel (T16)', () => {
     await resolver.probe();
     expect(resolver.resolveModel({ kind: 'chat' })).toBe('generalist:32b');
     expect(resolver.resolveModel({ kind: 'maintenance' })).toBe('generalist:32b');
+  });
+});
+
+describe('LocalModelResolver — warm on selection change (T19/T20)', () => {
+  it('warms the newly-resolved model when the selection changes', async () => {
+    const warmModel = vi.fn();
+    let detected = ['a'];
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a', 'b'],
+      warmModel,
+      fetchModels: async () => detected,
+    });
+
+    await resolver.probe();
+    // First resolution (null → 'a') is a change → warm 'a'.
+    expect(warmModel).toHaveBeenCalledTimes(1);
+    expect(warmModel).toHaveBeenLastCalledWith('a');
+
+    // Same selection on the next probe → no re-warm.
+    await resolver.probe();
+    expect(warmModel).toHaveBeenCalledTimes(1);
+
+    // 'a' disappears, 'b' resolves → selection change → warm 'b'.
+    detected = ['b'];
+    await resolver.probe();
+    expect(warmModel).toHaveBeenCalledTimes(2);
+    expect(warmModel).toHaveBeenLastCalledWith('b');
+  });
+
+  it('does not warm when the selection becomes null (nothing loaded)', async () => {
+    const warmModel = vi.fn();
+    let detected: string[] = ['a'];
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a'],
+      warmModel,
+      fetchModels: async () => detected,
+    });
+    await resolver.probe();
+    expect(warmModel).toHaveBeenCalledTimes(1); // warmed 'a'
+
+    detected = []; // model unloaded → resolved becomes null
+    await resolver.probe();
+    // null is not a warmable target — no extra call.
+    expect(warmModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('a throwing warm hook never breaks the probe', async () => {
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a'],
+      warmModel: () => {
+        throw new Error('warm boom');
+      },
+      fetchModels: async () => ['a'],
+    });
+    const status = await resolver.probe();
+    expect(status.resolved).toBe('a'); // probe succeeded despite the throw
+  });
+});
+
+describe('defaultWarmModel (T19)', () => {
+  it('POSTs an empty-prompt keep_alive request to the native Ollama generate endpoint', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return { ok: true } as Response;
+    }) as unknown as typeof fetch;
+    try {
+      await defaultWarmModel('http://localhost:11434/v1', 'qwen3:32b', 'ollama', '10m');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    expect(calls).toHaveLength(1);
+    // /v1 is stripped → native generate endpoint.
+    expect(calls[0]!.url).toBe('http://localhost:11434/api/generate');
+    expect(calls[0]!.init.method).toBe('POST');
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body).toMatchObject({ model: 'qwen3:32b', prompt: '', keep_alive: '10m' });
+  });
+
+  it('swallows fetch failures (best-effort)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    try {
+      await expect(
+        defaultWarmModel('http://localhost:11434/v1', 'qwen3:32b')
+      ).resolves.toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/orchestrator/tests/agent/local-model-resolver.test.ts
+++ b/packages/orchestrator/tests/agent/local-model-resolver.test.ts
@@ -825,3 +825,67 @@ describe('LocalModelResolver — poolState integration (Phase 4)', () => {
     expect(status.resolved).toBe('b');
   });
 });
+
+describe('LocalModelResolver — circuit breaker (T10)', () => {
+  it('deprioritizes a model after N consecutive failures; a healthy peer wins', async () => {
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a', 'b'], // 'a' preferred by order
+      breakerThreshold: 3,
+      fetchModels: async () => ['a', 'b'],
+    });
+    expect((await resolver.probe()).resolved).toBe('a');
+
+    // Two failures are below threshold — still 'a'.
+    resolver.recordFailure('a');
+    resolver.recordFailure('a');
+    expect((await resolver.probe()).resolved).toBe('a');
+
+    // Third trips the breaker — 'a' sinks, 'b' resolves.
+    resolver.recordFailure('a');
+    expect((await resolver.probe()).resolved).toBe('b');
+  });
+
+  it('a success clears the trip and re-prefers the recovered model', async () => {
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a', 'b'],
+      breakerThreshold: 2,
+      fetchModels: async () => ['a', 'b'],
+    });
+    resolver.recordFailure('a');
+    resolver.recordFailure('a'); // tripped
+    expect((await resolver.probe()).resolved).toBe('b');
+
+    resolver.recordSuccess('a');
+    expect((await resolver.probe()).resolved).toBe('a');
+  });
+
+  it('the trip clears after the cooldown elapses (injected clock)', async () => {
+    let clock = 1_000;
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a', 'b'],
+      breakerThreshold: 1,
+      breakerCooldownMs: 500,
+      now: () => clock,
+      fetchModels: async () => ['a', 'b'],
+    });
+    resolver.recordFailure('a'); // threshold 1 → immediately tripped
+    expect((await resolver.probe()).resolved).toBe('b');
+
+    clock += 500; // cooldown elapsed
+    expect((await resolver.probe()).resolved).toBe('a');
+  });
+
+  it('resolves a tripped model as a last resort when it is the only loaded candidate', async () => {
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: ['a'],
+      breakerThreshold: 1,
+      fetchModels: async () => ['a'],
+    });
+    resolver.recordFailure('a'); // tripped, but it's the only option
+    expect((await resolver.probe()).resolved).toBe('a');
+  });
+});

--- a/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
+++ b/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
@@ -69,6 +69,51 @@ describe('OrchestratorBackendFactory', () => {
     expect(invokedFor).toBe(null);
   });
 
+  it('T11: forwards getModelUsageHooksFor to a local backend (onModelUsed/onModelFailed)', async () => {
+    const { LocalBackend } = await import('../../src/agent/backends/local.js');
+    const localDef: BackendDef = { type: 'local', endpoint: 'http://x:11434/v1', model: 'm' };
+    const onModelUsed = vi.fn();
+    const onModelFailed = vi.fn();
+    let hooksQueriedFor: string | null = null;
+    const factory = new OrchestratorBackendFactory({
+      backends: { cloud, localx: localDef },
+      routing: { default: 'cloud', 'quick-fix': 'localx' } as RoutingConfig,
+      sandboxPolicy: 'none',
+      getResolverModelFor: () => () => 'resolved-model',
+      getModelUsageHooksFor: (name: string) => {
+        hooksQueriedFor = name;
+        return { onModelUsed, onModelFailed };
+      },
+    });
+    const backend = factory.forUseCase({ kind: 'tier', tier: 'quick-fix' });
+    expect(backend).toBeInstanceOf(LocalBackend);
+    expect(hooksQueriedFor).toBe('localx');
+    // The hooks reached the constructed backend (private fields, runtime-visible).
+    const priv = backend as unknown as {
+      onModelUsed?: (m: string) => void;
+      onModelFailed?: (m: string) => void;
+    };
+    expect(priv.onModelUsed).toBe(onModelUsed);
+    expect(priv.onModelFailed).toBe(onModelFailed);
+  });
+
+  it('T11: a local backend builds fine when no usage hooks are registered', async () => {
+    const { LocalBackend } = await import('../../src/agent/backends/local.js');
+    const localDef: BackendDef = { type: 'local', endpoint: 'http://x:11434/v1', model: 'm' };
+    const factory = new OrchestratorBackendFactory({
+      backends: { cloud, localx: localDef },
+      routing: { default: 'cloud', 'quick-fix': 'localx' } as RoutingConfig,
+      sandboxPolicy: 'none',
+      getResolverModelFor: () => () => 'resolved-model',
+      // no getModelUsageHooksFor
+    });
+    const backend = factory.forUseCase({ kind: 'tier', tier: 'quick-fix' });
+    expect(backend).toBeInstanceOf(LocalBackend);
+    const priv = backend as unknown as { onModelUsed?: unknown; onModelFailed?: unknown };
+    expect(priv.onModelUsed).toBeUndefined();
+    expect(priv.onModelFailed).toBeUndefined();
+  });
+
   it('wraps with ContainerBackend when sandboxPolicy=docker AND container set (PFC-3)', async () => {
     const { ContainerBackend } = await import('../../src/agent/backends/container.js');
     const factory = new OrchestratorBackendFactory({

--- a/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
+++ b/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
@@ -54,6 +54,23 @@ describe('OrchestratorBackendFactory', () => {
     expect(invokedFor).toBe('local');
   });
 
+  it('T17: passes the routed use-case to getResolverModelFor', () => {
+    let receivedUseCase: unknown = null;
+    const factory = new OrchestratorBackendFactory({
+      backends,
+      routing,
+      sandboxPolicy: 'none',
+      getResolverModelFor: (_name: string, useCase: unknown) => {
+        receivedUseCase = useCase;
+        return () => 'resolved-model';
+      },
+    });
+    // 'quick-fix' routes to the local backend in this fixture, so the resolver
+    // hook fires and receives the full use-case.
+    factory.forUseCase({ kind: 'tier', tier: 'quick-fix' });
+    expect(receivedUseCase).toEqual({ kind: 'tier', tier: 'quick-fix' });
+  });
+
   it('does not call getResolverModelFor for non-local backends', () => {
     let invokedFor: string | null = null;
     const factory = new OrchestratorBackendFactory({

--- a/packages/orchestrator/tests/integration/orchestrator-local-resolver.test.ts
+++ b/packages/orchestrator/tests/integration/orchestrator-local-resolver.test.ts
@@ -233,6 +233,72 @@ describe('Orchestrator + LocalModelResolver wiring (Phase 3)', () => {
     });
   });
 
+  describe('T2 — event-driven refresh on local-models:pool', () => {
+    it('re-probes the resolver when a local-models:pool event fires', async () => {
+      const fetchModels = vi.fn().mockResolvedValue(['gemma-4-e4b']);
+      const config = makeConfig({
+        localBackend: 'openai-compatible',
+        localModel: 'gemma-4-e4b',
+        localEndpoint: 'http://localhost:11434/v1',
+        localProbeIntervalMs: 300_000, // long interval — only the event refresh should re-probe
+      });
+      const orch = new Orchestrator(config, 'Prompt', {
+        tracker: makeMockTracker(),
+        backend: new MockBackend(),
+        execFileFn: noopExecFile,
+      });
+      const resolver = firstResolver(orch);
+      expect(resolver).not.toBeNull();
+      // Small debounce so the test doesn't idle for the 250ms default.
+      (resolver as unknown as { refreshDebounceMs: number }).refreshDebounceMs = 10;
+      (
+        resolver as unknown as { fetchModels: (e: string, k?: string) => Promise<string[]> }
+      ).fetchModels = fetchModels;
+
+      await orch.start();
+      try {
+        expect(fetchModels).toHaveBeenCalledTimes(1); // start() probe
+
+        // A pool mutation fires on the orchestrator bus.
+        orch.emit('local-models:pool', { pool: [], evicted: [] });
+        // Wait past the debounce window for the coalesced re-probe.
+        await new Promise((r) => setTimeout(r, 60));
+        expect(fetchModels).toHaveBeenCalledTimes(2); // event-driven re-probe
+      } finally {
+        await orch.stop();
+      }
+    });
+
+    it('detaches the pool listener on stop() (no re-probe after stop)', async () => {
+      const fetchModels = vi.fn().mockResolvedValue(['gemma-4-e4b']);
+      const config = makeConfig({
+        localBackend: 'openai-compatible',
+        localModel: 'gemma-4-e4b',
+        localEndpoint: 'http://localhost:11434/v1',
+        localProbeIntervalMs: 300_000,
+      });
+      const orch = new Orchestrator(config, 'Prompt', {
+        tracker: makeMockTracker(),
+        backend: new MockBackend(),
+        execFileFn: noopExecFile,
+      });
+      const resolver = firstResolver(orch);
+      (resolver as unknown as { refreshDebounceMs: number }).refreshDebounceMs = 10;
+      (
+        resolver as unknown as { fetchModels: (e: string, k?: string) => Promise<string[]> }
+      ).fetchModels = fetchModels;
+
+      await orch.start();
+      await orch.stop();
+      const callsAfterStop = fetchModels.mock.calls.length;
+
+      // Late emit must not re-arm a stopped resolver.
+      orch.emit('local-models:pool', { pool: [], evicted: [] });
+      await new Promise((r) => setTimeout(r, 60));
+      expect(fetchModels).toHaveBeenCalledTimes(callsAfterStop);
+    });
+  });
+
   describe('SC13 — warn-level log on no candidate', () => {
     it('OT4: createAnalysisProvider logs warn when resolver reports unavailable', async () => {
       const fetchModels = vi.fn().mockResolvedValue(['some-other-model']);

--- a/packages/orchestrator/tests/proposals/model-handlers.test.ts
+++ b/packages/orchestrator/tests/proposals/model-handlers.test.ts
@@ -177,6 +177,33 @@ describe('onApproveModelProposal (F11 stale-target cancellation)', () => {
     expect(h.events.some((e) => e.topic === 'local-models:pool')).toBe(true);
   });
 
+  it('T7: threads the proposal targetScore as initialScore so the entry is seeded (not 0)', async () => {
+    const pool = fakePool({
+      install: { status: 'success', entry: REPLACED, evicted: [] },
+      evict: { status: 'success', name: 'qwen2.5:32b', removed: REPLACED },
+    });
+    const scored = modelProposal({ targetScore: 78.4 });
+    const h = harness(pool, scored);
+
+    const outcome = await onApproveModelProposal(h.deps, scored);
+
+    expect(outcome.status).toBe('approved');
+    expect(pool.installCalls[0]!.initialScore).toBe(78.4);
+  });
+
+  it('T7: omits initialScore for a legacy proposal without targetScore', async () => {
+    const pool = fakePool({
+      install: { status: 'success', entry: REPLACED, evicted: [] },
+      evict: { status: 'success', name: 'qwen2.5:32b', removed: REPLACED },
+    });
+    // Default modelProposal() carries no targetScore.
+    const h = harness(pool, proposal);
+
+    await onApproveModelProposal(h.deps, proposal);
+
+    expect(pool.installCalls[0]!.initialScore).toBeUndefined();
+  });
+
   it('success approve ALSO emits local-models:proposal { approved } (XP-1: symmetric with reject/created)', async () => {
     const pool = fakePool({
       install: { status: 'success', entry: REPLACED, evicted: [] },

--- a/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
+++ b/packages/orchestrator/tests/server/routes/v1/local-models-pool-mutation.test.ts
@@ -194,6 +194,36 @@ describe('POST /local-models/pool/install', () => {
     expect(proposals[0]!.status).toBe('approved');
   });
 
+  it('T7: seeds the pool install with the ranked score (targetScore → initialScore), not 0', async () => {
+    const bus = new EventEmitter();
+    const { waitTerminal } = installFrames(bus);
+    const installCalls: InstallPoolRequest[] = [];
+    const pool = fakePool({
+      install: async (r) => {
+        installCalls.push(r);
+        return { status: 'success', entry: { ...ENTRY, ollamaName: r.ollamaName }, evicted: [] };
+      },
+    });
+    const d = deps({ bus, getModelPool: () => pool });
+    const { res, statusCode, done } = makeRes();
+    handleV1LocalModelsMutationRoute(
+      makeReq('POST', '/api/v1/local-models/pool/install', {
+        hfRepoId: 'Qwen/Qwen3-32B-GGUF',
+      }),
+      res,
+      d
+    );
+    await done;
+    expect(statusCode()).toBe(202);
+    await waitTerminal();
+    // RANKED.score is 71 — the operator install carries it through as the seed.
+    expect(installCalls[0]!.initialScore).toBe(71);
+
+    // The persisted proposal also records the absolute score for audit.
+    const proposals = await listProposals(tmpDir, { kind: 'model' });
+    expect(proposals[0]!.model.targetScore).toBe(71);
+  });
+
   it('responds 202 WITHOUT awaiting the pull (regression: proxy headersTimeout 502)', async () => {
     // The root cause of the observed `502 ... (cause: Headers Timeout Error)`:
     // the route used to await the full multi-GB `ollama pull` before sending any

--- a/packages/types/src/proposals.ts
+++ b/packages/types/src/proposals.ts
@@ -154,6 +154,14 @@ export const ModelProposalContentSchema = z
     target: z.object({ hfRepoId: z.string().min(1), ollamaName: z.string().min(1) }),
     replaces: z.object({ ollamaName: z.string().min(1) }).optional(),
     scoreDelta: z.number(),
+    /**
+     * Consumption Phase 2 (T6): the target's *absolute* ranked score (not the
+     * delta). Optional + additive so older persisted proposals round-trip. When
+     * present, `onApproveModelProposal` seeds the new pool entry's `currentScore`
+     * from it so an explicitly-installed model isn't buried at 0 until the next
+     * re-rank. Absent → the entry starts at 0 (legacy behavior).
+     */
+    targetScore: z.number().optional(),
     justification: z.object({
       summary: z.string(),
       benchmarkBasis: z.array(z.string()),

--- a/packages/types/tests/proposals-migration.test.ts
+++ b/packages/types/tests/proposals-migration.test.ts
@@ -80,6 +80,46 @@ describe('read-migration (legacy → discriminated)', () => {
     expect(ProposalSchema.safeParse(model).success).toBe(true);
     expect(ModelProposalContentSchema.safeParse(model.model).success).toBe(true);
   });
+
+  it('T6: accepts and round-trips an optional absolute targetScore', () => {
+    const withScore = {
+      action: 'add' as const,
+      target: { hfRepoId: 'Qwen/Qwen3-32B-GGUF', ollamaName: 'qwen3:32b' },
+      scoreDelta: 81.5,
+      targetScore: 81.5,
+      justification: {
+        summary: 's',
+        benchmarkBasis: [],
+        hardwareFit: '27GB',
+        evidence: 'direct',
+        freshness: '2026-05-21',
+      },
+      diskImpactGb: 3.2,
+    };
+    const parsed = ModelProposalContentSchema.safeParse(withScore);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.targetScore).toBe(81.5);
+  });
+
+  it('T6: targetScore is optional — legacy proposals without it still parse', () => {
+    const legacy = {
+      action: 'swap' as const,
+      target: { hfRepoId: 'Qwen/Qwen3-32B-GGUF', ollamaName: 'qwen3:32b' },
+      replaces: { ollamaName: 'qwen2.5:32b' },
+      scoreDelta: 7.4,
+      justification: {
+        summary: 's',
+        benchmarkBasis: [],
+        hardwareFit: '27GB',
+        evidence: 'direct',
+        freshness: '2026-05-21',
+      },
+      diskImpactGb: 3.2,
+    };
+    const parsed = ModelProposalContentSchema.safeParse(legacy);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.targetScore).toBeUndefined();
+  });
 });
 
 describe('ProposalTypeSchema', () => {


### PR DESCRIPTION
## Why

The LMLM **install** side is fast and unattended, but **consumption** — how a pooled model actually reaches inference — was pull-based and static. A newly installed model wasn't dispatched for up to a poll cycle (and by the analysis pipeline never, until a restart), a fresh entry sat at `currentScore: 0`, runtime failures didn't feed back, and selection ignored the ranker's per-task profiles. This wires the pool through to inference.

Implements `docs/changes/lmlm-pool-consumption/proposal.md` (spec approved) and its 21-task plan, milestone-by-milestone with TDD. See **ADR 0064** for the rationale.

## What changed (by milestone)

**1 — Freshness loop.** `LocalModelResolver.refresh()` debounce-re-probes on a `local-models:pool` mutation; the orchestrator subscribes every resolver (listener detached on stop). The analysis provider reads its model **live per request** (`getModel` seam) instead of snapshotting once — unless the operator pinned a layer model.

**2 — Score-seed.** Additive optional `ModelProposalContent.targetScore` (absolute ranked score); producers set it (operator dashboard install + scheduler swap proposals) and `onApproveModelProposal` threads it as `initialScore`, so an installed model enters at its real rank, not `0`. Fixes the operator-reported *"pool member scoring 0"*.

**3 — Runtime feedback.** `LocalBackend` `onModelUsed`/`onModelFailed` seams fire best-effort on turn success/failure; the orchestrator binds them to `pool.markUsed` (LRU `lastUsedAt`) + a per-model **circuit breaker** in the resolver (N consecutive failures deprioritize a model until success/cooldown; still a last resort if it's the only one loaded).

**4 — Task-aware selection + ADR.** The ranker computes `scoresByProfile` (general/coding/reasoning) from profile-relevant benchmarks; the scheduler writes them onto pool entries (`PoolEntry.scoresByProfile`, additive); `poolStateToCandidates(state, profile?)` orders by them; `resolveModel(useCase?)` maps the routed use-case to a profile (code tiers → coding, diagnostic → reasoning, else → general) and picks the best profile-scored **loaded** model. ADR 0064.

**5 — Warming + docs.** On a selection change the resolver best-effort **warms** the new model into VRAM via Ollama `keep_alive` (`defaultWarmModel`). Operator guide gains a "How pooled models are consumed" section.

## Degradation (nothing regresses)

`targetScore`, `scoresByProfile`, and the `useCase` parameter are all **additive/optional**. `general` always equals the composite score; a profile with no relevant benchmark, or an entry without a profile score, falls back to the composite / `currentScore`; a `general`-mapped use-case returns the cached composite resolution. Older persisted proposals/pool entries and existing call sites are byte-identical.

## Scope cuts (documented in ADR 0064)

- Runtime feedback is a binary circuit breaker, not full latency/quality-into-scoring.
- The `pi` (LM Studio) backend wires freshness but not the usage/failure hooks or warming yet (its streaming turn path is a follow-up); warming is Ollama-only.

## Testing

TDD throughout. Full suites green locally: **types 56, intelligence 339, local-models 331, orchestrator 1656** (+1 skipped). Pre-push gate passed (coverage ratchet within baselines, reference docs fresh, changeset present).

New/changed tests cover: resolver refresh/coalesce/stop; event re-probe + listener detach; provider `getModel` precedence; proposal schema round-trip + handler/route seeding; circuit-breaker deprioritize/recover/cooldown/last-resort; backend usage hooks + throw-safety; ranker per-profile divergence/fallback/unfit; profile candidate ordering + writeback; task-aware resolve; warm-on-change + `defaultWarmModel` request shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
