### PR TITLE
feat: AMR observability + e2e round-trip + operator guide (harden the routing subsystem)

### DIFF
--- a/.changeset/amr-observability.md
+++ b/.changeset/amr-observability.md
@@ -1,0 +1,23 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/cli': minor
+'@harness-engineering/types': minor
+---
+
+AMR operator observability. Adds a live routing status surface so operators
+running adaptive routing can see spend, degradation, and escalation — previously
+only routing _decisions_ were inspectable.
+
+- **`GET /api/v1/routing/status`** (`read-telemetry`) — the live operator view:
+  whether AMR is active, budget **spend-vs-cap** (using the monotonic accumulator
+  that actually drives the D8 clamp, not the telemetry ring sum), the coherence
+  units that have climbed their escalation floor, and the active provider
+  allowlist. Always 200; an inactive payload when AMR is off.
+- **`harness routing status`** — renders that payload (budget bar, `DEGRADING`
+  flag, escalated-unit table, allowlist).
+- **`harness routing telemetry`** — renders the existing `/routing/telemetry`
+  projection with a per-tier distribution and per-decision cost breakdown.
+
+New: `AdaptiveRouter.getStatus()`, `Orchestrator.getRoutingStatus()`,
+`EscalationState.climbedUnits()`, and the `RoutingStatus` / `RoutingBudgetStatus`
+/ `RoutingEscalationUnit` types. Read-only; no dispatch behavior change.

--- a/.changeset/amr-observability.md
+++ b/.changeset/amr-observability.md
@@ -2,6 +2,7 @@
 '@harness-engineering/orchestrator': minor
 '@harness-engineering/cli': minor
 '@harness-engineering/types': minor
+'@harness-engineering/intelligence': patch
 ---
 
 AMR operator observability. Adds a live routing status surface so operators

--- a/docs/guides/adaptive-model-routing.md
+++ b/docs/guides/adaptive-model-routing.md
@@ -1,0 +1,180 @@
+# Adaptive Model Routing (AMR)
+
+Adaptive Model Routing picks a **capability tier** (`fast` → `standard` → `strong`)
+per dispatch based on the task's estimated complexity, then routes to the cheapest
+backend that qualifies at that tier — so trivial work runs on a cheap/local model
+and hard work escalates to a strong one. It layers on top of
+[multi-backend routing](./multi-backend-routing.md): `agent.backends` still defines
+the named backends; AMR chooses **which tier** each dispatch needs.
+
+**AMR is strictly opt-in and default-off.** With no `agent.routing.policy` set, the
+orchestrator dispatches exactly as before — byte-identical, no complexity
+classification, no added latency. Everything below activates only once you set a
+policy.
+
+## Quick start
+
+Add a `policy` block under `agent.routing`:
+
+```yaml
+agent:
+  backends:
+    local-fast:
+      {
+        type: local,
+        endpoint: http://localhost:1234/v1,
+        model: qwen3:8b,
+        capabilities: { tier: fast, costPer1kTokens: 0, privacyClass: on-device },
+      }
+    cloud-strong:
+      {
+        type: anthropic,
+        model: claude-opus-4-8,
+        capabilities: { tier: strong, costPer1kTokens: 15, privacyClass: shared-cloud },
+      }
+  routing:
+    default: cloud-strong
+    policy:
+      # Optional: override the built-in complexity→tier matrix.
+      complexityTierMatrix: { trivial: fast, simple: fast, moderate: standard, complex: strong }
+      # Optional: keep spend under a soft cap (see "Budget" below).
+      budget: { capUsd: 20, degradeAtPct: 90, onBudgetExhausted: degrade }
+```
+
+Now a `trivial` task routes to `local-fast` (free), a `complex` one to
+`cloud-strong`, and everything degrades a tier once you've spent 90% of the cap.
+
+Backends need a `capabilities` block (`tier`, `costPer1kTokens`, `privacyClass`,
+`contextWindow`) for AMR to compare them; a backend without one is invisible to
+tier selection and only reachable via the identity/default chain.
+
+## `agent.routing.policy`
+
+| field                  | type                                           | effect                                                                                              |
+| ---------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `complexityTierMatrix` | `{ trivial\|simple\|moderate\|complex: tier }` | Maps the classified complexity level to a required tier. Defaults are provided; override per level. |
+| `skillTierOverrides`   | `{ [skillName]: tier }`                        | Pin a specific skill/phase to a tier, evaluated before the matrix.                                  |
+| `privacyFloor`         | `on-device \| byo-endpoint \| shared-cloud`    | Excludes backends whose `privacyClass` is weaker than the floor. Fail-closed (see below).           |
+| `budget`               | `{ capUsd, degradeAtPct?, onBudgetExhausted }` | Soft spend cap that degrades the tier under pressure. See **Budget**.                               |
+| `allowedProviders`     | `BackendType[]`                                | Provider-type allowlist; only these backend `type`s are eligible. Fail-closed if it empties.        |
+| `escalationThreshold`  | `number` (default 2)                           | Consecutive quality failures before a unit's tier floor climbs. See **Escalation**.                 |
+
+### How a tier is chosen
+
+For each dispatch, AMR resolves the required tier in order:
+
+1. **`skillTierOverride`** for the skill, else **`complexityTierMatrix`** for the
+   classified complexity.
+2. **Blast-radius veto (D5):** a sensitive-path / high-risk task is forced to
+   `strong` regardless.
+3. **Budget clamp (D8):** if over the degrade threshold, step the tier **down** one
+   (never below the veto floor).
+4. **Escalation floor (D10):** if the coherence unit has climbed, raise the tier
+   (never lowers it).
+
+Then it selects the cheapest backend qualifying at that tier, honoring
+`privacyFloor` and `allowedProviders`. If a privacy/allowlist constraint leaves
+**no** compliant backend, selection **fails closed** (the unit surfaces to a human
+as `routing:no-tier-match`) — it never silently routes to a non-compliant backend.
+
+## Budget
+
+`budget` is a **soft, lagging** cap — a degrade _signal_, not a hard ceiling:
+
+- Spend accrues as a **monotonic** total of estimated per-dispatch cost. Once it
+  reaches `degradeAtPct` (default 90) of `capUsd`, the tier is clamped **one step
+  down** for subsequent dispatches (`strong → standard → fast`), never below the
+  blast-radius veto floor.
+- It is **lagging under concurrency**: several dispatches in flight all read the
+  same pre-accrual total, so a burst can overshoot the cap before the clamp
+  engages. It nudges routing cheaper; it does not gate admission.
+- `onBudgetExhausted` (`degrade | pause | human`) is the declared intent; the
+  shipped clamp implements the `degrade` behavior.
+
+Watch spend against the cap with `harness routing status` (below).
+
+## Escalation
+
+When a coherence unit's output repeatedly fails a **quality gate**, AMR raises that
+unit's tier floor (`escalationThreshold` consecutive failures → climb one step,
+`strong`-capped). If a unit re-crosses the threshold already at `strong`, it
+**hard-fails to a human** (`routing:escalation-exhausted`).
+
+This is **live for staged workflows** — a `pass-required` stage's gate outcome
+feeds the escalation directly. For **single-agent** dispatch the escalation
+mechanism and seam are complete but **not yet fed** (there is no sound per-issue
+quality verdict source today — see
+[ADR 0069](../knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md)).
+
+## Split-routing workflows
+
+Declare a multi-stage workflow under `agent.workflows` to run a unit as an ordered
+sequence of stages, **each routed independently** at its own required tier on one
+shared worktree:
+
+```yaml
+agent:
+  workflows:
+    - name: implement-then-review
+      match: { labels: [feature] }
+      stages:
+        - {
+            skill: implement,
+            produces: code,
+            gate: pass-required,
+            routingHint: { complexity: complex },
+          }
+        - {
+            skill: review,
+            produces: review,
+            expects: code,
+            gate: pass-required,
+            routingHint: { complexity: moderate },
+          }
+```
+
+Staged **execution** is single opt-in: the declaration alone selects the staged
+path. Per-stage **tier routing** is the additional opt-in — with `routing.policy`
+set, each stage calls the router at its own tier; without it, stages use the
+identity/default chain. Each stage renders a real prompt from the work item, its
+role, and the prior stages' outputs (threaded by `produces`). Absent a matching
+≥2-stage workflow, dispatch is byte-identical to single-agent.
+
+## Observability
+
+The `harness routing` command group inspects a running orchestrator (set
+`HARNESS_ORCHESTRATOR_URL`, default `http://127.0.0.1:8080`):
+
+| command                     | shows                                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `harness routing status`    | Live status: AMR on/off, budget **spend-vs-cap** + `DEGRADING` flag, escalated units, allowlist. |
+| `harness routing telemetry` | Recent decisions with a per-tier distribution and per-decision cost.                             |
+| `harness routing decisions` | The raw recent-decision ring, filterable by `--skill`/`--mode`/`--backend`.                      |
+| `harness routing config`    | The resolved routing config + fallback chains.                                                   |
+| `harness routing trace`     | Dry-run a decision (`--skill`, `--complexity`, `--risk`) with no side effects.                   |
+
+Each takes `--json` for scripting.
+
+### Runtime control plane
+
+For programmatic / multi-tenant control (e.g. the Shuttle SaaS layer), the
+orchestrator exposes:
+
+- `PUT /api/v1/routing/policy` (`admin` scope) — ingest a `RoutingPolicy` at
+  runtime, hot-swapping the live router (preserving accumulated escalation). An
+  empty `{}` body restores default-off.
+- `GET /api/v1/routing/telemetry` (`read-telemetry`) — decisions in the
+  cross-repo wire shape (`{ decisions, spentUsd }`).
+- `GET /api/v1/routing/status` (`read-telemetry`) — the live operator status.
+
+## Limitations
+
+- **Budget is a soft cap** (lagging, single-step degrade), not a hard ceiling — see
+  **Budget**.
+- **Single-agent escalation is deferred** — the mechanism and seam are complete and
+  staged workflows escalate, but single-agent dispatch has no live quality-verdict
+  source yet ([ADR 0069](../knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md)).
+- **Two `spentUsd` numbers exist:** `routing telemetry`/`GET /telemetry` report the
+  bounded ring sum (last N decisions, telemetry-grade); `routing status` reports the
+  monotonic accumulator that actually drives the budget clamp. Use `status` for
+  budget decisions.

