### PR TITLE
feat(orchestrator): live AMR spend accumulator — make the D8 budget clamp actually fire

### DIFF
--- a/.changeset/amr-spend-accumulator.md
+++ b/.changeset/amr-spend-accumulator.md
@@ -1,0 +1,26 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+Make the AMR budget clamp (D8) live. `AdaptiveRouter` now keeps a monotonic
+spend accumulator — the sum of `estCostUsd` over every routing decision — and
+`route()` reads it before deriving a tier, so `deriveRequiredTier`'s budget
+clamp fires as spend accrues. Previously the router's `budgetState` was an
+un-wired `{ spentUsd: 0 }` stub, so a `routing.policy.budget` had no effect at all.
+
+This is a **soft degrade signal, not a hard ceiling**, and only affects
+orchestrators with a `budget` set (opt-in):
+
+- **Lagging under concurrency.** The clamp reads spend accrued from prior
+  dispatches; a burst of concurrent dispatches can overshoot `capUsd` before the
+  clamp engages. It nudges routing cheaper as spend climbs — it does not gate
+  admission.
+- **Single-step degrade.** Budget pressure lowers the tier by exactly one step
+  and never below the D5 blast-radius veto floor (a sensitive-path task stays
+  `strong` regardless of overspend).
+- **Monotonic** (deliberately not the bounded `projectTelemetry` ring-sum) so a
+  long run can't evict early spend and un-clamp. Persists across `setPolicy`, so
+  lowering `capUsd` mid-run clamps immediately and irreversibly.
+
+With no budget the accumulator still advances but the clamp no-ops (routing
+unchanged). New `AdaptiveRouter.getSpentUsd()` returns the effective spend.

