### PR TITLE
fix: declare plugin agents as file paths so harness-claude installs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,24 @@
   "keywords": ["harness", "agent-first", "skills", "subagents", "hooks", "mcp", "claude-code"],
   "skills": ["./agents/skills/claude-code"],
   "commands": "./.claude-plugin/commands/",
-  "agents": "./.claude-plugin/agents/",
+  "agents": [
+    "./.claude-plugin/agents/harness-adversarial-reviewer.md",
+    "./.claude-plugin/agents/harness-architecture-enforcer.md",
+    "./.claude-plugin/agents/harness-code-reviewer.md",
+    "./.claude-plugin/agents/harness-codebase-health-analyst.md",
+    "./.claude-plugin/agents/harness-documentation-maintainer.md",
+    "./.claude-plugin/agents/harness-entropy-cleaner.md",
+    "./.claude-plugin/agents/harness-frontend-races-reviewer.md",
+    "./.claude-plugin/agents/harness-graph-maintainer.md",
+    "./.claude-plugin/agents/harness-harness-pm.md",
+    "./.claude-plugin/agents/harness-parallel-coordinator.md",
+    "./.claude-plugin/agents/harness-performance-guardian.md",
+    "./.claude-plugin/agents/harness-planner.md",
+    "./.claude-plugin/agents/harness-security-reviewer.md",
+    "./.claude-plugin/agents/harness-task-executor.md",
+    "./.claude-plugin/agents/harness-typescript-strict-reviewer.md",
+    "./.claude-plugin/agents/harness-verifier.md"
+  ],
   "hooks": "./.claude-plugin/hooks.json",
   "mcpServers": {
     "harness": {


### PR DESCRIPTION
## Summary

`harness-claude` fails to install via `claude plugin install harness-claude@harness` on current Claude Code because `.claude-plugin/plugin.json` declares `agents` as a directory, which the plugin manifest schema rejects:

```
✘ Failed to install plugin "harness-claude@harness": invalid manifest file …
Validation errors: agents: Invalid input
```

The manifest schema treats `agents` and `commands` differently:

- **`commands`** — `union([ <file-or-directory path>, array(...) ])` → a directory string is valid.
- **`agents`** — `union([ <file path>, array(<file path>) ])` → **only file paths**, no directory.

So `"agents": "./.claude-plugin/agents/"` is invalid, while the sibling `"commands": "./.claude-plugin/commands/"` is fine. That's why only `agents` errors.

## Changes

- `.claude-plugin/plugin.json`: replace the `agents` directory string with an explicit array of the 16 persona agent file paths under `./.claude-plugin/agents/`. Per the schema's own note ("when set, the `agents/` directory is not auto-loaded — list its files here"), every file is listed.
- `commands` is intentionally left unchanged (a directory is valid there).

## Testing

- [x] `node -e "JSON.parse(...)"` — manifest is valid JSON; `agents` has 16 entries matching the files in `.claude-plugin/agents/`.
- [x] Verified end-to-end: with this change, `claude plugin install harness-claude@harness` succeeds and the plugin loads (skills, `/harness:*` commands, 16 agents, hooks, MCP server). Without it, install fails with the error above.

_(This is a one-file manifest fix; the build/lint/typecheck boxes from the template don't apply to it.)_

## Related Issues

Closes # <!-- none filed; happy to open a tracking issue if preferred -->
