### PR TITLE
feat(orchestrator): bash exit code, read paging/line-numbers, edit replace_all

### DIFF
--- a/.changeset/ollama-tool-affordances.md
+++ b/.changeset/ollama-tool-affordances.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+Add three proven agent-tool affordances to the OllamaBackend, matching Claude Code / Codex:
+
+- **Bash exit code.** A non-zero command exit is now annotated (`[command exited with code N]`) so
+  the local model can tell success from failure without parsing output.
+- **Read paging + line numbers.** `read_file` output is line-numbered (`<n>\t<content>`, reference
+  only) and accepts optional `offset` (1-based start line) and `limit` params, so large files can be
+  read in chunks instead of returning a truncated whole-file blob. It also reports a clean
+  "file not found" instead of throwing.
+- **Edit `replace_all`.** The `edit` tool takes an optional `replace_all: true` to change every
+  occurrence (e.g. renaming a symbol) instead of requiring a unique match; the default remains the
+  unique-match guard.

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -307,14 +307,19 @@ const TOOL_SCHEMAS = [
       description:
         'Make a targeted edit to an EXISTING file by replacing an exact substring. ' +
         'Prefer this over write_file for changing existing files — it avoids rewriting ' +
-        'the whole file (which loses prior fixes). `old_string` must appear EXACTLY once; ' +
-        'if it is not unique, include more surrounding context to disambiguate.',
+        'the whole file (which loses prior fixes). By default `old_string` must appear EXACTLY ' +
+        'once; if it is not unique, add surrounding context, or set `replace_all: true` to change ' +
+        'every occurrence (e.g. renaming a symbol).',
       parameters: {
         type: 'object',
         properties: {
           path: { type: 'string' },
-          old_string: { type: 'string', description: 'Exact text to replace (must be unique).' },
+          old_string: { type: 'string', description: 'Exact text to replace.' },
           new_string: { type: 'string', description: 'Replacement text.' },
+          replace_all: {
+            type: 'boolean',
+            description: 'Replace every occurrence instead of requiring a unique match (optional).',
+          },
         },
         required: ['path', 'old_string', 'new_string'],
       },
@@ -324,10 +329,18 @@ const TOOL_SCHEMAS = [
     type: 'function',
     function: {
       name: 'read_file',
-      description: "Read a file's contents, relative to the workspace root.",
+      description:
+        'Read a file relative to the workspace root. Output is line-numbered ' +
+        '(`<n>\\t<content>`) for reference ONLY — the line-number prefix is NOT part of the file, ' +
+        'so never include it in an `edit` old_string. For large files, page with `offset` (1-based ' +
+        'start line) and `limit` (number of lines).',
       parameters: {
         type: 'object',
-        properties: { path: { type: 'string' } },
+        properties: {
+          path: { type: 'string' },
+          offset: { type: 'number', description: '1-based line to start from (optional).' },
+          limit: { type: 'number', description: 'Max number of lines to return (optional).' },
+        },
         required: ['path'],
       },
     },
@@ -1064,10 +1077,16 @@ export class OllamaBackend implements AgentBackend {
             session.workspacePath,
             asString(args.path),
             asString(args.old_string),
-            asString(args.new_string)
+            asString(args.new_string),
+            args.replace_all === true
           );
         case 'read_file':
-          return await this.runReadFile(session.workspacePath, asString(args.path));
+          return await this.runReadFile(
+            session.workspacePath,
+            asString(args.path),
+            typeof args.offset === 'number' ? args.offset : undefined,
+            typeof args.limit === 'number' ? args.limit : undefined
+          );
         default:
           return `ERROR: unknown tool ${name}`;
       }
@@ -1118,12 +1137,18 @@ export class OllamaBackend implements AgentBackend {
           /* process (group) already gone */
         }
       }, this.bashTimeoutMs);
