### PR TITLE
fix(orchestrator): green the harness CI check (durable SEC-INJ-001 suppression)

### DIFF
--- a/.changeset/security-check-config-scanner-fp.md
+++ b/.changeset/security-check-config-scanner-fp.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): durably suppress the self-referential SEC-INJ-001 FP in config-scanner
+
+The `harness` CI check (`ci check --skip arch`) has been red on main because the
+security scanner flags `config-scanner.ts`'s OWN documentation — a JSDoc comment that
+names `eval(` while explaining the SEC-INJ-001 rule the scanner downgrades. It's a
+self-referential false positive that prior commits kept dodging by rewording the
+comment (whack-a-mole: each reword changes the finding hash → "new" finding → fails
+again). Replace the reword with the sanctioned, durable `// harness-ignore SEC-INJ-001`
+inline suppression (same pattern `injection-patterns.ts` uses for its own detector),
+so the finding stays acknowledged permanently. This greens the `harness` CI job.

--- a/packages/orchestrator/src/workspace/config-scanner.ts
+++ b/packages/orchestrator/src/workspace/config-scanner.ts
@@ -34,10 +34,10 @@ const BLOCKING_INJECTION_PREFIXES = ['INJ-UNI-', 'INJ-REROL-'];
  *    dangerously-skip-permissions) which appear in AGENTS.md documentation about
  *    hooks that *block* these flags — flagging documentation of a security
  *    measure as a security violation.
- *  - SEC-INJ-001 matches `eval(` / the Function constructor. Agent-guidance docs
- *    routinely NAME these as examples of what NOT to do; a markdown file cannot
- *    execute them. Treated as taint, not a dispatch-blocking finding (otherwise a
- *    single doc mention of `eval()` in AGENTS.md fail-closes every dispatch).
+ *  - SEC-INJ-001 matches `eval(` / the Function constructor. // harness-ignore SEC-INJ-001: definitional — documents the rule this scanner downgrades; prose, not executable code.
+ *    Agent-guidance docs routinely NAME these as examples of what NOT to do; a
+ *    markdown file cannot execute them, so a single doc mention must not
+ *    fail-close every dispatch. Treated as taint, not a dispatch-blocking finding.
  */
 const DOWNGRADED_SECURITY_RULES = new Set(['SEC-AGT-006', 'SEC-INJ-001']);
 


### PR DESCRIPTION
**Root cause of the perpetually-red `harness` CI check** (red on main, on every PR): `ci check --skip arch` fails because the `security` sub-check flags `config-scanner.ts`'s OWN JSDoc — it names `eval(` while documenting the SEC-INJ-001 rule the scanner downgrades. Self-referential FP. Prior commits kept rewording the comment (whack-a-mole; each reword = new finding hash = fails again). This replaces the reword with the sanctioned durable `// harness-ignore SEC-INJ-001` inline suppression (same mechanism `injection-patterns.ts` uses for its own detector). Verified: `ci check --skip arch` now exits 0. This is the docs-check-red root cause the earlier PRs (#937/#942) had to admin-override past.