### PR TITLE
feat(eslint-plugin): add no-focused-tests rule (first fully-autonomous local-model build)

### DIFF
--- a/.changeset/eslint-no-focused-tests.md
+++ b/.changeset/eslint-no-focused-tests.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/eslint-plugin': minor
+---
+
+Add the `no-focused-tests` rule: flags focused tests — `describe.only` /
+`it.only` / `test.only`, and bare `fdescribe` / `fit` — so a focused test can't
+slip into CI and silently skip the rest of the suite. Object-name-gated, so an
+unrelated `.only` member access is not a false positive. Enabled as `error` in
+the recommended config.

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -28,6 +28,7 @@ const plugin = {
         '@harness-engineering/no-hardcoded-path-separator': 'warn',
         '@harness-engineering/no-process-env-in-spawn': 'error',
         '@harness-engineering/require-path-normalization': 'warn',
+        '@harness-engineering/no-focused-tests': 'error',
       },
     },
     strict: {
@@ -49,6 +50,7 @@ const plugin = {
         '@harness-engineering/no-hardcoded-path-separator': 'error',
         '@harness-engineering/no-process-env-in-spawn': 'error',
         '@harness-engineering/require-path-normalization': 'error',
+        '@harness-engineering/no-focused-tests': 'error',
       },
     },
   },

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -12,6 +12,7 @@ import noHardcodedPathSeparator from './no-hardcoded-path-separator';
 import noProcessEnvInSpawn from './no-process-env-in-spawn';
 import requirePathNormalization from './require-path-normalization';
 import noUndefinedOptionalAssignment from './no-undefined-optional-assignment';
+import noFocusedTests from './no-focused-tests';
 
 export const rules = {
   'enforce-doc-exports': enforceDocExports,
@@ -27,4 +28,5 @@ export const rules = {
   'no-unix-shell-command': noUnixShellCommand,
   'require-boundary-schema': requireBoundarySchema,
   'require-path-normalization': requirePathNormalization,
+  'no-focused-tests': noFocusedTests,
 };

--- a/packages/eslint-plugin/src/rules/no-focused-tests.ts
+++ b/packages/eslint-plugin/src/rules/no-focused-tests.ts
@@ -1,0 +1,55 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/harness-engineering/eslint-plugin/blob/main/docs/rules/${name}.md`
+);
+
+type MessageIds = 'focusedTest';
+
+export default createRule<[], MessageIds>({
+  name: 'no-focused-tests',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow focused tests that must not be committed.',
+    },
+    messages: {
+      focusedTest:
+        "Focused test — remove '.only'/'f' prefix before committing so the whole suite runs.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Check for describe.only(), it.only(), test.only()
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          (node.callee.object.name === 'describe' ||
+            node.callee.object.name === 'it' ||
+            node.callee.object.name === 'test') &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'only'
+        ) {
+          context.report({
+            node,
+            messageId: 'focusedTest',
+          });
+        }
+
+        // Check for fdescribe() and fit()
+        if (
+          node.callee.type === 'Identifier' &&
+          (node.callee.name === 'fdescribe' || node.callee.name === 'fit')
+        ) {
+          context.report({
+            node,
+            messageId: 'focusedTest',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/integration/plugin.test.ts
+++ b/packages/eslint-plugin/tests/integration/plugin.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect } from 'vitest';
 import plugin from '../../src/index';
 
 describe('plugin exports', () => {
-  it('exports all 13 rules', () => {
-    expect(Object.keys(plugin.rules)).toHaveLength(13);
+  it('exports all 14 rules', () => {
+    expect(Object.keys(plugin.rules)).toHaveLength(14);
     expect(plugin.rules['no-undefined-optional-assignment']).toBeDefined();
     expect(plugin.rules['no-layer-violation']).toBeDefined();
     expect(plugin.rules['no-circular-deps']).toBeDefined();
@@ -18,6 +18,7 @@ describe('plugin exports', () => {
     expect(plugin.rules['no-unix-shell-command']).toBeDefined();
     expect(plugin.rules['no-hardcoded-path-separator']).toBeDefined();
     expect(plugin.rules['require-path-normalization']).toBeDefined();
+    expect(plugin.rules['no-focused-tests']).toBeDefined();
   });
 
   it('exports recommended config', () => {

--- a/packages/eslint-plugin/tests/rules/no-focused-tests.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-focused-tests.test.ts
@@ -1,0 +1,50 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll } from 'vitest';
+import rule from '../../src/rules/no-focused-tests';
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-focused-tests', rule, {
+  valid: [
+    // Regular describe, it, test calls
+    { code: `describe('suite', () => {});` },
+    { code: `it('test', () => {});` },
+    { code: `test('test', () => {});` },
+    // Regular function calls
+    { code: `console.log('hello');` },
+    { code: `someFunction();` },
+    // Nested calls with .only
+    { code: `describe('suite', () => { it('test', () => {}); });` },
+  ],
+  invalid: [
+    // describe.only()
+    {
+      code: `describe.only('suite', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+    // it.only()
+    {
+      code: `it.only('test', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+    // test.only()
+    {
+      code: `test.only('test', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+    // fdescribe()
+    {
+      code: `fdescribe('suite', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+    // fit()
+    {
+      code: `fit('test', () => {});`,
+      errors: [{ messageId: 'focusedTest' }],
+    },
+  ],
+});


### PR DESCRIPTION
Adds `no-focused-tests` to `@harness-engineering/eslint-plugin`: flags `describe.only` / `it.only` / `test.only` (and bare `fdescribe` / `fit`) so a focused test can't slip into CI and silently skip the rest of the suite. Object-name-gated, so an unrelated `.only` member access is not a false positive. Enabled as `error` in the recommended config.

## Why this PR exists
It's a genuinely useful rule — **and** it's the first change **authored end-to-end by the local model** (`qwen3-coder:30b`) through the harness OllamaBackend dispatch, as the payoff of the local-dispatch work. The model read the existing rule + test as templates (via the harness `code_search`/`code_outline` MCP tools), wrote the rule, registered it in both places, wrote the RuleTester test, and iterated to green in ~16 tool calls with no stalls.

## Supervision (verified, not self-reported)
Built + reviewed independently in an isolated worktree before commit:
- `eslint-plugin` typecheck: **clean**
- full `eslint-plugin` suite: **20 files / 203 tests pass** (incl. the new rule's valid/invalid cases + the updated integration rule-count)
- rule logic read + confirmed correct (object-name-gated `CallExpression` visitor; no false positives on unrelated `.only`)
- confirmed it doesn't break the repo's own lint (the one repo match is a string fixture, not a real focused test; `eslint.config.js` cherry-picks rules rather than applying `recommended` wholesale)

The complementary finding from the same effort: the model **correctly failed** on core-store surgery (broke a cross-file type contract, tests red — caught by the gates, nothing shipped). So the system routes contained work to the local model and holds bigger work for a human — which is the point.