### PR TITLE
feat(local-models): recency-aware discovery (wide-net trending+downloads) + expand allowedOrgs

### DIFF
--- a/.changeset/recommendation-engine-recency.md
+++ b/.changeset/recommendation-engine-recency.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/local-models': minor
+'@harness-engineering/orchestrator': minor
+---
+
+Recency-aware local-model discovery. Discovery is now a wide net: per approved org it merges HuggingFace `trending` (new/hot) with `downloads` (established), dedupes by model id, and caps at the per-org limit, then hands the union to the benchmark ranker — instead of pre-filtering by cumulative downloads, which crowded out brand-new leaders before they could be scored. A failing `trending` call falls back to `downloads` (discovery never breaks). The `allowedOrgs` allowlist gains `openai`, `zai-org`, `THUDM`, `moonshotai` so the current-leader orgs can be considered. The benchmark ranker is unchanged — this only widens what reaches it.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -291,7 +291,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 198722,
+      "value": 198748,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -291,7 +291,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 198748,
+      "value": 198752,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/docs/changes/recommendation-engine-recency/plans/2026-07-17-recommendation-engine-recency-plan.md
+++ b/docs/changes/recommendation-engine-recency/plans/2026-07-17-recommendation-engine-recency-plan.md
@@ -1,0 +1,367 @@
+# Plan: Recommendation Engine — Recency-Aware Discovery
+
+**Date:** 2026-07-17 | **Spec:** docs/changes/recommendation-engine-recency/proposal.md | **Tasks:** 8 | **Time:** ~30 min | **Integration Tier:** small
+
+## Goal
+
+Make local-model discovery a wide net (merge HF `trending` + `downloads`, deduped and capped) and expand `allowedOrgs` to include the 2026-leader orgs, so the benchmark ranker — not a popularity pre-filter — decides which models get recommended.
+
+## Observable Truths (Acceptance Criteria)
+
+1. **SC1** — When the HF client returns a NEW model only under `sort: 'trending'` (absent from the top-`downloads` slice), `discoverCandidates` includes that model in the candidate pool. (unit test, mocked sort-aware client)
+2. **SC2** — The merged candidate set is deduped by model id and the per-org inspection is capped at `perOrgLimit` (no duplicate `listModels`-derived ids reach `getModel`; no count blow-up). (unit test)
+3. **SC3** — If the `trending` `listModels` call throws, `discoverOrg` falls back to the `downloads` result and discovery still returns candidates (no thrown error, warning recorded). (unit test)
+4. **SC4** — `allowedOrgs` includes `openai`, `zai-org`, `THUDM`, `moonshotai` in the three config files that carry a `pool.allowedOrgs` block; a `select` unit test proves a candidate from an added org (e.g. `openai/...`) now passes `selectCandidates`'s org filter. (config assertion + unit test)
+5. **SC5** — No regression: `ranker/evidence.ts` and `benchmarks/merge.ts` are untouched; all existing `discover`/`select`/ranker tests stay green; the byte-identical `.local` config pair stays pinned by `local-template-lint.test.ts`.
+
+## Uncertainties
+
+- **[RESOLVED / spec correction] "all FOUR config files."** Only THREE files actually contain a `pool.allowedOrgs` block: `harness.orchestrator.md` (root, full config, L147), `harness.orchestrator.local.md` (root, L143), and `templates/orchestrator/harness.orchestrator.local.md` (L143). The fourth file the spec names — `templates/orchestrator/harness.orchestrator.md` — is a 162-line **shim** with NO pool config, so there is nothing to change there. The plan edits the three real files. This satisfies D3/SC4 fully; the "four" in the spec is an off-by-one on the shim.
+- **[RESOLVED] Byte-identity pin.** `harness.orchestrator.local.md` and `templates/orchestrator/harness.orchestrator.local.md` are byte-identical and pinned by `packages/orchestrator/src/local-template-lint.test.ts`. Both `.local` files must receive the identical edit. Verified with `diff` (IDENTICAL).
+- **[ASSUMPTION] Changeset package for config edits.** Config `.md` files are repo-root scaffold sources (not copied into any package's `files[]`/`dist`); historically config-semantics changes ship under `@harness-engineering/orchestrator` changesets, and the template-lint test lives in that package. Plan uses `@harness-engineering/local-models` (minor, the code change) + `@harness-engineering/orchestrator` (minor, the config change). If the maintainer prefers `cli` for template ownership, only the changeset frontmatter changes — no task rework.
+- **[DEFERRABLE] Stale docs example.** `docs/guides/local-model-lifecycle.md:27` shows a different, illustrative `allowedOrgs` example (`mistralai`, quoted strings). It is illustrative, not the live config; the docs task adds the wide-net rationale near it without forcing the example to match the config verbatim.
+- **[NOTE] Existing discover mock ignores `sort`.** The current `fakeClient` in `discover.test.ts` returns the same listing regardless of `sort`. SC1/SC2/SC3 tests need a **sort-aware** fake client (keyed on `sort`), added in the test tasks — the existing fake is left intact for the existing tests.
+
+## Ranker-Untouched Risk Flag
+
+**D4/SC5 hard constraint:** `packages/local-models/src/ranker/evidence.ts` and `packages/local-models/src/benchmarks/merge.ts` MUST NOT be modified. This change only widens the input set handed to the ranker (`discover.ts` output → `select.ts` → ranker). No task in this plan opens either file. Task 8 explicitly asserts (via `git diff --stat`) that neither ranker file appears in the change set. If any task tempts a ranker edit, STOP — the discovery/ranking boundary (ADR, Task 7) is the whole point of the fix.
+
+## File Map
+
+- MODIFY `packages/local-models/tests/candidates/discover.test.ts` (add sort-aware fake + SC1/SC2/SC3 tests)
+- MODIFY `packages/local-models/src/candidates/discover.ts` (`discoverOrg`: trending+downloads merge/dedupe/limit/fallback)
+- MODIFY `packages/local-models/tests/candidates/select.test.ts` (add SC4 added-org test)
+- MODIFY `harness.orchestrator.md` (allowedOrgs, L147)
+- MODIFY `harness.orchestrator.local.md` (allowedOrgs, L143)
+- MODIFY `templates/orchestrator/harness.orchestrator.local.md` (allowedOrgs, L143 — keep byte-identical to root `.local`)
+- MODIFY `docs/guides/local-model-lifecycle.md` (wide-net rationale note)
+- CREATE `docs/knowledge/decisions/0077-discovery-is-a-wide-net-ranker-judges.md` (ADR for D1)
+- CREATE `.changeset/recommendation-engine-recency.md` (changeset)
+
+## Skeleton
+
+1. Wide-net discovery, TDD (~4 tasks, ~16 min) — failing SC1 test, implement merge/dedupe/limit, then SC2 + SC3 tests
+2. Config allowlist + select test (~2 tasks, ~8 min) — SC4 test then edit three config files
+3. Docs + ADR + changeset + regression sweep (~2 tasks, ~6 min) — SC5
+
+_Skeleton approved: implicit — mirrors the spec's approved Implementation Order; direction pre-approved by the spec._
+
+## Tasks
+
+### Task 1: Failing SC1 test — a trending-only new model is currently dropped
+
+**Depends on:** none | **Files:** `packages/local-models/tests/candidates/discover.test.ts`
+
+1. In `packages/local-models/tests/candidates/discover.test.ts`, add a **sort-aware** fake client helper below the existing `fakeClient` (do not modify the existing `fakeClient` — existing tests depend on it):
+
+   ```ts
+   /** Sort-aware fake: `listing[author][sort]` lets a test return different ids per sort. */
+   function sortAwareClient(
+     listing: Record<string, Partial<Record<string, HuggingFaceModel[]>>>,
+     details: Record<string, HuggingFaceModelDetail>,
+     opts: { throwOnSort?: string } = {}
+   ) {
+     const calls = { list: [] as Array<{ author: string; sort: string }>, get: [] as string[] };
+     return {
+       calls,
+       client: {
+         async listModels(o: { author?: string; sort?: string }) {
+           const author = o.author ?? '';
+           const sort = o.sort ?? 'downloads';
+           calls.list.push({ author, sort });
+           if (opts.throwOnSort && sort === opts.throwOnSort) throw new Error(`HF ${sort} 503`);
+           return listing[author]?.[sort] ?? [];
+         },
+         async getModel(id: string) {
+           calls.get.push(id);
+           const d = details[id];
+           if (!d) throw new Error(`no detail for ${id}`);
+           return d;
+         },
+       },
+     };
+   }
+   ```
+
+2. Extend the module-level curation map so both a downloads-established and a trending-only model are installable. Add a second `describe` block, `describe('discoverCandidates wide-net (SC1)', ...)`, with this test:
+
+   ```ts
+   const WIDE_CURATION = new Map<string, CurationTags>([
+     ['Qwen/Qwen3-32B-GGUF', { ollamaName: 'qwen3:32b', family: 'qwen3' }],
+     ['Qwen/Qwen3.6-27B-GGUF', { ollamaName: 'qwen3.6:27b', family: 'qwen3' }],
+   ]);
+
+   it('SC1: includes a NEW model returned only under `trending` (absent from `downloads`)', async () => {
+     const { client } = sortAwareClient(
+       {
+         Qwen: {
+           downloads: [{ id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+           trending: [{ id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+         },
+       },
+       {
+         'Qwen/Qwen3-32B-GGUF': detail('Qwen/Qwen3-32B-GGUF', ['Q4_K_M']),
+         'Qwen/Qwen3.6-27B-GGUF': detail('Qwen/Qwen3.6-27B-GGUF', ['Q4_K_M']),
+       }
+     );
+     const res = await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client });
+     const ids = res.candidates.map((c) => c.hfRepoId);
+     expect(ids).toContain('Qwen/Qwen3.6-27B-GGUF'); // trending-only new model reaches the pool
+     expect(ids).toContain('Qwen/Qwen3-32B-GGUF'); // established still present
+   });
+   ```
+
+3. Run: `pnpm --filter @harness-engineering/local-models test -- discover` — observe the SC1 test **FAIL** (current `discoverOrg` only calls `sort: 'downloads'`, so the trending-only model is dropped).
+4. Commit: `test(local-models): failing test — trending-only new model dropped from pool`
+
+### Task 2: Implement trending+downloads merge in `discoverOrg`
+
+**Depends on:** Task 1 | **Files:** `packages/local-models/src/candidates/discover.ts`
+
+1. In `packages/local-models/src/candidates/discover.ts`, replace the body of `discoverOrg` (currently L96-110) with a two-call merge + dedupe + limit + graceful trending-fallback:
+
+   ```ts
+   /** List one org's popular GGUF repos and fold each into `collected`. Fail-soft. */
+   async function discoverOrg(org: string, ctx: DiscoverContext): Promise<void> {
+     const { client, limit, opts, warn } = ctx;
+
+     // Established quality (cumulative downloads). If this base call fails, the org is skipped.
+     let downloads: Awaited<ReturnType<typeof client.listModels>>;
+     try {
+       downloads = await client.listModels({
+         author: org,
+         search: 'gguf',
+         sort: 'downloads',
+         limit,
+       });
+     } catch (err) {
+       warn(`HF list failed for ${org}: ${messageOf(err)}`, err);
+       return;
+     }
+
+     // New/hot models (trending). Graceful (D2): a trending failure falls back to downloads only.
+     let trending: Awaited<ReturnType<typeof client.listModels>> = [];
+     try {
+       trending = await client.listModels({ author: org, search: 'gguf', sort: 'trending', limit });
+     } catch (err) {
+       warn(
+         `HF trending list failed for ${org} (falling back to downloads): ${messageOf(err)}`,
+         err
+       );
+     }
+
+     // Wide net: merge both sorts, dedupe by model id, cap at the per-org limit (D1 — no blow-up).
+     const merged = new Map<string, (typeof downloads)[number]>();
+     for (const model of [...trending, ...downloads]) {
+       if (merged.size >= limit && !merged.has(model.id)) continue;
+       if (!merged.has(model.id)) merged.set(model.id, model);
+     }
+
+     for (const model of merged.values()) {
+       if (opts.signal?.aborted) break;
+       if (!model.tags?.includes('gguf')) continue;
+       await discoverModel(model.id, ctx);
+     }
+   }
+   ```
+
+   Notes: trending is listed first in the merge so new leaders are preferred when the cap bites; dedupe is by `model.id` before `getModel` so no repo is fetched twice; the `limit` guard caps the merged set (not `2*limit`).
+
+2. Run: `pnpm --filter @harness-engineering/local-models test -- discover` — observe the SC1 test now **PASSES** and all pre-existing `discover` tests stay green (the existing tests use `fakeClient`, whose `listModels` ignores `sort` and returns the same listing for both calls — dedupe collapses the duplicate, so counts are unchanged).
+3. Run: `node packages/cli/dist/bin/harness.js validate 2>&1 | tail -3` (expect only pre-existing baseline noise: dashboard CSS tokens, orchestrator circular dep — nothing from local-models).
+4. Commit: `feat(local-models): wide-net discovery — merge trending + downloads, dedupe, cap`
+
+### Task 3: SC2 test — merged set deduped and capped (no blow-up)
+
+**Depends on:** Task 2 | **Files:** `packages/local-models/tests/candidates/discover.test.ts`
+
+1. Add to the `describe('discoverCandidates wide-net ...')` block:
+
+   ```ts
+   it('SC2: dedupes overlap by id and caps the inspected set at perOrgLimit', async () => {
+     const shared = { id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel;
+     const { client, calls } = sortAwareClient(
+       {
+         Qwen: {
+           downloads: [shared, { id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+           trending: [shared], // overlaps downloads → must dedupe, not double
+         },
+       },
+       {
+         'Qwen/Qwen3-32B-GGUF': detail('Qwen/Qwen3-32B-GGUF', ['Q4_K_M']),
+         'Qwen/Qwen3.6-27B-GGUF': detail('Qwen/Qwen3.6-27B-GGUF', ['Q4_K_M']),
+       }
+     );
+     await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client, perOrgLimit: 5 });
+     // shared id fetched exactly once (deduped across the two sorts)
+     const sharedFetches = calls.get.filter((id) => id === 'Qwen/Qwen3-32B-GGUF');
+     expect(sharedFetches).toHaveLength(1);
+     // both sorts were queried
+     expect(calls.list.map((c) => c.sort).sort()).toEqual(['downloads', 'trending']);
+   });
+
+   it('SC2: never inspects more than perOrgLimit distinct repos', async () => {
+     const many = (n: number) =>
+       Array.from(
+         { length: n },
+         (_, i) => ({ id: `Qwen/M${i}-GGUF`, tags: ['gguf'] }) as HuggingFaceModel
+       );
+     const { client, calls } = sortAwareClient(
+       { Qwen: { downloads: many(4), trending: many(4).map((m) => ({ ...m, id: m.id + 'T' })) } },
+       {}
+     );
+     // getModel throws for all (uncurated) — we only assert the cap on inspection count
+     await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client, perOrgLimit: 3 });
+     expect(calls.get.length).toBeLessThanOrEqual(3);
+   });
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/local-models test -- discover` — observe both SC2 tests **PASS**.
+3. Commit: `test(local-models): SC2 — wide-net dedupe + per-org cap`
+
+### Task 4: SC3 test — throwing `trending` falls back to `downloads`
+
+**Depends on:** Task 3 | **Files:** `packages/local-models/tests/candidates/discover.test.ts`
+
+1. Add to the same `describe` block:
+
+   ```ts
+   it('SC3: a throwing `trending` call falls back to `downloads`; discovery still returns candidates', async () => {
+     const { client } = sortAwareClient(
+       {
+         Qwen: {
+           downloads: [{ id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+           trending: [],
+         },
+       },
+       { 'Qwen/Qwen3-32B-GGUF': detail('Qwen/Qwen3-32B-GGUF', ['Q4_K_M']) },
+       { throwOnSort: 'trending' }
+     );
+     const res = await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client });
+     expect(res.candidates.map((c) => c.hfRepoId)).toContain('Qwen/Qwen3-32B-GGUF'); // downloads survived
+     expect(res.warnings.some((w) => /trending.*fall/i.test(w))).toBe(true); // fallback warned
+   });
+
+   it('SC3: a throwing `downloads` (base) call skips the org fail-soft (unchanged behavior)', async () => {
+     const { client } = sortAwareClient({}, {}, { throwOnSort: 'downloads' });
+     const res = await discoverCandidates({ orgs: ['broken'], curation: WIDE_CURATION, client });
+     expect(res.candidates).toHaveLength(0);
+     expect(res.warnings.some((w) => /HF list failed for broken/.test(w))).toBe(true);
+   });
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/local-models test -- discover` — observe both SC3 tests **PASS**, entire `discover` suite green.
+3. Run: `node packages/cli/dist/bin/harness.js check-deps 2>&1 | tail -3` (no NEW circular deps from local-models; pre-existing orchestrator cycle is baseline).
+4. Commit: `test(local-models): SC3 — graceful trending fallback to downloads`
+
+### Task 5: SC4 test — an added-org candidate passes `selectCandidates`
+
+**Depends on:** none | **Files:** `packages/local-models/tests/candidates/select.test.ts`
+
+1. In `packages/local-models/tests/candidates/select.test.ts`, add to the `describe('selectCandidates', ...)` block:
+
+   ```ts
+   it('SC4: a candidate from an added leader org (openai) passes the org filter', () => {
+     const withLeader: FrozenCandidate[] = [
+       ...CANDIDATES,
+       {
+         hfRepoId: 'openai/gpt-oss-20B-GGUF',
+         ollamaName: 'gpt-oss:20b',
+         sizeB: 20,
+         quant: 'Q4_K_M',
+       },
+     ];
+     const result = selectCandidates(withLeader, {
+       allowedOrgs: [
+         'Qwen',
+         'deepseek-ai',
+         'meta-llama',
+         'google',
+         'openai',
+         'zai-org',
+         'THUDM',
+         'moonshotai',
+       ],
+       allowedFamilies: [],
+     });
+     expect(result.map((c) => c.hfRepoId)).toContain('openai/gpt-oss-20B-GGUF');
+   });
+   ```
+
+2. Run: `pnpm --filter @harness-engineering/local-models test -- select` — observe the SC4 test **PASSES** (this is a pure-function assertion over `selectCandidates`, which already honors any `allowedOrgs` passed; the config wiring is Task 6). All existing `select` tests stay green.
+3. Commit: `test(local-models): SC4 — added leader org passes the org filter`
+
+### Task 6: Expand `allowedOrgs` in the three config files
+
+**Depends on:** Task 5 | **Files:** `harness.orchestrator.md`, `harness.orchestrator.local.md`, `templates/orchestrator/harness.orchestrator.local.md` | **Category:** integration
+
+1. In **all three** files, replace the `allowedOrgs` line
+   `    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google]`
+   with
+   `    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google, openai, zai-org, THUDM, moonshotai]`
+   - `harness.orchestrator.md` — line 147
+   - `harness.orchestrator.local.md` — line 143
+   - `templates/orchestrator/harness.orchestrator.local.md` — line 143
+
+   (Note: `templates/orchestrator/harness.orchestrator.md` is a shim with no `pool` block — do NOT create one; the spec's "fourth file" does not exist as a config surface.)
+
+2. Verify the byte-identical `.local` pair stays identical:
+   `diff harness.orchestrator.local.md templates/orchestrator/harness.orchestrator.local.md && echo IDENTICAL`
+   — must print `IDENTICAL`.
+3. Run: `pnpm --filter @harness-engineering/orchestrator test -- local-template-lint` — the byte-identity pin (SC5) stays green.
+4. Run: `node packages/cli/dist/bin/harness.js validate 2>&1 | tail -3` (baseline noise only).
+5. Commit: `feat(orchestrator): add openai/zai-org/THUDM/moonshotai to allowedOrgs`
+
+### Task 7: ADR — discovery is a wide net, the ranker judges
+
+**Depends on:** Task 2 | **Files:** `docs/knowledge/decisions/0077-discovery-is-a-wide-net-ranker-judges.md` | **Category:** integration
+
+1. Confirm `0077` is the next number: `ls docs/knowledge/decisions/ | sort | tail -3` (highest is currently `0076-staged-empty-diff-halt.md`).
+2. Create `docs/knowledge/decisions/0077-discovery-is-a-wide-net-ranker-judges.md` following the shape of a neighboring ADR (open `0076-staged-empty-diff-halt.md` for the exact heading/frontmatter convention and mirror it). Content must capture:
+   - **Title:** Discovery is a wide net; the benchmark ranker judges.
+   - **Status:** Accepted (2026-07-17).
+   - **Context:** Discovery previously sorted only by cumulative downloads, silently doing quality selection by popularity and crowding out new models before they reached the ranker. Result: 6-month-stale recommendations.
+   - **Decision (D1):** Discovery merges `trending` + `downloads` per org (deduped, capped) — a wide net. It does NOT judge quality. The benchmark ranker (`ranker/evidence.ts`) is the sole quality authority. `allowedOrgs`/`allowedFamilies` remain the operator trust gate (`select.ts`), not a quality gate.
+   - **Consequences:** New leaders reach the ranker; the ranker is untouched (D4); discovery is best-effort and fail-soft (D2). The discovery↔ranking boundary is now explicit and must not be blurred (no re-adding popularity filters to discovery, no adding discovery heuristics to the ranker).
+3. Run: `node packages/cli/dist/bin/harness.js validate 2>&1 | tail -3`.
+4. Commit: `docs(local-models): ADR 0077 — discovery wide-net vs ranker judgement`
+
+### Task 8: Docs note + changeset + regression sweep (SC5)
+
+**Depends on:** Task 6, Task 7 | **Files:** `docs/guides/local-model-lifecycle.md`, `.changeset/recommendation-engine-recency.md` | **Category:** integration
+
+1. In `docs/guides/local-model-lifecycle.md`, near the discovery/`allowedOrgs` section (around L27), add a short paragraph on the wide-net rationale: discovery now merges HF `trending` (new/hot) with `downloads` (established), deduped and capped per org, so brand-new leaders are not crowded out by cumulative-download popularity before the benchmark ranker can score them. Link the ADR: `docs/knowledge/decisions/0077-discovery-is-a-wide-net-ranker-judges.md`. Do NOT rewrite the pre-existing illustrative `allowedOrgs` example line — it is illustrative, not the live config.
+2. Create `.changeset/recommendation-engine-recency.md`:
+
+   ```md
+   ---
+   '@harness-engineering/local-models': minor
+   '@harness-engineering/orchestrator': minor
+   ---
+
+   Recency-aware local-model discovery. Discovery is now a wide net: per approved org it merges HuggingFace `trending` (new/hot) with `downloads` (established), dedupes by model id, and caps at the per-org limit, then hands the union to the benchmark ranker — instead of pre-filtering by cumulative downloads, which crowded out brand-new leaders before they could be scored. A failing `trending` call falls back to `downloads` (discovery never breaks). The `allowedOrgs` allowlist gains `openai`, `zai-org`, `THUDM`, `moonshotai` so the current-leader orgs can be considered. The benchmark ranker is unchanged — this only widens what reaches it.
+   ```
+
+   (If the maintainer owns `templates/orchestrator/` scaffolds under `cli` rather than `orchestrator`, swap the second package — no code changes.)
+
+3. **Ranker-untouched assertion (D4/SC5):** run
+   `git diff --stat main -- packages/local-models/src/ranker/ packages/local-models/src/benchmarks/`
+   — must print **nothing** (no ranker/benchmark files changed).
+4. Full regression sweep: `pnpm --filter @harness-engineering/local-models test` and `pnpm --filter @harness-engineering/orchestrator test -- local-template-lint` — all green.
+5. Run: `node packages/cli/dist/bin/harness.js validate 2>&1 | tail -3` (baseline noise only).
+6. Commit: `docs(local-models): wide-net rationale + changeset for recency-aware discovery`
+
+## Change Specification (delta)
+
+### Local-model discovery (`discover.ts`)
+
+- [MODIFIED] `discoverOrg` fetches BOTH `sort: 'trending'` and `sort: 'downloads'` (was: `downloads` only), merges + dedupes by model id, caps the merged set at `perOrgLimit`.
+- [ADDED] Graceful fallback: a throwing `trending` call is warned and dropped, leaving the `downloads` result; the base `downloads` failure keeps the existing org-skip fail-soft behavior.
+
+### Config allowlist
+
+- [MODIFIED] `pool.allowedOrgs` in `harness.orchestrator.md`, `harness.orchestrator.local.md`, and `templates/orchestrator/harness.orchestrator.local.md` gains `openai`, `zai-org`, `THUDM`, `moonshotai`.
+
+### Untouched (D4)
+
+- [UNCHANGED] `ranker/evidence.ts`, `benchmarks/merge.ts` — asserted empty in the diff (Task 8).

--- a/docs/changes/recommendation-engine-recency/proposal.md
+++ b/docs/changes/recommendation-engine-recency/proposal.md
@@ -1,0 +1,55 @@
+# Recommendation Engine — Recency-Aware Discovery
+
+**Keywords:** local-models, discovery, huggingface, recency, trending, allowedOrgs, benchmark-ranker, pool
+
+## Overview and Goals
+
+**Problem.** The local-model recommendation engine keeps recommending **6-month-stale models** (it surfaced `Qwen3-32B`/`Llama-2/3-70B`-era candidates in July 2026, never the current leaders like `qwen3.6:27b` or `gpt-oss:20b`). Two independent causes:
+
+1. **Discovery sorts by cumulative downloads.** `packages/local-models/src/candidates/discover.ts:100` fetches the top-`DEFAULT_PER_ORG_LIMIT` (50) GGUF models per org with `sort: 'downloads'`. Cumulative downloads favor _old, established_ models — a brand-new model has near-zero cumulative downloads and is crowded out of the 50 slots, so it **never reaches the benchmark ranker** that would score its actual capability. Discovery is silently doing _quality selection by popularity_, and getting it wrong.
+2. **The org allowlist excludes the current leaders.** `allowedOrgs: [Qwen, deepseek-ai, meta-llama, google]` (config, in `harness.orchestrator.md` + `.local` + templates). The 2026 leaders ship from orgs NOT in the list — `openai` (gpt-oss), `zai-org`/`THUDM` (GLM), `moonshotai` (Kimi). The filter (`candidates/select.ts:40`, "keep only candidates whose org is in `allowedOrgs`") is a hard gate, so those models can never be _considered_, regardless of capability.
+
+**Goals.**
+
+1. Make discovery a **wide net** — surface new models so the benchmark ranker can evaluate them — instead of pre-filtering by popularity.
+2. Expand `allowedOrgs` so the current-leader orgs can be considered.
+3. Preserve the correct division of labor: **discovery finds candidates, the benchmark ranker judges them.**
+
+**Out of scope.** Changing the ranker's benchmark scoring (it already scores capability, `ranker/evidence.ts`). Auto-pulling models. The refresh cadence itself (daily interval is fine; the bug is _what_ it discovers).
+
+**On-strategy.** STRATEGY.md tracks a local-model pool that keeps itself current; a discovery step biased toward stale models defeats that.
+
+## Decisions made
+
+- **D1 — Wide-net discovery (merge `trending` + `downloads`).** Per org, fetch BOTH `sort: 'trending'` (surfaces new/hot models) AND `sort: 'downloads'` (established quality), dedupe by model id, cap at the per-org limit, and hand the union to the ranker. _Why:_ catches new leaders without dropping established ones; the ranker does the quality selection it's built for.
+- **D2 — Graceful degradation.** If the `trending` call fails (HF error/timeout), fall back to the `downloads` result — discovery must never break. _Why:_ the refresh is best-effort maintenance; a discovery failure must not halt it.
+- **D3 — Expand `allowedOrgs`.** Add `openai`, `zai-org`, `THUDM`, `moonshotai` to the config allowlist (all config copies: `harness.orchestrator.md`, `harness.orchestrator.local.md`, and the `templates/orchestrator/` pair). _Why:_ let the engine _consider_ the current leaders; the ranker still filters by benchmark quality.
+- **D4 — No ranker change.** The benchmark ranker (`ranker/evidence.ts`, `benchmarks/merge.ts`) is untouched — it already scores capability. This change only widens what reaches it.
+
+## Technical design
+
+**D1/D2 — discover.ts.** In `discoverOrg` (`packages/local-models/src/candidates/discover.ts` ~90-100), replace the single `listModels({ ..., sort: 'downloads', limit })` with two calls (`sort: 'trending'` and `sort: 'downloads'`), merge + dedupe by model id, and slice to `limit`. The HF client (`huggingface/client.ts` `listModels`) already accepts a `sort` param (`huggingface/types.ts:60` lists `'downloads' | 'trending' | 'lastModified'`), and its cache TTL absorbs the extra call. Wrap the `trending` call so a failure falls back to `downloads` only (D2). The per-org limit is respected on the merged set (D1 — do not double the candidate count).
+
+**D3 — config.** Extend `allowedOrgs` in all four config files. Keep them consistent (the byte-identical `.local` pair is test-pinned by `local-template-lint.test.ts`).
+
+## Integration Points
+
+- **Entry Points.** No new CLI/MCP. Changes the local-model discovery step + the `allowedOrgs` config.
+- **Registrations Required.** None.
+- **Documentation Updates.** A note in the local-model-lifecycle docs / discovery module on the trending+downloads wide-net rationale.
+- **Architectural Decisions.** D1 (discovery is a wide net; the ranker judges) is ADR-worthy — it sets the discovery-vs-ranking boundary.
+- **Knowledge Impact.** Concept: "recency-aware model discovery"; relationship: discovery-finds → ranker-judges.
+
+## Success Criteria
+
+- **SC1** Discovery merges `trending` + `downloads` per org: given an HF client that returns a NEW model only under `trending` (not in the top-`downloads`), that model appears in the candidate pool. (unit test, mocked client)
+- **SC2** The merged candidate set is deduped by id and capped at the per-org limit (no count blow-up, no duplicates). (unit test)
+- **SC3** Graceful: a throwing/failing `trending` call falls back to the `downloads` result; discovery still returns candidates. (unit test)
+- **SC4** `allowedOrgs` includes `openai`, `zai-org`, `THUDM`, `moonshotai` in all four config files; a candidate from one of those orgs now passes `select.ts`'s org filter. (config assertion + a `select` unit test)
+- **SC5** No regression: the benchmark ranker is unchanged; existing discovery/select/ranker tests stay green; the byte-identical `.local` config pair stays pinned.
+
+## Implementation Order
+
+1. **Discovery wide-net (D1/D2)** — failing test (a trending-only new model is currently dropped); implement the trending+downloads merge + dedupe + limit + graceful fallback; SC1/SC2/SC3.
+2. **Config allowlist (D3)** — extend `allowedOrgs` in the four files; a `select` test that an added-org candidate passes the filter; SC4.
+3. **Docs + ADR + changeset + regression sweep (SC5).**

--- a/docs/guides/local-model-lifecycle.md
+++ b/docs/guides/local-model-lifecycle.md
@@ -59,6 +59,19 @@ within. Inside that boundary the orchestrator may pull, swap, and evict autonomo
 nothing crosses that line without an explicit proposal approval. This per-pool (not
 per-model) authorization is the core of [ADR 0062](../knowledge/decisions/0062-pool-bounded-autonomy-and-ollama-first-install.md).
 
+### Discovery is a wide net; the ranker judges
+
+For each approved org, candidate discovery casts a **wide net**: it merges
+HuggingFace `trending` (new/hot) with `downloads` (established), dedupes by model id,
+and caps the union at the per-org limit. This is deliberate — sorting by cumulative
+downloads alone lags the landscape by months, so a brand-new leader gets crowded out
+of the pool before the benchmark ranker can score it (the cause of stale
+recommendations). Discovery's job is **coverage, not quality**: the `allowedOrgs` /
+`allowedFamilies` allowlist is the operator's trust gate, and the benchmark ranker is
+the sole quality authority — it decides which of the discovered candidates to
+recommend. A HuggingFace `trending` outage degrades gracefully to `downloads` only, so
+a refresh never breaks. See [ADR 0077](../knowledge/decisions/0077-discovery-is-a-wide-net-ranker-judges.md).
+
 ## What a proposal looks like
 
 When LMLM wants to change the pool it emits a **model proposal** into the shared review

--- a/docs/knowledge/decisions/0077-discovery-is-a-wide-net-ranker-judges.md
+++ b/docs/knowledge/decisions/0077-discovery-is-a-wide-net-ranker-judges.md
@@ -1,0 +1,87 @@
+---
+number: 0077
+title: Discovery is a wide net; the benchmark ranker judges
+date: 2026-07-17
+status: accepted
+tier: integration
+source: docs/changes/recommendation-engine-recency/proposal.md
+---
+
+## Context
+
+The local-model recommendation engine was recommending 6-month-stale models. Two
+mechanisms in the discovery layer quietly did quality selection by popularity —
+work the benchmark ranker is supposed to own — before the ranker ever saw the
+candidates:
+
+1. **Sort-by-downloads pre-filter.** `discoverOrg`
+   (`packages/local-models/src/candidates/discover.ts`) listed each approved org's
+   GGUF repos with `sort: 'downloads'` only. Cumulative downloads are a
+   months-to-years-lagging popularity signal, so a brand-new leader with few
+   cumulative downloads never appeared in the per-org slice — it was crowded out
+   of the pool before the ranker could score it. Discovery was, in effect, ranking
+   by popularity under the guise of "listing candidates."
+2. **A too-narrow `allowedOrgs`.** The pool's `allowedOrgs` allowlist
+   (`harness.orchestrator*.md`) omitted several current-leader orgs (`openai`,
+   `zai-org`, `THUDM`, `moonshotai`), so even their established models could not
+   enter the pool.
+
+The benchmark ranker (`packages/local-models/src/ranker/evidence.ts`) is the
+intended sole quality authority — it scores candidates on agentic-suitability
+evidence. Letting discovery pre-decide quality by download count made the ranker's
+judgement moot for exactly the new models the engine most needs to surface.
+
+## Decision
+
+**D1 — Discovery is a wide net; it does not judge quality.** `discoverOrg` now
+fetches BOTH `sort: 'trending'` (new/hot) AND `sort: 'downloads'` (established) per
+org, merges the two lists, dedupes by model id, and caps the merged set at
+`perOrgLimit` (no count blow-up). The union — not a popularity-pre-filtered slice —
+is handed downstream. Discovery's job is coverage, not selection.
+
+**D2 — Discovery is best-effort and fail-soft.** A throwing `trending` list call is
+warned and dropped, leaving the `downloads` result (discovery never breaks on the
+new call). A throwing base `downloads` call keeps the existing org-skip fail-soft
+behavior. Trending is listed first in the merge so new leaders win the per-org cap
+tie-break, and dedupe is by model id before `getModel` so no repo is fetched twice.
+
+**D3 — `allowedOrgs`/`allowedFamilies` remain the operator TRUST gate, not a
+quality gate.** `select.ts` still filters candidates to the operator's approved
+orgs/families — the same line the pool enforces at install time. Expanding
+`allowedOrgs` to include the 2026-leader orgs widens what the operator trusts; it
+does not rank. Quality remains the ranker's sole call.
+
+**D4 — The benchmark ranker is untouched.** This change only widens the input set
+handed to the ranker. `ranker/evidence.ts` and `benchmarks/merge.ts` are not
+modified (asserted via an empty `git diff --stat` for those paths).
+
+## Consequences
+
+- New leaders now reach the ranker: a model that is trending but not yet a
+  top-cumulative-downloads repo enters the candidate pool and gets scored on merit.
+- **This is a discovery-coverage change, not a ranking change.** It does not — and
+  is not meant to — alter how candidates are scored; it only ensures the ranker sees
+  the right set. The ranker's scoring is out of scope (D4).
+- Discovery is best-effort: a HuggingFace `trending` outage degrades to the prior
+  downloads-only behavior rather than breaking a refresh (D2).
+- **The discovery↔ranking boundary is now explicit and must not be blurred.** Do not
+  re-add popularity filters to discovery (that re-hides the crowd-out bug), and do
+  not add discovery/recency heuristics to the ranker (that forks the quality
+  authority). Popularity, if it should influence recommendations at all, belongs in
+  the ranker's evidence model — never as a discovery pre-filter.
+
+## Alternatives rejected
+
+- **Raise the per-org `downloads` limit instead of adding `trending`.** A larger
+  downloads slice still orders by cumulative popularity, so a brand-new leader with
+  few cumulative downloads stays at the bottom and is still crowded out below the
+  cap. `trending` is the signal that surfaces recency; a bigger downloads window is
+  not. Rejected.
+- **Add recency weighting to the ranker and leave discovery as-is.** The ranker
+  cannot score a candidate it never receives; the crowd-out happens upstream in
+  discovery. Fixing recency purely in the ranker would leave the pool blind to new
+  models. Rejected in favor of widening discovery (D1) and keeping the ranker as the
+  quality authority (D4).
+- **Make discovery rank (e.g. blend trending + downloads into a score).** That would
+  re-introduce quality selection into discovery — exactly the coupling this ADR
+  removes. Discovery merges and dedupes; it does not score (D1). Rejected.

--- a/harness.orchestrator.local.md
+++ b/harness.orchestrator.local.md
@@ -140,7 +140,7 @@ localModels:
   enabled: true
   pool:
     diskBudgetGb: 100
-    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google]
+    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google, openai, zai-org, THUDM, moonshotai]
     allowedFamilies: []
   refresh:
     intervalMs: 86400000

