### PR TITLE
feat(lmlm): wire pi backend into runtime feedback + warming

### DIFF
--- a/.changeset/lmlm-pi-consumption-hooks.md
+++ b/.changeset/lmlm-pi-consumption-hooks.md
@@ -1,0 +1,22 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+feat(lmlm): wire pi (LM Studio) backend into runtime feedback + warming
+
+The pool-consumption work landed runtime feedback (LRU `lastUsedAt` + circuit
+breaker) and model warming for the `local` (Ollama) backend only; the `pi`
+(LM Studio / OpenAI-compatible) backend had freshness but not these. This closes
+the gap so both backends behave identically:
+
+- `PiBackend` gains `onModelUsed` / `onModelFailed` seams, fired best-effort with
+  the session's resolved model on turn success / failure (or timeout). The
+  orchestrator's existing `getModelUsageHooksFor` binding now flows to `pi`, so a
+  completed pi turn stamps `lastUsedAt` and clears the resolver's circuit breaker,
+  and a failed pi turn feeds the breaker.
+- Warming now covers `pi` via `defaultWarmModelViaCompletion` — a 1-token chat
+  completion that JIT-loads the model, since LM Studio has no `keep_alive`
+  primitive. `local` keeps using Ollama's native `keep_alive`.
+
+Both hooks are best-effort (a throwing hook never breaks a turn) and only fire
+when a model name is resolved.

--- a/docs/guides/local-model-lifecycle.md
+++ b/docs/guides/local-model-lifecycle.md
@@ -129,9 +129,13 @@ for the rationale.
   pooled alternative — until it succeeds again or a cooldown elapses. If the failing
   model is the _only_ one loaded, it is still used (a flaky model beats none).
 - **Warming.** When the resolver's selection changes, it best-effort **warms** the new
-  model into VRAM via Ollama's `keep_alive`, so the next dispatch isn't a cold start.
-  Warming is Ollama-only and never blocks a dispatch; a warm failure just means the
-  first request pays the load cost.
+  model into VRAM so the next dispatch isn't a cold start — via Ollama's `keep_alive` for
+  the `local` backend, and via a 1-token completion for the `pi` (LM Studio /
+  OpenAI-compatible) backend, which has no `keep_alive`. Warming never blocks a dispatch;
+  a warm failure just means the first request pays the load cost.
+
+Runtime feedback (usage stamping + circuit breaker) and warming apply to **both** the
+`local` and `pi` backends.
 
 ## Known limitations (read before relying on autonomy)
 

--- a/docs/knowledge/decisions/0064-lmlm-task-aware-pool-consumption.md
+++ b/docs/knowledge/decisions/0064-lmlm-task-aware-pool-consumption.md
@@ -71,8 +71,10 @@ use-cases).
   degrades to composite score-order. The `tier`-based mapping assumes the routing tier
   approximates task type — a mismatched routing config would mis-map. Runtime feedback is
   a binary circuit breaker, not a full latency/quality signal into scoring (a deliberate
-  scope cut — full runtime scoring is deferred). The `pi` backend wires freshness but not
-  the usage/failure hooks yet (its streaming turn path is a follow-up).
+  scope cut — full runtime scoring is deferred). Both the `local` (Ollama) and `pi`
+  (LM Studio / OpenAI-compatible) backends wire freshness, runtime feedback, and
+  warming; the `pi` path warms via a 1-token completion since LM Studio has no
+  `keep_alive` primitive.
 - **Neutral.** Adds a small amount of per-model state to the resolver (failure counts +
   trip timestamps) and one extra map on `PoolEntry`. The circuit-breaker thresholds and
   cooldown are constants with injectable seams for tests.

