### PR TITLE
feat(orchestrator): AMR D8 hard budget cap — force fast / surface to steward at capUsd

### DIFF
--- a/.changeset/amr-hard-budget-cap.md
+++ b/.changeset/amr-hard-budget-cap.md
@@ -1,0 +1,31 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/intelligence': minor
+'@harness-engineering/types': minor
+'@harness-engineering/cli': patch
+---
+
+feat(adaptive-model-routing): D8 hard budget cap — force `fast` / surface to a steward at the cap
+
+Turns the AMR budget from a purely soft, single-step degrade into a cap that
+actually bites at 100% of `capUsd`, while staying **opt-in / default-off** (no
+`routing.policy.budget` ⇒ dispatch is byte-identical).
+
+- **Hard floor (`degrade`/`pause`):** at/above `capUsd`, the tier is forced all the
+  way to `fast` (not just one step). Sound because it only ever routes _cheaper_
+  than the existing soft clamp, and it sits **below** the D5 blast-radius veto, so a
+  security-forced `strong` task still stays `strong`. `pause` behaves as `degrade`
+  here — true blocking admission remains deferred.
+- **`human` mode:** at/above the cap, `AdaptiveRouter.route()` throws a fail-closed
+  `RoutingError('budget-exhausted')` **before** selecting a backend (an un-routed
+  dispatch spends nothing). The dispatch boundary surfaces the unit once to a
+  steward as `routing:budget-exhausted` and drives it terminal — no auto-retry into
+  the same cap (mirrors the `privacy-no-match` terminal path). Raise `capUsd` via
+  `PUT /api/v1/routing/policy` and re-queue to resume.
+- **Observability:** `RoutingBudgetStatus` gains an `exhausted` flag; `harness
+routing status` shows an `EXHAUSTED` state once spend crosses the cap.
+
+Behavior change to note in release notes: existing `budget` policies that were
+only ever degrading one step will now force `fast` (or surface to a steward, for
+`human`) once spend reaches the cap. It remains a lagging cap under concurrency —
+not an admission gate.

--- a/docs/guides/adaptive-model-routing.md
+++ b/docs/guides/adaptive-model-routing.md
@@ -67,8 +67,9 @@ For each dispatch, AMR resolves the required tier in order:
    classified complexity.
 2. **Blast-radius veto (D5):** a sensitive-path / high-risk task is forced to
    `strong` regardless.
-3. **Budget clamp (D8):** if over the degrade threshold, step the tier **down** one
-   (never below the veto floor).
+3. **Budget clamp (D8):** over the soft threshold, step the tier **down** one; at
+   the hard cap, force **`fast`** (`degrade`/`pause`) or surface to a steward
+   (`human`) — never below the veto floor. See **Budget**.
 4. **Escalation floor (D10):** if the coherence unit has climbed, raise the tier
    (never lowers it).
 
@@ -79,19 +80,30 @@ as `routing:no-tier-match`) — it never silently routes to a non-compliant back
 
 ## Budget
 
-`budget` is a **soft, lagging** cap — a degrade _signal_, not a hard ceiling:
+`budget` is a **lagging** cap with two thresholds — a **soft** degrade signal and
+a **hard** floor at the cap. It is still not a true admission gate (see the
+concurrency note), but the hard floor makes the cap bite:
 
-- Spend accrues as a **monotonic** total of estimated per-dispatch cost. Once it
-  reaches `degradeAtPct` (default 90) of `capUsd`, the tier is clamped **one step
-  down** for subsequent dispatches (`strong → standard → fast`), never below the
-  blast-radius veto floor.
+- Spend accrues as a **monotonic** total of estimated per-dispatch cost.
+- **Soft (`degradeAtPct`, default 90%):** once spend reaches this fraction of
+  `capUsd`, the tier is clamped **one step down** for subsequent dispatches
+  (`strong → standard → fast`), never below the blast-radius veto floor.
+- **Hard (100% of `capUsd`):** `onBudgetExhausted` decides what happens once spend
+  reaches the cap:
+  - `degrade` (and `pause`) — the tier is forced all the way to **`fast`** (not
+    just one step), still never below the blast-radius veto floor. `pause` behaves
+    as `degrade` here: true blocking admission is deferred.
+  - `human` — the dispatch is **not routed at all**; the unit surfaces to a steward
+    as `routing:budget-exhausted` (the same needs-human channel as
+    `routing:no-tier-match`). It is terminal — no auto-retry into the same wall.
+    Raise `capUsd` (or reset) via `PUT /api/v1/routing/policy`, then re-queue.
 - It is **lagging under concurrency**: several dispatches in flight all read the
-  same pre-accrual total, so a burst can overshoot the cap before the clamp
-  engages. It nudges routing cheaper; it does not gate admission.
-- `onBudgetExhausted` (`degrade | pause | human`) is the declared intent; the
-  shipped clamp implements the `degrade` behavior.
+  same pre-accrual total, so a burst can overshoot the cap before the clamp or the
+  hard floor engages. The hard floor bounds the routing _decision_ once the read
+  crosses the cap; it cannot retroactively prevent an in-flight overshoot.
 
-Watch spend against the cap with `harness routing status` (below).
+Watch spend against the cap with `harness routing status` (below) — it shows an
+`EXHAUSTED` state once spend crosses the hard cap.
 
 ## Escalation
 