--- a/harness.orchestrator.md
+++ b/harness.orchestrator.md
@@ -144,7 +144,7 @@ localModels:
   enabled: true
   pool:
     diskBudgetGb: 100
-    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google]
+    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google, openai, zai-org, THUDM, moonshotai]
     allowedFamilies: []
   refresh:
     intervalMs: 86400000

--- a/packages/local-models/src/candidates/discover.ts
+++ b/packages/local-models/src/candidates/discover.ts
@@ -92,18 +92,49 @@ interface DiscoverContext {
   collected: Map<string, FrozenCandidate>;
 }
 
+type HfModel = Awaited<ReturnType<Pick<HuggingFaceClient, 'listModels'>['listModels']>>[number];
+
+/** One `listModels` call for a given sort. Returns `null` on failure (caller decides fail-soft policy). */
+async function listSort(
+  org: string,
+  sort: 'downloads' | 'trending',
+  ctx: DiscoverContext
+): Promise<HfModel[] | null> {
+  try {
+    return await ctx.client.listModels({ author: org, search: 'gguf', sort, limit: ctx.limit });
+  } catch (err) {
+    // Base (downloads) failure keeps the original org-skip wording; trending failure is a fallback warning.
+    const message =
+      sort === 'trending'
+        ? `HF trending list failed for ${org} (falling back to downloads): ${messageOf(err)}`
+        : `HF list failed for ${org}: ${messageOf(err)}`;
+    ctx.warn(message, err);
+    return null;
+  }
+}
+
+/** Wide net: merge both sorts, dedupe by model id, cap at `limit` (D1 — no blow-up). */
+function mergeCapped(trending: HfModel[], downloads: HfModel[], limit: number): HfModel[] {
+  const merged = new Map<string, HfModel>();
+  for (const model of [...trending, ...downloads]) {
+    if (merged.has(model.id)) continue;
+    if (merged.size >= limit) continue;
+    merged.set(model.id, model);
+  }
+  return [...merged.values()];
+}
+
 /** List one org's popular GGUF repos and fold each into `collected`. Fail-soft. */
 async function discoverOrg(org: string, ctx: DiscoverContext): Promise<void> {
-  const { client, limit, opts, warn } = ctx;
-  let models;
-  try {
-    models = await client.listModels({ author: org, search: 'gguf', sort: 'downloads', limit });
-  } catch (err) {
-    warn(`HF list failed for ${org}: ${messageOf(err)}`, err);
-    return;
-  }
-  for (const model of models) {
-    if (opts.signal?.aborted) break;
+  // Established quality (cumulative downloads). If this base call fails, the org is skipped.
+  const downloads = await listSort(org, 'downloads', ctx);
+  if (downloads === null) return;
+
+  // New/hot models (trending). Graceful (D2): a trending failure falls back to downloads only.
+  const trending = (await listSort(org, 'trending', ctx)) ?? [];
+
+  for (const model of mergeCapped(trending, downloads, ctx.limit)) {
+    if (ctx.opts.signal?.aborted) break;
     if (!model.tags?.includes('gguf')) continue;
     await discoverModel(model.id, ctx);
   }

--- a/packages/local-models/src/candidates/discover.ts
+++ b/packages/local-models/src/candidates/discover.ts
@@ -113,7 +113,11 @@ async function listSort(
   }
 }
 
-/** Wide net: merge both sorts, dedupe by model id, cap at `limit` (D1 — no blow-up). */
+/**
+ * Wide net: merge both sorts, dedupe by model id, cap at `limit` (D1 — no blow-up).
+ * `trending` is iterated first — recency wins cap ties. Do NOT reorder the args to
+ * "base first"; that would silently invert the recency bias (ADR 0077).
+ */
 function mergeCapped(trending: HfModel[], downloads: HfModel[], limit: number): HfModel[] {
   const merged = new Map<string, HfModel>();
   for (const model of [...trending, ...downloads]) {

--- a/packages/local-models/tests/candidates/discover.test.ts
+++ b/packages/local-models/tests/candidates/discover.test.ts
@@ -38,8 +38,40 @@ function fakeClient(
   };
 }
 
+/** Sort-aware fake: `listing[author][sort]` lets a test return different ids per sort. */
+function sortAwareClient(
+  listing: Record<string, Partial<Record<string, HuggingFaceModel[]>>>,
+  details: Record<string, HuggingFaceModelDetail>,
+  opts: { throwOnSort?: string } = {}
+) {
+  const calls = { list: [] as Array<{ author: string; sort: string }>, get: [] as string[] };
+  return {
+    calls,
+    client: {
+      async listModels(o: { author?: string; sort?: string }) {
+        const author = o.author ?? '';
+        const sort = o.sort ?? 'downloads';
+        calls.list.push({ author, sort });
+        if (opts.throwOnSort && sort === opts.throwOnSort) throw new Error(`HF ${sort} 503`);
+        return listing[author]?.[sort] ?? [];
+      },
+      async getModel(id: string) {
+        calls.get.push(id);
+        const d = details[id];
+        if (!d) throw new Error(`no detail for ${id}`);
+        return d;
+      },
+    },
+  };
+}
+
 const CURATION = new Map<string, CurationTags>([
   ['Qwen/Qwen3-32B-GGUF', { ollamaName: 'qwen3:32b', family: 'qwen3' }],
+]);
+
+const WIDE_CURATION = new Map<string, CurationTags>([
+  ['Qwen/Qwen3-32B-GGUF', { ollamaName: 'qwen3:32b', family: 'qwen3' }],
+  ['Qwen/Qwen3.6-27B-GGUF', { ollamaName: 'qwen3.6:27b', family: 'qwen3' }],
 ]);
 
 describe('discoverCandidates', () => {
@@ -98,6 +130,27 @@ describe('discoverCandidates', () => {
     const res = await discoverCandidates({ orgs: ['Qwen'], curation: CURATION, client });
     expect(res.candidates).toHaveLength(0);
     expect(calls.get).toHaveLength(0); // never fetched the non-gguf model
+  });
+});
+
+describe('discoverCandidates wide-net (SC1)', () => {
+  it('SC1: includes a NEW model returned only under `trending` (absent from `downloads`)', async () => {
+    const { client } = sortAwareClient(
+      {
+        Qwen: {
+          downloads: [{ id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+          trending: [{ id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+        },
+      },
+      {
+        'Qwen/Qwen3-32B-GGUF': detail('Qwen/Qwen3-32B-GGUF', ['Q4_K_M']),
+        'Qwen/Qwen3.6-27B-GGUF': detail('Qwen/Qwen3.6-27B-GGUF', ['Q4_K_M']),
+      }
+    );
+    const res = await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client });
+    const ids = res.candidates.map((c) => c.hfRepoId);
+    expect(ids).toContain('Qwen/Qwen3.6-27B-GGUF'); // trending-only new model reaches the pool
+    expect(ids).toContain('Qwen/Qwen3-32B-GGUF'); // established still present
   });
 });
 

--- a/packages/local-models/tests/candidates/discover.test.ts
+++ b/packages/local-models/tests/candidates/discover.test.ts
@@ -189,6 +189,29 @@ describe('discoverCandidates wide-net (SC1)', () => {
     await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client, perOrgLimit: 3 });
     expect(calls.get.length).toBeLessThanOrEqual(3);
   });
+
+  it('SC3: a throwing `trending` call falls back to `downloads`; discovery still returns candidates', async () => {
+    const { client } = sortAwareClient(
+      {
+        Qwen: {
+          downloads: [{ id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+          trending: [],
+        },
+      },
+      { 'Qwen/Qwen3-32B-GGUF': detail('Qwen/Qwen3-32B-GGUF', ['Q4_K_M']) },
+      { throwOnSort: 'trending' }
+    );
+    const res = await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client });
+    expect(res.candidates.map((c) => c.hfRepoId)).toContain('Qwen/Qwen3-32B-GGUF'); // downloads survived
+    expect(res.warnings.some((w) => /trending.*fall/i.test(w))).toBe(true); // fallback warned
+  });
+
+  it('SC3: a throwing `downloads` (base) call skips the org fail-soft (unchanged behavior)', async () => {
+    const { client } = sortAwareClient({}, {}, { throwOnSort: 'downloads' });
+    const res = await discoverCandidates({ orgs: ['broken'], curation: WIDE_CURATION, client });
+    expect(res.candidates).toHaveLength(0);
+    expect(res.warnings.some((w) => /HF list failed for broken/.test(w))).toBe(true);
+  });
 });
 
 describe('curationFromCandidates', () => {

--- a/packages/local-models/tests/candidates/discover.test.ts
+++ b/packages/local-models/tests/candidates/discover.test.ts
@@ -152,6 +152,43 @@ describe('discoverCandidates wide-net (SC1)', () => {
     expect(ids).toContain('Qwen/Qwen3.6-27B-GGUF'); // trending-only new model reaches the pool
     expect(ids).toContain('Qwen/Qwen3-32B-GGUF'); // established still present
   });
+
+  it('SC2: dedupes overlap by id and caps the inspected set at perOrgLimit', async () => {
+    const shared = { id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel;
+    const { client, calls } = sortAwareClient(
+      {
+        Qwen: {
+          downloads: [shared, { id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+          trending: [shared], // overlaps downloads → must dedupe, not double
+        },
+      },
+      {
+        'Qwen/Qwen3-32B-GGUF': detail('Qwen/Qwen3-32B-GGUF', ['Q4_K_M']),
+        'Qwen/Qwen3.6-27B-GGUF': detail('Qwen/Qwen3.6-27B-GGUF', ['Q4_K_M']),
+      }
+    );
+    await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client, perOrgLimit: 5 });
+    // shared id fetched exactly once (deduped across the two sorts)
+    const sharedFetches = calls.get.filter((id) => id === 'Qwen/Qwen3-32B-GGUF');
+    expect(sharedFetches).toHaveLength(1);
+    // both sorts were queried
+    expect(calls.list.map((c) => c.sort).sort()).toEqual(['downloads', 'trending']);
+  });
+
+  it('SC2: never inspects more than perOrgLimit distinct repos', async () => {
+    const many = (n: number) =>
+      Array.from(
+        { length: n },
+        (_, i) => ({ id: `Qwen/M${i}-GGUF`, tags: ['gguf'] }) as HuggingFaceModel
+      );
+    const { client, calls } = sortAwareClient(
+      { Qwen: { downloads: many(4), trending: many(4).map((m) => ({ ...m, id: m.id + 'T' })) } },
+      {}
+    );
+    // getModel throws for all (uncurated) — we only assert the cap on inspection count
+    await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client, perOrgLimit: 3 });
+    expect(calls.get.length).toBeLessThanOrEqual(3);
+  });
 });
 
 describe('curationFromCandidates', () => {

--- a/packages/local-models/tests/candidates/select.test.ts
+++ b/packages/local-models/tests/candidates/select.test.ts
@@ -59,4 +59,30 @@ describe('selectCandidates', () => {
     });
     expect('family' in first!).toBe(false);
   });
