### PR TITLE
feat(analyses): consume guardian diff-coverage findings in outcome_eval + pre-merge-brief + code-review (Fixes #914)

### DIFF
--- a/.changeset/consume-guardian-diff-coverage.md
+++ b/.changeset/consume-guardian-diff-coverage.md
@@ -1,5 +1,6 @@
 ---
 '@harness-engineering/intelligence': patch
+'@harness-engineering/core': patch
 '@harness-engineering/cli': patch
 ---
 
@@ -8,8 +9,17 @@ feat(analyses): consume guardian diff-coverage findings from `.harness/analyses/
 Define a harness-owned, tolerant, advisory `GuardianAnalysis` contract
 (`schema: harness.guardian.diff-coverage`) plus a degrade-safe reader that lists
 `.harness/analyses/`, selects guardian records by discriminator, validates with
-zod, and skips unknown/malformed shapes without ever throwing. Wire it into two
-consumers: `outcome_eval` folds the guardian signal into the verdict rationale
-(never affects TS-derived authority), and `pre-merge-brief` surfaces a Guardian
-diff-coverage section and adds flagged records to "Worth your eyes". A missing or
-empty archive leaves both consumers byte-identical to today.
+zod, and skips unknown/malformed shapes without ever throwing. Wire it into three
+review consumers:
+
+- `outcome_eval` folds the guardian signal into the verdict rationale (never
+  affects TS-derived authority).
+- `pre-merge-brief` surfaces a Guardian diff-coverage section and adds flagged
+  records to "Worth your eyes".
+- `harness-code-review` (the 7-phase `runReviewPipeline`) surfaces the guardian
+  summary as an advisory context file on every review bundle the agents receive.
+  Read caller-side at the CLI layer (`run_code_review` MCP tool + `agent review`
+  command) and passed in as plain data, so `@harness-engineering/core` never
+  depends on `@harness-engineering/intelligence`.
+
+A missing/empty/malformed archive leaves every consumer byte-identical to today.

--- a/.changeset/consume-guardian-diff-coverage.md
+++ b/.changeset/consume-guardian-diff-coverage.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/intelligence': patch
+'@harness-engineering/cli': patch
+---
+
+feat(analyses): consume guardian diff-coverage findings from `.harness/analyses/` (#914)
+
+Define a harness-owned, tolerant, advisory `GuardianAnalysis` contract
+(`schema: harness.guardian.diff-coverage`) plus a degrade-safe reader that lists
+`.harness/analyses/`, selects guardian records by discriminator, validates with
+zod, and skips unknown/malformed shapes without ever throwing. Wire it into two
+consumers: `outcome_eval` folds the guardian signal into the verdict rationale
+(never affects TS-derived authority), and `pre-merge-brief` surfaces a Guardian
+diff-coverage section and adds flagged records to "Worth your eyes". A missing or
+empty archive leaves both consumers byte-identical to today.

--- a/packages/cli/src/commands/agent/review.ts
+++ b/packages/cli/src/commands/agent/review.ts
@@ -7,6 +7,7 @@ import { resolveConfig } from '../../config/loader';
 import { OutputMode, type OutputModeType } from '../../output/formatter';
 import { logger } from '../../output/logger';
 import { CLIError, ExitCode } from '../../utils/errors';
+import { loadGuardianCoverage } from '../../utils/guardian-context';
 
 interface ReviewOptions {
   configPath?: string;
@@ -81,6 +82,10 @@ export async function runAgentReview(options: ReviewOptions): Promise<
     fileDiffs: new Map(codeChanges.files.map((f) => [f.path, ''])),
   };
 
+  // Advisory guardian diff-coverage input (#914): read + render from the
+  // project's .harness/analyses/ archive; undefined when absent (degrade-safe).
+  const guardianCoverage = await loadGuardianCoverage(config.rootDir);
+
   // Run the unified pipeline
   const pipelineResult = await runReviewPipeline({
     projectRoot: config.rootDir,
@@ -95,6 +100,7 @@ export async function runAgentReview(options: ReviewOptions): Promise<
       ...(options.isolated ? { isolated: true } : {}),
     },
     config: config as unknown as Record<string, unknown>,
+    ...(guardianCoverage != null ? { guardianCoverage } : {}),
   });
 
   return Ok({

--- a/packages/cli/src/commands/pre-merge-brief.ts
+++ b/packages/cli/src/commands/pre-merge-brief.ts
@@ -7,7 +7,13 @@ import { GraphStore } from '@harness-engineering/graph';
 import type { NodeType } from '@harness-engineering/graph';
 import { gatherSignals } from '@harness-engineering/signals';
 import type { SignalResult, SignalsResult } from '@harness-engineering/signals';
-import type { OutcomeVerdict } from '@harness-engineering/intelligence';
+import type { OutcomeVerdict, GuardianAnalysis } from '@harness-engineering/intelligence';
+import {
+  readGuardianAnalyses,
+  summarizeGuardian,
+  guardianFlags,
+  guardianFileLines,
+} from '@harness-engineering/intelligence';
 import { buildDiffInfo, resolveDiffRange, type RunGit } from './review-ci';
 
 /** Hidden HTML marker used to find + upsert the sticky comment. */
@@ -23,6 +29,12 @@ export interface BriefInputs {
   signals?: SignalResult[] | undefined;
   /** Outcome-eval verdict for the head commit; undefined = "not yet evaluated". */
   outcome?: OutcomeVerdict | undefined;
+  /**
+   * Advisory guardian diff-coverage records from `.harness/analyses/` (#914).
+   * Empty/undefined degrades the section to "unavailable"; a flagged record
+   * (fail / error-severity) additionally contributes to "Worth your eyes".
+   */
+  guardian?: GuardianAnalysis[] | undefined;
 }
 
 /** Standard degradation line for an input that could not be gathered. */
@@ -123,10 +135,30 @@ function renderOutcomeEval(outcome?: OutcomeVerdict): string[] {
 }
 
 /**
+ * Render the **Guardian diff-coverage** section from advisory records in
+ * `.harness/analyses/` (#914). Degrades to an "unavailable" line when no
+ * guardian record is present — a missing/empty archive never errors and never
+ * changes the rest of the brief.
+ */
+function renderGuardian(guardian?: GuardianAnalysis[]): string[] {
+  const out: string[] = ['## Guardian diff-coverage', ''];
+  if (!guardian || guardian.length === 0) {
+    out.push(UNAVAILABLE);
+    return out;
+  }
+  out.push(summarizeGuardian(guardian) ?? UNAVAILABLE);
+  const fileLines = guardianFileLines(guardian);
+  if (fileLines.length > 0) {
+    out.push('', ...fileLines.map((l) => `- \`${l}\``));
+  }
+  return out;
+}
+
+/**
  * Derive the **"👀 Worth your eyes"** section: EXACTLY the union of (a) review
- * blocking findings, (b) signals with status `warn` or `alert`, and (c) unmet
- * outcome criteria — no more, no fewer. Renders "nothing flagged" when the
- * union is empty.
+ * blocking findings, (b) signals with status `warn` or `alert`, (c) unmet
+ * outcome criteria, and (d) flagged guardian diff-coverage records — no more,
+ * no fewer. Renders "nothing flagged" when the union is empty.
  */
 /**
  * Collect the "Worth your eyes" bullets: the union of (a) review blocking
@@ -152,8 +184,20 @@ function unmetBullets(inputs: BriefInputs): string[] {
   return unmet.map((c) => `- 🎯 ${c}`);
 }
 
+/** One bullet per FLAGGED guardian record (fail / error-severity). */
+function guardianBullets(inputs: BriefInputs): string[] {
+  return (inputs.guardian ?? [])
+    .filter(guardianFlags)
+    .map((g) => `- 🛡️ ${summarizeGuardian([g]) ?? 'Guardian diff-coverage flagged.'}`);
+}
+
 function collectWorthYourEyesBullets(inputs: BriefInputs): string[] {
-  return [...blockingBullets(inputs), ...signalBullets(inputs), ...unmetBullets(inputs)];
+  return [
+    ...blockingBullets(inputs),
+    ...signalBullets(inputs),
+    ...unmetBullets(inputs),
+    ...guardianBullets(inputs),
+  ];
 }
 
 function deriveWorthYourEyes(inputs: BriefInputs): string[] {
@@ -185,6 +229,8 @@ export function buildBriefBody(inputs: BriefInputs): string {
     ...renderSignalStatus(inputs.signals),
     '',
     ...renderOutcomeEval(inputs.outcome),
+    '',
+    ...renderGuardian(inputs.guardian),
     '',
     ...deriveWorthYourEyes(inputs),
   ];
@@ -317,6 +363,27 @@ export async function gatherSignalsSafe(
   }
 }
 
