### PR TITLE
fix(orchestrator): wire the AMR config-file surface (accept capabilities + routing.policy)

### DIFF
--- a/.changeset/amr-config-file-schema.md
+++ b/.changeset/amr-config-file-schema.md
@@ -1,0 +1,26 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/cli': patch
+---
+
+fix(orchestrator): wire the AMR config-file surface — accept backend `capabilities` + `routing.policy`
+
+AMR's types (`BackendDef.capabilities`, `RoutingConfig.policy`) and the engine that
+reads them shipped, but the config-file Zod validators were never extended, so a
+config carrying them was **rejected** ("Unrecognized key(s)") by both `harness
+validate` and the orchestrator loader — you could not enable AMR from
+`harness.config.json` / `harness.orchestrator.md` at all (only via the runtime
+`PUT /api/v1/routing/policy` endpoint). The AMR guide's config-file example was
+therefore aspirational.
+
+- `BackendDefSchema` gains an optional `capabilities` (`BackendCapabilitiesSchema`:
+  tier / costPer1kTokens / privacyClass / contextWindow / vision? / toolUse?),
+  `.strict()` so config typos fail loudly.
+- `RoutingConfigSchema` gains an optional `policy` (`RoutingPolicySchema`).
+- The `PUT /routing/policy` route now **imports** the canonical `RoutingPolicySchema`
+  instead of its own copy, so the config-file and HTTP-endpoint validation can never
+  drift again. (The route-local copy had a 3-value `privacyFloor` enum, silently
+  **missing `pooled-isolated`** — now fixed as a side effect.)
+- Additive + default-off: a config without `capabilities`/`policy` validates and
+  behaves byte-identically. A compile-time guard + a full-config `validateWorkflowConfig`
+  round-trip test (the front door that was never exercised) pin the fix.

--- a/docs/guides/adaptive-model-routing.md
+++ b/docs/guides/adaptive-model-routing.md
@@ -24,13 +24,15 @@ agent:
         type: local,
         endpoint: http://localhost:1234/v1,
         model: qwen3:8b,
-        capabilities: { tier: fast, costPer1kTokens: 0, privacyClass: on-device },
+        capabilities:
+          { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 8192 },
       }
     cloud-strong:
       {
         type: anthropic,
         model: claude-opus-4-8,
-        capabilities: { tier: strong, costPer1kTokens: 15, privacyClass: shared-cloud },
+        capabilities:
+          { tier: strong, costPer1kTokens: 15, privacyClass: shared-cloud, contextWindow: 200000 },
       }
   routing:
     default: cloud-strong

