### PR TITLE
fix(orchestrator): preserve worktree on within-run retry (unblocks local-model convergence)

### DIFF
--- a/.changeset/retry-preserves-worktree.md
+++ b/.changeset/retry-preserves-worktree.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+Preserve the workspace across within-run retries so a verification-failure retry no longer discards the agent's partial progress. `ensureWorkspace` previously removed the git worktree on every dispatch (correct for an orchestrator restart, but it wiped uncommitted work when the tick loop re-dispatched a failed unit, so units could never converge). It now takes a `preserve` option and returns `{ path, reused }`: a dispatch of a unit already provisioned in this process reuses the existing worktree (skipping remove/add/seed and the `afterCreate` hook), while a fresh dispatch — and every dispatch after a restart, since the in-process `dispatchedThisRun` set is empty then — still wipes and recreates from the base ref (anti-stale guarantee intact). `beforeRun` and the workspace config-injection scan still run on every dispatch. Single-dispatch and unstaged workflow paths are byte-identical.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -291,7 +291,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 198752,
+      "value": 198810,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/docs/changes/retry-preserves-worktree/proposal.md
+++ b/docs/changes/retry-preserves-worktree/proposal.md
@@ -1,0 +1,62 @@
+# Retry Preserves Worktree
+
+**Keywords:** orchestrator, workspace, worktree, retry, dispatch, ensureWorkspace, local-model-convergence, staged-workflow
+
+## Overview and Goals
+
+**Problem.** A verification-failure retry of an in-flight unit **discards the agent's partial progress**, so the unit can never converge. `ensureWorkspace` (`packages/orchestrator/src/workspace/manager.ts:138-191`) unconditionally runs `git worktree remove --force` on any existing worktree at the start of **every** dispatch, then recreates it detached from the base ref. That is correct for an orchestrator **restart** (avoid agents working on stale code — the documented reason, `manager.ts:142-144`), but catastrophic for the **retry loop**: when a staged unit fails verification, the tick loop re-selects the still-non-terminal unit and calls `dispatchIssue` again (logged `Dispatching issue: <id> (attempt null)` repeatedly → `ensureWorkspace` at `orchestrator.ts:2089`), wiping the worktree and all uncommitted work. The model redoes everything from zero, fails again, and wipes again.
+
+**Evidence (live, 2026-07-17).** Running the real staged dispatch on a local-model pilot, `qwen3-coder:30b` produced `no-only-tests.test.ts` in pass 2; re-dispatch #3 **deleted it**; 3 re-dispatches / ~25 min, no convergence — for every reasoner tested (`llama3.3:70b`, `gpt-oss:20b`, `qwen3.6:27b`). The failure is the harness discarding work between retries, not model capability. `orchestrator.ts:2155` already states the intent is to "reuse the ONE worktree (D11)" — a direct contradiction with the unconditional remove.
+
+**Goal.** Make a within-run retry **reuse** the existing worktree (preserving uncommitted progress) so partial work accumulates toward done, while a genuinely fresh dispatch / orchestrator restart **still wipes** (anti-stale guarantee intact).
+
+**Out of scope (deferred phase 2).** Durability _across_ an orchestrator restart via committing partial work between stages + rebasing a recreated worktree. This spec does the minimal reuse-on-retry fix; phase 2 is gated on whether it alone achieves convergence.
+
+## Decisions made
+
+- **D1 — In-memory "dispatched-this-run" set (Approach A).** `dispatchIssue` maintains a per-process `Set<identifier>` of units it has provisioned since process start. A dispatch whose identifier is already in the set (and whose worktree still exists and is valid) is a **retry** → preserve the worktree. Otherwise it is a fresh dispatch → wipe + recreate (current behavior). _Why:_ captures the intent exactly ("this process already provisioned this unit → reuse its worktree"), is **restart-correct by construction** (the set is empty after a restart, so the first dispatch of any leftover worktree wipes it), and avoids the lane-state approach whose reconciliation re-derives an `in_progress` lane on restart and would wrongly preserve a stale worktree.
+- **D2 — `ensureWorkspace` gains a `preserve` option and reports `reused`.** Signature becomes `ensureWorkspace(identifier, opts?: { preserve?: boolean })` returning `Result<{ path: string; reused: boolean }, Error>`. When `preserve` is true **and** a valid worktree exists, it returns that worktree untouched (`reused: true`, no remove/recreate/seed). Otherwise it performs the current remove→add→seed flow (`reused: false`). _Why:_ a return value is needed so the caller can skip create-only side effects; `preserve` defaults false so every existing caller is byte-identical.
+- **D3 — Skip create-only side effects on reuse.** `afterCreate` (`orchestrator.ts:2094`) runs only when `reused === false`; `seedWorkspace` is skipped inside `ensureWorkspace` on the reuse path. `beforeRun` still runs every dispatch (unchanged). _Why:_ re-seeding `fs.cp(force:true)`-overwrites the seed paths (`.harness/proposals`, `docs/roadmap.md`) and could clobber an in-progress proposal the design stage wrote; the `afterCreate` comment already scopes it to "workspace just created/recreated".
+- **D4 — Default off / opt-in via the set only.** The reuse path engages only through the in-memory set inside `dispatchIssue`. Single-dispatch and unstaged callers pass no `preserve` → false → unchanged. _Why:_ the hard constraint is byte-identical behavior for the single-dispatch + unstaged paths.
+
+## Technical design
+
+**`packages/orchestrator/src/workspace/manager.ts` (D2).**
+
+- `ensureWorkspace(identifier: string, opts?: { preserve?: boolean }): Promise<Result<{ path: string; reused: boolean }, Error>>`.
+- New guard at the top of the try: if `opts?.preserve` and the target path has a valid `.git` marker (existing worktree), return `Ok({ path, reused: true })` **before** the remove block — skipping remove, `worktree add`, and `seedWorkspace`.
+- All existing return sites become `Ok({ path, reused: false })`. The remove/recreate/seed body is otherwise unchanged, preserving the anti-stale flow for the fresh path.
+
+**`packages/orchestrator/src/orchestrator.ts` (D1/D3).**
+
+- Add a private field `#dispatchedThisRun = new Set<string>()` (reset only by process lifetime).
+- In `dispatchIssue`, before `ensureWorkspace`: `const preserve = this.#dispatchedThisRun.has(issue.identifier);`
+- Call `ensureWorkspace(issue.identifier, { preserve })`; read `{ path, reused }`.
+- `this.#dispatchedThisRun.add(issue.identifier);` (idempotent).
+- Gate `afterCreate`: `if (!reused) { await this.hooks.afterCreate(workspacePath); ... }`.
+- The staged-workflow branch (`orchestrator.ts:2158`) and single-agent path are otherwise unchanged — they consume `workspacePath` exactly as today.
+
+**Restart correctness.** After a process restart, `#dispatchedThisRun` is empty. The first dispatch of any unit (even one with a leftover worktree and an `in_progress` lane read-back) computes `preserve = false` → wipes and recreates from base → **anti-stale guarantee preserved**. Only the _second and later_ dispatches of a unit _within the same run_ preserve.
+
+## Integration Points
+
+- **Entry Points.** No new CLI/MCP/route. Internal: `WorkspaceManager.ensureWorkspace` signature/return change; `Orchestrator.dispatchIssue` reuse bookkeeping. No public API surface change (both are internal to `@harness-engineering/orchestrator`).
+- **Registrations Required.** None. No barrel/export changes (neither symbol is re-exported from the package root beyond existing internal use).
+- **Documentation Updates.** A short note in the orchestrator workspace/dispatch docs (or the multi-backend/staged-workflow guide) that within-run retries reuse the worktree while restarts wipe. Update the `ensureWorkspace` and `dispatchIssue` doc comments to state the reuse-on-retry contract and retire the "removes on every dispatch" wording.
+- **Architectural Decisions.** D1 (in-memory dispatched-this-run set as the retry/fresh discriminator, chosen over lane-state and on-disk sentinel) warrants a standalone ADR — it establishes the retry-vs-restart boundary for workspace lifecycle and explains why lane state is unsuitable.
+- **Knowledge Impact.** Concept: "within-run retry reuses the worktree; restart wipes." Relationship: retry-preserves-progress → local-model-convergence.
+
+## Success Criteria
+
+- **SC1** A second `dispatchIssue` for the same identifier within one run **reuses** the worktree: an uncommitted file written after the first dispatch still exists after the second. (unit/integration test with an injected git/worktree seam)
+- **SC2** A genuinely fresh first dispatch **still wipes + recreates** from the base ref (existing remove→add→seed flow runs, `reused: false`). (regression test)
+- **SC3** After a simulated restart (new `Orchestrator`/`WorkspaceManager` instance, empty set), an existing leftover worktree is **wiped** on its first dispatch — anti-stale guarantee holds. (test)
+- **SC4** `afterCreate` and `seedWorkspace` run **only on fresh create**, not on reuse. (test asserts hook/seed call counts across a fresh-then-reuse sequence)
+- **SC5** No regression: single-dispatch + unstaged workflow paths are byte-identical; all existing orchestrator + workspace tests stay green; `ensureWorkspace` callers that pass no `opts` behave exactly as before.
+- **SC6** (live acceptance, post-merge) Re-running the qwen3.6 staged pilot on the `no-only-tests` item: the workspace diff **accumulates across re-dispatches** (the test file persists) and the unit converges to a verification-passing rule instead of looping.
+
+## Implementation Order
+
+1. **`ensureWorkspace` preserve + return shape (D2)** — failing test first (SC1 reuse, SC2 fresh-wipe, SC3 restart-wipe against the manager with an injected git seam); implement the `preserve` guard + `{ path, reused }` return; migrate internal call sites.
+2. **`dispatchIssue` reuse bookkeeping (D1/D3)** — failing test first (SC4 hook/seed call counts across fresh→reuse); add the `#dispatchedThisRun` set, compute `preserve`, gate `afterCreate` on `!reused`.
+3. **Docs + ADR + changeset + regression sweep (SC5)** — ADR for D1; doc-comment/guide updates; `@harness-engineering/orchestrator` minor changeset; full orchestrator + workspace suite green.

