### PR TITLE
fix(orchestrator): put per-phase-routing staged decl in the main workflow file

### DIFF
--- a/harness.orchestrator.md
+++ b/harness.orchestrator.md
@@ -57,11 +57,29 @@ agent:
       #     tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]
       #                             # narrow harness's ~95 tools to the read-oriented set
       #                             # so a local model isn't flooded (omit tools = all).
+    # Local REASONING backend for the DESIGN phases of a staged workflow
+    # (cognitiveMode: thinking). A larger reasoning model (qwen3:32b) with
+    # reasoning LEFT ON — the design stages benefit from the <think> trace, so
+    # unlike the `local` coder we do NOT set disableReasoning. routing.modes.thinking
+    # points here (see routing.modes below).
+    reasoner:
+      type: ollama
+      endpoint: http://127.0.0.1:11434/v1
+      model: ['qwen3:32b']
+      # Reasoning stays ON for design (thinking) stages — this is the reasoner.
+      disableReasoning: false
+      capabilities:
+        { tier: strong, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
   # Routing — controls WHICH backend handles each use case.
   routing:
     default: primary
     quick-fix: local
     diagnostic: local
+    # Per-phase routing: a staged workflow's DESIGN stages (cognitiveMode: thinking)
+    # route here — to the local reasoner — while its execution stages carry no
+    # cognitiveMode and fall to routing.default. See the `workflows:` decl below.
+    modes:
+      thinking: reasoner
     # Route the intelligence pipeline (sel/pesl) to the local backend.
     intelligence:
       sel: local
@@ -101,6 +119,22 @@ agent:
   turnTimeoutMs: 300000
   readTimeoutMs: 30000
   stallTimeoutMs: 60000
+# Staged workflows (per-phase routing). A matched unit is dispatched as ONE
+# multi-stage run on a single worktree instead of chained skill invocations:
+# the DESIGN stages carry `cognitiveMode: thinking` and route to
+# routing.modes.thinking (the local `reasoner`); the EXECUTION stages carry no
+# cognitiveMode and fall to routing.default. Each stage's prior output threads
+# to the next over the text channel (expects/produces). A local-endpoint routed
+# stage renders the `harness skill run <skill> --autonomous` indirection prompt
+# automatically. `workflowFor` only returns a plan for a decl with >= 2 stages.
+workflows:
+  - name: local-full-workflow
+    match: { identifierPrefix: 'LOCAL-' }
+    stages:
+      - { skill: harness-brainstorming, cognitiveMode: thinking, produces: spec }
+      - { skill: harness-planning, cognitiveMode: thinking, expects: spec, produces: plan }
+      - { skill: harness-execution, expects: plan, produces: impl }
+      - { skill: harness-verification, expects: impl, produces: verify }
 intelligence:
   enabled: true
   requestTimeoutMs: 180000

--- a/packages/orchestrator/src/local-template-lint.test.ts
+++ b/packages/orchestrator/src/local-template-lint.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PromptRenderer } from './prompt/renderer';
+import { WorkflowLoader } from './workflow/loader';
 
 /**
  * Lint guard for the two copies of the local-backend prompt template.
@@ -170,4 +171,41 @@ describe('local template lint — render variables survive (SC7)', () => {
       });
     }
   }
+});
+
+/**
+ * Regression guard for the per-phase-routing decl-in-MAIN gap.
+ *
+ * The WorkflowLoader reads the workflow CONFIG from the main `harness.orchestrator.md`
+ * and takes only the PROMPT template from the `.local` sibling. So a staged
+ * `workflows:` decl (plus its `reasoner` backend and `routing.modes.thinking`
+ * mapping) MUST live in the main file to take effect — placing it only in
+ * `.local` (as the original per-phase-routing change did) means the loader never
+ * sees it and the feature silently never fires. This asserts the authoritative
+ * main file carries the decl so the local per-phase pipeline is actually reachable.
+ */
+describe('per-phase routing decl is reachable from the MAIN workflow file', () => {
+  const MAIN = path.join(REPO_ROOT, 'harness.orchestrator.md');
+
+  it('harness.orchestrator.md loads the local-full-workflow staged decl + reasoner backend + routing.modes.thinking', async () => {
+    const res = await new WorkflowLoader().loadWorkflow(MAIN);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const cfg = res.value.config as {
+      workflows?: { name: string; stages: unknown[] }[];
+      agent?: {
+        routing?: { modes?: Record<string, string> };
+        backends?: Record<string, unknown>;
+      };
+    };
+    const decl = cfg.workflows?.find((w) => w.name === 'local-full-workflow');
+    expect(
+      decl,
+      'staged decl must live in the MAIN workflow file — the loader reads config from it, not .local'
+    ).toBeDefined();
+    expect(decl!.stages.length).toBeGreaterThanOrEqual(2);
+    // the design stages (cognitiveMode: thinking) route to the reasoner
+    expect(cfg.agent?.routing?.modes?.thinking).toBe('reasoner');
+    expect(cfg.agent?.backends?.reasoner).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a gap in the per-phase backend routing feature (#876): the staged `workflows:` decl, the `reasoner` backend, and `routing.modes.thinking` were added **only to `harness.orchestrator.local.md`** — but the `WorkflowLoader` reads the workflow **config** from the main `harness.orchestrator.md` and takes only the **prompt template** from the `.local` sibling. So the loader never saw the decl, and the staged design→reasoner / execution→coder pipeline **silently never fired** via the normal `harness orchestrator run --workflow harness.orchestrator.md` invocation.

**Found by running the real orchestrator pilot end-to-end.** With the decl moved into the main file, the pilot now dispatches the staged workflow and the design stages (`cognitiveMode: thinking`) route to the `reasoner` — confirmed live:
```
routing-decision {skillName: 'harness-brainstorming', cognitiveMode: 'thinking'} → backendName: 'reasoner'
```

## Change
- Move the three blocks (`reasoner` backend, `routing.modes.thinking`, `workflows:` staged decl) into the authoritative `harness.orchestrator.md`, preserving its `afterCreate` hook.
- **Regression test** (`local-template-lint.test.ts`): loads `harness.orchestrator.md` via `WorkflowLoader` and asserts the `local-full-workflow` decl, the `reasoner` backend, and `routing.modes.thinking` are reachable from the main file. This fails on `main` (which lacks them) and passes with the fix.

## Not in scope (follow-ups)
- `templates/orchestrator/harness.orchestrator.md` has the same gap **plus** a broader generic-vs-repo-specific inconsistency (the template `.local` carries repo-specific model names) — a separate template cleanup.
- Running the pilot also surfaced: execution stages routing to the reasoner instead of the coder, hollow stage completion (no artifacts), and a completed-item re-dispatch loop — tracked separately.
