### PR TITLE
feat(orchestrator): activate split-routing `expects` as the prior-stage channel filter (4b)

### DIFF
--- a/.changeset/amr-4b-expects-channel.md
+++ b/.changeset/amr-4b-expects-channel.md
@@ -1,0 +1,24 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+feat(orchestrator): split-routing `expects` narrows the prior-stage text channel (4b)
+
+`expects` was declared, schema-valid, and documented on workflow stages but had no
+runtime effect — the text channel threaded _every_ prior stage's output into
+_every_ later stage's prompt. This activates it as a sound, opt-in filter:
+
+- **Runtime:** a stage that declares `expects: <label>` now receives **only** that
+  one upstream artifact in its prompt (instead of all priors) — leaner prompts and
+  a smaller prompt-injection surface. Omitting `expects` keeps the full-priors
+  default, byte-identical to before. If the named producer emitted no output, the
+  channel is simply empty (never a crash).
+- **Config-load validation:** a new cross-field refinement on
+  `StagedWorkflowDeclSchema` rejects an `expects` that does not name a `produces`
+  from an **earlier** stage (catches label typos, forward references, and
+  self-references), with the error path pointed at the offending `stages[i].expects`.
+
+Note on scope: this deliberately does **not** add file-path artifact threading.
+All stages share one worktree, so files a stage writes are already on disk for
+later stages; a `produces: { files: [...] }` manifest would only add a redundant
+hint. The real gap was that `expects` did nothing — now it does.

--- a/docs/guides/adaptive-model-routing.md
+++ b/docs/guides/adaptive-model-routing.md
@@ -143,6 +143,15 @@ identity/default chain. Each stage renders a real prompt from the work item, its
 role, and the prior stages' outputs (threaded by `produces`). Absent a matching
 ≥2-stage workflow, dispatch is byte-identical to single-agent.
 
+**`expects` (optional) narrows the thread.** By default every prior stage's output
+is threaded into a stage's prompt. Declaring `expects: <label>` on a stage threads
+**only** that one upstream artifact — the operator states exactly which output the
+stage consumes, keeping prompts lean and shrinking the injection surface. The label
+must be a `produces` from an **earlier** stage (validated at config-load — a typo
+or forward/self reference is rejected). Omit `expects` for the all-priors default.
+(All stages share one worktree, so the _files_ a stage writes are already on disk
+for later stages regardless; `expects` governs the prompt-text channel.)
+
 ## Observability
 
 The `harness routing` command group inspects a running orchestrator (set

--- a/packages/orchestrator/src/workflow/execute-workflow.4b.test.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.4b.test.ts
@@ -303,4 +303,85 @@ describe('executeWorkflow — stage N output threads to stage N+1 (D4)', () => {
     await executeWorkflow(ctx, plan);
     expect(renderCalls[1]!.priorOutputs).toEqual({}); // spec produced nothing ⇒ nothing threaded
   });
+
+  // Runs `stages` where each stage's captured output is `content[i]` (undefined ⇒
+  // the stage emits no result event). Returns what each render saw.
+  async function threadOutputs(
+    stages: WorkflowStep[],
+    content: (string | undefined)[]
+  ): Promise<Record<string, string>[]> {
+    const seen: Record<string, string>[] = [];
+    let stageIx = 0;
+    const ctx: WorkflowEngineContext = {
+      ...fakeCtx({}),
+      makeRunner: () => ({
+        async *runSession(_i: unknown, _ws: string, _p: string) {
+          const ix = stageIx++;
+          if (content[ix] !== undefined) {
+            yield { type: 'result', content: content[ix], timestamp: 't' } as unknown as AgentEvent;
+          }
+          return {
+            sessionId: `sess-${ix}`,
+            success: true,
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        },
+      }),
+      renderStagePrompt: (_step, index, priorOutputs) => {
+        seen[index] = { ...priorOutputs };
+        return `prompt-${index}`;
+      },
+    };
+    await executeWorkflow(ctx, { coherenceUnit: 'issue-1', stages });
+    return seen;
+  }
+
+  it('a prototype-name label (`constructor`) with a no-output producer threads {} — not the inherited member', async () => {
+    // The producer of `constructor` emits nothing, so the label is not an OWN key
+    // of the prior-output map. A bare bracket lookup would return
+    // Object.prototype.constructor (a function); the hasOwnProperty guard must
+    // instead thread nothing.
+    const seen = await threadOutputs(
+      [
+        step({ skill: 'a', produces: 'constructor' }),
+        step({ skill: 'b', produces: 'review', expects: 'constructor' }),
+      ],
+      [undefined, 'out-1']
+    );
+    expect(seen[1]).toEqual({}); // NOT { constructor: <function> }
+  });
+
+  it('a prototype-name label that IS produced threads its real value', async () => {
+    const seen = await threadOutputs(
+      [
+        step({ skill: 'a', produces: 'toString' }),
+        step({ skill: 'b', produces: 'review', expects: 'toString' }),
+      ],
+      ['real-value', 'out-1']
+    );
+    expect(seen[1]).toEqual({ toString: 'real-value' });
+  });
+
+  it('`expects` on a last-write label threads the LATER producer’s output', async () => {
+    const seen = await threadOutputs(
+      [
+        step({ skill: 'draft', produces: 'code' }),
+        step({ skill: 'refine', produces: 'code' }),
+        step({ skill: 'review', produces: 'review', expects: 'code' }),
+      ],
+      ['first', 'second', 'out-2']
+    );
+    expect(seen[2]).toEqual({ code: 'second' }); // last-write wins
+  });
+
+  it('threads an empty-string output (not filtered as absent)', async () => {
+    const seen = await threadOutputs(
+      [
+        step({ skill: 'a', produces: 'code' }),
+        step({ skill: 'b', produces: 'review', expects: 'code' }),
+      ],
+      ['', 'out-1']
+    );
+    expect(seen[1]).toEqual({ code: '' });
+  });
 });

