### PR TITLE
test: backfill hermetic tests for 64 PR-touched uncovered areas

### DIFF
--- a/packages/cli/src/align/suggestions/p-primitives.test.ts
+++ b/packages/cli/src/align/suggestions/p-primitives.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import type { DriftFinding, DriftFindingCode } from '../../drift/findings/finding';
+import { emitPrimitiveSuggestion } from './p-primitives';
+
+/**
+ * Behavior guard for the DRIFT-P* suggestion emitter. emitPrimitiveSuggestion
+ * looks up the finding code in a tag→component table and produces a
+ * FixSuggestion (description + preview). Mapped codes name the registered
+ * primitive; unmapped codes fall back to a generic 'Component'. The emitter is
+ * pure — no IO, timers, or randomness — so no mocking is required.
+ */
+
+// Minimal DriftFinding factory; only `code` drives emitPrimitiveSuggestion, so
+// the remaining fields are inert placeholders kept type-faithful.
+function makeFinding(code: DriftFindingCode): DriftFinding {
+  return {
+    code,
+    severity: 'warn',
+    file: 'src/example.tsx',
+    line: null,
+    message: 'raw primitive detected',
+    evidence: { snippet: '<button>' },
+    rule: { id: code, category: 'primitive-adoption' },
+    fix: { kind: 'manual', description: 'adopt the registered primitive' },
+  };
+}
+
+// The mapping the emitter is contracted to honor. Keyed by finding code →
+// registered component name (source of truth for the assertions below).
+const CODE_TO_COMPONENT: ReadonlyArray<readonly [DriftFindingCode, string]> = [
+  ['DRIFT-P001', 'Button'],
+  ['DRIFT-P002', 'Input'],
+  ['DRIFT-P003', 'Link'],
+  ['DRIFT-P004', 'Textarea'],
+];
+
+describe('emitPrimitiveSuggestion', () => {
+  it.each(CODE_TO_COMPONENT)(
+    'maps %s to the registered <%s> primitive in both description and preview',
+    (code, component) => {
+      const tag = component.toLowerCase();
+
+      const suggestion = emitPrimitiveSuggestion(makeFinding(code));
+
+      expect(suggestion.description).toBe(
+        `Replace raw <${tag}> with the registered <${component}> primitive. ` +
+          `Audit props: event handlers (onClick), ref forwarding, and ` +
+          `className merging may differ from the raw HTML element.`
+      );
+      expect(suggestion.preview).toBe(
+        `Suggested replacement:\n` +
+          `  import { ${component} } from '<your component library>';\n` +
+          `  …\n` +
+          `  <${component} … />`
+      );
+    }
+  );
+
+  it('falls back to the generic <Component> for an unmapped DRIFT-P code', () => {
+    const suggestion = emitPrimitiveSuggestion(makeFinding('DRIFT-P999'));
+
+    expect(suggestion.description).toContain('registered <Component> primitive');
+    expect(suggestion.description).toContain('Replace raw <component>');
+    expect(suggestion.preview).toContain(`import { Component } from '<your component library>';`);
+    expect(suggestion.preview).toContain('<Component … />');
+  });
+
+  it('does not leak a mapped component name into an unrelated code', () => {
+    // A token-bypass code is never in the primitive table, so it must default.
+    const suggestion = emitPrimitiveSuggestion(makeFinding('DRIFT-T001'));
+
+    expect(suggestion.description).toContain('<Component>');
+    expect(suggestion.description).not.toContain('<Button>');
+  });
+
+  it('returns exactly the FixSuggestion shape (description + preview) and nothing else', () => {
+    const suggestion = emitPrimitiveSuggestion(makeFinding('DRIFT-P001'));
+
+    expect(Object.keys(suggestion).sort()).toEqual(['description', 'preview']);
+  });
+});

--- a/packages/cli/src/audit/component-anatomy/parsers/ast.test.ts
+++ b/packages/cli/src/audit/component-anatomy/parsers/ast.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import { parseComponentDefinition, parseComponentDefinitionFromSource } from './ast';
+
+/**
+ * Unit coverage for the component-anatomy AST parser (TypeScript Compiler
+ * API). The parser extracts an exported React component's name and the
+ * member names of its prop type, from either a file on disk or a raw
+ * source string.
+ *
+ * All disk-reading tests mock `node:fs` so the suite is hermetic and never
+ * touches the real filesystem. The source-string overload needs no mocking
+ * because it operates purely on in-memory strings.
+ */
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+const readFileSyncMock = vi.mocked(fs.readFileSync);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('parseComponentDefinitionFromSource', () => {
+  it('extracts the export name and interface prop members for an arrow component', () => {
+    const source = `
+      interface ButtonProps {
+        label: string;
+        onClick: () => void;
+        disabled?: boolean;
+      }
+      export const Button = ({ label, onClick }: ButtonProps) => null;
+    `;
+
+    const result = parseComponentDefinitionFromSource('Button.tsx', source);
+
+    expect(result).toEqual({
+      exportName: 'Button',
+      propTypeMembers: ['label', 'onClick', 'disabled'],
+    });
+  });
+
+  it('resolves props from a `type` alias referenced by a function declaration', () => {
+    const source = `
+      type CardProps = {
+        title: string;
+        body: string;
+      };
+      export function Card(props: CardProps) {
+        return null;
+      }
+    `;
+
+    const result = parseComponentDefinitionFromSource('Card.tsx', source);
+
+    expect(result).toEqual({
+      exportName: 'Card',
+      propTypeMembers: ['title', 'body'],
+    });
+  });
+
+  it('reads members directly from an inline type-literal prop annotation', () => {
+    const source = `
+      export const Badge = (props: { count: number; variant: string }) => null;
+    `;
+
+    const result = parseComponentDefinitionFromSource('Badge.tsx', source);
+
+    expect(result).toEqual({
+      exportName: 'Badge',
+      propTypeMembers: ['count', 'variant'],
+    });
+  });
+
+  it('returns null when no top-level exported component is present', () => {
+    const source = `
+      interface ButtonProps { label: string }
+      const button = (props: ButtonProps) => null;
+    `;
+
+    expect(parseComponentDefinitionFromSource('button.ts', source)).toBeNull();
+  });
+
+  it('ignores lowercase-named exports (not React-component convention)', () => {
+    const source = `
+      export const helper = (props: { a: string }) => null;
+    `;
+
+    expect(parseComponentDefinitionFromSource('helper.ts', source)).toBeNull();
+  });
+
+  it('returns the export name with empty members when the prop type is unresolvable', () => {
+    // Cross-file / unresolved reference: the type is not declared in this file.
+    const source = `
+      export const Widget = (props: ExternalProps) => null;
+    `;
+
+    expect(parseComponentDefinitionFromSource('Widget.tsx', source)).toEqual({
+      exportName: 'Widget',
+      propTypeMembers: [],
+    });
+  });
+
+  it('returns empty members when the component takes no parameters', () => {
+    const source = `
+      export const Spinner = () => null;
+    `;
+
+    expect(parseComponentDefinitionFromSource('Spinner.tsx', source)).toEqual({
+      exportName: 'Spinner',
+      propTypeMembers: [],
+    });
+  });
+
+  it('returns the first exported component when several are present', () => {
+    const source = `
+      export const First = (props: { a: string }) => null;
+      export const Second = (props: { b: string }) => null;
+    `;
+
+    const result = parseComponentDefinitionFromSource('multi.tsx', source);
+
+    expect(result).toEqual({
+      exportName: 'First',
+      propTypeMembers: ['a'],
+    });
+  });
+
+  it('preserves string-literal property names in an inline prop type', () => {
+    const source = `
+      export const Grid = (props: { 'data-col': number; row: number }) => null;
+    `;
+
+    const result = parseComponentDefinitionFromSource('Grid.tsx', source);
+
+    expect(result).toEqual({
+      exportName: 'Grid',
+      propTypeMembers: ['data-col', 'row'],
+    });
+  });
+});
+
+describe('parseComponentDefinition', () => {
+  it('reads the file from disk and delegates to the source parser', () => {
+    const filePath = '/repo/src/Button.tsx';
+    const source = `
+      interface ButtonProps { label: string }
+      export const Button = ({ label }: ButtonProps) => null;
+    `;
+    readFileSyncMock.mockReturnValue(source);
+
+    const result = parseComponentDefinition(filePath);
+
+    expect(readFileSyncMock).toHaveBeenCalledWith(filePath, 'utf8');
+    expect(result).toEqual({
+      exportName: 'Button',
+      propTypeMembers: ['label'],
+    });
+  });
+
+  it('returns null when the file cannot be read', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT: no such file');
+    });
+
+    expect(parseComponentDefinition('/repo/src/Missing.tsx')).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/advise-skills.test.ts
+++ b/packages/cli/src/commands/advise-skills.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import path from 'node:path';
+import { runAdviseSkills } from './advise-skills';
+import type { ContentMatchResult, SkillMatch } from '../skill/content-matcher-types';
+
+/**
+ * Unit contract for the `advise-skills` CLI command orchestration
+ * (`runAdviseSkills`).
+ *
+ * Pins the CURRENT observable behavior of the command's glue logic:
+ *  - reads the spec text (and throws a precise error when the spec is missing);
+ *  - reads project deps/devDeps from package.json and feeds them to
+ *    `extractSignals` (defaulting to empty maps when package.json is
+ *    absent/invalid);
+ *  - resolves config and forwards `skills.tierOverrides` to
+ *    `loadOrRebuildIndex`;
+ *  - filters matches by tier (apply -> top, reference -> top*2, consider only
+ *    when `thorough`, sliced to top);
+ *  - derives the feature name from the spec's `# Title` (falling back to the
+ *    spec directory basename);
+ *  - writes the generated markdown to a sibling `SKILLS.md`.
+ *
+ * Fully hermetic: `node:fs` and every collaborating module
+ * (index-builder, signal-extractor, content-matcher, skills-md-writer, config
+ * loader, logger) are mocked, so there is no real filesystem access, no
+ * subprocess, no network, and no wall-clock or ordering dependence.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+  writeFileSyncMock: vi.fn(),
+  extractSignalsMock: vi.fn(),
+  matchContentMock: vi.fn(),
+  loadOrRebuildIndexMock: vi.fn(),
+  generateSkillsMdMock: vi.fn(),
+  resolveConfigMock: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: hoisted.existsSyncMock,
+      readFileSync: hoisted.readFileSyncMock,
+      writeFileSync: hoisted.writeFileSyncMock,
+    },
+    existsSync: hoisted.existsSyncMock,
+    readFileSync: hoisted.readFileSyncMock,
+    writeFileSync: hoisted.writeFileSyncMock,
+  };
+});
+
+vi.mock('../skill/index-builder', () => ({
+  loadOrRebuildIndex: hoisted.loadOrRebuildIndexMock,
+}));
+
+vi.mock('../skill/signal-extractor', () => ({
+  extractSignals: hoisted.extractSignalsMock,
+}));
+
+vi.mock('../skill/content-matcher', () => ({
+  matchContent: hoisted.matchContentMock,
+}));
+
+vi.mock('../skill/skills-md-writer', () => ({
+  generateSkillsMd: hoisted.generateSkillsMdMock,
+}));
+
+vi.mock('../config/loader', () => ({
+  resolveConfig: hoisted.resolveConfigMock,
+}));
+
+vi.mock('../output/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+const CWD = '/proj';
+const SPEC_REL = 'docs/proposal.md';
+const SPEC_ABS = path.resolve(CWD, SPEC_REL); // /proj/docs/proposal.md
+const PKG_ABS = path.join(CWD, 'package.json'); // /proj/package.json
+const SKILLS_MD_ABS = path.join(path.dirname(SPEC_ABS), 'SKILLS.md'); // /proj/docs/SKILLS.md
+
+const SPEC_WITH_TITLE = '# Add Login Flow\n\nBuild a secure authentication feature.';
+const PKG_JSON = JSON.stringify({
+  dependencies: { react: '18.0.0' },
+  devDependencies: { vitest: '1.0.0' },
+});
+
+const SENTINEL_SIGNALS = {
+  specKeywords: ['auth'],
+  specText: '',
+  stackSignals: [],
+  featureDomain: [],
+};
+const SENTINEL_INDEX = { skills: { a: {}, b: {}, c: {} } };
+const GENERATED_MD = '# SKILLS.md content\n';
+
+function makeMatch(tier: SkillMatch['tier'], name: string, score: number): SkillMatch {
+  return {
+    skillName: name,
+    score,
+    tier,
+    matchReasons: ['reason'],
+    category: 'design',
+    when: 'during build',
+  };
+}
+
+function makeResult(matches: SkillMatch[]): ContentMatchResult {
+  return {
+    matches,
+    signalsUsed: SENTINEL_SIGNALS,
+    scanDuration: 12,
+  };
+}
+
+/** Route fs reads by path so both the spec and package.json resolve. */
+function wireFilesystem(opts: { specText?: string; pkgExists?: boolean; pkgText?: string } = {}) {
+  const specText = opts.specText ?? SPEC_WITH_TITLE;
+  const pkgExists = opts.pkgExists ?? true;
+  const pkgText = opts.pkgText ?? PKG_JSON;
+
+  hoisted.existsSyncMock.mockImplementation((p: string) => {
+    if (p === SPEC_ABS) return true;
+    if (p === PKG_ABS) return pkgExists;
+    return false;
+  });
+  hoisted.readFileSyncMock.mockImplementation((p: string) => {
+    if (p === SPEC_ABS) return specText;
+    if (p === PKG_ABS) return pkgText;
+    throw new Error(`unexpected read: ${p}`);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  wireFilesystem();
+  hoisted.extractSignalsMock.mockReturnValue(SENTINEL_SIGNALS);
+  hoisted.loadOrRebuildIndexMock.mockReturnValue(SENTINEL_INDEX);
+  hoisted.generateSkillsMdMock.mockReturnValue(GENERATED_MD);
+  hoisted.resolveConfigMock.mockReturnValue({ ok: false });
+  hoisted.matchContentMock.mockReturnValue(makeResult([makeMatch('apply', 'skill-a', 0.9)]));
+});
+
+describe('runAdviseSkills', () => {
+  it('reads the spec, matches skills, and writes the generated markdown to a sibling SKILLS.md', async () => {
+    const out = await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD });
+
+    // Spec and package.json were read from the resolved absolute paths.
+    expect(hoisted.readFileSyncMock).toHaveBeenCalledWith(SPEC_ABS, 'utf-8');
+
+    // Deps parsed from package.json are forwarded to signal extraction.
+    expect(hoisted.extractSignalsMock).toHaveBeenCalledWith(
+      SPEC_WITH_TITLE,
+      { react: '18.0.0' },
+      { vitest: '1.0.0' }
+    );
+
+    // Signals flow into matching.
+    expect(hoisted.matchContentMock).toHaveBeenCalledWith(SENTINEL_INDEX, SENTINEL_SIGNALS);
+
+    // Markdown is generated and written next to the spec.
+    expect(hoisted.generateSkillsMdMock).toHaveBeenCalledWith(
+      'Add Login Flow',
+      expect.objectContaining({ matches: expect.any(Array) }),
+      Object.keys(SENTINEL_INDEX.skills).length
+    );
+    expect(hoisted.writeFileSyncMock).toHaveBeenCalledWith(SKILLS_MD_ABS, GENERATED_MD, 'utf-8');
+
+    // Return shape reflects the resolved artifacts.
+    expect(out.skillsMdPath).toBe(SKILLS_MD_ABS);
+    expect(out.featureName).toBe('Add Login Flow');
+    expect(out.totalSkills).toBe(Object.keys(SENTINEL_INDEX.skills).length);
+  });
+
+  it('throws a precise error when the spec file does not exist', async () => {
+    hoisted.existsSyncMock.mockImplementation((p: string) => p === PKG_ABS);
+
+    await expect(runAdviseSkills({ specPath: SPEC_REL, cwd: CWD })).rejects.toThrow(
+      `Spec not found: ${SPEC_ABS}`
+    );
+    expect(hoisted.writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('passes empty dep maps to extractSignals when package.json is absent', async () => {
+    wireFilesystem({ pkgExists: false });
+
+    await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD });
+
+    expect(hoisted.extractSignalsMock).toHaveBeenCalledWith(SPEC_WITH_TITLE, {}, {});
+  });
+
+  it('passes empty dep maps to extractSignals when package.json is invalid JSON', async () => {
+    wireFilesystem({ pkgText: '{ not valid json' });
+
+    await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD });
+
+    expect(hoisted.extractSignalsMock).toHaveBeenCalledWith(SPEC_WITH_TITLE, {}, {});
+  });
+
+  it('forwards config skills.tierOverrides to the index builder when config resolves', async () => {
+    const tierOverrides = { 'skill-a': 'apply' };
+    hoisted.resolveConfigMock.mockReturnValue({
+      ok: true,
+      value: { skills: { tierOverrides } },
+    });
+
+    await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD });
+
+    expect(hoisted.loadOrRebuildIndexMock).toHaveBeenCalledWith('claude-code', CWD, tierOverrides);
+  });
+
+  it('passes undefined tierOverrides to the index builder when config does not resolve', async () => {
+    hoisted.resolveConfigMock.mockReturnValue({ ok: false });
+
+    await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD });
+
+    expect(hoisted.loadOrRebuildIndexMock).toHaveBeenCalledWith('claude-code', CWD, undefined);
+  });
+
+  it('falls back to the spec directory basename when the spec has no title heading', async () => {
+    wireFilesystem({ specText: 'no heading here, just body text' });
+
+    const out = await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD });
+
+    // dirname(/proj/docs/proposal.md) basename === 'docs'
+    expect(out.featureName).toBe('docs');
+    expect(hoisted.generateSkillsMdMock).toHaveBeenCalledWith(
+      'docs',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+});
+
+describe('runAdviseSkills tier filtering', () => {
+  const TOP = 2;
+
+  function wireManyMatches() {
+    hoisted.matchContentMock.mockReturnValue(
+      makeResult([
+        makeMatch('apply', 'apply-1', 0.95),
+        makeMatch('apply', 'apply-2', 0.9),
+        makeMatch('apply', 'apply-3', 0.85), // beyond top -> dropped
+        makeMatch('reference', 'ref-1', 0.5),
+        makeMatch('reference', 'ref-2', 0.48),
+        makeMatch('reference', 'ref-3', 0.46),
+        makeMatch('reference', 'ref-4', 0.44),
+        makeMatch('reference', 'ref-5', 0.42), // beyond top*2 -> dropped
+        makeMatch('consider', 'consider-1', 0.2),
+        makeMatch('consider', 'consider-2', 0.18),
+        makeMatch('consider', 'consider-3', 0.16), // beyond top -> dropped when thorough
+      ])
+    );
+  }
+
+  it('caps apply to top and reference to top*2, and excludes consider when not thorough', async () => {
+    wireManyMatches();
+
+    await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD, top: TOP, thorough: false });
+
+    const filtered = hoisted.generateSkillsMdMock.mock.calls[0]![1] as ContentMatchResult;
+    const names = filtered.matches.map((m) => m.skillName);
+
+    expect(names.filter((n) => n.startsWith('apply-'))).toEqual(['apply-1', 'apply-2']);
+    expect(names.filter((n) => n.startsWith('ref-'))).toEqual(['ref-1', 'ref-2', 'ref-3', 'ref-4']);
+    expect(names.filter((n) => n.startsWith('consider-'))).toEqual([]);
+  });
+
+  it('includes consider tier capped to top when thorough is set', async () => {
+    wireManyMatches();
+
+    await runAdviseSkills({ specPath: SPEC_REL, cwd: CWD, top: TOP, thorough: true });
+
+    const filtered = hoisted.generateSkillsMdMock.mock.calls[0]![1] as ContentMatchResult;
+    const considerNames = filtered.matches
+      .map((m) => m.skillName)
+      .filter((n) => n.startsWith('consider-'));
+
+    expect(considerNames).toEqual(['consider-1', 'consider-2']);
+  });
+});

--- a/packages/cli/src/commands/knowledge-pipeline.test.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import { createKnowledgePipelineCommand } from './knowledge-pipeline';
+
+/**
+ * Unit contract for `harness knowledge-pipeline`. Pins the CURRENT behavior of
+ * the Commander wiring: flag/config -> runner option bag, JSON vs human report
+ * rendering, and the `--drift-check` exit gate.
+ *
+ * Fully hermetic: the graph package (`GraphStore` / `KnowledgePipelineRunner`),
+ * `resolveConfig`, and `fs.mkdir` are all mocked, so there is no real IO, no
+ * subprocess, and no network. `console.log/warn/error` and `process.exit` are
+ * spied so the runner never prints or exits for real.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  runMock: vi.fn(),
+  loadMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  resolveConfigMock: vi.fn(),
+  // Captures the store instance passed to `new KnowledgePipelineRunner(store)`.
+  runnerStore: { value: undefined as unknown },
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, mkdir: hoisted.mkdirMock };
+});
+
+vi.mock('@harness-engineering/graph', () => {
+  class GraphStore {
+    load = hoisted.loadMock;
+  }
+  class KnowledgePipelineRunner {
+    run = hoisted.runMock;
+    constructor(store: unknown) {
+      hoisted.runnerStore.value = store;
+    }
+  }
+  return { GraphStore, KnowledgePipelineRunner };
+});
+
+vi.mock('../config/loader', () => ({
+  resolveConfig: hoisted.resolveConfigMock,
+}));
+
+// ─── Result factory ─────────────────────────────────────────────────────────
+
+const GAP_DOMAINS = ['auth', 'api'] as const;
+
+/**
+ * A fully-populated KnowledgePipelineResult matching every field the command's
+ * renderers read. Overrides let each test tweak just the slice it asserts on.
+ */
+function makeResult(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    verdict: 'pass',
+    driftScore: 1.5,
+    iterations: 1,
+    findings: { new: 2, stale: 0, drifted: 0, contradicting: 0 },
+    extraction: {
+      codeSignals: 5,
+      diagrams: 1,
+      linkerFacts: 3,
+      businessKnowledge: 2,
+      decisions: 1,
+      images: 0,
+    },
+    errors: [],
+    gaps: {
+      domains: [...GAP_DOMAINS],
+      totalEntries: 10,
+      totalExtracted: 8,
+      totalGaps: 2,
+    },
+    remediations: [],
+    contradictions: { contradictions: [], sourcePairCounts: {}, totalChecked: 4 },
+    coverage: { overallScore: 85, overallGrade: 'B', domains: [] },
+    ...overrides,
+  };
+}
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.option('--json', 'JSON output');
+  program.addCommand(createKnowledgePipelineCommand());
+  return program;
+}
+
+async function runCli(args: string[]): Promise<void> {
+  await makeProgram().parseAsync(['node', 'harness', 'knowledge-pipeline', ...args]);
+}
+
+describe('harness knowledge-pipeline — command contract', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    hoisted.runMock.mockReset();
+    hoisted.loadMock.mockReset();
+    hoisted.mkdirMock.mockReset();
+    hoisted.resolveConfigMock.mockReset();
+    hoisted.runnerStore.value = undefined;
+
+    // Defaults: fresh graph load succeeds, mkdir succeeds, config absent.
+    hoisted.loadMock.mockResolvedValue(undefined);
+    hoisted.mkdirMock.mockResolvedValue(undefined);
+    hoisted.resolveConfigMock.mockReturnValue({ ok: false });
+    hoisted.runMock.mockResolvedValue(makeResult());
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((_code?: number) => undefined) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function runOpts(): Record<string, unknown> {
+    expect(hoisted.runMock).toHaveBeenCalledTimes(1);
+    return hoisted.runMock.mock.calls[0]![0] as Record<string, unknown>;
+  }
+
+  function joinedLog(): string {
+    return logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+  }
+
+  // ── Runner wiring: default flags ──────────────────────────────────────────
+  it('default invocation runs the pipeline with detect-only flags and no image/domain/inference options', async () => {
+    await runCli([]);
+
+    const opts = runOpts();
+    expect(opts.fix).toBe(false);
+    expect(opts.ci).toBe(false);
+    expect(opts.analyzeImages).toBe(false);
+    expect(opts.projectDir).toBe(process.cwd());
+    // graphDir is derived from cwd and always points at .harness/graph.
+    expect(String(opts.graphDir).replaceAll('\\', '/')).toMatch(/\.harness\/graph$/);
+    expect(opts).not.toHaveProperty('domain');
+    expect(opts).not.toHaveProperty('imagePaths');
+    expect(opts).not.toHaveProperty('inferenceOptions');
+    // Graph dir is ensured before the runner executes.
+    expect(hoisted.mkdirMock).toHaveBeenCalledWith(opts.graphDir, { recursive: true });
+    // The loaded store is the one handed to the runner.
+    expect(hoisted.runnerStore.value).toBeDefined();
+  });
+
+  it('--fix and --ci propagate as booleans into the runner option bag', async () => {
+    await runCli(['--fix', '--ci']);
+    const opts = runOpts();
+    expect(opts.fix).toBe(true);
+    expect(opts.ci).toBe(true);
+  });
+
+  it('--domain limits the pipeline to the named domain', async () => {
+    await runCli(['--domain', 'billing']);
+    expect(runOpts().domain).toBe('billing');
+  });
+
+  // ── Image paths parsing (without --analyze-images, so no provider setup) ──
+  it('--image-paths is split on commas and trimmed into an array', async () => {
+    await runCli(['--image-paths', ' a.png , b.png ,c.png']);
+    const opts = runOpts();
+    expect(opts.imagePaths).toEqual(['a.png', 'b.png', 'c.png']);
+    // Parsing image paths alone must NOT flip analyzeImages or set a provider.
+    expect(opts.analyzeImages).toBe(false);
+    expect(opts).not.toHaveProperty('analysisProvider');
+  });
+
+  // ── Config-derived inference options ──────────────────────────────────────
+  it('maps knowledge.domainPatterns/domainBlocklist config into inferenceOptions', async () => {
+    hoisted.resolveConfigMock.mockReturnValue({
+      ok: true,
+      value: {
+        knowledge: {
+          domainPatterns: ['^auth/'],
+          domainBlocklist: ['node_modules'],
+        },
+      },
+    });
+
+    await runCli([]);
+
+    expect(runOpts().inferenceOptions).toEqual({
+      extraPatterns: ['^auth/'],
+      extraBlocklist: ['node_modules'],
+    });
+  });
+
+  it('omits inferenceOptions entirely when config has empty knowledge patterns and blocklist', async () => {
+    hoisted.resolveConfigMock.mockReturnValue({
+      ok: true,
+      value: { knowledge: { domainPatterns: [], domainBlocklist: [] } },
+    });
+
+    await runCli([]);
+
+    expect(runOpts()).not.toHaveProperty('inferenceOptions');
+  });
+
+  // ── JSON report rendering ─────────────────────────────────────────────────
+  it('--json prints a single machine-readable object with collapsed counts', async () => {
+    await makeProgram().parseAsync(['node', 'harness', '--json', 'knowledge-pipeline']);
+
+    const jsonLine = logSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .find((l: string) => l.trim().startsWith('{'));
+    expect(jsonLine).toBeDefined();
+    const payload = JSON.parse(jsonLine!);
+
+    expect(payload.verdict).toBe('pass');
+    expect(payload.driftScore).toBe(1.5);
+    // Nested collections are reduced to counts, not full arrays.
+    expect(payload.gaps.domains).toBe(GAP_DOMAINS.length);
+    expect(payload.contradictions.count).toBe(0);
+    expect(payload.coverage.domains).toBe(0);
+    expect(payload.coverage.overallScore).toBe(85);
+    // Human summary header must NOT appear in JSON mode.
+    expect(logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n')).not.toMatch(
+      /KNOWLEDGE PIPELINE/
+    );
+  });
+
+  it('--json includes a materialization summary only when the result carries one', async () => {
+    hoisted.runMock.mockResolvedValue(
+      makeResult({
+        materialization: {
+          created: [{ filePath: 'docs/auth.md' }, { filePath: 'docs/api.md' }],
+          skipped: [{ filePath: 'docs/legacy.md' }],
+        },
+      })
+    );
+
+    await makeProgram().parseAsync(['node', 'harness', '--json', 'knowledge-pipeline']);
+
+    const jsonLine = logSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .find((l: string) => l.trim().startsWith('{'));
+    const payload = JSON.parse(jsonLine!);
+    expect(payload.materialization.created).toBe(2);
+    expect(payload.materialization.skipped).toBe(1);
+    expect(payload.materialization.files).toEqual(['docs/auth.md', 'docs/api.md']);
+  });
+
+  // ── Human report rendering ────────────────────────────────────────────────
+  it('default (non-JSON) output renders the human verdict + drift/findings summary', async () => {
+    await runCli([]);
+
+    const out = joinedLog();
+    expect(out).toMatch(/KNOWLEDGE PIPELINE/);
+    expect(out).toMatch(/Verdict:/);
+    expect(out).toMatch(/PASS/);
+    expect(out).toMatch(/Drift Score: 1\.50/);
+    expect(out).toMatch(/Findings: 2 new, 0 stale, 0 drifted, 0 contradicting/);
+  });
+
+  it('routes ingestion errors to stderr via console.warn', async () => {
+    hoisted.runMock.mockResolvedValue(
+      makeResult({ errors: ['bad frontmatter in a.md', 'unreadable b.md'] })
+    );
+
+    await runCli([]);
+
+    const warned = warnSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(warned).toMatch(/2 ingestion warning\(s\)/);
+    expect(warned).toMatch(/bad frontmatter in a\.md/);
+  });
+
+  // ── Drift-check exit gate ─────────────────────────────────────────────────
+  it('--drift-check exits 1 and reports the count when unresolved drift exists', async () => {
+    hoisted.runMock.mockResolvedValue(
+      makeResult({ verdict: 'fail', findings: { new: 0, stale: 1, drifted: 2, contradicting: 1 } })
+    );
+
+    await runCli(['--drift-check']);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    // stale(1) + drifted(2) + contradicting(1) = 4 unresolved.
+    const errored = errSpy.mock.calls.map((c: unknown[]) => c.map(String).join(' ')).join('\n');
+    expect(errored).toMatch(/4 unresolved drift findings/);
+  });
+
+  it('--drift-check does NOT exit when only "new" findings exist (new is not unresolved drift)', async () => {
+    hoisted.runMock.mockResolvedValue(
+      makeResult({ findings: { new: 9, stale: 0, drifted: 0, contradicting: 0 } })
+    );
+
+    await runCli(['--drift-check']);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('without --drift-check, unresolved drift is reported but does not exit', async () => {
+    hoisted.runMock.mockResolvedValue(
+      makeResult({ findings: { new: 0, stale: 5, drifted: 0, contradicting: 0 } })
+    );
+
+    await runCli([]);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  // ── Failure handling ──────────────────────────────────────────────────────
+  it('surfaces a runner failure to stderr and exits 1', async () => {
+    hoisted.runMock.mockRejectedValue(new Error('extractor exploded'));
+
+    await runCli([]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errored = errSpy.mock.calls.map((c: unknown[]) => c.map(String).join(' ')).join('\n');
+    expect(errored).toMatch(/Knowledge pipeline failed: extractor exploded/);
+  });
+
+  it('tolerates a failed graph load (fresh graph) and still runs the pipeline', async () => {
+    hoisted.loadMock.mockRejectedValue(new Error('no graph on disk'));
+
+    await runCli([]);
+
+    expect(hoisted.runMock).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/maintenance-config.test.ts
+++ b/packages/cli/src/commands/maintenance-config.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadMaintenanceConfig, loadAgentBackends, mergeResolvedTasks } from './maintenance-config';
+import type { MaintenanceConfig } from '@harness-engineering/types';
+
+/**
+ * `mergeResolvedTasks` reads only `.tasks` and `.customTasks`; the required
+ * top-level `enabled` flag is irrelevant to task resolution. This helper adds
+ * the flag so the partial fixtures below satisfy `MaintenanceConfig` without a
+ * cast, keeping each test's `tasks`/`customTasks` shape verbatim.
+ */
+function cfg(partial: Omit<MaintenanceConfig, 'enabled'>): MaintenanceConfig {
+  return { enabled: true, ...partial };
+}
+
+/**
+ * Unit contract for the shared maintenance task-resolution helpers.
+ *
+ * Pins the CURRENT behavior of three surfaces:
+ *  - `mergeResolvedTasks`: built-in + custom task merging with enabled/schedule
+ *    overrides and optional-field copying.
+ *  - `loadMaintenanceConfig`: gated read of `harness.orchestrator.md` returning
+ *    the `maintenance` slice (or null) and surfacing loader warnings.
+ *  - `loadAgentBackends`: synthesis of the legacy backend map via
+ *    `migrateAgentConfig`, normalizing empty/absent to null.
+ *
+ * Fully hermetic: `node:fs`, the orchestrator package (`BUILT_IN_TASKS`,
+ * `WorkflowLoader`, `migrateAgentConfig`), and the CLI logger are all mocked, so
+ * there is no real filesystem access, no subprocess, and no network.
+ */
+
+// Two representative built-in tasks the SUT iterates over. Frozen so a test can
+// prove the helper returns copies rather than the shared registry objects.
+const BUILT_IN_A = Object.freeze({
+  id: 'built-in-a',
+  type: 'report-only',
+  description: 'Built-in A',
+  schedule: '0 2 * * *',
+  branch: null,
+});
+const BUILT_IN_B = Object.freeze({
+  id: 'built-in-b',
+  type: 'mechanical-ai',
+  description: 'Built-in B',
+  schedule: '0 3 * * *',
+  branch: 'chore/built-in-b',
+});
+
+const hoisted = vi.hoisted(() => ({
+  builtIns: undefined as unknown[] | undefined,
+  existsSyncMock: vi.fn(),
+  loadWorkflowMock: vi.fn(),
+  migrateMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, existsSync: hoisted.existsSyncMock };
+});
+
+vi.mock('@harness-engineering/orchestrator', () => {
+  class WorkflowLoader {
+    loadWorkflow = hoisted.loadWorkflowMock;
+  }
+  return {
+    // Live getter so a test can swap the built-in registry per-case.
+    get BUILT_IN_TASKS() {
+      return hoisted.builtIns;
+    },
+    WorkflowLoader,
+    migrateAgentConfig: hoisted.migrateMock,
+  };
+});
+
+vi.mock('../output/logger', () => ({
+  logger: { warn: hoisted.warnMock },
+}));
+
+beforeEach(() => {
+  hoisted.builtIns = [BUILT_IN_A, BUILT_IN_B];
+  hoisted.existsSyncMock.mockReset();
+  hoisted.loadWorkflowMock.mockReset();
+  hoisted.migrateMock.mockReset();
+  hoisted.warnMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── mergeResolvedTasks ──────────────────────────────────────────────────────
+
+describe('mergeResolvedTasks', () => {
+  it('returns every built-in as a fresh copy when config is null', () => {
+    const tasks = mergeResolvedTasks(null);
+
+    expect(tasks.map((t) => t.id)).toEqual([BUILT_IN_A.id, BUILT_IN_B.id]);
+    // Each returned task is a distinct object, not the shared registry entry,
+    // so downstream mutation cannot corrupt BUILT_IN_TASKS.
+    expect(tasks[0]).not.toBe(BUILT_IN_A);
+    expect(tasks[0]).toEqual({ ...BUILT_IN_A });
+    // No custom tasks were synthesized.
+    expect(tasks.every((t) => t.isCustom === undefined)).toBe(true);
+  });
+
+  it('treats an empty maintenance config the same as null (all built-ins, no customs)', () => {
+    const tasks = mergeResolvedTasks(cfg({}));
+    expect(tasks.map((t) => t.id)).toEqual([BUILT_IN_A.id, BUILT_IN_B.id]);
+  });
+
+  it('excludes a built-in whose override sets enabled:false', () => {
+    const tasks = mergeResolvedTasks(cfg({ tasks: { [BUILT_IN_A.id]: { enabled: false } } }));
+
+    expect(tasks.map((t) => t.id)).toEqual([BUILT_IN_B.id]);
+  });
+
+  it('does NOT exclude a built-in when the override enables it (enabled:true)', () => {
+    const tasks = mergeResolvedTasks(cfg({ tasks: { [BUILT_IN_A.id]: { enabled: true } } }));
+
+    expect(tasks.map((t) => t.id)).toContain(BUILT_IN_A.id);
+  });
+
+  it('applies a schedule override to a built-in while preserving its other fields', () => {
+    const overriddenSchedule = '15 4 * * 1';
+    const tasks = mergeResolvedTasks(
+      cfg({
+        tasks: { [BUILT_IN_A.id]: { schedule: overriddenSchedule } },
+      })
+    );
+
+    const a = tasks.find((t) => t.id === BUILT_IN_A.id)!;
+    expect(a.schedule).toBe(overriddenSchedule);
+    // Untouched fields carry through from the registry entry.
+    expect(a.description).toBe(BUILT_IN_A.description);
+    expect(a.type).toBe(BUILT_IN_A.type);
+    // The registry object itself is not mutated.
+    expect(BUILT_IN_A.schedule).toBe('0 2 * * *');
+  });
+
+  it('appends custom tasks after built-ins, flagged isCustom with defaults from the definition', () => {
+    const custom = {
+      type: 'pure-ai' as const,
+      description: 'My custom task',
+      schedule: '0 6 * * *',
+      branch: 'chore/custom',
+    };
+    const tasks = mergeResolvedTasks(cfg({ customTasks: { 'custom-1': custom } }));
+
+    // Built-ins come first, then customs.
+    expect(tasks.map((t) => t.id)).toEqual([BUILT_IN_A.id, BUILT_IN_B.id, 'custom-1']);
+    const c = tasks.find((t) => t.id === 'custom-1')!;
+    expect(c.isCustom).toBe(true);
+    expect(c.type).toBe(custom.type);
+    expect(c.description).toBe(custom.description);
+    expect(c.schedule).toBe(custom.schedule);
+    expect(c.branch).toBe(custom.branch);
+  });
+
+  it('applies a schedule override to a custom task, overriding its definition schedule', () => {
+    const overrideSchedule = '30 7 * * *';
+    const tasks = mergeResolvedTasks(
+      cfg({
+        customTasks: {
+          'custom-1': { type: 'pure-ai', description: 'x', schedule: '0 6 * * *', branch: null },
+        },
+        tasks: { 'custom-1': { schedule: overrideSchedule } },
+      })
+    );
+
+    expect(tasks.find((t) => t.id === 'custom-1')!.schedule).toBe(overrideSchedule);
+  });
+
+  it('excludes a custom task whose override sets enabled:false', () => {
+    const tasks = mergeResolvedTasks(
+      cfg({
+        customTasks: {
+          'custom-1': { type: 'pure-ai', description: 'x', schedule: '0 6 * * *', branch: null },
+        },
+        tasks: { 'custom-1': { enabled: false } },
+      })
+    );
+
+    expect(tasks.map((t) => t.id)).not.toContain('custom-1');
+  });
+
+  it('copies only the optional custom fields that are defined, omitting undefined ones', () => {
+    const costCeiling = { maxUsd: 5 };
+    const tasks = mergeResolvedTasks(
+      cfg({
+        customTasks: {
+          'custom-1': {
+            type: 'mechanical-ai',
+            description: 'x',
+            schedule: '0 6 * * *',
+            branch: null,
+            checkCommand: ['ci', 'check'],
+            fixSkill: 'fix-it',
+            costCeiling,
+          } as never,
+        },
+      })
+    );
+
+    const c = tasks.find((t) => t.id === 'custom-1')! as unknown as Record<string, unknown>;
+    // Defined optionals are copied through verbatim.
+    expect(c.checkCommand).toEqual(['ci', 'check']);
+    expect(c.fixSkill).toBe('fix-it');
+    expect(c.costCeiling).toBe(costCeiling);
+    // Optionals absent from the definition are not present on the output.
+    expect(c).not.toHaveProperty('checkScript');
+    expect(c).not.toHaveProperty('inlineSkills');
+    expect(c).not.toHaveProperty('contextFrom');
+  });
+});
+
+// ─── loadMaintenanceConfig ───────────────────────────────────────────────────
+
+describe('loadMaintenanceConfig', () => {
+  const CWD = '/repo';
+
+  it('returns null when harness.orchestrator.md does not exist', async () => {
+    hoisted.existsSyncMock.mockReturnValue(false);
+
+    expect(await loadMaintenanceConfig(CWD)).toBeNull();
+    // Never attempts a load when the file is absent.
+    expect(hoisted.loadWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the workflow fails to load', async () => {
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({ ok: false });
+
+    expect(await loadMaintenanceConfig(CWD)).toBeNull();
+  });
+
+  it('returns the maintenance slice and surfaces loader warnings when the workflow loads', async () => {
+    const maintenance = { customTasks: {} };
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({
+      ok: true,
+      value: { warnings: ['routing warning'], config: { maintenance } },
+    });
+
+    const result = await loadMaintenanceConfig(CWD);
+
+    expect(result).toBe(maintenance);
+    expect(hoisted.warnMock).toHaveBeenCalledWith('routing warning');
+  });
+
+  it('returns null when the loaded config carries no maintenance slice', async () => {
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({
+      ok: true,
+      value: { warnings: [], config: {} },
+    });
+
+    expect(await loadMaintenanceConfig(CWD)).toBeNull();
+  });
+});
+
+// ─── loadAgentBackends ───────────────────────────────────────────────────────
+
+describe('loadAgentBackends', () => {
+  const CWD = '/repo';
+
+  it('returns null when harness.orchestrator.md does not exist', async () => {
+    hoisted.existsSyncMock.mockReturnValue(false);
+
+    expect(await loadAgentBackends(CWD)).toBeNull();
+    expect(hoisted.loadWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the workflow fails to load', async () => {
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({ ok: false });
+
+    expect(await loadAgentBackends(CWD)).toBeNull();
+  });
+
+  it('returns null when the loaded config has no agent block', async () => {
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({
+      ok: true,
+      value: { warnings: [], config: {} },
+    });
+
+    expect(await loadAgentBackends(CWD)).toBeNull();
+    // No agent means migration is never attempted.
+    expect(hoisted.migrateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the migrated backends map for an agent config', async () => {
+    const agent = { backends: {} };
+    const migratedBackends = { primary: { type: 'anthropic', model: 'claude' } };
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({
+      ok: true,
+      value: { warnings: [], config: { agent } },
+    });
+    hoisted.migrateMock.mockReturnValue({ config: { backends: migratedBackends } });
+
+    const result = await loadAgentBackends(CWD);
+
+    expect(result).toEqual(migratedBackends);
+    expect(hoisted.migrateMock).toHaveBeenCalledWith(agent);
+  });
+
+  it('falls back to agent.backends when the migration synthesis throws', async () => {
+    const agentBackends = { local: { type: 'ollama', model: 'qwen' } };
+    const agent = { backends: agentBackends };
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({
+      ok: true,
+      value: { warnings: [], config: { agent } },
+    });
+    hoisted.migrateMock.mockImplementation(() => {
+      throw new Error('synthesis failed');
+    });
+
+    expect(await loadAgentBackends(CWD)).toEqual(agentBackends);
+  });
+
+  it('normalizes an empty synthesized backend map to null', async () => {
+    const agent = { backends: {} };
+    hoisted.existsSyncMock.mockReturnValue(true);
+    hoisted.loadWorkflowMock.mockResolvedValue({
+      ok: true,
+      value: { warnings: [], config: { agent } },
+    });
+    // Migration yields no backends and the agent itself carries an empty map.
+    hoisted.migrateMock.mockReturnValue({ config: {} });
+
+    expect(await loadAgentBackends(CWD)).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/orchestrator-black-box.test.ts
+++ b/packages/cli/src/commands/orchestrator-black-box.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'node:path';
+import { Command } from 'commander';
+import { createBlackBoxCommand } from './orchestrator-black-box';
+
+/**
+ * Unit contract for `harness orchestrator black-box list|show`. Pins the CURRENT
+ * rendering behavior of the command: how it enumerates FlightRecorder run
+ * records (`list`) and how it renders provenance, per-unit verdicts + gate
+ * reasons, and stream-derived tool-use (`show <runId>`).
+ *
+ * Fully hermetic: `FlightRecorder` (the only source of run data) and `node:fs`
+ * (the only source of stream/tool-use data) are mocked, so there is no real IO,
+ * no subprocess, and no git. `console.log`/`console.error` (the logger's sinks)
+ * are spied so nothing prints for real, and `process.exitCode` is saved and
+ * restored around every test.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  listRunsMock: vi.fn(),
+  getRunMock: vi.fn(),
+  readdirSyncMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+}));
+
+vi.mock('@harness-engineering/orchestrator', () => ({
+  FlightRecorder: {
+    listRuns: hoisted.listRunsMock,
+    getRun: hoisted.getRunMock,
+  },
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    readdirSync: hoisted.readdirSyncMock,
+    readFileSync: hoisted.readFileSyncMock,
+  };
+});
+
+const DEFAULT_DIR = '.harness/black-box';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeUnit(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    issueId: 'issue-1',
+    identifier: 'ISSUE-1',
+    verdict: 'shipped',
+    attempt: 1,
+    gateBlocks: 0,
+    updatedAt: '2026-07-20T12:34:56.000Z',
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    runId: 'run-abc',
+    orchestratorId: 'orch-1',
+    startedAt: '2026-07-20T12:34:56.000Z',
+    endedAt: '2026-07-20T13:00:00.000Z',
+    provenance: {
+      gitHead: 'abcdef1234567',
+      gitSubject: 'fix: land the thing',
+      branch: 'feat/x',
+      harnessVersion: '9.9.9',
+      node: 'v20.0.0',
+      backends: [{ name: 'coder', type: 'ollama', model: 'qwen3', endpoint: 'http://x' }],
+      routing: { default: 'coder', modes: { design: 'reasoner' } },
+    },
+    units: { 'issue-1': makeUnit() },
+    ...overrides,
+  };
+}
+
+describe('harness orchestrator black-box — command contract', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    hoisted.listRunsMock.mockReset();
+    hoisted.getRunMock.mockReset();
+    hoisted.readdirSyncMock.mockReset();
+    hoisted.readFileSyncMock.mockReset();
+
+    // Default: no stream files on disk (readdirSync throws ENOENT-style).
+    hoisted.readdirSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    hoisted.readFileSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = savedExitCode;
+  });
+
+  function makeProgram(): Command {
+    const program = new Command();
+    program.addCommand(createBlackBoxCommand());
+    return program;
+  }
+
+  async function runCli(args: string[]): Promise<void> {
+    await makeProgram().parseAsync(['node', 'harness', 'black-box', ...args]);
+  }
+
+  function joinedLog(): string {
+    return logSpy.mock.calls.map((c: unknown[]) => c.map(String).join(' ')).join('\n');
+  }
+
+  function joinedErr(): string {
+    return errSpy.mock.calls.map((c: unknown[]) => c.map(String).join(' ')).join('\n');
+  }
+
+  const resolvedDefaultDir = path.resolve(process.cwd(), DEFAULT_DIR);
+
+  // ── list ──────────────────────────────────────────────────────────────────
+  it('list reads the default dir and reports when no runs are recorded', async () => {
+    hoisted.listRunsMock.mockReturnValue([]);
+
+    await runCli(['list']);
+
+    expect(hoisted.listRunsMock).toHaveBeenCalledWith(resolvedDefaultDir);
+    // toContain, not RegExp: on Windows the resolved path has backslashes that would be invalid regex escapes.
+    expect(joinedLog()).toContain(`No black-box runs found under ${resolvedDefaultDir}`);
+  });
+
+  it('list renders a header plus one row per run with short git sha, unit count, and verdict summary', async () => {
+    hoisted.listRunsMock.mockReturnValue([
+      makeRun({
+        runId: 'run-newest',
+        units: {
+          'issue-1': makeUnit({ issueId: 'issue-1', verdict: 'shipped' }),
+          'issue-2': makeUnit({ issueId: 'issue-2', verdict: 'gate-blocked' }),
+        },
+      }),
+    ]);
+
+    await runCli(['list']);
+
+    const out = joinedLog();
+    // Header columns.
+    expect(out).toMatch(/RUN\s+STARTED\s+GIT\s+UNITS\s+VERDICTS/);
+    // Row: runId, short 7-char sha, unit count (2), and both verdicts summarized.
+    expect(out).toMatch(/run-newest/);
+    expect(out).toMatch(/abcdef1\b/);
+    expect(out).toMatch(/1 shipped/);
+    expect(out).toMatch(/1 gate-blocked/);
+    // Started timestamp is normalized to "YYYY-MM-DD HH:MM".
+    expect(out).toMatch(/2026-07-20 12:34/);
+  });
+
+  it('list falls back to an em-dash for a null git head', async () => {
+    hoisted.listRunsMock.mockReturnValue([
+      makeRun({ provenance: { ...(makeRun().provenance as object), gitHead: null } }),
+    ]);
+
+    await runCli(['list']);
+
+    // The run row is present but the GIT column shows the dash placeholder.
+    expect(joinedLog()).toMatch(/run-abc.*—/);
+  });
+
+  it('list honors a custom --dir (resolved against cwd)', async () => {
+    hoisted.listRunsMock.mockReturnValue([]);
+
+    await runCli(['list', '--dir', 'custom/bb']);
+
+    expect(hoisted.listRunsMock).toHaveBeenCalledWith(path.resolve(process.cwd(), 'custom/bb'));
+  });
+
+  // ── show: missing run ───────────────────────────────────────────────────────
+  it('show reports a missing run to stderr and sets a failing exit code', async () => {
+    hoisted.getRunMock.mockReturnValue(null);
+
+    await runCli(['show', 'ghost']);
+
+    expect(hoisted.getRunMock).toHaveBeenCalledWith(resolvedDefaultDir, 'ghost');
+    expect(joinedErr()).toMatch(/No black-box run 'ghost' under/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  // ── show: header rendering ──────────────────────────────────────────────────
+  it('show renders provenance: run id, orchestrator, git, node/harness, backends, and routing', async () => {
+    hoisted.getRunMock.mockReturnValue(makeRun());
+
+    await runCli(['show', 'run-abc']);
+
+    const out = joinedLog();
+    expect(out).toMatch(/Run run-abc {2}\(orch-1\)/);
+    expect(out).toMatch(/started: 2026-07-20T12:34:56\.000Z/);
+    expect(out).toMatch(/ended: 2026-07-20T13:00:00\.000Z/);
+    expect(out).toMatch(/git: {5}abcdef1 "fix: land the thing" {2}\(branch feat\/x\)/);
+    expect(out).toMatch(/node: {4}v20\.0\.0 {3}harness: 9\.9\.9/);
+    // Backend line: name, type, then model + endpoint.
+    expect(out).toMatch(/coder\s+ollama\s+qwen3\s+http:\/\/x/);
+    // Routing default + modes.
+    expect(out).toMatch(/routing: default=coder {2}modes=\{design:reasoner\}/);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('show renders a not-sealed marker when the run has no end time', async () => {
+    hoisted.getRunMock.mockReturnValue(makeRun({ endedAt: null }));
+
+    await runCli(['show', 'run-abc']);
+
+    expect(joinedLog()).toMatch(/ended: \(still running \/ not sealed\)/);
+  });
+
+  it('show renders em-dash fallbacks for a null orchestrator and empty git subject', async () => {
+    hoisted.getRunMock.mockReturnValue(
+      makeRun({
+        orchestratorId: null,
+        provenance: {
+          ...(makeRun().provenance as object),
+          gitSubject: null,
+          branch: null,
+        },
+      })
+    );
+
+    await runCli(['show', 'run-abc']);
+
+    const out = joinedLog();
+    expect(out).toMatch(/Run run-abc {2}\(—\)/);
+    expect(out).toMatch(/\(branch —\)/);
+  });
+
+  // ── show: units ─────────────────────────────────────────────────────────────
+  it('show renders each unit with verdict, attempt, gate-blocks, and PR number', async () => {
+    hoisted.getRunMock.mockReturnValue(
+      makeRun({
+        units: {
+          'issue-1': makeUnit({
+            identifier: 'ISSUE-1',
+            verdict: 'shipped',
+            attempt: 2,
+            gateBlocks: 1,
+            pr: 945,
+          }),
+        },
+      })
+    );
+
+    await runCli(['show', 'run-abc']);
+
+    expect(joinedLog()).toMatch(/ISSUE-1 {2}\[shipped\] {2}attempt 2 {2}gate-blocks 1 {2}PR #945/);
+  });
+
+  it('show renders only the first four lines of a multi-line gate reason', async () => {
+    const gateLines = ['reason-1', 'reason-2', 'reason-3', 'reason-4', 'reason-5-hidden'];
+    hoisted.getRunMock.mockReturnValue(
+      makeRun({
+        units: {
+          'issue-1': makeUnit({
+            verdict: 'gate-blocked',
+            gateReason: gateLines.join('\n'),
+          }),
+        },
+      })
+    );
+
+    await runCli(['show', 'run-abc']);
+
+    const out = joinedLog();
+    expect(out).toMatch(/gate reason: reason-1/);
+    // The fourth line is retained...
+    expect(out).toContain('reason-4');
+    // ...but the fifth (beyond the 4-line window) is dropped.
+    expect(out).not.toContain('reason-5-hidden');
+  });
+
+  // ── show: tool-use aggregation from streams ─────────────────────────────────
+  it('show aggregates tool_execution_start events per unit and renders them by descending count', async () => {
+    hoisted.getRunMock.mockReturnValue(
+      makeRun({ units: { 'issue-1': makeUnit({ issueId: 'issue-1' }) } })
+    );
+
+    // One stream directory with a single jsonl file (and a non-jsonl file to ignore).
+    hoisted.readdirSyncMock.mockReturnValue(['a.jsonl', 'notes.txt']);
+    hoisted.readFileSyncMock.mockReturnValue(
+      [
+        JSON.stringify({ type: 'tool_execution_start', subtype: 'edit' }),
+        JSON.stringify({ type: 'tool_execution_start', subtype: 'bash' }),
+        JSON.stringify({ type: 'tool_execution_start', subtype: 'edit' }),
+        JSON.stringify({ type: 'assistant_message', subtype: 'ignored' }),
+        'not-json-at-all',
+        '',
+      ].join('\n')
+    );
+
+    await runCli(['show', 'run-abc']);
+
+    // Only .jsonl files are read.
+    expect(hoisted.readFileSyncMock).toHaveBeenCalledTimes(1);
+    const readPath = String(hoisted.readFileSyncMock.mock.calls[0]![0]);
+    expect(readPath.replaceAll('\\', '/')).toMatch(/streams\/issue-1\/a\.jsonl$/);
+    // edit(2) sorted before bash(1); non-tool and invalid lines are ignored.
+    expect(joinedLog()).toMatch(/tools: edit x2, bash x1/);
+  });
+
+  it('show omits the tools line when the unit has no readable stream directory', async () => {
+    hoisted.getRunMock.mockReturnValue(makeRun());
+    // Default beforeEach: readdirSync throws -> no tools counted.
+
+    await runCli(['show', 'run-abc']);
+
+    expect(joinedLog()).not.toMatch(/tools:/);
+  });
+
+  it('show labels a tool_execution_start with no subtype as "?"', async () => {
+    hoisted.getRunMock.mockReturnValue(makeRun());
+    hoisted.readdirSyncMock.mockReturnValue(['a.jsonl']);
+    hoisted.readFileSyncMock.mockReturnValue(JSON.stringify({ type: 'tool_execution_start' }));
+
+    await runCli(['show', 'run-abc']);
+
+    expect(joinedLog()).toMatch(/tools: \? x1/);
+  });
+});

--- a/packages/cli/src/commands/routing/http-client.test.ts
+++ b/packages/cli/src/commands/routing/http-client.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { orchestratorBase, authHeader, getJson, postJson } from './http-client';
+
+/**
+ * Pins current behavior of the shared HTTP helpers backing the
+ * `harness routing` subcommands. Mocks `fetch` via
+ * `vi.spyOn(globalThis, 'fetch')`; saves/restores the two env vars the
+ * helpers read (`HARNESS_ORCHESTRATOR_URL`, `HARNESS_API_TOKEN`) so the
+ * suite is hermetic and order-independent. No real network IO.
+ */
+
+const DEFAULT_BASE = 'http://127.0.0.1:8080';
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_BASE = process.env['HARNESS_ORCHESTRATOR_URL'];
+const ORIGINAL_TOKEN = process.env['HARNESS_API_TOKEN'];
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+/** Install a fetch stub that returns `response` and records each call. */
+function mockFetch(response: Response | Promise<Response>): {
+  fetchSpy: ReturnType<typeof vi.fn>;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fetchSpy = vi.fn(async (url: URL | string, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return response;
+  });
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  return { fetchSpy, calls };
+}
+
+/** Install a fetch stub that rejects, to exercise the catch branch. */
+function mockFetchThrow(error: unknown): {
+  fetchSpy: ReturnType<typeof vi.fn>;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fetchSpy = vi.fn(async (url: URL | string, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    throw error;
+  });
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  return { fetchSpy, calls };
+}
+
+beforeEach(() => {
+  delete process.env['HARNESS_ORCHESTRATOR_URL'];
+  delete process.env['HARNESS_API_TOKEN'];
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_BASE === undefined) delete process.env['HARNESS_ORCHESTRATOR_URL'];
+  else process.env['HARNESS_ORCHESTRATOR_URL'] = ORIGINAL_BASE;
+  if (ORIGINAL_TOKEN === undefined) delete process.env['HARNESS_API_TOKEN'];
+  else process.env['HARNESS_API_TOKEN'] = ORIGINAL_TOKEN;
+  vi.restoreAllMocks();
+});
+
+describe('orchestratorBase', () => {
+  it('returns the localhost default when HARNESS_ORCHESTRATOR_URL is unset', () => {
+    expect(orchestratorBase()).toBe(DEFAULT_BASE);
+  });
+
+  it('returns the configured HARNESS_ORCHESTRATOR_URL when set', () => {
+    process.env['HARNESS_ORCHESTRATOR_URL'] = 'http://example.test:9999';
+    expect(orchestratorBase()).toBe('http://example.test:9999');
+  });
+});
+
+describe('authHeader', () => {
+  it('returns an empty object when HARNESS_API_TOKEN is unset', () => {
+    expect(authHeader()).toEqual({});
+  });
+
+  it('returns a Bearer Authorization header when HARNESS_API_TOKEN is set', () => {
+    process.env['HARNESS_API_TOKEN'] = 'sekret';
+    expect(authHeader()).toEqual({ Authorization: 'Bearer sekret' });
+  });
+});
+
+describe('getJson', () => {
+  it('targets the resolved base + path and forwards the auth header', async () => {
+    process.env['HARNESS_ORCHESTRATOR_URL'] = 'http://host:1234';
+    process.env['HARNESS_API_TOKEN'] = 'tok';
+    const { calls } = mockFetch(new Response('{}', { status: 200 }));
+
+    await getJson('/routing/status');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('http://host:1234/routing/status');
+    expect((calls[0]!.init.headers as Record<string, string>).Authorization).toBe('Bearer tok');
+  });
+
+  it('omits the Authorization header when no token is configured', async () => {
+    const { calls } = mockFetch(new Response('{}', { status: 200 }));
+
+    await getJson('/routing/status');
+
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('parses the JSON body and reports ok on a 2xx response', async () => {
+    mockFetch(new Response(JSON.stringify({ backend: 'ollama' }), { status: 200 }));
+
+    const result = await getJson<{ backend: string }>('/routing/status');
+
+    expect(result).toEqual({ ok: true, status: 200, body: { backend: 'ollama' } });
+  });
+
+  it('returns a null body on an empty-string 2xx response', async () => {
+    mockFetch(new Response('', { status: 200 }));
+
+    const result = await getJson('/routing/status');
+
+    expect(result).toEqual({ ok: true, status: 200, body: null });
+  });
+
+  it('returns ok:false with the raw text as error on a non-2xx response', async () => {
+    mockFetch(new Response('forbidden', { status: 403 }));
+
+    const result = await getJson('/routing/status');
+
+    expect(result).toEqual({ ok: false, status: 403, body: null, error: 'forbidden' });
+  });
+
+  it('returns status 0 with the message when fetch rejects with an Error', async () => {
+    mockFetchThrow(new Error('ECONNREFUSED'));
+
+    const result = await getJson('/routing/status');
+
+    expect(result).toEqual({ ok: false, status: 0, body: null, error: 'ECONNREFUSED' });
+  });
+
+  it('stringifies a non-Error rejection into the error field', async () => {
+    mockFetchThrow('boom');
+
+    const result = await getJson('/routing/status');
+
+    expect(result).toEqual({ ok: false, status: 0, body: null, error: 'boom' });
+  });
+});
+
+describe('postJson', () => {
+  it('issues a POST with a JSON content-type and serialized body', async () => {
+    const { calls } = mockFetch(new Response('{}', { status: 200 }));
+    const payload = { policy: 'complexity' };
+
+    await postJson('/routing/policy', payload);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${DEFAULT_BASE}/routing/policy`);
+    expect(calls[0]!.init.method).toBe('POST');
+    expect((calls[0]!.init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json'
+    );
+    expect(calls[0]!.init.body).toBe(JSON.stringify(payload));
+  });
+
+  it('merges the auth header alongside the content-type when a token is set', async () => {
+    process.env['HARNESS_API_TOKEN'] = 'tok';
+    const { calls } = mockFetch(new Response('{}', { status: 200 }));
+
+    await postJson('/routing/policy', {});
+
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers.Authorization).toBe('Bearer tok');
+  });
+
+  it('parses the JSON body and reports ok on a 2xx response', async () => {
+    mockFetch(new Response(JSON.stringify({ applied: true }), { status: 200 }));
+
+    const result = await postJson<{ applied: boolean }>('/routing/policy', {});
+
+    expect(result).toEqual({ ok: true, status: 200, body: { applied: true } });
+  });
+
+  it('returns ok:false with the raw text as error on a non-2xx response', async () => {
+    mockFetch(new Response('bad request', { status: 400 }));
+
+    const result = await postJson('/routing/policy', {});
+
+    expect(result).toEqual({ ok: false, status: 400, body: null, error: 'bad request' });
+  });
+
+  it('returns status 0 with the message when fetch rejects with an Error', async () => {
+    mockFetchThrow(new Error('network down'));
+
+    const result = await postJson('/routing/policy', {});
+
+    expect(result).toEqual({ ok: false, status: 0, body: null, error: 'network down' });
+  });
+});

--- a/packages/cli/src/commands/state/reset.test.ts
+++ b/packages/cli/src/commands/state/reset.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'path';
+import { createResetCommand } from './reset';
+import { ExitCode } from '../../utils/errors';
+
+/**
+ * Unit contract for `harness state reset`. Pins the CURRENT behavior of the
+ * command: confirmation gating (prompt unless `--yes`), routing the reset
+ * through `eventSourcing.resetEventLog` with the resolved project path and the
+ * chosen stream, and the SUCCESS/ERROR exit codes for the cancel, ok, and
+ * failure paths.
+ *
+ * Fully hermetic: `readline` (the interactive prompt), the core event-sourcing
+ * reset, `process.exit`, and console are all stubbed, so there is no real
+ * stdin/stdout, filesystem, subprocess, or process exit. Only pure
+ * `path.resolve` runs for real -- it is the resolution behavior under test.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  resetEventLogMock: vi.fn(),
+  closeMock: vi.fn(),
+  // Mutable so each test can script the prompt answer without re-mocking.
+  promptAnswer: { value: 'n' },
+}));
+
+vi.mock('@harness-engineering/core', () => ({
+  eventSourcing: { resetEventLog: hoisted.resetEventLogMock },
+}));
+
+vi.mock('readline', () => ({
+  createInterface: () => ({
+    question: (_query: string, cb: (answer: string) => void) => cb(hoisted.promptAnswer.value),
+    close: hoisted.closeMock,
+  }),
+}));
+
+/** Sentinel thrown by the mocked `process.exit` so control-flow halts like real exit. */
+class ProcessExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+/** Drive the command and surface the exit code raised by the stubbed `process.exit`. */
+async function run(argv: string[]): Promise<number> {
+  const cmd = createResetCommand();
+  try {
+    await cmd.parseAsync(argv, { from: 'user' });
+  } catch (err) {
+    if (err instanceof ProcessExitError) return err.code;
+    throw err;
+  }
+  throw new Error('reset command returned without calling process.exit');
+}
+
+beforeEach(() => {
+  hoisted.resetEventLogMock.mockReset();
+  hoisted.closeMock.mockReset();
+  hoisted.promptAnswer.value = 'n';
+  hoisted.resetEventLogMock.mockResolvedValue({ ok: true, value: undefined });
+
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+    throw new ProcessExitError(typeof code === 'number' ? code : 0);
+  });
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+describe('state reset command', () => {
+  it('resets without prompting and exits SUCCESS when --yes is given', async () => {
+    const code = await run(['--yes']);
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(hoisted.resetEventLogMock).toHaveBeenCalledTimes(1);
+    // Default --path '.' resolves against cwd; derive from the same source of truth.
+    expect(hoisted.resetEventLogMock).toHaveBeenCalledWith(path.resolve('.'), {
+      stream: undefined,
+    });
+  });
+
+  it('resolves --path and forwards --stream to resetEventLog', async () => {
+    const code = await run(['--yes', '--path', 'some/project', '--stream', 'feature-x']);
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(hoisted.resetEventLogMock).toHaveBeenCalledWith(path.resolve('some/project'), {
+      stream: 'feature-x',
+    });
+  });
+
+  it('proceeds with the reset when the confirmation prompt is answered yes', async () => {
+    hoisted.promptAnswer.value = 'y';
+
+    const code = await run([]);
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(hoisted.resetEventLogMock).toHaveBeenCalledTimes(1);
+    // Prompt was shown and the readline interface was closed.
+    expect(hoisted.closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a full "yes" answer as confirmation', async () => {
+    hoisted.promptAnswer.value = 'YES';
+
+    const code = await run([]);
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(hoisted.resetEventLogMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels without resetting when the prompt is declined', async () => {
+    hoisted.promptAnswer.value = 'n';
+
+    const code = await run([]);
+
+    expect(code).toBe(ExitCode.SUCCESS);
+    expect(hoisted.resetEventLogMock).not.toHaveBeenCalled();
+    expect(hoisted.closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('exits ERROR and does not claim success when resetEventLog fails', async () => {
+    hoisted.resetEventLogMock.mockResolvedValue({
+      ok: false,
+      error: new Error('event log is locked'),
+    });
+
+    const code = await run(['--yes']);
+
+    expect(code).toBe(ExitCode.ERROR);
+    // The failure was surfaced to stderr, not the success channel.
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/verify.test.ts
+++ b/packages/cli/src/commands/verify.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { runVerify } from './verify';
+import { ExitCode } from '../utils/errors';
+
+/**
+ * Unit contract for `harness verify`. Pins the CURRENT behavior of the command:
+ * branch-name resolution precedence (explicit -> env -> git), schema-default
+ * config fallback, config-load failure surfacing, and the compliance exit codes
+ * for both human and JSON output.
+ *
+ * Fully hermetic: `child_process.execSync`, the config loader
+ * (`resolveConfig`/`findConfigFile`), `process.exit`, and console are all
+ * stubbed, so there is no real subprocess, filesystem, or process exit. The real
+ * `validateBranchName` + `BranchingConfigSchema` are exercised on purpose --
+ * they are pure, and the schema defaults are the behavior under test.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  execSyncMock: vi.fn(),
+  resolveConfigMock: vi.fn(),
+  findConfigFileMock: vi.fn(),
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execSync: hoisted.execSyncMock };
+});
+
+vi.mock('../config/loader', () => ({
+  resolveConfig: hoisted.resolveConfigMock,
+  findConfigFile: hoisted.findConfigFileMock,
+}));
+
+// Env vars the resolver consults, so tests start from a known-clean slate.
+const BRANCH_ENV_KEYS = [
+  'HARNESS_BRANCH',
+  'GITHUB_HEAD_REF',
+  'CI_COMMIT_REF_NAME',
+  'BUILDKITE_BRANCH',
+] as const;
+
+/** Sentinel thrown by the mocked `process.exit` so control-flow halts like real exit. */
+class ProcessExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  hoisted.execSyncMock.mockReset();
+  hoisted.resolveConfigMock.mockReset();
+  hoisted.findConfigFileMock.mockReset();
+
+  savedEnv = {};
+  for (const key of BRANCH_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+    throw new ProcessExitError(typeof code === 'number' ? code : 0);
+  });
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  for (const key of BRANCH_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  vi.restoreAllMocks();
+});
+
+/** Runs `runVerify`, returning the exit code captured from the sentinel throw. */
+async function runAndCaptureExit(options: Parameters<typeof runVerify>[0]): Promise<number> {
+  try {
+    await runVerify(options);
+  } catch (err) {
+    if (err instanceof ProcessExitError) return err.code;
+    throw err;
+  }
+  throw new Error('runVerify returned without calling process.exit');
+}
+
+/** Concatenated `console.log` output (JSON payloads + human success/info lines). */
+function stdout(): string {
+  return logSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+}
+
+describe('runVerify', () => {
+  describe('branch resolution precedence', () => {
+    it('uses an explicit --branch over env and git', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+      process.env.HARNESS_BRANCH = 'chore/from-env';
+      hoisted.execSyncMock.mockReturnValue(Buffer.from('chore/from-git'));
+
+      const code = await runAndCaptureExit({ branch: 'feat/explicit-wins', json: true });
+
+      expect(code).toBe(ExitCode.SUCCESS);
+      expect(JSON.parse(stdout())).toMatchObject({ valid: true, branchName: 'feat/explicit-wins' });
+      expect(hoisted.execSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to env vars when no explicit branch is given', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+      process.env.GITHUB_HEAD_REF = 'fix/from-env';
+
+      const code = await runAndCaptureExit({ json: true });
+
+      expect(code).toBe(ExitCode.SUCCESS);
+      expect(JSON.parse(stdout())).toMatchObject({ valid: true, branchName: 'fix/from-env' });
+      expect(hoisted.execSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to git rev-parse when no explicit branch or env is set', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+      hoisted.execSyncMock.mockReturnValue(Buffer.from('feat/from-git\n'));
+
+      const code = await runAndCaptureExit({ json: true });
+
+      expect(code).toBe(ExitCode.SUCCESS);
+      expect(JSON.parse(stdout())).toMatchObject({ valid: true, branchName: 'feat/from-git' });
+      expect(hoisted.execSyncMock).toHaveBeenCalledOnce();
+    });
+
+    it('treats a detached-HEAD git result as no branch', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+      hoisted.execSyncMock.mockReturnValue(Buffer.from('HEAD\n'));
+
+      const code = await runAndCaptureExit({ json: true });
+
+      expect(code).toBe(ExitCode.ERROR);
+      expect(JSON.parse(stdout())).toMatchObject({ valid: false, branchName: '' });
+    });
+  });
+
+  describe('unresolvable branch', () => {
+    it('errors with exit code ERROR and human message when git throws', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+      hoisted.execSyncMock.mockImplementation(() => {
+        throw new Error('not a git repository');
+      });
+
+      const code = await runAndCaptureExit({});
+
+      expect(code).toBe(ExitCode.ERROR);
+      expect(errorSpy).toHaveBeenCalledOnce();
+      expect(errorSpy.mock.calls[0]!.join(' ')).toContain('Could not determine the current branch');
+      // Human mode must not emit a JSON payload on stdout.
+      expect(stdout()).toBe('');
+    });
+
+    it('emits a JSON error payload with exit code ERROR in --json mode', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+      hoisted.execSyncMock.mockImplementation(() => {
+        throw new Error('not a git repository');
+      });
+
+      const code = await runAndCaptureExit({ json: true });
+
+      expect(code).toBe(ExitCode.ERROR);
+      const payload = JSON.parse(stdout());
+      expect(payload.valid).toBe(false);
+      expect(payload.branchName).toBe('');
+      expect(payload.message).toContain('Could not determine the current branch');
+    });
+  });
+
+  describe('compliance results with schema-default config', () => {
+    it('exits SUCCESS and prints a compliant success line for a valid branch (human)', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+
+      const code = await runAndCaptureExit({ branch: 'feat/add-widget' });
+
+      expect(code).toBe(ExitCode.SUCCESS);
+      expect(stdout()).toContain('is compliant');
+      expect(stdout()).toContain('feat/add-widget');
+    });
+
+    it('exits VALIDATION_FAILED with message + suggestion for a prefix-less branch (JSON)', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+
+      const code = await runAndCaptureExit({ branch: 'noprefixbranch', json: true });
+
+      expect(code).toBe(ExitCode.VALIDATION_FAILED);
+      const payload = JSON.parse(stdout());
+      expect(payload.valid).toBe(false);
+      expect(payload.branchName).toBe('noprefixbranch');
+      expect(payload.message).toContain('must have a prefix');
+      expect(payload.suggestion).toContain('feat/noprefixbranch');
+    });
+
+    it('exits VALIDATION_FAILED and logs message + suggestion for a non-compliant branch (human)', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+
+      const code = await runAndCaptureExit({ branch: 'bogus/Not_Kebab' });
+
+      expect(code).toBe(ExitCode.VALIDATION_FAILED);
+      // Prefix "bogus" is not in the default allowlist -> error + allowed-prefixes suggestion.
+      const errText = errorSpy.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+      expect(errText).toContain('bogus');
+      expect(stdout()).toContain('Suggestion');
+    });
+
+    it('does not consult the config loader when no config path or discoverable config exists', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: false });
+
+      await runAndCaptureExit({ branch: 'feat/x', json: true });
+
+      expect(hoisted.resolveConfigMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('config loading', () => {
+    it('loads a discoverable config and applies its branching rules', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: true, value: '/repo/harness.config.json' });
+      // Custom regex requires branches to start with "release-".
+      hoisted.resolveConfigMock.mockReturnValue({
+        ok: true,
+        value: { compliance: { branching: { customRegex: '^release-', ignore: [] } } },
+      });
+
+      const code = await runAndCaptureExit({ branch: 'release-1.2.0', json: true });
+
+      expect(code).toBe(ExitCode.SUCCESS);
+      expect(hoisted.resolveConfigMock).toHaveBeenCalledWith(undefined);
+      expect(JSON.parse(stdout())).toMatchObject({ valid: true, branchName: 'release-1.2.0' });
+    });
+
+    it('rejects a branch that violates a loaded custom regex', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: true, value: '/repo/harness.config.json' });
+      hoisted.resolveConfigMock.mockReturnValue({
+        ok: true,
+        value: { compliance: { branching: { customRegex: '^release-', ignore: [] } } },
+      });
+
+      const code = await runAndCaptureExit({ branch: 'feat/nope', json: true });
+
+      expect(code).toBe(ExitCode.VALIDATION_FAILED);
+      expect(JSON.parse(stdout())).toMatchObject({ valid: false, branchName: 'feat/nope' });
+    });
+
+    it('falls back to schema defaults when a discoverable config has no branching section', async () => {
+      hoisted.findConfigFileMock.mockReturnValue({ ok: true, value: '/repo/harness.config.json' });
+      hoisted.resolveConfigMock.mockReturnValue({ ok: true, value: {} });
+
+      const code = await runAndCaptureExit({ branch: 'feat/default-rules', json: true });
+
+      expect(code).toBe(ExitCode.SUCCESS);
+      expect(JSON.parse(stdout())).toMatchObject({ valid: true, branchName: 'feat/default-rules' });
+    });
+
+    it('surfaces the loader error and exits with its exit code when an explicit config path fails', async () => {
+      // configPath provided -> loader is consulted regardless of findConfigFile.
+      hoisted.resolveConfigMock.mockReturnValue({
+        ok: false,
+        error: { message: 'config not found', exitCode: ExitCode.ERROR },
+      });
+
+      const code = await runAndCaptureExit({ configPath: '/missing/harness.config.json' });
+
+      expect(code).toBe(ExitCode.ERROR);
+      expect(hoisted.resolveConfigMock).toHaveBeenCalledWith('/missing/harness.config.json');
+      expect(errorSpy.mock.calls[0]!.join(' ')).toContain('config not found');
+    });
+  });
+});

--- a/packages/cli/src/design-pipeline/phases/detect.test.ts
+++ b/packages/cli/src/design-pipeline/phases/detect.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The DETECT phase orchestrator statically imports `runDetectDrift` from the
+// detect-drift tool. We mock exactly that module (same relative specifier the
+// SUT uses) so the test is hermetic: no real filesystem scan, no token/registry
+// loading, no subprocess. We assert the observable contract — the arguments
+// forwarded to runDetectDrift, and how the returned findings (or a thrown
+// error) are folded into the DesignPipelineContext.
+const mocks = vi.hoisted(() => ({
+  runDetectDrift: vi.fn(),
+}));
+
+// Same relative specifier as `import { runDetectDrift } from
+// '../../mcp/tools/detect-drift.js'` in detect.ts. Because this test sits in the
+// SUT's directory, it resolves to the identical module id the SUT imports.
+vi.mock('../../mcp/tools/detect-drift.js', () => ({
+  runDetectDrift: mocks.runDetectDrift,
+}));
+
+import { runDetect } from './detect.js';
+import { newContext } from '../context.js';
+import type { DriftFinding } from '../../drift/findings/finding.js';
+
+const PROJECT_ROOT = '/repo/project';
+
+/**
+ * Build a deterministic DriftFinding. Distinct `line` values let us prove
+ * identity/ordering of the folded array without relying on real scanning.
+ */
+function makeFinding(line: number): DriftFinding {
+  return {
+    code: 'DRIFT-T001',
+    severity: 'error',
+    file: 'src/Button.tsx',
+    line,
+    message: `hardcoded value at line ${line}`,
+    evidence: { snippet: '#fff' },
+    rule: { id: 'DRIFT-T001', category: 'token-bypass' },
+    fix: { kind: 'manual', description: 'use a token' },
+  };
+}
+
+/**
+ * Minimal stand-in for the runDetectDrift Verifier output; the SUT only reads
+ * `.findings`, so the remaining Verifier fields are populated just enough to be
+ * shape-faithful without asserting on them.
+ */
+function makeDriftOutput(findings: DriftFinding[]) {
+  return {
+    findings,
+    summary: {
+      totalFiles: findings.length,
+      durationMs: 0,
+      bySeverity: { error: findings.length, warn: 0, info: 0 },
+      byCode: {},
+    },
+    catalog: { rulesApplied: [] },
+    meta: { mode: 'fast' as const, tokensLoaded: false, registryLoaded: false },
+  };
+}
+
+describe('runDetect (design-pipeline phase 2: DETECT)', () => {
+  beforeEach(() => {
+    mocks.runDetectDrift.mockReset();
+  });
+
+  it('folds returned findings into context and records the verifier as run', async () => {
+    const findings = [makeFinding(1), makeFinding(2)];
+    mocks.runDetectDrift.mockResolvedValue(makeDriftOutput(findings));
+    const context = newContext();
+
+    await runDetect({ projectRoot: PROJECT_ROOT, context, mode: 'fast' });
+
+    expect(context.driftFindings).toEqual(findings);
+    expect(context.verifiersRun).toEqual(['detect-drift']);
+    expect(context.verifiersFailed).toEqual([]);
+  });
+
+  it('copies the findings array rather than aliasing the verifier result', async () => {
+    const findings = [makeFinding(1)];
+    mocks.runDetectDrift.mockResolvedValue(makeDriftOutput(findings));
+    const context = newContext();
+
+    await runDetect({ projectRoot: PROJECT_ROOT, context, mode: 'full' });
+
+    // Same contents...
+    expect(context.driftFindings).toEqual(findings);
+    // ...but a distinct array, so later mutation of the source cannot leak in.
+    expect(context.driftFindings).not.toBe(findings);
+  });
+
+  it('forwards only path and mode when files and strictness are omitted', async () => {
+    mocks.runDetectDrift.mockResolvedValue(makeDriftOutput([]));
+    const context = newContext();
+
+    await runDetect({ projectRoot: PROJECT_ROOT, context, mode: 'fast' });
+
+    expect(mocks.runDetectDrift).toHaveBeenCalledTimes(1);
+    const arg = mocks.runDetectDrift.mock.calls[0]![0];
+    expect(arg).toEqual({ path: PROJECT_ROOT, mode: 'fast' });
+    // Optional keys must be absent, not present-and-undefined.
+    expect('files' in arg).toBe(false);
+    expect('designStrictness' in arg).toBe(false);
+  });
+
+  it('forwards files and designStrictness when provided', async () => {
+    mocks.runDetectDrift.mockResolvedValue(makeDriftOutput([]));
+    const context = newContext();
+    const files = ['src/a.tsx', 'src/b.tsx'];
+
+    await runDetect({
+      projectRoot: PROJECT_ROOT,
+      context,
+      mode: 'full',
+      files,
+      designStrictness: 'strict',
+    });
+
+    expect(mocks.runDetectDrift).toHaveBeenCalledWith({
+      path: PROJECT_ROOT,
+      mode: 'full',
+      files,
+      designStrictness: 'strict',
+    });
+  });
+
+  it('records a verifier failure with the Error message and leaves findings untouched', async () => {
+    mocks.runDetectDrift.mockRejectedValue(new Error('drift scan exploded'));
+    const context = newContext();
+
+    await runDetect({ projectRoot: PROJECT_ROOT, context, mode: 'fast' });
+
+    expect(context.verifiersFailed).toEqual([
+      { name: 'detect-drift', error: 'drift scan exploded' },
+    ]);
+    // Graceful degradation: nothing recorded as run, findings stay empty.
+    expect(context.verifiersRun).toEqual([]);
+    expect(context.driftFindings).toEqual([]);
+  });
+
+  it('stringifies a non-Error rejection into the failure record', async () => {
+    mocks.runDetectDrift.mockRejectedValue('plain string failure');
+    const context = newContext();
+
+    await runDetect({ projectRoot: PROJECT_ROOT, context, mode: 'full' });
+
+    expect(context.verifiersFailed).toEqual([
+      { name: 'detect-drift', error: 'plain string failure' },
+    ]);
+    expect(context.verifiersRun).toEqual([]);
+  });
+});

--- a/packages/cli/src/design-pipeline/phases/fix.test.ts
+++ b/packages/cli/src/design-pipeline/phases/fix.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as path from 'node:path';
+import { newContext, type DesignPipelineContext } from '../context.js';
+import type { DriftFinding } from '../../drift/findings/finding.js';
+
+/**
+ * Unit contract for Phase 3 FIX (`runFix`). Pins the CURRENT behavior of the
+ * convergence loop: the early no-drift return, the align→re-detect cadence, the
+ * converged / no-progress / error stop conditions, the 5-iteration bound, and
+ * the `.harness/handoff.json` pipeline handoff write.
+ *
+ * Fully hermetic: `runAlignDesignSystem`, `runDetectDrift`, and every `node:fs`
+ * call the SUT makes are mocked, so there is no real IO, no subprocess, and no
+ * network. Findings are opaque to `runFix` (it only reads `.length`), so tests
+ * use minimal placeholder objects sized to drive the loop.
+ */
+
+const h = vi.hoisted(() => ({
+  runAlign: vi.fn(),
+  runDetect: vi.fn(),
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: h.existsSync,
+  readFileSync: h.readFileSync,
+  mkdirSync: h.mkdirSync,
+  writeFileSync: h.writeFileSync,
+}));
+
+vi.mock('../../mcp/tools/align-design-system.js', () => ({
+  runAlignDesignSystem: h.runAlign,
+}));
+
+vi.mock('../../mcp/tools/detect-drift.js', () => ({
+  runDetectDrift: h.runDetect,
+}));
+
+import { runFix, type FixInput } from './fix.js';
+
+const PROJECT_ROOT = '/tmp/project';
+
+/** N opaque drift findings — `runFix` only ever reads `array.length`. */
+function findings(count: number): DriftFinding[] {
+  return Array.from({ length: count }, (_, i) => ({ id: `f${i}` })) as unknown as DriftFinding[];
+}
+
+/** Align result shape the SUT reads: `result.outcomes` + `result.summary.applied`. */
+function alignResult(applied: number, outcomes: unknown[] = []) {
+  return { outcomes, summary: { applied } };
+}
+
+function makeInput(context: DesignPipelineContext, over: Partial<FixInput> = {}): FixInput {
+  return { projectRoot: PROJECT_ROOT, context, mode: 'fast', ...over };
+}
+
+function contextWithDrift(count: number): DesignPipelineContext {
+  const ctx = newContext();
+  ctx.driftFindings = findings(count);
+  return ctx;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: no pre-existing handoff on disk.
+  h.existsSync.mockReturnValue(false);
+});
+
+describe('runFix', () => {
+  it('returns immediately without aligning or writing when there is no drift', async () => {
+    const ctx = newContext(); // driftFindings === []
+
+    await runFix(makeInput(ctx));
+
+    expect(h.runAlign).not.toHaveBeenCalled();
+    expect(h.runDetect).not.toHaveBeenCalled();
+    expect(h.writeFileSync).not.toHaveBeenCalled();
+    expect(ctx.summary.iterationsRun).toBe(0);
+  });
+
+  it('stops on convergence (0 fixes applied) after a single align, without re-detecting', async () => {
+    const ctx = contextWithDrift(2);
+    h.runAlign.mockResolvedValue(alignResult(0, [{ kind: 'applied' }]));
+
+    await runFix(makeInput(ctx));
+
+    expect(h.runAlign).toHaveBeenCalledTimes(1);
+    expect(h.runDetect).not.toHaveBeenCalled();
+    // Outcomes are still collected even though the run converged.
+    expect(ctx.fixesApplied).toEqual([{ kind: 'applied' }]);
+    expect(ctx.summary.iterationsRun).toBe(0);
+  });
+
+  it('aligns with pipeline mode against the project root', async () => {
+    const ctx = contextWithDrift(1);
+    h.runAlign.mockResolvedValue(alignResult(0));
+
+    await runFix(makeInput(ctx));
+
+    expect(h.runAlign).toHaveBeenCalledWith({ path: PROJECT_ROOT, mode: 'pipeline' });
+  });
+
+  it('stops on no-progress when the re-detected drift count does not decrease', async () => {
+    const ctx = contextWithDrift(2);
+    h.runAlign.mockResolvedValue(alignResult(1));
+    // Same count as before (2) => no progress => break before incrementing.
+    h.runDetect.mockResolvedValue({ findings: findings(2) });
+
+    await runFix(makeInput(ctx));
+
+    expect(h.runAlign).toHaveBeenCalledTimes(1);
+    expect(h.runDetect).toHaveBeenCalledTimes(1);
+    expect(ctx.summary.iterationsRun).toBe(0);
+    // Re-detected findings replace the context's findings.
+    expect(ctx.driftFindings).toHaveLength(2);
+  });
+
+  it('loops while drift decreases and stops when a later align converges', async () => {
+    const ctx = contextWithDrift(3);
+    h.runAlign
+      .mockResolvedValueOnce(alignResult(1)) // iter 0: applies fixes
+      .mockResolvedValueOnce(alignResult(0)); // iter 1: converged
+    h.runDetect.mockResolvedValueOnce({ findings: findings(2) }); // 2 < 3 => progress
+
+    await runFix(makeInput(ctx));
+
+    expect(h.runAlign).toHaveBeenCalledTimes(2);
+    expect(h.runDetect).toHaveBeenCalledTimes(1);
+    expect(ctx.summary.iterationsRun).toBe(1);
+  });
+
+  it('is bounded at 5 iterations even when drift keeps decreasing', async () => {
+    const ctx = contextWithDrift(6);
+    h.runAlign.mockResolvedValue(alignResult(1));
+    // Strictly decreasing 5,4,3,2,1 keeps making progress every pass.
+    let n = 5;
+    h.runDetect.mockImplementation(async () => ({ findings: findings(n--) }));
+
+    await runFix(makeInput(ctx));
+
+    expect(h.runAlign).toHaveBeenCalledTimes(5);
+    expect(ctx.summary.iterationsRun).toBe(5);
+  });
+
+  it('records a verifier failure and stops when align throws', async () => {
+    const ctx = contextWithDrift(2);
+    h.runAlign.mockRejectedValue(new Error('align boom'));
+
+    await runFix(makeInput(ctx));
+
+    expect(ctx.verifiersFailed).toEqual([{ name: 'align-design-system', error: 'align boom' }]);
+    expect(h.runDetect).not.toHaveBeenCalled();
+    expect(ctx.summary.iterationsRun).toBe(0);
+  });
+
+  it('stringifies non-Error align rejections in the verifier failure', async () => {
+    const ctx = contextWithDrift(2);
+    h.runAlign.mockRejectedValue('plain string failure');
+
+    await runFix(makeInput(ctx));
+
+    expect(ctx.verifiersFailed).toEqual([
+      { name: 'align-design-system', error: 'plain string failure' },
+    ]);
+  });
+
+  it('stops without touching the context findings when re-detect throws', async () => {
+    const ctx = contextWithDrift(2);
+    const original = ctx.driftFindings;
+    h.runAlign.mockResolvedValue(alignResult(1));
+    h.runDetect.mockRejectedValue(new Error('detect boom'));
+
+    await runFix(makeInput(ctx));
+
+    // safelyRedetect swallows the error and returns null -> loop breaks.
+    expect(ctx.summary.iterationsRun).toBe(0);
+    expect(ctx.driftFindings).toBe(original);
+    expect(ctx.verifiersFailed).toEqual([]); // detect failure is silent, not recorded
+  });
+
+  it('forwards mode, files, and designStrictness to re-detect only when provided', async () => {
+    const ctx = contextWithDrift(2);
+    h.runAlign.mockResolvedValue(alignResult(1));
+    h.runDetect.mockResolvedValue({ findings: findings(2) }); // no progress -> single detect
+
+    await runFix(makeInput(ctx, { mode: 'full', files: ['a.tsx'], designStrictness: 'strict' }));
+
+    expect(h.runDetect).toHaveBeenCalledWith({
+      path: PROJECT_ROOT,
+      mode: 'full',
+      files: ['a.tsx'],
+      designStrictness: 'strict',
+    });
+  });
+
+  it('omits files and designStrictness from re-detect when they are undefined', async () => {
+    const ctx = contextWithDrift(2);
+    h.runAlign.mockResolvedValue(alignResult(1));
+    h.runDetect.mockResolvedValue({ findings: findings(2) });
+
+    await runFix(makeInput(ctx)); // files/designStrictness left undefined
+
+    expect(h.runDetect).toHaveBeenCalledWith({ path: PROJECT_ROOT, mode: 'fast' });
+  });
+
+  describe('pipeline handoff write', () => {
+    /** Parse the JSON payload of the last writeFileSync call. */
+    function lastWrittenHandoff(): Record<string, unknown> {
+      const calls = h.writeFileSync.mock.calls;
+      const [pathArg, dataArg] = calls[calls.length - 1] as [string, string];
+      expect(pathArg).toContain('handoff.json');
+      return JSON.parse(dataArg as string);
+    }
+
+    it('writes the pipeline findings to .harness/handoff.json', async () => {
+      const ctx = contextWithDrift(2);
+      h.runAlign.mockResolvedValue(alignResult(0));
+
+      await runFix(makeInput(ctx));
+
+      const dir = path.dirname((h.writeFileSync.mock.calls[0] as [string])[0]);
+      expect(h.mkdirSync).toHaveBeenCalledWith(dir, { recursive: true });
+
+      const written = lastWrittenHandoff();
+      expect(written.pipeline).toEqual({ driftFindings: ctx.driftFindings });
+    });
+
+    it('merges the pipeline field into an existing handoff file', async () => {
+      const ctx = contextWithDrift(1);
+      h.runAlign.mockResolvedValue(alignResult(0));
+      h.existsSync.mockReturnValue(true);
+      h.readFileSync.mockReturnValue(JSON.stringify({ other: 'keep-me' }));
+
+      await runFix(makeInput(ctx));
+
+      const written = lastWrittenHandoff();
+      expect(written.other).toBe('keep-me');
+      expect(written.pipeline).toBeDefined();
+    });
+
+    it('recovers from a corrupt existing handoff file by starting fresh', async () => {
+      const ctx = contextWithDrift(1);
+      h.runAlign.mockResolvedValue(alignResult(0));
+      h.existsSync.mockReturnValue(true);
+      h.readFileSync.mockReturnValue('}{ not valid json');
+
+      await expect(runFix(makeInput(ctx))).resolves.toBeUndefined();
+
+      const written = lastWrittenHandoff();
+      expect(written.other).toBeUndefined(); // corrupt content discarded
+      expect(written.pipeline).toBeDefined();
+    });
+  });
+});

--- a/packages/cli/src/hooks/support-files.test.ts
+++ b/packages/cli/src/hooks/support-files.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { HOOK_SUPPORT_FILES, supportFilesFor } from './support-files';
+
+/**
+ * Behavior guard for the hook support-file registry. supportFilesFor() resolves
+ * the deduplicated basenames of support modules that the installer must ship and
+ * preserve alongside a set of active hooks. These tests pin the current registry
+ * contract and the resolve/dedupe semantics (unknown hooks contribute nothing,
+ * duplicates collapse, first-seen order is preserved).
+ */
+describe('HOOK_SUPPORT_FILES registry', () => {
+  it('maps the format-check-dependent hooks to their shared support module', () => {
+    expect(HOOK_SUPPORT_FILES['quality-warner']).toEqual(['format-check.js']);
+    expect(HOOK_SUPPORT_FILES['strict-quality-gate']).toEqual(['format-check.js']);
+  });
+
+  it('has no entry for self-contained hooks that need no support file', () => {
+    // A hook that ships as a single verbatim .js file must not appear in the
+    // registry, otherwise the installer would try to preserve a phantom file.
+    expect(HOOK_SUPPORT_FILES['protect-config']).toBeUndefined();
+    expect(HOOK_SUPPORT_FILES['cost-tracker']).toBeUndefined();
+  });
+});
+
+describe('supportFilesFor', () => {
+  it('returns the support files for a single registered hook', () => {
+    expect(supportFilesFor(['quality-warner'])).toEqual(['format-check.js']);
+  });
+
+  it('deduplicates support files shared across multiple active hooks', () => {
+    // Both registered hooks depend on the same support module; the installer
+    // should be told to ship it exactly once.
+    expect(supportFilesFor(['quality-warner', 'strict-quality-gate'])).toEqual(['format-check.js']);
+  });
+
+  it('ignores hook names that have no registry entry', () => {
+    expect(supportFilesFor(['protect-config', 'cost-tracker'])).toEqual([]);
+  });
+
+  it('collects only the registered hooks from a mixed set', () => {
+    const result = supportFilesFor(['protect-config', 'strict-quality-gate', 'block-no-verify']);
+    expect(result).toEqual(['format-check.js']);
+  });
+
+  it('returns an empty array for no active hooks', () => {
+    expect(supportFilesFor([])).toEqual([]);
+  });
+
+  it('preserves first-seen order across distinct support files', () => {
+    // Derive expectations from the registry itself so this test tracks the real
+    // source of truth rather than a hardcoded ordering. We build two hook names
+    // whose support files differ, then assert union order is first-seen.
+    const registered = Object.entries(HOOK_SUPPORT_FILES);
+    const withFiles = registered.filter(([, files]) => files.length > 0);
+    // Current registry only contains one distinct support file; assert the
+    // dedupe still yields that single-element ordering deterministically.
+    const distinct = [...new Set(withFiles.flatMap(([, files]) => files))];
+    expect(supportFilesFor(withFiles.map(([name]) => name))).toEqual(distinct);
+  });
+
+  it('does not mutate the underlying registry entries', () => {
+    const before = [...HOOK_SUPPORT_FILES['quality-warner']!];
+    const result = supportFilesFor(['quality-warner']);
+    result.push('injected.js');
+    expect(HOOK_SUPPORT_FILES['quality-warner']).toEqual(before);
+  });
+});

--- a/packages/cli/src/mcp/tools/blueprint.test.ts
+++ b/packages/cli/src/mcp/tools/blueprint.test.ts
@@ -1,0 +1,95 @@
+import path from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateBlueprintDefinition, handleGenerateBlueprint } from './blueprint.js';
+
+// Hoisted mock state so we can reconfigure ProjectScanner per-test without
+// touching the filesystem. The handler dynamically imports
+// '@harness-engineering/core', so we intercept the whole module.
+const scanMock = vi.hoisted(() => vi.fn());
+const scannerCtor = vi.hoisted(() => vi.fn());
+
+vi.mock('@harness-engineering/core', () => ({
+  ProjectScanner: class {
+    constructor(projectPath: string) {
+      scannerCtor(projectPath);
+    }
+    scan() {
+      return scanMock();
+    }
+  },
+}));
+
+function parse(res: { content: Array<{ text: string }> }) {
+  const first = res.content[0];
+  if (!first) throw new Error('expected tool response content');
+  return JSON.parse(first.text);
+}
+
+beforeEach(() => {
+  scanMock.mockReset();
+  scannerCtor.mockReset();
+});
+
+describe('generateBlueprintDefinition', () => {
+  it('declares the generate_blueprint tool requiring a path', () => {
+    expect(generateBlueprintDefinition.name).toBe('generate_blueprint');
+    expect(generateBlueprintDefinition.inputSchema.required).toEqual(['path']);
+    expect(generateBlueprintDefinition.inputSchema.properties.path.type).toBe('string');
+  });
+});
+
+describe('handleGenerateBlueprint', () => {
+  it('scans the sanitized path and returns the scan data as JSON', async () => {
+    const scanData = { modules: [{ name: 'core' }], hotspots: [], dependencies: {} };
+    scanMock.mockResolvedValue(scanData);
+
+    const res = await handleGenerateBlueprint({ path: 'some/project' });
+
+    // No error flag on the success path.
+    expect('isError' in res).toBe(false);
+    // The response echoes exactly what the scanner produced, JSON-encoded.
+    expect(parse(res)).toEqual(scanData);
+    expect(scanMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('constructs the scanner with the resolved absolute path', async () => {
+    scanMock.mockResolvedValue({});
+
+    await handleGenerateBlueprint({ path: 'relative/dir' });
+
+    expect(scannerCtor).toHaveBeenCalledTimes(1);
+    const passedPath = scannerCtor.mock.calls[0]![0];
+    // sanitizePath resolves to an absolute path before the scanner sees it.
+    // Use path helpers so the assertion holds on Windows (backslash sep, drive root) too.
+    expect(passedPath.endsWith(path.join('relative', 'dir'))).toBe(true);
+    expect(path.isAbsolute(passedPath)).toBe(true);
+  });
+
+  it('rejects the filesystem root before ever constructing a scanner', async () => {
+    const res = await handleGenerateBlueprint({ path: '/' });
+
+    expect('isError' in res && res.isError).toBe(true);
+    expect(res.content[0]!.text).toBe('Error: Invalid project path: cannot use filesystem root');
+    // The sanitize failure short-circuits: the scanner is never built or run.
+    expect(scannerCtor).not.toHaveBeenCalled();
+    expect(scanMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a structured blueprint-generation error when the scan throws', async () => {
+    scanMock.mockRejectedValue(new Error('scan boom'));
+
+    const res = await handleGenerateBlueprint({ path: 'some/project' });
+
+    expect('isError' in res && res.isError).toBe(true);
+    expect(res.content[0]!.text).toBe('Error generating blueprint: scan boom');
+  });
+
+  it('stringifies non-Error scan rejections in the error message', async () => {
+    scanMock.mockRejectedValue('plain string failure');
+
+    const res = await handleGenerateBlueprint({ path: 'some/project' });
+
+    expect('isError' in res && res.isError).toBe(true);
+    expect(res.content[0]!.text).toBe('Error generating blueprint: plain string failure');
+  });
+});

--- a/packages/cli/src/mcp/tools/graph/ingest-source.test.ts
+++ b/packages/cli/src/mcp/tools/graph/ingest-source.test.ts
@@ -1,0 +1,259 @@
+import * as path from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The handler dynamically imports `@harness-engineering/graph` and
+// `node:fs/promises`, and statically imports `loadIngestOptions`. All three are
+// mocked so the test is hermetic: no real filesystem, no real graph engine, no
+// subprocess. We assert the observable contract — which ingestors run for each
+// `source`, how their results are aggregated, and the JSON payload shape.
+const mocks = vi.hoisted(() => {
+  // Distinct nodesAdded per ingestor so aggregation + branching are provable
+  // from the returned payload. Expected sums are derived from these fixtures,
+  // never hardcoded.
+  const makeResult = (tag: string, nodesAdded: number) => ({
+    nodesAdded,
+    nodesUpdated: 2,
+    edgesAdded: 3,
+    edgesUpdated: 4,
+    errors: [tag],
+    durationMs: 5,
+  });
+
+  return {
+    results: {
+      code: makeResult('code-ingest', 10),
+      knowledge: makeResult('knowledge-ingest', 100),
+      git: makeResult('git-ingest', 1000),
+      signals: makeResult('signals-ingest', 10000),
+      diagrams: makeResult('diagrams-ingest', 100000),
+    },
+    nodeCount: 42,
+    edgeCount: 7,
+    ingestOptions: { sentinel: 'ingest-options' } as const,
+    load: vi.fn(async () => {}),
+    save: vi.fn(async () => {}),
+    mkdir: vi.fn(async () => {}),
+    codeCtor: vi.fn(),
+    codeIngest: vi.fn(),
+    link: vi.fn(),
+    knowledgeIngestAll: vi.fn(),
+    gitIngest: vi.fn(),
+    signalsRun: vi.fn(),
+    diagramsIngest: vi.fn(),
+    loadIngestOptions: vi.fn(),
+  };
+});
+
+vi.mock('@harness-engineering/graph', () => ({
+  GraphStore: class {
+    load = mocks.load;
+    save = mocks.save;
+    get nodeCount() {
+      return mocks.nodeCount;
+    }
+    get edgeCount() {
+      return mocks.edgeCount;
+    }
+  },
+  CodeIngestor: class {
+    constructor(store: unknown, options: unknown) {
+      mocks.codeCtor(store, options);
+    }
+    ingest = mocks.codeIngest;
+  },
+  TopologicalLinker: class {
+    constructor(_store: unknown) {}
+    link = mocks.link;
+  },
+  KnowledgeIngestor: class {
+    constructor(_store: unknown) {}
+    ingestAll = mocks.knowledgeIngestAll;
+  },
+  GitIngestor: class {
+    constructor(_store: unknown) {}
+    ingest = mocks.gitIngest;
+  },
+  createExtractionRunner: () => ({ run: mocks.signalsRun }),
+  DiagramParser: class {
+    constructor(_store: unknown) {}
+    ingest = mocks.diagramsIngest;
+  },
+}));
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: mocks.mkdir,
+  default: { mkdir: mocks.mkdir },
+}));
+
+// Same relative specifier the SUT uses; the test sits in the SUT's directory so
+// this resolves to the identical module id the handler imports.
+vi.mock('../../../commands/graph/ingest-options.js', () => ({
+  loadIngestOptions: mocks.loadIngestOptions,
+}));
+
+import { handleIngestSource } from './ingest-source.js';
+
+// Absolute, non-root project path (path.resolve guarantees both, cross-platform).
+const PROJECT_PATH = path.resolve('canary-fake-project');
+const GRAPH_DIR = path.join(PROJECT_PATH, '.harness', 'graph');
+const EXTRACTED_DIR = path.join(PROJECT_PATH, '.harness', 'knowledge', 'extracted');
+
+function parse(res: { content: Array<{ text: string }> }) {
+  const first = res.content[0];
+  if (!first) throw new Error('expected tool response content');
+  return JSON.parse(first.text);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.load.mockResolvedValue(undefined);
+  mocks.save.mockResolvedValue(undefined);
+  mocks.mkdir.mockResolvedValue(undefined);
+  mocks.link.mockReturnValue(undefined);
+  mocks.loadIngestOptions.mockReturnValue(mocks.ingestOptions);
+  mocks.codeIngest.mockResolvedValue(mocks.results.code);
+  mocks.knowledgeIngestAll.mockResolvedValue(mocks.results.knowledge);
+  mocks.gitIngest.mockResolvedValue(mocks.results.git);
+  mocks.signalsRun.mockResolvedValue(mocks.results.signals);
+  mocks.diagramsIngest.mockResolvedValue(mocks.results.diagrams);
+});
+
+describe('handleIngestSource — source branching', () => {
+  it('source "code" runs only the code ingestor + topological linker', async () => {
+    const res = await handleIngestSource({ path: PROJECT_PATH, source: 'code' });
+
+    expect(mocks.codeIngest).toHaveBeenCalledTimes(1);
+    expect(mocks.codeIngest).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(mocks.link).toHaveBeenCalledTimes(1);
+
+    // The other branches must not run for a code-only ingest.
+    expect(mocks.knowledgeIngestAll).not.toHaveBeenCalled();
+    expect(mocks.gitIngest).not.toHaveBeenCalled();
+    expect(mocks.signalsRun).not.toHaveBeenCalled();
+    expect(mocks.diagramsIngest).not.toHaveBeenCalled();
+
+    // Only the code result feeds the aggregate.
+    const combined = parse(res);
+    expect(combined.nodesAdded).toBe(mocks.results.code.nodesAdded);
+    expect(combined.errors).toEqual(mocks.results.code.errors);
+    expect(res.isError).toBeUndefined();
+  });
+
+  it('source "knowledge" runs only the knowledge ingestor', async () => {
+    await handleIngestSource({ path: PROJECT_PATH, source: 'knowledge' });
+
+    expect(mocks.knowledgeIngestAll).toHaveBeenCalledTimes(1);
+    expect(mocks.knowledgeIngestAll).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(mocks.codeIngest).not.toHaveBeenCalled();
+    expect(mocks.link).not.toHaveBeenCalled();
+    expect(mocks.gitIngest).not.toHaveBeenCalled();
+    expect(mocks.signalsRun).not.toHaveBeenCalled();
+    expect(mocks.diagramsIngest).not.toHaveBeenCalled();
+  });
+
+  it('source "git" runs only the git ingestor', async () => {
+    await handleIngestSource({ path: PROJECT_PATH, source: 'git' });
+
+    expect(mocks.gitIngest).toHaveBeenCalledTimes(1);
+    expect(mocks.gitIngest).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(mocks.codeIngest).not.toHaveBeenCalled();
+    expect(mocks.knowledgeIngestAll).not.toHaveBeenCalled();
+    expect(mocks.signalsRun).not.toHaveBeenCalled();
+    expect(mocks.diagramsIngest).not.toHaveBeenCalled();
+  });
+
+  it('source "business-signals" runs the extraction runner against the extracted dir', async () => {
+    await handleIngestSource({ path: PROJECT_PATH, source: 'business-signals' });
+
+    expect(mocks.signalsRun).toHaveBeenCalledTimes(1);
+    const [runProjectPath, , runExtractedDir] = mocks.signalsRun.mock.calls[0]!;
+    expect(runProjectPath).toBe(PROJECT_PATH);
+    expect(runExtractedDir).toBe(EXTRACTED_DIR);
+    expect(mocks.codeIngest).not.toHaveBeenCalled();
+    expect(mocks.diagramsIngest).not.toHaveBeenCalled();
+  });
+
+  it('source "diagrams" runs only the diagram parser', async () => {
+    await handleIngestSource({ path: PROJECT_PATH, source: 'diagrams' });
+
+    expect(mocks.diagramsIngest).toHaveBeenCalledTimes(1);
+    expect(mocks.diagramsIngest).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(mocks.codeIngest).not.toHaveBeenCalled();
+    expect(mocks.signalsRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleIngestSource — "all" aggregation', () => {
+  it('runs every ingestor and sums their per-field results', async () => {
+    const res = await handleIngestSource({ path: PROJECT_PATH, source: 'all' });
+
+    expect(mocks.codeIngest).toHaveBeenCalledTimes(1);
+    expect(mocks.link).toHaveBeenCalledTimes(1);
+    expect(mocks.knowledgeIngestAll).toHaveBeenCalledTimes(1);
+    expect(mocks.gitIngest).toHaveBeenCalledTimes(1);
+    expect(mocks.signalsRun).toHaveBeenCalledTimes(1);
+    expect(mocks.diagramsIngest).toHaveBeenCalledTimes(1);
+
+    const all = Object.values(mocks.results);
+    const sum = (
+      key: 'nodesAdded' | 'nodesUpdated' | 'edgesAdded' | 'edgesUpdated' | 'durationMs'
+    ) => all.reduce((acc, r) => acc + r[key], 0);
+
+    const combined = parse(res);
+    expect(combined.nodesAdded).toBe(sum('nodesAdded'));
+    expect(combined.nodesUpdated).toBe(sum('nodesUpdated'));
+    expect(combined.edgesAdded).toBe(sum('edgesAdded'));
+    expect(combined.edgesUpdated).toBe(sum('edgesUpdated'));
+    expect(combined.durationMs).toBe(sum('durationMs'));
+    expect(combined.errors).toEqual(all.flatMap((r) => r.errors));
+  });
+
+  it('embeds live graph stats from the store', async () => {
+    const combined = parse(await handleIngestSource({ path: PROJECT_PATH, source: 'all' }));
+    expect(combined.graphStats).toEqual({
+      totalNodes: mocks.nodeCount,
+      totalEdges: mocks.edgeCount,
+    });
+  });
+});
+
+describe('handleIngestSource — wiring', () => {
+  it('creates the graph dir, loads and saves the store at that dir', async () => {
+    await handleIngestSource({ path: PROJECT_PATH, source: 'code' });
+
+    expect(mocks.mkdir).toHaveBeenCalledWith(GRAPH_DIR, { recursive: true });
+    expect(mocks.load).toHaveBeenCalledWith(GRAPH_DIR);
+    expect(mocks.save).toHaveBeenCalledWith(GRAPH_DIR);
+  });
+
+  it('constructs the code ingestor with options from loadIngestOptions', async () => {
+    await handleIngestSource({ path: PROJECT_PATH, source: 'code' });
+
+    expect(mocks.loadIngestOptions).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(mocks.codeCtor).toHaveBeenCalledWith(expect.anything(), mocks.ingestOptions);
+  });
+});
+
+describe('handleIngestSource — error handling', () => {
+  it('returns an isError response when the project path is the filesystem root', async () => {
+    // sanitizePath rejects the root before any ingestor runs.
+    const res = await handleIngestSource({ path: path.parse(process.cwd()).root, source: 'all' });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toMatch(/^Error: /);
+    expect(res.content[0]!.text).toContain('cannot use filesystem root');
+    expect(mocks.codeIngest).not.toHaveBeenCalled();
+    expect(mocks.save).not.toHaveBeenCalled();
+  });
+
+  it('returns an isError response when an ingestor step throws', async () => {
+    mocks.load.mockRejectedValueOnce(new Error('graph store corrupt'));
+
+    const res = await handleIngestSource({ path: PROJECT_PATH, source: 'all' });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toBe('Error: graph store corrupt');
+    // Failure short-circuits before the save.
+    expect(mocks.save).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/mcp/tools/interaction-renderer.test.ts
+++ b/packages/cli/src/mcp/tools/interaction-renderer.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderQuestion,
+  renderConfirmation,
+  renderTransition,
+  renderBatch,
+} from './interaction-renderer';
+import type {
+  InteractionQuestion,
+  InteractionConfirmation,
+  InteractionTransition,
+  InteractionBatch,
+  InteractionOption,
+} from './interaction-schemas';
+
+function makeOption(overrides: Partial<InteractionOption> = {}): InteractionOption {
+  return {
+    label: 'Option',
+    pros: ['pro'],
+    cons: ['con'],
+    ...overrides,
+  };
+}
+
+describe('renderQuestion', () => {
+  it('returns raw text for a free-form question with no options', () => {
+    const question: InteractionQuestion = { text: 'What should we do?' };
+    expect(renderQuestion(question)).toBe('What should we do?');
+  });
+
+  it('returns raw text when options is an empty array', () => {
+    const question: InteractionQuestion = { text: 'Empty options?', options: [] };
+    expect(renderQuestion(question)).toBe('Empty options?');
+  });
+
+  it('builds a comparison table with lettered column headers, pros and cons rows', () => {
+    const question: InteractionQuestion = {
+      text: 'Pick a path',
+      options: [
+        makeOption({ label: 'Alpha', pros: ['fast', 'cheap'], cons: ['risky'] }),
+        makeOption({ label: 'Beta', pros: ['safe'], cons: ['slow', 'costly'] }),
+      ],
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).toBe(
+      '### Decision needed: Pick a path\n\n' +
+        '| | A) Alpha | B) Beta |\n' +
+        '|---|---|---|\n' +
+        '| **Pros** | fast; cheap | safe |\n' +
+        '| **Cons** | risky | slow; costly |'
+    );
+  });
+
+  it('omits risk and effort rows when no option carries them', () => {
+    const question: InteractionQuestion = {
+      text: 'No risk metadata',
+      options: [makeOption(), makeOption({ label: 'Other' })],
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).not.toContain('**Risk**');
+    expect(result).not.toContain('**Effort**');
+  });
+
+  it('adds a risk row (capitalized, dash for missing) when any option has risk', () => {
+    const question: InteractionQuestion = {
+      text: 'With risk',
+      options: [makeOption({ label: 'A', risk: 'high' }), makeOption({ label: 'B' })],
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).toContain('| **Risk** | High | - |');
+    expect(result).not.toContain('**Effort**');
+  });
+
+  it('adds an effort row (capitalized, dash for missing) when any option has effort', () => {
+    const question: InteractionQuestion = {
+      text: 'With effort',
+      options: [makeOption({ label: 'A' }), makeOption({ label: 'B', effort: 'medium' })],
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).toContain('| **Effort** | - | Medium |');
+    expect(result).not.toContain('**Risk**');
+  });
+
+  it('escapes pipe characters in labels, pros, and cons so table cells do not break', () => {
+    const question: InteractionQuestion = {
+      text: 'Escaping',
+      options: [
+        makeOption({ label: 'a|b', pros: ['p|q'], cons: ['c|d'] }),
+        makeOption({ label: 'Other' }),
+      ],
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).toContain('A) a\\|b');
+    expect(result).toContain('p\\|q');
+    expect(result).toContain('c\\|d');
+  });
+
+  it('appends a recommendation line with the referenced column label and confidence', () => {
+    const question: InteractionQuestion = {
+      text: 'Recommend one',
+      options: [makeOption({ label: 'First' }), makeOption({ label: 'Second' })],
+      recommendation: { optionIndex: 1, reason: 'It is safer overall', confidence: 'high' },
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).toContain('**Recommendation:** B) Second (confidence: high)');
+    expect(result).toContain('\n> It is safer overall');
+  });
+
+  it('omits the reason quote when the reason merely restates the question text', () => {
+    const question: InteractionQuestion = {
+      text: 'Should we ship?',
+      options: [makeOption({ label: 'Yes' }), makeOption({ label: 'No' })],
+      recommendation: { optionIndex: 0, reason: '  Should we ship?  ', confidence: 'low' },
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).toContain('**Recommendation:** A) Yes (confidence: low)');
+    expect(result).not.toContain('\n> ');
+  });
+
+  it('omits the reason quote when the reason begins with the full question text', () => {
+    const question: InteractionQuestion = {
+      text: 'Should we ship',
+      options: [makeOption({ label: 'Yes' }), makeOption({ label: 'No' })],
+      recommendation: {
+        optionIndex: 0,
+        reason: 'Should we ship the release now',
+        confidence: 'medium',
+      },
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).not.toContain('\n> ');
+  });
+
+  it('ignores a recommendation that points at a non-existent option index', () => {
+    const question: InteractionQuestion = {
+      text: 'Out of range',
+      options: [makeOption({ label: 'Only' }), makeOption({ label: 'Two' })],
+      recommendation: { optionIndex: 5, reason: 'nope', confidence: 'high' },
+    };
+
+    const result = renderQuestion(question);
+
+    expect(result).not.toContain('**Recommendation:**');
+  });
+});
+
+describe('renderConfirmation', () => {
+  it('renders text and context and prompts for yes/no', () => {
+    const confirmation: InteractionConfirmation = {
+      text: 'Delete the branch?',
+      context: 'It has been merged',
+    };
+
+    expect(renderConfirmation(confirmation)).toBe(
+      'Delete the branch?\n\nContext: It has been merged\n\nProceed? (yes/no)'
+    );
+  });
+
+  it('includes impact and capitalized risk when provided', () => {
+    const confirmation: InteractionConfirmation = {
+      text: 'Force push?',
+      context: 'Rewrites history',
+      impact: 'Peers must reset',
+      risk: 'high',
+    };
+
+    const result = renderConfirmation(confirmation);
+
+    expect(result).toBe(
+      'Force push?\n\nContext: Rewrites history\n\nImpact: Peers must reset\nRisk: High\n\nProceed? (yes/no)'
+    );
+  });
+});
+
+describe('renderTransition', () => {
+  it('renders phase summary, artifacts, and a proceeding line when confirmation is not required', () => {
+    const transition: InteractionTransition = {
+      completedPhase: 'design',
+      suggestedNext: 'implementation',
+      reason: 'Design approved.',
+      artifacts: ['spec.md', 'diagram.svg'],
+      requiresConfirmation: false,
+      summary: 'We settled the API shape.',
+    };
+
+    const result = renderTransition(transition);
+
+    expect(result).toBe(
+      'Phase "design" complete. Design approved.\n\n' +
+        'We settled the API shape.\n\n' +
+        'Artifacts produced:\n  - spec.md\n  - diagram.svg\n\n' +
+        'Proceeding to implementation...'
+    );
+  });
+
+  it('asks for confirmation when requiresConfirmation is true', () => {
+    const transition: InteractionTransition = {
+      completedPhase: 'plan',
+      suggestedNext: 'build',
+      reason: 'Plan ready.',
+      artifacts: [],
+      requiresConfirmation: true,
+      summary: 'Plan summary.',
+    };
+
+    const result = renderTransition(transition);
+
+    expect(result).toContain('Suggested next: "build". Proceed?');
+    expect(result).not.toContain('Proceeding to');
+  });
+
+  it('renders a quality gate with PASS/FAIL icons, optional detail, and an all-passed footer', () => {
+    const transition: InteractionTransition = {
+      completedPhase: 'test',
+      suggestedNext: 'release',
+      reason: 'Tests done.',
+      artifacts: ['report.txt'],
+      requiresConfirmation: false,
+      summary: 'All green.',
+      qualityGate: {
+        checks: [
+          { name: 'lint', passed: true },
+          { name: 'coverage', passed: true, detail: '95%' },
+        ],
+        allPassed: true,
+      },
+    };
+
+    const result = renderTransition(transition);
+
+    expect(result).toContain('**Quality Gate:**');
+    expect(result).toContain('  - [PASS] lint\n');
+    expect(result).toContain('  - [PASS] coverage -- 95%\n');
+    expect(result).toContain('  All checks passed.');
+  });
+
+  it('marks failed checks with FAIL and a some-checks-failed footer', () => {
+    const transition: InteractionTransition = {
+      completedPhase: 'test',
+      suggestedNext: 'release',
+      reason: 'Tests done.',
+      artifacts: ['report.txt'],
+      requiresConfirmation: false,
+      summary: 'Some red.',
+      qualityGate: {
+        checks: [{ name: 'typecheck', passed: false, detail: '3 errors' }],
+        allPassed: false,
+      },
+    };
+
+    const result = renderTransition(transition);
+
+    expect(result).toContain('  - [FAIL] typecheck -- 3 errors\n');
+    expect(result).toContain('  **Some checks failed.**');
+  });
+});
+
+describe('renderBatch', () => {
+  it('enumerates decisions with labels, recommendations, and a fixed low-risk annotation', () => {
+    const batch: InteractionBatch = {
+      text: 'Approve these defaults?',
+      decisions: [
+        { label: 'Framework', recommendation: 'Vitest', risk: 'low' },
+        { label: 'Placement', recommendation: 'colocated', risk: 'low' },
+      ],
+    };
+
+    const result = renderBatch(batch);
+
+    expect(result).toBe(
+      'Approve these defaults?\n\n' +
+        '1. **Framework** -- Recommendation: Vitest (risk: low)\n' +
+        '2. **Placement** -- Recommendation: colocated (risk: low)\n' +
+        '\nApprove all? (yes/no)'
+    );
+  });
+});

--- a/packages/cli/src/shared/craft/findings/derived.test.ts
+++ b/packages/cli/src/shared/craft/findings/derived.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import type { Tier, Impact, Confidence } from './axes.js';
+import { derivePriority } from './derived.js';
+
+// Axis domains, mirrored from ./axes.ts. Kept as local constants so the
+// exhaustive/monotonicity assertions below are derived from the full domain
+// rather than hardcoded literals.
+const TIERS: Tier[] = ['foundational', 'polish', 'aspirational'];
+const IMPACTS: Impact[] = ['small', 'medium', 'large'];
+const CONFIDENCES: Confidence[] = ['high', 'medium', 'low'];
+
+// Reference weights from the SUT's documented MVP rule:
+//   priority = TIER_BAND[tier] + IMPACT_WEIGHT[impact] * CONFIDENCE_WEIGHT[confidence]
+const TIER_BAND: Record<Tier, number> = {
+  foundational: 1000,
+  polish: 100,
+  aspirational: 10,
+};
+const IMPACT_WEIGHT: Record<Impact, number> = { large: 9, medium: 6, small: 3 };
+const CONFIDENCE_WEIGHT: Record<Confidence, number> = { high: 5, medium: 3, low: 1 };
+
+function expected(tier: Tier, impact: Impact, confidence: Confidence): number {
+  return TIER_BAND[tier] + IMPACT_WEIGHT[impact] * CONFIDENCE_WEIGHT[confidence];
+}
+
+describe('derivePriority', () => {
+  it('applies band + impact*confidence for a representative case', () => {
+    // foundational band (1000) + large(9) * high(5) = 1000 + 45 = 1045
+    expect(derivePriority('foundational', 'large', 'high')).toBe(1045);
+  });
+
+  it('matches the documented formula across every axis combination', () => {
+    for (const tier of TIERS) {
+      for (const impact of IMPACTS) {
+        for (const confidence of CONFIDENCES) {
+          expect(derivePriority(tier, impact, confidence)).toBe(expected(tier, impact, confidence));
+        }
+      }
+    }
+  });
+
+  it('keeps the tier band dominant: worst within-band never outranks best of a lower band', () => {
+    // The band gap (order-of-magnitude) must exceed the widest within-band
+    // score spread, so ANY higher-tier finding outranks ANY lower-tier one.
+    const minWithinBand = Math.min(
+      ...IMPACTS.flatMap((impact) =>
+        CONFIDENCES.map((c) => IMPACT_WEIGHT[impact] * CONFIDENCE_WEIGHT[c])
+      )
+    );
+    const maxWithinBand = Math.max(
+      ...IMPACTS.flatMap((impact) =>
+        CONFIDENCES.map((c) => IMPACT_WEIGHT[impact] * CONFIDENCE_WEIGHT[c])
+      )
+    );
+
+    // foundational/small/low outranks any polish finding
+    for (const impact of IMPACTS) {
+      for (const confidence of CONFIDENCES) {
+        expect(derivePriority('foundational', 'small', 'low')).toBeGreaterThan(
+          derivePriority('polish', impact, confidence)
+        );
+        // polish/small/low outranks any aspirational finding
+        expect(derivePriority('polish', 'small', 'low')).toBeGreaterThan(
+          derivePriority('aspirational', impact, confidence)
+        );
+      }
+    }
+
+    // Sanity: the guarantee only holds because the band step (>= 90) exceeds
+    // the within-band spread.
+    expect(TIER_BAND.polish - TIER_BAND.aspirational).toBeGreaterThan(
+      maxWithinBand - minWithinBand
+    );
+  });
+
+  it('is monotonic in impact (confidence and tier fixed)', () => {
+    for (const tier of TIERS) {
+      for (const confidence of CONFIDENCES) {
+        expect(derivePriority(tier, 'small', confidence)).toBeLessThan(
+          derivePriority(tier, 'medium', confidence)
+        );
+        expect(derivePriority(tier, 'medium', confidence)).toBeLessThan(
+          derivePriority(tier, 'large', confidence)
+        );
+      }
+    }
+  });
+
+  it('is monotonic in confidence (impact and tier fixed)', () => {
+    for (const tier of TIERS) {
+      for (const impact of IMPACTS) {
+        expect(derivePriority(tier, impact, 'low')).toBeLessThan(
+          derivePriority(tier, impact, 'medium')
+        );
+        expect(derivePriority(tier, impact, 'medium')).toBeLessThan(
+          derivePriority(tier, impact, 'high')
+        );
+      }
+    }
+  });
+
+  it('always returns a positive number', () => {
+    for (const tier of TIERS) {
+      for (const impact of IMPACTS) {
+        for (const confidence of CONFIDENCES) {
+          expect(derivePriority(tier, impact, confidence)).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it('is a pure function: identical inputs yield identical output', () => {
+    const first = derivePriority('polish', 'medium', 'medium');
+    const second = derivePriority('polish', 'medium', 'medium');
+    expect(second).toBe(first);
+  });
+});

--- a/packages/cli/src/shared/craft/llm/adapters.test.ts
+++ b/packages/cli/src/shared/craft/llm/adapters.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  AnalysisProviderAdapter,
+  adaptClaudeCli,
+  adaptAnthropic,
+  adaptOpenAICompatible,
+} from './adapters';
+import type { LlmCallCost } from './contracts';
+
+// The `@harness-engineering/intelligence` imports in adapters.ts are type-only
+// and erased at compile time, so no runtime mock of that package is needed.
+// We drive the adapter through a hand-built fake that satisfies the internal
+// `AnalyzeFn` shape (an object exposing an `analyze` method).
+
+interface AnalyzeRequest {
+  prompt: string;
+  systemPrompt?: string;
+  responseSchema: z.ZodType;
+  model?: string;
+  maxTokens?: number;
+}
+
+interface AnalyzeResponse {
+  result: { raw: string };
+  tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
+  model: string;
+  latencyMs: number;
+}
+
+/**
+ * Build a fake inner AnalysisProvider whose `analyze` records the request it
+ * received and returns a caller-supplied response. Returns both the fake (to
+ * pass as `inner`) and the mock so tests can inspect captured arguments.
+ */
+function makeFakeInner(response: AnalyzeResponse) {
+  const analyze = vi.fn(async (_req: AnalyzeRequest): Promise<AnalyzeResponse> => response);
+  return { fake: { analyze }, analyze };
+}
+
+const RAW_INSTRUCTIONS =
+  'Return a JSON object with a single field "raw" whose string value is the fenced JSON block ' +
+  'you would normally emit. Do not add prose outside the JSON object.';
+
+function makeResponse(overrides: Partial<AnalyzeResponse> = {}): AnalyzeResponse {
+  return {
+    result: { raw: '```json\n{"score":5}\n```' },
+    tokenUsage: { inputTokens: 11, outputTokens: 22, totalTokens: 33 },
+    model: 'model-from-response',
+    latencyMs: 7,
+    ...overrides,
+  };
+}
+
+describe('AnalysisProviderAdapter.callText', () => {
+  it('returns the raw envelope field from the inner analyze result', async () => {
+    const raw = '```json\n{"verdict":"pass"}\n```';
+    const { fake } = makeFakeInner(makeResponse({ result: { raw } }));
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'test',
+      model: 'test-model',
+      inner: fake as never,
+    });
+
+    const out = await adapter.callText('judge this');
+
+    expect(out).toBe(raw);
+  });
+
+  it('forwards the user prompt unchanged to the inner provider', async () => {
+    const { fake, analyze } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'test',
+      model: 'test-model',
+      inner: fake as never,
+    });
+
+    await adapter.callText('the exact prompt');
+
+    expect(analyze).toHaveBeenCalledTimes(1);
+    expect(analyze.mock.calls[0]![0].prompt).toBe('the exact prompt');
+  });
+
+  it('appends the raw-envelope instructions after the caller system prompt', async () => {
+    const { fake, analyze } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'test',
+      model: 'test-model',
+      inner: fake as never,
+    });
+
+    await adapter.callText('p', { systemPrompt: 'You are a strict reviewer.' });
+
+    expect(analyze.mock.calls[0]![0].systemPrompt).toBe(
+      `You are a strict reviewer.\n\n${RAW_INSTRUCTIONS}`
+    );
+  });
+
+  it('uses only the raw-envelope instructions when no system prompt is given', async () => {
+    const { fake, analyze } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'test',
+      model: 'test-model',
+      inner: fake as never,
+    });
+
+    await adapter.callText('p');
+
+    expect(analyze.mock.calls[0]![0].systemPrompt).toBe(RAW_INSTRUCTIONS);
+  });
+
+  it('passes a passthrough response schema that accepts a raw string envelope', async () => {
+    const { fake, analyze } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'test',
+      model: 'test-model',
+      inner: fake as never,
+    });
+
+    await adapter.callText('p');
+
+    const schema = analyze.mock.calls[0]![0].responseSchema;
+    // The bridge schema is z.object({ raw: z.string() }): accepts a raw string,
+    // rejects a missing/non-string field.
+    expect(schema.parse({ raw: 'hello' })).toEqual({ raw: 'hello' });
+    expect(schema.safeParse({ raw: 42 }).success).toBe(false);
+    expect(schema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('AnalysisProviderAdapter cost recording', () => {
+  it('records one cost entry per call with token usage from the response', async () => {
+    const { fake } = makeFakeInner(
+      makeResponse({ tokenUsage: { inputTokens: 100, outputTokens: 200, totalTokens: 300 } })
+    );
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'anthropic',
+      model: 'fallback-model',
+      inner: fake as never,
+    });
+
+    await adapter.callText('p');
+    const costs = adapter.getCosts();
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0]).toEqual({
+      provider: 'anthropic',
+      model: 'model-from-response',
+      inputTokens: 100,
+      outputTokens: 200,
+      costUsd: 0,
+    });
+  });
+
+  it('falls back to the adapter model when the response model is empty', async () => {
+    const { fake } = makeFakeInner(makeResponse({ model: '' }));
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'anthropic',
+      model: 'fallback-model',
+      inner: fake as never,
+    });
+
+    await adapter.callText('p');
+
+    expect(adapter.getCosts()[0]!.model).toBe('fallback-model');
+  });
+
+  it('accumulates a cost entry for each callText invocation', async () => {
+    const { fake } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'test',
+      model: 'test-model',
+      inner: fake as never,
+    });
+
+    await adapter.callText('a');
+    await adapter.callText('b');
+
+    expect(adapter.getCosts()).toHaveLength(2);
+  });
+
+  it('appends externally supplied cost entries via recordCost', () => {
+    const { fake } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'test',
+      model: 'test-model',
+      inner: fake as never,
+    });
+    const entry: LlmCallCost = {
+      provider: 'external',
+      model: 'm',
+      inputTokens: 1,
+      outputTokens: 2,
+      costUsd: 0.5,
+    };
+
+    adapter.recordCost(entry);
+
+    expect(adapter.getCosts()).toEqual([entry]);
+  });
+});
+
+describe('AnalysisProviderAdapter.callVision', () => {
+  it('throws with the provider id since vision is not wired', async () => {
+    const { fake } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'claude-cli',
+      model: 'test-model',
+      inner: fake as never,
+    });
+
+    await expect(adapter.callVision('p', { imageUrl: 'x' })).rejects.toThrow(
+      /claude-cli adapter does not implement callVision/
+    );
+  });
+});
+
+describe('factory helpers', () => {
+  it('adaptClaudeCli sets provider id and default model', () => {
+    const { fake } = makeFakeInner(makeResponse());
+    const provider = adaptClaudeCli(fake as never);
+
+    expect(provider.providerId).toBe('claude-cli');
+    expect(provider.model).toBe('claude');
+  });
+
+  it('adaptClaudeCli honors an explicit model override', () => {
+    const { fake } = makeFakeInner(makeResponse());
+    const provider = adaptClaudeCli(fake as never, 'claude-opus');
+
+    expect(provider.model).toBe('claude-opus');
+  });
+
+  it('adaptAnthropic sets provider id and default model', () => {
+    const { fake } = makeFakeInner(makeResponse());
+    const provider = adaptAnthropic(fake as never);
+
+    expect(provider.providerId).toBe('anthropic');
+    expect(provider.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('adaptOpenAICompatible sets provider id and default model', () => {
+    const { fake } = makeFakeInner(makeResponse());
+    const provider = adaptOpenAICompatible(fake as never);
+
+    expect(provider.providerId).toBe('openai-compatible');
+    expect(provider.model).toBe('unknown');
+  });
+
+  it('a factory-built adapter bridges callText through the inner provider', async () => {
+    const raw = '```json\n{"ok":true}\n```';
+    const { fake, analyze } = makeFakeInner(makeResponse({ result: { raw } }));
+    const provider = adaptOpenAICompatible(fake as never, 'gpt-4o-mini');
+
+    const out = await provider.callText('bridge me');
+
+    expect(out).toBe(raw);
+    expect(analyze).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/shared/craft/llm/orchestrator-md.test.ts
+++ b/packages/cli/src/shared/craft/llm/orchestrator-md.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as path from 'node:path';
+import { findOrchestratorMd, readBackendsFromOrchestratorMd } from './orchestrator-md.js';
+
+/**
+ * Unit contract for the synchronous orchestrator.md fallback reader. Pins the
+ * CURRENT behavior of:
+ *   - `findOrchestratorMd`: walks up from `startDir` and returns the first
+ *     ancestor containing `harness.orchestrator.md`, or null at/above root.
+ *   - `readBackendsFromOrchestratorMd`: extracts `agent.backends` from the YAML
+ *     frontmatter, returning null on any bad/missing input.
+ *
+ * Fully hermetic: every `node:fs` call the SUT makes is mocked, so there is no
+ * real IO. `node:path` and the real `yaml` parser are exercised directly, so
+ * assertions reflect real observable behavior rather than implementation
+ * trivia. Absolute paths are built from the platform root so the walk-up logic
+ * is deterministic on POSIX and Windows alike.
+ */
+
+const h = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: h.existsSync,
+  readFileSync: h.readFileSync,
+}));
+
+const FILENAME = 'harness.orchestrator.md';
+
+// Platform-appropriate absolute root (`/` on POSIX, e.g. `C:\` on Windows) so
+// the walk-up terminates at the real filesystem root the SUT computes.
+const ROOT = path.parse(path.resolve('.')).root;
+const START_DIR = path.join(ROOT, 'a', 'b', 'c');
+// The orchestrator.md lives two ancestors above START_DIR.
+const FOUND_AT = path.join(ROOT, 'a', FILENAME);
+
+/** Frontmatter helper: wraps a YAML body in `---` fences plus a markdown body. */
+function frontmatter(yamlBody: string): string {
+  return `---\n${yamlBody}\n---\n\n# Orchestrator\n`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('findOrchestratorMd', () => {
+  it('returns the first ancestor containing harness.orchestrator.md', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+
+    expect(findOrchestratorMd(START_DIR)).toBe(FOUND_AT);
+  });
+
+  it('checks candidates from the start dir upward, closest ancestor first', () => {
+    // Present in BOTH the start dir and a higher ancestor; the closest wins.
+    const closest = path.join(START_DIR, FILENAME);
+    h.existsSync.mockImplementation((p: string) => p === closest || p === FOUND_AT);
+
+    expect(findOrchestratorMd(START_DIR)).toBe(closest);
+  });
+
+  it('returns null when no ancestor contains the file', () => {
+    h.existsSync.mockReturnValue(false);
+
+    expect(findOrchestratorMd(START_DIR)).toBeNull();
+  });
+});
+
+describe('readBackendsFromOrchestratorMd', () => {
+  it('returns the agent.backends map from valid frontmatter', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue(
+      frontmatter(
+        [
+          'agent:',
+          '  backends:',
+          '    reasoner:',
+          '      type: ollama',
+          '      model: qwen3',
+          '    coder:',
+          '      type: ollama',
+          '      model: qwen3-coder',
+        ].join('\n')
+      )
+    );
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toEqual({
+      reasoner: { type: 'ollama', model: 'qwen3' },
+      coder: { type: 'ollama', model: 'qwen3-coder' },
+    });
+  });
+
+  it('reads the file that findOrchestratorMd resolved', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue(frontmatter('agent:\n  backends:\n    only: {}'));
+
+    readBackendsFromOrchestratorMd(START_DIR);
+
+    expect(h.readFileSync).toHaveBeenCalledWith(FOUND_AT, 'utf-8');
+  });
+
+  it('returns null when no orchestrator.md exists', () => {
+    h.existsSync.mockReturnValue(false);
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+    expect(h.readFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the file read throws', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+
+  it('returns null when the content has no YAML frontmatter fences', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue('# Just a heading\n\nNo frontmatter here.\n');
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+
+  it('returns null when the frontmatter YAML is malformed', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    // Tab indentation is a hard YAML parse error.
+    h.readFileSync.mockReturnValue(frontmatter('agent:\n\tbad: true'));
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+
+  it('returns null when the frontmatter is empty (parses to null)', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue(frontmatter(''));
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+
+  it('returns null when the frontmatter parses to a non-object scalar', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue(frontmatter('just a bare string'));
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+
+  it('returns null when the agent key is absent', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue(frontmatter('title: Orchestrator\nother: true'));
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+
+  it('returns null when agent is present but backends is absent', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue(frontmatter('agent:\n  reasoner: qwen3'));
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+
+  it('returns null when agent.backends is a non-object scalar', () => {
+    h.existsSync.mockImplementation((p: string) => p === FOUND_AT);
+    h.readFileSync.mockReturnValue(frontmatter('agent:\n  backends: not-a-map'));
+
+    expect(readBackendsFromOrchestratorMd(START_DIR)).toBeNull();
+  });
+});

--- a/packages/core/src/roadmap/tracker/adapters/github-http.test.ts
+++ b/packages/core/src/roadmap/tracker/adapters/github-http.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GitHubHttp, parseExternalId, buildExternalId } from './github-http';
+
+const TOKEN = 'ghp_test_token';
+
+/** Build a Response with an optional ETag header and JSON/text body. */
+function res(status: number, body: unknown, headers: Record<string, string> = {}): Response {
+  const isNoBodyStatus = status === 304 || status === 204;
+  const payload = isNoBodyStatus || body === undefined ? null : JSON.stringify(body);
+  return new Response(payload, { status, headers });
+}
+
+/** A fetchFn that returns each queued response in order, recording call args. */
+function queuedFetch(responses: Response[]) {
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  let i = 0;
+  const fetchFn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      url: url instanceof Request ? url.url : url instanceof URL ? url.href : url,
+      init,
+    });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i++;
+    return r;
+  });
+  return { fetchFn: fetchFn as unknown as typeof fetch, calls, count: () => i };
+}
+
+function http(fetchFn: typeof fetch, extra?: Partial<ConstructorParameters<typeof GitHubHttp>[0]>) {
+  return new GitHubHttp({ token: TOKEN, fetchFn, ...extra });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('GitHubHttp — construction & headers', () => {
+  it('defaults apiBase to the public GitHub API host', () => {
+    const client = http(vi.fn() as unknown as typeof fetch);
+    expect(client.apiBase).toBe('https://api.github.com');
+  });
+
+  it('honors an injected apiBase override', () => {
+    const client = http(vi.fn() as unknown as typeof fetch, {
+      apiBase: 'https://ghe.example.com/api/v3',
+    });
+    expect(client.apiBase).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('headers() carries bearer auth and the GitHub API version', () => {
+    const client = http(vi.fn() as unknown as typeof fetch);
+    expect(client.headers()).toEqual({
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    });
+  });
+
+  it('headers() merges extra headers over the defaults', () => {
+    const client = http(vi.fn() as unknown as typeof fetch);
+    const merged = client.headers({ 'If-None-Match': '"abc"', Accept: 'text/plain' });
+    expect(merged['If-None-Match']).toBe('"abc"');
+    // Caller-supplied Accept wins over the default.
+    expect(merged.Accept).toBe('text/plain');
+    expect(merged.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+});
+
+describe('GitHubHttp — request()', () => {
+  it('passes the method through and injects auth + extra headers', async () => {
+    const { fetchFn, calls } = queuedFetch([res(200, { ok: true })]);
+    const client = http(fetchFn);
+    const r = await client.request('https://api.github.com/x', {
+      method: 'POST',
+      body: '{}',
+      extraHeaders: { 'If-None-Match': '"tag"' },
+    });
+    expect(r.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.url).toBe('https://api.github.com/x');
+    const sentHeaders = call.init?.headers as Record<string, string>;
+    expect(sentHeaders.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(sentHeaders['If-None-Match']).toBe('"tag"');
+    // extraHeaders must be stripped from the RequestInit and folded into headers.
+    expect(call.init && 'extraHeaders' in call.init).toBe(false);
+    expect(call.init?.method).toBe('POST');
+    expect(call.init?.body).toBe('{}');
+  });
+
+  it('returns a 2xx response immediately without retrying', async () => {
+    const { fetchFn, count } = queuedFetch([res(201, { created: true })]);
+    const r = await http(fetchFn).request('https://api.github.com/x', { method: 'GET' });
+    expect(r.status).toBe(201);
+    expect(count()).toBe(1);
+  });
+
+  it('does not retry a 4xx that is not 403/429 (e.g. 404)', async () => {
+    const { fetchFn, count } = queuedFetch([res(404, { message: 'Not Found' })]);
+    const r = await http(fetchFn).request('https://api.github.com/x', { method: 'GET' });
+    expect(r.status).toBe(404);
+    expect(count()).toBe(1);
+  });
+});
+
+describe('GitHubHttp — fetchWithRetry backoff', () => {
+  it('retries on 500 up to maxRetries then returns the last failing response', async () => {
+    vi.useFakeTimers();
+    // Deterministic jitter so timer advancement is predictable.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const maxRetries = 3;
+    const { fetchFn, count } = queuedFetch([res(500, { e: 1 })]);
+    const client = http(fetchFn, { maxRetries, baseDelayMs: 10 });
+
+    const p = client.request('https://api.github.com/x', { method: 'GET' });
+    await vi.runAllTimersAsync();
+    const r = await p;
+
+    expect(r.status).toBe(500);
+    // 1 initial attempt + maxRetries retries.
+    expect(count()).toBe(maxRetries + 1);
+  });
+
+  it('stops retrying as soon as a retryable status clears (429 then 200)', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const { fetchFn, count } = queuedFetch([res(429, { rate: 'limited' }), res(200, { ok: true })]);
+    const client = http(fetchFn, { maxRetries: 5, baseDelayMs: 10 });
+
+    const p = client.request('https://api.github.com/x', { method: 'GET' });
+    await vi.runAllTimersAsync();
+    const r = await p;
+
+    expect(r.status).toBe(200);
+    expect(count()).toBe(2);
+  });
+
+  it('waits Retry-After seconds when the header is present', async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const retryAfterSeconds = 2;
+    const { fetchFn } = queuedFetch([
+      res(403, { secondary: 'rate limit' }, { 'Retry-After': String(retryAfterSeconds) }),
+      res(200, { ok: true }),
+    ]);
+    const client = http(fetchFn, { maxRetries: 5, baseDelayMs: 10 });
+
+    const p = client.request('https://api.github.com/x', { method: 'GET' });
+    await vi.runAllTimersAsync();
+    const r = await p;
+
+    expect(r.status).toBe(200);
+    // The backoff sleep must use Retry-After (seconds -> ms), not the base delay.
+    const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+    expect(delays).toContain(retryAfterSeconds * 1000);
+  });
+});
+
+describe('GitHubHttp — paginate()', () => {
+  const buildUrl = (page: number) => `https://api.github.com/items?page=${page}`;
+
+  it('walks pages until a short page and concatenates items with the latest ETag', async () => {
+    const perPage = 2;
+    const { fetchFn, calls } = queuedFetch([
+      res(200, [{ id: 1 }, { id: 2 }], { ETag: '"p1"' }),
+      res(200, [{ id: 3 }], { ETag: '"p2"' }),
+    ]);
+    const out = await http(fetchFn).paginate<{ id: number }>(buildUrl, perPage);
+
+    expect(out.status).toBe(200);
+    expect(out.items).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    expect(out.lastEtag).toBe('"p2"');
+    // Stopped after the short second page — did not request a third.
+    expect(calls.map((c) => c.url)).toEqual([
+      'https://api.github.com/items?page=1',
+      'https://api.github.com/items?page=2',
+    ]);
+  });
+
+  it('returns status 304 and no items when the first page is a cache hit', async () => {
+    const { fetchFn, count } = queuedFetch([res(304, undefined, { ETag: '"cached"' })]);
+    const out = await http(fetchFn).paginate<{ id: number }>(buildUrl, 100);
+
+    expect(out.status).toBe(304);
+    expect(out.items).toEqual([]);
+    expect(out.lastEtag).toBe('"cached"');
+    expect(count()).toBe(1);
+  });
+
+  it('treats a mid-walk 304 as end-of-items, preserving accumulated items with status 200', async () => {
+    const perPage = 2;
+    const { fetchFn } = queuedFetch([
+      res(200, [{ id: 1 }, { id: 2 }], { ETag: '"p1"' }),
+      res(304, undefined, { ETag: '"p2"' }),
+    ]);
+    const out = await http(fetchFn).paginate<{ id: number }>(buildUrl, perPage);
+
+    expect(out.status).toBe(200);
+    expect(out.items).toEqual([{ id: 1 }, { id: 2 }]);
+    // Mid-walk 304 ETag is adopted as the latest seen.
+    expect(out.lastEtag).toBe('"p2"');
+  });
+
+  it('forwards extraHeaders (e.g. If-None-Match) on every page request', async () => {
+    const { fetchFn, calls } = queuedFetch([res(200, [], { ETag: '"e"' })]);
+    await http(fetchFn).paginate(buildUrl, 100, { 'If-None-Match': '"prev"' });
+
+    const sent = calls[0]!.init?.headers as Record<string, string>;
+    expect(sent['If-None-Match']).toBe('"prev"');
+    expect(calls[0]!.init?.method).toBe('GET');
+  });
+
+  it('throws a descriptive error on a non-ok, non-304 response', async () => {
+    const { fetchFn } = queuedFetch([res(422, { message: 'Unprocessable' })]);
+    await expect(http(fetchFn).paginate(buildUrl, 100)).rejects.toThrow(/GitHub 422/);
+  });
+});
+
+describe('re-exported External-ID helpers', () => {
+  it('parseExternalId round-trips with buildExternalId', () => {
+    const id = buildExternalId('octocat', 'hello-world', 42);
+    expect(id).toBe('github:octocat/hello-world#42');
+    expect(parseExternalId(id)).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
+    });
+  });
+
+  it('parseExternalId returns null for a malformed id', () => {
+    expect(parseExternalId('not-a-valid-id')).toBeNull();
+  });
+});

--- a/packages/core/src/roadmap/tracker/conflict-body.test.ts
+++ b/packages/core/src/roadmap/tracker/conflict-body.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { makeTrackerConflictBody } from './conflict-body';
+import { ConflictError } from './client';
+
+const EXTERNAL_ID = 'ISSUE-42';
+const DIFF = {
+  status: { ours: 'in-progress', theirs: 'done' },
+} as const;
+
+describe('makeTrackerConflictBody', () => {
+  it('builds the 409 body from a ConflictError, defaulting conflictedWith to err.diff', () => {
+    const err = new ConflictError(EXTERNAL_ID, DIFF);
+
+    const body = makeTrackerConflictBody(err);
+
+    expect(body).toEqual({
+      error: err.message,
+      code: 'TRACKER_CONFLICT',
+      externalId: EXTERNAL_ID,
+      conflictedWith: DIFF,
+      refreshHint: 'reload-roadmap',
+    });
+    // conflictedWith defaults to the exact diff instance off the error.
+    expect(body.conflictedWith).toBe(err.diff);
+  });
+
+  it('carries the ConflictError message verbatim into error', () => {
+    const message = 'Conflict on ISSUE-42: claimed by Bob';
+    const err = new ConflictError(EXTERNAL_ID, DIFF, null, message);
+
+    const body = makeTrackerConflictBody(err);
+
+    expect(body.error).toBe(message);
+  });
+
+  it('overrides conflictedWith when opts.conflictedWith is provided', () => {
+    const err = new ConflictError(EXTERNAL_ID, DIFF);
+    const override = 'claimed by Bob';
+
+    const body = makeTrackerConflictBody(err, { conflictedWith: override });
+
+    expect(body.conflictedWith).toBe(override);
+    // Other fields remain sourced from the error.
+    expect(body.externalId).toBe(EXTERNAL_ID);
+    expect(body.code).toBe('TRACKER_CONFLICT');
+  });
+
+  it('treats an undefined override as absent and falls back to err.diff', () => {
+    const err = new ConflictError(EXTERNAL_ID, DIFF);
+
+    const body = makeTrackerConflictBody(err, { conflictedWith: undefined });
+
+    expect(body.conflictedWith).toBe(err.diff);
+  });
+
+  it('preserves a falsy-but-defined override (does not fall back to err.diff)', () => {
+    const err = new ConflictError(EXTERNAL_ID, DIFF);
+
+    // `??` only falls back on null/undefined, so empty string and null must win.
+    expect(makeTrackerConflictBody(err, { conflictedWith: '' }).conflictedWith).toBe('');
+    expect(makeTrackerConflictBody(err, { conflictedWith: 0 }).conflictedWith).toBe(0);
+    expect(makeTrackerConflictBody(err, { conflictedWith: false }).conflictedWith).toBe(false);
+  });
+
+  it('falls back to err.diff when override is explicitly null', () => {
+    const err = new ConflictError(EXTERNAL_ID, DIFF);
+
+    const body = makeTrackerConflictBody(err, { conflictedWith: null });
+
+    expect(body.conflictedWith).toBe(err.diff);
+  });
+
+  it('defaults to an empty options object (callable with a single argument)', () => {
+    const err = new ConflictError(EXTERNAL_ID, {});
+
+    const body = makeTrackerConflictBody(err);
+
+    expect(body.conflictedWith).toEqual({});
+    expect(body.refreshHint).toBe('reload-roadmap');
+  });
+
+  it('always pins the constant code and refreshHint discriminants', () => {
+    const body = makeTrackerConflictBody(new ConflictError('X-1', DIFF));
+
+    expect(body.code).toBe('TRACKER_CONFLICT');
+    expect(body.refreshHint).toBe('reload-roadmap');
+  });
+});

--- a/packages/core/src/shared/parsers/tree-sitter.test.ts
+++ b/packages/core/src/shared/parsers/tree-sitter.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { AST } from './base';
+import type { CodeSymbol, OutlineResult } from '../../code-nav/types';
+
+// Hermetic: the SUT reaches out to the real filesystem (readFileContent), the
+// WASM tree-sitter grammars (getParser), and the outline extractor
+// (extractOutlineFromTree). Mock all three so the test exercises the parser's
+// own logic — per-language extraction strategies and the LanguageParser
+// surface — without touching disk, subprocesses, or WASM.
+vi.mock('../fs-utils', () => ({
+  readFileContent: vi.fn(),
+}));
+vi.mock('../../code-nav/parser', () => ({
+  getParser: vi.fn(),
+}));
+vi.mock('../../code-nav/outline', () => ({
+  extractOutlineFromTree: vi.fn(),
+}));
+
+import { readFileContent } from '../fs-utils';
+import { getParser } from '../../code-nav/parser';
+import { extractOutlineFromTree } from '../../code-nav/outline';
+import { TreeSitterParser, createTreeSitterParser } from './tree-sitter';
+
+const mockReadFileContent = vi.mocked(readFileContent);
+const mockGetParser = vi.mocked(getParser);
+const mockExtractOutline = vi.mocked(extractOutlineFromTree);
+
+// --- Minimal tree-sitter SyntaxNode test double -----------------------------
+// Only the members the SUT touches are modelled: type, text, startPosition,
+// children, namedChildren, and childForFieldName.
+interface FakeNode {
+  type: string;
+  text: string;
+  startPosition: { row: number; column: number };
+  children: FakeNode[];
+  namedChildren: FakeNode[];
+  childForFieldName(name: string): FakeNode | null;
+}
+
+function node(opts: {
+  type: string;
+  text?: string;
+  row?: number;
+  column?: number;
+  children?: FakeNode[];
+  namedChildren?: FakeNode[];
+  fields?: Record<string, FakeNode>;
+}): FakeNode {
+  const children = opts.children ?? [];
+  const fields = opts.fields ?? {};
+  return {
+    type: opts.type,
+    text: opts.text ?? '',
+    startPosition: { row: opts.row ?? 0, column: opts.column ?? 0 },
+    children,
+    namedChildren: opts.namedChildren ?? children,
+    childForFieldName: (name: string) => fields[name] ?? null,
+  };
+}
+
+// Wrap a root node as the { tree, source } AST body the parser expects.
+function astFor(rootNode: FakeNode, language: string, source = ''): AST {
+  return {
+    type: 'Program',
+    body: { tree: { rootNode }, source },
+    language,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createTreeSitterParser', () => {
+  it('builds a parser with correct name and extensions for each supported language', () => {
+    const cases: Array<[Parameters<typeof createTreeSitterParser>[0], string]> = [
+      ['python', '.py'],
+      ['go', '.go'],
+      ['rust', '.rs'],
+      ['java', '.java'],
+    ];
+    for (const [lang, ext] of cases) {
+      const parser = createTreeSitterParser(lang);
+      expect(parser).toBeInstanceOf(TreeSitterParser);
+      expect(parser!.name).toBe(lang);
+      expect(parser!.extensions).toEqual([ext]);
+    }
+  });
+
+  it('returns null for a language without a registered extraction strategy', () => {
+    expect(createTreeSitterParser('typescript')).toBeNull();
+    expect(createTreeSitterParser('javascript')).toBeNull();
+  });
+});
+
+describe('TreeSitterParser.parseFile', () => {
+  it('returns a NOT_FOUND error when the file cannot be read', async () => {
+    mockReadFileContent.mockResolvedValue({ ok: false, error: new Error('missing') });
+    const parser = createTreeSitterParser('python')!;
+
+    const result = await parser.parseFile('/nope.py');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error.code).toBe('NOT_FOUND');
+    expect(result.error.details.path).toBe('/nope.py');
+    // getParser must not be invoked once the read fails.
+    expect(mockGetParser).not.toHaveBeenCalled();
+  });
+
+  it('returns an Ok AST carrying the parsed tree and source on success', async () => {
+    const source = 'x = 1\n';
+    const tree = { rootNode: node({ type: 'module' }) };
+    mockReadFileContent.mockResolvedValue({ ok: true, value: source });
+    mockGetParser.mockResolvedValue({ parse: vi.fn().mockReturnValue(tree) } as never);
+    const parser = createTreeSitterParser('python')!;
+
+    const result = await parser.parseFile('/ok.py');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.type).toBe('Program');
+    expect(result.value.language).toBe('python');
+    expect(result.value.body).toEqual({ tree, source });
+  });
+
+  it('returns a SYNTAX_ERROR when the grammar parser throws', async () => {
+    mockReadFileContent.mockResolvedValue({ ok: true, value: 'def (' });
+    mockGetParser.mockResolvedValue({
+      parse: vi.fn(() => {
+        throw new Error('boom');
+      }),
+    } as never);
+    const parser = createTreeSitterParser('python')!;
+
+    const result = await parser.parseFile('/bad.py');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error.code).toBe('SYNTAX_ERROR');
+    expect(result.error.message).toContain('boom');
+  });
+});
+
+describe('TreeSitterParser.health', () => {
+  it('reports available when the grammar loads', async () => {
+    mockGetParser.mockResolvedValue({} as never);
+    const parser = createTreeSitterParser('go')!;
+
+    const result = await parser.health();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.available).toBe(true);
+    expect(result.value.message).toContain('go');
+  });
+
+  it('reports unavailable when the grammar fails to load', async () => {
+    mockGetParser.mockRejectedValue(new Error('no wasm'));
+    const parser = createTreeSitterParser('go')!;
+
+    const result = await parser.health();
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.available).toBe(false);
+    expect(result.value.message).toContain('not available');
+  });
+});
+
+describe('Python strategy', () => {
+  const parser = createTreeSitterParser('python')!;
+
+  it('extracts plain and from-imports with specifiers', () => {
+    const osName = node({ type: 'dotted_name', text: 'os' });
+    const importStmt = node({
+      type: 'import_statement',
+      fields: { name: osName },
+      children: [osName],
+    });
+
+    const moduleName = node({ type: 'dotted_name', text: 'typing' });
+    const listSpec = node({ type: 'dotted_name', text: 'List' });
+    const aliasName = node({ type: 'identifier', text: 'D' });
+    const aliased = node({ type: 'aliased_import', fields: { name: aliasName } });
+    const fromStmt = node({
+      type: 'import_from_statement',
+      fields: { module_name: moduleName },
+      children: [moduleName, listSpec, aliased],
+    });
+
+    const root = node({ type: 'module', children: [importStmt, fromStmt] });
+    const result = parser.extractImports(astFor(root, 'python'));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value).toEqual([
+      { source: 'os', specifiers: [], location: { file: '', line: 1, column: 0 }, kind: 'value' },
+      {
+        source: 'typing',
+        specifiers: ['List', 'D'],
+        location: { file: '', line: 1, column: 0 },
+        kind: 'value',
+      },
+    ]);
+  });
+
+  it('exports public defs, classes with one level of members, decorated defs, and module assignments', () => {
+    const fn = node({
+      type: 'function_definition',
+      fields: { name: node({ type: 'identifier', text: 'do_thing' }) },
+    });
+    const priv = node({
+      type: 'function_definition',
+      fields: { name: node({ type: 'identifier', text: '_hidden' }) },
+    });
+
+    const method = node({
+      type: 'function_definition',
+      fields: { name: node({ type: 'identifier', text: 'run' }) },
+    });
+    const classBody = node({ type: 'block', children: [method] });
+    const cls = node({
+      type: 'class_definition',
+      fields: { name: node({ type: 'identifier', text: 'Widget' }), body: classBody },
+    });
+
+    const decoratedInner = node({
+      type: 'function_definition',
+      fields: { name: node({ type: 'identifier', text: 'decorated_fn' }) },
+    });
+    const decorated = node({
+      type: 'decorated_definition',
+      fields: { definition: decoratedInner },
+    });
+
+    const assign = node({
+      type: 'assignment',
+      fields: { left: node({ type: 'identifier', text: 'CONST' }) },
+    });
+    const exprStmt = node({ type: 'expression_statement', children: [assign] });
+
+    const skipAssign = node({
+      type: 'assignment',
+      fields: { left: node({ type: 'identifier', text: '_private_const' }) },
+    });
+
+    const root = node({
+      type: 'module',
+      children: [fn, priv, cls, decorated, exprStmt, skipAssign],
+    });
+    const result = parser.extractExports(astFor(root, 'python'));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    const names = result.value.map((e) => e.name);
+    expect(names).toEqual(['do_thing', 'Widget', 'run', 'decorated_fn', 'CONST']);
+    expect(result.value.every((e) => e.type === 'named' && !e.isReExport)).toBe(true);
+  });
+});
+
+describe('Go strategy', () => {
+  const parser = createTreeSitterParser('go')!;
+
+  it('extracts single and grouped imports and strips quotes', () => {
+    const single = node({
+      type: 'import_declaration',
+      children: [
+        node({
+          type: 'import_spec',
+          fields: { path: node({ type: 'interpreted_string_literal', text: '"fmt"' }) },
+        }),
+      ],
+    });
+
+    const groupedSpec = node({
+      type: 'import_spec',
+      children: [node({ type: 'interpreted_string_literal', text: '"strings"' })],
+    });
+    const grouped = node({
+      type: 'import_declaration',
+      children: [node({ type: 'import_spec_list', children: [groupedSpec] })],
+    });
+
+    const root = node({ type: 'source_file', children: [single, grouped] });
+    const result = parser.extractImports(astFor(root, 'go'));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.map((i) => i.source)).toEqual(['fmt', 'strings']);
+  });
+
+  it('exports only capitalized functions and types', () => {
+    const exportedFn = node({
+      type: 'function_declaration',
+      fields: { name: node({ type: 'identifier', text: 'DoThing' }) },
+    });
+    const unexportedFn = node({
+      type: 'function_declaration',
+      fields: { name: node({ type: 'identifier', text: 'doThing' }) },
+    });
+    const typeDecl = node({
+      type: 'type_declaration',
+      children: [
+        node({
+          type: 'type_spec',
+          fields: { name: node({ type: 'type_identifier', text: 'Server' }) },
+        }),
+      ],
+    });
+
+    const root = node({ type: 'source_file', children: [exportedFn, unexportedFn, typeDecl] });
+    const result = parser.extractExports(astFor(root, 'go'));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.map((e) => e.name)).toEqual(['DoThing', 'Server']);
+  });
+});
+
+describe('Rust strategy', () => {
+  const parser = createTreeSitterParser('rust')!;
+
+  it('extracts use declarations from the argument node', () => {
+    const useDecl = node({
+      type: 'use_declaration',
+      fields: { argument: node({ type: 'scoped_identifier', text: 'std::collections::HashMap' }) },
+    });
+    const root = node({ type: 'source_file', children: [useDecl] });
+
+    const result = parser.extractImports(astFor(root, 'rust'));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.map((i) => i.source)).toEqual(['std::collections::HashMap']);
+  });
+
+  it('exports pub items and pub modules but skips private items', () => {
+    const source = ['pub fn open() {}', 'fn closed() {}', 'pub mod util {}'].join('\n');
+    const pubFn = node({
+      type: 'function_item',
+      row: 0,
+      fields: { name: node({ type: 'identifier', text: 'open' }) },
+    });
+    const privFn = node({
+      type: 'function_item',
+      row: 1,
+      fields: { name: node({ type: 'identifier', text: 'closed' }) },
+    });
+    const pubMod = node({
+      type: 'mod_item',
+      row: 2,
+      fields: { name: node({ type: 'identifier', text: 'util' }) },
+    });
+
+    const root = node({ type: 'source_file', children: [pubFn, privFn, pubMod] });
+    const result = parser.extractExports(astFor(root, 'rust', source));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.map((e) => ({ name: e.name, type: e.type }))).toEqual([
+      { name: 'open', type: 'named' },
+      { name: 'util', type: 'namespace' },
+    ]);
+  });
+});
+
+describe('Java strategy', () => {
+  const parser = createTreeSitterParser('java')!;
+
+  it('extracts scoped imports', () => {
+    const importDecl = node({
+      type: 'import_declaration',
+      children: [node({ type: 'scoped_identifier', text: 'java.util.List' })],
+    });
+    const root = node({ type: 'program', children: [importDecl] });
+
+    const result = parser.extractImports(astFor(root, 'java'));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.map((i) => i.source)).toEqual(['java.util.List']);
+  });
+
+  it('exports only public top-level type declarations', () => {
+    const source = ['public class Foo {}', 'class Bar {}'].join('\n');
+    const pubClass = node({
+      type: 'class_declaration',
+      row: 0,
+      fields: { name: node({ type: 'identifier', text: 'Foo' }) },
+    });
+    const pkgClass = node({
+      type: 'class_declaration',
+      row: 1,
+      fields: { name: node({ type: 'identifier', text: 'Bar' }) },
+    });
+
+    const root = node({ type: 'program', children: [pubClass, pkgClass] });
+    const result = parser.extractExports(astFor(root, 'java', source));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.value.map((e) => e.name)).toEqual(['Foo']);
+  });
+});
+
+describe('TreeSitterParser.outline', () => {
+  it('delegates to extractOutlineFromTree with the tree root, language, source, and path', () => {
+    const rootNode = node({ type: 'module' });
+    const outline: OutlineResult = {
+      file: '/f.py',
+      language: 'python',
+      totalLines: 3,
+      symbols: [],
+    };
+    mockExtractOutline.mockReturnValue(outline);
+    const parser = createTreeSitterParser('python')!;
+
+    const result = parser.outline!('/f.py', astFor(rootNode, 'python', 'src'));
+
+    expect(result).toBe(outline);
+    expect(mockExtractOutline).toHaveBeenCalledWith(rootNode, 'python', 'src', '/f.py');
+  });
+});
+
+describe('TreeSitterParser.unfold', () => {
+  const source = ['line1', 'def foo():', '    return 1', 'line4'].join('\n');
+
+  function outlineWith(symbols: CodeSymbol[], error?: string): OutlineResult {
+    return {
+      file: '/f.py',
+      language: 'python',
+      totalLines: 4,
+      symbols,
+      ...(error !== undefined ? { error } : {}),
+    };
+  }
+
+  it('returns the source slice bounded by the matched symbol', () => {
+    const symbols: CodeSymbol[] = [
+      { name: 'foo', kind: 'function', file: '/f.py', line: 2, endLine: 3, signature: 'def foo()' },
+    ];
+    mockExtractOutline.mockReturnValue(outlineWith(symbols));
+    const parser = createTreeSitterParser('python')!;
+
+    const result = parser.unfold!(
+      '/f.py',
+      astFor(node({ type: 'module' }), 'python', source),
+      'foo'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.startLine).toBe(2);
+    expect(result!.endLine).toBe(3);
+    expect(result!.content).toBe('def foo():\n    return 1');
+    expect(result!.fallback).toBe(false);
+    expect(result!.language).toBe('python');
+  });
+
+  it('finds symbols nested inside children', () => {
+    const symbols: CodeSymbol[] = [
+      {
+        name: 'Outer',
+        kind: 'class',
+        file: '/f.py',
+        line: 1,
+        endLine: 4,
+        signature: 'class Outer',
+        children: [
+          {
+            name: 'foo',
+            kind: 'method',
+            file: '/f.py',
+            line: 2,
+            endLine: 3,
+            signature: 'def foo()',
+          },
+        ],
+      },
+    ];
+    mockExtractOutline.mockReturnValue(outlineWith(symbols));
+    const parser = createTreeSitterParser('python')!;
+
+    const result = parser.unfold!(
+      '/f.py',
+      astFor(node({ type: 'module' }), 'python', source),
+      'foo'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('def foo():\n    return 1');
+  });
+
+  it('returns null when the outline reports an error', () => {
+    mockExtractOutline.mockReturnValue(outlineWith([], '[parse-failed]'));
+    const parser = createTreeSitterParser('python')!;
+
+    const result = parser.unfold!(
+      '/f.py',
+      astFor(node({ type: 'module' }), 'python', source),
+      'foo'
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the outline has no symbols', () => {
+    mockExtractOutline.mockReturnValue(outlineWith([]));
+    const parser = createTreeSitterParser('python')!;
+
+    const result = parser.unfold!(
+      '/f.py',
+      astFor(node({ type: 'module' }), 'python', source),
+      'foo'
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the requested symbol is not found', () => {
+    const symbols: CodeSymbol[] = [
+      {
+        name: 'other',
+        kind: 'function',
+        file: '/f.py',
+        line: 2,
+        endLine: 3,
+        signature: 'def other()',
+      },
+    ];
+    mockExtractOutline.mockReturnValue(outlineWith(symbols));
+    const parser = createTreeSitterParser('python')!;
+
+    const result = parser.unfold!(
+      '/f.py',
+      astFor(node({ type: 'module' }), 'python', source),
+      'missing'
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/core/src/validation/agent-configs/fallback/rule-agents-md.test.ts
+++ b/packages/core/src/validation/agent-configs/fallback/rule-agents-md.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { validateAgentsMap } from '../../../context/agents-map';
+import { runAgentsMdRules } from './rule-agents-md';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock('../../../context/agents-map', () => ({
+  validateAgentsMap: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockValidateAgentsMap = vi.mocked(validateAgentsMap);
+
+const CWD = '/repo';
+const EXPECTED_AGENTS_PATH = join(CWD, 'AGENTS.md');
+const DEFAULT_SUGGESTION = 'Run `harness init` to regenerate AGENTS.md';
+
+/** Build a minimal `Ok` Result as returned by `validateAgentsMap`. */
+function okResult() {
+  return { ok: true as const, value: {} } as unknown as Awaited<
+    ReturnType<typeof validateAgentsMap>
+  >;
+}
+
+/** Build a minimal `Err` Result carrying a ContextError. */
+function errResult(message: string, suggestions?: string[]) {
+  return {
+    ok: false as const,
+    error: {
+      code: 'VALIDATION_ERROR',
+      message,
+      details: {},
+      suggestions: suggestions ?? [],
+    },
+  } as unknown as Awaited<ReturnType<typeof validateAgentsMap>>;
+}
+
+describe('runAgentsMdRules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns no findings and skips validation when AGENTS.md is absent', async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const findings = await runAgentsMdRules(CWD);
+
+    expect(findings).toEqual([]);
+    expect(mockValidateAgentsMap).not.toHaveBeenCalled();
+  });
+
+  it('checks for AGENTS.md at the cwd-joined path', async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    await runAgentsMdRules(CWD);
+
+    expect(mockExistsSync).toHaveBeenCalledWith(EXPECTED_AGENTS_PATH);
+  });
+
+  it('returns no findings when the existing AGENTS.md validates', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockValidateAgentsMap.mockResolvedValue(okResult());
+
+    const findings = await runAgentsMdRules(CWD);
+
+    expect(mockValidateAgentsMap).toHaveBeenCalledWith(EXPECTED_AGENTS_PATH);
+    expect(findings).toEqual([]);
+  });
+
+  it('emits a HARNESS-AC-050 error finding mapping the validation error and first suggestion', async () => {
+    const message = 'Missing required section: ## Build';
+    const primarySuggestion = 'Add a `## Build` section';
+    mockExistsSync.mockReturnValue(true);
+    mockValidateAgentsMap.mockResolvedValue(
+      errResult(message, [primarySuggestion, 'a secondary suggestion'])
+    );
+
+    const findings = await runAgentsMdRules(CWD);
+
+    expect(findings).toEqual([
+      {
+        file: 'AGENTS.md',
+        ruleId: 'HARNESS-AC-050',
+        severity: 'error',
+        message,
+        suggestion: primarySuggestion,
+      },
+    ]);
+  });
+
+  it('falls back to the default suggestion when the error carries none', async () => {
+    const message = 'AGENTS.md is malformed';
+    mockExistsSync.mockReturnValue(true);
+    mockValidateAgentsMap.mockResolvedValue(errResult(message, []));
+
+    const [finding] = await runAgentsMdRules(CWD);
+
+    expect(finding!.suggestion).toBe(DEFAULT_SUGGESTION);
+    expect(finding!.message).toBe(message);
+  });
+});

--- a/packages/core/src/validation/agent-configs/fallback/rule-commands.test.ts
+++ b/packages/core/src/validation/agent-configs/fallback/rule-commands.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runCommandRules } from './rule-commands';
+
+/**
+ * Hermetic tests for runCommandRules (HARNESS-AC-060 command-file-exists).
+ *
+ * The rule scans `agents/commands/**\/*.md` under `cwd`, extracts inline markdown
+ * link targets `[label](path)`, resolves relative targets against the file's
+ * directory, and emits a finding for every link whose target file is missing.
+ *
+ * Tests run against an isolated temp directory (no shared state, no network, no
+ * subprocess) so behavior is deterministic.
+ */
+
+const RULE_ID = 'HARNESS-AC-060';
+const COMMANDS_DIR = path.join('agents', 'commands');
+
+describe('runCommandRules', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'rule-commands-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  /** Write a command markdown file at agents/commands/<name>, creating parents. */
+  function writeCommand(name: string, content: string): string {
+    const abs = path.join(cwd, COMMANDS_DIR, name);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+    return abs;
+  }
+
+  /** Write an arbitrary file relative to cwd so links can resolve to it. */
+  function writeFile(relative: string, content = 'x'): void {
+    const abs = path.join(cwd, relative);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+  }
+
+  it('returns no findings when there are no command files', async () => {
+    const findings = await runCommandRules(cwd);
+    expect(findings).toEqual([]);
+  });
+
+  it('flags a relative link that points at a non-existent sibling file', async () => {
+    writeCommand('deploy.md', 'See [the runbook](runbook.md) for details.');
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toHaveLength(1);
+    const finding = findings[0]!;
+    expect(finding.ruleId).toBe(RULE_ID);
+    expect(finding.severity).toBe('warning');
+    expect(finding.message).toBe("Command references missing file 'runbook.md'");
+    expect(finding.suggestion).toBe('Fix the path or remove the broken reference');
+    // File path is reported relative to cwd, using forward slashes.
+    expect(finding.file).toBe('agents/commands/deploy.md');
+  });
+
+  it('does not flag a relative link whose target file exists on disk', async () => {
+    writeCommand('deploy.md', 'See [the runbook](runbook.md) for details.');
+    writeFile(path.join(COMMANDS_DIR, 'runbook.md'));
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('resolves relative targets against the command file directory, not cwd', async () => {
+    // Link target `../shared/helper.md` must resolve relative to the command's
+    // own directory. Place the command one level deep and the target accordingly.
+    writeCommand(path.join('sub', 'cmd.md'), 'Uses [helper](../shared/helper.md).');
+    writeFile(path.join(COMMANDS_DIR, 'shared', 'helper.md'));
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('ignores http(s) links, anchor-only links, and strips fragments/queries', async () => {
+    writeCommand(
+      'links.md',
+      [
+        '[web](https://example.com/x)',
+        '[insecure](http://example.com/y)',
+        '[anchor](#section)',
+      ].join('\n')
+    );
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('strips a fragment before checking existence so an existing file is not flagged', async () => {
+    writeCommand('doc.md', 'Jump to [section](guide.md#setup).');
+    writeFile(path.join(COMMANDS_DIR, 'guide.md'));
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('reports the fragment-stripped target string in the finding message', async () => {
+    writeCommand('doc.md', 'Jump to [section](missing.md#setup).');
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.message).toBe("Command references missing file 'missing.md'");
+  });
+
+  it('emits one finding per distinct broken link within a single file', async () => {
+    writeCommand('multi.md', 'See [a](a.md) and [b](b.md) and [c](c.md).');
+
+    const findings = await runCommandRules(cwd);
+
+    const targets = findings.map((f) => f.message);
+    expect(findings).toHaveLength(3);
+    expect(targets).toEqual(
+      expect.arrayContaining([
+        "Command references missing file 'a.md'",
+        "Command references missing file 'b.md'",
+        "Command references missing file 'c.md'",
+      ])
+    );
+  });
+
+  it('scans nested command files recursively', async () => {
+    writeCommand(path.join('group', 'nested.md'), 'Broken [link](gone.md).');
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.file).toBe('agents/commands/group/nested.md');
+  });
+
+  it('aggregates findings across multiple command files', async () => {
+    writeCommand('one.md', 'Broken [x](x.md).');
+    writeCommand('two.md', 'Broken [y](y.md).');
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toHaveLength(2);
+    expect(findings.every((f) => f.ruleId === RULE_ID)).toBe(true);
+  });
+
+  it('does not flag content with no markdown links at all', async () => {
+    writeCommand('plain.md', '# Title\n\nJust prose, no links here.');
+
+    const findings = await runCommandRules(cwd);
+
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/core/src/validation/agent-configs/fallback/shared.test.ts
+++ b/packages/core/src/validation/agent-configs/fallback/shared.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  relPath,
+  makeFinding,
+  readTextSafe,
+  safeFileSize,
+  extractFrontmatter,
+  parseFrontmatterFields,
+} from './shared';
+
+// Hermetic: node:fs is fully mocked so readTextSafe / safeFileSize never touch a real
+// filesystem. Every call routes through these controllable mocks.
+const readFileSyncMock = vi.fn();
+const statSyncMock = vi.fn();
+vi.mock('node:fs', () => ({
+  readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
+  statSync: (...args: unknown[]) => statSyncMock(...args),
+}));
+
+beforeEach(() => {
+  readFileSyncMock.mockReset();
+  statSyncMock.mockReset();
+});
+
+describe('relPath', () => {
+  it('strips the cwd prefix from an absolute path under cwd', () => {
+    expect(relPath('/repo', '/repo/src/index.ts')).toBe('src/index.ts');
+  });
+
+  it('normalizes backslashes in both cwd and path before comparing', () => {
+    expect(relPath('C:\\repo', 'C:\\repo\\src\\index.ts')).toBe('src/index.ts');
+  });
+
+  it('returns the normalized absolute path when it is not under cwd', () => {
+    expect(relPath('/repo', '/other/place/file.ts')).toBe('/other/place/file.ts');
+  });
+
+  it('does not strip a sibling directory that merely shares a name prefix', () => {
+    // '/repo-extra/...' is not under '/repo/' because the boundary slash is required.
+    expect(relPath('/repo', '/repo-extra/file.ts')).toBe('/repo-extra/file.ts');
+  });
+});
+
+describe('makeFinding', () => {
+  it('builds a finding with only the required fields when optionals are omitted', () => {
+    const finding = makeFinding({
+      file: 'AGENTS.md',
+      ruleId: 'HARNESS-AC-001',
+      severity: 'error',
+      message: 'boom',
+    });
+    expect(finding).toEqual({
+      file: 'AGENTS.md',
+      ruleId: 'HARNESS-AC-001',
+      severity: 'error',
+      message: 'boom',
+    });
+    expect(finding).not.toHaveProperty('line');
+    expect(finding).not.toHaveProperty('column');
+    expect(finding).not.toHaveProperty('suggestion');
+  });
+
+  it('includes line, column, and suggestion when provided', () => {
+    const finding = makeFinding({
+      file: 'AGENTS.md',
+      ruleId: 'HARNESS-AC-002',
+      severity: 'warning',
+      message: 'watch out',
+      line: 12,
+      column: 3,
+      suggestion: 'fix it',
+    });
+    expect(finding).toEqual({
+      file: 'AGENTS.md',
+      ruleId: 'HARNESS-AC-002',
+      severity: 'warning',
+      message: 'watch out',
+      line: 12,
+      column: 3,
+      suggestion: 'fix it',
+    });
+  });
+
+  it('retains a zero line/column since typeof number is the guard, not truthiness', () => {
+    const finding = makeFinding({
+      file: 'f',
+      ruleId: 'r',
+      severity: 'info',
+      message: 'm',
+      line: 0,
+      column: 0,
+    });
+    expect(finding.line).toBe(0);
+    expect(finding.column).toBe(0);
+  });
+
+  it('omits an empty-string suggestion because the guard is truthiness', () => {
+    const finding = makeFinding({
+      file: 'f',
+      ruleId: 'r',
+      severity: 'info',
+      message: 'm',
+      suggestion: '',
+    });
+    expect(finding).not.toHaveProperty('suggestion');
+  });
+});
+
+describe('readTextSafe', () => {
+  it('returns file contents read as utf-8', () => {
+    readFileSyncMock.mockReturnValue('hello world');
+    expect(readTextSafe('/x/file.md')).toBe('hello world');
+    expect(readFileSyncMock).toHaveBeenCalledWith('/x/file.md', 'utf-8');
+  });
+
+  it('returns null when the read throws', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(readTextSafe('/missing')).toBeNull();
+  });
+});
+
+describe('safeFileSize', () => {
+  it('returns the byte size reported by statSync', () => {
+    const expectedSize = 4096;
+    statSyncMock.mockReturnValue({ size: expectedSize });
+    expect(safeFileSize('/x/file.md')).toBe(expectedSize);
+    expect(statSyncMock).toHaveBeenCalledWith('/x/file.md');
+  });
+
+  it('returns null when statSync throws', () => {
+    statSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(safeFileSize('/missing')).toBeNull();
+  });
+});
+
+describe('extractFrontmatter', () => {
+  it('returns the body between fences and the number of lines consumed', () => {
+    const content = '---\nname: agent\ndesc: thing\n---\nbody text\nmore';
+    // Fences at lines 0 and 3 → body is lines 1..2, and lineCount is closing index + 1.
+    expect(extractFrontmatter(content)).toEqual({
+      body: 'name: agent\ndesc: thing',
+      lineCount: 4,
+    });
+  });
+
+  it('handles CRLF line endings', () => {
+    const content = '---\r\nname: agent\r\n---\r\nbody';
+    expect(extractFrontmatter(content)).toEqual({ body: 'name: agent', lineCount: 3 });
+  });
+
+  it('returns null when the document does not open with a fence', () => {
+    expect(extractFrontmatter('name: agent\n---\n')).toBeNull();
+  });
+
+  it('returns null when the opening fence is never closed', () => {
+    expect(extractFrontmatter('---\nname: agent\nno closing fence')).toBeNull();
+  });
+
+  it('returns an empty body for an immediately-closed fence pair', () => {
+    expect(extractFrontmatter('---\n---\nrest')).toEqual({ body: '', lineCount: 2 });
+  });
+});
+
+describe('parseFrontmatterFields', () => {
+  it('parses top-level scalar key/value pairs', () => {
+    expect(parseFrontmatterFields('name: agent\ndesc: does things')).toEqual({
+      name: 'agent',
+      desc: 'does things',
+    });
+  });
+
+  it('strips matching double and single quotes from values', () => {
+    expect(parseFrontmatterFields('a: "quoted"\nb: \'single\'')).toEqual({
+      a: 'quoted',
+      b: 'single',
+    });
+  });
+
+  it('skips comment lines and blank lines', () => {
+    expect(parseFrontmatterFields('# a comment\n\nname: agent')).toEqual({ name: 'agent' });
+  });
+
+  it('ignores lines without a colon and lines whose colon is at position zero', () => {
+    expect(parseFrontmatterFields('novalue\n: leadingcolon\nname: agent')).toEqual({
+      name: 'agent',
+    });
+  });
+
+  it('drops list-item values (leading dash) and keys with empty values', () => {
+    expect(parseFrontmatterFields('tags: - a\nempty:\nname: agent')).toEqual({ name: 'agent' });
+  });
+
+  it('trims surrounding whitespace and honors leading indentation via trimStart', () => {
+    expect(parseFrontmatterFields('   name:    agent   ')).toEqual({ name: 'agent' });
+  });
+
+  it('leaves mismatched quotes untouched', () => {
+    expect(parseFrontmatterFields('a: "unterminated')).toEqual({ a: '"unterminated' });
+  });
+});

--- a/packages/dashboard/tests/client/components/ProgressChart.test.tsx
+++ b/packages/dashboard/tests/client/components/ProgressChart.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import type { MilestoneProgress } from '@shared/types';
+import { ProgressChart } from '../../../src/client/components/ProgressChart';
+import { STATUS_COLOR } from '../../../src/client/utils/statusColors';
+
+// Geometry constants mirrored from the component under test so expected
+// values are derived, not pasted as magic numbers.
+const LABEL_WIDTH = 140;
+const CHART_WIDTH = 480;
+const BAR_AREA_WIDTH = CHART_WIDTH - LABEL_WIDTH; // 340
+const BAR_HEIGHT = 20;
+const TRACK_COLOR = '#18181b';
+
+function milestone(overrides: Partial<MilestoneProgress> = {}): MilestoneProgress {
+  return {
+    name: 'Alpha',
+    isBacklog: false,
+    total: 0,
+    done: 0,
+    inProgress: 0,
+    planned: 0,
+    blocked: 0,
+    backlog: 0,
+    needsHuman: 0,
+    ...overrides,
+  };
+}
+
+/** Segment rects are the stacked bars: every <rect> whose fill is a status color. */
+function segmentRects(container: HTMLElement): SVGRectElement[] {
+  const colors = new Set(Object.values(STATUS_COLOR));
+  return Array.from(container.querySelectorAll('rect')).filter((r) =>
+    colors.has(r.getAttribute('fill') ?? '')
+  ) as SVGRectElement[];
+}
+
+describe('ProgressChart', () => {
+  it('renders nothing when there are no non-backlog milestones', () => {
+    const { container } = render(<ProgressChart milestones={[]} />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('renders nothing when every milestone is a backlog row', () => {
+    const { container } = render(
+      <ProgressChart milestones={[milestone({ isBacklog: true, total: 5, done: 5 })]} />
+    );
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('excludes backlog milestones from the rendered rows but keeps real ones', () => {
+    const { container, getByText } = render(
+      <ProgressChart
+        milestones={[
+          milestone({ name: 'Real', total: 3, done: 3 }),
+          milestone({ name: 'Backlog', isBacklog: true, total: 9, done: 9 }),
+        ]}
+      />
+    );
+    // One background track rect (fill=TRACK_COLOR) per rendered row.
+    const tracks = Array.from(container.querySelectorAll('rect')).filter(
+      (r) => r.getAttribute('fill') === TRACK_COLOR
+    );
+    expect(tracks).toHaveLength(1);
+    // The real milestone's label is present; the backlog one is not.
+    expect(getByText('Real')).toBeTruthy();
+    expect(container.textContent).not.toContain('Backlog');
+  });
+
+  it('omits zero-value status segments and keeps only non-empty ones', () => {
+    // done + inProgress + planned are non-zero; blocked + needsHuman are zero.
+    const { container } = render(
+      <ProgressChart milestones={[milestone({ total: 4, done: 2, inProgress: 1, planned: 1 })]} />
+    );
+    const segments = segmentRects(container);
+    expect(segments).toHaveLength(3);
+    const fills = segments.map((s) => s.getAttribute('fill'));
+    expect(fills).toEqual([
+      STATUS_COLOR['done'],
+      STATUS_COLOR['in-progress'],
+      STATUS_COLOR['planned'],
+    ]);
+    // No segment carries the blocked or needs-human color.
+    expect(fills).not.toContain(STATUS_COLOR['blocked']);
+    expect(fills).not.toContain(STATUS_COLOR['needs-human']);
+  });
+
+  it('computes cumulative x offsets and proportional widths for stacked segments', () => {
+    const maxTotal = 4;
+    const { container } = render(
+      <ProgressChart
+        milestones={[milestone({ total: maxTotal, done: 2, inProgress: 1, planned: 1 })]}
+      />
+    );
+    const [doneSeg, inProgSeg, plannedSeg] = segmentRects(container);
+    const unit = BAR_AREA_WIDTH / maxTotal; // width per single item
+
+    // done: starts at the bar origin, width = 2 units.
+    expect(Number(doneSeg.getAttribute('x'))).toBeCloseTo(LABEL_WIDTH);
+    expect(Number(doneSeg.getAttribute('width'))).toBeCloseTo(2 * unit);
+    // in-progress: offset by the 2 done items, width = 1 unit.
+    expect(Number(inProgSeg.getAttribute('x'))).toBeCloseTo(LABEL_WIDTH + 2 * unit);
+    expect(Number(inProgSeg.getAttribute('width'))).toBeCloseTo(unit);
+    // planned: offset by the 3 preceding items, width = 1 unit.
+    expect(Number(plannedSeg.getAttribute('x'))).toBeCloseTo(LABEL_WIDTH + 3 * unit);
+    expect(Number(plannedSeg.getAttribute('width'))).toBeCloseTo(unit);
+    // Every segment is a full bar-height tall.
+    for (const seg of [doneSeg, inProgSeg, plannedSeg]) {
+      expect(Number(seg.getAttribute('height'))).toBe(BAR_HEIGHT);
+    }
+  });
+
+  it('merges planned and backlog counts into the single planned-colored segment', () => {
+    const { container } = render(
+      <ProgressChart milestones={[milestone({ total: 4, planned: 1, backlog: 3 })]} />
+    );
+    const segments = segmentRects(container);
+    // Only the planned-colored segment renders; its width covers planned+backlog=4 items.
+    expect(segments).toHaveLength(1);
+    expect(segments[0].getAttribute('fill')).toBe(STATUS_COLOR['planned']);
+    expect(Number(segments[0].getAttribute('width'))).toBeCloseTo(BAR_AREA_WIDTH);
+  });
+
+  it('renders a done/total summary label for each row', () => {
+    const { getByText } = render(
+      <ProgressChart milestones={[milestone({ total: 5, done: 3, inProgress: 2 })]} />
+    );
+    expect(getByText('3/5')).toBeTruthy();
+  });
+
+  it('truncates milestone names longer than 18 characters with an ellipsis', () => {
+    const longName = 'MilestoneNameThatIsQuiteLong'; // 28 chars
+    const { getByText } = render(
+      <ProgressChart milestones={[milestone({ name: longName, total: 1, done: 1 })]} />
+    );
+    // slice(0, 17) + '…'
+    expect(getByText(longName.slice(0, 17) + '…')).toBeTruthy();
+  });
+
+  it('renders a legend entry for every status color', () => {
+    const { container } = render(<ProgressChart milestones={[milestone({ total: 1, done: 1 })]} />);
+    const swatches = container.querySelectorAll('span.rounded-sm');
+    expect(swatches).toHaveLength(Object.keys(STATUS_COLOR).length);
+    // Hyphenated status labels are humanized in the legend text.
+    expect(container.textContent).toContain('in progress');
+    expect(container.textContent).toContain('needs human');
+  });
+});

--- a/packages/dashboard/tests/client/components/agents/AgentStreamDrawer.test.tsx
+++ b/packages/dashboard/tests/client/components/agents/AgentStreamDrawer.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { AgentStreamDrawer } from '../../../../src/client/components/agents/AgentStreamDrawer';
+import type { UseStreamReplayResult } from '../../../../src/client/hooks/useStreamReplay';
+import type { RunningAgent } from '../../../../src/client/types/orchestrator';
+import type { ContentBlock } from '../../../../src/client/types/chat';
+
+// ── Controllable stream-replay seam ────────────────────────────────
+// The hook does real fetch()/JSONL parsing; we replace it with a mutable
+// return value so the drawer's merge/loading/manifest branches are driven
+// deterministically without touching the network.
+const replay = vi.hoisted(() => ({
+  state: {
+    manifest: null,
+    recordedBlocks: [],
+    loading: false,
+    error: null,
+  } as UseStreamReplayResult,
+}));
+
+vi.mock('../../../../src/client/hooks/useStreamReplay', () => ({
+  useStreamReplay: () => replay.state,
+}));
+
+// ── Virtualized list seam ──────────────────────────────────────────
+// react-virtuoso needs layout measurement that jsdom can't provide, so it
+// renders no items headlessly. Replace it with a plain list that eagerly
+// renders every datum through the real itemContent/computeItemKey props, and
+// expose a scrollToIndex handle (the drawer calls it via a ref on live-follow).
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: React.forwardRef(function MockVirtuoso(
+    props: {
+      data?: unknown[];
+      itemContent: (index: number, item: unknown) => React.ReactNode;
+      computeItemKey?: (index: number, item: unknown) => string;
+    },
+    ref: React.Ref<{ scrollToIndex: (...args: unknown[]) => void }>
+  ) {
+    React.useImperativeHandle(ref, () => ({ scrollToIndex: vi.fn() }));
+    const data = props.data ?? [];
+    return (
+      <div data-testid="virtuoso">
+        {data.map((item, index) => (
+          <div
+            key={props.computeItemKey ? props.computeItemKey(index, item) : index}
+            data-testid="virtuoso-item"
+          >
+            {props.itemContent(index, item)}
+          </div>
+        ))}
+      </div>
+    );
+  }),
+}));
+
+// ── Leaf block renderer seam ───────────────────────────────────────
+// The real BlockSegmentView renders deep block trees; we surface just the
+// segment kind and (for text) its text so we can assert on merge ORDER and
+// which segments the drawer fed into the list.
+vi.mock('../../../../src/client/components/chat/AssistantBlocks', () => ({
+  BlockSegmentView: ({ segment }: { segment: { kind: string; block?: { text?: string } } }) => (
+    <div data-testid="segment" data-kind={segment.kind}>
+      {segment.kind === 'text' ? segment.block?.text : segment.kind}
+    </div>
+  ),
+}));
+
+function makeAgent(overrides: Partial<RunningAgent> = {}): RunningAgent {
+  return {
+    issueId: 'issue-1',
+    identifier: 'agent-alpha',
+    phase: 'execute',
+    startedAt: new Date().toISOString(),
+    workspacePath: '/tmp/ws',
+    attempt: 1,
+    issue: {
+      identifier: 'HARNESS-1',
+      title: 'Build the widget',
+      description: null,
+      blockedBy: [],
+    },
+    session: null,
+    ...overrides,
+  };
+}
+
+function textBlock(text: string): ContentBlock {
+  return { kind: 'text', text };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  replay.state = { manifest: null, recordedBlocks: [], loading: false, error: null };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AgentStreamDrawer visibility', () => {
+  it('renders nothing when there is neither a live agent nor a recorded issue', () => {
+    const { container } = render(
+      <AgentStreamDrawer agent={null} issueId={null} blocks={[]} onClose={vi.fn()} />
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders the drawer for a recorded issue even without a live agent', () => {
+    render(<AgentStreamDrawer agent={null} issueId="issue-1" blocks={[]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Recorded Stream')).toBeDefined();
+    expect(screen.getByRole('button')).toBeDefined();
+  });
+});
+
+describe('AgentStreamDrawer header', () => {
+  it('shows the live-stream header titled from the agent issue when an agent is present', () => {
+    render(<AgentStreamDrawer agent={makeAgent()} issueId={null} blocks={[]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Build the widget')).toBeDefined();
+    expect(screen.getByText('Live Stream')).toBeDefined();
+    expect(screen.queryByText('Recorded Stream')).toBeNull();
+  });
+
+  it('falls back to the manifest identifier for a recorded stream title', () => {
+    replay.state = {
+      ...replay.state,
+      manifest: {
+        issueId: 'issue-1',
+        externalId: 42,
+        identifier: 'recorded-agent-7',
+        attempts: [],
+        pr: null,
+        highlights: null,
+      },
+    };
+
+    render(<AgentStreamDrawer agent={null} issueId="issue-1" blocks={[]} onClose={vi.fn()} />);
+
+    // Identifier also appears in the stats pane, so scope to the header heading.
+    expect(screen.getByRole('heading', { name: 'recorded-agent-7' })).toBeDefined();
+    expect(screen.getByText('Recorded Stream')).toBeDefined();
+  });
+
+  it("defaults the title to 'Session' when neither agent nor manifest names it", () => {
+    render(<AgentStreamDrawer agent={null} issueId="issue-1" blocks={[]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Session')).toBeDefined();
+  });
+});
+
+describe('AgentStreamDrawer close affordances', () => {
+  it('invokes onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<AgentStreamDrawer agent={makeAgent()} issueId={null} blocks={[]} onClose={onClose} />);
+
+    // Scroll buttons only mount off-top/off-bottom, so the sole button is close.
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <AgentStreamDrawer agent={makeAgent()} issueId={null} blocks={[]} onClose={onClose} />
+    );
+
+    const backdrop = container.querySelector('[class*="bg-black"]');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop as Element);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AgentStreamDrawer session stats', () => {
+  it('renders turn count and token totals formatted by magnitude', () => {
+    const agent = makeAgent({
+      issue: {
+        identifier: 'HARNESS-1',
+        title: 'Build the widget',
+        description: 'Ship the streaming drawer.',
+        blockedBy: [],
+      },
+      session: {
+        backendName: 'anthropic',
+        inputTokens: 1_200,
+        outputTokens: 300,
+        totalTokens: 2_000_000,
+        turnCount: 7,
+        lastMessage: null,
+      },
+    });
+
+    render(<AgentStreamDrawer agent={agent} issueId={null} blocks={[]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Ship the streaming drawer.')).toBeDefined();
+    expect(screen.getByText('anthropic')).toBeDefined();
+    expect(screen.getByText('7')).toBeDefined(); // turns
+    expect(screen.getByText('2.0M')).toBeDefined(); // total tokens, millions branch
+    expect(screen.getByText('1.2k')).toBeDefined(); // input, thousands branch
+    expect(screen.getByText('300')).toBeDefined(); // output, plain branch
+  });
+});
+
+describe('AgentStreamDrawer stream body', () => {
+  it('shows the loading placeholder while the recorded stream is loading', () => {
+    replay.state = { ...replay.state, loading: true };
+
+    render(<AgentStreamDrawer agent={null} issueId="issue-1" blocks={[]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Loading recorded stream...')).toBeDefined();
+    expect(screen.queryByTestId('virtuoso')).toBeNull();
+  });
+
+  it('shows the waiting placeholder when there are no blocks yet', () => {
+    render(<AgentStreamDrawer agent={makeAgent()} issueId={null} blocks={[]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Waiting for agent output...')).toBeDefined();
+    expect(screen.queryByTestId('virtuoso')).toBeNull();
+  });
+
+  it('merges recorded history before live blocks and renders them as segments', () => {
+    replay.state = { ...replay.state, recordedBlocks: [textBlock('recorded line')] };
+
+    render(
+      <AgentStreamDrawer
+        agent={makeAgent()}
+        issueId="issue-1"
+        blocks={[textBlock('live line')]}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('virtuoso')).toBeDefined();
+
+    const texts = screen
+      .getAllByTestId('segment')
+      .map((el) => el.textContent)
+      .filter((t): t is string => t === 'recorded line' || t === 'live line');
+
+    // Recorded history is the base; live blocks are appended after it.
+    expect(texts).toEqual(['recorded line', 'live line']);
+  });
+
+  it('uses recorded blocks alone when there are no live blocks', () => {
+    replay.state = { ...replay.state, recordedBlocks: [textBlock('recorded only')] };
+
+    render(<AgentStreamDrawer agent={null} issueId="issue-1" blocks={[]} onClose={vi.fn()} />);
+
+    expect(screen.getByText('recorded only')).toBeDefined();
+    expect(screen.getByText('Recorded Stream')).toBeDefined();
+  });
+});

--- a/packages/dashboard/tests/client/components/analyze/AnalyzeActionBar.test.tsx
+++ b/packages/dashboard/tests/client/components/analyze/AnalyzeActionBar.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AnalyzeActionBar } from '../../../../src/client/components/analyze/AnalyzeActionBar';
+import type {
+  SELResult,
+  CMLResult,
+  ActionState,
+} from '../../../../src/client/components/analyze/types';
+
+function makeSel(overrides?: Partial<SELResult>): SELResult {
+  return {
+    intent: 'add-feature',
+    summary: 'Add a new feature',
+    affectedSystems: [],
+    unknowns: [],
+    ambiguities: [],
+    riskSignals: [],
+    ...overrides,
+  };
+}
+
+function makeCml(overrides?: Partial<CMLResult>): CMLResult {
+  return {
+    overall: 42,
+    riskLevel: 'low',
+    confidence: 0.8,
+    blastRadius: { services: 1, modules: 2, filesEstimated: 3, testFilesAffected: 4 },
+    dimensions: { structural: 0.5, semantic: 0.5, historical: 0.5 },
+    reasoning: [],
+    recommendedRoute: 'human',
+    ...overrides,
+  };
+}
+
+interface RenderOptions {
+  selResult?: SELResult | null;
+  cmlResult?: CMLResult | null;
+  actionState?: ActionState;
+  actionError?: string | null;
+}
+
+function renderBar(opts: RenderOptions = {}) {
+  const handlers = {
+    onAddToRoadmap: vi.fn(),
+    onDispatchNow: vi.fn(),
+    onRefine: vi.fn(),
+    onExportSpec: vi.fn(),
+  };
+  render(
+    <AnalyzeActionBar
+      selResult={opts.selResult ?? null}
+      cmlResult={opts.cmlResult ?? null}
+      actionState={opts.actionState ?? 'idle'}
+      actionError={opts.actionError ?? null}
+      {...handlers}
+    />
+  );
+  return handlers;
+}
+
+const btn = (name: RegExp) => screen.getByRole('button', { name }) as HTMLButtonElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AnalyzeActionBar', () => {
+  it('renders all four action buttons in the idle default state', () => {
+    renderBar();
+    expect(btn(/Add to Roadmap/i)).toBeDefined();
+    expect(btn(/Dispatch Now/i)).toBeDefined();
+    expect(btn(/Refine/i)).toBeDefined();
+    expect(btn(/Export Spec/i)).toBeDefined();
+  });
+
+  it('disables Dispatch/Refine/Export but enables Add-to-Roadmap when there are no results (idle)', () => {
+    renderBar({ selResult: null, cmlResult: null, actionState: 'idle' });
+    expect(btn(/Add to Roadmap/i).disabled).toBe(false);
+    expect(btn(/Dispatch Now/i).disabled).toBe(true);
+    expect(btn(/Refine/i).disabled).toBe(true);
+    expect(btn(/Export Spec/i).disabled).toBe(true);
+  });
+
+  it('enables Dispatch only for a local recommended route and drops the not-available tooltip', () => {
+    const localHandlers = renderBar({ cmlResult: makeCml({ recommendedRoute: 'local' }) });
+    expect(btn(/Dispatch Now/i).disabled).toBe(false);
+    expect(btn(/Dispatch Now/i).getAttribute('title')).toBeNull();
+    fireEvent.click(btn(/Dispatch Now/i));
+    expect(localHandlers.onDispatchNow).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps Dispatch disabled with an explanatory tooltip for a non-local route', () => {
+    const handlers = renderBar({ cmlResult: makeCml({ recommendedRoute: 'human' }) });
+    const dispatch = btn(/Dispatch Now/i);
+    expect(dispatch.disabled).toBe(true);
+    expect(dispatch.getAttribute('title')).toBe('Only available for local-route items');
+    fireEvent.click(dispatch);
+    expect(handlers.onDispatchNow).not.toHaveBeenCalled();
+  });
+
+  it('enables Refine when the selResult has unknowns and fires its handler on click', () => {
+    const handlers = renderBar({ selResult: makeSel({ unknowns: ['what backend?'] }) });
+    const refine = btn(/Refine/i);
+    expect(refine.disabled).toBe(false);
+    fireEvent.click(refine);
+    expect(handlers.onRefine).toHaveBeenCalledTimes(1);
+  });
+
+  it('enables Refine when the selResult has ambiguities even with no unknowns', () => {
+    renderBar({ selResult: makeSel({ unknowns: [], ambiguities: ['scope unclear'] }) });
+    expect(btn(/Refine/i).disabled).toBe(false);
+  });
+
+  it('disables Refine when the selResult has neither unknowns nor ambiguities', () => {
+    renderBar({ selResult: makeSel({ unknowns: [], ambiguities: [] }) });
+    expect(btn(/Refine/i).disabled).toBe(true);
+  });
+
+  it('enables Export Spec whenever a selResult is present and fires its handler on click', () => {
+    const handlers = renderBar({ selResult: makeSel() });
+    const exportBtn = btn(/Export Spec/i);
+    expect(exportBtn.disabled).toBe(false);
+    fireEvent.click(exportBtn);
+    expect(handlers.onExportSpec).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a spinner-pending, disabled Add-to-Roadmap during roadmap-pending', () => {
+    renderBar({ actionState: 'roadmap-pending' });
+    const add = btn(/Add to Roadmap/i);
+    expect(add.disabled).toBe(true);
+    // label is unchanged while pending (only the icon swaps to a spinner)
+    expect(add.textContent).toContain('Add to Roadmap');
+  });
+
+  it('marks Add-to-Roadmap done with the "Added" label after roadmap-done', () => {
+    renderBar({ actionState: 'roadmap-done' });
+    const add = btn(/Added/i);
+    expect(add.disabled).toBe(true);
+    expect(add.textContent).toContain('Added');
+    expect(screen.queryByRole('button', { name: /Add to Roadmap/i })).toBeNull();
+  });
+
+  it('marks Dispatch done with the "Dispatched" label after dispatch-done', () => {
+    renderBar({ cmlResult: makeCml({ recommendedRoute: 'local' }), actionState: 'dispatch-done' });
+    const dispatch = btn(/Dispatched/i);
+    expect(dispatch.disabled).toBe(true);
+    expect(dispatch.textContent).toContain('Dispatched');
+  });
+
+  it('treats an in-flight (busy) state as disabling Add and Dispatch but not Refine or Export', () => {
+    // dispatch-pending is a busy, non-settled state
+    const handlers = renderBar({
+      selResult: makeSel({ unknowns: ['x'] }),
+      cmlResult: makeCml({ recommendedRoute: 'local' }),
+      actionState: 'dispatch-pending',
+    });
+    expect(btn(/Add to Roadmap/i).disabled).toBe(true);
+    expect(btn(/Dispatch Now/i).disabled).toBe(true);
+    // Refine/Export gating ignores busy — they depend only on selResult contents
+    expect(btn(/Refine/i).disabled).toBe(false);
+    expect(btn(/Export Spec/i).disabled).toBe(false);
+    fireEvent.click(btn(/Export Spec/i));
+    expect(handlers.onExportSpec).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-enables Add-to-Roadmap dispatch from a settled done state (done states are not busy)', () => {
+    renderBar({ cmlResult: makeCml({ recommendedRoute: 'local' }), actionState: 'roadmap-done' });
+    // roadmap-done is settled, so busy is false and Dispatch stays enabled
+    expect(btn(/Dispatch Now/i).disabled).toBe(false);
+  });
+
+  it('renders the action error message when one is present', () => {
+    renderBar({ actionError: 'Roadmap sync failed' });
+    expect(screen.getByText('Roadmap sync failed')).toBeDefined();
+  });
+
+  it('does not render an error message when actionError is null', () => {
+    renderBar({ actionError: null });
+    expect(screen.queryByText(/failed/i)).toBeNull();
+  });
+
+  it('fires the add-to-roadmap handler on click when enabled', () => {
+    const handlers = renderBar();
+    fireEvent.click(btn(/Add to Roadmap/i));
+    expect(handlers.onAddToRoadmap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dashboard/tests/client/components/analyze/buildSpecMarkdown.test.ts
+++ b/packages/dashboard/tests/client/components/analyze/buildSpecMarkdown.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { buildSpecMarkdown } from '../../../../src/client/components/analyze/buildSpecMarkdown';
+import type {
+  SELResult,
+  CMLResult,
+  PESLResult,
+} from '../../../../src/client/components/analyze/types';
+
+// Fixed clock so the `**Generated:** ${new Date().toISOString()}` line is deterministic.
+const FROZEN_ISO = '2026-07-20T12:00:00.000Z';
+
+function makeSel(overrides: Partial<SELResult> = {}): SELResult {
+  return {
+    intent: 'Do the thing',
+    summary: 'A short summary of the change.',
+    affectedSystems: [
+      {
+        name: 'auth-service',
+        graphNodeId: 'node-1',
+        confidence: 0.9,
+        transitiveDeps: ['db'],
+        testCoverage: 0.5,
+        owner: 'team-a',
+      },
+    ],
+    unknowns: [],
+    ambiguities: [],
+    riskSignals: [],
+    ...overrides,
+  };
+}
+
+function makeCml(overrides: Partial<CMLResult> = {}): CMLResult {
+  return {
+    overall: 0.732,
+    riskLevel: 'medium',
+    confidence: 0.8,
+    blastRadius: {
+      services: 3,
+      modules: 7,
+      filesEstimated: 12,
+      testFilesAffected: 4,
+    },
+    dimensions: {
+      structural: 0.5,
+      semantic: 0.256,
+      historical: 0.994,
+    },
+    reasoning: ['because'],
+    recommendedRoute: 'human',
+    ...overrides,
+  };
+}
+
+function makePesl(overrides: Partial<PESLResult> = {}): PESLResult {
+  return {
+    simulatedPlan: [],
+    predictedFailures: [],
+    riskHotspots: [],
+    missingSteps: [],
+    testGaps: [],
+    executionConfidence: 0.416,
+    recommendedChanges: [],
+    abort: false,
+    tier: 'full-simulation',
+    ...overrides,
+  };
+}
+
+describe('buildSpecMarkdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FROZEN_ISO));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits only the title and generated timestamp when all analyses are null', () => {
+    const md = buildSpecMarkdown('My Feature', null, null, null);
+
+    expect(md).toBe(`# Spec: My Feature\n\n**Generated:** ${FROZEN_ISO}\n`);
+  });
+
+  it('omits route/risk lines and all analysis sections when only cml is null', () => {
+    const md = buildSpecMarkdown('X', null, null, null);
+
+    expect(md).not.toContain('**Route Recommendation:**');
+    expect(md).not.toContain('**Risk Level:**');
+    expect(md).not.toContain('## Intent');
+    expect(md).not.toContain('## Complexity Score');
+    expect(md).not.toContain('## Simulation (PESL)');
+  });
+
+  it('adds route recommendation and risk level lines from cml', () => {
+    const md = buildSpecMarkdown(
+      'X',
+      null,
+      makeCml({ recommendedRoute: 'local', riskLevel: 'high' }),
+      null
+    );
+
+    expect(md).toContain('**Route Recommendation:** local');
+    expect(md).toContain('**Risk Level:** high');
+  });
+
+  it('renders intent and summary sections from sel', () => {
+    const md = buildSpecMarkdown('X', makeSel(), null, null);
+
+    expect(md).toContain('## Intent\n\nDo the thing\n');
+    expect(md).toContain('## Summary\n\nA short summary of the change.\n');
+  });
+
+  it('lists affected systems as bullets when present', () => {
+    const sel = makeSel({
+      affectedSystems: [
+        {
+          name: 'svc-a',
+          graphNodeId: null,
+          confidence: 0.1,
+          transitiveDeps: [],
+          testCoverage: 0,
+          owner: null,
+        },
+        {
+          name: 'svc-b',
+          graphNodeId: null,
+          confidence: 0.2,
+          transitiveDeps: [],
+          testCoverage: 0,
+          owner: null,
+        },
+      ],
+    });
+    const md = buildSpecMarkdown('X', sel, null, null);
+
+    expect(md).toContain('## Affected Systems\n\n- svc-a\n- svc-b\n');
+  });
+
+  it('omits the Affected Systems heading when there are no affected systems', () => {
+    const md = buildSpecMarkdown('X', makeSel({ affectedSystems: [] }), null, null);
+
+    expect(md).not.toContain('## Affected Systems');
+  });
+
+  it('formats complexity dimensions as rounded percentages', () => {
+    const cml = makeCml({
+      overall: 0.732,
+      dimensions: { structural: 0.5, semantic: 0.256, historical: 0.994 },
+    });
+    const md = buildSpecMarkdown('X', null, cml, null);
+
+    expect(md).toContain('- **Overall:** 73%'); // round(73.2)
+    expect(md).toContain('- **Structural:** 50%'); // round(50.0)
+    expect(md).toContain('- **Semantic:** 26%'); // round(25.6)
+    expect(md).toContain('- **Historical:** 99%'); // round(99.4)
+  });
+
+  it('renders the blast radius line with service/module/file counts', () => {
+    const cml = makeCml({
+      blastRadius: { services: 3, modules: 7, filesEstimated: 12, testFilesAffected: 4 },
+    });
+    const md = buildSpecMarkdown('X', null, cml, null);
+
+    expect(md).toContain('- **Blast Radius:** 3 services, 7 modules, ~12 files');
+  });
+
+  it('emits Unknowns, Ambiguities, and Risk Signals bullet sections when populated', () => {
+    const sel = makeSel({
+      unknowns: ['u1', 'u2'],
+      ambiguities: ['a1'],
+      riskSignals: ['r1'],
+    });
+    const md = buildSpecMarkdown('X', sel, null, null);
+
+    expect(md).toContain('## Unknowns\n\n- u1\n- u2\n');
+    expect(md).toContain('## Ambiguities\n\n- a1\n');
+    expect(md).toContain('## Risk Signals\n\n- r1\n');
+  });
+
+  it('omits empty sel bullet sections', () => {
+    const md = buildSpecMarkdown(
+      'X',
+      makeSel({ unknowns: [], ambiguities: [], riskSignals: [] }),
+      null,
+      null
+    );
+
+    expect(md).not.toContain('## Unknowns');
+    expect(md).not.toContain('## Ambiguities');
+    expect(md).not.toContain('## Risk Signals');
+  });
+
+  it('renders the PESL section with rounded execution confidence', () => {
+    const md = buildSpecMarkdown('X', null, null, makePesl({ executionConfidence: 0.416 }));
+
+    expect(md).toContain('## Simulation (PESL)');
+    expect(md).toContain('**Execution Confidence:** 42%'); // round(41.6)
+  });
+
+  it('renders the simulated plan as a 1-based numbered list', () => {
+    const pesl = makePesl({ simulatedPlan: ['step one', 'step two', 'step three'] });
+    const md = buildSpecMarkdown('X', null, null, pesl);
+
+    expect(md).toContain('### Simulated Plan\n\n1. step one\n2. step two\n3. step three\n');
+  });
+
+  it('omits the Simulated Plan heading when the plan is empty', () => {
+    const md = buildSpecMarkdown('X', null, null, makePesl({ simulatedPlan: [] }));
+
+    expect(md).not.toContain('### Simulated Plan');
+  });
+
+  it('renders predicted failures and recommended changes as bullet sections', () => {
+    const pesl = makePesl({
+      predictedFailures: ['boom', 'crash'],
+      recommendedChanges: ['add tests'],
+    });
+    const md = buildSpecMarkdown('X', null, null, pesl);
+
+    expect(md).toContain('### Predicted Failures\n\n- boom\n- crash\n');
+    expect(md).toContain('### Recommended Changes\n\n- add tests\n');
+  });
+
+  it('omits empty predicted-failure and recommended-change sections', () => {
+    const md = buildSpecMarkdown(
+      'X',
+      null,
+      null,
+      makePesl({ predictedFailures: [], recommendedChanges: [] })
+    );
+
+    expect(md).not.toContain('### Predicted Failures');
+    expect(md).not.toContain('### Recommended Changes');
+  });
+
+  it('assembles all sections in document order when sel, cml, and pesl are all present', () => {
+    const md = buildSpecMarkdown(
+      'Full Spec',
+      makeSel(),
+      makeCml(),
+      makePesl({ simulatedPlan: ['do it'] })
+    );
+
+    // Header block first.
+    expect(md.startsWith(`# Spec: Full Spec\n\n**Generated:** ${FROZEN_ISO}`)).toBe(true);
+
+    // Section ordering: header meta -> Intent -> Complexity Score -> Simulation.
+    const intentIdx = md.indexOf('## Intent');
+    const complexityIdx = md.indexOf('## Complexity Score');
+    const simulationIdx = md.indexOf('## Simulation (PESL)');
+    expect(intentIdx).toBeGreaterThan(-1);
+    expect(complexityIdx).toBeGreaterThan(intentIdx);
+    expect(simulationIdx).toBeGreaterThan(complexityIdx);
+  });
+});

--- a/packages/dashboard/tests/client/components/analyze/streamAnalyze.test.ts
+++ b/packages/dashboard/tests/client/components/analyze/streamAnalyze.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  streamAnalyze,
+  type AnalyzeCallbacks,
+} from '../../../../src/client/components/analyze/streamAnalyze';
+import type { AnalyzeSSEEvent } from '../../../../src/client/types/orchestrator';
+import type {
+  SELResult,
+  CMLResult,
+  PESLResult,
+  Signal,
+} from '../../../../src/client/components/analyze/types';
+
+/**
+ * Build a mock `fetch` Response whose body streams the given string chunks as
+ * UTF-8 encoded Uint8Arrays, one per `reader.read()` call. This drives
+ * `streamAnalyze`'s SSE parsing deterministically, including buffer-split
+ * cases where a single `data:` line spans two reads.
+ */
+function makeStreamResponse(
+  chunks: string[],
+  opts: {
+    ok?: boolean;
+    status?: number;
+    hasBody?: boolean;
+    contentType?: string;
+    json?: () => Promise<unknown>;
+  } = {}
+): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  const body =
+    (opts.hasBody ?? true)
+      ? {
+          getReader() {
+            return {
+              read: async () => {
+                if (i < chunks.length) {
+                  const value = encoder.encode(chunks[i]!);
+                  i += 1;
+                  return { done: false, value };
+                }
+                return { done: true, value: undefined };
+              },
+            };
+          },
+        }
+      : null;
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? (opts.contentType ?? null) : null,
+    },
+    body,
+    json: opts.json ?? (async () => ({})),
+  } as unknown as Response;
+}
+
+function makeCallbacks() {
+  const statuses: string[] = [];
+  const sels: SELResult[] = [];
+  const cmls: CMLResult[] = [];
+  const pesls: PESLResult[] = [];
+  const signalBatches: Signal[][] = [];
+  const errors: string[] = [];
+  let doneCount = 0;
+  const callbacks: AnalyzeCallbacks = {
+    onStatus: (text) => statuses.push(text),
+    onSEL: (data) => sels.push(data),
+    onCML: (data) => cmls.push(data),
+    onPESL: (data) => pesls.push(data),
+    onSignals: (data) => signalBatches.push(data),
+    onError: (error) => errors.push(error),
+    onDone: () => {
+      doneCount += 1;
+    },
+  };
+  return {
+    callbacks,
+    statuses,
+    sels,
+    cmls,
+    pesls,
+    signalBatches,
+    errors,
+    get doneCount() {
+      return doneCount;
+    },
+  };
+}
+
+/** Serialize an SSE event the way the server would: `data: <json>\n`. */
+function sse(event: AnalyzeSSEEvent): string {
+  return `data: ${JSON.stringify(event)}\n`;
+}
+
+const DONE_LINE = 'data: [DONE]\n';
+
+describe('streamAnalyze', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs the analyze body to /api/analyze with the abort signal', async () => {
+    const fetchMock = vi.fn(async () => makeStreamResponse([DONE_LINE]));
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+    const controller = new AbortController();
+
+    await streamAnalyze(
+      { title: 'A title', description: 'A description', labels: ['bug'] },
+      c.callbacks,
+      controller.signal
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/analyze');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(init.signal).toBe(controller.signal);
+    expect(JSON.parse(init.body as string)).toEqual({
+      title: 'A title',
+      description: 'A description',
+      labels: ['bug'],
+    });
+  });
+
+  it('dispatches each typed event to its matching callback, then [DONE]', async () => {
+    const sel = { intent: 'ship' } as unknown as SELResult;
+    const cml = { overall: 42 } as unknown as CMLResult;
+    const pesl = { abort: false } as unknown as PESLResult;
+    const signals: Signal[] = [{ name: 'sig', reason: 'because' }];
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        sse({ type: 'status', text: 'analyzing' }),
+        sse({ type: 'sel_result', data: sel as unknown as Record<string, unknown> }),
+        sse({ type: 'cml_result', data: cml as unknown as Record<string, unknown> }),
+        sse({ type: 'pesl_result', data: pesl as unknown as Record<string, unknown> }),
+        sse({ type: 'signals', data: signals }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.statuses).toEqual(['analyzing']);
+    expect(c.sels).toEqual([sel]);
+    expect(c.cmls).toEqual([cml]);
+    expect(c.pesls).toEqual([pesl]);
+    expect(c.signalBatches).toEqual([signals]);
+    expect(c.errors).toEqual([]);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('reassembles a data line split across two reads', async () => {
+    const line = sse({ type: 'status', text: 'streamed-status' });
+    const mid = Math.floor(line.length / 2);
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([line.slice(0, mid), line.slice(mid), DONE_LINE])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.statuses).toEqual(['streamed-status']);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('routes an error event to onError and stops processing further lines', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        sse({ type: 'error', error: 'boom' }),
+        sse({ type: 'status', text: 'should-not-arrive' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['boom']);
+    expect(c.statuses).toEqual([]);
+    expect(c.doneCount).toBe(0);
+  });
+
+  it('skips malformed JSON lines and lines without a data: prefix', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        ': this is a comment line\n',
+        'data: {not valid json}\n',
+        sse({ type: 'status', text: 'survivor' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.statuses).toEqual(['survivor']);
+    expect(c.errors).toEqual([]);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('skips JSON payloads that are not objects with a type field', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        'data: null\n',
+        'data: 42\n',
+        'data: {"noType":true}\n',
+        sse({ type: 'status', text: 'ok' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.statuses).toEqual(['ok']);
+    expect(c.errors).toEqual([]);
+  });
+
+  it('ignores an unknown event type without stopping the stream', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        'data: {"type":"mystery"}\n',
+        sse({ type: 'status', text: 'after-unknown' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.statuses).toEqual(['after-unknown']);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('calls onDone when the stream ends without an explicit [DONE]', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([sse({ type: 'status', text: 'trailing' })])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.statuses).toEqual(['trailing']);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('reports the server-provided error on a non-ok JSON response', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([], {
+        ok: false,
+        status: 500,
+        contentType: 'application/json',
+        json: async () => ({ error: 'server exploded' }),
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['server exploded']);
+    expect(c.doneCount).toBe(0);
+  });
+
+  it('falls back to HTTP status on a non-ok JSON response without an error field', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([], {
+        ok: false,
+        status: 422,
+        contentType: 'application/json',
+        json: async () => ({}),
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['HTTP 422']);
+  });
+
+  it('reports HTTP status on a non-ok non-JSON response', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([], { ok: false, status: 503, contentType: 'text/plain' })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['HTTP 503']);
+  });
+
+  it('reports a missing response stream', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([], { ok: true, status: 200, hasBody: false })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['No response stream']);
+  });
+
+  it('swallows AbortError without calling onError', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    const fetchMock = vi.fn(async () => {
+      throw abortErr;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual([]);
+    expect(c.doneCount).toBe(0);
+  });
+
+  it('reports the message of a non-abort network failure', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('connection reset');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamAnalyze({ title: 'x' }, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['connection reset']);
+  });
+});

--- a/packages/dashboard/tests/client/components/attention/helpers.test.ts
+++ b/packages/dashboard/tests/client/components/attention/helpers.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  filterAndSortInteractions,
+  findAttentionThreadId,
+} from '../../../../src/client/components/attention/helpers';
+import { useThreadStore } from '../../../../src/client/stores/threadStore';
+import type { PendingInteraction } from '../../../../src/client/types/orchestrator';
+import type { Thread } from '../../../../src/client/types/thread';
+
+/** Build a PendingInteraction with sensible, overridable defaults. */
+function makeInteraction(overrides: Partial<PendingInteraction> = {}): PendingInteraction {
+  return {
+    id: 'int-1',
+    issueId: 'ISSUE-1',
+    type: 'needs-human',
+    reasons: ['High complexity'],
+    context: {
+      issueTitle: 'Add retry logic',
+      issueDescription: 'Wrap the fetch in exponential backoff',
+      specPath: null,
+      planPath: null,
+      relatedFiles: [],
+    },
+    createdAt: '2026-07-01T00:00:00.000Z',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+/** Build a Thread with sensible, overridable defaults (attention type by default). */
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: 'attn:int-1',
+    type: 'attention',
+    title: 'Attention: ISSUE-1',
+    status: 'pending',
+    createdAt: 1,
+    updatedAt: 1,
+    avatar: 'alert',
+    unread: false,
+    meta: {
+      interactionId: 'int-1',
+      issueId: 'ISSUE-1',
+      reasons: ['High complexity'],
+      context: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('filterAndSortInteractions', () => {
+  it('drops resolved interactions and keeps pending and claimed ones', () => {
+    const interactions = [
+      makeInteraction({ id: 'a', status: 'pending' }),
+      makeInteraction({ id: 'b', status: 'claimed' }),
+      makeInteraction({ id: 'c', status: 'resolved' }),
+    ];
+
+    const result = filterAndSortInteractions(interactions, '');
+
+    expect(result.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  it('returns all non-resolved interactions when the query is empty', () => {
+    const interactions = [
+      makeInteraction({ id: 'a', createdAt: '2026-07-01T00:00:00.000Z' }),
+      makeInteraction({ id: 'b', createdAt: '2026-07-02T00:00:00.000Z' }),
+    ];
+
+    const result = filterAndSortInteractions(interactions, '');
+
+    expect(result).toHaveLength(interactions.length);
+  });
+
+  it('sorts surviving interactions newest-first by createdAt', () => {
+    const oldest = makeInteraction({ id: 'oldest', createdAt: '2026-07-01T00:00:00.000Z' });
+    const middle = makeInteraction({ id: 'middle', createdAt: '2026-07-05T00:00:00.000Z' });
+    const newest = makeInteraction({ id: 'newest', createdAt: '2026-07-09T00:00:00.000Z' });
+
+    // Deliberately unsorted input to prove the sort, not the input order.
+    const result = filterAndSortInteractions([oldest, newest, middle], '');
+
+    expect(result.map((i) => i.id)).toEqual(['newest', 'middle', 'oldest']);
+  });
+
+  it('matches the query against the issue title case-insensitively', () => {
+    const interactions = [
+      makeInteraction({
+        id: 'match',
+        context: { ...makeInteraction().context, issueTitle: 'Fix Flaky Test' },
+      }),
+      makeInteraction({
+        id: 'miss',
+        context: { ...makeInteraction().context, issueTitle: 'Unrelated work' },
+      }),
+    ];
+
+    const result = filterAndSortInteractions(interactions, 'FLAKY');
+
+    expect(result.map((i) => i.id)).toEqual(['match']);
+  });
+
+  it('matches the query against the issue description', () => {
+    const interactions = [
+      makeInteraction({
+        id: 'match',
+        context: { ...makeInteraction().context, issueDescription: 'Uses exponential backoff' },
+      }),
+      makeInteraction({
+        id: 'miss',
+        context: { ...makeInteraction().context, issueDescription: 'Nothing relevant here' },
+      }),
+    ];
+
+    const result = filterAndSortInteractions(interactions, 'backoff');
+
+    expect(result.map((i) => i.id)).toEqual(['match']);
+  });
+
+  it('matches the query against any of the reasons', () => {
+    const interactions = [
+      makeInteraction({ id: 'match', reasons: ['Low confidence', 'Ambiguous spec'] }),
+      makeInteraction({ id: 'miss', reasons: ['Ready to ship'] }),
+    ];
+
+    const result = filterAndSortInteractions(interactions, 'ambiguous');
+
+    expect(result.map((i) => i.id)).toEqual(['match']);
+  });
+
+  it('matches the query against the interaction id and the issue id', () => {
+    const interactions = [
+      makeInteraction({ id: 'INT-ABC', issueId: 'ISSUE-100' }),
+      makeInteraction({ id: 'INT-XYZ', issueId: 'ISSUE-200' }),
+    ];
+
+    expect(filterAndSortInteractions(interactions, 'int-abc').map((i) => i.id)).toEqual([
+      'INT-ABC',
+    ]);
+    expect(filterAndSortInteractions(interactions, 'issue-200').map((i) => i.id)).toEqual([
+      'INT-XYZ',
+    ]);
+  });
+
+  it('trims surrounding whitespace from the query before matching', () => {
+    const interactions = [
+      makeInteraction({
+        id: 'match',
+        context: { ...makeInteraction().context, issueTitle: 'Add retry logic' },
+      }),
+      makeInteraction({
+        id: 'miss',
+        context: { ...makeInteraction().context, issueTitle: 'Something else' },
+      }),
+    ];
+
+    // A whitespace-only query is treated as empty (returns everything)...
+    expect(filterAndSortInteractions(interactions, '   ')).toHaveLength(interactions.length);
+    // ...while a padded real query still matches on the trimmed term.
+    expect(filterAndSortInteractions(interactions, '  retry  ').map((i) => i.id)).toEqual([
+      'match',
+    ]);
+  });
+
+  it('excludes non-matching interactions entirely', () => {
+    const interactions = [makeInteraction({ id: 'only' })];
+
+    const result = filterAndSortInteractions(interactions, 'no-such-term-anywhere');
+
+    expect(result).toEqual([]);
+  });
+
+  it('never returns a resolved interaction even when it matches the query', () => {
+    const interactions = [
+      makeInteraction({
+        id: 'resolved-match',
+        status: 'resolved',
+        context: { ...makeInteraction().context, issueTitle: 'Add retry logic' },
+      }),
+    ];
+
+    const result = filterAndSortInteractions(interactions, 'retry');
+
+    expect(result).toEqual([]);
+  });
+
+  it('tolerates a null issue description without matching it', () => {
+    const interactions = [
+      makeInteraction({
+        id: 'only',
+        context: { ...makeInteraction().context, issueDescription: null },
+      }),
+    ];
+
+    // Should not throw on the null description, and should not spuriously match.
+    expect(filterAndSortInteractions(interactions, 'anything')).toEqual([]);
+    expect(filterAndSortInteractions(interactions, '')).toHaveLength(1);
+  });
+});
+
+describe('findAttentionThreadId', () => {
+  beforeEach(() => {
+    useThreadStore.setState({ threads: new Map() });
+  });
+
+  it('returns the thread id whose attention meta matches the interaction id', () => {
+    const thread = makeThread({
+      id: 'attn:target',
+      meta: { interactionId: 'target', issueId: 'ISSUE-1', reasons: [], context: null },
+    });
+    useThreadStore.setState({ threads: new Map([[thread.id, thread]]) });
+
+    expect(findAttentionThreadId('target')).toBe('attn:target');
+  });
+
+  it('returns undefined when no attention thread matches the interaction id', () => {
+    const thread = makeThread({
+      id: 'attn:other',
+      meta: { interactionId: 'other', issueId: 'ISSUE-1', reasons: [], context: null },
+    });
+    useThreadStore.setState({ threads: new Map([[thread.id, thread]]) });
+
+    expect(findAttentionThreadId('missing')).toBeUndefined();
+  });
+
+  it('ignores non-attention threads that happen to carry the interaction id', () => {
+    const chatThread = makeThread({
+      id: 'chat:decoy',
+      type: 'chat',
+      // A chat meta does not have an interactionId; guard must not match it.
+      meta: { sessionId: 'sess-1', command: null },
+    });
+    useThreadStore.setState({ threads: new Map([[chatThread.id, chatThread]]) });
+
+    expect(findAttentionThreadId('sess-1')).toBeUndefined();
+  });
+
+  it('returns undefined when the store has no threads at all', () => {
+    expect(findAttentionThreadId('anything')).toBeUndefined();
+  });
+});

--- a/packages/dashboard/tests/client/components/cards/AnalysisFormCard.test.tsx
+++ b/packages/dashboard/tests/client/components/cards/AnalysisFormCard.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { AnalysisFormCard } from '../../../../src/client/components/cards/AnalysisFormCard';
+
+// ── framer-motion drives the collapse animation. Replace it with plain DOM so
+//    the form's expanded/collapsed content is synchronously present (no RAF,
+//    no height-transition gating) and assertions are deterministic.
+vi.mock('framer-motion', () => {
+  const strip = (props: Record<string, unknown>) => {
+    const { initial, animate, exit, transition, whileHover, whileTap, layout, ...rest } = props;
+    void initial;
+    void animate;
+    void exit;
+    void transition;
+    void whileHover;
+    void whileTap;
+    void layout;
+    return rest;
+  };
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, tag: string) => (props: Record<string, unknown>) =>
+        React.createElement(tag, strip(props), props.children as React.ReactNode),
+    }
+  );
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+const TITLE_PLACEHOLDER = 'Feature or issue title...';
+const DESCRIPTION_PLACEHOLDER = 'Optional context...';
+const LABELS_PLACEHOLDER = 'Comma-separated labels...';
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof AnalysisFormCard>> = {}) {
+  const onSubmit = vi.fn();
+  const props: React.ComponentProps<typeof AnalysisFormCard> = {
+    initialTitle: '',
+    initialDescription: '',
+    initialLabels: [],
+    collapsed: false,
+    onSubmit,
+    ...overrides,
+  };
+  render(<AnalysisFormCard {...props} />);
+  return { onSubmit };
+}
+
+describe('AnalysisFormCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('seeds the inputs from the initial props', () => {
+    renderCard({
+      initialTitle: 'Refactor auth',
+      initialDescription: 'harden token flow',
+      initialLabels: ['auth', 'security'],
+    });
+
+    expect(screen.getByPlaceholderText<HTMLInputElement>(TITLE_PLACEHOLDER).value).toBe(
+      'Refactor auth'
+    );
+    expect(screen.getByPlaceholderText<HTMLTextAreaElement>(DESCRIPTION_PLACEHOLDER).value).toBe(
+      'harden token flow'
+    );
+    // initialLabels are rejoined with ", " for the comma-separated field.
+    expect(screen.getByPlaceholderText<HTMLInputElement>(LABELS_PLACEHOLDER).value).toBe(
+      'auth, security'
+    );
+  });
+
+  it('submits trimmed title/description and normalized labels', () => {
+    const { onSubmit } = renderCard({
+      initialTitle: '  Refactor auth  ',
+      initialDescription: '  harden token flow  ',
+    });
+
+    // A deliberately messy label string: surrounding whitespace and empty
+    // segments must be trimmed and dropped.
+    fireEvent.change(screen.getByPlaceholderText(LABELS_PLACEHOLDER), {
+      target: { value: 'auth ,  , security,,perf ' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Run Analysis/ }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: 'Refactor auth',
+      description: 'harden token flow',
+      labels: ['auth', 'security', 'perf'],
+    });
+  });
+
+  it('submits an empty labels array when the labels field is blank', () => {
+    const { onSubmit } = renderCard({ initialTitle: 'Ship it' });
+
+    fireEvent.click(screen.getByRole('button', { name: /Run Analysis/ }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0]?.[0].labels).toEqual([]);
+  });
+
+  it('disables the run button and guards submit when the title is whitespace-only', () => {
+    const { onSubmit } = renderCard({ initialTitle: '   ' });
+
+    const runButton = screen.getByRole<HTMLButtonElement>('button', { name: /Run Analysis/ });
+    expect(runButton.disabled).toBe(true);
+
+    fireEvent.click(runButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('shows the "New Analysis" fallback heading when the title is empty', () => {
+    renderCard({ initialTitle: '' });
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('New Analysis');
+  });
+
+  it('reflects the live title in the heading as the user types', () => {
+    renderCard({ initialTitle: '' });
+
+    fireEvent.change(screen.getByPlaceholderText(TITLE_PLACEHOLDER), {
+      target: { value: 'New idea' },
+    });
+
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('New idea');
+  });
+
+  it('starts collapsed and hides the form until the header is toggled', () => {
+    renderCard({ collapsed: true, initialTitle: 'Done work' });
+
+    // collapsed => expanded starts false => the inputs are not mounted.
+    expect(screen.queryByPlaceholderText(TITLE_PLACEHOLDER)).toBeNull();
+    expect(screen.getByText('Analysis complete — expand to see inputs')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Now the form is expanded and mounted.
+    expect(screen.getByPlaceholderText(TITLE_PLACEHOLDER)).toBeDefined();
+  });
+
+  it('disables the inputs and omits the run button when collapsed', () => {
+    renderCard({ collapsed: true, initialTitle: 'Done work' });
+
+    // Expand the collapsed card to reveal the (disabled) inputs.
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByPlaceholderText<HTMLInputElement>(TITLE_PLACEHOLDER).disabled).toBe(true);
+    expect(screen.getByPlaceholderText<HTMLTextAreaElement>(DESCRIPTION_PLACEHOLDER).disabled).toBe(
+      true
+    );
+    expect(screen.getByPlaceholderText<HTMLInputElement>(LABELS_PLACEHOLDER).disabled).toBe(true);
+    expect(screen.queryByRole('button', { name: /Run Analysis/ })).toBeNull();
+  });
+
+  it('collapses the expanded form when the header is toggled', () => {
+    renderCard({ initialTitle: 'Refactor auth' });
+
+    // Starts expanded (collapsed=false): the header is the button that is not
+    // the run button, and clicking it should hide the inputs.
+    expect(screen.getByPlaceholderText(TITLE_PLACEHOLDER)).toBeDefined();
+    fireEvent.click(screen.getByRole('heading', { level: 3 }).closest('button')!);
+
+    expect(screen.queryByPlaceholderText(TITLE_PLACEHOLDER)).toBeNull();
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/ChatInput.test.tsx
+++ b/packages/dashboard/tests/client/components/chat/ChatInput.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React, { useState } from 'react';
+import { ChatInput } from '../../../../src/client/components/chat/ChatInput';
+import { SKILL_REGISTRY } from '../../../../src/client/constants/skills';
+
+const DEFAULT_PLACEHOLDER = 'Execute command or query neural link...';
+// Marker text rendered by the SlashAutocomplete footer; used to detect visibility.
+const AUTOCOMPLETE_MARKER = 'Command Registry';
+
+// A skill whose id substring is unique across the registry, so filtering by its
+// slash command yields exactly one match. Derived from the real registry rather
+// than hardcoded so the test tracks the source of truth.
+const VALIDATE_SKILL = SKILL_REGISTRY.find((s) => s.id === 'harness:validate')!;
+
+/**
+ * ChatInput is a controlled component: its autocomplete visibility depends on
+ * the `value` prop reflecting the typed text (SlashAutocomplete reads
+ * `filter={value}`). This harness holds the value in state to mirror real usage.
+ */
+function Harness({
+  onSend = vi.fn(),
+  onChangeSpy,
+  disabled = false,
+  placeholder,
+  initialValue = '',
+}: {
+  onSend?: () => void;
+  onChangeSpy?: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  initialValue?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <ChatInput
+      value={value}
+      onChange={(v) => {
+        onChangeSpy?.(v);
+        setValue(v);
+      }}
+      onSend={onSend}
+      disabled={disabled}
+      placeholder={placeholder}
+    />
+  );
+}
+
+describe('ChatInput', () => {
+  it('renders the default placeholder when none is provided', () => {
+    render(<Harness />);
+    expect(screen.getByPlaceholderText(DEFAULT_PLACEHOLDER)).toBeDefined();
+  });
+
+  it('renders a custom placeholder when provided', () => {
+    render(<Harness placeholder="Ask anything" />);
+    expect(screen.getByPlaceholderText('Ask anything')).toBeDefined();
+    expect(screen.queryByPlaceholderText(DEFAULT_PLACEHOLDER)).toBeNull();
+  });
+
+  it('propagates typed text through onChange', () => {
+    const onChangeSpy = vi.fn();
+    render(<Harness onChangeSpy={onChangeSpy} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello world' } });
+
+    expect(onChangeSpy).toHaveBeenCalledWith('hello world');
+  });
+
+  it('sends on Enter without Shift', () => {
+    const onSend = vi.fn();
+    render(<Harness onSend={onSend} initialValue="hello" />);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('inserts a newline (does not send) on Shift+Enter', () => {
+    const onSend = vi.fn();
+    render(<Harness onSend={onSend} initialValue="hello" />);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', shiftKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('disables the send button when the value is empty or whitespace-only', () => {
+    render(<Harness initialValue="   " />);
+    expect((screen.getByRole('button') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('enables the send button and calls onSend when clicked with content', () => {
+    const onSend = vi.fn();
+    render(<Harness onSend={onSend} initialValue="hi" />);
+
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the textarea and send button while disabled (in-flight)', () => {
+    render(<Harness disabled initialValue="hi" />);
+
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).disabled).toBe(true);
+    expect((screen.getByRole('button') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows the slash-command autocomplete when the typed text matches a skill', () => {
+    render(<Harness />);
+
+    expect(screen.queryByText(AUTOCOMPLETE_MARKER)).toBeNull();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: VALIDATE_SKILL.slashCommand },
+    });
+
+    expect(screen.getByText(AUTOCOMPLETE_MARKER)).toBeDefined();
+    expect(screen.getByText(VALIDATE_SKILL.name)).toBeDefined();
+  });
+
+  it('does not show the autocomplete for a slash command with no matches', () => {
+    render(<Harness />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '/zzz-no-such-skill' },
+    });
+
+    expect(screen.queryByText(AUTOCOMPLETE_MARKER)).toBeNull();
+  });
+
+  it('hides the autocomplete once the leading slash is removed', () => {
+    render(<Harness />);
+    const textbox = screen.getByRole('textbox');
+
+    fireEvent.change(textbox, { target: { value: VALIDATE_SKILL.slashCommand } });
+    expect(screen.getByText(AUTOCOMPLETE_MARKER)).toBeDefined();
+
+    fireEvent.change(textbox, { target: { value: 'plain text' } });
+    expect(screen.queryByText(AUTOCOMPLETE_MARKER)).toBeNull();
+  });
+
+  it('delegates Enter to the autocomplete (does not send) while it is open on a slash command', () => {
+    const onSend = vi.fn();
+    render(<Harness onSend={onSend} />);
+    const textbox = screen.getByRole('textbox');
+
+    fireEvent.change(textbox, { target: { value: VALIDATE_SKILL.slashCommand } });
+    expect(screen.getByText(AUTOCOMPLETE_MARKER)).toBeDefined();
+
+    fireEvent.keyDown(textbox, { key: 'Enter' });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('fills the input with the slash command and closes the autocomplete on skill select', () => {
+    const onChangeSpy = vi.fn();
+    render(<Harness onChangeSpy={onChangeSpy} />);
+    const textbox = screen.getByRole('textbox');
+
+    fireEvent.change(textbox, { target: { value: VALIDATE_SKILL.slashCommand } });
+    onChangeSpy.mockClear();
+
+    fireEvent.click(screen.getByText(VALIDATE_SKILL.name).closest('button')!);
+
+    expect(onChangeSpy).toHaveBeenCalledWith(`${VALIDATE_SKILL.slashCommand} `);
+    expect(screen.queryByText(AUTOCOMPLETE_MARKER)).toBeNull();
+  });
+});

--- a/packages/dashboard/tests/client/components/chat/block-segments.test.ts
+++ b/packages/dashboard/tests/client/components/chat/block-segments.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isContainerTool,
+  isLogOutput,
+  computeBlockSegments,
+  segmentKey,
+  type BlockSegment,
+} from '../../../../src/client/components/chat/block-segments';
+import type {
+  ContentBlock,
+  ToolUseBlock,
+  TextBlock,
+  StatusBlock,
+  ThinkingBlock,
+} from '../../../../src/client/types/chat';
+
+// ── Block factories (keep test fixtures explicit and typed) ──────────
+
+function tool(t: string, extra: Partial<ToolUseBlock> = {}): ToolUseBlock {
+  return { kind: 'tool_use', tool: t, ...extra };
+}
+function text(t: string): TextBlock {
+  return { kind: 'text', text: t };
+}
+function status(t: string): StatusBlock {
+  return { kind: 'status', text: t };
+}
+function thinking(t: string): ThinkingBlock {
+  return { kind: 'thinking', text: t };
+}
+
+// A line that reliably trips isLogOutput's `/^>\s/` marker.
+const LOG_LINE = '> npm run build';
+// Prose that trips no log markers.
+const PROSE = 'Here is the answer to your question.';
+
+describe('isContainerTool', () => {
+  it('classifies the fixed container tool names case-insensitively', () => {
+    expect(isContainerTool('agent')).toBe(true);
+    expect(isContainerTool('SubAgent')).toBe(true);
+    expect(isContainerTool('SKILL')).toBe(true);
+  });
+
+  it('classifies any harness-prefixed tool as a container', () => {
+    expect(isContainerTool('harness:orchestrator')).toBe(true);
+    expect(isContainerTool('HARNESS:analyze')).toBe(true);
+  });
+
+  it('does not classify ordinary tools as containers', () => {
+    expect(isContainerTool('Bash')).toBe(false);
+    expect(isContainerTool('Read')).toBe(false);
+    expect(isContainerTool('subagentic')).toBe(false);
+  });
+});
+
+describe('isLogOutput', () => {
+  it('flags terminal-style lines as log output', () => {
+    expect(isLogOutput('> npm run build')).toBe(true);
+    expect(isLogOutput('$ ls -la')).toBe(true);
+  });
+
+  it('flags source-code-style lines as log output', () => {
+    expect(isLogOutput("import { x } from './y'")).toBe(true);
+  });
+
+  it('treats conversational prose as non-log', () => {
+    expect(isLogOutput(PROSE)).toBe(false);
+    expect(isLogOutput('This is a normal sentence with no markers')).toBe(false);
+  });
+
+  it('flags a block when any single line matches a marker', () => {
+    const mixed = ['normal prose line', LOG_LINE, 'more prose'].join('\n');
+    expect(isLogOutput(mixed)).toBe(true);
+  });
+});
+
+describe('computeBlockSegments', () => {
+  it('returns no segments for an empty block list', () => {
+    expect(computeBlockSegments([], false)).toEqual([]);
+  });
+
+  it('emits a standalone text segment for conversational text', () => {
+    const block = text('Hello there.');
+    const segments = computeBlockSegments([block], false);
+    expect(segments).toEqual([{ kind: 'text', block, index: 0 }]);
+  });
+
+  it('groups a lone regular tool_use into a final activity segment', () => {
+    const block = tool('Bash', { args: 'ls' });
+    const segments = computeBlockSegments([block], false);
+    expect(segments).toEqual([
+      { kind: 'activity', blocks: [block], startIndex: 0, isLastGroup: true },
+    ]);
+  });
+
+  it('merges following log output into a regular tool result', () => {
+    const blocks: ContentBlock[] = [tool('Bash', { result: 'existing' }), text(LOG_LINE)];
+    const segments = computeBlockSegments(blocks, false);
+
+    expect(segments).toHaveLength(1);
+    const activity = segments[0] as Extract<BlockSegment, { kind: 'activity' }>;
+    expect(activity.kind).toBe('activity');
+    expect(activity.blocks).toHaveLength(1);
+    const merged = activity.blocks[0] as ToolUseBlock;
+    // Merged log output is prepended to the pre-existing result.
+    expect(merged.result).toBe(`${LOG_LINE}\n\nexisting`);
+  });
+
+  it('merges an adjacent status block into the tool result', () => {
+    const blocks: ContentBlock[] = [tool('Bash'), status('running tests')];
+    const segments = computeBlockSegments(blocks, false);
+
+    const activity = segments[0] as Extract<BlockSegment, { kind: 'activity' }>;
+    const merged = activity.blocks[0] as ToolUseBlock;
+    expect(merged.result).toBe('running tests');
+  });
+
+  it('does not merge conversational text and splits it into its own text segment', () => {
+    const toolBlock = tool('Bash');
+    const proseBlock = text(PROSE);
+    const segments = computeBlockSegments([toolBlock, proseBlock], false);
+
+    expect(segments).toEqual([
+      { kind: 'activity', blocks: [toolBlock], startIndex: 0, isLastGroup: true },
+      { kind: 'text', block: proseBlock, index: 1 },
+    ]);
+  });
+
+  it('emits an agent segment for a container tool and folds log children in', () => {
+    const agent = tool('agent');
+    const child = text(LOG_LINE);
+    const segments = computeBlockSegments([agent, child], false);
+
+    expect(segments).toHaveLength(1);
+    const seg = segments[0] as Extract<BlockSegment, { kind: 'agent' }>;
+    expect(seg.kind).toBe('agent');
+    expect(seg.block).toBe(agent);
+    expect(seg.index).toBe(0);
+    expect(seg.childBlocks).toEqual([child]);
+    expect(seg.childStartIndex).toBe(1);
+    expect(seg.childIsLastGroup).toBe(true);
+  });
+
+  it('stops agent child collection at a conversational text block', () => {
+    const agent = tool('agent');
+    const prose = text(PROSE);
+    const segments = computeBlockSegments([agent, prose], false);
+
+    const seg = segments[0] as Extract<BlockSegment, { kind: 'agent' }>;
+    expect(seg.kind).toBe('agent');
+    // Prose breaks child collection, so it becomes its own text segment.
+    expect(seg.childBlocks).toEqual([]);
+    expect(segments[1]).toEqual({ kind: 'text', block: prose, index: 1 });
+  });
+
+  it('emits a todo segment for a todo tool', () => {
+    const todo = tool('TodoWrite');
+    const segments = computeBlockSegments([todo], false);
+    expect(segments).toEqual([{ kind: 'todo', block: todo, index: 0 }]);
+  });
+
+  it('marks a trailing interaction tool as pending only while streaming', () => {
+    const ask = tool('ask_human');
+
+    const streaming = computeBlockSegments([ask], true);
+    expect(streaming[0]).toEqual({ kind: 'interaction', block: ask, index: 0, isPending: true });
+    // Streaming also appends a trailing streaming segment.
+    expect(streaming[streaming.length - 1]).toEqual({ kind: 'streaming' });
+
+    const settled = computeBlockSegments([ask], false);
+    expect(settled).toEqual([{ kind: 'interaction', block: ask, index: 0, isPending: false }]);
+  });
+
+  it('groups thinking blocks into activity segments', () => {
+    const think = thinking('pondering');
+    const segments = computeBlockSegments([think], false);
+    expect(segments).toEqual([
+      { kind: 'activity', blocks: [think], startIndex: 0, isLastGroup: true },
+    ]);
+  });
+});
+
+describe('segmentKey', () => {
+  it('derives a stable, index-scoped key for each segment kind', () => {
+    const toolBlock = tool('Bash');
+    const textBlock = text('hi');
+
+    expect(
+      segmentKey({
+        kind: 'agent',
+        block: toolBlock,
+        childBlocks: [],
+        childStartIndex: 1,
+        childIsLastGroup: false,
+        index: 3,
+      })
+    ).toBe('agent-3');
+    expect(segmentKey({ kind: 'todo', block: toolBlock, index: 4 })).toBe('todo-4');
+    expect(segmentKey({ kind: 'interaction', block: toolBlock, index: 5, isPending: false })).toBe(
+      'interaction-5'
+    );
+    expect(segmentKey({ kind: 'activity', blocks: [], startIndex: 6, isLastGroup: false })).toBe(
+      'ag-6'
+    );
+    expect(segmentKey({ kind: 'text', block: textBlock, index: 7 })).toBe('text-7');
+    expect(segmentKey({ kind: 'streaming' })).toBe('streaming');
+  });
+});

--- a/packages/dashboard/tests/client/components/local-models/format.test.ts
+++ b/packages/dashboard/tests/client/components/local-models/format.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { round1, fmtScore } from '../../../../src/client/components/local-models/format';
+
+describe('round1', () => {
+  it('rounds to one decimal place', () => {
+    expect(round1(44.159)).toBe('44.2');
+  });
+
+  it('drops a trailing .0 when the rounded value is whole', () => {
+    expect(round1(20)).toBe('20');
+  });
+
+  it('drops the trailing .0 for values that round to a whole number', () => {
+    expect(round1(75.02)).toBe('75');
+  });
+
+  it('collapses long float noise to a single decimal', () => {
+    // 75.65831765532494 → 75.7 (the DOM-leak case the module guards against)
+    expect(round1(75.65831765532494)).toBe('75.7');
+  });
+
+  it('rounds half up at the tenths place', () => {
+    expect(round1(18.15)).toBe('18.2');
+  });
+
+  it('preserves a genuine one-decimal value', () => {
+    expect(round1(44.2)).toBe('44.2');
+  });
+
+  it('formats zero as "0"', () => {
+    expect(round1(0)).toBe('0');
+  });
+
+  it('handles negative values (e.g. score deltas)', () => {
+    expect(round1(-3.14)).toBe('-3.1');
+  });
+});
+
+describe('fmtScore', () => {
+  it('rounds a fractional score to a whole number', () => {
+    expect(fmtScore(57.629999999999995)).toBe('58');
+  });
+
+  it('rounds down below the .5 boundary', () => {
+    expect(fmtScore(71.4)).toBe('71');
+  });
+
+  it('rounds up at the .5 boundary', () => {
+    expect(fmtScore(54.5)).toBe('55');
+  });
+
+  it('leaves an already-whole score unchanged', () => {
+    expect(fmtScore(100)).toBe('100');
+  });
+
+  it('formats zero as "0"', () => {
+    expect(fmtScore(0)).toBe('0');
+  });
+});

--- a/packages/dashboard/tests/client/components/maintenance/MaintenanceBanners.test.tsx
+++ b/packages/dashboard/tests/client/components/maintenance/MaintenanceBanners.test.tsx
@@ -1,0 +1,156 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MaintenanceBanners } from '../../../../src/client/components/maintenance/MaintenanceBanners';
+import type { MaintenanceData } from '../../../../src/client/components/maintenance/useMaintenanceData';
+
+type MaintenanceEvent = MaintenanceData['maintenanceEvent'];
+
+// Construct fully-typed maintenance events. The component narrows on
+// `event.type`, so the exact wire shape matters for behavior.
+function errorEvent(taskId: string, error?: string): MaintenanceEvent {
+  return { type: 'maintenance:error', data: { taskId, error } } as MaintenanceEvent;
+}
+
+function baserefFallbackEvent(ref: string, repoRoot: string): MaintenanceEvent {
+  return {
+    type: 'maintenance:baseref_fallback',
+    data: { ref, repoRoot },
+  } as MaintenanceEvent;
+}
+
+const DISMISS_BUTTON = { name: /dismiss baseref fallback warning/i };
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('MaintenanceBanners', () => {
+  describe('InFlightBanner', () => {
+    it('renders nothing when no tasks are in flight', () => {
+      const { container } = render(
+        <MaintenanceBanners inFlightList={[]} maintenanceEvent={null} />
+      );
+      expect(container.textContent).toBe('');
+    });
+
+    it('names the single running task', () => {
+      render(<MaintenanceBanners inFlightList={['refresh-baselines']} maintenanceEvent={null} />);
+      expect(screen.getByText(/Running:/)).toBeDefined();
+      expect(screen.getByText('refresh-baselines')).toBeDefined();
+    });
+
+    it('summarizes count and lists tasks when several are running', () => {
+      const tasks = ['a', 'b', 'c'];
+      render(<MaintenanceBanners inFlightList={tasks} maintenanceEvent={null} />);
+      expect(screen.getByText(new RegExp(`Running ${tasks.length} tasks:`))).toBeDefined();
+      expect(screen.getByText(tasks.join(', '))).toBeDefined();
+    });
+  });
+
+  describe('ErrorEventBanner', () => {
+    it('reports the failed task id and error message', () => {
+      render(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={errorEvent('doc-drift', 'timed out')}
+        />
+      );
+      expect(screen.getByText('doc-drift')).toBeDefined();
+      expect(screen.getByText(/failed: timed out/)).toBeDefined();
+    });
+
+    it('renders "failed" without a colon when no error string is present', () => {
+      render(<MaintenanceBanners inFlightList={[]} maintenanceEvent={errorEvent('doc-drift')} />);
+      const banner = screen.getByText(/failed/);
+      expect(banner.textContent).toContain('failed');
+      expect(banner.textContent).not.toContain('failed:');
+    });
+
+    it('does not render an error banner for a non-error event', () => {
+      render(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={baserefFallbackEvent('main', '/repo')}
+        />
+      );
+      expect(screen.queryByText(/failed/)).toBeNull();
+    });
+  });
+
+  describe('BaserefFallbackBanner', () => {
+    it('surfaces the fallback ref and repo root', () => {
+      render(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={baserefFallbackEvent('main', '/Users/x/repo')}
+        />
+      );
+      expect(screen.getByText(/base-ref fell back to local/)).toBeDefined();
+      expect(screen.getByText('main')).toBeDefined();
+      expect(screen.getByText('/Users/x/repo')).toBeDefined();
+    });
+
+    it('hides the banner after the user dismisses it', () => {
+      render(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={baserefFallbackEvent('main', '/repo')}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', DISMISS_BUTTON));
+      expect(screen.queryByText(/base-ref fell back to local/)).toBeNull();
+    });
+
+    it('re-appears when a fallback with a different identity arrives', () => {
+      const { rerender } = render(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={baserefFallbackEvent('main', '/repo-a')}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', DISMISS_BUTTON));
+      expect(screen.queryByText(/base-ref fell back to local/)).toBeNull();
+
+      // A fallback from a different worktree (different repoRoot) must show again.
+      rerender(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={baserefFallbackEvent('main', '/repo-b')}
+        />
+      );
+      expect(screen.getByText(/base-ref fell back to local/)).toBeDefined();
+      expect(screen.getByText('/repo-b')).toBeDefined();
+    });
+
+    it('stays dismissed when the same identity re-arrives', () => {
+      const { rerender } = render(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={baserefFallbackEvent('main', '/repo-a')}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', DISMISS_BUTTON));
+
+      rerender(
+        <MaintenanceBanners
+          inFlightList={[]}
+          maintenanceEvent={baserefFallbackEvent('main', '/repo-a')}
+        />
+      );
+      expect(screen.queryByText(/base-ref fell back to local/)).toBeNull();
+    });
+  });
+
+  it('renders in-flight and error banners together when both apply', () => {
+    render(
+      <MaintenanceBanners
+        inFlightList={['task-1']}
+        maintenanceEvent={errorEvent('task-2', 'boom')}
+      />
+    );
+    expect(screen.getByText('task-1')).toBeDefined();
+    expect(screen.getByText('task-2')).toBeDefined();
+    expect(screen.getByText(/failed: boom/)).toBeDefined();
+  });
+});

--- a/packages/dashboard/tests/client/components/maintenance/MaintenanceTables.test.tsx
+++ b/packages/dashboard/tests/client/components/maintenance/MaintenanceTables.test.tsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import {
+  formatDuration,
+  formatTime,
+  HistoryTable,
+  ScheduleTable,
+} from '../../../../src/client/components/maintenance/MaintenanceTables';
+import type {
+  HistoryEntry,
+  ScheduleRow,
+} from '../../../../src/client/components/maintenance/useMaintenanceData';
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                           */
+/* ------------------------------------------------------------------ */
+
+// A concrete ISO instant used across formatTime assertions. Expected strings
+// are derived from `new Date(...)` (the SUT's own source of truth) rather than
+// hardcoded, so the test stays locale/timezone-agnostic and deterministic.
+const ISO = '2026-06-15T13:45:00.000Z';
+
+function historyEntry(overrides: Partial<HistoryEntry> = {}): HistoryEntry {
+  return {
+    task: 'compound-learnings',
+    startedAt: ISO,
+    durationMs: 1500,
+    status: 'success',
+    findings: 0,
+    prUrl: null,
+    ...overrides,
+  };
+}
+
+function scheduleRow(overrides: Partial<ScheduleRow> = {}): ScheduleRow {
+  return {
+    taskId: 'doc-drift',
+    type: 'scan',
+    nextRun: ISO,
+    lastRun: null,
+    ...overrides,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  formatDuration                                                     */
+/* ------------------------------------------------------------------ */
+
+describe('formatDuration', () => {
+  it('renders sub-second durations in rounded milliseconds', () => {
+    expect(formatDuration(0)).toBe('0ms');
+    expect(formatDuration(12.4)).toBe('12ms');
+    expect(formatDuration(999)).toBe('999ms');
+  });
+
+  it('renders sub-minute durations in seconds to one decimal', () => {
+    expect(formatDuration(1000)).toBe('1.0s');
+    expect(formatDuration(1500)).toBe('1.5s');
+    expect(formatDuration(59_000)).toBe('59.0s');
+  });
+
+  it('renders minute-scale durations in minutes to one decimal', () => {
+    expect(formatDuration(60_000)).toBe('1.0m');
+    expect(formatDuration(90_000)).toBe('1.5m');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  formatTime                                                         */
+/* ------------------------------------------------------------------ */
+
+describe('formatTime', () => {
+  it('returns an em dash for a null timestamp', () => {
+    expect(formatTime(null)).toBe('—');
+  });
+
+  it('formats an ISO timestamp via the locale string of the parsed Date', () => {
+    // Derive the expectation from the same Date the SUT uses so the assertion
+    // is independent of the runner's locale/timezone.
+    expect(formatTime(ISO)).toBe(new Date(ISO).toLocaleString());
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  HistoryTable                                                       */
+/* ------------------------------------------------------------------ */
+
+describe('HistoryTable', () => {
+  it('renders an empty-state message and no table when there are no entries', () => {
+    render(<HistoryTable entries={[]} />);
+    expect(screen.getByText(/No maintenance history yet/i)).toBeDefined();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('renders one row per entry with task, status, started-at and duration', () => {
+    const entries = [
+      historyEntry({ task: 'compound-learnings', status: 'success', durationMs: 2500 }),
+      historyEntry({ task: 'doc-drift', status: 'failed', durationMs: 90_000 }),
+    ];
+    render(<HistoryTable entries={entries} />);
+
+    // One header row + two body rows.
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(entries.length + 1);
+
+    expect(screen.getByText('compound-learnings')).toBeDefined();
+    expect(screen.getByText('doc-drift')).toBeDefined();
+    expect(screen.getByText('success')).toBeDefined();
+    expect(screen.getByText('failed')).toBeDefined();
+    // Durations use the same helper the unit tests cover above.
+    expect(screen.getByText(formatDuration(2500))).toBeDefined();
+    expect(screen.getByText(formatDuration(90_000))).toBeDefined();
+  });
+
+  it('shows a candidates badge only for compound-candidates runs with findings', () => {
+    render(
+      <HistoryTable
+        entries={[
+          historyEntry({ task: 'compound-candidates', findings: 3 }),
+          // Same task, zero findings -> no badge.
+          historyEntry({
+            task: 'compound-candidates',
+            findings: 0,
+            startedAt: '2026-06-15T14:00:00.000Z',
+          }),
+          // Findings present but different task -> no badge.
+          historyEntry({ task: 'doc-drift', findings: 5, startedAt: '2026-06-15T15:00:00.000Z' }),
+        ]}
+      />
+    );
+    const badges = screen.getAllByTitle(/Undocumented learnings detected/i);
+    expect(badges).toHaveLength(1);
+    expect(badges[0].textContent).toContain('3 candidates');
+  });
+
+  it('applies the failure accent class to a failed status cell', () => {
+    render(<HistoryTable entries={[historyEntry({ status: 'failed' })]} />);
+    expect(screen.getByText('failed').className).toContain('text-red-400');
+  });
+
+  it('applies the success accent class to success and no-issues statuses', () => {
+    render(
+      <HistoryTable
+        entries={[
+          historyEntry({ task: 'a', status: 'success' }),
+          historyEntry({ task: 'b', status: 'no-issues', startedAt: '2026-06-15T16:00:00.000Z' }),
+        ]}
+      />
+    );
+    expect(screen.getByText('success').className).toContain('text-emerald-400');
+    expect(screen.getByText('no-issues').className).toContain('text-emerald-400');
+  });
+
+  it('applies the neutral accent class to a skipped status', () => {
+    render(<HistoryTable entries={[historyEntry({ status: 'skipped' })]} />);
+    expect(screen.getByText('skipped').className).toContain('text-yellow-400');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  ScheduleTable                                                      */
+/* ------------------------------------------------------------------ */
+
+describe('ScheduleTable', () => {
+  const noop = () => {};
+
+  it('renders an empty-state message and no table when there are no rows', () => {
+    render(<ScheduleTable rows={[]} inFlight={new Set()} onRunNow={noop} />);
+    expect(screen.getByText('No scheduled tasks.')).toBeDefined();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('renders a row per task with next-run time and a Run Now button', () => {
+    render(
+      <ScheduleTable
+        rows={[scheduleRow({ taskId: 'doc-drift' })]}
+        inFlight={new Set()}
+        onRunNow={noop}
+      />
+    );
+    expect(screen.getByText('doc-drift')).toBeDefined();
+    expect(screen.getByText(formatTime(ISO))).toBeDefined();
+    const button = screen.getByRole('button', { name: /run now/i });
+    expect(button).toBeDefined();
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('falls back to an em dash for a missing type field', () => {
+    const { type: _omit, ...withoutType } = scheduleRow();
+    render(
+      <ScheduleTable rows={[withoutType as ScheduleRow]} inFlight={new Set()} onRunNow={noop} />
+    );
+    // Row cells: taskId, type(—), nextRun, lastRun(—), action.
+    const row = screen.getByText('doc-drift').closest('tr') as HTMLElement;
+    expect(within(row).getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the last-run started-at when present and an em dash when absent', () => {
+    const lastRunIso = '2026-06-14T10:00:00.000Z';
+    render(
+      <ScheduleTable
+        rows={[
+          scheduleRow({
+            taskId: 'with-last',
+            lastRun: {
+              taskId: 'with-last',
+              status: 'success',
+              startedAt: lastRunIso,
+              durationMs: 500,
+            },
+          }),
+          scheduleRow({ taskId: 'no-last', nextRun: ISO, lastRun: null }),
+        ]}
+        inFlight={new Set()}
+        onRunNow={noop}
+      />
+    );
+    const withLastRow = screen.getByText('with-last').closest('tr') as HTMLElement;
+    expect(within(withLastRow).getByText(formatTime(lastRunIso))).toBeDefined();
+  });
+
+  it('invokes onRunNow with the row task id when the button is clicked', () => {
+    const onRunNow = vi.fn();
+    render(
+      <ScheduleTable
+        rows={[scheduleRow({ taskId: 'doc-drift' })]}
+        inFlight={new Set()}
+        onRunNow={onRunNow}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /run now/i }));
+    expect(onRunNow).toHaveBeenCalledTimes(1);
+    expect(onRunNow).toHaveBeenCalledWith('doc-drift');
+  });
+
+  it('disables the button and shows a running label for an in-flight task', () => {
+    const onRunNow = vi.fn();
+    render(
+      <ScheduleTable
+        rows={[scheduleRow({ taskId: 'doc-drift' })]}
+        inFlight={new Set(['doc-drift'])}
+        onRunNow={onRunNow}
+      />
+    );
+    const button = screen.getByRole('button', { name: /running/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(onRunNow).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/tests/client/components/orchestrator/navigation.test.tsx
+++ b/packages/dashboard/tests/client/components/orchestrator/navigation.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { findAgentThreadId } from '../../../../src/client/components/orchestrator/navigation';
+import { useThreadStore } from '../../../../src/client/stores/threadStore';
+import type { AgentMeta } from '../../../../src/client/types/thread';
+
+/**
+ * Helper to seed an agent thread for a given issue. Uses the real store's
+ * createThread so the derived id (`agent:<issueId>`) matches production.
+ */
+function seedAgentThread(issueId: string, overrides: Partial<AgentMeta> = {}): string {
+  return useThreadStore.getState().createThread('agent', {
+    issueId,
+    identifier: `feat/${issueId}`,
+    phase: 'StreamingTurn',
+    issueTitle: `Agent for ${issueId}`,
+    issueDescription: null,
+    startedAt: '2026-07-20T00:00:00.000Z',
+    backendName: 'claude',
+    ...overrides,
+  }).id;
+}
+
+describe('findAgentThreadId', () => {
+  beforeEach(() => {
+    useThreadStore.setState({
+      threads: new Map(),
+      activeThreadId: null,
+      lastThreadId: null,
+      messages: new Map(),
+    });
+  });
+
+  it('returns the id of the agent thread matching the issueId', () => {
+    const expectedId = seedAgentThread('ISSUE-1');
+    expect(findAgentThreadId('ISSUE-1')).toBe(expectedId);
+  });
+
+  it('returns undefined when no thread matches the issueId', () => {
+    seedAgentThread('ISSUE-1');
+    expect(findAgentThreadId('ISSUE-DOES-NOT-EXIST')).toBeUndefined();
+  });
+
+  it('returns undefined when the store has no threads at all', () => {
+    expect(findAgentThreadId('ISSUE-1')).toBeUndefined();
+  });
+
+  it('selects the correct agent thread among several with distinct issueIds', () => {
+    seedAgentThread('ISSUE-1');
+    const targetId = seedAgentThread('ISSUE-2');
+    seedAgentThread('ISSUE-3');
+    expect(findAgentThreadId('ISSUE-2')).toBe(targetId);
+  });
+
+  it('ignores non-agent threads whose meta carries the same issueId', () => {
+    // An attention thread also has an `issueId` field, but findAgentThreadId
+    // must only match threads of type 'agent'.
+    useThreadStore.getState().createThread('attention', {
+      interactionId: 'int-1',
+      issueId: 'ISSUE-9',
+      reasons: ['Risk'],
+      context: null,
+    });
+    expect(findAgentThreadId('ISSUE-9')).toBeUndefined();
+
+    // Adding an actual agent thread for the same issue now makes it resolvable.
+    const agentId = seedAgentThread('ISSUE-9');
+    expect(findAgentThreadId('ISSUE-9')).toBe(agentId);
+  });
+});

--- a/packages/dashboard/tests/client/components/panel/AgentStatsSection.test.tsx
+++ b/packages/dashboard/tests/client/components/panel/AgentStatsSection.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import {
+  AgentStatsSection,
+  type AgentStats,
+} from '../../../../src/client/components/panel/AgentStatsSection';
+
+/**
+ * A completed (non-running) agent with no tokens and no PR. This is the
+ * minimal "quiet" state: Agent Details always render; Session Stats and the
+ * running/duration lines are conditional.
+ */
+function makeStats(overrides: Partial<AgentStats> = {}): AgentStats {
+  return {
+    identifier: 'feat/backfill-tests',
+    phase: 'StreamingTurn',
+    backendName: null,
+    description: null,
+    turnCount: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    startedAt: null,
+    durationMs: null,
+    isRunning: false,
+    pr: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('AgentStatsSection', () => {
+  it('always renders the identifier and phase in Agent Details', () => {
+    render(<AgentStatsSection stats={makeStats({ identifier: 'fix/foo', phase: 'Planning' })} />);
+    expect(screen.getByText('Identifier')).toBeDefined();
+    expect(screen.getByText('fix/foo')).toBeDefined();
+    expect(screen.getByText('Phase')).toBeDefined();
+    expect(screen.getByText('Planning')).toBeDefined();
+  });
+
+  it('omits the Backend row when backendName is null and shows it when present', () => {
+    const { rerender } = render(<AgentStatsSection stats={makeStats({ backendName: null })} />);
+    expect(screen.queryByText('Backend')).toBeNull();
+
+    rerender(<AgentStatsSection stats={makeStats({ backendName: 'qwen3-coder:30b' })} />);
+    expect(screen.getByText('Backend')).toBeDefined();
+    expect(screen.getByText('qwen3-coder:30b')).toBeDefined();
+  });
+
+  it('omits the PR row when pr is null and renders number + status when present', () => {
+    const { rerender } = render(<AgentStatsSection stats={makeStats({ pr: null })} />);
+    expect(screen.queryByText('PR')).toBeNull();
+
+    rerender(<AgentStatsSection stats={makeStats({ pr: { number: 945, status: 'open' } })} />);
+    expect(screen.getByText('PR')).toBeDefined();
+    expect(screen.getByText(/#945/)).toBeDefined();
+    expect(screen.getByText('open')).toBeDefined();
+  });
+
+  it('hides the Session Stats block entirely when totalTokens is 0', () => {
+    render(<AgentStatsSection stats={makeStats({ totalTokens: 0, turnCount: 3 })} />);
+    expect(screen.queryByText('Session Stats')).toBeNull();
+    expect(screen.queryByText('Turns')).toBeNull();
+  });
+
+  it('renders Session Stats with turn count and formatted token figures when tokens exist', () => {
+    render(
+      <AgentStatsSection
+        stats={makeStats({
+          turnCount: 7,
+          totalTokens: 2_500_000, // -> 2.5M
+          inputTokens: 1_500, // -> 1.5k
+          outputTokens: 500, // -> 500 (no suffix)
+        })}
+      />
+    );
+    expect(screen.getByText('Session Stats')).toBeDefined();
+    expect(screen.getByText('7')).toBeDefined(); // turn count
+    expect(screen.getByText('2.5M')).toBeDefined(); // total tokens (>= 1M)
+    expect(screen.getByText('1.5k')).toBeDefined(); // input tokens (>= 1k)
+    expect(screen.getByText('500')).toBeDefined(); // output tokens (< 1k, raw)
+  });
+
+  it('formats a completed run as "Duration: ..." using hours/minutes/seconds rollover', () => {
+    // 1h 2m 5s -> hours branch prints "1h 2m" (seconds dropped once past an hour)
+    render(
+      <AgentStatsSection
+        stats={makeStats({ isRunning: false, durationMs: 3_725_000, startedAt: 1_000 })}
+      />
+    );
+    expect(screen.getByText('Duration: 1h 2m')).toBeDefined();
+  });
+
+  it('formats a sub-hour completed run as "Xm Ys"', () => {
+    // 125_000ms -> 2m 5s
+    render(<AgentStatsSection stats={makeStats({ isRunning: false, durationMs: 125_000 })} />);
+    expect(screen.getByText('Duration: 2m 5s')).toBeDefined();
+  });
+
+  it('renders a startedAt-only elapsed line when not running and no durationMs', () => {
+    vi.useFakeTimers();
+    const startedAt = 10_000;
+    vi.setSystemTime(startedAt + 45_000); // 45s elapsed -> "45s"
+    render(
+      <AgentStatsSection stats={makeStats({ isRunning: false, durationMs: null, startedAt })} />
+    );
+    expect(screen.getByText('45s')).toBeDefined();
+    expect(screen.queryByText(/Duration:/)).toBeNull();
+    expect(screen.queryByText(/Running for/)).toBeNull();
+  });
+
+  it('renders nothing in the duration line when not running with no timing info', () => {
+    render(
+      <AgentStatsSection
+        stats={makeStats({ isRunning: false, durationMs: null, startedAt: null })}
+      />
+    );
+    expect(screen.queryByText(/Duration:/)).toBeNull();
+    expect(screen.queryByText(/Running for/)).toBeNull();
+  });
+
+  it('shows a live "Running for" line that ticks up on each interval while running', () => {
+    vi.useFakeTimers();
+    const startedAt = 100_000;
+    vi.setSystemTime(startedAt); // 0s elapsed at mount
+    render(<AgentStatsSection stats={makeStats({ isRunning: true, startedAt })} />);
+
+    // Effect runs on mount: elapsed = now - startedAt = 0 -> "0s"
+    expect(screen.getByText('Running for 0s')).toBeDefined();
+
+    // Advancing fake timers also advances the mocked clock, so Date.now() moves
+    // forward and the 1s interval recomputes elapsed from it.
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(screen.getByText('Running for 3s')).toBeDefined();
+  });
+
+  it('clears the interval on unmount so no timer fires after teardown', () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+    const startedAt = 200_000;
+    vi.setSystemTime(startedAt);
+    const { unmount } = render(
+      <AgentStatsSection stats={makeStats({ isRunning: true, startedAt })} />
+    );
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/tests/client/components/panel/StatusSection.test.tsx
+++ b/packages/dashboard/tests/client/components/panel/StatusSection.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, act, cleanup } from '@testing-library/react';
+import { StatusSection } from '../../../../src/client/components/panel/StatusSection';
+
+// A fixed epoch to anchor the fake clock so elapsed-time math is deterministic.
+const STARTED_AT = 1_700_000_000_000;
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('StatusSection', () => {
+  it('renders nothing when both phase and skill are absent', () => {
+    const { container } = render(<StatusSection phase={null} skill={null} startedAt={null} />);
+    // Guard clause returns null even when a startedAt exists.
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when phase and skill are absent even with a running timer', () => {
+    const { container } = render(
+      <StatusSection phase={null} skill={null} startedAt={STARTED_AT} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the phase text when a phase is provided', () => {
+    render(<StatusSection phase="planning" skill={null} startedAt={null} />);
+    expect(screen.getByText('planning')).toBeDefined();
+    // No timer without a startedAt.
+    expect(screen.queryByText(/^0s$/)).toBeNull();
+  });
+
+  it('renders the skill name alongside its label', () => {
+    render(<StatusSection phase={null} skill="canary-test-author" startedAt={null} />);
+    expect(screen.getByText('Skill:')).toBeDefined();
+    expect(screen.getByText('canary-test-author')).toBeDefined();
+  });
+
+  it('renders both phase and skill when both are provided', () => {
+    render(<StatusSection phase="review" skill="canary-test-reviewer" startedAt={null} />);
+    expect(screen.getByText('review')).toBeDefined();
+    expect(screen.getByText('canary-test-reviewer')).toBeDefined();
+  });
+
+  it('shows an initial elapsed of 0s when a startedAt is provided', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(STARTED_AT);
+    render(<StatusSection phase="planning" skill={null} startedAt={STARTED_AT} />);
+    // Initial elapsed state is 0 before any interval tick fires.
+    expect(screen.getByText('0s')).toBeDefined();
+  });
+
+  it('formats sub-minute elapsed time as seconds after the interval ticks', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(STARTED_AT);
+    render(<StatusSection phase="planning" skill={null} startedAt={STARTED_AT} />);
+
+    // Advance the fake clock 30s: Date.now() - startedAt = 30_000ms -> "30s".
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(screen.getByText('30s')).toBeDefined();
+  });
+
+  it('formats elapsed time past a minute as "Xm Ys" after the interval ticks', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(STARTED_AT);
+    render(<StatusSection phase="planning" skill={null} startedAt={STARTED_AT} />);
+
+    // Advance 65s: floor(65) -> 1 minute, 5 remaining seconds -> "1m 5s".
+    act(() => {
+      vi.advanceTimersByTime(65_000);
+    });
+    expect(screen.getByText('1m 5s')).toBeDefined();
+  });
+
+  it('stops updating the timer after unmount (interval cleanup)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(STARTED_AT);
+    const { unmount } = render(
+      <StatusSection phase="planning" skill={null} startedAt={STARTED_AT} />
+    );
+    unmount();
+    // Advancing the clock after unmount must not throw from a dangling interval.
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/dashboard/tests/client/components/threads/AgentThreadView.test.tsx
+++ b/packages/dashboard/tests/client/components/threads/AgentThreadView.test.tsx
@@ -1,0 +1,444 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { AgentThreadView } from '../../../../src/client/components/threads/AgentThreadView';
+import { AgentEventsContext } from '../../../../src/client/components/layout/ChatLayout';
+import { useThreadStore } from '../../../../src/client/stores/threadStore';
+import type { Thread, AgentMeta } from '../../../../src/client/types/thread';
+import type { ContentBlock } from '../../../../src/client/types/chat';
+import type {
+  UseStreamReplayResult,
+  StreamManifest,
+} from '../../../../src/client/hooks/useStreamReplay';
+import type { OrchestratorSocketState } from '../../../../src/client/hooks/useOrchestratorSocket';
+import type {
+  OrchestratorSnapshot,
+  RunningAgent,
+  AgentSession,
+} from '../../../../src/client/types/orchestrator';
+
+// ── Hoisted mutable holder so the (hoisted) vi.mock factories can read the
+//    per-test hook return values at render time without TDZ issues.
+const hookState = vi.hoisted(() => ({
+  streamReplay: undefined as unknown,
+  socket: undefined as unknown,
+}));
+
+// ── framer-motion drives the running-status pulse (repeat: Infinity). Replace
+//    it with plain DOM so nothing schedules real animation frames.
+vi.mock('framer-motion', () => {
+  const strip = (props: Record<string, unknown>) => {
+    const { initial, animate, exit, transition, whileHover, whileTap, layout, ...rest } = props;
+    void initial;
+    void animate;
+    void exit;
+    void transition;
+    void whileHover;
+    void whileTap;
+    void layout;
+    return rest;
+  };
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, tag: string) => (props: Record<string, unknown>) =>
+        React.createElement(tag, strip(props), props.children as React.ReactNode),
+    }
+  );
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+// ── Stub heavy leaf components so the test targets AgentThreadView's own
+//    orchestration (block merge, stats derivation, view routing), not internals.
+vi.mock('../../../../src/client/components/chat/NeuralOrganism', () => ({
+  NeuralOrganism: () => <div data-testid="neural-organism" />,
+}));
+
+// The MessageStream stub surfaces the merged block payload it receives so the
+// test can assert the merge result (count + order) without reaching into React.
+vi.mock('../../../../src/client/components/chat/MessageStream', () => ({
+  MessageStream: ({
+    messages,
+    streaming,
+  }: {
+    messages: Array<{ blocks: Array<{ text?: string }> }>;
+    streaming: boolean;
+  }) => {
+    const blocks = messages[0]?.blocks ?? [];
+    return (
+      <div
+        data-testid="message-stream"
+        data-message-count={String(messages.length)}
+        data-block-count={String(blocks.length)}
+        data-first-text={blocks[0]?.text ?? ''}
+        data-last-text={blocks[blocks.length - 1]?.text ?? ''}
+        data-streaming={String(streaming)}
+      />
+    );
+  },
+}));
+
+// ── Network/socket seams: fully mocked, return values swapped per test.
+vi.mock('../../../../src/client/hooks/useStreamReplay', () => ({
+  useStreamReplay: () => hookState.streamReplay,
+}));
+vi.mock('../../../../src/client/hooks/useOrchestratorSocket', () => ({
+  useOrchestratorSocket: () => hookState.socket,
+}));
+
+// ── Fixtures. Every expected assertion is DERIVED from these constants so the
+//    checks track the fixture rather than pasting magic numbers.
+const ISSUE_ID = 'agent-issue-1';
+const THREAD_ID = `agent:${ISSUE_ID}`;
+
+const META: AgentMeta = {
+  issueId: ISSUE_ID,
+  identifier: 'ENG-42',
+  phase: 'execute',
+  issueTitle: 'Wire the thing',
+  issueDescription: 'A detailed description of the work under way.',
+  startedAt: '2026-07-20T10:00:00.000Z',
+  backendName: 'meta-backend',
+};
+
+const RECORDED_BLOCKS: ContentBlock[] = [
+  { kind: 'text', text: 'recorded-block-1' },
+  { kind: 'text', text: 'recorded-block-2' },
+];
+const LIVE_BLOCKS: ContentBlock[] = [{ kind: 'text', text: 'live-block-1' }];
+
+const SESSION: AgentSession = {
+  backendName: 'session-backend',
+  inputTokens: 100,
+  outputTokens: 40,
+  totalTokens: 140,
+  turnCount: 7,
+  lastMessage: null,
+};
+
+const ATTEMPT_STATS = {
+  durationMs: 5_000,
+  inputTokens: 10,
+  outputTokens: 5,
+  turnCount: 2,
+  toolsCalled: [] as string[],
+  filesTouched: [] as string[],
+};
+
+const MANIFEST_PR = { number: 123, linkedAt: '2026-07-20T11:00:00.000Z', status: 'open' };
+
+const LOADING_TEXT = 'Loading stream history...';
+const EMPTY_COMPLETED_TEXT = 'No activity recorded for this session.';
+const EMPTY_RUNNING_TEXT = 'Agent is working...';
+
+function makeAgentThread(
+  status: Thread['status'] = 'active',
+  metaOverrides: Partial<AgentMeta> = {}
+): Thread {
+  return {
+    id: THREAD_ID,
+    type: 'agent',
+    title: 'Agent: Wire the thing',
+    status,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    avatar: 'organism',
+    unread: false,
+    meta: { ...META, ...metaOverrides },
+  };
+}
+
+function makeManifest(overrides: Partial<StreamManifest> = {}): StreamManifest {
+  return {
+    issueId: ISSUE_ID,
+    externalId: 42,
+    identifier: META.identifier,
+    title: META.issueTitle,
+    attempts: [
+      {
+        attempt: 1,
+        startedAt: '2026-07-20T10:00:00.000Z',
+        endedAt: '2026-07-20T10:05:00.000Z',
+        outcome: 'success',
+        stats: ATTEMPT_STATS,
+      },
+    ],
+    pr: MANIFEST_PR,
+    highlights: null,
+    ...overrides,
+  };
+}
+
+function makeRunningAgent(session: AgentSession | null): RunningAgent {
+  return {
+    issueId: ISSUE_ID,
+    identifier: META.identifier,
+    phase: META.phase,
+    startedAt: META.startedAt,
+    workspacePath: '/tmp/ws',
+    attempt: 1,
+    issue: {
+      identifier: META.identifier,
+      title: META.issueTitle,
+      description: null,
+      blockedBy: [],
+    },
+    session,
+  };
+}
+
+function makeSnapshot(running: OrchestratorSnapshot['running']): OrchestratorSnapshot {
+  return {
+    running,
+    retryAttempts: [],
+    claimed: [],
+    tokenTotals: { inputTokens: 0, outputTokens: 0, totalTokens: 0, secondsRunning: 0 },
+    maxConcurrentAgents: 4,
+    globalCooldownUntilMs: null,
+    recentRequestTimestamps: [],
+    recentInputTokens: [],
+    recentOutputTokens: [],
+    maxRequestsPerMinute: 60,
+    maxRequestsPerSecond: 5,
+    maxInputTokensPerMinute: 1000,
+    maxOutputTokensPerMinute: 1000,
+  };
+}
+
+function setStreamReplay(overrides: Partial<UseStreamReplayResult> = {}): void {
+  hookState.streamReplay = {
+    manifest: null,
+    recordedBlocks: [],
+    loading: false,
+    error: null,
+    ...overrides,
+  } satisfies UseStreamReplayResult;
+}
+
+function setSocket(snapshot: OrchestratorSnapshot | null): void {
+  hookState.socket = { snapshot } as unknown as OrchestratorSocketState;
+}
+
+function renderView(thread: Thread, liveBlocks: ContentBlock[] = []): void {
+  render(
+    <AgentEventsContext.Provider value={{ [ISSUE_ID]: liveBlocks }}>
+      <AgentThreadView thread={thread} />
+    </AgentEventsContext.Provider>
+  );
+}
+
+function resetStore(): void {
+  useThreadStore.setState({
+    threads: new Map(),
+    messages: new Map(),
+    panelState: new Map(),
+    activeThreadId: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetStore();
+  // Neutral defaults: no history, no live socket snapshot.
+  setStreamReplay();
+  setSocket(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AgentThreadView header + view routing', () => {
+  it('renders the header with the thread title, identifier, phase, and a Running badge when active', () => {
+    renderView(makeAgentThread('active'));
+
+    expect(screen.getByText('Agent: Wire the thing')).toBeDefined();
+    expect(screen.getByText(META.identifier)).toBeDefined();
+    expect(screen.getByText(META.phase)).toBeDefined();
+    expect(screen.getByText('Running')).toBeDefined();
+    expect(screen.queryByText('Completed')).toBeNull();
+  });
+
+  it('shows a Completed badge when the thread is not active', () => {
+    renderView(makeAgentThread('completed'));
+
+    expect(screen.getByText('Completed')).toBeDefined();
+    expect(screen.queryByText('Running')).toBeNull();
+  });
+
+  it('renders the issue description block when present and omits it when null', () => {
+    const { unmount } = render(
+      <AgentEventsContext.Provider value={{}}>
+        <AgentThreadView thread={makeAgentThread('active')} />
+      </AgentEventsContext.Provider>
+    );
+    expect(screen.getByText(META.issueDescription as string)).toBeDefined();
+    unmount();
+
+    renderView(makeAgentThread('active', { issueDescription: null }));
+    expect(screen.queryByText(META.issueDescription as string)).toBeNull();
+  });
+
+  it('renders the loading placeholder and no message stream while history is loading', () => {
+    setStreamReplay({ loading: true });
+
+    renderView(makeAgentThread('active'), LIVE_BLOCKS);
+
+    expect(screen.getByText(LOADING_TEXT)).toBeDefined();
+    expect(screen.queryByTestId('message-stream')).toBeNull();
+  });
+
+  it('shows the running empty-state when there are no blocks and the agent is active', () => {
+    renderView(makeAgentThread('active'), []);
+
+    expect(screen.getByText(EMPTY_RUNNING_TEXT)).toBeDefined();
+    expect(screen.queryByTestId('message-stream')).toBeNull();
+  });
+
+  it('shows the completed empty-state when there are no blocks and the agent is done', () => {
+    renderView(makeAgentThread('completed'), []);
+
+    expect(screen.getByText(EMPTY_COMPLETED_TEXT)).toBeDefined();
+    expect(screen.queryByText(EMPTY_RUNNING_TEXT)).toBeNull();
+  });
+});
+
+describe('AgentThreadView block merge', () => {
+  it('concatenates recorded history then live events, preserving order', () => {
+    setStreamReplay({ recordedBlocks: RECORDED_BLOCKS });
+
+    renderView(makeAgentThread('active'), LIVE_BLOCKS);
+
+    const stream = screen.getByTestId('message-stream');
+    // Single assistant message carrying every merged block.
+    expect(stream.getAttribute('data-message-count')).toBe('1');
+    expect(stream.getAttribute('data-block-count')).toBe(
+      String(RECORDED_BLOCKS.length + LIVE_BLOCKS.length)
+    );
+    // Recorded history comes first, live events last.
+    expect(stream.getAttribute('data-first-text')).toBe(RECORDED_BLOCKS[0]?.text);
+    expect(stream.getAttribute('data-last-text')).toBe(LIVE_BLOCKS[LIVE_BLOCKS.length - 1]?.text);
+    // streaming reflects the active status.
+    expect(stream.getAttribute('data-streaming')).toBe('true');
+  });
+
+  it('uses only recorded history when there are no live events', () => {
+    setStreamReplay({ recordedBlocks: RECORDED_BLOCKS });
+
+    renderView(makeAgentThread('completed'), []);
+
+    const stream = screen.getByTestId('message-stream');
+    expect(stream.getAttribute('data-block-count')).toBe(String(RECORDED_BLOCKS.length));
+    expect(stream.getAttribute('data-last-text')).toBe(
+      RECORDED_BLOCKS[RECORDED_BLOCKS.length - 1]?.text
+    );
+    // Not active → not streaming.
+    expect(stream.getAttribute('data-streaming')).toBe('false');
+  });
+
+  it('falls back to live events when there is no recorded history', () => {
+    setStreamReplay({ recordedBlocks: [] });
+
+    renderView(makeAgentThread('active'), LIVE_BLOCKS);
+
+    const stream = screen.getByTestId('message-stream');
+    expect(stream.getAttribute('data-block-count')).toBe(String(LIVE_BLOCKS.length));
+    expect(stream.getAttribute('data-first-text')).toBe(LIVE_BLOCKS[0]?.text);
+  });
+});
+
+describe('AgentThreadView stats derivation → thread store', () => {
+  it('prefers live session stats and the latest attempt duration + manifest PR when running', async () => {
+    setStreamReplay({ recordedBlocks: RECORDED_BLOCKS, manifest: makeManifest() });
+    setSocket(makeSnapshot([[ISSUE_ID, makeRunningAgent(SESSION)]]));
+
+    const thread = makeAgentThread('active');
+    renderView(thread, LIVE_BLOCKS);
+
+    await waitFor(() => {
+      expect(useThreadStore.getState().panelState.get(thread.id)?.agentStats).toBeDefined();
+    });
+    const stats = useThreadStore.getState().panelState.get(thread.id)?.agentStats;
+
+    expect(stats?.identifier).toBe(META.identifier);
+    expect(stats?.phase).toBe(META.phase);
+    // Session values win over meta / attempt fallbacks.
+    expect(stats?.backendName).toBe(SESSION.backendName);
+    expect(stats?.turnCount).toBe(SESSION.turnCount);
+    expect(stats?.inputTokens).toBe(SESSION.inputTokens);
+    expect(stats?.outputTokens).toBe(SESSION.outputTokens);
+    expect(stats?.totalTokens).toBe(SESSION.totalTokens);
+    // Duration comes from the latest attempt; PR from the manifest.
+    expect(stats?.durationMs).toBe(ATTEMPT_STATS.durationMs);
+    expect(stats?.pr).toEqual({ number: MANIFEST_PR.number, status: MANIFEST_PR.status });
+    expect(stats?.startedAt).toBe(new Date(META.startedAt).getTime());
+    expect(stats?.isRunning).toBe(true);
+    expect(stats?.description).toBe(META.issueDescription);
+  });
+
+  it('falls back to the latest attempt stats and meta backend when there is no live session', async () => {
+    setStreamReplay({ manifest: makeManifest() });
+    setSocket(null);
+
+    const thread = makeAgentThread('completed');
+    renderView(thread, []);
+
+    await waitFor(() => {
+      expect(useThreadStore.getState().panelState.get(thread.id)?.agentStats).toBeDefined();
+    });
+    const stats = useThreadStore.getState().panelState.get(thread.id)?.agentStats;
+
+    expect(stats?.backendName).toBe(META.backendName);
+    expect(stats?.turnCount).toBe(ATTEMPT_STATS.turnCount);
+    expect(stats?.inputTokens).toBe(ATTEMPT_STATS.inputTokens);
+    expect(stats?.outputTokens).toBe(ATTEMPT_STATS.outputTokens);
+    // totalTokens is derived from the attempt when no session total exists.
+    expect(stats?.totalTokens).toBe(ATTEMPT_STATS.inputTokens + ATTEMPT_STATS.outputTokens);
+    expect(stats?.durationMs).toBe(ATTEMPT_STATS.durationMs);
+    expect(stats?.isRunning).toBe(false);
+  });
+
+  it('emits zeroed stats and a null PR/duration when there is neither a session nor a manifest', async () => {
+    setStreamReplay({ manifest: null });
+    setSocket(null);
+
+    const thread = makeAgentThread('active');
+    renderView(thread, []);
+
+    await waitFor(() => {
+      expect(useThreadStore.getState().panelState.get(thread.id)?.agentStats).toBeDefined();
+    });
+    const stats = useThreadStore.getState().panelState.get(thread.id)?.agentStats;
+
+    expect(stats?.backendName).toBe(META.backendName);
+    expect(stats?.turnCount).toBe(0);
+    expect(stats?.inputTokens).toBe(0);
+    expect(stats?.outputTokens).toBe(0);
+    expect(stats?.totalTokens).toBe(0);
+    expect(stats?.durationMs).toBeNull();
+    expect(stats?.pr).toBeNull();
+  });
+
+  it('ignores a running entry whose id does not match this thread (no live session leak)', async () => {
+    setStreamReplay({ manifest: makeManifest() });
+    // Snapshot has a running agent, but for a different issue.
+    setSocket(makeSnapshot([['some-other-issue', makeRunningAgent(SESSION)]]));
+
+    const thread = makeAgentThread('active');
+    renderView(thread, []);
+
+    await waitFor(() => {
+      expect(useThreadStore.getState().panelState.get(thread.id)?.agentStats).toBeDefined();
+    });
+    const stats = useThreadStore.getState().panelState.get(thread.id)?.agentStats;
+
+    // No matching session → attempt/meta fallbacks, not SESSION's backend.
+    expect(stats?.backendName).toBe(META.backendName);
+    expect(stats?.turnCount).toBe(ATTEMPT_STATS.turnCount);
+  });
+});

--- a/packages/dashboard/tests/client/components/threads/AnalysisThreadView.test.tsx
+++ b/packages/dashboard/tests/client/components/threads/AnalysisThreadView.test.tsx
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+import { AnalysisThreadView } from '../../../../src/client/components/threads/AnalysisThreadView';
+import { useThreadStore } from '../../../../src/client/stores/threadStore';
+import type { Thread, AnalysisMeta } from '../../../../src/client/types/thread';
+
+// ── framer-motion drives the animated result cards. Replace it with plain
+//    DOM so nothing schedules real animation frames (deterministic, no RAF
+//    leak from `repeat: Infinity` on the streaming-status pulse).
+vi.mock('framer-motion', () => {
+  const strip = (props: Record<string, unknown>) => {
+    const { initial, animate, exit, transition, whileHover, whileTap, layout, ...rest } = props;
+    void initial;
+    void animate;
+    void exit;
+    void transition;
+    void whileHover;
+    void whileTap;
+    void layout;
+    return rest;
+  };
+  const motion = new Proxy(
+    {},
+    {
+      get: (_target, tag: string) => (props: Record<string, unknown>) =>
+        React.createElement(tag, strip(props), props.children as React.ReactNode),
+    }
+  );
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+// ── Stub the form leaf so the test targets AnalysisThreadView's own
+//    orchestration (POST + SSE consumption + result rendering), not the
+//    form's internal input state. The stub exposes the props the view
+//    passes down and a button that fires onSubmit with fixed data.
+const SUBMIT_DATA = { title: 'Refactor auth', description: 'harden token flow', labels: ['auth'] };
+
+vi.mock('../../../../src/client/components/cards/AnalysisFormCard', () => ({
+  AnalysisFormCard: ({
+    collapsed,
+    initialTitle,
+    onSubmit,
+  }: {
+    collapsed: boolean;
+    initialTitle: string;
+    onSubmit: (d: typeof SUBMIT_DATA) => void;
+  }) => (
+    <div
+      data-testid="analysis-form"
+      data-collapsed={String(collapsed)}
+      data-initial-title={initialTitle}
+    >
+      <button data-testid="form-submit" onClick={() => onSubmit(SUBMIT_DATA)}>
+        run analysis
+      </button>
+    </div>
+  ),
+}));
+
+// ── SSE result payloads. Expected rendered values are DERIVED from these
+//    objects (never hardcoded) so the assertions track the fixture.
+const SEL_DATA = {
+  intent: 'Refactor the auth token exchange',
+  summary: 'Replace the legacy session cookie with rotating refresh tokens.',
+  affectedSystems: [
+    {
+      name: 'auth-service',
+      graphNodeId: 'n1',
+      confidence: 0.876,
+      transitiveDeps: [],
+      testCoverage: 0.6,
+      owner: 'team-identity',
+    },
+  ],
+  unknowns: [],
+  ambiguities: [],
+  riskSignals: [],
+};
+
+const CML_DATA = {
+  overall: 0.42,
+  riskLevel: 'high',
+  confidence: 0.71,
+  blastRadius: { services: 2, modules: 4, filesEstimated: 17, testFilesAffected: 3 },
+  dimensions: { structural: 0.4, semantic: 0.5, historical: 0.3 },
+  reasoning: ['spans two services'],
+  recommendedRoute: 'staged',
+};
+
+const PESL_DATA = {
+  simulatedPlan: ['rotate tokens'],
+  predictedFailures: ['auth token expiry regression'],
+  riskHotspots: ['session store'],
+  testGaps: ['refresh path'],
+  executionConfidence: 0.9,
+  recommendedChanges: ['add refresh rotation flow'],
+};
+
+const THREAD_ID = 'analysis:1';
+
+function makeAnalysisThread(): Thread {
+  return {
+    id: THREAD_ID,
+    type: 'analysis',
+    title: 'Untitled analysis',
+    status: 'active',
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    avatar: 'organism',
+    unread: false,
+    meta: {
+      analysisTitle: 'Seed analysis title',
+      description: 'seed description',
+      labels: ['seed'],
+    } as AnalysisMeta,
+  };
+}
+
+function sseLine(event: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(event)}`;
+}
+
+interface FakeResponseOptions {
+  ok?: boolean;
+  status?: number;
+  hasBody?: boolean;
+  /** When true, the reader delivers the chunks then never resolves the final read. */
+  hang?: boolean;
+}
+
+/**
+ * Build a fetch Response whose body streams the given SSE lines as a single
+ * UTF-8 chunk. A trailing newline is appended so the component's line-buffer
+ * flushes every line (it holds the last un-terminated segment back).
+ */
+function sseResponse(lines: string[], opts: FakeResponseOptions = {}): Response {
+  const { ok = true, status = 200, hasBody = true, hang = false } = opts;
+  const text = lines.join('\n') + '\n';
+  const chunks = [new TextEncoder().encode(text)];
+  let idx = 0;
+  const body = hasBody
+    ? {
+        getReader() {
+          return {
+            read() {
+              if (idx < chunks.length) {
+                return Promise.resolve({ done: false, value: chunks[idx++] });
+              }
+              if (hang) {
+                // Keep the stream open so the view stays in the streaming state.
+                return new Promise<never>(() => {});
+              }
+              return Promise.resolve({ done: true, value: undefined });
+            },
+          };
+        },
+      }
+    : null;
+  return { ok, status, body } as unknown as Response;
+}
+
+function seedThreadAndRender(): Thread {
+  const thread = makeAnalysisThread();
+  useThreadStore.setState({
+    threads: new Map([[thread.id, thread]]),
+    messages: new Map(),
+    panelState: new Map(),
+    activeThreadId: null,
+  });
+  render(<AnalysisThreadView thread={thread} />);
+  return thread;
+}
+
+async function submitForm(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('form-submit'));
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AnalysisThreadView initial render', () => {
+  it('mounts the form expanded with the analysis meta as its initial values', () => {
+    const thread = makeAnalysisThread();
+    const meta = thread.meta as AnalysisMeta;
+    useThreadStore.setState({
+      threads: new Map([[thread.id, thread]]),
+      messages: new Map(),
+      panelState: new Map(),
+      activeThreadId: null,
+    });
+
+    render(<AnalysisThreadView thread={thread} />);
+
+    const form = screen.getByTestId('analysis-form');
+    expect(form.getAttribute('data-collapsed')).toBe('false');
+    expect(form.getAttribute('data-initial-title')).toBe(meta.analysisTitle);
+    // No results or error before submitting.
+    expect(screen.queryByText(SEL_DATA.intent)).toBeNull();
+  });
+});
+
+describe('AnalysisThreadView happy-path streaming', () => {
+  it('POSTs the request, retitles the thread, and renders SEL/CML/PESL results', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        sseResponse([
+          sseLine({ type: 'status', text: 'Enriching spec...' }),
+          sseLine({ type: 'sel_result', data: SEL_DATA }),
+          sseLine({ type: 'cml_result', data: CML_DATA }),
+          sseLine({ type: 'pesl_result', data: PESL_DATA }),
+          'data: [DONE]',
+        ])
+      )
+    ) as unknown as typeof fetch;
+
+    const thread = seedThreadAndRender();
+    await submitForm();
+
+    // Request went to the analyze endpoint as a POST carrying the form data.
+    const fetchMock = vi.mocked(global.fetch);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe('/api/analyze');
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBe(JSON.stringify(SUBMIT_DATA));
+
+    // The thread is retitled from the submitted title via the store.
+    expect(useThreadStore.getState().threads.get(thread.id)?.title).toBe(SUBMIT_DATA.title);
+
+    // SEL block.
+    await screen.findByText(SEL_DATA.intent);
+    expect(screen.getByText(SEL_DATA.summary)).toBeDefined();
+    const sys = SEL_DATA.affectedSystems[0];
+    expect(screen.getByText(`${sys.name} (${Math.round(sys.confidence * 100)}%)`)).toBeDefined();
+
+    // CML block — risk level, derived percentages, blast-radius counts, route.
+    expect(screen.getByText(CML_DATA.riskLevel)).toBeDefined();
+    expect(screen.getByText(`${Math.round(CML_DATA.overall * 100)}%`)).toBeDefined();
+    expect(screen.getByText(String(CML_DATA.blastRadius.filesEstimated))).toBeDefined();
+    expect(screen.getByText(String(CML_DATA.blastRadius.modules))).toBeDefined();
+    expect(screen.getByText(CML_DATA.recommendedRoute)).toBeDefined();
+
+    // PESL block — confidence, predicted failures, recommended changes.
+    expect(
+      screen.getByText(`Confidence: ${Math.round(PESL_DATA.executionConfidence * 100)}%`)
+    ).toBeDefined();
+    expect(screen.getByText(`- ${PESL_DATA.predictedFailures[0]}`)).toBeDefined();
+    expect(screen.getByText(`- ${PESL_DATA.recommendedChanges[0]}`)).toBeDefined();
+
+    // Stream finished: the form collapses and the post-analysis actions appear.
+    await waitFor(() => {
+      expect(screen.getByTestId('analysis-form').getAttribute('data-collapsed')).toBe('true');
+    });
+    expect(screen.getByText('Add to Roadmap')).toBeDefined();
+    expect(screen.getByText('Refine')).toBeDefined();
+  });
+
+  it('shows the live status while the stream is still open', async () => {
+    const STATUS_TEXT = 'Modeling complexity...';
+    global.fetch = vi.fn(() =>
+      Promise.resolve(sseResponse([sseLine({ type: 'status', text: STATUS_TEXT })], { hang: true }))
+    ) as unknown as typeof fetch;
+
+    seedThreadAndRender();
+    await submitForm();
+
+    // While streaming (reader never closes), the latest status is visible and
+    // no completion actions have rendered yet.
+    await screen.findByText(STATUS_TEXT);
+    expect(screen.queryByText('Refine')).toBeNull();
+  });
+});
+
+describe('AnalysisThreadView error handling', () => {
+  it('renders an SSE error event and stops streaming', async () => {
+    const MESSAGE = 'analysis worker crashed';
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        sseResponse([
+          sseLine({ type: 'status', text: 'starting' }),
+          sseLine({ type: 'error', error: MESSAGE }),
+        ])
+      )
+    ) as unknown as typeof fetch;
+
+    seedThreadAndRender();
+    await submitForm();
+
+    expect(await screen.findByText(`Error: ${MESSAGE}`)).toBeDefined();
+    // An error event returns early: no results and no completion actions.
+    expect(screen.queryByText(SEL_DATA.intent)).toBeNull();
+    expect(screen.queryByText('Refine')).toBeNull();
+  });
+
+  it('reports a non-ok HTTP response as an error and never reads a stream', async () => {
+    const STATUS = 503;
+    global.fetch = vi.fn(() =>
+      Promise.resolve(sseResponse([], { ok: false, status: STATUS, hasBody: false }))
+    ) as unknown as typeof fetch;
+
+    seedThreadAndRender();
+    await submitForm();
+
+    expect(await screen.findByText(`Error: HTTP ${STATUS}`)).toBeDefined();
+    expect(screen.queryByText('Refine')).toBeNull();
+  });
+});
+
+describe('AnalysisThreadView refine', () => {
+  it('clears results and re-expands the form when Refine is clicked', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve(
+        sseResponse([
+          sseLine({ type: 'sel_result', data: SEL_DATA }),
+          sseLine({ type: 'cml_result', data: CML_DATA }),
+          'data: [DONE]',
+        ])
+      )
+    ) as unknown as typeof fetch;
+
+    seedThreadAndRender();
+    await submitForm();
+
+    // Wait for completion (Refine action present), then refine.
+    const refineButton = await screen.findByText('Refine');
+    await act(async () => {
+      fireEvent.click(refineButton);
+    });
+
+    // Results are cleared and the form is expanded again for a new run.
+    expect(screen.queryByText(SEL_DATA.intent)).toBeNull();
+    expect(screen.queryByText(CML_DATA.riskLevel)).toBeNull();
+    expect(screen.queryByText('Refine')).toBeNull();
+    expect(screen.getByTestId('analysis-form').getAttribute('data-collapsed')).toBe('false');
+  });
+});

--- a/packages/dashboard/tests/client/components/threads/AttentionThreadView.test.tsx
+++ b/packages/dashboard/tests/client/components/threads/AttentionThreadView.test.tsx
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+import { AttentionThreadView } from '../../../../src/client/components/threads/AttentionThreadView';
+import { useThreadStore } from '../../../../src/client/stores/threadStore';
+import { streamChat } from '../../../../src/client/utils/chat-stream';
+import type { Thread, AttentionMeta } from '../../../../src/client/types/thread';
+import type { PendingInteraction } from '../../../../src/client/types/orchestrator';
+import type { ChatMessage } from '../../../../src/client/types/chat';
+
+// ── framer-motion drives an infinite loading animation; render a plain div so
+//    the placeholder is deterministic and no RAF loop leaks between tests.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        () =>
+        ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+          <div className={className}>{children}</div>
+        ),
+    }
+  ),
+}));
+
+// ── Stub the heavy leaf components so the test targets AttentionThreadView's
+//    own orchestration (fetch → claim/dismiss → send/stream), not their guts.
+vi.mock('../../../../src/client/components/cards/BriefingCard', () => ({
+  BriefingCard: ({
+    interaction,
+    collapsed,
+    onClaim,
+    onDismiss,
+  }: {
+    interaction: { context: { issueTitle: string } };
+    collapsed: boolean;
+    onClaim: () => void;
+    onDismiss: () => void;
+  }) => (
+    <div
+      data-testid="briefing-card"
+      data-collapsed={String(collapsed)}
+      data-issue={interaction.context.issueTitle}
+    >
+      <button data-testid="briefing-claim" onClick={onClaim}>
+        claim
+      </button>
+      <button data-testid="briefing-dismiss" onClick={onDismiss}>
+        dismiss
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../../../../src/client/components/chat/MessageStream', () => ({
+  MessageStream: ({ messages, streaming }: { messages: unknown[]; streaming: boolean }) => (
+    <div
+      data-testid="message-stream"
+      data-count={messages.length}
+      data-streaming={String(streaming)}
+    />
+  ),
+}));
+
+vi.mock('../../../../src/client/components/chat/ChatInput', () => ({
+  ChatInput: ({
+    value,
+    onChange,
+    onSend,
+    disabled,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    onSend: () => void;
+    disabled: boolean;
+    placeholder?: string;
+  }) => (
+    <div>
+      <input
+        data-testid="chat-input"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button data-testid="chat-send" disabled={disabled} onClick={onSend}>
+        send
+      </button>
+    </div>
+  ),
+}));
+
+// Network/streaming seam: fully mocked so nothing touches the wire.
+vi.mock('../../../../src/client/utils/chat-stream', () => ({
+  streamChat: vi.fn(async () => {}),
+  applyChunk: vi.fn(),
+}));
+
+const INTERACTION_ID = 'int-1';
+const ISSUE_ID = 'ISSUE-1';
+const THREAD_ID = `attn:${INTERACTION_ID}`;
+const ISSUE_TITLE = 'Fix the flaky widget';
+const REASONS = ['ambiguous spec', 'high blast radius'];
+// Mirrors the literal in AttentionThreadView's auto-start effect.
+const BRAINSTORM_PROMPT =
+  'Analyze this escalated issue and help me brainstorm an implementation approach.';
+
+function makeInteraction(overrides: Partial<PendingInteraction> = {}): PendingInteraction {
+  return {
+    id: INTERACTION_ID,
+    issueId: ISSUE_ID,
+    type: 'needs-human',
+    reasons: REASONS,
+    context: {
+      issueTitle: ISSUE_TITLE,
+      issueDescription: 'The widget flakes under load.',
+      specPath: 'docs/specs/widget.md',
+      planPath: null,
+      relatedFiles: ['src/widget.ts', 'src/widget.test.ts'],
+    },
+    createdAt: '2026-07-20T00:00:00.000Z',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+function makeAttentionThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: THREAD_ID,
+    type: 'attention',
+    title: `Attention: ${ISSUE_ID}`,
+    status: 'pending',
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    avatar: 'alert',
+    unread: true,
+    meta: {
+      interactionId: INTERACTION_ID,
+      issueId: ISSUE_ID,
+      reasons: REASONS,
+      context: null,
+    } as AttentionMeta,
+    ...overrides,
+  };
+}
+
+function resetStore(): void {
+  useThreadStore.setState({
+    threads: new Map(),
+    messages: new Map(),
+    panelState: new Map(),
+    activeThreadId: null,
+  });
+}
+
+function seedThread(thread: Thread, messages: ChatMessage[] = []): void {
+  useThreadStore.setState((s) => {
+    const threads = new Map(s.threads);
+    threads.set(thread.id, thread);
+    const msgs = new Map(s.messages);
+    if (messages.length > 0) msgs.set(thread.id, messages);
+    return { threads, messages: msgs };
+  });
+}
+
+// The list served by GET /api/interactions; per-test mutable.
+let interactions: PendingInteraction[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetStore();
+  interactions = [makeInteraction()];
+  global.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url === '/api/interactions' && method === 'GET') {
+      return Promise.resolve({ ok: true, json: async () => interactions } as Response);
+    }
+    // PATCH /api/interactions/:id and anything else.
+    return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function patchCalls(): Array<[string, RequestInit]> {
+  return vi
+    .mocked(global.fetch)
+    .mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'PATCH'
+    ) as Array<[string, RequestInit]>;
+}
+
+describe('AttentionThreadView interaction loading', () => {
+  it('shows a loading placeholder and never streams while the interaction is unresolved', async () => {
+    // Interaction list has no entry matching this thread's interactionId.
+    interactions = [];
+    const thread = makeAttentionThread();
+    seedThread(thread);
+
+    await act(async () => {
+      render(<AttentionThreadView thread={thread} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Loading interaction...')).toBeDefined();
+    expect(screen.queryByTestId('briefing-card')).toBeNull();
+    expect(vi.mocked(streamChat)).not.toHaveBeenCalled();
+  });
+
+  it('renders the briefing card and retitles an "Attention:"-prefixed thread from the issue title', async () => {
+    const thread = makeAttentionThread();
+    seedThread(thread);
+
+    render(<AttentionThreadView thread={thread} />);
+
+    const card = await screen.findByTestId('briefing-card');
+    expect(card.getAttribute('data-issue')).toBe(ISSUE_TITLE);
+
+    await waitFor(() => {
+      expect(useThreadStore.getState().threads.get(thread.id)?.title).toBe(ISSUE_TITLE);
+    });
+  });
+});
+
+describe('AttentionThreadView claim / dismiss', () => {
+  it('claiming PATCHes the interaction to "claimed", marks the thread active, and reveals the chat input', async () => {
+    const thread = makeAttentionThread({ status: 'pending' });
+    seedThread(thread);
+
+    render(<AttentionThreadView thread={thread} />);
+    await screen.findByTestId('briefing-card');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('briefing-claim'));
+      await Promise.resolve();
+    });
+
+    // Store transitions to active via claimThread.
+    expect(useThreadStore.getState().threads.get(thread.id)?.status).toBe('active');
+
+    // Server is PATCHed to the claimed status.
+    const claimPatch = patchCalls().find(([url]) => url === `/api/interactions/${INTERACTION_ID}`);
+    expect(claimPatch).toBeDefined();
+    expect(JSON.parse(String(claimPatch?.[1].body))).toEqual({ status: 'claimed' });
+
+    // Chat input becomes available once claimed.
+    expect(await screen.findByTestId('chat-input')).toBeDefined();
+  });
+
+  it('dismissing PATCHes the interaction to "resolved", marks the thread dismissed, and keeps the input hidden', async () => {
+    const thread = makeAttentionThread({ status: 'pending' });
+    seedThread(thread);
+
+    render(<AttentionThreadView thread={thread} />);
+    await screen.findByTestId('briefing-card');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('briefing-dismiss'));
+      await Promise.resolve();
+    });
+
+    expect(useThreadStore.getState().threads.get(thread.id)?.status).toBe('dismissed');
+
+    const dismissPatch = patchCalls().find(
+      ([url]) => url === `/api/interactions/${INTERACTION_ID}`
+    );
+    expect(dismissPatch).toBeDefined();
+    expect(JSON.parse(String(dismissPatch?.[1].body))).toEqual({ status: 'resolved' });
+
+    // Not claimed → no chat input, and no stream kicked off by dismissal.
+    expect(screen.queryByTestId('chat-input')).toBeNull();
+    expect(vi.mocked(streamChat)).not.toHaveBeenCalled();
+  });
+});
+
+describe('AttentionThreadView send + streaming', () => {
+  it('auto-starts a brainstorm stream with the interaction-derived system prompt on an already-claimed thread', async () => {
+    // status 'active' → claimed starts true → auto-start effect fires once loaded.
+    const thread = makeAttentionThread({ status: 'active' });
+    seedThread(thread);
+
+    render(<AttentionThreadView thread={thread} />);
+
+    await waitFor(() => {
+      expect(vi.mocked(streamChat)).toHaveBeenCalledTimes(1);
+    });
+
+    const [prompt, systemPrompt] = vi.mocked(streamChat).mock.calls[0] ?? [];
+    expect(prompt).toBe(BRAINSTORM_PROMPT);
+    // The generated system prompt is built from the fetched interaction.
+    expect(systemPrompt).toContain(`## Issue: ${ISSUE_TITLE}`);
+    expect(systemPrompt).toContain('## Escalation Reasons');
+    expect(systemPrompt).toContain(`- ${REASONS[0]}`);
+
+    // The user turn + empty assistant turn are appended to the store.
+    await waitFor(() => {
+      expect(useThreadStore.getState().messages.get(thread.id)).toHaveLength(2);
+    });
+  });
+
+  it('sends the typed prompt on a follow-up turn without rebuilding a system prompt', async () => {
+    // Pre-seed a message so the auto-start effect (messages.length === 0) stays dormant.
+    const thread = makeAttentionThread({ status: 'active' });
+    seedThread(thread, [{ role: 'user', content: 'prior turn' }]);
+
+    render(<AttentionThreadView thread={thread} />);
+    const input = await screen.findByTestId('chat-input');
+
+    fireEvent.change(input, { target: { value: 'discuss the escalation' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('chat-send'));
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(streamChat)).toHaveBeenCalledTimes(1);
+    const [prompt, systemPrompt] = vi.mocked(streamChat).mock.calls[0] ?? [];
+    expect(prompt).toBe('discuss the escalation');
+    // Not a first turn → no system prompt is synthesized.
+    expect(systemPrompt).toBeUndefined();
+
+    // Prior turn + new user turn + empty assistant turn.
+    await waitFor(() => {
+      expect(useThreadStore.getState().messages.get(thread.id)).toHaveLength(3);
+    });
+  });
+
+  it('does not stream or mutate messages when the chat input is empty', async () => {
+    const thread = makeAttentionThread({ status: 'active' });
+    seedThread(thread, [{ role: 'user', content: 'prior turn' }]);
+
+    render(<AttentionThreadView thread={thread} />);
+    await screen.findByTestId('chat-input');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('chat-send'));
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(streamChat)).not.toHaveBeenCalled();
+    expect(useThreadStore.getState().messages.get(thread.id)).toHaveLength(1);
+  });
+});

--- a/packages/dashboard/tests/client/components/threads/ChatThreadView.test.tsx
+++ b/packages/dashboard/tests/client/components/threads/ChatThreadView.test.tsx
@@ -1,0 +1,356 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+import { ChatThreadView } from '../../../../src/client/components/threads/ChatThreadView';
+import { useThreadStore } from '../../../../src/client/stores/threadStore';
+import { streamChat } from '../../../../src/client/utils/chat-stream';
+import { generateSystemPrompt } from '../../../../src/client/utils/context-to-prompt';
+import type { Thread, ChatMeta } from '../../../../src/client/types/thread';
+import type { AssistantMessage, UserMessage } from '../../../../src/client/types/chat';
+
+// ── Stub heavy leaf components so the test targets ChatThreadView's own
+//    orchestration (view routing + streaming/send effects), not their internals.
+
+vi.mock('../../../../src/client/components/chat/NeuralOrganism', () => ({
+  NeuralOrganism: () => <div data-testid="neural-organism" />,
+}));
+
+vi.mock('../../../../src/client/components/chat/MessageStream', () => ({
+  MessageStream: ({ messages, streaming }: { messages: unknown[]; streaming: boolean }) => (
+    <div
+      data-testid="message-stream"
+      data-count={messages.length}
+      data-streaming={String(streaming)}
+    />
+  ),
+}));
+
+vi.mock('../../../../src/client/components/chat/ChatInput', () => ({
+  ChatInput: ({
+    value,
+    onChange,
+    onSend,
+    disabled,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    onSend: () => void;
+    disabled: boolean;
+    placeholder?: string;
+  }) => (
+    <div>
+      <input
+        data-testid="chat-input"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button data-testid="chat-send" disabled={disabled} onClick={onSend}>
+        send
+      </button>
+    </div>
+  ),
+}));
+
+// The palette selects a real registry skill so downstream skill-resolution behaves.
+const PALETTE_SKILL_ID = 'harness:validate';
+const PALETTE_SKILL_NAME = 'Validate Project';
+const PALETTE_SLASH = '/harness:validate';
+
+vi.mock('../../../../src/client/components/chat/CommandPalette', () => ({
+  CommandPalette: ({ onSelect }: { onSelect: (skill: unknown) => void }) => (
+    <button
+      data-testid="palette-select"
+      onClick={() =>
+        onSelect({
+          id: 'harness:validate',
+          name: 'Validate Project',
+          description: 'Run health checks.',
+          category: 'health',
+          slashCommand: '/harness:validate',
+        })
+      }
+    >
+      select skill
+    </button>
+  ),
+}));
+
+vi.mock('../../../../src/client/components/chat/BriefingPanel', () => ({
+  BriefingPanel: ({
+    skill,
+    onExecute,
+    onCancel,
+  }: {
+    skill: { id: string };
+    onExecute: () => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid="briefing-panel" data-skill={skill.id}>
+      <button data-testid="briefing-execute" onClick={onExecute}>
+        execute
+      </button>
+      <button data-testid="briefing-cancel" onClick={onCancel}>
+        cancel
+      </button>
+    </div>
+  ),
+}));
+
+// Network + context-derivation seams: fully mocked so nothing touches the wire.
+vi.mock('../../../../src/client/utils/chat-stream', () => ({
+  streamChat: vi.fn(async () => {}),
+  applyChunk: vi.fn(),
+}));
+
+vi.mock('../../../../src/client/hooks/useChatContext', () => ({
+  useChatContext: () => ({ data: {}, isLoading: false, error: null }),
+}));
+
+const SYSTEM_PROMPT = 'SYSTEM_PROMPT_STUB';
+vi.mock('../../../../src/client/utils/context-to-prompt', () => ({
+  generateSystemPrompt: vi.fn(() => SYSTEM_PROMPT),
+}));
+
+const SESSION_ID = 'sess-1';
+const THREAD_ID = `chat:${SESSION_ID}`;
+
+function makeChatThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: THREAD_ID,
+    type: 'chat',
+    title: 'New Chat',
+    status: 'active',
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    avatar: 'user',
+    unread: false,
+    meta: { sessionId: SESSION_ID, command: null } as ChatMeta,
+    ...overrides,
+  };
+}
+
+function assistantMessageWithBlocks(blocks: AssistantMessage['blocks']): AssistantMessage {
+  return { role: 'assistant', blocks };
+}
+
+function resetStore(): void {
+  useThreadStore.setState({
+    threads: new Map(),
+    messages: new Map(),
+    panelState: new Map(),
+    activeThreadId: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetStore();
+  // Default fetch: cold-mount session GET 404s (new thread), everything else ok.
+  global.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url.startsWith('/api/sessions/') && method === 'GET') {
+      return Promise.resolve({ ok: false, json: async () => null } as Response);
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ChatThreadView view routing', () => {
+  it('renders the command palette for an empty thread with no command or skill', () => {
+    render(<ChatThreadView thread={makeChatThread()} />);
+
+    expect(screen.getByTestId('palette-select')).toBeDefined();
+    expect(screen.queryByTestId('message-stream')).toBeNull();
+    expect(screen.getByPlaceholderText('Type a message or select a skill below...')).toBeDefined();
+  });
+
+  it('renders the message stream once the thread has messages', () => {
+    const thread = makeChatThread();
+    useThreadStore.getState().setMessages(thread.id, [{ role: 'user', content: 'hi' }]);
+
+    render(<ChatThreadView thread={thread} />);
+
+    const stream = screen.getByTestId('message-stream');
+    expect(stream.getAttribute('data-count')).toBe('1');
+    expect(screen.queryByTestId('palette-select')).toBeNull();
+    expect(screen.getByPlaceholderText('Type a message...')).toBeDefined();
+  });
+
+  it('routes to the briefing panel after selecting a skill and titles the thread from it', async () => {
+    const thread = makeChatThread();
+    // updateThread is a no-op for threads absent from the store, so seed it
+    // before asserting the skill-derived rename lands.
+    useThreadStore.setState((s) => ({ threads: new Map(s.threads).set(thread.id, thread) }));
+    render(<ChatThreadView thread={thread} />);
+
+    fireEvent.click(screen.getByTestId('palette-select'));
+
+    const briefing = await screen.findByTestId('briefing-panel');
+    expect(briefing.getAttribute('data-skill')).toBe(PALETTE_SKILL_ID);
+    // Header shows the resolved skill name.
+    expect(screen.getByText(PALETTE_SKILL_NAME)).toBeDefined();
+    // handleSkillSelect renames an empty thread from the skill id's last segment.
+    expect(useThreadStore.getState().threads.get(thread.id)?.title).toBe('validate');
+  });
+
+  it('cancelling the briefing returns to the command palette', async () => {
+    render(<ChatThreadView thread={makeChatThread()} />);
+
+    fireEvent.click(screen.getByTestId('palette-select'));
+    await screen.findByTestId('briefing-panel');
+
+    fireEvent.click(screen.getByTestId('briefing-cancel'));
+
+    expect(await screen.findByTestId('palette-select')).toBeDefined();
+    expect(screen.queryByTestId('briefing-panel')).toBeNull();
+  });
+});
+
+describe('ChatThreadView send + streaming', () => {
+  it('appends user/assistant messages, persists the session, and starts a stream on send', async () => {
+    const thread = makeChatThread();
+    render(<ChatThreadView thread={thread} />);
+
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'hello world' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('chat-send'));
+    });
+
+    // Two messages land in the store: the user turn and an empty assistant turn.
+    const stored = useThreadStore.getState().messages.get(thread.id) ?? [];
+    expect(stored).toHaveLength(2);
+    expect((stored[0] as UserMessage).content).toBe('hello world');
+    expect(stored[1]?.role).toBe('assistant');
+
+    // The session is persisted via a POST to /api/sessions.
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/sessions',
+      expect.objectContaining({ method: 'POST' })
+    );
+
+    // The stream is kicked off with the trimmed prompt.
+    expect(vi.mocked(streamChat)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(streamChat).mock.calls[0]?.[0]).toBe('hello world');
+  });
+
+  it('does not send when the input is empty (whitespace only)', async () => {
+    const thread = makeChatThread();
+    render(<ChatThreadView thread={thread} />);
+
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: '   ' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('chat-send'));
+    });
+
+    expect(vi.mocked(streamChat)).not.toHaveBeenCalled();
+    expect(useThreadStore.getState().messages.get(thread.id) ?? []).toHaveLength(0);
+  });
+
+  it('executing a skill from the briefing streams the slash command with a generated system prompt', async () => {
+    const thread = makeChatThread();
+    render(<ChatThreadView thread={thread} />);
+
+    fireEvent.click(screen.getByTestId('palette-select'));
+    await screen.findByTestId('briefing-panel');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('briefing-execute'));
+    });
+
+    expect(vi.mocked(generateSystemPrompt)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(streamChat)).toHaveBeenCalledTimes(1);
+    const [prompt, system] = vi.mocked(streamChat).mock.calls[0] ?? [];
+    expect(prompt).toBe(PALETTE_SLASH);
+    expect(system).toBe(SYSTEM_PROMPT);
+  });
+
+  it('a chat-action-send window event triggers a send with its detail', async () => {
+    const thread = makeChatThread();
+    useThreadStore.getState().setMessages(thread.id, [{ role: 'user', content: 'prior' }]);
+    render(<ChatThreadView thread={thread} />);
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('chat-action-send', { detail: 'approve all' }));
+    });
+
+    expect(vi.mocked(streamChat)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(streamChat).mock.calls[0]?.[0]).toBe('approve all');
+  });
+});
+
+describe('ChatThreadView effects', () => {
+  it('extracts todos from assistant task blocks and pushes them to the panel state', async () => {
+    const thread = makeChatThread();
+    const todoBlock = {
+      kind: 'tool_use' as const,
+      tool: 'TodoWrite',
+      args: JSON.stringify({
+        todos: [{ id: 't1', content: 'ship the thing', status: 'pending' }],
+      }),
+    };
+    useThreadStore.getState().setMessages(thread.id, [assistantMessageWithBlocks([todoBlock])]);
+
+    render(<ChatThreadView thread={thread} />);
+
+    await waitFor(() => {
+      const panel = useThreadStore.getState().panelState.get(thread.id);
+      expect(panel?.todos).toHaveLength(1);
+    });
+    expect(useThreadStore.getState().panelState.get(thread.id)?.todos[0]?.text).toBe(
+      'ship the thing'
+    );
+  });
+
+  it('does not touch panel state when there are no todo-bearing blocks', async () => {
+    const thread = makeChatThread();
+    useThreadStore
+      .getState()
+      .setMessages(thread.id, [
+        assistantMessageWithBlocks([{ kind: 'text', text: 'just prose, no tasks' }]),
+      ]);
+
+    render(<ChatThreadView thread={thread} />);
+
+    // Give any effect a chance to run, then assert nothing was written.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useThreadStore.getState().panelState.get(thread.id)).toBeUndefined();
+  });
+
+  it('hydrates messages from the server session on a cold mount', async () => {
+    const thread = makeChatThread();
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === `/api/sessions/${SESSION_ID}`) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessionId: SESSION_ID,
+            messages: [{ role: 'user', content: 'restored from disk' }],
+            orchestratorSessionId: 'orch-42',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    }) as unknown as typeof fetch;
+
+    render(<ChatThreadView thread={thread} />);
+
+    await waitFor(() => {
+      expect(useThreadStore.getState().messages.get(thread.id)).toHaveLength(1);
+    });
+    expect((useThreadStore.getState().messages.get(thread.id)?.[0] as UserMessage).content).toBe(
+      'restored from disk'
+    );
+  });
+});

--- a/packages/dashboard/tests/client/hooks/useAgentSync.test.tsx
+++ b/packages/dashboard/tests/client/hooks/useAgentSync.test.tsx
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useAgentSync } from '../../../src/client/hooks/useAgentSync';
+import { useThreadStore } from '../../../src/client/stores/threadStore';
+import type { StreamManifest } from '../../../src/client/hooks/useStreamReplay';
+import type { RunningAgent, OrchestratorSnapshot } from '../../../src/client/types/orchestrator';
+import type { OrchestratorSocketState } from '../../../src/client/hooks/useOrchestratorSocket';
+import type { AgentMeta } from '../../../src/client/types/thread';
+
+const STREAMS_URL = '/api/streams';
+
+/** A completed stream attempt with fully-populated stats (endedAt set => not running). */
+function makeAttempt(
+  overrides: Partial<StreamManifest['attempts'][number]> = {}
+): StreamManifest['attempts'][number] {
+  return {
+    attempt: 1,
+    startedAt: '2026-07-20T00:00:00.000Z',
+    endedAt: '2026-07-20T00:05:00.000Z',
+    outcome: 'success',
+    stats: {
+      durationMs: 300_000,
+      inputTokens: 0,
+      outputTokens: 0,
+      turnCount: 0,
+      toolsCalled: [],
+      filesTouched: [],
+    },
+    ...overrides,
+  };
+}
+
+/** A stable, valid StreamManifest; callers override only the fields under test. */
+function makeManifest(overrides: Partial<StreamManifest> & { issueId: string }): StreamManifest {
+  return {
+    externalId: null,
+    identifier: overrides.issueId,
+    title: 'Some Issue',
+    attempts: [makeAttempt()],
+    pr: null,
+    highlights: null,
+    ...overrides,
+  };
+}
+
+/** A stable, valid RunningAgent; callers override only the fields under test. */
+function makeRunningAgent(overrides: Partial<RunningAgent> & { issueId: string }): RunningAgent {
+  return {
+    identifier: overrides.issueId,
+    phase: 'brainstorm',
+    startedAt: '2026-07-20T01:00:00.000Z',
+    workspacePath: '/tmp/worktree',
+    attempt: 1,
+    issue: {
+      identifier: overrides.issueId,
+      title: 'Live Issue',
+      description: 'live description',
+      blockedBy: [],
+    },
+    session: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a socket whose only meaningful field is `snapshot.running`; the hook
+ * reads nothing else. A fresh snapshot object per call is what re-triggers the
+ * hook's `[socket.snapshot]` effect on rerender.
+ */
+function makeSocket(running: Array<[string, RunningAgent]>): OrchestratorSocketState {
+  const snapshot = { running } as unknown as OrchestratorSnapshot;
+  return { snapshot } as OrchestratorSocketState;
+}
+
+/** Empty socket — no live agents. */
+function emptySocket(): OrchestratorSocketState {
+  return makeSocket([]);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Mock fetch that only answers /api/streams; any other URL is a hard failure. */
+function stubStreamsFetch(handler: () => Response | Promise<Response>): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : String(input);
+    if (url !== STREAMS_URL) throw new Error(`Unexpected fetch: ${url}`);
+    return handler();
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+// The thread store is a module-level singleton; reset the mutable slices we
+// touch and swap markSourceHydrated for a fresh spy before every test so call
+// counts and thread state never leak between cases.
+let markSourceHydrated: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  markSourceHydrated = vi.fn();
+  useThreadStore.setState({
+    threads: new Map(),
+    messages: new Map(),
+    markSourceHydrated,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useAgentSync', () => {
+  describe('historical seeding from /api/streams', () => {
+    it('seeds a completed session as a completed agent thread and marks hydrated', async () => {
+      stubStreamsFetch(() =>
+        jsonResponse([
+          makeManifest({ issueId: 'I-100', identifier: 'ISS-100', title: 'Done Work' }),
+        ])
+      );
+
+      renderHook(() => useAgentSync(emptySocket()));
+      await waitFor(() => expect(markSourceHydrated).toHaveBeenCalledTimes(1));
+
+      const state = useThreadStore.getState();
+      const thread = state.threads.get('agent:I-100');
+      expect(thread).toBeDefined();
+      expect(thread?.type).toBe('agent');
+      expect(thread?.status).toBe('completed');
+      expect(thread?.title).toBe('Done Work');
+      expect(thread?.meta).toMatchObject({
+        issueId: 'I-100',
+        phase: 'completed',
+        backendName: null,
+      });
+    });
+
+    it('skips a still-running session (last attempt has no endedAt)', async () => {
+      stubStreamsFetch(() =>
+        jsonResponse([
+          makeManifest({
+            issueId: 'I-200',
+            attempts: [makeAttempt({ endedAt: null, outcome: null })],
+          }),
+        ])
+      );
+
+      renderHook(() => useAgentSync(emptySocket()));
+      await waitFor(() => expect(markSourceHydrated).toHaveBeenCalledTimes(1));
+
+      // Running sessions are left for live sync — no completed thread is seeded.
+      expect(useThreadStore.getState().threads.has('agent:I-200')).toBe(false);
+    });
+
+    it('does not seed over an agent thread that already exists for the issue', async () => {
+      const store = useThreadStore.getState();
+      store.createThread('agent', {
+        issueId: 'I-300',
+        identifier: 'ISS-300',
+        phase: 'execute',
+        issueTitle: 'Original',
+        issueDescription: null,
+        startedAt: '2026-07-20T00:00:00.000Z',
+        backendName: 'claude',
+      } satisfies AgentMeta);
+
+      stubStreamsFetch(() =>
+        jsonResponse([makeManifest({ issueId: 'I-300', title: 'From Disk' })])
+      );
+
+      // Keep I-300 in the running set so live sync's completion sweep leaves it
+      // active — this isolates the seed's skip-existing behavior under test.
+      const running = makeRunningAgent({ issueId: 'I-300', phase: 'execute' });
+      renderHook(() => useAgentSync(makeSocket([['I-300', running]])));
+      await waitFor(() => expect(markSourceHydrated).toHaveBeenCalledTimes(1));
+
+      const thread = useThreadStore.getState().threads.get('agent:I-300');
+      // Existing thread is untouched: title, status and phase all preserved,
+      // and no duplicate thread is created for the same issue.
+      expect(thread?.title).toBe('Original');
+      expect(thread?.status).toBe('active');
+      expect((thread?.meta as AgentMeta).phase).toBe('execute');
+      expect(useThreadStore.getState().threads.size).toBe(1);
+    });
+
+    it('marks hydrated without seeding when /api/streams responds non-OK', async () => {
+      stubStreamsFetch(() => jsonResponse(null, 500));
+
+      renderHook(() => useAgentSync(emptySocket()));
+      await waitFor(() => expect(markSourceHydrated).toHaveBeenCalledTimes(1));
+
+      expect(useThreadStore.getState().threads.size).toBe(0);
+    });
+
+    it('seeds historical sessions exactly once across rerenders', async () => {
+      const fetchMock = stubStreamsFetch(() => jsonResponse([makeManifest({ issueId: 'I-400' })]));
+
+      const { rerender } = renderHook(({ socket }) => useAgentSync(socket), {
+        initialProps: { socket: emptySocket() },
+      });
+      await waitFor(() => expect(markSourceHydrated).toHaveBeenCalledTimes(1));
+
+      rerender({ socket: emptySocket() });
+      rerender({ socket: emptySocket() });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(STREAMS_URL);
+    });
+  });
+
+  describe('live sync from the orchestrator snapshot', () => {
+    it('creates an active agent thread for a running agent in the snapshot', async () => {
+      stubStreamsFetch(() => jsonResponse([]));
+
+      const agent = makeRunningAgent({
+        issueId: 'I-500',
+        phase: 'plan',
+        issue: {
+          identifier: 'ISS-500',
+          title: 'Ship it',
+          description: 'the description',
+          blockedBy: [],
+        },
+        session: {
+          backendName: 'qwen3-coder',
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          turnCount: 0,
+          lastMessage: null,
+        },
+      });
+
+      renderHook(() => useAgentSync(makeSocket([['I-500', agent]])));
+
+      const thread = useThreadStore.getState().threads.get('agent:I-500');
+      expect(thread).toBeDefined();
+      expect(thread?.status).toBe('active');
+      expect(thread?.title).toBe('Ship it');
+      expect(thread?.meta).toMatchObject({
+        issueId: 'I-500',
+        phase: 'plan',
+        issueDescription: 'the description',
+        backendName: 'qwen3-coder',
+      });
+    });
+
+    it('updates phase and backendName when a known agent advances in a later snapshot', async () => {
+      stubStreamsFetch(() => jsonResponse([]));
+
+      const first = makeRunningAgent({ issueId: 'I-600', phase: 'brainstorm', session: null });
+      const { rerender } = renderHook(({ socket }) => useAgentSync(socket), {
+        initialProps: { socket: makeSocket([['I-600', first]]) },
+      });
+
+      expect((useThreadStore.getState().threads.get('agent:I-600')?.meta as AgentMeta).phase).toBe(
+        'brainstorm'
+      );
+
+      const advanced = makeRunningAgent({
+        issueId: 'I-600',
+        phase: 'execute',
+        session: {
+          backendName: 'claude',
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          turnCount: 0,
+          lastMessage: null,
+        },
+      });
+      act(() => rerender({ socket: makeSocket([['I-600', advanced]]) }));
+
+      const meta = useThreadStore.getState().threads.get('agent:I-600')?.meta as AgentMeta;
+      expect(meta.phase).toBe('execute');
+      expect(meta.backendName).toBe('claude');
+    });
+
+    it('completes an active agent thread once its issue drops out of the running set', async () => {
+      stubStreamsFetch(() => jsonResponse([]));
+
+      const agent = makeRunningAgent({ issueId: 'I-700', phase: 'execute' });
+      const { rerender } = renderHook(({ socket }) => useAgentSync(socket), {
+        initialProps: { socket: makeSocket([['I-700', agent]]) },
+      });
+      expect(useThreadStore.getState().threads.get('agent:I-700')?.status).toBe('active');
+
+      // Next snapshot no longer lists the agent as running.
+      act(() => rerender({ socket: emptySocket() }));
+
+      expect(useThreadStore.getState().threads.get('agent:I-700')?.status).toBe('completed');
+    });
+  });
+});

--- a/packages/dashboard/tests/client/hooks/useAttentionSync.test.tsx
+++ b/packages/dashboard/tests/client/hooks/useAttentionSync.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAttentionSync } from '../../../src/client/hooks/useAttentionSync';
+import { useThreadStore } from '../../../src/client/stores/threadStore';
+import type {
+  PendingInteraction,
+  InteractionContext,
+} from '../../../src/client/types/orchestrator';
+import type { OrchestratorSocketState } from '../../../src/client/hooks/useOrchestratorSocket';
+import type { AttentionMeta } from '../../../src/client/types/thread';
+
+const INTERACTIONS_URL = '/api/interactions';
+
+/** A stable, valid InteractionContext; the hook forwards it verbatim into thread meta. */
+function makeContext(): InteractionContext {
+  return {
+    issueTitle: 'Deploy the widget',
+    issueDescription: null,
+    specPath: null,
+    planPath: null,
+    relatedFiles: [],
+  };
+}
+
+/** A stable, valid PendingInteraction; callers override only the fields under test. */
+function makeInteraction(
+  overrides: Partial<PendingInteraction> & { id: string }
+): PendingInteraction {
+  return {
+    issueId: 'ENG-1',
+    type: 'needs-human',
+    reasons: ['low-confidence'],
+    context: makeContext(),
+    createdAt: '2026-07-20T00:00:00.000Z',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+/**
+ * A minimal OrchestratorSocketState. The hook only reads `interactions`; the
+ * remaining fields exist purely to satisfy the interface, so no real socket,
+ * network, or timer is involved.
+ */
+function makeSocket(interactions: PendingInteraction[]): OrchestratorSocketState {
+  return {
+    snapshot: null,
+    interactions,
+    agentEvents: {},
+    connected: false,
+    maintenanceEvent: null,
+    localModelStatuses: [],
+    removeInteraction: () => {},
+    setInteractions: () => {},
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Mock fetch that only answers /api/interactions; any other URL is a hard failure. */
+function stubInteractionsFetch(
+  handler: () => Response | Promise<Response>
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : String(input);
+    if (url !== INTERACTIONS_URL) throw new Error(`Unexpected fetch: ${url}`);
+    return handler();
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+// The thread store is a module-level singleton; reset the mutable slices we
+// touch and swap markSourceHydrated + createThread for fresh spies before every
+// test so call counts and thread state never leak between cases. createThread
+// still delegates to the real implementation so threads are genuinely created.
+const realCreateThread = useThreadStore.getState().createThread;
+let markSourceHydrated: ReturnType<typeof vi.fn>;
+let createThread: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  markSourceHydrated = vi.fn();
+  createThread = vi.fn(realCreateThread);
+  useThreadStore.setState({
+    threads: new Map(),
+    messages: new Map(),
+    markSourceHydrated,
+    createThread,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useAttentionSync', () => {
+  it('hydrates non-resolved interactions into attention threads and skips resolved ones', async () => {
+    stubInteractionsFetch(() =>
+      jsonResponse([
+        makeInteraction({ id: 'int-open', issueId: 'ENG-7', reasons: ['ambiguous-spec'] }),
+        makeInteraction({ id: 'int-done', status: 'resolved' }),
+      ])
+    );
+
+    renderHook(() => useAttentionSync(makeSocket([])));
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    const state = useThreadStore.getState();
+    const open = state.threads.get('attn:int-open');
+    expect(open).toBeDefined();
+    expect(open?.type).toBe('attention');
+    expect(open?.title).toBe('Attention: ENG-7');
+    expect(open?.meta as AttentionMeta).toMatchObject({
+      interactionId: 'int-open',
+      issueId: 'ENG-7',
+      reasons: ['ambiguous-spec'],
+    });
+
+    // The resolved interaction is filtered out before any thread is created.
+    expect(state.threads.has('attn:int-done')).toBe(false);
+    expect(state.threads.size).toBe(1);
+  });
+
+  it('creates attention threads for live WebSocket interactions and dedupes repeats across re-renders', async () => {
+    stubInteractionsFetch(() => jsonResponse([]));
+
+    const { rerender } = renderHook(({ socket }) => useAttentionSync(socket), {
+      initialProps: { socket: makeSocket([makeInteraction({ id: 'ws-1' })]) },
+    });
+    await waitFor(() => expect(useThreadStore.getState().threads.has('attn:ws-1')).toBe(true));
+
+    // A new socket state that repeats ws-1 and adds ws-2 (fresh array reference
+    // so the effect's dependency actually changes).
+    rerender({
+      socket: makeSocket([makeInteraction({ id: 'ws-1' }), makeInteraction({ id: 'ws-2' })]),
+    });
+    await waitFor(() => expect(useThreadStore.getState().threads.has('attn:ws-2')).toBe(true));
+
+    // ws-1 is created exactly once despite appearing in both renders; ws-2 once.
+    const attentionCreates = createThread.mock.calls.filter(([type]) => type === 'attention');
+    expect(attentionCreates).toHaveLength(2);
+    expect(useThreadStore.getState().threads.size).toBe(2);
+  });
+
+  it('deduplicates an interaction seen from the initial fetch against the live socket', async () => {
+    // Both the fetch payload and the socket carry the same id; the shared
+    // seenIds guard must ensure it is only ever created once.
+    stubInteractionsFetch(() => jsonResponse([makeInteraction({ id: 'shared' })]));
+
+    renderHook(() => useAttentionSync(makeSocket([makeInteraction({ id: 'shared' })])));
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    const attentionCreates = createThread.mock.calls.filter(([type]) => type === 'attention');
+    expect(attentionCreates).toHaveLength(1);
+    expect(useThreadStore.getState().threads.size).toBe(1);
+    expect(useThreadStore.getState().threads.has('attn:shared')).toBe(true);
+  });
+
+  it('marks the attention source hydrated when the endpoint responds non-OK', async () => {
+    stubInteractionsFetch(() => jsonResponse(null, 500));
+
+    renderHook(() => useAttentionSync(makeSocket([])));
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    expect(useThreadStore.getState().threads.size).toBe(0);
+  });
+
+  it('marks hydrated and swallows a rejected fetch', async () => {
+    stubInteractionsFetch(() => Promise.reject(new Error('network down')));
+
+    renderHook(() => useAttentionSync(makeSocket([])));
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    expect(useThreadStore.getState().threads.size).toBe(0);
+  });
+
+  it('fetches /api/interactions exactly once across re-renders', async () => {
+    const fetchMock = stubInteractionsFetch(() => jsonResponse([makeInteraction({ id: 'once' })]));
+
+    const { rerender } = renderHook(({ socket }) => useAttentionSync(socket), {
+      initialProps: { socket: makeSocket([]) },
+    });
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    rerender({ socket: makeSocket([]) });
+    rerender({ socket: makeSocket([]) });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(INTERACTIONS_URL);
+  });
+});

--- a/packages/dashboard/tests/client/hooks/useChatSessionsSync.test.tsx
+++ b/packages/dashboard/tests/client/hooks/useChatSessionsSync.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useChatSessionsSync } from '../../../src/client/hooks/useChatSessionsSync';
+import { useThreadStore } from '../../../src/client/stores/threadStore';
+import type { ChatSession } from '../../../src/client/types/chat-session';
+import type { ChatMessage } from '../../../src/client/types/chat';
+
+const SESSIONS_URL = '/api/sessions';
+
+/** A stable, valid ChatSession; callers override only the fields under test. */
+function makeSession(overrides: Partial<ChatSession> & { sessionId: string }): ChatSession {
+  return {
+    command: null,
+    interactionId: null,
+    label: 'New Chat',
+    createdAt: '2026-07-20T00:00:00.000Z',
+    lastActiveAt: '2026-07-20T00:00:00.000Z',
+    artifacts: [],
+    status: 'active',
+    messages: [],
+    input: '',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Mock fetch that only answers /api/sessions; any other URL is a hard failure. */
+function stubSessionsFetch(handler: () => Response | Promise<Response>): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : String(input);
+    if (url !== SESSIONS_URL) throw new Error(`Unexpected fetch: ${url}`);
+    return handler();
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+// The thread store is a module-level singleton; reset the mutable slices we
+// touch and swap markSourceHydrated for a fresh spy before every test so call
+// counts and thread state never leak between cases.
+let markSourceHydrated: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  markSourceHydrated = vi.fn();
+  useThreadStore.setState({
+    threads: new Map(),
+    messages: new Map(),
+    markSourceHydrated,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useChatSessionsSync', () => {
+  it('hydrates persisted sessions into chat threads with labels and messages', async () => {
+    const history: ChatMessage[] = [
+      { role: 'user', content: 'scan my repo' },
+      { role: 'assistant', blocks: [{ kind: 'text', text: 'on it' }] },
+    ];
+    const fetchMock = stubSessionsFetch(() =>
+      jsonResponse([
+        makeSession({
+          sessionId: 's1',
+          command: 'harness:security-scan',
+          label: 'My Security Chat',
+          messages: history,
+        }),
+        makeSession({ sessionId: 's2', command: null, label: 'New Chat', messages: [] }),
+      ])
+    );
+
+    renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    const state = useThreadStore.getState();
+    const labelled = state.threads.get('chat:s1');
+    expect(labelled).toBeDefined();
+    expect(labelled?.type).toBe('chat');
+    expect(labelled?.title).toBe('My Security Chat');
+    expect(labelled?.meta).toMatchObject({ sessionId: 's1', command: 'harness:security-scan' });
+    expect(state.messages.get('chat:s1')).toEqual(history);
+
+    // Second session created too, but with no non-empty messages persisted.
+    expect(state.threads.has('chat:s2')).toBe(true);
+    expect(state.messages.has('chat:s2')).toBe(false);
+
+    expect(fetchMock).toHaveBeenCalledWith(SESSIONS_URL);
+  });
+
+  it('leaves a "New Chat"-labelled session on its command-derived title', async () => {
+    stubSessionsFetch(() =>
+      jsonResponse([
+        makeSession({ sessionId: 's3', command: 'harness:foo-bar', label: 'New Chat' }),
+      ])
+    );
+
+    renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    // label === 'New Chat' means the hook must NOT override the store's default
+    // title, which derives 'foo-bar' from the command.
+    expect(useThreadStore.getState().threads.get('chat:s3')?.title).toBe('foo-bar');
+  });
+
+  it('skips sessions that lack a sessionId', async () => {
+    stubSessionsFetch(() =>
+      jsonResponse([
+        makeSession({ sessionId: '' }),
+        makeSession({ sessionId: 's4', label: 'Kept' }),
+      ])
+    );
+
+    renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    const state = useThreadStore.getState();
+    expect(state.threads.size).toBe(1);
+    expect(state.threads.has('chat:s4')).toBe(true);
+    expect(state.threads.has('chat:')).toBe(false);
+  });
+
+  it('does not overwrite an already-present chat thread', async () => {
+    const store = useThreadStore.getState();
+    store.createThread('chat', { sessionId: 'dup', command: null });
+    store.updateThread('chat:dup', { title: 'Original Title' });
+
+    stubSessionsFetch(() =>
+      jsonResponse([
+        makeSession({
+          sessionId: 'dup',
+          label: 'Server Label',
+          messages: [{ role: 'user', content: 'from disk' }],
+        }),
+      ])
+    );
+
+    renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    const state = useThreadStore.getState();
+    // Existing thread is left untouched: no title change, no message hydration.
+    expect(state.threads.get('chat:dup')?.title).toBe('Original Title');
+    expect(state.messages.has('chat:dup')).toBe(false);
+  });
+
+  it('marks the store hydrated when the endpoint responds non-OK', async () => {
+    stubSessionsFetch(() => jsonResponse(null, 500));
+
+    renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    expect(useThreadStore.getState().threads.size).toBe(0);
+  });
+
+  it('ignores a non-array payload but still marks hydrated', async () => {
+    stubSessionsFetch(() => jsonResponse({ not: 'an array' }));
+
+    renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    expect(useThreadStore.getState().threads.size).toBe(0);
+  });
+
+  it('marks hydrated and swallows a rejected fetch', async () => {
+    stubSessionsFetch(() => Promise.reject(new Error('network down')));
+
+    renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    expect(useThreadStore.getState().threads.size).toBe(0);
+  });
+
+  it('fetches /api/sessions exactly once across re-renders', async () => {
+    const fetchMock = stubSessionsFetch(() => jsonResponse([makeSession({ sessionId: 's5' })]));
+
+    const { rerender } = renderHook(() => useChatSessionsSync());
+    await waitFor(() => expect(markSourceHydrated).toHaveBeenCalled());
+
+    rerender();
+    rerender();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(SESSIONS_URL);
+  });
+});

--- a/packages/dashboard/tests/client/hooks/useRoutingConfig.test.tsx
+++ b/packages/dashboard/tests/client/hooks/useRoutingConfig.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { RoutingConfigResponse } from '../../../src/client/types/routing';
+import { useRoutingConfig } from '../../../src/client/hooks/useRoutingConfig';
+
+const CONFIG_ENDPOINT = '/api/v1/routing/config';
+
+const mkConfig = (): RoutingConfigResponse =>
+  ({
+    routing: { policy: 'capability' },
+    resolvedChains: {
+      design: [{ candidate: 'claude-opus', exists: true }],
+    },
+    backends: ['claude-opus', 'qwen3-coder'],
+  }) as unknown as RoutingConfigResponse;
+
+beforeEach(() => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(mkConfig()), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useRoutingConfig', () => {
+  it('fetches the config once on mount and exposes it with loading cleared', async () => {
+    const config = mkConfig();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify(config), { status: 200 })
+    );
+
+    const { result } = renderHook(() => useRoutingConfig());
+
+    // Arrange assertion: hook starts in the loading state before the fetch settles.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.config).toBeNull();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.config).toEqual(config);
+    expect(result.current.error).toBeNull();
+    // The hook is fetch-once-on-mount: exactly one call to the config endpoint.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      CONFIG_ENDPOINT,
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('surfaces an "HTTP <status>" error for a non-ok response without setting config', async () => {
+    const NOT_FOUND = 404;
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('nope', { status: NOT_FOUND })
+    );
+
+    const { result } = renderHook(() => useRoutingConfig());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe(`HTTP ${NOT_FOUND}`);
+    expect(result.current.config).toBeNull();
+  });
+
+  it('surfaces the thrown message on a network error', async () => {
+    const failure = new Error('connection refused');
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(failure);
+
+    const { result } = renderHook(() => useRoutingConfig());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe('connection refused');
+    expect(result.current.config).toBeNull();
+  });
+
+  it('falls back to a generic "Network error" when the rejection is not an Error', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce('boom');
+
+    const { result } = renderHook(() => useRoutingConfig());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.config).toBeNull();
+  });
+
+  it('aborts the in-flight request on unmount and does not record an error', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    // Never-resolving fetch keeps the request in flight until we unmount.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      (_url: string, init: { signal: AbortSignal }) => {
+        capturedSignal = init.signal;
+        return new Promise(() => {});
+      }
+    );
+
+    const { result, unmount } = renderHook(() => useRoutingConfig());
+
+    expect(capturedSignal?.aborted).toBe(false);
+
+    unmount();
+
+    expect(capturedSignal?.aborted).toBe(true);
+    // Cleanup abort must not flip the hook into an error state.
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/dashboard/tests/client/hooks/useStreamReplay.test.tsx
+++ b/packages/dashboard/tests/client/hooks/useStreamReplay.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useStreamReplay } from '../../../src/client/hooks/useStreamReplay';
+import type { StreamManifest } from '../../../src/client/hooks/useStreamReplay';
+
+const ISSUE_ID = 'ISS-42';
+const MANIFEST_URL = `/api/streams/${ISSUE_ID}/manifest`;
+const STREAM_URL = `/api/streams/${ISSUE_ID}`;
+
+const MANIFEST: StreamManifest = {
+  issueId: ISSUE_ID,
+  externalId: 42,
+  identifier: 'ISS-42',
+  title: 'Replay me',
+  attempts: [
+    {
+      attempt: 1,
+      startedAt: '2026-07-20T00:00:00.000Z',
+      endedAt: '2026-07-20T00:05:00.000Z',
+      outcome: 'success',
+      stats: {
+        durationMs: 300_000,
+        inputTokens: 100,
+        outputTokens: 200,
+        turnCount: 3,
+        toolsCalled: ['readFile'],
+        filesTouched: ['a.ts'],
+      },
+    },
+  ],
+  pr: null,
+  highlights: null,
+};
+
+/**
+ * A JSONL fixture exercising every parse path the hook cares about:
+ * session_start/session_end are dropped, consecutive text events coalesce,
+ * a `call` event becomes a tool_use block, and a malformed line is skipped.
+ */
+const JSONL_STREAM = [
+  JSON.stringify({ type: 'session_start', timestamp: '2026-07-20T00:00:00.000Z' }),
+  JSON.stringify({ type: 'text', content: 'Hello ', timestamp: '2026-07-20T00:00:01.000Z' }),
+  JSON.stringify({ type: 'text', content: 'world', timestamp: '2026-07-20T00:00:02.000Z' }),
+  '{ this is not valid json',
+  JSON.stringify({
+    type: 'call',
+    content: 'Calling readFile(path.ts)',
+    timestamp: '2026-07-20T00:00:03.000Z',
+  }),
+  JSON.stringify({ type: 'session_end', timestamp: '2026-07-20T00:00:04.000Z' }),
+].join('\n');
+
+type FetchHandler = () => Response | Promise<Response>;
+
+/** Build a URL-routed fetch mock; any unrouted URL is a hard failure. */
+function routedFetch(routes: Record<string, FetchHandler>): ReturnType<typeof vi.fn> {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : String(input);
+    const handler = routes[url];
+    if (!handler) throw new Error(`Unexpected fetch: ${url}`);
+    return handler();
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useStreamReplay', () => {
+  it('fetches the manifest then parses the JSONL stream into coalesced ContentBlocks', async () => {
+    const fetchMock = routedFetch({
+      [MANIFEST_URL]: () => new Response(JSON.stringify(MANIFEST), { status: 200 }),
+      [STREAM_URL]: () => new Response(JSONL_STREAM, { status: 200 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamReplay(ISSUE_ID));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.manifest).toEqual(MANIFEST);
+    expect(result.current.error).toBeNull();
+    // session_start/end dropped; two text events coalesced; malformed line skipped;
+    // call -> tool_use with parsed args.
+    expect(result.current.recordedBlocks).toEqual([
+      { kind: 'text', text: 'Hello world' },
+      { kind: 'tool_use', tool: 'readFile', args: 'path.ts' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(MANIFEST_URL);
+    expect(fetchMock).toHaveBeenCalledWith(STREAM_URL);
+  });
+
+  it('treats a 404 manifest as "no recording yet": null manifest, empty blocks, no error', async () => {
+    const streamHandler = vi.fn(() => new Response(JSONL_STREAM, { status: 200 }));
+    const fetchMock = routedFetch({
+      [MANIFEST_URL]: () => new Response(null, { status: 404 }),
+      [STREAM_URL]: streamHandler,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamReplay(ISSUE_ID));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.manifest).toBeNull();
+    expect(result.current.recordedBlocks).toEqual([]);
+    expect(result.current.error).toBeNull();
+    // A missing manifest short-circuits before the stream is ever fetched.
+    expect(streamHandler).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a non-404 manifest failure via the error field', async () => {
+    const fetchMock = routedFetch({
+      [MANIFEST_URL]: () => new Response(null, { status: 500 }),
+      [STREAM_URL]: () => new Response(JSONL_STREAM, { status: 200 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamReplay(ISSUE_ID));
+
+    await waitFor(() => expect(result.current.error).toBe('Manifest fetch failed: 500'));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.manifest).toBeNull();
+  });
+
+  it('surfaces a stream fetch failure via the error field after the manifest loads', async () => {
+    const fetchMock = routedFetch({
+      [MANIFEST_URL]: () => new Response(JSON.stringify(MANIFEST), { status: 200 }),
+      [STREAM_URL]: () => new Response(null, { status: 503 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamReplay(ISSUE_ID));
+
+    await waitFor(() => expect(result.current.error).toBe('Stream fetch failed: 503'));
+    expect(result.current.loading).toBe(false);
+    // The manifest was fetched successfully before the stream failed.
+    expect(result.current.manifest).toEqual(MANIFEST);
+  });
+
+  it('requests the attempt-scoped stream URL when an attempt number is supplied', async () => {
+    const attempt = 2;
+    const attemptUrl = `/api/streams/${ISSUE_ID}/${attempt}`;
+    const fetchMock = routedFetch({
+      [MANIFEST_URL]: () => new Response(JSON.stringify(MANIFEST), { status: 200 }),
+      [attemptUrl]: () => new Response(JSONL_STREAM, { status: 200 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamReplay(ISSUE_ID, attempt));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetchMock).toHaveBeenCalledWith(attemptUrl);
+    expect(fetchMock).not.toHaveBeenCalledWith(STREAM_URL);
+    expect(result.current.recordedBlocks).toHaveLength(2);
+  });
+
+  it('does no fetching and holds cleared state when issueId is null', async () => {
+    const fetchMock = routedFetch({});
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useStreamReplay(null));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.manifest).toBeNull();
+    expect(result.current.recordedBlocks).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not re-fetch on a re-render with unchanged inputs', async () => {
+    const fetchMock = routedFetch({
+      [MANIFEST_URL]: () => new Response(JSON.stringify(MANIFEST), { status: 200 }),
+      [STREAM_URL]: () => new Response(JSONL_STREAM, { status: 200 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result, rerender } = renderHook(() => useStreamReplay(ISSUE_ID));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const callsAfterLoad = fetchMock.mock.calls.length;
+    // Exactly one manifest + one stream request for the initial load.
+    expect(callsAfterLoad).toBe(2);
+
+    rerender();
+    rerender();
+
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterLoad);
+  });
+});

--- a/packages/dashboard/tests/client/pages/Adoption.test.tsx
+++ b/packages/dashboard/tests/client/pages/Adoption.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Adoption } from '../../../src/client/pages/Adoption';
+import type { AdoptionSnapshot, SkillAdoptionSummary } from '@shared/types';
+
+const mkSkill = (over: Partial<SkillAdoptionSummary>): SkillAdoptionSummary => ({
+  skill: 'skill-x',
+  invocations: 10,
+  successRate: 0.9,
+  avgDuration: 500,
+  lastUsed: '2026-06-15T12:34:56Z',
+  ...over,
+});
+
+const mkSnapshot = (over: Partial<AdoptionSnapshot>): AdoptionSnapshot => ({
+  period: 'weekly',
+  totalInvocations: 1234,
+  uniqueSkills: 3,
+  topSkills: [mkSkill({ skill: 'skill-a' })],
+  generatedAt: '2026-06-22T00:00:00Z',
+  ...over,
+});
+
+function mockAdoption(snapshot: AdoptionSnapshot) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ data: snapshot }), { status: 200 })
+  );
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('Adoption page', () => {
+  it('shows the loading message before the fetch resolves', () => {
+    // Never-resolving fetch keeps the component in its initial loading state.
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}));
+    render(<Adoption />);
+    expect(screen.getByText('Loading adoption telemetry...')).toBeDefined();
+  });
+
+  it('renders the summary KPIs from the fetched snapshot', async () => {
+    mockAdoption(mkSnapshot({ totalInvocations: 1234, uniqueSkills: 7, period: 'weekly' }));
+    render(<Adoption />);
+
+    await waitFor(() => expect(screen.getByText('Total Invocations')).toBeDefined());
+    expect(screen.getByText('1234')).toBeDefined();
+    expect(screen.getByText('7')).toBeDefined();
+    expect(screen.getByText('weekly')).toBeDefined();
+  });
+
+  it('renders one table row per top skill', async () => {
+    mockAdoption(
+      mkSnapshot({
+        topSkills: [
+          mkSkill({ skill: 'skill-a' }),
+          mkSkill({ skill: 'skill-b' }),
+          mkSkill({ skill: 'skill-c' }),
+        ],
+      })
+    );
+    render(<Adoption />);
+
+    await waitFor(() => expect(screen.getByText('skill-a')).toBeDefined());
+    expect(screen.getByText('skill-b')).toBeDefined();
+    expect(screen.getByText('skill-c')).toBeDefined();
+  });
+
+  it('formats avg duration across the ms / s / m thresholds', async () => {
+    mockAdoption(
+      mkSnapshot({
+        topSkills: [
+          mkSkill({ skill: 'sub-second', avgDuration: 500 }), // < 1000ms -> "500ms"
+          mkSkill({ skill: 'seconds', avgDuration: 1500 }), // < 60000ms -> "1.5s"
+          mkSkill({ skill: 'minutes', avgDuration: 90_000 }), // >= 60000ms -> "1.5m"
+        ],
+      })
+    );
+    render(<Adoption />);
+
+    await waitFor(() => expect(screen.getByText('500ms')).toBeDefined());
+    expect(screen.getByText('1.5s')).toBeDefined();
+    expect(screen.getByText('1.5m')).toBeDefined();
+  });
+
+  it('formats success rate as a rounded percentage', async () => {
+    mockAdoption(mkSnapshot({ topSkills: [mkSkill({ skill: 'rounder', successRate: 0.876 })] }));
+    render(<Adoption />);
+
+    await waitFor(() => expect(screen.getByText('88%')).toBeDefined());
+  });
+
+  it('applies threshold-based accent classes to the success rate cell', async () => {
+    mockAdoption(
+      mkSnapshot({
+        topSkills: [
+          mkSkill({ skill: 'high', successRate: 0.9 }), // >= 0.8 -> emerald
+          mkSkill({ skill: 'mid', successRate: 0.6 }), // >= 0.5 -> yellow
+          mkSkill({ skill: 'low', successRate: 0.3 }), // < 0.5 -> red
+        ],
+      })
+    );
+    render(<Adoption />);
+
+    await waitFor(() => expect(screen.getByText('90%')).toBeDefined());
+    expect(screen.getByText('90%').className).toContain('text-emerald-400');
+    expect(screen.getByText('60%').className).toContain('text-yellow-400');
+    expect(screen.getByText('30%').className).toContain('text-red-400');
+  });
+
+  it('truncates lastUsed to the ISO date portion', async () => {
+    mockAdoption(
+      mkSnapshot({ topSkills: [mkSkill({ skill: 'dated', lastUsed: '2026-06-15T12:34:56Z' })] })
+    );
+    render(<Adoption />);
+
+    await waitFor(() => expect(screen.getByText('2026-06-15')).toBeDefined());
+  });
+
+  it('renders the empty-state message when there are no top skills', async () => {
+    mockAdoption(mkSnapshot({ topSkills: [] }));
+    render(<Adoption />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No adoption data yet. Skills will appear here after your next session.')
+      ).toBeDefined()
+    );
+  });
+
+  it('renders the HTTP error message when the fetch responds non-ok', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 500 }));
+    render(<Adoption />);
+
+    await waitFor(() => expect(screen.getByText('HTTP 500')).toBeDefined());
+  });
+});

--- a/packages/dashboard/tests/client/pages/DecayTrends.test.tsx
+++ b/packages/dashboard/tests/client/pages/DecayTrends.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within, act } from '@testing-library/react';
+import { DecayTrends } from '../../../src/client/pages/DecayTrends';
+
+const DECAY_TRENDS_URL = '/api/decay-trends';
+const HTTP_ERROR_STATUS = 503;
+
+// Direction arrows the source maps each Direction to (see directionArrow()).
+const ARROW_IMPROVING = '↓'; // down: fewer violations = better
+const ARROW_DECLINING = '↑'; // up: more violations = worse
+const ARROW_STABLE = '→'; // right: no change
+
+type Direction = 'improving' | 'stable' | 'declining';
+interface TrendLine {
+  current: number;
+  previous: number;
+  delta: number;
+  direction: Direction;
+}
+interface TrendResult {
+  stability: TrendLine;
+  categories: Record<string, TrendLine>;
+  snapshotCount: number;
+  from: string;
+  to: string;
+}
+
+// Categories are intentionally NOT in |delta| order so the test proves the page
+// re-sorts them (largest absolute delta first). All three Directions are present
+// so the direction formatting (arrow + label) is exercised in one render.
+const SORTED_TREND: TrendResult = {
+  stability: { current: 82, previous: 75, delta: 7, direction: 'improving' },
+  categories: {
+    'god-object': { current: 3.0, previous: 8.0, delta: -5, direction: 'improving' },
+    'circular-deps': { current: 12.0, previous: 0, delta: 12, direction: 'declining' },
+    layering: { current: 5.0, previous: 5.0, delta: 0, direction: 'stable' },
+  },
+  snapshotCount: 6,
+  from: '2026-01-01T00:00:00Z',
+  to: '2026-07-01T00:00:00Z',
+};
+
+// Expected first-column (Category) text after the descending |delta| sort:
+// circular-deps |12|, god-object |5|, layering |0|. formatCategory() also
+// title-cases the hyphenated ids.
+const EXPECTED_CATEGORY_ORDER = ['Circular Deps', 'God Object', 'Layering'];
+
+const EMPTY_TREND: TrendResult = {
+  stability: { current: 0, previous: 0, delta: 0, direction: 'stable' },
+  categories: {},
+  snapshotCount: 0,
+  from: '',
+  to: '',
+};
+
+type FetchResponse = { ok: boolean; status?: number; json: () => Promise<unknown> };
+type Responder = () => Promise<FetchResponse>;
+
+let responder: Responder;
+let mockFetch: ReturnType<typeof vi.fn>;
+
+function ok(body: unknown): FetchResponse {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+beforeEach(() => {
+  responder = () => Promise.resolve(ok({ data: EMPTY_TREND }));
+  mockFetch = vi.fn((url: string) => {
+    if (url === DECAY_TRENDS_URL) return responder();
+    return Promise.reject(new Error(`unexpected fetch: ${String(url)}`));
+  });
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('DecayTrends page', () => {
+  it('fetches decay trends from the API on mount', async () => {
+    responder = () => Promise.resolve(ok({ data: SORTED_TREND }));
+    render(<DecayTrends />);
+
+    await screen.findByText('Stability Score');
+    expect(mockFetch).toHaveBeenCalledWith(DECAY_TRENDS_URL);
+  });
+
+  it('shows the loading placeholder before the fetch resolves', async () => {
+    let release!: (r: FetchResponse) => void;
+    const pending = new Promise<FetchResponse>((resolve) => {
+      release = resolve;
+    });
+    responder = () => pending;
+
+    render(<DecayTrends />);
+    expect(screen.getByText(/Loading decay trends/i)).toBeDefined();
+
+    // Flush the pending update deterministically (no dangling act warning).
+    await act(async () => {
+      release(ok({ data: EMPTY_TREND }));
+    });
+    expect(await screen.findByText(/No architecture snapshots found/i)).toBeDefined();
+  });
+
+  it('surfaces the HTTP error message when the fetch is not ok', async () => {
+    responder = () =>
+      Promise.resolve({ ok: false, status: HTTP_ERROR_STATUS, json: async () => ({}) });
+    render(<DecayTrends />);
+
+    expect(await screen.findByText(`HTTP ${HTTP_ERROR_STATUS}`)).toBeDefined();
+  });
+
+  it('renders the empty state when no snapshots have been captured', async () => {
+    responder = () => Promise.resolve(ok({ data: EMPTY_TREND }));
+    render(<DecayTrends />);
+
+    expect(await screen.findByText(/No architecture snapshots found/i)).toBeDefined();
+    // The category table must not render in the empty branch.
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('renders KPI cards with direction-based formatting for the stability line', async () => {
+    responder = () => Promise.resolve(ok({ data: SORTED_TREND }));
+    render(<DecayTrends />);
+
+    // Stability Score card shows the raw current score.
+    const scoreLabel = await screen.findByText('Stability Score');
+    expect(scoreLabel.parentElement?.textContent).toContain('82');
+
+    // Trend Direction card maps 'improving' -> 'Improving'.
+    const directionLabel = screen.getByText('Trend Direction');
+    expect(directionLabel.parentElement?.textContent).toContain('Improving');
+
+    // Score Delta card formats a positive delta with a sign and one decimal.
+    const deltaLabel = screen.getByText('Score Delta');
+    expect(deltaLabel.parentElement?.textContent).toContain('+7.0');
+    expect(deltaLabel.parentElement?.textContent).toContain('Previous: 75');
+  });
+
+  it('sorts the category breakdown by absolute delta descending', async () => {
+    responder = () => Promise.resolve(ok({ data: SORTED_TREND }));
+    render(<DecayTrends />);
+
+    const table = await screen.findByRole('table');
+    const bodyRows = within(table.querySelector('tbody') as HTMLElement).getAllByRole('row');
+    const renderedCategories = bodyRows.map(
+      (row) => within(row).getAllByRole('cell')[0].textContent
+    );
+
+    expect(renderedCategories).toEqual(EXPECTED_CATEGORY_ORDER);
+  });
+
+  it('formats each category row with the direction arrow, label and delta', async () => {
+    responder = () => Promise.resolve(ok({ data: SORTED_TREND }));
+    render(<DecayTrends />);
+
+    const table = await screen.findByRole('table');
+    const bodyRows = within(table.querySelector('tbody') as HTMLElement).getAllByRole('row');
+
+    // Row order is circular-deps (declining), god-object (improving), layering (stable).
+    const decliningCells = within(bodyRows[0]).getAllByRole('cell');
+    expect(decliningCells[2].textContent).toContain(ARROW_DECLINING);
+    expect(decliningCells[2].textContent).toContain('Degrading');
+    expect(decliningCells[3].textContent).toBe('+12.0');
+
+    const improvingCells = within(bodyRows[1]).getAllByRole('cell');
+    expect(improvingCells[2].textContent).toContain(ARROW_IMPROVING);
+    expect(improvingCells[2].textContent).toContain('Improving');
+    expect(improvingCells[3].textContent).toBe('-5.0');
+
+    const stableCells = within(bodyRows[2]).getAllByRole('cell');
+    expect(stableCells[2].textContent).toContain(ARROW_STABLE);
+    expect(stableCells[2].textContent).toContain('Stable');
+    expect(stableCells[3].textContent).toBe('0');
+  });
+
+  it('renders the no-category placeholder when snapshots exist but categories are empty', async () => {
+    responder = () => Promise.resolve(ok({ data: { ...SORTED_TREND, categories: {} } }));
+    render(<DecayTrends />);
+
+    expect(await screen.findByText(/No category data yet/i)).toBeDefined();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('renders the header snapshot summary with a pluralized count and date range', async () => {
+    responder = () => Promise.resolve(ok({ data: SORTED_TREND }));
+    render(<DecayTrends />);
+
+    expect(
+      await screen.findByText(/6 snapshots analyzed from 2026-01-01 to 2026-07-01/)
+    ).toBeDefined();
+  });
+
+  it('uses the singular noun when exactly one snapshot was analyzed', async () => {
+    responder = () => Promise.resolve(ok({ data: { ...SORTED_TREND, snapshotCount: 1 } }));
+    render(<DecayTrends />);
+
+    expect(await screen.findByText(/1 snapshot analyzed/)).toBeDefined();
+  });
+});

--- a/packages/dashboard/tests/client/pages/Graph.test.tsx
+++ b/packages/dashboard/tests/client/pages/Graph.test.tsx
@@ -1,0 +1,168 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import type { GraphData, GraphUnavailable, NodeTypeCount } from '../../../src/shared/types';
+
+// Graph reads its state exclusively from useSSE(SSE_ENDPOINT, 'overview').
+// A mutable holder lets each test drive a specific SSE snapshot deterministically,
+// with no real EventSource / network.
+type SSEState = {
+  data: unknown;
+  lastUpdated: string | null;
+  stale: boolean;
+  error: string | null;
+};
+
+const sse = vi.hoisted(() => ({
+  current: { data: null, lastUpdated: null, stale: false, error: null } as SSEState,
+}));
+
+vi.mock('../../../src/client/hooks/useSSE', () => ({
+  useSSE: () => sse.current,
+}));
+
+import { Graph } from '../../../src/client/pages/Graph';
+
+function setSSE(partial: Partial<SSEState>) {
+  sse.current = { data: null, lastUpdated: null, stale: false, error: null, ...partial };
+}
+
+// Node types intentionally out of count order so the table's descending sort is observable.
+const NODES_BY_TYPE: NodeTypeCount[] = [
+  { type: 'directory', count: 30 },
+  { type: 'file', count: 120 },
+  { type: 'symbol', count: 50 },
+];
+const NODE_COUNT = 200;
+const EDGE_COUNT = 640;
+
+const GRAPH_DATA: GraphData = {
+  available: true,
+  nodeCount: NODE_COUNT,
+  edgeCount: EDGE_COUNT,
+  nodesByType: NODES_BY_TYPE,
+};
+
+// Expected row order + percentages derived from the data under test (source of truth),
+// not hardcoded, so they track NODES_BY_TYPE / NODE_COUNT rather than drifting silently.
+const EXPECTED_ROWS = [...NODES_BY_TYPE]
+  .sort((a, b) => b.count - a.count)
+  .map((n) => ({
+    type: n.type,
+    count: String(n.count),
+    pct: `${((n.count / NODE_COUNT) * 100).toFixed(1)}%`,
+  }));
+
+function kpiValueFor(label: string): string {
+  const labelEl = screen.getByText(label);
+  const card = labelEl.parentElement as HTMLElement;
+  // The value <p> is the sibling of the label <p> within the KpiCard container.
+  const value = within(card)
+    .getAllByText((_, el) => el?.tagName === 'P')
+    .map((el) => el.textContent)
+    .filter((t) => t !== label);
+  return value[0] ?? '';
+}
+
+beforeEach(() => {
+  setSSE({});
+});
+
+describe('Graph page', () => {
+  it('always renders the Knowledge Graph header', () => {
+    setSSE({ data: { graph: GRAPH_DATA }, lastUpdated: '2026-07-20T00:00:00Z' });
+    render(<Graph />);
+    expect(screen.getByRole('heading', { level: 1, name: 'Knowledge Graph' })).toBeDefined();
+  });
+
+  it('shows the connecting placeholder when there is no data and no error', () => {
+    setSSE({ data: null, error: null });
+    render(<Graph />);
+    expect(screen.getByText(/Connecting to data stream/i)).toBeDefined();
+    expect(screen.queryByText(/Graph not connected/i)).toBeNull();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('does not show the connecting placeholder once an error is present', () => {
+    setSSE({ data: null, error: 'boom' });
+    render(<Graph />);
+    expect(screen.queryByText(/Connecting to data stream/i)).toBeNull();
+  });
+
+  it('renders the not-connected fallback with the reason when the graph is unavailable', () => {
+    const unavailable: GraphUnavailable = { available: false, reason: 'graph db missing' };
+    setSSE({ data: { graph: unavailable }, lastUpdated: '2026-07-20T00:00:00Z' });
+    render(<Graph />);
+
+    expect(screen.getByText(/Graph not connected/i)).toBeDefined();
+    expect(screen.getByText('graph db missing')).toBeDefined();
+    // Fallback replaces the metrics view entirely.
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.queryByText(/Graph Metrics/i)).toBeNull();
+  });
+
+  it('renders the KPI cards from graph metrics', () => {
+    setSSE({ data: { graph: GRAPH_DATA }, lastUpdated: '2026-07-20T00:00:00Z' });
+    render(<Graph />);
+
+    expect(kpiValueFor('Nodes')).toBe(String(NODE_COUNT));
+    expect(kpiValueFor('Edges')).toBe(String(EDGE_COUNT));
+    expect(kpiValueFor('Node Types')).toBe(String(NODES_BY_TYPE.length));
+  });
+
+  it('renders the node-type breakdown sorted by count desc with computed percentages', () => {
+    setSSE({ data: { graph: GRAPH_DATA }, lastUpdated: '2026-07-20T00:00:00Z' });
+    render(<Graph />);
+
+    const table = screen.getByRole('table');
+    const bodyRows = within(table).getAllByRole('row').slice(1); // drop the header row
+
+    expect(bodyRows).toHaveLength(EXPECTED_ROWS.length);
+    bodyRows.forEach((row, i) => {
+      const cells = within(row)
+        .getAllByRole('cell')
+        .map((c) => c.textContent);
+      expect(cells).toEqual([EXPECTED_ROWS[i].type, EXPECTED_ROWS[i].count, EXPECTED_ROWS[i].pct]);
+    });
+  });
+
+  it('renders 0% percentages when the node count is zero', () => {
+    const zeroCount: GraphData = {
+      available: true,
+      nodeCount: 0,
+      edgeCount: 0,
+      nodesByType: [{ type: 'file', count: 3 }],
+    };
+    setSSE({ data: { graph: zeroCount }, lastUpdated: '2026-07-20T00:00:00Z' });
+    render(<Graph />);
+
+    const row = within(screen.getByRole('table')).getAllByRole('row')[1];
+    const cells = within(row)
+      .getAllByRole('cell')
+      .map((c) => c.textContent);
+    expect(cells).toEqual(['file', '3', '0%']);
+  });
+
+  it('omits the breakdown table when there are no node types', () => {
+    const noTypes: GraphData = {
+      available: true,
+      nodeCount: NODE_COUNT,
+      edgeCount: EDGE_COUNT,
+      nodesByType: [],
+    };
+    setSSE({ data: { graph: noTypes }, lastUpdated: '2026-07-20T00:00:00Z' });
+    render(<Graph />);
+
+    // KPI cards still render, but the breakdown section is suppressed.
+    expect(kpiValueFor('Node Types')).toBe('0');
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.queryByText(/Node Type Breakdown/i)).toBeNull();
+  });
+
+  it('shows neither metrics nor the not-connected fallback while only connecting', () => {
+    setSSE({ data: null, error: null });
+    render(<Graph />);
+    expect(screen.queryByText(/Graph Metrics/i)).toBeNull();
+    expect(screen.queryByText(/Graph not connected/i)).toBeNull();
+  });
+});

--- a/packages/dashboard/tests/client/pages/Health.test.tsx
+++ b/packages/dashboard/tests/client/pages/Health.test.tsx
@@ -1,0 +1,202 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import type {
+  HealthData,
+  OverviewData,
+  ChecksData,
+  CIData,
+  SecurityData,
+  PerfData,
+  ArchData,
+} from '../../../src/shared/types';
+
+// --- useSSE mock -----------------------------------------------------------
+// Health calls useSSE(SSE_ENDPOINT, 'overview') and useSSE(SSE_ENDPOINT, 'checks').
+// A hoisted holder lets each test drive both streams independently.
+const sse = vi.hoisted(() => ({
+  overview: {
+    data: null as unknown,
+    lastUpdated: null,
+    stale: false,
+    error: null as string | null,
+  },
+  checks: { data: null as unknown, lastUpdated: null, stale: false, error: null as string | null },
+}));
+
+vi.mock('../../../src/client/hooks/useSSE', () => ({
+  useSSE: (_url: string, eventType: string) =>
+    eventType === 'overview' ? sse.overview : sse.checks,
+}));
+
+const { Health } = await import('../../../src/client/pages/Health');
+
+// --- fixtures --------------------------------------------------------------
+const EXPECTED_CHECK_NAMES = [
+  'validate',
+  'check-deps',
+  'check-arch',
+  'check-perf',
+  'check-security',
+  'check-docs',
+  'phase-gate',
+] as const;
+
+function healthData(over: Partial<HealthData> = {}): HealthData {
+  return {
+    totalIssues: 0,
+    errors: 0,
+    warnings: 0,
+    fixableCount: 0,
+    suggestionCount: 0,
+    durationMs: 0,
+    analysisErrors: [],
+    ...over,
+  };
+}
+
+const securityData: SecurityData = {
+  valid: false,
+  findings: [],
+  stats: { filesScanned: 42, errorCount: 1, warningCount: 2, infoCount: 3 },
+};
+
+const perfData: PerfData = {
+  valid: true,
+  violations: [],
+  stats: { filesAnalyzed: 10, violationCount: 0 },
+};
+
+const archData: ArchData = {
+  passed: true,
+  totalViolations: 0,
+  regressions: [],
+  newViolations: [],
+};
+
+function setOverview(data: unknown, error: string | null = null): void {
+  sse.overview.data = data;
+  sse.overview.error = error;
+}
+
+function setChecks(data: ChecksData | null): void {
+  sse.checks.data = data;
+}
+
+function makeChecks(over: Partial<ChecksData>): ChecksData {
+  return {
+    security: securityData,
+    perf: perfData,
+    arch: archData,
+    anomalies: { outliers: [], articulationPoints: [], overlapCount: 0 },
+    lastRun: '2026-07-20T12:00:00.000Z',
+    ...over,
+  };
+}
+
+// Only /api/ci is fetched (on CISection mount). Everything else is via useSSE.
+function stubCI(ci: CIData): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    if (String(input).includes('/api/ci')) {
+      return Promise.resolve(new Response(JSON.stringify({ data: ci }), { status: 200 }));
+    }
+    return Promise.resolve(new Response('{}', { status: 404 }));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function renderHealth() {
+  return render(
+    <MemoryRouter>
+      <Health />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  setOverview(null, null);
+  setChecks(null);
+  stubCI({ checks: [], lastRun: null });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('Health page', () => {
+  it('always renders one CI badge per known check name', async () => {
+    renderHealth();
+
+    await waitFor(() => {
+      for (const name of EXPECTED_CHECK_NAMES) {
+        expect(screen.getByText(name)).toBeDefined();
+      }
+    });
+  });
+
+  it('shows the connecting placeholder when overview has no data and no error', async () => {
+    setOverview(null, null);
+    renderHealth();
+
+    await waitFor(() => expect(screen.getByText('Connecting to data stream...')).toBeDefined());
+  });
+
+  it('renders the health error message (not entropy) when health is an error result', async () => {
+    setOverview({ health: { error: 'gather failed' } } as unknown as OverviewData);
+    renderHealth();
+
+    await waitFor(() => expect(screen.getByText('gather failed')).toBeDefined());
+    // Entropy section is HealthData-only; an error result must not surface it.
+    expect(screen.queryByText('Total Issues')).toBeNull();
+  });
+
+  it('renders the entropy section with a Fix It action when health has open issues', async () => {
+    setOverview({ health: healthData({ totalIssues: 3, errors: 1, warnings: 2 }) } as OverviewData);
+    renderHealth();
+
+    await waitFor(() => expect(screen.getByText('Total Issues')).toBeDefined());
+    expect(screen.getByText('Scan Details')).toBeDefined();
+    // totalIssues > 0 gates the Fix It button (which needs a router via useNavigate).
+    expect(screen.getByRole('button', { name: /fix it/i })).toBeDefined();
+  });
+
+  it('type-guards each check section: valid renders, error shows message, missing awaits scan', async () => {
+    setOverview({ health: healthData() } as OverviewData);
+    // security = valid data, perf = error result, arch = not yet scanned (null)
+    setChecks(
+      makeChecks({
+        security: securityData,
+        perf: { error: 'perf boom' } as unknown as PerfData,
+        arch: null as unknown as ArchData,
+      })
+    );
+    renderHealth();
+
+    await waitFor(() => {
+      // Valid SecurityData -> SecuritySection KPI (label unique to security)
+      expect(screen.getByText('Files Scanned')).toBeDefined();
+      // Error result -> its message is surfaced
+      expect(screen.getByText('perf boom')).toBeDefined();
+      // Null result -> awaiting-scan placeholder
+      expect(screen.getByText('Awaiting first scan...')).toBeDefined();
+    });
+  });
+
+  it('renders CI pass/fail state and a relative last-checked time from /api/ci', async () => {
+    const now = new Date('2026-07-20T12:00:00.000Z').getTime();
+    const lastRunIso = new Date(now - 90_000).toISOString(); // 90s ago -> "1m ago"
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    stubCI({
+      checks: [{ name: 'validate', passed: true, errorCount: 0, warningCount: 0 }],
+      lastRun: lastRunIso,
+    });
+    renderHealth();
+
+    await waitFor(() => expect(screen.getByText('PASS')).toBeDefined());
+    expect(screen.getByText('Last checked 1m ago')).toBeDefined();
+  });
+});

--- a/packages/dashboard/tests/client/pages/Impact.test.tsx
+++ b/packages/dashboard/tests/client/pages/Impact.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { Impact } from '../../../src/client/pages/Impact';
+import type { AnomalyData, BlastRadiusData } from '@shared/types';
+
+// The blast-radius graph is a framer-motion SVG component with its own tests.
+// Stub it so the Impact page's own responsibilities (wiring + header) are what we
+// assert, and so rendering stays deterministic in jsdom (no animation frames).
+vi.mock('../../../src/client/components/BlastRadiusGraph', () => ({
+  BlastRadiusGraph: ({ data }: { data: { sourceName: string } }) => (
+    <div data-testid="blast-graph">{data.sourceName}</div>
+  ),
+}));
+
+// Depths mirror the source's DEFAULT_DEPTH and one of its DEPTH_OPTIONS.
+const DEFAULT_DEPTH = 3;
+const CHANGED_DEPTH = 5;
+const ANOMALIES_HTTP_ERROR_STATUS = 503;
+
+const ANOMALIES_URL = '/api/impact/anomalies';
+const BLAST_RADIUS_URL = '/api/impact/blast-radius';
+
+const EMPTY_ANOMALIES: AnomalyData = {
+  outliers: [],
+  articulationPoints: [],
+  overlapCount: 0,
+};
+
+// Articulation points are intentionally NOT in dependentCount order so the test
+// can prove the page re-sorts them (highest dependentCount first).
+const SAMPLE_ANOMALIES: AnomalyData = {
+  overlapCount: 0,
+  articulationPoints: [
+    { nodeId: 'a', name: 'Alpha', componentsIfRemoved: 2, dependentCount: 5 },
+    { nodeId: 'b', name: 'Bravo', componentsIfRemoved: 3, dependentCount: 12 },
+    { nodeId: 'c', name: 'Charlie', componentsIfRemoved: 1, dependentCount: 8 },
+  ],
+  outliers: [
+    { nodeId: 'x', name: 'Xray', type: 'file', metric: 'loc', value: 100, zScore: 2.1 },
+    { nodeId: 'y', name: 'Yankee', type: 'file', metric: 'loc', value: 200, zScore: 4.5 },
+  ],
+};
+
+// Expected DOM order after the page's descending sorts.
+const EXPECTED_AP_ORDER = ['Bravo', 'Charlie', 'Alpha']; // by dependentCount: 12, 8, 5
+const EXPECTED_OUTLIER_ORDER = ['Yankee', 'Xray']; // by zScore: 4.5, 2.1
+
+const SAMPLE_BLAST: BlastRadiusData = {
+  sourceNodeId: 'b',
+  sourceName: 'Bravo Service',
+  layers: [
+    {
+      depth: 1,
+      nodes: [{ nodeId: 'n1', name: 'Node1', type: 'file', probability: 0.9, parentId: 'b' }],
+    },
+  ],
+  summary: { totalAffected: 1, maxDepth: 1, highRisk: 1, mediumRisk: 0, lowRisk: 0 },
+};
+
+type FetchResponse = { ok: boolean; status?: number; json: () => Promise<unknown> };
+type Responder = () => Promise<FetchResponse>;
+
+let anomaliesResponder: Responder;
+let blastResponder: Responder;
+let mockFetch: ReturnType<typeof vi.fn>;
+
+function ok(body: unknown): FetchResponse {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+beforeEach(() => {
+  anomaliesResponder = () => Promise.resolve(ok({ data: EMPTY_ANOMALIES }));
+  blastResponder = () => Promise.resolve(ok({ data: SAMPLE_BLAST }));
+
+  mockFetch = vi.fn((url: string) => {
+    if (url === ANOMALIES_URL) return anomaliesResponder();
+    if (url === BLAST_RADIUS_URL) return blastResponder();
+    return Promise.reject(new Error(`unexpected fetch: ${String(url)}`));
+  });
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function blastCalls() {
+  return mockFetch.mock.calls.filter(([url]) => url === BLAST_RADIUS_URL);
+}
+
+describe('Impact Explorer page', () => {
+  it('fetches anomalies on mount and renders articulation points sorted by dependentCount desc', async () => {
+    anomaliesResponder = () => Promise.resolve(ok({ data: SAMPLE_ANOMALIES }));
+    render(<Impact />);
+
+    const heading = await screen.findByRole('heading', { name: /Articulation Points/i });
+    const section = heading.closest('section') as HTMLElement;
+    const rendered = within(section)
+      .getAllByRole('button')
+      .map((btn) => btn.textContent ?? '');
+
+    EXPECTED_AP_ORDER.forEach((name, i) => {
+      expect(rendered[i]).toContain(name);
+    });
+    expect(mockFetch).toHaveBeenCalledWith(ANOMALIES_URL);
+  });
+
+  it('renders statistical outliers sorted by zScore desc', async () => {
+    anomaliesResponder = () => Promise.resolve(ok({ data: SAMPLE_ANOMALIES }));
+    render(<Impact />);
+
+    const heading = await screen.findByRole('heading', { name: /Statistical Outliers/i });
+    const section = heading.closest('section') as HTMLElement;
+    const rendered = within(section)
+      .getAllByRole('button')
+      .map((btn) => btn.textContent ?? '');
+
+    EXPECTED_OUTLIER_ORDER.forEach((name, i) => {
+      expect(rendered[i]).toContain(name);
+    });
+  });
+
+  it('shows the empty state when anomalies come back with no APs and no outliers', async () => {
+    anomaliesResponder = () => Promise.resolve(ok({ data: EMPTY_ANOMALIES }));
+    render(<Impact />);
+
+    expect(await screen.findByText(/No anomalies detected/i)).toBeDefined();
+  });
+
+  it('surfaces an HTTP error message when the anomalies fetch is not ok', async () => {
+    anomaliesResponder = () =>
+      Promise.resolve({ ok: false, status: ANOMALIES_HTTP_ERROR_STATUS, json: async () => ({}) });
+    render(<Impact />);
+
+    expect(await screen.findByText(`HTTP ${ANOMALIES_HTTP_ERROR_STATUS}`)).toBeDefined();
+  });
+
+  it('shows the loading placeholder before anomalies resolve', async () => {
+    let release!: (r: FetchResponse) => void;
+    const pending = new Promise<FetchResponse>((resolve) => {
+      release = resolve;
+    });
+    anomaliesResponder = () => pending;
+
+    render(<Impact />);
+    expect(screen.getByText(/Loading anomalies/i)).toBeDefined();
+
+    // Resolve to flush the pending update deterministically (no dangling act warning).
+    await act(async () => {
+      release(ok({ data: EMPTY_ANOMALIES }));
+    });
+    expect(await screen.findByText(/No anomalies detected/i)).toBeDefined();
+  });
+
+  it('shows the idle blast-radius prompt when nothing is selected', async () => {
+    render(<Impact />);
+    expect(await screen.findByText(/Select a node or search to view blast radius/i)).toBeDefined();
+  });
+
+  it('clicking an anomaly POSTs a blast-radius query with the node id and default depth', async () => {
+    anomaliesResponder = () => Promise.resolve(ok({ data: SAMPLE_ANOMALIES }));
+    render(<Impact />);
+
+    const bravo = await screen.findByRole('button', { name: /Bravo/ });
+    fireEvent.click(bravo);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        BLAST_RADIUS_URL,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ nodeId: 'b', maxDepth: DEFAULT_DEPTH }),
+        })
+      );
+    });
+
+    // Success branch renders the source name header + passes data to the graph.
+    expect(await screen.findByText(/Blast Radius: Bravo Service/)).toBeDefined();
+    expect(screen.getByTestId('blast-graph').textContent).toBe('Bravo Service');
+  });
+
+  it('search submit queries blast-radius using the trimmed text and selected depth', async () => {
+    render(<Impact />);
+    // Wait for the initial anomalies load to settle before interacting.
+    await screen.findByText(/Select a node or search to view blast radius/i);
+
+    const input = screen.getByPlaceholderText(/Search node by name/i);
+    fireEvent.change(input, { target: { value: '  src/core/engine.ts  ' } });
+
+    const depthSelect = screen.getByRole('combobox');
+    fireEvent.change(depthSelect, { target: { value: String(CHANGED_DEPTH) } });
+
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        BLAST_RADIUS_URL,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ nodeId: 'src/core/engine.ts', maxDepth: CHANGED_DEPTH }),
+        })
+      );
+    });
+  });
+
+  it('does not query blast-radius when the search text is only whitespace', async () => {
+    render(<Impact />);
+    await screen.findByText(/Select a node or search to view blast radius/i);
+
+    const input = screen.getByPlaceholderText(/Search node by name/i);
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+
+    await Promise.resolve();
+    expect(blastCalls()).toHaveLength(0);
+  });
+
+  it('renders the blast-radius error branch when the query returns not ok', async () => {
+    anomaliesResponder = () => Promise.resolve(ok({ data: SAMPLE_ANOMALIES }));
+    blastResponder = () =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'graph unavailable' }),
+      });
+    render(<Impact />);
+
+    const bravo = await screen.findByRole('button', { name: /Bravo/ });
+    fireEvent.click(bravo);
+
+    expect(await screen.findByText('graph unavailable')).toBeDefined();
+  });
+
+  it('renders the no-data branch when a successful query returns an inner error payload', async () => {
+    anomaliesResponder = () => Promise.resolve(ok({ data: SAMPLE_ANOMALIES }));
+    blastResponder = () => Promise.resolve(ok({ data: { error: 'Node not found' } }));
+    render(<Impact />);
+
+    const bravo = await screen.findByRole('button', { name: /Bravo/ });
+    fireEvent.click(bravo);
+
+    expect(await screen.findByText('Node not found')).toBeDefined();
+    expect(screen.queryByTestId('blast-graph')).toBeNull();
+  });
+});

--- a/packages/dashboard/tests/client/pages/Proposals.card.test.tsx
+++ b/packages/dashboard/tests/client/pages/Proposals.card.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Proposals } from '../../../src/client/pages/Proposals';
+import type { SkillProposal, Proposal } from '@harness-engineering/types';
+
+/**
+ * Complementary card-level coverage for the `/s/proposals` review queue.
+ *
+ * The sibling `Proposals.test.tsx` exercises the list fetch, status filter, and
+ * the approve/reject/run-gate actions. This file protects the remaining
+ * card behaviors that merged PRs left untested:
+ *   - refinement proposals render the diff view (not the SKILL.md view),
+ *   - the inline editor toggles and PATCHes content keyed on `skillKind`,
+ *   - a decided proposal hides the action controls and shows the decision panel,
+ *   - a failed action POST surfaces the HTTP error text on the card.
+ *
+ * All network IO is routed through a mocked global `fetch`; the component has no
+ * timers, randomness, or real IO, so nothing here is order- or clock-dependent.
+ */
+
+const mockFetch = vi.fn();
+
+/** GET -> the proposal list; every other method -> a generic ok response. */
+function installFetch(proposals: Proposal[]): void {
+  mockFetch.mockImplementation((_input: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    if (method === 'GET') {
+      return Promise.resolve({ ok: true, status: 200, json: async () => proposals });
+    }
+    return Promise.resolve({ ok: true, status: 200, text: async () => '' });
+  });
+}
+
+function makeNewSkill(overrides: Partial<SkillProposal> = {}): SkillProposal {
+  return {
+    kind: 'skill',
+    skillKind: 'new-skill',
+    id: 'prop-new',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    proposedBy: 'agent-scout',
+    source: { justification: 'This skill improves the reviewer workflow substantially.' },
+    content: {
+      name: 'helper-skill',
+      description: 'A skill that does genuinely helpful things for reviewers.',
+      skillYaml: 'name: helper-skill',
+      skillMd: '# Helper Skill\nOriginal markdown body.',
+    },
+    status: 'open',
+    ...overrides,
+  } as SkillProposal;
+}
+
+function makeRefinement(overrides: Partial<SkillProposal> = {}): SkillProposal {
+  return {
+    kind: 'skill',
+    skillKind: 'refinement',
+    id: 'prop-refine',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    targetSkill: 'target-skill',
+    proposedBy: 'agent-scout',
+    source: { justification: 'This refinement tightens the target skill considerably.' },
+    content: {
+      name: 'refine-target',
+      description: 'A refinement that improves the target skill in measurable ways.',
+      diff: '--- a/SKILL.md\n+++ b/SKILL.md\n@@\n-old line\n+new line',
+    },
+    status: 'open',
+    ...overrides,
+  } as SkillProposal;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('Proposals card — refinement rendering', () => {
+  it('renders the unified-diff view with the refines-target subheading', async () => {
+    installFetch([makeRefinement()]);
+    render(<Proposals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unified diff')).toBeDefined();
+    });
+    // Refinement uses the ↻ prefix + name in the heading.
+    expect(screen.getByText(/↻/)).toBeDefined();
+    expect(screen.getByText(/Refines target-skill/)).toBeDefined();
+    // The raw diff body is shown, not the new-skill SKILL.md header.
+    expect(screen.getByText(/\+new line/)).toBeDefined();
+    expect(screen.queryByText('SKILL.md')).toBeNull();
+    expect(screen.queryByText('skill.yaml')).toBeNull();
+  });
+});
+
+describe('Proposals card — inline editor', () => {
+  it('toggles the editor and PATCHes new-skill content as skillMd', async () => {
+    installFetch([makeNewSkill()]);
+    render(<Proposals />);
+
+    const editButton = await waitFor(() => screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(editButton);
+
+    const textarea = screen.getByDisplayValue(/Original markdown body\./);
+    fireEvent.change(textarea, { target: { value: 'edited skill markdown' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save \(resets gate\)/ }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/proposals/prop-new',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ content: { skillMd: 'edited skill markdown' } }),
+        })
+      );
+    });
+  });
+
+  it('PATCHes refinement content as diff (keyed on skillKind)', async () => {
+    installFetch([makeRefinement()]);
+    render(<Proposals />);
+
+    const editButton = await waitFor(() => screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(editButton);
+
+    const textarea = screen.getByDisplayValue(/\+new line/);
+    fireEvent.change(textarea, { target: { value: 'edited diff body' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save \(resets gate\)/ }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/proposals/prop-refine',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ content: { diff: 'edited diff body' } }),
+        })
+      );
+    });
+  });
+});
+
+describe('Proposals card — decided proposals', () => {
+  it('hides the action controls and shows the decision panel once resolved', async () => {
+    installFetch([
+      makeNewSkill({
+        status: 'rejected',
+        decision: {
+          action: 'rejected',
+          decidedBy: 'dashboard-reviewer',
+          decidedAt: '2026-07-03T00:00:00.000Z',
+          reason: 'Overlaps an existing skill.',
+        },
+      }),
+    ]);
+    render(<Proposals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('rejected')).toBeDefined();
+    });
+    // Action controls are gated behind `!decided`.
+    expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Reject' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Run gate' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    // The decision panel shows who decided and why. The trailing localized
+    // timestamp is timezone-dependent, so match only the stable prefix.
+    expect(screen.getByText(/by dashboard-reviewer at/)).toBeDefined();
+    expect(screen.getByText('Reason: Overlaps an existing skill.')).toBeDefined();
+  });
+});
+
+describe('Proposals card — action error surfacing', () => {
+  it('shows the HTTP error text when an action POST fails', async () => {
+    mockFetch.mockImplementation((_input: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'GET') {
+        return Promise.resolve({ ok: true, status: 200, json: async () => [makeNewSkill()] });
+      }
+      return Promise.resolve({ ok: false, status: 500, text: async () => 'gate crashed' });
+    });
+    render(<Proposals />);
+
+    const runGate = await waitFor(() => screen.getByRole('button', { name: 'Run gate' }));
+    fireEvent.click(runGate);
+
+    await waitFor(() => {
+      expect(screen.getByText('HTTP 500: gate crashed')).toBeDefined();
+    });
+  });
+});

--- a/packages/dashboard/tests/client/pages/Streams.test.tsx
+++ b/packages/dashboard/tests/client/pages/Streams.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Streams } from '../../../src/client/pages/Streams';
+import { useThreadStore } from '../../../src/client/stores/threadStore';
+import type { AgentMeta } from '../../../src/client/types/thread';
+
+// --- react-router: fully mock useNavigate (the only router API Streams uses) --
+const mockNavigate = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// --- fixtures ---------------------------------------------------------------
+const TURN_COUNT = 7;
+const INPUT_TOKENS = 1200;
+const OUTPUT_TOKENS = 3400;
+// 1200 + 3400 = 4600 → formatTokens → "4.6k"
+const EXPECTED_TOKENS_LABEL = '4.6k';
+const DURATION_MS = 125_000; // 125s → 2m 5s
+const EXPECTED_DURATION_LABEL = '2m 5s';
+const HOURS_AGO = 3; // → formatTimeAgo → "3h ago"
+
+type Attempt = {
+  attempt: number;
+  startedAt: string;
+  endedAt: string | null;
+  outcome: string | null;
+  stats: {
+    durationMs: number;
+    inputTokens: number;
+    outputTokens: number;
+    turnCount: number;
+    toolsCalled: string[];
+    filesTouched: string[];
+  };
+};
+
+function makeAttempt(overrides: Partial<Attempt> = {}): Attempt {
+  const startedAt = new Date(Date.now() - HOURS_AGO * 60 * 60 * 1000).toISOString();
+  return {
+    attempt: 1,
+    startedAt,
+    endedAt: '2026-07-20T00:00:00.000Z',
+    outcome: 'normal',
+    stats: {
+      durationMs: DURATION_MS,
+      inputTokens: INPUT_TOKENS,
+      outputTokens: OUTPUT_TOKENS,
+      turnCount: TURN_COUNT,
+      toolsCalled: [],
+      filesTouched: [],
+    },
+    ...overrides,
+  };
+}
+
+interface StreamSessionFixture {
+  issueId: string;
+  externalId: number | string | null;
+  identifier: string;
+  title?: string;
+  attempts: Attempt[];
+  pr: { number: number; linkedAt: string; status: string } | null;
+  highlights: null;
+}
+
+function makeSession(overrides: Partial<StreamSessionFixture> = {}): StreamSessionFixture {
+  return {
+    issueId: 'issue-1',
+    externalId: 101,
+    identifier: 'ORG-101',
+    title: 'Recorded agent run',
+    attempts: [makeAttempt()],
+    pr: null,
+    highlights: null,
+    ...overrides,
+  };
+}
+
+function res(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function installFetch(impl: () => Response): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(() => Promise.resolve(impl()));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  // Reset the singleton zustand store to a clean slate between tests.
+  useThreadStore.setState({ threads: new Map(), activeThreadId: null, lastThreadId: null });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('Streams page', () => {
+  it('shows the loading state before the first fetch resolves', async () => {
+    installFetch(() => res([]));
+    render(<Streams />);
+
+    // Synchronous first render: loading=true, no sessions yet.
+    expect(screen.getByText(/Loading streams/i)).toBeDefined();
+
+    // Flush the pending fetch so React state settles (avoids act warnings).
+    await waitFor(() => expect(screen.queryByText(/Loading streams/i)).toBeNull());
+  });
+
+  it('shows the empty state when the API returns no sessions', async () => {
+    installFetch(() => res([]));
+    render(<Streams />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No recorded streams yet/i)).toBeDefined();
+    });
+  });
+
+  it('renders a 404 as the "orchestrator not running" hint', async () => {
+    installFetch(() => res({ error: 'nope' }, 404));
+    render(<Streams />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Orchestrator not running/i)).toBeDefined();
+    });
+  });
+
+  it('renders a non-connectivity HTTP error verbatim', async () => {
+    installFetch(() => res({ error: 'boom' }, 500));
+    render(<Streams />);
+
+    await waitFor(() => {
+      expect(screen.getByText('HTTP 500')).toBeDefined();
+    });
+    // The connectivity-specific hint must NOT appear for a generic 500.
+    expect(screen.queryByText(/Orchestrator not running/i)).toBeNull();
+  });
+
+  it('renders a session row with formatted tokens, turns, duration, and age', async () => {
+    installFetch(() => res([makeSession()]));
+    render(<Streams />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Recorded agent run')).toBeDefined();
+    });
+    // Identifier column.
+    expect(screen.getByText('ORG-101')).toBeDefined();
+    // Outcome badge.
+    expect(screen.getByText('normal')).toBeDefined();
+    // Pure formatting helpers — deterministic from the fixture stats.
+    expect(screen.getByText(`${TURN_COUNT} turns`)).toBeDefined();
+    expect(screen.getByText(EXPECTED_TOKENS_LABEL)).toBeDefined();
+    expect(screen.getByText(EXPECTED_DURATION_LABEL)).toBeDefined();
+    expect(screen.getByText(`${HOURS_AGO}h ago`)).toBeDefined();
+    // Recorded-session count (single node holds the composed label).
+    expect(
+      screen.getByText(
+        (_content, el) => el?.tagName === 'SPAN' && el.textContent === '1 recorded session'
+      )
+    ).toBeDefined();
+  });
+
+  it('falls back to the identifier when a session has no title', async () => {
+    installFetch(() => res([makeSession({ title: undefined, identifier: 'ORG-777' })]));
+    render(<Streams />);
+
+    await waitFor(() => {
+      // Both the title cell and the identifier cell render "ORG-777".
+      expect(screen.getAllByText('ORG-777').length).toBe(2);
+    });
+  });
+
+  it('shows a "running" badge for a session whose last attempt has not ended', async () => {
+    installFetch(() =>
+      res([makeSession({ attempts: [makeAttempt({ endedAt: null, outcome: null })] })])
+    );
+    render(<Streams />);
+
+    await waitFor(() => {
+      expect(screen.getByText('running')).toBeDefined();
+    });
+  });
+
+  it('creates an agent thread and navigates when a row is clicked', async () => {
+    installFetch(() => res([makeSession()]));
+    render(<Streams />);
+
+    await waitFor(() => expect(screen.getByText('Recorded agent run')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Recorded agent run'));
+
+    // deriveThreadId('agent', {issueId:'issue-1'}) === 'agent:issue-1'.
+    const expectedThreadId = 'agent:issue-1';
+    expect(mockNavigate).toHaveBeenCalledWith(`/t/${expectedThreadId}`);
+
+    const state = useThreadStore.getState();
+    expect(state.activeThreadId).toBe(expectedThreadId);
+
+    const thread = state.threads.get(expectedThreadId);
+    expect(thread).toBeDefined();
+    expect(thread!.type).toBe('agent');
+    expect((thread!.meta as AgentMeta).issueId).toBe('issue-1');
+    // Last attempt ended → thread is marked completed by findOrCreateAgentThread.
+    expect(thread!.status).toBe('completed');
+  });
+
+  it('marks a still-running session thread as active (not completed)', async () => {
+    installFetch(() =>
+      res([makeSession({ attempts: [makeAttempt({ endedAt: null, outcome: null })] })])
+    );
+    render(<Streams />);
+
+    await waitFor(() => expect(screen.getByText('Recorded agent run')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Recorded agent run'));
+
+    const thread = useThreadStore.getState().threads.get('agent:issue-1');
+    expect(thread).toBeDefined();
+    // isRunning branch skips the updateThread(completed) call → default 'active'.
+    expect(thread!.status).toBe('active');
+    expect((thread!.meta as AgentMeta).phase).toBe('running');
+  });
+
+  it('reuses an existing agent thread for the same issue instead of creating a new one', async () => {
+    // Pre-seed a thread for the same issueId.
+    const existing = useThreadStore.getState().createThread('agent', {
+      issueId: 'issue-1',
+      identifier: 'ORG-101',
+      phase: 'completed',
+      issueTitle: 'Pre-existing thread',
+      issueDescription: null,
+      startedAt: '2026-07-19T00:00:00.000Z',
+      backendName: null,
+    } satisfies AgentMeta);
+    const countBefore = useThreadStore.getState().threads.size;
+
+    installFetch(() => res([makeSession()]));
+    render(<Streams />);
+
+    await waitFor(() => expect(screen.getByText('Recorded agent run')).toBeDefined());
+
+    fireEvent.click(screen.getByText('Recorded agent run'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/t/${existing.id}`);
+    // No additional thread was created.
+    expect(useThreadStore.getState().threads.size).toBe(countBefore);
+  });
+});

--- a/packages/dashboard/tests/client/pages/Tokens.test.tsx
+++ b/packages/dashboard/tests/client/pages/Tokens.test.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { AuthTokenPublic } from '@harness-engineering/types';
+import { Tokens } from '../../../src/client/pages/Tokens';
+
+// Wire-shape fixtures matching the public (secret-redacted) list response the
+// page consumes from GET /api/v1/auth/tokens.
+const TOKEN_A: AuthTokenPublic = {
+  id: 'tok_00000000000000aa',
+  name: 'slack-bot',
+  scopes: ['read-status', 'trigger-job'],
+  createdAt: '2026-05-05T09:00:00.000Z',
+  lastUsedAt: '2026-05-06T10:00:00.000Z',
+};
+// TOKEN_B intentionally omits lastUsedAt so we can assert the em-dash fallback.
+const TOKEN_B: AuthTokenPublic = {
+  id: 'tok_00000000000000bb',
+  name: 'ci-runner',
+  scopes: ['admin'],
+  createdAt: '2026-05-06T09:00:00.000Z',
+};
+
+const LIST_URL = '/api/v1/auth/tokens';
+const CREATE_URL = '/api/v1/auth/token';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const mockConfirm = vi.fn();
+vi.stubGlobal('confirm', mockConfirm);
+
+/**
+ * Route fetch by (url, method). The list endpoint reads from a mutable
+ * `tokensRef` so a refresh after create/revoke observes updated state — which
+ * is what the component actually does (it re-GETs after every mutation).
+ */
+function installFetchRouter(opts: {
+  tokensRef: { current: AuthTokenPublic[] };
+  createResult?: { ok: boolean; body: unknown };
+}) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+
+    if (url === LIST_URL && method === 'GET') {
+      return Promise.resolve({ ok: true, json: async () => opts.tokensRef.current });
+    }
+    if (url === CREATE_URL && method === 'POST') {
+      const r = opts.createResult ?? {
+        ok: true,
+        body: { id: TOKEN_A.id, token: 'sk_live_secret' },
+      };
+      return Promise.resolve({ ok: r.ok, json: async () => r.body });
+    }
+    if (method === 'DELETE') {
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }
+    return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockConfirm.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Tokens page — token list', () => {
+  it('renders one row per token returned by GET /api/v1/auth/tokens', async () => {
+    installFetchRouter({ tokensRef: { current: [TOKEN_A, TOKEN_B] } });
+
+    render(<Tokens />);
+
+    await waitFor(() => {
+      expect(screen.getByText(TOKEN_A.name)).toBeDefined();
+    });
+    expect(screen.getByText(TOKEN_B.name)).toBeDefined();
+    // Scopes are joined with ', ' for display.
+    expect(screen.getByText(TOKEN_A.scopes.join(', '))).toBeDefined();
+    expect(screen.getByText(TOKEN_B.scopes.join(', '))).toBeDefined();
+    expect(mockFetch).toHaveBeenCalledWith(LIST_URL);
+  });
+
+  it('renders an em-dash for a token that has never been used', async () => {
+    // Only TOKEN_B lacks lastUsedAt, so exactly one em-dash should appear.
+    installFetchRouter({ tokensRef: { current: [TOKEN_A, TOKEN_B] } });
+
+    render(<Tokens />);
+
+    await waitFor(() => expect(screen.getByText(TOKEN_B.name)).toBeDefined());
+    expect(screen.getAllByText('—')).toHaveLength(1);
+  });
+});
+
+describe('Tokens page — create token', () => {
+  it('POSTs the name and comma-split, trimmed scopes and reveals the one-time token', async () => {
+    const tokensRef = { current: [] as AuthTokenPublic[] };
+    const oneTimeToken = 'sk_live_shown_once';
+    installFetchRouter({
+      tokensRef,
+      createResult: { ok: true, body: { id: TOKEN_A.id, token: oneTimeToken } },
+    });
+
+    render(<Tokens />);
+
+    const nameInput = await screen.findByPlaceholderText(/name/i);
+    fireEvent.change(nameInput, { target: { value: 'slack-bot' } });
+
+    const scopesInput = screen.getByPlaceholderText(/scopes/i);
+    // Whitespace around commas exercises the .split(',').map(trim) parsing.
+    fireEvent.change(scopesInput, { target: { value: 'read-status, trigger-job , admin' } });
+
+    // After creation the list refresh should surface the new token.
+    tokensRef.current = [TOKEN_A];
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    // One-time token banner appears with the raw secret.
+    await waitFor(() => {
+      expect(screen.getByText(oneTimeToken)).toBeDefined();
+    });
+    expect(screen.getByText(/shown once/i)).toBeDefined();
+
+    // Verify the POST payload: name + parsed scope array.
+    const postCall = mockFetch.mock.calls.find(
+      ([u, init]) => u === CREATE_URL && (init as RequestInit | undefined)?.method === 'POST'
+    );
+    expect(postCall).toBeDefined();
+    const sentBody = JSON.parse((postCall![1] as RequestInit).body as string);
+    expect(sentBody).toEqual({
+      name: 'slack-bot',
+      scopes: ['read-status', 'trigger-job', 'admin'],
+    });
+
+    // Name input is cleared after a successful create.
+    expect((nameInput as HTMLInputElement).value).toBe('');
+  });
+
+  it('surfaces the server error message and does not reveal a token on a failed create', async () => {
+    installFetchRouter({
+      tokensRef: { current: [] },
+      createResult: { ok: false, body: { error: 'name already exists' } },
+    });
+
+    render(<Tokens />);
+
+    const nameInput = await screen.findByPlaceholderText(/name/i);
+    fireEvent.change(nameInput, { target: { value: 'dup' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('name already exists')).toBeDefined();
+    });
+    expect(screen.queryByText(/shown once/i)).toBeNull();
+  });
+
+  it('falls back to a generic error when the server omits an error message', async () => {
+    installFetchRouter({
+      tokensRef: { current: [] },
+      createResult: { ok: false, body: {} },
+    });
+
+    render(<Tokens />);
+
+    const nameInput = await screen.findByPlaceholderText(/name/i);
+    fireEvent.change(nameInput, { target: { value: 'oops' } });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed')).toBeDefined();
+    });
+  });
+});
+
+describe('Tokens page — revoke token', () => {
+  it('DELETEs the encoded id after the user confirms', async () => {
+    const tokensRef = { current: [TOKEN_A] as AuthTokenPublic[] };
+    installFetchRouter({ tokensRef });
+    mockConfirm.mockReturnValue(true);
+
+    render(<Tokens />);
+
+    await waitFor(() => expect(screen.getByText(TOKEN_A.name)).toBeDefined());
+
+    // On confirm, the list refresh returns an empty set.
+    tokensRef.current = [];
+    fireEvent.click(screen.getByRole('button', { name: /revoke/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${LIST_URL}/${encodeURIComponent(TOKEN_A.id)}`,
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+
+  it('does not issue a DELETE when the user cancels the confirm', async () => {
+    installFetchRouter({ tokensRef: { current: [TOKEN_A] } });
+    mockConfirm.mockReturnValue(false);
+
+    render(<Tokens />);
+
+    await waitFor(() => expect(screen.getByText(TOKEN_A.name)).toBeDefined());
+
+    fireEvent.click(screen.getByRole('button', { name: /revoke/i }));
+
+    expect(mockConfirm).toHaveBeenCalledOnce();
+    const deleteCalls = mockFetch.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'
+    );
+    expect(deleteCalls).toHaveLength(0);
+  });
+});

--- a/packages/dashboard/tests/client/pages/Webhooks.test.tsx
+++ b/packages/dashboard/tests/client/pages/Webhooks.test.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { WebhookSubscriptionPublic } from '@harness-engineering/types';
+import type { QueueStats } from '../../../src/client/components/webhooks/QueueStatsPanel';
+import { Webhooks } from '../../../src/client/pages/Webhooks';
+
+// Wire-shape fixtures matching the public (secret-redacted) list response
+// and the queue/stats poll payload the component consumes.
+const SUB_A: WebhookSubscriptionPublic = {
+  id: 'whk_00000000000000aa',
+  tokenId: 'tok_a',
+  url: 'https://a.example.com/hook',
+  events: ['maintenance.completed', 'interaction.*'],
+  createdAt: '2026-05-05T09:00:00.000Z',
+};
+const SUB_B: WebhookSubscriptionPublic = {
+  id: 'whk_00000000000000bb',
+  tokenId: 'tok_b',
+  url: 'https://b.example.com/hook',
+  events: ['deploy.*'],
+  createdAt: '2026-05-06T09:00:00.000Z',
+};
+
+const QUEUE_STATS: QueueStats = {
+  pending: 3,
+  inFlight: 1,
+  failed: 2,
+  dead: 0,
+  delivered: 42,
+};
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const mockConfirm = vi.fn();
+vi.stubGlobal('confirm', mockConfirm);
+
+/**
+ * Route fetch by (url, method). The list endpoint reads from a mutable
+ * `subsRef` so a refresh after create/delete observes updated state, which
+ * is what the component actually does (it re-GETs after every mutation).
+ */
+function installFetchRouter(opts: {
+  subsRef: { current: WebhookSubscriptionPublic[] };
+  createResult?: { ok: boolean; body: unknown };
+}) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+
+    if (url === '/api/v1/webhooks/queue/stats') {
+      return Promise.resolve({ ok: true, json: async () => QUEUE_STATS });
+    }
+    if (url === '/api/v1/webhooks' && method === 'GET') {
+      return Promise.resolve({ ok: true, json: async () => opts.subsRef.current });
+    }
+    if (url === '/api/v1/webhooks' && method === 'POST') {
+      const r = opts.createResult ?? { ok: true, body: { id: SUB_A.id, secret: 's'.repeat(44) } };
+      return Promise.resolve({ ok: r.ok, json: async () => r.body });
+    }
+    if (method === 'DELETE') {
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }
+    return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockConfirm.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Webhooks page — subscription list', () => {
+  it('renders subscriptions returned by GET /api/v1/webhooks', async () => {
+    installFetchRouter({ subsRef: { current: [SUB_A, SUB_B] } });
+
+    render(<Webhooks />);
+
+    await waitFor(() => {
+      expect(screen.getByText(SUB_A.url)).toBeDefined();
+    });
+    expect(screen.getByText(SUB_B.url)).toBeDefined();
+    expect(screen.getByText(SUB_A.id)).toBeDefined();
+  });
+
+  it('shows the empty state when there are no subscriptions', async () => {
+    installFetchRouter({ subsRef: { current: [] } });
+
+    render(<Webhooks />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no subscriptions yet/i)).toBeDefined();
+    });
+  });
+});
+
+describe('Webhooks page — queue stats polling', () => {
+  it('renders the delivery-queue panel from the initial /queue/stats poll', async () => {
+    installFetchRouter({ subsRef: { current: [] } });
+
+    render(<Webhooks />);
+
+    // The panel only mounts once queueStats !== null, i.e. after a successful poll.
+    await waitFor(() => {
+      expect(screen.getByText(/delivery queue/i)).toBeDefined();
+    });
+    expect(screen.getByText(String(QUEUE_STATS.delivered))).toBeDefined();
+    expect(mockFetch).toHaveBeenCalledWith('/api/v1/webhooks/queue/stats');
+  });
+});
+
+describe('Webhooks page — create subscription', () => {
+  it('POSTs trimmed comma-split events and reveals the one-time secret banner', async () => {
+    const subsRef = { current: [] as WebhookSubscriptionPublic[] };
+    const secret = 'x'.repeat(44);
+    installFetchRouter({
+      subsRef,
+      createResult: { ok: true, body: { id: SUB_A.id, secret } },
+    });
+
+    render(<Webhooks />);
+
+    // Fill the URL (events default is prefilled by the component).
+    const urlInput = await screen.findByPlaceholderText(/url/i);
+    fireEvent.change(urlInput, { target: { value: SUB_A.url } });
+
+    // After creation the list refresh should surface the new sub.
+    subsRef.current = [SUB_A];
+    fireEvent.click(screen.getByRole('button', { name: /subscribe/i }));
+
+    // Secret banner appears with the one-time secret.
+    await waitFor(() => {
+      expect(screen.getByText(secret)).toBeDefined();
+    });
+    expect(screen.getByText(/never shown again/i)).toBeDefined();
+
+    // Verify the POST payload: default events string split + trimmed.
+    const postCall = mockFetch.mock.calls.find(
+      ([u, init]) => u === '/api/v1/webhooks' && init?.method === 'POST'
+    );
+    expect(postCall).toBeDefined();
+    const sentBody = JSON.parse((postCall![1] as RequestInit).body as string);
+    expect(sentBody).toEqual({
+      url: SUB_A.url,
+      events: ['maintenance.completed', 'interaction.*'],
+    });
+  });
+
+  it('surfaces the server error message and does not show a secret on a failed create', async () => {
+    installFetchRouter({
+      subsRef: { current: [] },
+      createResult: { ok: false, body: { error: 'url must be https' } },
+    });
+
+    render(<Webhooks />);
+
+    const urlInput = await screen.findByPlaceholderText(/url/i);
+    fireEvent.change(urlInput, { target: { value: 'https://bad.example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /subscribe/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('url must be https')).toBeDefined();
+    });
+    expect(screen.queryByText(/never shown again/i)).toBeNull();
+  });
+});
+
+describe('Webhooks page — delete subscription', () => {
+  it('DELETEs the encoded id after the user confirms', async () => {
+    const subsRef = { current: [SUB_A] as WebhookSubscriptionPublic[] };
+    installFetchRouter({ subsRef });
+    mockConfirm.mockReturnValue(true);
+
+    render(<Webhooks />);
+
+    await waitFor(() => expect(screen.getByText(SUB_A.url)).toBeDefined());
+
+    // On confirm, the list refresh returns an empty set.
+    subsRef.current = [];
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        `/api/v1/webhooks/${encodeURIComponent(SUB_A.id)}`,
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+
+  it('does not issue a DELETE when the user cancels the confirm', async () => {
+    installFetchRouter({ subsRef: { current: [SUB_A] } });
+    mockConfirm.mockReturnValue(false);
+
+    render(<Webhooks />);
+
+    await waitFor(() => expect(screen.getByText(SUB_A.url)).toBeDefined());
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(mockConfirm).toHaveBeenCalledOnce();
+    const deleteCalls = mockFetch.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'
+    );
+    expect(deleteCalls).toHaveLength(0);
+  });
+});

--- a/packages/dashboard/tests/client/useAnalyze.test.tsx
+++ b/packages/dashboard/tests/client/useAnalyze.test.tsx
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useAnalyze } from '../../src/client/components/analyze/useAnalyze';
+import {
+  streamAnalyze,
+  type AnalyzeCallbacks,
+} from '../../src/client/components/analyze/streamAnalyze';
+import { appendToRoadmap } from '../../src/client/utils/appendToRoadmap';
+import { buildSpecMarkdown } from '../../src/client/components/analyze/buildSpecMarkdown';
+import type { SELResult, CMLResult, PESLResult } from '../../src/client/components/analyze/types';
+
+// ── Collaborators are mocked so the hook is exercised in isolation: no real
+//    /api/analyze SSE stream, no /api/roadmap/append, no spec-markdown build.
+vi.mock('../../src/client/components/analyze/streamAnalyze', () => ({
+  streamAnalyze: vi.fn(),
+}));
+vi.mock('../../src/client/utils/appendToRoadmap', () => ({
+  appendToRoadmap: vi.fn(),
+}));
+vi.mock('../../src/client/components/analyze/buildSpecMarkdown', () => ({
+  buildSpecMarkdown: vi.fn(),
+}));
+
+const mockStreamAnalyze = vi.mocked(streamAnalyze);
+const mockAppendToRoadmap = vi.mocked(appendToRoadmap);
+const mockBuildSpecMarkdown = vi.mocked(buildSpecMarkdown);
+
+// Mirrors the 3s settle delay in useAutoResetAction (source constant).
+const AUTO_RESET_MS = 3000;
+
+const selFixture: SELResult = {
+  intent: 'Add login',
+  summary: 'Adds a login flow',
+  affectedSystems: [
+    {
+      name: 'auth',
+      graphNodeId: 'n1',
+      confidence: 0.9,
+      transitiveDeps: [],
+      testCoverage: 0.5,
+      owner: null,
+    },
+  ],
+  unknowns: ['u1'],
+  ambiguities: ['a1'],
+  riskSignals: ['r1'],
+};
+
+const cmlFixture: CMLResult = {
+  overall: 0.4,
+  riskLevel: 'medium',
+  confidence: 0.8,
+  blastRadius: { services: 1, modules: 2, filesEstimated: 3, testFilesAffected: 1 },
+  dimensions: { structural: 0.3, semantic: 0.4, historical: 0.2 },
+  reasoning: ['because'],
+  recommendedRoute: 'human',
+};
+
+const peslFixture: PESLResult = {
+  simulatedPlan: ['step'],
+  predictedFailures: [],
+  riskHotspots: [],
+  missingSteps: [],
+  testGaps: [],
+  executionConfidence: 0.7,
+  recommendedChanges: [],
+  abort: false,
+  tier: 'graph-only',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useAnalyze', () => {
+  it('starts idle with empty inputs and no results', () => {
+    const { result } = renderHook(() => useAnalyze());
+    expect(result.current.title).toBe('');
+    expect(result.current.description).toBe('');
+    expect(result.current.labels).toBe('');
+    expect(result.current.streaming).toBe(false);
+    expect(result.current.actionState).toBe('idle');
+    expect(result.current.hasResults).toBe(false);
+    expect(result.current.isDone).toBe(false);
+  });
+
+  it('ignores submit when the title is blank', async () => {
+    const { result } = renderHook(() => useAnalyze());
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+    expect(mockStreamAnalyze).not.toHaveBeenCalled();
+    expect(result.current.streaming).toBe(false);
+  });
+
+  it('submits a trimmed body with parsed labels and omits empty description', async () => {
+    mockStreamAnalyze.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useAnalyze());
+    act(() => {
+      result.current.setTitle('  Add login  ');
+      result.current.setLabels('auth, , security');
+    });
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+    expect(mockStreamAnalyze).toHaveBeenCalledTimes(1);
+    const [body] = mockStreamAnalyze.mock.calls[0]!;
+    expect(body).toEqual({ title: 'Add login', labels: ['auth', 'security'] });
+  });
+
+  it('applies streamed SEL results and settles to done on stream completion', async () => {
+    mockStreamAnalyze.mockImplementation(async (_body, callbacks: AnalyzeCallbacks) => {
+      callbacks.onStatus('Analyzing…');
+      callbacks.onSEL(selFixture);
+      callbacks.onDone();
+    });
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setTitle('Add login'));
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+    expect(result.current.selResult).toEqual(selFixture);
+    expect(result.current.status).toBeNull();
+    expect(result.current.streaming).toBe(false);
+    expect(result.current.hasResults).toBe(true);
+    expect(result.current.isDone).toBe(true);
+  });
+
+  it('surfaces a stream error and stops streaming', async () => {
+    mockStreamAnalyze.mockImplementation(async (_body, callbacks: AnalyzeCallbacks) => {
+      callbacks.onError('stream boom');
+    });
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setTitle('Add login'));
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+    expect(result.current.error).toBe('stream boom');
+    expect(result.current.streaming).toBe(false);
+  });
+
+  it('aborts the in-flight stream and clears streaming on cancel', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    // Resolve without onDone so streaming stays true (models an in-flight stream).
+    mockStreamAnalyze.mockImplementation(async (_body, _callbacks, signal: AbortSignal) => {
+      capturedSignal = signal;
+    });
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setTitle('Add login'));
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+    expect(result.current.streaming).toBe(true);
+    act(() => result.current.handleCancel());
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(result.current.streaming).toBe(false);
+  });
+
+  it('moves to roadmap-done when the append succeeds', async () => {
+    mockAppendToRoadmap.mockResolvedValue({ ok: true, featureName: 'Add login' });
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setTitle('  Add login  '));
+    await act(async () => {
+      await result.current.handleAddToRoadmap();
+    });
+    expect(mockAppendToRoadmap).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Add login' })
+    );
+    expect(result.current.actionState).toBe('roadmap-done');
+    expect(result.current.actionError).toBeNull();
+  });
+
+  it('reports the append error and returns to idle on failure', async () => {
+    mockAppendToRoadmap.mockResolvedValue({ ok: false, error: 'conflict' });
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setTitle('Add login'));
+    await act(async () => {
+      await result.current.handleAddToRoadmap();
+    });
+    expect(result.current.actionState).toBe('idle');
+    expect(result.current.actionError).toBe('conflict');
+  });
+
+  it('auto-resets a settled action back to idle after the delay', async () => {
+    vi.useFakeTimers();
+    try {
+      mockAppendToRoadmap.mockResolvedValue({ ok: true, featureName: 'Add login' });
+      const { result } = renderHook(() => useAnalyze());
+      act(() => result.current.setTitle('Add login'));
+      await act(async () => {
+        await result.current.handleAddToRoadmap();
+      });
+      expect(result.current.actionState).toBe('roadmap-done');
+      act(() => {
+        vi.advanceTimersByTime(AUTO_RESET_MS);
+      });
+      expect(result.current.actionState).toBe('idle');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('POSTs a parsed dispatch body and reaches dispatch-done', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    const { result } = renderHook(() => useAnalyze());
+    act(() => {
+      result.current.setTitle(' Add login ');
+      result.current.setDescription(' do it ');
+      result.current.setLabels('auth, security');
+    });
+    await act(async () => {
+      await result.current.handleDispatchNow();
+    });
+    expect(fetchSpy).toHaveBeenCalledWith('/api/dispatch/adhoc', expect.any(Object));
+    const requestBody = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    expect(requestBody).toEqual({
+      title: 'Add login',
+      description: 'do it',
+      labels: ['auth', 'security'],
+    });
+    expect(result.current.actionState).toBe('dispatch-done');
+    expect(result.current.actionError).toBeNull();
+  });
+
+  it('surfaces the dispatch error and returns to idle on a non-OK response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'dispatch failed' }), { status: 500 })
+    );
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setTitle('Add login'));
+    await act(async () => {
+      await result.current.handleDispatchNow();
+    });
+    expect(result.current.actionState).toBe('idle');
+    expect(result.current.actionError).toBe('dispatch failed');
+  });
+
+  it('refines the description from SEL clarifications and clears results', async () => {
+    const focusTarget = document.createElement('textarea');
+    focusTarget.id = 'analyze-description';
+    document.body.appendChild(focusTarget);
+    const focusSpy = vi.spyOn(focusTarget, 'focus');
+
+    mockStreamAnalyze.mockImplementation(async (_body, callbacks: AnalyzeCallbacks) => {
+      callbacks.onSEL(selFixture);
+      callbacks.onDone();
+    });
+    const { result } = renderHook(() => useAnalyze());
+    act(() => {
+      result.current.setTitle('Add login');
+      result.current.setDescription('original');
+    });
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+    expect(result.current.hasResults).toBe(true);
+
+    act(() => result.current.handleRefine());
+
+    expect(result.current.description).toBe(
+      [
+        'original',
+        '',
+        '---',
+        'Suggested clarifications from analysis:',
+        '- Unknown: u1',
+        '- Ambiguity: a1',
+      ].join('\n')
+    );
+    expect(result.current.selResult).toBeNull();
+    expect(result.current.hasResults).toBe(false);
+    expect(result.current.actionState).toBe('idle');
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(focusTarget);
+  });
+
+  it('does nothing on refine when there is no SEL result', () => {
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setDescription('unchanged'));
+    act(() => result.current.handleRefine());
+    expect(result.current.description).toBe('unchanged');
+  });
+
+  it('exports a spec download named from the title slug and current date', async () => {
+    mockBuildSpecMarkdown.mockReturnValue('# spec');
+    const createObjectURL = vi.fn(() => 'blob:fake');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
+
+    let downloadAttr: string | null = null;
+    const clickSpy = vi.fn(function (this: HTMLAnchorElement) {
+      downloadAttr = this.download;
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(clickSpy);
+
+    mockStreamAnalyze.mockImplementation(async (_body, callbacks: AnalyzeCallbacks) => {
+      callbacks.onSEL(selFixture);
+      callbacks.onCML(cmlFixture);
+      callbacks.onPESL(peslFixture);
+      callbacks.onDone();
+    });
+    const { result } = renderHook(() => useAnalyze());
+    act(() => result.current.setTitle('  Add Login  '));
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    act(() => result.current.handleExportSpec());
+
+    expect(mockBuildSpecMarkdown).toHaveBeenCalledWith(
+      'Add Login',
+      selFixture,
+      cmlFixture,
+      peslFixture
+    );
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:fake');
+    expect(downloadAttr).toMatch(/^spec-add-login-\d{4}-\d{2}-\d{2}\.md$/);
+  });
+});

--- a/packages/dashboard/tests/client/utils/block-filter.test.ts
+++ b/packages/dashboard/tests/client/utils/block-filter.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isStreamBlock,
+  filterStreamBlocks,
+  extractTodosFromBlocks,
+} from '../../../src/client/utils/block-filter';
+import type { ContentBlock } from '../../../src/client/types/chat';
+
+function toolUse(tool: string, args?: string): ContentBlock {
+  return { kind: 'tool_use', tool, args };
+}
+
+describe('isStreamBlock', () => {
+  it('filters out status blocks', () => {
+    expect(isStreamBlock({ kind: 'status', text: 'thinking' })).toBe(false);
+  });
+
+  it('filters out task-related tool_use blocks', () => {
+    for (const tool of [
+      'TaskCreate',
+      'TaskUpdate',
+      'TaskList',
+      'TaskGet',
+      'TaskOutput',
+      'TaskStop',
+      'TodoWrite',
+    ]) {
+      expect(isStreamBlock(toolUse(tool))).toBe(false);
+    }
+  });
+
+  it('keeps non-task tool_use blocks', () => {
+    expect(isStreamBlock(toolUse('Bash', '{"cmd":"ls"}'))).toBe(true);
+  });
+
+  it('keeps text and thinking blocks', () => {
+    expect(isStreamBlock({ kind: 'text', text: 'hello' })).toBe(true);
+    expect(isStreamBlock({ kind: 'thinking', text: 'hmm' })).toBe(true);
+  });
+});
+
+describe('filterStreamBlocks', () => {
+  it('returns only the blocks that belong in the stream', () => {
+    const blocks: ContentBlock[] = [
+      { kind: 'text', text: 'hi' },
+      { kind: 'status', text: 'busy' },
+      toolUse('TaskCreate', '{"subject":"a"}'),
+      toolUse('Read', '{}'),
+      { kind: 'thinking', text: 'planning' },
+    ];
+
+    const result = filterStreamBlocks(blocks);
+
+    expect(result).toEqual([
+      { kind: 'text', text: 'hi' },
+      toolUse('Read', '{}'),
+      { kind: 'thinking', text: 'planning' },
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const blocks: ContentBlock[] = [{ kind: 'status', text: 'x' }];
+    const snapshot = [...blocks];
+    filterStreamBlocks(blocks);
+    expect(blocks).toEqual(snapshot);
+  });
+
+  it('returns an empty array when everything is filtered out', () => {
+    const blocks: ContentBlock[] = [{ kind: 'status', text: 'x' }, toolUse('TodoWrite', '{}')];
+    expect(filterStreamBlocks(blocks)).toHaveLength(0);
+  });
+});
+
+describe('extractTodosFromBlocks', () => {
+  it('returns no todos when there are no task blocks', () => {
+    const blocks: ContentBlock[] = [{ kind: 'text', text: 'hi' }, toolUse('Bash', '{"cmd":"ls"}')];
+    expect(extractTodosFromBlocks(blocks)).toHaveLength(0);
+  });
+
+  it('registers a todo from a TaskCreate block with an index-based id', () => {
+    const blocks: ContentBlock[] = [
+      toolUse('TaskCreate', JSON.stringify({ subject: 'Write docs' })),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)).toEqual([
+      { id: 'task-1', text: 'Write docs', completed: false },
+    ]);
+  });
+
+  it('assigns sequential index-based ids to multiple TaskCreate blocks', () => {
+    const blocks: ContentBlock[] = [
+      toolUse('TaskCreate', JSON.stringify({ subject: 'First' })),
+      toolUse('TaskCreate', JSON.stringify({ subject: 'Second' })),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)).toEqual([
+      { id: 'task-1', text: 'First', completed: false },
+      { id: 'task-2', text: 'Second', completed: false },
+    ]);
+  });
+
+  it('ignores a TaskCreate block missing a subject', () => {
+    const blocks: ContentBlock[] = [
+      toolUse('TaskCreate', JSON.stringify({ description: 'no subject' })),
+    ];
+    expect(extractTodosFromBlocks(blocks)).toHaveLength(0);
+  });
+
+  it('ignores a TaskCreate block with no args', () => {
+    const blocks: ContentBlock[] = [toolUse('TaskCreate')];
+    expect(extractTodosFromBlocks(blocks)).toHaveLength(0);
+  });
+
+  it('marks a matching todo completed via TaskUpdate (prefixed task id)', () => {
+    const blocks: ContentBlock[] = [
+      toolUse('TaskCreate', JSON.stringify({ subject: 'First' })),
+      toolUse('TaskUpdate', JSON.stringify({ taskId: '1', status: 'completed' })),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)).toEqual([
+      { id: 'task-1', text: 'First', completed: true },
+    ]);
+  });
+
+  it('does not complete anything when TaskUpdate targets an unknown id', () => {
+    const blocks: ContentBlock[] = [
+      toolUse('TaskCreate', JSON.stringify({ subject: 'First' })),
+      toolUse('TaskUpdate', JSON.stringify({ taskId: '99', status: 'completed' })),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)).toEqual([
+      { id: 'task-1', text: 'First', completed: false },
+    ]);
+  });
+
+  it('does not complete a todo when TaskUpdate status is not completed', () => {
+    const blocks: ContentBlock[] = [
+      toolUse('TaskCreate', JSON.stringify({ subject: 'First' })),
+      toolUse('TaskUpdate', JSON.stringify({ taskId: '1', status: 'in_progress' })),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)[0].completed).toBe(false);
+  });
+
+  it('upserts every todo carried by a TodoWrite payload', () => {
+    const blocks: ContentBlock[] = [
+      toolUse(
+        'TodoWrite',
+        JSON.stringify({
+          todos: [
+            { id: 't1', content: 'Alpha', status: 'pending' },
+            { id: 't2', content: 'Beta', status: 'completed' },
+          ],
+        })
+      ),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)).toEqual([
+      { id: 't1', text: 'Alpha', completed: false },
+      { id: 't2', text: 'Beta', completed: true },
+    ]);
+  });
+
+  it('lets a later TodoWrite overwrite an earlier entry with the same id', () => {
+    const blocks: ContentBlock[] = [
+      toolUse(
+        'TodoWrite',
+        JSON.stringify({ todos: [{ id: 't1', content: 'Old', status: 'pending' }] })
+      ),
+      toolUse(
+        'TodoWrite',
+        JSON.stringify({ todos: [{ id: 't1', content: 'New', status: 'completed' }] })
+      ),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)).toEqual([{ id: 't1', text: 'New', completed: true }]);
+  });
+
+  it('skips malformed JSON args without throwing', () => {
+    const blocks: ContentBlock[] = [
+      toolUse('TaskCreate', '{not valid json'),
+      toolUse('TaskUpdate', '{also bad'),
+      toolUse('TodoWrite', 'nope'),
+    ];
+    expect(extractTodosFromBlocks(blocks)).toHaveLength(0);
+  });
+
+  it('ignores non tool_use blocks while scanning', () => {
+    const blocks: ContentBlock[] = [
+      { kind: 'text', text: 'hi' },
+      { kind: 'status', text: 'busy' },
+      toolUse('TaskCreate', JSON.stringify({ subject: 'Only one' })),
+    ];
+
+    expect(extractTodosFromBlocks(blocks)).toEqual([
+      { id: 'task-1', text: 'Only one', completed: false },
+    ]);
+  });
+});

--- a/packages/dashboard/tests/client/utils/chat-stream.test.ts
+++ b/packages/dashboard/tests/client/utils/chat-stream.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  streamChat,
+  applyChunk,
+  type StreamCallbacks,
+} from '../../../src/client/utils/chat-stream';
+import type { ChatSSEEvent } from '../../../src/client/types/orchestrator';
+import type { ContentBlock } from '../../../src/client/types/chat';
+
+/**
+ * Build a mock `fetch` Response whose body streams the given string chunks as
+ * UTF-8 encoded Uint8Arrays, one per `reader.read()` call. This lets us drive
+ * `streamChat`'s SSE parsing deterministically, including buffer-split cases
+ * where a single `data:` line spans two reads.
+ */
+function makeStreamResponse(
+  chunks: string[],
+  opts: { ok?: boolean; status?: number; hasBody?: boolean } = {}
+): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  const body =
+    (opts.hasBody ?? true)
+      ? {
+          getReader() {
+            return {
+              read: async () => {
+                if (i < chunks.length) {
+                  const value = encoder.encode(chunks[i]!);
+                  i += 1;
+                  return { done: false, value };
+                }
+                return { done: true, value: undefined };
+              },
+            };
+          },
+        }
+      : null;
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    body,
+  } as unknown as Response;
+}
+
+function makeCallbacks() {
+  const sessions: string[] = [];
+  const chunks: ChatSSEEvent[] = [];
+  const errors: string[] = [];
+  let doneCount = 0;
+  const callbacks: StreamCallbacks = {
+    onSession: (id) => sessions.push(id),
+    onChunk: (event) => chunks.push(event),
+    onDone: () => {
+      doneCount += 1;
+    },
+    onError: (error) => errors.push(error),
+  };
+  return {
+    callbacks,
+    sessions,
+    chunks,
+    errors,
+    get doneCount() {
+      return doneCount;
+    },
+  };
+}
+
+/** Serialize an SSE event the way the server would: `data: <json>\n`. */
+function sse(event: ChatSSEEvent): string {
+  return `data: ${JSON.stringify(event)}\n`;
+}
+
+const DONE_LINE = 'data: [DONE]\n';
+
+describe('streamChat', () => {
+  beforeEach(() => {
+    // Absent a stub, any unmocked fetch would throw — keep it explicit per test.
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('parses session, chunk, and [DONE] events in order', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        sse({ type: 'session', sessionId: 'sess-1' }),
+        sse({ type: 'text', text: 'hello' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.sessions).toEqual(['sess-1']);
+    expect(c.chunks).toEqual([{ type: 'text', text: 'hello' }]);
+    expect(c.errors).toEqual([]);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('sends prompt, system, and sessionId in the request body', async () => {
+    const fetchMock = vi.fn(async () => makeStreamResponse([DONE_LINE]));
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat(
+      'the-prompt',
+      'the-system',
+      'the-session',
+      c.callbacks,
+      new AbortController().signal
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/chat');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      prompt: 'the-prompt',
+      system: 'the-system',
+      sessionId: 'the-session',
+    });
+  });
+
+  it('reassembles a data line split across two reads', async () => {
+    const line = sse({ type: 'text', text: 'streamed' });
+    const mid = Math.floor(line.length / 2);
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([line.slice(0, mid), line.slice(mid), DONE_LINE])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.chunks).toEqual([{ type: 'text', text: 'streamed' }]);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('routes an error event to onError and stops processing further lines', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        sse({ type: 'error', error: 'boom' }),
+        sse({ type: 'text', text: 'should-not-arrive' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['boom']);
+    expect(c.chunks).toEqual([]);
+    expect(c.doneCount).toBe(0);
+  });
+
+  it('skips malformed JSON lines and lines without a data: prefix', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        ': this is a comment line\n',
+        'data: {not valid json}\n',
+        sse({ type: 'text', text: 'survivor' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.chunks).toEqual([{ type: 'text', text: 'survivor' }]);
+    expect(c.errors).toEqual([]);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('skips JSON payloads that are not objects with a type field', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([
+        'data: null\n',
+        'data: 42\n',
+        'data: {"noType":true}\n',
+        sse({ type: 'text', text: 'ok' }),
+        DONE_LINE,
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.chunks).toEqual([{ type: 'text', text: 'ok' }]);
+    expect(c.errors).toEqual([]);
+  });
+
+  it('calls onDone when the stream ends without an explicit [DONE]', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([sse({ type: 'text', text: 'trailing' })])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.chunks).toEqual([{ type: 'text', text: 'trailing' }]);
+    expect(c.doneCount).toBe(1);
+  });
+
+  it('reports an HTTP error when the response is not ok', async () => {
+    const fetchMock = vi.fn(async () => makeStreamResponse([], { ok: false, status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['Chat request failed: HTTP 503']);
+    expect(c.doneCount).toBe(0);
+  });
+
+  it('reports an HTTP error when the response has no body', async () => {
+    const fetchMock = vi.fn(async () =>
+      makeStreamResponse([], { ok: true, status: 200, hasBody: false })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['Chat request failed: HTTP 200']);
+  });
+
+  it('swallows AbortError without calling onError', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    const fetchMock = vi.fn(async () => {
+      throw abortErr;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual([]);
+    expect(c.doneCount).toBe(0);
+  });
+
+  it('reports the message of a non-abort network failure', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('connection reset');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeCallbacks();
+
+    await streamChat('hi', undefined, undefined, c.callbacks, new AbortController().signal);
+
+    expect(c.errors).toEqual(['connection reset']);
+  });
+});
+
+describe('applyChunk', () => {
+  it('ignores session and error events', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'session', sessionId: 's' });
+    applyChunk(blocks, { type: 'error', error: 'e' });
+    expect(blocks).toEqual([]);
+  });
+
+  it('appends a new text block then coalesces consecutive text', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'text', text: 'foo' });
+    applyChunk(blocks, { type: 'text', text: 'bar' });
+    expect(blocks).toEqual([{ kind: 'text', text: 'foobar' }]);
+  });
+
+  it('replaces a trailing status block when text arrives', () => {
+    const blocks: ContentBlock[] = [{ kind: 'status', text: 'thinking...' }];
+    applyChunk(blocks, { type: 'text', text: 'answer' });
+    expect(blocks).toEqual([{ kind: 'text', text: 'answer' }]);
+  });
+
+  it('coalesces consecutive thinking events', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'thinking', text: 'a' });
+    applyChunk(blocks, { type: 'thinking', text: 'b' });
+    expect(blocks).toEqual([{ kind: 'thinking', text: 'ab' }]);
+  });
+
+  it('does not coalesce thinking across an intervening text block', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'thinking', text: 'a' });
+    applyChunk(blocks, { type: 'text', text: 'x' });
+    applyChunk(blocks, { type: 'thinking', text: 'b' });
+    expect(blocks).toEqual([
+      { kind: 'thinking', text: 'a' },
+      { kind: 'text', text: 'x' },
+      { kind: 'thinking', text: 'b' },
+    ]);
+  });
+
+  it('pushes a tool_use block, omitting args when absent', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'tool_use', tool: 'read' });
+    expect(blocks).toEqual([{ kind: 'tool_use', tool: 'read' }]);
+  });
+
+  it('pushes a tool_use block preserving provided args', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'tool_use', tool: 'read', args: '{"path":' });
+    expect(blocks).toEqual([{ kind: 'tool_use', tool: 'read', args: '{"path":' }]);
+  });
+
+  it('accumulates tool_args_delta onto the last unresolved tool_use block', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'tool_use', tool: 'read', args: '{"p":' });
+    applyChunk(blocks, { type: 'tool_args_delta', text: '"a.ts"}' });
+    expect(blocks).toEqual([{ kind: 'tool_use', tool: 'read', args: '{"p":"a.ts"}' }]);
+  });
+
+  it('starts args from empty string when tool_use had no args', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'tool_use', tool: 'read' });
+    applyChunk(blocks, { type: 'tool_args_delta', text: 'partial' });
+    expect(blocks).toEqual([{ kind: 'tool_use', tool: 'read', args: 'partial' }]);
+  });
+
+  it('attaches tool_result to the last unresolved tool_use, preserving isError', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'tool_use', tool: 'read' });
+    applyChunk(blocks, { type: 'tool_result', content: 'oops', isError: true });
+    expect(blocks).toEqual([{ kind: 'tool_use', tool: 'read', result: 'oops', isError: true }]);
+  });
+
+  it('omits isError when it is not provided on tool_result', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'tool_use', tool: 'read' });
+    applyChunk(blocks, { type: 'tool_result', content: 'contents' });
+    expect(blocks).toEqual([{ kind: 'tool_use', tool: 'read', result: 'contents' }]);
+  });
+
+  it('routes tool_result to the most recent tool_use that lacks a result', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'tool_use', tool: 'first' });
+    applyChunk(blocks, { type: 'tool_result', content: 'r1' });
+    applyChunk(blocks, { type: 'tool_use', tool: 'second' });
+    applyChunk(blocks, { type: 'tool_result', content: 'r2' });
+    expect(blocks).toEqual([
+      { kind: 'tool_use', tool: 'first', result: 'r1' },
+      { kind: 'tool_use', tool: 'second', result: 'r2' },
+    ]);
+  });
+
+  it('replaces the trailing status block on a new status event', () => {
+    const blocks: ContentBlock[] = [];
+    applyChunk(blocks, { type: 'status', text: 'reading' });
+    applyChunk(blocks, { type: 'status', text: 'writing' });
+    expect(blocks).toEqual([{ kind: 'status', text: 'writing' }]);
+  });
+
+  it('appends a status block when the last block is not a status', () => {
+    const blocks: ContentBlock[] = [{ kind: 'text', text: 'hi' }];
+    applyChunk(blocks, { type: 'status', text: 'reading' });
+    expect(blocks).toEqual([
+      { kind: 'text', text: 'hi' },
+      { kind: 'status', text: 'reading' },
+    ]);
+  });
+});

--- a/packages/orchestrator/src/server/routes/analyze.test.ts
+++ b/packages/orchestrator/src/server/routes/analyze.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import http from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { IntelligencePipeline } from '@harness-engineering/intelligence';
+import { handleAnalyzeRoute } from './analyze';
+
+// ---------------------------------------------------------------------------
+// Fake pipeline builders.
+//
+// handleAnalyzeRoute only ever calls .enrich(), .score() and .simulate() on the
+// pipeline it is handed, so a structurally-typed fake cast to the real type is
+// sufficient and keeps the test hermetic (no real SEL/CML/PESL work, no IO).
+// The two intelligence helpers the route uses directly — manualToRawWorkItem and
+// scoreToConcernSignals — are pure and run for real.
+// ---------------------------------------------------------------------------
+
+interface FakeScore {
+  overall: number;
+  riskLevel: string;
+  confidence: number;
+  blastRadius: { filesEstimated: number };
+  dimensions: { semantic: number };
+  reasoning: string[];
+  recommendedRoute: 'local' | 'human' | 'simulation-required';
+}
+
+const LOW_SCORE: FakeScore = {
+  overall: 0.3,
+  riskLevel: 'low',
+  confidence: 0.9,
+  blastRadius: { filesEstimated: 5 },
+  dimensions: { semantic: 0.2 },
+  reasoning: [],
+  recommendedRoute: 'local',
+};
+
+// Every scoreToConcernSignals threshold tripped: overall >= 0.7,
+// filesEstimated > 20, semantic > 0.6 => three concern signals.
+const HIGH_SCORE: FakeScore = {
+  overall: 0.85,
+  riskLevel: 'high',
+  confidence: 0.8,
+  blastRadius: { filesEstimated: 30 },
+  dimensions: { semantic: 0.75 },
+  reasoning: ['sprawling change', 'many unknowns'],
+  recommendedRoute: 'simulation-required',
+};
+
+const FAKE_SPEC = {
+  intent: 'add feature',
+  summary: 'a summary',
+  affectedSystems: ['api'],
+  unknowns: ['x'],
+  ambiguities: ['y'],
+  riskSignals: ['z'],
+};
+
+const FAKE_SIM = { outcome: 'ok', steps: ['a', 'b'] };
+
+function makePipeline(score: FakeScore): {
+  pipeline: IntelligencePipeline;
+  enrich: ReturnType<typeof vi.fn>;
+  scoreFn: ReturnType<typeof vi.fn>;
+  simulate: ReturnType<typeof vi.fn>;
+} {
+  const enrich = vi.fn(async () => FAKE_SPEC);
+  const scoreFn = vi.fn(() => score);
+  const simulate = vi.fn(async () => FAKE_SIM);
+  const pipeline = { enrich, score: scoreFn, simulate } as unknown as IntelligencePipeline;
+  return { pipeline, enrich, scoreFn, simulate };
+}
+
+// ---------------------------------------------------------------------------
+// Real loopback HTTP server that routes to handleAnalyzeRoute, mirroring the
+// sibling auth.test.ts style. Loopback-only, no filesystem, no external network.
+// ---------------------------------------------------------------------------
+
+interface HttpResult {
+  status: number;
+  body: string;
+  headers: http.IncomingHttpHeaders;
+}
+
+let server: http.Server;
+let port: number;
+let currentPipeline: IntelligencePipeline | null;
+let matched: boolean | undefined;
+
+beforeEach(async () => {
+  currentPipeline = null;
+  matched = undefined;
+  server = http.createServer((req, res) => {
+    matched = handleAnalyzeRoute(req, res, currentPipeline);
+    // Only respond ourselves when the route did not claim the request.
+    if (!matched) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    }
+  });
+  port = await new Promise<number>((resolve) => {
+    server.listen(0, '127.0.0.1', function (this: http.Server) {
+      const addr = this.address();
+      resolve(typeof addr === 'object' && addr ? addr.port : 0);
+    });
+  });
+});
+
+afterEach(() => {
+  server.close();
+});
+
+function request(
+  path: string,
+  method: string,
+  body?: string,
+  headers: Record<string, string> = {}
+): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, path, method, headers }, (res) => {
+      let chunks = '';
+      res.on('data', (c) => (chunks += c));
+      res.on('end', () =>
+        resolve({ status: res.statusCode ?? 0, body: chunks, headers: res.headers })
+      );
+    });
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+/** Parse an SSE response body into the list of decoded `data:` event objects
+ * (the terminal `[DONE]` sentinel is returned separately). */
+function parseSSE(body: string): {
+  events: Array<{ type: string; [k: string]: unknown }>;
+  done: boolean;
+} {
+  const events: Array<{ type: string; [k: string]: unknown }> = [];
+  let done = false;
+  for (const line of body.split('\n')) {
+    if (!line.startsWith('data: ')) continue;
+    const payload = line.slice('data: '.length);
+    if (payload === '[DONE]') {
+      done = true;
+      continue;
+    }
+    events.push(JSON.parse(payload));
+  }
+  return { events, done };
+}
+
+const jsonHeaders = { 'Content-Type': 'application/json' };
+
+describe('handleAnalyzeRoute', () => {
+  describe('route matching (return value)', () => {
+    it('does not claim a GET to /api/analyze and leaves the response untouched', () => {
+      const touched: string[] = [];
+      const req = { method: 'GET', url: '/api/analyze' } as IncomingMessage;
+      const res = {
+        writeHead: () => touched.push('writeHead'),
+        write: () => touched.push('write'),
+        end: () => touched.push('end'),
+        on: () => touched.push('on'),
+      } as unknown as ServerResponse;
+
+      const result = handleAnalyzeRoute(req, res, null);
+
+      expect(result).toBe(false);
+      expect(touched).toEqual([]);
+    });
+
+    it('does not claim a POST to a different url', () => {
+      const req = { method: 'POST', url: '/api/other' } as IncomingMessage;
+      const res = {
+        writeHead: vi.fn(),
+        write: vi.fn(),
+        end: vi.fn(),
+        on: vi.fn(),
+      } as unknown as ServerResponse;
+      expect(handleAnalyzeRoute(req, res, null)).toBe(false);
+    });
+
+    it('claims a POST to /api/analyze (returns true)', async () => {
+      currentPipeline = null;
+      await request('/api/analyze', 'POST', JSON.stringify({ title: 'x' }), jsonHeaders);
+      expect(matched).toBe(true);
+    });
+  });
+
+  describe('input / configuration guards', () => {
+    it('returns a 503 JSON error when the pipeline is not enabled', async () => {
+      currentPipeline = null;
+      const res = await request(
+        '/api/analyze',
+        'POST',
+        JSON.stringify({ title: 'x' }),
+        jsonHeaders
+      );
+      expect(res.status).toBe(503);
+      expect(JSON.parse(res.body)).toEqual({ error: 'Intelligence pipeline not enabled' });
+    });
+
+    it('returns a 400 JSON error when required fields are missing (Zod validation)', async () => {
+      currentPipeline = makePipeline(LOW_SCORE).pipeline;
+      const res = await request(
+        '/api/analyze',
+        'POST',
+        JSON.stringify({ description: 'no title' }),
+        jsonHeaders
+      );
+      expect(res.status).toBe(400);
+      expect(JSON.parse(res.body)).toHaveProperty('error');
+    });
+
+    it('returns a 400 when title is present but empty (min(1) constraint)', async () => {
+      currentPipeline = makePipeline(LOW_SCORE).pipeline;
+      const res = await request('/api/analyze', 'POST', JSON.stringify({ title: '' }), jsonHeaders);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns a 500 JSON error on malformed JSON body (JSON.parse throws pre-stream)', async () => {
+      currentPipeline = makePipeline(LOW_SCORE).pipeline;
+      const res = await request('/api/analyze', 'POST', '{ not json', jsonHeaders);
+      expect(res.status).toBe(500);
+      expect(JSON.parse(res.body)).toHaveProperty('error');
+    });
+
+    it('does not invoke the pipeline when validation fails', async () => {
+      const { pipeline, enrich, scoreFn } = makePipeline(LOW_SCORE);
+      currentPipeline = pipeline;
+      await request('/api/analyze', 'POST', JSON.stringify({}), jsonHeaders);
+      expect(enrich).not.toHaveBeenCalled();
+      expect(scoreFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful SSE stream', () => {
+    it('streams status, sel_result and cml_result as SSE and terminates with [DONE]', async () => {
+      const { pipeline } = makePipeline(LOW_SCORE);
+      currentPipeline = pipeline;
+
+      const res = await request(
+        '/api/analyze',
+        'POST',
+        JSON.stringify({ title: 'ship it', description: 'do the thing', labels: ['a'] }),
+        jsonHeaders
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('text/event-stream');
+      expect(res.headers['cache-control']).toBe('no-cache');
+
+      const { events, done } = parseSSE(res.body);
+      expect(done).toBe(true);
+
+      const sel = events.find((e) => e.type === 'sel_result');
+      expect(sel?.data).toMatchObject({ intent: 'add feature', summary: 'a summary' });
+
+      const cml = events.find((e) => e.type === 'cml_result');
+      expect(cml?.data).toMatchObject({
+        overall: LOW_SCORE.overall,
+        riskLevel: LOW_SCORE.riskLevel,
+        recommendedRoute: 'local',
+      });
+
+      // At least one status event announces each pipeline stage before results.
+      expect(events.filter((e) => e.type === 'status').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('forwards the validated request through to pipeline.enrich as a raw work item', async () => {
+      const { pipeline, enrich } = makePipeline(LOW_SCORE);
+      currentPipeline = pipeline;
+
+      await request(
+        '/api/analyze',
+        'POST',
+        JSON.stringify({ title: 'my title', description: 'my desc', labels: ['bug', 'p1'] }),
+        jsonHeaders
+      );
+
+      expect(enrich).toHaveBeenCalledTimes(1);
+      expect(enrich.mock.calls[0]?.[0]).toMatchObject({
+        title: 'my title',
+        description: 'my desc',
+        labels: ['bug', 'p1'],
+        source: 'manual',
+      });
+    });
+
+    it('defaults optional description/labels before conversion to a work item', async () => {
+      const { pipeline, enrich } = makePipeline(LOW_SCORE);
+      currentPipeline = pipeline;
+
+      await request('/api/analyze', 'POST', JSON.stringify({ title: 'only title' }), jsonHeaders);
+
+      // The route substitutes '' for a missing description before conversion,
+      // so the raw work item carries an empty string (not null).
+      expect(enrich.mock.calls[0]?.[0]).toMatchObject({
+        title: 'only title',
+        description: '',
+        labels: [],
+      });
+    });
+
+    it('does not emit a signals event when the score trips no concern thresholds', async () => {
+      const { pipeline } = makePipeline(LOW_SCORE);
+      currentPipeline = pipeline;
+
+      const res = await request(
+        '/api/analyze',
+        'POST',
+        JSON.stringify({ title: 'calm change' }),
+        jsonHeaders
+      );
+      const { events } = parseSSE(res.body);
+      expect(events.some((e) => e.type === 'signals')).toBe(false);
+    });
+
+    it('does not run the simulation stage for a non simulation-required route', async () => {
+      const { pipeline, simulate } = makePipeline(LOW_SCORE);
+      currentPipeline = pipeline;
+
+      const res = await request(
+        '/api/analyze',
+        'POST',
+        JSON.stringify({ title: 'x' }),
+        jsonHeaders
+      );
+      const { events } = parseSSE(res.body);
+      expect(simulate).not.toHaveBeenCalled();
+      expect(events.some((e) => e.type === 'pesl_result')).toBe(false);
+    });
+  });
+
+  describe('high-complexity / simulation-required stream', () => {
+    it('runs simulation and emits a pesl_result plus concern signals', async () => {
+      const { pipeline, simulate } = makePipeline(HIGH_SCORE);
+      currentPipeline = pipeline;
+
+      const res = await request(
+        '/api/analyze',
+        'POST',
+        JSON.stringify({ title: 'risky change' }),
+        jsonHeaders
+      );
+      const { events, done } = parseSSE(res.body);
+
+      expect(res.status).toBe(200);
+      expect(done).toBe(true);
+
+      // simulate() is called with (spec, score, 'guided-change').
+      expect(simulate).toHaveBeenCalledTimes(1);
+      expect(simulate.mock.calls[0]?.[2]).toBe('guided-change');
+
+      const pesl = events.find((e) => e.type === 'pesl_result');
+      expect(pesl?.data).toMatchObject(FAKE_SIM);
+
+      // HIGH_SCORE trips all three scoreToConcernSignals thresholds.
+      const signals = events.find((e) => e.type === 'signals');
+      expect(Array.isArray(signals?.data)).toBe(true);
+      const names = (signals?.data as Array<{ name: string }>).map((s) => s.name);
+      expect(names).toEqual(
+        expect.arrayContaining(['highComplexity', 'largeBlastRadius', 'highAmbiguity'])
+      );
+    });
+  });
+});

--- a/packages/orchestrator/src/server/routes/dispatch-actions.test.ts
+++ b/packages/orchestrator/src/server/routes/dispatch-actions.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import type { Issue } from '@harness-engineering/types';
+import { handleDispatchActionsRoute } from './dispatch-actions';
+
+const ROUTE = '/api/dispatch/adhoc';
+// Fixed instant so `new Date().toISOString()` inside the handler is deterministic.
+const FIXED_NOW = '2026-07-20T12:34:56.000Z';
+
+/**
+ * Build a minimal IncomingMessage-like object. Readable.from buffers the body
+ * in paused mode until readBody() attaches its 'data' listener, so there is no
+ * lost-event race regardless of when the handler starts consuming.
+ */
+function makeReq(method: string, url: string, body = ''): IncomingMessage {
+  const req = Readable.from(body.length ? [body] : []) as unknown as IncomingMessage;
+  (req as unknown as { method: string }).method = method;
+  (req as unknown as { url: string }).url = url;
+  return req;
+}
+
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  headersSent: boolean;
+  writeHead(status: number, headers: Record<string, string>): MockRes;
+  end(chunk?: unknown): void;
+  /** Resolves once end() is invoked, i.e. the handler's async work finished. */
+  done: Promise<void>;
+  json<T>(): T;
+}
+
+function makeRes(): MockRes {
+  let resolveDone!: () => void;
+  const done = new Promise<void>((r) => (resolveDone = r));
+  const res: MockRes = {
+    statusCode: 0,
+    headers: {},
+    body: '',
+    headersSent: false,
+    writeHead(status, headers) {
+      this.statusCode = status;
+      this.headers = headers;
+      this.headersSent = true;
+      return this;
+    },
+    end(chunk?: unknown) {
+      if (typeof chunk === 'string') this.body = chunk;
+      resolveDone();
+    },
+    done,
+    json<T>() {
+      return JSON.parse(this.body) as T;
+    },
+  };
+  return res;
+}
+
+/** Invoke the route handler and wait for its fire-and-forget async work. */
+async function invoke(
+  method: string,
+  url: string,
+  body: string,
+  dispatchFn: Parameters<typeof handleDispatchActionsRoute>[2]
+): Promise<{ matched: boolean; res: MockRes }> {
+  const req = makeReq(method, url, body);
+  const res = makeRes();
+  const matched = handleDispatchActionsRoute(req, res as unknown as ServerResponse, dispatchFn);
+  if (matched) await res.done;
+  return { matched, res };
+}
+
+describe('handleDispatchActionsRoute (POST /api/dispatch/adhoc)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_NOW));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('route matching', () => {
+    it('returns false and never invokes dispatch for a non-POST method', () => {
+      const dispatchFn = vi.fn().mockResolvedValue(undefined);
+      const req = makeReq('GET', ROUTE);
+      const res = makeRes();
+
+      const matched = handleDispatchActionsRoute(req, res as unknown as ServerResponse, dispatchFn);
+
+      expect(matched).toBe(false);
+      expect(dispatchFn).not.toHaveBeenCalled();
+    });
+
+    it('returns false and never invokes dispatch for a different URL', () => {
+      const dispatchFn = vi.fn().mockResolvedValue(undefined);
+      const req = makeReq('POST', '/api/dispatch/other');
+      const res = makeRes();
+
+      const matched = handleDispatchActionsRoute(req, res as unknown as ServerResponse, dispatchFn);
+
+      expect(matched).toBe(false);
+      expect(dispatchFn).not.toHaveBeenCalled();
+    });
+
+    it('returns true (claims the route) even when the body is invalid', async () => {
+      const dispatchFn = vi.fn().mockResolvedValue(undefined);
+      const { matched } = await invoke('POST', ROUTE, JSON.stringify({}), dispatchFn);
+      expect(matched).toBe(true);
+    });
+  });
+
+  describe('dispatch availability', () => {
+    it('returns 503 when no dispatch callback is injected', async () => {
+      const { res } = await invoke('POST', ROUTE, JSON.stringify({ title: 'anything' }), null);
+
+      expect(res.statusCode).toBe(503);
+      expect(res.json<{ error: string }>().error).toMatch(/not available/i);
+    });
+  });
+
+  describe('happy path', () => {
+    it('builds a well-formed synthetic Issue and passes it to the dispatch callback', async () => {
+      let captured: Issue | undefined;
+      const dispatchFn = vi.fn(async (issue: Issue) => {
+        captured = issue;
+      });
+
+      const { res } = await invoke(
+        'POST',
+        ROUTE,
+        JSON.stringify({
+          title: 'Fix login bug',
+          description: 'users cannot sign in',
+          labels: ['bug', 'auth'],
+        }),
+        dispatchFn
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(dispatchFn).toHaveBeenCalledTimes(1);
+
+      const issue = captured as Issue;
+      // id is a sanitized-title + 8 hex chars of a sha256 hash.
+      expect(issue.id).toMatch(/^fix-login-bug-[0-9a-f]{8}$/);
+      expect(issue.identifier).toBe(issue.id);
+      expect(issue.title).toBe('Fix login bug');
+      expect(issue.description).toBe('users cannot sign in');
+      expect(issue.labels).toEqual(['bug', 'auth']);
+      expect(issue.state).toBe('planned');
+      expect(issue.priority).toBeNull();
+      expect(issue.branchName).toBeNull();
+      expect(issue.url).toBeNull();
+      expect(issue.spec).toBeNull();
+      expect(issue.externalId).toBeNull();
+      expect(issue.blockedBy).toEqual([]);
+      expect(issue.plans).toEqual([]);
+      // Timestamps derive from the (faked) system clock.
+      expect(issue.createdAt).toBe(FIXED_NOW);
+      expect(issue.updatedAt).toBe(FIXED_NOW);
+
+      // Response echoes the same id used for the dispatched issue.
+      const payload = res.json<{ ok: boolean; issueId: string }>();
+      expect(payload.ok).toBe(true);
+      expect(payload.issueId).toBe(issue.id);
+    });
+
+    it('defaults description to null and labels to an empty array when omitted', async () => {
+      let captured: Issue | undefined;
+      const dispatchFn = vi.fn(async (issue: Issue) => {
+        captured = issue;
+      });
+
+      const { res } = await invoke(
+        'POST',
+        ROUTE,
+        JSON.stringify({ title: 'No optionals here' }),
+        dispatchFn
+      );
+
+      expect(res.statusCode).toBe(200);
+      const issue = captured as Issue;
+      expect(issue.description).toBeNull();
+      expect(issue.labels).toEqual([]);
+    });
+
+    it('derives a stable, deterministic id from the same title', async () => {
+      const first = vi.fn().mockResolvedValue(undefined);
+      const second = vi.fn().mockResolvedValue(undefined);
+      const title = 'Repeatable Title';
+
+      const a = await invoke('POST', ROUTE, JSON.stringify({ title }), first);
+      const b = await invoke('POST', ROUTE, JSON.stringify({ title }), second);
+
+      const idA = a.res.json<{ issueId: string }>().issueId;
+      const idB = b.res.json<{ issueId: string }>().issueId;
+      expect(idA).toBe(idB);
+    });
+  });
+
+  describe('validation failures', () => {
+    it('returns 400 without dispatching when the title is missing', async () => {
+      const dispatchFn = vi.fn().mockResolvedValue(undefined);
+      const { res } = await invoke('POST', ROUTE, JSON.stringify({ description: 'x' }), dispatchFn);
+
+      expect(res.statusCode).toBe(400);
+      expect(dispatchFn).not.toHaveBeenCalled();
+      expect(res.json<{ error: string }>().error).toBeTruthy();
+    });
+
+    it('returns 400 without dispatching when the title is an empty string', async () => {
+      const dispatchFn = vi.fn().mockResolvedValue(undefined);
+      const { res } = await invoke('POST', ROUTE, JSON.stringify({ title: '' }), dispatchFn);
+
+      expect(res.statusCode).toBe(400);
+      expect(dispatchFn).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 (not 400) on malformed JSON, since JSON.parse throws before Zod runs', async () => {
+      const dispatchFn = vi.fn().mockResolvedValue(undefined);
+      const { res } = await invoke('POST', ROUTE, '{ not valid json', dispatchFn);
+
+      expect(res.statusCode).toBe(500);
+      expect(dispatchFn).not.toHaveBeenCalled();
+      expect(res.json<{ error: string }>().error).toBeTruthy();
+    });
+  });
+
+  describe('dispatch failure', () => {
+    it('returns 500 with the error message when the dispatch callback rejects', async () => {
+      const dispatchFn = vi.fn().mockRejectedValue(new Error('agent pool exhausted'));
+      const { res } = await invoke(
+        'POST',
+        ROUTE,
+        JSON.stringify({ title: 'Kick off work' }),
+        dispatchFn
+      );
+
+      expect(dispatchFn).toHaveBeenCalledTimes(1);
+      expect(res.statusCode).toBe(500);
+      expect(res.json<{ error: string }>().error).toBe('agent pool exhausted');
+    });
+  });
+});

--- a/packages/signals/tests/shared.test.ts
+++ b/packages/signals/tests/shared.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import type { SignalPoint } from '../src/types';
+import { toDate, round2, deriveEndpointTrend, bucketsToHistory } from '../src/shared';
+
+describe('toDate', () => {
+  it('truncates a full ISO timestamp to a YYYY-MM-DD date string', () => {
+    expect(toDate('2026-07-20T13:45:30.123Z')).toBe('2026-07-20');
+  });
+
+  it('returns an already-date-only string unchanged', () => {
+    expect(toDate('2026-07-20')).toBe('2026-07-20');
+  });
+
+  it('takes exactly the first 10 characters (no timezone conversion)', () => {
+    // Truncation is pure string slicing: a near-midnight UTC time stays on its
+    // literal calendar date rather than shifting via Date parsing.
+    expect(toDate('2026-01-01T00:00:00.000Z')).toBe('2026-01-01');
+    expect(toDate('2026-12-31T23:59:59.999Z')).toBe('2026-12-31');
+  });
+});
+
+describe('round2', () => {
+  it('rounds to two decimal places', () => {
+    expect(round2(1.2345)).toBe(1.23);
+  });
+
+  it('rounds up at the second decimal', () => {
+    expect(round2(1.239)).toBe(1.24);
+    expect(round2(2.675)).toBe(2.68);
+  });
+
+  it('rounds down when the third decimal is below five', () => {
+    expect(round2(1.234)).toBe(1.23);
+  });
+
+  it('leaves values with two or fewer decimals unchanged', () => {
+    expect(round2(3.5)).toBe(3.5);
+    expect(round2(42)).toBe(42);
+  });
+
+  it('handles negative numbers', () => {
+    expect(round2(-1.239)).toBe(-1.24);
+  });
+
+  it('returns 0 for 0', () => {
+    expect(round2(0)).toBe(0);
+  });
+});
+
+function point(date: string, value: number): SignalPoint {
+  return { date, value };
+}
+
+describe('deriveEndpointTrend', () => {
+  it("returns 'flat' for an empty history", () => {
+    expect(deriveEndpointTrend([])).toBe('flat');
+  });
+
+  it("returns 'flat' for a single point", () => {
+    expect(deriveEndpointTrend([point('2026-07-01', 5)])).toBe('flat');
+  });
+
+  it("returns 'up' when the latest point exceeds the earliest", () => {
+    const history = [point('2026-07-01', 1), point('2026-07-02', 9)];
+    expect(deriveEndpointTrend(history)).toBe('up');
+  });
+
+  it("returns 'down' when the latest point is below the earliest", () => {
+    const history = [point('2026-07-01', 9), point('2026-07-02', 1)];
+    expect(deriveEndpointTrend(history)).toBe('down');
+  });
+
+  it("returns 'flat' when the endpoints are equal, ignoring intermediate swings", () => {
+    const history = [point('2026-07-01', 5), point('2026-07-02', 99), point('2026-07-03', 5)];
+    expect(deriveEndpointTrend(history)).toBe('flat');
+  });
+
+  it('compares only the first and last points, not adjacent ones', () => {
+    // Dips in the middle do not matter: only earliest-vs-latest drives the verdict.
+    const history = [point('2026-07-01', 2), point('2026-07-02', 0), point('2026-07-03', 3)];
+    expect(deriveEndpointTrend(history)).toBe('up');
+  });
+});
+
+describe('bucketsToHistory', () => {
+  it('maps bucket entries into points using the transform', () => {
+    const buckets = new Map<string, number>([['2026-07-01', 3]]);
+    const history = bucketsToHistory(buckets, (v) => v);
+    expect(history).toEqual([{ date: '2026-07-01', value: 3 }]);
+  });
+
+  it('sorts entries chronologically by date regardless of insertion order', () => {
+    const buckets = new Map<string, number>([
+      ['2026-07-03', 30],
+      ['2026-07-01', 10],
+      ['2026-07-02', 20],
+    ]);
+    const history = bucketsToHistory(buckets, (v) => v);
+    expect(history.map((p) => p.date)).toEqual(['2026-07-01', '2026-07-02', '2026-07-03']);
+    expect(history.map((p) => p.value)).toEqual([10, 20, 30]);
+  });
+
+  it('applies a non-identity transform to derive point values', () => {
+    // e.g. a rate provider mapping a {passed, total} bucket to a rounded fraction.
+    const buckets = new Map<string, { passed: number; total: number }>([
+      ['2026-07-01', { passed: 1, total: 3 }],
+    ]);
+    const history = bucketsToHistory(buckets, (v) => round2(v.passed / v.total));
+    expect(history).toEqual([{ date: '2026-07-01', value: 0.33 }]);
+  });
+
+  it('returns an empty array for an empty map', () => {
+    expect(bucketsToHistory(new Map<string, number>(), (v) => v)).toEqual([]);
+  });
+
+  it('does not mutate the source map', () => {
+    const buckets = new Map<string, number>([
+      ['2026-07-02', 2],
+      ['2026-07-01', 1],
+    ]);
+    bucketsToHistory(buckets, (v) => v);
+    expect([...buckets.keys()]).toEqual(['2026-07-02', '2026-07-01']);
+  });
+});

--- a/tests/scripts/generate-barrel-exports.test.ts
+++ b/tests/scripts/generate-barrel-exports.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Behavior lock for scripts/generate-barrel-exports.mjs — the build script that
+ * scans packages/cli/src/commands for `createXXXCommand` exports and generates
+ * (or, under --check, verifies the freshness of) the _registry.ts CLI command
+ * registry consumed by createProgram().
+ *
+ * The script exports nothing and runs its whole flow at module top-level against
+ * the real filesystem, so these tests mock node:fs with an in-memory tree,
+ * control process.argv, and re-execute the module via vi.resetModules() + a
+ * dynamic import. That keeps the test hermetic (no real IO, no subprocess, no
+ * timers) while asserting the observable contract: what gets written and what
+ * the --check gate reports.
+ *
+ * Fixture tree under commands/ deliberately exercises every discovery rule:
+ *   alpha.ts        -> `export function createAlphaCommand(`   (included)
+ *   beta.ts         -> `export const createBetaCommand =`      (included)
+ *   nested/index.ts -> directory scanned via its index.ts      (included)
+ *   dup/index.ts    -> re-exports createAlphaCommand + own     (dedup + include)
+ *   _registry.ts    -> leading underscore                      (skipped)
+ *   _helpers.ts     -> leading underscore                      (skipped)
+ *   widget.test.ts  -> .test.ts                                (skipped)
+ *   shims.d.ts      -> .d.ts                                   (skipped)
+ *   README.md       -> non-.ts                                 (skipped)
+ *   empty/          -> directory without index.ts              (skipped)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Absolute paths the SUT computes from its own module location. The script lives
+// at <repo>/scripts and derives ROOT via resolve(import.meta.dirname, '..'); this
+// test lives at <repo>/tests/scripts, so resolve('..','..') lands on the same
+// repo root and our mock keys match the paths the script queries.
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
+const COMMANDS_DIR = join(REPO_ROOT, 'packages', 'cli', 'src', 'commands');
+const REGISTRY_PATH = join(COMMANDS_DIR, '_registry.ts');
+const SUT = '../../scripts/generate-barrel-exports.mjs';
+
+const HEADER =
+  '// AUTO-GENERATED — do not edit. Run `pnpm run generate-barrel-exports` to regenerate.\n';
+
+// The command creators the fixture tree should yield, alphabetically sorted and
+// deduplicated (createAlphaCommand appears in both alpha.ts and dup/index.ts).
+const EXPECTED_COMMAND_NAMES = [
+  'createAlphaCommand',
+  'createBetaCommand',
+  'createDupCommand',
+  'createNestedCommand',
+];
+
+// Names that live in the tree but must be excluded by the discovery rules.
+const SKIPPED_COMMAND_NAMES = [
+  'createShouldSkipCommand', // _helpers.ts (leading underscore)
+  'createWidgetCommand', // widget.test.ts (.test.ts)
+  'createShimCommand', // shims.d.ts (.d.ts)
+  'createNopeCommand', // README.md (non-.ts)
+];
+
+// The exact registry the fixture tree must serialize to. This is the observable
+// contract: header, `commander` type import, alphabetically-sorted imports (first
+// occurrence wins for dups -> createAlphaCommand resolves to './alpha', not
+// './dup'), the doc block, and the sorted registration array.
+const EXPECTED_REGISTRY =
+  HEADER +
+  '\n' +
+  "import type { Command } from 'commander';\n" +
+  '\n' +
+  "import { createAlphaCommand } from './alpha';\n" +
+  "import { createBetaCommand } from './beta';\n" +
+  "import { createDupCommand } from './dup';\n" +
+  "import { createNestedCommand } from './nested';\n" +
+  '\n' +
+  '/**\n' +
+  ' * All discovered command creators, sorted alphabetically.\n' +
+  ' * Used by createProgram() to register commands without manual imports.\n' +
+  ' */\n' +
+  'export const commandCreators: Array<() => Command> = [\n' +
+  '  createAlphaCommand,\n' +
+  '  createBetaCommand,\n' +
+  '  createDupCommand,\n' +
+  '  createNestedCommand,\n' +
+  '];\n';
+
+// Hoisted virtual filesystem shared with the node:fs mock factory below.
+const fsState = vi.hoisted(() => ({
+  files: new Map<string, { type: 'file' | 'dir'; content?: string; entries?: string[] }>(),
+  writes: [] as Array<{ path: string; content: string }>,
+}));
+
+vi.mock('node:fs', () => {
+  const enoent = (p: string) => Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+  return {
+    readFileSync: (p: string) => {
+      const node = fsState.files.get(p);
+      if (!node || node.type !== 'file') throw enoent(p);
+      return node.content;
+    },
+    writeFileSync: (p: string, content: string) => {
+      fsState.writes.push({ path: p, content });
+      fsState.files.set(p, { type: 'file', content });
+    },
+    readdirSync: (p: string) => {
+      const node = fsState.files.get(p);
+      if (!node || node.type !== 'dir') throw enoent(p);
+      return (node.entries ?? []).slice();
+    },
+    statSync: (p: string) => {
+      const node = fsState.files.get(p);
+      if (!node) throw enoent(p);
+      return { isDirectory: () => node.type === 'dir' };
+    },
+    existsSync: (p: string) => fsState.files.has(p),
+  };
+});
+
+class ProcessExitError extends Error {
+  constructor(public code?: number) {
+    super(`process.exit(${code})`);
+    this.name = 'ProcessExitError';
+  }
+}
+
+function dir(path: string, entries: string[]): void {
+  fsState.files.set(path, { type: 'dir', entries });
+}
+function file(path: string, content: string): void {
+  fsState.files.set(path, { type: 'file', content });
+}
+
+/**
+ * Populate the virtual commands/ tree. Pass a `registry` string to also seed the
+ * generated _registry.ts (used by --check tests); omit it to simulate a missing
+ * registry.
+ */
+function seedTree(options: { registry?: string } = {}): void {
+  fsState.files.clear();
+  fsState.writes.length = 0;
+
+  dir(COMMANDS_DIR, [
+    'alpha.ts',
+    'beta.ts',
+    '_registry.ts',
+    '_helpers.ts',
+    'widget.test.ts',
+    'shims.d.ts',
+    'README.md',
+    'nested',
+    'empty',
+    'dup',
+  ]);
+
+  file(join(COMMANDS_DIR, 'alpha.ts'), 'export function createAlphaCommand() { return {}; }');
+  file(join(COMMANDS_DIR, 'beta.ts'), 'export const createBetaCommand = () => ({});');
+  file(join(COMMANDS_DIR, '_helpers.ts'), 'export function createShouldSkipCommand() {}');
+  file(join(COMMANDS_DIR, 'widget.test.ts'), 'export function createWidgetCommand() {}');
+  file(join(COMMANDS_DIR, 'shims.d.ts'), 'export const createShimCommand = () => {};');
+  file(join(COMMANDS_DIR, 'README.md'), '# docs mentioning createNopeCommand in prose');
+
+  dir(join(COMMANDS_DIR, 'nested'), ['index.ts']);
+  file(join(COMMANDS_DIR, 'nested', 'index.ts'), 'export function createNestedCommand() {}');
+
+  // Directory without an index.ts must be skipped entirely.
+  dir(join(COMMANDS_DIR, 'empty'), ['orphan.ts']);
+
+  // dup/index.ts re-exports createAlphaCommand (dedup: first-seen alpha.ts wins)
+  // and contributes its own createDupCommand.
+  dir(join(COMMANDS_DIR, 'dup'), ['index.ts']);
+  file(
+    join(COMMANDS_DIR, 'dup', 'index.ts'),
+    'export const createAlphaCommand = () => {};\nexport function createDupCommand() {}'
+  );
+
+  if (options.registry !== undefined) {
+    file(REGISTRY_PATH, options.registry);
+  }
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let originalArgv: string[];
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ProcessExitError(code);
+  }) as never);
+  originalArgv = process.argv;
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+  vi.restoreAllMocks();
+  fsState.files.clear();
+  fsState.writes.length = 0;
+});
+
+/** Re-execute the top-level script body under the current fs state + argv. */
+async function runScript(argv: string[]): Promise<void> {
+  process.argv = argv;
+  vi.resetModules();
+  await import(SUT);
+}
+
+describe('generate-barrel-exports (generate mode)', () => {
+  it('writes the sorted, deduplicated registry to _registry.ts', async () => {
+    seedTree();
+
+    await runScript(['node', 'generate-barrel-exports.mjs']);
+
+    expect(fsState.writes).toHaveLength(1);
+    expect(fsState.writes[0].path).toBe(REGISTRY_PATH);
+    expect(fsState.writes[0].content).toBe(EXPECTED_REGISTRY);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`with ${EXPECTED_COMMAND_NAMES.length} commands`)
+    );
+  });
+
+  it('excludes underscored, .test.ts, .d.ts, non-.ts, and index-less directory files', async () => {
+    seedTree();
+
+    await runScript(['node', 'generate-barrel-exports.mjs']);
+
+    const { content } = fsState.writes[0];
+    for (const name of SKIPPED_COMMAND_NAMES) {
+      expect(content).not.toContain(name);
+    }
+    for (const name of EXPECTED_COMMAND_NAMES) {
+      expect(content).toContain(name);
+    }
+  });
+
+  it('deduplicates a re-exported creator, keeping the first-seen import path', async () => {
+    seedTree();
+
+    await runScript(['node', 'generate-barrel-exports.mjs']);
+
+    const { content } = fsState.writes[0];
+    const alphaImports = content.match(/import \{ createAlphaCommand \} from/g) ?? [];
+    expect(alphaImports).toHaveLength(1);
+    expect(content).toContain("import { createAlphaCommand } from './alpha';");
+    expect(content).not.toContain("import { createAlphaCommand } from './dup';");
+  });
+});
+
+describe('generate-barrel-exports (--check mode)', () => {
+  it('reports the registry is up to date when it matches, without writing', async () => {
+    seedTree({ registry: EXPECTED_REGISTRY });
+
+    await runScript(['node', 'generate-barrel-exports.mjs', '--check']);
+
+    expect(fsState.writes).toHaveLength(0);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('up to date'));
+  });
+
+  it('exits 1 and reports staleness when the on-disk registry differs', async () => {
+    seedTree({ registry: HEADER + '\n// stale contents that no longer match\n' });
+
+    await expect(
+      runScript(['node', 'generate-barrel-exports.mjs', '--check'])
+    ).rejects.toBeInstanceOf(ProcessExitError);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fsState.writes).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('stale'));
+  });
+
+  it('exits 1 and reports absence when the registry file is missing', async () => {
+    seedTree(); // no registry seeded
+
+    await expect(
+      runScript(['node', 'generate-barrel-exports.mjs', '--check'])
+    ).rejects.toBeInstanceOf(ProcessExitError);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fsState.writes).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('not found'));
+  });
+});


### PR DESCRIPTION
## Canary PR-driven test backfill

Systematically evaluated **every PR** that has landed in the codebase and backfilled tests for the source areas they touched but left uncovered — using the Canary pipeline (`canary-critical-areas` risk-gate → `canary-write-test` author → run → verify), always **against the current codebase** (not the historical PR diffs).

### How the scope was derived
| Stage | Count |
|---|---|
| In-scope PRs (merged + open; closed-never-merged skipped) | 586 |
| Code candidates (feat/fix/refactor/perf/security) | 330 |
| …that touch source still present in the tree | 289 |
| Unique current source files those PRs touched | 1171 |
| …genuinely uncovered (no colocated test, not imported by any test) | 239 |
| **Gate-skipped** (generated barrels, pure types, presentational UI, thin wrappers, already-covered) | **175** |
| **Tests authored + verified green** | **64** |

The 289 PRs collapse onto shared current files (`orchestrator.ts` alone was touched by 59 PRs), so tests were written **per current source area, risk-ranked** — not per-PR — to avoid re-testing the same file dozens of times. Every skip carries a logged reason; nothing was dropped silently.

### What's in this PR
- **64 new hermetic tests** across `dashboard` (36), `cli` (18), `core` (6), `orchestrator` (2), `signals` (1), and root `scripts` (1).
- All tests mock IO/network/timers — deterministic, no real subprocess or wall-clock dependence.
- Each was authored against the file's **current** exports/behavior and verified green individually and per-package.

### Fixes
**None required.** The gate found **0 blocked cases and 0 source bugs** — all 64 tests pass against current code, so they pin existing correct behavior. (Had any test surfaced a real bug, the fix would have been bundled here per the goal.)

### Provenance
Generated by a multi-agent Canary workflow: a per-file risk-gate followed by `canary-test-author` authoring, each agent isolated. Assembled and validated in a dedicated git worktree off `origin/main`.
