### PR TITLE
chore(orchestrator): enable AMR on the harness repo's own orchestrator (dogfood)

### DIFF
--- a/harness.config.json
+++ b/harness.config.json
@@ -162,12 +162,24 @@
     "backends": {
       "primary": {
         "type": "claude",
-        "command": "claude"
+        "command": "claude",
+        "capabilities": {
+          "tier": "strong",
+          "costPer1kTokens": 15,
+          "privacyClass": "shared-cloud",
+          "contextWindow": 200000
+        }
       },
       "local": {
         "type": "pi",
         "endpoint": "http://localhost:1234/v1",
-        "model": ["google/gemma-4-e4b"]
+        "model": ["google/gemma-4-e4b"],
+        "capabilities": {
+          "tier": "fast",
+          "costPer1kTokens": 0,
+          "privacyClass": "on-device",
+          "contextWindow": 32768
+        }
       }
     },
     "routing": {
@@ -177,6 +189,15 @@
       "intelligence": {
         "sel": "local",
         "pesl": "local"
+      },
+      "policy": {
+        "complexityTierMatrix": {
+          "trivial": "fast",
+          "simple": "fast",
+          "moderate": "standard",
+          "complex": "strong"
+        },
+        "escalationThreshold": 2
       }
     }
   },

--- a/harness.orchestrator.md
+++ b/harness.orchestrator.md
@@ -16,8 +16,14 @@ hooks:
   timeoutMs: 60000
 agent:
   # Named backend definitions (Spec 2). See docs/guides/multi-backend-routing.md.
+  # `capabilities` (tier/cost/privacy/context) let AMR compare backends and select a
+  # capability tier per dispatch — a backend without one is invisible to tier selection.
   backends:
-    primary: { type: claude, command: claude }
+    primary:
+      type: claude
+      command: claude
+      capabilities:
+        { tier: strong, costPer1kTokens: 15, privacyClass: shared-cloud, contextWindow: 200000 }
     # Local backend for autonomous execution of simple tasks.
     # `model` accepts a string OR a prefer-and-fallback array — first
     # match wins after a `/v1/models` probe.
@@ -30,6 +36,8 @@ agent:
       # first (local routes are quick-fix/diagnostic), general model as fallback.
       # Quote the names — the ':tag' colon otherwise breaks YAML flow parsing.
       model: ['qwen2.5-coder:7b', 'gemma3n:e4b']
+      capabilities:
+        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
   # Routing — controls WHICH backend handles each use case.
   routing:
     default: primary
@@ -39,6 +47,17 @@ agent:
     intelligence:
       sel: local
       pesl: local
+    # AMR (Adaptive Model Routing) — opt-in; its PRESENCE flips dispatch from the
+    # identity/default chain to complexity-aware tier selection. trivial/simple →
+    # local (fast, free); moderate/complex → claude (no `standard` backend, so a
+    # `standard` requirement resolves to the cheapest backend at-or-above it =
+    # primary). The always-on baseline-relative security-defect feeder climbs a
+    # unit's tier after `escalationThreshold` consecutive quality failures
+    # (strong-capped, then hard-fails to a human). Budget cap + LLM acceptance-eval
+    # are available opt-ins (docs/guides/adaptive-model-routing.md) — left off here.
+    policy:
+      complexityTierMatrix: { trivial: fast, simple: fast, moderate: standard, complex: strong }
+      escalationThreshold: 2
   # Escalation — controls WHETHER a tier dispatches at all (orthogonal to routing).
   escalation:
     alwaysHuman: [full-exploration]


### PR DESCRIPTION
## What

With v6.0.1 wiring the AMR config-file surface (#817), this turns on **Adaptive Model Routing** for this repo's own dogfooding orchestrator — the payoff of the AMR chain (#800/#803/#805/#810/#812/#813/#815/#817).

- **Backends gain `capabilities`:** `primary` (claude) = strong / shared-cloud / 200k ctx; `local` (pi/ollama) = fast / on-device / free / 32k ctx.
- **`routing.policy`:** complexity-aware tier selection — `trivial`/`simple` → the free local model, `moderate`/`complex` → claude (there's no `standard` backend, so a `standard` requirement resolves to the cheapest backend at-or-above it = `primary`). The always-on baseline-relative **security-defect** feeder climbs a unit's tier after `escalationThreshold` (2) consecutive quality failures (strong-capped → then hard-fails to a human).
- Applied to **both** `harness.orchestrator.md` (the live runtime config) and `harness.config.json` (project config, so `harness validate` stays consistent).

## Deliberately off (one-line opt-ins when wanted)

- **`budget`** — a monotonic accumulator on a long-running daemon would eventually clamp *everything* to local; enable with a reset/ops story.
- **`acceptanceEval`** — adds an LLM call per single-agent exit (low signal on a 7B local eval model).

## Default-off preserved

`routing.policy`'s presence is the opt-in; anyone without it dispatches byte-identically. Verified: `harness validate` (v6.0.1) accepts the config with zero key-rejections, and the orchestrator frontmatter YAML parses cleanly (`policy` present, `primary`→strong, `local`→fast). Tune the `complexityTierMatrix` to taste (e.g. `moderate: fast` to keep more work local).