+/** Injected guardian-read seam. Defaults to the real `readGuardianAnalyses`. */
+export type ReadGuardian = (analysesDir: string) => Promise<GuardianAnalysis[]>;
+
+/**
+ * Read advisory guardian diff-coverage records from `<cwd>/.harness/analyses`,
+ * degrading to `[]` (never throwing) when the archive is absent or the read
+ * rejects — the Guardian section then renders "unavailable" and nothing else in
+ * the brief changes. `readGuardianAnalyses` is already tolerant; this wrapper
+ * only guards against an unexpected reject from an injected seam.
+ */
+export async function gatherGuardianSafe(
+  cwd: string,
+  read: ReadGuardian = readGuardianAnalyses
+): Promise<GuardianAnalysis[]> {
+  try {
+    return await read(join(cwd, '.harness', 'analyses'));
+  } catch {
+    return [];
+  }
+}
+
 /** The minimal graph-store surface the outcome lookup needs. */
 export interface OutcomeStore {
   findNodes(query: { type: NodeType }): Array<{ metadata: Record<string, unknown> }>;
@@ -403,6 +470,8 @@ export interface PreMergeBriefOptions {
   resolveRaw?: (range: string, cwd: string, runGit: RunGit) => string;
   readFile?: ReadFile;
   gather?: GatherSignals;
+  /** Injected guardian-read seam (default: real tolerant reader). */
+  readGuardian?: ReadGuardian;
   store?: OutcomeStore | undefined;
   postBrief?: PostBrief;
   log?: (message: string) => void;
@@ -439,8 +508,9 @@ export async function runPreMergeBrief(opts: PreMergeBriefOptions): Promise<{ bo
   const review = readReview(opts.from, opts.readFile);
   const signals = await gatherSignalsSafe(cwd, opts.gather);
   const outcome = findOutcomeVerdict(opts.store, opts.headSha);
+  const guardian = await gatherGuardianSafe(cwd, opts.readGuardian);
 
-  const body = buildBriefBody({ diff, review, signals, outcome });
+  const body = buildBriefBody({ diff, review, signals, outcome, guardian });
 
   const log = opts.log ?? ((m: string) => process.stdout.write(m + '\n'));
   if (opts.comment) {

--- a/packages/cli/src/mcp/tools/outcome-eval.ts
+++ b/packages/cli/src/mcp/tools/outcome-eval.ts
@@ -19,6 +19,9 @@
  * Source: docs/changes/outcome-eval/proposal.md (Surface area -> MCP tool).
  */
 
+import * as path from 'node:path';
+import { readGuardianAnalyses } from '@harness-engineering/intelligence';
+import type { GuardianAnalysis } from '@harness-engineering/intelligence';
 import { sanitizePath } from '../utils/sanitize-path.js';
 import { loadGraphStore } from '../utils/graph-loader.js';
 
@@ -130,7 +133,12 @@ function validateInput(input: OutcomeEvalToolInput): string | null {
  * produces INCONCLUSIVE/advisory and authority stays TS-derived.
  */
 async function buildEvaluator(input: OutcomeEvalToolInput): Promise<{
-  evaluate: (i: { specPath: string; diff: string; testOutput: string }) => Promise<unknown>;
+  evaluate: (i: {
+    specPath: string;
+    diff: string;
+    testOutput: string;
+    guardian?: GuardianAnalysis[];
+  }) => Promise<unknown>;
 }> {
   const projectRoot = sanitizePath(input.path ?? process.cwd());
   const { OutcomeEvaluator } = await import('@harness-engineering/intelligence');
@@ -145,16 +153,33 @@ async function buildEvaluator(input: OutcomeEvalToolInput): Promise<{
   );
 }
 
+/**
+ * Best-effort read of advisory guardian diff-coverage records from the
+ * project's `.harness/analyses/` archive (#914). Degrade-safe: any failure (and
+ * the common absent-archive case) yields `[]`, so the verdict stays
+ * byte-identical to no guardian wiring.
+ */
+async function loadGuardian(input: OutcomeEvalToolInput): Promise<GuardianAnalysis[]> {
+  try {
+    const projectRoot = sanitizePath(input.path ?? process.cwd());
+    return await readGuardianAnalyses(path.join(projectRoot, '.harness', 'analyses'));
+  } catch {
+    return [];
+  }
+}
+
 export async function handleOutcomeEval(input: OutcomeEvalToolInput): Promise<ToolResponse> {
   const validationError = validateInput(input);
   if (validationError !== null) return errorResponse(validationError);
 
   try {
     const evaluator = await buildEvaluator(input);
+    const guardian = await loadGuardian(input);
     const verdict = await evaluator.evaluate({
       specPath: input.specPath,
       diff: input.diff,
       testOutput: input.testOutput,
+      ...(guardian.length > 0 ? { guardian } : {}),
     });
 
     // Return the verdict EXACTLY as the evaluator produced it — authority is

--- a/packages/cli/src/mcp/tools/review-pipeline.ts
+++ b/packages/cli/src/mcp/tools/review-pipeline.ts
@@ -1,6 +1,7 @@
 import { paginate } from '@harness-engineering/core';
 import { sanitizePath } from '../utils/sanitize-path.js';
 import { sortFindingsBySeverity } from '../utils/severity.js';
+import { loadGuardianCoverage } from '../../utils/guardian-context.js';
 
 // ============ run_code_review ============
 
@@ -111,6 +112,10 @@ export async function handleRunCodeReview(input: {
       ),
     };
 
+    // Advisory guardian diff-coverage input (#914): read + render from the
+    // project's .harness/analyses/ archive; undefined when absent (degrade-safe).
+    const guardianCoverage = await loadGuardianCoverage(projectRoot);
+
     const result = await runReviewPipeline({
       projectRoot,
       diff: diffInfo,
@@ -123,6 +128,7 @@ export async function handleRunCodeReview(input: {
         ...(input.depth != null ? { depth: input.depth } : {}),
       },
       ...(input.repo != null ? { repo: input.repo } : {}),
+      ...(guardianCoverage != null ? { guardianCoverage } : {}),
     });
 
     const sortedFindings = sortFindingsBySeverity(

--- a/packages/cli/src/utils/guardian-context.ts
+++ b/packages/cli/src/utils/guardian-context.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared CLI helper: read advisory guardian diff-coverage records from a
+ * project's `.harness/analyses/` archive and project them into a pre-rendered
+ * advisory block for the code-review pipeline (#914, issue box 1 —
+ * harness-code-review consumer).
+ *
+ * This lives at the CLI layer on purpose: the review pipeline in
+ * `@harness-engineering/core` must not depend on `@harness-engineering/intelligence`
+ * (core is the lower layer). Mirroring how `domainAccuracy` is derived
+ * caller-side, the CLI reads + projects the guardian contract here and passes a
+ * plain string into `runReviewPipeline({ guardianCoverage })`.
+ *
+ * Degrade-safe: an absent/empty/malformed archive yields `undefined`, so the
+ * pipeline behaves byte-identically to today.
+ */
+
+import * as path from 'node:path';
+
+/**
+ * Read the project's guardian diff-coverage archive and render an advisory
+ * markdown block, or `undefined` when there is nothing to surface.
+ *
+ * Never throws: any read/parse failure (and the common absent-archive case)
+ * returns `undefined`.
+ *
+ * The intelligence package is imported dynamically (not statically) so pulling
+ * this helper into a CLI command does not eagerly load intelligence's heavy
+ * barrel — which transitively imports `child_process` for its CLI providers and
+ * would otherwise break test suites that partially mock `child_process`.
+ */
+export async function loadGuardianCoverage(projectRoot: string): Promise<string | undefined> {
+  try {
+    const { readGuardianAnalyses, summarizeGuardian, guardianFileLines } =
+      await import('@harness-engineering/intelligence');
+    const analyses = await readGuardianAnalyses(path.join(projectRoot, '.harness', 'analyses'));
+    const summary = summarizeGuardian(analyses);
+    if (!summary) return undefined; // no records → no signal
+    const fileLines = guardianFileLines(analyses);
+    const lines = ['## Guardian diff-coverage (advisory)', '', summary];
+    if (fileLines.length > 0) {
+      lines.push('', 'Uncovered changed lines:', ...fileLines.map((l) => `- ${l}`));
+    }
+    return lines.join('\n');
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/tests/commands/pre-merge-brief-guardian.test.ts
+++ b/packages/cli/tests/commands/pre-merge-brief-guardian.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import {
   GUARDIAN_ANALYSIS_SCHEMA,
@@ -8,6 +11,8 @@ import {
   BRIEF_MARKER,
   buildBriefBody,
   gatherGuardianSafe,
+  loadOutcomeStore,
+  readReview,
   runPreMergeBrief,
 } from '../../src/commands/pre-merge-brief';
 
@@ -106,5 +111,53 @@ describe('runPreMergeBrief guardian wiring', () => {
     });
     expect(res.body).toContain('## Guardian diff-coverage');
     expect(res.body).toContain('_unavailable / not configured._');
+  });
+
+  it('reads a real .harness/analyses archive via the DEFAULT reader seam', async () => {
+    // Drives the real default guardian read path (gatherGuardianSafe ->
+    // readGuardianAnalyses) and defaultResolveRaw (no resolveRaw override)
+    // against an on-disk archive, end-to-end, with only git stubbed.
+    const cwd = mkdtempSync(join(tmpdir(), 'pmb-guardian-'));
+    const analysesDir = join(cwd, '.harness', 'analyses');
+    mkdirSync(analysesDir, { recursive: true });
+    writeFileSync(join(analysesDir, 'g.json'), JSON.stringify(makeGuardian()), 'utf-8');
+
+    const res = await runPreMergeBrief({
+      cwd,
+      // Injected git returns a non-empty diff so the diff section renders and
+      // defaultResolveRaw (the un-overridden seam) is exercised.
+      runGit: (args: string[]) => (args[0] === 'diff' ? 'diff --git a/x b/x\n+line' : 'main'),
+      readFile: () => 'unused',
+      gather: async () => ({ signals: [], generatedAt: '2026-07-02T00:00:00Z' }),
+      store: undefined,
+      headSha: undefined,
+      from: undefined,
+      comment: false,
+      log: () => {},
+    });
+
+    expect(res.body).toContain('Guardian diff-coverage: FAIL');
+    expect(res.body).toContain('`src/a.ts: lines 10, 11`');
+  });
+});
+
+describe('loadOutcomeStore degradation', () => {
+  it('returns undefined when the project has no .harness/graph directory', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pmb-nograph-'));
+    await expect(loadOutcomeStore(cwd)).resolves.toBeUndefined();
+  });
+});
+
+describe('readReview default file-read seam', () => {
+  it('reads + parses a review-ci --json artifact from disk (default readFile)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pmb-review-'));
+    const p = join(dir, 'review.json');
+    writeFileSync(p, JSON.stringify({ verdict: { assessment: 'pass', runner: 'ci' } }), 'utf-8');
+    // No readFile injected → exercises the real defaultReadFile seam.
+    expect(readReview(p)?.assessment).toBe('pass');
+  });
+
+  it('degrades to undefined when the artifact path does not exist', () => {
+    expect(readReview(join(tmpdir(), 'nope-does-not-exist.json'))).toBeUndefined();
   });
 });

--- a/packages/cli/tests/commands/pre-merge-brief-guardian.test.ts
+++ b/packages/cli/tests/commands/pre-merge-brief-guardian.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GUARDIAN_ANALYSIS_SCHEMA,
+  GUARDIAN_ANALYSIS_VERSION,
+} from '@harness-engineering/intelligence';
+import type { GuardianAnalysis } from '@harness-engineering/intelligence';
+import {
+  BRIEF_MARKER,
+  buildBriefBody,
+  gatherGuardianSafe,
+  runPreMergeBrief,
+} from '../../src/commands/pre-merge-brief';
+
+function makeGuardian(over: Partial<GuardianAnalysis> = {}): GuardianAnalysis {
+  return {
+    schema: GUARDIAN_ANALYSIS_SCHEMA,
+    version: GUARDIAN_ANALYSIS_VERSION,
+    generatedAt: '2026-07-19T00:00:00.000Z',
+    verdict: 'fail',
+    severity: 'error',
+    coverageDelta: -4.2,
+    files: [{ file: 'src/a.ts', uncoveredLines: [10, 11] }],
+    summary: 'handler uncovered',
+    ...over,
+  };
+}
+
+describe('pre-merge-brief guardian section (buildBriefBody)', () => {
+  it('renders the Guardian diff-coverage section with summary + file lines when present', () => {
+    const body = buildBriefBody({ guardian: [makeGuardian()] });
+    expect(body).toContain('## Guardian diff-coverage');
+    expect(body).toContain('Guardian diff-coverage: FAIL');
+    expect(body).toContain('`src/a.ts: lines 10, 11`');
+  });
+
+  it('degrades the Guardian section to "unavailable" when no records are present', () => {
+    const body = buildBriefBody({ guardian: [] });
+    expect(body).toContain('## Guardian diff-coverage');
+    expect(body).toContain('_unavailable / not configured._');
+  });
+
+  it('adds a flagged guardian record to "Worth your eyes"', () => {
+    const body = buildBriefBody({ guardian: [makeGuardian({ verdict: 'fail' })] });
+    const worth = body.slice(body.indexOf('## 👀 Worth your eyes'));
+    expect(worth).toContain('🛡️');
+    expect(worth).toContain('Guardian diff-coverage: FAIL');
+  });
+
+  it('does NOT add a non-flagged (pass/info) guardian record to "Worth your eyes"', () => {
+    const body = buildBriefBody({
+      guardian: [makeGuardian({ verdict: 'pass', severity: 'info' })],
+    });
+    const worth = body.slice(body.indexOf('## 👀 Worth your eyes'));
+    expect(worth).toContain('_Nothing flagged');
+  });
+});
+
+describe('gatherGuardianSafe', () => {
+  it('degrades to [] when the injected reader rejects (never throws)', async () => {
+    const result = await gatherGuardianSafe('/proj', async () => {
+      throw new Error('disk error');
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('reads from <cwd>/.harness/analyses via the injected seam', async () => {
+    let seenDir = '';
+    const result = await gatherGuardianSafe('/proj', async (dir) => {
+      seenDir = dir;
+      return [makeGuardian()];
+    });
+    expect(seenDir.replace(/\\/g, '/')).toBe('/proj/.harness/analyses');
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('runPreMergeBrief guardian wiring', () => {
+  function baseOpts() {
+    return {
+      cwd: '/proj',
+      runGit: (_args: string[]) => '',
+      resolveRaw: () => 'diff --git a/x b/x\n+line',
+      readFile: () => 'unused',
+      gather: async () => ({ signals: [], generatedAt: '2026-07-02T00:00:00Z' }),
+      store: undefined,
+      headSha: undefined,
+      from: undefined,
+      comment: false,
+      log: () => {},
+    };
+  }
+
+  it('includes guardian findings in the brief when the reader returns records', async () => {
+    const res = await runPreMergeBrief({
+      ...baseOpts(),
+      readGuardian: async () => [makeGuardian()],
+    });
+    expect(res.body).toContain(BRIEF_MARKER);
+    expect(res.body).toContain('Guardian diff-coverage: FAIL');
+  });
+
+  it('degrades silently when the reader returns [] (absent archive)', async () => {
+    const res = await runPreMergeBrief({
+      ...baseOpts(),
+      readGuardian: async () => [],
+    });
+    expect(res.body).toContain('## Guardian diff-coverage');
+    expect(res.body).toContain('_unavailable / not configured._');
+  });
+});

--- a/packages/cli/tests/mcp/tools/outcome-eval.test.ts
+++ b/packages/cli/tests/mcp/tools/outcome-eval.test.ts
@@ -101,6 +101,50 @@ describe('handleOutcomeEval degrade-safe behaviour', () => {
     expect(Array.isArray(verdict.unmetCriteria)).toBe(true);
   });
 
+  it('surfaces guardian diff-coverage records from .harness/analyses/ in the rationale', async () => {
+    const specPath = path.join(tmpDir, 'spec.md');
+    await fs.writeFile(specPath, '# Spec\n\n## Success Criteria\n\n- Does a thing.\n');
+    // Drop a valid guardian record into the project's analyses archive.
+    const analysesDir = path.join(tmpDir, '.harness', 'analyses');
+    await fs.mkdir(analysesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(analysesDir, 'guardian-1.json'),
+      JSON.stringify({
+        schema: 'harness.guardian.diff-coverage',
+        version: 1,
+        generatedAt: '2026-07-19T00:00:00.000Z',
+        verdict: 'fail',
+        severity: 'error',
+        coverageDelta: -3.1,
+        files: [{ file: 'src/x.ts', uncoveredLines: [1, 2] }],
+      })
+    );
+
+    const result = await handleOutcomeEval({
+      specPath,
+      diff: 'diff --git a/x b/x\n+added',
+      testOutput: 'PASS',
+      path: tmpDir,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result).rationale).toContain('Guardian diff-coverage: FAIL');
+  });
+
+  it('leaves the rationale free of guardian text when the archive is absent', async () => {
+    const specPath = path.join(tmpDir, 'spec.md');
+    await fs.writeFile(specPath, '# Spec\n\n## Success Criteria\n\n- Does a thing.\n');
+
+    const result = await handleOutcomeEval({
+      specPath,
+      diff: 'd',
+      testOutput: 'PASS',
+      path: tmpDir,
+    });
+
+    expect(parseResult(result).rationale).not.toContain('Guardian diff-coverage');
+  });
+
   it('returns the full OutcomeVerdict shape', async () => {
     const specPath = path.join(tmpDir, 'spec.md');
     await fs.writeFile(specPath, '# Spec\n\n## Success Criteria\n\n- Does a thing.\n');

--- a/packages/cli/tests/utils/guardian-context.test.ts
+++ b/packages/cli/tests/utils/guardian-context.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import {
+  GUARDIAN_ANALYSIS_SCHEMA,
+  GUARDIAN_ANALYSIS_VERSION,
+} from '@harness-engineering/intelligence';
+import { loadGuardianCoverage } from '../../src/utils/guardian-context';
+
+function projectWithGuardian(record: unknown): string {
+  const root = mkdtempSync(join(tmpdir(), 'guardian-ctx-'));
+  const dir = join(root, '.harness', 'analyses');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'g.json'), JSON.stringify(record), 'utf-8');
+  return root;
+}
+
+const VALID_RECORD = {
+  schema: GUARDIAN_ANALYSIS_SCHEMA,
+  version: GUARDIAN_ANALYSIS_VERSION,
+  generatedAt: '2026-07-19T00:00:00.000Z',
+  verdict: 'fail',
+  severity: 'error',
+  coverageDelta: -4.2,
+  files: [{ file: 'src/foo.ts', uncoveredLines: [1, 2] }],
+};
+
+describe('loadGuardianCoverage', () => {
+  it('renders an advisory block from a real .harness/analyses guardian record', async () => {
+    const root = projectWithGuardian(VALID_RECORD);
+    const block = await loadGuardianCoverage(root);
+    expect(block).toBeDefined();
+    expect(block).toContain('## Guardian diff-coverage (advisory)');
+    expect(block).toContain('Guardian diff-coverage: FAIL');
+    expect(block).toContain('- src/foo.ts: lines 1, 2');
+  });
+
+  it('returns undefined when the archive is absent (degrade-safe)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'guardian-ctx-empty-'));
+    await expect(loadGuardianCoverage(root)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when the archive holds only non-guardian records', async () => {
+    // An intelligence-pipeline AnalysisRecord shares the dir but is not guardian.
+    const root = projectWithGuardian({
+      issueId: '42',
+      identifier: 'PROJ-42',
+      analyzedAt: '2026-07-19T00:00:00.000Z',
+      spec: null,
+      score: null,
+      simulation: null,
+      externalId: null,
+    });
+    await expect(loadGuardianCoverage(root)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/review/index.ts
+++ b/packages/core/src/review/index.ts
@@ -138,7 +138,7 @@ export {
 } from './constants';
 
 // Pipeline orchestrator
-export { runReviewPipeline } from './pipeline-orchestrator';
+export { runReviewPipeline, attachGuardianCoverage } from './pipeline-orchestrator';
 export type { RunPipelineOptions } from './pipeline-orchestrator';
 
 // Parallel-group scheduling (reusable beyond review)

--- a/packages/core/src/review/pipeline-orchestrator.ts
+++ b/packages/core/src/review/pipeline-orchestrator.ts
@@ -12,6 +12,7 @@ import type {
   CommitHistoryEntry,
   EvidenceCoverageReport,
   ContextBundle,
+  ContextFile,
   Rubric,
   ReviewDomain,
 } from './types';
@@ -56,12 +57,47 @@ export interface RunPipelineOptions {
   /** Session slug for loading evidence entries (optional) */
   sessionSlug?: string;
   /**
+   * Advisory guardian diff-coverage summary (#914), pre-rendered by the caller
+   * from `.harness/analyses/` guardian records (via the intelligence package's
+   * `readGuardianAnalyses` + summary projections — mirrors how `domainAccuracy`
+   * is derived caller-side so core never depends on intelligence). When present,
+   * it is surfaced as an advisory context file on every review bundle so agents
+   * can weigh uncovered changed lines. Absent/empty leaves bundles
+   * byte-identical to today. Never blocks the pipeline.
+   */
+  guardianCoverage?: string;
+  /**
    * Per-domain accuracy overrides for trust scoring (optional).
    * When provided, replaces the static DOMAIN_BASELINES for the historical
    * accuracy factor. Callers can derive these from PersonaEffectiveness
    * scores in the intelligence package.
    */
   domainAccuracy?: Partial<Record<ReviewDomain, number>>;
+}
+
+/**
+ * Attach an advisory guardian diff-coverage context file to every bundle (#914).
+ *
+ * Mirrors the `checkDepsOutput` precedent: a synthetic, project-relative-less
+ * context file (`reason: 'convention'`) carrying the pre-rendered guardian
+ * summary. Advisory + degrade-safe by construction — the caller only invokes
+ * this when `guardianCoverage` is a non-empty string, so an absent/empty archive
+ * leaves the bundles untouched. Pure; returns new bundle objects.
+ */
+export function attachGuardianCoverage(
+  bundles: ContextBundle[],
+  guardianCoverage: string
+): ContextBundle[] {
+  const guardianFile: ContextFile = {
+    path: 'harness-guardian-diff-coverage',
+    content: guardianCoverage,
+    lines: guardianCoverage.split('\n').length,
+    reason: 'convention',
+  };
+  return bundles.map((b) => ({
+    ...b,
+    contextFiles: [...b.contextFiles, guardianFile],
+  }));
 }
 
 /**
@@ -91,6 +127,7 @@ export async function runReviewPipeline(
     commitHistory,
     sessionSlug,
     domainAccuracy,
+    guardianCoverage,
   } = options;
 
   // --- Phase 1: GATE ---
@@ -210,6 +247,12 @@ export async function runReviewPipeline(
   // Attach rubric to every bundle so agents can reference it.
   if (rubric) {
     contextBundles = contextBundles.map((b) => ({ ...b, rubric }));
+  }
+
+  // Attach advisory guardian diff-coverage (#914) to every bundle. Guarded on a
+  // non-empty string so an absent/empty archive leaves bundles byte-identical.
+  if (guardianCoverage) {
+    contextBundles = attachGuardianCoverage(contextBundles, guardianCoverage);
   }
 
   // --- Phase 3.5: CALIBRATE DEPTH ---

--- a/packages/core/tests/review/guardian-coverage.test.ts
+++ b/packages/core/tests/review/guardian-coverage.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runReviewPipeline, attachGuardianCoverage } from '../../src/review/pipeline-orchestrator';
+import { fanOutReview, fanOutConditionalSubagents } from '../../src/review/fan-out';
+import type { ContextBundle, DiffInfo, PipelineFlags } from '../../src/review/types';
+
+// Capture the bundles that reach the review agents so we can assert whether the
+// advisory guardian diff-coverage context file was threaded into them.
+vi.mock('../../src/review/fan-out', () => ({
+  fanOutReview: vi.fn(async () => []),
+  fanOutConditionalSubagents: vi.fn(async () => []),
+}));
+
+const DIFF: DiffInfo = {
+  changedFiles: ['src/foo.ts'],
+  newFiles: [],
+  deletedFiles: [],
+  totalDiffLines: 10,
+  fileDiffs: new Map([['src/foo.ts', '+const x = 1;']]),
+};
+
+// noMechanical skips the mechanical phase so the test stays hermetic (no tool spawn).
+const FLAGS: PipelineFlags = { comment: false, ci: false, deep: false, noMechanical: true };
+
+const GUARDIAN_BLOCK = [
+  '## Guardian diff-coverage (advisory)',
+  '',
+  'Guardian diff-coverage: FAIL — 1 record(s), 1 file(s) with uncovered diff lines, worst coverage delta -4.2%.',
+  '',
+  'Uncovered changed lines:',
+  '- src/foo.ts: lines 1, 2',
+].join('\n');
+
+function bundlesSeenByAgents(): ContextBundle[] {
+  const call = vi.mocked(fanOutReview).mock.calls[0];
+  return (call![0] as { bundles: ContextBundle[] }).bundles;
+}
+
+function guardianFileOn(bundle: ContextBundle) {
+  return bundle.contextFiles.find((f) => f.path === 'harness-guardian-diff-coverage');
+}
+
+describe('attachGuardianCoverage (pure)', () => {
+  const bundles: ContextBundle[] = [
+    {
+      domain: 'bug',
+      changeType: 'feature',
+      changedFiles: [],
+      contextFiles: [],
+      commitHistory: [],
+      diffLines: 1,
+      contextLines: 0,
+    },
+  ];
+
+  it('adds one guardian advisory context file to every bundle', () => {
+    const out = attachGuardianCoverage(bundles, GUARDIAN_BLOCK);
+    const file = guardianFileOn(out[0]!);
+    expect(file).toBeDefined();
+    expect(file!.content).toBe(GUARDIAN_BLOCK);
+    expect(file!.reason).toBe('convention');
+    expect(file!.lines).toBe(GUARDIAN_BLOCK.split('\n').length);
+  });
+
+  it('does not mutate the input bundles (pure)', () => {
+    attachGuardianCoverage(bundles, GUARDIAN_BLOCK);
+    expect(bundles[0]!.contextFiles).toEqual([]);
+  });
+});
+
+describe('runReviewPipeline guardian wiring', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('surfaces the guardian advisory in the context bundles the agents receive', async () => {
+    await runReviewPipeline({
+      projectRoot: '/tmp/does-not-matter',
+      diff: DIFF,
+      commitMessage: 'feat: x',
+      flags: FLAGS,
+      guardianCoverage: GUARDIAN_BLOCK,
+    });
+
+    const bundles = bundlesSeenByAgents();
+    expect(bundles.length).toBeGreaterThan(0);
+    // EVERY bundle carries the guardian advisory as a review input.
+    for (const b of bundles) {
+      const file = guardianFileOn(b);
+      expect(file).toBeDefined();
+      expect(file!.content).toContain('Guardian diff-coverage: FAIL');
+    }
+  });
+
+  it('leaves bundles byte-identical (no guardian file) when guardianCoverage is absent', async () => {
+    await runReviewPipeline({
+      projectRoot: '/tmp/does-not-matter',
+      diff: DIFF,
+      commitMessage: 'feat: x',
+      flags: FLAGS,
+    });
+
+    const bundles = bundlesSeenByAgents();
+    expect(bundles.length).toBeGreaterThan(0);
+    for (const b of bundles) {
+      expect(guardianFileOn(b)).toBeUndefined();
+    }
+  });
+});

--- a/packages/intelligence/src/guardian/index.ts
+++ b/packages/intelligence/src/guardian/index.ts
@@ -1,0 +1,12 @@
+// guardian — harness-owned, tolerant, advisory diff-coverage contract read from
+// the `.harness/analyses/` archive (issue #914).
+export { GUARDIAN_ANALYSIS_SCHEMA, GUARDIAN_ANALYSIS_VERSION } from './types.js';
+export type {
+  GuardianAnalysis,
+  GuardianFileCoverage,
+  GuardianVerdict,
+  GuardianSeverity,
+} from './types.js';
+export { guardianAnalysisSchema } from './schema.js';
+export { readGuardianAnalyses } from './reader.js';
+export { summarizeGuardian, guardianFlags, guardianFileLines } from './summary.js';

--- a/packages/intelligence/src/guardian/reader.ts
+++ b/packages/intelligence/src/guardian/reader.ts
@@ -1,0 +1,63 @@
+/**
+ * Tolerant reader for guardian diff-coverage records in `.harness/analyses/`.
+ *
+ * Contract (issue #914): NEVER throw and NEVER change consumer behavior when the
+ * archive is absent, empty, or full of foreign/malformed records. The reader
+ * lists the directory, parses each JSON file best-effort, selects guardian
+ * records by the `schema` discriminator, validates them with zod, and skips
+ * anything that does not validate. The result is advisory input only.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { guardianAnalysisSchema } from './schema.js';
+import type { GuardianAnalysis } from './types.js';
+
+/**
+ * Read every valid guardian diff-coverage record from `analysesDir`
+ * (conventionally `<projectRoot>/.harness/analyses`).
+ *
+ * Degrade-safe: a missing directory yields `[]`; a file that is unreadable, is
+ * not JSON, or is not a valid guardian record is skipped. Order follows
+ * directory listing and is not otherwise guaranteed.
+ */
+export async function readGuardianAnalyses(analysesDir: string): Promise<GuardianAnalysis[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(analysesDir);
+  } catch {
+    // Absent directory (ENOENT) or any listing error → no guardian input.
+    return [];
+  }
+
+  const out: GuardianAnalysis[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const record = await tryReadGuardianRecord(path.join(analysesDir, entry));
+    if (record) out.push(record);
+  }
+  return out;
+}
+
+/** Read + parse + validate a single file, returning null on any failure. */
+async function tryReadGuardianRecord(filePath: string): Promise<GuardianAnalysis | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  // Discriminator + shape are both enforced by the schema (the `schema`/
+  // `version` literals). A non-guardian record (e.g. an intelligence
+  // AnalysisRecord) fails the literal check and is skipped silently.
+  const result = guardianAnalysisSchema.safeParse(parsed);
+  return result.success ? (result.data as GuardianAnalysis) : null;
+}

--- a/packages/intelligence/src/guardian/schema.ts
+++ b/packages/intelligence/src/guardian/schema.ts
@@ -1,0 +1,35 @@
+/**
+ * Zod validation for the {@link GuardianAnalysis} contract. Used by the tolerant
+ * reader to accept only well-formed guardian diff-coverage records and skip
+ * everything else (foreign shapes, malformed JSON, intelligence records).
+ */
+
+import { z } from 'zod';
+import { GUARDIAN_ANALYSIS_SCHEMA, GUARDIAN_ANALYSIS_VERSION } from './types.js';
+
+/** `[startLine, endLine]` inclusive uncovered range. */
+const regionSchema = z.tuple([z.number().int().nonnegative(), z.number().int().nonnegative()]);
+
+const fileCoverageSchema = z.object({
+  file: z.string().min(1),
+  uncoveredLines: z.array(z.number().int().nonnegative()),
+  uncoveredRegions: z.array(regionSchema).optional(),
+});
+
+/**
+ * Strict-enough schema for a guardian diff-coverage record. The `schema` and
+ * `version` literals are the discriminator — a record failing them is not a
+ * guardian record and is silently skipped by the reader. Unknown extra keys are
+ * stripped (not rejected) so a forward-compatible producer that adds fields does
+ * not get dropped wholesale.
+ */
+export const guardianAnalysisSchema = z.object({
+  schema: z.literal(GUARDIAN_ANALYSIS_SCHEMA),
+  version: z.literal(GUARDIAN_ANALYSIS_VERSION),
+  generatedAt: z.string().min(1),
+  verdict: z.enum(['pass', 'fail']),
+  severity: z.enum(['info', 'warn', 'error']),
+  coverageDelta: z.number(),
+  files: z.array(fileCoverageSchema),
+  summary: z.string().optional(),
+});

--- a/packages/intelligence/src/guardian/summary.ts
+++ b/packages/intelligence/src/guardian/summary.ts
@@ -1,0 +1,72 @@
+/**
+ * Deterministic, LLM-free projections of guardian diff-coverage records into
+ * human/consumer-facing text. Kept pure so both `outcome_eval` (rationale
+ * annotation) and `pre-merge-brief` (review section) surface the SAME signal.
+ */
+
+import type { GuardianAnalysis, GuardianFileCoverage } from './types.js';
+
+/** A guardian record "flags" a change when it failed or is error-severity. */
+export function guardianFlags(a: GuardianAnalysis): boolean {
+  return a.verdict === 'fail' || a.severity === 'error';
+}
+
+/** Total distinct files carrying uncovered diff lines across all records. */
+function totalUncoveredFiles(analyses: GuardianAnalysis[]): number {
+  const files = new Set<string>();
+  for (const a of analyses) {
+    for (const f of a.files) {
+      if (f.uncoveredLines.length > 0 || (f.uncoveredRegions?.length ?? 0) > 0) files.add(f.file);
+    }
+  }
+  return files.size;
+}
+
+/** Worst (most negative) coverage delta across records, or null when none. */
+function worstCoverageDelta(analyses: GuardianAnalysis[]): number | null {
+  if (analyses.length === 0) return null;
+  return Math.min(...analyses.map((a) => a.coverageDelta));
+}
+
+/**
+ * One-line advisory summary of the guardian signal, or `null` when there is no
+ * guardian input at all (the "no signal" case — consumers must treat this as
+ * byte-identical to having no guardian wiring).
+ */
+export function summarizeGuardian(analyses: GuardianAnalysis[]): string | null {
+  if (analyses.length === 0) return null;
+  const flagged = analyses.some(guardianFlags);
+  const verdict = flagged ? 'FAIL' : 'PASS';
+  const fileCount = totalUncoveredFiles(analyses);
+  const delta = worstCoverageDelta(analyses);
+  const deltaStr = delta === null ? 'n/a' : `${delta > 0 ? '+' : ''}${delta}%`;
+  return (
+    `Guardian diff-coverage: ${verdict} — ${analyses.length} record(s), ` +
+    `${fileCount} file(s) with uncovered diff lines, worst coverage delta ${deltaStr}.`
+  );
+}
+
+/** Render a single file's uncovered lines/regions as a compact string. */
+function fileDetail(f: GuardianFileCoverage): string {
+  const parts: string[] = [];
+  if (f.uncoveredLines.length > 0) parts.push(`lines ${f.uncoveredLines.join(', ')}`);
+  for (const [start, end] of f.uncoveredRegions ?? []) parts.push(`${start}-${end}`);
+  const detail = parts.length > 0 ? parts.join('; ') : 'uncovered';
+  return `${f.file}: ${detail}`;
+}
+
+/**
+ * Per-file detail lines suitable for a review brief, most impactful producers
+ * first is not attempted — files are listed in record/declaration order.
+ */
+export function guardianFileLines(analyses: GuardianAnalysis[]): string[] {
+  const lines: string[] = [];
+  for (const a of analyses) {
+    for (const f of a.files) {
+      if (f.uncoveredLines.length > 0 || (f.uncoveredRegions?.length ?? 0) > 0) {
+        lines.push(fileDetail(f));
+      }
+    }
+  }
+  return lines;
+}

--- a/packages/intelligence/src/guardian/types.ts
+++ b/packages/intelligence/src/guardian/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Guardian diff-coverage analysis contract (issue #914, checkboxes 1 & 2).
+ *
+ * The `.harness/analyses/` archive is written by multiple producers. Alongside
+ * the intelligence-pipeline `AnalysisRecord` (spec/score/simulation), canary's
+ * PR guardian drops diff-coverage findings — but nothing on the harness side has
+ * ever READ them. This module defines the harness-OWNED, TOLERANT, ADVISORY
+ * contract for those guardian records so both `outcome_eval` and
+ * `pre-merge-brief` can consume them as a review input.
+ *
+ * Ownership + reconciliation: this shape is defined HERE (harness side) as the
+ * documented contract canary conforms to. It is intentionally self-describing
+ * (`schema` + `version` discriminator) and read TOLERANTLY — the reader selects
+ * guardian records by the discriminator and SKIPS anything it cannot validate,
+ * so an intelligence `AnalysisRecord`, a malformed file, or a future/foreign
+ * shape never crashes a consumer and never changes behavior. If canary's
+ * emitted shape drifts, reconcile the schema here (bump `version`) rather than
+ * loosening the tolerant reader.
+ */
+
+/**
+ * Stable discriminator. A `.harness/analyses/*.json` file carrying
+ * `schema: GUARDIAN_ANALYSIS_SCHEMA` is a guardian diff-coverage record; every
+ * other JSON in the directory (e.g. an intelligence `AnalysisRecord`) is ignored
+ * by the guardian reader.
+ */
+export const GUARDIAN_ANALYSIS_SCHEMA = 'harness.guardian.diff-coverage' as const;
+
+/** Contract version. Bump on a breaking shape change; the reader validates it. */
+export const GUARDIAN_ANALYSIS_VERSION = 1 as const;
+
+/** Overall pass/fail of the guardian diff-coverage gate for a change. */
+export type GuardianVerdict = 'pass' | 'fail';
+
+/** Advisory severity of the guardian finding. Never derives ship authority. */
+export type GuardianSeverity = 'info' | 'warn' | 'error';
+
+/** Per-file diff-coverage finding: which added/changed lines are uncovered. */
+export interface GuardianFileCoverage {
+  /** Repo-relative path of the file whose diff lines are uncovered. */
+  file: string;
+  /** Specific uncovered line numbers introduced/changed by the diff. */
+  uncoveredLines: number[];
+  /**
+   * Optional contiguous uncovered ranges `[startLine, endLine]` (inclusive),
+   * a compact alternative to enumerating every line.
+   */
+  uncoveredRegions?: Array<[number, number]>;
+}
+
+/**
+ * A single guardian diff-coverage analysis record, as persisted under
+ * `.harness/analyses/`. Self-describing so a tolerant reader can validate it in
+ * a directory shared with other analysis producers.
+ */
+export interface GuardianAnalysis {
+  schema: typeof GUARDIAN_ANALYSIS_SCHEMA;
+  version: typeof GUARDIAN_ANALYSIS_VERSION;
+  /** ISO timestamp when the guardian produced this record. */
+  generatedAt: string;
+  /** Overall gate verdict for the diff-coverage check. */
+  verdict: GuardianVerdict;
+  /** Advisory severity. */
+  severity: GuardianSeverity;
+  /**
+   * Coverage delta introduced by the diff, in percentage points. Negative is a
+   * regression (coverage went down).
+   */
+  coverageDelta: number;
+  /** Per-file uncovered diff-coverage findings (empty when nothing uncovered). */
+  files: GuardianFileCoverage[];
+  /** Optional human-readable one-line summary from the guardian. */
+  summary?: string;
+}

--- a/packages/intelligence/src/index.ts
+++ b/packages/intelligence/src/index.ts
@@ -83,6 +83,23 @@ export type {
   OutcomeEvaluatorOptions,
 } from './outcome-eval/index.js';
 
+// Guardian — tolerant, advisory diff-coverage records read from .harness/analyses/ (#914)
+export {
+  GUARDIAN_ANALYSIS_SCHEMA,
+  GUARDIAN_ANALYSIS_VERSION,
+  guardianAnalysisSchema,
+  readGuardianAnalyses,
+  summarizeGuardian,
+  guardianFlags,
+  guardianFileLines,
+} from './guardian/index.js';
+export type {
+  GuardianAnalysis,
+  GuardianFileCoverage,
+  GuardianVerdict,
+  GuardianSeverity,
+} from './guardian/index.js';
+
 // Acceptance-Eval — pre-execution acceptance-criteria measurability judgment (upstream twin)
 export {
   deriveAcceptanceAuthority,

--- a/packages/intelligence/src/outcome-eval/evaluator.ts
+++ b/packages/intelligence/src/outcome-eval/evaluator.ts
@@ -9,6 +9,26 @@ import { OUTCOME_EVAL_SYSTEM_PROMPT, buildUserPrompt, verdictSchema } from './pr
 import type { LlmVerdict } from './prompts.js';
 import { ExecutionOutcomeConnector } from '../outcome/connector.js';
 import type { ExecutionOutcome } from '../outcome/types.js';
+import { summarizeGuardian } from '../guardian/summary.js';
+import type { GuardianAnalysis } from '../guardian/types.js';
+
+/**
+ * Fold advisory guardian diff-coverage records into a verdict's rationale as a
+ * single deterministic line (#914). Pure and total: an absent/empty guardian
+ * input returns the verdict UNCHANGED (referentially identical), preserving the
+ * "no guardian wiring" contract byte-for-byte. Never touches `authority` — ship
+ * authority stays TS-derived from (verdict, confidence).
+ */
+export function withGuardianSignal(
+  verdict: OutcomeVerdict,
+  guardian: GuardianAnalysis[] | undefined
+): OutcomeVerdict {
+  if (!guardian || guardian.length === 0) return verdict;
+  const summary = summarizeGuardian(guardian);
+  if (!summary) return verdict;
+  const rationale = verdict.rationale ? `${verdict.rationale}\n\n${summary}` : summary;
+  return { ...verdict, rationale };
+}
 
 export interface OutcomeEvaluatorOptions {
   /** Override model for the outcome-eval LLM call. */
@@ -116,10 +136,16 @@ export class OutcomeEvaluator {
     );
   }
 
-  /** Persist (Phase 4 seam) then return the verdict. */
+  /**
+   * Fold in the advisory guardian signal, persist (Phase 4 seam), then return
+   * the verdict. Applying guardian here (not per-branch) means every path —
+   * judged, no-section, and degraded — surfaces the guardian signal uniformly,
+   * and the persisted `execution_outcome` node carries the annotated rationale.
+   */
   private async finish(verdict: OutcomeVerdict, input: OutcomeEvalInput): Promise<OutcomeVerdict> {
-    await this.persistOutcome(verdict, input);
-    return verdict;
+    const withGuardian = withGuardianSignal(verdict, input.guardian);
+    await this.persistOutcome(withGuardian, input);
+    return withGuardian;
   }
 
   private async resolveJudgmentSection(

--- a/packages/intelligence/src/outcome-eval/types.ts
+++ b/packages/intelligence/src/outcome-eval/types.ts
@@ -6,6 +6,8 @@
  * response — see `verdictSchema` in `./prompts.js`, which omits it.
  */
 
+import type { GuardianAnalysis } from '../guardian/types.js';
+
 export type Verdict = 'SATISFIED' | 'NOT_SATISFIED' | 'INCONCLUSIVE';
 
 export type Confidence = 'low' | 'medium' | 'high';
@@ -24,6 +26,14 @@ export interface OutcomeEvalInput {
   testOutput: string;
   /** Pre-resolved judgment section; otherwise the section-resolver runs. */
   specSection?: string;
+  /**
+   * Advisory guardian diff-coverage records read from `.harness/analyses/`
+   * (#914). Absent/empty leaves the verdict byte-identical to no guardian
+   * wiring; when present, a deterministic one-line signal is appended to the
+   * verdict rationale. Never affects ship authority (still TS-derived from
+   * verdict + confidence).
+   */
+  guardian?: GuardianAnalysis[];
 }
 
 export interface OutcomeVerdict {

--- a/packages/intelligence/tests/guardian/reader.test.ts
+++ b/packages/intelligence/tests/guardian/reader.test.ts
@@ -1,0 +1,147 @@
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import {
+  readGuardianAnalyses,
+  summarizeGuardian,
+  guardianFlags,
+  guardianFileLines,
+  GUARDIAN_ANALYSIS_SCHEMA,
+  GUARDIAN_ANALYSIS_VERSION,
+} from '../../src/guardian/index.js';
+import type { GuardianAnalysis } from '../../src/guardian/index.js';
+
+/** A valid guardian diff-coverage record fixture. */
+function makeGuardian(over: Partial<GuardianAnalysis> = {}): GuardianAnalysis {
+  return {
+    schema: GUARDIAN_ANALYSIS_SCHEMA,
+    version: GUARDIAN_ANALYSIS_VERSION,
+    generatedAt: '2026-07-19T00:00:00.000Z',
+    verdict: 'fail',
+    severity: 'error',
+    coverageDelta: -4.2,
+    files: [{ file: 'src/a.ts', uncoveredLines: [10, 11, 12] }],
+    summary: 'new endpoint handler is uncovered',
+    ...over,
+  };
+}
+
+/** Write a JSON file into `dir` and return its path. */
+function writeJson(dir: string, name: string, value: unknown): void {
+  writeFileSync(join(dir, name), JSON.stringify(value, null, 2), 'utf-8');
+}
+
+function freshDir(): string {
+  return mkdtempSync(join(tmpdir(), 'guardian-reader-'));
+}
+
+describe('readGuardianAnalyses', () => {
+  it('parses and validates a well-formed guardian record', async () => {
+    const dir = freshDir();
+    writeJson(dir, 'issue-1.json', makeGuardian());
+
+    const records = await readGuardianAnalyses(dir);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]!.verdict).toBe('fail');
+    expect(records[0]!.files[0]!.uncoveredLines).toEqual([10, 11, 12]);
+  });
+
+  it('returns [] when the analyses directory is absent (never throws)', async () => {
+    const records = await readGuardianAnalyses(join(freshDir(), 'does', 'not', 'exist'));
+    expect(records).toEqual([]);
+  });
+
+  it('returns [] for an empty analyses directory', async () => {
+    expect(await readGuardianAnalyses(freshDir())).toEqual([]);
+  });
+
+  it('skips a non-guardian record (intelligence AnalysisRecord shape) by discriminator', async () => {
+    const dir = freshDir();
+    // The intelligence-pipeline AnalysisRecord shape shares the directory but
+    // carries no guardian `schema` discriminator — it must be silently skipped.
+    writeJson(dir, 'intel-42.json', {
+      issueId: '42',
+      identifier: 'PROJ-42',
+      spec: null,
+      score: null,
+      simulation: null,
+      analyzedAt: '2026-07-19T00:00:00.000Z',
+      externalId: null,
+    });
+
+    expect(await readGuardianAnalyses(dir)).toEqual([]);
+  });
+
+  it('skips malformed JSON and structurally-invalid records, keeping the valid ones', async () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, 'broken.json'), '{ not valid json', 'utf-8');
+    // Right discriminator, wrong shape (coverageDelta must be a number).
+    writeJson(dir, 'bad-shape.json', {
+      schema: GUARDIAN_ANALYSIS_SCHEMA,
+      version: GUARDIAN_ANALYSIS_VERSION,
+      generatedAt: '2026-07-19T00:00:00.000Z',
+      verdict: 'fail',
+      severity: 'error',
+      coverageDelta: 'nope',
+      files: [],
+    });
+    writeJson(dir, 'good.json', makeGuardian({ verdict: 'pass', severity: 'info' }));
+
+    const records = await readGuardianAnalyses(dir);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]!.verdict).toBe('pass');
+  });
+
+  it('ignores non-.json files and subdirectories', async () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, 'README.txt'), 'not json', 'utf-8');
+    mkdirSync(join(dir, 'nested'));
+    writeJson(dir, 'g.json', makeGuardian());
+
+    expect(await readGuardianAnalyses(dir)).toHaveLength(1);
+  });
+});
+
+describe('guardian summary projections', () => {
+  it('summarizeGuardian returns null for no records (the "no signal" case)', () => {
+    expect(summarizeGuardian([])).toBeNull();
+  });
+
+  it('summarizeGuardian reports FAIL and worst delta when any record flags', () => {
+    const summary = summarizeGuardian([
+      makeGuardian({ verdict: 'pass', severity: 'info', coverageDelta: 1 }),
+      makeGuardian({ verdict: 'fail', severity: 'error', coverageDelta: -5 }),
+    ]);
+    expect(summary).toContain('FAIL');
+    expect(summary).toContain('-5%');
+  });
+
+  it('summarizeGuardian reports PASS when nothing flags', () => {
+    const summary = summarizeGuardian([
+      makeGuardian({ verdict: 'pass', severity: 'info', coverageDelta: 0, files: [] }),
+    ]);
+    expect(summary).toContain('PASS');
+  });
+
+  it('guardianFlags is true for fail or error-severity, false otherwise', () => {
+    expect(guardianFlags(makeGuardian({ verdict: 'fail', severity: 'info' }))).toBe(true);
+    expect(guardianFlags(makeGuardian({ verdict: 'pass', severity: 'error' }))).toBe(true);
+    expect(guardianFlags(makeGuardian({ verdict: 'pass', severity: 'warn' }))).toBe(false);
+  });
+
+  it('guardianFileLines lists only files with uncovered lines/regions', () => {
+    const lines = guardianFileLines([
+      makeGuardian({
+        files: [
+          { file: 'src/a.ts', uncoveredLines: [3, 4] },
+          { file: 'src/b.ts', uncoveredLines: [], uncoveredRegions: [[8, 9]] },
+          { file: 'src/covered.ts', uncoveredLines: [] },
+        ],
+      }),
+    ]);
+    expect(lines).toEqual(['src/a.ts: lines 3, 4', 'src/b.ts: 8-9']);
+  });
+});

--- a/packages/intelligence/tests/outcome-eval/guardian-signal.test.ts
+++ b/packages/intelligence/tests/outcome-eval/guardian-signal.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { GraphStore } from '@harness-engineering/graph';
+import type { AnalysisProvider } from '../../src/analysis-provider/interface.js';
+import { OutcomeEvaluator, withGuardianSignal } from '../../src/outcome-eval/evaluator.js';
+import type { OutcomeVerdict } from '../../src/outcome-eval/types.js';
+import { GUARDIAN_ANALYSIS_SCHEMA, GUARDIAN_ANALYSIS_VERSION } from '../../src/guardian/index.js';
+import type { GuardianAnalysis } from '../../src/guardian/index.js';
+
+function makeGuardian(over: Partial<GuardianAnalysis> = {}): GuardianAnalysis {
+  return {
+    schema: GUARDIAN_ANALYSIS_SCHEMA,
+    version: GUARDIAN_ANALYSIS_VERSION,
+    generatedAt: '2026-07-19T00:00:00.000Z',
+    verdict: 'fail',
+    severity: 'error',
+    coverageDelta: -4.2,
+    files: [{ file: 'src/a.ts', uncoveredLines: [10, 11] }],
+    ...over,
+  };
+}
+
+function baseVerdict(over: Partial<OutcomeVerdict> = {}): OutcomeVerdict {
+  return {
+    verdict: 'SATISFIED',
+    confidence: 'high',
+    rationale: 'All criteria met.',
+    judgedAgainst: 'success-criteria',
+    unmetCriteria: [],
+    authority: 'advisory',
+    ...over,
+  };
+}
+
+/** Provider that always rejects → the evaluator degrades to INCONCLUSIVE. */
+const rejectingProvider: AnalysisProvider = {
+  async analyze() {
+    throw new Error('no provider');
+  },
+};
+
+/** Write a spec markdown to a temp file and return its path. */
+function writeSpec(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'guardian-eval-'));
+  const p = join(dir, 'spec.md');
+  writeFileSync(p, body, 'utf-8');
+  return p;
+}
+
+describe('withGuardianSignal (pure)', () => {
+  it('returns the verdict UNCHANGED when guardian is undefined', () => {
+    const v = baseVerdict();
+    expect(withGuardianSignal(v, undefined)).toBe(v);
+  });
+
+  it('returns the verdict UNCHANGED when guardian is empty', () => {
+    const v = baseVerdict();
+    expect(withGuardianSignal(v, [])).toBe(v);
+  });
+
+  it('appends a deterministic guardian line to the rationale when present', () => {
+    const v = baseVerdict({ rationale: 'All criteria met.' });
+    const out = withGuardianSignal(v, [makeGuardian()]);
+    expect(out).not.toBe(v);
+    expect(out.rationale.startsWith('All criteria met.')).toBe(true);
+    expect(out.rationale).toContain('Guardian diff-coverage: FAIL');
+    // Authority is never touched by the guardian signal.
+    expect(out.authority).toBe(v.authority);
+    expect(out.verdict).toBe(v.verdict);
+  });
+});
+
+describe('OutcomeEvaluator guardian wiring', () => {
+  it('surfaces the guardian signal in the verdict rationale', async () => {
+    const evaluator = new OutcomeEvaluator(rejectingProvider, new GraphStore());
+    const verdict = await evaluator.evaluate({
+      specPath: writeSpec('# Spec\n## Success Criteria\n1. returns 200\n'),
+      diff: 'diff --git a/x b/x',
+      testOutput: 'ok',
+      guardian: [makeGuardian()],
+    });
+    expect(verdict.rationale).toContain('Guardian diff-coverage: FAIL');
+  });
+
+  it('leaves the rationale byte-identical when no guardian is supplied', async () => {
+    const specPath = writeSpec('# Spec\n## Success Criteria\n1. returns 200\n');
+    const withoutGuardian = await new OutcomeEvaluator(
+      rejectingProvider,
+      new GraphStore()
+    ).evaluate({ specPath, diff: 'd', testOutput: 'ok' });
+    expect(withoutGuardian.rationale).not.toContain('Guardian diff-coverage');
+  });
+});


### PR DESCRIPTION
## Summary

The `.harness/analyses/` archive had guardian diff-coverage writers (canary's PR guardian `--emit-analysis`, plus `sync-analyses`/`publish-analyses`) but the records were never READ. This completes ALL remaining #914 work (box 3, test-craft verdict emit, already shipped in #923).

### Harness-owned contract
New `GuardianAnalysis` type (`schema: harness.guardian.diff-coverage`, `version: 1`) + zod schema in `@harness-engineering/intelligence` — self-describing, discriminated: per-file uncovered lines/regions, coverage delta, pass/fail verdict, advisory severity. Documented as the harness-side contract canary conforms to; reconcilable (bump `version`) if canary's shape drifts.

### Tolerant reader
`readGuardianAnalyses(dir)` lists `.harness/analyses/`, selects guardian records by discriminator, validates with zod, SKIPS unknown/malformed shapes. Never throws; absent/empty ⇒ `[]`.

### Three review consumers (all advisory + degrade-safe)
- **outcome_eval** — `OutcomeEvalInput.guardian` folds the signal into the verdict rationale on every path. Ship authority stays TS-derived; guardian never affects it. MCP tool reads the archive and passes it through.
- **pre-merge-brief** — new "Guardian diff-coverage" section; flagged (fail/error) records feed "👀 Worth your eyes".
- **harness-code-review** — the 7-phase `runReviewPipeline` surfaces the guardian summary as an advisory context file (`harness-guardian-diff-coverage`, mirroring the `checkDepsOutput` precedent) on **every** review bundle the agents receive. Read caller-side at the CLI layer (`run_code_review` MCP tool + `agent review` command) and passed in as plain data via a new `guardianCoverage?: string` option, so `@harness-engineering/core` never depends on `@harness-engineering/intelligence` (same pattern as the existing `domainAccuracy` option).

A missing/empty/malformed archive leaves every consumer byte-identical to today.

## #914 checkboxes
- [x] Box 1 — **pre-merge-brief AND harness-code-review** read guardian diff-coverage findings as a review input ✅ (both consumers wired)
- [x] Box 2 — outcome_eval accepts guardian verdicts as a signal ✅
- [x] Box 3 — test-craft emits a machine-readable verdict ✅ (shipped #923)

## Tests (revert-verified)
- `packages/intelligence/tests/guardian/reader.test.ts` — parse/validate, absent⇒[], non-guardian + malformed skipped, summary projections.
- `packages/intelligence/tests/outcome-eval/guardian-signal.test.ts` — `withGuardianSignal` unchanged when absent, appends when present, never touches authority; evaluator surfaces + degrades.
- `packages/cli/tests/commands/pre-merge-brief-guardian.test.ts` — section render, flagged→Worth-your-eyes, degrade paths, real-archive default-seam integration.
- `packages/cli/tests/mcp/tools/outcome-eval.test.ts` — end-to-end read of a real archive fixture.
- `packages/core/tests/review/guardian-coverage.test.ts` — `attachGuardianCoverage` pure unit + **end-to-end**: mocks fan-out and asserts every bundle the agents receive carries the guardian advisory when provided, and none when absent. Revert-verified (disabling the orchestrator threading fails this test; the pure-helper tests still pass).
- `packages/cli/tests/utils/guardian-context.test.ts` — `loadGuardianCoverage` renders the advisory from a real archive; undefined when absent / only non-guardian records.

## Gates
Full authoritative ratchet run as CI does (`pnpm test:ci` → flagless `node scripts/coverage-ratchet.mjs`): **"all packages meet or exceed baselines"** (core fn 93.43% ≥ 93.24; cli fn 81.63% ≥ 81.45; intelligence unchanged). Local arch gate passes (helper extracted to keep pipeline complexity flat). No CLI command/flag or MCP schema changes → `generate-docs --check` clean.

Fixes #914