### PR TITLE
feat(orchestrator): opt-in LLM spec-satisfaction verdict for single-agent escalation (4c v2)

### DIFF
--- a/.changeset/amr-4c-acceptance-eval.md
+++ b/.changeset/amr-4c-acceptance-eval.md
@@ -13,10 +13,10 @@ baseline-relative security-defect feeder shipped earlier.
 - On a normal single-agent exit, **after** the cheap security scan comes back clean
   (so a defect never wastes a model call), the orchestrator runs the shared
   `OutcomeEvaluator` over the introduced diff vs the spec's success-criteria
-  section and feeds `quality-fail` **only** on a high-confidence `NOT_SATISFIED`
+  section and feeds `quality-fail` **only** on a high-confidence NOT_SATISFIED
   verdict (`authority === 'blocking'`, derived in TypeScript — an LLM-forged
   `authority` is stripped at the evaluator's strict-parse boundary).
-- **Conservative + guarded:** `SATISFIED` / `INCONCLUSIVE` / lower-confidence /
+- **Conservative + guarded:** SATISFIED / INCONCLUSIVE / lower-confidence /
   no-spec / no-provider / empty-diff / any error → neutral (never a premature
   `quality-pass`). Fully no-op when AMR is off or the flag is unset.
 - **No new model plumbing:** reuses the SEL-layer `AnalysisProvider` the live

--- a/.changeset/amr-4c-acceptance-eval.md
+++ b/.changeset/amr-4c-acceptance-eval.md
@@ -1,0 +1,30 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/types': minor
+---
+
+feat(orchestrator): opt-in LLM spec-satisfaction verdict for single-agent escalation (4c v2)
+
+Adds the second sound quality-verdict source named in ADR 0069 — an LLM
+spec-satisfaction (outcome-eval) judgment — behind a new **default-off** flag
+`routing.policy.acceptanceEval.enabled`. It complements the always-on
+baseline-relative security-defect feeder shipped earlier.
+
+- On a normal single-agent exit, **after** the cheap security scan comes back clean
+  (so a defect never wastes a model call), the orchestrator runs the shared
+  `OutcomeEvaluator` over the introduced diff vs the spec's success-criteria
+  section and feeds `quality-fail` **only** on a high-confidence `NOT_SATISFIED`
+  verdict (`authority === 'blocking'`, derived in TypeScript — an LLM-forged
+  `authority` is stripped at the evaluator's strict-parse boundary).
+- **Conservative + guarded:** `SATISFIED` / `INCONCLUSIVE` / lower-confidence /
+  no-spec / no-provider / empty-diff / any error → neutral (never a premature
+  `quality-pass`). Fully no-op when AMR is off or the flag is unset.
+- **No new model plumbing:** reuses the SEL-layer `AnalysisProvider` the live
+  complexity classifier already builds inline (ADR 0069's "orchestrator can't run a
+  model inline" no longer holds). New surface is minimal: a `WorkspaceManager.getIntroducedDiffText`
+  raw-diff accessor (merge-base relative, seeded overlay excluded via git pathspec),
+  a pure `outcomeVerdictToQualityFail` mapper, and the `acceptanceEval` policy field.
+
+Still deferred: escalation on general logic quality beyond security defects +
+spec-satisfaction. `RoutingPolicy` gains `acceptanceEval?: { enabled; model? }`
+(also accepted on `PUT /api/v1/routing/policy`).

--- a/docs/guides/adaptive-model-routing.md
+++ b/docs/guides/adaptive-model-routing.md
@@ -50,14 +50,15 @@ tier selection and only reachable via the identity/default chain.
 
 ## `agent.routing.policy`
 
-| field                  | type                                           | effect                                                                                              |
-| ---------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `complexityTierMatrix` | `{ trivial\|simple\|moderate\|complex: tier }` | Maps the classified complexity level to a required tier. Defaults are provided; override per level. |
-| `skillTierOverrides`   | `{ [skillName]: tier }`                        | Pin a specific skill/phase to a tier, evaluated before the matrix.                                  |
-| `privacyFloor`         | `on-device \| byo-endpoint \| shared-cloud`    | Excludes backends whose `privacyClass` is weaker than the floor. Fail-closed (see below).           |
-| `budget`               | `{ capUsd, degradeAtPct?, onBudgetExhausted }` | Soft spend cap that degrades the tier under pressure. See **Budget**.                               |
-| `allowedProviders`     | `BackendType[]`                                | Provider-type allowlist; only these backend `type`s are eligible. Fail-closed if it empties.        |
-| `escalationThreshold`  | `number` (default 2)                           | Consecutive quality failures before a unit's tier floor climbs. See **Escalation**.                 |
+| field                  | type                                           | effect                                                                                                                                                  |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `complexityTierMatrix` | `{ trivial\|simple\|moderate\|complex: tier }` | Maps the classified complexity level to a required tier. Defaults are provided; override per level.                                                     |
+| `skillTierOverrides`   | `{ [skillName]: tier }`                        | Pin a specific skill/phase to a tier, evaluated before the matrix.                                                                                      |
+| `privacyFloor`         | `on-device \| byo-endpoint \| shared-cloud`    | Excludes backends whose `privacyClass` is weaker than the floor. Fail-closed (see below).                                                               |
+| `budget`               | `{ capUsd, degradeAtPct?, onBudgetExhausted }` | Soft spend cap that degrades the tier under pressure. See **Budget**.                                                                                   |
+| `allowedProviders`     | `BackendType[]`                                | Provider-type allowlist; only these backend `type`s are eligible. Fail-closed if it empties.                                                            |
+| `escalationThreshold`  | `number` (default 2)                           | Consecutive quality failures before a unit's tier floor climbs. See **Escalation**.                                                                     |
+| `acceptanceEval`       | `{ enabled, model? }`                          | Opt-in LLM spec-satisfaction check on single-agent exit; escalates only on high-confidence `NOT_SATISFIED`. Off by default (heavy). See **Escalation**. |
 
 ### How a tier is chosen
 
@@ -120,6 +121,15 @@ This is **live for both dispatch paths**:
   count) feeds `quality-fail` on a new error-severity finding. It is a no-op when
   AMR is off and never breaks completion. Design rationale + why it was deferred
   until a sound source existed: [ADR 0069](../knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md).
+  - **Optional LLM spec-satisfaction check** — set `acceptanceEval.enabled` to
+    `true` on the policy to _also_ run an outcome-eval (LLM) judgment on each
+    single-agent exit: it judges the introduced diff against the spec's
+    success-criteria section and
+    feeds `quality-fail` only on a **high-confidence `NOT_SATISFIED`** verdict
+    (`SATISFIED` / `INCONCLUSIVE` / lower-confidence / no-spec / no-provider are all
+    neutral — never a premature pass). It is **off by default** because it is heavy
+    (one model call + latency per exit) and runs only after the cheap security scan
+    comes back clean, so a security defect never wastes a model call.
 
 ## Split-routing workflows
 
@@ -200,10 +210,13 @@ orchestrator exposes:
 - **`pause` mode is not true blocking** — it behaves as `degrade` at the hard cap.
   Real pause/admission-blocking is deferred (it needs blocking-admission machinery
   the lagging accumulator can't provide).
-- **Single-agent escalation is scoped to security defects (v1)** — it escalates on a
-  new error-severity _security_ finding in the diff, not on spec-satisfaction or
-  logic quality (that needs an LLM acceptance-eval, still deferred —
-  [ADR 0069](../knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md)).
+- **Single-agent security escalation is always-on; spec-satisfaction is opt-in.**
+  The baseline-relative _security_ scan runs whenever AMR is on. The LLM
+  spec-satisfaction (outcome-eval) check escalates only when
+  `policy.acceptanceEval.enabled` is set, and only on a high-confidence
+  `NOT_SATISFIED` (see **Escalation**). Neither escalates on general logic quality
+  beyond what the security scan / spec judgment covers —
+  [ADR 0069](../knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md).
 - **Two `spentUsd` numbers exist:** `routing telemetry`/`GET /telemetry` report the
   bounded ring sum (last N decisions, telemetry-grade); `routing status` reports the
   monotonic accumulator that actually drives the budget clamp. Use `status` for

--- a/docs/guides/adaptive-model-routing.md
+++ b/docs/guides/adaptive-model-routing.md
@@ -50,15 +50,15 @@ tier selection and only reachable via the identity/default chain.
 
 ## `agent.routing.policy`
 
-| field                  | type                                           | effect                                                                                                                                                  |
-| ---------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `complexityTierMatrix` | `{ trivial\|simple\|moderate\|complex: tier }` | Maps the classified complexity level to a required tier. Defaults are provided; override per level.                                                     |
-| `skillTierOverrides`   | `{ [skillName]: tier }`                        | Pin a specific skill/phase to a tier, evaluated before the matrix.                                                                                      |
-| `privacyFloor`         | `on-device \| byo-endpoint \| shared-cloud`    | Excludes backends whose `privacyClass` is weaker than the floor. Fail-closed (see below).                                                               |
-| `budget`               | `{ capUsd, degradeAtPct?, onBudgetExhausted }` | Soft spend cap that degrades the tier under pressure. See **Budget**.                                                                                   |
-| `allowedProviders`     | `BackendType[]`                                | Provider-type allowlist; only these backend `type`s are eligible. Fail-closed if it empties.                                                            |
-| `escalationThreshold`  | `number` (default 2)                           | Consecutive quality failures before a unit's tier floor climbs. See **Escalation**.                                                                     |
-| `acceptanceEval`       | `{ enabled, model? }`                          | Opt-in LLM spec-satisfaction check on single-agent exit; escalates only on high-confidence `NOT_SATISFIED`. Off by default (heavy). See **Escalation**. |
+| field                  | type                                           | effect                                                                                                                                                |
+| ---------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `complexityTierMatrix` | `{ trivial\|simple\|moderate\|complex: tier }` | Maps the classified complexity level to a required tier. Defaults are provided; override per level.                                                   |
+| `skillTierOverrides`   | `{ [skillName]: tier }`                        | Pin a specific skill/phase to a tier, evaluated before the matrix.                                                                                    |
+| `privacyFloor`         | `on-device \| byo-endpoint \| shared-cloud`    | Excludes backends whose `privacyClass` is weaker than the floor. Fail-closed (see below).                                                             |
+| `budget`               | `{ capUsd, degradeAtPct?, onBudgetExhausted }` | Soft spend cap that degrades the tier under pressure. See **Budget**.                                                                                 |
+| `allowedProviders`     | `BackendType[]`                                | Provider-type allowlist; only these backend `type`s are eligible. Fail-closed if it empties.                                                          |
+| `escalationThreshold`  | `number` (default 2)                           | Consecutive quality failures before a unit's tier floor climbs. See **Escalation**.                                                                   |
+| `acceptanceEval`       | `{ enabled, model? }`                          | Opt-in LLM spec-satisfaction check on single-agent exit; escalates only on high-confidence NOT_SATISFIED. Off by default (heavy). See **Escalation**. |
 
 ### How a tier is chosen
 
@@ -125,8 +125,8 @@ This is **live for both dispatch paths**:
     `true` on the policy to _also_ run an outcome-eval (LLM) judgment on each
     single-agent exit: it judges the introduced diff against the spec's
     success-criteria section and
-    feeds `quality-fail` only on a **high-confidence `NOT_SATISFIED`** verdict
-    (`SATISFIED` / `INCONCLUSIVE` / lower-confidence / no-spec / no-provider are all
+    feeds `quality-fail` only on a **high-confidence NOT_SATISFIED** verdict
+    (SATISFIED / INCONCLUSIVE / lower-confidence / no-spec / no-provider are all
     neutral — never a premature pass). It is **off by default** because it is heavy
     (one model call + latency per exit) and runs only after the cheap security scan
     comes back clean, so a security defect never wastes a model call.
@@ -214,7 +214,7 @@ orchestrator exposes:
   The baseline-relative _security_ scan runs whenever AMR is on. The LLM
   spec-satisfaction (outcome-eval) check escalates only when
   `policy.acceptanceEval.enabled` is set, and only on a high-confidence
-  `NOT_SATISFIED` (see **Escalation**). Neither escalates on general logic quality
+  NOT_SATISFIED (see **Escalation**). Neither escalates on general logic quality
   beyond what the security scan / spec judgment covers —
   [ADR 0069](../knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md).
 - **Two `spentUsd` numbers exist:** `routing telemetry`/`GET /telemetry` report the

--- a/docs/knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md
+++ b/docs/knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md
@@ -28,7 +28,7 @@ source: docs/changes/adaptive-model-routing/proposal.md
 > provider the live classifier already builds — the "orchestrator does not run a
 > model inline" constraint no longer holds) over the introduced diff vs the spec's
 > success-criteria section, and feeds `quality-fail` only on a **high-confidence
-> `NOT_SATISFIED`** (`authority === 'blocking'`, TS-derived). It is gated separately
+> NOT_SATISFIED** (`authority === 'blocking'`, TS-derived). It is gated separately
 > from the cheap security scan because a model call is heavy; it is conservative
 > (never a premature `quality-pass`) and fully guarded (no spec / no provider /
 > empty diff / any error → neutral). See `Orchestrator.deriveAcceptanceEvalVerdict`,

--- a/docs/knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md
+++ b/docs/knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md
@@ -19,6 +19,20 @@ source: docs/changes/adaptive-model-routing/proposal.md
 > `WorkspaceManager.getIntroducedDiff`, and `Orchestrator.deriveSingleAgentQualityVerdict`.
 > The decision below stands as the record of _why_ it was deferred and _which_
 > option was chosen.
+>
+> **Update (2026-07-13): the LLM acceptance-eval (option 4) is now also built —
+> opt-in.** The second sound source named below has landed behind
+> `routing.policy.acceptanceEval.enabled` (off by default). On a normal
+> single-agent exit, _after_ the always-on security scan comes back clean, the
+> orchestrator runs the shared `OutcomeEvaluator` (reusing the SEL-layer analysis
+> provider the live classifier already builds — the "orchestrator does not run a
+> model inline" constraint no longer holds) over the introduced diff vs the spec's
+> success-criteria section, and feeds `quality-fail` only on a **high-confidence
+> `NOT_SATISFIED`** (`authority === 'blocking'`, TS-derived). It is gated separately
+> from the cheap security scan because a model call is heavy; it is conservative
+> (never a premature `quality-pass`) and fully guarded (no spec / no provider /
+> empty diff / any error → neutral). See `Orchestrator.deriveAcceptanceEvalVerdict`,
+> `outcomeVerdictToQualityFail`, and `WorkspaceManager.getIntroducedDiffText`.
 
 ## Context
 

--- a/packages/orchestrator/src/agent/quality-verdict.test.ts
+++ b/packages/orchestrator/src/agent/quality-verdict.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { SecurityScanner } from '@harness-engineering/core';
-import { parseIntroducedHunks, hasIntroducedSecurityDefect } from './quality-verdict';
+import type { OutcomeVerdict } from '@harness-engineering/intelligence';
+import {
+  parseIntroducedHunks,
+  hasIntroducedSecurityDefect,
+  outcomeVerdictToQualityFail,
+} from './quality-verdict';
 
 /** AMR 4c — baseline-relative diff parsing + introduced-security-defect verdict. */
 
@@ -108,5 +113,50 @@ describe('hasIntroducedSecurityDefect', () => {
       { file: 'src/x.ts', addedContent: 'const ok = true; // just a comment', startLine: 1 },
     ];
     expect(hasIntroducedSecurityDefect(hunks, scanner)).toBe(false);
+  });
+});
+
+describe('outcomeVerdictToQualityFail (4c v2 acceptance-eval mapping)', () => {
+  const verdict = (over: Partial<OutcomeVerdict>): OutcomeVerdict => ({
+    verdict: 'INCONCLUSIVE',
+    confidence: 'low',
+    rationale: 'r',
+    judgedAgainst: 'success-criteria',
+    unmetCriteria: [],
+    authority: 'advisory',
+    ...over,
+  });
+
+  it('maps a BLOCKING verdict (high-confidence NOT_SATISFIED) to quality-fail', () => {
+    expect(
+      outcomeVerdictToQualityFail(
+        verdict({ verdict: 'NOT_SATISFIED', confidence: 'high', authority: 'blocking' })
+      )
+    ).toBe('quality-fail');
+  });
+
+  it('maps every non-blocking verdict to undefined (neutral, never a premature pass)', () => {
+    // SATISFIED, INCONCLUSIVE, and a LOWER-confidence NOT_SATISFIED are all advisory.
+    expect(
+      outcomeVerdictToQualityFail(verdict({ verdict: 'SATISFIED', confidence: 'high' }))
+    ).toBeUndefined();
+    expect(
+      outcomeVerdictToQualityFail(verdict({ verdict: 'INCONCLUSIVE', confidence: 'low' }))
+    ).toBeUndefined();
+    expect(
+      outcomeVerdictToQualityFail(
+        verdict({ verdict: 'NOT_SATISFIED', confidence: 'medium', authority: 'advisory' })
+      )
+    ).toBeUndefined();
+  });
+
+  it('trusts the TS-derived authority, not the raw verdict/confidence', () => {
+    // Even a NOT_SATISFIED+high shape must NOT escalate if authority says advisory
+    // (defends against an LLM-forged verdict that slipped an inconsistent authority).
+    expect(
+      outcomeVerdictToQualityFail(
+        verdict({ verdict: 'NOT_SATISFIED', confidence: 'high', authority: 'advisory' })
+      )
+    ).toBeUndefined();
   });
 });

--- a/packages/orchestrator/src/agent/quality-verdict.ts
+++ b/packages/orchestrator/src/agent/quality-verdict.ts
@@ -101,7 +101,7 @@ export function hasIntroducedSecurityDefect(
 }
 
 /**
- * AMR 4c v2: map an outcome-eval (spec-satisfaction) verdict to the single-agent
+ * AMR 4c v2: map an outcome-eval spec-satisfaction verdict to the single-agent
  * escalation quality class. Only a BLOCKING verdict escalates — `authority` is
  * TS-derived (`deriveAuthority`) as `'blocking'` iff a high-confidence
  * NOT_SATISFIED, so SATISFIED / INCONCLUSIVE / any lower-confidence verdict

--- a/packages/orchestrator/src/agent/quality-verdict.ts
+++ b/packages/orchestrator/src/agent/quality-verdict.ts
@@ -104,7 +104,7 @@ export function hasIntroducedSecurityDefect(
  * AMR 4c v2: map an outcome-eval (spec-satisfaction) verdict to the single-agent
  * escalation quality class. Only a BLOCKING verdict escalates — `authority` is
  * TS-derived (`deriveAuthority`) as `'blocking'` iff a high-confidence
- * `NOT_SATISFIED`, so `SATISFIED` / `INCONCLUSIVE` / any lower-confidence verdict
+ * NOT_SATISFIED, so SATISFIED / INCONCLUSIVE / any lower-confidence verdict
  * maps to `undefined` (neutral) and never a premature `quality-pass`. Trusting the
  * TS-derived `authority` (not the raw verdict/confidence) keeps the blocking rule
  * in one place and immune to an LLM-injected `authority` (the evaluator strips it

--- a/packages/orchestrator/src/agent/quality-verdict.ts
+++ b/packages/orchestrator/src/agent/quality-verdict.ts
@@ -1,4 +1,5 @@
 import type { SecurityScanner } from '@harness-engineering/core';
+import type { OutcomeVerdict } from '@harness-engineering/intelligence';
 
 /**
  * AMR 4c: a single-agent quality-verdict source (ADR 0069). The escalation
@@ -97,4 +98,18 @@ export function hasIntroducedSecurityDefect(
     if (findings.some((f) => f.severity === 'error')) return true;
   }
   return false;
+}
+
+/**
+ * AMR 4c v2: map an outcome-eval (spec-satisfaction) verdict to the single-agent
+ * escalation quality class. Only a BLOCKING verdict escalates — `authority` is
+ * TS-derived (`deriveAuthority`) as `'blocking'` iff a high-confidence
+ * `NOT_SATISFIED`, so `SATISFIED` / `INCONCLUSIVE` / any lower-confidence verdict
+ * maps to `undefined` (neutral) and never a premature `quality-pass`. Trusting the
+ * TS-derived `authority` (not the raw verdict/confidence) keeps the blocking rule
+ * in one place and immune to an LLM-injected `authority` (the evaluator strips it
+ * at a `.strict()` parse boundary).
+ */
+export function outcomeVerdictToQualityFail(verdict: OutcomeVerdict): 'quality-fail' | undefined {
+  return verdict.authority === 'blocking' ? 'quality-fail' : undefined;
 }

--- a/packages/orchestrator/src/orchestrator.quality-verdict.test.ts
+++ b/packages/orchestrator/src/orchestrator.quality-verdict.test.ts
@@ -86,6 +86,14 @@ const withPolicy = (): WorkflowConfig =>
   });
 const withoutPolicy = (): WorkflowConfig =>
   makeConfig({ backends: BACKENDS, routing: { default: 'cheapFast' } });
