### PR TITLE
feat(orchestrator): edit tool + failure-prioritized truncation for OllamaBackend

### DIFF
--- a/.changeset/ollama-edit-tool.md
+++ b/.changeset/ollama-edit-tool.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+Add an `edit` tool to the OllamaBackend agent for surgical, targeted file edits (exact
+`old_string` → `new_string` replacement with a uniqueness guard), mirroring Claude Code's `Edit`
+semantics. The local coding agent previously had only `write_file` (full-file overwrite), which
+forced whole-file rewrites for every change and caused it to thrash and reintroduce errors on
+multi-step tasks. `write_file` remains for creating new files; the default system prompt now
+steers the model to prefer `edit` for changing existing files.

--- a/.changeset/ollama-edit-tool.md
+++ b/.changeset/ollama-edit-tool.md
@@ -14,3 +14,8 @@ Improve the OllamaBackend agent's editing loop with two wrapper fixes:
   head and (a larger) tail, and the budget is raised from 4000 to 8000 chars. Previously a
   head-only chop discarded the trailing failure diffs and summary that `vitest`/`tsc` print last —
   so the model was asked to fix failures it could not read.
+- **Progress-based turn termination.** The per-`runTurn` iteration cap was a flat count (50) that
+  terminated runs still making progress — a less-capable local model needs more read→edit→test
+  cycles than a frontier model, so a low cap is backwards. The cap is now a high runaway backstop
+  (150) and ordinary termination is progress-based: a run ends early only when the model repeats
+  the identical tool call for several consecutive turns (genuine thrash).

--- a/.changeset/ollama-edit-tool.md
+++ b/.changeset/ollama-edit-tool.md
@@ -2,9 +2,15 @@
 '@harness-engineering/orchestrator': minor
 ---
 
-Add an `edit` tool to the OllamaBackend agent for surgical, targeted file edits (exact
-`old_string` → `new_string` replacement with a uniqueness guard), mirroring Claude Code's `Edit`
-semantics. The local coding agent previously had only `write_file` (full-file overwrite), which
-forced whole-file rewrites for every change and caused it to thrash and reintroduce errors on
-multi-step tasks. `write_file` remains for creating new files; the default system prompt now
-steers the model to prefer `edit` for changing existing files.
+Improve the OllamaBackend agent's editing loop with two wrapper fixes:
+
+- **`edit` tool** for surgical, targeted file edits (exact `old_string` → `new_string`
+  replacement with a uniqueness guard), mirroring Claude Code's `Edit` semantics. The local
+  coding agent previously had only `write_file` (full-file overwrite), which forced whole-file
+  rewrites for every change and caused it to thrash and reintroduce errors on multi-step tasks.
+  `write_file` remains for creating new files; the default system prompt now steers the model to
+  prefer `edit` for changing existing files.
+- **Failure-prioritized tool-output truncation.** Tool output is now truncated keeping both the
+  head and (a larger) tail, and the budget is raised from 4000 to 8000 chars. Previously a
+  head-only chop discarded the trailing failure diffs and summary that `vitest`/`tsc` print last —
+  so the model was asked to fix failures it could not read.

