### PR TITLE
fix(graph): ingest .mjs/.cjs/.mts/.cts source files (#949)

### DIFF
--- a/.changeset/dashboard-ts2742.md
+++ b/.changeset/dashboard-ts2742.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/dashboard': patch
+---
+
+Add an explicit `Hono` type annotation to the exported `app` so its inferred type is nameable via the direct `hono` dependency rather than a hoisted `.pnpm` path (fixes TS2742 in the whole-tree typecheck). Behavior-preserving.

--- a/.changeset/eslint-plugin-ts2742.md
+++ b/.changeset/eslint-plugin-ts2742.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/eslint-plugin': patch
+---
+
+Add explicit type annotations to the `plugin`, `configs`, and `rules` exports so their inferred types are nameable via the direct `@typescript-eslint/utils` dependency rather than a hoisted `.pnpm` path (fixes TS2742 in the DTS build). Behavior-preserving.

--- a/.changeset/ingest-mjs-cjs-949.md
+++ b/.changeset/ingest-mjs-cjs-949.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/graph': patch
+---
+
+Ingest `.mjs`/`.cjs`/`.mts`/`.cts` source files. `CodeIngestor.SUPPORTED_EXTENSIONS` previously omitted ESM/CJS module extensions, so those files produced no graph `file` nodes and `@req` annotations inside them created no `verified_by` edges — silently under-reporting requirement test-verification for repos with `.mjs`/`.cjs` test suites. Fixes #949.

--- a/packages/dashboard/src/server/index.ts
+++ b/packages/dashboard/src/server/index.ts
@@ -74,6 +74,8 @@ export function buildApp(ctx: ServerContext): Hono {
   return app;
 }
 
-const app = buildApp(buildContext({ sseManager: new SSEManager() }));
+// Explicit annotation so the exported type is nameable via the direct `hono`
+// dependency rather than a hoisted `.pnpm` path (avoids TS2742). Behavior-preserving.
+const app: Hono = buildApp(buildContext({ sseManager: new SSEManager() }));
 
 export { app };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,8 +1,11 @@
 // src/index.ts
+import type { TSESLint } from '@typescript-eslint/utils';
 import { rules } from './rules';
 
-// Define the plugin object
-const plugin = {
+// Explicit annotations so the inferred types are nameable via the direct
+// @typescript-eslint/utils dependency rather than the hoisted .pnpm path
+// (avoids TS2742 in downstream DTS builds).
+const plugin: TSESLint.FlatConfig.Plugin = {
   meta: {
     name: '@harness-engineering/eslint-plugin',
     version: '0.3.0',
@@ -66,4 +69,4 @@ export default plugin;
 
 // Named exports for flexibility
 export { rules };
-export const configs = plugin.configs;
+export const configs: TSESLint.FlatConfig.Plugin['configs'] = plugin.configs;

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -17,8 +17,12 @@ import noSkippedTests from './no-skipped-tests';
 import noDisabledTests from './no-disabled-tests';
 import noHardcodedTestCount from './no-hardcoded-test-count';
 import noEmptyDescribe from './no-empty-describe';
+import type { TSESLint } from '@typescript-eslint/utils';
 
-export const rules = {
+// Explicit annotation so the exported type is nameable via the direct
+// @typescript-eslint/utils dependency rather than the hoisted .pnpm path
+// (avoids TS2742 in downstream DTS builds).
+export const rules: Record<string, TSESLint.RuleModule<string, unknown[]>> = {
   'enforce-doc-exports': enforceDocExports,
   'no-circular-deps': noCircularDeps,
   'no-forbidden-imports': noForbiddenImports,

--- a/packages/graph/src/ingest/CodeIngestor.ts
+++ b/packages/graph/src/ingest/CodeIngestor.ts
@@ -105,8 +105,12 @@ function countBraces(line: string): number {
 const SUPPORTED_EXTENSIONS = new Set([
   '.ts',
   '.tsx',
+  '.mts',
+  '.cts',
   '.js',
   '.jsx',
+  '.mjs',
+  '.cjs',
   '.py',
   '.go',
   '.rs',
@@ -875,7 +879,20 @@ export class CodeIngestor {
     const resolved = path.normalize(path.join(fromDir, importPath)).replace(/\\/g, '/');
 
     // Try with extensions
-    const extensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+    const extensions = [
+      '.ts',
+      '.tsx',
+      '.mts',
+      '.cts',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.py',
+      '.go',
+      '.rs',
+      '.java',
+    ];
     for (const ext of extensions) {
       const candidate = resolved.replace(/\.js$/, '') + ext;
       const fullPath = path.join(rootDir, candidate);

--- a/packages/graph/src/ingest/extractors/ApiPathExtractor.ts
+++ b/packages/graph/src/ingest/extractors/ApiPathExtractor.ts
@@ -8,7 +8,20 @@ import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
  */
 export class ApiPathExtractor implements SignalExtractor {
   readonly name = 'api-paths';
-  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+  readonly supportedExtensions = [
+    '.ts',
+    '.tsx',
+    '.mts',
+    '.cts',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+    '.py',
+    '.go',
+    '.rs',
+    '.java',
+  ];
 
   extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
     switch (language) {

--- a/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
+++ b/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
@@ -35,7 +35,20 @@ interface GoConstLine {
  */
 export class EnumConstantExtractor implements SignalExtractor {
   readonly name = 'enum-constants';
-  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+  readonly supportedExtensions = [
+    '.ts',
+    '.tsx',
+    '.mts',
+    '.cts',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+    '.py',
+    '.go',
+    '.rs',
+    '.java',
+  ];
 
   extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
     switch (language) {

--- a/packages/graph/src/ingest/extractors/TestDescriptionExtractor.ts
+++ b/packages/graph/src/ingest/extractors/TestDescriptionExtractor.ts
@@ -30,7 +30,20 @@ const JAVA_METHOD_RE =
  */
 export class TestDescriptionExtractor implements SignalExtractor {
   readonly name = 'test-descriptions';
-  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+  readonly supportedExtensions = [
+    '.ts',
+    '.tsx',
+    '.mts',
+    '.cts',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+    '.py',
+    '.go',
+    '.rs',
+    '.java',
+  ];
 
   extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
     const records: ExtractionRecord[] = [];

--- a/packages/graph/src/ingest/extractors/ValidationRuleExtractor.ts
+++ b/packages/graph/src/ingest/extractors/ValidationRuleExtractor.ts
@@ -8,7 +8,20 @@ import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
  */
 export class ValidationRuleExtractor implements SignalExtractor {
   readonly name = 'validation-rules';
-  readonly supportedExtensions = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'];
+  readonly supportedExtensions = [
+    '.ts',
+    '.tsx',
+    '.mts',
+    '.cts',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+    '.py',
+    '.go',
+    '.rs',
+    '.java',
+  ];
 
   extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
     switch (language) {

--- a/packages/graph/tests/ingest/CodeIngestor-req-annotation.test.ts
+++ b/packages/graph/tests/ingest/CodeIngestor-req-annotation.test.ts
@@ -165,4 +165,42 @@ describe('CodeIngestor @req annotation parsing', () => {
       expect(edge.metadata!.method).toBe('annotation');
     }
   });
+
+  it('should ingest .mjs/.cjs files and honor their @req annotations (regression #949)', async () => {
+    const srcDir = path.join(tmpDir, 'src');
+    await fs.mkdir(srcDir, { recursive: true });
+    // ESM test file — the shape used by e.g. node:test suites
+    await fs.writeFile(
+      path.join(srcDir, 'auth.test.mjs'),
+      [
+        '// @req auth-feature#2',
+        "import { test } from 'node:test';",
+        'test("hashes passwords", () => {});',
+      ].join('\n')
+    );
+    // CommonJS file
+    await fs.writeFile(
+      path.join(srcDir, 'legacy.cjs'),
+      ['// @req auth-feature#3', 'module.exports = { validate() { return true; } };'].join('\n')
+    );
+
+    const reqIngestor = new RequirementIngestor(store);
+    await reqIngestor.ingestSpecs(path.join(tmpDir, 'docs', 'changes'));
+
+    const codeIngestor = new CodeIngestor(store);
+    await codeIngestor.ingest(tmpDir);
+
+    // .mjs and .cjs files must become first-class file nodes
+    const exts = store.findNodes({ type: 'file' }).map((n) => path.extname(n.name));
+    expect(exts).toContain('.mjs');
+    expect(exts).toContain('.cjs');
+
+    // and their @req annotations must produce verified_by edges
+    const annotationTags = store
+      .getEdges({ type: 'verified_by' })
+      .filter((e) => e.metadata?.method === 'annotation')
+      .map((e) => e.metadata!.tag);
+    expect(annotationTags).toContain('@req auth-feature#2');
+    expect(annotationTags).toContain('@req auth-feature#3');
+  });
 });

--- a/packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts
+++ b/packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts
@@ -20,7 +20,20 @@ const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-pro
 function createStubExtractor(name: string): SignalExtractor {
   return {
     name,
-    supportedExtensions: ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java'],
+    supportedExtensions: [
+      '.ts',
+      '.tsx',
+      '.mts',
+      '.cts',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.py',
+      '.go',
+      '.rs',
+      '.java',
+    ],
     extract(content: string, filePath: string, language: Language): ExtractionRecord[] {
       return [
         {


### PR DESCRIPTION
## Summary

Fixes #949: the graph code-ingestor silently skipped ESM/CJS module source files.

`CodeIngestor.SUPPORTED_EXTENSIONS` (and the extractor allowlists in `packages/graph`) omitted `.mjs`, `.cjs`, `.mts`, and `.cts`. As a result those files produced no graph `file` nodes, and `@req` annotations inside them created no `verified_by` edges — silently under-reporting requirement test-verification for repos with `.mjs`/`.cjs` test suites.

### Main change (`@harness-engineering/graph`)

- Add `.mjs`/`.cjs`/`.mts`/`.cts` to `SUPPORTED_EXTENSIONS` and the extractor allowlists.
- Regression test `tests/ingest/CodeIngestor-req-annotation.test.ts` confirms `.mjs` files are ingested and `@req` annotations wire up `verified_by` edges (4/4 passing).

### Required to pass the repo-wide pre-push typecheck

The pre-push hook runs `turbo run typecheck` across the affected packages + dependents. Two pre-existing, unrelated **TS2742** portability errors surfaced there and blocked the push. Both are fixed with minimal, behavior-preserving explicit type annotations so the exported type is nameable via the package's *direct* dependency instead of a hoisted `.pnpm/...` path:

- **`@harness-engineering/eslint-plugin`** — annotate the `plugin`, `configs`, and `rules` exports (`TSESLint.FlatConfig.Plugin` / `Record<string, TSESLint.RuleModule<string, unknown[]>>` via the direct `@typescript-eslint/utils` dep). Emitted `.d.ts` no longer references the `.pnpm` path.
- **`@harness-engineering/dashboard`** — annotate the exported `app` as `Hono` (via the direct `hono` dep) in `src/server/index.ts`.

These are pure type annotations with no runtime effect.

## Testing

- `pnpm --filter @harness-engineering/graph exec vitest run tests/ingest/CodeIngestor-req-annotation.test.ts` — 4/4 pass
- `pnpm --filter @harness-engineering/eslint-plugin typecheck` and `build` (DTS) — pass
- `pnpm --filter @harness-engineering/dashboard typecheck` — pass
- Full pre-push gate (whole-tree changeset check, affected `turbo typecheck`, affected `test:coverage` with coverage ratchet, docs freshness) — pass

## Changesets

- `@harness-engineering/graph`: patch (the #949 fix)
- `@harness-engineering/eslint-plugin`: patch (TS2742 portability annotation)
- `@harness-engineering/dashboard`: patch (TS2742 portability annotation)
