### PR TITLE
feat(test-craft): emit machine-readable per-test verdict report (Part of #914)

### DIFF
--- a/.changeset/test-craft-emit-verdicts.md
+++ b/.changeset/test-craft-emit-verdicts.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+test-craft can now emit a machine-readable per-test verdict report (`--emit <path>` CLI flag / `emitTo` MCP arg) so downstream tooling can consume its findings instead of losing them to chat. Part of #914.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -532,6 +532,7 @@ LLM-judgment critique of test quality across vitest/jest/mocha/playwright/pytest
 - `--max-files` — Cap test file count (default: 100)
 - `--max-tests-per-file` — Cap per-file test critique (default: 20)
 - `--no-source-pair` — Skip source-pairing resolution
+- `--emit` — Write a machine-readable per-test verdict report (JSON) to this path for downstream tooling
 
 ### `harness traceability`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -725,6 +725,7 @@ LLM-judgment critique of test quality across vitest/jest/mocha/playwright/pytest
 - `maxFiles` (number, optional) — Cap test file count (default: 100)
 - `maxTestsPerFile` (number, optional) — Cap per-file test critique (default: 20)
 - `sourcePair` (boolean, optional) — Resolve source file under test for richer prompt context (default: true)
+- `emitTo` (string, optional) — Write a machine-readable per-test verdict report (JSON) to this path so downstream tooling can consume the findings; relative paths resolve against the project root
 
 ### `trigger_maintenance_job`
 

--- a/packages/cli/src/commands/test-craft.ts
+++ b/packages/cli/src/commands/test-craft.ts
@@ -24,6 +24,7 @@ interface TestCraftCliOptions {
   maxFiles?: string;
   maxTestsPerFile?: string;
   noSourcePair?: boolean;
+  emit?: string;
 }
 
 export function createTestCraftCommand(): Command {
@@ -37,19 +38,17 @@ export function createTestCraftCommand(): Command {
     .option('--max-files <n>', 'Cap test file count (default: 100)')
     .option('--max-tests-per-file <n>', 'Cap per-file test critique (default: 20)')
     .option('--no-source-pair', 'Skip source-pairing resolution')
+    .option(
+      '--emit <path>',
+      'Write a machine-readable per-test verdict report (JSON) to this path for downstream tooling'
+    )
     .action(async (opts: TestCraftCliOptions, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const outputMode = resolveOutputMode(globalOpts);
       const formatter = new OutputFormatter(outputMode);
       const cwd = (globalOpts.cwd as string | undefined) ?? process.cwd();
 
-      const input: TestCraftInput = { path: cwd };
-      if (opts.files !== undefined) input.files = opts.files;
-      if (opts.frameworks !== undefined) input.frameworks = opts.frameworks as TestFramework[];
-      if (opts.maxFiles !== undefined) input.maxFiles = parseInt(opts.maxFiles, 10);
-      if (opts.maxTestsPerFile !== undefined)
-        input.maxTestsPerFile = parseInt(opts.maxTestsPerFile, 10);
-      if (opts.noSourcePair === true) input.sourcePair = false;
+      const input = buildInput(opts, cwd);
 
       let result: TestCraftOutput;
       try {
@@ -74,6 +73,19 @@ export function createTestCraftCommand(): Command {
       const hasFoundational = result.findings.some((f) => f.tier === 'foundational');
       process.exit(hasFoundational ? ExitCode.VALIDATION_FAILED : ExitCode.SUCCESS);
     });
+}
+
+/** Map parsed CLI options onto a TestCraftInput. Extracted to keep the action handler small. */
+function buildInput(opts: TestCraftCliOptions, cwd: string): TestCraftInput {
+  const input: TestCraftInput = { path: cwd };
+  if (opts.files !== undefined) input.files = opts.files;
+  if (opts.frameworks !== undefined) input.frameworks = opts.frameworks as TestFramework[];
+  if (opts.maxFiles !== undefined) input.maxFiles = parseInt(opts.maxFiles, 10);
+  if (opts.maxTestsPerFile !== undefined)
+    input.maxTestsPerFile = parseInt(opts.maxTestsPerFile, 10);
+  if (opts.noSourcePair === true) input.sourcePair = false;
+  if (opts.emit !== undefined) input.emitTo = opts.emit;
+  return input;
 }
 
 function printResult(

--- a/packages/cli/src/mcp/tools/test-craft.ts
+++ b/packages/cli/src/mcp/tools/test-craft.ts
@@ -46,6 +46,12 @@ export const testCraftDefinition = {
         type: 'boolean',
         description: 'Resolve source file under test for richer prompt context (default: true)',
       },
+      emitTo: {
+        type: 'string',
+        description:
+          'Write a machine-readable per-test verdict report (JSON) to this path so downstream ' +
+          'tooling can consume the findings; relative paths resolve against the project root',
+      },
     },
     required: ['path'],
   },

--- a/packages/cli/src/test-craft/emit.ts
+++ b/packages/cli/src/test-craft/emit.ts
@@ -1,0 +1,131 @@
+/**
+ * Machine-readable per-test verdict emission for test-craft (issue #914,
+ * checkbox 3).
+ *
+ * test-craft's raw output is a flat list of per-(test, rubric) findings. When
+ * that output is only rendered to chat / the MCP text response, downstream
+ * tooling (e.g. a test-promotion gate in the canary ecosystem) loses the
+ * structured 8-axis findings. This module projects the findings into a stable,
+ * per-test verdict document and writes it to a JSON file so the "consume" side
+ * has a real seam to read.
+ *
+ * The projection is a pure function over `TestCraftOutput`; the file write is a
+ * thin side-effect on top of it.
+ *
+ * Source: docs/changes/craft-pipeline/test-craft/proposal.md (Outputs).
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { Tier } from '../shared/craft/findings/axes.js';
+import type { TestCraftOutput, TestCraftSummary, TestFinding } from './findings/schema.js';
+
+/** Stable discriminator so a reader can validate it is looking at this document. */
+export const TEST_CRAFT_REPORT_SCHEMA = 'harness.test-craft.verdicts' as const;
+export const TEST_CRAFT_REPORT_VERSION = 1 as const;
+
+/**
+ * Tier severity, most-severe first. `foundational` means the test fails its
+ * basic job, so it is the worst tier a per-test verdict can carry.
+ */
+const TIER_SEVERITY: Record<Tier, number> = {
+  foundational: 0,
+  polish: 1,
+  aspirational: 2,
+};
+
+/** The most severe tier among a test's findings (foundational beats polish beats aspirational). */
+function worstTier(findings: readonly TestFinding[]): Tier {
+  return findings.reduce<Tier>(
+    (worst, f) => (TIER_SEVERITY[f.tier] < TIER_SEVERITY[worst] ? f.tier : worst),
+    'aspirational'
+  );
+}
+
+/** A single test's aggregated verdict — the per-test roll-up of its per-rubric findings. */
+export interface TestVerdict {
+  target: TestFinding['target'];
+  /** Most severe tier among this test's findings. */
+  worstTier: Tier;
+  /** Number of findings rolled into this verdict. */
+  findingCount: number;
+  /**
+   * Machine-readable promotion signal for a downstream test-promotion gate:
+   * a `foundational` finding means the test fails its basic job, so it is not
+   * promotable. Every other tier is above-floor and does not block promotion.
+   */
+  promotable: boolean;
+  /** The underlying per-rubric findings for this test, preserved verbatim. */
+  findings: TestFinding[];
+}
+
+/** The emitted document: self-describing header + per-test verdicts + run summary. */
+export interface TestCraftReport {
+  schema: typeof TEST_CRAFT_REPORT_SCHEMA;
+  version: typeof TEST_CRAFT_REPORT_VERSION;
+  /** ISO timestamp when the report was built. */
+  generatedAt: string;
+  /** Correlates with `TestCraftSummary.runId`. */
+  runId: string;
+  verdicts: TestVerdict[];
+  summary: TestCraftSummary;
+}
+
+/** Stable key that groups every rubric finding belonging to the same test. */
+function verdictKey(target: TestFinding['target']): string {
+  return `${target.file}::${target.line}::${target.nesting.join('>')}::${target.testName}`;
+}
+
+/**
+ * Project a flat findings list into per-test verdicts. Pure — a test with no
+ * findings never appears (its absence is the "clean" signal for a consumer);
+ * a test with findings gets one verdict rolling up every rubric that fired.
+ */
+export function toTestVerdicts(output: TestCraftOutput): TestVerdict[] {
+  const byTest = new Map<string, TestFinding[]>();
+  for (const finding of output.findings) {
+    const key = verdictKey(finding.target);
+    const list = byTest.get(key);
+    if (list) list.push(finding);
+    else byTest.set(key, [finding]);
+  }
+
+  const verdicts: TestVerdict[] = [];
+  for (const findings of byTest.values()) {
+    const tier = worstTier(findings);
+    verdicts.push({
+      target: findings[0]!.target,
+      worstTier: tier,
+      findingCount: findings.length,
+      promotable: tier !== 'foundational',
+      findings,
+    });
+  }
+  return verdicts;
+}
+
+/** Build the self-describing report document from a test-craft run. */
+export function buildTestCraftReport(output: TestCraftOutput): TestCraftReport {
+  return {
+    schema: TEST_CRAFT_REPORT_SCHEMA,
+    version: TEST_CRAFT_REPORT_VERSION,
+    generatedAt: new Date().toISOString(),
+    runId: output.summary.runId,
+    verdicts: toTestVerdicts(output),
+    summary: output.summary,
+  };
+}
+
+/**
+ * Write the machine-readable per-test verdict report to `filePath`, creating
+ * parent directories as needed. Returns the resolved absolute path written.
+ */
+export async function emitTestCraftReport(
+  output: TestCraftOutput,
+  filePath: string
+): Promise<string> {
+  const resolved = path.resolve(filePath);
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await fs.writeFile(resolved, JSON.stringify(buildTestCraftReport(output), null, 2), 'utf-8');
+  return resolved;
+}

--- a/packages/cli/src/test-craft/index.ts
+++ b/packages/cli/src/test-craft/index.ts
@@ -17,6 +17,7 @@ import { extractPythonTests, isPythonTestFile } from './extract/python-tests.js'
 import { resolveSourceFile } from './extract/source-pair.js';
 import { SEED_RUBRICS, type TestRubric } from './catalog/rubrics/index.js';
 import { critiqueOne } from './phases/critique.js';
+import { emitTestCraftReport } from './emit.js';
 import type {
   TestCraftOutput,
   TestFinding,
@@ -31,6 +32,12 @@ export interface TestCraftInput {
   maxFiles?: number;
   maxTestsPerFile?: number;
   sourcePair?: boolean;
+  /**
+   * When set, write a machine-readable per-test verdict report (issue #914)
+   * to this path so downstream tooling can consume the 8-axis findings instead
+   * of losing them to chat. Relative paths resolve against the project root.
+   */
+  emitTo?: string;
   /** Test-only LLM provider override. */
   __testProvider?: LlmProvider;
 }
@@ -88,30 +95,56 @@ export async function runTestCraft(input: TestCraftInput): Promise<TestCraftOutp
     findings.push(...(await critiqueTest(test, rubrics, provider, pair)));
   }
 
+  const output: TestCraftOutput = {
+    findings,
+    summary: buildSummary({ provider, rubrics, files, extraction, startedAt }),
+  };
+
+  await maybeEmitReport(output, input.emitTo, projectRoot);
+  return output;
+}
+
+/** Assemble the run summary. Extracted to keep runTestCraft under the complexity floor. */
+function buildSummary(args: {
+  provider: LlmProvider;
+  rubrics: ReadonlyArray<TestRubric>;
+  files: readonly string[];
+  extraction: ExtractionResult;
+  startedAt: number;
+}): TestCraftOutput['summary'] {
+  const { provider, rubrics, files, extraction, startedAt } = args;
   const totalCost = sumCosts(provider);
   return {
-    findings,
-    summary: {
-      phaseRun: ['critique'],
-      mode: 'fast',
-      durationMs: Date.now() - startedAt,
-      llmCalls: {
-        provider: provider.providerId,
-        model: provider.model,
-        count: totalCost.count,
-        costUsd: totalCost.costUsd,
-      },
-      catalog: { rubricsApplied: rubrics.map((r) => r.id) },
-      counts: {
-        filesScanned: files.length,
-        testsExtracted: extraction.allTests.length,
-        testsSkippedOrTodo: extraction.testsSkippedOrTodo,
-        sourcePaired: extraction.sourcePairedCount,
-      },
-      frameworksDetected: extraction.frameworksDetected,
-      runId: randomUUID(),
+    phaseRun: ['critique'],
+    mode: 'fast',
+    durationMs: Date.now() - startedAt,
+    llmCalls: {
+      provider: provider.providerId,
+      model: provider.model,
+      count: totalCost.count,
+      costUsd: totalCost.costUsd,
     },
+    catalog: { rubricsApplied: rubrics.map((r) => r.id) },
+    counts: {
+      filesScanned: files.length,
+      testsExtracted: extraction.allTests.length,
+      testsSkippedOrTodo: extraction.testsSkippedOrTodo,
+      sourcePaired: extraction.sourcePairedCount,
+    },
+    frameworksDetected: extraction.frameworksDetected,
+    runId: randomUUID(),
   };
+}
+
+/** Write the machine-readable verdict report when an emit path is configured (issue #914). */
+async function maybeEmitReport(
+  output: TestCraftOutput,
+  emitTo: string | undefined,
+  projectRoot: string
+): Promise<void> {
+  if (emitTo === undefined || emitTo.length === 0) return;
+  const target = path.isAbsolute(emitTo) ? emitTo : path.join(projectRoot, emitTo);
+  await emitTestCraftReport(output, target);
 }
 
 interface ExtractionResult {
@@ -309,3 +342,11 @@ export type {
   TestFramework,
   ExtractedTest,
 } from './findings/schema.js';
+export {
+  buildTestCraftReport,
+  emitTestCraftReport,
+  toTestVerdicts,
+  TEST_CRAFT_REPORT_SCHEMA,
+  TEST_CRAFT_REPORT_VERSION,
+} from './emit.js';
+export type { TestCraftReport, TestVerdict } from './emit.js';

--- a/packages/cli/tests/test-craft/emit.test.ts
+++ b/packages/cli/tests/test-craft/emit.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runTestCraft } from '../../src/test-craft';
+import {
+  toTestVerdicts,
+  buildTestCraftReport,
+  TEST_CRAFT_REPORT_SCHEMA,
+  TEST_CRAFT_REPORT_VERSION,
+  type TestCraftReport,
+} from '../../src/test-craft/emit';
+import type { TestCraftOutput, TestFinding } from '../../src/test-craft/findings/schema';
+import { MockLlmProvider } from '../../src/shared/craft/llm/provider';
+
+function finding(over: Partial<TestFinding> & { target: TestFinding['target'] }): TestFinding {
+  return {
+    code: 'TEST-R001',
+    phase: 'critique',
+    tier: 'polish',
+    impact: 'small',
+    confidence: 'medium',
+    message: 'x',
+    cite: { rubricId: 'TEST-R001', source: 'seed' },
+    derived: { priority: 1 },
+    ...over,
+  };
+}
+
+const targetA: TestFinding['target'] = {
+  file: 'src/foo.test.ts',
+  line: 3,
+  testName: 'returns null',
+  nesting: ['foo'],
+  framework: 'vitest',
+};
+const targetB: TestFinding['target'] = {
+  file: 'src/bar.test.ts',
+  line: 9,
+  testName: 'adds',
+  nesting: [],
+  framework: 'vitest',
+};
+
+function outputWith(findings: TestFinding[]): TestCraftOutput {
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: 1,
+      llmCalls: { provider: 'mock', model: 'mock', count: 0, costUsd: 0 },
+      catalog: { rubricsApplied: [] },
+      counts: { filesScanned: 1, testsExtracted: 1, testsSkippedOrTodo: 0, sourcePaired: 0 },
+      frameworksDetected: {
+        vitest: 1,
+        jest: 0,
+        mocha: 0,
+        playwright: 0,
+        pytest: 0,
+        unknown: 0,
+      },
+      runId: 'run-123',
+    },
+  };
+}
+
+describe('toTestVerdicts', () => {
+  it('rolls multiple rubric findings on one test into a single verdict', () => {
+    const out = outputWith([
+      finding({ target: targetA, tier: 'polish', code: 'TEST-R001' }),
+      finding({ target: targetA, tier: 'aspirational', code: 'TEST-R002' }),
+    ]);
+    const verdicts = toTestVerdicts(out);
+    expect(verdicts).toHaveLength(1);
+    expect(verdicts[0]!.findingCount).toBe(2);
+    expect(verdicts[0]!.target.testName).toBe('returns null');
+  });
+
+  it('worstTier picks the most severe tier and drives promotability', () => {
+    const foundational = toTestVerdicts(
+      outputWith([
+        finding({ target: targetA, tier: 'aspirational' }),
+        finding({ target: targetA, tier: 'foundational' }),
+      ])
+    );
+    expect(foundational[0]!.worstTier).toBe('foundational');
+    expect(foundational[0]!.promotable).toBe(false);
+
+    const polishOnly = toTestVerdicts(outputWith([finding({ target: targetB, tier: 'polish' })]));
+    expect(polishOnly[0]!.worstTier).toBe('polish');
+    expect(polishOnly[0]!.promotable).toBe(true);
+  });
+
+  it('keeps distinct tests as separate verdicts', () => {
+    const verdicts = toTestVerdicts(
+      outputWith([finding({ target: targetA }), finding({ target: targetB })])
+    );
+    expect(verdicts).toHaveLength(2);
+  });
+});
+
+describe('buildTestCraftReport', () => {
+  it('produces a self-describing document keyed to the run', () => {
+    const report = buildTestCraftReport(outputWith([finding({ target: targetA })]));
+    expect(report.schema).toBe(TEST_CRAFT_REPORT_SCHEMA);
+    expect(report.version).toBe(TEST_CRAFT_REPORT_VERSION);
+    expect(report.runId).toBe('run-123');
+    expect(report.verdicts).toHaveLength(1);
+    expect(typeof report.generatedAt).toBe('string');
+  });
+});
+
+describe('runTestCraft emitTo (issue #914)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-craft-emit-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes a machine-readable per-test verdict report to the emit path', async () => {
+    const testFile = path.join(tmpDir, 'src', 'foo.test.ts');
+    fs.mkdirSync(path.dirname(testFile), { recursive: true });
+    fs.writeFileSync(testFile, `it('works', () => {});`);
+
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'works',
+        response:
+          '```json\n{"tier":"foundational","impact":"large","confidence":"high","message":"no assertion"}\n```',
+      },
+    ]);
+
+    const emitPath = path.join(tmpDir, '.harness', 'analyses', 'test-craft.json');
+    const out = await runTestCraft({
+      path: tmpDir,
+      __testProvider: provider,
+      emitTo: emitPath,
+    });
+
+    // The chat return is unchanged...
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+
+    // ...but the machine-readable report is now on disk for downstream tooling.
+    expect(fs.existsSync(emitPath)).toBe(true);
+    const report = JSON.parse(fs.readFileSync(emitPath, 'utf-8')) as TestCraftReport;
+    expect(report.schema).toBe(TEST_CRAFT_REPORT_SCHEMA);
+    expect(report.version).toBe(TEST_CRAFT_REPORT_VERSION);
+    expect(report.runId).toBe(out.summary.runId);
+    expect(report.verdicts.length).toBeGreaterThanOrEqual(1);
+
+    const verdict = report.verdicts.find((v) => v.target.testName === 'works');
+    expect(verdict).toBeDefined();
+    expect(verdict!.worstTier).toBe('foundational');
+    expect(verdict!.promotable).toBe(false);
+    expect(verdict!.findings.length).toBe(verdict!.findingCount);
+  });
+
+  it('resolves a relative emit path against the project root', async () => {
+    const testFile = path.join(tmpDir, 'src', 'foo.test.ts');
+    fs.mkdirSync(path.dirname(testFile), { recursive: true });
+    fs.writeFileSync(testFile, `it('works', () => {});`);
+
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'works',
+        response:
+          '```json\n{"tier":"polish","impact":"small","confidence":"low","message":"ok"}\n```',
+      },
+    ]);
+
+    await runTestCraft({
+      path: tmpDir,
+      __testProvider: provider,
+      emitTo: 'report.json',
+    });
+
+    expect(fs.existsSync(path.join(tmpDir, 'report.json'))).toBe(true);
+  });
+
+  it('does not write a report when emitTo is unset', async () => {
+    const testFile = path.join(tmpDir, 'src', 'foo.test.ts');
+    fs.mkdirSync(path.dirname(testFile), { recursive: true });
+    fs.writeFileSync(testFile, `it('works', () => {});`);
+
+    await runTestCraft({ path: tmpDir });
+    expect(fs.readdirSync(tmpDir)).not.toContain('report.json');
+  });
+});


