### PR TITLE
fix(cli): hooks add resolves bundled dist/hooks layout

### DIFF
--- a/.changeset/hooks-add-bundled-source-dir.md
+++ b/.changeset/hooks-add-bundled-source-dir.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+`harness hooks add` now resolves hook scripts from the bundled `dist/hooks/` layout. Previously it only probed the dev layout (`src/hooks/`), so every invocation on a published npm/mise install failed with "Hook scripts not found". It now shares `resolveHookSourceDir()` with `hooks init`, which already handled both layouts.

--- a/packages/cli/src/commands/hooks/add.ts
+++ b/packages/cli/src/commands/hooks/add.ts
@@ -1,22 +1,14 @@
 import { Command } from 'commander';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { HOOK_SCRIPTS } from '../../hooks/profiles';
 import { supportFilesFor } from '../../hooks/support-files';
 import { logger } from '../../output/logger';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { resolveHookSourceDir } from './init';
 
 const ALIASES: Record<string, string[]> = {
   sentinel: ['sentinel-pre', 'sentinel-post'],
 };
-
-function hookSourceDir(): string {
-  const d = path.resolve(__dirname, '..', '..', 'hooks');
-  if (fs.existsSync(d)) return d;
-  throw new Error(`Hook scripts not found: ${d}`);
-}
 
 export interface AddResult {
   added: string[];
@@ -42,7 +34,7 @@ function registerHook(s: JsonObject, ev: string, matcher: string, name: string):
 export function addHooks(hookName: string, projectDir: string): AddResult {
   const names = ALIASES[hookName] ?? [hookName];
   const result: AddResult = { added: [], alreadyInstalled: [], notFound: [] };
-  const srcDir = hookSourceDir();
+  const srcDir = resolveHookSourceDir();
   const destDir = path.join(projectDir, '.harness', 'hooks');
   fs.mkdirSync(destDir, { recursive: true });
 

--- a/packages/cli/src/commands/hooks/init.ts
+++ b/packages/cli/src/commands/hooks/init.ts
@@ -18,7 +18,7 @@ const VALID_PROFILES: HookProfile[] = ['minimal', 'standard', 'strict'];
  * In dev:  __dirname = src/commands/hooks/ → ../../hooks/ = src/hooks/
  * In dist: __dirname = dist/ (flat bundle)  → ./hooks/    = dist/hooks/
  */
-function resolveHookSourceDir(): string {
+export function resolveHookSourceDir(): string {
   const candidates = [
     // Dev layout: src/commands/hooks/ → ../../hooks/
     path.resolve(__dirname, '..', '..', 'hooks'),


### PR DESCRIPTION
Closes #797.

## Problem

`harness hooks add <name>` always fails on published (npm/mise) installs:

```text
x Failed to add hook: Hook scripts not found: …/@harness-engineering/hooks
```

`hookSourceDir()` in `packages/cli/src/commands/hooks/add.ts` only probed the dev layout (`__dirname/../../hooks`). In the published package the command is bundled flat into `dist/`, so that resolves to the nonexistent `@harness-engineering/hooks` sibling; the scripts actually ship at `dist/hooks/` (via `copy-assets.mjs`).

## Fix

`init.ts` already carries the correct two-candidate probe (`resolveHookSourceDir()` — dev layout, then bundled layout). This PR exports it and uses it from `add.ts`, deleting the stale single-path copy. No behavior change in dev; bundled installs now find the scripts. Changeset included (patch).

## Testing

- `tests/commands/hooks.test.ts` + `tests/hooks/hooks-cli-integration.test.ts`: 36/36 pass.
- Manually reproduced the failure on a mise install of 5.0.0 and confirmed the scripts copied from `dist/hooks/` install and run clean (the workaround this fix obsoletes).