--- a/packages/orchestrator/src/agent/backends/pi.ts
+++ b/packages/orchestrator/src/agent/backends/pi.ts
@@ -27,12 +27,32 @@ export interface PiBackendConfig {
    * can set the same value on either backend type.
    */
   timeoutMs?: number | undefined;
+  /**
+   * Consumption Phase 3 (T9, pi follow-up): called with the resolved model name
+   * after a turn completes successfully. The orchestrator binds this to
+   * `pool.markUsed` (LRU `lastUsedAt`) + the resolver's circuit-breaker success
+   * path — identical to `LocalBackendConfig.onModelUsed`. Best-effort: a thrown
+   * error is swallowed so a telemetry hook never breaks a good turn.
+   */
+  onModelUsed?: ((model: string) => void) | undefined;
+  /**
+   * Consumption Phase 3 (T11, pi follow-up): called with the resolved model name
+   * when a turn fails (inference error or timeout). Bound to the resolver's
+   * circuit breaker so a repeatedly-failing model is deprioritized. Best-effort.
+   */
+  onModelFailed?: ((model: string) => void) | undefined;
 }
 
 interface PiSession extends AgentSession {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   piSession: any;
   unsubscribe: (() => void) | null;
+  /**
+   * Model name resolved at session start (from `getModel()` if provided, else
+   * `config.model`). Carried on the session so `runTurn` can report it to the
+   * usage/failure hooks. `undefined` when neither is set (pi SDK default model).
+   */
+  resolvedModel?: string;
 }
 
 /** Events that are internal lifecycle and should not be surfaced. */
@@ -233,6 +253,7 @@ export class PiBackend implements AgentBackend {
         startedAt: new Date().toISOString(),
         piSession,
         unsubscribe: null,
+        ...(resolvedModelName !== undefined && { resolvedModel: resolvedModelName }),
       };
 
       return Ok(session);
@@ -362,8 +383,11 @@ export class PiBackend implements AgentBackend {
     }
 
     const totalTokens = inputTokens + outputTokens;