@@ -172,8 +184,13 @@ orchestrator exposes:
 
 ## Limitations
 
-- **Budget is a soft cap** (lagging, single-step degrade), not a hard ceiling — see
-  **Budget**.
+- **Budget is a lagging cap, not an admission gate.** It has a soft single-step
+  degrade (90%) and a hard floor at the cap (`degrade`/`pause` → forced `fast`;
+  `human` → surface to a steward), but because spend is read pre-accrual, a
+  concurrent burst can still overshoot before either engages — see **Budget**.
+- **`pause` mode is not true blocking** — it behaves as `degrade` at the hard cap.
+  Real pause/admission-blocking is deferred (it needs blocking-admission machinery
+  the lagging accumulator can't provide).
 - **Single-agent escalation is scoped to security defects (v1)** — it escalates on a
   new error-severity _security_ finding in the diff, not on spec-satisfaction or
   logic quality (that needs an LLM acceptance-eval, still deferred —

--- a/packages/cli/src/commands/routing/routing.test.ts
+++ b/packages/cli/src/commands/routing/routing.test.ts
@@ -431,7 +431,14 @@ describe('harness routing — subcommand acceptance contracts (Spec B Phase 6)',
   it('status: renders the budget bar + escalation + allowlist from /routing/status', async () => {
     const status = {
       active: true,
-      budget: { spentUsd: 80, capUsd: 100, degradeAtPct: 50, spentPct: 80, degrading: true },
+      budget: {
+        spentUsd: 80,
+        capUsd: 100,
+        degradeAtPct: 50,
+        spentPct: 80,
+        degrading: true,
+        exhausted: false,
+      },
       escalation: [{ coherenceUnit: 'issue-7', floor: 'strong' }],
       allowedProviders: ['local'],
     };
@@ -444,6 +451,27 @@ describe('harness routing — subcommand acceptance contracts (Spec B Phase 6)',
     expect(allLog).toMatch(/DEGRADING/);
     expect(allLog).toMatch(/issue-7/);
     expect(allLog).toMatch(/local/);
+  });
+
+  it('status: renders EXHAUSTED (hard cap) over DEGRADING once spend crosses the cap', async () => {
+    const status = {
+      active: true,
+      budget: {
+        spentUsd: 120,
+        capUsd: 100,
+        degradeAtPct: 50,
+        spentPct: 120,
+        degrading: true,
+        exhausted: true,
+      },
+      escalation: [],
+      allowedProviders: null,
+    };
+    mockFetch(() => new Response(JSON.stringify(status), { status: 200 }));
+    await createStatusCommand().parseAsync([], { from: 'user' });
+    const allLog = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(allLog).toMatch(/EXHAUSTED/);
+    expect(allLog).not.toMatch(/DEGRADING/); // exhausted supersedes the degrade label
   });
 
   it('status: renders OFF when routing is inactive', async () => {

--- a/packages/cli/src/commands/routing/status.ts
+++ b/packages/cli/src/commands/routing/status.ts
@@ -26,7 +26,12 @@ function renderHuman(s: RoutingStatus): void {
 
   if (s.budget) {
     const b = s.budget;
-    const state = b.degrading ? 'DEGRADING (clamping tiers down)' : 'ok';
+    // Hard cap (>=100%) supersedes the soft degrade state in the display.
+    const state = b.exhausted
+      ? 'EXHAUSTED (hard cap — forcing fast / surfacing to steward)'
+      : b.degrading
+        ? 'DEGRADING (clamping tiers down)'
+        : 'ok';
     console.log('');
     console.log('Budget:');
     console.log(

--- a/packages/intelligence/src/complexity/derive-tier.test.ts
+++ b/packages/intelligence/src/complexity/derive-tier.test.ts
@@ -198,6 +198,69 @@ describe('deriveRequiredTier — D5 × D8 interaction (veto is a HARD floor)', (
   });
 });
 
+describe('deriveRequiredTier — D8 HARD cap (>=100% of capUsd)', () => {
+  const hardCap = (mode: 'degrade' | 'pause' | 'human'): RoutingPolicy => ({
+    budget: { capUsd: 100, degradeAtPct: 90, onBudgetExhausted: mode },
+  });
+  const atCap = { spentUsd: 100 };
+  const overCap = { spentUsd: 250 };
+
+  it('degrade mode forces fast from EVERY complexity level (not just one step)', () => {
+    const policy = hardCap('degrade');
+    for (const level of ALL_LEVELS) {
+      expect(deriveRequiredTier(verdict(level), noRisk, policy, atCap, 'fast')).toBe('fast');
+      expect(deriveRequiredTier(verdict(level), noRisk, policy, overCap, 'fast')).toBe('fast');
+    }
+  });
+
+  it('pause mode also forces fast at the hard cap (conservative fallback — true blocking is deferred)', () => {
+    const policy = hardCap('pause');
+    expect(deriveRequiredTier(verdict('complex'), noRisk, policy, atCap, 'fast')).toBe('fast');
+  });
+
+  it('human mode is NOT cheapened in the pure clamp — it takes the soft one-step degrade (route() halts it)', () => {
+    // The pure derivation never forces fast for `human`; AdaptiveRouter.route()
+    // intercepts at the cap and surfaces to a steward before this value is used.
+    const policy = hardCap('human');
+    expect(deriveRequiredTier(verdict('complex'), noRisk, policy, atCap, 'fast')).toBe('standard');
+  });
+
+  it('the hard cap is never MORE expensive than the soft one-step clamp', () => {
+    const policy = hardCap('degrade');
+    const softSpend = { spentUsd: 95 }; // in [degradeAt, 100%) → one-step degrade
+    for (const level of ALL_LEVELS) {
+      const soft = deriveRequiredTier(verdict(level), noRisk, policy, softSpend, 'fast');
+      const hard = deriveRequiredTier(verdict(level), noRisk, policy, atCap, 'fast');
+      expect(RANK[hard]).toBeLessThanOrEqual(RANK[soft]);
+    }
+  });
+
+  it('the D5 veto STILL beats the hard cap — a sensitive/core task stays strong at 100%', () => {
+    const policy = hardCap('degrade');
+    const sensitive: RoutingRisk = { blastRadius: 0, sensitivePath: true };
+    const core: RoutingRisk = { blastRadius: 0, sensitivePath: false, layer: 'core' };
+    expect(deriveRequiredTier(verdict('trivial'), sensitive, policy, overCap, 'fast')).toBe(
+      'strong'
+    );
+    expect(deriveRequiredTier(verdict('trivial'), core, policy, overCap, 'fast')).toBe('strong');
+  });
+
+  it('the D10 escalation floor STILL re-raises above the hard cap', () => {
+    // hard cap forces fast, but a climbed strong floor wins (floor only ever raises).
+    const policy = hardCap('degrade');
+    expect(deriveRequiredTier(verdict('complex'), noRisk, policy, overCap, 'strong')).toBe(
+      'strong'
+    );
+  });
+
+  it('no hard-cap effect below 100% (soft one-step degrade preserved)', () => {
+    const policy = hardCap('degrade');
+    expect(deriveRequiredTier(verdict('complex'), noRisk, policy, { spentUsd: 99 }, 'fast')).toBe(
+      'standard'
+    );
+  });
+});
+
 describe('deriveRequiredTier — D10 escalation floor', () => {
   it('escalationFloor strong forces strong on trivial/low-risk/no-budget', () => {
     expect(deriveRequiredTier(verdict('trivial'), noRisk, emptyPolicy, noSpend, 'strong')).toBe(

--- a/packages/intelligence/src/complexity/derive-tier.ts
+++ b/packages/intelligence/src/complexity/derive-tier.ts
@@ -100,11 +100,22 @@ export function baseTier(
 const DEFAULT_DEGRADE_AT_PCT = 90;
 
 /**
- * D8: while spend is at/above `degradeAtPct` of `capUsd`, clamp the tier DOWN
- * one step (`strong→standard→fast`, `fast→fast`). The D5 blast-radius veto is a
- * HARD `strong` floor the clamp must NOT undercut (SC5 says sensitive-path /
- * core|types / publicApi force `strong` "regardless"), so a vetoed request stays
- * `strong` even under budget pressure. No budget block ⇒ no clamp.
+ * D8: budget-pressure tier clamp. Two thresholds:
+ *
+ * - **Soft (`degradeAtPct`, default 90%):** clamp the tier DOWN one step
+ *   (`strong→standard→fast`, `fast→fast`) — a lagging degrade signal.
+ * - **Hard (100% of `capUsd`):** for `degrade`/`pause` policies, force the tier
+ *   all the way to `fast` — the strongest sound floor on the routing DECISION
+ *   (it is not an admission gate; the monotonic accumulator lags under
+ *   concurrency, so it cannot prevent overshoot, only route the cheapest tier
+ *   once the read crosses the cap). `human` mode is handled one layer up in
+ *   `AdaptiveRouter.route()`, which surfaces the unit to a steward instead of
+ *   routing; here it falls through to the soft one-step degrade.
+ *
+ * The D5 blast-radius veto is a HARD `strong` floor the clamp must NOT undercut
+ * (SC5 says sensitive-path / core|types / publicApi force `strong` "regardless"),
+ * so a vetoed request stays `strong` even at the hard cap — the veto guard sits
+ * ABOVE both the hard-floor and the soft-step branches. No budget block ⇒ no clamp.
  */
 export function applyBudgetClamp(
   tier: CapabilityTier,
@@ -119,8 +130,15 @@ export function applyBudgetClamp(
   const spentFraction = spend.spentUsd / budget.capUsd;
   if (spentFraction < degradeAt) return tier;
 
-  // Under budget pressure — but the D5 veto floor is inviolable.
+  // Under budget pressure — but the D5 veto floor is inviolable, so it wins over
+  // BOTH the hard floor and the soft step below.
   if (blastRadiusVeto(risk)) return tier; // stays strong
+
+  // Hard cap: at/above 100%, `degrade`/`pause` drop straight to `fast` (never
+  // more expensive than the soft one-step degrade). `human` is intercepted in
+  // route() before it reaches here; if it ever does, it takes the soft step.
+  const mode = budget.onBudgetExhausted ?? 'degrade';
+  if (spentFraction >= 1 && mode !== 'human') return 'fast';
 
   return tierAtRank(TIER_RANK[tier] - 1);
 }

--- a/packages/orchestrator/src/agent/adaptive-router.budget-terminal.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.budget-terminal.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execSync, type execFile } from 'node:child_process';
+import type { WorkflowConfig, IssueTrackerClient, Issue } from '@harness-engineering/types';
+import { Ok, RoutingError } from '@harness-engineering/types';
+import { Orchestrator } from '../orchestrator.js';
+
+/**
+ * AMR D8 hard cap, `onBudgetExhausted: 'human'` — at/above the cap, `route()`
+ * throws a fail-closed `RoutingError('budget-exhausted')` and the dispatch
+ * boundary must treat it EXACTLY like the privacy-no-match terminal path: surface
+ * ONE steward escalation, enqueue NO retry, and drive the unit terminal — never
+ * fall through to `emitWorkerExit('error')` (whose error branch would retry into
+ * the same wall up to `maxRetries` times).
+ *
+ * Mirrors adaptive-router.privacy-terminal.test.ts (the sibling deterministic
+ * fail-closed path) — the only differences are the thrown error code and the
+ * steward tag (`routing:budget-exhausted`).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const noopExecFileFn = ((...args: unknown[]) => {
+  const cb = args[args.length - 1];
+  if (typeof cb === 'function') process.nextTick(() => cb(null, '0\n', ''));
+  return undefined as any;
+}) as typeof execFile;
+(noopExecFileFn as any)[Symbol.for('nodejs.util.promisify.custom')] = () =>
+  Promise.resolve({ stdout: '0\n', stderr: '' });
+const noopExecFile: typeof execFile = noopExecFileFn;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let tmpDir: string;
+
+function makeMockTracker(): IssueTrackerClient {
+  return {
+    fetchCandidateIssues: vi.fn().mockResolvedValue(Ok([])),
+    fetchIssuesByStates: vi.fn().mockResolvedValue(Ok([])),
+    fetchIssueStatesByIds: vi.fn().mockResolvedValue(Ok(new Map())),
+    markIssueComplete: vi.fn().mockResolvedValue(Ok(undefined)),
+    claimIssue: vi.fn().mockResolvedValue(Ok(undefined)),
+    releaseIssue: vi.fn().mockResolvedValue(Ok(undefined)),
+  } as unknown as IssueTrackerClient;
+}
+
+const BACKENDS = {
+  cheapFast: {
+    type: 'mock' as const,
+    capabilities: {
+      tier: 'fast' as const,
+      costPer1kTokens: 0,
+      privacyClass: 'on-device' as const,
+      contextWindow: 8192,
+    },
+  },
+  strong: {
+    type: 'mock' as const,
+    capabilities: {
+      tier: 'strong' as const,
+      costPer1kTokens: 10,
+      privacyClass: 'shared-cloud' as const,
+      contextWindow: 200000,
+    },
+  },
+};
+const ROUTING = { default: 'strong', 'quick-fix': 'cheapFast' } as const;
+
+function makeConfig(agentOverride: Partial<WorkflowConfig['agent']>): WorkflowConfig {
+  return {
+    tracker: { kind: 'mock', activeStates: ['planned'], terminalStates: ['done'] },
+    polling: { intervalMs: 1000 },
+    workspace: { root: path.join(tmpDir, '.harness', 'workspaces') },
+    hooks: {
+      afterCreate: null,
+      beforeRun: null,
+      afterRun: null,
+      beforeRemove: null,
+      timeoutMs: 1000,
+    },
+    agent: {
+      backend: 'mock',
+      maxConcurrentAgents: 2,
+      maxTurns: 3,
+      maxRetryBackoffMs: 1000,
+      maxRetries: 5,
+      maxConcurrentAgentsByState: { planned: 1 },
+      turnTimeoutMs: 5000,
+      readTimeoutMs: 5000,
+      stallTimeoutMs: 5000,
+      ...agentOverride,
+    } as unknown as WorkflowConfig['agent'],
+    server: { port: null },
+    intelligence: { enabled: true },
+  } as unknown as WorkflowConfig;
+}
+
+function livePolicyConfig(): WorkflowConfig {
+  return makeConfig({
+    backends: BACKENDS,
+    routing: { ...ROUTING, policy: { budget: { capUsd: 10, onBudgetExhausted: 'human' } } },
+  });
+}
+
+function newOrch(cfg: WorkflowConfig): Orchestrator {
+  // No `backend` override — an override short-circuits the AMR branch in
+  // `dispatchIssue`, so `route()` would never be called and the fail-closed catch
+  // could never fire. Dropping it lets the live AdaptiveRouter branch hit the
+  // stubbed `route()`.
+  return new Orchestrator(cfg, 'Prompt', {
+    tracker: makeMockTracker(),
+    execFileFn: noopExecFile,
+  });
+}
+
+interface QueuedInteraction {
+  issueId: string;
+  type: string;
+  reasons: string[];
+  context: { issueTitle: string; issueDescription: string | null };
+}
+
+const ISSUE = {
+  id: 'issue-budget-terminal',
+  identifier: 'ISS-budget-terminal',
+  title: 'A task dispatched after the routing budget is exhausted',
+  description: 'onBudgetExhausted=human should surface to a steward, not route.',
+  labels: [],
+  externalId: null,
+  state: 'planned',
+} as unknown as Issue;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-amr-budget-terminal-'));
+  execSync(
+    'git init && git config user.email "test@test" && git config user.name "test" && git commit --allow-empty -m "init"',
+    { cwd: tmpDir, stdio: 'ignore' }
+  );
+  fs.mkdirSync(path.join(tmpDir, '.harness', 'workspaces'), { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+/**
+ * Drive the FULL dispatch catch path: stub the live AdaptiveRouter's `route()` to
+ * fail closed with a `budget-exhausted` RoutingError, then dispatch through
+ * `dispatchAdHoc` (which seeds running+claimed then calls `dispatchIssue`).
+ */
+async function dispatchWithBudgetExhausted(): Promise<{
+  orch: Orchestrator;
+  queued: QueuedInteraction[];
+}> {
+  const orch = newOrch(livePolicyConfig());
+  const router = orch.getAdaptiveRouter();
+  expect(router).not.toBeNull();
+  vi.spyOn(router!, 'route').mockRejectedValue(
+    new RoutingError('budget-exhausted', 'routing budget cap $10 reached; onBudgetExhausted=human')
+  );
+
+  const queued: QueuedInteraction[] = [];
+  (
+    orch as unknown as {
+      interactionQueue: { onPush: (fn: (i: QueuedInteraction) => void) => void };
+    }
+  ).interactionQueue.onPush((interaction) => queued.push(interaction));
+
+  await orch.dispatchAdHoc(ISSUE);
+  for (let n = 0; n < 50 && queued.filter((q) => q.issueId === ISSUE.id).length === 0; n++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return { orch, queued };
+}
+
+function snapshotOf(orch: Orchestrator): {
+  running: [string, unknown][];
+  claimed: string[];
+  retryAttempts: [string, unknown][];
+} {
+  return orch.getSnapshot() as unknown as {
+    running: [string, unknown][];
+    claimed: string[];
+    retryAttempts: [string, unknown][];
+  };
+}
+
+describe('budget-exhausted (human mode) fail-closed is TERMINAL, not a retry loop', () => {
+  it('queues exactly ONE routing:budget-exhausted steward escalation for the unit', async () => {
+    const { queued } = await dispatchWithBudgetExhausted();
+    const escs = queued.filter((q) => q.issueId === ISSUE.id);
+    expect(escs).toHaveLength(1);
+    expect(escs[0]!.type).toBe('needs-human');
+    expect(escs[0]!.reasons.join(' ')).toMatch(/budget-exhausted/);
+  });
+
+  it('enqueues NO retry — auto-retry would just re-hit the same cap', async () => {
+    const { orch } = await dispatchWithBudgetExhausted();
+    const snap = snapshotOf(orch);
+    expect(snap.retryAttempts.find(([id]) => id === ISSUE.id)).toBeUndefined();
+    expect(snap.retryAttempts).toHaveLength(0);
+  });
+
+  it('reaches a terminal state — out of running and no longer claimed', async () => {
+    const { orch } = await dispatchWithBudgetExhausted();
+    const snap = snapshotOf(orch);
+    expect(snap.running.find(([id]) => id === ISSUE.id)).toBeUndefined();
+    expect(snap.claimed).not.toContain(ISSUE.id);
+  });
+});

--- a/packages/orchestrator/src/agent/adaptive-router.spend.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.spend.test.ts
@@ -136,8 +136,11 @@ describe('AdaptiveRouter — live spend accumulator (D8)', () => {
     expect(decision.backendName).toBe('strong');
 
     // Control: the SAME over-budget state, but a non-risky request DOES clamp.
+    // Spend is far past the hard cap (capUsd $1), so the D8 hard floor forces it
+    // all the way to `fast` (not just the soft one-step degrade) — the veto above
+    // is what keeps the risky request at `strong` regardless.
     const { decision: clamped } = await r.route(REQ);
-    expect(clamped.tierRequired).toBe('standard');
+    expect(clamped.tierRequired).toBe('fast');
   });
 
   it('a fail-closed (PrivacyNoMatch) dispatch does NOT accrue spend', async () => {

--- a/packages/orchestrator/src/agent/adaptive-router.status.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.status.test.ts
@@ -90,7 +90,21 @@ describe('AdaptiveRouter.getStatus', () => {
       degradeAtPct: 50,
       spentPct: 80,
       degrading: true, // 80% >= 50%
+      exhausted: false, // 80% < 100% (hard cap)
     });
+  });
+
+  it('reports exhausted once monotonic spend reaches the hard cap', async () => {
+    // capUsd 100; strong dispatches accrue ~40 each until the clamp cheapens them,
+    // so a few dispatches push the monotonic accumulator to/over the cap.
+    const r = build({ budget: { capUsd: 100, degradeAtPct: 50, onBudgetExhausted: 'degrade' } });
+    await r.route(REQ);
+    await r.route(REQ);
+    await r.route(REQ);
+    const s = r.getStatus();
+    expect(s.budget!.spentUsd).toBeGreaterThanOrEqual(100); // at/over the hard cap
+    expect(s.budget?.exhausted).toBe(true);
+    expect(s.budget?.degrading).toBe(true);
   });
 
   it('degrading is false below the threshold, and defaults degradeAtPct to 90', async () => {

--- a/packages/orchestrator/src/agent/adaptive-router.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.test.ts
@@ -464,6 +464,45 @@ describe('AdaptiveRouter — D8 HARD cap (route-layer: human surfaces, degrade f
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('human mode over the cap throws BEFORE routing even for a veto (sensitive) task — paused, not cheapened', async () => {
+    // The throw sits before deriveRequiredTier/selectTarget/accrual, so a
+    // security-forced `strong` task at the cap is PAUSED for human budget approval
+    // (never routed, never cheapened). Pins the throw-before-risk ordering so a
+    // refactor that moved the throw below tier derivation would fail loudly.
+    const router = new BackendRouter({ backends, routing: { default: 'priceyStrong' } });
+    const registry = buildCapabilityRegistry(backends);
+    const spy = vi.spyOn(router, 'resolveDecisionAndDef');
+    const adaptive = new AdaptiveRouter({
+      router,
+      registry,
+      policy: { budget: { capUsd: 10, degradeAtPct: 90, onBudgetExhausted: 'human' } },
+      classify: () => verdict('trivial'),
+      budgetState: () => ({ spentUsd: 50 }), // way over the cap
+    });
+    await expect(
+      adaptive.route({
+        useCase: { kind: 'tier', tier: 'quick-fix' },
+        risk: { blastRadius: 0, sensitivePath: true }, // D5 veto would force strong
+      })
+    ).rejects.toMatchObject({ name: 'RoutingError', code: 'budget-exhausted' });
+    expect(spy).not.toHaveBeenCalled(); // never routed → nothing accrued
+  });
+
+  it('no budget policy ⇒ the new hard-cap throw guard never fires (default-off byte-identical)', async () => {
+    const router = new BackendRouter({ backends, routing: { default: 'cheapFast' } });
+    const registry = buildCapabilityRegistry(backends);
+    const adaptive = new AdaptiveRouter({
+      router,
+      registry,
+      policy: {}, // no budget at all
+      classify: () => verdict('complex'),
+      budgetState: () => ({ spentUsd: 1_000_000 }), // huge, but no cap to compare against
+    });
+    // Must resolve normally — the throw guard's `budget && ...` clause is unreachable.
+    const { decision } = await adaptive.route({ useCase: { kind: 'tier', tier: 'quick-fix' } });
+    expect(decision.tierRequired).toBeDefined();
+  });
+
   it('human mode below the cap routes normally (no throw)', async () => {
     const router = new BackendRouter({ backends, routing: { default: 'cheapFast' } });
     const registry = buildCapabilityRegistry(backends);

--- a/packages/orchestrator/src/agent/adaptive-router.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.test.ts
@@ -439,3 +439,78 @@ describe('AdaptiveRouter — escalation floor + recordOutcome (D10/SC16, Task 6)
     expect(() => adaptive.recordOutcome('u', 'fast', false)).not.toThrow();
   });
 });
+
+describe('AdaptiveRouter — D8 HARD cap (route-layer: human surfaces, degrade forces fast)', () => {
+  const backends = {
+    cheapFast: localDef(cap({ tier: 'fast', costPer1kTokens: 0 })),
+    priceyStrong: localDef(cap({ tier: 'strong', costPer1kTokens: 30 })),
+  };
+
+  it('human mode at/over the cap throws RoutingError(budget-exhausted) WITHOUT routing (fail-closed)', async () => {
+    const router = new BackendRouter({ backends, routing: { default: 'cheapFast' } });
+    const registry = buildCapabilityRegistry(backends);
+    const spy = vi.spyOn(router, 'resolveDecisionAndDef');
+    const adaptive = new AdaptiveRouter({
+      router,
+      registry,
+      policy: { budget: { capUsd: 10, degradeAtPct: 90, onBudgetExhausted: 'human' } },
+      classify: () => verdict('moderate'),
+      budgetState: () => ({ spentUsd: 10 }), // exactly at the cap
+    });
+    await expect(
+      adaptive.route({ useCase: { kind: 'tier', tier: 'quick-fix' } })
+    ).rejects.toMatchObject({ name: 'RoutingError', code: 'budget-exhausted' });
+    // No backend was ever selected/resolved ⇒ an un-routed dispatch spends nothing.
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('human mode below the cap routes normally (no throw)', async () => {
+    const router = new BackendRouter({ backends, routing: { default: 'cheapFast' } });
+    const registry = buildCapabilityRegistry(backends);
+    const adaptive = new AdaptiveRouter({
+      router,
+      registry,
+      policy: { budget: { capUsd: 10, degradeAtPct: 90, onBudgetExhausted: 'human' } },
+      classify: () => verdict('moderate'),
+      budgetState: () => ({ spentUsd: 5 }), // half the cap
+    });
+    const { decision } = await adaptive.route({ useCase: { kind: 'tier', tier: 'quick-fix' } });
+    expect(decision.tierRequired).toBeDefined();
+  });
+
+  it('degrade mode at the cap does NOT throw — it routes, forced to fast by the hard clamp', async () => {
+    const router = new BackendRouter({ backends, routing: { default: 'cheapFast' } });
+    const registry = buildCapabilityRegistry(backends);
+    const adaptive = new AdaptiveRouter({
+      router,
+      registry,
+      policy: { budget: { capUsd: 10, onBudgetExhausted: 'degrade' } },
+      classify: () => verdict('complex'), // would be strong; hard cap forces fast
+      budgetState: () => ({ spentUsd: 20 }),
+    });
+    const { decision } = await adaptive.route({ useCase: { kind: 'tier', tier: 'quick-fix' } });
+    expect(decision.tierRequired).toBe('fast');
+  });
+
+  it('getStatus() reports exhausted once spend >= cap (and not below)', () => {
+    const router = new BackendRouter({ backends, routing: { default: 'cheapFast' } });
+    const registry = buildCapabilityRegistry(backends);
+    const over = new AdaptiveRouter({
+      router,
+      registry,
+      policy: { budget: { capUsd: 10, onBudgetExhausted: 'degrade' } },
+      classify: () => verdict('moderate'),
+      budgetState: () => ({ spentUsd: 12 }),
+    });
+    expect(over.getStatus().budget?.exhausted).toBe(true);
+
+    const under = new AdaptiveRouter({
+      router,
+      registry,
+      policy: { budget: { capUsd: 10, onBudgetExhausted: 'degrade' } },
+      classify: () => verdict('moderate'),
+      budgetState: () => ({ spentUsd: 3 }),
+    });
+    expect(under.getStatus().budget?.exhausted).toBe(false);
+  });
+});

--- a/packages/orchestrator/src/agent/adaptive-router.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.ts
@@ -17,6 +17,7 @@ import {
   RANK_TIER,
   DEFAULT_DEGRADE_AT_PCT,
 } from '@harness-engineering/intelligence';
+import { RoutingError } from '@harness-engineering/types';
 import type { PoolStateProvider } from '@harness-engineering/local-models';
 import type { BackendRouter } from './backend-router.js';
 import {
@@ -232,9 +233,10 @@ export class AdaptiveRouter {
         capUsd: budget.capUsd,
         degradeAtPct,
         spentPct: Math.round((spentUsd / budget.capUsd) * 100),
-        // Compute from the exact fraction so this matches the real clamp condition
-        // (`spentFraction >= degradeAt`), not the display-rounded percent.
+        // Compute from the exact fraction so these match the real clamp conditions
+        // (`spentFraction >= degradeAt` / `>= 1`), not the display-rounded percent.
         degrading: spentUsd / budget.capUsd >= degradeAtPct / 100,
+        exhausted: spentUsd / budget.capUsd >= 1,
       };
     }
     return {
@@ -253,6 +255,28 @@ export class AdaptiveRouter {
     // accumulator. From here to the accumulate below there is NO `await`, so the
     // read → derive → accumulate window is atomic per call (no lost updates).
     const spend = this.deps.budgetState ? this.deps.budgetState() : { spentUsd: this.spentUsd };
+    // D8 hard cap, `human` mode: at/above 100% of `capUsd`, do NOT route — throw a
+    // fail-closed `budget-exhausted` that the dispatch boundary turns into a single
+    // `routing:budget-exhausted` steward escalation (mirrors the privacy-no-match
+    // path). Thrown BEFORE any backend selection / cost accrual, so an un-routed
+    // dispatch spends nothing. Fires regardless of the D5 veto: a sensitive task is
+    // not cheapened, it is paused for a human's budget decision (`degrade`/`pause`
+    // stay in the pure clamp — route cheaper, never halt). Default-off: no budget ⇒
+    // this is skipped and dispatch is byte-identical.
+    const budget = this.deps.policy.budget;
+    if (
+      budget &&
+      budget.capUsd > 0 &&
+      budget.onBudgetExhausted === 'human' &&
+      spend.spentUsd / budget.capUsd >= 1
+    ) {
+      throw new RoutingError(
+        'budget-exhausted',
+        `routing budget cap $${budget.capUsd} reached (spent ~$${spend.spentUsd.toFixed(
+          2
+        )}); onBudgetExhausted=human — surfacing to a steward instead of routing`
+      );
+    }
     // D10: the escalation floor raises the derived tier for a coherence unit that
     // has climbed on repeated quality failure. Absent EscalationState ⇒ no-op 'fast'.
     // split-routing D8(a): a caller (the workflow engine's one-shot per-stage

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2406,17 +2406,33 @@ export class Orchestrator extends EventEmitter {
    * refused to pick a non-compliant backend, and returning `true` here stops the
    * caller from falling through to any further routing.
    *
-   * Returns `true` when the boundary CLAIMED the error (privacy-no-match), so the
-   * caller returns without ANY `emitWorkerExit`. Returns `false` for any other
-   * error (including `escalation-exhausted`, which the `onExhausted` seam owns) so
-   * the generic dispatch-error path runs unchanged.
+   * Returns `true` when the boundary CLAIMED the error (`privacy-no-match` or the
+   * hard-cap `budget-exhausted`), so the caller returns without ANY
+   * `emitWorkerExit`. Returns `false` for any other error (including
+   * `escalation-exhausted`, which the `onExhausted` seam owns) so the generic
+   * dispatch-error path runs unchanged.
    */
   private async handleRoutingFailure(
     issue: { id: string; identifier?: string },
     error: unknown
   ): Promise<boolean> {
-    if (!(error instanceof RoutingError) || error.code !== 'privacy-no-match') return false;
-    this.logger.warn('routing:no-tier-match', {
+    // Two fail-closed route() codes ride this terminal steward-escalation path:
+    //  - `privacy-no-match`: deterministic (config-driven empty candidate set).
+    //  - `budget-exhausted`: `onBudgetExhausted:'human'` at/above the hard cap. NOT
+    //    deterministic (a cap raise / accumulator reset could let it proceed), but an
+    //    auto-retry would just re-hit the same cap up to `maxRetries` times, so it is
+    //    ALSO terminal: surface once to a steward, who raises the cap and re-queues.
+    if (
+      !(error instanceof RoutingError) ||
+      (error.code !== 'privacy-no-match' && error.code !== 'budget-exhausted')
+    ) {
+      return false;
+    }
+    // `escalateRoutingToHuman` tags the escalation `routing:${error.code}`; mirror
+    // that in the operator log so the two failure modes read distinctly.
+    const logTag =
+      error.code === 'budget-exhausted' ? 'routing:budget-exhausted' : 'routing:no-tier-match';
+    this.logger.warn(logTag, {
       coherenceUnit: issue.id,
       identifier: issue.identifier,
       reason: error.message,

--- a/packages/orchestrator/src/server/routes/v1/routing.amr-endpoints.test.ts
+++ b/packages/orchestrator/src/server/routes/v1/routing.amr-endpoints.test.ts
@@ -206,7 +206,14 @@ describe('GET /api/v1/routing/status', () => {
   it('returns the live status payload (200)', () => {
     const status = {
       active: true,
-      budget: { spentUsd: 40, capUsd: 100, degradeAtPct: 90, spentPct: 40, degrading: false },
+      budget: {
+        spentUsd: 40,
+        capUsd: 100,
+        degradeAtPct: 90,
+        spentPct: 40,
+        degrading: false,
+        exhausted: false,
+      },
       escalation: [{ coherenceUnit: 'issue-1', floor: 'standard' as const }],
       allowedProviders: ['local' as const],
     };

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -428,7 +428,7 @@ export interface RoutingRequest {
  */
 export class RoutingError extends Error {
   constructor(
-    readonly code: 'privacy-no-match' | 'escalation-exhausted',
+    readonly code: 'privacy-no-match' | 'escalation-exhausted' | 'budget-exhausted',
     message: string
   ) {
     super(message);
@@ -814,6 +814,12 @@ export interface RoutingBudgetStatus {
   spentPct: number;
   /** True once `spentPct >= degradeAtPct` — the clamp is now stepping tiers down. */
   degrading: boolean;
+  /**
+   * True once `spentUsd >= capUsd` — the D8 HARD cap. At/above it, `degrade`/`pause`
+   * routing is forced all the way to `fast` and `human` mode surfaces the unit to a
+   * steward (`routing:budget-exhausted`) instead of routing.
+   */
+  exhausted: boolean;
 }
 
 /** AMR observability: one coherence unit that has climbed its escalation floor. */


### PR DESCRIPTION
## What

Turns the AMR (Adaptive Model Routing) budget from a purely **soft, single-step degrade** into a cap that **actually bites at 100% of `capUsd`**, while staying strictly opt-in / default-off. Closes the honesty gap where `onBudgetExhausted` was declared (`degrade | pause | human`) but only the one-step degrade was ever implemented.

## Behavior

- **Hard floor (`degrade`/`pause`):** at/above `capUsd`, the tier is forced all the way to `fast` (not just one step). It sits **below** the D5 blast-radius veto guard, so a security-forced `strong` task (sensitivePath / publicApi / core|types layer / blastRadius≥25) still stays `strong`. It only ever routes **cheaper** than the existing soft clamp. `pause` behaves as `degrade` here — true blocking admission is deferred (needs machinery the lagging accumulator can't provide).
- **`human` mode:** at/above the cap, `AdaptiveRouter.route()` throws a fail-closed `RoutingError('budget-exhausted')` **before** selecting a backend (an un-routed dispatch spends nothing). The dispatch boundary surfaces the unit **once** to a steward as `routing:budget-exhausted` and drives it **terminal** — no auto-retry into the same cap (mirrors the existing `privacy-no-match` terminal path). Raise `capUsd` via `PUT /api/v1/routing/policy` and re-queue to resume.
- **Observability:** `RoutingBudgetStatus` gains `exhausted`; `harness routing status` shows an `EXHAUSTED` state once spend crosses the cap.

## Soundness (opt-in / default-off preserved)

Every new branch is nested under `budget && capUsd > 0`, so **with no `routing.policy.budget`, dispatch is byte-identical**. Invariants verified: veto precedence over the hard floor; hard floor never more expensive than the soft clamp; escalation floor still raises above the cap; `exhausted` computed from the exact fraction (not the rounded percent).

## Review

Adversarial `harness-code-reviewer` pass: **Approve**, 0 blockers/high/medium (validated with a 10,368-combo brute force + boundary probes). Its two Low findings are addressed in the follow-up test commit (L1 pins the security-critical `human`-throw-before-risk ordering; L2 the default-off guard). The `pause`-aliases-`degrade` nit is documented in the guide + changeset.

## Tests

- intelligence `derive-tier.test.ts`: hard-cap forces-fast (every level), veto-still-wins at 100%, floor-still-raises, never-more-expensive, no-effect-below-100%.
- orchestrator `adaptive-router.test.ts`: `human` throws-without-routing (incl. sensitive/veto task), degrade-routes-fast, no-budget-never-throws, `getStatus.exhausted`.
- orchestrator `adaptive-router.budget-terminal.test.ts` (new): `budget-exhausted` = one steward escalation, zero retries, terminal state (mirrors privacy-terminal).

Guide (`docs/guides/adaptive-model-routing.md`) + changeset updated.