--- a/packages/cli/src/config/schema.amr.test.ts
+++ b/packages/cli/src/config/schema.amr.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { AgentConfigSchema } from './schema';
+
+/**
+ * `harness validate` (harness.config.json) front door: the project-config agent
+ * schema must accept backend `capabilities` + `routing.policy` — the exact keys it
+ * used to reject ("Unrecognized key(s)"), silently blocking config-file AMR. It
+ * reuses the orchestrator's BackendDefSchema/RoutingConfigSchema, so this guards
+ * that the shared fix flows through to the CLI validate path too.
+ */
+describe('AgentConfigSchema — AMR config-file surface', () => {
+  it('accepts backend capabilities and a routing policy', () => {
+    const r = AgentConfigSchema.safeParse({
+      backends: {
+        primary: {
+          type: 'claude',
+          command: 'claude',
+          capabilities: {
+            tier: 'strong',
+            costPer1kTokens: 15,
+            privacyClass: 'shared-cloud',
+            contextWindow: 200000,
+          },
+        },
+        local: {
+          type: 'pi',
+          endpoint: 'http://localhost:1234/v1',
+          model: 'gemma3n:e4b',
+          capabilities: {
+            tier: 'fast',
+            costPer1kTokens: 0,
+            privacyClass: 'on-device',
+            contextWindow: 32768,
+          },
+        },
+      },
+      routing: {
+        default: 'primary',
+        policy: {
+          complexityTierMatrix: { trivial: 'fast', complex: 'strong' },
+          escalationThreshold: 2,
+          acceptanceEval: { enabled: true },
+        },
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('still accepts an agent WITHOUT capabilities/policy (backward-compatible)', () => {
+    const r = AgentConfigSchema.safeParse({
+      backends: { primary: { type: 'claude', command: 'claude' } },
+      routing: { default: 'primary' },
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/orchestrator/src/server/routes/v1/routing.ts
+++ b/packages/orchestrator/src/server/routes/v1/routing.ts
@@ -17,6 +17,7 @@ import { z } from 'zod';
 import { deriveRequiredTier } from '@harness-engineering/intelligence';
 import { BackendRouter, toArray } from '../../../agent/backend-router';
 import { estimateCost } from '../../../agent/cost-estimator';
+import { RoutingPolicySchema } from '../../../workflow/schema';
 import {
   buildCapabilityRegistry,
   selectCheapestQualifying,
@@ -378,42 +379,10 @@ async function handleTrace(
   return true;
 }
 
-const CAPABILITY_TIER = z.enum(['fast', 'standard', 'strong']);
-const COMPLEXITY_LEVEL = z.enum(['trivial', 'simple', 'moderate', 'complex']);
-const PRIVACY_CLASS = z.enum(['on-device', 'byo-endpoint', 'shared-cloud']);
-
-/**
- * AMR Phase 5 (D3/D4): inbound `RoutingPolicy` schema for `PUT /routing/policy`.
- * Mirrors the `RoutingPolicy` interface; NOT `.strict()` so the schema tolerates
- * forward-compatible extra fields the Shuttle control plane may add.
- *
- * `allowedProviders` is validated as `string[]`, NOT narrowed to the finite
- * `BackendDef['type']` union: Shuttle types it `readonly string[]`, and an
- * unknown provider string must fail CLOSED at tier selection (it simply never
- * matches a backend `type`) rather than 4xx-ing the entire policy push
- * (Phase-1 review note). An empty `{}` body is valid — it restores default-off.
- */
-const RoutingPolicySchema = z.object({
-  complexityTierMatrix: z.record(COMPLEXITY_LEVEL, CAPABILITY_TIER).optional(),
-  skillTierOverrides: z.record(z.string(), CAPABILITY_TIER).optional(),
-  privacyFloor: PRIVACY_CLASS.optional(),
-  budget: z
-    .object({
-      capUsd: z.number(),
-      degradeAtPct: z.number().optional(),
-      onBudgetExhausted: z.enum(['degrade', 'pause', 'human']),
-    })
-    .optional(),
-  sensitivePaths: z.array(z.string()).optional(),
-  escalationThreshold: z.number().optional(),
-  allowedProviders: z.array(z.string()).optional(),
-  acceptanceEval: z
-    .object({
-      enabled: z.boolean(),
-      model: z.string().optional(),
-    })
-    .optional(),
-});
+// `RoutingPolicySchema` is the CANONICAL schema (workflow/schema.ts), shared with
+// the config-file loader so the PUT-endpoint and config-file validation can never
+// drift — the route-local copy this replaced had a 3-value `privacyFloor` enum
+// (missing `pooled-isolated`).
 
 /**
  * AMR Phase 5 (D1/D4/D5): `PUT /api/v1/routing/policy`. Validates a

--- a/packages/orchestrator/src/workflow/schema.amr-config.test.ts
+++ b/packages/orchestrator/src/workflow/schema.amr-config.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BackendDefSchema,
+  RoutingConfigSchema,
+  BackendCapabilitiesSchema,
+  RoutingPolicySchema,
+} from './schema';
+import { validateWorkflowConfig, getDefaultConfig } from './config';
+import type { WorkflowConfig } from '@harness-engineering/types';
+
+/**
+ * AMR config-file surface — the "front door" that the AMR types + engine expected
+ * but the config schema never exposed (backends silently rejected `capabilities`,
+ * routing silently rejected `policy`, so config-file AMR could not be enabled).
+ * These are the regression guards for that type-vs-schema drift.
+ */
+
+const caps = {
+  tier: 'fast',
+  costPer1kTokens: 0,
+  privacyClass: 'on-device',
+  contextWindow: 32768,
+};
+
+describe('BackendDefSchema — capabilities (AMR)', () => {
+  it('accepts a backend with a full capabilities block', () => {
+    const r = BackendDefSchema.safeParse({
+      type: 'pi',
+      endpoint: 'http://localhost:11434/v1',
+      model: 'qwen2.5-coder:7b',
+      capabilities: caps,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts pooled-isolated privacyClass (the value the old route-local enum omitted)', () => {
+    expect(
+      BackendCapabilitiesSchema.safeParse({ ...caps, privacyClass: 'pooled-isolated' }).success
+    ).toBe(true);
+  });
+
+  it('rejects a mistyped capabilities field (strict — catches config typos)', () => {
+    const r = BackendDefSchema.safeParse({
+      type: 'claude',
+      capabilities: { ...caps, costPer1KTokens: 0 }, // wrong case
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('still accepts a backend with NO capabilities (backward-compatible / default-off)', () => {
+    expect(BackendDefSchema.safeParse({ type: 'claude', command: 'claude' }).success).toBe(true);
+  });
+
+  it('rejects nonsense numeric capabilities (negative cost, non-positive context)', () => {
+    // The schema adds runtime refinements the `number` type cannot express — a
+    // regression here would silently accept a policy that can never route sanely.
+    expect(BackendCapabilitiesSchema.safeParse({ ...caps, costPer1kTokens: -1 }).success).toBe(
+      false
+    );
+    expect(BackendCapabilitiesSchema.safeParse({ ...caps, contextWindow: 0 }).success).toBe(false);
+  });
+});
+
+describe('RoutingConfigSchema — policy (AMR)', () => {
+  const policy = {
+    complexityTierMatrix: { trivial: 'fast', complex: 'strong' },
+    budget: { capUsd: 20, degradeAtPct: 90, onBudgetExhausted: 'degrade' },
+    escalationThreshold: 2,
+    acceptanceEval: { enabled: true, model: 'claude-opus-4-8' },
+    allowedProviders: ['anthropic'],
+    privacyFloor: 'pooled-isolated',
+  };
+
+  it('accepts a full policy AND preserves its fields (Zod does not strip them)', () => {
+    const r = RoutingConfigSchema.safeParse({ default: 'primary', policy });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      // Survival — the parse output carries every field intact (contrast the
+      // loader, which returns the raw input, so this is the real strip check).
+      expect(r.data.policy?.escalationThreshold).toBe(2);
+      expect(r.data.policy?.complexityTierMatrix?.complex).toBe('strong');
+      expect(r.data.policy?.privacyFloor).toBe('pooled-isolated');
+      expect(r.data.policy?.acceptanceEval?.enabled).toBe(true);
+      expect(r.data.policy?.budget?.capUsd).toBe(20);
+    }
+  });
+
+  it('tolerates a forward-compatible extra field INSIDE the policy (shared with the Shuttle wire)', () => {
+    expect(RoutingPolicySchema.safeParse({ ...policy, futureField: 'x' }).success).toBe(true);
+  });
+
+  it('still rejects an unknown key at the routing level (outer schema stays strict)', () => {
+    expect(RoutingConfigSchema.safeParse({ default: 'primary', bogusKey: 'x' }).success).toBe(
+      false
+    );
+  });
+
+  it('still accepts routing with NO policy (default-off, backward-compatible)', () => {
+    expect(RoutingConfigSchema.safeParse({ default: 'primary' }).success).toBe(true);
+  });
+});
+
+describe('validateWorkflowConfig — full-config round-trip (the front door that was missed)', () => {
+  it('loads a config whose backends carry capabilities and routing carries a policy', () => {
+    const base = getDefaultConfig();
+    const agent = {
+      ...base.agent,
+      backends: {
+        primary: {
+          type: 'claude',
+          command: 'claude',
+          capabilities: {
+            tier: 'strong',
+            costPer1kTokens: 15,
+            privacyClass: 'shared-cloud',
+            contextWindow: 200000,
+          },
+        },
+        local: {
+          type: 'pi',
+          endpoint: 'http://localhost:11434/v1',
+          model: 'qwen2.5-coder:7b',
+          capabilities: caps,
+        },
+      },
+      routing: {
+        default: 'primary',
+        policy: {
+          complexityTierMatrix: {
+            trivial: 'fast',
+            simple: 'fast',
+            moderate: 'standard',
+            complex: 'strong',
+          },
+          escalationThreshold: 2,
+        },
+      },
+    };
+    // `backend` (legacy single-backend) and `backends` are mutually exclusive (SC15).
+    delete (agent as { backend?: unknown }).backend;
+    const config = { ...base, agent } as unknown as WorkflowConfig;
+
+    // The regression this pins: the loader ACCEPTS a config carrying
+    // capabilities/policy. Without the fix it returns Err at the backends/routing
+    // Zod parse — the exact "front door" failure. (Field survival is asserted
+    // separately on the schema parse output above; validateWorkflowConfig returns
+    // the raw input config, so re-reading it here would be tautological.)
+    const r = validateWorkflowConfig(config);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import type { BackendDef, RoutingConfig } from '@harness-engineering/types';
+import type {
+  BackendDef,
+  RoutingConfig,
+  BackendCapabilities,
+  RoutingPolicy,
+} from '@harness-engineering/types';
 
 /**
  * Reusable schema for the local/pi `model` field — either a non-empty
@@ -17,6 +22,74 @@ const ModelSchema = z.union([z.string().min(1), z.array(z.string().min(1)).nonem
   }),
 });
 
+// --- AMR (Adaptive Model Routing) shared enums ---
+const CAPABILITY_TIER = z.enum(['fast', 'standard', 'strong']);
+const COMPLEXITY_LEVEL = z.enum(['trivial', 'simple', 'moderate', 'complex']);
+const PRIVACY_CLASS = z.enum(['on-device', 'pooled-isolated', 'byo-endpoint', 'shared-cloud']);
+
+/**
+ * AMR: a backend's capability profile (`BackendCapabilities`). With it, AMR can
+ * compare backends and select a capability tier per dispatch; without it the
+ * backend is invisible to tier selection (identity/default routing only).
+ * `.strict()` so a mistyped or misspelled field fails at config-load
+ * rather than being silently dropped. This is the config-file surface the AMR
+ * types + engine expected but the schema never exposed.
+ */
+export const BackendCapabilitiesSchema = z
+  .object({
+    tier: CAPABILITY_TIER,
+    costPer1kTokens: z.number().nonnegative(),
+    privacyClass: PRIVACY_CLASS,
+    contextWindow: z.number().int().positive(),
+    vision: z.boolean().optional(),
+    toolUse: z.boolean().optional(),
+  })
+  .strict();
+
+/**
+ * AMR: the canonical `RoutingPolicy` schema — the SINGLE source of validation for
+ * the config-file loader (`agent.routing.policy`) AND the `PUT /api/v1/routing/policy`
+ * endpoint (which imports this rather than defining its own, so the two can never
+ * drift again — the previous route-local copy had a 3-value `privacyFloor` enum,
+ * missing `pooled-isolated`). NOT `.strict()`: it tolerates forward-compatible
+ * extra fields a control plane (Shuttle) may push. An empty `{}` restores default-off.
+ * ASYMMETRY: unlike the strict `capabilities` block, a typo'd policy field in a
+ * config file (a misspelled policy key) is silently ignored, not rejected —
+ * the forward-compat cost of sharing one schema with the Shuttle wire.
+ */
+export const RoutingPolicySchema = z.object({
+  complexityTierMatrix: z.record(COMPLEXITY_LEVEL, CAPABILITY_TIER).optional(),
+  skillTierOverrides: z.record(z.string(), CAPABILITY_TIER).optional(),
+  privacyFloor: PRIVACY_CLASS.optional(),
+  budget: z
+    .object({
+      capUsd: z.number(),
+      degradeAtPct: z.number().optional(),
+      onBudgetExhausted: z.enum(['degrade', 'pause', 'human']),
+    })
+    .optional(),
+  sensitivePaths: z.array(z.string()).optional(),
+  escalationThreshold: z.number().optional(),
+  // string[], NOT the finite BackendDef['type'] union: an unknown provider must
+  // fail CLOSED at tier selection, not reject the whole policy (Shuttle wire).
+  allowedProviders: z.array(z.string()).optional(),
+  acceptanceEval: z
+    .object({
+      enabled: z.boolean(),
+      model: z.string().optional(),
+    })
+    .optional(),
+});
+
+// Drift guard: the schema output must be assignable to the canonical type, so a
+// wrong field TYPE (e.g. `costPer1kTokens: string`) stops compiling. Field-PRESENCE
+// (the bug this fixes — the schema not exposing `capabilities`/`policy` at all) is
+// pinned by the config round-trip test in schema.amr-config.test.ts.
+const _capsGuard = (c: BackendCapabilities): z.infer<typeof BackendCapabilitiesSchema> => c;
+const _policyGuard = (p: RoutingPolicy): z.infer<typeof RoutingPolicySchema> => p;
+void _capsGuard;
+void _policyGuard;
+
 /**
  * Zod schema for `BackendDef` (Spec 2 — multi-backend routing).
  *
@@ -28,11 +101,14 @@ const ModelSchema = z.union([z.string().min(1), z.array(z.string().min(1)).nonem
  * for standalone unit testing.
  */
 export const BackendDefSchema = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('mock') }).strict(),
+  z
+    .object({ type: z.literal('mock'), capabilities: BackendCapabilitiesSchema.optional() })
+    .strict(),
   z
     .object({
       type: z.literal('claude'),
       command: z.string().optional(),
+      capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),
   z
@@ -40,6 +116,7 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       type: z.literal('anthropic'),
       model: z.string().min(1),
       apiKey: z.string().optional(),
+      capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),
   z
@@ -47,6 +124,7 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       type: z.literal('openai'),
       model: z.string().min(1),
       apiKey: z.string().optional(),
+      capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),
   z
@@ -54,6 +132,7 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       type: z.literal('gemini'),
       model: z.string().min(1),
       apiKey: z.string().optional(),
+      capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),
   z
@@ -64,6 +143,7 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       apiKey: z.string().optional(),
       timeoutMs: z.number().int().positive().optional(),
       probeIntervalMs: z.number().int().min(1000).optional(),
+      capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),
   z
@@ -74,6 +154,7 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       apiKey: z.string().optional(),
       timeoutMs: z.number().int().positive().optional(),
       probeIntervalMs: z.number().int().min(1000).optional(),
+      capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),
 ]);
@@ -133,6 +214,10 @@ export const RoutingConfigSchema = z
     // --- Spec B Phase 0: new optional maps (resolver wired in Phase 1) ---
     skills: z.record(z.string().min(1), RoutingValueSchema).optional(),
     modes: z.record(z.string().min(1), RoutingValueSchema).optional(),
+    // --- AMR: opt-in adaptive-routing policy. Its PRESENCE flips the orchestrator
+    // from identity/default dispatch to complexity-aware tier routing (default-off
+    // when absent). Previously accepted by the runtime PUT endpoint only. ---
+    policy: RoutingPolicySchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## What

Fixes a **type-vs-schema drift** that made AMR impossible to enable from a config file. The AMR types (`BackendDef.capabilities`, `RoutingConfig.policy`) and the engine that reads them shipped — but the config-file Zod validators (`BackendDefSchema`, `RoutingConfigSchema`, both `.strict()`) were never extended. So a config carrying `capabilities`/`routing.policy` was **rejected** ("Unrecognized key(s)") by *both* `harness validate` and the orchestrator config loader. AMR could only be driven via the runtime `PUT /api/v1/routing/policy` endpoint; the guide's config-file example was aspirational.

### How it was missed

Backend `capabilities` were built **programmatically** in unit tests (bypassing the validator), and `RoutingPolicy` was exercised through the HTTP endpoint's **own** schema. No test ever round-tripped a real *config file* through the loader, so the strict schemas silently diverged from the types. This PR adds exactly that front-door test.

## Changes

- `BackendDefSchema` gains an optional **`capabilities`** (`BackendCapabilitiesSchema` — `.strict()`, so config typos fail loudly) on every variant.
- `RoutingConfigSchema` gains an optional **`policy`** (`RoutingPolicySchema`).
- The `PUT /routing/policy` route now **imports the canonical `RoutingPolicySchema`** instead of its own copy, so config-file and HTTP validation can't drift again. Side-effect fix: the route-local copy's `privacyFloor` enum was missing **`pooled-isolated`** — now all 4 values.
- Guide `capabilities` examples corrected to include the required `contextWindow` (they'd have failed the new strict validation).
- Additive / default-off: a config without the fields validates and behaves byte-identically.

## Review

Adversarial review: **Approve**, all 7 invariants hold (backward-compat, schema↔type fidelity, route dedup preserves PUT behavior + the #803 strip-to-empty guard, `.strict()` split, discriminatedUnion integrity, cross-package flow, tests). Its Medium (the loader returns the raw input, so the round-trip's field-survival assertions were tautological) is **fixed** — field survival is now asserted on the schema parse output directly, and the round-trip pins the real regression (loader *accepts* vs *rejects*). Low (numeric-refinement reject test) and Nit (tolerant-policy typo asymmetry doc note) also addressed.

## Verification

`tsc` clean, orchestrator suite (289) + new schema/CLI tests green, and — the end-to-end proof — the **locally-built `harness validate` now accepts an AMR config** (`capabilities` + `policy`) with **zero** key-rejection errors, where it errored before.

Compile-time drift guards (`Type → z.infer`) now catch a wrong field type or a missing enum value (e.g. a re-dropped `pooled-isolated`). Once released, the config I drafted for `harness.orchestrator.md` goes straight in.