### PR TITLE
fix(arch): noise-tolerant architecture ratchet + prettier-proof no-release changeset marker

### DIFF
--- a/.changeset/arch-baseline-noise-tolerance.md
+++ b/.changeset/arch-baseline-noise-tolerance.md
@@ -1,0 +1,32 @@
+---
+'@harness-engineering/core': patch
+'@harness-engineering/cli': patch
+---
+
+fix(arch): give the architecture ratchet a noise tolerance so merging `main` stops forcing `baselines.json` rewrites
+
+The architecture baseline flagged a regression on _any_ aggregate increase
+(strict `agg.value > baselineValue` in `diff()`), while the coverage and
+benchmark ratchets already absorb run-to-run jitter with a tolerance. That
+asymmetry made `baselines.json` a constant merge-conflict source: when a branch
+merged `main`, main's legitimately-grown totals (e.g. total complexity 283→284,
+module size +119 bytes) counted as _the branch's_ regression against its now
+stale baseline, so the pre-commit gate forced `check-arch --update-baseline`.
+Every concurrent PR rewrote the file to slightly different values and they
+conflicted with each other — and because `.gitattributes` `merge=ours` is inert
+on GitHub's server-side merge, they conflicted there too.
+
+`ArchConfig` now carries a `regressionTolerance` (fraction, default `0.01`).
+`diff()` accepts it and allows `baselineValue + floor(baselineValue * tolerance)`
+before reporting a regression, so sub-tolerance merge drift no longer trips the
+gate. It self-scales: 1% of a ~300 complexity total is ~3, but 1% of a max-depth
+of 5 floors to 0, so shallow-integer metrics stay strict. Genuine regressions
+(which move the aggregate far past the tolerance) still fail. `diff()` defaults
+to a strict `>` when no tolerance is supplied, so the pure-function contract is
+unchanged.
+
+Also makes the no-release changeset marker robust to prettier: the empty-marker
+detector in `scripts/check-changesets.mjs` now parses frontmatter by line and
+accepts both `---\n\n---` and prettier's collapsed `---\n---`, so no-release
+markers no longer need a per-PR `.prettierignore` entry (those entries were
+themselves a recurring conflict source).

--- a/packages/cli/src/commands/check-arch.ts
+++ b/packages/cli/src/commands/check-arch.ts
@@ -172,8 +172,12 @@ export async function runCheckArch(
     });
   }
 
-  // Baseline mode: run diff
-  const diffResult: ArchDiffResult = diff(results, baseline);
+  // Baseline mode: run diff. Honor the configured regression tolerance so a
+  // branch does not report false regressions (and force a baseline rewrite)
+  // for the sub-tolerance drift it inherits when it merges `main`.
+  const diffResult: ArchDiffResult = diff(results, baseline, {
+    regressionTolerance: archConfig.regressionTolerance,
+  });
 
   // Fail if EITHER threshold exceeded OR baseline regressed
   const passed = diffResult.passed && thresholdViolations.length === 0;

--- a/packages/core/src/architecture/diff.ts
+++ b/packages/core/src/architecture/diff.ts
@@ -38,7 +38,9 @@ function aggregateByCategory(results: MetricResult[]): Map<ArchMetricCategory, A
  *
  * Pure function implementing the ratchet logic:
  * - New violations (in current but not baseline) cause failure
- * - Aggregate value exceeding baseline causes failure (regression)
+ * - Aggregate value exceeding baseline (beyond `regressionTolerance`) causes
+ *   failure (regression); the tolerance defaults to 0 for a strict `>` here
+ *   and is supplied by config at the call site
  * - Pre-existing violations (in both) are allowed
  * - Resolved violations (in baseline but not current) are celebrated
  *
