### PR TITLE
fix(craft): surface empty-result diagnostic + error on missing named backend (#896)

### DIFF
--- a/.changeset/craft-empty-result-diagnostic.md
+++ b/.changeset/craft-empty-result-diagnostic.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix #896: craft skills now emit a one-line diagnostic so an empty result is
+distinguishable from "ran clean". The shared summary reports the resolved
+provider/mode and files scanned vs. skipped (with a reason such as an
+unsupported language producing 0 analyzable files), and `HARNESS_CRAFT_LLM`
+naming a backend absent from `agent.backends` now errors explicitly instead of
+silently degrading to in-session.

--- a/packages/cli/src/commands/copy-craft.ts
+++ b/packages/cli/src/commands/copy-craft.ts
@@ -17,6 +17,8 @@ import {
   type CopyCraftOutput,
   type CopySurface,
 } from '../copy-craft/index.js';
+import { resolveCraftLlmConfig, type CraftLlmResolution } from '../shared/craft/llm/provider.js';
+import { formatCraftDiagnostic, type CraftScanTally } from '../shared/craft/diagnostics.js';
 
 interface CopyCraftCliOptions {
   files?: string[];
@@ -75,7 +77,7 @@ export function createCopyCraftCommand(): Command {
       if (outputMode === OutputMode.JSON) {
         console.log(JSON.stringify(result, null, 2));
       } else {
-        printResult(result, outputMode, formatter);
+        printResult(result, outputMode, formatter, resolveCraftLlmConfig({ projectRoot: cwd }));
       }
 
       const hasFoundational = result.findings.some((f) => f.tier === 'foundational');
@@ -83,10 +85,29 @@ export function createCopyCraftCommand(): Command {
     });
 }
 
+function copyScanTally(summary: CopyCraftOutput['summary']): CraftScanTally {
+  const analyzed = Object.values(summary.counts).reduce((sum, n) => sum + n, 0);
+  const tally: CraftScanTally = {
+    unit: 'copy items',
+    analyzed,
+    // Surface-level skips are reported in their own "Skipped surfaces" block;
+    // the item tally counts extracted items, so skipped items stays 0 here.
+    skipped: 0,
+  };
+  if (analyzed === 0) {
+    tally.skipReason =
+      summary.skippedSurfaces.length > 0
+        ? 'no items extracted; some surfaces skipped (see below)'
+        : 'no items on supported source (.ts, .tsx, .js, .jsx) or git surfaces';
+  }
+  return tally;
+}
+
 function printResult(
   result: CopyCraftOutput,
   mode: OutputModeType,
-  _formatter: OutputFormatter
+  _formatter: OutputFormatter,
+  resolution: CraftLlmResolution
 ): void {
   const verbose = mode === OutputMode.VERBOSE;
   const { findings, summary } = result;
@@ -122,6 +143,7 @@ function printResult(
       `(${summary.catalog.rubricsApplied.length} rubrics, ${summary.llmCalls.count} LLM calls, ` +
       `$${summary.llmCalls.costUsd.toFixed(4)}, ${summary.durationMs}ms)`
   );
+  console.log(formatCraftDiagnostic({ resolution, scan: copyScanTally(summary) }));
   if (summary.skippedSurfaces.length > 0) {
     console.log(`Skipped surfaces:`);
     for (const s of summary.skippedSurfaces) {

--- a/packages/cli/src/commands/naming-craft.ts
+++ b/packages/cli/src/commands/naming-craft.ts
@@ -17,6 +17,8 @@ import {
   type NamingCraftOutput,
   type IdentifierKind,
 } from '../naming-craft/index.js';
+import { resolveCraftLlmConfig, type CraftLlmResolution } from '../shared/craft/llm/provider.js';
+import { formatCraftDiagnostic, type CraftScanTally } from '../shared/craft/diagnostics.js';
 
 interface NamingCraftCliOptions {
   files?: string[];
@@ -68,7 +70,7 @@ export function createNamingCraftCommand(): Command {
       if (outputMode === OutputMode.JSON) {
         console.log(JSON.stringify(result, null, 2));
       } else {
-        printResult(result, outputMode, formatter);
+        printResult(result, outputMode, formatter, resolveCraftLlmConfig({ projectRoot: cwd }));
       }
 
       const hasError = result.findings.some((f) => f.tier === 'foundational');
@@ -76,10 +78,23 @@ export function createNamingCraftCommand(): Command {
     });
 }
 
+function namingScanTally(summary: NamingCraftOutput['summary']): CraftScanTally {
+  const tally: CraftScanTally = {
+    unit: 'files',
+    analyzed: summary.filesScanned,
+    skipped: 0,
+  };
+  if (summary.filesScanned === 0) {
+    tally.skipReason = 'no source files for supported languages (.ts, .tsx, .js, .jsx)';
+  }
+  return tally;
+}
+
 function printResult(
   result: NamingCraftOutput,
   mode: OutputModeType,
-  _formatter: OutputFormatter
+  _formatter: OutputFormatter,
+  resolution: CraftLlmResolution
 ): void {
   const verbose = mode === OutputMode.VERBOSE;
   const { findings, summary } = result;
@@ -117,4 +132,5 @@ function printResult(
     `Convention: vars=${summary.convention.variables ?? '?'}, funcs=${summary.convention.functions ?? '?'}, ` +
       `types=${summary.convention.types ?? '?'}, files=${summary.convention.files ?? '?'}`
   );
+  console.log(formatCraftDiagnostic({ resolution, scan: namingScanTally(summary) }));
 }

--- a/packages/cli/src/commands/security-craft.ts
+++ b/packages/cli/src/commands/security-craft.ts
@@ -16,6 +16,8 @@ import {
   type SecurityCraftInput,
   type SecurityCraftOutput,
 } from '../security-craft/index.js';
+import { resolveCraftLlmConfig, type CraftLlmResolution } from '../shared/craft/llm/provider.js';
+import { formatCraftDiagnostic, type CraftScanTally } from '../shared/craft/diagnostics.js';
 
 interface SecurityCraftCliOptions {
   files?: string[];
@@ -66,7 +68,7 @@ export function createSecurityCraftCommand(): Command {
       if (outputMode === OutputMode.JSON) {
         console.log(JSON.stringify(result, null, 2));
       } else {
-        printResult(result, outputMode, formatter);
+        printResult(result, outputMode, formatter, resolveCraftLlmConfig({ projectRoot: cwd }));
       }
 
       const hasFoundational = result.findings.some((f) => f.tier === 'foundational');
@@ -74,10 +76,30 @@ export function createSecurityCraftCommand(): Command {
     });
 }
 
+function securityScanTally(summary: SecurityCraftOutput['summary']): CraftScanTally {
+  const { filesScanned, filesSkippedNoSignal } = summary.counts;
+  if (filesScanned === 0 && filesSkippedNoSignal === 0) {
+    return {
+      unit: 'files',
+      analyzed: 0,
+      skipped: 0,
+      skipReason: 'no source files for supported languages (.ts, .tsx, .js, .jsx)',
+    };
+  }
+  const tally: CraftScanTally = {
+    unit: 'files',
+    analyzed: filesScanned,
+    skipped: filesSkippedNoSignal,
+  };
+  if (filesSkippedNoSignal > 0) tally.skipReason = 'no security signal';
+  return tally;
+}
+
 function printResult(
   result: SecurityCraftOutput,
   mode: OutputModeType,
-  _formatter: OutputFormatter
+  _formatter: OutputFormatter,
+  resolution: CraftLlmResolution
 ): void {
   const verbose = mode === OutputMode.VERBOSE;
   const { findings, summary } = result;
@@ -110,4 +132,5 @@ function printResult(
       `${summary.catalog.rubricsApplied.length} rubrics, ${summary.llmCalls.count} LLM calls, ` +
       `$${summary.llmCalls.costUsd.toFixed(4)}, ${summary.durationMs}ms)`
   );
+  console.log(formatCraftDiagnostic({ resolution, scan: securityScanTally(summary) }));
 }

--- a/packages/cli/src/commands/spec-craft.ts
+++ b/packages/cli/src/commands/spec-craft.ts
@@ -17,6 +17,8 @@ import {
   type SpecCraftOutput,
   type SpecKind,
 } from '../spec-craft/index.js';
+import { resolveCraftLlmConfig, type CraftLlmResolution } from '../shared/craft/llm/provider.js';
+import { formatCraftDiagnostic, type CraftScanTally } from '../shared/craft/diagnostics.js';
 
 interface SpecCraftCliOptions {
   files?: string[];
@@ -68,7 +70,7 @@ export function createSpecCraftCommand(): Command {
       if (outputMode === OutputMode.JSON) {
         console.log(JSON.stringify(result, null, 2));
       } else {
-        printResult(result, outputMode, formatter);
+        printResult(result, outputMode, formatter, resolveCraftLlmConfig({ projectRoot: cwd }));
       }
 
       const hasFoundational = result.findings.some((f) => f.tier === 'foundational');
@@ -76,10 +78,23 @@ export function createSpecCraftCommand(): Command {
     });
 }
 
+function specScanTally(summary: SpecCraftOutput['summary']): CraftScanTally {
+  const tally: CraftScanTally = {
+    unit: 'docs',
+    analyzed: summary.docsScanned,
+    skipped: 0,
+  };
+  if (summary.docsScanned === 0) {
+    tally.skipReason = 'no proposals or ADRs found in scope';
+  }
+  return tally;
+}
+
 function printResult(
   result: SpecCraftOutput,
   mode: OutputModeType,
-  _formatter: OutputFormatter
+  _formatter: OutputFormatter,
+  resolution: CraftLlmResolution
 ): void {
   const verbose = mode === OutputMode.VERBOSE;
   const { findings, summary } = result;
@@ -111,4 +126,5 @@ function printResult(
       `(${summary.sectionsScanned} sections, ${summary.catalog.rubricsApplied.length} rubrics, ` +
       `${summary.llmCalls.count} LLM calls, $${summary.llmCalls.costUsd.toFixed(4)}, ${summary.durationMs}ms)`
   );
+  console.log(formatCraftDiagnostic({ resolution, scan: specScanTally(summary) }));
 }

--- a/packages/cli/src/naming-craft/findings/schema.ts
+++ b/packages/cli/src/naming-craft/findings/schema.ts
@@ -42,6 +42,12 @@ export interface NamingCraftSummary {
   llmCalls: { provider: string; model: string; count: number; costUsd: number };
   catalog: { rubricsApplied: string[] };
   convention: ProjectConvention;
+  /**
+   * Count of source files walked/read. Zero means nothing analyzable was
+   * found — e.g. a non-TS/JS (Python, Go, …) project — which the diagnostic
+   * surfaces so an empty result isn't mistaken for a clean bill of health.
+   */
+  filesScanned: number;
   runId: string;
 }
 

--- a/packages/cli/src/naming-craft/index.ts
+++ b/packages/cli/src/naming-craft/index.ts
@@ -81,6 +81,8 @@ interface NamingRunMeta {
   startedAt: number;
   convention: ProjectConvention;
   rubricsApplied: string[];
+  /** Count of source files walked at collect time (see NamingCraftSummary). */
+  filesScanned: number;
   /** Pairs every queued prompt to the data needed to build a finding. */
   prompts: Array<{
     promptId: string;
@@ -130,7 +132,7 @@ export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCra
     );
   }
 
-  const { perFile, convention } = gatherProjectContext(input);
+  const { files, perFile, convention } = gatherProjectContext(input);
   const rubrics = SEED_RUBRICS;
   const findings: NamingFinding[] = [];
 
@@ -165,6 +167,7 @@ export async function runNamingCraft(input: NamingCraftInput): Promise<NamingCra
       },
       catalog: { rubricsApplied: rubrics.map((r) => r.id) },
       convention,
+      filesScanned: files.length,
       runId: randomUUID(),
     },
   };
@@ -180,7 +183,7 @@ export async function collectNamingCraftPrompts(
 ): Promise<CollectPromptsOutput> {
   const maxIdentifiersPerFile = input.maxIdentifiersPerFile ?? DEFAULT_MAX_IDENTIFIERS_PER_FILE;
   const budget = input.promptBudget ?? DEFAULT_PROMPT_BUDGET;
-  const { projectRoot, perFile, convention } = gatherProjectContext(input);
+  const { projectRoot, files, perFile, convention } = gatherProjectContext(input);
   const rubrics = SEED_RUBRICS;
   const runId = randomUUID();
 
@@ -219,6 +222,7 @@ export async function collectNamingCraftPrompts(
     startedAt: Date.now(),
     convention,
     rubricsApplied: rubrics.map((r) => r.id),
+    filesScanned: files.length,
     prompts: promptRecords,
   };
   pruneOldRuns(projectRoot);
@@ -295,6 +299,7 @@ export async function finalizeNamingCraft(
       },
       catalog: { rubricsApplied: state.meta.rubricsApplied },
       convention: state.meta.convention,
+      filesScanned: state.meta.filesScanned ?? 0,
       runId: input.runId,
     },
   };

