### PR TITLE
fix(cli): check-security --severity bounds the verdict, not just the report (#915)

### DIFF
--- a/.changeset/fix-check-security-severity-verdict.md
+++ b/.changeset/fix-check-security-severity-verdict.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix #915: `check-security --severity` now bounds the pass/fail verdict, not just the report. The verdict was hardcoded to fail only on `error` findings, so `--severity warning`/`info` filtered the displayed findings but could never fail the gate, while lower-severity findings appeared to leak into higher-severity gates. The command now fails only when a finding at or above the requested severity exists — info findings never fail a `--severity error` gate, and a requested threshold actually gates at that level.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -124,7 +124,7 @@ Run lightweight security scan: secrets, injection, XSS, weak crypto
 
 **Options:**
 
-- `--severity` — Minimum severity threshold (default: "warning")
+- `--severity` — Minimum severity that fails the command; findings below it are excluded from the report and never fail the gate (error, warning, info) (default: "warning")
 - `--changed-only` — Only scan git-changed files
 
 ### `harness cleanup`

--- a/packages/cli/src/commands/check-security.ts
+++ b/packages/cli/src/commands/check-security.ts
@@ -109,10 +109,16 @@ export async function runCheckSecurity(
   const thresholdRank = SEVERITY_RANK[threshold];
   const filtered = result.findings.filter((f) => SEVERITY_RANK[f.severity] >= thresholdRank);
 
-  const hasErrors = filtered.some((f) => f.severity === 'error');
-
+  // `--severity` bounds BOTH the reported findings and the pass/fail verdict:
+  // the command fails only when a finding at or above the requested threshold
+  // exists. Findings below the threshold (e.g. info findings under
+  // `--severity error`) are excluded from `filtered`, so they never fail the
+  // gate. Previously the verdict was hardcoded to `error`, which meant the flag
+  // filtered the report but not the verdict — leaving lower-severity requests
+  // (`--severity warning`/`info`) unable to fail and giving downstream gates the
+  // impression that findings below the requested severity were blocking.
   return Ok({
-    valid: !hasErrors,
+    valid: filtered.length === 0,
     findings: filtered,
     stats: {
       filesScanned: result.scannedFiles,
@@ -172,7 +178,11 @@ async function runCheckSecurityAction(
 export function createCheckSecurityCommand(): Command {
   const command = new Command('check-security')
     .description('Run lightweight security scan: secrets, injection, XSS, weak crypto')
-    .option('--severity <level>', 'Minimum severity threshold', 'warning')
+    .option(
+      '--severity <level>',
+      'Minimum severity that fails the command; findings below it are excluded from the report and never fail the gate (error, warning, info)',
+      'warning'
+    )
     .hook('preAction', (thisCommand) => {
       const severity = thisCommand.opts().severity;
       if (!['error', 'warning', 'info'].includes(severity)) {

--- a/packages/cli/tests/commands/check-security.test.ts
+++ b/packages/cli/tests/commands/check-security.test.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 
 const CLEAN_FIXTURES = path.join(__dirname, '../fixtures/valid-project');
 const INSECURE_FIXTURES = path.join(__dirname, '../fixtures/security-findings');
+// Fixture that contains ONLY an info-severity finding (SEC-NET-003 http:// URL).
+const INFO_ONLY_FIXTURES = path.join(__dirname, '../fixtures/security-info-only');
 
 describe('runCheckSecurity', () => {
   it('returns valid:true when no findings exist', async () => {
@@ -45,6 +47,38 @@ describe('runCheckSecurity', () => {
 
     // Error-only count should be <= all findings count
     expect(errorResult.value.findings.length).toBeLessThanOrEqual(allCount);
+  });
+
+  // Regression for #915: `--severity` must bound the VERDICT, not just the report.
+  describe('severity bounds the pass/fail verdict (#915)', () => {
+    it('does NOT fail --severity error on a new info-only finding', async () => {
+      const result = await runCheckSecurity(INFO_ONLY_FIXTURES, { severity: 'error' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // The info finding is below the requested threshold, so the gate passes.
+      expect(result.value.stats.infoCount).toBe(0);
+      expect(result.value.findings).toEqual([]);
+      expect(result.value.valid).toBe(true);
+    });
+
+    it('DOES fail --severity error on a new error finding', async () => {
+      const result = await runCheckSecurity(INSECURE_FIXTURES, { severity: 'error' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.stats.errorCount).toBeGreaterThan(0);
+      expect(result.value.valid).toBe(false);
+    });
+
+    it('fails when the requested severity is at-or-below the finding severity', async () => {
+      // Guard: `--severity info` must actually gate on the info finding.
+      // Before the fix the verdict was hardcoded to error, so this passed
+      // incorrectly (valid:true) even though an info finding was present.
+      const result = await runCheckSecurity(INFO_ONLY_FIXTURES, { severity: 'info' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.stats.infoCount).toBeGreaterThan(0);
+      expect(result.value.valid).toBe(false);
+    });
   });
 
   it('returns stats with correct shape', async () => {

--- a/packages/cli/tests/fixtures/security-info-only/harness.config.json
+++ b/packages/cli/tests/fixtures/security-info-only/harness.config.json
@@ -1,0 +1,4 @@
+{
+  "name": "security-info-only-fixture",
+  "layers": []
+}

--- a/packages/cli/tests/fixtures/security-info-only/src/net.ts
+++ b/packages/cli/tests/fixtures/security-info-only/src/net.ts
@@ -1,0 +1,4 @@
+// This file intentionally contains only an INFO-severity finding for testing.
+// SEC-NET-003 (Hardcoded HTTP URL) is severity: 'info'.
+
+export const REMOTE_ENDPOINT = 'http://example.com/api/v1/resource';


### PR DESCRIPTION
## Summary
`harness check-security --severity <level>` filtered the reported findings by severity but computed the pass/fail verdict from a hardcoded `error`-only check (`valid: !hasErrors`). So the `--severity` flag filtered the report but not the verdict: `--severity warning`/`info` could never actually fail the gate, and the flag failed to bound what fails the command — the exact behavior #915 describes ("the flag filters the report but not the verdict").

The verdict now fails only when a finding at or above the requested severity exists (`valid: filtered.length === 0`, where `filtered` is already the at-or-above-threshold set). This means:
- `--severity error` never fails on a lower-severity (e.g. info) finding — matching the issue's expectation.
- a new error-severity finding still fails `--severity error`.
- a requested threshold (`warning`/`info`) now actually gates at that level.

The `--severity` help text now documents that it bounds the verdict, not just the report.

## Debugging (harness:debugging)
- Root cause: the verdict was `valid: !filtered.some(f => f.severity === 'error')`, hardcoding `error` as the fail threshold and ignoring the requested `--severity`, so the flag filtered the report but not the verdict.
- Fix: compute the verdict from the already-severity-filtered set — `valid: filtered.length === 0` — so `--severity` bounds both the report and the pass/fail decision.
- Regression test: `packages/cli/tests/commands/check-security.test.ts` (new `severity bounds the pass/fail verdict (#915)` block, new `security-info-only` fixture with an info-only SEC-NET-003 finding). Verified by reverting the fix: the `--severity info` info-gate assertion fails without the fix and passes with it; the error-gate and info-does-not-fail-error-gate assertions hold both ways.

Fixes #915