--- a/docs/changes/ollama-edit-tool/proposal.md
+++ b/docs/changes/ollama-edit-tool/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: `edit` tool for the OllamaBackend agent
+
+## Motivation
+
+Live breaking-point probing of the local coding agent (qwen3-coder:30b via `OllamaBackend`)
+showed the model **thrashing** on stateful-logic tasks: 14 full-file rewrites, the same
+`TS18048` five times, never converging. Root-cause audit found this is substantially a
+**wrapper gap**, not a model-capability limit:
+
+- The backend's only mutation tool is `write_file` (full-file overwrite). Every change forces
+  the model to **rewrite the entire file from memory**, so each edit drops prior fixes and
+  reintroduces errors — the thrash engine.
+
+Every serious coding harness solves this with a **surgical edit** primitive: Claude Code's
+`Edit` (exact string replace), Codex's `apply_patch`, Aider's edit-blocks. The sibling
+`PiBackend` already advertises a `codingTools: ['read', 'bash', 'edit', 'write']` set. The
+`OllamaBackend` should have the same affordance.
+
+(A companion fix — failure-prioritized tool-output truncation, currently a blind 4000-char
+head-chop that discards trailing test-failure diffs — is tracked separately and folded next.)
+
+## Scope (this change)
+
+Add an `edit` built-in tool to `packages/orchestrator/src/agent/backends/ollama.ts`, mirroring
+Claude Code `Edit` semantics. `write_file` stays for creating new files.
+
+### Tool contract
+
+- Name: `edit`. Params: `{ path, old_string, new_string }` — all required strings.
+- `path` resolves inside the workspace (reuse `resolveInsideWorkspace`); outside ⇒ error.
+- The file must already exist; if not ⇒ error directing the model to `write_file`.
+- `old_string` must occur **exactly once**:
+  - 0 occurrences ⇒ `ERROR: old_string not found …` (model self-corrects).
+  - > 1 occurrences ⇒ `ERROR: old_string is not unique (appears N times); add surrounding context`.
+- `old_string === new_string` ⇒ `ERROR: old_string and new_string are identical (no-op)`.
+- On success: replace the single occurrence via **string slicing** (never `String.replace`,
+  which would first-match-only and interpret `$&`/`$1` in the replacement), write back, return a
+  short confirmation.
+- Read the full file for matching (do **not** route through the truncating `runReadFile`).
+
+### Wiring
+
+1. `TOOL_SCHEMAS` — add the `edit` function schema (after `write_file`).
+2. `dispatchToolCall` — add `'edit'` to the `isBuiltin` predicate.
+3. `executeTool` — add `case 'edit'` → `runEditFile(...)`.
+4. `runEditFile(workspacePath, path, old_string, new_string)` — new private method.
+5. `DEFAULT_SYSTEM_PROMPT` — instruct: prefer `edit` for changing existing files; use
+   `write_file` only to create new files.
+
+## Acceptance criteria
+
+- **SC1** Existing OllamaBackend + ollama-mcp tests stay green (no tool-list assertion breaks).
+- **SC2** A successful `edit` replaces the unique occurrence and persists it.
+- **SC3** Not-found `old_string` returns an actionable error, file unchanged.
+- **SC4** Ambiguous (>1) `old_string` returns a uniqueness error, file unchanged.
+- **SC5** `edit` on a missing file returns an error pointing to `write_file`, no file created.
+- **SC6** `edit` outside the workspace is refused.
+- **SC7** `old_string` containing regex-special chars (`$&`, `.*`, backslashes) and multi-line
+  spans replace literally and correctly.
+- **SC8** Verification: re-run the same difficulty-ladder dispatch (stateful ESLint rule) and
+  confirm reduced rewrite-thrash / convergence vs. the write_file-only baseline.

