### PR TITLE
fix(core): division-by-zero heuristic ignores path-like slashes

### DIFF
--- a/.changeset/division-heuristic-path-slashes.md
+++ b/.changeset/division-heuristic-path-slashes.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/core': patch
+---
+
+Tighten the review division-by-zero heuristic so it no longer flags
+path-like slashes. The detector matched any `x/y`, so a scoped-package
+import (`@harness-engineering/types`) read as a division — reddening the
+floor-only (no-LLM) required-review tier on essentially every code PR.
+It now skips `import`/`export` lines, comment/URL slashes, and requires a
+real spaced division shape (`a / b`) with a variable/paren divisor — which
+is how division always appears in a prettier-formatted codebase. Real
+division is still detected; scoped imports and paths are not.

--- a/packages/core/src/review/agents/bug-agent.ts
+++ b/packages/core/src/review/agents/bug-agent.ts
@@ -52,8 +52,20 @@ function detectDivisionByZero(bundle: ContextBundle): ReviewFinding[] {
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
-      // Look for division operations that don't have a preceding zero check
-      if (!line.match(/[^=!<>]\s*\/\s*[a-zA-Z_]\w*/) || line.includes('//')) continue;
+      const trimmed = line.trimStart();
+      // A scoped package path (`@scope/pkg`) in an import/export, a comment line,
+      // or a URL (`//`) contains a `/` that is NOT division. Real division in a
+      // prettier-formatted codebase is always spaced (`a / b`), so require
+      // whitespace around the `/` and a variable/paren divisor. This drops the
+      // `word/word` path false positives that flagged every scoped import.
+      if (
+        trimmed.startsWith('import ') ||
+        trimmed.startsWith('export ') ||
+        trimmed.startsWith('*') ||
+        line.includes('//')
+      )
+        continue;
+      if (!line.match(/[^=!<>*/]\s+\/\s+[a-zA-Z_(]/)) continue;
       if (hasPrecedingZeroCheck(lines, i)) continue;
       findings.push({
         id: makeFindingId('bug', cf.path, i + 1, 'division by zero'),

--- a/packages/core/tests/review/agents/bug-agent.test.ts
+++ b/packages/core/tests/review/agents/bug-agent.test.ts
@@ -91,6 +91,29 @@ describe('runBugDetectionAgent()', () => {
     ).toBe(true);
   });
 
+  it('does not flag scoped-package import paths in code as division', () => {
+    // `@harness-engineering/types` etc. contain a `/` but are not division —
+    // real division in a prettier-formatted codebase is spaced (`a / b`).
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/factory.ts',
+          content: [
+            "import { BackendDef } from '@harness-engineering/types';",
+            "import { rankModels } from '@harness-engineering/local-models';",
+            'export function make(): number {',
+            '  return 42;',
+            '}',
+          ].join('\n'),
+          reason: 'changed',
+          lines: 5,
+        },
+      ],
+    });
+    const findings = runBugDetectionAgent(bundle);
+    expect(findings.some((f) => f.title.toLowerCase().includes('division'))).toBe(false);
+  });
+
   it('does not scan non-code files for division-by-zero (scoped pkg name in a changeset)', () => {
     // A Markdown changeset lists scoped package names like `@scope/pkg`; the `/`
     // must not be read as a division operator (regression: required-review FP).


### PR DESCRIPTION
Follow-up to #852. That PR stopped the review division-by-zero heuristic from scanning **non-code** files (Markdown changesets). But it still matched scoped-package import paths in **code** files — `import … from '@harness-engineering/types'` → `g/types` reads as a division — so the floor-only (no-LLM) `required-review` tier posted request-changes on nearly every code PR (e.g. #855 flagged `backend-factory.ts:1,26,49`).

## Fix
The detector now:
- skips `import`/`export` lines, comment lines, and URLs (`//`);
- requires a **real spaced division shape** (`a / b` with a variable/paren divisor) — which is how division always appears in a prettier-formatted codebase.

Real division is still detected (existing test green); scoped imports and paths are not (new test).

## Test
bug-agent suite 11/11 (spaced-division detection preserved + new scoped-import-no-FP case). Typecheck clean.

Greens `required-review` across the repo's code PRs.