--- a/docs/guides/multi-backend-routing.md
+++ b/docs/guides/multi-backend-routing.md
@@ -2,6 +2,8 @@
 
 The orchestrator's `agent.backends` map defines named backend instances; `agent.routing` selects which named backend handles each use case. This is the modern config surface — it replaces `agent.backend` / `agent.localBackend` (which still work via an in-memory migration shim with a deprecation warning at orchestrator start).
 
+> **Routing by complexity + cost?** See [Adaptive Model Routing](./adaptive-model-routing.md) for tier-based routing, budgets, split-routing workflows, and the `harness routing` observability commands.
+
 ## Quick example
 
 ```yaml

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1174,7 +1174,7 @@ Read the signal timeline and propose reverts for threshold crossings (signal arm
 
 ## Routing Commands
 
-Inspect routing config, trace decisions, and read recent dispatches
+Inspect routing config, trace decisions, and read AMR telemetry + status
 
 ### `harness routing config`
 
@@ -1194,6 +1194,23 @@ List recent routing decisions from the orchestrator ring buffer (Spec B F8)
 - `--mode` — Filter by useCase.cognitiveMode
 - `--backend` — Filter by chosen backendName
 - `--last` — Limit to the N most recent decisions
+- `--json` — Emit JSON to stdout instead of human-readable text
+
+### `harness routing status`
+
+Live routing status: budget spend-vs-cap, escalated units, provider allowlist (AMR)
+
+**Options:**
+
+- `--json` — Emit JSON to stdout instead of human-readable text
+
+### `harness routing telemetry`
+
+Routing telemetry: per-decision tier/backend/cost + tier distribution (AMR)
+
+**Options:**
+
+- `--last` — Show only the N most recent decisions in the per-decision table
 - `--json` — Emit JSON to stdout instead of human-readable text
 
 ### `harness routing trace`

--- a/packages/cli/src/commands/routing/index.ts
+++ b/packages/cli/src/commands/routing/index.ts
@@ -2,18 +2,23 @@ import { Command } from 'commander';
 import { createConfigCommand } from './config';
 import { createTraceCommand } from './trace';
 import { createDecisionsCommand } from './decisions';
+import { createTelemetryCommand } from './telemetry';
+import { createStatusCommand } from './status';
 
 /**
- * Spec B Phase 6: `harness routing` subcommand group. Operator-facing
- * inspection of routing config, dry-run trace, and recent decisions.
- * Consumes the Phase 5 routes under `/api/v1/routing/{config,trace,decisions}`.
+ * Spec B Phase 6 + AMR observability: `harness routing` subcommand group.
+ * Operator-facing inspection of routing config, dry-run trace, recent decisions,
+ * the AMR telemetry projection, and live routing status. Consumes the routes
+ * under `/api/v1/routing/{config,trace,decisions,telemetry,status}`.
  */
 export function createRoutingCommand(): Command {
   const cmd = new Command('routing').description(
-    'Inspect routing config, trace decisions, and read recent dispatches'
+    'Inspect routing config, trace decisions, and read AMR telemetry + status'
   );
   cmd.addCommand(createConfigCommand());
   cmd.addCommand(createTraceCommand());
   cmd.addCommand(createDecisionsCommand());
+  cmd.addCommand(createTelemetryCommand());
+  cmd.addCommand(createStatusCommand());
   return cmd;
 }

--- a/packages/cli/src/commands/routing/routing.test.ts
+++ b/packages/cli/src/commands/routing/routing.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createConfigCommand } from './config';
 import { createTraceCommand } from './trace';
 import { createDecisionsCommand } from './decisions';
+import { createTelemetryCommand } from './telemetry';
+import { createStatusCommand } from './status';
 
 /**
  * Spec B Phase 6: pins Observable Truths 1, 2, 3, 4, 5, 7, 8 for the
@@ -349,5 +351,69 @@ describe('harness routing — subcommand acceptance contracts (Spec B Phase 6)',
     expect(exitSpy).toHaveBeenCalledWith(2);
     const allErr = errSpy.mock.calls.map((c: unknown[]) => String(c[1] ?? c[0])).join('\n');
     expect(allErr).toMatch(/Routing observability not available/);
+  });
+
+  // -------------------------------------------------------------------------
+  // AMR observability: telemetry + status commands
+  // -------------------------------------------------------------------------
+  it('telemetry: renders tier distribution + per-decision cost from /routing/telemetry', async () => {
+    const telemetry = {
+      spentUsd: 0.6,
+      decisions: [
+        {
+          decisionTs: '2026-07-12T12:00:00.000Z',
+          tierRequired: 'strong',
+          backend: 'cloud',
+          estCostUsd: 0.4,
+        },
+        {
+          decisionTs: '2026-07-12T12:00:01.000Z',
+          tierRequired: 'fast',
+          backend: 'local',
+          estCostUsd: 0.2,
+        },
+      ],
+    };
+    const { calls } = mockFetch(() => new Response(JSON.stringify(telemetry), { status: 200 }));
+    await createTelemetryCommand().parseAsync([], { from: 'user' });
+    expect(calls[0]!.url).toContain('/api/v1/routing/telemetry');
+    const allLog = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(allLog).toMatch(/Ring spend total:\s+\$0\.6000/);
+    expect(allLog).toMatch(/strong/);
+    expect(allLog).toMatch(/cloud/);
+    expect(allLog).toMatch(/\$0\.4000/);
+  });
+
+  it('telemetry --json: emits the raw payload', async () => {
+    mockFetch(() => new Response(JSON.stringify({ decisions: [], spentUsd: 0 }), { status: 200 }));
+    await createTelemetryCommand().parseAsync(['--json'], { from: 'user' });
+    const allLog = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(allLog).toMatch(/"spentUsd"/);
+  });
+
+  it('status: renders the budget bar + escalation + allowlist from /routing/status', async () => {
+    const status = {
+      active: true,
+      budget: { spentUsd: 80, capUsd: 100, degradeAtPct: 50, spentPct: 80, degrading: true },
+      escalation: [{ coherenceUnit: 'issue-7', floor: 'strong' }],
+      allowedProviders: ['local'],
+    };
+    const { calls } = mockFetch(() => new Response(JSON.stringify(status), { status: 200 }));
+    await createStatusCommand().parseAsync([], { from: 'user' });
+    expect(calls[0]!.url).toContain('/api/v1/routing/status');
+    const allLog = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(allLog).toMatch(/Adaptive routing: ON/);
+    expect(allLog).toMatch(/\$80\.0000 \/ \$100\.00/);
+    expect(allLog).toMatch(/DEGRADING/);
+    expect(allLog).toMatch(/issue-7/);
+    expect(allLog).toMatch(/local/);
+  });
+
+  it('status: renders OFF when routing is inactive', async () => {
+    const status = { active: false, budget: null, escalation: [], allowedProviders: null };
+    mockFetch(() => new Response(JSON.stringify(status), { status: 200 }));
+    await createStatusCommand().parseAsync([], { from: 'user' });
+    const allLog = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(allLog).toMatch(/Adaptive routing: OFF/);
   });
 });

--- a/packages/cli/src/commands/routing/routing.test.ts
+++ b/packages/cli/src/commands/routing/routing.test.ts
@@ -391,6 +391,43 @@ describe('harness routing — subcommand acceptance contracts (Spec B Phase 6)',
     expect(allLog).toMatch(/"spentUsd"/);
   });
 
+  it('telemetry --last bounds only the per-decision table; distribution summarizes the full ring', async () => {
+    const telemetry = {
+      spentUsd: 1.0,
+      decisions: [
+        {
+          decisionTs: '2026-07-12T12:00:00.000Z',
+          tierRequired: 'strong',
+          backend: 'a',
+          estCostUsd: 0.5,
+        },
+        {
+          decisionTs: '2026-07-12T12:00:01.000Z',
+          tierRequired: 'strong',
+          backend: 'b',
+          estCostUsd: 0.3,
+        },
+        {
+          decisionTs: '2026-07-12T12:00:02.000Z',
+          tierRequired: 'fast',
+          backend: 'c',
+          estCostUsd: 0.2,
+        },
+      ],
+    };
+    mockFetch(() => new Response(JSON.stringify(telemetry), { status: 200 }));
+    await createTelemetryCommand().parseAsync(['--last', '1'], { from: 'user' });
+    const allLog = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    // Distribution reflects the full ring (3 decisions), not the limited table.
+    expect(allLog).toMatch(/Decisions \(retained ring\): 3/);
+    expect(allLog).toMatch(/strong\s+2/); // 2 strong across the full ring
+    // The per-decision table is limited to the latest 1 and says so.
+    expect(allLog).toMatch(/latest 1 of 3/);
+    // Only backend 'a' (first row) shows in the table; 'b'/'c' are omitted.
+    expect(allLog).toMatch(/ a /);
+    expect(allLog).not.toMatch(/ c /);
+  });
+
   it('status: renders the budget bar + escalation + allowlist from /routing/status', async () => {
     const status = {
       active: true,

--- a/packages/cli/src/commands/routing/status.ts
+++ b/packages/cli/src/commands/routing/status.ts
@@ -1,0 +1,92 @@
+import { Command } from 'commander';
+import { getJson, orchestratorBase } from './http-client';
+import { logger } from '../../output/logger';
+import { ExitCode } from '../../utils/errors';
+import type { RoutingStatus } from '@harness-engineering/types';
+
+/**
+ * AMR observability: `harness routing status` — GET /api/v1/routing/status.
+ * The live operator view of the adaptive router: whether it's active, budget
+ * spend-vs-cap (the MONOTONIC accumulator that drives the D8 clamp — not the
+ * telemetry ring sum), the coherence units that have escalated, and the active
+ * provider allowlist.
+ */
+function bar(pct: number, width = 24): string {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.round((clamped / 100) * width);
+  return `[${'#'.repeat(filled)}${'-'.repeat(width - filled)}]`;
+}
+
+function renderHuman(s: RoutingStatus): void {
+  if (!s.active) {
+    console.log('Adaptive routing: OFF (no routing.policy configured — dispatch is unchanged)');
+    return;
+  }
+  console.log('Adaptive routing: ON');
+
+  if (s.budget) {
+    const b = s.budget;
+    const state = b.degrading ? 'DEGRADING (clamping tiers down)' : 'ok';
+    console.log('');
+    console.log('Budget:');
+    console.log(
+      `  $${b.spentUsd.toFixed(4)} / $${b.capUsd.toFixed(2)}  ${bar(b.spentPct)} ${b.spentPct}%`
+    );
+    console.log(`  degrade at ${b.degradeAtPct}% → ${state}`);
+  } else {
+    console.log('Budget:      (none configured)');
+  }
+
+  console.log('');
+  if (s.escalation.length === 0) {
+    console.log('Escalation:  (no units have climbed above the fast floor)');
+  } else {
+    console.log(`Escalation:  ${s.escalation.length} unit(s) climbed`);
+    console.log('  UNIT                                   FLOOR');
+    for (const u of s.escalation) {
+      console.log(`  ${u.coherenceUnit.padEnd(38)} ${u.floor}`);
+    }
+  }
+
+  console.log('');
+  console.log(
+    `Allowlist:   ${
+      s.allowedProviders && s.allowedProviders.length > 0
+        ? s.allowedProviders.join(', ')
+        : '(all providers allowed)'
+    }`
+  );
+}
+
+export function createStatusCommand(): Command {
+  return new Command('status')
+    .description(
+      'Live routing status: budget spend-vs-cap, escalated units, provider allowlist (AMR)'
+    )
+    .option('--json', 'Emit JSON to stdout instead of human-readable text')
+    .action(async (opts: { json?: boolean }) => {
+      const r = await getJson<RoutingStatus>('/api/v1/routing/status');
+      if (!r.ok) {
+        if (r.status === 0) {
+          logger.error(
+            `Failed to reach orchestrator at ${orchestratorBase()}: ${r.error ?? 'unknown error'}`
+          );
+        } else {
+          logger.error(`Request failed (${r.status}): ${r.error ?? ''}`);
+        }
+        process.exit(ExitCode.ERROR);
+        return;
+      }
+      const body = r.body ?? {
+        active: false,
+        budget: null,
+        escalation: [],
+        allowedProviders: null,
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(body, null, 2));
+        return;
+      }
+      renderHuman(body);
+    });
+}

--- a/packages/cli/src/commands/routing/telemetry.ts
+++ b/packages/cli/src/commands/routing/telemetry.ts
@@ -1,0 +1,89 @@
+import { Command } from 'commander';
+import { getJson, orchestratorBase } from './http-client';
+import { logger } from '../../output/logger';
+import { ExitCode } from '../../utils/errors';
+import type { RoutingTelemetry, CapabilityTier } from '@harness-engineering/types';
+
+/**
+ * AMR observability: `harness routing telemetry` — GET /api/v1/routing/telemetry.
+ * The enriched decision ring projected into the Shuttle wire shape
+ * ({ decisions, spentUsd }): per-decision tier/backend/cost, plus a tier
+ * distribution and the ring spend total. `spentUsd` here is the ring-sum
+ * (telemetry-grade); the budget accumulator that drives the clamp is in
+ * `harness routing status`.
+ */
+const TIERS: CapabilityTier[] = ['fast', 'standard', 'strong'];
+
+function shortIso(iso: string): string {
+  const tail = iso.split('T')[1] ?? iso;
+  return tail.replace('Z', '');
+}
+
+function renderHuman(data: RoutingTelemetry): void {
+  if (data.decisions.length === 0) {
+    console.log('(no routing telemetry — AMR is off or no decisions recorded yet)');
+    return;
+  }
+  // Tier distribution.
+  const byTier = new Map<CapabilityTier, { count: number; cost: number }>();
+  for (const t of TIERS) byTier.set(t, { count: 0, cost: 0 });
+  for (const d of data.decisions) {
+    const bucket = byTier.get(d.tierRequired);
+    if (bucket) {
+      bucket.count += 1;
+      bucket.cost += d.estCostUsd;
+    }
+  }
+  console.log(`Decisions (retained ring): ${data.decisions.length}`);
+  console.log(`Ring spend total:          $${data.spentUsd.toFixed(4)}`);
+  console.log('');
+  console.log('TIER      COUNT   SHARE   COST');
+  for (const t of TIERS) {
+    const b = byTier.get(t)!;
+    const share = data.decisions.length ? Math.round((b.count / data.decisions.length) * 100) : 0;
+    console.log(
+      `${t.padEnd(9)} ${String(b.count).padStart(5)}   ${String(share).padStart(4)}%   $${b.cost.toFixed(4)}`
+    );
+  }
+  console.log('');
+  console.log('TIMESTAMP     TIER      BACKEND         COST');
+  for (const d of data.decisions) {
+    const ts = shortIso(d.decisionTs).padEnd(13);
+    const tier = d.tierRequired.padEnd(9);
+    const be = d.backend.padEnd(15);
+    console.log(`${ts} ${tier} ${be} $${d.estCostUsd.toFixed(4)}`);
+  }
+}
+
+export function createTelemetryCommand(): Command {
+  return new Command('telemetry')
+    .description('Routing telemetry: per-decision tier/backend/cost + tier distribution (AMR)')
+    .option('--last <N>', 'Show only the N most recent decisions in the per-decision table')
+    .option('--json', 'Emit JSON to stdout instead of human-readable text')
+    .action(async (opts: { last?: string; json?: boolean }) => {
+      const r = await getJson<RoutingTelemetry>('/api/v1/routing/telemetry');
+      if (!r.ok) {
+        if (r.status === 0) {
+          logger.error(
+            `Failed to reach orchestrator at ${orchestratorBase()}: ${r.error ?? 'unknown error'}`
+          );
+        } else {
+          logger.error(`Request failed (${r.status}): ${r.error ?? ''}`);
+        }
+        process.exit(ExitCode.ERROR);
+        return;
+      }
+      const body = r.body ?? { decisions: [], spentUsd: 0 };
+      // `--last N` bounds only the per-decision table; the tier distribution +
+      // spend total still summarize the full retained ring.
+      const limited: RoutingTelemetry =
+        opts.last && Number.isFinite(Number(opts.last)) && Number(opts.last) > 0
+          ? { ...body, decisions: body.decisions.slice(0, Math.floor(Number(opts.last))) }
+          : body;
+      if (opts.json) {
+        console.log(JSON.stringify(limited, null, 2));
+        return;
+      }
+      renderHuman(limited);
+    });
+}

--- a/packages/cli/src/commands/routing/telemetry.ts
+++ b/packages/cli/src/commands/routing/telemetry.ts
@@ -19,12 +19,14 @@ function shortIso(iso: string): string {
   return tail.replace('Z', '');
 }
 
-function renderHuman(data: RoutingTelemetry): void {
+// The tier distribution + spend total always summarize the FULL retained ring;
+// `tableLimit` bounds only the verbose per-decision table below them.
+function renderHuman(data: RoutingTelemetry, tableLimit?: number): void {
   if (data.decisions.length === 0) {
     console.log('(no routing telemetry — AMR is off or no decisions recorded yet)');
     return;
   }
-  // Tier distribution.
+  // Tier distribution over the full ring.
   const byTier = new Map<CapabilityTier, { count: number; cost: number }>();
   for (const t of TIERS) byTier.set(t, { count: 0, cost: 0 });
   for (const d of data.decisions) {
@@ -40,14 +42,17 @@ function renderHuman(data: RoutingTelemetry): void {
   console.log('TIER      COUNT   SHARE   COST');
   for (const t of TIERS) {
     const b = byTier.get(t)!;
-    const share = data.decisions.length ? Math.round((b.count / data.decisions.length) * 100) : 0;
+    const share = Math.round((b.count / data.decisions.length) * 100);
     console.log(
       `${t.padEnd(9)} ${String(b.count).padStart(5)}   ${String(share).padStart(4)}%   $${b.cost.toFixed(4)}`
     );
   }
   console.log('');
-  console.log('TIMESTAMP     TIER      BACKEND         COST');
-  for (const d of data.decisions) {
+  const rows = tableLimit !== undefined ? data.decisions.slice(0, tableLimit) : data.decisions;
+  console.log(
+    `TIMESTAMP     TIER      BACKEND         COST${tableLimit !== undefined ? `  (latest ${rows.length} of ${data.decisions.length})` : ''}`
+  );
+  for (const d of rows) {
     const ts = shortIso(d.decisionTs).padEnd(13);
     const tier = d.tierRequired.padEnd(9);
     const be = d.backend.padEnd(15);
@@ -74,16 +79,18 @@ export function createTelemetryCommand(): Command {
         return;
       }
       const body = r.body ?? { decisions: [], spentUsd: 0 };
-      // `--last N` bounds only the per-decision table; the tier distribution +
-      // spend total still summarize the full retained ring.
-      const limited: RoutingTelemetry =
-        opts.last && Number.isFinite(Number(opts.last)) && Number(opts.last) > 0
-          ? { ...body, decisions: body.decisions.slice(0, Math.floor(Number(opts.last))) }
-          : body;
       if (opts.json) {
-        console.log(JSON.stringify(limited, null, 2));
+        // JSON is the full retained payload (for scripting); `--last` is a
+        // display convenience for the human table only.
+        console.log(JSON.stringify(body, null, 2));
         return;
       }
-      renderHuman(limited);
+      // `--last N` bounds only the per-decision table; the tier distribution +
+      // spend total still summarize the full retained ring.
+      const tableLimit =
+        opts.last && Number.isFinite(Number(opts.last)) && Number(opts.last) > 0
+          ? Math.floor(Number(opts.last))
+          : undefined;
+      renderHuman(body, tableLimit);
     });
 }

--- a/packages/intelligence/src/complexity/derive-tier.ts
+++ b/packages/intelligence/src/complexity/derive-tier.ts
@@ -148,4 +148,4 @@ export function deriveRequiredTier(
   return tierAtRank(Math.max(TIER_RANK[escalationFloor], TIER_RANK[clamped]));
 }
 
-export { TIER_RANK, RANK_TIER, DEFAULT_MATRIX };
+export { TIER_RANK, RANK_TIER, DEFAULT_MATRIX, DEFAULT_DEGRADE_AT_PCT };

--- a/packages/intelligence/src/complexity/index.ts
+++ b/packages/intelligence/src/complexity/index.ts
@@ -22,6 +22,7 @@ export {
   SENSITIVE_BLAST_THRESHOLD,
   TIER_RANK,
   RANK_TIER,
+  DEFAULT_DEGRADE_AT_PCT,
 } from './derive-tier.js';
 
 export { serializeSignals } from './signals.js';

--- a/packages/intelligence/src/index.ts
+++ b/packages/intelligence/src/index.ts
@@ -155,6 +155,7 @@ export {
   SENSITIVE_BLAST_THRESHOLD,
   TIER_RANK,
   RANK_TIER,
+  DEFAULT_DEGRADE_AT_PCT,
   serializeSignals,
 } from './complexity/index.js';
 export type {

--- a/packages/orchestrator/src/agent/adaptive-router.status.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.status.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  BackendCapabilities,
+  BackendDef,
+  ComplexityVerdict,
+  RoutingPolicy,
+} from '@harness-engineering/types';
+import { BackendRouter } from './backend-router.js';
+import { AdaptiveRouter } from './adaptive-router.js';
+import { EscalationState } from './escalation-state.js';
+
+/** AMR observability — EscalationState.climbedUnits() + AdaptiveRouter.getStatus(). */
+
+const cap = (over: Partial<BackendCapabilities> = {}): BackendCapabilities => ({
+  tier: 'fast',
+  costPer1kTokens: 0,
+  privacyClass: 'on-device',
+  contextWindow: 8192,
+  ...over,
+});
+const localDef = (capabilities: BackendCapabilities): BackendDef => ({
+  type: 'local',
+  endpoint: 'http://localhost:1234',
+  model: 'm',
+  capabilities,
+});
+const verdict = (level: ComplexityVerdict['level']): ComplexityVerdict => ({
+  level,
+  confidence: 'high',
+  signals: {},
+  source: 'static',
+});
+const backends = {
+  fast: localDef(cap({ tier: 'fast', costPer1kTokens: 0 })),
+  mid: localDef(cap({ tier: 'standard', costPer1kTokens: 5 })),
+  strong: localDef(cap({ tier: 'strong', costPer1kTokens: 10 })),
+};
+const build = (policy: RoutingPolicy, escalation?: EscalationState): AdaptiveRouter =>
+  AdaptiveRouter.fromConfig({
+    router: new BackendRouter({ backends, routing: { default: 'strong' } }),
+    backends,
+    policy,
+    classify: () => verdict('complex'),
+    ...(escalation ? { escalation } : {}),
+  });
+const REQ = { useCase: { kind: 'tier' as const, tier: 'quick-fix' as const } };
+
+describe('EscalationState.climbedUnits', () => {
+  it('lists only units that have climbed above the fast floor, with their tier', () => {
+    const esc = new EscalationState(1); // one failure climbs
+    esc.recordOutcome('unit-a', 'fast', false); // → standard
+    esc.recordOutcome('unit-b', 'fast', true); // stays fast (a pass)
+    esc.recordOutcome('unit-c', 'fast', false); // → standard
+    esc.recordOutcome('unit-c', 'standard', false); // → strong
+
+    const climbed = esc
+      .climbedUnits()
+      .sort((a, b) => a.coherenceUnit.localeCompare(b.coherenceUnit));
+    expect(climbed).toEqual([
+      { coherenceUnit: 'unit-a', floor: 'standard' },
+      { coherenceUnit: 'unit-c', floor: 'strong' },
+    ]);
+  });
+
+  it('is empty when nothing has escalated', () => {
+    const esc = new EscalationState(2);
+    esc.recordOutcome('u', 'fast', false); // 1 failure < threshold 2 ⇒ no climb
+    expect(esc.climbedUnits()).toEqual([]);
+  });
+});
+
+describe('AdaptiveRouter.getStatus', () => {
+  it('reports active + no budget/escalation/allowlist for a bare policy', () => {
+    const s = build({}).getStatus();
+    expect(s.active).toBe(true);
+    expect(s.budget).toBeNull();
+    expect(s.escalation).toEqual([]);
+    expect(s.allowedProviders).toBeNull();
+  });
+
+  it('reports budget spend-vs-cap using the monotonic accumulator, with the degrading flag', async () => {
+    const r = build({ budget: { capUsd: 100, degradeAtPct: 50, onBudgetExhausted: 'degrade' } });
+    // Two strong dispatches (rate 10 ⇒ estCost 40 each) ⇒ spend 80.
+    await r.route(REQ);
+    await r.route(REQ);
+    const s = r.getStatus();
+    expect(s.budget).toEqual({
+      spentUsd: 80,
+      capUsd: 100,
+      degradeAtPct: 50,
+      spentPct: 80,
+      degrading: true, // 80% >= 50%
+    });
+  });
+
+  it('degrading is false below the threshold, and defaults degradeAtPct to 90', async () => {
+    const r = build({ budget: { capUsd: 1000, onBudgetExhausted: 'degrade' } }); // no degradeAtPct
+    await r.route(REQ); // spend 40 ⇒ 4%
+    const s = r.getStatus();
+    expect(s.budget?.degradeAtPct).toBe(90);
+    expect(s.budget?.spentPct).toBe(4);
+    expect(s.budget?.degrading).toBe(false);
+  });
+
+  it('surfaces climbed escalation units and the provider allowlist', () => {
+    const esc = new EscalationState(1);
+    const r = build({ allowedProviders: ['local', 'anthropic'] }, esc);
+    esc.recordOutcome('issue-42', 'fast', false); // → standard
+    const s = r.getStatus();
+    expect(s.escalation).toEqual([{ coherenceUnit: 'issue-42', floor: 'standard' }]);
+    expect(s.allowedProviders).toEqual(['local', 'anthropic']);
+  });
+});

--- a/packages/orchestrator/src/agent/adaptive-router.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.ts
@@ -8,6 +8,8 @@ import type {
   RoutingRequest,
   RoutingTelemetry,
   RoutingTelemetryDecision,
+  RoutingStatus,
+  RoutingBudgetStatus,
 } from '@harness-engineering/types';
 import { deriveRequiredTier, TIER_RANK, RANK_TIER } from '@harness-engineering/intelligence';
 import type { PoolStateProvider } from '@harness-engineering/local-models';
@@ -203,6 +205,38 @@ export class AdaptiveRouter {
    */
   getSpentUsd(): number {
     return this.deps.budgetState ? this.deps.budgetState().spentUsd : this.spentUsd;
+  }
+
+  /**
+   * AMR observability: the live operator status — budget spend-vs-cap (using the
+   * monotonic accumulator that drives the clamp, NOT the telemetry ring sum),
+   * the coherence units that have climbed their escalation floor, and the active
+   * provider allowlist. Called only on a live router, so `active` is always true.
+   */
+  getStatus(): RoutingStatus {
+    const policy = this.deps.policy;
+    const budget = policy.budget;
+    let budgetStatus: RoutingBudgetStatus | null = null;
+    if (budget && budget.capUsd > 0) {
+      const spentUsd = this.getSpentUsd();
+      // Mirror deriveRequiredTier's default (derive-tier.ts DEFAULT_DEGRADE_AT_PCT).
+      const degradeAtPct = budget.degradeAtPct ?? 90;
+      budgetStatus = {
+        spentUsd,
+        capUsd: budget.capUsd,
+        degradeAtPct,
+        spentPct: Math.round((spentUsd / budget.capUsd) * 100),
+        // Compute from the exact fraction so this matches the real clamp condition
+        // (`spentFraction >= degradeAt`), not the display-rounded percent.
+        degrading: spentUsd / budget.capUsd >= degradeAtPct / 100,
+      };
+    }
+    return {
+      active: true,
+      budget: budgetStatus,
+      escalation: this.deps.escalation?.climbedUnits() ?? [],
+      allowedProviders: policy.allowedProviders ?? null,
+    };
   }
 
   async route(req: RoutingRequest): Promise<{ decision: RoutingDecision; def: BackendDef }> {

--- a/packages/orchestrator/src/agent/adaptive-router.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.ts
@@ -11,7 +11,12 @@ import type {
   RoutingStatus,
   RoutingBudgetStatus,
 } from '@harness-engineering/types';
-import { deriveRequiredTier, TIER_RANK, RANK_TIER } from '@harness-engineering/intelligence';
+import {
+  deriveRequiredTier,
+  TIER_RANK,
+  RANK_TIER,
+  DEFAULT_DEGRADE_AT_PCT,
+} from '@harness-engineering/intelligence';
 import type { PoolStateProvider } from '@harness-engineering/local-models';
 import type { BackendRouter } from './backend-router.js';
 import {
@@ -219,8 +224,9 @@ export class AdaptiveRouter {
     let budgetStatus: RoutingBudgetStatus | null = null;
     if (budget && budget.capUsd > 0) {
       const spentUsd = this.getSpentUsd();
-      // Mirror deriveRequiredTier's default (derive-tier.ts DEFAULT_DEGRADE_AT_PCT).
-      const degradeAtPct = budget.degradeAtPct ?? 90;
+      // Same default the clamp uses, imported (not hardcoded) so status can't
+      // drift from deriveRequiredTier's actual behavior.
+      const degradeAtPct = budget.degradeAtPct ?? DEFAULT_DEGRADE_AT_PCT;
       budgetStatus = {
         spentUsd,
         capUsd: budget.capUsd,

--- a/packages/orchestrator/src/agent/escalation-state.ts
+++ b/packages/orchestrator/src/agent/escalation-state.ts
@@ -39,6 +39,21 @@ export class EscalationState {
   }
 
   /**
+   * AMR observability: the coherence units that have climbed ABOVE the `fast`
+   * floor, with their current floor tier. Operator status only (read-only) — an
+   * empty list means nothing has escalated. Units still at `fast` are omitted.
+   */
+  climbedUnits(): Array<{ coherenceUnit: string; floor: CapabilityTier }> {
+    const out: Array<{ coherenceUnit: string; floor: CapabilityTier }> = [];
+    for (const [coherenceUnit, state] of this.units) {
+      if (TIER_RANK[state.floorTier] > TIER_RANK.fast) {
+        out.push({ coherenceUnit, floor: state.floorTier });
+      }
+    }
+    return out;
+  }
+
+  /**
    * SC16: a QUALITY failure at `tier` increments this unit's counter; on the
    * Nth (threshold) consecutive failure the floor climbs one step (fast→standard
    * →strong), the count resets, and `escalated` latches true. `strong` is the

--- a/packages/orchestrator/src/orchestrator.routing-ingestion.test.ts
+++ b/packages/orchestrator/src/orchestrator.routing-ingestion.test.ts
@@ -178,4 +178,21 @@ describe('Orchestrator.ingestRoutingPolicy', () => {
     const orch = newOrch(withoutPolicy());
     expect(orch.getRoutingTelemetry()).toEqual({ decisions: [], spentUsd: 0 });
   });
+
+  it('getRoutingStatus reports inactive when routing is off', () => {
+    const orch = newOrch(withoutPolicy());
+    expect(orch.getRoutingStatus()).toEqual({
+      active: false,
+      budget: null,
+      escalation: [],
+      allowedProviders: null,
+    });
+  });
+
+  it('getRoutingStatus reports active + the budget picture when a budget policy is set', () => {
+    const orch = newOrch(withPolicy()); // budget capUsd 10
+    const s = orch.getRoutingStatus();
+    expect(s.active).toBe(true);
+    expect(s.budget).toMatchObject({ capUsd: 10, spentUsd: 0, degrading: false });
+  });
 });

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -8,6 +8,7 @@ import type {
   RoutingDecision,
   RoutingPolicy,
   RoutingTelemetry,
+  RoutingStatus,
   StageRun,
   WorkflowExecutionPlan,
 } from '@harness-engineering/types';
@@ -818,6 +819,7 @@ export class Orchestrator extends EventEmitter {
         // AMR Phase 5 (D1/D2): runtime policy ingestion + telemetry projection.
         ingestRoutingPolicy: (p) => this.ingestRoutingPolicy(p),
         getRoutingTelemetry: () => this.getRoutingTelemetry(),
+        getRoutingStatus: () => this.getRoutingStatus(),
         plansDir: path.resolve(config.workspace.root, '..', 'docs', 'plans'),
         pipeline: this.pipeline,
         analysisArchive: this.analysisArchive,
@@ -3264,6 +3266,22 @@ export class Orchestrator extends EventEmitter {
    */
   public getRoutingTelemetry(): RoutingTelemetry {
     return this.adaptiveRouter?.projectTelemetry() ?? { decisions: [], spentUsd: 0 };
+  }
+
+  /**
+   * AMR observability: the live operator status (budget spend-vs-cap, escalated
+   * units, allowlist), or an inactive payload when AMR is off. Backs
+   * `GET /api/v1/routing/status`.
+   */
+  public getRoutingStatus(): RoutingStatus {
+    return (
+      this.adaptiveRouter?.getStatus() ?? {
+        active: false,
+        budget: null,
+        escalation: [],
+        allowedProviders: null,
+      }
+    );
   }
 
   /**

--- a/packages/orchestrator/src/server/http.ts
+++ b/packages/orchestrator/src/server/http.ts
@@ -40,6 +40,7 @@ import type {
   RoutingDecision,
   RoutingPolicy,
   RoutingTelemetry,
+  RoutingStatus,
 } from '@harness-engineering/types';
 import type { WebhookStore } from '../gateway/webhooks/store';
 import type { WebhookDelivery } from '../gateway/webhooks/delivery';
@@ -180,6 +181,8 @@ export interface ServerDependencies {
    */
   ingestRoutingPolicy?: (policy: RoutingPolicy) => void;
   getRoutingTelemetry?: () => RoutingTelemetry;
+  /** AMR observability: live operator status (`GET /routing/status`). */
+  getRoutingStatus?: () => RoutingStatus;
   /**
    * Hermes Phase 4: project root used as the base path for
    * `.harness/proposals/` reads/writes and `agents/skills/` promotion.
@@ -267,6 +270,7 @@ export class OrchestratorServer {
   // AMR Phase 5 — runtime routing-policy ingestion + telemetry projection.
   private ingestRoutingPolicyFn: ((policy: RoutingPolicy) => void) | null = null;
   private getRoutingTelemetryFn: (() => RoutingTelemetry) | null = null;
+  private getRoutingStatusFn: (() => RoutingStatus) | null = null;
   // LMLM Phase 6 — live model pool + refresh scheduler accessors.
   private getModelPoolFn: (() => ModelPoolOps | null) | null = null;
   private getRefreshSchedulerFn: (() => RefreshSchedulerOps | null) | null = null;
@@ -345,6 +349,7 @@ export class OrchestratorServer {
     this.getBackendsFn = deps?.getBackends ?? null;
     this.ingestRoutingPolicyFn = deps?.ingestRoutingPolicy ?? null;
     this.getRoutingTelemetryFn = deps?.getRoutingTelemetry ?? null;
+    this.getRoutingStatusFn = deps?.getRoutingStatus ?? null;
     // LMLM Phase 6 — model pool + refresh scheduler accessors (null when disabled).
     this.getModelPoolFn = deps?.getModelPool ?? null;
     this.getRefreshSchedulerFn = deps?.getRefreshScheduler ?? null;
@@ -597,6 +602,7 @@ export class OrchestratorServer {
           backends: this.getBackendsFn?.() ?? null,
           ingestRoutingPolicy: this.ingestRoutingPolicyFn,
           getTelemetry: this.getRoutingTelemetryFn,
+          getStatus: this.getRoutingStatusFn,
         }),
       // Hermes Phase 4 — skill proposal review queue. Read scopes
       // (`read-status`) and write scopes (`manage-proposals`) are enforced

--- a/packages/orchestrator/src/server/routes/v1/routing.amr-endpoints.test.ts
+++ b/packages/orchestrator/src/server/routes/v1/routing.amr-endpoints.test.ts
@@ -201,3 +201,33 @@ describe('GET /api/v1/routing/telemetry', () => {
     expect(JSON.parse(chunks.join(''))).toEqual({ decisions: [], spentUsd: 0 });
   });
 });
+
+describe('GET /api/v1/routing/status', () => {
+  it('returns the live status payload (200)', () => {
+    const status = {
+      active: true,
+      budget: { spentUsd: 40, capUsd: 100, degradeAtPct: 90, spentPct: 40, degrading: false },
+      escalation: [{ coherenceUnit: 'issue-1', floor: 'standard' as const }],
+      allowedProviders: ['local' as const],
+    };
+    const req = makeReq('GET', '/api/v1/routing/status');
+    const { res, chunks, statusCode } = makeRes();
+    const handled = handleV1RoutingRoute(req, res, baseDeps({ getStatus: () => status }));
+    expect(handled).toBe(true);
+    expect(statusCode()).toBe(200);
+    expect(JSON.parse(chunks.join(''))).toEqual(status);
+  });
+
+  it('returns an inactive payload (200) when no status accessor is wired', () => {
+    const req = makeReq('GET', '/api/v1/routing/status');
+    const { res, chunks, statusCode } = makeRes();
+    handleV1RoutingRoute(req, res, baseDeps());
+    expect(statusCode()).toBe(200);
+    expect(JSON.parse(chunks.join(''))).toEqual({
+      active: false,
+      budget: null,
+      escalation: [],
+      allowedProviders: null,
+    });
+  });
+});

--- a/packages/orchestrator/src/server/routes/v1/routing.ts
+++ b/packages/orchestrator/src/server/routes/v1/routing.ts
@@ -7,6 +7,7 @@ import type {
   RoutingPolicy,
   RoutingRisk,
   RoutingTelemetry,
+  RoutingStatus,
   RoutingUseCase,
   RoutingValue,
 } from '@harness-engineering/types';
@@ -27,6 +28,7 @@ const DECISIONS_RE = /^\/api\/v1\/routing\/decisions(?:\?.*)?$/;
 const TRACE_RE = /^\/api\/v1\/routing\/trace(?:\?.*)?$/;
 const POLICY_RE = /^\/api\/v1\/routing\/policy(?:\?.*)?$/;
 const TELEMETRY_RE = /^\/api\/v1\/routing\/telemetry(?:\?.*)?$/;
+const STATUS_RE = /^\/api\/v1\/routing\/status(?:\?.*)?$/;
 
 /**
  * Spec B Phase 5 — routing observability route dependencies.
@@ -54,6 +56,11 @@ export interface RoutingRouteDeps {
    * shape. Absent/null in fakes/tests ⇒ the GET returns an empty payload (safe).
    */
   getTelemetry?: (() => RoutingTelemetry) | null;
+  /**
+   * AMR observability: live operator status (budget/escalation/allowlist).
+   * Absent/null ⇒ the GET returns an inactive payload.
+   */
+  getStatus?: (() => RoutingStatus) | null;
 }
 
 function sendJSON(res: ServerResponse, status: number, body: unknown): void {
@@ -444,6 +451,22 @@ function handleTelemetry(res: ServerResponse, deps: RoutingRouteDeps): boolean {
 }
 
 /**
+ * AMR observability: `GET /api/v1/routing/status`. The live operator view —
+ * budget spend-vs-cap, escalated units, allowlist. Idempotent; always 200 (an
+ * inactive payload when AMR is off / the accessor is absent). `read-telemetry`.
+ */
+function handleStatus(res: ServerResponse, deps: RoutingRouteDeps): boolean {
+  const status: RoutingStatus = deps.getStatus?.() ?? {
+    active: false,
+    budget: null,
+    escalation: [],
+    allowedProviders: null,
+  };
+  sendJSON(res, 200, status);
+  return true;
+}
+
+/**
  * Spec B Phase 5 + AMR Phase 5 dispatcher:
  *   GET  /api/v1/routing/config     — resolved config + chains
  *   GET  /api/v1/routing/decisions  — recent decision ring
@@ -471,5 +494,6 @@ export function handleV1RoutingRoute(
     return true;
   }
   if (method === 'GET' && TELEMETRY_RE.test(url)) return handleTelemetry(res, deps);
+  if (method === 'GET' && STATUS_RE.test(url)) return handleStatus(res, deps);
   return false;
 }

--- a/packages/orchestrator/src/server/v1-bridge-routes.test.ts
+++ b/packages/orchestrator/src/server/v1-bridge-routes.test.ts
@@ -60,6 +60,7 @@ describe('V1_BRIDGE_ROUTES registry', () => {
     // read-only observability → read-telemetry (matches config/decisions/trace).
     expect(requiredBridgeScope('PUT', '/api/v1/routing/policy')).toBe('admin');
     expect(requiredBridgeScope('GET', '/api/v1/routing/telemetry')).toBe('read-telemetry');
+    expect(requiredBridgeScope('GET', '/api/v1/routing/status')).toBe('read-telemetry');
     expect(isV1Bridge('PUT', '/api/v1/routing/policy')).toBe(true);
     expect(isV1Bridge('GET', '/api/v1/routing/telemetry?since=0')).toBe(true);
     // A GET on the policy write-path is NOT registered (no accidental read alias).

--- a/packages/orchestrator/src/server/v1-bridge-routes.ts
+++ b/packages/orchestrator/src/server/v1-bridge-routes.ts
@@ -210,6 +210,12 @@ export const V1_BRIDGE_ROUTES: ReadonlyArray<V1BridgeRoute> = [
     description:
       'Routing telemetry projected into the Shuttle wire shape ({ decisions, spentUsd }).',
   },
+  {
+    method: 'GET',
+    pattern: /^\/api\/v1\/routing\/status(?:\?.*)?$/,
+    scope: 'read-telemetry',
+    description: 'Live routing status: budget spend-vs-cap, escalated units, provider allowlist.',
+  },
 ];
 
 export function isV1Bridge(method: string, url: string): boolean {

--- a/packages/orchestrator/tests/integration/amr-routing-endpoints-e2e.test.ts
+++ b/packages/orchestrator/tests/integration/amr-routing-endpoints-e2e.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import { EventEmitter } from 'node:events';
+import { OrchestratorServer } from '../../src/server/http';
+import { BackendRouter } from '../../src/agent/backend-router';
+import { RoutingDecisionBus } from '../../src/routing/decision-bus';
+import { AdaptiveRouter } from '../../src/agent/adaptive-router';
+import type {
+  BackendCapabilities,
+  BackendDef,
+  ComplexityVerdict,
+  RoutingConfig,
+  RoutingPolicy,
+  RoutingStatus,
+  RoutingTelemetry,
+} from '@harness-engineering/types';
+
+/**
+ * AMR Phase 5 end-to-end: the routing control plane over the real HTTP server.
+ * Proves the full round-trip the component tests only cover in pieces:
+ *   PUT /routing/policy → ingestion swaps the live AdaptiveRouter → a dispatch
+ *   routes UNDER the pushed policy (budget degrades the tier) → GET /telemetry
+ *   returns rows in Shuttle's wire shape → GET /status reflects spend/degradation
+ *   → PUT {} restores default-off.
+ */
+
+const cap = (over: Partial<BackendCapabilities> = {}): BackendCapabilities => ({
+  tier: 'fast',
+  costPer1kTokens: 0,
+  privacyClass: 'on-device',
+  contextWindow: 8192,
+  ...over,
+});
+const localDef = (capabilities: BackendCapabilities): BackendDef => ({
+  type: 'local',
+  endpoint: 'http://localhost:1234/v1',
+  model: 'm',
+  capabilities,
+});
+const verdict = (level: ComplexityVerdict['level']): ComplexityVerdict => ({
+  level,
+  confidence: 'high',
+  signals: {},
+  source: 'static',
+});
+
+const backends: Record<string, BackendDef> = {
+  fast: localDef(cap({ tier: 'fast', costPer1kTokens: 0 })),
+  mid: localDef(cap({ tier: 'standard', costPer1kTokens: 5 })), // estCost 20
+  strong: localDef(cap({ tier: 'strong', costPer1kTokens: 10 })), // estCost 40
+};
+const routing: RoutingConfig = { default: 'strong' };
+
+function httpReq(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<{ statusCode: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const data = body === undefined ? undefined : JSON.stringify(body);
+    const req = http.request(
+      {
+        host: 'localhost',
+        port,
+        path,
+        method,
+        headers: data
+          ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) }
+          : {},
+      },
+      (res) => {
+        let chunk = '';
+        res.on('data', (c) => (chunk += c));
+        res.on('end', () =>
+          resolve({ statusCode: res.statusCode ?? 0, body: chunk ? JSON.parse(chunk) : null })
+        );
+      }
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+describe('AMR routing endpoints — end-to-end over the HTTP server', () => {
+  let server: OrchestratorServer;
+  let port: number;
+  let bus: RoutingDecisionBus;
+  let router: BackendRouter;
+  // The live router the ingestion swaps — mirrors Orchestrator.adaptiveRouter.
+  let adaptiveRouter: AdaptiveRouter | null;
+
+  // Faithful re-creation of Orchestrator.ingestRoutingPolicy's branch logic.
+  const ingest = (policy: RoutingPolicy): void => {
+    if (Object.keys(policy).length === 0) {
+      adaptiveRouter = null;
+      return;
+    }
+    if (adaptiveRouter) adaptiveRouter.setPolicy(policy);
+    else
+      adaptiveRouter = AdaptiveRouter.fromConfig({
+        router,
+        backends,
+        policy,
+        classify: () => verdict('complex'),
+        decisionBus: bus,
+      });
+  };
+
+  beforeEach(() => {
+    port = Math.floor(Math.random() * 10000) + 30000;
+    bus = new RoutingDecisionBus();
+    router = new BackendRouter({ backends, routing, decisionBus: bus });
+    adaptiveRouter = null;
+    const mockOrchestrator = Object.assign(new EventEmitter(), {
+      getSnapshot: vi.fn().mockReturnValue({ running: [], retryAttempts: [], claimed: [] }),
+    });
+    server = new OrchestratorServer(mockOrchestrator, port, {
+      getBackendRouter: () => router,
+      getRoutingDecisionBus: () => bus,
+      getRoutingConfig: () => routing,
+      getBackends: () => backends,
+      ingestRoutingPolicy: ingest,
+      getRoutingTelemetry: () =>
+        adaptiveRouter?.projectTelemetry() ?? { decisions: [], spentUsd: 0 },
+      getRoutingStatus: () =>
+        adaptiveRouter?.getStatus() ?? {
+          active: false,
+          budget: null,
+          escalation: [],
+          allowedProviders: null,
+        },
+    });
+  });
+
+  afterEach(async () => {
+    server.stop();
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  it('PUT policy → routes under it (budget degrades tier) → GET telemetry (Shuttle shape) + status → PUT {} off', async () => {
+    await server.start();
+
+    // 1. Default-off before any policy.
+    let s = await httpReq(port, 'GET', '/api/v1/routing/status');
+    expect(s.statusCode).toBe(200);
+    expect(s.body).toMatchObject({ active: false });
+
+    // 2. Push a budget policy (degrade at 50% of a $100 cap) → 204, no body.
+    const put = await httpReq(port, 'PUT', '/api/v1/routing/policy', {
+      budget: { capUsd: 100, degradeAtPct: 50, onBudgetExhausted: 'degrade' },
+    });
+    expect(put.statusCode).toBe(204);
+    expect(adaptiveRouter).not.toBeNull();
+
+    // 3. Drive dispatches through the now-live router. Each `complex` route picks
+    //    `strong` (estCost 40); after two, spend is 80 = 80% of cap.
+    const d1 = await adaptiveRouter!.route({ useCase: { kind: 'tier', tier: 'quick-fix' } });
+    const d2 = await adaptiveRouter!.route({ useCase: { kind: 'tier', tier: 'quick-fix' } });
+    expect(d1.decision.tierRequired).toBe('strong');
+    expect(d2.decision.tierRequired).toBe('strong');
+    // The pushed budget now bites: the third dispatch degrades one tier → standard.
+    const d3 = await adaptiveRouter!.route({ useCase: { kind: 'tier', tier: 'quick-fix' } });
+    expect(d3.decision.tierRequired).toBe('standard');
+    expect(d3.decision.backendName).toBe('mid');
+
+    // 4. GET telemetry → three rows, each EXACTLY Shuttle's wire shape (the C1 fix
+    //    proven over the wire), with the summed spend.
+    const t = await httpReq(port, 'GET', '/api/v1/routing/telemetry');
+    expect(t.statusCode).toBe(200);
+    const tel = t.body as RoutingTelemetry;
+    expect(tel.decisions).toHaveLength(3);
+    for (const dec of tel.decisions) {
+      expect(Object.keys(dec).sort()).toEqual([
+        'backend',
+        'decisionTs',
+        'estCostUsd',
+        'tierRequired',
+      ]);
+    }
+    expect(tel.spentUsd).toBeCloseTo(100); // 40 + 40 + 20
+
+    // 5. GET status → active, budget spend-vs-cap, degrading.
+    s = await httpReq(port, 'GET', '/api/v1/routing/status');
+    const st = s.body as RoutingStatus;
+    expect(st.active).toBe(true);
+    expect(st.budget).toMatchObject({ capUsd: 100, degradeAtPct: 50, degrading: true });
+    expect(st.budget!.spentUsd).toBeGreaterThan(0);
+
+    // 6. PUT {} → default-off restored end-to-end.
+    const off = await httpReq(port, 'PUT', '/api/v1/routing/policy', {});
+    expect(off.statusCode).toBe(204);
+    expect(adaptiveRouter).toBeNull();
+    s = await httpReq(port, 'GET', '/api/v1/routing/status');
+    expect((s.body as RoutingStatus).active).toBe(false);
+  });
+
+  it('a schema-invalid policy PUT is rejected (400) and does not change routing', async () => {
+    await server.start();
+    const bad = await httpReq(port, 'PUT', '/api/v1/routing/policy', { privacyFloor: 'nonsense' });
+    expect(bad.statusCode).toBe(400);
+    expect(adaptiveRouter).toBeNull(); // unchanged — still off
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -171,6 +171,10 @@ export type {
   // --- AMR Phase 5: telemetry projection wire types (types-only) ---
   RoutingTelemetryDecision,
   RoutingTelemetry,
+  // --- AMR observability: operator status types (types-only) ---
+  RoutingBudgetStatus,
+  RoutingEscalationUnit,
+  RoutingStatus,
 } from './orchestrator';
 
 // --- AMR Phase 4: routing error (value/class export, D10) ---

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -800,6 +800,46 @@ export interface RoutingTelemetry {
 }
 
 /**
+ * AMR observability (operator status): the live budget picture, distinct from
+ * the {@link RoutingTelemetry} ring-sum. `spentUsd` here is the MONOTONIC
+ * accumulator that actually drives the D8 clamp (not the bounded ring sum).
+ */
+export interface RoutingBudgetStatus {
+  /** Monotonic total spend that drives the clamp (`AdaptiveRouter.getSpentUsd()`). */
+  spentUsd: number;
+  capUsd: number;
+  /** Degrade threshold as a percent of `capUsd` (default 90). */
+  degradeAtPct: number;
+  /** `spentUsd / capUsd * 100`, rounded. */
+  spentPct: number;
+  /** True once `spentPct >= degradeAtPct` — the clamp is now stepping tiers down. */
+  degrading: boolean;
+}
+
+/** AMR observability: one coherence unit that has climbed its escalation floor. */
+export interface RoutingEscalationUnit {
+  coherenceUnit: string;
+  floor: CapabilityTier;
+}
+
+/**
+ * AMR observability payload for `GET /api/v1/routing/status` — the live operator
+ * view of the adaptive router: whether it's active, budget spend-vs-cap, the
+ * units that have escalated, and the active provider allowlist. Read-only; NOT
+ * the Shuttle wire contract (that is {@link RoutingTelemetry}).
+ */
+export interface RoutingStatus {
+  /** AMR active for this container (a `routing.policy` is set). */
+  active: boolean;
+  /** Budget picture, or `null` when no `budget` is configured. */
+  budget: RoutingBudgetStatus | null;
+  /** Coherence units that have climbed above the `fast` floor (empty if none). */
+  escalation: RoutingEscalationUnit[];
+  /** Active provider-type allowlist, or `null` when unset. */
+  allowedProviders: BackendDef['type'][] | null;
+}
+
+/**
  * Discriminated union describing a single routing query (Spec 2 §3 / SC16-SC21).
  *
  * Consumed by `BackendRouter.resolve(useCase)` and


### PR DESCRIPTION
Closes the three "rock solid" gaps for the merged AMR/routing work: you couldn't **see** it, there was no end-to-end **proof**, and it was **undocumented**.

## 1. Observability — see spend, degradation, escalation

Operators could inspect routing *decisions* but not the things that matter when running AMR: budget spend-vs-cap and escalation. Added a live status surface:

- **`GET /api/v1/routing/status`** (`read-telemetry`) — active?, budget **spend-vs-cap** using the *monotonic accumulator that drives the D8 clamp* (not the telemetry ring sum), the coherence units that have climbed their escalation floor, and the allowlist. Always 200 (inactive payload when off).
- **`harness routing status`** — budget bar + `DEGRADING` flag + escalated-unit table + allowlist.
- **`harness routing telemetry`** — the `/telemetry` projection with a per-tier distribution + per-decision cost.
- New `AdaptiveRouter.getStatus()`, `Orchestrator.getRoutingStatus()`, `EscalationState.climbedUnits()`, `RoutingStatus` types. Read-only; **no dispatch behavior change**.

## 2. End-to-end round-trip test

One integration test over the **real HTTP server** proving what the component tests only covered in pieces: `PUT /routing/policy` → ingestion swaps the live router → dispatches **route under the pushed policy** (tier degrades `strong→standard` as spend crosses `degradeAtPct`) → `GET /telemetry` returns rows in **Shuttle's exact wire shape** (the C1 fix, proven over the wire) → `GET /status` reflects spend/degradation → `PUT {}` restores default-off. Plus a 400-rejection leaving routing unchanged.

## 3. Operator guide

`docs/guides/adaptive-model-routing.md` — enabling `routing.policy`, every policy field, how a tier is chosen, soft-budget semantics, split-routing workflows, the `harness routing` commands + control-plane endpoints, and the honest limitations (soft cap, single-agent escalation deferred per ADR 0069, the two `spentUsd` numbers).

## Diligence

Adversarial review (assessment: approve) confirmed the budget-math `degrading` flag **exactly** matches the real clamp condition, no hot-path change, default-off + `read-telemetry` scope enforced. Fixes applied from the review: `telemetry --last` now bounds only the per-decision table (distribution + spend summarize the full ring); `getStatus` imports `DEFAULT_DEGRADE_AT_PCT` instead of hardcoding it so status can't drift from the clamp.

Full suites green: intelligence 387, orchestrator agent+server+integration 320+, CLI routing 16, types 63.