-      child.on('close', () => {
+      child.on('close', (code: number | null) => {
         clearTimeout(timer);
         const body = out.length > 0 ? out : '(no output)';
-        resolve(
-          truncate(killed ? `ERROR: command killed after ${this.bashTimeoutMs}ms\n${body}` : body)
-        );
+        if (killed) {
+          resolve(truncate(`ERROR: command killed after ${this.bashTimeoutMs}ms\n${body}`));
+          return;
+        }
+        // Surface the exit code so the model can tell success from failure
+        // without parsing output (parity with Claude Code / Codex). A zero exit
+        // is the expected case, so only annotate a non-zero exit to avoid noise.
+        const suffix = code !== null && code !== 0 ? `\n[command exited with code ${code}]` : '';
+        resolve(truncate(body) + suffix);
       });
       child.on('error', (err: Error) => {
         clearTimeout(timer);
@@ -1160,7 +1185,8 @@ export class OllamaBackend implements AgentBackend {
     workspacePath: string,
     requested: string,
     oldStr: string,
-    newStr: string
+    newStr: string,
+    replaceAll = false
   ): Promise<string> {
     const target = resolveInsideWorkspace(workspacePath, requested);
     if (target === null) {
@@ -1182,22 +1208,52 @@ export class OllamaBackend implements AgentBackend {
     if (first === -1) {
       return `ERROR: old_string not found in ${requested}`;
     }
+    if (replaceAll) {
+      // Literal replace-every via split/join (never String.replaceAll's `$&`/`$1` interpretation).
+      const count = content.split(oldStr).length - 1;
+      const updated = content.split(oldStr).join(newStr);
+      await fs.writeFile(target, updated, 'utf8');
+      return `edited ${requested} (replaced ${count} occurrence${count === 1 ? '' : 's'}, ${content.length} → ${updated.length} bytes)`;
+    }
     if (content.indexOf(oldStr, first + oldStr.length) !== -1) {
       const count = content.split(oldStr).length - 1;
-      return `ERROR: old_string is not unique in ${requested} (appears ${count} times); add surrounding context to make it unique`;
+      return `ERROR: old_string is not unique in ${requested} (appears ${count} times); add surrounding context to make it unique, or pass replace_all:true`;
     }
     const updated = content.slice(0, first) + newStr + content.slice(first + oldStr.length);
     await fs.writeFile(target, updated, 'utf8');
     return `edited ${requested} (replaced 1 occurrence, ${content.length} → ${updated.length} bytes)`;
   }
 
-  private async runReadFile(workspacePath: string, requested: string): Promise<string> {
+  private async runReadFile(
+    workspacePath: string,
+    requested: string,
+    offset?: number,
+    limit?: number
+  ): Promise<string> {
     const target = resolveInsideWorkspace(workspacePath, requested);
     if (target === null) {
       return `ERROR: refusing to read outside workspace: ${requested}`;
     }
-    const content = await fs.readFile(target, 'utf8');
-    return truncate(content);
+    let content: string;
+    try {
+      content = await fs.readFile(target, 'utf8');
+    } catch {
+      return `ERROR: file not found: ${requested}`;
+    }
+    const lines = content.split('\n');
+    const start = offset !== undefined && offset > 0 ? offset - 1 : 0;
+    const end = limit !== undefined && limit > 0 ? start + limit : lines.length;
+    const slice = lines.slice(start, end);
+    // Line-numbered (`<n>\t<line>`, 1-based) for reference — display-only, mirrors
+    // Claude Code's Read so the model can cite lines; the prefix must not leak into edits.
+    const numbered = slice
+      .map((line, i) => `${String(start + i + 1).padStart(6, ' ')}\t${line}`)
+      .join('\n');
+    const paged =
+      start > 0 || end < lines.length
+        ? `\n[showing lines ${start + 1}-${Math.min(end, lines.length)} of ${lines.length}]`
+        : '';
+    return truncate(numbered) + paged;
   }
 
   private errorEvent(sessionId: string, message: string): AgentEvent {

--- a/packages/orchestrator/tests/agent/backends/ollama.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama.test.ts
@@ -1066,3 +1066,99 @@ describe('truncate — failure-prioritized head+tail tool output', () => {
     expect(out).toContain('(12000 chars truncated)');
   });
 });
+
+describe('OllamaBackend — tool affordances (exit code, read paging, replace_all)', () => {
+  let workspace: string;
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'ollama-aff-'));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  /** Drive a single tool call (then TASK_COMPLETE) and return the tool result the model sees. */
+  const driveOne = async (
+    toolCall: { name: string; args: unknown },
+    seed?: { path: string; content: string }
+  ): Promise<string> => {
+    if (seed) writeFileSync(join(workspace, seed.path), seed.content);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okFetch(chatResponse({ toolCalls: [toolCall] })))
+      .mockResolvedValueOnce(okFetch(chatResponse({ content: 'TASK_COMPLETE' })));
+    vi.stubGlobal('fetch', fetchMock);
+    const backend = new OllamaBackend(baseConfig);
+    const start = await backend.startSession({ workspacePath: workspace, permissionMode: 'full' });
+    if (!start.ok) throw new Error('startSession failed');
+    await drain(
+      backend.runTurn(start.value, {
+        sessionId: start.value.sessionId,
+        prompt: 'go',
+        isContinuation: false,
+      })
+    );
+    const session = start.value as import('../../../src/agent/backends/ollama').OllamaSession;
+    return session.messages.find((m) => m.role === 'tool')?.content ?? '';
+  };
+
+  it.skipIf(process.platform === 'win32')('bash annotates a non-zero exit code', async () => {
+    const out = await driveOne({ name: 'bash', args: { command: 'echo boom; exit 3' } });
+    expect(out).toContain('boom');
+    expect(out).toContain('[command exited with code 3]');
+  });
+
+  it.skipIf(process.platform === 'win32')('bash does NOT annotate a successful exit', async () => {
+    const out = await driveOne({ name: 'bash', args: { command: 'echo ok' } });
+    expect(out).toContain('ok');
+    expect(out).not.toContain('exited with code');
+  });
+
+  it('read_file returns line-numbered content', async () => {
+    const out = await driveOne(
+      { name: 'read_file', args: { path: 'f.txt' } },
+      { path: 'f.txt', content: 'alpha\nbeta\ngamma' }
+    );
+    expect(out).toMatch(/1\talpha/);
+    expect(out).toMatch(/2\tbeta/);
+    expect(out).toMatch(/3\tgamma/);
+  });
+
+  it('read_file pages with offset+limit and reports the shown range', async () => {
+    const content = Array.from({ length: 10 }, (_, i) => `line${i + 1}`).join('\n');
+    const out = await driveOne(
+      { name: 'read_file', args: { path: 'f.txt', offset: 3, limit: 2 } },
+      { path: 'f.txt', content }
+    );
+    expect(out).toMatch(/3\tline3/);
+    expect(out).toMatch(/4\tline4/);
+    expect(out).not.toContain('line5');
+    expect(out).toContain('showing lines 3-4 of 10');
+  });
+
+  it('read_file errors cleanly on a missing file', async () => {
+    const out = await driveOne({ name: 'read_file', args: { path: 'nope.txt' } });
+    expect(out).toContain('file not found');
+  });
+
+  it('edit replace_all replaces every occurrence (bypasses the uniqueness guard)', async () => {
+    const out = await driveOne(
+      {
+        name: 'edit',
+        args: { path: 'f.txt', old_string: 'x', new_string: 'y', replace_all: true },
+      },
+      { path: 'f.txt', content: 'x x x' }
+    );
+    expect(out).toMatch(/replaced 3 occurrences/);
+    expect(readFileSync(join(workspace, 'f.txt'), 'utf8')).toBe('y y y');
+  });
+
+  it('edit without replace_all still rejects a non-unique old_string', async () => {
+    const out = await driveOne(
+      { name: 'edit', args: { path: 'f.txt', old_string: 'x', new_string: 'y' } },
+      { path: 'f.txt', content: 'x x x' }
+    );
+    expect(out).toContain('not unique');
+    expect(out).toContain('replace_all');
+  });
+});


### PR DESCRIPTION
## Summary

Adds three proven agent-tool affordances the OllamaBackend was missing — each one standard in Claude Code / Codex — to make the local coding agent more effective. Follow-up to #870 (edit tool + truncation + progress-based termination).

### 1. Bash exit code
`runBash` ignored the child process exit code, so the model could only guess whether a command (e.g. `pnpm test`) passed or failed by parsing its output. A non-zero exit is now annotated: `\n[command exited with code N]`. Zero exits are left unannotated to avoid noise.

### 2. Read paging + line numbers
`read_file` returned the whole file as an unnumbered blob (head+tail truncated for large files). Now, matching Claude Code's `Read`:
- Output is **line-numbered** (`<n>\t<content>`) for reference — the description makes clear the prefix is display-only and must not appear in an `edit` old_string.
- Optional **`offset`** (1-based start line) + **`limit`** params page large files in chunks instead of a truncated blob; the shown range is reported (`[showing lines X-Y of Z]`).
- A missing file now returns a clean `ERROR: file not found` instead of throwing.

### 3. Edit `replace_all`
`edit` takes an optional **`replace_all: true`** to change every occurrence (e.g. renaming a symbol) instead of requiring a unique match. Default behavior is unchanged (unique-match guard); replace-all uses literal split/join (no `$&`/`$1` interpretation).

## Tests
62 ollama tests pass (7 new: exit-code annotate/no-annotate, line-numbered read, offset/limit paging, missing-file, replace_all, non-unique-still-guarded). tsc + lint + arch gates green.

## Deferred (bigger, separate efforts)
Conversation compaction (long-run context management) and a todo/plan scratchpad — both higher-effort; flagged for their own PRs.