### PR DESCRIPTION
## Summary

Issue #914 (\"Consume guardian analyses + emit test-craft verdicts\") is a 3-item checklist spanning multiple consumers. This PR lands the single cleanest, fully self-contained slice: **the test-craft emit side**.

Previously test-craft produced per-(test, rubric) findings but only returned them as JSON text to the MCP/CLI caller — i.e. \"lost to chat.\" There was no machine-readable artifact a downstream tool (e.g. a test-promotion gate) could consume. This turns that water on.

### What changed
- New `packages/cli/src/test-craft/emit.ts`:
  - `toTestVerdicts(output)` — pure projection that rolls the flat per-rubric findings into **per-test verdicts**, deriving `worstTier` (foundational > polish > aspirational) and a `promotable` boolean (`false` iff a `foundational` finding exists — the test fails its basic job).
  - `buildTestCraftReport(output)` / `emitTestCraftReport(output, path)` — a self-describing report (`schema: \"harness.test-craft.verdicts\"`, `version: 1`, `generatedAt`, `runId`, `verdicts`, `summary`) written to a JSON file.
- Wired `emitTo` into `TestCraftInput` and `runTestCraft` (relative paths resolve against project root).
- Surfaced it on both existing surfaces: `--emit <path>` CLI flag and `emitTo` MCP tool arg. Reference docs regenerated.

