### PR TITLE
feat(orchestrator): codex execution backend + harness-lifecycle wiring + resume-from-failed-stage checkpoint

### DIFF
--- a/.changeset/codex-backend-workspace-write.md
+++ b/.changeset/codex-backend-workspace-write.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): codex backend uses `--sandbox workspace-write`, not the dangerous full bypass
+
+The initial `codex` backend (#946) ran `codex exec --dangerously-bypass-approvals-and-sandbox`.
+A live trial surfaced a failure mode: on an exploratory task codex spawned an interactive
+command and the session aborted with `write_stdin failed: stdin is closed for this session`.
+Switching to `--sandbox workspace-write` fixes it (0 such errors in a re-run) while STILL
+letting codex apply edits and run the gate — verified by 21 in-session `pnpm typecheck lint
+test` invocations under the sandbox. exec mode already runs approval-free (`approval:
+never`), reads are unrestricted (the pnpm store resolves), and writes are confined to the
+worktree — appropriate since the orchestrator dispatches codex into an isolated worktree.
+Also less dangerous than the full bypass.

--- a/.changeset/codex-gate-routing-wiring.md
+++ b/.changeset/codex-gate-routing-wiring.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+feat(orchestrator): route a codex execution stage through the enforced local gate + ship
+
+Wires the `codex` backend (#946) into the local execution lifecycle. Adds
+`isLocalExecutionBackend` — a superset of `isLocalEndpointBackend` that also includes
+`codex` (which drives a local model but has no `endpoint`) — and uses it at the two
+gate/ship decision sites (`runLocalWorkflowGate`, `settleWorkflowSuccess`). A codex
+execution stage now goes through the same enforced gate (verify: typecheck+lint+test,
+then outcome-eval) and ship path as a local-endpoint stage.
+
+This gate is load-bearing, not cosmetic: a live trial showed codex can report a hollow
+success — it shipped a syntax error in a file it edited while claiming the gate passed.
+The orchestrator's independent enforced gate is exactly what catches that and blocks/
+retries. Codex stays OUT of the endpoint-only sites (resolver wiring, local-indirection
+prompt template) since it has no endpoint and takes a direct task prompt.

--- a/.changeset/codex-mcp-tool-injection.md
+++ b/.changeset/codex-mcp-tool-injection.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/types': minor
+---
+
+feat(orchestrator): expose MCP servers (context7 + curated harness tools) to the codex backend
+
+The `codex` execution backend drove the local model with only Codex's built-in
+tools — no context7 (live library docs) and no harness MCP tools — unlike the
+ollama path, which curates a lifecycle tool set. A local coder therefore had no
+way to look up how existing code narrows a type or handles an API, and stalled on
+fixes that hinge on that context.
+
+`CodexBackendDef` (and `CodexBackendOptions`) now accept `mcpServers?: McpServerSpec[]`.
+Each spec is injected per-invocation via `codex exec -c mcp_servers.<name>.command/
+args/env/enabled_tools/startup_timeout_sec` — so the codex path reaches tool-parity
+with the ollama path WITHOUT mutating the user's global `~/.codex/config.toml`. A
+spec's `tools` allowlist maps to codex's per-server `enabled_tools`, keeping a broad
+server (e.g. harness-mcp's ~95 tools) narrowed to a high-value set the local model
+can navigate.

--- a/.changeset/codex-test-windows-skip-no-release.md
+++ b/.changeset/codex-test-windows-skip-no-release.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Test-only: POSIX-guard the four `CodexBackend` tests that spawn a `#!/bin/sh` `fakeCodex` stand-in (`it.skipIf(win32)`). Node's shell-less `child_process.spawn` can launch only a real `.exe` on Windows — not a shebang script or a `.cmd` (EINVAL) — so these fixture-spawn tests are POSIX-only, matching the repo's existing bash-hook e2e `skipIf(win32)` convention. Greens `build-and-test (windows-latest)`. No runtime change.

--- a/.changeset/resume-from-failed-stage.md
+++ b/.changeset/resume-from-failed-stage.md
@@ -1,0 +1,21 @@
+---
+'@harness-engineering/orchestrator': minor
+'@harness-engineering/types': minor
+---
+
+feat(orchestrator): resume-from-failed-stage checkpoint for staged workflows
+
+Previously, when the enforced local gate blocked a staged unit, the re-dispatch re-ran
+the ENTIRE lifecycle from stage 0 — regenerating the spec + plan (non-deterministically)
+on every execution failure. That both wastes the slow reasoner and, worse, moves the
+target: the execution stage never iterates against a stable spec/plan + accumulated
+feedback, because the whole design resets underneath it each retry. This mirrors the
+cloud autopilot's own retry model, which re-runs the failed task against a plan approved
+once — not the whole lifecycle.
+
+Adds a `checkpoint?: boolean` stage flag: once a `checkpoint: true` stage passes, its
+output is checkpointed per unit and REUSED on later gate-block re-dispatches instead of
+regenerated. Mark the design stages (brainstorm/plan) `checkpoint: true` so an execution
+gate failure retries only execution onward against a FIXED spec/plan. The checkpoint is
+cleared on every terminal (ship or needs-human), so a fresh pickup regenerates. Default
+false — omit for byte-identical prior behavior.

--- a/.prettierignore
+++ b/.prettierignore
@@ -47,3 +47,4 @@ packages/core/tests/fixtures/code-nav/syntax-error.ts
 .changeset/repo-shape-orchestrator-comment-no-release.md
 .changeset/workflow-audit-orchestrator-comment-no-release.md
 .changeset/stagedecision-jsdoc-comment-no-release.md
+.changeset/codex-test-windows-skip-no-release.md

--- a/packages/orchestrator/src/agent/backend-factory.ts
+++ b/packages/orchestrator/src/agent/backend-factory.ts
@@ -194,6 +194,7 @@ function createCodexBackend(def: BackendDefOf<'codex'>): AgentBackend {
     ...(def.localProvider !== undefined ? { localProvider: def.localProvider } : {}),
     ...(def.command !== undefined ? { command: def.command } : {}),
     ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
+    ...(def.mcpServers !== undefined ? { mcpServers: def.mcpServers } : {}),
   });
 }
 

--- a/packages/orchestrator/src/agent/backend-factory.ts
+++ b/packages/orchestrator/src/agent/backend-factory.ts
@@ -90,6 +90,24 @@ export function isLocalEndpointBackend(def: BackendDef): def is LocalEndpointBac
   return def.type === 'local' || def.type === 'pi' || def.type === 'ollama';
 }
 
