### PR TITLE
feat(eslint-plugin): add no-undefined-optional-assignment rule

### DIFF
--- a/.changeset/eslint-no-undefined-optional-assignment.md
+++ b/.changeset/eslint-no-undefined-optional-assignment.md
@@ -1,0 +1,17 @@
+---
+'@harness-engineering/eslint-plugin': minor
+---
+
+feat(eslint-plugin): add `no-undefined-optional-assignment` rule
+
+Flags an object-literal property whose value is a variable declared `T | undefined` assigned
+directly (e.g. `{ field: maybeUndefined }`), which breaks `exactOptionalPropertyTypes`, and points
+at the conditional-spread form `...(value !== undefined && { field: value })`. Sound + syntactic
+(keys off the DECLARED annotation, since this plugin's RuleTester runs without type info): it flags
+`let x: T | undefined; { field: x }` and typed `T | undefined` params, exempts the already-guarded
+`(x !== undefined && { field: x })` form, and stays silent when the annotation is absent
+(unknown ⇒ no false positive).
+
+Authored as the human-review completion of an autonomous local-model draft (the model produced a
+plausible type-aware attempt that didn't fit this repo's syntactic-only test infra and failed
+typecheck).

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -11,6 +11,7 @@ import noUnixShellCommand from './no-unix-shell-command';
 import noHardcodedPathSeparator from './no-hardcoded-path-separator';
 import noProcessEnvInSpawn from './no-process-env-in-spawn';
 import requirePathNormalization from './require-path-normalization';
+import noUndefinedOptionalAssignment from './no-undefined-optional-assignment';
 
 export const rules = {
   'enforce-doc-exports': enforceDocExports,
@@ -21,6 +22,7 @@ export const rules = {
   'no-nested-loops-in-critical': noNestedLoopsInCritical,
   'no-process-env-in-spawn': noProcessEnvInSpawn,
   'no-sync-io-in-async': noSyncIoInAsync,
+  'no-undefined-optional-assignment': noUndefinedOptionalAssignment,
   'no-unbounded-array-chains': noUnboundedArrayChains,
   'no-unix-shell-command': noUnixShellCommand,
   'require-boundary-schema': requireBoundarySchema,

--- a/packages/eslint-plugin/src/rules/no-undefined-optional-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-undefined-optional-assignment.ts
@@ -1,0 +1,108 @@
+// src/rules/no-undefined-optional-assignment.ts
+import { ESLintUtils, type TSESTree, type TSESLint } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/harness-engineering/eslint-plugin/blob/main/docs/rules/${name}.md`
+);
+
+type MessageIds = 'undefinedOptionalAssignment';
+
+/**
+ * True when a type annotation is a union that spells out `undefined` (e.g. `string | undefined`).
+ * Purely syntactic — this plugin's RuleTester runs WITHOUT type information (no `parserServices`),
+ * so the rule keys off the DECLARED annotation rather than the inferred type. Sound but narrow:
+ * it flags the common `let x: T | undefined; return { field: x }` gotcha and stays silent when the
+ * annotation is absent (unknown ⇒ no false positive).
+ */
+function unionIncludesUndefined(typeNode: TSESTree.TypeNode | undefined): boolean {
+  return (
+    typeNode?.type === 'TSUnionType' && typeNode.types.some((t) => t.type === 'TSUndefinedKeyword')
+  );
+}
+
+/**
+ * The declared type annotation of the variable `identifier` resolves to (its nearest def), if any.
+ * `def.name` is the declared Identifier for both `let`/`const` declarators and function params and
+ * carries the `x: T | undefined` annotation.
+ */
+function declaredType(
+  identifier: TSESTree.Identifier,
+  scope: TSESLint.Scope.Scope
+): TSESTree.TypeNode | undefined {
+  const ref = scope.references.find((r) => r.identifier === identifier);
+  const name = ref?.resolved?.defs[0]?.name;
+  // `name` is a BindingName | StringLiteral; only a plain Identifier carries `x: T` here
+  // (destructuring patterns and string-keyed defs never spell out `| undefined` this way).
+  if (name?.type !== 'Identifier') return undefined;
+  return name.typeAnnotation?.typeAnnotation;
+}
+
+/** True for `name !== undefined` / `name != null` (either operand order). */
+function checksDefined(expr: TSESTree.Node, name: string): boolean {
+  if (expr.type !== 'BinaryExpression' || (expr.operator !== '!==' && expr.operator !== '!=')) {
+    return false;
+  }
+  const refsName = (n: TSESTree.Node): boolean => n.type === 'Identifier' && n.name === name;
+  const isNullish = (n: TSESTree.Node): boolean =>
+    (n.type === 'Identifier' && n.name === 'undefined') ||
+    (n.type === 'Literal' && n.value === null);
+  return (
+    (refsName(expr.left) && isNullish(expr.right)) || (refsName(expr.right) && isNullish(expr.left))
+  );
+}
+
+/**
+ * True when an enclosing `&&` already guards `name` against undefined/null — i.e. the code is
+ * ALREADY using the recommended `...(name !== undefined && { field: name })` form, which must not
+ * be flagged.
+ */
+function isGuarded(node: TSESTree.Node, name: string): boolean {
+  for (let cur = node.parent; cur; cur = cur.parent) {
+    if (
+      cur.type === 'LogicalExpression' &&
+      cur.operator === '&&' &&
+      checksDefined(cur.left, name)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export default createRule<[], MessageIds>({
+  name: 'no-undefined-optional-assignment',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow assigning a possibly-undefined variable directly to an object property, which ' +
+        'breaks `exactOptionalPropertyTypes`; use a conditional spread instead.',
+    },
+    messages: {
+      undefinedOptionalAssignment:
+        "Assigning possibly-undefined '{{name}}' directly to '{{field}}' breaks " +
+        'exactOptionalPropertyTypes. Use a conditional spread: ' +
+        "...({{name}} !== undefined && {{ '{' }} {{field}}: {{name}} {{ '}' }}).",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      Property(node) {
+        if (node.computed || node.value.type !== 'Identifier') return;
+        if (node.key.type !== 'Identifier' && node.key.type !== 'Literal') return;
+        const value = node.value;
+        const scope = context.sourceCode.getScope(value);
+        if (!unionIncludesUndefined(declaredType(value, scope))) return;
+        if (isGuarded(node, value.name)) return; // already the recommended conditional-spread form
+        const field = node.key.type === 'Identifier' ? node.key.name : String(node.key.value);
+        context.report({
+          node: value,
+          messageId: 'undefinedOptionalAssignment',
+          data: { name: value.name, field },
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/integration/plugin.test.ts
+++ b/packages/eslint-plugin/tests/integration/plugin.test.ts
@@ -3,8 +3,9 @@ import { describe, it, expect } from 'vitest';
 import plugin from '../../src/index';
 
 describe('plugin exports', () => {
-  it('exports all 12 rules', () => {
-    expect(Object.keys(plugin.rules)).toHaveLength(12);
+  it('exports all 13 rules', () => {
+    expect(Object.keys(plugin.rules)).toHaveLength(13);
+    expect(plugin.rules['no-undefined-optional-assignment']).toBeDefined();
     expect(plugin.rules['no-layer-violation']).toBeDefined();
     expect(plugin.rules['no-circular-deps']).toBeDefined();
     expect(plugin.rules['no-forbidden-imports']).toBeDefined();

--- a/packages/eslint-plugin/tests/rules/no-undefined-optional-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-undefined-optional-assignment.test.ts
@@ -1,0 +1,53 @@
+// tests/rules/no-undefined-optional-assignment.test.ts
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll } from 'vitest';
+import rule from '../../src/rules/no-undefined-optional-assignment';
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-undefined-optional-assignment', rule, {
+  valid: [
+    // A non-optional typed variable is safe to assign directly.
+    { code: `let v: string = 'x'; const o = { field: v };` },
+    // The conditional-spread form the rule recommends — not a direct property, so not flagged.
+    { code: `let v: string | undefined; const o = { ...(v !== undefined && { field: v }) };` },
+    // No type annotation ⇒ unknown ⇒ no false positive (the rule is deliberately narrow).
+    { code: `let v = maybe(); const o = { field: v };` },
+    // A literal/non-identifier value is out of scope.
+    { code: `const o = { field: 'literal' };` },
+    // A union WITHOUT undefined is fine.
+    { code: `let v: string | number; const o = { field: v };` },
+    // Guard via `!= null` (loose) is also accepted.
+    { code: `let v: string | undefined; const o = { ...(v != null && { field: v }) };` },
+    // Guard with the operands reversed (`undefined !== v`).
+    { code: `let v: string | undefined; const o = { ...(undefined !== v && { field: v }) };` },
+    // A computed key is out of scope (we can't name the field).
+    { code: `const k = 'x'; let v: string | undefined; const o = { [k]: v };` },
+  ],
+  invalid: [
+    // `let x: T | undefined` assigned directly to a property.
+    {
+      code: `let v: string | undefined; const o = { field: v };`,
+      errors: [{ messageId: 'undefinedOptionalAssignment' }],
+    },
+    // A function parameter typed `T | undefined`.
+    {
+      code: `function f(v: number | undefined) { return { count: v }; }`,
+      errors: [{ messageId: 'undefinedOptionalAssignment' }],
+    },
+    // Shorthand-style resolves to the same Identifier value.
+    {
+      code: `let field: string | undefined; const o = { field: field };`,
+      errors: [{ messageId: 'undefinedOptionalAssignment' }],
+    },
+    // A string-literal key (exercises the Literal-key branch).
+    {
+      code: `let v: string | undefined; const o = { 'field': v };`,
+      errors: [{ messageId: 'undefinedOptionalAssignment' }],
+    },
+  ],
+});


### PR DESCRIPTION
## What
Adds the `no-undefined-optional-assignment` ESLint rule (roadmap item): flags `{ field: maybeUndefined }` where the value is declared `T | undefined` (breaks `exactOptionalPropertyTypes`) and points at `...(value !== undefined && { field: value })`.

## Design
Sound + **syntactic** (keys off the *declared* annotation) because this plugin's `RuleTester` runs **without** type info. Flags `let x: T | undefined; { field: x }` and `T | undefined` params; **exempts** the already-guarded `(x !== undefined && { field: x })` / `(x != null && …)` form; silent when the annotation is absent (unknown ⇒ no false positive). 13 rule tests + full plugin suite green; typecheck + coverage-ratchet clean.

## Provenance
The **human-review completion of an autonomous local-model draft**. A local model (qwen3:32b via the pi-coding-agent path) produced a plausible but type-aware-and-untestable-here attempt that stopped before registering/testing and failed typecheck. NOTE: that draft was produced by a *bare* agentic run — NOT through the harness brainstorm→spec→plan→autopilot→review pipeline — so it is not a fair model-quality comparison; it tests raw tool-loop capability only.