### PR TITLE
fix(config): warn on silently stripped/mis-nested harness.config.json keys (#862)

### DIFF
--- a/.changeset/config-stripped-key-warning.md
+++ b/.changeset/config-stripped-key-warning.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix #862: warn on silently stripped/mis-nested harness.config.json keys. The
+shared config loader now performs a schema-aware recursive diff of the raw JSON
+against the zod schema and emits a non-fatal stderr warning naming each dropped
+key (with a near-typo "did you mean" hint), while respecting `.passthrough()`
+sections (security, performance) whose extra keys are intentionally kept. Load
+still succeeds. Also declares the legitimate top-level `pulse` block on the
+schema so it is no longer silently stripped.

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import type { Result } from '@harness-engineering/core';
 import { Ok, Err } from '@harness-engineering/core';
 import { HarnessConfigSchema, type HarnessConfig } from './schema';
+import { collectStrippedKeys, formatStrippedKeyWarnings } from './stripped-keys';
 import { CLIError, ExitCode } from '../utils/errors';
 
 const CONFIG_FILENAMES = ['harness.config.json'];
@@ -68,7 +69,31 @@ export function loadConfig(configPath: string): Result<HarnessConfig, CLIError> 
     return Err(new CLIError(`Invalid config:\n${issues}`, ExitCode.ERROR));
   }
 
+  // Non-fatal: warn about keys the schema silently dropped (unknown or
+  // mis-nested). zod strips these with no signal, so a plausible-but-wrong
+  // config becomes a silent no-op (issue #862). Sections that intentionally
+  // use `.passthrough()` (security, performance, ...) are respected and never
+  // reported. Loading still succeeds.
+  warnStrippedKeys(rawConfig);
+
   return Ok(parsed.data);
+}
+
+/**
+ * Emit a non-fatal warning to stderr for each config key the schema dropped.
+ * Written to stderr so JSON stdout stays clean; never throws and never affects
+ * load success.
+ */
+function warnStrippedKeys(rawConfig: unknown): void {
+  if (process.env.HARNESS_SUPPRESS_CONFIG_WARNINGS === '1') return;
+  try {
+    const dropped = collectStrippedKeys(HarnessConfigSchema, rawConfig);
+    for (const line of formatStrippedKeyWarnings(dropped)) {
+      process.stderr.write(`${line}\n`);
+    }
+  } catch {
+    // Detection is best-effort diagnostics; a walk failure must never break load.
+  }
 }
 
 /**

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -915,6 +915,15 @@ export const HarnessConfigSchema = z.object({
    * `docs/changes/local-model-lifecycle-manager/proposal.md`.
    */
   localModels: LocalModelsConfigSchema.optional(),