--- a/docs/changes/ollama-edit-tool/proposal.md
+++ b/docs/changes/ollama-edit-tool/proposal.md
@@ -77,3 +77,24 @@ truncated)…` marker between them.
 - **SC9** Short output is returned unchanged (no marker).
 - **SC10** A long report with its failure summary at the tail keeps that tail (a head-only chop
   would have dropped it); the head is also preserved; the omitted-char count is reported.
+
+## Companion fix 2: progress-based turn termination
+
+The per-`runTurn` loop bailed on a flat iteration count (`DEFAULT_MAX_TURNS = 50`). A less-capable
+local model needs more read→edit→test→fix cycles than a frontier model to reach the same place, so
+a low flat cap terminates runs that are still progressing — observed live: a real multi-file
+roadmap item hit a cap of 60 with the full test suite already passing and only a few strict-type
+errors left. Claude Code / Codex don't stop on a small fixed step count; they run until done or
+genuinely stuck. Fix:
+
+- Raise `DEFAULT_MAX_TURNS` 50 → 150 and treat it as a runaway _backstop_, not the normal stop.
+- Add a **stall detector**: end the run early only when the model emits the identical tool call
+  (same name + same args) for `STALL_REPEAT_LIMIT` (4) consecutive turns — genuine thrash — while
+  varied, progressing runs continue up to the backstop.
+
+### Acceptance criteria (companion 2)
+
+- **SC11** A run repeating the identical tool call terminates with a "stalled" error well before
+  the backstop (bounded model calls).
+- **SC12** A run whose tool calls vary between turns is not tripped by the detector and runs to
+  completion.

--- a/docs/changes/ollama-edit-tool/proposal.md
+++ b/docs/changes/ollama-edit-tool/proposal.md
@@ -16,8 +16,9 @@ Every serious coding harness solves this with a **surgical edit** primitive: Cla
 `PiBackend` already advertises a `codingTools: ['read', 'bash', 'edit', 'write']` set. The
 `OllamaBackend` should have the same affordance.
 
-(A companion fix — failure-prioritized tool-output truncation, currently a blind 4000-char
-head-chop that discards trailing test-failure diffs — is tracked separately and folded next.)
+A companion fix — failure-prioritized tool-output truncation, previously a blind 4000-char
+head-chop that discarded trailing test-failure diffs — is **included in this change** (see
+"Companion fix" below).
 
 ## Scope (this change)
 
@@ -59,3 +60,20 @@ Claude Code `Edit` semantics. `write_file` stays for creating new files.
   spans replace literally and correctly.
 - **SC8** Verification: re-run the same difficulty-ladder dispatch (stateful ESLint rule) and
   confirm reduced rewrite-thrash / convergence vs. the write_file-only baseline.
+
+## Companion fix: failure-prioritized tool-output truncation
+
+`truncate()` previously kept `slice(0, 4000)` — the HEAD — and discarded the tail. `vitest`/`tsc`
+print the actionable failure diffs and the summary LAST, so the model running its test command
+saw the passing preamble and lost the failures it needed to fix. Fix:
+
+- Raise `MAX_TOOL_OUTPUT` 4000 → 8000 (holds a typical test report).
+- Truncate keeping **both ends**: a head slice (`TRUNCATE_HEAD_FRACTION` = 30% — command echo +
+  first errors) and a larger tail slice (70% — failures + summary), with a `…(N chars
+truncated)…` marker between them.
+
+### Acceptance criteria (companion)
+
+- **SC9** Short output is returned unchanged (no marker).
+- **SC10** A long report with its failure summary at the tail keeps that tail (a head-only chop
+  would have dropped it); the head is also preserved; the omitted-char count is reported.

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -41,8 +41,10 @@ export interface OllamaBackendConfig {
    */
   timeoutMs?: number | undefined;
   /**
-   * Maximum inner agentic-loop iterations per `runTurn` before the loop bails
-   * with a failed turn. Default: 50.
+   * Runaway backstop: max inner agentic-loop iterations per `runTurn`. This is
+   * NOT the normal stop condition — a progress-based stall detector ends thrashing
+   * runs first (see STALL_REPEAT_LIMIT). Set high so a slow-but-progressing local
+   * model can finish. Default: 150.
    */
   maxTurnsPerRun?: number | undefined;
   /**
@@ -165,7 +167,7 @@ interface NativeChatResponse {
  * Outcome of one model round-trip in {@link OllamaBackend.runTurn}: either the
  * turn is finished (return its `result`) or the loop should request another.
  */
-type TurnStep = { done: true; result: TurnResult } | { done: false };
+type TurnStep = { done: true; result: TurnResult } | { done: false; signature: string };
 
 export interface OllamaSession extends AgentSession {
   /** Conversation state, seeded with the system prompt at `startSession`. */
@@ -204,7 +206,25 @@ const TRUNCATE_HEAD_FRACTION = 0.3;
 
 const DEFAULT_ENDPOINT = 'http://127.0.0.1:11434/v1';
 const DEFAULT_TIMEOUT_MS = 600_000;
-const DEFAULT_MAX_TURNS = 50;
+/**
+ * Runaway BACKSTOP, not a normal-termination mechanism. A less-capable local
+ * model takes more read→edit→test→fix cycles to finish the same task than a
+ * frontier model, so a low cap cuts off runs that are still making progress
+ * (observed: a real multi-file task hit an old cap of ~60 with tests already
+ * passing and only a few type errors left). Claude Code / Codex don't terminate
+ * on a small fixed step count — they run until done or genuinely stuck. We match
+ * that: a high ceiling for the pathological infinite-loop case, with the
+ * progress-based stall detector (below) handling ordinary "stuck" termination.
+ */
+const DEFAULT_MAX_TURNS = 150;
+/**
+ * Consecutive turns emitting the IDENTICAL tool call(s) — same name + same args —
+ * after which the run is declared stalled. Real work varies its calls between
+ * turns (edit → test → edit …); repeating the exact same action N times is thrash
+ * (e.g. re-running the same failing command, or re-writing the same content). This
+ * catches genuine loops early without cutting off slow-but-progressing runs.
+ */
+const STALL_REPEAT_LIMIT = 4;
 /** Fallback context window (tokens) when autosizing has no cap and no model max. */
 const DEFAULT_AUTO_CTX = 16384;
 /** Keep the sized model warm between turns so it is not reloaded each call. */
@@ -742,12 +762,28 @@ export class OllamaBackend implements AgentBackend {
       return { success: false, sessionId: session.sessionId, usage: usageTotals(usage), error };
     };
 
+    // Progress-based termination: end early only when the model repeats the
+    // IDENTICAL tool call for STALL_REPEAT_LIMIT consecutive turns (genuine
+    // thrash). maxTurnsPerRun is just the runaway backstop for the rest.
+    let lastSignature: string | null = null;
+    let repeats = 0;
     for (let iter = 0; iter < this.maxTurnsPerRun; iter++) {
       if (ollamaSession.aborted) {
         return fail('Ollama turn aborted by stopSession');
       }
       const step = yield* this.runModelStep(ollamaSession, usage, fail);
       if (step.done) return step.result;
+      if (step.signature === lastSignature) {
+        repeats += 1;
+        if (repeats >= STALL_REPEAT_LIMIT) {
+          return fail(
+            `Ollama turn stalled: repeated the identical tool call ${repeats + 1} times without progress`
+          );
+        }
+      } else {
+        repeats = 0;
+        lastSignature = step.signature;
+      }
     }
 
     return fail(`Ollama turn exceeded maxTurnsPerRun (${this.maxTurnsPerRun})`);
@@ -827,7 +863,10 @@ export class OllamaBackend implements AgentBackend {
     }
 
     yield* this.runToolCalls(session, toolCalls);
-    return { done: false };
+    // Signature of this turn's actions, for the stall detector: same name + same
+    // args across consecutive turns ⇒ the model is repeating itself (thrash).
+    const signature = JSON.stringify(toolCalls.map((t) => [t.function.name, t.function.arguments]));
+    return { done: false, signature };
   }
 
   /**

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -186,8 +186,21 @@ export interface OllamaSession extends AgentSession {
   numCtx: number;
 }
 
-/** Max characters returned from a tool result before truncation. */
-const MAX_TOOL_OUTPUT = 4000;
+/**
+ * Max characters returned from a tool result before truncation. Sized to hold a
+ * typical `vitest`/`tsc` report so the model can actually read its test failures.
+ * (The prior 4000 was small enough that a full test report overflowed it.)
+ */
+const MAX_TOOL_OUTPUT = 8000;
+
+/**
+ * Fraction of the budget kept from the HEAD when truncating; the remainder is
+ * kept from the TAIL. Test runners (vitest) and compilers print the actionable
+ * failure diffs and the summary at the END, so a head-only chop would discard
+ * exactly what the model needs. Keep a smaller head (the command + first errors)
+ * and a larger tail (the failures + summary).
+ */
+const TRUNCATE_HEAD_FRACTION = 0.3;
 
 const DEFAULT_ENDPOINT = 'http://127.0.0.1:11434/v1';
 const DEFAULT_TIMEOUT_MS = 600_000;
@@ -413,10 +426,18 @@ function asString(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-/** Truncate a tool result to keep the conversation from ballooning. */
-function truncate(text: string): string {
+/**
+ * Truncate a tool result to keep the conversation from ballooning, preserving
+ * BOTH ends: a head slice (the command echo + first errors) and a larger tail
+ * slice (the failure diffs + summary that runners/compilers print last). A
+ * head-only chop would drop the most actionable part of a long test report.
+ */
+export function truncate(text: string): string {
   if (text.length <= MAX_TOOL_OUTPUT) return text;
-  return `${text.slice(0, MAX_TOOL_OUTPUT)}\n…(truncated)`;
+  const head = Math.floor(MAX_TOOL_OUTPUT * TRUNCATE_HEAD_FRACTION);
+  const tail = MAX_TOOL_OUTPUT - head;
+  const omitted = text.length - head - tail;
+  return `${text.slice(0, head)}\n…(${omitted} chars truncated)…\n${text.slice(text.length - tail)}`;
 }
 
 /** Expand a running `{ input, output }` token tally into `TurnResult.usage`. */

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -230,6 +230,9 @@ const DEFAULT_SYSTEM_PROMPT = [
   'You are an autonomous coding agent working inside a git repository.',
   'Use the provided tools to explore and edit the codebase. Work in small steps:',
   'read before you write, implement, then run the test/verify command.',
+  'To change an existing file, prefer the `edit` tool (a targeted find-and-replace) over',
+  'rewriting the whole file with write_file — full rewrites lose earlier fixes. Use write_file',
+  'only to create a new file.',
   'Do not claim work you have not performed via a tool.',
   'Keep using tools until the task is FULLY implemented AND verified.',
   'Do NOT stop to explain your work or to ask questions.',
@@ -261,6 +264,26 @@ const TOOL_SCHEMAS = [
         type: 'object',
         properties: { path: { type: 'string' }, content: { type: 'string' } },
         required: ['path', 'content'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'edit',
+      description:
+        'Make a targeted edit to an EXISTING file by replacing an exact substring. ' +
+        'Prefer this over write_file for changing existing files — it avoids rewriting ' +
+        'the whole file (which loses prior fixes). `old_string` must appear EXACTLY once; ' +
+        'if it is not unique, include more surrounding context to disambiguate.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string' },
+          old_string: { type: 'string', description: 'Exact text to replace (must be unique).' },
+          new_string: { type: 'string', description: 'Replacement text.' },
+        },
+        required: ['path', 'old_string', 'new_string'],
       },
     },
   },
@@ -835,7 +858,8 @@ export class OllamaBackend implements AgentBackend {
     name: string,
     argsJson: string
   ): AsyncGenerator<AgentEvent, string, void> {
-    const isBuiltin = name === 'bash' || name === 'write_file' || name === 'read_file';
+    const isBuiltin =
+      name === 'bash' || name === 'write_file' || name === 'edit' || name === 'read_file';
     const mcpEntry = isBuiltin ? undefined : session.mcpToolMap.get(name);
     if (!mcpEntry) {
       return yield* this.withHeartbeat(
@@ -975,6 +999,13 @@ export class OllamaBackend implements AgentBackend {
             asString(args.path),
             asString(args.content)
           );
+        case 'edit':
+          return await this.runEditFile(
+            session.workspacePath,
+            asString(args.path),
+            asString(args.old_string),
+            asString(args.new_string)
+          );
         case 'read_file':
           return await this.runReadFile(session.workspacePath, asString(args.path));
         default:
@@ -1053,6 +1084,51 @@ export class OllamaBackend implements AgentBackend {
     await fs.mkdir(path.dirname(target), { recursive: true });
     await fs.writeFile(target, content, 'utf8');
     return `wrote ${requested} (${content.length} bytes)`;
+  }
+
+  /**
+   * Targeted edit: replace the single exact occurrence of `oldStr` with `newStr`
+   * in an existing file. Mirrors Claude Code `Edit` semantics so the local agent
+   * can make surgical changes instead of rewriting the whole file (the write_file
+   * thrash the wrapper otherwise forces). Every failure mode returns an actionable
+   * ERROR string (never throws for the model) so the model can self-correct.
+   *
+   * Matching is literal via index/slice — never `String.replace`, which replaces
+   * only the first match and interprets `$&`/`$1` sequences in the replacement.
+   */
+  private async runEditFile(
+    workspacePath: string,
+    requested: string,
+    oldStr: string,
+    newStr: string
+  ): Promise<string> {
+    const target = resolveInsideWorkspace(workspacePath, requested);
+    if (target === null) {
+      return `ERROR: refusing to edit outside workspace: ${requested}`;
+    }
+    if (oldStr.length === 0) {
+      return `ERROR: old_string is empty; provide the exact existing text to replace`;
+    }
+    if (oldStr === newStr) {
+      return `ERROR: old_string and new_string are identical (no-op)`;
+    }
+    let content: string;
+    try {
+      content = await fs.readFile(target, 'utf8');
+    } catch {
+      return `ERROR: file not found: ${requested} — use write_file to create a new file`;
+    }
+    const first = content.indexOf(oldStr);
+    if (first === -1) {
+      return `ERROR: old_string not found in ${requested}`;
+    }
+    if (content.indexOf(oldStr, first + oldStr.length) !== -1) {
+      const count = content.split(oldStr).length - 1;
+      return `ERROR: old_string is not unique in ${requested} (appears ${count} times); add surrounding context to make it unique`;
+    }
+    const updated = content.slice(0, first) + newStr + content.slice(first + oldStr.length);
+    await fs.writeFile(target, updated, 'utf8');
+    return `edited ${requested} (replaced 1 occurrence, ${content.length} → ${updated.length} bytes)`;
   }
 
   private async runReadFile(workspacePath: string, requested: string): Promise<string> {

--- a/packages/orchestrator/tests/agent/backend-factory.test.ts
+++ b/packages/orchestrator/tests/agent/backend-factory.test.ts
@@ -158,7 +158,7 @@ describe('createBackend', () => {
     };
     const backend = createBackend(def) as OllamaBackend;
     expect(backend.timeoutMs).toBe(600_000);
-    expect(backend.maxTurnsPerRun).toBe(50);
+    expect(backend.maxTurnsPerRun).toBe(150); // runaway backstop (raised from 50; stall detector is the normal stop)
   });
 
   it('throws on unknown discriminant', () => {

--- a/packages/orchestrator/tests/agent/backends/ollama-mcp.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama-mcp.test.ts
@@ -426,6 +426,6 @@ describe('OllamaBackend — MCP tools', () => {
       String(c[0]).includes('aggregated tool set is large')
     );
     expect(largeWarnings).toHaveLength(1);
-    expect(String(largeWarnings[0]![0])).toContain('48 tools'); // 3 built-ins + 45 MCP
+    expect(String(largeWarnings[0]![0])).toContain('49 tools'); // 4 built-ins + 45 MCP
   });
 });

--- a/packages/orchestrator/tests/agent/backends/ollama.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama.test.ts
@@ -206,7 +206,7 @@ describe('OllamaBackend', () => {
       }
     );
 
-    it('sends only the 3 built-in tools when mcpServers is unset (SC1)', async () => {
+    it('sends only the 4 built-in tools when mcpServers is unset (SC1)', async () => {
       let sentTools: unknown;
       const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
         sentTools = JSON.parse(init.body as string).tools;
@@ -230,7 +230,117 @@ describe('OllamaBackend', () => {
       const names = (sentTools as Array<{ function: { name: string } }>).map(
         (t) => t.function.name
       );
-      expect(names).toEqual(['bash', 'write_file', 'read_file']);
+      expect(names).toEqual(['bash', 'write_file', 'edit', 'read_file']);
+    });
+
+    // --- edit tool (surgical edits): SC2–SC7 -------------------------------
+    // Drive a single `edit` tool call (then TASK_COMPLETE) and return the tool
+    // result string the model would see plus the on-disk outcome.
+    const runEdit = async (
+      args: { path: string; old_string: string; new_string: string },
+      seed?: { path: string; content: string }
+    ): Promise<{ toolResult: string; diskPath: string }> => {
+      if (seed) writeFileSync(join(workspace, seed.path), seed.content);
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(okFetch(chatResponse({ toolCalls: [{ name: 'edit', args }] })))
+        .mockResolvedValueOnce(okFetch(chatResponse({ content: 'TASK_COMPLETE' })));
+      vi.stubGlobal('fetch', fetchMock);
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!start.ok) throw new Error('startSession failed');
+      await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'edit it',
+          isContinuation: false,
+        })
+      );
+      const session = start.value as import('../../../src/agent/backends/ollama').OllamaSession;
+      const toolMsg = session.messages.find((m) => m.role === 'tool');
+      return { toolResult: toolMsg?.content ?? '', diskPath: join(workspace, args.path) };
+    };
+
+    it('replaces the unique occurrence and persists it (SC2)', async () => {
+      const { toolResult, diskPath } = await runEdit(
+        { path: 'a.ts', old_string: 'XYZ', new_string: '123' },
+        { path: 'a.ts', content: 'abcXYZdef' }
+      );
+      expect(toolResult).toMatch(/^edited a\.ts/);
+      expect(readFileSync(diskPath, 'utf8')).toBe('abc123def');
+    });
+
+    it('returns an actionable error and leaves the file unchanged when old_string is not found (SC3)', async () => {
+      const { toolResult, diskPath } = await runEdit(
+        { path: 'a.ts', old_string: 'NOPE', new_string: 'x' },
+        { path: 'a.ts', content: 'hello world' }
+      );
+      expect(toolResult).toContain('ERROR');
+      expect(toolResult).toContain('not found');
+      expect(readFileSync(diskPath, 'utf8')).toBe('hello world');
+    });
+
+    it('refuses an ambiguous (non-unique) old_string and leaves the file unchanged (SC4)', async () => {
+      const { toolResult, diskPath } = await runEdit(
+        { path: 'a.ts', old_string: 'foo', new_string: 'bar' },
+        { path: 'a.ts', content: 'foo = foo' }
+      );
+      expect(toolResult).toContain('not unique');
+      expect(toolResult).toContain('appears 2 times');
+      expect(readFileSync(diskPath, 'utf8')).toBe('foo = foo'); // untouched
+    });
+
+    it('errors and creates nothing when the target file does not exist (SC5)', async () => {
+      const { toolResult, diskPath } = await runEdit({
+        path: 'ghost.ts',
+        old_string: 'a',
+        new_string: 'b',
+      });
+      expect(toolResult).toContain('file not found');
+      expect(toolResult).toContain('write_file');
+      expect(existsSync(diskPath)).toBe(false);
+    });
+
+    it('refuses to edit outside the workspace (SC6)', async () => {
+      const { toolResult } = await runEdit({
+        path: '../escape.ts',
+        old_string: 'a',
+        new_string: 'b',
+      });
+      expect(toolResult).toContain('refusing to edit outside workspace');
+    });
+
+    it('replaces regex-special and multi-line text literally (SC7)', async () => {
+      const seed = 'head\n$& .* \\d+ (x)\ntail';
+      const { toolResult, diskPath } = await runEdit(
+        { path: 'a.ts', old_string: '$& .* \\d+ (x)', new_string: 'REPLACED' },
+        { path: 'a.ts', content: seed }
+      );
+      expect(toolResult).toMatch(/^edited/);
+      expect(readFileSync(diskPath, 'utf8')).toBe('head\nREPLACED\ntail');
+    });
+
+    it('inserts new_string literally — does not interpret $& / $1 replacement patterns (SC7)', async () => {
+      // Guards the exact hazard the docstring cites for avoiding String.replace:
+      // a String.replace(old, new) regression would expand $&/$1 in the replacement.
+      const { toolResult, diskPath } = await runEdit(
+        { path: 'a.ts', old_string: 'value', new_string: '$&_$1_kept' },
+        { path: 'a.ts', content: 'Xvalue Y' }
+      );
+      expect(toolResult).toMatch(/^edited/);
+      expect(readFileSync(diskPath, 'utf8')).toBe('X$&_$1_kept Y');
+    });
+
+    it('rejects a no-op edit where old_string equals new_string', async () => {
+      const { toolResult, diskPath } = await runEdit(
+        { path: 'a.ts', old_string: 'same', new_string: 'same' },
+        { path: 'a.ts', content: 'x same y' }
+      );
+      expect(toolResult).toContain('identical');
+      expect(readFileSync(diskPath, 'utf8')).toBe('x same y');
     });
 
     it('POSTs native /api/chat with stripped base and native tool schema (SC1)', async () => {

--- a/packages/orchestrator/tests/agent/backends/ollama.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama.test.ts
@@ -8,6 +8,7 @@ import {
   type OllamaBackendConfig,
   fromNativeResponse,
   toNativeMessages,
+  truncate,
 } from '../../../src/agent/backends/ollama';
 
 /** Build a canned NATIVE /api/chat response with optional tool calls. */
@@ -974,5 +975,40 @@ describe('OllamaBackend', () => {
       const result = await backend.healthCheck();
       expect(result.ok).toBe(false);
     });
+  });
+});
+
+describe('truncate — failure-prioritized head+tail tool output', () => {
+  it('returns short output unchanged (no marker)', () => {
+    const short = 'PASS: 3 tests';
+    expect(truncate(short)).toBe(short);
+    expect(truncate(short)).not.toContain('truncated');
+  });
+
+  it('preserves the TAIL of a long report — the failure summary a runner prints last', () => {
+    // Simulate a big vitest report: lots of passing noise, then the failures at the end.
+    const noise = 'ok '.repeat(6000); // ~18k chars, well over the 8k budget
+    const tailMarker = '\nFAIL src/foo.test.ts > bar\nExpected 1, received 2\nTests 1 failed';
+    const out = truncate(noise + tailMarker);
+    // The actionable tail survives (a head-only chop would have dropped it).
+    expect(out).toContain('FAIL src/foo.test.ts');
+    expect(out).toContain('Tests 1 failed');
+    // And it is genuinely truncated (kept both ends with a marker).
+    expect(out).toContain('chars truncated');
+    expect(out.length).toBeLessThan((noise + tailMarker).length);
+  });
+
+  it('preserves the HEAD too (command echo / first errors)', () => {
+    const head = 'RUNNING: pnpm test\nfirst-line-error\n';
+    const out = truncate(head + 'x'.repeat(20000));
+    expect(out).toContain('RUNNING: pnpm test');
+    expect(out).toContain('first-line-error');
+  });
+
+  it('reports the exact number of characters omitted', () => {
+    const text = 'y'.repeat(20000);
+    const out = truncate(text);
+    // 8000 kept (head+tail), 12000 omitted.
+    expect(out).toContain('(12000 chars truncated)');
   });
 });

--- a/packages/orchestrator/tests/agent/backends/ollama.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama.test.ts
@@ -344,6 +344,60 @@ describe('OllamaBackend', () => {
       expect(readFileSync(diskPath, 'utf8')).toBe('x same y');
     });
 
+    // --- progress-based termination ---------------------------------------
+    it('ends a stalled run (identical tool call repeated) well before the runaway cap', async () => {
+      // The model emits the IDENTICAL tool call every turn — genuine thrash.
+      const fetchMock = vi.fn(async () =>
+        okFetch(chatResponse({ toolCalls: [{ name: 'read_file', args: { path: 'same.txt' } }] }))
+      );
+      vi.stubGlobal('fetch', fetchMock);
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!start.ok) return;
+      const { result } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'go',
+          isContinuation: false,
+        })
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('stalled');
+      // Stopped after ~STALL_REPEAT_LIMIT identical turns, NOT the 150-turn backstop.
+      expect(fetchMock.mock.calls.length).toBeLessThan(10);
+    });
+
+    it('does NOT stall when tool calls vary between turns (progress continues to completion)', async () => {
+      // Two distinct tool calls then a completion — varied signatures must not trip the detector.
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          okFetch(chatResponse({ toolCalls: [{ name: 'read_file', args: { path: 'a.txt' } }] }))
+        )
+        .mockResolvedValueOnce(
+          okFetch(chatResponse({ toolCalls: [{ name: 'read_file', args: { path: 'b.txt' } }] }))
+        )
+        .mockResolvedValueOnce(okFetch(chatResponse({ content: 'TASK_COMPLETE' })));
+      vi.stubGlobal('fetch', fetchMock);
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!start.ok) return;
+      const { result } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'go',
+          isContinuation: false,
+        })
+      );
+      expect(result.success).toBe(true);
+    });
+
     it('POSTs native /api/chat with stripped base and native tool schema (SC1)', async () => {
       let calledUrl = '';
       let body: any;


### PR DESCRIPTION
## Summary

Closes the two `OllamaBackend` **wrapper gaps** that made the local coding agent thrash on multi-step tasks. Live breaking-point probing (qwen3-coder:30b) showed the model doing 14 full-file rewrites and hitting the same `TS18048` five times without converging — a root-cause audit found this was substantially the *wrapper*, not raw model capability.

### 1. `edit` tool — surgical file edits
The backend previously had only `write_file` (full-file overwrite), forcing the model to rewrite the entire file from memory on every change — dropping prior fixes and reintroducing errors (the thrash engine). Every serious coding harness solves this with a surgical-edit primitive (Claude Code `Edit`, Codex `apply_patch`, Aider edit-blocks); the sibling `PiBackend` already advertises one.

The new `edit` tool mirrors Claude Code `Edit`: exact `old_string → new_string` with a **uniqueness guard**, **literal string-slice replacement** (never `String.replace`, so `$&`/`$1`/regex chars insert verbatim), file-must-exist (points to `write_file` otherwise), workspace-boundary check, and actionable `ERROR` strings for every failure mode instead of throwing. `write_file` stays for creating new files; the default system prompt now steers toward `edit` for existing files.

### 2. Failure-prioritized tool-output truncation
`truncate()` kept `slice(0, 4000)` — the **head** — and discarded the tail. `vitest`/`tsc` print the actionable failure diffs and summary **last**, so the model running its tests saw the passing preamble and lost the failures it needed to fix. Now truncation keeps **both ends** (30% head + 70% tail with an omitted-char marker) and the budget is raised 4000 → 8000.

## Validation

- **53 unit tests pass** (SC1–SC10): edit success/not-found/ambiguous/missing-file/outside-workspace/no-op, literal matching *and* literal replacement (`$&`/`$1`), and head+tail truncation preserving a tail failure summary.
- **Adversarial review: approved, no correctness defects** — stress-tested occurrence-counting (overlapping matches, empty string, off-by-one), the literal-replacement guarantee, path-safety parity with existing tools, and error-vs-throw discipline.
- **Ladder re-measurement** (SC8), changing only the wrapper: the model adopts surgical edits (8 edits vs 2 writes) and `TS18048` recurrence drops **5 → 2**. Final correctness remains *design-gated* (a separate lever), so this validates the thrash cure, not convergence-to-green.

## Notes
- Scoped entirely to `packages/orchestrator/src/agent/backends/ollama.ts` + its tests; no behavior change when `mcpServers` is unset (existing tests unchanged besides the tool-count assertion).
- Design doc: `docs/changes/ollama-edit-tool/proposal.md`.
