### PR TITLE
fix(routing): 'harness routing trace' shows the AMR-effective backend, not the identity default

### DIFF
--- a/.changeset/routing-trace-effective-backend.md
+++ b/.changeset/routing-trace-effective-backend.md
@@ -1,0 +1,22 @@
+---
+'@harness-engineering/orchestrator': patch
+'@harness-engineering/cli': patch
+---
+
+fix(routing): `harness routing trace` shows the AMR-effective backend, not the identity default
+
+`trace --complexity <level>` displayed `decision.backendName` — the identity/default
+chain pick — as the "Backend", so a `trivial` task under AMR showed `primary`/claude
+even though it routes to the `fast`/local backend (the `$0` cost already reflected
+local, making Backend↔cost inconsistent). The trace handler already computed the
+tier-selected backend (`costedBackendName` via the same `selectCheapestQualifying`
+real dispatch uses); the CLI just ignored it and the server didn't return its type.
+
+- Server: the trace response now also carries `costedBackendType` alongside
+  `costedBackendName`.
+- CLI: under a `--complexity`/`--risk` dry-run, the `Backend:` line shows the
+  tier-selected backend + type (what real dispatch would use), and notes when AMR
+  overrides the identity pick. Non-AMR traces are unchanged.
+
+Routing behavior itself was always correct — this is a display/observability fix so
+`trace` reflects what the orchestrator actually dispatches.

--- a/packages/cli/src/commands/routing/routing.test.ts
+++ b/packages/cli/src/commands/routing/routing.test.ts
@@ -195,6 +195,37 @@ describe('harness routing — subcommand acceptance contracts (Spec B Phase 6)',
     expect(allLog).toMatch(/Est cost: \$0\.0240/);
   });
 
