### PR TITLE
feat(lmlm): probe + require agentic tool-calling capability for build routing

### DIFF
--- a/.changeset/lmlm-tool-calling-capability.md
+++ b/.changeset/lmlm-tool-calling-capability.md
@@ -1,0 +1,27 @@
+---
+'@harness-engineering/local-models': minor
+'@harness-engineering/orchestrator': minor
+---
+
+feat(lmlm): probe + store per-model agentic tool-calling capability; require it for build routing
+
+The pool ranked local models purely on benchmark scores, so a model that can't drive an agentic
+build (it emits tool calls as TEXT the coding-agent SDK can't parse — e.g. qwen2.5-coder:7b) could
+rank top and silently no-op a build. Bake the capability into the pool so selection is aware of it:
+
+- **`probeToolCalling`** (`local-models`) — cheap-first: gate on Ollama `/api/show` `capabilities`
+  (free; no `tools` ⇒ `false` with no inference), then one `/v1` tool-schema call to confirm the
+  model actually emits native `tool_calls` (catches the "claims tools but emits text" false
+  positive). Any failure ⇒ `undefined` (unknown ⇒ fail-open). The single-call FORMAT probe is
+  deterministic, unlike the flaky multi-turn agentic loop.
+- **`PoolEntry.toolCalling?`** — additive, round-trips via the existing clone/loader; written once
+  per model by the scheduler re-score (an injected probe seam) and never re-probed once decided.
+- **`poolStateToCandidates(state, profile, { requireToolCalling })`** — excludes entries known not
+  to tool-call (`false`), keeping `true` + unprobed (`undefined`, fail-open).
+- **`LocalModelResolver`** requires tool-calling for AGENTIC (tier) use-cases only — a build never
+  routes to a text-only model; triage/classification (which needs no tool-calling) is untouched.
+- The orchestrator binds the probe to the local backend endpoint when starting the refresh
+  scheduler.
+
+Verified live: the probe returns `false` for qwen2.5-coder:7b and `true` for qwen3:8b / qwen3:32b.
+This makes the config-ordering fallback a belt-and-suspenders rather than the primary guard.

--- a/docs/roadmap.d/lmlm-build-quality-model-selection.md
+++ b/docs/roadmap.d/lmlm-build-quality-model-selection.md
@@ -1,0 +1,16 @@
+---
+slug: "lmlm-build-quality-model-selection"
+milestone: "Intake"
+order: 3
+---
+
+### LMLM: feed post-build quality into per-model build routing
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-on to the deterministic tool-calling capability signal (PR #833). Add a LEARNED build-quality signal so a local model that tool-calls but produces failing/buggy builds is deprioritized for build routing over time — the soft-quality dimension the capability probe deliberately does NOT cover. Approach (minimal slice): attribute each build's quality outcome (tests/review, or the roadmap-auto-triage Phase-4 retrospective verdict) to the SPECIFIC resolved local model — today only `lastRoutedTier` is stashed on the running entry, so the ollama model id must be threaded through the completion/retrospective path — then feed quality-fails into the EXISTING `LocalModelResolver` circuit breaker (threshold 3 + cooldown) rather than a new scoring subsystem, reusing its anti-flakiness + recovery. Keep capability (deterministic probe) separate from reliability (learned). Design MUST include decay/exploration so a model demoted on one flaky build can recover. **Gated on build throughput:** local agentic builds are minutes-to-tens-of-minutes, so meaningful per-model signal accrues slowly, and the acute hard-failure case is already covered by the breaker + the capability probe — so near-term value is low until build volume (cloud / faster hardware) makes learning worthwhile.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,6 +33,17 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** P2
 - **External-ID:** —
 
+### LMLM: feed post-build quality into per-model build routing
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-on to the deterministic tool-calling capability signal (PR #833). Add a LEARNED build-quality signal so a local model that tool-calls but produces failing/buggy builds is deprioritized for build routing over time — the soft-quality dimension the capability probe deliberately does NOT cover. Approach (minimal slice): attribute each build's quality outcome (tests/review, or the roadmap-auto-triage Phase-4 retrospective verdict) to the SPECIFIC resolved local model — today only `lastRoutedTier` is stashed on the running entry, so the ollama model id must be threaded through the completion/retrospective path — then feed quality-fails into the EXISTING `LocalModelResolver` circuit breaker (threshold 3 + cooldown) rather than a new scoring subsystem, reusing its anti-flakiness + recovery. Keep capability (deterministic probe) separate from reliability (learned). Design MUST include decay/exploration so a model demoted on one flaky build can recover. **Gated on build throughput:** local agentic builds are minutes-to-tens-of-minutes, so meaningful per-model signal accrues slowly, and the acute hard-failure case is already covered by the breaker + the capability probe — so near-term value is low until build volume (cloud / faster hardware) makes learning worthwhile.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P3
+- **External-ID:** —
+
 ### LMLM: dashboard direct install/evict (optional)
 
 - **Status:** planned

--- a/packages/local-models/src/capability/index.ts
+++ b/packages/local-models/src/capability/index.ts
@@ -1,0 +1,2 @@
+export { probeToolCalling } from './tool-calling.js';
+export type { ProbeToolCallingDeps } from './tool-calling.js';

--- a/packages/local-models/src/capability/tool-calling.ts
+++ b/packages/local-models/src/capability/tool-calling.ts
@@ -1,0 +1,96 @@
+// packages/local-models/src/capability/tool-calling.ts
+//
+// Determine whether a local model can drive an AGENTIC build — i.e. it emits native OpenAI
+// `tool_calls` rather than rendering the call as text (which the coding-agent SDK cannot parse).
+//
+// Two-stage, cheap-first:
+//   1. FREE capability gate — Ollama `/api/show` returns a `capabilities` array (derived from the
+//      model's GGUF/HF chat template). No `tools` there ⇒ definitely can't ⇒ `false`, no inference.
+//   2. GROUND TRUTH — one `/v1/chat/completions` call with a tool schema. `capabilities:['tools']`
+//      is NECESSARY but not SUFFICIENT (e.g. qwen2.5-coder:7b claims it yet emits the call as
+//      TEXT), so we confirm the response actually carries native `tool_calls`.
+//
+// Any transport/parse failure ⇒ `undefined` (unknown) so the caller fails OPEN (an unknown model
+// is not excluded from build routing; only a confirmed `false` is). The single tool-call FORMAT
+// probe is deterministic — unlike the multi-turn agentic loop — so one call is a reliable signal.
+
+/** Inputs for {@link probeToolCalling}. */
+export interface ProbeToolCallingDeps {
+  /** Ollama model id, e.g. `qwen3:32b`. */
+  model: string;
+  /** The OpenAI-compatible base URL, e.g. `http://127.0.0.1:11434/v1`. */
+  baseUrl: string;
+  /** Bearer token for the endpoint (Ollama ignores the value). */
+  apiKey?: string;
+  /** Injectable fetch for tests. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/** A minimal tool schema the model can answer with a single `tool_calls` entry. */
+const PROBE_TOOL = [
+  {
+    type: 'function',
+    function: {
+      name: 'write_file',
+      description: 'Write content to a file on disk',
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string' }, content: { type: 'string' } },
+        required: ['path', 'content'],
+      },
+    },
+  },
+];
+
+/**
+ * Probe whether `model` emits native OpenAI `tool_calls`. Returns `true` (confirmed),
+ * `false` (no `tools` capability, or tools-capable but emits text), or `undefined` (unknown —
+ * probe unreachable/failed). Never throws.
+ */
+export async function probeToolCalling(deps: ProbeToolCallingDeps): Promise<boolean | undefined> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const v1 = deps.baseUrl.replace(/\/$/, '');
+  const root = v1.replace(/\/v1$/, '');
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(deps.apiKey !== undefined ? { Authorization: `Bearer ${deps.apiKey}` } : {}),
+  };
+  try {
+    // 1. Free capability gate.
+    const showRes = await fetchImpl(`${root}/api/show`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ model: deps.model }),
+    });
+    if (!showRes.ok) return undefined;
+    const show = (await showRes.json()) as { capabilities?: unknown };
+    const caps = Array.isArray(show.capabilities) ? show.capabilities : [];
+    if (!caps.includes('tools')) return false; // definitely can't — free negative, no inference
+
+    // 2. Ground truth: does it actually emit native tool_calls?
+    const chatRes = await fetchImpl(`${v1}/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: deps.model,
+        messages: [
+          {
+            role: 'user',
+            content: "Create a file named hello.txt containing 'hi'. Use the write_file tool.",
+          },
+        ],
+        tools: PROBE_TOOL,
+        stream: false,
+        max_tokens: 512,
+      }),
+    });
+    if (!chatRes.ok) return undefined;
+    const chat = (await chatRes.json()) as {
+      choices?: Array<{ message?: { tool_calls?: unknown } }>;
+    };
+    const toolCalls = chat.choices?.[0]?.message?.tool_calls;
+    return Array.isArray(toolCalls) && toolCalls.length > 0;
+  } catch {
+    return undefined; // unknown ⇒ fail-open (caller does not exclude unknowns)
+  }
+}

--- a/packages/local-models/src/index.ts
+++ b/packages/local-models/src/index.ts
@@ -27,6 +27,7 @@ export const LOCAL_MODELS_PACKAGE = '@harness-engineering/local-models' as const
 export const LOCAL_MODELS_VERSION = '0.1.0' as const;
 
 export * from './candidates/index.js';
+export * from './capability/index.js';
 export * from './hardware/index.js';
 export * from './huggingface/index.js';
 export * from './installer/index.js';

--- a/packages/local-models/src/pool/index.ts
+++ b/packages/local-models/src/pool/index.ts
@@ -31,6 +31,7 @@ export type {
 } from './types.js';
 
 export { poolStateToCandidates } from './provider.js';
+export type { PoolCandidateOptions } from './provider.js';
 export type { PoolStateProvider } from './provider.js';
 
 export { PoolManager } from './manager.js';

--- a/packages/local-models/src/pool/manager.ts
+++ b/packages/local-models/src/pool/manager.ts
@@ -157,6 +157,11 @@ export interface ScoreUpdate {
    * `scoresByProfile` untouched.
    */
   scoresByProfile?: Partial<Record<RankProfile, number>>;
+  /**
+   * Agentic tool-calling capability (see `PoolEntry.toolCalling`), written once the scheduler has
+   * probed it. Optional so callers that don't probe leave the entry's existing value untouched.
+   */
+  toolCalling?: boolean;
 }
 
 export interface AllowCheckRequest {
@@ -593,6 +598,7 @@ export class PoolManager {
           ...(update.scoresByProfile !== undefined
             ? { scoresByProfile: update.scoresByProfile }
             : {}),
+          ...(update.toolCalling !== undefined ? { toolCalling: update.toolCalling } : {}),
         };
       }),
     }));

--- a/packages/local-models/src/pool/provider.ts
+++ b/packages/local-models/src/pool/provider.ts
@@ -29,15 +29,34 @@ function scoreForProfile(entry: PoolEntry, profile?: RankProfile): number {
   return entry.currentScore;
 }
 
+/** Options for {@link poolStateToCandidates}. */
+export interface PoolCandidateOptions {
+  /**
+   * When true, drop entries KNOWN not to drive an agentic build (`toolCalling === false`),
+   * keeping those that can (`true`) or are unprobed (`undefined`, fail-open). Set only for
+   * agentic BUILD routing — never for triage/classification, which needs no tool-calling.
+   */
+  requireToolCalling?: boolean;
+}
+
 /**
  * Derive the resolver candidate list from pool state: entries ordered by score
  * descending, mapped to `ollamaName`. When `profile` is given, entries order by
  * their per-profile score (falling back to `currentScore`) so a task-tagged
  * dispatch prefers the profile's best-fit model; `ollamaName` breaks ties for a
- * stable order. Pure; does not mutate the input.
+ * stable order. With `opts.requireToolCalling`, entries known NOT to tool-call are
+ * excluded first (fail-open on unknowns). Pure; does not mutate the input.
  */
-export function poolStateToCandidates(state: PoolState, profile?: RankProfile): string[] {
-  return [...state.entries]
+export function poolStateToCandidates(
+  state: PoolState,
+  profile?: RankProfile,
+  opts?: PoolCandidateOptions
+): string[] {
+  const entries =
+    opts?.requireToolCalling === true
+      ? state.entries.filter((e) => e.toolCalling !== false) // keep true + undefined (fail-open)
+      : state.entries;
+  return [...entries]
     .sort((a, b) => {
       const diff = scoreForProfile(b, profile) - scoreForProfile(a, profile);
       if (diff !== 0) return diff;

--- a/packages/local-models/src/pool/types.ts
+++ b/packages/local-models/src/pool/types.ts
@@ -49,6 +49,17 @@ export interface PoolEntry {
    * task-tagged dispatch. Absent ⇒ selection falls back to `currentScore`.
    */
   scoresByProfile?: Partial<Record<RankProfile, number>>;
+  /**
+   * Whether this model can drive an AGENTIC build — i.e. it emits native OpenAI
+   * `tool_calls` (not the call rendered as text, which the coding-agent SDK can't
+   * parse). Determined by `probeToolCalling` (a cheap `/api/show` capability gate
+   * + one tool-schema inference call) and written back by the scheduler re-score.
+   * Optional + additive (round-trips via `cloneEntry`'s spread; the loader tolerates
+   * its absence). Consumed by `poolStateToCandidates(state, profile, {requireToolCalling})`
+   * to keep an agentic BUILD from routing to a text-only model. Absent ⇒ unknown ⇒
+   * NOT filtered (fail-open; only `false` excludes). Triage/classification never sets it.
+   */
+  toolCalling?: boolean;
 }
 
 /**

--- a/packages/local-models/src/scheduler/refresh.ts
+++ b/packages/local-models/src/scheduler/refresh.ts
@@ -62,6 +62,13 @@ export interface RefreshTickDeps {
   proposalThreshold: number;
   /** VRAM budget forwarded to the justification renderer. Defaults to `hardware.vramGb`. */
   vramGb?: number;
+  /**
+   * Optional agentic tool-calling probe (a `probeToolCalling` binding over the local endpoint,
+   * wired by the composition root). Called ONCE per model whose capability is still unknown
+   * (`toolCalling === undefined`) during score writeback, so a build never routes to a text-only
+   * model. Absent ⇒ no probing (capability stays unknown ⇒ fail-open in candidate selection).
+   */
+  probeToolCalling?: (ollamaName: string) => Promise<boolean | undefined>;
 }
 
 /** Structured metrics for one tick — the body of the O1 log line. */
@@ -221,10 +228,19 @@ async function writeBackScores(
   for (const entry of deps.poolManager.snapshot().entries) {
     const model = byName.get(entry.ollamaName);
     if (model !== undefined) {
+      // Probe agentic tool-calling ONCE per model (only while still unknown) — a stable model
+      // property, so we never re-probe a decided entry. A probe error leaves it unknown to retry.
+      let toolCalling: boolean | undefined;
+      if (entry.toolCalling === undefined && deps.probeToolCalling !== undefined) {
+        toolCalling = await tryStage(`probeToolCalling ${entry.ollamaName}`, errors, () =>
+          deps.probeToolCalling!(entry.ollamaName)
+        );
+      }
       updates.push({
         ollamaName: entry.ollamaName,
         currentScore: model.score,
         scoresByProfile: { ...model.scoresByProfile },
+        ...(toolCalling !== undefined ? { toolCalling } : {}),
       });
     }
   }

--- a/packages/local-models/tests/capability/tool-calling.test.ts
+++ b/packages/local-models/tests/capability/tool-calling.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { probeToolCalling } from '../../src/capability/tool-calling.js';
+
+/**
+ * Build a fake `fetch` that routes `/api/show` and `/v1/chat/completions` to configurable
+ * responses. `show.capabilities` gates whether the (more expensive) chat probe even runs.
+ */
+function fakeFetch(cfg: {
+  showOk?: boolean;
+  capabilities?: string[];
+  chatOk?: boolean;
+  toolCalls?: unknown[] | null; // null ⇒ text-only response (no tool_calls field)
+  throwOn?: 'show' | 'chat';
+}) {
+  return vi.fn(async (url: string) => {
+    const isShow = url.includes('/api/show');
+    if (cfg.throwOn === 'show' && isShow) throw new Error('ECONNREFUSED');
+    if (cfg.throwOn === 'chat' && !isShow) throw new Error('ECONNREFUSED');
+    if (isShow) {
+      return {
+        ok: cfg.showOk ?? true,
+        json: async () => ({ capabilities: cfg.capabilities ?? [] }),
+      } as unknown as Response;
+    }
+    // /v1/chat/completions
+    const message =
+      cfg.toolCalls === null ? { content: '{"name":"write_file"}' } : { tool_calls: cfg.toolCalls };
+    return {
+      ok: cfg.chatOk ?? true,
+      json: async () => ({ choices: [{ message }] }),
+    } as unknown as Response;
+  });
+}
+
+const BASE = 'http://127.0.0.1:11434/v1';
+
+describe('probeToolCalling', () => {
+  it('returns false WITHOUT an inference call when /api/show lacks the tools capability', async () => {
+    const f = fakeFetch({ capabilities: ['completion', 'insert'] });
+    const result = await probeToolCalling({ model: 'no-tools:1b', baseUrl: BASE, fetchImpl: f });
+    expect(result).toBe(false);
+    expect(f).toHaveBeenCalledTimes(1); // only /api/show — the free negative, no /v1 probe
+    expect(f.mock.calls[0]![0]).toContain('/api/show');
+  });
+
+  it('returns true when tools-capable AND the model emits native tool_calls', async () => {
+    const f = fakeFetch({
+      capabilities: ['completion', 'tools'],
+      toolCalls: [{ function: { name: 'write_file' } }],
+    });
+    expect(await probeToolCalling({ model: 'qwen3:32b', baseUrl: BASE, fetchImpl: f })).toBe(true);
+    expect(f).toHaveBeenCalledTimes(2); // /api/show then /v1
+  });
+
+  it('returns FALSE when tools-capable but the model emits the call as TEXT (no tool_calls) — the coder-7b case', async () => {
+    const f = fakeFetch({ capabilities: ['completion', 'tools', 'insert'], toolCalls: null });
+    expect(await probeToolCalling({ model: 'qwen2.5-coder:7b', baseUrl: BASE, fetchImpl: f })).toBe(
+      false
+    );
+  });
+
+  it('returns false for an empty tool_calls array', async () => {
+    const f = fakeFetch({ capabilities: ['tools'], toolCalls: [] });
+    expect(await probeToolCalling({ model: 'x', baseUrl: BASE, fetchImpl: f })).toBe(false);
+  });
+
+  it('returns undefined (unknown) when /api/show is unreachable', async () => {
+    const f = fakeFetch({ throwOn: 'show' });
+    expect(await probeToolCalling({ model: 'x', baseUrl: BASE, fetchImpl: f })).toBeUndefined();
+  });
+
+  it('returns undefined (unknown) when /api/show returns non-2xx', async () => {
+    const f = fakeFetch({ showOk: false });
+    expect(await probeToolCalling({ model: 'x', baseUrl: BASE, fetchImpl: f })).toBeUndefined();
+  });
+
+  it('returns undefined (unknown) when the chat probe errors', async () => {
+    const f = fakeFetch({ capabilities: ['tools'], throwOn: 'chat' });
+    expect(await probeToolCalling({ model: 'x', baseUrl: BASE, fetchImpl: f })).toBeUndefined();
+  });
+
+  it('derives /api/show from the /v1 base URL', async () => {
+    const f = fakeFetch({
+      capabilities: ['tools'],
+      toolCalls: [{ function: { name: 'write_file' } }],
+    });
+    await probeToolCalling({ model: 'x', baseUrl: 'http://host:11434/v1', fetchImpl: f });
+    expect(f.mock.calls[0]![0]).toBe('http://host:11434/api/show');
+    expect(f.mock.calls[1]![0]).toBe('http://host:11434/v1/chat/completions');
+  });
+});

--- a/packages/local-models/tests/pool/manager.test.ts
+++ b/packages/local-models/tests/pool/manager.test.ts
@@ -680,6 +680,17 @@ describe('PoolManager — bookkeeping seams', () => {
     await manager.updateScores([{ ollamaName: 'ghost', currentScore: 99 }]);
     expect(fs.ops.filter((o) => o.op === 'rename')).toEqual([]);
   });
+
+  it('updateScores stamps toolCalling when supplied and leaves it untouched when omitted', async () => {
+    const seeded = seededState({}, [entry({ ollamaName: 'a', currentScore: 10 })]);
+    const { manager } = await makeManager(seeded);
+    await manager.updateScores([{ ollamaName: 'a', currentScore: 88, toolCalling: true }]);
+    const find = () => manager.snapshot().entries.find((e) => e.ollamaName === 'a');
+    expect(find()?.toolCalling).toBe(true);
+    // A later score-only update must NOT wipe the probed capability.
+    await manager.updateScores([{ ollamaName: 'a', currentScore: 90 }]);
+    expect(find()?.toolCalling).toBe(true);
+  });
 });
 
 describe('PoolManager — configurePool + snapshot + isAllowed (Phase 7 seams)', () => {

--- a/packages/local-models/tests/pool/provider.test.ts
+++ b/packages/local-models/tests/pool/provider.test.ts
@@ -67,6 +67,87 @@ describe('poolStateToCandidates', () => {
   });
 });
 
+describe('poolStateToCandidates — requireToolCalling filter (agentic build gate)', () => {
+  const withTool = (name: string, score: number, toolCalling?: boolean): PoolEntry => ({
+    ...entry(name, score),
+    ...(toolCalling !== undefined ? { toolCalling } : {}),
+  });
+
+  it('excludes entries KNOWN not to tool-call (toolCalling === false)', () => {
+    const state: PoolState = {
+      ...EmptyPoolState(),
+      entries: [withTool('coder:7b', 90, false), withTool('qwen3:32b', 50, true)],
+    };
+    // coder:7b outranks 32b by score but can't tool-call → dropped for a build.
+    expect(poolStateToCandidates(state, undefined, { requireToolCalling: true })).toEqual([
+      'qwen3:32b',
+    ]);
+  });
+
+  it('KEEPS entries with unknown capability (toolCalling === undefined) — fail-open', () => {
+    const state: PoolState = {
+      ...EmptyPoolState(),
+      entries: [withTool('unprobed:8b', 80), withTool('qwen3:32b', 50, true)],
+    };
+    expect(poolStateToCandidates(state, undefined, { requireToolCalling: true })).toEqual([
+      'unprobed:8b',
+      'qwen3:32b',
+    ]);
+  });
+
+  it('does NOT filter when requireToolCalling is absent/false (byte-identical to before)', () => {
+    const state: PoolState = {
+      ...EmptyPoolState(),
+      entries: [withTool('coder:7b', 90, false), withTool('qwen3:32b', 50, true)],
+    };
+    expect(poolStateToCandidates(state)).toEqual(['coder:7b', 'qwen3:32b']);
+    expect(poolStateToCandidates(state, undefined, { requireToolCalling: false })).toEqual([
+      'coder:7b',
+      'qwen3:32b',
+    ]);
+  });
+
+  it('preserves score ordering among the survivors', () => {
+    const state: PoolState = {
+      ...EmptyPoolState(),
+      entries: [
+        withTool('a:8b', 30, true),
+        withTool('dud:7b', 99, false),
+        withTool('b:32b', 60, true),
+      ],
+    };
+    expect(poolStateToCandidates(state, undefined, { requireToolCalling: true })).toEqual([
+      'b:32b',
+      'a:8b',
+    ]);
+  });
+
+  it('round-trips toolCalling through PoolStateStore persist/load (additive field)', async () => {
+    const fs = new Map<string, string>();
+    const backend = {
+      readFile: async (p: string) => {
+        const v = fs.get(p);
+        if (v === undefined) throw Object.assign(new Error('nf'), { code: 'ENOENT' });
+        return v;
+      },
+      writeFile: async (p: string, c: string) => void fs.set(p, c),
+      rename: async (from: string, to: string) => {
+        fs.set(to, fs.get(from)!);
+        fs.delete(from);
+      },
+      mkdir: async () => undefined,
+    };
+    const store = new PoolStateStore({ path: '/pool.json', fs: backend });
+    await store.load();
+    store.update((s) => ({ ...s, entries: [withTool('qwen3:32b', 50, true)] }));
+    await store.persist();
+
+    const reloaded = new PoolStateStore({ path: '/pool.json', fs: backend });
+    await reloaded.load();
+    expect(reloaded.snapshot().entries[0]?.toolCalling).toBe(true);
+  });
+});
+
 describe('PoolStateProvider structural conformance', () => {
   it('PoolStateStore satisfies PoolStateProvider', () => {
     const provider: PoolStateProvider = new PoolStateStore();

--- a/packages/local-models/tests/scheduler/refresh.test.ts
+++ b/packages/local-models/tests/scheduler/refresh.test.ts
@@ -150,6 +150,31 @@ describe('runRefreshTick (reconcile → rescore → diff → emit)', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('probes and stamps toolCalling once for an unknown-capability entry', async () => {
+    const pool = await seededPool(baseState(), [{ ollamaName: 'old:8b', sizeOnDiskGb: 20 }]);
+    const ranked = [
+      rankedModel({ ollamaName: 'old:8b', hfRepoId: 'Qwen/Qwen3-8B-GGUF', sizeB: 8, score: 62 }),
+    ];
+    const probed: string[] = [];
+    const deps: RefreshTickDeps = {
+      detectHardware: async () => HARDWARE,
+      recommend: async () => recommendResult(ranked),
+      poolManager: pool,
+      dedupSource: async () => ({ pending: [], rejected: [] }),
+      emitProposal: async () => undefined,
+      proposalThreshold: 5,
+      probeToolCalling: async (name) => {
+        probed.push(name);
+        return true;
+      },
+    };
+
+    await runRefreshTick(deps);
+
+    expect(probed).toEqual(['old:8b']); // probed once for the unknown-capability entry
+    expect(pool.snapshot().entries.find((e) => e.ollamaName === 'old:8b')?.toolCalling).toBe(true);
+  });
+
   it('T14: writes per-profile scores back onto the pooled entry', async () => {
     const pool = await seededPool(baseState(), [{ ollamaName: 'old:8b', sizeOnDiskGb: 20 }]);
     const ranked = [

--- a/packages/orchestrator/src/agent/local-model-resolver.ts
+++ b/packages/orchestrator/src/agent/local-model-resolver.ts
@@ -1,5 +1,9 @@
 import type { LocalModelStatus, RoutingUseCase } from '@harness-engineering/types';
-import type { PoolStateProvider, RankProfile } from '@harness-engineering/local-models';
+import type {
+  PoolStateProvider,
+  RankProfile,
+  PoolCandidateOptions,
+} from '@harness-engineering/local-models';
 import { poolStateToCandidates } from '@harness-engineering/local-models';
 
 /**
@@ -346,7 +350,10 @@ export class LocalModelResolver {
     if (profile === 'general') return this.resolved;
     // Re-select from the last-probed detected set ordered by the profile score.
     // No re-probe: `this.detected` reflects the most recent poll/refresh.
-    return this.selectMatch(this.candidates(profile), this.detected);
+    // A non-`general` profile here is ALWAYS a `tier` use-case (execution) — i.e. an AGENTIC
+    // dispatch that needs a model which emits native tool_calls. Exclude models known not to
+    // (fail-open on unprobed ones) so a build never routes to a text-only model.
+    return this.selectMatch(this.candidates(profile, { requireToolCalling: true }), this.detected);
   }
 
   getStatus(): LocalModelStatus {
@@ -366,9 +373,9 @@ export class LocalModelResolver {
    * from pool entries (currentScore desc → ollamaName); otherwise the static
    * `configured` list is returned unchanged (byte-identical to pre-Phase-4).
    */
-  private candidates(profile?: RankProfile): string[] {
+  private candidates(profile?: RankProfile, opts?: PoolCandidateOptions): string[] {
     return this.poolState
-      ? poolStateToCandidates(this.poolState.snapshot(), profile)
+      ? poolStateToCandidates(this.poolState.snapshot(), profile, opts)
       : [...this.configured];
   }
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -66,6 +66,7 @@ import {
   loadFrozenCandidates,
   selectCandidates,
   curationFromCandidates,
+  probeToolCalling,
 } from '@harness-engineering/local-models';
 import type {
   PoolStateProvider,
@@ -3075,6 +3076,19 @@ export class Orchestrator extends EventEmitter {
     // makes the change take effect on the next tick and the next route call.
     this.seedRecommender(candidates, 'frozen');
     const recommend = (hardware: HardwareProfile) => this.modelRecommender!(hardware);
+    // Bind the agentic tool-calling probe to the local backend's endpoint so the score
+    // writeback can stamp each pooled model's capability once — keeping a build from routing
+    // to a text-only model (see `PoolEntry.toolCalling`). Absent local endpoint ⇒ no probe
+    // (capability stays unknown ⇒ fail-open in candidate selection).
+    let localEndpoint: string | undefined;
+    let localApiKey: string | undefined;
+    for (const def of Object.values(this.config.agent.backends ?? {})) {
+      if ((def.type === 'local' || def.type === 'pi') && typeof def.endpoint === 'string') {
+        localEndpoint = def.endpoint;
+        localApiKey = def.apiKey;
+        break;
+      }
+    }
     this.refreshScheduler = new RefreshScheduler({
       runTick: () =>
         runRefreshTick({
@@ -3095,6 +3109,16 @@ export class Orchestrator extends EventEmitter {
               });
             }),
           proposalThreshold: refreshCfg?.proposalThreshold ?? 5,
+          ...(localEndpoint !== undefined
+            ? {
+                probeToolCalling: (ollamaName: string) =>
+                  probeToolCalling({
+                    model: ollamaName,
+                    baseUrl: localEndpoint,
+                    ...(localApiKey !== undefined ? { apiKey: localApiKey } : {}),
+                  }),
+              }
+            : {}),
         }).then((result) => {
           // S1 drain liveness (P7-SUG-DRAIN-LIVENESS): run completion is the
           // primary drain trigger, but if the final run's evict fails

--- a/packages/orchestrator/tests/agent/local-model-resolver.test.ts
+++ b/packages/orchestrator/tests/agent/local-model-resolver.test.ts
@@ -936,6 +936,46 @@ describe('LocalModelResolver — task-aware resolveModel (T16)', () => {
     expect(resolver.resolveModel({ kind: 'tier', tier: 'diagnostic' })).toBe('generalist:32b');
   });
 
+  it('a build (tier) use-case EXCLUDES a model known not to tool-call, even if it scores higher', async () => {
+    const poolState: PoolStateProvider = {
+      snapshot: () => ({
+        ...EmptyPoolState(),
+        entries: [
+          {
+            ollamaName: 'coder:7b',
+            hfRepoId: 'Org/coder',
+            sizeOnDiskGb: 1,
+            installedAt: '2026-07-07T00:00:00.000Z',
+            lastUsedAt: null,
+            currentScore: 95,
+            scoresByProfile: { coding: 95 },
+            toolCalling: false, // emits tool calls as text → can't drive a build
+          },
+          {
+            ollamaName: 'qwen3:32b',
+            hfRepoId: 'Org/qwen3',
+            sizeOnDiskGb: 1,
+            installedAt: '2026-07-07T00:00:00.000Z',
+            lastUsedAt: null,
+            currentScore: 60,
+            scoresByProfile: { coding: 60 },
+            toolCalling: true,
+          },
+        ],
+      }),
+    };
+    const resolver = new LocalModelResolver({
+      endpoint: 'http://localhost:11434/v1',
+      configured: [],
+      poolState,
+      fetchModels: async () => ['coder:7b', 'qwen3:32b'], // both loaded
+    });
+    await resolver.probe();
+
+    // coder:7b wins on coding score but can't tool-call → a BUILD (tier) routes to qwen3:32b.
+    expect(resolver.resolveModel({ kind: 'tier', tier: 'quick-fix' })).toBe('qwen3:32b');
+  });
+
   it('only considers loaded models for the profile selection', async () => {
     const poolState = profiledProvider([
       { name: 'coder:7b', currentScore: 60, scoresByProfile: { coding: 95 } },


### PR DESCRIPTION
## What

Bake **agentic tool-calling capability** into the LMLM pool + model selection, so a build never routes to a model that can't drive the coding-agent tool loop. This is the durable fix behind the interim config-ordering band-aid (#832).

## Why

The pool ranked local models purely on benchmark scores. But a model that emits tool calls as **text** (which the pi-coding-agent SDK can't parse — e.g. `qwen2.5-coder:7b`) could rank top for the `coding` profile and then silently **no-op a build**. Capability was invisible to selection.

Verified across all four installed models — `qwen3:8b/32b/70b` emit native `tool_calls`; `qwen2.5-coder:7b` emits text. Ollama's `/api/show` `capabilities` array *claims* `tools` for all four (necessary but **not sufficient**), so metadata alone gives a false positive on the coder — a probe is required.

## How

| Piece | |
|---|---|
| `probeToolCalling` (`local-models`) | Cheap-first: free `/api/show` capability gate, then one `/v1` tool-schema call → does it emit native `tool_calls`? Any failure ⇒ `undefined` (unknown ⇒ fail-open). Deterministic single-call FORMAT probe (unlike the flaky multi-turn loop). |
| `PoolEntry.toolCalling?` | Additive (round-trips via the existing clone/loader); written **once** per model by the scheduler re-score, never re-probed once decided. |
| `poolStateToCandidates(…, { requireToolCalling })` | Excludes `toolCalling === false`; keeps `true` + unprobed (`undefined`, fail-open). |
| `LocalModelResolver` | Requires tool-calling for **agentic (tier) use-cases only** — triage/classification (no tool-calling needed) is untouched. |
| Orchestrator | Binds the probe to the local backend endpoint when starting the refresh scheduler. |

## Design notes

- **Capability (deterministic) vs reliability (learned) are kept separate.** This probe is the deterministic pre-filter. Hard failures already flow to the resolver's circuit breaker; soft build-quality is the retrospective/outcome loop's job (future).
- **Fail-open on unknowns** so a probe hiccup never starves build routing; only a *confirmed* `false` excludes.

## Tests

TDD throughout: probe (8), candidate filter + round-trip (6), `updateScores` persistence (1), scheduler population (1), resolver exclusion (1). Full local-models suite (346) + resolver/backend suites (80) green; typecheck clean.

**Live-verified:** `probeToolCalling` returns `false` for `qwen2.5-coder:7b`, `true` for `qwen3:8b`/`qwen3:32b`.

## Relationship to #832

#832 (lead the config fallback with a tool-calling model) becomes belt-and-suspenders — the pool now *knows* which models can build, on any hardware, without hand-ordering a list.