+    const resolvedModel = (session as PiSession).resolvedModel;
 
     if (promptErrorMsg) {
+      // T11: feed the inference failure (or timeout) to the resolver's breaker.
+      if (resolvedModel !== undefined) this.notify(this.config.onModelFailed, resolvedModel);
       return {
         success: false,
         sessionId: session.sessionId,
@@ -372,11 +396,25 @@ export class PiBackend implements AgentBackend {
       };
     }
 
+    // T9: a turn completed against `resolvedModel` — stamp real usage (LRU) and
+    // clear the circuit breaker via the orchestrator-bound hook.
+    if (resolvedModel !== undefined) this.notify(this.config.onModelUsed, resolvedModel);
+
     return {
       success: true,
       sessionId: session.sessionId,
       usage: { inputTokens, outputTokens, totalTokens },
     };
+  }
+
+  /** Best-effort telemetry hook invocation — a throwing hook never breaks a turn. */
+  private notify(hook: ((model: string) => void) | undefined, model: string): void {
+    if (!hook) return;
+    try {
+      hook(model);
+    } catch {
+      // Swallow — usage/failure telemetry is advisory, not turn-critical.
+    }
   }
 
   /**

--- a/packages/orchestrator/src/agent/local-model-resolver.ts
+++ b/packages/orchestrator/src/agent/local-model-resolver.ts
@@ -190,6 +190,43 @@ export async function defaultWarmModel(
   }
 }
 
+/**
+ * Consumption Phase 5 (pi follow-up): warm `model` on an OpenAI-compatible
+ * endpoint (LM Studio, the `pi` backend's server) that has no `keep_alive`
+ * primitive. Issues a **1-token** chat completion against the model, which is
+ * enough to make a JIT-loading server (LM Studio loads on first request) pull
+ * the model into memory before the real dispatch. Best-effort: any failure
+ * (server down, model missing, non-completions server) resolves quietly.
+ * Fire-and-forget — callers swallow the returned promise.
+ */
+export async function defaultWarmModelViaCompletion(
+  endpoint: string,
+  model: string,
+  apiKey?: string,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS
+): Promise<void> {
+  const url = `${endpoint.replace(/\/$/, '')}/chat/completions`;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey ?? DEFAULT_API_KEY}`,
+      },
+      // Minimal request: one token is enough to force the server to load the
+      // model. The generated content is discarded — we only want the load.
+      body: JSON.stringify({
+        model,
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'warm' }],
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch {
+    // Best-effort — a cold model just costs the next dispatch a load. Swallow.
+  }
+}
+
 export class LocalModelResolver {
   private readonly endpoint: string;
   private readonly apiKey?: string;

--- a/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
+++ b/packages/orchestrator/src/agent/orchestrator-backend-factory.ts
@@ -188,14 +188,18 @@ export class OrchestratorBackendFactory {
       });
     }
     if (def.type === 'pi') {
-      // T11: PiBackend's streaming pi-session turn path doesn't yet surface the
-      // usage/failure hooks; runtime feedback is wired for `local` only. `getModel`
-      // (freshness) still applies. Extending pi is a follow-up.
+      // T11 (pi follow-up): PiBackend now surfaces the usage/failure hooks from
+      // its streaming turn path, so runtime feedback (LRU + circuit breaker)
+      // applies to `pi` too, matching `local`.
       return new PiBackend({
         endpoint: def.endpoint,
         getModel,
         ...(def.apiKey !== undefined ? { apiKey: def.apiKey } : {}),
         ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
+        ...(usageHooks?.onModelUsed !== undefined ? { onModelUsed: usageHooks.onModelUsed } : {}),
+        ...(usageHooks?.onModelFailed !== undefined
+          ? { onModelFailed: usageHooks.onModelFailed }
+          : {}),
       });
     }
     // Should be unreachable — the caller guards on type, but throw for

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -32,7 +32,11 @@ import { PromptRenderer } from './prompt/renderer';
 // `OrchestratorBackendFactory` + `createBackend` (factory module). The
 // orchestrator no longer constructs backends directly — factory handles
 // dispatch-time materialization.
-import { LocalModelResolver, defaultWarmModel } from './agent/local-model-resolver';
+import {
+  LocalModelResolver,
+  defaultWarmModel,
+  defaultWarmModelViaCompletion,
+} from './agent/local-model-resolver';
 import {
   PoolStateStore,
   PoolManager,
@@ -553,14 +557,19 @@ export class Orchestrator extends EventEmitter {
         if (def.apiKey !== undefined) resolverOpts.apiKey = def.apiKey;
         if (def.probeIntervalMs !== undefined) resolverOpts.probeIntervalMs = def.probeIntervalMs;
         if (this.poolStateProvider !== null) resolverOpts.poolState = this.poolStateProvider;
-        // T20: warm a newly-selected model into VRAM (Ollama keep_alive) so the
-        // next dispatch isn't a cold start. Only for the Ollama-first `local`
-        // backend; `pi` (LM Studio) has no equivalent keep_alive primitive.
+        // T20: warm a newly-selected model into VRAM so the next dispatch isn't a
+        // cold start. `local` (Ollama) uses the native keep_alive; `pi` (LM Studio
+        // and other OpenAI-compatible servers with no keep_alive) warms via a
+        // 1-token completion that JIT-loads the model.
+        const endpoint = def.endpoint;
+        const apiKey = def.apiKey;
         if (def.type === 'local') {
-          const endpoint = def.endpoint;
-          const apiKey = def.apiKey;
           resolverOpts.warmModel = (ollamaName) => {
             void defaultWarmModel(endpoint, ollamaName, apiKey);
+          };
+        } else {
+          resolverOpts.warmModel = (model) => {
+            void defaultWarmModelViaCompletion(endpoint, model, apiKey);
           };
         }
         this.localResolvers.set(name, new LocalModelResolver(resolverOpts));

--- a/packages/orchestrator/tests/agent/backends/pi.test.ts
+++ b/packages/orchestrator/tests/agent/backends/pi.test.ts
@@ -356,6 +356,87 @@ describe('PiBackend', () => {
     });
   });
 
+  describe('model-usage hooks (T9/T11, pi)', () => {
+    async function drain(gen: AsyncGenerator<AgentEvent, unknown, void>): Promise<unknown> {
+      let next = await gen.next();
+      while (!next.done) next = await gen.next();
+      return next.value;
+    }
+
+    function emitThenFinish() {
+      mockSubscribe.mockImplementation((listener: (event: unknown) => void) => {
+        setTimeout(() => {
+          listener({ type: 'agent_start' });
+          listener({ type: 'agent_end', messages: [] });
+        }, 10);
+        return vi.fn();
+      });
+      mockPrompt.mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 30)));
+    }
+
+    it('T9: calls onModelUsed with the resolved model on a successful turn', async () => {
+      emitThenFinish();
+      const onModelUsed = vi.fn();
+      const onModelFailed = vi.fn();
+      const b = new PiBackend({
+        endpoint: 'http://localhost:1234/v1',
+        getModel: () => 'gemma-4-e4b',
+        onModelUsed,
+        onModelFailed,
+      });
+      const s = await b.startSession({ workspacePath: '/tmp/workspace', permissionMode: 'full' });
+      if (!s.ok) throw new Error('startSession failed');
+
+      const result = (await drain(
+        b.runTurn(s.value, { sessionId: s.value.sessionId, prompt: 'hi', isContinuation: false })
+      )) as { success: boolean };
+      expect(result.success).toBe(true);
+      expect(onModelUsed).toHaveBeenCalledTimes(1);
+      expect(onModelUsed).toHaveBeenCalledWith('gemma-4-e4b');
+      expect(onModelFailed).not.toHaveBeenCalled();
+    });
+
+    it('T11: calls onModelFailed (not onModelUsed) when the prompt rejects', async () => {
+      mockSubscribe.mockImplementation(() => vi.fn());
+      mockPrompt.mockRejectedValue(new Error('Model connection failed'));
+      const onModelUsed = vi.fn();
+      const onModelFailed = vi.fn();
+      const b = new PiBackend({
+        endpoint: 'http://localhost:1234/v1',
+        getModel: () => 'gemma-4-e4b',
+        onModelUsed,
+        onModelFailed,
+      });
+      const s = await b.startSession({ workspacePath: '/tmp/workspace', permissionMode: 'full' });
+      if (!s.ok) throw new Error('startSession failed');
+
+      await drain(
+        b.runTurn(s.value, { sessionId: s.value.sessionId, prompt: 'fail', isContinuation: false })
+      );
+      expect(onModelFailed).toHaveBeenCalledTimes(1);
+      expect(onModelFailed).toHaveBeenCalledWith('gemma-4-e4b');
+      expect(onModelUsed).not.toHaveBeenCalled();
+    });
+
+    it('swallows a throwing hook so telemetry never breaks a turn', async () => {
+      emitThenFinish();
+      const b = new PiBackend({
+        endpoint: 'http://localhost:1234/v1',
+        getModel: () => 'gemma-4-e4b',
+        onModelUsed: () => {
+          throw new Error('hook boom');
+        },
+      });
+      const s = await b.startSession({ workspacePath: '/tmp/workspace', permissionMode: 'full' });
+      if (!s.ok) throw new Error('startSession failed');
+
+      const result = (await drain(
+        b.runTurn(s.value, { sessionId: s.value.sessionId, prompt: 'hi', isContinuation: false })
+      )) as { success: boolean };
+      expect(result.success).toBe(true);
+    });
+  });
+
   describe('stopSession', () => {
     it('calls abort on pi session', async () => {
       mockAbort.mockResolvedValue(undefined);

--- a/packages/orchestrator/tests/agent/local-model-resolver.test.ts
+++ b/packages/orchestrator/tests/agent/local-model-resolver.test.ts
@@ -4,6 +4,7 @@ import {
   LocalModelResolver,
   defaultFetchModels,
   defaultWarmModel,
+  defaultWarmModelViaCompletion,
 } from '../../src/agent/local-model-resolver';
 import type { PoolStateProvider } from '@harness-engineering/local-models';
 import { EmptyPoolState } from '@harness-engineering/local-models';
@@ -1056,6 +1057,42 @@ describe('defaultWarmModel (T19)', () => {
     try {
       await expect(
         defaultWarmModel('http://localhost:11434/v1', 'qwen3:32b')
+      ).resolves.toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('defaultWarmModelViaCompletion (pi warming)', () => {
+  it('POSTs a 1-token chat completion to warm a JIT-loading OpenAI-compatible server', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return { ok: true } as Response;
+    }) as unknown as typeof fetch;
+    try {
+      await defaultWarmModelViaCompletion('http://localhost:1234/v1', 'gemma-4-e4b', 'lm-studio');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('http://localhost:1234/v1/chat/completions');
+    expect(calls[0]!.init.method).toBe('POST');
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body).toMatchObject({ model: 'gemma-4-e4b', max_tokens: 1 });
+    expect(body.messages).toHaveLength(1);
+  });
+
+  it('swallows fetch failures (best-effort)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    try {
+      await expect(
+        defaultWarmModelViaCompletion('http://localhost:1234/v1', 'gemma-4-e4b')
       ).resolves.toBeUndefined();
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
+++ b/packages/orchestrator/tests/agent/orchestrator-backend-factory.test.ts
@@ -71,6 +71,28 @@ describe('OrchestratorBackendFactory', () => {
     expect(receivedUseCase).toEqual({ kind: 'tier', tier: 'quick-fix' });
   });
 
+  it('T11 (pi): forwards getModelUsageHooksFor to a pi backend', () => {
+    const onModelUsed = vi.fn();
+    const onModelFailed = vi.fn();
+    const factory = new OrchestratorBackendFactory({
+      backends, // `local` in this fixture is a pi-typed def
+      routing,
+      sandboxPolicy: 'none',
+      getResolverModelFor: () => () => 'resolved-model',
+      getModelUsageHooksFor: () => ({ onModelUsed, onModelFailed }),
+    });
+    const backend = factory.forUseCase({ kind: 'tier', tier: 'quick-fix' });
+    expect(backend).toBeInstanceOf(PiBackend);
+    // PiBackend stores hooks on its private `config`.
+    const cfg = (
+      backend as unknown as {
+        config: { onModelUsed?: unknown; onModelFailed?: unknown };
+      }
+    ).config;
+    expect(cfg.onModelUsed).toBe(onModelUsed);
+    expect(cfg.onModelFailed).toBe(onModelFailed);
+  });
+
   it('does not call getResolverModelFor for non-local backends', () => {
     let invokedFor: string | null = null;
     const factory = new OrchestratorBackendFactory({


### PR DESCRIPTION
## Why

#788 landed the consumption improvements (freshness, score-seed, runtime feedback, task-aware selection, warming) but explicitly scoped **runtime feedback and warming to the `local` (Ollama) backend**, leaving the `pi` (LM Studio / OpenAI-compatible) backend with freshness only. This closes that gap so both backends behave identically.

## What changed

- **Usage hooks (T9/T11 for pi).** `PiBackend` gains `onModelUsed` / `onModelFailed` seams, fired best-effort with the session's resolved model on turn **success** / **failure** (including timeout). The resolved model is now carried on the pi session so `runTurn` can report it. The orchestrator's existing `getModelUsageHooksFor` binding now flows to `pi`, so a completed pi turn stamps `lastUsedAt` (LRU) + clears the resolver's circuit breaker, and a failed pi turn feeds the breaker — identical to `local`.
- **Warming for pi.** LM Studio has no `keep_alive`, so `defaultWarmModelViaCompletion` warms via a **1-token chat completion** that JIT-loads the model. The orchestrator wires it for `pi` while `local` keeps Ollama's native `keep_alive`.
- **Docs.** ADR 0064 and the operator guide updated — pi is no longer a follow-up; runtime feedback + warming now apply to both backends.

## Safety

Both hooks are best-effort — a throwing hook never breaks a turn — and only fire when a model name is resolved (the LMLM path always resolves one). Warming never blocks a dispatch.

## Testing

Full orchestrator suite green (**1662 passed**, +6). New tests: pi `onModelUsed`/`onModelFailed` per outcome + throw-safety; factory forwards hooks to `PiBackend`; `defaultWarmModelViaCompletion` request shape + failure swallow. Pre-push gate passed (coverage ratchet within baselines, docs fresh, changeset present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