--- a/packages/cli/src/shared/craft/diagnostics.ts
+++ b/packages/cli/src/shared/craft/diagnostics.ts
@@ -1,0 +1,65 @@
+// packages/cli/src/shared/craft/diagnostics.ts
+//
+// Shared diagnostic surface for the craft skill family (copy / spec /
+// security / naming / …). One canonical formatter — not four copies — so
+// every craft summary can state WHY a result is empty.
+//
+// Motivation (issue #896): a craft skill can return `findings: []` for
+// reasons that have nothing to do with the code being clean — no backend
+// resolved (defaulted to in-session in a non-interactive context), an
+// unsupported-language project (0 analyzable files), or no extractable
+// signal. Without a diagnostic, "analyzed 0 items because X" is
+// indistinguishable from "analyzed 200 items, 0 findings", and a user reads
+// the empty result as a passing grade when no analysis actually ran.
+
+import type { CraftLlmResolution } from './llm/provider.js';
+
+/**
+ * Human-readable label for the resolved provider/mode, including the named
+ * backend when one was selected. Makes a silent in-session default visible.
+ */
+export function describeCraftResolution(resolution: CraftLlmResolution): string {
+  if (resolution.backendName !== undefined && resolution.backendName.length > 0) {
+    return `${resolution.mode} (backend "${resolution.backendName}")`;
+  }
+  return resolution.mode;
+}
+
+export interface CraftScanTally {
+  /** Plural unit noun for what was analyzed, e.g. "files", "docs", "items". */
+  unit: string;
+  /** Count of units actually fed to the critique/rubric loop. */
+  analyzed: number;
+  /** Count of units discovered but skipped before analysis. */
+  skipped: number;
+  /**
+   * Short reason units were skipped, or why nothing was analyzable. Shown
+   * verbatim so "analyzed 0 items because X" never reads like "0 findings".
+   */
+  skipReason?: string;
+}
+
+export interface CraftDiagnosticInput {
+  resolution: CraftLlmResolution;
+  scan?: CraftScanTally;
+}
+
+/**
+ * One-line diagnostic that distinguishes an empty result caused by "nothing
+ * to analyze" from a clean "analyzed N, found nothing". Always names the
+ * resolved provider/mode.
+ */
+export function formatCraftDiagnostic(input: CraftDiagnosticInput): string {
+  const parts = [`provider=${describeCraftResolution(input.resolution)}`];
+  const scan = input.scan;
+  if (scan !== undefined) {
+    if (scan.analyzed === 0 && scan.skipped === 0) {
+      const reason = scan.skipReason !== undefined ? ` (${scan.skipReason})` : '';
+      parts.push(`0 analyzable ${scan.unit}${reason}`);
+    } else {
+      const reason = scan.skipReason !== undefined ? ` — ${scan.skipReason}` : '';
+      parts.push(`analyzed ${scan.analyzed} ${scan.unit}, skipped ${scan.skipped}${reason}`);
+    }
+  }
+  return `Diagnostic: ${parts.join('; ')}`;
+}