@@ -106,7 +108,8 @@ function diffCategory(
   category: ArchMetricCategory,
   agg: AggregatedCategory,
   baselineCategory: CategoryBaseline | undefined,
-  acc: CategoryDiffAccumulator
+  acc: CategoryDiffAccumulator,
+  regressionTolerance: number
 ): void {
   const baselineViolationIds = new Set(baselineCategory?.violationIds ?? []);
   const baselineValue = baselineCategory?.value ?? 0;
@@ -118,7 +121,12 @@ function diffCategory(
   const currentViolationIds = new Set(agg.violations.map((v) => v.id));
   acc.resolvedViolations.push(...findResolvedViolations(baselineCategory, currentViolationIds));
 
-  if (baselineCategory && agg.value > baselineValue) {
+  // Absorb sub-tolerance drift (e.g. the growth inherited when a branch merges
+  // `main`) so the ratchet does not force a baseline rewrite for noise. The
+  // allowance floors at the exact baseline value, so a 0-tolerance run keeps
+  // the original strict `>` semantics.
+  const allowed = baselineValue + Math.floor(baselineValue * regressionTolerance);
+  if (baselineCategory && agg.value > allowed) {
     acc.regressions.push({
       category,
       baselineValue,
@@ -128,7 +136,12 @@ function diffCategory(
   }
 }
 
-export function diff(current: MetricResult[], baseline: ArchBaseline): ArchDiffResult {
+export function diff(
+  current: MetricResult[],
+  baseline: ArchBaseline,
+  options?: { regressionTolerance?: number }
+): ArchDiffResult {
+  const regressionTolerance = options?.regressionTolerance ?? 0;
   const aggregated = aggregateByCategory(current);
   const acc: CategoryDiffAccumulator = {
     newViolations: [],
@@ -140,7 +153,7 @@ export function diff(current: MetricResult[], baseline: ArchBaseline): ArchDiffR
 
   for (const [category, agg] of aggregated) {
     visitedCategories.add(category);
-    diffCategory(category, agg, baseline.metrics[category], acc);
+    diffCategory(category, agg, baseline.metrics[category], acc, regressionTolerance);
   }
 
   acc.resolvedViolations.push(...collectOrphanedBaselineViolations(baseline, visitedCategories));

--- a/packages/core/src/architecture/types.ts
+++ b/packages/core/src/architecture/types.ts
@@ -97,6 +97,18 @@ export const ArchConfigSchema = z.object({
   baselinePath: z.string().default('.harness/arch/baselines.json'),
   thresholds: ThresholdConfigSchema.default({}),
   modules: z.record(z.string(), ThresholdConfigSchema).default({}),
+  /**
+   * Fraction (0–1) by which an aggregate metric may exceed its baseline
+   * before it counts as a regression. Absorbs the small, monotonic drift a
+   * branch inherits when it merges `main` (e.g. total complexity 283→284,
+   * module size +119 bytes) so the ratchet does not force a baseline rewrite
+   * — and therefore a `baselines.json` merge conflict — on every sync. Real
+   * regressions (which move the aggregate by far more than the tolerance)
+   * still fail. Self-scaling: 1% of a ~300 complexity total is ~3, but 1% of
+   * a max-depth of 5 rounds to 0, so shallow-integer metrics stay strict.
+   * Mirrors the coverage ratchet's V8 variance tolerance.
+   */
+  regressionTolerance: z.number().min(0).max(1).default(0.01),
 });
 
 export type ArchConfig = z.infer<typeof ArchConfigSchema>;

--- a/packages/core/src/ci/check-orchestrator.ts
+++ b/packages/core/src/ci/check-orchestrator.ts
@@ -330,7 +330,9 @@ async function runArchCheck(
   const baseline = baselineManager.load();
 
   if (baseline) {
-    const diffResult = diff(results, baseline);
+    const diffResult = diff(results, baseline, {
+      regressionTolerance: archConfig.regressionTolerance,
+    });
     if (!diffResult.passed) {
       for (const v of diffResult.newViolations) {
         issues.push({

--- a/packages/core/tests/architecture/diff.test.ts
+++ b/packages/core/tests/architecture/diff.test.ts
@@ -111,6 +111,60 @@ describe('diff()', () => {
     expect(result.preExisting).toEqual(['cx-1']);
   });
 
+  describe('regressionTolerance', () => {
+    it('absorbs sub-tolerance drift so merge-inherited growth is not a regression', () => {
+      // Simulates a branch that merged `main`: total complexity ticked 283→284.
+      const baseline = makeBaseline({ complexity: { value: 283, violationIds: [] } });
+      const current: MetricResult[] = [
+        { category: 'complexity', scope: 'project', value: 284, violations: [] },
+      ];
+
+      const result = diff(current, baseline, { regressionTolerance: 0.01 });
+
+      expect(result.passed).toBe(true);
+      expect(result.regressions).toEqual([]);
+    });
+
+    it('still fails on a genuine regression beyond the tolerance', () => {
+      const baseline = makeBaseline({ complexity: { value: 283, violationIds: [] } });
+      const current: MetricResult[] = [
+        // 1% of 283 is 2 (floored); 290 is well past the 285 allowance.
+        { category: 'complexity', scope: 'project', value: 290, violations: [] },
+      ];
+
+      const result = diff(current, baseline, { regressionTolerance: 0.01 });
+
+      expect(result.passed).toBe(false);
+      expect(result.regressions).toHaveLength(1);
+      expect(result.regressions[0]!.delta).toBe(7);
+    });
+
+    it('rounds the allowance down so shallow-integer metrics stay strict', () => {
+      // 1% of a max-depth of 5 floors to 0 → any increase is still a regression.
+      const baseline = makeBaseline({ 'dependency-depth': { value: 5, violationIds: [] } });
+      const current: MetricResult[] = [
+        { category: 'dependency-depth', scope: 'project', value: 6, violations: [] },
+      ];
+
+      const result = diff(current, baseline, { regressionTolerance: 0.01 });
+
+      expect(result.passed).toBe(false);
+      expect(result.regressions).toHaveLength(1);
+    });
+
+    it('defaults to strict `>` when no tolerance is supplied', () => {
+      const baseline = makeBaseline({ complexity: { value: 283, violationIds: [] } });
+      const current: MetricResult[] = [
+        { category: 'complexity', scope: 'project', value: 284, violations: [] },
+      ];
+
+      const result = diff(current, baseline);
+
+      expect(result.passed).toBe(false);
+      expect(result.regressions).toHaveLength(1);
+    });
+  });
+
   it('handles multiple categories independently', () => {
     const baseline = makeBaseline({
       'circular-deps': { value: 1, violationIds: ['cd-1'] },

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -23,6 +23,38 @@
  */
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Parse a changeset file's frontmatter into `{ isEmpty, packages }`.
+ *
+ * A changeset's frontmatter is the block between the first `---` line and the
+ * next `---` line. Accept both the canonical empty marker (`---\n\n---`) and
+ * the form prettier collapses it to (`---\n---`) — both are valid no-release
+ * markers. Parsing by line (rather than a fixed-shape regex) keeps the gate
+ * from tripping over prettier reformatting the marker, which used to force a
+ * `.prettierignore` entry per no-release changeset.
+ *
+ * @param {string} raw
+ * @returns {{ isEmpty: boolean, packages: string[] }} `isEmpty` is false when
+ *   the text is not a changeset at all (no frontmatter block).
+ */
+export function parseChangesetFrontmatter(raw) {
+  const lines = raw.split(/\r?\n/);
+  if (lines[0].trim() !== '---') return { isEmpty: false, packages: [] };
+  const closeIdx = lines.indexOf('---', 1);
+  if (closeIdx === -1) return { isEmpty: false, packages: [] };
+  const body = lines.slice(1, closeIdx).join('\n').trim();
+  if (body === '') return { isEmpty: true, packages: [] };
+  const packages = [];
+  for (const line of body.split(/\r?\n/)) {
+    // Match `'@scope/pkg': patch|minor|major` or with double quotes.
+    const m = line.match(/^["']([^"']+)["']\s*:\s*(patch|minor|major)\s*$/);
+    if (m) packages.push(m[1]);
+  }
+  return { isEmpty: false, packages };
+}
 
 const BASE_REF = process.env.BASE_REF || 'origin/main';
 
@@ -61,81 +93,82 @@ function packageNameFor(dirName) {
   }
 }
 
-const changedFiles = gitFiles();
-const changedPackages = new Set();
-for (const f of changedFiles) {
-  if (SKIP_FILE.some((re) => re.test(f))) continue;
-  const m = f.match(PUBLISHABLE_FILE);
-  if (!m) continue;
-  const name = packageNameFor(m[1]);
-  if (name) changedPackages.add(name);
-}
-
-if (changedPackages.size === 0) {
-  console.log('No publishable package changes detected.');
-  process.exit(0);
-}
-
-// Look at every changeset file (added OR modified) in this PR. The standard
-// case is added, but reviewers sometimes amend an existing changeset to add a
-// missing package — both should count.
-const changesetFiles = gitFiles({
-  extraArgs: '--diff-filter=AM',
-  pathspec: '.changeset/',
-}).filter((f) => f.endsWith('.md') && !f.endsWith('README.md'));
-
-const mentionedPackages = new Set();
-let hasEmptyChangeset = false;
-
-for (const f of changesetFiles) {
-  let raw;
-  try {
-    raw = readFileSync(f, 'utf-8');
-  } catch {
-    continue;
+function main() {
+  const changedFiles = gitFiles();
+  const changedPackages = new Set();
+  for (const f of changedFiles) {
+    if (SKIP_FILE.some((re) => re.test(f))) continue;
+    const m = f.match(PUBLISHABLE_FILE);
+    if (!m) continue;
+    const name = packageNameFor(m[1]);
+    if (name) changedPackages.add(name);
   }
-  const frontmatter = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!frontmatter) continue;
-  const body = frontmatter[1].trim();
-  if (body === '') {
-    hasEmptyChangeset = true;
-    continue;
-  }
-  for (const line of body.split(/\r?\n/)) {
-    // Match `'@scope/pkg': patch|minor|major` or with double quotes.
-    const m = line.match(/^["']([^"']+)["']\s*:\s*(patch|minor|major)\s*$/);
-    if (m) mentionedPackages.add(m[1]);
-  }
-}
 
-if (hasEmptyChangeset) {
-  console.log(
-    `Empty changeset present — accepting source changes without per-package changesets.`
+  if (changedPackages.size === 0) {
+    console.log('No publishable package changes detected.');
+    process.exit(0);
+  }
+
+  // Look at every changeset file (added OR modified) in this PR. The standard
+  // case is added, but reviewers sometimes amend an existing changeset to add a
+  // missing package — both should count.
+  const changesetFiles = gitFiles({
+    extraArgs: '--diff-filter=AM',
+    pathspec: '.changeset/',
+  }).filter((f) => f.endsWith('.md') && !f.endsWith('README.md'));
+
+  const mentionedPackages = new Set();
+  let hasEmptyChangeset = false;
+
+  for (const f of changesetFiles) {
+    let raw;
+    try {
+      raw = readFileSync(f, 'utf-8');
+    } catch {
+      continue;
+    }
+    const { isEmpty, packages } = parseChangesetFrontmatter(raw);
+    if (isEmpty) {
+      hasEmptyChangeset = true;
+      continue;
+    }
+    for (const p of packages) mentionedPackages.add(p);
+  }
+
+  if (hasEmptyChangeset) {
+    console.log(
+      `Empty changeset present — accepting source changes without per-package changesets.`
+    );
+    console.log(`Changed packages: ${[...changedPackages].sort().join(', ')}`);
+    process.exit(0);
+  }
+
+  const missing = [...changedPackages].filter((p) => !mentionedPackages.has(p)).sort();
+  if (missing.length === 0) {
+    console.log(`Changeset check OK. Covered: ${[...changedPackages].sort().join(', ')}`);
+    process.exit(0);
+  }
+
+  console.error('');
+  console.error('Missing changeset for the following changed package(s):');
+  for (const p of missing) console.error(`  - ${p}`);
+  console.error('');
+  console.error('Every PR that changes a publishable package must add a `.changeset/*.md`');
+  console.error('file that lists that package and the bump level (patch | minor | major).');
+  console.error('');
+  console.error('Run `pnpm changeset` to create one interactively.');
+  console.error('');
+  console.error('If this change should NOT release, run `pnpm changeset --empty` to add an');
+  console.error('explicit no-release marker.');
+  console.error('');
+  console.error(
+    `Context: incident ${'#'}332 — a missing changeset shipped an orchestrator dist that imported`
   );
-  console.log(`Changed packages: ${[...changedPackages].sort().join(', ')}`);
-  process.exit(0);
+  console.error('symbols from an unreleased types build, breaking every fresh CLI install.');
+  process.exit(1);
 }
 
-const missing = [...changedPackages].filter((p) => !mentionedPackages.has(p)).sort();
-if (missing.length === 0) {
-  console.log(`Changeset check OK. Covered: ${[...changedPackages].sort().join(', ')}`);
-  process.exit(0);
-}
-
-console.error('');
-console.error('Missing changeset for the following changed package(s):');
-for (const p of missing) console.error(`  - ${p}`);
-console.error('');
-console.error('Every PR that changes a publishable package must add a `.changeset/*.md`');
-console.error('file that lists that package and the bump level (patch | minor | major).');
-console.error('');
-console.error('Run `pnpm changeset` to create one interactively.');
-console.error('');
-console.error('If this change should NOT release, run `pnpm changeset --empty` to add an');
-console.error('explicit no-release marker.');
-console.error('');
-console.error(
-  `Context: incident ${'#'}332 — a missing changeset shipped an orchestrator dist that imported`
-);
-console.error('symbols from an unreleased types build, breaking every fresh CLI install.');
-process.exit(1);
+// Only run the git-driven gate when invoked as a script; importing the module
+// (e.g. from tests) exposes `parseChangesetFrontmatter` without side effects.
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/tests/scripts/check-changesets.test.mjs
+++ b/tests/scripts/check-changesets.test.mjs
@@ -1,0 +1,51 @@
+/**
+ * Regression test for the no-release changeset marker being fragile under
+ * prettier.
+ *
+ * `pnpm changeset --empty` writes an empty marker whose frontmatter is
+ * `---\n\n---` (a blank line between delimiters). Prettier collapses that to
+ * `---\n---`, which the old fixed-shape regex (`/^---\r?\n([\s\S]*?)\r?\n---/`)
+ * failed to match — so the gate no longer saw the marker as "empty" and
+ * demanded a per-package changeset. The workaround was to add every marker to
+ * `.prettierignore`, and those per-PR lines then conflicted between concurrent
+ * PRs.
+ *
+ * The fix parses the frontmatter by line so both forms read as empty. These
+ * tests assert that. Run with: node --test tests/scripts/
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseChangesetFrontmatter } from '../../scripts/check-changesets.mjs';
+
+test('changeset: canonical empty marker (---\\n\\n---) is empty', () => {
+  const { isEmpty, packages } = parseChangesetFrontmatter('---\n\n---\n\nNo release.\n');
+  assert.equal(isEmpty, true);
+  assert.deepEqual(packages, []);
+});
+
+test('changeset: prettier-collapsed marker (---\\n---) is also empty', () => {
+  // The exact shape prettier produces after reformatting the canonical marker.
+  const { isEmpty, packages } = parseChangesetFrontmatter('---\n---\n\nNo release.\n');
+  assert.equal(isEmpty, true);
+  assert.deepEqual(packages, []);
+});
+
+test('changeset: CRLF-collapsed marker is empty', () => {
+  const { isEmpty } = parseChangesetFrontmatter('---\r\n---\r\n\r\nNo release.\r\n');
+  assert.equal(isEmpty, true);
+});
+
+test('changeset: a real changeset reports its packages and is not empty', () => {
+  const raw = "---\n'@harness-engineering/core': patch\n'@harness-engineering/cli': minor\n---\n\nDid a thing.\n";
+  const { isEmpty, packages } = parseChangesetFrontmatter(raw);
+  assert.equal(isEmpty, false);
+  assert.deepEqual(packages, ['@harness-engineering/core', '@harness-engineering/cli']);
+});
+
+test('changeset: non-changeset text (no frontmatter) is not treated as empty', () => {
+  const { isEmpty, packages } = parseChangesetFrontmatter('# Just a heading\n\nsome prose\n');
+  assert.equal(isEmpty, false);
+  assert.deepEqual(packages, []);
+});


### PR DESCRIPTION
## Why

`baselines.json` conflicts have been a constant chore. Two root causes, both fixed here.

### 1. The architecture ratchet had no noise tolerance (the main one)

The arch baseline flagged a regression on **any** aggregate increase (strict `agg.value > baselineValue` in `diff()`), while the **coverage and benchmark ratchets already absorb jitter** with a tolerance. That asymmetry made `baselines.json` a merge-conflict magnet:

- When a branch merged `main`, main's legitimately-grown totals (e.g. total complexity 283→284, module size +119 bytes) counted as **the branch's** regression against its now-stale baseline.
- The pre-commit gate forced `check-arch --update-baseline`, rewriting the file.
- Every concurrent PR rewrote it to slightly different values → they conflicted with each other.
- `.gitattributes` has `merge=ours` for baselines, but **GitHub's server-side merge ignores custom merge drivers**, so they conflicted on GitHub regardless.

**Fix:** `ArchConfig` gains `regressionTolerance` (fraction, default `0.01`). `diff()` allows `baselineValue + floor(baselineValue * tolerance)` before reporting a regression. Self-scaling — 1% of a ~300 complexity total is ~3, but 1% of a max-depth of 5 floors to 0, so shallow-integer metrics stay strict. Genuine regressions still fail. `diff()` defaults to a strict `>` when no tolerance is passed, so the pure-function contract is unchanged.

Verified end-to-end against the real baseline + built code:

```
baseline complexity       : 290
current (merged main)     : 291
STRICT   -> regressions   : 1 (FAIL -> forces baseline rewrite)
TOLERANT -> regressions   : 0 (PASS -> no rewrite, no conflict)
GENUINE +20 -> regressions: 1 (FAIL - correct)
```

### 2. No-release changeset markers were fragile under prettier

`pnpm changeset --empty` writes `---\n\n---`; prettier collapses it to `---\n---`, which the old fixed-shape regex no longer recognized as empty — forcing a per-PR `.prettierignore` entry, and those entries then conflicted between concurrent PRs. The detector in `scripts/check-changesets.mjs` now parses frontmatter by line and accepts both forms. No more `.prettierignore` churn for no-release markers.

## Tests

- `packages/core/tests/architecture/diff.test.ts` — tolerance absorbs sub-tolerance drift, still fails genuine regressions, stays strict on shallow-integer metrics, defaults to strict.
- `tests/scripts/check-changesets.test.mjs` — both marker shapes (and CRLF) read as empty; real changesets still report packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)