+
+  it('SC4: a candidate from an added leader org (openai) passes the org filter', () => {
+    const withLeader: FrozenCandidate[] = [
+      ...CANDIDATES,
+      {
+        hfRepoId: 'openai/gpt-oss-20B-GGUF',
+        ollamaName: 'gpt-oss:20b',
+        sizeB: 20,
+        quant: 'Q4_K_M',
+      },
+    ];
+    const result = selectCandidates(withLeader, {
+      allowedOrgs: [
+        'Qwen',
+        'deepseek-ai',
+        'meta-llama',
+        'google',
+        'openai',
+        'zai-org',
+        'THUDM',
+        'moonshotai',
+      ],
+      allowedFamilies: [],
+    });
+    expect(result.map((c) => c.hfRepoId)).toContain('openai/gpt-oss-20B-GGUF');
+  });
 });

--- a/templates/orchestrator/harness.orchestrator.local.md
+++ b/templates/orchestrator/harness.orchestrator.local.md
@@ -140,7 +140,7 @@ localModels:
   enabled: true
   pool:
     diskBudgetGb: 100
-    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google]
+    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google, openai, zai-org, THUDM, moonshotai]
     allowedFamilies: []
   refresh:
     intervalMs: 86400000


### PR DESCRIPTION
## Problem