--- a/packages/cli/src/shared/craft/llm/provider.ts
+++ b/packages/cli/src/shared/craft/llm/provider.ts
@@ -184,15 +184,25 @@ export function resolveCraftLlmConfig(opts: { projectRoot?: string } = {}): Craf
     if (envRaw === 'in-session' || envRaw === 'mock') {
       return { mode: envRaw };
     }
+    // HARNESS_CRAFT_LLM naming a backend is an explicit user override. If the
+    // name doesn't resolve, fail loudly instead of silently degrading to
+    // in-session — a silent fall-through makes an empty result indistinguishable
+    // from "no analysis ran" (issue #896, failure mode 3).
     const def = fileConfig?.backends?.[envRaw];
-    if (def !== undefined && typeof def === 'object' && def !== null) {
-      const backendDef = def as Record<string, unknown>;
-      const type = backendDef.type;
-      if (typeof type === 'string' && isBackendType(type)) {
-        return { mode: type, backendName: envRaw, backendDef };
-      }
+    if (def === undefined || typeof def !== 'object' || def === null) {
+      throw new Error(
+        `HARNESS_CRAFT_LLM="${envRaw}" names backend "${envRaw}" which was not found in agent.backends. ` +
+          'Add it to agent.backends in harness.config.json, or set HARNESS_CRAFT_LLM to "in-session" or "mock".'
+      );
     }
-    // Fall through to config-file resolution if the env value doesn't match a known backend.
+    const backendDef = def as Record<string, unknown>;
+    const type = backendDef.type;
+    if (typeof type !== 'string' || !isBackendType(type)) {
+      throw new Error(
+        `HARNESS_CRAFT_LLM="${envRaw}": agent.backends["${envRaw}"] has unsupported type "${String(type)}" for craft skills.`
+      );
+    }
+    return { mode: type, backendName: envRaw, backendDef };
   }
 
   // Config-file resolution.