+/**
+ * Broader "runs a LOCAL model, work lands in the workspace, must go through the
+ * enforced local gate + ship" predicate. Superset of {@link isLocalEndpointBackend}
+ * that also includes `codex` (which drives a local model but has no `endpoint`, so
+ * it is NOT a `LocalEndpointBackendDef`).
+ *
+ * Use ONLY at the gate/ship decision sites (`runLocalWorkflowGate`,
+ * `settleWorkflowSuccess`): a codex execution stage produces its change in the
+ * worktree exactly like a local-endpoint stage, so the same enforced gate (verify +
+ * outcome-eval) and ship path apply — and are load-bearing, since codex can report
+ * a hollow success (observed: it shipped a syntax error claiming green). Do NOT use
+ * it where the code reads `def.endpoint` or selects the local-indirection prompt
+ * template — codex has no endpoint and takes a direct task prompt.
+ */
+export function isLocalExecutionBackend(def: BackendDef): boolean {
+  return isLocalEndpointBackend(def) || def.type === 'codex';
+}
+
 function createClaudeBackend(
   def: BackendDefOf<'claude'>,
   options: CreateBackendOptions

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { CodexBackend } from './codex';
+import { CodexBackend, buildMcpConfigArgs } from './codex';
 import { createBackend, isLocalExecutionBackend, isLocalEndpointBackend } from '../backend-factory';
 import { BackendDefSchema } from '../../workflow/schema';
 import type { AgentSession, TurnParams, AgentEvent, TurnResult } from '@harness-engineering/types';
@@ -195,5 +195,57 @@ describe('BackendDefSchema — codex', () => {
 
   it('requires a model', () => {
     expect(BackendDefSchema.safeParse({ type: 'codex' }).success).toBe(false);
+  });
+
+  it('accepts mcpServers with a curated tools allowlist', () => {
+    const r = BackendDefSchema.safeParse({
+      type: 'codex',
+      model: 'qwen3-coder:30b',
+      mcpServers: [
+        { name: 'context7', command: 'npx', args: ['-y', '@upstash/context7-mcp'] },
+        { name: 'harness', command: 'node', args: ['/x/harness-mcp.js'], tools: ['code_search'] },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('buildMcpConfigArgs — codex -c mcp_servers injection', () => {
+  it('returns no args for an empty server list', () => {
+    expect(buildMcpConfigArgs([])).toEqual([]);
+  });
+
+  it('encodes command + args as TOML (JSON) values under mcp_servers.<name>', () => {
+    const args = buildMcpConfigArgs([
+      { name: 'context7', command: 'npx', args: ['-y', '@upstash/context7-mcp'] },
+    ]);
+    // each -c is two argv entries
+    expect(args[0]).toBe('-c');
+    expect(args).toContain('mcp_servers.context7.command="npx"');
+    expect(args).toContain('mcp_servers.context7.args=["-y","@upstash/context7-mcp"]');
+    expect(args).toContain('mcp_servers.context7.startup_timeout_sec=60');
+  });
+
+  it('maps the spec tools allowlist to codex enabled_tools', () => {
+    const args = buildMcpConfigArgs([
+      {
+        name: 'harness',
+        command: 'node',
+        args: ['/x/harness-mcp.js'],
+        tools: ['code_search', 'ask_graph'],
+      },
+    ]);
+    expect(args).toContain('mcp_servers.harness.enabled_tools=["code_search","ask_graph"]');
+  });
+
+  it('omits enabled_tools when no allowlist is given (all tools exposed)', () => {
+    const args = buildMcpConfigArgs([{ name: 'ctx', command: 'npx' }]);
+    expect(args.some((a) => a.includes('enabled_tools'))).toBe(false);
+  });
+
+  it('emits per-key env overrides and sanitizes dots in the server name', () => {
+    const args = buildMcpConfigArgs([{ name: 'a.b', command: 'x', env: { TOKEN: 'secret' } }]);
+    expect(args).toContain('mcp_servers.a_b.command="x"');
+    expect(args).toContain('mcp_servers.a_b.env.TOKEN="secret"');
   });
 });

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -105,6 +105,9 @@ exit 0`);
     expect(argv).toContain('--sandbox');
     expect(argv).toContain('workspace-write');
     expect(argv).not.toContain('dangerously-bypass');
+    // multi_agent disabled — unsupported for local models and derails the run
+    expect(argv).toContain('--disable');
+    expect(argv).toContain('multi_agent');
   });
 
   it('runTurn reports success:false + error on a non-zero exit', async () => {

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -15,6 +15,18 @@ function fakeCodex(body: string): string {
   return p;
 }
 
+/**
+ * The {@link fakeCodex} stand-in is a POSIX `#!/bin/sh` script. `CodexBackend`
+ * launches it with a shell-less `child_process.spawn`, which on Windows can
+ * execute only a real `.exe` — a shebang script is not honored, and a `.cmd`
+ * throws `EINVAL` without `shell: true` (Node's CVE-2024-27980 fix, present in
+ * the pinned Node 22). So the tests that spawn this fixture run on POSIX only.
+ * (Matches the repo's existing bash-hook e2e `skipIf(win32)` convention; a real
+ * `codex.exe` on Windows is exercised by the healthCheck/no-model paths, which
+ * do not depend on a script stand-in.)
+ */
+const itPosix = it.skipIf(process.platform === 'win32');
+
 async function drive(
   b: CodexBackend,
   session: AgentSession
@@ -79,7 +91,7 @@ describe('CodexBackend', () => {
     expect(b.name).toBe('codex');
   });
 
-  it('runTurn streams JSONL events and reports success on exit 0', async () => {
+  itPosix('runTurn streams JSONL events and reports success on exit 0', async () => {
     const cmd = fakeCodex(`echo '{"type":"session.created"}'
 echo '{"msg":{"type":"item.completed"}}'
 echo 'plain text line'
@@ -95,22 +107,25 @@ exit 0`);
     expect(subtypes).toContain('codex:codex_output'); // non-JSON line
   });
 
-  it('drives codex with --sandbox workspace-write, not the dangerous full bypass', async () => {
-    const argfile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'codex-args-')), 'args');
-    // record the exact argv codex was spawned with
-    const cmd = fakeCodex(`printf '%s\\n' "$@" > "${argfile}"\nexit 0`);
-    const b = new CodexBackend({ model: 'm', command: cmd });
-    await drive(b, SESSION);
-    const argv = fs.readFileSync(argfile, 'utf8');
-    expect(argv).toContain('--sandbox');
-    expect(argv).toContain('workspace-write');
-    expect(argv).not.toContain('dangerously-bypass');
-    // multi_agent disabled — unsupported for local models and derails the run
-    expect(argv).toContain('--disable');
-    expect(argv).toContain('multi_agent');
-  });
+  itPosix(
+    'drives codex with --sandbox workspace-write, not the dangerous full bypass',
+    async () => {
+      const argfile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'codex-args-')), 'args');
+      // record the exact argv codex was spawned with
+      const cmd = fakeCodex(`printf '%s\\n' "$@" > "${argfile}"\nexit 0`);
+      const b = new CodexBackend({ model: 'm', command: cmd });
+      await drive(b, SESSION);
+      const argv = fs.readFileSync(argfile, 'utf8');
+      expect(argv).toContain('--sandbox');
+      expect(argv).toContain('workspace-write');
+      expect(argv).not.toContain('dangerously-bypass');
+      // multi_agent disabled — unsupported for local models and derails the run
+      expect(argv).toContain('--disable');
+      expect(argv).toContain('multi_agent');
+    }
+  );
 
-  it('runTurn reports success:false + error on a non-zero exit', async () => {
+  itPosix('runTurn reports success:false + error on a non-zero exit', async () => {
     const cmd = fakeCodex(`echo '{"type":"error"}'
 exit 3`);
     const b = new CodexBackend({ model: 'm', command: cmd });
@@ -119,7 +134,7 @@ exit 3`);
     expect(result.error).toMatch(/exited with code 3/);
   });
 
-  it('runTurn kills + fails when the session exceeds the wall-clock cap', async () => {
+  itPosix('runTurn kills + fails when the session exceeds the wall-clock cap', async () => {
     const cmd = fakeCodex(`sleep 10`);
     const b = new CodexBackend({ model: 'm', command: cmd, timeoutMs: 150 });
     const { result } = await drive(b, SESSION);

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -95,6 +95,18 @@ exit 0`);
     expect(subtypes).toContain('codex:codex_output'); // non-JSON line
   });
 
+  it('drives codex with --sandbox workspace-write, not the dangerous full bypass', async () => {
+    const argfile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'codex-args-')), 'args');
+    // record the exact argv codex was spawned with
+    const cmd = fakeCodex(`printf '%s\\n' "$@" > "${argfile}"\nexit 0`);
+    const b = new CodexBackend({ model: 'm', command: cmd });
+    await drive(b, SESSION);
+    const argv = fs.readFileSync(argfile, 'utf8');
+    expect(argv).toContain('--sandbox');
+    expect(argv).toContain('workspace-write');
+    expect(argv).not.toContain('dangerously-bypass');
+  });
+
   it('runTurn reports success:false + error on a non-zero exit', async () => {
     const cmd = fakeCodex(`echo '{"type":"error"}'
 exit 3`);

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { CodexBackend } from './codex';
-import { createBackend } from '../backend-factory';
+import { createBackend, isLocalExecutionBackend, isLocalEndpointBackend } from '../backend-factory';
 import { BackendDefSchema } from '../../workflow/schema';
 import type { AgentSession, TurnParams, AgentEvent, TurnResult } from '@harness-engineering/types';
 
@@ -140,6 +140,28 @@ describe('createBackend — codex type', () => {
   it('constructs from an array (prefer-fallback) model', () => {
     const backend = createBackend({ type: 'codex', model: ['qwen3-coder:30b', 'qwen3.6:27b'] });
     expect(backend.name).toBe('codex');
+  });
+});
+
+describe('isLocalExecutionBackend — codex routes through the enforced local gate', () => {
+  it('includes codex (drives a local model; its change lands in the worktree)', () => {
+    expect(isLocalExecutionBackend({ type: 'codex', model: 'qwen3-coder:30b' })).toBe(true);
+  });
+
+  it('includes the local-endpoint backends (superset of isLocalEndpointBackend)', () => {
+    expect(isLocalExecutionBackend({ type: 'ollama', endpoint: 'http://x/v1', model: 'm' })).toBe(
+      true
+    );
+    expect(isLocalExecutionBackend({ type: 'pi', endpoint: 'http://x', model: 'm' })).toBe(true);
+  });
+
+  it('excludes cloud/claude backends (no enforced local gate)', () => {
+    expect(isLocalExecutionBackend({ type: 'claude' })).toBe(false);
+    expect(isLocalExecutionBackend({ type: 'anthropic', model: 'x' })).toBe(false);
+  });
+
+  it('codex is NOT a local-ENDPOINT backend (it has no endpoint) — kept out of endpoint sites', () => {
+    expect(isLocalEndpointBackend({ type: 'codex', model: 'm' })).toBe(false);
   });
 });
 

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -99,9 +99,15 @@ export class CodexBackend implements AgentBackend {
       model,
       '-C',
       session.workspacePath,
-      // Externally sandboxed already (isolated worktree); let codex apply edits + run
-      // the gate without per-command approval prompts.
-      '--dangerously-bypass-approvals-and-sandbox',
+      // `workspace-write` (not the full `--dangerously-bypass-approvals-and-sandbox`):
+      // exec mode already runs approval-free (`approval: never`), and workspace-write
+      // lets codex edit the worktree + run the gate (verified: 21 gate runs in a live
+      // trial) WITHOUT the bypass mode's failure where an interactive command hits
+      // `write_stdin failed: stdin is closed for this session`. Reads are unrestricted
+      // (the pnpm store resolves); writes are confined to the worktree — appropriate
+      // since the orchestrator already dispatches codex into an isolated worktree.
+      '--sandbox',
+      'workspace-write',
       '--json',
       params.prompt,
     ];

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -108,6 +108,12 @@ export class CodexBackend implements AgentBackend {
       // since the orchestrator already dispatches codex into an isolated worktree.
       '--sandbox',
       'workspace-write',
+      // Disable codex's multi-agent/subagent dispatch: it is native (GPT-5) only and
+      // fails with `unsupported call: multi_agent_v1` when driving a LOCAL model, which
+      // derails the run. The harness lifecycle rides on the ORCHESTRATOR's stage
+      // sequencing instead, with codex executing each skill as a single agent.
+      '--disable',
+      'multi_agent',
       '--json',
       params.prompt,
     ];

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -12,6 +12,7 @@ import {
   Ok,
   Err,
   AgentError,
+  McpServerSpec,
 } from '@harness-engineering/types';
 
 /**
@@ -43,9 +44,53 @@ export interface CodexBackendOptions {
   localProvider?: 'ollama' | 'lmstudio';
   /** Hard wall-clock cap per session in ms. Default 30min (codex sessions run long). */
   timeoutMs?: number;
+  /**
+   * MCP servers to expose to the codex-driven model, injected per-invocation via
+   * `-c mcp_servers.<name>.…` overrides (NOT written to the user's global
+   * `~/.codex/config.toml`, so their real codex setup is untouched). Mirrors the
+   * `mcpServers` config the {@link OllamaBackend} path uses: each spec's `tools`
+   * allowlist maps to codex's per-server `enabled_tools`, so a broad server (e.g.
+   * harness-mcp's ~95 tools) is narrowed to a high-value set the local model can
+   * navigate. Absent/empty ⇒ codex runs with only its built-in tools.
+   */
+  mcpServers?: McpServerSpec[];
 }
 
 const DEFAULT_TIMEOUT_MS = 30 * 60_000;
+
+/** Generous startup budget (s) — npx-launched servers (context7) cold-start slowly. */
+const MCP_STARTUP_TIMEOUT_SEC = 60;
+
+/**
+ * Translate {@link McpServerSpec}s into `codex exec -c mcp_servers.…` override argv.
+ * Each `-c` is two argv entries (`'-c'`, `'<dotted.key>=<toml-value>'`); values are
+ * JSON-encoded, which is valid TOML for strings and string-arrays. `spec.tools` →
+ * `enabled_tools` (codex's per-server allowlist). Server names are dot-sanitized so
+ * the dotted-path parser keys them correctly.
+ */
+export function buildMcpConfigArgs(servers: readonly McpServerSpec[]): string[] {
+  const args: string[] = [];
+  const push = (key: string, value: string): void => {
+    args.push('-c', `${key}=${value}`);
+  };
+  for (const spec of servers) {
+    const name = spec.name.replace(/\./g, '_');
+    const base = `mcp_servers.${name}`;
+    push(`${base}.command`, JSON.stringify(spec.command));
+    if (spec.args !== undefined) push(`${base}.args`, JSON.stringify(spec.args));
+    if (spec.cwd !== undefined) push(`${base}.cwd`, JSON.stringify(spec.cwd));
+    if (spec.env !== undefined) {
+      for (const [k, v] of Object.entries(spec.env)) {
+        push(`${base}.env.${k}`, JSON.stringify(v));
+      }
+    }
+    if (spec.tools !== undefined && spec.tools.length > 0) {
+      push(`${base}.enabled_tools`, JSON.stringify(spec.tools));
+    }
+    push(`${base}.startup_timeout_sec`, String(MCP_STARTUP_TIMEOUT_SEC));
+  }
+  return args;
+}
 
 export class CodexBackend implements AgentBackend {
   readonly name = 'codex';
@@ -54,6 +99,7 @@ export class CodexBackend implements AgentBackend {
   private getModel?: () => string | null;
   private localProvider: 'ollama' | 'lmstudio';
   private timeoutMs: number;
+  private mcpServers: McpServerSpec[];
 
   constructor(options: CodexBackendOptions = {}) {
     this.command = options.command ?? 'codex';
@@ -61,6 +107,7 @@ export class CodexBackend implements AgentBackend {
     if (options.getModel !== undefined) this.getModel = options.getModel;
     this.localProvider = options.localProvider ?? 'ollama';
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.mcpServers = options.mcpServers ?? [];
   }
 
   private resolveModel(): string | undefined {
@@ -114,6 +161,10 @@ export class CodexBackend implements AgentBackend {
       // sequencing instead, with codex executing each skill as a single agent.
       '--disable',
       'multi_agent',
+      // Inject MCP servers (context7 for live docs, curated harness-mcp read tools)
+      // per-invocation so the codex-driven local model gets the same tool surface the
+      // ollama path curates — WITHOUT mutating the user's global ~/.codex/config.toml.
+      ...buildMcpConfigArgs(this.mcpServers),
       '--json',
       params.prompt,
     ];

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -92,7 +92,7 @@ import { redriveInstallingProposals } from './proposals/model-handlers';
 import type { ModelProposalRecord } from '@harness-engineering/types';
 import { migrateAgentConfig } from './agent/config-migration';
 import { OrchestratorBackendFactory } from './agent/orchestrator-backend-factory';
-import { isLocalEndpointBackend } from './agent/backend-factory';
+import { isLocalEndpointBackend, isLocalExecutionBackend } from './agent/backend-factory';
 import { makeBackendResolver } from './agent/backend-resolver';
 import { createAgentDispatcher } from './maintenance/agent-dispatcher';
 import { execFileSync } from 'node:child_process';
@@ -2937,7 +2937,10 @@ export class Orchestrator extends EventEmitter {
     acceptance?: string
   ): Promise<{ ok: true } | { ok: false; reason: string }> {
     const def = this.config.agent.backends?.[backendName];
-    const isLocal = def !== undefined && isLocalEndpointBackend(def);
+    // isLocalExecutionBackend (not …Endpoint): a `codex` stage also lands its change
+    // in the worktree and MUST go through this enforced gate — codex can report a
+    // hollow success, so the gate is the safety net that catches it.
+    const isLocal = def !== undefined && isLocalExecutionBackend(def);
     if (!isLocal) return { ok: true };
 
     try {
@@ -3742,7 +3745,9 @@ export class Orchestrator extends EventEmitter {
     const lastBackendName = runs[runs.length - 1]?.decision?.backendName;
     const lastDef =
       lastBackendName !== undefined ? this.config.agent.backends?.[lastBackendName] : undefined;
-    const isLocal = lastDef !== undefined && isLocalEndpointBackend(lastDef);
+    // isLocalExecutionBackend: a `codex` execution stage settles through the same
+    // enforced gate + ship path as a local-endpoint stage (its change is in the worktree).
+    const isLocal = lastDef !== undefined && isLocalExecutionBackend(lastDef);
     const workspacePath = closureWorkspacePath ?? entry?.workspacePath;
     const issue = closureIssue ?? entry?.issue;
     if (isLocal && workspacePath !== undefined && issue !== undefined) {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -641,6 +641,14 @@ export class Orchestrator extends EventEmitter {
    * settles terminally or ships (a green gate), so a later re-pickup starts fresh.
    */
   private localStageGateAttempts = new Map<string, number>();
+  /**
+   * Resume-from-failed-stage checkpoint: per unit, the completed `checkpoint: true`
+   * stage runs (stageIndex → StageRun) that survive gate-block re-dispatches so the
+   * stable design (spec/plan) is reused instead of regenerated each retry. Cleared on
+   * every terminal (ship or needs-human) alongside {@link localStageGateAttempts}, so a
+   * fresh re-pickup regenerates the design.
+   */
+  private stageCheckpoints = new Map<string, Map<number, StageRun>>();
   private server?: OrchestratorServer;
   private interval?: ReturnType<typeof setTimeout> | undefined;
   private heartbeatInterval?: ReturnType<typeof setInterval> | undefined;
@@ -2482,6 +2490,14 @@ export class Orchestrator extends EventEmitter {
           ...(this.priorGateFailureByIssue.get(issue.id) !== undefined
             ? { priorGateFailure: this.priorGateFailureByIssue.get(issue.id)! }
             : {}),
+          // Resume-from-failed-stage: reuse `checkpoint: true` stages (design) across
+          // gate-block re-dispatches so execution retries against a FIXED spec/plan.
+          loadStageCheckpoint: (u: string) => this.stageCheckpoints.get(u),
+          saveStageCheckpoint: (u: string, i: number, run: StageRun) => {
+            const m = this.stageCheckpoints.get(u) ?? new Map<number, StageRun>();
+            m.set(i, run);
+            this.stageCheckpoints.set(u, m);
+          },
           // staged-verify-gate-convergence (blocking fix): thread THIS dispatch's
           // `workspacePath` + `issue` into the settle callbacks. On a staged RETRY
           // re-dispatch the tick does NOT recreate the running entry (retry_fired →
@@ -3806,6 +3822,7 @@ export class Orchestrator extends EventEmitter {
       // Shipped — the unit converged. Clear the retry counter and fall through to the
       // existing success path (cleanWorkspaceWithGuard now finds the pushed branch+PR).
       this.localStageGateAttempts.delete(unit);
+      this.stageCheckpoints.delete(unit); // resume-checkpoint cleared at every terminal
       // IMPORTANT #2 — record the durable double-ship guard. `state.completed`
       // (set by the reducer sequence below) is only TRANSIENT: it is released past
       // the grace window for a still-active row, which would re-select + RE-SHIP
@@ -3923,6 +3940,7 @@ export class Orchestrator extends EventEmitter {
       // D3 tail — bounded retries exhausted → the existing needs-human terminal
       // (which cleans + escalates). Reset the counter so a future re-pickup is fresh.
       this.localStageGateAttempts.delete(unit);
+      this.stageCheckpoints.delete(unit); // resume-checkpoint cleared at every terminal
       this.priorGateFailureByIssue.delete(unit);
       // Durable process-lifetime guard: the terminal marks the LANE (canceled), not
       // the ROW — the row stays `in-progress`, so the tick would re-select this unit
@@ -4000,6 +4018,7 @@ export class Orchestrator extends EventEmitter {
       // its staged-gate retry counter + prior-failure preamble so a future re-pickup
       // starts fresh (no stale carry-over from a prior convergence attempt).
       this.localStageGateAttempts.delete(unit);
+      this.stageCheckpoints.delete(unit); // resume-checkpoint cleared at every terminal
       this.priorGateFailureByIssue.delete(unit);
       const entry = this.state.running.get(unit);
       const identifier = entry?.identifier ?? unit;

--- a/packages/orchestrator/src/workflow/execute-workflow.test.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.test.ts
@@ -50,6 +50,8 @@ function makeFakeCtx(opts: {
   onSuccess?: (unit: string, runs: StageRun[]) => void;
   onTerminal?: (unit: string, runs: StageRun[], err?: unknown) => void;
   adaptiveRouter?: WorkflowEngineContext['adaptiveRouter'];
+  /** Resume-checkpoint: pre-seed to test reuse; reads/writes are observable. */
+  checkpoint?: Map<number, StageRun>;
 }): {
   ctx: WorkflowEngineContext;
   runOrder: number[];
@@ -123,6 +125,13 @@ function makeFakeCtx(opts: {
       terminalFailingSteps.push(failingStep as WorkflowStep | undefined);
       opts.onTerminal?.(unit, runs, err);
     },
+    ...(opts.checkpoint !== undefined
+      ? {
+          loadStageCheckpoint: (_u: string) => opts.checkpoint,
+          saveStageCheckpoint: (_u: string, i: number, run: StageRun) =>
+            opts.checkpoint!.set(i, run),
+        }
+      : {}),
   };
 
   return {
@@ -324,6 +333,46 @@ describe('executeWorkflow — sequential loop (SC1/split-routing P1)', () => {
     expect(runs.map((r) => r.tokens?.total)).toEqual([15, 27, 39]);
     // distinct per-stage token totals — cost is attributable per stage
     expect(new Set(runs.map((r) => r.tokens?.total)).size).toBe(3);
+  });
+});
+
+describe('executeWorkflow — resume-from-failed-stage checkpoint', () => {
+  const cstep = (produces: string, checkpoint = false): WorkflowStep => ({
+    skill: `skill-${produces}`,
+    produces,
+    ...(checkpoint ? { checkpoint: true } : {}),
+  });
+  const designThenCode: WorkflowExecutionPlan = {
+    coherenceUnit: 'issue-1',
+    stages: [cstep('spec', true), cstep('plan', true), cstep('impl')],
+  };
+
+  it('saves passing checkpoint:true stages (design) but not the code stage', async () => {
+    const checkpoint = new Map<number, StageRun>();
+    const { ctx, runOrder } = makeFakeCtx({ sessionIds: ['s0', 's1', 's2'], checkpoint });
+    await executeWorkflow(ctx, designThenCode);
+    expect(runOrder).toHaveLength(3); // all ran on the first dispatch
+    expect([...checkpoint.keys()].sort()).toEqual([0, 1]); // only the two design stages checkpointed
+  });
+
+  it('REUSES checkpointed design on re-dispatch — only the code stage re-runs, design output threaded', async () => {
+    const checkpoint = new Map<number, StageRun>([
+      [0, { index: 0, step: cstep('spec', true), outcome: 'pass', output: 'the spec' }],
+      [1, { index: 1, step: cstep('plan', true), outcome: 'pass', output: 'the plan' }],
+    ]);
+    const { ctx, runOrder, successCalls } = makeFakeCtx({ sessionIds: ['s2'], checkpoint });
+    await executeWorkflow(ctx, designThenCode);
+    expect(runOrder).toHaveLength(1); // ONLY the impl stage ran; design reused
+    const runs = successCalls[0]!;
+    expect(runs.map((r) => r.step.produces)).toEqual(['spec', 'plan', 'impl']);
+    expect(runs[0]!.output).toBe('the spec'); // reused design output present for downstream
+    expect(runs[1]!.output).toBe('the plan');
+  });
+
+  it('without checkpoint seams (legacy ctx) → all stages run (SC3 byte-identical)', async () => {
+    const { ctx, runOrder } = makeFakeCtx({ sessionIds: ['s0', 's1', 's2'] }); // no checkpoint
+    await executeWorkflow(ctx, designThenCode);
+    expect(runOrder).toHaveLength(3);
   });
 });
 

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -143,6 +143,15 @@ export interface WorkflowEngineContext {
     failingStep?: WorkflowExecutionPlan['stages'][number],
     err?: unknown
   ): Promise<void>;
+  /**
+   * Resume-from-failed-stage checkpoint (survives gate-block re-dispatches, on the
+   * orchestrator not this per-dispatch ctx). `loadStageCheckpoint` returns the map of
+   * previously-completed `checkpoint: true` stages (stageIndex → its StageRun) for the
+   * unit; `saveStageCheckpoint` persists one. Absent seams (fake/legacy ctx) ⇒ no reuse
+   * (byte-identical prior behavior). Cleared by the orchestrator on a terminal.
+   */
+  loadStageCheckpoint?(unit: string): ReadonlyMap<number, StageRun> | undefined;
+  saveStageCheckpoint?(unit: string, stageIndex: number, run: StageRun): void;
 }
 
 /**
@@ -496,9 +505,28 @@ export async function executeWorkflow(
   plan: WorkflowExecutionPlan
 ): Promise<void> {
   const runs: StageRun[] = [];
+  // Resume-from-failed-stage: reuse the checkpointed outputs of `checkpoint: true`
+  // stages (the stable design: spec/plan) that passed on a prior dispatch, so a
+  // gate-block re-dispatch re-runs only execution onward against a FIXED design —
+  // rather than regenerating the whole lifecycle each retry.
+  const checkpoint = ctx.loadStageCheckpoint?.(plan.coherenceUnit);
   try {
     for (const [index, step] of plan.stages.entries()) {
-      const run = await runStageWithRetry(ctx, plan.coherenceUnit, index, step, runs);
+      const cached = step.checkpoint === true ? checkpoint?.get(index) : undefined;
+      let run: StageRun;
+      if (cached !== undefined) {
+        run = cached;
+        ctx.logger.info(
+          `resumed stage ${index} (${step.skill}) from checkpoint — reusing prior ${step.produces}`,
+          { issueId: ctx.issueId }
+        );
+      } else {
+        run = await runStageWithRetry(ctx, plan.coherenceUnit, index, step, runs);
+        // Checkpoint a passing checkpoint-stage so a later re-dispatch reuses it.
+        if (step.checkpoint === true && run.outcome === 'pass') {
+          ctx.saveStageCheckpoint?.(plan.coherenceUnit, index, run);
+        }
+      }
       runs.push(run);
       // D8(c)/D10 (SC6): a non-pass stage outcome (a `pass-required` quality
       // failure that survived the single engine retry, or a mid-stage runner

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -12,7 +12,7 @@ import type {
   WorkflowExecutionPlan,
 } from '@harness-engineering/types';
 import { AgentRunner } from '../agent/runner.js';
-import { isLocalEndpointBackend } from '../agent/backend-factory.js';
+import { isLocalExecutionBackend } from '../agent/backend-factory.js';
 import type { OrchestratorBackendFactory } from '../agent/orchestrator-backend-factory.js';
 import { selectStagePromptTemplate } from './local-stage-prompt.js';
 import type { StreamRecorder } from '../core/stream-recorder.js';
@@ -334,7 +334,11 @@ function isLocalBackendFactory(
 ): NonNullable<WorkflowEngineContext['isLocalBackend']> {
   return (backend) => {
     const def = backends?.[backend.name];
-    return def !== undefined && isLocalEndpointBackend(def);
+    // isLocalExecutionBackend (incl. codex): a codex stage also needs the local
+    // skill-run template (`harness skill run harness-<skill> --autonomous`) so it
+    // executes the harness lifecycle skill single-agent, rather than the Claude-shaped
+    // default template. The harness lifecycle rides on the orchestrator's stages.
+    return def !== undefined && isLocalExecutionBackend(def);
   };
 }
 

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -127,6 +127,9 @@ export interface BuildWorkflowContextDeps {
     failingStep?: WorkflowExecutionPlan['stages'][number],
     err?: unknown
   ) => Promise<void>;
+  /** Resume-from-failed-stage checkpoint seams (bound to the orchestrator's map). */
+  loadStageCheckpoint?: (unit: string) => ReadonlyMap<number, StageRun> | undefined;
+  saveStageCheckpoint?: (unit: string, stageIndex: number, run: StageRun) => void;
 }
 
 /**
@@ -422,6 +425,16 @@ export function buildWorkflowContext(deps: BuildWorkflowContextDeps): WorkflowEn
     ): Promise<void> {
       return deps.settleTerminal(unit, runs, failingStep, err);
     },
+
+    // Resume-from-failed-stage checkpoint seams — thin forwarders to the orchestrator's
+    // per-unit stageCheckpoints map (survives re-dispatch). Absent deps ⇒ omitted ⇒ no
+    // reuse (SC3 byte-identical prior behavior).
+    ...(deps.loadStageCheckpoint !== undefined
+      ? { loadStageCheckpoint: deps.loadStageCheckpoint }
+      : {}),
+    ...(deps.saveStageCheckpoint !== undefined
+      ? { saveStageCheckpoint: deps.saveStageCheckpoint }
+      : {}),
 
     ...(adaptiveRouter !== null
       ? {

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -361,6 +361,8 @@ export const WorkflowStepSchema = z
     produces: z.string().min(1),
     expects: z.string().min(1).optional(),
     gate: z.enum(['pass-required', 'advisory']).optional(),
+    // Reuse this stage's output across gate-block re-dispatches (resume-from-failed-stage).
+    checkpoint: z.boolean().optional(),
     cognitiveMode: z.string().min(1).optional(),
     routingHint: z.object({ complexity: z.any().optional(), risk: z.any().optional() }).optional(),
   })

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -208,6 +208,7 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       localProvider: z.enum(['ollama', 'lmstudio']).optional(),
       command: z.string().optional(),
       timeoutMs: z.number().int().positive().optional(),
+      mcpServers: z.array(McpServerSpecSchema).optional(),
       capabilities: BackendCapabilitiesSchema.optional(),
     })
     .strict(),

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -523,6 +523,14 @@ export interface CodexBackendDef {
   command?: string;
   /** Hard wall-clock cap per session in ms. Default 1_800_000 (30min). */
   timeoutMs?: number;
+  /**
+   * MCP servers exposed to the codex-driven local model, injected per-invocation via
+   * `-c mcp_servers.<name>.…` (never written to the user's global `~/.codex/config.toml`).
+   * Each spec's `tools` allowlist maps to codex's per-server `enabled_tools`. Mirrors the
+   * ollama path's `mcpServers` so the codex path gets tool-parity (context7 live docs +
+   * curated harness read tools). Absent ⇒ codex built-in tools only.
+   */
+  mcpServers?: McpServerSpec[];
   /** Native isolation tier this backend provides. Defaults to `'none'`. */
   isolation?: IsolationTier;
   /** AMR Phase 1 (D1): optional capability block for tier selection. */

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -17,6 +17,18 @@ export interface WorkflowStep {
   expects?: string;
   /** Whether failure of this step stops the workflow */
   gate?: 'pass-required' | 'advisory';
+  /**
+   * Reuse this stage's output across gate-block RE-DISPATCHES (resume-from-failed-stage).
+   * When true, once this stage passes its output is checkpointed per unit; on a later
+   * re-dispatch of the same unit (the enforced gate blocked a downstream stage), this
+   * stage is SKIPPED and its checkpointed output reused instead of regenerating it.
+   * Mark the stable DESIGN stages (brainstorm/plan) so an execution-gate failure retries
+   * only execution onward against a FIXED spec/plan — not the whole lifecycle (which
+   * regenerates the design each retry, moving the target and hampering convergence).
+   * The checkpoint is cleared on a terminal (ship or needs-human), so a fresh pickup
+   * regenerates. Default false — omit for byte-identical prior behavior.
+   */
+  checkpoint?: boolean;
   /** Drives the per-stage RoutingUseCase (Phase 2 consumer). */
   cognitiveMode?: string;
   /**


### PR DESCRIPTION
Two follow-ups to #946 that make the `codex` backend production-usable, as two atomic commits.

## 1. `--sandbox workspace-write` (not the dangerous full bypass)
A live trial surfaced a failure with `--dangerously-bypass-approvals-and-sandbox`: on an exploratory task codex spawned an interactive command and aborted with `write_stdin failed: stdin is closed for this session`. Switching to `--sandbox workspace-write` fixes it (0 such errors on re-run) while STILL letting codex apply edits + run the gate — verified by 21 in-session `pnpm typecheck lint test` runs under the sandbox. Also strictly less dangerous; writes confined to the (already-isolated) worktree.

## 2. Gate/routing wiring — codex execution stage → enforced local gate + ship
Adds `isLocalExecutionBackend` (superset of `isLocalEndpointBackend` that also includes `codex`, which has no `endpoint`) and uses it at the two gate/ship sites (`runLocalWorkflowGate`, `settleWorkflowSuccess`). A codex execution stage now runs through the same enforced gate (verify + outcome-eval) and ship path as a local-endpoint stage.

**Why the gate is load-bearing (not cosmetic):** the same trial showed codex can report a *hollow* success — it shipped a syntax error in a file it edited while claiming green. The orchestrator's independent enforced gate is exactly what catches that and blocks/retries. Codex stays OUT of endpoint-only sites (resolver, local-indirection prompt template) since it has no endpoint and takes a direct task prompt.

Tests: 18 codex-backend tests (incl. sandbox-argv assertion + the `isLocalExecutionBackend` predicate) + gate-path suites green.