--- a/packages/orchestrator/src/agent/adaptive-router.spend.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.spend.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  BackendCapabilities,
+  BackendDef,
+  ComplexityVerdict,
+  RoutingPolicy,
+} from '@harness-engineering/types';
+import { BackendRouter } from './backend-router.js';
+import { AdaptiveRouter } from './adaptive-router.js';
+
+/**
+ * D8 live spend accumulator — makes the budget clamp actually fire.
+ * `estimateCost` is deterministic: (4000/1000) × costPer1kTokens = 4 × rate.
+ */
+
+const cap = (over: Partial<BackendCapabilities> = {}): BackendCapabilities => ({
+  tier: 'fast',
+  costPer1kTokens: 0,
+  privacyClass: 'on-device',
+  contextWindow: 8192,
+  ...over,
+});
+
+const localDef = (capabilities: BackendCapabilities): BackendDef => ({
+  type: 'local',
+  endpoint: 'http://localhost:1234',
+  model: 'test-model',
+  capabilities,
+});
+
+const verdict = (level: ComplexityVerdict['level']): ComplexityVerdict => ({
+  level,
+  confidence: 'high',
+  signals: {},
+  source: 'static',
+});
+
+// strong: rate 10 → 40/dispatch; mid: rate 5 → 20/dispatch; fast: rate 0 → 0.
+const backends = {
+  fast: localDef(cap({ tier: 'fast', costPer1kTokens: 0 })),
+  mid: localDef(cap({ tier: 'standard', costPer1kTokens: 5 })),
+  strong: localDef(cap({ tier: 'strong', costPer1kTokens: 10 })),
+};
+
+const build = (
+  policy: RoutingPolicy,
+  level: ComplexityVerdict['level'] = 'complex'
+): AdaptiveRouter =>
+  AdaptiveRouter.fromConfig({
+    router: new BackendRouter({ backends, routing: { default: 'strong' } }),
+    backends,
+    policy,
+    classify: () => verdict(level),
+  });
+
+const REQ = { useCase: { kind: 'tier' as const, tier: 'quick-fix' as const } };
+
+describe('AdaptiveRouter — live spend accumulator (D8)', () => {
+  it('accumulates estCostUsd across dispatches (getSpentUsd grows)', async () => {
+    const r = build({}); // no budget ⇒ no clamp, but still accrues
+    expect(r.getSpentUsd()).toBe(0);
+    await r.route(REQ); // complex ⇒ strong (rate 10) ⇒ +40
+    expect(r.getSpentUsd()).toBe(40);
+    await r.route(REQ);
+    expect(r.getSpentUsd()).toBe(80);
+  });
+
+  it('a decision reflects the cost that was accrued (estCostUsd on the enriched decision)', async () => {
+    const r = build({});
+    const { decision } = await r.route(REQ);
+    expect(decision.estCostUsd).toBe(40); // strong, rate 10
+    expect(r.getSpentUsd()).toBe(40);
+  });
+
+  it('budget clamp FIRES as accrued spend crosses degradeAtPct (was dead before)', async () => {
+    // cap 100, degrade at 50% ⇒ clamp once spend >= 50. Each strong dispatch = 40.
+    const r = build({ budget: { capUsd: 100, degradeAtPct: 50, onBudgetExhausted: 'degrade' } });
+
+    // Dispatch 1: spend 0 (0%) ⇒ no clamp ⇒ strong.
+    const d1 = await r.route(REQ);
+    expect(d1.decision.tierRequired).toBe('strong');
+    expect(d1.decision.backendName).toBe('strong');
+    expect(r.getSpentUsd()).toBe(40);
+
+    // Dispatch 2: spend 40 (40% < 50%) ⇒ still no clamp ⇒ strong.
+    const d2 = await r.route(REQ);
+    expect(d2.decision.tierRequired).toBe('strong');
+    expect(r.getSpentUsd()).toBe(80);
+
+    // Dispatch 3: spend 80 (80% >= 50%) ⇒ clamp strong→standard ⇒ mid backend.
+    const d3 = await r.route(REQ);
+    expect(d3.decision.tierRequired).toBe('standard');
+    expect(d3.decision.backendName).toBe('mid');
+    expect(r.getSpentUsd()).toBe(100); // +20 (mid rate 5)
+  });
+
+  it('no budget policy ⇒ accrual is harmless, tier never clamps', async () => {
+    const r = build({}); // no budget
+    for (let i = 0; i < 5; i++) {
+      const { decision } = await r.route(REQ);
+      expect(decision.tierRequired).toBe('strong'); // never clamps regardless of spend
+    }
+    expect(r.getSpentUsd()).toBe(200); // 5 × 40, accrued but unused
+  });
+
+  it('an injected budgetState overrides the internal accumulator for the clamp', async () => {
+    // Inject a budgetState already over the degrade threshold ⇒ clamp on the FIRST
+    // dispatch, even though the internal accumulator is still 0 at read time.
+    const r = AdaptiveRouter.fromConfig({
+      router: new BackendRouter({ backends, routing: { default: 'strong' } }),
+      backends,
+      policy: { budget: { capUsd: 100, degradeAtPct: 50, onBudgetExhausted: 'degrade' } },
+      classify: () => verdict('complex'),
+      budgetState: () => ({ spentUsd: 90 }), // 90% ⇒ clamp
+    });
+    const { decision } = await r.route(REQ);
+    expect(decision.tierRequired).toBe('standard'); // clamped by the injected spend
+    // getSpentUsd() reflects the EFFECTIVE spend (the injected source that drove
+    // routing), not the internal tally — so an operator sees what actually clamped.
+    expect(r.getSpentUsd()).toBe(90);
+  });
+
+  it('the D5 blast-radius veto floor is INVIOLABLE under budget pressure (clamp cannot undercut strong)', async () => {
+    // A sensitive-path / high-blast-radius request forces `strong` "regardless"
+    // (SC5); the budget clamp must NOT degrade it even when massively over budget.
+    const r = build({ budget: { capUsd: 1, degradeAtPct: 10, onBudgetExhausted: 'degrade' } });
+    const riskyReq = {
+      ...REQ,
+      risk: { blastRadius: 10, sensitivePath: true }, // triggers the D5 veto
+    };
+    // Prime spend far over the cap so the clamp WOULD fire without the veto.
+    await r.route(riskyReq);
+    await r.route(riskyReq);
+    const { decision } = await r.route(riskyReq);
+    expect(decision.tierRequired).toBe('strong'); // veto pins strong despite overspend
+    expect(decision.backendName).toBe('strong');
+
+    // Control: the SAME over-budget state, but a non-risky request DOES clamp.
+    const { decision: clamped } = await r.route(REQ);
+    expect(clamped.tierRequired).toBe('standard');
+  });
+
+  it('a fail-closed (PrivacyNoMatch) dispatch does NOT accrue spend', async () => {
+    // Only a shared-cloud backend, but privacyFloor demands on-device ⇒ selection
+    // throws PrivacyNoMatch before the accrue. Spend must stay flat.
+    const cloudOnly = {
+      cloud: localDef(cap({ tier: 'strong', costPer1kTokens: 10, privacyClass: 'shared-cloud' })),
+    };
+    const r = AdaptiveRouter.fromConfig({
+      router: new BackendRouter({ backends: cloudOnly, routing: { default: 'cloud' } }),
+      backends: cloudOnly,
+      policy: { privacyFloor: 'on-device' },
+      classify: () => verdict('moderate'),
+    });
+    await expect(r.route(REQ)).rejects.toThrow(/PrivacyNoMatch|no backend/i);
+    expect(r.getSpentUsd()).toBe(0); // threw before accrual
+  });
+});

