### PR TITLE
chore(config): point local backend at the real ollama endpoint (:11434 / qwen2.5-coder)

### DIFF
--- a/harness.config.json
+++ b/harness.config.json
@@ -172,8 +172,8 @@
       },
       "local": {
         "type": "pi",
-        "endpoint": "http://localhost:1234/v1",
-        "model": ["google/gemma-4-e4b"],
+        "endpoint": "http://127.0.0.1:11434/v1",
+        "model": ["qwen2.5-coder:7b", "gemma3n:e4b"],
         "capabilities": {
           "tier": "fast",
           "costPer1kTokens": 0,


### PR DESCRIPTION
`harness.config.json`'s `local` backend still had the stale `http://localhost:1234/v1` + `google/gemma-4-e4b` (neither reachable on this host). Align it with `harness.orchestrator.md` and the actual running ollama — `http://127.0.0.1:11434/v1`, models `qwen2.5-coder:7b` → `gemma3n:e4b` (prefer-and-fallback) — so the project config and `harness validate` reflect reality.

The running orchestrator already reads `harness.orchestrator.md`, so this only affects config-file consistency (not live dispatch). `harness validate` passes.