### PR TITLE
fix(orchestrator): thread prior gate failure into staged retry prompts (staged-local convergence)

### DIFF
--- a/.changeset/staged-gate-feedback.md
+++ b/.changeset/staged-gate-feedback.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): thread the prior gate failure into staged retry prompts (staged-local convergence)
+
+On a staged workflow retry after a gate block, the executor was never told _why_
+the previous attempt failed. The single-agent dispatch path appends the gate/verify
+reason to its prompt, but the staged path renders fresh per-stage prompts via
+`renderStagePrompt` and dropped it — so on every retry the model got the identical
+task with no feedback and reproduced the same failure (e.g. passing tests while a
+`tsc` narrowing error kept the gate red). `buildWorkflowContext` now threads
+`priorGateFailure` into every stage prompt as a "fix this first" preamble that also
+reminds the model the gate runs typecheck + lint + tests, not tests alone. This is
+what lets the staged local retry loop actually converge.

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2457,6 +2457,14 @@ export class Orchestrator extends EventEmitter {
           ...(workflowMatch.stageDeadlineMs !== undefined
             ? { stageDeadlineMs: workflowMatch.stageDeadlineMs }
             : {}),
+          // On a staged retry after a gate block, thread the prior gate/verify
+          // reason into the per-stage prompts. The single-agent path does this at
+          // orchestrator.ts:2597, but the staged path renders fresh stage prompts
+          // and would otherwise DROP it — leaving the executor blind to why the
+          // last attempt was blocked (root cause of staged-local non-convergence).
+          ...(this.priorGateFailureByIssue.get(issue.id) !== undefined
+            ? { priorGateFailure: this.priorGateFailureByIssue.get(issue.id)! }
+            : {}),
           // staged-verify-gate-convergence (blocking fix): thread THIS dispatch's
           // `workspacePath` + `issue` into the settle callbacks. On a staged RETRY
           // re-dispatch the tick does NOT recreate the running entry (retry_fired →

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -108,6 +108,16 @@ export interface BuildWorkflowContextDeps {
   backends?: Record<string, BackendDef>;
   /** D12 override; absent ⇒ engine default DEFAULT_STAGE_DEADLINE_MS. */
   stageDeadlineMs?: number;
+  /**
+   * On a staged RE-dispatch after a gate block, the prior attempt's gate/verify
+   * reason (the `tsc`/lint/test failure). The single-agent path threads this into
+   * its dispatch prompt (orchestrator.ts:2597), but the staged path renders fresh
+   * per-stage prompts and would otherwise DROP it — leaving the executor blind to
+   * why the last attempt was blocked, so it reproduces the same failure every
+   * retry. Threaded into every stage prompt as a "fix this first" preamble so the
+   * staged retry loop actually converges. Absent on the first attempt.
+   */
+  priorGateFailure?: string;
   /** Terminal-success seam (Task 6/7): bound to `settleWorkflowSuccess`. */
   settleSuccess: (unit: string, runs: StageRun[]) => Promise<void>;
   /** Terminal-failure/safety-net seam (Task 6/7): bound to `settleWorkflowTerminal`. */
@@ -235,12 +245,22 @@ function stageDecisionFactory(
   };
 }
 
+/**
+ * The re-prompt preamble appended to a staged stage's prompt when the prior
+ * attempt was gate-blocked. Kept template-agnostic (appended post-render) to
+ * mirror the single-agent path (orchestrator.ts:2597) and dodge strictVariables.
+ */
+function gateFailurePreamble(reason: string): string {
+  return `\n\n## Previous attempt failed the enforced gate\n\nYour prior attempt at this task was blocked by the harness gate and re-dispatched. The gate runs typecheck + lint + tests on the changed packages — passing tests alone is NOT enough. Fix the following before finishing this stage:\n\n${reason}\n`;
+}
+
 /** Build the engine's `renderStagePrompt` seam over a pure renderer + issue. */
 function renderStagePromptFactory(
   promptRenderer: PromptRenderer,
-  issue: Issue
+  issue: Issue,
+  priorGateFailure?: string
 ): NonNullable<WorkflowEngineContext['renderStagePrompt']> {
-  return (step, index, priorOutputs, isLocalBackend) => {
+  return async (step, index, priorOutputs, isLocalBackend) => {
     const priorEntries = Object.entries(priorOutputs).map(([name, output]) => ({
       name,
       output,
@@ -248,20 +268,26 @@ function renderStagePromptFactory(
     // Per-phase routing: pick the LOCAL-indirection template for a local-endpoint
     // routed backend, else the byte-identical default (SC-LOCAL/SC3). The variable
     // bag is identical for both templates (strictVariables — no new required var).
-    return promptRenderer.render(selectStagePromptTemplate(isLocalBackend ?? false), {
-      stageNumber: index + 1,
-      identifier: issue.identifier,
-      title: issue.title,
-      description: issue.description ?? '',
-      skill: step.skill,
-      cognitiveMode: step.cognitiveMode ?? '',
-      // SC5: the stage's declared output label, threaded into BOTH templates so the
-      // model is driven to PRODUCE it (not "run then stop"). Default to '' so
-      // strictVariables is satisfied and exactOptionalPropertyTypes never sees an
-      // explicit undefined.
-      produces: step.produces ?? '',
-      priorEntries,
-    });
+    const rendered = await promptRenderer.render(
+      selectStagePromptTemplate(isLocalBackend ?? false),
+      {
+        stageNumber: index + 1,
+        identifier: issue.identifier,
+        title: issue.title,
+        description: issue.description ?? '',
+        skill: step.skill,
+        cognitiveMode: step.cognitiveMode ?? '',
+        // SC5: the stage's declared output label, threaded into BOTH templates so the
+        // model is driven to PRODUCE it (not "run then stop"). Default to '' so
+        // strictVariables is satisfied and exactOptionalPropertyTypes never sees an
+        // explicit undefined.
+        produces: step.produces ?? '',
+        priorEntries,
+      }
+    );
+    // On a retry, append the prior gate failure so the executor targets the exact
+    // error (the staged path otherwise drops it — the root cause of non-convergence).
+    return priorGateFailure ? rendered + gateFailurePreamble(priorGateFailure) : rendered;
   };
 }
 
@@ -332,7 +358,9 @@ export function buildWorkflowContext(deps: BuildWorkflowContextDeps): WorkflowEn
 
     // split-routing 4b: render the real per-stage prompt (issue + stage role +
     // prior-stage outputs) via the pure PromptRenderer — no orchestrator import.
-    renderStagePrompt: renderStagePromptFactory(promptRenderer, issue),
+    // The prior gate failure (on a retry) is appended so the executor sees the
+    // exact error to fix instead of re-deriving the same blocked attempt.
+    renderStagePrompt: renderStagePromptFactory(promptRenderer, issue, deps.priorGateFailure),
 
     // per-phase routing: resolve a routed backend's locality so the renderer
     // selects the local-indirection template for local-endpoint stages. Absent

--- a/packages/orchestrator/tests/workflow/orchestrator-context.test.ts
+++ b/packages/orchestrator/tests/workflow/orchestrator-context.test.ts
@@ -400,3 +400,35 @@ describe('terminal seams — single exit (SC5)', () => {
     expect(fake.state.claimed.has('issue-1')).toBe(false);
   });
 });
+
+describe('renderStagePrompt — prior gate-failure re-prompt (staged convergence)', () => {
+  const priorOutputs: Record<string, string> = {};
+
+  it('appends the gate-failure preamble (with the reason) on a retry', async () => {
+    const reason =
+      "verify failed:\nsrc/rules/no-empty-describe.ts(37,24): error TS2339: Property 'body' does not exist";
+    const ctx = buildWorkflowContext(baseDeps({ priorGateFailure: reason }));
+    const prompt = await ctx.renderStagePrompt!(step, 0, priorOutputs, true);
+    // The real stage instructions must still be present (guards against the render
+    // Promise being concatenated as "[object Promise]" — i.e. an un-awaited render).
+    expect(prompt).not.toContain('[object Promise]');
+    expect(prompt).toContain('REV-42');
+    expect(prompt).toContain('Previous attempt failed the enforced gate');
+    expect(prompt).toContain('typecheck + lint + tests');
+    expect(prompt).toContain('error TS2339');
+  });
+
+  it('omits the preamble entirely on the first attempt (no prior failure)', async () => {
+    const ctx = buildWorkflowContext(baseDeps());
+    const prompt = await ctx.renderStagePrompt!(step, 0, priorOutputs, true);
+    expect(prompt).not.toContain('Previous attempt failed the enforced gate');
+  });
+
+  it('threads the preamble into EVERY stage, not just the first (executor is a later stage)', async () => {
+    const ctx = buildWorkflowContext(baseDeps({ priorGateFailure: 'lint failed: no-unused-vars' }));
+    const execStage: WorkflowStep = { skill: 'harness-execution', produces: 'diff' };
+    const prompt = await ctx.renderStagePrompt!(execStage, 2, priorOutputs, true);
+    expect(prompt).toContain('Previous attempt failed the enforced gate');
+    expect(prompt).toContain('lint failed: no-unused-vars');
+  });
+});


### PR DESCRIPTION
## The bug

On a staged-workflow retry after a gate block, **the executor was never told why the previous attempt failed.**

The single-agent dispatch path appends the gate/verify reason to its prompt (`orchestrator.ts:2597`). But the staged path renders **fresh per-stage prompts** via `renderStagePrompt` (`orchestrator-context.ts`) from a fixed variable bag that had no gate-failure field — so the reason was silently dropped. Every retry handed the model the identical task with zero feedback.

## Why it matters (observed)

In a fully-local staged run building an ESLint rule, the executor (qwen3-coder:30b) passed the plugin's tests on every attempt but the gate stayed red on a `tsc` type-narrowing error (`TS2339`). Because the tsc error never reached the execution stage, the model kept validating with `pnpm test` (green), **never ran typecheck**, and reproduced the identical error across **5+ gate-blocks** — never converging. It wasn't incapable; it was blind.

## The fix

`buildWorkflowContext` now threads `priorGateFailure` into **every** stage prompt as a "fix this first" preamble, which also reminds the model the gate runs **typecheck + lint + tests** (passing tests alone is not enough). This is the missing feedback edge that lets a staged local retry loop actually converge.

- `BuildWorkflowContextDeps.priorGateFailure?: string`, sourced from `priorGateFailureByIssue` at the staged dispatch site.
- `renderStagePromptFactory` appends the preamble post-render (template-agnostic, mirrors the single-agent path; dodges LiquidJS `strictVariables`).
- Fixed an un-awaited `render()` (it returns a `Promise`) caught in review — with a test assertion guarding against `[object Promise]`.

## Tests

3 new tests in `orchestrator-context.test.ts`: preamble appended with the reason on a retry, omitted on the first attempt, and threaded into a later (execution) stage — plus a guard that the real stage instructions survive. Full context suite green (18).

## Next

Re-running the **same** qwen3-coder that couldn't converge, now with this feedback, to demonstrate the first fully-local staged **ship**. Result to follow.