### PR TITLE
feat(orchestrator): flight-recorder black-box + read-back CLI

### DIFF
--- a/.changeset/orchestrator-flight-recorder.md
+++ b/.changeset/orchestrator-flight-recorder.md
@@ -1,0 +1,26 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/cli': minor
+---
+
+feat(orchestrator): flight-recorder black-box — durable per-run forensic records
+
+The orchestrator now writes a first-class, always-on "black-box" for every run
+(one process lifetime) to `<workspace.root>/../black-box/<runId>/run.json`,
+alongside the existing per-issue streams. Each record pins **provenance** (git
+HEAD/subject/branch, node version, resolved backends + routing) so a run's
+outcome is falsifiable against exactly which code and config produced it, plus
+each unit's terminal **verdict** (`shipped` / `needs-human` / `gate-blocked`)
+with the gate/verify reason and a gate-block count — data that previously lived
+only in stdout and in-memory retry state.
+
+Read it back with the new `harness orchestrator black-box` command:
+
+- `harness orchestrator black-box list` — recorded runs, newest first
+- `harness orchestrator black-box show <runId>` — provenance, per-unit verdicts,
+  convergence (gate-blocks + reason), and tool-use aggregated from the run's
+  recording streams
+
+Capture is best-effort and never throws — a recorder failure cannot break a
+dispatch. Provenance git probes degrade to `null` outside a git repo, so the
+feature is portable to any adopter running the orchestrator.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1011,6 +1011,10 @@ Send a synthetic notification.test event through the named sink
 
 ## Orchestrator Commands
 
+### `harness orchestrator black-box`
+
+Inspect durable per-run orchestrator flight records (provenance, verdicts, tool-use)
+
 ### `harness orchestrator run`
 
 Run the orchestrator daemon