+const withAcceptanceEval = (): WorkflowConfig =>
+  makeConfig({
+    backends: BACKENDS,
+    routing: {
+      default: 'cheapFast',
+      policy: { escalationThreshold: 2, acceptanceEval: { enabled: true } },
+    },
+  });
 
 function newOrch(cfg: WorkflowConfig): Orchestrator {
   return new Orchestrator(cfg, 'Prompt', {
@@ -121,6 +129,32 @@ function stubDiff(
   (orch as unknown as { workspace: { getIntroducedDiff: unknown } }).workspace.getIntroducedDiff =
     spy;
   return spy;
+}
+function stubDiffText(orch: Orchestrator, impl: () => Promise<string>): ReturnType<typeof vi.fn> {
+  const spy = vi.fn(impl);
+  (
+    orch as unknown as { workspace: { getIntroducedDiffText: unknown } }
+  ).workspace.getIntroducedDiffText = spy;
+  return spy;
+}
+/** Inject a fake analysis provider whose one-shot `analyze` returns a canned verdict. */
+function stubProvider(
+  orch: Orchestrator,
+  llmVerdict: Record<string, unknown> | null
+): ReturnType<typeof vi.fn> {
+  const analyze = vi.fn(async () => ({ result: llmVerdict }));
+  (orch as unknown as { resolveComplexityProvider: () => unknown }).resolveComplexityProvider =
+    () => (llmVerdict === null ? undefined : { analyze });
+  return analyze;
+}
+/** Write a spec with a judgeable `## Success Criteria` section; return its rel path. */
+function writeSpec(): string {
+  const rel = 'spec.md';
+  fs.writeFileSync(
+    path.join(tmpDir, rel),
+    '# Feature\n\n## Success Criteria\n\n- The widget must debounce input by 300ms.\n'
+  );
+  return rel;
 }
 
 beforeEach(() => {
@@ -174,5 +208,93 @@ describe('deriveSingleAgentQualityVerdict', () => {
       throw new Error('git blew up');
     });
     expect(await feeder(orch)(ISSUE, tmpDir)).toBeUndefined();
+  });
+});
+
+describe('deriveSingleAgentQualityVerdict — acceptance-eval (4c v2)', () => {
+  const withSpec = (): Issue => ({ ...ISSUE, spec: writeSpec() }) as unknown as Issue;
+
+  it('acceptanceEval DISABLED (default): the eval path is never taken (no diff-text read, no provider)', async () => {
+    const orch = newOrch(withPolicy()); // policy present but no acceptanceEval
+    stubDiff(orch, async () => cleanHunk); // security clean
+    const textSpy = stubDiffText(orch, async () => 'diff');
+    const analyze = stubProvider(orch, { verdict: 'NOT_SATISFIED', confidence: 'high' });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(analyze).not.toHaveBeenCalled();
+  });
+
+  it('enabled + blocking verdict (NOT_SATISFIED, high) → quality-fail', async () => {
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk); // security clean ⇒ reach the eval
+    stubDiffText(orch, async () => 'diff --git a/x b/x\n+broke it');
+    stubProvider(orch, {
+      verdict: 'NOT_SATISFIED',
+      confidence: 'high',
+      rationale: 'debounce not implemented',
+      unmetCriteria: ['debounce 300ms'],
+    });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBe('quality-fail');
+  });
+
+  it('enabled + SATISFIED → undefined (neutral; success never a premature quality-pass)', async () => {
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk);
+    stubDiffText(orch, async () => 'diff --git a/x b/x\n+ok');
+    stubProvider(orch, {
+      verdict: 'SATISFIED',
+      confidence: 'high',
+      rationale: 'looks right',
+      unmetCriteria: [],
+    });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
+  });
+
+  it('enabled + low-confidence NOT_SATISFIED → undefined (only high-confidence blocks)', async () => {
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk);
+    stubDiffText(orch, async () => 'diff --git a/x b/x\n+maybe');
+    stubProvider(orch, {
+      verdict: 'NOT_SATISFIED',
+      confidence: 'low',
+      rationale: 'unclear',
+      unmetCriteria: [],
+    });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
+  });
+
+  it('enabled but issue has no spec → undefined, provider never called', async () => {
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk);
+    const analyze = stubProvider(orch, { verdict: 'NOT_SATISFIED', confidence: 'high' });
+    expect(await feeder(orch)(ISSUE, tmpDir)).toBeUndefined(); // ISSUE.spec is undefined/null
+    expect(analyze).not.toHaveBeenCalled();
+  });
+
+  it('enabled but no analysis provider available → undefined (degrade)', async () => {
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk);
+    stubProvider(orch, null); // resolveComplexityProvider → undefined
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
+  });
+
+  it('a security defect SHORT-CIRCUITS the eval (no wasted model call)', async () => {
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => defectHunk); // security defect
+    const textSpy = stubDiffText(orch, async () => 'diff');
+    const analyze = stubProvider(orch, { verdict: 'SATISFIED', confidence: 'high' });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBe('quality-fail');
+    expect(textSpy).not.toHaveBeenCalled(); // eval path never reached
+    expect(analyze).not.toHaveBeenCalled();
+  });
+
+  it('enabled + eval throws → undefined (guarded, never breaks completion)', async () => {
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk);
+    stubDiffText(orch, async () => {
+      throw new Error('git diff blew up');
+    });
+    stubProvider(orch, { verdict: 'NOT_SATISFIED', confidence: 'high' });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
   });
 });

