### PR TITLE
fix(roadmap): guard monolith writes against destructive re-serialization (#839)

### DIFF
--- a/.changeset/roadmap-monolith-preservation-guard.md
+++ b/.changeset/roadmap-monolith-preservation-guard.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(roadmap): stop `manage_roadmap` write actions from destructively re-serializing a hand-authored monolith (#839)
+
+In single-file mode, every `manage_roadmap` write (`promote`, `add`, `update`,
+etc.) persisted through `MonolithStore.write()`, which unconditionally
+re-serializes the whole `docs/roadmap.md` from a model that captures only a fixed
+set of single-line fields. Any hand-authored content the model does not model was
+silently discarded on the round-trip: multi-line `- **Summary:**` bodies
+truncated to their first line, `- **Issue:**` links dropped, `>` blockquote
+intros and HTML comments deleted. On a ~1100-line hand-maintained roadmap this
+lost ~957 lines.
+
+`MonolithStore.write()` now refuses rather than destroys: before overwriting it
+scans the on-disk file with a new `findUnpreservedLines` guard and returns a
+`write-failed` error (never writing) when the file carries content a whole-file
+rewrite would drop, pointing the user to shard the roadmap (`docs/roadmap.d/`,
+which does surgical per-row writes) or remove the unmodeled content. Cosmetic
+normalizations the serializer legitimately makes — canonicalizing the H1 title to
+`# Roadmap`, stripping `Milestone:`/`Feature:` heading prefixes, and bumping
+frontmatter timestamps — are tolerated, so canonically-formatted and real-world
+roadmaps still write normally. The sharded backend and aggregate regeneration are
+unaffected; the guard is single-file-only.

--- a/packages/cli/tests/mcp/tools/roadmap.test.ts
+++ b/packages/cli/tests/mcp/tools/roadmap.test.ts
@@ -877,4 +877,46 @@ describe('manage_roadmap promote action', () => {
     expect(response.isError).toBe(true);
     expect(response.content[0].text).toMatch(/spec is required/);
   });
+
+  // #839: a hand-maintained monolith carrying content the model does not capture
+  // (multi-line Summary, `- **Issue:**` link, `>` blockquote intro) must NOT be
+  // destructively re-serialized. The write is refused and the file left intact.
+  it('refuses to promote when the monolith carries unpreservable content, leaving the file byte-for-byte intact', async () => {
+    const RICH = `---
+project: test-project
+version: 1
+last_synced: 2026-01-01T00:00:00Z
+last_manual_edit: 2026-01-01T00:00:00Z
+---
+
+# Project Roadmap
+
+## Backlog
+
+> Hand-authored intro that the single-file writer would drop.
+
+### Feature: Mobile App
+- **Status:** backlog
+- **Spec:** —
+- **Plans:** —
+- **Blocked by:** —
+- **Summary:** Native mobile application.
+  A second summary line the parser truncates away.
+- **Issue:** [#839](https://github.com/x/y/issues/839)
+`;
+    fs.writeFileSync(path.join(tmpDir, 'docs', 'roadmap.md'), RICH, 'utf-8');
+
+    const response = await handleManageRoadmap({
+      path: tmpDir,
+      action: 'promote',
+      feature: 'Mobile App',
+      spec: SPEC,
+    });
+
+    expect(response.isError).toBe(true);
+    const envelope = JSON.parse(response.content[0].text);
+    expect(envelope).toMatchObject({ ok: false, reason: 'write-failed' });
+    // The file was never rewritten — no content lost.
+    expect(readRoadmap()).toBe(RICH);
+  });
 });

