### PR TITLE
fix(orchestrator): stageDecisionFor must resolve routing key, not backend.name (unblocks local ship)

### DIFF
--- a/.changeset/local-staged-gate-decision-resolvename.md
+++ b/.changeset/local-staged-gate-decision-resolvename.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Fix the identity-path `stageDecisionFor` seam (added in the prior patch) so it
+actually populates the local staged gate's locality signal. It resolved the
+backend from the materialized backend's `.name`, but a materialized backend hard-
+codes `.name` to its TYPE label (`OllamaBackend.name === 'ollama'`,
+`LocalBackend.name === 'local'`), which does not key `agent.backends`. So the def
+lookup missed and `run.decision` stayed unset — leaving the prior fix inert: a
+fully-local (no-`routing.policy`) staged unit still completed without shipping and
+looped. `stageDecisionFor` now resolves the authoritative routing key via
+`backendFactory.resolveName(useCase)` (the same key the settle gate looks the def
+up under). The regression test now uses a factory whose `resolveName` returns a
+routing key distinct from the backend's `.name`, so a revert to reading `.name`
+would fail the test.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 284,
+      "value": 285,
       "violationIds": [
         "f0ab3e67d7d4319dc430b474b53fb9c8ca3eca675255696fd4906d628b6a67ae",
         "160a70b4728f1cfd65a3fccfe9ff46845b5686cf7bd7373024bde5dbe1113a1d",
@@ -296,7 +296,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 200796,
+      "value": 200805,
       "violationIds": [
         "e5162f4bcf3fa5b14ca7535ace40b58e6a1b319b38dd7e794d64ea1b577fae67",
         "c5b4c5a3ec42dfff0c1b6ecb8a0e2dc391925c3cef0645f6235b7b2ac2c03626",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2900,7 +2900,7 @@ export class Orchestrator extends EventEmitter {
      * (from the matched `StagedWorkflowDecl.acceptance`). When present it is the
      * mechanical step (run in the workspace, gated on exit code) IN PLACE OF
      * `verifyRunner`; when absent, `verifyRunner` is unchanged. The empty-diff halt
-     * (step 0) and outcome-eval (step 2) run identically either way.
+     * in step 0 and the outcome-eval stage in step 2 run identically either way.
      */
     acceptance?: string
   ): Promise<{ ok: true } | { ok: false; reason: string }> {

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -82,10 +82,7 @@ export interface WorkflowEngineContext {
    * `in_review` re-dispatch. This fills the same slot from the resolved backend's
    * name + type. ABSENT (fake/legacy contexts) ⇒ decision stays unset (byte-identical).
    */
-  stageDecisionFor?(
-    step: WorkflowExecutionPlan['stages'][number],
-    backend: AgentBackend
-  ): RoutingDecision | undefined;
+  stageDecisionFor?(step: WorkflowExecutionPlan['stages'][number]): RoutingDecision | undefined;
   /**
    * split-routing 4b: render the REAL per-stage prompt (issue + stage role +
    * prior-stage outputs), replacing the Phase-1 bare skill-name stub. Bound by
@@ -439,7 +436,7 @@ export async function runStageWithRetry(
           backend,
           priorOutputs(priorRuns, step)
         );
-        const identityDecision = ctx.stageDecisionFor?.(step, backend);
+        const identityDecision = ctx.stageDecisionFor?.(step);
         if (identityDecision !== undefined) run.decision = identityDecision;
       }
     } catch (err) {

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -208,16 +208,26 @@ function resolveStageBackendFactory(
  * backends map ⇒ undefined (decision stays unset — legacy byte-identical).
  */
 function stageDecisionFactory(
+  backendFactory: OrchestratorBackendFactory | null,
   backends: Record<string, BackendDef> | undefined
 ): NonNullable<WorkflowEngineContext['stageDecisionFor']> {
-  return (step, backend) => {
-    const def = backends?.[backend.name];
+  return (step) => {
+    if (backendFactory === null) return undefined;
+    // Resolve the ROUTING KEY (e.g. 'local'/'reasoner') via the router — NOT a
+    // materialized backend's `.name`, which is the backend's hardcoded TYPE label
+    // (`OllamaBackend.name === 'ollama'`, `LocalBackend.name === 'local'`) and does
+    // NOT key `agent.backends`. resolveName is the authoritative router key; the
+    // settle gate looks the def up under exactly this key. (Costs one extra
+    // decision-bus emission per identity stage — acceptable telemetry noise.)
+    const useCase = buildStageUseCase(step);
+    const backendName = backendFactory.resolveName(useCase);
+    const def = backends?.[backendName];
     if (def === undefined) return undefined;
     return {
       timestamp: new Date().toISOString(),
-      useCase: buildStageUseCase(step),
+      useCase,
       resolutionPath: [],
-      backendName: backend.name,
+      backendName,
       backendType: def.type,
       durationMs: 0,
     };
@@ -317,7 +327,7 @@ export function buildWorkflowContext(deps: BuildWorkflowContextDeps): WorkflowEn
 
     // Identity-path routing decision so the local staged settle gate's isLocal
     // check works without the adaptive router (see stageDecisionFactory).
-    stageDecisionFor: stageDecisionFactory(deps.backends),
+    stageDecisionFor: stageDecisionFactory(backendFactory, deps.backends),
 
     // split-routing 4b: render the real per-stage prompt (issue + stage role +
     // prior-stage outputs) via the pure PromptRenderer — no orchestrator import.

--- a/packages/orchestrator/tests/workflow/orchestrator-context.test.ts
+++ b/packages/orchestrator/tests/workflow/orchestrator-context.test.ts
@@ -47,12 +47,19 @@ function makeRecorderSpy() {
   };
 }
 
-/** A backend factory stub whose forUseCase returns a fresh MockBackend named per override. */
-function makeFactoryStub() {
+/**
+ * A backend factory stub. `forUseCase` returns a MockBackend named per override
+ * (default 'mock'). `resolveName` returns the ROUTING KEY (default 'mock',
+ * overridable) — the authoritative source stageDecisionFor must use. In production
+ * a materialized backend's `.name` is its TYPE label (OllamaBackend.name ===
+ * 'ollama'), NOT the routing key; reading `backend.name` is what made the first fix
+ * inert. Tests pass `routingKey` distinct from the backend name to prove the fix
+ * reads resolveName, not the backend.
+ */
+function makeFactoryStub(routingKey = 'mock') {
   return {
     forUseCase: vi.fn((_useCase: unknown, opts?: { invocationOverride?: string }) => {
       const name = opts?.invocationOverride ?? 'mock';
-      // A MockBackend is fine; we only assert on the resolved name.
       const backend = new MockBackend();
       return new Proxy(backend, {
         get(target, prop) {
@@ -60,6 +67,9 @@ function makeFactoryStub() {
           return Reflect.get(target, prop);
         },
       }) as unknown as AgentBackend;
+    }),
+    resolveName: vi.fn((_useCase: unknown, opts?: { invocationOverride?: string }) => {
+      return opts?.invocationOverride ?? routingKey;
     }),
   };
 }
@@ -140,27 +150,33 @@ describe('buildWorkflowContext — real seams (SC1/carry-forward)', () => {
   // stageDecisionFor is the identity-path fix: without it, a fully-local (no-AMR)
   // staged unit's `run.decision` stays unset, so settleWorkflowSuccess cannot derive
   // `isLocal` and SKIPS the gate+ship → the unit completes but never ships and loops.
-  it('stageDecisionFor(step, backend) synthesizes a decision carrying the resolved backend name + type', () => {
+  it('stageDecisionFor(step) uses the ROUTING KEY from resolveName, not a backend .name type-label', () => {
+    // routingKey 'local' resolves to a def; the materialized backend .name would be
+    // 'mock' (≠ 'local'). Reading backend.name (the inert first-fix bug) would look
+    // up backends['mock'] → undefined. Reading resolveName → backends['local'] → hit.
     const ctx = buildWorkflowContext(
       baseDeps({
+        backendFactory: makeFactoryStub('local') as never,
         backends: { local: { type: 'ollama', endpoint: 'http://x', model: ['m'] } } as never,
       })
     );
-    const decision = ctx.stageDecisionFor?.(step, { name: 'local' } as AgentBackend);
-    // backendName is load-bearing — settleWorkflowSuccess reads exactly this to
-    // look up the def and check isLocalEndpointBackend.
+    const decision = ctx.stageDecisionFor?.(step);
+    // backendName is load-bearing — settleWorkflowSuccess reads exactly this to look
+    // up the def and check isLocalEndpointBackend. Must be the routing key.
     expect(decision?.backendName).toBe('local');
     expect(decision?.backendType).toBe('ollama');
   });
 
-  it('stageDecisionFor returns undefined for a backend absent from the backends map (legacy byte-identical)', () => {
-    const ctx = buildWorkflowContext(baseDeps({ backends: {} as never }));
-    expect(ctx.stageDecisionFor?.(step, { name: 'nope' } as AgentBackend)).toBeUndefined();
+  it('stageDecisionFor returns undefined when the resolved routing key is absent from the backends map', () => {
+    const ctx = buildWorkflowContext(
+      baseDeps({ backendFactory: makeFactoryStub('not-in-map') as never, backends: {} as never })
+    );
+    expect(ctx.stageDecisionFor?.(step)).toBeUndefined();
   });
 
   it('stageDecisionFor returns undefined when no backends map is provided (fake/legacy context)', () => {
     const ctx = buildWorkflowContext(baseDeps());
-    expect(ctx.stageDecisionFor?.(step, { name: 'local' } as AgentBackend)).toBeUndefined();
+    expect(ctx.stageDecisionFor?.(step)).toBeUndefined();
   });
 
   it('resolveStageBackend(step) falls back to the routingDefault name when factory is null', () => {


### PR DESCRIPTION
## Summary
Follow-up correcting the **inert** identity-path decision fix from #904. The local staged gate now actually fires on default (no-AMR) configs — **live-validated**.

### The bug (why #904 was inert)
#904 added `stageDecisionFor` to populate `run.decision` on the identity path, but it derived the backend from the **materialized backend's `.name`**. A materialized backend hardcodes `.name` to its **type label** — `OllamaBackend.name === 'ollama'`, `LocalBackend.name === 'local'` — which does **not** key `agent.backends` (keyed by routing name: `local`, `reasoner`, …). So `backends[backend.name]` missed, `stageDecisionFor` returned undefined, `run.decision` stayed unset, `settleWorkflowSuccess`'s `isLocal` was still underivable, and the gate+ship block was still skipped. A fully-local staged unit kept completing without shipping and looping.

### The fix
Resolve the authoritative **routing key** via `backendFactory.resolveName(useCase)` — exactly the key the settle gate looks the def up under. (One extra decision-bus emission per identity stage; acceptable.)

### Live validation
Re-ran the real fully-local orchestrator on a terse roadmap item (`no-empty-describe` eslint rule). **The gate now FIRES**: 7 bounded retries (attempts 1–7) → clean needs-human halt when the local model's work failed the acceptance gate — instead of the prior infinite `in_review` loop. Routing confirmed fully local (brainstorm/plan→reasoner, exec/verify→local). The convergence machinery is now proven correct end-to-end; whether a unit *ships* is now a genuine function of model quality, no longer masked by this bug.

### Test hardening
The prior test used a name-only backend stub whose `.name` **coincidentally** matched the routing key, which is exactly what masked the inert bug. The regression test now uses a factory whose `resolveName` returns a key **distinct** from the backend's `.name`, so any revert to reading `.name` fails the test.

Full orchestrator suite green (2274 passed).