### PR TITLE
fix(cli): resolve check-arch cwd from config dir to stop baseline test leak (#911)

### DIFF
--- a/.changeset/fix-cli-baseline-test-isolation.md
+++ b/.changeset/fix-cli-baseline-test-isolation.md
@@ -1,0 +1,8 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix #911: check-arch resolves the working directory from the `-c` config's own
+project instead of process.cwd(), so `harness check-arch -c <path> --update-baseline`
+writes the baseline into that project — and the action-handler tests stop leaking
+writes into this repo's tracked `packages/cli/.harness/arch/baselines.json`.

--- a/packages/cli/src/commands/check-arch.ts
+++ b/packages/cli/src/commands/check-arch.ts
@@ -14,11 +14,12 @@ import type {
   MetricResult,
   Violation,
 } from '@harness-engineering/core';
-import { resolveConfig } from '../config/loader';
+import { findConfigFile, loadConfig } from '../config/loader';
 import { OutputFormatter, OutputMode, type OutputModeType } from '../output/formatter';
 import { logger } from '../output/logger';
 import { CLIError, ExitCode } from '../utils/errors';
 import { execSync } from 'node:child_process';
+import * as path from 'node:path';
 
 interface CheckArchOptions {
   cwd?: string;
@@ -78,14 +79,27 @@ function findThresholdViolations(results: MetricResult[]): Violation[] {
 export async function runCheckArch(
   options: CheckArchOptions
 ): Promise<Result<CheckArchResult, CLIError>> {
-  const cwd = options.cwd ?? process.cwd();
+  // Resolve the config file's location first so the working directory can
+  // default to the project that owns the config rather than the process's cwd.
+  // The baseline is read/written relative to `cwd` (via ArchBaselineManager),
+  // so without this a caller that points `-c` at a config in another directory
+  // — including every action-handler test that passes a mkdtemp fixture config
+  // — would run the collectors against, and write the baseline into,
+  // process.cwd() instead of the config's own project. That leaked writes into
+  // this repo's tracked packages/cli/.harness/arch/baselines.json (issue #911).
+  const configPathResult = options.configPath ? Ok(options.configPath) : findConfigFile();
+  if (!configPathResult.ok) {
+    return configPathResult;
+  }
+  const configPath = configPathResult.value;
 
-  // Load config
-  const configResult = resolveConfig(options.configPath);
+  const configResult = loadConfig(configPath);
   if (!configResult.ok) {
     return configResult;
   }
   const config = configResult.value;
+
+  const cwd = options.cwd ?? path.dirname(configPath);
 
   // Resolve architecture config (defaults if not present)
   const archConfig: ArchConfig = config.architecture ?? ArchConfigSchema.parse({});

--- a/packages/cli/tests/commands/check-arch.test.ts
+++ b/packages/cli/tests/commands/check-arch.test.ts
@@ -405,6 +405,55 @@ describe('check-arch command', () => {
       fsSync.rmSync(tmpDir, { recursive: true, force: true });
     });
 
+    // Regression for issue #911: the action handler must write the baseline
+    // into the project that owns the `-c` config, never into process.cwd().
+    // Previously `runCheckArch` defaulted cwd to process.cwd(), so invoking
+    // `check-arch -c <fixture>/harness.config.json --update-baseline` (as these
+    // action-handler tests do) rewrote this repo's tracked
+    // packages/cli/.harness/arch/baselines.json — a test-isolation leak that
+    // dirtied the working tree on every run.
+    it('writes the baseline into the config project, not process.cwd() (issue #911)', async () => {
+      const fsSync = await import('node:fs');
+      const osModule = await import('node:os');
+      const tmpDir = fsSync.mkdtempSync(path.join(osModule.tmpdir(), 'check-arch-911-'));
+
+      fsSync.writeFileSync(
+        path.join(tmpDir, 'harness.config.json'),
+        JSON.stringify({ version: 1, architecture: { enabled: true } })
+      );
+
+      // Snapshot process.cwd()'s real baseline (if any) so we can prove the run
+      // leaves it untouched — this is the file that leaked before the fix.
+      const cwdBaselinePath = path.join(process.cwd(), '.harness', 'arch', 'baselines.json');
+      const cwdBaselineBefore = fsSync.existsSync(cwdBaselinePath)
+        ? fsSync.readFileSync(cwdBaselinePath, 'utf-8')
+        : null;
+
+      const program = makeProgram();
+      await safeParseAsync(program, [
+        'node',
+        'test',
+        '-c',
+        path.join(tmpDir, 'harness.config.json'),
+        'check-arch',
+        '--update-baseline',
+      ]);
+
+      expect(mockExit).toHaveBeenCalledWith(0);
+
+      // The baseline must land inside the fixture project (the config's dir)...
+      const fixtureBaselinePath = path.join(tmpDir, '.harness', 'arch', 'baselines.json');
+      expect(fsSync.existsSync(fixtureBaselinePath)).toBe(true);
+
+      // ...and process.cwd()'s tracked baseline must be exactly as it was.
+      const cwdBaselineAfter = fsSync.existsSync(cwdBaselinePath)
+        ? fsSync.readFileSync(cwdBaselinePath, 'utf-8')
+        : null;
+      expect(cwdBaselineAfter).toBe(cwdBaselineBefore);
+
+      fsSync.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
     it('exits with SUCCESS for disabled architecture', async () => {
       const fsSync = await import('node:fs');
       const osModule = await import('node:os');


### PR DESCRIPTION
## Summary
Running the cli package's coverage/test suite mutated a tracked file — `packages/cli/.harness/arch/baselines.json` — dirtying the working tree. The `check-arch` action-handler `--update-baseline` tests pass a `-c <mkdtemp>/harness.config.json` fixture config, but `runCheckArch` defaulted its working directory to `process.cwd()`. Because the baseline is read/written by `ArchBaselineManager(cwd, …)`, the write escaped the fixture and landed in this repo's real baseline.

Root cause is broader than the tests: `harness check-arch -c /some/other/project/harness.config.json --update-baseline` would run the collectors against, and write the baseline into, `process.cwd()` rather than the project the config belongs to.

The fix resolves the config file's location first (given `-c`, or via `findConfigFile()`), and defaults `cwd` to that config's directory. An explicit `options.cwd` still wins, so the `runCheckArch`-level tests are unaffected. Now the writer targets the config's own project — the fixture in tests, the real project in production.

## Debugging (harness:debugging)
- Root cause: `runCheckArch` defaulted `cwd` to `process.cwd()`, so `ArchBaselineManager` wrote the baseline relative to the process, not to the `-c` config's project; the action-handler `--update-baseline` tests thus rewrote the repo's tracked `packages/cli/.harness/arch/baselines.json`.
- Fix: derive `cwd` from the resolved config file's directory (`options.cwd ?? path.dirname(configPath)`); resolve the config path via `findConfigFile()`/`loadConfig` so its dirname is available.
- Regression test: `packages/cli/tests/commands/check-arch.test.ts` — "writes the baseline into the config project, not process.cwd() (issue #911)"; asserts the fixture project gets the baseline and `process.cwd()`'s tracked baseline is byte-identical before/after. Verified it FAILS without the fix (reverted → 1 failed) and PASSES with it. Full cli suite (4691 tests) now leaves the working tree clean.

Fixes #911