--- a/packages/orchestrator/src/workflow/execute-workflow.4b.test.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.4b.test.ts
@@ -222,4 +222,85 @@ describe('executeWorkflow — stage N output threads to stage N+1 (D4)', () => {
     // stage 2 sees stage 1's output under stage 1's `produces` label.
     expect(renderCalls[1]!.priorOutputs).toEqual({ code: 'output-0' });
   });
+
+  it('`expects` NARROWS the threaded channel to just the named prior artifact', async () => {
+    const renderCalls: { index: number; priorOutputs: Record<string, string> }[] = [];
+    let stageIx = 0;
+    const ctx: WorkflowEngineContext = {
+      ...fakeCtx({}),
+      makeRunner: () => ({
+        async *runSession(_i: unknown, _ws: string, _p: string) {
+          const ix = stageIx++;
+          yield {
+            type: 'result',
+            content: `output-${ix}`,
+            timestamp: 't',
+          } as unknown as AgentEvent;
+          return {
+            sessionId: `sess-${ix}`,
+            success: true,
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        },
+      }),
+      renderStagePrompt: (_step, index, priorOutputs) => {
+        renderCalls.push({ index, priorOutputs: { ...priorOutputs } });
+        return `prompt-${index}`;
+      },
+    };
+    const plan: WorkflowExecutionPlan = {
+      coherenceUnit: 'issue-1',
+      stages: [
+        step({ skill: 'spec', produces: 'spec' }),
+        step({ skill: 'implement', produces: 'code' }),
+        // Stage 3 expects only `spec` — it must NOT also receive `code`.
+        step({ skill: 'review', produces: 'review', expects: 'spec' }),
+      ],
+    };
+    await executeWorkflow(ctx, plan);
+
+    expect(renderCalls).toHaveLength(3);
+    expect(renderCalls[1]!.priorOutputs).toEqual({ spec: 'output-0' }); // no `expects` ⇒ all priors (only spec so far)
+    // Stage 3 declared `expects: spec`, so `code` is filtered OUT.
+    expect(renderCalls[2]!.priorOutputs).toEqual({ spec: 'output-0' });
+  });
+
+  it('an `expects` whose producer emitted no output threads nothing (empty map, not a crash)', async () => {
+    const renderCalls: { index: number; priorOutputs: Record<string, string> }[] = [];
+    let stageIx = 0;
+    const ctx: WorkflowEngineContext = {
+      ...fakeCtx({}),
+      makeRunner: () => ({
+        async *runSession(_i: unknown, _ws: string, _p: string) {
+          const ix = stageIx++;
+          // Stage 1 emits NO result event ⇒ no captured output for `spec`.
+          if (ix > 0) {
+            yield {
+              type: 'result',
+              content: `output-${ix}`,
+              timestamp: 't',
+            } as unknown as AgentEvent;
+          }
+          return {
+            sessionId: `sess-${ix}`,
+            success: true,
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          };
+        },
+      }),
+      renderStagePrompt: (_step, index, priorOutputs) => {
+        renderCalls.push({ index, priorOutputs: { ...priorOutputs } });
+        return `prompt-${index}`;
+      },
+    };
+    const plan: WorkflowExecutionPlan = {
+      coherenceUnit: 'issue-1',
+      stages: [
+        step({ skill: 'spec', produces: 'spec' }),
+        step({ skill: 'review', produces: 'review', expects: 'spec' }),
+      ],
+    };
+    await executeWorkflow(ctx, plan);
+    expect(renderCalls[1]!.priorOutputs).toEqual({}); // spec produced nothing ⇒ nothing threaded
+  });
 });

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -2,6 +2,7 @@ import type {
   AgentBackend,
   AgentEvent,
   WorkflowExecutionPlan,
+  WorkflowStep,
   StageRun,
   RoutingRequest,
   RoutingDecision,
@@ -366,7 +367,7 @@ export async function runStageWithRetry(
           attempt,
           step,
           backend,
-          priorOutputs(priorRuns)
+          priorOutputs(priorRuns, step)
         );
         run.decision = decision;
         // One narrowed binding shared by the run.tier assign and the recordOutcome
@@ -393,7 +394,7 @@ export async function runStageWithRetry(
           attempt,
           step,
           backend,
-          priorOutputs(priorRuns)
+          priorOutputs(priorRuns, step)
         );
       }
     } catch (err) {
@@ -496,11 +497,23 @@ function resultEventText(content: unknown): string | undefined {
  * the most recent output for a given label. This is the TEXT channel (the common
  * case); file-artifact threading via `produces`/`expects` as paths is a separate
  * contract.
+ *
+ * `expects` (opt-in per stage) NARROWS the channel: when a stage declares
+ * `expects: <label>`, only that one prior artifact is threaded — the operator
+ * states exactly which upstream output this stage consumes, instead of every
+ * prior output landing in every prompt (which bloats the prompt and widens the
+ * injection surface). Absent `expects`, the FULL prior-output map is returned —
+ * byte-identical to the pre-`expects` default. A schema-time refinement
+ * (`schema.ts`) guarantees `expects` names a `produces` from an EARLIER stage, so
+ * at runtime a set `expects` that misses the map means the producing stage simply
+ * emitted no output (aborted / no `result` event) ⇒ nothing to thread.
  */
-function priorOutputs(runs: StageRun[]): Record<string, string> {
-  const out: Record<string, string> = {};
+function priorOutputs(runs: StageRun[], step: WorkflowStep): Record<string, string> {
+  const all: Record<string, string> = {};
   for (const run of runs) {
-    if (run.output !== undefined) out[run.step.produces] = run.output;
+    if (run.output !== undefined) all[run.step.produces] = run.output;
   }
-  return out;
+  if (step.expects === undefined) return all;
+  const wanted = all[step.expects];
+  return wanted !== undefined ? { [step.expects]: wanted } : {};
 }

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -514,6 +514,13 @@ function priorOutputs(runs: StageRun[], step: WorkflowStep): Record<string, stri
     if (run.output !== undefined) all[run.step.produces] = run.output;
   }
   if (step.expects === undefined) return all;
-  const wanted = all[step.expects];
-  return wanted !== undefined ? { [step.expects]: wanted } : {};
+  // `hasOwnProperty`, not `all[step.expects] !== undefined`: a label that collides
+  // with an Object.prototype member (`constructor`, `toString`, `__proto__`, …) is
+  // schema-valid, and if its producer emitted no output a bare bracket lookup would
+  // return the INHERITED prototype value (a function) instead of falling through to
+  // the empty map. Guard on own-key presence so a no-output producer always threads
+  // nothing, exactly as intended.
+  return Object.prototype.hasOwnProperty.call(all, step.expects)
+    ? { [step.expects]: all[step.expects]! }
+    : {};
 }

--- a/packages/orchestrator/src/workflow/schema.expects.test.ts
+++ b/packages/orchestrator/src/workflow/schema.expects.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { StagedWorkflowDeclSchema } from './schema';
+
+/**
+ * 4b — `StagedWorkflowDeclSchema` cross-field refinement: a stage's `expects`
+ * must name a `produces` from an EARLIER stage (the text channel can only thread
+ * outputs already captured on the shared worktree). Catches label typos /
+ * mis-orderings at config-load rather than silently threading nothing at runtime.
+ */
+
+const decl = (stages: Array<Record<string, unknown>>) => ({
+  name: 'wf',
+  match: { labels: ['feature'] },
+  stages,
+});
+
+describe('StagedWorkflowDeclSchema — expects → earlier produces', () => {
+  it('accepts a valid expects that references an earlier produces', () => {
+    const r = StagedWorkflowDeclSchema.safeParse(
+      decl([
+        { skill: 'implement', produces: 'code' },
+        { skill: 'review', produces: 'review', expects: 'code' },
+      ])
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts stages with no expects at all (byte-compatible with pre-4b decls)', () => {
+    const r = StagedWorkflowDeclSchema.safeParse(
+      decl([
+        { skill: 'implement', produces: 'code' },
+        { skill: 'review', produces: 'review' },
+      ])
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects an expects that names no earlier produces (typo)', () => {
+    const r = StagedWorkflowDeclSchema.safeParse(
+      decl([
+        { skill: 'implement', produces: 'code' },
+        { skill: 'review', produces: 'review', expects: 'cdoe' }, // typo
+      ])
+    );
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]!.path).toEqual(['stages', 1, 'expects']);
+      expect(r.error.issues[0]!.message).toMatch(/no earlier stage produces/);
+    }
+  });
+
+  it('rejects a forward reference — expecting a LATER stage’s produces', () => {
+    const r = StagedWorkflowDeclSchema.safeParse(
+      decl([
+        { skill: 'review', produces: 'review', expects: 'code' }, // code is produced later
+        { skill: 'implement', produces: 'code' },
+      ])
+    );
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a self-reference — a stage expecting its own produces (no earlier producer)', () => {
+    const r = StagedWorkflowDeclSchema.safeParse(
+      decl([{ skill: 'implement', produces: 'code', expects: 'code' }])
+    );
+    expect(r.success).toBe(false);
+  });
+
+  it('honors last-write: expecting a label re-produced by an earlier stage is valid', () => {
+    const r = StagedWorkflowDeclSchema.safeParse(
+      decl([
+        { skill: 'draft', produces: 'code' },
+        { skill: 'refine', produces: 'code' },
+        { skill: 'review', produces: 'review', expects: 'code' },
+      ])
+    );
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -178,7 +178,25 @@ export const StagedWorkflowDeclSchema = z
     stages: z.array(WorkflowStepSchema).min(1, 'a workflow must declare at least 1 stage (D13)'),
     stageDeadlineMs: z.number().int().positive().optional(),
   })
-  .strict();
+  .strict()
+  // 4b: a stage's `expects` must name a `produces` from an EARLIER stage — the
+  // text channel can only thread outputs already captured on the shared worktree.
+  // Catches label typos / mis-orderings at config-load instead of silently
+  // threading nothing at runtime. Mirrors validateBackendsAndRouting: the issue
+  // path points at the offending `stages[i].expects`.
+  .superRefine((decl, ctx) => {
+    const producedByEarlier = new Set<string>();
+    decl.stages.forEach((stage, i) => {
+      if (stage.expects !== undefined && !producedByEarlier.has(stage.expects)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['stages', i, 'expects'],
+          message: `stage '${stage.skill}' expects '${stage.expects}', which no earlier stage produces. Produced by earlier stages: [${[...producedByEarlier].join(', ')}].`,
+        });
+      }
+      producedByEarlier.add(stage.produces);
+    });
+  });
 
 /**
  * Cross-field validator: every value in `routing` must reference a key


### PR DESCRIPTION
## What

Activates the split-routing workflow **`expects`** field, which was declared, schema-valid, and documented on workflow stages but had **zero runtime effect** — the text channel threaded *every* prior stage's output into *every* later stage's prompt, ignoring `expects` entirely.

## Why this instead of file-artifact threading

The original follow-up idea was `produces`/`expects` as **file paths**. A feasibility trace showed that's speculative: all stages share **one worktree**, so every file a stage writes is already on disk for later stages — a `produces: { files: [...] }` manifest would only add a redundant "these files exist" hint, with no concrete workflow needing it. The *real* gap was that `expects` was dead config. This PR closes that gap soundly; the file-manifest idea stays deferred until a workflow actually needs it.

## Behavior

- **Runtime filter (opt-in):** a stage that declares `expects: <label>` now receives **only** that one upstream artifact in its prompt, instead of all priors — leaner prompts and a smaller prompt-injection surface. Omitting `expects` keeps the full-priors default, **byte-identical** to before. A producer that emitted no output threads an empty map (never a crash).
- **Config-load validation:** a new `.superRefine` on `StagedWorkflowDeclSchema` rejects an `expects` that does not name a `produces` from an **earlier** stage — catching label typos, forward references, and self-references at config-load, with the error path pointed at `stages[i].expects`. Mirrors the existing `validateBackendsAndRouting` pattern.

## Review

Adversarial `harness-code-reviewer` pass: **Approve with nits**, 0 blockers/high/medium — all six target invariants hold (byte-identical default, filter correctness, superRefine soundness, ZodEffects consumption, correct-`step` at both call sites, no coupling to routing/gate/escalation). Its one Low finding — a prototype-name label (`produces: "constructor"`) with a no-output producer could thread the inherited `Object.prototype` member — is **fixed** here (a `hasOwnProperty` guard) with a regression test, plus the two recommended edge-case tests (last-write filter, empty-string output).

## Tests

- `execute-workflow.4b.test.ts`: `expects` narrows to the named artifact; no-output producer threads `{}`; prototype-name label safe (threads `{}` when absent, real value when produced); last-write filter; empty-string output.
- `schema.expects.test.ts` (new): accept valid earlier ref + last-write re-produce; reject typo / forward-ref / self-ref, error path at `stages[i].expects`.

Guide (`docs/guides/adaptive-model-routing.md`) + changeset updated.