The verdict schema is entirely harness-owned (no invented canary contract). The **consume** side (test-promotion gate) is, per the issue, tracked in the canary ecosystem and out of scope here.

## Checklist status (issue #914)
- [x] test-craft emits a machine-readable per-test verdict (JSON) so downstream tooling can consume its findings instead of losing them to chat

Remaining follow-ups (still open, not addressed here):
- [ ] pre-merge-brief and harness-code-review read guardian diff-coverage findings from the analyses archive as a review input
- [ ] outcome_eval accepts guardian verdicts as a signal

Note for follow-ups: no `guardian`/`diff-coverage` schema exists anywhere in this repo today — those two boxes depend on the canary-owned guardian analysis-record contract, which is a genuine design decision (not derivable from the current code). They need that contract pinned before implementation.

## Testing (harness:debugging)
- Root cause: test-craft's structured findings had no machine-readable emit target; they only reached the caller as chat text.
- Fix: add a pure per-test verdict projection + a JSON report emitter, wired via an `emitTo` option on both CLI and MCP surfaces.
- Regression test: `packages/cli/tests/test-craft/emit.test.ts` — unit-tests the projection (worstTier/promotable/grouping) and drives `runTestCraft` end-to-end with a `MockLlmProvider` + `emitTo`, asserting the JSON report lands on disk with the expected verdict. Verified it FAILS when the `runTestCraft` emit wiring is reverted (2 tests fail) and PASSES with it.
- Gates: typecheck, full test-craft suite (66 tests), `harness ci check` arch/validate/traceability all green; changeset + generate-docs included.

Part of #914