--- a/packages/core/src/roadmap/preservation.ts
+++ b/packages/core/src/roadmap/preservation.ts
@@ -1,0 +1,109 @@
+/**
+ * Monolith write-preservation guard (#839).
+ *
+ * `serializeRoadmap` emits ONLY the fields `parseRoadmap` models, each on a single
+ * line. A whole-file rewrite of a hand-authored single-file roadmap therefore silently
+ * discards everything the parser does not capture: continuation lines of a
+ * multi-line field body, `- **Key:**` bullets whose key is not modeled (e.g.
+ * `- **Issue:**` links), `>` blockquote intros, HTML comments, and any other
+ * prose. This module detects that unpreservable content so the monolith store can
+ * refuse the destructive write instead of losing it.
+ */
+
+/**
+ * Field keys the roadmap model round-trips. Source of truth is
+ * `parseFeatureBlock` in `./parse` (which reads exactly these keys, including the
+ * `Blocked by`/`Plans` input aliases the serializer canonicalizes to
+ * `Blockers`/`Plan`). Kept in sync by `preservation.test.ts`, which asserts that
+ * `findUnpreservedLines(serializeRoadmap(...))` is empty for representative
+ * roadmaps — so a new serialized field fails that test until it is added here.
+ */
+const MODELED_FIELD_KEYS: ReadonlySet<string> = new Set([
+  'Status',
+  'Spec',
+  'Summary',
+  'Blockers',
+  'Blocked by',
+  'Plan',
+  'Plans',
+  'Assignee',
+  'Priority',
+  'External-ID',
+  'Updated-At',
+]);
+
+/** A source line whose content a monolith rewrite would drop. */
+export interface UnpreservedLine {
+  /** 1-based line number in the original document. */
+  line: number;
+  /** The line's text (trailing whitespace trimmed). */
+  text: string;
+}
+
+/**
+ * Return the lines of `markdown` that a `serializeRoadmap` rewrite would silently
+ * drop. A line is preservable iff it is frontmatter (regenerated from the model),
+ * blank, an H1 title, an H2/H3 heading, an assignment-history table row, or a
+ * single-line modeled `- **Key:** …` field. Everything else — multi-line field
+ * continuations, unmodeled bullets, blockquotes, comments, arbitrary prose — is
+ * reported. An empty result means the document round-trips without content loss.
+ *
+ * H1 / heading-prefix / frontmatter differences are treated as preservable: the
+ * serializer canonicalizes the title to `# Roadmap` and strips `Milestone:`/
+ * `Feature:` prefixes, and it rewrites frontmatter timestamps — all cosmetic,
+ * single-line normalizations the reporter explicitly did not count as loss. The
+ * guard fires only on the catastrophic body loss (#839): dropped prose, Issue
+ * bullets, blockquote intros, and truncated multi-line summaries.
+ *
+ * Patterns are anchored at column 0 to mirror `parseRoadmap`'s own anchoring: an
+ * indented `  ### x` or `  - **Status:** x` is NOT parsed as a heading/field and
+ * so is (correctly) reported as unpreserved.
+ */
+export function findUnpreservedLines(markdown: string): UnpreservedLine[] {
+  const lines = markdown.split('\n');
+  const lost: UnpreservedLine[] = [];
+
+  let inFrontmatter = false;
+  let frontmatterDone = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const text = line.replace(/\s+$/, '');
+    const trimmed = line.trim();
+
+    // Frontmatter fence: the opening `---` on line 0 through the next `---`. Every
+    // frontmatter line is regenerated from the model, so none can be "lost".
+    if (!frontmatterDone) {
+      if (i === 0 && trimmed === '---') {
+        inFrontmatter = true;
+        continue;
+      }
+      if (inFrontmatter) {
+        if (trimmed === '---') {
+          inFrontmatter = false;
+          frontmatterDone = true;
+        }
+        continue;
+      }
+      // No frontmatter fence at all: begin body classification immediately.
+      frontmatterDone = true;
+    }
+
+    if (trimmed === '') continue; // blank lines carry no content
+    if (/^# /.test(text)) continue; // H1 title (serializer canonicalizes it to `# Roadmap`)
+    if (/^## /.test(text)) continue; // milestone / Backlog / Assignment History heading
+    if (/^### /.test(text)) continue; // feature heading (`### x` or `### Feature: x`)
+    if (/^\s*\|.*\|\s*$/.test(text)) continue; // assignment-history table row/header/separator
+
+    // Single-line modeled field. The value is optional: the serializer emits
+    // `- **Status:** …` etc. unconditionally, so the line survives whether or not
+    // it carries a value. A modeled key with a MULTI-line body still surfaces its
+    // continuation lines here — they fail every pattern above and are reported.
+    const field = text.match(/^- \*\*(.+?):\*\*/);
+    if (field && MODELED_FIELD_KEYS.has(field[1]!)) continue;
+
+    lost.push({ line: i + 1, text });
+  }
+
+  return lost;
+}

--- a/packages/core/src/roadmap/store/monolith-store.ts
+++ b/packages/core/src/roadmap/store/monolith-store.ts
@@ -8,6 +8,7 @@ import type {
 import { Ok, Err } from '@harness-engineering/types';
 import { parseRoadmap } from '../parse';
 import { serializeRoadmap } from '../serialize';
+import { findUnpreservedLines } from '../preservation';
 import type { RoadmapStore, FeatureMutation, AddFeatureInput } from './roadmap-store';
 
 /** Minimal injectable file IO so the store is unit-testable without node:fs. */
@@ -162,6 +163,34 @@ export class MonolithStore implements RoadmapStore {
   }
 
   private async write(roadmap: Roadmap): Promise<Result<void>> {
+    // Data-loss guard (#839): a whole-file rewrite serializes only the fields the
+    // model captures, silently dropping hand-authored content the parser does not
+    // model — multi-line field bodies, unmodeled `- **Key:**` bullets (e.g. Issue
+    // links), `>` blockquote intros, HTML comments. Refuse rather than destroy.
+    // The shard backend (docs/roadmap.d/) does surgical per-row writes and is the
+    // supported way to edit a roadmap carrying such content.
+    let current: string | null;
+    try {
+      current = await this.io.readFile(this.roadmapPath);
+    } catch {
+      current = null; // first write / no prior file: nothing on disk to preserve
+    }
+    if (current !== null) {
+      const lost = findUnpreservedLines(current);
+      if (lost.length > 0) {
+        const first = lost[0]!;
+        return Err(
+          new Error(
+            `Refusing to rewrite ${this.roadmapPath}: it contains ${lost.length} line(s) the ` +
+              `single-file writer cannot preserve and would silently drop ` +
+              `(e.g. line ${first.line}: "${first.text}"). ` +
+              `Shard the roadmap into docs/roadmap.d/ for surgical per-row writes, ` +
+              `or remove the unmodeled content, then retry. See issue #839.`
+          )
+        );
+      }
+    }
+
     try {
       await this.io.writeFile(this.roadmapPath, serializeRoadmap(roadmap));
     } catch (err) {

--- a/packages/core/tests/roadmap/preservation.test.ts
+++ b/packages/core/tests/roadmap/preservation.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { findUnpreservedLines } from '../../src/roadmap/preservation';
+import { serializeRoadmap } from '../../src/roadmap/serialize';
+import { MONOLITH_ROADMAP, MIGRATION_ROADMAP, OLD_ROADMAP_MD } from './store/fixtures';
+
+describe('findUnpreservedLines (#839 monolith write-preservation guard)', () => {
+  describe('canonical serializer output round-trips losslessly (drift-catcher)', () => {
+    // If serializeRoadmap ever emits a new field, these break until the field is
+    // added to MODELED_FIELD_KEYS — keeping the guard's key set in sync.
+    it('reports nothing for a plain serialized roadmap', () => {
+      expect(findUnpreservedLines(serializeRoadmap(MONOLITH_ROADMAP))).toEqual([]);
+    });
+
+    it('reports nothing for a serialized roadmap with extended fields + assignment history', () => {
+      // MIGRATION_ROADMAP exercises Assignee/Priority/External-ID rows and a
+      // populated assignment-history table.
+      expect(findUnpreservedLines(serializeRoadmap(MIGRATION_ROADMAP))).toEqual([]);
+    });
+  });
+
+  describe('detects hand-authored content the serializer would drop', () => {
+    it('flags an unmodeled `- **Issue:**` bullet', () => {
+      const lost = findUnpreservedLines(OLD_ROADMAP_MD);
+      // OLD_ROADMAP_MD carries an HTML comment + a narrative prose line.
+      expect(lost.map((l) => l.text)).toContain(
+        '<!-- Hand-authored monolith with extra prose, to prove SEMANTIC (not byte) equivalence. -->'
+      );
+      expect(lost.map((l) => l.text)).toContain(
+        'This narrative line and the comment above are dropped by the lossy serializer.'
+      );
+    });
+
+    it('flags a multi-line Summary continuation, an Issue bullet, and a blockquote with correct line numbers', () => {
+      const md = [
+        '---',
+        'project: demo',
+        'version: 1',
+        'last_synced: 2026-07-17T00:00:00.000Z',
+        'last_manual_edit: 2026-07-17T00:00:00.000Z',
+        '---',
+        '',
+        '# Roadmap',
+        '',
+        '## Current Work',
+        '',
+        '> Section intro blockquote.',
+        '',
+        '### Local backend',
+        '',
+        '- **Status:** in-progress',
+        '- **Spec:** —',
+        '- **Summary:** Ship the local backend end to end.',
+        '  This second line is a continuation and is dropped.',
+        '- **Issue:** [#837](https://x/y/837)',
+        '- **Blockers:** —',
+        '- **Plan:** —',
+      ].join('\n');
+
+      const lost = findUnpreservedLines(md);
+      const byText = new Map(lost.map((l) => [l.text, l.line]));
+
+      expect(byText.get('> Section intro blockquote.')).toBe(12);
+      expect(byText.get('  This second line is a continuation and is dropped.')).toBe(19);
+      expect(byText.get('- **Issue:** [#837](https://x/y/837)')).toBe(20);
+      // Modeled single-line fields and headings are NOT flagged.
+      expect(lost.map((l) => l.text)).not.toContain('- **Status:** in-progress');
+      expect(lost.map((l) => l.text)).not.toContain('### Local backend');
+    });
+
+    it('flags an indented heading/field (parser anchors at column 0)', () => {
+      const md = [
+        '---',
+        'project: demo',
+        'version: 1',
+        'last_synced: 2026-07-17T00:00:00.000Z',
+        'last_manual_edit: 2026-07-17T00:00:00.000Z',
+        '---',
+        '',
+        '# Roadmap',
+        '',
+        '## Current Work',
+        '',
+        '  ### Indented feature',
+        '  - **Status:** planned',
+      ].join('\n');
+      const texts = findUnpreservedLines(md).map((l) => l.text);
+      expect(texts).toContain('  ### Indented feature');
+      expect(texts).toContain('  - **Status:** planned');
+    });
+  });
+
+  describe('tolerates cosmetic normalizations (not content loss)', () => {
+    it('does NOT flag a non-`# Roadmap` H1 title or `Milestone:`/`Feature:` heading prefixes', () => {
+      // The serializer canonicalizes the title to `# Roadmap` and strips the
+      // prefixes — cosmetic single-line normalizations, not the body loss #839
+      // is about. A real-world roadmap in this exact shape must still be writable.
+      const md = [
+        '---',
+        'project: demo',
+        'version: 1',
+        'last_synced: 2026-07-17T00:00:00.000Z',
+        'last_manual_edit: 2026-07-17T00:00:00.000Z',
+        '---',
+        '',
+        '# Project Roadmap',
+        '',
+        '## Milestone: MVP Release',
+        '',
+        '### Feature: Auth System',
+        '- **Status:** in-progress',
+        '- **Spec:** —',
+        '- **Summary:** Authentication',
+      ].join('\n');
+      expect(findUnpreservedLines(md)).toEqual([]);
+    });
+
+    it('does NOT flag `Blocked by`/`Plans` input aliases', () => {
+      const md = [
+        '---',
+        'project: demo',
+        'version: 1',
+        'last_synced: 2026-07-17T00:00:00.000Z',
+        'last_manual_edit: 2026-07-17T00:00:00.000Z',
+        '---',
+        '',
+        '# Roadmap',
+        '',
+        '## Current Work',
+        '',
+        '### A feature',
+        '',
+        '- **Status:** planned',
+        '- **Blocked by:** Some other feature',
+        '- **Plans:** docs/plan.md',
+        '- **Summary:** —',
+      ].join('\n');
+      expect(findUnpreservedLines(md)).toEqual([]);
+    });
+  });
+});

--- a/packages/core/tests/roadmap/store/monolith-store.test.ts
+++ b/packages/core/tests/roadmap/store/monolith-store.test.ts
@@ -205,4 +205,68 @@ describe('MonolithStore', () => {
     // One sibling survives — the other slug-colliding row is gone, not both.
     expect(written.value.milestones[0]!.features).toHaveLength(1);
   });
+
+  // #839 (destructive re-serialization): a write MUST NOT silently drop
+  // hand-authored content the model does not capture. When the on-disk file
+  // carries such content, write actions refuse and leave the file untouched.
+  describe('#839: refuses to rewrite a monolith carrying unpreservable content', () => {
+    // A canonical roadmap PLUS an `- **Issue:**` bullet, a multi-line Summary,
+    // and a `>` blockquote intro — exactly the content the reporter lost.
+    const RICH_ROADMAP_MD = `---
+project: harness-engineering
+version: 1
+last_synced: 2026-07-17T00:00:00.000Z
+last_manual_edit: 2026-07-17T00:00:00.000Z
+---
+
+# Roadmap
+
+## MVP Release
+
+> This blockquote intro is not modeled and would be dropped.
+
+### A feature
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** First line of the summary.
+  Second line that the single-line parser truncates away.
+- **Issue:** [#839](https://github.com/x/y/issues/839)
+- **Blockers:** —
+- **Plan:** —
+`;
+
+    it('patchFeature() returns Err and does not write', async () => {
+      const { io, files, writes } = makeIO({ [ROADMAP_PATH]: RICH_ROADMAP_MD });
+      const store = new MonolithStore({ roadmapPath: ROADMAP_PATH, io });
+      const r = await store.patchFeature('a-feature', (f) => ({ ...f, status: 'done' }));
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.message).toMatch(/#839/);
+      // No write happened; the file is byte-for-byte intact.
+      expect(writes).toHaveLength(0);
+      expect(files.get(ROADMAP_PATH)).toBe(RICH_ROADMAP_MD);
+    });
+
+    it('addFeature() returns Err and does not write', async () => {
+      const { io, files, writes } = makeIO({ [ROADMAP_PATH]: RICH_ROADMAP_MD });
+      const store = new MonolithStore({ roadmapPath: ROADMAP_PATH, io });
+      const r = await store.addFeature({
+        slug: 'b-feature',
+        milestone: 'MVP Release',
+        order: 20,
+        feature: feat('B feature', 'planned'),
+      });
+      expect(r.ok).toBe(false);
+      expect(writes).toHaveLength(0);
+      expect(files.get(ROADMAP_PATH)).toBe(RICH_ROADMAP_MD);
+    });
+
+    it('still writes normally when the on-disk file is canonical (guard is not over-eager)', async () => {
+      const { io, writes } = makeIO();
+      const store = new MonolithStore({ roadmapPath: ROADMAP_PATH, io });
+      const r = await store.patchFeature('a-feature', (f) => ({ ...f, status: 'done' }));
+      expect(r.ok).toBe(true);
+      expect(writes).toEqual([ROADMAP_PATH]);
+    });
+  });
 });


### PR DESCRIPTION
Closes #839.

## Problem

In single-file mode, every `manage_roadmap` write action (`promote`, `add`, `update`, …) persists through `MonolithStore.write()`, which unconditionally re-serializes the whole `docs/roadmap.md` from a model that captures only a fixed set of single-line fields. Any hand-authored content the model does not model is silently discarded on the parse→serialize round-trip:

- multi-line `- **Summary:**` bodies truncated to their first physical line
- `- **Issue:**` links dropped from every row
- `>` blockquote intros and HTML comments deleted
- non-`# Roadmap` H1 titles rewritten

On the reporter's ~1100-line hand-maintained roadmap this lost ~957 lines. The migration path has a round-trip guard, but it deliberately *canonicalizes the loss away* — the write path had no protection at all.

## Fix (issue option (b): refuse rather than destroy)

- **New `packages/core/src/roadmap/preservation.ts`** → `findUnpreservedLines(md)`: returns the body lines a `serializeRoadmap` rewrite would drop. A line is preservable iff it is frontmatter, blank, an H1 title, an H2/H3 heading, an assignment-history table row, or a single-line modeled `- **Key:** …` field (keys include the `Blocked by`/`Plans` input aliases). Patterns are anchored at column 0 to mirror `parseRoadmap`.
- **`MonolithStore.write()`** now scans the on-disk file with the guard and returns `Err` (surfacing as the `write-failed` envelope) **without writing** when the file carries content a rewrite would drop — pointing the user to shard the roadmap (`docs/roadmap.d/`, surgical per-row writes) or remove the unmodeled content.
- Cosmetic normalizations the serializer legitimately makes — canonicalizing the title to `# Roadmap`, stripping `Milestone:`/`Feature:` heading prefixes, bumping frontmatter timestamps — are tolerated, so canonically-formatted and real-world roadmaps still write normally.
- The sharded backend and aggregate regeneration are unaffected; the guard is single-file-only.

## Tests

Regression coverage at three layers, all following the revert protocol (fail without the guard, pass with it):

- `packages/core/tests/roadmap/preservation.test.ts` — unit tests + a drift-catcher asserting `findUnpreservedLines(serializeRoadmap(...)) === []` for representative roadmaps (fails if the serializer gains an unlisted field), plus the cosmetic-normalization tolerance cases.
- `packages/core/tests/roadmap/store/monolith-store.test.ts` — `#839` block: `patchFeature`/`addFeature` refuse and leave the file **byte-for-byte intact** on a rich monolith; a canonical file still writes (guard is not over-eager).
- `packages/cli/tests/mcp/tools/roadmap.test.ts` — end-to-end `promote` on a rich monolith returns a `write-failed` envelope and preserves the file.

Core full suite: 3595 passed / 1 skipped. CLI roadmap+mcp: 948 passed. Invariant-R read-source guard passes; typecheck + eslint + prettier clean. Changeset included (`@harness-engineering/core` patch).

## Out of scope (deferred)

The reporter's secondary point — parse aborts on the *first* non-canonical status value, forcing one-write-per-bad-row discovery; a single all-rows validation pass would improve that UX. This is separate from the destructive-rewrite "real issue" and left for a follow-up.