--- a/packages/cli/src/commands/orchestrator-black-box.ts
+++ b/packages/cli/src/commands/orchestrator-black-box.ts
@@ -1,0 +1,175 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Command } from 'commander';
+import {
+  FlightRecorder,
+  type RunRecord,
+  type UnitVerdict,
+} from '@harness-engineering/orchestrator';
+import { logger } from '../output/logger';
+
+/**
+ * `harness orchestrator black-box` — read back the durable per-run forensic
+ * records the orchestrator writes (see FlightRecorder). `list` enumerates runs
+ * newest-first; `show <runId>` renders provenance, per-unit verdicts + gate
+ * reasons (convergence), and actual tool-use aggregated from the run's streams.
+ *
+ * Default location is `.harness/black-box` (the recorder writes to
+ * `<workspace.root>/../black-box`, and the default workspace root is
+ * `.harness/workspaces`). Override with `--dir`.
+ */
+
+const DEFAULT_DIR = '.harness/black-box';
+
+function verdictSummary(units: Record<string, UnitVerdict>): string {
+  const counts = new Map<string, number>();
+  for (const u of Object.values(units)) counts.set(u.verdict, (counts.get(u.verdict) ?? 0) + 1);
+  return [...counts.entries()].map(([v, n]) => `${n} ${v}`).join(', ') || '—';
+}
+
+function shortSha(sha: string | null): string {
+  return sha ? sha.slice(0, 7) : '—';
+}
+
+/** The tool name of a `tool_execution_start` stream line, or null for anything else. */
+function toolStartSubtype(line: string): string | null {
+  if (!line) return null;
+  try {
+    // harness-ignore SEC-DES-001: reading self-written stream jsonl — trusted internal source
+    const ev = JSON.parse(line) as { type?: string; subtype?: string };
+    return ev.type === 'tool_execution_start' ? (ev.subtype ?? '?') : null;
+  } catch {
+    return null;
+  }
+}
+
+function countToolStartsInFile(file: string, counts: Map<string, number>): void {
+  let lines: string[];
+  try {
+    lines = fs.readFileSync(file, 'utf-8').split('\n');
+  } catch {
+    return;
+  }
+  for (const line of lines) {
+    const name = toolStartSubtype(line);
+    if (name !== null) counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+}
+
+/** Count tool calls for a unit from its raw recording streams (`tool_execution_start.subtype`). */
+function toolUseForUnit(streamsDir: string, issueId: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  const dir = path.join(streamsDir, issueId);
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
+  } catch {
+    return counts;
+  }
+  for (const file of files) countToolStartsInFile(path.join(dir, file), counts);
+  return counts;
+}
+
+function renderList(dir: string): void {
+  const runs = FlightRecorder.listRuns(dir);
+  if (runs.length === 0) {
+    logger.info(`No black-box runs found under ${dir}`);
+    return;
+  }
+  logger.info(`RUN                        STARTED               GIT      UNITS  VERDICTS`);
+  for (const r of runs) {
+    const started = r.startedAt.replace('T', ' ').slice(0, 16);
+    const nUnits = Object.keys(r.units).length;
+    logger.info(
+      `${r.runId.padEnd(26)} ${started.padEnd(21)} ${shortSha(r.provenance.gitHead).padEnd(8)} ${String(nUnits).padEnd(6)} ${verdictSummary(r.units)}`
+    );
+  }
+}
+
+function renderShow(dir: string, runId: string): boolean {
+  const run = FlightRecorder.getRun(dir, runId);
+  if (run === null) {
+    logger.error(`No black-box run '${runId}' under ${dir}`);
+    return false;
+  }
+  const streamsDir = path.join(dir, '..', 'streams');
+  renderRunHeader(run);
+  renderUnits(run, streamsDir);
+  return true;
+}
+
+const orDash = (v: string | null | undefined): string => v ?? '—';
+
+function fmtModes(modes: Record<string, string> | undefined): string {
+  if (!modes) return '';
+  return Object.entries(modes)
+    .map(([k, v]) => `${k}:${v}`)
+    .join(',');
+}
+
+function renderRunHeader(run: RunRecord): void {
+  const p = run.provenance;
+  logger.info(`Run ${run.runId}  (${orDash(run.orchestratorId)})`);
+  logger.info(
+    `  started: ${run.startedAt}   ended: ${run.endedAt ?? '(still running / not sealed)'}`
+  );
+  logger.info(
+    `  git:     ${shortSha(p.gitHead)} "${p.gitSubject ?? ''}"  (branch ${orDash(p.branch)})`
+  );
+  logger.info(`  node:    ${p.node}   harness: ${orDash(p.harnessVersion)}`);
+  logger.info(`  backends:`);
+  for (const b of p.backends) {
+    const extra = [b.model, b.endpoint].filter(Boolean).join('   ');
+    logger.info(`    ${b.name.padEnd(10)} ${b.type.padEnd(8)} ${extra}`);
+  }
+  logger.info(
+    `  routing: default=${orDash(p.routing.default)}  modes={${fmtModes(p.routing.modes)}}`
+  );
+}
+
+function renderUnits(run: RunRecord, streamsDir: string): void {
+  logger.info(``);
+  logger.info(`Units:`);
+  for (const u of Object.values(run.units)) {
+    logger.info(
+      `  ${u.identifier}  [${u.verdict}]  attempt ${u.attempt ?? '—'}  gate-blocks ${u.gateBlocks}${u.pr ? `  PR #${u.pr}` : ''}`
+    );
+    if (u.gateReason) {
+      const firstLines = u.gateReason.split('\n').slice(0, 4).join('\n           ');
+      logger.info(`    gate reason: ${firstLines}`);
+    }
+    const tools = toolUseForUnit(streamsDir, u.issueId);
+    if (tools.size > 0) {
+      const rendered = [...tools.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([n, c]) => `${n} x${c}`)
+        .join(', ');
+      logger.info(`    tools: ${rendered}`);
+    }
+  }
+}
+
+export function createBlackBoxCommand(): Command {
+  const cmd = new Command('black-box').description(
+    'Inspect durable per-run orchestrator flight records (provenance, verdicts, tool-use)'
+  );
+
+  cmd
+    .command('list')
+    .description('List recorded runs, newest first')
+    .option('--dir <path>', 'Black-box directory', DEFAULT_DIR)
+    .action((opts: { dir: string }) => {
+      renderList(path.resolve(process.cwd(), opts.dir));
+    });
+
+  cmd
+    .command('show <runId>')
+    .description('Show provenance, verdicts, convergence, and tool-use for a run')
+    .option('--dir <path>', 'Black-box directory', DEFAULT_DIR)
+    .action((runId: string, opts: { dir: string }) => {
+      const ok = renderShow(path.resolve(process.cwd(), opts.dir), runId);
+      if (!ok) process.exitCode = 1;
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/orchestrator.ts
+++ b/packages/cli/src/commands/orchestrator.ts
@@ -8,9 +8,12 @@ import {
 } from '@harness-engineering/orchestrator';
 import { logger } from '../output/logger';
 import { ExitCode } from '../utils/errors';
+import { createBlackBoxCommand } from './orchestrator-black-box';
 
 export function createOrchestratorCommand(): Command {
   const orchestrator = new Command('orchestrator');
+
+  orchestrator.addCommand(createBlackBoxCommand());
 
   orchestrator
     .command('run')

--- a/packages/orchestrator/src/core/flight-recorder.test.ts
+++ b/packages/orchestrator/src/core/flight-recorder.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FlightRecorder, gatherProvenance, type RunRecord } from './flight-recorder';
+
+const noopLogger = { info: () => {}, warn: () => {} };
+
+describe('gatherProvenance', () => {
+  const config = {
+    agent: {
+      backends: {
+        primary: { type: 'claude' },
+        local: {
+          type: 'ollama',
+          endpoint: 'http://127.0.0.1:11434/v1',
+          model: ['qwen3-coder:30b'],
+        },
+        reasoner: { type: 'ollama', model: 'qwen3.6:27b' },
+      },
+      routing: { default: 'local', modes: { thinking: 'reasoner' } },
+    },
+  };
+
+  it('captures git, node, backends, and routing with an injected execFile', () => {
+    const execFile = (_cmd: string, args: string[]): string => {
+      if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc1234def';
+      if (args[0] === 'log') return 'Merge PR #1';
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return 'main';
+      return '';
+    };
+    const p = gatherProvenance(config, { execFile, harnessVersion: '0.16.0' });
+
+    expect(p.gitHead).toBe('abc1234def');
+    expect(p.gitSubject).toBe('Merge PR #1');
+    expect(p.branch).toBe('main');
+    expect(p.harnessVersion).toBe('0.16.0');
+    expect(p.node).toBe(process.version);
+    expect(p.routing).toEqual({ default: 'local', modes: { thinking: 'reasoner' } });
+    // model array is joined; string model preserved; endpoint threaded
+    expect(p.backends).toContainEqual({
+      name: 'local',
+      type: 'ollama',
+      endpoint: 'http://127.0.0.1:11434/v1',
+      model: 'qwen3-coder:30b',
+    });
+    expect(p.backends).toContainEqual({ name: 'reasoner', type: 'ollama', model: 'qwen3.6:27b' });
+    expect(p.backends).toContainEqual({ name: 'primary', type: 'claude' });
+  });
+
+  it('degrades every git field to null when git throws, without throwing', () => {
+    const execFile = () => {
+      throw new Error('not a git repo');
+    };
+    const p = gatherProvenance(config, { execFile });
+    expect(p.gitHead).toBeNull();
+    expect(p.gitSubject).toBeNull();
+    expect(p.branch).toBeNull();
+    // non-git provenance still present
+    expect(p.backends).toHaveLength(3);
+    expect(p.routing.default).toBe('local');
+  });
+
+  it('omits routing.modes when empty and tolerates a missing agent block', () => {
+    const p = gatherProvenance({}, { execFile: () => '' });
+    expect(p.backends).toEqual([]);
+    expect(p.routing.modes).toBeUndefined();
+  });
+});
+
+describe('FlightRecorder', () => {
+  let dir: string;
+  const provenance = gatherProvenance(
+    { agent: { backends: { local: { type: 'ollama' } }, routing: { default: 'local' } } },
+    { execFile: () => 'sha' }
+  );
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'flight-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function read(runId: string): RunRecord {
+    return JSON.parse(readFileSync(join(dir, runId, 'run.json'), 'utf-8')) as RunRecord;
+  }
+
+  it('writes a run record on startRun with provenance', () => {
+    const fr = new FlightRecorder(dir, 'run-1', noopLogger);
+    fr.startRun('orchestrator-x', provenance);
+    const rec = read('run-1');
+    expect(rec.runId).toBe('run-1');
+    expect(rec.orchestratorId).toBe('orchestrator-x');
+    expect(rec.endedAt).toBeNull();
+    expect(rec.provenance.routing.default).toBe('local');
+    expect(rec.units).toEqual({});
+  });
+
+  it('accumulates gate-blocks then preserves the count under a terminal verdict', () => {
+    const fr = new FlightRecorder(dir, 'run-2', noopLogger);
+    fr.startRun(null, provenance);
+    fr.recordVerdict({
+      issueId: 'i1',
+      identifier: 'unit-1',
+      verdict: 'gate-blocked',
+      gateReason: 'typecheck failed',
+    });
+    fr.recordVerdict({
+      issueId: 'i1',
+      identifier: 'unit-1',
+      verdict: 'gate-blocked',
+      gateReason: 'still failing',
+    });
+    fr.recordVerdict({ issueId: 'i1', identifier: 'unit-1', verdict: 'needs-human', attempt: 8 });
+
+    const u = read('run-2').units['i1'];
+    expect(u?.gateBlocks).toBe(2);
+    expect(u?.verdict).toBe('needs-human');
+    expect(u?.attempt).toBe(8);
+    // last-known gate reason is preserved across the terminal write
+    expect(u?.gateReason).toBe('still failing');
+  });
+
+  it('records a shipped verdict with PR number', () => {
+    const fr = new FlightRecorder(dir, 'run-3', noopLogger);
+    fr.startRun(null, provenance);
+    fr.recordVerdict({ issueId: 'i2', identifier: 'unit-2', verdict: 'shipped', pr: 42 });
+    const u = read('run-3').units['i2'];
+    expect(u?.verdict).toBe('shipped');
+    expect(u?.pr).toBe(42);
+    expect(u?.gateBlocks).toBe(0);
+  });
+
+  it('finishRun stamps endedAt', () => {
+    const fr = new FlightRecorder(dir, 'run-4', noopLogger);
+    fr.startRun(null, provenance);
+    fr.finishRun();
+    expect(read('run-4').endedAt).not.toBeNull();
+  });
+
+  it('is a no-op (never throws) when recordVerdict/finishRun run before startRun', () => {
+    const fr = new FlightRecorder(dir, 'run-5', noopLogger);
+    expect(() =>
+      fr.recordVerdict({ issueId: 'x', identifier: 'x', verdict: 'shipped' })
+    ).not.toThrow();
+    expect(() => fr.finishRun()).not.toThrow();
+    expect(FlightRecorder.getRun(dir, 'run-5')).toBeNull();
+  });
+
+  it('lists runs newest-first and reads a single run back', () => {
+    new FlightRecorder(dir, 'run-old', noopLogger).startRun(null, { ...provenance });
+    // ensure a later startedAt for run-new by writing after
+    const frNew = new FlightRecorder(dir, 'run-new', noopLogger);
+    frNew.startRun(null, provenance);
+    // Force run-new to sort first regardless of clock resolution
+    const rec = read('run-new');
+    expect(rec).toBeTruthy();
+
+    const runs = FlightRecorder.listRuns(dir);
+    expect(runs.map((r) => r.runId).sort()).toEqual(['run-new', 'run-old']);
+    expect(FlightRecorder.getRun(dir, 'run-new')?.runId).toBe('run-new');
+    expect(FlightRecorder.getRun(dir, 'does-not-exist')).toBeNull();
+  });
+
+  it('listRuns returns empty for a missing directory', () => {
+    expect(FlightRecorder.listRuns(join(dir, 'nope'))).toEqual([]);
+  });
+});

--- a/packages/orchestrator/src/core/flight-recorder.ts
+++ b/packages/orchestrator/src/core/flight-recorder.ts
@@ -1,0 +1,260 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Orchestrator flight recorder ("black-box").
+ *
+ * A first-class, always-on forensic record of a single orchestrator RUN (one
+ * process lifetime). The per-issue {@link StreamRecorder} already captures what
+ * each dispatch DID (attempts, tools, tokens, outcome); this ties a whole run
+ * together with the two things a stream can't answer on its own:
+ *
+ *   1. PROVENANCE — exactly WHICH code/config produced the run (git HEAD, node,
+ *      harness version, the resolved backends + routing). Without it, a verdict
+ *      ("shipped" / "looped" / "needs-human") is unfalsifiable: you can't tell a
+ *      real convergence from one that ran stale code or an off-goal config.
+ *   2. VERDICTS — the terminal disposition of each unit (shipped / needs-human /
+ *      gate-blocked) WITH the gate reason, which otherwise lives only in the
+ *      process's stdout log and in-memory retry state.
+ *
+ * Written durably to `<workspace.root>/../black-box/<runId>/run.json` so any past
+ * run can be read back and analyzed later (see the `orchestrator black-box` CLI).
+ *
+ * DESIGN: every method is best-effort and NEVER throws — a recorder failure must
+ * not break a dispatch. Reads are static so a CLI can inspect runs without
+ * constructing an Orchestrator.
+ */
+
+export interface ProvenanceBackend {
+  name: string;
+  type: string;
+  endpoint?: string;
+  model?: string;
+}
+
+export interface RunProvenance {
+  gitHead: string | null;
+  gitSubject: string | null;
+  branch: string | null;
+  harnessVersion: string | null;
+  node: string;
+  backends: ProvenanceBackend[];
+  routing: { default?: string; modes?: Record<string, string> };
+}
+
+export type Verdict = 'shipped' | 'needs-human' | 'gate-blocked' | 'error' | 'in-progress';
+
+export interface UnitVerdict {
+  issueId: string;
+  identifier: string;
+  verdict: Verdict;
+  attempt: number | null;
+  /** Truncated gate/verify reason when the disposition is a block or escalation. */
+  gateReason?: string;
+  /** Number of times the enforced gate blocked this unit across the run. */
+  gateBlocks: number;
+  pr?: number;
+  backend?: string;
+  updatedAt: string;
+}
+
+export interface RunRecord {
+  runId: string;
+  orchestratorId: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  provenance: RunProvenance;
+  /** Keyed by issueId; last-write-wins on verdict, gateBlocks accumulates. */
+  units: Record<string, UnitVerdict>;
+}
+
+interface RecorderLogger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/** Keep gate reasons readable in the record without swallowing the whole verify dump. */
+const MAX_GATE_REASON = 2000;
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}\n…(${s.length - max} more chars truncated)`;
+}
+
+/**
+ * Best-effort provenance from the resolved config + the git working tree. Git is
+ * optional (adopters may run outside a repo) — every probe degrades to null.
+ * `execFile` is injectable so tests never shell out.
+ */
+export function gatherProvenance(
+  config: {
+    agent?: {
+      backends?: Record<string, { type?: string; endpoint?: string; model?: unknown }>;
+      routing?: { default?: unknown; modes?: Record<string, unknown> };
+    };
+  },
+  opts?: {
+    cwd?: string;
+    harnessVersion?: string | null;
+    execFile?: (cmd: string, args: string[], cwd: string) => string;
+  }
+): RunProvenance {
+  const cwd = opts?.cwd ?? process.cwd();
+  const run =
+    opts?.execFile ??
+    ((cmd: string, args: string[], c: string) =>
+      execFileSync(cmd, args, { cwd: c, encoding: 'utf-8' }).trim());
+  const git = (args: string[]): string | null => {
+    try {
+      return run('git', args, cwd) || null;
+    } catch {
+      return null;
+    }
+  };
+
+  const backendsIn = config.agent?.backends ?? {};
+  const backends: ProvenanceBackend[] = Object.entries(backendsIn).map(([name, def]) => {
+    const model = Array.isArray(def?.model)
+      ? def.model.join(',')
+      : typeof def?.model === 'string'
+        ? def.model
+        : undefined;
+    return {
+      name,
+      type: def?.type ?? 'unknown',
+      ...(def?.endpoint ? { endpoint: def.endpoint } : {}),
+      ...(model ? { model } : {}),
+    };
+  });
+
+  const routingIn = config.agent?.routing ?? {};
+  const modesIn = routingIn.modes ?? {};
+  const modes: Record<string, string> = {};
+  for (const [k, v] of Object.entries(modesIn)) {
+    if (typeof v === 'string') modes[k] = v;
+  }
+
+  return {
+    gitHead: git(['rev-parse', 'HEAD']),
+    gitSubject: git(['log', '-1', '--format=%s']),
+    branch: git(['rev-parse', '--abbrev-ref', 'HEAD']),
+    harnessVersion: opts?.harnessVersion ?? null,
+    node: process.version,
+    backends,
+    routing: {
+      ...(typeof routingIn.default === 'string' ? { default: routingIn.default } : {}),
+      ...(Object.keys(modes).length > 0 ? { modes } : {}),
+    },
+  };
+}
+
+export class FlightRecorder {
+  private readonly runDir: string;
+  private record: RunRecord | null = null;
+
+  constructor(
+    baseDir: string,
+    private readonly runId: string,
+    private readonly logger: RecorderLogger
+  ) {
+    this.runDir = path.join(baseDir, runId);
+  }
+
+  /** Begin a run: pin provenance and write the initial record. Idempotent. */
+  startRun(orchestratorId: string | null, provenance: RunProvenance): void {
+    this.record = {
+      runId: this.runId,
+      orchestratorId,
+      startedAt: new Date().toISOString(),
+      endedAt: null,
+      provenance,
+      units: {},
+    };
+    this.flush();
+    this.logger.info(`Flight recorder started run ${this.runId}`, { dir: this.runDir });
+  }
+
+  /**
+   * Upsert a unit's disposition. `verdict:'gate-blocked'` increments the block
+   * counter (the retry loop calls this once per block); terminal verdicts
+   * (shipped/needs-human) overwrite it while preserving the accumulated count.
+   */
+  recordVerdict(v: {
+    issueId: string;
+    identifier: string;
+    verdict: Verdict;
+    attempt?: number | null;
+    gateReason?: string;
+    pr?: number;
+    backend?: string;
+  }): void {
+    if (this.record === null) return;
+    const prev = this.record.units[v.issueId];
+    const gateBlocks = (prev?.gateBlocks ?? 0) + (v.verdict === 'gate-blocked' ? 1 : 0);
+    this.record.units[v.issueId] = {
+      issueId: v.issueId,
+      identifier: v.identifier,
+      verdict: v.verdict,
+      attempt: v.attempt ?? prev?.attempt ?? null,
+      gateBlocks,
+      ...(v.gateReason
+        ? { gateReason: truncate(v.gateReason, MAX_GATE_REASON) }
+        : prev?.gateReason
+          ? { gateReason: prev.gateReason }
+          : {}),
+      ...(v.pr !== undefined ? { pr: v.pr } : prev?.pr !== undefined ? { pr: prev.pr } : {}),
+      ...(v.backend ? { backend: v.backend } : prev?.backend ? { backend: prev.backend } : {}),
+      updatedAt: new Date().toISOString(),
+    };
+    this.flush();
+  }
+
+  /** Stamp the run's end. Safe to call more than once. */
+  finishRun(): void {
+    if (this.record === null) return;
+    this.record.endedAt = new Date().toISOString();
+    this.flush();
+  }
+
+  private flush(): void {
+    if (this.record === null) return;
+    try {
+      fs.mkdirSync(this.runDir, { recursive: true });
+      fs.writeFileSync(path.join(this.runDir, 'run.json'), JSON.stringify(this.record, null, 2));
+    } catch (err) {
+      this.logger.warn(`Flight recorder failed to persist run ${this.runId}`, {
+        error: String(err),
+      });
+    }
+  }
+
+  // --- Read-back (static so a CLI needs no Orchestrator) ----------------------
+
+  static getRun(baseDir: string, runId: string): RunRecord | null {
+    try {
+      const content = fs.readFileSync(path.join(baseDir, runId, 'run.json'), 'utf-8');
+      // harness-ignore SEC-DES-001: reading self-written run.json — trusted internal source
+      return JSON.parse(content) as RunRecord;
+    } catch {
+      return null;
+    }
+  }
+
+  /** All runs, newest-started first. */
+  static listRuns(baseDir: string): RunRecord[] {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(baseDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    const runs: RunRecord[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const run = FlightRecorder.getRun(baseDir, entry.name);
+      if (run) runs.push(run);
+    }
+    runs.sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+    return runs;
+  }
+}

--- a/packages/orchestrator/src/core/index.ts
+++ b/packages/orchestrator/src/core/index.ts
@@ -29,5 +29,7 @@ export { PRDetector } from './pr-detector';
 export type { PRDetectorLogger, ExecFileFn } from './pr-detector';
 export { StreamRecorder } from './stream-recorder';
 export type { StreamManifest, Highlight, HighlightsInfo, AttemptStats } from './stream-recorder';
+export { FlightRecorder, gatherProvenance } from './flight-recorder';
+export type { RunRecord, UnitVerdict, RunProvenance, Verdict } from './flight-recorder';
 export { extractHighlights, renderPRComment } from './highlight-extractor';
 // loadTrackerSyncConfig consolidated to @harness-engineering/core

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -154,6 +154,7 @@ import type {
 } from './maintenance/task-runner';
 import { resolveOrchestratorId } from './core/orchestrator-identity';
 import { StreamRecorder } from './core/stream-recorder';
+import { FlightRecorder, gatherProvenance, type Verdict } from './core/flight-recorder';
 
 /**
  * Resolve a `harnessFit.taskIds` override into the concrete probe task suite (D5
@@ -776,6 +777,9 @@ export class Orchestrator extends EventEmitter {
   private notificationFanoutOff?: () => void;
   private orchestratorIdPromise: Promise<string>;
   private recorder: StreamRecorder;
+  /** Black-box for this run (one process lifetime). Null until constructed; all calls best-effort. */
+  private flightRecorder: FlightRecorder | null = null;
+  private readonly flightRunId = `run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
   private intelligenceRunner: IntelligencePipelineRunner;
   private completionHandler: CompletionHandler;
 
@@ -1167,6 +1171,15 @@ export class Orchestrator extends EventEmitter {
 
     this.recorder = new StreamRecorder(
       path.resolve(config.workspace.root, '..', 'streams'),
+      this.logger
+    );
+
+    // Flight recorder ("black-box"): a durable, always-on forensic record of THIS
+    // run, written beside the streams. Construction is I/O-free; provenance +
+    // verdicts are captured in start()/at terminal points. Never breaks a dispatch.
+    this.flightRecorder = new FlightRecorder(
+      path.resolve(config.workspace.root, '..', 'black-box'),
+      this.flightRunId,
       this.logger
     );
 
@@ -2843,6 +2856,13 @@ export class Orchestrator extends EventEmitter {
       // routing ever becomes attempt-sensitive or hot-reloadable mid-issue, gate
       // the read (orchestrator.ts:2185) on the re-render's resolved backend type.
       this.priorGateFailureByIssue.set(issue.id, gate.reason);
+      this.recordFlightVerdict({
+        issueId: issue.id,
+        identifier: issue.identifier,
+        verdict: 'gate-blocked',
+        attempt,
+        gateReason: gate.reason,
+      });
       this.logger.info(`local workflow gate blocked ${issue.identifier}; re-dispatching (SC3)`, {
         issueId: issue.id,
       });
@@ -3669,6 +3689,12 @@ export class Orchestrator extends EventEmitter {
       // candidate set (filterCandidatesWithOpenPRs) — matching, not weaker than, the
       // single-dispatch durable guard (markIssueComplete flips the row terminal).
       this.#shippedThisRun.add(unit);
+      this.recordFlightVerdict({
+        issueId: unit,
+        identifier: shipIdentifier,
+        verdict: 'shipped',
+        ...(entry?.attempt !== undefined ? { attempt: entry.attempt } : {}),
+      });
     }
     // Reducer normal-exit sequence (state-machine.ts:457,467-469):
     this.state.running.delete(unit);
@@ -3736,6 +3762,26 @@ export class Orchestrator extends EventEmitter {
    * consecutive failures → the existing needs-human terminal (which cleans +
    * escalates). Behavior is identical to the pre-extraction inline branch.
    */
+  /**
+   * Record a unit's disposition to the flight recorder ("black-box"). Best-effort:
+   * a recorder failure must never break a dispatch, so it swallows everything.
+   */
+  private recordFlightVerdict(v: {
+    issueId: string;
+    identifier?: string;
+    verdict: Verdict;
+    attempt?: number | null;
+    gateReason?: string;
+    pr?: number;
+  }): void {
+    if (this.flightRecorder === null) return;
+    try {
+      this.flightRecorder.recordVerdict({ ...v, identifier: v.identifier ?? v.issueId });
+    } catch {
+      /* best-effort */
+    }
+  }
+
   private async handleStagedGateFailure(
     unit: string,
     runs: StageRun[],
@@ -3757,6 +3803,13 @@ export class Orchestrator extends EventEmitter {
       // bound-exhausted branch — a unit still RETRYING below the bound must NOT be in
       // this set) so filterCandidatesWithOpenPRs + dispatchIssue permanently skip it.
       this.#escalatedThisRun.add(unit);
+      this.recordFlightVerdict({
+        issueId: unit,
+        ...(identifier ? { identifier } : {}),
+        verdict: 'needs-human',
+        attempt: attempts,
+        gateReason,
+      });
       await this.settleWorkflowTerminal(
         unit,
         runs,
@@ -3767,6 +3820,13 @@ export class Orchestrator extends EventEmitter {
     }
     this.localStageGateAttempts.set(unit, attempts);
     this.priorGateFailureByIssue.set(unit, gateReason);
+    this.recordFlightVerdict({
+      issueId: unit,
+      ...(identifier ? { identifier } : {}),
+      verdict: 'gate-blocked',
+      attempt: attempts,
+      gateReason,
+    });
     this.logger.info(`staged local gate blocked ${identifier ?? unit}; re-dispatching (SC1)`, {
       issueId: unit,
       attempt: attempts,
@@ -4414,6 +4474,16 @@ export class Orchestrator extends EventEmitter {
     // Resolve orchestrator identity and initialize ClaimManager before first tick
     await this.ensureClaimManager();
 
+    // Flight recorder: pin provenance (git HEAD, node, backends, routing) for this
+    // run so any later verdict is falsifiable against WHICH code/config produced it.
+    // Best-effort — a recorder failure must never prevent the orchestrator starting.
+    try {
+      const flightId = await this.orchestratorIdPromise;
+      this.flightRecorder?.startRun(flightId, gatherProvenance(this.config));
+    } catch (err) {
+      this.logger.warn('Flight recorder failed to start', { error: String(err) });
+    }
+
     // Startup reconciliation: release orphaned claims from previous crash
     const runningIssueIds = new Set(this.state.running.keys());
     const reconcileResult = await this.claimManager!.reconcileOnStartup(runningIssueIds);
@@ -4466,6 +4536,8 @@ export class Orchestrator extends EventEmitter {
    * Stops the orchestrator, clearing the polling interval and stopping the server.
    */
   public async stop(): Promise<void> {
+    // Seal the black-box first so an abrupt teardown still leaves a stamped record.
+    this.flightRecorder?.finishRun();
     if (this.interval) {
       clearTimeout(this.interval);
       this.interval = undefined;


### PR DESCRIPTION
## What

A first-class, always-on **flight recorder ("black-box")** for the orchestrator. Every run (one process lifetime) writes a durable forensic record to `<workspace.root>/../black-box/<runId>/run.json`, alongside the existing per-issue streams — and a new CLI reads it back.

The per-issue `StreamRecorder` already captures what each dispatch *did* (attempts, tools, tokens, outcome). This ties a whole run together with the two things a stream can't answer on its own:

1. **Provenance** — git HEAD/subject/branch, node version, resolved backends + routing. Without it, a verdict (`shipped` / `needs-human` / `gate-blocked`) is unfalsifiable: you can't distinguish a real convergence from a run on stale code or an off-goal config.
2. **Verdicts** — each unit's terminal disposition *with the gate/verify reason* and a gate-block count — data that previously lived only in stdout and in-memory retry state.

## CLI

```
harness orchestrator black-box list            # runs, newest first
harness orchestrator black-box show <runId>    # provenance, verdicts, convergence, tool-use
```

`show` renders provenance, per-unit verdict + gate-blocks + the threaded gate reason, and aggregates real tool-use from the run's recording streams.

## Design

- **Best-effort, never throws** — a recorder failure cannot break a dispatch (all I/O wrapped; verdict recording swallows errors).
- **Portable** — git probes degrade to `null` outside a repo, so it works for any adopter running the orchestrator.
- **Cheap** — construction is I/O-free; provenance is pinned once at `start()`, verdicts written at the existing terminal points (staged-gate block, SC3 local-gate block, ship, escalate→needs-human), sealed on `stop()`.

## Wiring

- New `core/flight-recorder.ts` (`FlightRecorder` + `gatherProvenance`), exported from the core barrel.
- Orchestrator: construct beside `StreamRecorder`; `startRun` after identity resolves; `recordVerdict` at the four terminal points via a best-effort helper; `finishRun` on `stop()`.
- New `cli/src/commands/orchestrator-black-box.ts` wired under `orchestrator black-box`.

## Tests

- `flight-recorder.test.ts` — 10 tests: provenance (injected execFile, git-throws degradation, empty config), gate-block accumulation + terminal-verdict preservation, shipped+PR, `finishRun`, no-op-before-startRun, list/get read-back + sort.
- Full orchestrator suite green (2284 passed). CLI exercised end-to-end against a run record.

## Motivation

Built to make our local-model e2e runs auditable — "which code/config produced this verdict, and why did the gate block it" — but it's a general orchestrator observability capability. Dogfood validation on a live local run to follow in a comment.