### PR TITLE
feat(orchestrator): native OllamaBackend — a driver that actually works for local models

### DIFF
--- a/.changeset/ollama-backend.md
+++ b/.changeset/ollama-backend.md
@@ -1,0 +1,17 @@
+---
+'@harness-engineering/types': minor
+'@harness-engineering/orchestrator': minor
+---
+
+feat(orchestrator): add native Ollama agentic backend
+
+Add a production `OllamaBackend` (`type: 'ollama'`) that owns its
+`/v1/chat/completions` tool loop instead of embedding the pi-coding-agent SDK.
+`startSession` seeds conversation state with a system prompt; `runTurn` drives
+the inner agentic loop (call model → execute native `tool_calls`
+[`bash`/`write_file`/`read_file`, sandboxed to the workspace with
+path-traversal rejection] → append tool results → repeat until the model stops
+calling tools), yielding `tool_execution_start`/`tool_execution_end`/`usage`
+events and accumulating token usage. Wired through the config schema, the
+backend factory, and the analysis-provider factory. This drives Ollama-served
+tool-calling models (e.g. qwen3) that the pi/codex SDKs fail against.

--- a/packages/orchestrator/src/agent/analysis-provider-factory.ts
+++ b/packages/orchestrator/src/agent/analysis-provider-factory.ts
@@ -93,6 +93,7 @@ export function buildAnalysisProvider(args: BuildAnalysisProviderArgs): Analysis
   switch (def.type) {
     case 'local':
     case 'pi':
+    case 'ollama':
       return buildLocalLikeProvider(def, args, layerModel);
     case 'anthropic':
       return buildAnthropicProvider(def, args, layerModel);
@@ -112,7 +113,7 @@ export function buildAnalysisProvider(args: BuildAnalysisProviderArgs): Analysis
 }
 
 function buildLocalLikeProvider(
-  def: Extract<BackendDef, { type: 'local' | 'pi' }>,
+  def: Extract<BackendDef, { type: 'local' | 'pi' | 'ollama' }>,
   args: BuildAnalysisProviderArgs,
   layerModel: string | undefined
 ): AnalysisProvider | null {

--- a/packages/orchestrator/src/agent/backend-factory.ts
+++ b/packages/orchestrator/src/agent/backend-factory.ts
@@ -7,6 +7,7 @@ import { OpenAIBackend } from './backends/openai.js';
 import { GeminiBackend } from './backends/gemini.js';
 import { LocalBackend } from './backends/local.js';
 import { PiBackend } from './backends/pi.js';
+import { OllamaBackend } from './backends/ollama.js';
 import { SshBackend } from './backends/ssh.js';
 import { OciServerlessBackend } from './backends/serverless.js';
 
@@ -90,6 +91,16 @@ function createPiBackend(def: BackendDefOf<'pi'>): AgentBackend {
   });
 }
 