--- a/packages/orchestrator/src/agent/adaptive-router.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.ts
@@ -72,6 +72,29 @@ export interface AdaptiveRouterDeps {
  * selection abstains (`undefined`) dispatch falls through unchanged.
  */
 export class AdaptiveRouter {
+  /**
+   * D8 live spend accumulator. Monotonic sum of `estCostUsd` over every decision
+   * this router has made. `route()` reads it (via the `budgetState` default)
+   * BEFORE deriving a tier, so `deriveRequiredTier`'s budget clamp actually fires
+   * as spend accrues — previously `budgetState` was an un-wired `{ spentUsd: 0 }`
+   * stub, so the clamp was dead.
+   *
+   * Semantics (deliberately modest — do NOT read this as a hard ceiling):
+   * - **Soft, lagging cap.** The clamp reads spend accrued from PRIOR dispatches;
+   *   a burst of concurrent dispatches all read a stale-low total before any of
+   *   them accrues, so a burst can overshoot `capUsd` before the clamp engages.
+   *   This is a degrade *signal*, not an admission gate.
+   * - **Single-step degrade.** `deriveRequiredTier` lowers the tier by exactly ONE
+   *   step under budget pressure and never below the D5 privacy veto floor — it
+   *   does not throttle progressively toward `fast`.
+   * - **Monotonic** (NOT the bounded `projectTelemetry` ring-sum): a long run must
+   *   not evict early spend and un-clamp. Preserved across `setPolicy` (instance
+   *   persists) — note a *lowered* `capUsd` then clamps immediately and, since the
+   *   total never decreases, irreversibly for the rest of the run.
+   * An injected `deps.budgetState` overrides this for the clamp (DI/tests).
+   */
+  private spentUsd = 0;
+
   constructor(private readonly deps: AdaptiveRouterDeps) {}
 
   /**
@@ -125,6 +148,8 @@ export class AdaptiveRouter {
    * so the swapped-in tier matrix / privacy floor / allowlist / budget all apply.
    * The live {@link EscalationState} is preserved by reference: a unit's climbed
    * floor survives the swap (a policy edit must not reset accumulated escalation).
+   * The monotonic spend accumulator also persists — so a swap that LOWERS `capUsd`
+   * clamps immediately and irreversibly for the rest of the run (see `spentUsd`).
    *
    * Threshold note: the `EscalationState` was seeded with the ORIGINAL policy's
    * `escalationThreshold` and is intentionally NOT re-seeded here — re-seeding
@@ -170,9 +195,24 @@ export class AdaptiveRouter {
     return { decisions, spentUsd };
   }
 
+  /**
+   * D8: the EFFECTIVE spend total the budget clamp reads — the injected
+   * `budgetState` when present, otherwise the router's own monotonic accumulator.
+   * Returning the effective value (not blindly the internal tally) means an
+   * operator reading this always sees the number that actually drove routing.
+   */
+  getSpentUsd(): number {
+    return this.deps.budgetState ? this.deps.budgetState().spentUsd : this.spentUsd;
+  }
+
   async route(req: RoutingRequest): Promise<{ decision: RoutingDecision; def: BackendDef }> {
     const complexity = req.complexity ?? (await this.classifySafe(req));
-    const spend = (this.deps.budgetState ?? (() => ({ spentUsd: 0 })))();
+    // D8: the budget clamp reads the spend accrued from PRIOR dispatches (this
+    // decision's own cost isn't known until a backend is selected below). An
+    // injected `budgetState` wins (DI/tests); otherwise the live internal
+    // accumulator. From here to the accumulate below there is NO `await`, so the
+    // read → derive → accumulate window is atomic per call (no lost updates).
+    const spend = this.deps.budgetState ? this.deps.budgetState() : { spentUsd: this.spentUsd };
     // D10: the escalation floor raises the derived tier for a coherence unit that
     // has climbed on repeated quality failure. Absent EscalationState ⇒ no-op 'fast'.
     // split-routing D8(a): a caller (the workflow engine's one-shot per-stage
@@ -196,11 +236,17 @@ export class AdaptiveRouter {
     const { decision, def } = this.deps.router.resolveDecisionAndDef(req.useCase, {
       ...(target !== undefined ? { invocationOverride: target } : {}),
     });
+    const estCostUsd = estimateCost(def, req);
+    // D8: accrue this decision's estimated cost into the monotonic accumulator so
+    // the NEXT dispatch's budget clamp sees it. Always accrues (cheap; harmless
+    // when no budget is set — the clamp simply no-ops); an injected `budgetState`
+    // means the caller owns accounting, so we leave the internal total unused.
+    this.spentUsd += estCostUsd;
     const enriched: RoutingDecision = {
       ...decision,
       complexity,
       tierRequired: requiredTier,
-      estCostUsd: estimateCost(def, req),
+      estCostUsd,
     };
     // SC9: surface the enrichment to bus subscribers. `resolveDecisionAndDef`
     // already emitted the BASE decision (D2-frozen); this second emit carries the


### PR DESCRIPTION
## What & why

AMR's budget degradation (D8) was **dead**: `deriveRequiredTier` applies a budget clamp (step the tier down once `spentUsd/capUsd ≥ degradeAtPct`), but `AdaptiveRouter.route()` read spend from a `budgetState` that was an un-wired `{ spentUsd: 0 }` stub — never passed at construction. So a `routing.policy.budget` had **no effect at all**.

This wires a live monotonic spend accumulator: `route()` sums `estCostUsd` over every decision and reads that total before deriving the next tier, so the clamp fires as spend accrues.

## Honest semantics (a soft signal, not a hard cap)

The adversarial review pushed on what "making the clamp live" actually buys, and the framing here reflects it:

- **Lagging under concurrency.** The read→derive→accrue window is atomic *per call* (no `await` in it), but the orchestrator dispatches issues concurrently — a burst all reads a stale-low total before any accrues, so it can overshoot `capUsd`. This nudges routing cheaper as spend climbs; it does **not** gate admission.
- **Single-step degrade.** Budget pressure lowers the tier by exactly one step, never below the D5 blast-radius veto floor (a sensitive-path task stays `strong` regardless of overspend).
- **Monotonic**, deliberately not the bounded `projectTelemetry` ring-sum — a long run (>500 decisions) would otherwise evict early spend and silently un-clamp. Persists across `setPolicy`, so lowering `capUsd` mid-run clamps immediately and irreversibly.

Opt-in: with no `budget` set the accumulator still advances but the clamp no-ops, so routing is unchanged. AMR-off is untouched (the router isn't even constructed).

## Tests

7 tests: accrual, **live clamp firing** (`strong→standard` as spend crosses `degradeAtPct`, landing on the cheaper backend — not just that spend grew), no-budget harmlessness, injected-`budgetState` override, **D5 veto-floor inviolable under maximum budget pressure**, and **fail-closed (`PrivacyNoMatch`) does not accrue**. Full agent suite green (96).

## Follow-up (not in scope)

A hard admission cap would need read-time cost reservation before the classify await — noted but deliberately out of scope; this is the soft-degrade increment.