--- a/packages/cli/tests/naming-craft/integration.test.ts
+++ b/packages/cli/tests/naming-craft/integration.test.ts
@@ -28,6 +28,23 @@ describe('runNamingCraft (integration)', () => {
     expect(out.summary.catalog.rubricsApplied).toHaveLength(6);
   });
 
+  it('reports filesScanned=0 on an all-unsupported-language project (issue #896, mode 2)', async () => {
+    // A Python-only project: naming-craft analyzes only TS/JS, so nothing is
+    // analyzable. The empty result must be distinguishable from a clean pass —
+    // filesScanned=0 is what the CLI diagnostic renders as "0 analyzable files".
+    writeFile('app/main.py', 'def process_data(orders):\n    return orders\n');
+    writeFile('app/util.py', 'x = 1\n');
+    const out = await runNamingCraft({ path: tmpDir, __testProvider: new MockLlmProvider() });
+    expect(out.findings).toEqual([]);
+    expect(out.summary.filesScanned).toBe(0);
+  });
+
+  it('reports a non-zero filesScanned when TS source is present', async () => {
+    writeFile('src/orders.ts', 'export const userName = 1;\n');
+    const out = await runNamingCraft({ path: tmpDir, __testProvider: new MockLlmProvider() });
+    expect(out.summary.filesScanned).toBeGreaterThan(0);
+  });
+
   it('walks a real file and aggregates findings via mock provider', async () => {
     writeFile('src/orders.ts', `export function processData(orders) { return orders; }\n`);
     const provider = new MockLlmProvider([

--- a/packages/cli/tests/shared/craft/diagnostics.test.ts
+++ b/packages/cli/tests/shared/craft/diagnostics.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  describeCraftResolution,
+  formatCraftDiagnostic,
+} from '../../../src/shared/craft/diagnostics';
+import type { CraftLlmResolution } from '../../../src/shared/craft/llm/provider';
+
+describe('describeCraftResolution', () => {
+  it('names a bare mode without a backend', () => {
+    expect(describeCraftResolution({ mode: 'in-session' })).toBe('in-session');
+  });
+
+  it('names the resolved backend alongside its type', () => {
+    const resolution: CraftLlmResolution = { mode: 'local', backendName: 'ollama' };
+    expect(describeCraftResolution(resolution)).toBe('local (backend "ollama")');
+  });
+});
+
+describe('formatCraftDiagnostic', () => {
+  it('always names the resolved provider/mode (issue #896, mode 1)', () => {
+    const line = formatCraftDiagnostic({ resolution: { mode: 'in-session' } });
+    expect(line).toContain('provider=in-session');
+    expect(line.startsWith('Diagnostic:')).toBe(true);
+  });
+
+  it('reports "0 analyzable files" when nothing was analyzable (issue #896, mode 2)', () => {
+    const line = formatCraftDiagnostic({
+      resolution: { mode: 'mock' },
+      scan: {
+        unit: 'files',
+        analyzed: 0,
+        skipped: 0,
+        skipReason: 'no source files for supported languages (.ts, .tsx, .js, .jsx)',
+      },
+    });
+    expect(line).toContain('0 analyzable files');
+    expect(line).toContain('supported languages');
+  });
+
+  it('distinguishes "analyzed N, 0 findings" from "analyzed nothing"', () => {
+    const analyzedSomething = formatCraftDiagnostic({
+      resolution: { mode: 'mock' },
+      scan: { unit: 'files', analyzed: 200, skipped: 12, skipReason: 'no security signal' },
+    });
+    const analyzedNothing = formatCraftDiagnostic({
+      resolution: { mode: 'mock' },
+      scan: { unit: 'files', analyzed: 0, skipped: 0, skipReason: 'unsupported language' },
+    });
+    expect(analyzedSomething).toContain('analyzed 200 files, skipped 12 — no security signal');
+    expect(analyzedNothing).not.toContain('analyzed 200');
+    expect(analyzedSomething).not.toEqual(analyzedNothing);
+  });
+});

--- a/packages/cli/tests/shared/craft/llm-provider.test.ts
+++ b/packages/cli/tests/shared/craft/llm-provider.test.ts
@@ -117,6 +117,33 @@ describe('resolveCraftLlmConfig (config-file driven)', () => {
     expect(r.backendName).toBe('ollama');
   });
 
+  it('throws when HARNESS_CRAFT_LLM names a backend absent from agent.backends (issue #896)', () => {
+    // No agent.backends at all — the env override names a backend that
+    // cannot resolve. It must fail loudly, not silently degrade to in-session.
+    writeConfig({ craft: { llm: { mode: 'in-session' } } });
+    process.env.HARNESS_CRAFT_LLM = 'ghost-backend';
+    expect(() => resolveCraftLlmConfig({ projectRoot: tmp })).toThrow(
+      /HARNESS_CRAFT_LLM="ghost-backend".*not found in agent\.backends/
+    );
+  });
+
+  it('does NOT silently fall back to in-session for a missing named backend (issue #896)', () => {
+    writeConfig({
+      agent: {
+        executor: 'subprocess',
+        timeout: 300000,
+        backends: {
+          ollama: { type: 'local', endpoint: 'http://localhost:11434/v1', model: 'qwen3' },
+        },
+      },
+    });
+    // Names a backend that exists in neither the env nor agent.backends.
+    process.env.HARNESS_CRAFT_LLM = 'typo-backend';
+    expect(() => resolveCraftLlmConfig({ projectRoot: tmp })).toThrow(
+      /not found in agent\.backends/
+    );
+  });
+
   it('env HARNESS_CRAFT_LLM=mock wins over config-file backend', () => {
     writeConfig({
       agent: {


### PR DESCRIPTION
## Summary
The craft skills (`copy-craft`, `spec-craft`, `security-craft`, `naming-craft`) could return `findings: []` / `count: 0` for reasons unrelated to the code being clean, and nothing in the output distinguished "analyzed N items, found nothing" from "analyzed nothing." A user reasonably read the empty result as a passing grade when no analysis actually ran.

This adds a single shared diagnostic surface (not four copies) so every craft summary states WHY a result is empty, and turns one silent-degradation path into an explicit error.

## Debugging (harness:debugging)
- **Root cause:** the empty/zero result carried no diagnostic about why it was empty. Two shared gaps in `packages/cli/src/shared/craft/llm/provider.ts` and the four command summaries:
  1. `HARNESS_CRAFT_LLM=<name>` naming a backend absent from `agent.backends` silently fell through to `in-session` instead of erroring.
  2. The resolved provider/mode and files-scanned-vs-skipped were never surfaced, so an unsupported-language project (0 analyzable TS/JS files) looked identical to a clean pass.
- **Fix:**
  - `resolveCraftLlmConfig` now throws `HARNESS_CRAFT_LLM="<name>" names backend "<name>" which was not found in agent.backends...` instead of degrading to in-session (issue mode 3).
  - New shared `packages/cli/src/shared/craft/diagnostics.ts` (`describeCraftResolution` + `formatCraftDiagnostic`) emits one line: the resolved provider/mode plus `analyzed N <unit>, skipped M (<reason>)`, or `0 analyzable <unit> (<reason>)` when nothing was analyzable (modes 1 & 2).
  - Wired into all four craft command summaries. `naming-craft` gained a `filesScanned` count in its summary (and run-state meta for the in-session two-step) so it too reports "0 analyzable files."
- **Verified end-to-end:** Python-only project → `Diagnostic: provider=mock; 0 analyzable files (no source files for supported languages (.ts, .tsx, .js, .jsx))`; TS project → `analyzed 1 files, skipped 0`; missing named backend → explicit `naming-craft failed: HARNESS_CRAFT_LLM="ghost-backend" ... not found in agent.backends`.

## Regression tests
- `packages/cli/tests/shared/craft/llm-provider.test.ts` — named-backend-not-found now throws (verified: FAILS when the fix is reverted to the old fall-through, PASSES with it).
- `packages/cli/tests/shared/craft/diagnostics.test.ts` — diagnostic names the resolved provider/mode; distinguishes "0 analyzable files" from "analyzed N, 0 findings".
- `packages/cli/tests/naming-craft/integration.test.ts` — an all-unsupported-language (Python) project reports `summary.filesScanned === 0`.

## Notes
- Scope: the shared diagnostic is wired into all four CLI craft command summaries (text mode). JSON output and the MCP in-session tool responses were left unchanged to keep the change focused; extending the diagnostic there is a natural follow-up.

Fixes #896