--- a/docs/knowledge/decisions/0078-retry-reuses-worktree-restart-wipes.md
+++ b/docs/knowledge/decisions/0078-retry-reuses-worktree-restart-wipes.md
@@ -1,0 +1,35 @@
+# 0078 — Within-run retry reuses the worktree; restart wipes
+
+- **Status:** Accepted
+- **Date:** 2026-07-17
+- **Context tags:** orchestrator, workspace, worktree, retry, dispatch, local-model-convergence
+
+## Context
+
+`WorkspaceManager.ensureWorkspace` unconditionally ran `git worktree remove --force` on any existing worktree at the start of **every** dispatch, then recreated it detached from the base ref. That guarantees an agent never works on stale code after an orchestrator **restart** — the documented reason the remove exists.
+
+But the orchestrator retries a failed unit by **re-dispatching it**: when a staged unit fails verification, the tick loop re-selects the still-non-terminal unit and calls `dispatchIssue` again (`attempt null` each time — a fresh tick-driven dispatch, not an attempt-incrementing retry). Each re-dispatch called `ensureWorkspace`, which **wiped the worktree and all uncommitted partial progress**. The model redid everything from zero, failed again, and wiped again.
+
+This was observed live (2026-07-17) across a local-model pilot: `qwen3-coder:30b` produced a test file in one pass, and the next re-dispatch deleted it; three re-dispatches / ~25 min with no convergence, for every reasoner tested. **A capable model that gets incrementally closer each pass can never accumulate to done** — the harness discards its work between retries. The failure is the workspace lifecycle, not model capability.
+
+The fix must let a **within-run retry preserve** the worktree while a genuine **fresh dispatch / restart still wipes** — without regressing the anti-stale guarantee.
+
+## Decision
+
+Discriminate retry-from-fresh with an **in-memory, per-process `Set<identifier>` of units dispatched since process start** (`Orchestrator.#dispatchedThisRun`).
+
+- On dispatch, `preserve = #dispatchedThisRun.has(identifier)`. `ensureWorkspace(identifier, { preserve })` returns the existing worktree untouched (`reused: true`) when `preserve` is true **and** a valid worktree exists; otherwise it runs the unchanged remove→add→seed flow (`reused: false`).
+- The identifier is added to the set only **after** the dispatch clears the high-severity config-injection scan gate — a dispatch that aborts at the scan stays "fresh", so its next attempt wipes and recreates from base rather than reusing an un-vetted worktree. Create-only side effects (`afterCreate`, `seedWorkspace`) are skipped on reuse; `beforeRun` and the config-injection scan still run on **every** dispatch.
+
+**Restart-correct by construction:** after a process restart the set is empty, so the first dispatch of any leftover worktree computes `preserve = false` and wipes — the anti-stale guarantee holds. Only the second-and-later dispatches of a unit _within the same run_ preserve.
+
+## Alternatives considered
+
+- **Lane-state flag (derive "isRetry" from the lane machine).** Rejected: reconciliation re-derives an `in_progress` lane on restart, so a post-restart first dispatch would look like a retry and wrongly preserve a stale worktree — reintroducing the exact bug the wipe prevents. The lane state machine is also brittle (canceled lanes cannot reset).
+- **On-disk run-id sentinel in the worktree.** Equivalent semantics (a new process gets a new run-id → mismatch → wipe) but adds durable bookkeeping we do not need for this fix, and a sentinel file that must be kept out of git. Durability _across_ a restart is the separately-scoped phase-2 concern (commit partial work between stages + rebase), so an on-disk mechanism here would blur that boundary. Deferred.
+
+## Consequences
+
+- Verification-failure retries accumulate partial progress; the `#843`/`#886` empty-diff gate now sees a growing diff instead of a wiped-clean one.
+- Reuse is intentionally **not** durable across an orchestrator restart — a restart wipes and restarts the unit from base. If that proves too lossy in practice, phase 2 (stage-commits + rebase) is the follow-up; it is gated on whether reuse-on-retry alone achieves convergence.
+- Single-dispatch and unstaged workflow paths are unchanged (callers that pass no `opts` default `preserve` to false).

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -368,6 +368,15 @@ export class Orchestrator extends EventEmitter {
   private workspace: WorkspaceManager;
   private hooks: WorkspaceHooks;
   /**
+   * Identifiers this process has already provisioned a worktree for since
+   * startup (D1). A re-dispatch of an identifier in this set is a within-run
+   * retry → `ensureWorkspace` preserves the existing worktree (keeping the
+   * agent's uncommitted partial progress). The set is per-process and reset
+   * only by process lifetime, so after a restart it is empty and the first
+   * dispatch of any leftover worktree wipes it — anti-stale guarantee intact.
+   */
+  #dispatchedThisRun = new Set<string>();
+  /**
    * Spec 2 SC30 / Task 11: per-dispatch backend factory replaces the
    * Phase 1 `runner` / `localRunner` two-runner split. Each
    * `dispatchIssue()` call asks the factory for a `RoutingUseCase`-routed
@@ -2068,6 +2077,14 @@ export class Orchestrator extends EventEmitter {
   /**
    * Dispatches a new agent to work on an issue.
    *
+   * Within-run retries reuse the worktree: the first dispatch of an
+   * identifier in a given process provisions a fresh worktree, and any later
+   * dispatch of the SAME identifier within that run preserves it (via
+   * {@link WorkspaceManager.ensureWorkspace}'s `preserve` option) so the
+   * agent's uncommitted partial progress survives the retry. A restart
+   * (empty {@link #dispatchedThisRun}) wipes and recreates on first dispatch.
+   * `afterCreate` runs only on the fresh-create dispatch (D3), never on reuse.
+   *
    * @param issue - The issue to resolve
    * @param attempt - The retry attempt number
    */
@@ -2085,17 +2102,25 @@ export class Orchestrator extends EventEmitter {
     await this.persistLaneSafe(issue.id, 'dispatch');
 
     try {
-      // 1. Ensure workspace
-      const workspaceResult = await this.workspace.ensureWorkspace(issue.identifier);
+      // 1. Ensure workspace. A prior dispatch of this identifier in this run
+      // ⇒ preserve the existing worktree (within-run retry keeps partial
+      // progress); a fresh/first dispatch (or post-restart empty set) wipes
+      // and recreates from the base ref (anti-stale). (D1)
+      const preserve = this.#dispatchedThisRun.has(issue.identifier);
+      const workspaceResult = await this.workspace.ensureWorkspace(issue.identifier, { preserve });
       if (!workspaceResult.ok) throw workspaceResult.error;
-      const workspacePath = workspaceResult.value;
+      const { path: workspacePath, reused } = workspaceResult.value;
 
-      // 1b. Run afterCreate hook (workspace just created/recreated)
-      const afterCreateResult = await this.hooks.afterCreate(workspacePath);
-      if (!afterCreateResult.ok) {
-        this.logger.warn(
-          `afterCreate hook failed for ${issue.identifier}: ${afterCreateResult.error.message}`
-        );
+      // 1b. Run afterCreate hook — only when the workspace was actually
+      // (re)created, never on a preserved reuse (re-seeding would clobber the
+      // agent's in-progress artifacts). (D3)
+      if (!reused) {
+        const afterCreateResult = await this.hooks.afterCreate(workspacePath);
+        if (!afterCreateResult.ok) {
+          this.logger.warn(
+            `afterCreate hook failed for ${issue.identifier}: ${afterCreateResult.error.message}`
+          );
+        }
       }
 
       // 2. Run hooks (might generate/modify config files)
@@ -2123,6 +2148,12 @@ export class Orchestrator extends EventEmitter {
         );
         return;
       }
+
+      // Mark this unit as provisioned in this run ONLY after it clears the
+      // high-severity config-scan gate — a dispatch that aborts above stays a
+      // "fresh" dispatch, so its next attempt wipes and recreates from base
+      // rather than reusing an un-vetted worktree. (D1, review follow-up)
+      this.#dispatchedThisRun.add(issue.identifier);
 
       if (scanResult.exitCode === 1) {
         // Medium-severity findings — taint session, continue

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -134,10 +134,39 @@ export class WorkspaceManager {
   /**
    * Ensures the workspace exists as a git worktree so the agent has
    * access to the full project source.
+   *
+   * Reuse-on-retry contract: when `opts.preserve` is true AND a valid
+   * worktree already exists at the target path, the existing worktree is
+   * returned untouched (`reused: true`) — skipping remove, `worktree add`,
+   * and seeding — so a within-run retry preserves the agent's uncommitted
+   * partial progress. Otherwise (the default, and every fresh dispatch /
+   * orchestrator restart) the worktree is removed and recreated from the
+   * latest base ref (`reused: false`), preserving the anti-stale guarantee.
+   *
+   * @param identifier - The issue/unit identifier for the workspace.
+   * @param opts.preserve - When true, reuse an existing valid worktree
+   *   instead of wiping it. Defaults false → current wipe-and-recreate flow.
    */
-  public async ensureWorkspace(identifier: string): Promise<Result<string, Error>> {
+  public async ensureWorkspace(
+    identifier: string,
+    opts?: { preserve?: boolean }
+  ): Promise<Result<{ path: string; reused: boolean }, Error>> {
     try {
       const workspacePath = path.resolve(this.resolvePath(identifier));
+
+      // Reuse-on-retry: if the caller opted to preserve AND a valid worktree
+      // already exists (same `.git` marker check used below), return it
+      // untouched — skipping remove, recreate, and seeding — so a within-run
+      // retry keeps the agent's uncommitted progress. Without a leftover
+      // worktree we fall through to the fresh-create path (anti-stale).
+      if (opts?.preserve === true) {
+        try {
+          await fs.access(path.join(workspacePath, '.git'));
+          return Ok({ path: workspacePath, reused: true });
+        } catch {
+          // No valid worktree to preserve — proceed to fresh create below.
+        }
+      }
 
       // Remove any existing worktree so the agent always starts from the
       // latest base ref. Previously this path reused stale worktrees which
@@ -184,7 +213,7 @@ export class WorkspaceManager {
       // a dispatched agent with a roadmap entry but no proposal to work from.
       await this.seedWorkspace(workspacePath, repoRoot);
 
-      return Ok(workspacePath);
+      return Ok({ path: workspacePath, reused: false });
     } catch (error) {
       return Err(error instanceof Error ? error : new Error(String(error)));
     }

--- a/packages/orchestrator/tests/core/lane-effect-persistence.test.ts
+++ b/packages/orchestrator/tests/core/lane-effect-persistence.test.ts
@@ -94,7 +94,7 @@ describe('Orchestrator lane persistence at the effect boundary', () => {
     const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'h-1');
     vi.spyOn(WorkspaceManager.prototype, 'ensureWorkspace').mockImplementation(async () => {
       fs.mkdirSync(workspacePath, { recursive: true });
-      return Ok(workspacePath);
+      return Ok({ path: workspacePath, reused: false });
     });
     vi.spyOn(WorkspaceManager.prototype, 'removeWorkspace').mockResolvedValue(Ok(undefined));
     vi.spyOn(WorkspaceManager.prototype, 'sweepStaleBranches').mockResolvedValue([]);

--- a/packages/orchestrator/tests/integration/orchestrator.test.ts
+++ b/packages/orchestrator/tests/integration/orchestrator.test.ts
@@ -81,7 +81,7 @@ describe('Orchestrator Integration', () => {
     const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'h-1');
     vi.spyOn(WorkspaceManager.prototype, 'ensureWorkspace').mockImplementation(async () => {
       fs.mkdirSync(workspacePath, { recursive: true });
-      return Ok(workspacePath);
+      return Ok({ path: workspacePath, reused: false });
     });
     vi.spyOn(WorkspaceManager.prototype, 'removeWorkspace').mockResolvedValue(Ok(undefined));
     vi.spyOn(WorkspaceManager.prototype, 'sweepStaleBranches').mockResolvedValue([]);

--- a/packages/orchestrator/tests/workflow/orchestrator.workflow-dispatch.test.ts
+++ b/packages/orchestrator/tests/workflow/orchestrator.workflow-dispatch.test.ts
@@ -229,7 +229,7 @@ function makeDispatchOrch(workflows?: WorkflowConfig['workflows']): Orchestrator
   const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'ws');
   vi.spyOn(WorkspaceManager.prototype, 'ensureWorkspace').mockImplementation(async () => {
     fs.mkdirSync(workspacePath, { recursive: true });
-    return Ok(workspacePath);
+    return Ok({ path: workspacePath, reused: false });
   });
   const mockTracker = {
     fetchCandidateIssues: vi.fn().mockResolvedValue(Ok([])),
@@ -291,6 +291,78 @@ describe('dispatchIssue workflow branch (SC4 identity / D13 / workflow entry)', 
 
     expect(bgSpy).toHaveBeenCalledTimes(1);
     expect(wfSpy).not.toHaveBeenCalled();
+  });
+
+  it('SC4: within-run re-dispatch of same identifier preserves worktree; afterCreate runs only on fresh create', async () => {
+    orch = makeDispatchOrch(undefined);
+    // Override the workspace spy so `reused` mirrors the caller-passed `preserve`,
+    // as the real WorkspaceManager would when a worktree already exists.
+    const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'ws');
+    const ensureSpy = vi
+      .spyOn(WorkspaceManager.prototype, 'ensureWorkspace')
+      .mockImplementation(async (_id: string, opts?: { preserve?: boolean }) => {
+        fs.mkdirSync(workspacePath, { recursive: true });
+        return Ok({ path: workspacePath, reused: opts?.preserve === true });
+      });
+    // Keep the single-agent path from actually launching a background agent.
+    vi.spyOn(
+      orch as unknown as { runAgentInBackgroundTask: (...a: unknown[]) => void },
+      'runAgentInBackgroundTask'
+    ).mockImplementation(() => {});
+    const afterCreateSpy = vi.spyOn(
+      (orch as unknown as { hooks: { afterCreate: (p: string) => Promise<unknown> } }).hooks,
+      'afterCreate'
+    );
+
+    const issue = makeIssue({ identifier: 'REV-1' });
+
+    // Fresh first dispatch.
+    await dispatch(orch, issue);
+    // Same-identifier re-dispatch within the SAME orchestrator instance.
+    await dispatch(orch, issue);
+
+    // First call: preserve false (fresh). Second: preserve true (retry).
+    expect(ensureSpy).toHaveBeenCalledTimes(2);
+    expect(ensureSpy.mock.calls[0]![1]).toEqual({ preserve: false });
+    expect(ensureSpy.mock.calls[1]![1]).toEqual({ preserve: true });
+
+    // afterCreate runs only on the fresh create (reused: false), not the reuse.
+    expect(afterCreateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('SC3/restart: a second orchestrator instance treats the same identifier as fresh (per-instance set, not shared)', async () => {
+    // Create both instances first, then install the persisting ensure spy so it
+    // captures dispatches from both (makeDispatchOrch installs its own spy each
+    // call, so the last-applied spy below is the active one for both dispatches).
+    const orch1 = makeDispatchOrch(undefined);
+    const orch2 = makeDispatchOrch(undefined);
+    for (const o of [orch1, orch2]) {
+      vi.spyOn(
+        o as unknown as { runAgentInBackgroundTask: (...a: unknown[]) => void },
+        'runAgentInBackgroundTask'
+      ).mockImplementation(() => {});
+    }
+    const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'ws');
+    const ensureSpy = vi
+      .spyOn(WorkspaceManager.prototype, 'ensureWorkspace')
+      .mockImplementation(async (_id: string, opts?: { preserve?: boolean }) => {
+        fs.mkdirSync(workspacePath, { recursive: true });
+        return Ok({ path: workspacePath, reused: opts?.preserve === true });
+      });
+
+    const issue = makeIssue({ identifier: 'REV-1' });
+
+    // orch1 provisions the unit (fresh), then orch2 — simulating an orchestrator
+    // restart — dispatches the SAME identifier. orch2's #dispatchedThisRun set is
+    // empty, so it must treat the unit as fresh and wipe (anti-stale), NOT reuse
+    // orch1's worktree. This locks the per-instance contract against a future
+    // refactor to a static/shared set.
+    await dispatch(orch1, issue);
+    await dispatch(orch2, issue);
+
+    expect(ensureSpy).toHaveBeenCalledTimes(2);
+    expect(ensureSpy.mock.calls[0]![1]).toEqual({ preserve: false });
+    expect(ensureSpy.mock.calls[1]![1]).toEqual({ preserve: false });
   });
 
   it('SC4/D13: a 1-stage decl → single-agent path (workflowFor returns undefined)', async () => {
@@ -432,7 +504,7 @@ describe('SC2 end-to-end — two stages route to two tiers through the real cont
     const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'ws');
     vi.spyOn(WorkspaceManager.prototype, 'ensureWorkspace').mockImplementation(async () => {
       fs.mkdirSync(workspacePath, { recursive: true });
-      return Ok(workspacePath);
+      return Ok({ path: workspacePath, reused: false });
     });
     vi.spyOn(WorkspaceManager.prototype, 'findPushedBranch').mockResolvedValue(null);
     vi.spyOn(WorkspaceManager.prototype, 'removeWorkspace').mockResolvedValue(Ok(undefined));
@@ -532,7 +604,7 @@ describe('D11 restart-from-0 + SC5/SC6/SC7 through the real workflow context', (
       .spyOn(WorkspaceManager.prototype, 'ensureWorkspace')
       .mockImplementation(async () => {
         fs.mkdirSync(workspacePath, { recursive: true });
-        return Ok(workspacePath);
+        return Ok({ path: workspacePath, reused: false });
       });
     orch = makeDispatchOrch([
       { name: 'w', match: { identifierPrefix: 'REV-' }, stages: twoStages },
@@ -616,7 +688,7 @@ describe('D11 restart-from-0 + SC5/SC6/SC7 through the real workflow context', (
     const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'ws');
     vi.spyOn(WorkspaceManager.prototype, 'ensureWorkspace').mockImplementation(async () => {
       fs.mkdirSync(workspacePath, { recursive: true });
-      return Ok(workspacePath);
+      return Ok({ path: workspacePath, reused: false });
     });
     // Force the runner to always report TurnResult.success=false so the pass-required
     // gate fails on both the attempt-0 and attempt-1 (bumped-floor) runs.
@@ -672,7 +744,7 @@ describe('D11 restart-from-0 + SC5/SC6/SC7 through the real workflow context', (
     const workspacePath = path.join(tmpDir, '.harness', 'workspaces', 'ws');
     vi.spyOn(WorkspaceManager.prototype, 'ensureWorkspace').mockImplementation(async () => {
       fs.mkdirSync(workspacePath, { recursive: true });
-      return Ok(workspacePath);
+      return Ok({ path: workspacePath, reused: false });
     });
     // A runner that never returns within the 50ms deadline (hangs on the first turn).
     const factory = (

--- a/packages/orchestrator/tests/workspace/manager.test.ts
+++ b/packages/orchestrator/tests/workspace/manager.test.ts
@@ -53,7 +53,8 @@ describe('WorkspaceManager', () => {
     const result = await manager.ensureWorkspace('test-issue');
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value).toBe(path.resolve('/tmp/workspaces', 'test-issue'));
+      expect(result.value.path).toBe(path.resolve('/tmp/workspaces', 'test-issue'));
+      expect(result.value.reused).toBe(false);
     }
 
     // Should have called git worktree add
@@ -211,6 +212,95 @@ describe('WorkspaceManager', () => {
       // this test is purely that no exception escaped from the (absent)
       // emitter path.
       expect(worktreeAddRef(manager)).toBe('HEAD');
+    });
+  });
+
+  describe('reuse-on-retry (preserve option)', () => {
+    it('SC1: preserve + existing valid worktree → reuses untouched (no remove/add/seed)', async () => {
+      // A valid worktree exists: the .git access check resolves.
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+
+      const result = await manager.ensureWorkspace('test-issue', { preserve: true });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.path).toBe(path.resolve('/tmp/workspaces', 'test-issue'));
+        expect(result.value.reused).toBe(true);
+      }
+
+      // The existing worktree must NOT be removed or recreated.
+      const removeCall = manager.gitCalls.find(
+        (c) => c.args[0] === 'worktree' && c.args[1] === 'remove'
+      );
+      const addCall = manager.gitCalls.find((c) => c.args[0] === 'worktree' && c.args[1] === 'add');
+      expect(removeCall).toBeUndefined();
+      expect(addCall).toBeUndefined();
+      // seedWorkspace must not copy anything on the reuse path.
+      expect(fs.cp).not.toHaveBeenCalled();
+    });
+
+    it('SC2: no opts → current remove→add→seed flow runs, reused: false', async () => {
+      // Existing worktree (.git resolves once), then gone after removal so the
+      // recreate path proceeds — mirrors the stale-recreate regression test.
+      let gitCheckCount = 0;
+      vi.mocked(fs.access).mockImplementation(async (p) => {
+        const pathStr = String(p).replaceAll('\\', '/');
+        if (pathStr.endsWith('.git')) {
+          gitCheckCount++;
+          if (gitCheckCount === 1) return undefined; // exists initially
+          throw new Error('ENOENT'); // gone after removal
+        }
+        if (pathStr.startsWith('/repo/')) return undefined; // seed sources exist
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+
+      const result = await manager.ensureWorkspace('test-issue');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.reused).toBe(false);
+      }
+
+      // Full remove→add→seed flow must have run.
+      expect(
+        manager.gitCalls.find((c) => c.args[0] === 'worktree' && c.args[1] === 'remove')
+      ).toBeDefined();
+      expect(
+        manager.gitCalls.find((c) => c.args[0] === 'worktree' && c.args[1] === 'add')
+      ).toBeDefined();
+      expect(fs.cp).toHaveBeenCalled();
+    });
+
+    it('SC3: preserve but NO existing worktree (.git throws) → falls through to fresh create, reused: false', async () => {
+      // No .git marker anywhere, no stale dir → fresh create path (anti-stale).
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+      vi.mocked(fs.cp).mockResolvedValue(undefined);
+      manager.setGitImpl((args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
+        if (args[0] === 'symbolic-ref') return 'origin/main\n';
+        return '';
+      });
+
+      const result = await manager.ensureWorkspace('test-issue', { preserve: true });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.reused).toBe(false);
+      }
+
+      // A fresh worktree was created from the base ref.
+      const addCall = manager.gitCalls.find((c) => c.args[0] === 'worktree' && c.args[1] === 'add');
+      expect(addCall).toBeDefined();
+      expect(addCall!.args).toContain('--detach');
     });
   });
 


### PR DESCRIPTION
## Problem

The orchestrator's `ensureWorkspace` ran `git worktree remove --force` on the existing worktree at the start of **every** dispatch, then recreated it from the base ref. That's correct for an orchestrator **restart** (don't work on stale code) but catastrophic for the **retry loop**: when a staged unit fails verification, the tick loop re-dispatches the same still-non-terminal unit (`attempt null` each time), and each re-dispatch **wiped all uncommitted partial progress**. The model redid everything from zero, failed again, and wiped again — so a unit could never converge.

**Found live (2026-07-17):** running the real staged dispatch on a local-model pilot, `qwen3-coder:30b` produced a test file in one pass; the next re-dispatch **deleted it**; 3 re-dispatches / ~25 min with no convergence, for every reasoner tested. The failure was the harness discarding work between retries — not model capability. (`orchestrator.ts` already commented that the intent was to "reuse the ONE worktree" — a direct contradiction with the unconditional remove.)

## Fix (phase 1 — reuse-on-retry)

Discriminate a within-run **retry** (preserve the worktree) from a fresh dispatch / restart (wipe) with a **per-process `#dispatchedThisRun` set**:

- `ensureWorkspace(id, { preserve })` now returns `{ path, reused }`. When `preserve` is true **and** a valid worktree exists, it returns that worktree untouched (skips remove/add/seed); otherwise the unchanged remove→add→seed fresh path (`reused: false`).
- `dispatchIssue` computes `preserve = #dispatchedThisRun.has(identifier)`, and marks the unit provisioned **only after it clears the high-severity config-scan gate** (a scan-blocked dispatch stays fresh). `afterCreate` is gated on `!reused`.
- **Restart-correct by construction:** the in-memory set is empty after a restart, so the first dispatch of any leftover worktree computes `preserve = false` and wipes — the anti-stale guarantee holds. Only second-and-later dispatches *within the same run* preserve.
- `beforeRun` and the config-injection scan still run on **every** dispatch (no security regression on reuse). Single-dispatch and unstaged paths are byte-identical.

**Out of scope (phase 2, deferred):** durability *across* an orchestrator restart via committing partial work between stages + rebase. Gated on whether reuse-on-retry alone achieves convergence.

## Success criteria

| SC | What | Status |
|----|------|--------|
| SC1 | Within-run retry reuses the worktree (no remove/add/seed) | ✅ unit test |
| SC2 | Fresh dispatch still wipes + recreates from base | ✅ regression test |
| SC3 | `preserve` but no worktree → fresh create (anti-stale) | ✅ unit test |
| SC4 | Within one instance: fresh→reuse; `afterCreate` only on fresh | ✅ test |
| SC3/restart | A **second instance** treats the same id as fresh (per-instance set, not `static`) | ✅ cross-instance test |
| SC5 (hard) | Single-dispatch + unstaged paths byte-identical | ✅ full suite green |

## Verification & review

- **Verifier: PASS** — all 5 SCs at EXISTS/SUBSTANTIVE/WIRED, 0 gaps. WIRED confirmed: the set is consulted before `ensureWorkspace`, populated after the scan gate, `reused` gates `afterCreate`, the preserve guard sits before the worktree-remove, and the single production call site is migrated.
- **Code review: Approve** — 0 critical, 0 important. Confirmed restart-correctness (genuine per-instance field), the security config-scan runs every dispatch (not gated on `reused`), guard placement + `.git` check + clean fall-through, complete return-shape migration, byte-identical fresh path. Both suggestions folded in: the cross-instance restart test, and moving `.add` past the scan gate.
- Full orchestrator suite: **2206 passed / 1 pre-existing skip**; typecheck clean.

## ADR

`docs/knowledge/decisions/0078-retry-reuses-worktree-restart-wipes.md` (documents why lane-state and on-disk-sentinel were rejected). Changeset: `@harness-engineering/orchestrator` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
