### PR TITLE
feat(orchestrator): per-server MCP tool allowlist for the local agent

### DIFF
--- a/.changeset/local-mcp-tool-curation.md
+++ b/.changeset/local-mcp-tool-curation.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/types': minor
+---
+
+Add a per-server MCP tool allowlist for the local `ollama` agent. A broad
+MCP server floods a local model with tools — in a live e2e the harness MCP
+alone exposed 95 tools and `qwen3-coder:30b` over-explored without cleanly
+signalling completion. `mcpServers[].tools?: string[]` narrows a server to
+named tools (filtered on the server's own pre-namespacing tool name);
+unset ⇒ all tools (byte-identical to before). Requested-but-unexposed names
+warn once and are skipped (graceful). When the aggregated tool set
+(built-ins + MCP) exceeds a threshold, the backend logs a one-line advisory
+pointing at `tools` — no hard cap. The scaffolded local configs narrow the
+harness example to a read-oriented set (`code_search`, `ask_graph`,
+`review_changes`, `outcome_eval`, `gather_context`).

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ agents/agents/
 # Plugin generator staging dirs (per-target, cleaned up after each run)
 tmp-plugin-*-commands/
 tmp-plugin-*-agents/
+
+# Local e2e scratch (model pull logs, pids)
+.harness/e2e/

--- a/docs/changes/local-mcp-tool-curation/proposal.md
+++ b/docs/changes/local-mcp-tool-curation/proposal.md
@@ -1,0 +1,91 @@
+---
+title: Curate which MCP-server tools the local agent sees
+status: draft
+keywords: ollama-backend, mcp, tool-allowlist, tool-curation, local-dispatch, choice-paralysis, agent-tools
+---
+
+# Curate which MCP-server tools the local agent sees
+
+## Overview & Goals
+
+[[ollama-backend-mcp-tools]] (PR #849) lets the local `OllamaBackend` agent use tools from configured MCP
+servers, but it aggregates **every** tool a server exposes. In the live e2e (2026-07-16) the harness MCP
+server alone contributed **95 tools**; with ~98 tools total, `qwen3-coder:30b` wrote the correct file (via
+context7) but then **over-explored** — a `cat`/`find`/`read_file`/`ls` verification loop — without cleanly
+emitting `TASK_COMPLETE`, so a real dispatch would terminate via `maxTurnsPerRun` instead of a clean
+success. The limiter was **tool count (choice paralysis)**, not context size (the model had 262144 ctx).
+
+**Goal:** let an operator curate which tools from a configured MCP server the agent receives, so a broad
+server can be narrowed to the high-value set — making the local MCP interaction robust (fewer, better tools
+→ less choice paralysis → cleaner completion). Keep the default (no allowlist) byte-identical to today.
+
+**Non-goals (YAGNI):** per-tool renaming/aliasing; changing the harness MCP server's own tool surface
+(that's `add-harness-mcp-list-capabilities`); tool _selection intelligence_ (ranking tools by task); a hard
+cap that silently drops tools (we warn, never truncate silently).
+
+## Decisions made
+
+- **D1 — Per-server `tools?: string[]` allowlist on `McpServerSpec`.** When present, only tools whose
+  (pre-namespacing) name is in the list are aggregated from that server; absent ⇒ all tools (unchanged).
+  _(Rationale: portable to any server, opt-in, predictable, smallest surface.)_
+- **D2 — Curate the scaffolded harness example to the read-oriented set.** The commented `harness` server
+  example gains `tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]` (the
+  [[ollama-backend-mcp-tools]] D3 read set) instead of exposing all 95. context7 stays un-narrowed (it has
+  few tools). _(Rationale: ships a good default that avoids the 95-tool flood out of the box.)_
+- **D3 — Unknown allowlisted names are warned + skipped, never fatal.** If an allowlist names a tool the
+  server doesn't expose (typo, version drift), log a warning and continue — the server still connects with
+  the tools it does have. _(Rationale: one stale name must not break a dispatch; matches the existing
+  graceful-degradation posture.)_
+- **D4 — Soft warn on a large aggregated tool set.** After aggregation, if the total tool count (built-ins
+  - all MCP tools) exceeds a threshold (`LARGE_TOOL_SET_WARN = 40`), log a one-line warning pointing at the
+    `tools` allowlist. No hard cap — the operator decides. _(Rationale: surfaces the choice-paralysis risk
+    without silently changing behavior.)_
+
+## Technical design
+
+### Config
+
+- `McpServerSpec` (in `packages/orchestrator/src/agent/backends/ollama.ts`, the `OllamaBackendDef` in
+  `packages/types/src/orchestrator.ts`, and the `.strict()` ollama Zod variant in
+  `packages/orchestrator/src/workflow/schema.ts`) gains `tools?: string[]`.
+- `backend-factory.ts` needs no change (it threads `mcpServers` whole).
+
+### Aggregation (`connectMcpServer`)
+
+In the existing per-server tool loop, before namespacing/adding a tool:
+`if (spec.tools !== undefined && !spec.tools.includes(tool.name)) continue;`
+After the loop, if `spec.tools` is set, compute which requested names were never seen and
+`console.warn` them once (D3). After all servers aggregate (end of `startSession`), if
+`builtinCount + session.mcpTools.length > LARGE_TOOL_SET_WARN`, warn once (D4).
+
+### Scaffolds
+
+The commented `harness` example in `harness.orchestrator.md`, `harness.orchestrator.local.md`, and the two
+`templates/orchestrator/*` copies gains a `tools:` line listing the read set (D2).
+
+## Integration Points
+
+- **Entry Points:** `tools` on the ollama backend def; the filter in `OllamaBackend.connectMcpServer`.
+- **Registrations Required:** the `ollama` Zod variant gains `tools` on each `mcpServers` entry; scaffolds
+  updated. No barrel/skill changes.
+- **Documentation Updates:** `docs/guides/multi-backend-routing.md#mcp-tools` — document `tools` and the
+  read-set default; a sentence on why (choice paralysis for local models).
+- **Knowledge Impact:** concept — _MCP tool allowlist / curation_; relationship —
+  `mcpServers[].tools → narrows → aggregated agent tools`.
+
+## Success Criteria
+
+- SC1: `tools` unset ⇒ all of a server's tools aggregated (byte-identical; existing ollama tests green).
+- SC2: `tools: ['echo']` on an in-memory server exposing `echo` + `other` ⇒ only `<server>__echo` appears in
+  the tool set. Unit test.
+- SC3: `tools: ['echo','missing']` ⇒ `echo` aggregated, `missing` warned + skipped, `startSession`
+  succeeds. Unit test.
+- SC4: the four scaffolded configs' `harness` example lists the read-oriented `tools` set.
+- SC5: an aggregated tool set larger than `LARGE_TOOL_SET_WARN` emits a single warning naming the count and
+  pointing at `tools`. Unit test (inject a server exposing many tools).
+
+## Implementation Order
+
+- **Phase 1 — Allowlist + warnings.** `tools?: string[]` on def/schema/config; the filter + unknown-name
+  warning + large-set warning in `connectMcpServer`/`startSession`; tests SC1–SC3, SC5.
+- **Phase 2 — Curate + document.** Scaffold `tools` read-set (SC4) + guide note. SC4.

--- a/docs/guides/multi-backend-routing.md
+++ b/docs/guides/multi-backend-routing.md
@@ -198,6 +198,8 @@ Tools appear to the model **namespaced** as `<server>__<tool>` (so two servers c
 
 `harness-mcp` — and any server without an explicit `cwd` — is spawned with `cwd =` the agent's workspace (the git worktree it is editing), so harness's own code-intelligence tools (`code_search`, `ask_graph`, `review_changes`, `outcome_eval`) operate on the code the agent is building rather than the daemon's repo. Set a per-server `cwd` to override.
 
+Each server entry also takes an optional `tools` — a per-server allowlist of tool names (the server's own names, before namespacing). When set, only those tools are aggregated from that server; omit it (the default) to expose **all** of the server's tools. This exists because a broad server floods a local model with choice: `harness-mcp` alone exposes ~95 tools, and past a threshold the model over-explores instead of cleanly finishing (choice paralysis, not a context limit). If an allowlisted name isn't one the server exposes (a typo or version drift), it is warned and skipped — never fatal, so one stale name can't break a dispatch. When the aggregated set (built-ins + all MCP tools) grows large, the backend logs a one-line advisory pointing back here; there is no hard cap. The shipped `harness` example narrows to the read-oriented set (`code_search`, `ask_graph`, `review_changes`, `outcome_eval`, `gather_context`) for exactly this reason; `context7` is left un-narrowed because it exposes only a few tools.
+
 ```yaml
 agent:
   backends:
@@ -211,6 +213,7 @@ agent:
           args: ['-y', '@upstash/context7-mcp']
         - name: harness # code_search / ask_graph / review_changes / outcome_eval,
           command: harness-mcp # run against the agent's workspace
+          tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context] # narrow ~95 → read set
 ```
 
 ## Migrating from the legacy schema

--- a/docs/roadmap.d/local-mcp-tool-curation.md
+++ b/docs/roadmap.d/local-mcp-tool-curation.md
@@ -1,0 +1,16 @@
+---
+slug: "local-mcp-tool-curation"
+milestone: "Intake"
+order: 27
+---
+
+### Curate which MCP-server tools the local agent sees (per-server tool allowlist)
+
+- **Status:** in-progress
+- **Spec:** docs/changes/local-mcp-tool-curation/proposal.md
+- **Summary:** [[ollama-backend-mcp-tools]] wires whole MCP servers into the local agent, but a broad server floods the model: in the live e2e (2026-07-16) the harness MCP alone exposed **95 tools**, and `qwen3-coder:30b` — given ~98 tools total — wrote the correct file via context7 but then **over-explored** (a cat/find/read/ls verification loop) without cleanly emitting `TASK_COMPLETE`, so a real dispatch would end via `maxTurns` rather than clean success. Choice-paralysis, not context size (the model had 262144 ctx). Fix: a **per-server `tools?: string[]` allowlist** on `McpServerSpec` — when set, only those tool names from that server are aggregated (namespaced), default unset = all tools (byte-identical). Curate the scaffolded harness example to the read-oriented set ([[ollama-backend-mcp-tools]] D3: `code_search`, `ask_graph`, `review_changes`, `outcome_eval`, `gather_context`) instead of all 95. Warn (not hard-cap) when the aggregated tool count crosses a large threshold, pointing at the allowlist. Portable — the allowlist works for any server, not just harness. Directly improves the robustness of the just-shipped local MCP path.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** Chad Warner
+- **Priority:** P1
+- **External-ID:** —

--- a/docs/roadmap.d/ollama-backend-mcp-tools.md
+++ b/docs/roadmap.d/ollama-backend-mcp-tools.md
@@ -6,11 +6,11 @@ order: 26
 
 ### Wire suggested MCP servers (incl. harness itself) into the OllamaBackend agent
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/ollama-mcp-tools/proposal.md
 - **Summary:** Give the local `OllamaBackend` agent the same power cloud drivers get from MCP: expose the harness-suggested MCP servers as agent tools alongside `bash`/`read_file`/`write_file`. Today the local agent has only those three built-ins, so it writes code from stale memory — e.g. it used the deprecated `@typescript-eslint/utils` RuleTester import when **context7** returns the current `@typescript-eslint/rule-tester` API (verified live). The fix generalizes: an **MCP client in `OllamaBackend`** that, at `startSession`, connects to the configured/suggested MCP servers (from the refreshed catalog — [[mcp-catalog-refresh]]), enumerates each server's tools, and adds them (namespaced, e.g. `context7__query-docs`, `harness__code_search`) to the tool schema it sends to the model; on a tool call for an MCP tool it forwards to the server and returns the result. **Include harness's own MCP** so the local agent can `code_search` / `ask_graph` / `outcome_eval` / `review_changes` on itself — the highest-leverage set for harness-native work. Reuse the harness's existing MCP client plumbing + the `@modelcontextprotocol/sdk` rather than a bespoke per-server tool. Config: a per-backend allowlist of which suggested servers the agent gets (default a safe set: context7 docs + harness read-only tools; opt-in for write/network-heavy servers). Respect the interactive vs full-tool permission mode. This is the single biggest capability lever for local-model success — combined with a stronger model ([[local-model-discovery-recommendation]]) it directly targets the observed failure (writes plausible code but with wrong/old APIs and no doc lookup). MVP: context7 `lookup_docs` (HTTP, no key — proven) + the harness MCP; then generalize to the full catalog.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —
 - **Priority:** P1
-- **External-ID:** —
+- **External-ID:** 849

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,12 +167,23 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Wire suggested MCP servers (incl. harness itself) into the OllamaBackend agent
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/ollama-mcp-tools/proposal.md
 - **Summary:** Give the local `OllamaBackend` agent the same power cloud drivers get from MCP: expose the harness-suggested MCP servers as agent tools alongside `bash`/`read_file`/`write_file`. Today the local agent has only those three built-ins, so it writes code from stale memory — e.g. it used the deprecated `@typescript-eslint/utils` RuleTester import when **context7** returns the current `@typescript-eslint/rule-tester` API (verified live). The fix generalizes: an **MCP client in `OllamaBackend`** that, at `startSession`, connects to the configured/suggested MCP servers (from the refreshed catalog — [[mcp-catalog-refresh]]), enumerates each server's tools, and adds them (namespaced, e.g. `context7__query-docs`, `harness__code_search`) to the tool schema it sends to the model; on a tool call for an MCP tool it forwards to the server and returns the result. **Include harness's own MCP** so the local agent can `code_search` / `ask_graph` / `outcome_eval` / `review_changes` on itself — the highest-leverage set for harness-native work. Reuse the harness's existing MCP client plumbing + the `@modelcontextprotocol/sdk` rather than a bespoke per-server tool. Config: a per-backend allowlist of which suggested servers the agent gets (default a safe set: context7 docs + harness read-only tools; opt-in for write/network-heavy servers). Respect the interactive vs full-tool permission mode. This is the single biggest capability lever for local-model success — combined with a stronger model ([[local-model-discovery-recommendation]]) it directly targets the observed failure (writes plausible code but with wrong/old APIs and no doc lookup). MVP: context7 `lookup_docs` (HTTP, no key — proven) + the harness MCP; then generalize to the full catalog.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —
+- **Priority:** P1
+- **External-ID:** 849
+
+### Curate which MCP-server tools the local agent sees (per-server tool allowlist)
+
+- **Status:** in-progress
+- **Spec:** docs/changes/local-mcp-tool-curation/proposal.md
+- **Summary:** [[ollama-backend-mcp-tools]] wires whole MCP servers into the local agent, but a broad server floods the model: in the live e2e (2026-07-16) the harness MCP alone exposed **95 tools**, and `qwen3-coder:30b` — given ~98 tools total — wrote the correct file via context7 but then **over-explored** (a cat/find/read/ls verification loop) without cleanly emitting `TASK_COMPLETE`, so a real dispatch would end via `maxTurns` rather than clean success. Choice-paralysis, not context size (the model had 262144 ctx). Fix: a **per-server `tools?: string[]` allowlist** on `McpServerSpec` — when set, only those tool names from that server are aggregated (namespaced), default unset = all tools (byte-identical). Curate the scaffolded harness example to the read-oriented set ([[ollama-backend-mcp-tools]] D3: `code_search`, `ask_graph`, `review_changes`, `outcome_eval`, `gather_context`) instead of all 95. Warn (not hard-cap) when the aggregated tool count crosses a large threshold, pointing at the allowlist. Portable — the allowlist works for any server, not just harness. Directly improves the robustness of the just-shipped local MCP path.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** Chad Warner
 - **Priority:** P1
 - **External-ID:** —
 

--- a/harness.orchestrator.local.md
+++ b/harness.orchestrator.local.md
@@ -50,6 +50,9 @@ agent:
       #     args: ['-y', '@upstash/context7-mcp']
       #   - name: harness          # code_search / ask_graph / review_changes /
       #     command: harness-mcp    # outcome_eval, run against the agent's workspace
+      #     tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]
+      #                             # narrow harness's ~95 tools to the read-oriented set
+      #                             # so a local model isn't flooded (omit tools = all).
   # Routing — controls WHICH backend handles each use case.
   routing:
     default: primary

--- a/harness.orchestrator.md
+++ b/harness.orchestrator.md
@@ -54,6 +54,9 @@ agent:
       #     args: ['-y', '@upstash/context7-mcp']
       #   - name: harness          # code_search / ask_graph / review_changes /
       #     command: harness-mcp    # outcome_eval, run against the agent's workspace
+      #     tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]
+      #                             # narrow harness's ~95 tools to the read-oriented set
+      #                             # so a local model isn't flooded (omit tools = all).
   # Routing — controls WHICH backend handles each use case.
   routing:
     default: primary

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -171,6 +171,13 @@ const DEFAULT_HEARTBEAT_MS = 30_000;
 const DEFAULT_BASH_TIMEOUT_MS = 300_000;
 /** Bounded wall-clock (ms) for a single MCP server connect+listTools. */
 const DEFAULT_MCP_CONNECT_TIMEOUT_MS = 15_000;
+/**
+ * Aggregated tool count (built-ins + all MCP tools) above which the backend logs
+ * a one-line advisory pointing at the per-server `tools` allowlist. A large tool
+ * set induces choice paralysis in a local model (it over-explores and never
+ * cleanly signals completion); this surfaces the risk without a hard cap.
+ */
+const LARGE_TOOL_SET_WARN = 40;
 
 /**
  * The distinctive completion marker the model must emit — on its own line, with
@@ -277,6 +284,42 @@ function resolveInsideWorkspace(workspacePath: string, requested: string): strin
 /** Sanitize a segment to `[A-Za-z0-9_-]` for use in a namespaced tool name. */
 function sanitizeSegment(s: string): string {
   return s.replace(/[^A-Za-z0-9_-]/g, '_');
+}
+
+/**
+ * Apply a server's `tools` allowlist (D1): keep only tools whose pre-namespacing
+ * name is listed. Absent ⇒ every tool (byte-identical to prior behavior). Also
+ * warns once (D3) for any requested name the server never exposed (typo/version
+ * drift) — never fatal; the server still connects with the tools it does have.
+ */
+function filterServerTools(spec: McpServerSpec, tools: McpToolDescriptor[]): McpToolDescriptor[] {
+  if (spec.tools === undefined) return tools;
+  const allow = spec.tools;
+  const kept = tools.filter((t) => allow.includes(t.name));
+  const exposed = new Set(tools.map((t) => t.name));
+  const missing = [...new Set(allow.filter((name) => !exposed.has(name)))];
+  if (missing.length > 0) {
+    console.warn(
+      `[ollama-mcp] server '${spec.name}': requested tools not found: ${missing.join(', ')}`
+    );
+  }
+  return kept;
+}
+
+/**
+ * Warn once (D4) when the aggregated tool set (built-ins + `mcpToolCount` MCP
+ * tools) exceeds {@link LARGE_TOOL_SET_WARN}. Uses the live built-in count
+ * ({@link TOOL_SCHEMAS} length) rather than a magic number. Advisory only — no
+ * hard cap; the operator narrows via each server's `tools` allowlist.
+ */
+function warnIfLargeToolSet(mcpToolCount: number): void {
+  const total = TOOL_SCHEMAS.length + mcpToolCount;
+  if (total > LARGE_TOOL_SET_WARN) {
+    console.warn(
+      `[ollama-mcp] aggregated tool set is large (${total} tools > ${LARGE_TOOL_SET_WARN}); ` +
+        "a local model may over-explore — narrow it via each server's `tools` allowlist."
+    );
+  }
 }
 
 /**
@@ -442,6 +485,7 @@ export class OllamaBackend implements AgentBackend {
     await Promise.all(
       specs.map((spec) => this.connectMcpServer(spec, session, connect, params.workspacePath))
     );
+    warnIfLargeToolSet(session.mcpTools.length);
 
     return Ok(session);
   }
@@ -471,7 +515,7 @@ export class OllamaBackend implements AgentBackend {
       );
       session.mcpClients.push(client);
       const nsPrefix = sanitizeSegment(spec.name);
-      for (const tool of tools) {
+      for (const tool of filterServerTools(spec, tools)) {
         const namespaced = `${nsPrefix}__${sanitizeSegment(tool.name)}`;
         if (session.mcpToolMap.has(namespaced)) continue;
         session.mcpTools.push({

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -36,6 +36,7 @@ const McpServerSpecSchema = z
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
     cwd: z.string().min(1).optional(),
+    tools: z.array(z.string()).optional(),
   })
   .strict();
 

--- a/packages/orchestrator/tests/agent/backends/ollama-mcp.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama-mcp.test.ts
@@ -85,6 +85,46 @@ async function makeLinkedServer(opts: { callDelayMs?: number } = {}): Promise<Cl
   return client;
 }
 
+/**
+ * Stand up a linked in-memory MCP server exposing an arbitrary set of tools (each
+ * carrying `ECHO_SCHEMA`), plus a connected Client. Used by the allowlist +
+ * large-tool-set tests to control exactly which tools a server reports.
+ */
+async function makeMultiToolServer(toolNames: string[]): Promise<Client> {
+  const server = new Server({ name: 'multi', version: '1.0.0' }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: toolNames.map((name) => ({
+      name,
+      description: `${name} tool`,
+      inputSchema: ECHO_SCHEMA,
+    })),
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (req) => ({
+    content: [{ type: 'text', text: `called:${String(req.params.name)}` }],
+  }));
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverT);
+  const client = new Client({ name: 'test', version: '1.0.0' }, { capabilities: {} });
+  await client.connect(clientT);
+  return client;
+}
+
+/** connectMcp seam returning a server that exposes exactly `toolNames`. */
+function multiToolConnect(toolNames: string[]): NonNullable<OllamaBackendConfig['connectMcp']> {
+  return async (): Promise<{ client: Client; tools: McpToolDescriptor[] }> => {
+    const client = await makeMultiToolServer(toolNames);
+    const listed = await client.listTools();
+    return {
+      client,
+      tools: listed.tools.map((t) => ({
+        name: t.name,
+        ...(t.description !== undefined ? { description: t.description } : {}),
+        inputSchema: t.inputSchema as Record<string, unknown>,
+      })),
+    };
+  };
+}
+
 /** connectMcp seam returning the linked in-memory client + its listTools result. */
 function inMemoryConnect(opts: { callDelayMs?: number } = {}) {
   return async (): Promise<{ client: Client; tools: McpToolDescriptor[] }> => {
@@ -313,5 +353,75 @@ describe('OllamaBackend — MCP tools', () => {
     if (!start.ok) return;
     expect(seen).toContain(workspace);
     expect(seen).toContain('/custom');
+  });
+
+  // SC1 — `tools` unset ⇒ every tool a server exposes is aggregated (byte-identical).
+  it("aggregates all of a server's tools when `tools` is unset (SC1)", async () => {
+    const backend = new OllamaBackend({
+      ...baseConfig,
+      mcpServers: [{ name: 'multi', command: 'x' }],
+      connectMcp: multiToolConnect(['echo', 'other']),
+    });
+    const start = await backend.startSession({ workspacePath: workspace, permissionMode: 'full' });
+    expect(start.ok).toBe(true);
+    if (!start.ok) return;
+    const session = start.value as OllamaSession;
+    const names = session.mcpTools.map((t) => t.function.name);
+    expect(names).toEqual(['multi__echo', 'multi__other']);
+  });
+
+  // SC2 — `tools: ['echo']` narrows a server exposing echo+other to only echo.
+  it('aggregates only allowlisted tools when `tools` is set (SC2)', async () => {
+    const backend = new OllamaBackend({
+      ...baseConfig,
+      mcpServers: [{ name: 'multi', command: 'x', tools: ['echo'] }],
+      connectMcp: multiToolConnect(['echo', 'other']),
+    });
+    const start = await backend.startSession({ workspacePath: workspace, permissionMode: 'full' });
+    expect(start.ok).toBe(true);
+    if (!start.ok) return;
+    const session = start.value as OllamaSession;
+    const names = session.mcpTools.map((t) => t.function.name);
+    expect(names).toEqual(['multi__echo']);
+    expect(names).not.toContain('multi__other');
+  });
+
+  // SC3 — an allowlisted name the server doesn't expose is warned + skipped;
+  // the tools it does have are still aggregated and startSession succeeds.
+  it('warns and skips an unknown allowlisted tool name, session still ok (SC3)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const backend = new OllamaBackend({
+      ...baseConfig,
+      mcpServers: [{ name: 'multi', command: 'x', tools: ['echo', 'missing'] }],
+      connectMcp: multiToolConnect(['echo', 'other']),
+    });
+    const start = await backend.startSession({ workspacePath: workspace, permissionMode: 'full' });
+    expect(start.ok).toBe(true);
+    if (!start.ok) return;
+    const session = start.value as OllamaSession;
+    expect(session.mcpTools.map((t) => t.function.name)).toEqual(['multi__echo']);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("server 'multi': requested tools not found: missing")
+    );
+  });
+
+  // SC5 — a server exposing more than LARGE_TOOL_SET_WARN tools fires exactly one
+  // large-tool-set advisory (built-ins + MCP tools exceed the threshold).
+  it('fires exactly one large-tool-set warning past the threshold (SC5)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manyTools = Array.from({ length: 45 }, (_, i) => `tool${i}`);
+    const backend = new OllamaBackend({
+      ...baseConfig,
+      mcpServers: [{ name: 'multi', command: 'x' }],
+      connectMcp: multiToolConnect(manyTools),
+    });
+    const start = await backend.startSession({ workspacePath: workspace, permissionMode: 'full' });
+    expect(start.ok).toBe(true);
+    if (!start.ok) return;
+    const largeWarnings = warn.mock.calls.filter((c) =>
+      String(c[0]).includes('aggregated tool set is large')
+    );
+    expect(largeWarnings).toHaveLength(1);
+    expect(String(largeWarnings[0]![0])).toContain('48 tools'); // 3 built-ins + 45 MCP
   });
 });

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -619,6 +619,13 @@ export interface McpServerSpec {
   env?: Record<string, string>;
   /** Working directory; defaults to the session `workspacePath`. */
   cwd?: string;
+  /**
+   * Per-server tool allowlist (pre-namespacing tool names). When present, only
+   * these tools are aggregated from the server; absent ⇒ all tools (byte-identical
+   * to prior behavior). Narrows a broad server (e.g. `harness-mcp`'s ~95 tools) to
+   * a high-value set so a local model is not overwhelmed by choice.
+   */
+  tools?: string[];
 }
 
 export interface OllamaBackendDef {

--- a/templates/orchestrator/harness.orchestrator.local.md
+++ b/templates/orchestrator/harness.orchestrator.local.md
@@ -50,6 +50,9 @@ agent:
       #     args: ['-y', '@upstash/context7-mcp']
       #   - name: harness          # code_search / ask_graph / review_changes /
       #     command: harness-mcp    # outcome_eval, run against the agent's workspace
+      #     tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]
+      #                             # narrow harness's ~95 tools to the read-oriented set
+      #                             # so a local model isn't flooded (omit tools = all).
   # Routing — controls WHICH backend handles each use case.
   routing:
     default: primary

--- a/templates/orchestrator/harness.orchestrator.md
+++ b/templates/orchestrator/harness.orchestrator.md
@@ -43,6 +43,9 @@ agent:
       #     args: ['-y', '@upstash/context7-mcp']
       #   - name: harness          # code_search / ask_graph / review_changes /
       #     command: harness-mcp    # outcome_eval, run against the agent's workspace
+      #     tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]
+      #                             # narrow harness's ~95 tools to the read-oriented set
+      #                             # so a local model isn't flooded (omit tools = all).
   # Routing — controls WHICH backend handles each use case.
   routing:
     default: primary


### PR DESCRIPTION
Follow-up to #849 (local OllamaBackend MCP tools). Part of the **robust local model interaction** campaign.

## Why
In the live e2e the harness MCP alone exposed **95 tools**; with ~98 total, `qwen3-coder:30b` wrote the correct file (via context7) but then over-explored a verification loop without cleanly emitting `TASK_COMPLETE` — choice paralysis, not context size.

## What
- `mcpServers[].tools?: string[]` on `McpServerSpec` — narrows a server to named tools (filtered on the server's own pre-namespacing name). Unset ⇒ all tools (**SC1 byte-identical**).
- Requested-but-unexposed names warn once (deduped) and are skipped — graceful, never fatal.
- `warnIfLargeToolSet`: one advisory when built-ins + MCP tools exceed `LARGE_TOOL_SET_WARN` (40), pointing at `tools`. No hard cap.
- Scaffolds narrow the commented harness example to a read-oriented set; documented in `multi-backend-routing.md#mcp-tools`.

## Rigor
Spec `docs/changes/local-mcp-tool-curation/proposal.md` (SC1–SC5, D1–D4) → TDD executor → adversarial review (APPROVE-WITH-NITS; both nits addressed: deduped the warning, gitignored the e2e scratch).

## Gates
ollama suite **31/31** (27 base green + SC1/SC2/SC3/SC5) · typecheck clean · changeset (orchestrator+types minor) · all pre-push gates green.