### PR TITLE
fix(config): lead local model fallback with a native-tool-calling model for builds

### DIFF
--- a/harness.config.json
+++ b/harness.config.json
@@ -173,7 +173,7 @@
       "local": {
         "type": "pi",
         "endpoint": "http://127.0.0.1:11434/v1",
-        "model": ["qwen2.5-coder:7b", "gemma3n:e4b"],
+        "model": ["qwen3:32b", "qwen2.5-coder:7b", "gemma3n:e4b"],
         "capabilities": {
           "tier": "fast",
           "costPer1kTokens": 0,


### PR DESCRIPTION
## What

Lead the `agent.backends.local.model` fallback list with a **native-tool-calling** model, so a pool-less agentic build doesn't route to a model that can't drive the tool loop.

## Why (verified across all four installed local models)

Tested native tool-calling via Ollama `/api/chat` **and** the OpenAI-compat `/v1` (the endpoint the pi-coding-agent SDK uses), with a `write_file` tool schema:

| Model | Native `tool_calls`? | In the agentic SDK |
|---|---|---|
| `qwen2.5-coder:7b` | ❌ emits the call as **text** (`{"name":...}`) | can't be parsed → build no-ops |
| `qwen3:8b` | ✅ (5s) | drives the loop (fast, flakier/buggier) |
| `qwen3:32b` | ✅ (32s) | drives the loop (reliable, correct code) |
| `llama3.3:70b` | ✅ (273s) | too slow to be practical |

The pool (preferred source) already ranks `qwen3:32b` top for the `coding` profile, so the live build path was fine. But the **pool-less config fallback** led with `qwen2.5-coder:7b` — the one model that can't emit native tool calls — which would silently no-op an agentic build. This leads the fallback with `qwen3:32b` (most reliable + best code quality of the tool-callers; `qwen3:8b` is faster but flakier). It's health-check-gated (served-only) in the resolver, so it degrades to the next entry if `qwen3:32b` isn't loaded.

Triage is unaffected: it uses native `think:false` (fast) and the pool health-check picks the served model.

## Scope

One-line config change + this rationale. No code. Found while verifying the full local pick→build→PR loop end to end.
