### PR TITLE
fix(pre-commit): pipefail so ci check failures block commits (#726)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,16 @@
 # Fail-closed: any check failure (including arch regressions) blocks the commit.
 # To accept an intentional arch baseline change, run `harness check-arch
 # --update-baseline` explicitly and stage the baselines.json change as a visible edit.
-if ! node packages/cli/dist/bin/harness.js ci check --skip entropy,docs,perf,security,deps,phase-gate 2>&1 | tee /tmp/harness-pre-commit.log; then
+#
+# NOTE: do NOT pipe the check into `tee` inside this `if !` test. A pipeline's exit
+# status is that of its LAST command, so `! ( producer | tee )` sees tee's status
+# (~always 0) and the fail-closed branch below is NEVER taken (#726). Husky invokes
+# this hook via `sh -e`, where `sh` may be dash — so `set -o pipefail` (dash: "Illegal
+# option") and `${PIPESTATUS[0]}` (a bashism, unset in dash) are both non-portable.
+# Instead we drop the pipe entirely: redirect output to the log, test the producer's
+# real exit code, then `cat` the log so output is still shown (on success and failure).
+if ! node packages/cli/dist/bin/harness.js ci check --skip entropy,docs,perf,security,deps,phase-gate >/tmp/harness-pre-commit.log 2>&1; then
+  cat /tmp/harness-pre-commit.log
   echo ""
   echo "✗ Commit blocked: harness ci check failed (see output above)."
   echo ""
@@ -13,6 +22,7 @@ if ! node packages/cli/dist/bin/harness.js ci check --skip entropy,docs,perf,sec
   echo ""
   exit 1
 fi
+cat /tmp/harness-pre-commit.log
 npx lint-staged
 
 # Auto-regenerate plugin artifacts if any generator input is staged.

--- a/packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts
+++ b/packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * End-to-end regression proof for #726: the `.husky/pre-commit` ci-check gate must
+ * be FAIL-CLOSED — a nonzero exit from `harness ci check` (e.g. an arch regression)
+ * must BLOCK the commit.
+ *
+ * The bug: the gate was written as
+ *
+ *   if ! node .../harness.js ci check ... 2>&1 | tee /tmp/harness-pre-commit.log; then
+ *
+ * A pipeline's exit status is that of its LAST command (`tee`, ~always 0), so
+ * `! ( producer | tee )` evaluates `! 0` = false and the `exit 1` branch is NEVER
+ * taken even when `ci check` prints `x arch: fail` and exits nonzero. The gate was
+ * silently disarmed.
+ *
+ * This test extracts the REAL ci-check gate block from the committed
+ * `.husky/pre-commit` (not a hand-rewritten copy) so a regression back to a
+ * masking pipe (`| tee`, or a `set -o pipefail` that dies under dash) fails here.
+ * Only the producer — the `node .../harness.js ci check ...` invocation — is
+ * rewritten to a stub whose exit code is driven by the CI_CHECK_EXIT env var, so
+ * the pipe/redirect STRUCTURE of the gate is what is under test, deterministically.
+ *
+ * Husky v9 invokes hooks via `sh -e "$s"` (see `.husky/_/h`), so `sh` may be dash
+ * on Linux CI. The test runs the block under `/bin/sh` via a real `git commit`,
+ * exactly mirroring how the gate executes in production.
+ */
+
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error('Could not locate monorepo root (pnpm-workspace.yaml not found)');
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Extract the ci-check gate block from the real `.husky/pre-commit` — everything
+ * from the top of the file up to (but not including) `npx lint-staged`, which is
+ * the first line after the gate's closing `fi` + success `cat`. Rewrite the
+ * `harness ci check` producer to a stub that exits with $CI_CHECK_EXIT, keeping the
+ * `if ! <producer> >log 2>&1; then ... fi` structure verbatim.
+ */
+function buildGateHook(repoRoot: string): string {
+  const hookSrc = fs.readFileSync(path.join(repoRoot, '.husky', 'pre-commit'), 'utf-8');
+  const lines = hookSrc.split('\n');
+  const endIdx = lines.findIndex((l) => l.trim() === 'npx lint-staged');
+  if (endIdx === -1) {
+    throw new Error('`npx lint-staged` marker not found in .husky/pre-commit');
+  }
+  const block = lines.slice(0, endIdx).join('\n');
+
+  // Replace the producer invocation with a controllable stub. The regex matches the
+  // real `node packages/cli/dist/bin/harness.js ci check --skip ...` producer up to
+  // (but not including) the output redirection, so the `>log 2>&1` and the `if !`
+  // wrapper stay exactly as committed.
+  const rewritten = block.replace(
+    /node packages\/cli\/dist\/bin\/harness\.js ci check[^>|]*/,
+    'sh -c \'echo "x arch: fail (stub)"; exit ${CI_CHECK_EXIT:-0}\' '
+  );
+  if (rewritten === block) {
+    throw new Error('ci-check producer line not found/rewritten in .husky/pre-commit');
+  }
+  return `#!/bin/sh\n${rewritten}\n`;
+}
+
+let repoRoot: string;
+let cwd: string;
+
+function git(args: string[], env?: NodeJS.ProcessEnv): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', env: { ...process.env, ...env } });
+}
+
+beforeEach(() => {
+  repoRoot = findRepoRoot(path.dirname(fileURLToPath(import.meta.url)));
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'cicheck-gate-e2e-'));
+
+  git(['init', '-q']);
+  git(['config', 'user.email', 't@example.com']);
+  git(['config', 'user.name', 'Test']);
+  git(['config', 'commit.gpgsign', 'false']);
+
+  const hookPath = path.join(cwd, '.git', 'hooks', 'pre-commit');
+  fs.writeFileSync(hookPath, buildGateHook(repoRoot));
+  fs.chmodSync(hookPath, 0o755);
+
+  // Baseline commit created with the hook bypassed (env unset → stub exits 0, so
+  // the gate passes anyway, but --no-verify keeps the baseline independent of it).
+  fs.writeFileSync(path.join(cwd, 'README.md'), '# scratch\n');
+  git(['add', 'README.md']);
+  git(['commit', '-q', '--no-verify', '-m', 'baseline']);
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+// This e2e runs the POSIX-shell `.husky/pre-commit` ci-check gate block via a real
+// `git commit`. The hook runs under `sh` (husky uses `sh -e`); the windows-latest CI
+// runner can't reliably reproduce that shell for git hooks. Skip on win32 — the fix
+// is a shell-portability guarantee that only the POSIX platforms need to prove.
+describe.skipIf(process.platform === 'win32')('pre-commit ci-check gate (e2e)', () => {
+  it('BLOCKS the commit when `harness ci check` exits nonzero (#726 fail-closed)', () => {
+    const headBefore = git(['rev-parse', 'HEAD']).trim();
+
+    fs.writeFileSync(path.join(cwd, 'change.txt'), 'a staged change\n');
+    git(['add', 'change.txt']);
+
+    let failed = false;
+    let output = '';
+    try {
+      // CI_CHECK_EXIT=1 → the stubbed producer exits nonzero (an arch regression).
+      git(['commit', '-m', 'change that should be blocked'], { CI_CHECK_EXIT: '1' });
+    } catch (err) {
+      failed = true;
+      const e = err as { stdout?: string; stderr?: string };
+      output = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    }
+
+    // The gate must block: nonzero exit from `ci check` → nonzero exit from the hook.
+    expect(failed).toBe(true);
+    expect(output).toContain('Commit blocked');
+    // The producer's captured output is surfaced (proves the log is shown on failure).
+    expect(output).toContain('x arch: fail (stub)');
+    // No commit was created.
+    expect(git(['rev-parse', 'HEAD']).trim()).toBe(headBefore);
+  });
+
+  it('ALLOWS the commit when `harness ci check` exits zero', () => {
+    const headBefore = git(['rev-parse', 'HEAD']).trim();
+
+    fs.writeFileSync(path.join(cwd, 'change.txt'), 'a staged change\n');
+    git(['add', 'change.txt']);
+
+    // CI_CHECK_EXIT=0 → the stubbed producer passes; the commit proceeds. Bypass the
+    // downstream lint-staged/plugin/roadmap blocks (not under test) via --no-verify?
+    // No — those blocks are part of the extracted hook only up to `npx lint-staged`,
+    // which is excluded, so the temp hook ends right after the gate's success `cat`.
+    git(['commit', '-q', '-m', 'change that should pass'], { CI_CHECK_EXIT: '0' });
+
+    expect(git(['rev-parse', 'HEAD']).trim()).not.toBe(headBefore);
+    const tree = git(['ls-tree', '-r', '--name-only', 'HEAD']);
+    expect(tree).toContain('change.txt');
+  });
+});