+  /**
+   * Pulse metrics configuration block, written to harness.config.json by
+   * `harness pulse` and validated by the dedicated `PulseConfigSchema` in
+   * `@harness-engineering/core`. The CLI does not consume it directly; it is
+   * declared here as a tolerant passthrough so the shared loader recognizes it
+   * as a legitimate top-level key rather than silently dropping it (which would
+   * also trip the stripped-key warning added for issue #862).
+   */
+  pulse: z.object({}).passthrough().optional(),
 });
 
 /**

--- a/packages/cli/src/config/stripped-keys.test.ts
+++ b/packages/cli/src/config/stripped-keys.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { collectStrippedKeys, formatStrippedKeyWarnings } from './stripped-keys';
+import { HarnessConfigSchema } from './schema';
+import { loadConfig } from './loader';
+
+/**
+ * Regression guard for issue #862: harness.config.json is validated with zod
+ * schemas that run in strip mode, so unknown / mis-nested keys were silently
+ * dropped with no error and no warning (a plausible-but-wrong config became a
+ * silent no-op). The loader now emits a non-fatal warning naming each dropped
+ * key, while respecting `.passthrough()` sections that intentionally keep extra
+ * keys.
+ */
+describe('collectStrippedKeys — schema-aware dropped-key detection', () => {
+  it('reports a mis-nested key (the #838 / #862 trap) by its stripped path', () => {
+    // The honored path is entropy.drift.checkApiSignatures; nesting it under
+    // entropy.analyze.drift silently dropped the whole `entropy.analyze` block.
+    const raw = { version: 1, entropy: { analyze: { drift: { checkApiSignatures: false } } } };
+    const dropped = collectStrippedKeys(HarnessConfigSchema, raw);
+    expect(dropped.map((d) => d.path)).toContain('entropy.analyze');
+  });
+
+  it('does NOT report extra keys under `.passthrough()` sections (security, performance)', () => {
+    const raw = {
+      version: 1,
+      security: { enabled: true, customTuning: { foo: 1 } },
+      performance: { arbitraryBudget: true },
+    };
+    expect(collectStrippedKeys(HarnessConfigSchema, raw)).toEqual([]);
+  });
+
+  it('reports nothing for a fully-valid config', () => {
+    const raw = {
+      version: 1,
+      name: 'demo',
+      entropy: { autoFix: true, drift: { checkApiSignatures: false } },
+      security: { enabled: true },
+    };
+    expect(collectStrippedKeys(HarnessConfigSchema, raw)).toEqual([]);
+  });
+
+  it('offers a near-typo suggestion for a close sibling but not for a wholesale mis-nesting', () => {
+    const typo = collectStrippedKeys(HarnessConfigSchema, {
+      version: 1,
+      securty: { enabled: true },
+    });
+    expect(typo).toEqual([{ path: 'securty', suggestion: 'security' }]);
+
+    // `entropy.analyze` is not a near-typo of any entropy field → no suggestion.
+    const misnested = collectStrippedKeys(HarnessConfigSchema, {
+      version: 1,
+      entropy: { analyze: {} },
+    });
+    expect(misnested).toEqual([{ path: 'entropy.analyze' }]);
+    expect(misnested[0]).not.toHaveProperty('suggestion');
+  });
+
+  it('formats a warning line that names the stripped path', () => {
+    const lines = formatStrippedKeyWarnings([{ path: 'entropy.analyze' }]);
+    expect(lines).toEqual(["⚠ harness.config.json: ignored unknown key 'entropy.analyze'"]);
+  });
+
+  it('formats a did-you-mean sibling path when a suggestion is present', () => {
+    const lines = formatStrippedKeyWarnings([{ path: 'securty', suggestion: 'security' }]);
+    expect(lines[0]).toBe(
+      "⚠ harness.config.json: ignored unknown key 'securty' (did you mean 'security'?)"
+    );
+  });
+});
+
+describe('loadConfig — non-fatal stripped-key warning wiring (#862)', () => {
+  const tmpFiles: string[] = [];
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const f of tmpFiles.splice(0)) fs.rmSync(f, { force: true });
+  });
+
+  function writeConfig(obj: unknown): string {
+    const p = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'harness-cfg-')),
+      'harness.config.json'
+    );
+    fs.writeFileSync(p, JSON.stringify(obj));
+    tmpFiles.push(p);
+    return p;
+  }
+
+  it('warns to stderr for a mis-nested key without failing the load', () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const p = writeConfig({
+      version: 1,
+      entropy: { analyze: { drift: { checkApiSignatures: false } } },
+    });
+
+    const result = loadConfig(p);
+
+    expect(result.ok).toBe(true); // load still succeeds — warning is non-fatal
+    const output = stderr.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain("ignored unknown key 'entropy.analyze'");
+  });
+
+  it('emits no warning for a config whose extras live under a passthrough section', () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const p = writeConfig({ version: 1, security: { enabled: true, customFoo: { bar: 1 } } });
+
+    const result = loadConfig(p);
+
+    expect(result.ok).toBe(true);
+    const output = stderr.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).not.toContain('ignored unknown key');
+  });
+});