--- a/packages/orchestrator/src/orchestrator.quality-verdict.test.ts
+++ b/packages/orchestrator/src/orchestrator.quality-verdict.test.ts
@@ -297,4 +297,35 @@ describe('deriveSingleAgentQualityVerdict — acceptance-eval (4c v2)', () => {
     stubProvider(orch, { verdict: 'NOT_SATISFIED', confidence: 'high' });
     expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
   });
+
+  it('a model that FORGES authority:blocking on a SATISFIED verdict is stripped → neutral (end-to-end)', async () => {
+    // The real OutcomeEvaluator re-parses the provider payload with a `.strict()`
+    // schema that OMITS `authority`; an injected key is rejected → degraded
+    // INCONCLUSIVE/advisory → neutral. This pins the highest-value adversarial
+    // case (a buggy/malicious model cannot self-promote to blocking) end-to-end,
+    // so loosening the schema to `.passthrough()` would fail here.
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk);
+    stubDiffText(orch, async () => 'diff --git a/x b/x\n+ok');
+    stubProvider(orch, {
+      verdict: 'SATISFIED',
+      confidence: 'high',
+      authority: 'blocking', // forged — must be stripped, not honored
+      rationale: 'trust me',
+      unmetCriteria: [],
+    });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
+  });
+
+  it('enabled + empty introduced diff-text → undefined, evaluator never invoked', async () => {
+    // deriveAcceptanceEvalVerdict has its own `diff.trim() === ''` guard, distinct
+    // from the security path's `introduced.length === 0`: the provider resolves but
+    // no model call is made.
+    const orch = newOrch(withAcceptanceEval());
+    stubDiff(orch, async () => cleanHunk); // security non-empty ⇒ reach the eval
+    stubDiffText(orch, async () => '   \n  '); // whitespace-only introduced diff
+    const analyze = stubProvider(orch, { verdict: 'NOT_SATISFIED', confidence: 'high' });
+    expect(await feeder(orch)(withSpec(), tmpDir)).toBeUndefined();
+    expect(analyze).not.toHaveBeenCalled();
+  });
 });

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2283,7 +2283,7 @@ export class Orchestrator extends EventEmitter {
    * an available analysis provider. Runs the shared `OutcomeEvaluator` over the
    * introduced diff vs the spec's judgment section, reusing the SEL-layer provider
    * the live classifier already builds; a BLOCKING verdict (high-confidence
-   * `NOT_SATISFIED`) → `'quality-fail'`. Conservative + fully guarded: no
+   * NOT_SATISFIED) → `'quality-fail'`. Conservative + fully guarded: no
    * spec / no provider / empty diff / any error → `undefined` (neutral). The mapper
    * only ever emits the negative, so success can never become a premature
    * `'quality-pass'`. An absent GraphStore falls back to an ephemeral one — the

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -15,8 +15,8 @@ import type {
 import { RoutingError } from '@harness-engineering/types';
 import type { Issue, IssueTrackerClient } from '@harness-engineering/core';
 import { writeTaint, SecurityScanner } from '@harness-engineering/core';
-import { hasIntroducedSecurityDefect } from './agent/quality-verdict';
-import { IntelligencePipeline } from '@harness-engineering/intelligence';
+import { hasIntroducedSecurityDefect, outcomeVerdictToQualityFail } from './agent/quality-verdict';
+import { IntelligencePipeline, OutcomeEvaluator } from '@harness-engineering/intelligence';
 import type { EnrichedSpec, AnalysisProvider } from '@harness-engineering/intelligence';
 import { GraphStore } from '@harness-engineering/graph';
 import type { OrchestratorState, LiveSession, RunningEntry } from './types/internal';
@@ -2259,6 +2259,9 @@ export class Orchestrator extends EventEmitter {
         });
         return 'quality-fail';
       }