+function createOllamaBackend(def: BackendDefOf<'ollama'>): AgentBackend {
+  return new OllamaBackend({
+    endpoint: def.endpoint,
+    model: def.model,
+    ...(def.apiKey !== undefined ? { apiKey: def.apiKey } : {}),
+    ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
+    ...(def.maxTurnsPerRun !== undefined ? { maxTurnsPerRun: def.maxTurnsPerRun } : {}),
+  });
+}
+
 function createSshBackend(def: BackendDefOf<'ssh'>): AgentBackend {
   return new SshBackend({
     host: def.host,
@@ -144,6 +155,8 @@ export function createBackend(def: BackendDef, options: CreateBackendOptions = {
       return createLocalBackend(def);
     case 'pi':
       return createPiBackend(def);
+    case 'ollama':
+      return createOllamaBackend(def);
     case 'ssh':
       return createSshBackend(def);
     case 'serverless':

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -1,0 +1,514 @@
+import { randomUUID } from 'node:crypto';
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  AgentBackend,
+  SessionStartParams,
+  AgentSession,
+  TurnParams,
+  AgentEvent,
+  TurnResult,
+  Result,
+  Ok,
+  Err,
+  AgentError,
+} from '@harness-engineering/types';
+
+/**
+ * Configuration for {@link OllamaBackend}. Mirrors the shape of
+ * {@link import('./pi.js').PiBackendConfig} so a caller can point either backend
+ * at the same local endpoint. Unlike pi (which embeds the pi-coding-agent SDK),
+ * this backend owns its `/v1/chat/completions` tool loop.
+ */
+export interface OllamaBackendConfig {
+  /** Ollama OpenAI-compatible base URL. Default: `http://127.0.0.1:11434/v1`. */
+  endpoint?: string | undefined;
+  /**
+   * Model name(s). A bare string resolves to itself; an array resolves to its
+   * head (prefer-fallback — richer probe-aware resolution lives in Spec 1).
+   */
+  model?: string | string[] | undefined;
+  /** API key threaded as `Authorization: Bearer`. Ollama ignores it. */
+  apiKey?: string | undefined;
+  /**
+   * Per-request timeout in ms for each chat-completion HTTP call. Default:
+   * 600_000. Enforced by an AbortController on `fetch`. `<= 0` disables it.
+   */
+  timeoutMs?: number | undefined;
+  /**
+   * Maximum inner agentic-loop iterations per `runTurn` before the loop bails
+   * with a failed turn. Default: 50.
+   */
+  maxTurnsPerRun?: number | undefined;
+  /**
+   * Called with the resolved model name after a turn completes successfully.
+   * Bound by the orchestrator to `pool.markUsed` (LRU) + the resolver's
+   * circuit-breaker success path. Best-effort — a throwing hook never breaks a
+   * good turn.
+   */
+  onModelUsed?: ((model: string) => void) | undefined;
+  /**
+   * Called with the resolved model name when a turn fails (HTTP error or
+   * timeout). Bound to the resolver's circuit breaker so a repeatedly-failing
+   * model is deprioritized. Best-effort.
+   */
+  onModelFailed?: ((model: string) => void) | undefined;
+}
+
+/** An OpenAI-shaped chat message carried on the session's conversation state. */
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+}
+
+/** A native OpenAI `tool_calls[]` entry as returned by Ollama's chat endpoint. */
+interface ToolCall {
+  id: string;
+  type?: string;
+  function: { name: string; arguments: string };
+}
+
+export interface OllamaSession extends AgentSession {
+  /** Conversation state, seeded with the system prompt at `startSession`. */
+  messages: ChatMessage[];
+  /** Set by `stopSession`; checked between loop iterations to bail early. */
+  aborted: boolean;
+  /** The in-flight per-call AbortController, so `stopSession` can cancel fetch. */
+  activeController: AbortController | null;
+  /** Model name resolved at session start (head-of-array or the string). */
+  resolvedModel: string;
+}
+
+/** Max characters returned from a tool result before truncation. */
+const MAX_TOOL_OUTPUT = 4000;
+
+const DEFAULT_ENDPOINT = 'http://127.0.0.1:11434/v1';
+const DEFAULT_TIMEOUT_MS = 600_000;
+const DEFAULT_MAX_TURNS = 50;
+
+/** Default coding-agent system prompt when the caller supplies none. */
+const DEFAULT_SYSTEM_PROMPT = [
+  'You are an autonomous coding agent working inside a git repository.',
+  'Use the provided tools to explore and edit the codebase. Work in small steps:',
+  'read before you write, implement, then run the test/verify command.',
+  'Do not claim work you have not performed via a tool.',
+  'When the task is fully complete, respond with a final message and no tool call.',
+].join(' ');
+
+/** OpenAI function-tool schemas for the three tools this backend exposes. */
+const TOOL_SCHEMAS = [
+  {
+    type: 'function',
+    function: {
+      name: 'bash',
+      description: 'Run a shell command in the workspace root and get stdout+stderr.',
+      parameters: {
+        type: 'object',
+        properties: { command: { type: 'string' } },
+        required: ['command'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'write_file',
+      description: 'Write (create/overwrite) a file, relative to the workspace root.',
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string' }, content: { type: 'string' } },
+        required: ['path', 'content'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'read_file',
+      description: "Read a file's contents, relative to the workspace root.",
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string' } },
+        required: ['path'],
+      },
+    },
+  },
+] as const;
+
+/** Resolve `model` (string | string[]) to a single model name (head-of-array). */
+function resolveModelName(model: string | string[] | undefined): string | null {
+  if (typeof model === 'string') return model.length > 0 ? model : null;
+  if (Array.isArray(model) && model.length > 0) return model[0] ?? null;
+  return null;
+}
+
+/** Coerce a JSON-parsed tool argument to a string, defaulting to `''`. */
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** Truncate a tool result to keep the conversation from ballooning. */
+function truncate(text: string): string {
+  if (text.length <= MAX_TOOL_OUTPUT) return text;
+  return `${text.slice(0, MAX_TOOL_OUTPUT)}\n…(truncated)`;
+}
+
+/**
+ * Resolve a tool-supplied relative path against the workspace root and reject
+ * traversal that escapes it. Returns the absolute path, or `null` when the
+ * resolved path lands outside `workspacePath` (e.g. `../../etc/passwd`).
+ */
+function resolveInsideWorkspace(workspacePath: string, requested: string): string | null {
+  const root = path.resolve(workspacePath);
+  const resolved = path.resolve(root, requested);
+  const rel = path.relative(root, resolved).replaceAll('\\', '/');
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return resolved;
+}
+
+/**
+ * Native Ollama agentic backend. Owns its `/v1/chat/completions` tool loop:
+ * `startSession` seeds conversation state, `runTurn` drives the inner loop
+ * (call model → execute native `tool_calls` → append results → repeat until the
+ * model returns no tool call), and `stopSession` aborts an in-flight turn.
+ *
+ * The pi/codex SDKs return empty completions / reject tool calls against
+ * Ollama-served tool-calling models; this harness-owned driver drives the same
+ * model correctly. Proven by the standalone prototype it productionizes.
+ */
+export class OllamaBackend implements AgentBackend {
+  readonly name = 'ollama';
+  private config: OllamaBackendConfig;
+  readonly endpoint: string;
+  readonly timeoutMs: number;
+  readonly maxTurnsPerRun: number;
+
+  constructor(config: OllamaBackendConfig = {}) {
+    this.config = config;
+    this.endpoint = config.endpoint ?? DEFAULT_ENDPOINT;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxTurnsPerRun = config.maxTurnsPerRun ?? DEFAULT_MAX_TURNS;
+  }
+
+  async startSession(params: SessionStartParams): Promise<Result<AgentSession, AgentError>> {
+    const resolvedModel = resolveModelName(this.config.model);
+    if (resolvedModel === null) {
+      return Err({
+        category: 'agent_not_found',
+        message: 'No Ollama model configured; set `model` on the backend def.',
+      });
+    }
+
+    const systemPrompt = params.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+    const session: OllamaSession = {
+      sessionId: randomUUID(),
+      workspacePath: params.workspacePath,
+      backendName: this.name,
+      startedAt: new Date().toISOString(),
+      messages: [{ role: 'system', content: systemPrompt }],
+      aborted: false,
+      activeController: null,
+      resolvedModel,
+    };
+    return Ok(session);
+  }
+
+  async *runTurn(
+    session: AgentSession,
+    params: TurnParams
+  ): AsyncGenerator<AgentEvent, TurnResult, void> {
+    const ollamaSession = session as OllamaSession;
+    ollamaSession.aborted = false;
+    ollamaSession.messages.push({ role: 'user', content: params.prompt });
+
+    let inputTokens = 0;
+    let outputTokens = 0;
+
+    const fail = (error: string): TurnResult => {
+      this.notify(this.config.onModelFailed, ollamaSession.resolvedModel);
+      return {
+        success: false,
+        sessionId: session.sessionId,
+        usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
+        error,
+      };
+    };
+
+    for (let iter = 0; iter < this.maxTurnsPerRun; iter++) {
+      if (ollamaSession.aborted) {
+        return fail('Ollama turn aborted by stopSession');
+      }
+
+      let response: OllamaChatResponse;
+      try {
+        response = await this.callModel(ollamaSession);
+      } catch (err) {
+        if (ollamaSession.aborted) return fail('Ollama turn aborted by stopSession');
+        const message = err instanceof Error ? err.message : String(err);
+        yield this.errorEvent(session.sessionId, message);
+        return fail(message);
+      }
+
+      const message = response.choices[0]?.message;
+      if (!message) {
+        return fail('Ollama response contained no message');
+      }
+
+      // Accumulate usage and surface it on a yielded event so the orchestrator
+      // state machine (which reads `event.usage`, not TurnResult.usage) advances
+      // session totals + rate-limit windows.
+      if (response.usage) {
+        inputTokens += response.usage.prompt_tokens ?? 0;
+        outputTokens += response.usage.completion_tokens ?? 0;
+        yield {
+          type: 'usage',
+          timestamp: new Date().toISOString(),
+          sessionId: session.sessionId,
+          usage: {
+            inputTokens,
+            outputTokens,
+            totalTokens: inputTokens + outputTokens,
+          },
+        };
+      }
+
+      const toolCalls = message.tool_calls ?? [];
+
+      // Append the assistant turn (with its tool_calls, if any) to the
+      // conversation before executing tools, mirroring the OpenAI protocol.
+      ollamaSession.messages.push({
+        role: 'assistant',
+        content: message.content ?? '',
+        ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+      });
+
+      // No tool calls → the model gave its final answer. Clean stop.
+      if (toolCalls.length === 0) {
+        this.notify(this.config.onModelUsed, ollamaSession.resolvedModel);
+        return {
+          success: true,
+          sessionId: session.sessionId,
+          usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
+        };
+      }
+
+      for (const toolCall of toolCalls) {
+        const name = toolCall.function.name;
+        const argsJson = toolCall.function.arguments;
+        yield {
+          type: 'tool_execution_start',
+          subtype: name,
+          timestamp: new Date().toISOString(),
+          sessionId: session.sessionId,
+          content: `Calling ${name}(${argsJson})`,
+        };
+
+        const result = await this.executeTool(ollamaSession, name, argsJson);
+
+        yield {
+          type: 'tool_execution_end',
+          subtype: name,
+          timestamp: new Date().toISOString(),
+          sessionId: session.sessionId,
+          content: truncate(result),
+        };
+
+        ollamaSession.messages.push({
+          role: 'tool',
+          tool_call_id: toolCall.id,
+          content: truncate(result),
+        });
+      }
+    }
+
+    return fail(`Ollama turn exceeded maxTurnsPerRun (${this.maxTurnsPerRun})`);
+  }
+
+  /** POST the current conversation + tool schemas and return the parsed response. */
+  private async callModel(session: OllamaSession): Promise<OllamaChatResponse> {
+    const controller = new AbortController();
+    session.activeController = controller;
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    if (this.timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => controller.abort(), this.timeoutMs);
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.config.apiKey !== undefined) {
+      headers.Authorization = `Bearer ${this.config.apiKey}`;
+    }
+
+    try {
+      const res = await fetch(`${this.endpoint}/chat/completions`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          model: session.resolvedModel,
+          messages: session.messages,
+          tools: TOOL_SCHEMAS,
+          stream: false,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`Ollama HTTP ${res.status} ${res.statusText}: ${truncate(body)}`);
+      }
+
+      return (await res.json()) as OllamaChatResponse;
+    } catch (err) {
+      if (controller.signal.aborted && !session.aborted) {
+        throw new Error(`Ollama request timed out after ${this.timeoutMs}ms`, { cause: err });
+      }
+      throw err;
+    } finally {
+      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+      session.activeController = null;
+    }
+  }
+
+  /** Dispatch a single tool call. Never throws — returns an error string instead. */
+  private async executeTool(
+    session: OllamaSession,
+    name: string,
+    argsJson: string
+  ): Promise<string> {
+    let args: Record<string, unknown>;
+    try {
+      args = JSON.parse(argsJson) as Record<string, unknown>;
+    } catch {
+      return `ERROR: could not parse arguments for ${name}: ${argsJson}`;
+    }
+
+    try {
+      switch (name) {
+        case 'bash':
+          return await this.runBash(session.workspacePath, asString(args.command));
+        case 'write_file':
+          return await this.runWriteFile(
+            session.workspacePath,
+            asString(args.path),
+            asString(args.content)
+          );
+        case 'read_file':
+          return await this.runReadFile(session.workspacePath, asString(args.path));
+        default:
+          return `ERROR: unknown tool ${name}`;
+      }
+    } catch (err) {
+      return `ERROR: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  /**
+   * Run a shell command via `execFile('/bin/sh', ['-c', command])` in the
+   * workspace. Using execFile (not exec-with-interpolation) keeps the command
+   * a single opaque argv entry — no shell metacharacter injection beyond the
+   * command the model already authored — satisfying `no-unix-shell-command`.
+   */
+  private runBash(workspacePath: string, command: string): Promise<string> {
+    return new Promise((resolve) => {
+      childProcess.execFile(
+        '/bin/sh',
+        ['-c', command],
+        { cwd: workspacePath, timeout: 300_000, maxBuffer: 10 * 1024 * 1024 },
+        (error, stdout, stderr) => {
+          const combined = `${stdout}${stderr}`;
+          if (error && combined.length === 0) {
+            resolve(truncate(`ERROR: ${error.message}`));
+            return;
+          }
+          resolve(truncate(combined.length > 0 ? combined : '(no output)'));
+        }
+      );
+    });
+  }
+
+  private async runWriteFile(
+    workspacePath: string,
+    requested: string,
+    content: string
+  ): Promise<string> {
+    const target = resolveInsideWorkspace(workspacePath, requested);
+    if (target === null) {
+      return `ERROR: refusing to write outside workspace: ${requested}`;
+    }
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, content, 'utf8');
+    return `wrote ${requested} (${content.length} bytes)`;
+  }
+
+  private async runReadFile(workspacePath: string, requested: string): Promise<string> {
+    const target = resolveInsideWorkspace(workspacePath, requested);
+    if (target === null) {
+      return `ERROR: refusing to read outside workspace: ${requested}`;
+    }
+    const content = await fs.readFile(target, 'utf8');
+    return truncate(content);
+  }
+
+  private errorEvent(sessionId: string, message: string): AgentEvent {
+    return {
+      type: 'error',
+      timestamp: new Date().toISOString(),
+      sessionId,
+      content: message,
+    };
+  }
+
+  /** Best-effort telemetry hook — a throwing hook never breaks a turn. */
+  private notify(hook: ((model: string) => void) | undefined, model: string): void {
+    if (!hook) return;
+    try {
+      hook(model);
+    } catch {
+      // Swallow — usage/failure telemetry is advisory, not turn-critical.
+    }
+  }
+
+  async stopSession(session: AgentSession): Promise<Result<void, AgentError>> {
+    const ollamaSession = session as OllamaSession;
+    ollamaSession.aborted = true;
+    try {
+      ollamaSession.activeController?.abort();
+    } catch {
+      // Controller may already be settled.
+    }
+    return Ok(undefined);
+  }
+
+  async healthCheck(): Promise<Result<void, AgentError>> {
+    try {
+      const headers: Record<string, string> = {};
+      if (this.config.apiKey !== undefined) {
+        headers.Authorization = `Bearer ${this.config.apiKey}`;
+      }
+      const res = await fetch(`${this.endpoint}/models`, { method: 'GET', headers });
+      if (!res.ok) {
+        return Err({
+          category: 'response_error',
+          message: `Ollama health check failed: HTTP ${res.status} ${res.statusText}`,
+        });
+      }
+      return Ok(undefined);
+    } catch (err) {
+      return Err({
+        category: 'agent_not_found',
+        message: `Ollama endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+}
+
+/** Minimal shape of Ollama's OpenAI-compatible chat-completions response. */
+interface OllamaChatResponse {
+  choices: Array<{
+    message?: { content?: string | null; tool_calls?: ToolCall[] };
+  }>;
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+}

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -159,6 +159,17 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),
+  z
+    .object({
+      type: z.literal('ollama'),
+      endpoint: z.string().url(),
+      model: ModelSchema,
+      apiKey: z.string().optional(),
+      timeoutMs: z.number().int().positive().optional(),
+      maxTurnsPerRun: z.number().int().positive().optional(),
+      capabilities: BackendCapabilitiesSchema.optional(),
+    })
+    .strict(),
 ]);
 
 /**

--- a/packages/orchestrator/tests/agent/backend-factory.test.ts
+++ b/packages/orchestrator/tests/agent/backend-factory.test.ts
@@ -8,6 +8,7 @@ import { OpenAIBackend } from '../../src/agent/backends/openai.js';
 import { GeminiBackend } from '../../src/agent/backends/gemini.js';
 import { LocalBackend } from '../../src/agent/backends/local.js';
 import { PiBackend } from '../../src/agent/backends/pi.js';
+import { OllamaBackend } from '../../src/agent/backends/ollama.js';
 
 describe('createBackend', () => {
   it('builds MockBackend for type=mock', () => {
@@ -97,6 +98,49 @@ describe('createBackend', () => {
     };
     const backend = createBackend(def) as PiBackend;
     expect((backend as unknown as { timeoutMs: number }).timeoutMs).toBe(90_000);
+  });
+
+  it('builds OllamaBackend for type=ollama with string model', () => {
+    const def: BackendDef = {
+      type: 'ollama',
+      endpoint: 'http://127.0.0.1:11434/v1',
+      model: 'qwen3-agent:32b',
+    };
+    expect(createBackend(def)).toBeInstanceOf(OllamaBackend);
+  });
+
+  it('builds OllamaBackend for type=ollama with array model', () => {
+    const def: BackendDef = {
+      type: 'ollama',
+      endpoint: 'http://127.0.0.1:11434/v1',
+      model: ['m-a', 'm-b'],
+    };
+    expect(createBackend(def)).toBeInstanceOf(OllamaBackend);
+  });
+
+  it('propagates timeoutMs and maxTurnsPerRun to OllamaBackend when set', () => {
+    const def: BackendDef = {
+      type: 'ollama',
+      endpoint: 'http://127.0.0.1:11434/v1',
+      model: 'qwen3-agent:32b',
+      timeoutMs: 45_000,
+      maxTurnsPerRun: 12,
+    };
+    const backend = createBackend(def) as OllamaBackend;
+    expect(backend).toBeInstanceOf(OllamaBackend);
+    expect(backend.timeoutMs).toBe(45_000);
+    expect(backend.maxTurnsPerRun).toBe(12);
+  });
+
+  it('uses default timeoutMs and maxTurnsPerRun on OllamaBackend when not set', () => {
+    const def: BackendDef = {
+      type: 'ollama',
+      endpoint: 'http://127.0.0.1:11434/v1',
+      model: 'qwen3-agent:32b',
+    };
+    const backend = createBackend(def) as OllamaBackend;
+    expect(backend.timeoutMs).toBe(600_000);
+    expect(backend.maxTurnsPerRun).toBe(50);
   });
 
   it('throws on unknown discriminant', () => {

--- a/packages/orchestrator/tests/agent/backends/ollama.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AgentEvent, TurnResult } from '@harness-engineering/types';
+import { OllamaBackend, type OllamaBackendConfig } from '../../../src/agent/backends/ollama';
+
+/** Build a canned OpenAI-compatible chat response with optional tool calls. */
+function chatResponse(opts: {
+  content?: string;
+  toolCalls?: Array<{ id: string; name: string; args: unknown }>;
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+}) {
+  const message: Record<string, unknown> = { content: opts.content ?? '' };
+  if (opts.toolCalls) {
+    message.tool_calls = opts.toolCalls.map((tc) => ({
+      id: tc.id,
+      type: 'function',
+      function: { name: tc.name, arguments: JSON.stringify(tc.args) },
+    }));
+  }
+  return { choices: [{ message }], ...(opts.usage ? { usage: opts.usage } : {}) };
+}
+
+/** A `fetch` mock that returns the given JSON body with status 200. */
+function okFetch(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/** Drain a runTurn generator, collecting events and the terminal TurnResult. */
+async function drain(
+  gen: AsyncGenerator<AgentEvent, TurnResult, void>
+): Promise<{ events: AgentEvent[]; result: TurnResult }> {
+  const events: AgentEvent[] = [];
+  let next = await gen.next();
+  while (!next.done) {
+    events.push(next.value);
+    next = await gen.next();
+  }
+  return { events, result: next.value };
+}
+
+const baseConfig: OllamaBackendConfig = {
+  endpoint: 'http://127.0.0.1:11434/v1',
+  model: 'qwen3-agent:32b',
+};
+
+describe('OllamaBackend', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'ollama-be-'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  describe('startSession', () => {
+    it('returns a session with backendName ollama and a seeded system message', async () => {
+      const backend = new OllamaBackend(baseConfig);
+      const result = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.backendName).toBe('ollama');
+      expect(result.value.workspacePath).toBe(workspace);
+      const session = result.value as import('../../../src/agent/backends/ollama').OllamaSession;
+      expect(session.messages).toHaveLength(1);
+      expect(session.messages[0]!.role).toBe('system');
+      expect(session.messages[0]!.content.length).toBeGreaterThan(0);
+      expect(session.resolvedModel).toBe('qwen3-agent:32b');
+    });
+
+    it('uses the caller systemPrompt when provided', async () => {
+      const backend = new OllamaBackend(baseConfig);
+      const result = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+        systemPrompt: 'CUSTOM SYSTEM',
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const session = result.value as import('../../../src/agent/backends/ollama').OllamaSession;
+      expect(session.messages[0]!.content).toBe('CUSTOM SYSTEM');
+    });
+
+    it('resolves the head of an array model', async () => {
+      const backend = new OllamaBackend({ ...baseConfig, model: ['m-first', 'm-second'] });
+      const result = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const session = result.value as import('../../../src/agent/backends/ollama').OllamaSession;
+      expect(session.resolvedModel).toBe('m-first');
+    });
+
+    it('fails with agent_not_found when no model configured', async () => {
+      const backend = new OllamaBackend({ endpoint: baseConfig.endpoint });
+      const result = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.category).toBe('agent_not_found');
+    });
+  });
+
+  describe('runTurn — agentic loop', () => {
+    it('executes a bash tool call then stops on a plain final message', async () => {
+      // Call 1 → model asks to run bash; Call 2 → model gives a final answer.
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          okFetch(
+            chatResponse({
+              toolCalls: [
+                { id: 'call-1', name: 'bash', args: { command: 'echo hi > marker.txt' } },
+              ],
+              usage: { prompt_tokens: 30, completion_tokens: 5 },
+            })
+          )
+        )
+        .mockResolvedValueOnce(
+          okFetch(
+            chatResponse({ content: 'DONE', usage: { prompt_tokens: 40, completion_tokens: 3 } })
+          )
+        );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      expect(start.ok).toBe(true);
+      if (!start.ok) return;
+
+      const { events, result } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'make a marker',
+          isContinuation: false,
+        })
+      );
+
+      // The bash tool actually ran in the workspace.
+      expect(existsSync(join(workspace, 'marker.txt'))).toBe(true);
+      expect(readFileSync(join(workspace, 'marker.txt'), 'utf8').trim()).toBe('hi');
+
+      // Two model calls were made (tool loop iterated once, then final).
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      // The tool result was appended to the conversation as a `tool` message.
+      const session = start.value as import('../../../src/agent/backends/ollama').OllamaSession;
+      const toolMsg = session.messages.find((m) => m.role === 'tool');
+      expect(toolMsg).toBeDefined();
+      expect(toolMsg!.tool_call_id).toBe('call-1');
+
+      // Tool lifecycle events were emitted.
+      const startEvt = events.find((e) => e.type === 'tool_execution_start');
+      const endEvt = events.find((e) => e.type === 'tool_execution_end');
+      expect(startEvt?.subtype).toBe('bash');
+      expect(endEvt?.subtype).toBe('bash');
+
+      // Success with accumulated usage across both responses.
+      expect(result.success).toBe(true);
+      expect(result.usage.inputTokens).toBe(70);
+      expect(result.usage.outputTokens).toBe(8);
+      expect(result.usage.totalTokens).toBe(78);
+
+      // Usage surfaced on yielded events for the state machine.
+      const usageEvents = events.filter((e) => e.usage);
+      expect(usageEvents.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('surfaces failure on a non-200 HTTP response', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: async () => 'boom',
+        json: async () => ({}),
+      } as unknown as Response);
+      vi.stubGlobal('fetch', fetchMock);
+
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      expect(start.ok).toBe(true);
+      if (!start.ok) return;
+
+      const { events, result } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'anything',
+          isContinuation: false,
+        })
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/HTTP 500/);
+      expect(events.some((e) => e.type === 'error')).toBe(true);
+    });
+
+    it('calls onModelFailed on failure and onModelUsed on success', async () => {
+      const onModelUsed = vi.fn();
+      const onModelFailed = vi.fn();
+
+      // Success path.
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okFetch(chatResponse({ content: 'done' }))));
+      const okBackend = new OllamaBackend({ ...baseConfig, onModelUsed, onModelFailed });
+      const okStart = await okBackend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!okStart.ok) return;
+      await drain(
+        okBackend.runTurn(okStart.value, {
+          sessionId: okStart.value.sessionId,
+          prompt: 'x',
+          isContinuation: false,
+        })
+      );
+      expect(onModelUsed).toHaveBeenCalledWith('qwen3-agent:32b');
+      expect(onModelFailed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('stopSession', () => {
+    it('aborts the loop between iterations', async () => {
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      expect(start.ok).toBe(true);
+      if (!start.ok) return;
+      const session = start.value;
+
+      // First model response asks for a tool; we stop the session during the
+      // tool execution so the NEXT loop iteration observes `aborted` and bails.
+      const fetchMock = vi.fn().mockImplementation(async () => {
+        await backend.stopSession(session);
+        return okFetch(
+          chatResponse({
+            toolCalls: [{ id: 'c1', name: 'bash', args: { command: 'echo hello' } }],
+          })
+        );
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const { result } = await drain(
+        backend.runTurn(session, {
+          sessionId: session.sessionId,
+          prompt: 'loop',
+          isContinuation: false,
+        })
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/abort/i);
+      // Only the first model call happened; the loop bailed before a second.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('path traversal', () => {
+    it('rejects a write_file that escapes the workspace', async () => {
+      const escapeTarget = join(workspace, '..', 'escaped.txt');
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          okFetch(
+            chatResponse({
+              toolCalls: [
+                {
+                  id: 'w1',
+                  name: 'write_file',
+                  args: { path: '../escaped.txt', content: 'PWNED' },
+                },
+              ],
+            })
+          )
+        )
+        .mockResolvedValueOnce(okFetch(chatResponse({ content: 'done' })));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!start.ok) return;
+
+      const { events } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'escape',
+          isContinuation: false,
+        })
+      );
+
+      // File was NOT written outside the workspace.
+      expect(existsSync(escapeTarget)).toBe(false);
+      // The refusal was reported back to the model as the tool result.
+      const endEvt = events.find((e) => e.type === 'tool_execution_end');
+      expect(String(endEvt?.content)).toMatch(/refusing to write outside workspace/);
+    });
+
+    it('rejects a read_file that escapes the workspace', async () => {
+      // Plant a secret one level above the workspace.
+      const secret = join(workspace, '..', 'secret.txt');
+      writeFileSync(secret, 'TOP SECRET');
+      try {
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(
+            okFetch(
+              chatResponse({
+                toolCalls: [{ id: 'r1', name: 'read_file', args: { path: '../secret.txt' } }],
+              })
+            )
+          )
+          .mockResolvedValueOnce(okFetch(chatResponse({ content: 'done' })));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const backend = new OllamaBackend(baseConfig);
+        const start = await backend.startSession({
+          workspacePath: workspace,
+          permissionMode: 'full',
+        });
+        if (!start.ok) return;
+
+        const { events } = await drain(
+          backend.runTurn(start.value, {
+            sessionId: start.value.sessionId,
+            prompt: 'read secret',
+            isContinuation: false,
+          })
+        );
+
+        const endEvt = events.find((e) => e.type === 'tool_execution_end');
+        expect(String(endEvt?.content)).toMatch(/refusing to read outside workspace/);
+        expect(String(endEvt?.content)).not.toContain('TOP SECRET');
+      } finally {
+        rmSync(secret, { force: true });
+      }
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns Ok on a 200 from /models', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' } as Response)
+      );
+      const backend = new OllamaBackend(baseConfig);
+      const result = await backend.healthCheck();
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns Err when the endpoint is unreachable', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+      const backend = new OllamaBackend(baseConfig);
+      const result = await backend.healthCheck();
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/packages/orchestrator/tests/workflow/schema.test.ts
+++ b/packages/orchestrator/tests/workflow/schema.test.ts
@@ -77,6 +77,31 @@ describe('BackendDefSchema', () => {
     expect(messages).toContain('non-empty string or array of strings');
   });
 
+  it('OT1: accepts a valid ollama backend and honors optional fields', () => {
+    const result = BackendDefSchema.safeParse({
+      type: 'ollama',
+      endpoint: 'http://127.0.0.1:11434/v1',
+      model: ['qwen3-agent:32b', 'qwen3:8b'],
+      apiKey: 'ollama',
+      timeoutMs: 600000,
+      maxTurnsPerRun: 50,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an ollama backend with an unknown field (strict)', () => {
+    const result = BackendDefSchema.safeParse({
+      type: 'ollama',
+      endpoint: 'http://127.0.0.1:11434/v1',
+      model: 'qwen3-agent:32b',
+      bogusField: true,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const codes = result.error.issues.map((i) => i.code);
+    expect(codes).toContain('unrecognized_keys');
+  });
+
   it('OT16: same actionable message applies to pi variant', () => {
     const result = BackendDefSchema.safeParse({
       type: 'pi',

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -501,6 +501,7 @@ export type BackendDef =
   | GeminiBackendDef
   | LocalBackendDef
   | PiBackendDef
+  | OllamaBackendDef
   | SshBackendDef
   | ServerlessBackendDef;
 
@@ -584,6 +585,33 @@ export interface PiBackendDef {
   timeoutMs?: number;
   /** Probe interval in ms for resolver. Default: 30_000. Minimum: 1_000. */
   probeIntervalMs?: number;
+  /** Native isolation tier this backend provides. Defaults to `'none'`. */
+  isolation?: IsolationTier;
+  /** AMR Phase 1 (D1): optional capability block for tier selection. */
+  capabilities?: BackendCapabilities;
+}
+
+/**
+ * Native Ollama agentic backend pointing at an Ollama OpenAI-compatible server.
+ *
+ * Unlike the `pi` backend (which embeds the pi-coding-agent SDK), this backend
+ * owns its agentic tool loop: it drives `/v1/chat/completions` directly, parses
+ * native `tool_calls`, executes `bash`/`write_file`/`read_file` inside the
+ * workspace, and appends tool results until the model stops calling tools. The
+ * pi/codex SDKs fail against Ollama-served tool-calling models (empty
+ * completions / rejected tool calls) where this harness-owned driver succeeds.
+ */
+export interface OllamaBackendDef {
+  type: 'ollama';
+  /** Ollama OpenAI-compatible base URL (e.g., `http://127.0.0.1:11434/v1`). */
+  endpoint: string;
+  /** Model name(s). Array form supports prefer-fallback resolution. */
+  model: string | string[];
+  apiKey?: string;
+  /** Per-request timeout in ms for each chat-completion call. Default: 600_000. */
+  timeoutMs?: number;
+  /** Maximum inner agentic-loop iterations per `runTurn`. Default: 50. */
+  maxTurnsPerRun?: number;
   /** Native isolation tier this backend provides. Defaults to `'none'`. */
   isolation?: IsolationTier;
   /** AMR Phase 1 (D1): optional capability block for tier selection. */


### PR DESCRIPTION
## Summary

Adds a thin, harness-owned `OllamaBackend` (`type: 'ollama'`) that drives local tool-calling models via a direct `/v1/chat/completions` agentic loop — where the existing PiBackend and Codex CLI both fail.

**Why:** live e2e (see #840) proved the failure is the *driver*, not the model:
- PiBackend (0.79 + 0.80): empty `0/0/0` completions.
- Codex `--oss`: rejects the model's native `tool_calls`.
- **Direct `/v1/chat/completions` + tools: drives qwen3 flawlessly** — a prototype produced a correct, registered ESLint rule + tests via a real read→write→test loop.

## What it does

`OllamaBackend` implements `AgentBackend` alongside `ClaudeBackend`:
- `startSession` seeds per-session `messages` with a system prompt, resolves the model (head of a `string[]` prefer-list), fails `agent_not_found` if unconfigured.
- `runTurn` runs the inner agentic loop (≤ `maxTurnsPerRun`, default 50): POST chat/completions + tool schemas → accumulate + **yield `usage` events** (state machine reads `event.usage`) → append assistant message → **no tool calls ⇒ `success:true`** → else execute each tool (`bash` via `execFile('/bin/sh',['-c',cmd])` cwd=workspace; `write_file`/`read_file` resolved inside workspace with **path-traversal rejection**; outputs truncated), yielding `tool_execution_start/end`, and feed results back.
- Timeout watchdog (AbortController + `timeoutMs`) per call; `stopSession` aborts mid-loop; non-200/exception/exhaustion ⇒ `success:false` + `onModelFailed`.

## Wiring
- `OllamaBackendDef` added to the `BackendDef` union (types) + `.strict()` Zod `ollama` variant (schema) + `createOllamaBackend` in the factory. The exhaustive `analysis-provider-factory` switch routes `ollama` alongside `local`/`pi` to the local-like analysis provider.

## Tests
- +18 tests (12 backend incl. tool-execution/abort/path-traversal/HTTP-error, 4 factory, 2 schema). Orchestrator suite 2094 → 2112 green; types typecheck clean; new files pass the harness eslint rules. Changeset: minor for `types` + `orchestrator`.

## Not included
- No live-Ollama integration test (all `fetch` mocked, per scope). A follow-up wires local dispatch to route to this backend and runs the full workflow e2e against a running endpoint.