The local-model recommendation engine kept recommending **6-month-stale models** — in July 2026 it surfaced `Qwen3-32B`/`Llama-70B`-era candidates and never the current leaders (`qwen3.6:27b`, `gpt-oss:20b`). Two independent causes:

1. **Discovery sorted by cumulative downloads only.** `discoverOrg` fetched the top-50 GGUF repos per org with `sort: 'downloads'`. Cumulative downloads favor *old, established* models — a brand-new model has near-zero cumulative downloads and is crowded out of the 50 slots, so it **never reached the benchmark ranker** that would score its actual capability. Discovery was silently doing quality-selection-by-popularity, and getting it wrong.
2. **The org allowlist excluded the 2026 leaders.** `allowedOrgs: [Qwen, deepseek-ai, meta-llama, google]` is a hard gate; `openai` (gpt-oss), `zai-org`/`THUDM` (GLM), `moonshotai` (Kimi) could never be *considered*, regardless of capability.

## Fix

- **Wide-net discovery (D1/D2).** Per org, fetch **both** `sort: 'trending'` (new/hot) and `sort: 'downloads'` (established), dedupe by model id, cap at the per-org limit, hand the union to the ranker. A `trending` failure falls back to downloads-only (discovery never breaks); a `downloads` (base) failure still surfaces the original `HF list failed` org-skip — no dual-silent-empty path.
- **Expand `allowedOrgs` (D3).** Add `openai`, `zai-org`, `THUDM`, `moonshotai` across all three real config files (`harness.orchestrator.md`, `harness.orchestrator.local.md`, `templates/orchestrator/harness.orchestrator.local.md`); byte-identical `.local` pair stays pinned.
- **No ranker change (D4).** The benchmark ranker already scores capability — this only widens what reaches it. Division of labor preserved: **discovery finds candidates, the ranker judges them** (ADR 0077).