+      // Opt-in LLM spec-satisfaction verdict (4c v2). Only reached when the cheap
+      // security scan is clean, so a defect never wastes a model call.
+      return await this.deriveAcceptanceEvalVerdict(issue, workspacePath);
     } catch (err) {
       this.logger.debug('amr quality verdict skipped (best-effort)', {
         issueId: issue.id,
@@ -2266,6 +2269,55 @@ export class Orchestrator extends EventEmitter {
       });
     }
     return undefined;
+  }
+
+  /**
+   * AMR 4c v2: opt-in LLM spec-satisfaction verdict. Gated on
+   * `routing.policy.acceptanceEval.enabled` (HEAVY — one model call + latency per
+   * exit, so separate from the always-on cheap security scan), a present spec, and
+   * an available analysis provider. Runs the shared `OutcomeEvaluator` over the
+   * introduced diff vs the spec's judgment section, reusing the SEL-layer provider
+   * the live classifier already builds; a BLOCKING verdict (high-confidence
+   * `NOT_SATISFIED`) → `'quality-fail'`. Conservative + fully guarded: no
+   * spec / no provider / empty diff / any error → `undefined` (neutral). The mapper
+   * only ever emits the negative, so success can never become a premature
+   * `'quality-pass'`. An absent GraphStore falls back to an ephemeral one — the
+   * evaluator's `execution_outcome` persistence is best-effort and never blocks.
+   */
+  private async deriveAcceptanceEvalVerdict(
+    issue: Issue,
+    workspacePath: string
+  ): Promise<'quality-fail' | undefined> {
+    const acceptanceEval = this.config.agent.routing?.policy?.acceptanceEval;
+    if (acceptanceEval?.enabled !== true || issue.spec === null) return undefined;
+    const provider = this.resolveComplexityProvider();
+    if (provider === undefined) return undefined;
+    try {
+      const diff = await this.workspace.getIntroducedDiffText(issue.identifier);
+      if (diff.trim() === '') return undefined;
+      const evaluator = new OutcomeEvaluator(provider, this.graphStore ?? new GraphStore(), {
+        ...(acceptanceEval.model !== undefined ? { model: acceptanceEval.model } : {}),
+      });
+      const verdict = await evaluator.evaluate({
+        specPath: path.join(workspacePath, issue.spec),
+        diff,
+        testOutput: '',
+      });
+      const cls = outcomeVerdictToQualityFail(verdict);
+      if (cls === 'quality-fail') {
+        this.logger.info('amr:quality-fail — acceptance-eval NOT_SATISFIED (high confidence)', {
+          issueId: issue.id,
+          rationale: verdict.rationale,
+        });
+      }
+      return cls;
+    } catch (err) {
+      this.logger.debug('amr acceptance-eval skipped (best-effort)', {
+        issueId: issue.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    }
   }
 
   /**

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2250,6 +2250,11 @@ export class Orchestrator extends EventEmitter {
     if (this.adaptiveRouter === null) return undefined;
     try {
       const introduced = await this.workspace.getIntroducedDiff(issue.identifier);
+      // No introduced (added) lines ⇒ nothing to judge: skip BOTH the security scan
+      // and the acceptance-eval. A pure-deletion / no-op change is therefore not
+      // spec-checked — deliberate (a NOT_SATISFIED on an empty added-line set is
+      // low-value and this matches the security feeder's boundary); do NOT "fix"
+      // this into a path that runs the eval on an empty diff.
       if (introduced.length === 0) return undefined;
       const scanner = new SecurityScanner();
       scanner.configureForProject(workspacePath);
@@ -2301,6 +2306,9 @@ export class Orchestrator extends EventEmitter {
       const verdict = await evaluator.evaluate({
         specPath: path.join(workspacePath, issue.spec),
         diff,
+        // No captured test output at the single-agent-exit seam — intentionally
+        // omitted (the evaluator judges diff-vs-spec and treats absent test output
+        // as weaker evidence → lower confidence, never a false blocking verdict).
         testOutput: '',
       });
       const cls = outcomeVerdictToQualityFail(verdict);

--- a/packages/orchestrator/src/server/routes/v1/routing.ts
+++ b/packages/orchestrator/src/server/routes/v1/routing.ts
@@ -407,6 +407,12 @@ const RoutingPolicySchema = z.object({
   sensitivePaths: z.array(z.string()).optional(),
   escalationThreshold: z.number().optional(),
   allowedProviders: z.array(z.string()).optional(),
+  acceptanceEval: z
+    .object({
+      enabled: z.boolean(),
+      model: z.string().optional(),
+    })
+    .optional(),
 });
 
 /**

--- a/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
+++ b/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
@@ -33,6 +33,24 @@ class StubWM extends WorkspaceManager {
   }
 }
 
+const RAW_DIFF_TEXT = [
+  'diff --git a/src/app.ts b/src/app.ts',
+  '@@ -1,2 +1,3 @@',
+  ' unchanged context',
+  '+const r = eval(x);',
+].join('\n');
+
+class RawStubWM extends WorkspaceManager {
+  public readonly calls: string[][] = [];
+  protected async git(args: string[], _cwd: string): Promise<string> {
+    this.calls.push(args);
+    if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+    if (args[0] === 'merge-base') return 'basesha123\n';
+    if (args[0] === 'diff') return RAW_DIFF_TEXT;
+    return 'ok\n';
+  }
+}
+
 const config = (over: Partial<WorkspaceConfig> = {}): WorkspaceConfig =>
   ({ root: '/tmp/ws', baseRef: 'origin/main', ...over }) as WorkspaceConfig;
 
@@ -60,5 +78,31 @@ describe('WorkspaceManager.getIntroducedDiff', () => {
     const hunks = await wm.getIntroducedDiff('ISS-1');
     // src/app.ts now excluded; roadmap.md is no longer a seed ⇒ it comes through.
     expect(hunks.map((h) => h.file)).toEqual(['docs/roadmap.md']);
+  });
+});
+
+describe('WorkspaceManager.getIntroducedDiffText (4c v2 — raw diff for the eval)', () => {
+  it('returns the RAW unified diff (with context) vs merge-base, seed paths excluded via pathspec', async () => {
+    const wm = new RawStubWM(config()); // DEFAULT_SEED_PATHS = .harness/proposals, docs/roadmap.md
+    const text = await wm.getIntroducedDiffText('ISS-1');
+
+    // Merge-base relative (robust to a moving base branch).
+    expect(
+      wm.calls.some((c) => c[0] === 'merge-base' && c.includes('HEAD') && c.includes('origin/main'))
+    ).toBe(true);
+    // Full-context diff (NOT --unified=0) with git `:(exclude)` pathspecs for the
+    // seeded handoff overlay, so the judge never reads pre-seeded content.
+    const diffCall = wm.calls.find((c) => c[0] === 'diff');
+    expect(diffCall).toEqual([
+      'diff',
+      'basesha123',
+      '--',
+      '.',
+      ':(exclude).harness/proposals',
+      ':(exclude)docs/roadmap.md',
+    ]);
+    // Raw text is returned verbatim (unparsed) — context + removed lines preserved.
+    expect(text).toBe(RAW_DIFF_TEXT);
+    expect(text).toContain(' unchanged context'); // context line survives (no --unified=0)
   });
 });

--- a/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
+++ b/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
@@ -105,4 +105,13 @@ describe('WorkspaceManager.getIntroducedDiffText (4c v2 — raw diff for the eva
     expect(text).toBe(RAW_DIFF_TEXT);
     expect(text).toContain(' unchanged context'); // context line survives (no --unified=0)
   });
+
+  it('relativizes an absolute seed path against the repo root before excluding it', async () => {
+    // repoRoot is '/repo' (rev-parse --show-toplevel stub). An absolute in-repo
+    // seed must become a repo-relative pathspec so `:(exclude)` actually matches.
+    const wm = new RawStubWM(config({ seedPaths: ['/repo/docs/roadmap.md'] }));
+    await wm.getIntroducedDiffText('ISS-1');
+    const diffCall = wm.calls.find((c) => c[0] === 'diff');
+    expect(diffCall).toEqual(['diff', 'basesha123', '--', '.', ':(exclude)docs/roadmap.md']);
+  });
 });

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -88,6 +88,25 @@ export class WorkspaceManager {
   }
 
   /**
+   * AMR 4c v2: the SAME introduced change as {@link getIntroducedDiff}, but as the
+   * RAW unified diff text (default context, NOT `--unified=0`) — the input an LLM
+   * spec-satisfaction eval needs to judge whether the diff satisfies the spec.
+   * Merge-base relative for the same reason (a base branch that advanced
+   * mid-dispatch never attributes other merges here), and the seeded handoff
+   * overlay is excluded via git `:(exclude)` pathspecs so the judge never reads
+   * pre-seeded proposal/roadmap content as the agent's work.
+   */
+  public async getIntroducedDiffText(identifier: string): Promise<string> {
+    const workspacePath = path.resolve(this.resolvePath(identifier));
+    const repoRoot = await this.getRepoRoot();
+    const baseRef = await this.resolveBaseRef(repoRoot);
+    const mergeBase = (await this.git(['merge-base', 'HEAD', baseRef], workspacePath)).trim();
+    const seedPaths = this.config.seedPaths ?? WorkspaceManager.DEFAULT_SEED_PATHS;
+    const excludes = seedPaths.map((p) => `:(exclude)${p}`);
+    return this.git(['diff', mergeBase, '--', '.', ...excludes], workspacePath);
+  }
+
+  /**
    * Discovers the git repository root from the workspace root directory.
    */
   private async getRepoRoot(): Promise<string> {

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -102,7 +102,16 @@ export class WorkspaceManager {
     const baseRef = await this.resolveBaseRef(repoRoot);
     const mergeBase = (await this.git(['merge-base', 'HEAD', baseRef], workspacePath)).trim();
     const seedPaths = this.config.seedPaths ?? WorkspaceManager.DEFAULT_SEED_PATHS;
-    const excludes = seedPaths.map((p) => `:(exclude)${p}`);
+    // Normalize identically to seedWorkspace: relativize an absolute seed entry
+    // against the repo root and drop anything that escapes it, so a git
+    // `:(exclude)` pathspec always matches the same overlay that was seeded (an
+    // un-relativized absolute path would be a silent no-op exclude, leaking the
+    // seeded overlay into the eval diff). Array argv (no shell) makes each pathspec
+    // a single literal arg — special chars can't break or inject.
+    const excludes = seedPaths
+      .map((p) => (path.isAbsolute(p) ? path.relative(repoRoot, p).replaceAll('\\', '/') : p))
+      .filter((rel) => rel && rel !== '..' && !rel.startsWith('../') && !path.isAbsolute(rel))
+      .map((rel) => `:(exclude)${rel}`);
     return this.git(['diff', mergeBase, '--', '.', ...excludes], workspacePath);
   }
 

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -467,8 +467,8 @@ export interface RoutingPolicy {
    * escalation on a NORMAL exit, ALONGSIDE the always-on baseline-relative
    * security-defect feeder. Off unless `enabled: true` — it is heavy (one model
    * call + latency per exit), so it is gated separately from the cheap security
-   * scan. Conservative by construction: only a high-confidence `NOT_SATISFIED`
-   * outcome-eval verdict escalates (`quality-fail`); `SATISFIED` / `INCONCLUSIVE`
+   * scan. Conservative by construction: only a high-confidence NOT_SATISFIED
+   * outcome-eval verdict escalates (`quality-fail`); SATISFIED / INCONCLUSIVE
    * / any lower-confidence verdict, a missing spec, or an unavailable model
    * provider is neutral (never a premature `quality-pass`).
    */

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -463,6 +463,21 @@ export interface RoutingPolicy {
   /** consecutive quality failures before tier bump; default 2 (D10, consumed Phase 4). */
   escalationThreshold?: number;
   /**
+   * AMR 4c (v2): opt-in LLM spec-satisfaction verdict fed into single-agent
+   * escalation on a NORMAL exit, ALONGSIDE the always-on baseline-relative
+   * security-defect feeder. Off unless `enabled: true` — it is heavy (one model
+   * call + latency per exit), so it is gated separately from the cheap security
+   * scan. Conservative by construction: only a high-confidence `NOT_SATISFIED`
+   * outcome-eval verdict escalates (`quality-fail`); `SATISFIED` / `INCONCLUSIVE`
+   * / any lower-confidence verdict, a missing spec, or an unavailable model
+   * provider is neutral (never a premature `quality-pass`).
+   */
+  acceptanceEval?: {
+    enabled: boolean;
+    /** Override model for the eval call; defaults to the SEL intelligence layer. */
+    model?: string;
+  };
+  /**
    * AMR Phase 5 (D3): provider-type allowlist. When present and non-empty, tier
    * selection considers only backends whose `type` is in this set (fail-closed
    * if it empties the qualifying set). Absent/empty → all backends eligible.


### PR DESCRIPTION
## What

Adds the **LLM acceptance-eval (spec-satisfaction) verdict** named as the second sound source in [ADR 0069](../blob/main/docs/knowledge/decisions/0069-amr-single-agent-quality-gate-deferred.md), behind a new **default-off** flag `routing.policy.acceptanceEval.enabled`. It complements the always-on baseline-relative security-defect feeder shipped earlier — closing the last remaining harness-side AMR follow-up.

## Behavior

On a normal single-agent exit, **after** the cheap security scan comes back clean (so a defect never wastes a model call), and only when the flag is set + the issue has a spec + an analysis provider is available, the orchestrator runs the shared `OutcomeEvaluator` over the introduced diff vs the spec's success-criteria section and feeds `quality-fail` **only** on a high-confidence `NOT_SATISFIED` verdict.

- **Conservative by construction:** the escalation gate is the TS-derived `authority === 'blocking'` (== `NOT_SATISFIED && high`). `SATISFIED` / `INCONCLUSIVE` / lower-confidence / no-spec / no-provider / empty-diff / any error → **neutral**. The method's return type is `'quality-fail' | undefined`, so success can never become a premature `quality-pass`.
- **An LLM cannot self-promote to blocking:** the evaluator re-parses the model payload with a `.strict()` schema that omits `authority`; a forged key is rejected → degraded INCONCLUSIVE/advisory → neutral. Pinned by an end-to-end test.
- **Fully guarded / opt-in:** double try/catch + the only pre-try `await` (`resolveComplexityProvider`) is sync and self-guarded, so nothing breaks completion. No-op (byte-identical) when AMR is off or the flag is unset.

## Why this is now buildable

ADR 0069 deferred this because "the orchestrator does not run a model inline." That's no longer true: the live complexity classifier already builds and calls a SEL-layer `AnalysisProvider` inline per dispatch. This reuses that exact provider — **no new model plumbing**. New surface is minimal: a `WorkspaceManager.getIntroducedDiffText` raw-diff accessor (merge-base relative, seeded overlay excluded via git `:(exclude)` pathspec), a pure `outcomeVerdictToQualityFail` mapper, and the `acceptanceEval` policy field (also accepted on `PUT /api/v1/routing/policy`).

## Review

Adversarial `harness-code-reviewer` pass: **no blockers / high / medium; all 8 invariants hold** (default-off, conservative bias, guardedness, security short-circuit, diff-text correctness, GraphStore fallback, specPath resolution, no unbounded hang). Its 2 Low + 3 Nit findings are all addressed in the follow-up commit (empty-diff-skips-eval comment; forged-authority end-to-end test; absolute-seed-path relativization + test; empty-diff-text guard test; testOutput comment).

## Tests

`quality-verdict.test.ts` (mapper: blocking→fail, all else neutral, trusts TS authority), `manager.introduced-diff.test.ts` (git wiring + absolute-seed relativization), `orchestrator.quality-verdict.test.ts` (gating: disabled-skips, blocking→fail, SATISFIED/low-conf/no-spec/no-provider neutral, security short-circuit, guarded-throw, forged-authority-stripped, empty-diff-text). Guide + ADR 0069 + changeset updated.