--- a/packages/cli/src/config/stripped-keys.ts
+++ b/packages/cli/src/config/stripped-keys.ts
@@ -1,0 +1,209 @@
+import type { z } from 'zod';
+
+/**
+ * A key present in the raw config JSON that the schema silently dropped
+ * (unknown or mis-nested), together with an optional closest-known-sibling
+ * suggestion.
+ */
+export interface StrippedKey {
+  /** Dotted path of the dropped key, e.g. `entropy.analyze`. */
+  path: string;
+  /** Closest known sibling key at the same level, when a near-typo is likely. */
+  suggestion?: string;
+}
+
+/** A zod schema node with the internal `_def` we walk. Typed loosely on purpose. */
+type ZodDef = {
+  typeName?: string;
+  innerType?: z.ZodTypeAny;
+  schema?: z.ZodTypeAny;
+  getter?: () => z.ZodTypeAny;
+  type?: z.ZodTypeAny;
+  valueType?: z.ZodTypeAny;
+  options?: z.ZodTypeAny[];
+  unknownKeys?: 'strip' | 'strict' | 'passthrough';
+  shape?: () => Record<string, z.ZodTypeAny>;
+};
+
+function defOf(schema: z.ZodTypeAny): ZodDef {
+  return (schema as unknown as { _def: ZodDef })._def;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Case-insensitive Levenshtein distance, capped for short identifiers.
+ */
+function editDistance(a: string, b: string): number {
+  const s = a.toLowerCase();
+  const t = b.toLowerCase();
+  const m = s.length;
+  const n = t.length;
+  // prev/curr are fully initialized number[] of length n+1, so every indexed
+  // read below is in-bounds; `!` silences noUncheckedIndexedAccess. Empty
+  // strings are handled naturally (the guarded loops simply don't run).
+  let prev: number[] = Array.from({ length: n + 1 }, (_, j) => j);
+  let curr: number[] = new Array<number>(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = s[i - 1] === t[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j]! + 1, curr[j - 1]! + 1, prev[j - 1]! + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[n]!;
+}
+
+/**
+ * Suggest the closest known sibling for a dropped key, but only when the match
+ * is close enough to plausibly be a typo (not a wholesale mis-nesting). Returns
+ * undefined when nothing is close.
+ */
+function closestKnownKey(dropped: string, knownKeys: string[]): string | undefined {
+  let best: string | undefined;
+  let bestDistance = Infinity;
+  for (const known of knownKeys) {
+    const d = editDistance(dropped, known);
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = known;
+    }
+  }
+  if (best === undefined) return undefined;
+  // Conservative: at most 2 edits, and no more than ~40% of the longer name,
+  // so `securty`→`security` fires but `analyze`→`drift` does not.
+  const threshold = Math.min(2, Math.floor(Math.max(dropped.length, best.length) * 0.4));
+  return bestDistance <= threshold ? best : undefined;
+}
+
+/**
+ * Walk a zod schema alongside the raw parsed-JSON input and collect every key
+ * the schema would silently drop, respecting `.passthrough()` sections (whose
+ * extra keys are intentionally kept and must NOT be reported).
+ *
+ * This is a schema-aware alternative to a blanket `.strict()` (which would turn
+ * strip into a hard parse error and break existing configs). Descends through
+ * the wrapper types the config schema actually uses — optional / default /
+ * nullable / effects (refine/superRefine) / lazy — and recurses into objects,
+ * records, arrays, and unions so mis-nested keys at any depth are caught.
+ *
+ * @param schema - The zod schema the value was validated against.
+ * @param value - The raw (pre-parse) JSON value.
+ * @param pathPrefix - Dotted path accumulated so far (empty at the root).
+ * @returns The dropped keys, each with an optional near-typo suggestion.
+ */
+export function collectStrippedKeys(
+  schema: z.ZodTypeAny,
+  value: unknown,
+  pathPrefix = ''
+): StrippedKey[] {
+  const out: StrippedKey[] = [];
+  walk(schema, value, pathPrefix, out);
+  return out;
+}
+
+function join(prefix: string, key: string): string {
+  return prefix ? `${prefix}.${key}` : key;
+}
+
+/** Wrapper types that carry no keys of their own — unwrap and continue. */
+const WRAPPERS: Record<string, (def: ZodDef) => z.ZodTypeAny | undefined> = {
+  ZodOptional: (d) => d.innerType,
+  ZodNullable: (d) => d.innerType,
+  ZodDefault: (d) => d.innerType,
+  ZodEffects: (d) => d.schema,
+  ZodLazy: (d) => d.getter?.(),
+};
+
+function walk(schema: z.ZodTypeAny, value: unknown, prefix: string, out: StrippedKey[]): void {
+  const def = defOf(schema);
+  const typeName = def.typeName ?? '';
+
+  const unwrapper = WRAPPERS[typeName];
+  if (unwrapper) {
+    const inner = unwrapper(def);
+    if (inner) walk(inner, value, prefix, out);
+    return;
+  }
+
+  switch (typeName) {
+    case 'ZodObject':
+      return walkObject(def, value, prefix, out);
+    case 'ZodRecord':
+      return walkRecord(def, value, prefix, out);
+    case 'ZodArray':
+      return walkArray(def, value, prefix, out);
+    case 'ZodUnion':
+    case 'ZodDiscriminatedUnion':
+      return walkUnion(def, value, prefix, out);
+    default:
+      // Primitives and anything else carry no droppable keys.
+      return;
+  }
+}
+
+function walkObject(def: ZodDef, value: unknown, prefix: string, out: StrippedKey[]): void {
+  if (!isPlainObject(value)) return;
+  const shape = def.shape ? def.shape() : {};
+  const knownKeys = Object.keys(shape);
+  const passthrough = def.unknownKeys === 'passthrough';
+  for (const key of Object.keys(value)) {
+    const child = shape[key];
+    const childPath = join(prefix, key);
+    if (child) {
+      walk(child, value[key], childPath, out);
+    } else if (!passthrough) {
+      // `strict` would already have failed the top-level parse, so any key we
+      // reach here under a non-passthrough object was strip-dropped. Passthrough
+      // extras are intentionally kept and are never reported.
+      const suggestion = closestKnownKey(key, knownKeys);
+      out.push(suggestion ? { path: childPath, suggestion } : { path: childPath });
+    }
+  }
+}
+
+function walkRecord(def: ZodDef, value: unknown, prefix: string, out: StrippedKey[]): void {
+  // Arbitrary keys are allowed; recurse into each value with the value schema.
+  if (!isPlainObject(value) || !def.valueType) return;
+  for (const key of Object.keys(value)) {
+    walk(def.valueType, value[key], join(prefix, key), out);
+  }
+}
+
+function walkArray(def: ZodDef, value: unknown, prefix: string, out: StrippedKey[]): void {
+  if (!Array.isArray(value) || !def.type) return;
+  const elem = def.type;
+  value.forEach((item, i) => walk(elem, item, `${prefix}[${i}]`, out));
+}
+
+function walkUnion(def: ZodDef, value: unknown, prefix: string, out: StrippedKey[]): void {
+  // Recurse into the first option that accepts the value (that is the branch the
+  // parse used), so passthrough branches suppress and strip branches report —
+  // matching what actually happened at parse time.
+  for (const option of def.options ?? []) {
+    if (option.safeParse(value).success) {
+      walk(option, value, prefix, out);
+      return;
+    }
+  }
+}
+
+/**
+ * Format collected stripped keys into human-readable, non-fatal warning lines
+ * for `harness.config.json`.
+ */
+export function formatStrippedKeyWarnings(dropped: StrippedKey[]): string[] {
+  return dropped.map(({ path, suggestion }) => {
+    const hint = suggestion ? ` (did you mean '${siblingPath(path, suggestion)}'?)` : '';
+    return `⚠ harness.config.json: ignored unknown key '${path}'${hint}`;
+  });
+}
+
+/** Replace the last path segment with the suggested sibling. */
+function siblingPath(path: string, suggestion: string): string {
+  const idx = path.lastIndexOf('.');
+  return idx === -1 ? suggestion : `${path.slice(0, idx + 1)}${suggestion}`;
+}


### PR DESCRIPTION
## Summary
`harness.config.json` is validated with zod schemas that run in strip mode, so unknown or mis-nested keys were silently dropped with no error and no warning — a plausible-but-wrong config became a silent no-op. This is the latent trap behind #838 (a user nested `entropy.analyze.drift.checkApiSignatures` — the internal `EntropyConfig` field path — instead of the honored `entropy.drift.checkApiSignatures`; zod stripped `entropy.analyze` and the tuning had zero effect, with no signal).

The shared loader now performs a **schema-aware recursive diff** of the raw parsed JSON against the zod schema and emits a **non-fatal stderr warning** naming each dropped key (with a conservative near-typo "did you mean" hint). It respects `.passthrough()` sections (`security`, `performance`, ...) whose extra keys are intentionally kept and are never reported. Load still succeeds — no behavior change beyond the warning. `HARNESS_SUPPRESS_CONFIG_WARNINGS=1` silences it.

While validating, I found the repo's own legitimate top-level `pulse` block (written by `harness pulse`, validated by a separate `PulseConfigSchema` in core) was absent from the CLI's `HarnessConfigSchema` and thus silently stripped — so it is now declared as a tolerant passthrough block.

Notably NOT done: no schema was converted to `.strict()` (that would hard-error and break existing configs), per the issue's constraints.

## Debugging (harness:debugging)
- Root cause: `HarnessConfigSchema.safeParse` runs zod strip mode; `loader.ts` returned `parsed.data` with unknown/mis-nested keys silently dropped and no diff against the raw input, so wrong keys were invisible.
- Fix: new `packages/cli/src/config/stripped-keys.ts` walks the schema alongside the raw JSON (unwrapping optional/default/nullable/effects/lazy; recursing into objects/records/arrays/unions), collecting keys dropped under non-passthrough objects; wired into `loadConfig` to emit warnings to stderr. Added `pulse` to the schema.
- Regression test: `packages/cli/src/config/stripped-keys.test.ts` — mis-nested `entropy.analyze` produces a warning naming the stripped path; extras under `.passthrough()` (security/performance) produce none; a fully-valid config produces none; loader wiring test asserts the warning fires on stderr while `loadConfig` still returns ok. Verified it fails without the fix (temporarily neutralized the walk → 3 failures) and passes with it.

Fixes #862