### PR TITLE
fix(orchestrator): generous timeout for reasoner unstick advisory

### DIFF
--- a/.changeset/reasoner-unstick-timeout.md
+++ b/.changeset/reasoner-unstick-timeout.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): give the reasoner unstick advisory a generous timeout
+
+The reasoner unstick advisory (#937) fired correctly on a stalled retry but its call
+was killed by the general `intelligence.requestTimeoutMs` (90s default) — observed live
+(af8): `reasoner unstick advisory skipped … "Request timed out"`. A thinking reasoner
+(e.g. qwen3.6 with reasoning ON) produces its structured diagnosis in minutes, and over
+Ollama's `/v1` endpoint the thinking cannot be disabled, so the model reasons well past
+90s before answering. Floor the advisory's timeout at 300s (never shortening a larger
+operator-configured value) so it actually delivers its guidance instead of silently
+degrading to the raw retry. It only fires on a genuine stall, so the occasional
+multi-minute wait is worth avoiding a needs-human escalation.

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -11,6 +11,7 @@ import type {
   RoutingStatus,
   StageRun,
   WorkflowExecutionPlan,
+  IntelligenceConfig,
 } from '@harness-engineering/types';
 import { RoutingError } from '@harness-engineering/types';
 import type { Issue, IssueTrackerClient } from '@harness-engineering/core';
@@ -111,6 +112,7 @@ import {
   UNSTICK_SCHEMA,
   UNSTICK_SYSTEM_PROMPT,
   DEFAULT_REASONER_ASSIST_AFTER,
+  REASONER_UNSTICK_TIMEOUT_MS,
   type UnstickAdvice,
 } from './workflow/unstick-advisory';
 import { workflowFor } from './workflow/workflow-for';
@@ -3161,6 +3163,16 @@ export class Orchestrator extends EventEmitter {
       if (name === undefined || name === '') return undefined;
       const def = this.config.agent.backends?.[name];
       if (!def) return undefined;
+      // Floor the timeout for the reasoner advisory: a thinking reasoner over /v1 needs
+      // minutes to answer, far longer than the general SEL classify budget (which killed
+      // it mid-think in af8). Never shorten a larger operator-configured value.
+      const intel: IntelligenceConfig = {
+        ...(this.config.intelligence ?? { enabled: false }),
+        requestTimeoutMs: Math.max(
+          this.config.intelligence?.requestTimeoutMs ?? 0,
+          REASONER_UNSTICK_TIMEOUT_MS
+        ),
+      };
       const provider =
         buildAnalysisProvider({
           def,
@@ -3177,7 +3189,7 @@ export class Orchestrator extends EventEmitter {
               detected: s.detected,
             };
           },
-          intelligence: this.config.intelligence,
+          intelligence: intel,
           logger: this.logger,
         }) ?? undefined;
       if (provider === undefined) return undefined;

--- a/packages/orchestrator/src/workflow/unstick-advisory.test.ts
+++ b/packages/orchestrator/src/workflow/unstick-advisory.test.ts
@@ -5,6 +5,7 @@ import {
   formatUnstickAdvisory,
   UNSTICK_SCHEMA,
   DEFAULT_REASONER_ASSIST_AFTER,
+  REASONER_UNSTICK_TIMEOUT_MS,
 } from './unstick-advisory';
 
 describe('shouldRequestUnstickAdvice', () => {
@@ -71,6 +72,14 @@ describe('formatUnstickAdvisory', () => {
     expect(out).toContain('noUncheckedIndexedAccess');
     expect(out).toContain('Fix to apply:');
     expect(out).toContain('line 48');
+  });
+});
+
+describe('REASONER_UNSTICK_TIMEOUT_MS', () => {
+  it('is generous enough for a thinking reasoner (well above the 90s SEL default)', () => {
+    // A thinking reasoner over /v1 reasons for minutes before answering; the general
+    // 90s classify timeout kills it mid-think (af8). Guard the floor stays generous.
+    expect(REASONER_UNSTICK_TIMEOUT_MS).toBeGreaterThanOrEqual(180_000);
   });
 });
 

--- a/packages/orchestrator/src/workflow/unstick-advisory.ts
+++ b/packages/orchestrator/src/workflow/unstick-advisory.ts
@@ -41,6 +41,18 @@ export const UNSTICK_SYSTEM_PROMPT =
 export const DEFAULT_REASONER_ASSIST_AFTER = 3;
 
 /**
+ * Timeout floor for the reasoner advisory call. A thinking reasoner (e.g. qwen3.6 with
+ * reasoning ON) produces its structured diagnosis MUCH slower than a quick SEL classify —
+ * and over Ollama's `/v1` endpoint the thinking cannot be disabled, so the model reasons
+ * for minutes before answering. The general `intelligence.requestTimeoutMs` (90s default)
+ * kills it mid-think (observed live, af8: `reasoner unstick advisory skipped … "Request
+ * timed out"`). Floor the advisory's timeout generously so it actually delivers; it only
+ * fires on a genuine stall, so the occasional multi-minute wait is worth avoiding a
+ * needs-human escalation.
+ */
+export const REASONER_UNSTICK_TIMEOUT_MS = 300_000;
+
+/**
  * Gate: should this re-dispatch carry a reasoner advisory? True once the executor has
  * stalled (`attempts >= assistAfter`) but still has retry budget (`attempts < bound`),
  * and a reasoner backend is actually configured. Pure.


### PR DESCRIPTION
The reasoner unstick advisory (#937) fired correctly on a stalled retry but its call was killed by the general `intelligence.requestTimeoutMs` (90s default) — observed live (af8): `reasoner unstick advisory skipped … "Request timed out"`. A thinking reasoner (qwen3.6, reasoning ON) reasons for minutes before answering, and over Ollama's `/v1` the thinking can't be disabled. Floors the advisory timeout at 300s (never shortening a larger operator value) so it actually delivers instead of degrading to the raw retry. Follow-up to #937.