### PR TITLE
feat(eslint-plugin): add no-hardcoded-test-count rule

### DIFF
--- a/.changeset/eslint-no-hardcoded-test-count.md
+++ b/.changeset/eslint-no-hardcoded-test-count.md
@@ -1,0 +1,8 @@
+---
+'@harness-engineering/eslint-plugin': minor
+---
+
+Add the `no-hardcoded-test-count` ESLint rule. It flags hardcoded numeric literals in test-count
+assertions — `expect(x).toHaveLength(<number>)` and `expect(x.length).toBe(<number>)` — which drift
+silently as items are added or removed. A variable or computed expected value is not reported. The
+rule is registered in the recommended config.

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -29,6 +29,7 @@ const plugin = {
         '@harness-engineering/no-process-env-in-spawn': 'error',
         '@harness-engineering/require-path-normalization': 'warn',
         '@harness-engineering/no-focused-tests': 'error',
+        '@harness-engineering/no-hardcoded-test-count': 'error',
       },
     },
     strict: {

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -13,6 +13,7 @@ import noProcessEnvInSpawn from './no-process-env-in-spawn';
 import requirePathNormalization from './require-path-normalization';
 import noUndefinedOptionalAssignment from './no-undefined-optional-assignment';
 import noFocusedTests from './no-focused-tests';
+import noHardcodedTestCount from './no-hardcoded-test-count';
 
 export const rules = {
   'enforce-doc-exports': enforceDocExports,
@@ -29,4 +30,5 @@ export const rules = {
   'require-boundary-schema': requireBoundarySchema,
   'require-path-normalization': requirePathNormalization,
   'no-focused-tests': noFocusedTests,
+  'no-hardcoded-test-count': noHardcodedTestCount,
 };

--- a/packages/eslint-plugin/src/rules/no-hardcoded-test-count.ts
+++ b/packages/eslint-plugin/src/rules/no-hardcoded-test-count.ts
@@ -1,0 +1,77 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/harness-engineering/eslint-plugin/blob/main/docs/rules/${name}.md`
+);
+
+type MessageIds = 'hardcodedTestCount';
+
+/** True when `node` is a call to the bare identifier `expect(...)`. */
+function isExpectCall(node: TSESTree.Expression): node is TSESTree.CallExpression {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'expect'
+  );
+}
+
+/** The matcher name of an `expect(...).<name>(...)` call, else null. */
+function expectMatcherName(node: TSESTree.CallExpression): string | null {
+  const callee = node.callee;
+  if (
+    callee.type === 'MemberExpression' &&
+    isExpectCall(callee.object) &&
+    callee.property.type === 'Identifier'
+  ) {
+    return callee.property.name;
+  }
+  return null;
+}
+
+/** True when the first argument is a hardcoded numeric literal (the drift-prone count). */
+function hasNumericLiteralArg(args: TSESTree.CallExpressionArgument[]): boolean {
+  const arg = args[0];
+  return arg !== undefined && arg.type === 'Literal' && typeof arg.value === 'number';
+}
+
+/** True when the value under assertion is a `<x>.length` access, i.e. `expect(x.length)`. */
+function assertsLengthProperty(node: TSESTree.CallExpression): boolean {
+  const callee = node.callee;
+  if (callee.type !== 'MemberExpression' || callee.object.type !== 'CallExpression') return false;
+  const inner = callee.object.arguments[0];
+  return (
+    inner !== undefined &&
+    inner.type === 'MemberExpression' &&
+    inner.property.type === 'Identifier' &&
+    inner.property.name === 'length'
+  );
+}
+
+export default createRule<[], MessageIds>({
+  name: 'no-hardcoded-test-count',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow hardcoded numeric literals in test-count assertions.',
+    },
+    messages: {
+      hardcodedTestCount:
+        'Hardcoded test-count literal; counts drift when items change — compare against a derived value instead.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        const matcher = expectMatcherName(node);
+        if (matcher === null || !hasNumericLiteralArg(node.arguments)) return;
+        // `expect(x).toHaveLength(<n>)` is always a hardcoded count;
+        // `expect(x.length).toBe(<n>)` only when the value under test is a `.length`.
+        if (matcher === 'toHaveLength' || (matcher === 'toBe' && assertsLengthProperty(node))) {
+          context.report({ node, messageId: 'hardcodedTestCount' });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/integration/plugin.test.ts
+++ b/packages/eslint-plugin/tests/integration/plugin.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect } from 'vitest';
 import plugin from '../../src/index';
 
 describe('plugin exports', () => {
-  it('exports all 14 rules', () => {
-    expect(Object.keys(plugin.rules)).toHaveLength(14);
+  it('exports all 15 rules', () => {
+    expect(Object.keys(plugin.rules)).toHaveLength(15);
     expect(plugin.rules['no-undefined-optional-assignment']).toBeDefined();
     expect(plugin.rules['no-layer-violation']).toBeDefined();
     expect(plugin.rules['no-circular-deps']).toBeDefined();
@@ -19,6 +19,7 @@ describe('plugin exports', () => {
     expect(plugin.rules['no-hardcoded-path-separator']).toBeDefined();
     expect(plugin.rules['require-path-normalization']).toBeDefined();
     expect(plugin.rules['no-focused-tests']).toBeDefined();
+    expect(plugin.rules['no-hardcoded-test-count']).toBeDefined();
   });
 
   it('exports recommended config', () => {

--- a/packages/eslint-plugin/tests/rules/no-hardcoded-test-count.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-hardcoded-test-count.test.ts
@@ -1,0 +1,50 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll } from 'vitest';
+import rule from '../../src/rules/no-hardcoded-test-count';
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-hardcoded-test-count', rule, {
+  valid: [
+    // toHaveLength with variable
+    { code: `expect(rules).toHaveLength(expected);` },
+    { code: `expect(rules).toHaveLength(someFunction());` },
+
+    // toBe with variable (length)
+    { code: `expect(x.length).toBe(expected);` },
+    { code: `expect(x.length).toBe(someFunction());` },
+    { code: `expect(x.length).toBe(items.length);` },
+
+    // Other valid test patterns
+    { code: `describe('suite', () => {});` },
+    { code: `it('test', () => {});` },
+    { code: `test('test', () => {});` },
+    { code: `console.log('hello');` },
+    { code: `someFunction();` },
+  ],
+  invalid: [
+    // toHaveLength with numeric literal
+    {
+      code: `expect(rules).toHaveLength(12);`,
+      errors: [{ messageId: 'hardcodedTestCount' }],
+    },
+    {
+      code: `expect(rules).toHaveLength(5);`,
+      errors: [{ messageId: 'hardcodedTestCount' }],
+    },
+
+    // toBe with numeric literal (length)
+    {
+      code: `expect(x.length).toBe(5);`,
+      errors: [{ messageId: 'hardcodedTestCount' }],
+    },
+    {
+      code: `expect(items.length).toBe(10);`,
+      errors: [{ messageId: 'hardcodedTestCount' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Adds the `no-hardcoded-test-count` ESLint rule to `@harness-engineering/eslint-plugin`. It flags hardcoded numeric literals in test-count assertions — the exact drift problem this repo keeps hitting (rule-count, tool-count assertions that go stale when items are added/removed):

- `expect(x).toHaveLength(<number>)` → flagged
- `expect(x.length).toBe(<number>)` → flagged
- `expect(x).toHaveLength(expected)` / `toBe(items.length)` (variable/computed) → **not** flagged

Registered in the recommended config; the plugin's integration rule-count is updated 14→15.

## Provenance (e2e verification)

This rule was **built end-to-end by the local `qwen3-coder:30b` model** via the improved OllamaBackend (edit tool + failure-prioritized truncation + progress-based turn termination, #870), as an e2e verification of that wrapper. The model produced a functionally-correct, tsc-clean rule with all 217 plugin tests green, and correctly handled the cross-file rule-count update on its own.

The generated rule was then **refactored before landing** to meet repo quality bars the model missed: it had used `(arg as any)` casts (unnecessary — `Literal` already types `.value`) and packed everything into one deeply-nested visitor (cyclomatic 23 > 15). The landed version uses proper `TSESTree` types and small single-purpose helpers. Same behavior, same tests.

## Tests
`pnpm --filter @harness-engineering/eslint-plugin test` — 217 pass, tsc clean, lint + arch gates green.