+  it('trace: shows the AMR-selected backend (costedBackendName), not the identity default', async () => {
+    // Reproduces the reported bug: trivial → tier fast → AMR routes to `local`,
+    // but the identity chain default is `primary`. The Backend line must show the
+    // EFFECTIVE backend (what real dispatch uses), not `primary`.
+    const body = {
+      decision: {
+        backendName: 'primary',
+        backendType: 'claude',
+        useCase: { kind: 'skill', skillName: 'implement' },
+        resolutionPath: [{ source: 'default', candidate: 'primary', outcome: 'chosen' }],
+        timestamp: '2026-07-13T00:00:00Z',
+        durationMs: 0.01,
+      },
+      def: { type: 'claude' },
+      tierRequired: 'fast',
+      estCostUsd: 0,
+      costedBackendName: 'local',
+      costedBackendType: 'pi',
+    };
+    mockFetch(() => new Response(JSON.stringify(body), { status: 200 }));
+    await createTraceCommand().parseAsync(['--skill', 'implement', '--complexity', 'trivial'], {
+      from: 'user',
+    });
+    const allLog = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(allLog).toMatch(/Backend: local \(type: pi\)/); // the AMR-effective backend
+    expect(allLog).not.toMatch(/Backend: primary/); // NOT the identity default
+    expect(allLog).toMatch(/AMR overrides the identity pick 'primary'/);
+    expect(allLog).toMatch(/Tier required: fast/);
+    expect(allLog).toMatch(/Est cost: \$0\.0000/);
+  });
+
   it('trace WITHOUT --complexity/--risk: omits those flags AND the tier/cost lines', async () => {
     const body = {
       decision: {

--- a/packages/cli/src/commands/routing/trace.ts
+++ b/packages/cli/src/commands/routing/trace.ts
@@ -15,6 +15,13 @@ interface TraceResponse {
   /** AMR Phase 3 (SC10): present when --complexity/--risk were supplied. */
   tierRequired?: string;
   estCostUsd?: number;
+  /**
+   * AMR: the backend the router would ACTUALLY dispatch to at `tierRequired`
+   * (cheapest qualifying) + its type. Distinct from `decision.backendName`, which
+   * is the identity/default-chain pick. Present on --complexity/--risk dry-runs.
+   */
+  costedBackendName?: string;
+  costedBackendType?: string;
 }
 
 // Client-side enum guards mirror the server's zod schema
@@ -45,19 +52,31 @@ function buildUseCase(opts: { skill?: string; mode?: string }): RoutingUseCase |
 }
 
 function renderHuman(r: TraceResponse): void {
-  console.log(`Backend: ${r.decision.backendName} (type: ${r.def.type})`);
+  // Under AMR (a --complexity/--risk dry-run), the EFFECTIVE backend is the
+  // tier-selected one (`costedBackendName`) — what real dispatch routes to — not
+  // the identity/default-chain pick in `decision`. Show that so Backend↔tier↔cost
+  // read consistently; the identity pick is surfaced below when they differ.
+  const amr = r.tierRequired !== undefined && r.costedBackendName !== undefined;
+  const backend = amr ? r.costedBackendName! : r.decision.backendName;
+  const type = amr && r.costedBackendType !== undefined ? r.costedBackendType : r.def.type;
+  console.log(`Backend: ${backend} (type: ${type})`);
   console.log(`Duration: ${r.decision.durationMs.toFixed(2)} ms`);
   console.log('Resolution path:');
   if (r.decision.resolutionPath.length === 0) {
     console.log('  (empty)');
-    return;
-  }
-  for (const step of r.decision.resolutionPath) {
-    console.log(`  ${step.source}:${step.candidate} -> ${step.outcome}`);
+  } else {
+    for (const step of r.decision.resolutionPath) {
+      console.log(`  ${step.source}:${step.candidate} -> ${step.outcome}`);
+    }
   }
   // AMR Phase 3 (SC10): only present on --complexity/--risk dry-runs.
   if (r.tierRequired !== undefined) {
     console.log(`Tier required: ${r.tierRequired}`);
+  }
+  if (amr && r.costedBackendName !== r.decision.backendName) {
+    console.log(
+      `  (AMR overrides the identity pick '${r.decision.backendName}' → cheapest backend at/above the tier)`
+    );
   }
   if (r.estCostUsd !== undefined) {
     console.log(`Est cost: $${r.estCostUsd.toFixed(4)}`);

--- a/packages/orchestrator/src/server/routes/v1/routing.test.ts
+++ b/packages/orchestrator/src/server/routes/v1/routing.test.ts
@@ -234,8 +234,58 @@ describe('handleV1RoutingRoute — POST /api/v1/routing/trace', () => {
     expect(body.tierRequired).toBe('strong');
     expect(typeof body.estCostUsd).toBe('number');
     expect(body.estCostUsd).toBeGreaterThan(0);
+    // The AMR-effective backend + its type accompany the tier (single backend here).
+    expect(body.costedBackendName).toBe('strong');
+    expect(body.costedBackendType).toBe('anthropic');
     // dry-run invariant preserved.
     expect(bus.recent().length).toBe(ringBefore);
+  });
+
+  it('costedBackendName is the TIER-selected backend, not the identity default (the trace-display bug)', async () => {
+    const backends: Record<string, BackendDef> = {
+      primary: {
+        type: 'anthropic',
+        model: 'claude-opus',
+        capabilities: {
+          tier: 'strong',
+          costPer1kTokens: 15,
+          privacyClass: 'shared-cloud',
+          contextWindow: 200000,
+        },
+      },
+      local: {
+        type: 'local',
+        endpoint: 'http://localhost:11434/v1',
+        model: 'qwen2.5-coder:7b',
+        capabilities: {
+          tier: 'fast',
+          costPer1kTokens: 0,
+          privacyClass: 'on-device',
+          contextWindow: 32768,
+        },
+      },
+    };
+    const routing: RoutingConfig = { default: 'primary' };
+    const req = makeJsonReq('POST', '/api/v1/routing/trace', {
+      useCase: { kind: 'tier', tier: 'quick-fix' },
+      complexity: 'trivial',
+    });
+    const { res, chunks, statusCode } = makeRes();
+    handleV1RoutingRoute(req, res, {
+      router: new BackendRouter({ backends, routing }),
+      bus: new RoutingDecisionBus(),
+      routing,
+      backends,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(statusCode()).toBe(200);
+    const body = JSON.parse(chunks.join(''));
+    // The identity chain default is `primary`; AMR routes trivial → fast → `local`.
+    expect(body.decision.backendName).toBe('primary'); // identity default (unchanged)
+    expect(body.tierRequired).toBe('fast');
+    expect(body.costedBackendName).toBe('local'); // the backend AMR actually dispatches to
+    expect(body.costedBackendType).toBe('local');
+    expect(body.estCostUsd).toBe(0); // local's cost, not primary's
   });
 
   it('SC10 consistency: multi-backend dry-run costs the TIER-SELECTED backend, not the identity default', async () => {

--- a/packages/orchestrator/src/server/routes/v1/routing.ts
+++ b/packages/orchestrator/src/server/routes/v1/routing.ts
@@ -221,7 +221,12 @@ function deriveTraceCost(
   def: BackendDef,
   routing: RoutingConfig,
   backends: Record<string, BackendDef>
-): { tierRequired: CapabilityTier; estCostUsd: number; costedBackendName: string } {
+): {
+  tierRequired: CapabilityTier;
+  estCostUsd: number;
+  costedBackendName: string;
+  costedBackendType: BackendDef['type'];
+} {
   const verdict: ComplexityVerdict = {
     level: (body.complexity ?? 'moderate') as ComplexityLevel,
     confidence: 'high',
@@ -247,7 +252,12 @@ function deriveTraceCost(
     backends
   );
   const estCostUsd = estimateCost(costedDef, { useCase: body.useCase as RoutingUseCase });
-  return { tierRequired, estCostUsd, costedBackendName: costedName };
+  return {
+    tierRequired,
+    estCostUsd,
+    costedBackendName: costedName,
+    costedBackendType: costedDef.type,
+  };
 }
 
 /**
@@ -354,7 +364,7 @@ async function handleTrace(
     // required tier + estimated cost WITHOUT dispatching. The tier is TS-derived
     // (never LLM-trusted); no bus emission, so the dry-run invariant holds.
     if (r.data.complexity !== undefined || r.data.risk !== undefined) {
-      const { tierRequired, estCostUsd, costedBackendName } = deriveTraceCost(
+      const { tierRequired, estCostUsd, costedBackendName, costedBackendType } = deriveTraceCost(
         r.data,
         decision,
         def,
@@ -366,9 +376,12 @@ async function handleTrace(
         def: { type: def.type },
         tierRequired,
         estCostUsd,
-        // Name the backend the cost belongs to so operators see tier↔cost↔backend
-        // are consistent (was implicit + divergent before this fix).
+        // The backend AMR would ACTUALLY dispatch to at this tier (cheapest
+        // qualifying) + its type — distinct from the identity-chain `decision`
+        // above. The CLI shows this as the effective backend so tier↔cost↔backend
+        // read consistently (was implicit + divergent before).
         costedBackendName,
+        costedBackendType,
       });
       return true;
     }


### PR DESCRIPTION
## The bug (found by testing the dogfood AMR config)

`harness routing trace --skill implement --complexity trivial` printed:

```
Backend: primary (type: claude)      ← wrong
Tier required: fast
Est cost: $0.0000                     ← local's cost (inconsistent with the backend shown)
```

It displayed `decision.backendName` — the **identity/default-chain** pick (`primary`/claude) — as the Backend, even though AMR routes a `trivial`/`fast` task to the `local` backend. The `$0` cost already reflected `local`, so Backend↔cost read inconsistently.

**Routing itself was always correct** — the trace handler already computes the tier-selected backend via the *same* `selectCheapestQualifying` real dispatch uses (returned as `costedBackendName`), and real dispatch passes it as the invocation override. So `trivial` genuinely runs on `local`/qwen. The CLI just showed the wrong field, and the server didn't return the tier backend's type.

## Fix

- **Server:** the trace response now carries `costedBackendType` alongside `costedBackendName`.
- **CLI:** under a `--complexity`/`--risk` dry-run, the `Backend:` line shows the **tier-selected** backend + type (what real dispatch uses), and notes when AMR overrides the identity pick:

```
Backend: local (type: pi)
Tier required: fast
  (AMR overrides the identity pick 'primary' → cheapest backend at/above the tier)
Est cost: $0.0000
```

Non-AMR traces (no `--complexity`/`--risk`) are unchanged.

## Tests

- Server: trace response includes `costedBackendType`; a **two-backend divergence** case (`trivial` → `local` ≠ default `primary`, cost `$0`).
- CLI: renders the effective backend (`local (type: pi)`), asserts it's **not** `primary`, and shows the override note — the exact reported scenario.

Display/observability only — no routing-logic change.