### PR DESCRIPTION
## Problem (#726)

`.husky/pre-commit`'s fail-closed ci-check gate was written as:

```sh
if ! node packages/cli/dist/bin/harness.js ci check --skip ... 2>&1 | tee /tmp/harness-pre-commit.log; then
  ... exit 1
fi
```

A pipeline's exit status is that of its **last** command (`tee`, ~always 0), so `! ( producer | tee )` evaluates `! 0` = false and the `exit 1` branch is **never** taken. An arch/complexity/module-size regression prints `x arch: fail` and exits nonzero, yet the commit proceeds — the documented fail-closed guard was silently disarmed.

## Fix

**Drop the masking pipe** rather than add `set -o pipefail`. Husky v9 invokes hooks via `sh -e "$s"` (see `.husky/_/h`), where `sh` may be **dash** on Linux CI. Verified live:

- `dash -e 'set -o pipefail'` → `set: Illegal option -o pipefail` (exit 2) — would break the hook on CI.
- `${PIPESTATUS[0]}` is a bashism, **unset** in dash.
- Husky ignores the hook's own shebang, so switching to `#!/usr/bin/env bash` wouldn't help.

So both suggested approaches are non-portable here. Instead the gate now redirects `ci check` output to the log, tests the **producer's** real exit code, then `cat`s the log so output is still shown on success and failure:

```sh
if ! node ... ci check ... >/tmp/harness-pre-commit.log 2>&1; then
  cat /tmp/harness-pre-commit.log
  ... exit 1
fi
cat /tmp/harness-pre-commit.log
```

This is POSIX-portable across sh / dash / bash / zsh with no pipefail dependency.

## Audit of every other pipe in the hook

- Lines with `git diff --cached --name-only | grep -qE '...'` (plugin-artifact regen, roadmap-regen guards): **correct as-is** — `grep` is the terminal command and its exit code *is* the intended `if` condition. `pipefail` would not change their behavior.
- The other gates (`generate:plugin:check`, `roadmap regen`) have no pipe.

**Line 5 (`| tee`) was the only exit-code-masking gating pipe.**

## Regression test

`packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts` (follows the existing `roadmap-regen-hook.e2e.test.ts` pattern): extracts the **real** gate block from `.husky/pre-commit`, stubs the producer to a controllable exit code, installs it into a throwaway repo, and asserts a real `git commit` is **BLOCKED** when `ci check` exits nonzero and **ALLOWED** when it exits zero. `skipIf(win32)`.

Verified **revert-and-fail**: with the buggy `| tee` form restored, the BLOCKS test fails (`expect(failed).toBe(true)` got `false`), proving the test catches the bug. The commit that created this PR passed through the now-armed gate.

Closes #726