### PR TITLE
fix(core): review bug heuristics skip non-code files

### DIFF
--- a/.changeset/review-bug-agent-skip-non-code.md
+++ b/.changeset/review-bug-agent-skip-non-code.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/core': patch
+---
+
+The review bug-detection heuristics (division-by-zero, empty-catch) now only
+scan code files. They read raw lines and match code patterns, so running them
+on non-code files produced false positives — most notably a `/` in a scoped
+package name inside a Markdown changeset (`@scope/pkg`) read as a division,
+flagging every publishable PR's changeset as "potential division by zero" in
+the floor-only (no-LLM) review tier. Gated both detectors to
+`.ts/.tsx/.js/.jsx/.mjs/.cjs/.mts/.cts` via an `isCodeFile` check.

--- a/packages/core/src/review/agents/bug-agent.ts
+++ b/packages/core/src/review/agents/bug-agent.ts
@@ -17,6 +17,19 @@ export const BUG_DETECTION_DESCRIPTOR: ReviewAgentDescriptor = {
 };
 
 /**
+ * Extensions the source-scanning heuristics (division-by-zero, empty-catch)
+ * apply to. These detectors read raw lines and match code patterns, so running
+ * them on non-code files produces false positives — e.g. a `/` in a scoped
+ * package name inside a Markdown changeset (`@scope/pkg`) reads as a division.
+ */
+const CODE_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts'];
+
+/** True when `path` is a code file the line-pattern heuristics should scan. */
+function isCodeFile(path: string): boolean {
+  return CODE_FILE_EXTENSIONS.some((ext) => path.endsWith(ext));
+}
+
+/**
  * Returns true when the lines preceding index i contain a zero-guard.
  */
 function hasPrecedingZeroCheck(lines: string[], i: number): boolean {
@@ -35,6 +48,7 @@ function hasPrecedingZeroCheck(lines: string[], i: number): boolean {
 function detectDivisionByZero(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   for (const cf of bundle.changedFiles) {
+    if (!isCodeFile(cf.path)) continue;
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
@@ -78,6 +92,7 @@ function isEmptyCatch(lines: string[], i: number): boolean {
 function detectEmptyCatch(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   for (const cf of bundle.changedFiles) {
+    if (!isCodeFile(cf.path)) continue;
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       // Match: catch (e) {} or catch(e){} or catch (e) { }

--- a/packages/core/tests/review/agents/bug-agent.test.ts
+++ b/packages/core/tests/review/agents/bug-agent.test.ts
@@ -91,6 +91,30 @@ describe('runBugDetectionAgent()', () => {
     ).toBe(true);
   });
 
+  it('does not scan non-code files for division-by-zero (scoped pkg name in a changeset)', () => {
+    // A Markdown changeset lists scoped package names like `@scope/pkg`; the `/`
+    // must not be read as a division operator (regression: required-review FP).
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: '.changeset/some-change.md',
+          content: [
+            '---',
+            "'@harness-engineering/orchestrator': minor",
+            "'@harness-engineering/types': minor",
+            '---',
+            '',
+            'A change.',
+          ].join('\n'),
+          reason: 'changed',
+          lines: 6,
+        },
+      ],
+    });
+    const findings = runBugDetectionAgent(bundle);
+    expect(findings.some((f) => f.title.toLowerCase().includes('division'))).toBe(false);
+  });
+
   it('detects missing test files when no test context is present', () => {
     const bundle = makeBundle({
       changedFiles: [


### PR DESCRIPTION
## Problem
The `required-review` floor-only tier (no LLM) posts **request-changes** on every publishable PR: the bug-detection division-by-zero heuristic scans **all** changed files, and a scoped package name in a Markdown changeset — `@harness-engineering/orchestrator` — matches its regex (`g/orchestrator` reads as a division). Empty-catch has the same all-files problem.

## Fix
Gate both line-scanning detectors (`detectDivisionByZero`, `detectEmptyCatch`) to code-file extensions (`.ts/.tsx/.js/.jsx/.mjs/.cjs/.mts/.cts`) via a new `isCodeFile` check. `detectMissingTests` already operated on source files.

## Test
A changeset fixture with scoped package names now produces zero division findings; bug-agent suite 10/10. Typecheck clean.

Unblocks clean `required-review` runs across the local-model campaign PRs (#851 and siblings).