## Success criteria

| SC | What | Status |
|----|------|--------|
| SC1 | Merge trending+downloads (trending-only new model reaches the pool) | ✅ unit test |
| SC2 | Deduped by id, capped at per-org limit (no blow-up) | ✅ unit test |
| SC3 | Graceful: trending failure → downloads fallback; base failure surfaces original message | ✅ unit test |
| SC4 | `allowedOrgs` +4 orgs in all 3 configs; an `openai/…` candidate clears the org filter | ✅ config + select test |
| SC5 (hard) | No ranker regression — `git diff` of `ranker/`+`benchmarks/` empty; `.local` pair byte-identical | ✅ empty diff |

## Verification & review

- **Verifier: PASS** — all 5 SCs at EXISTS/SUBSTANTIVE/WIRED, 0 gaps. Merged set flows to the real orchestrator consumer (`discoverCandidates` → `orchestrator.ts:3707`), not a dead local. Suites fresh: local-models **365/365**, orchestrator template-lint **36/36**.
- **Code review: Approve** — 0 critical, 0 important. Dedupe single-keyed on `model.id`; cap binds the merged set (never doubled); trending fallback genuinely isolated; helper extraction (`listSort`/`mergeCapped`) semantics-preserving; no `any`. Two advisory notes on the intentional trending-first cap-tie bias (documented, ADR 0077) — one folded in as a guard-comment on `mergeCapped`.

## Changeset

`@harness-engineering/local-models` minor + `@harness-engineering/orchestrator` minor (config surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
