### PR TITLE
fix(ci): coverage ratchet grades only fresh coverage on pre-push (#939)

### DIFF
--- a/.changeset/coverage-ratchet-prune-stale.md
+++ b/.changeset/coverage-ratchet-prune-stale.md
@@ -1,0 +1,22 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(ci): coverage ratchet grades only fresh coverage on pre-push (#939)
+
+The `pre-push` hook runs `turbo run test:coverage --affected` then the coverage
+ratchet with `--allow-missing`. `--affected` regenerates coverage only for
+changed packages, so an UNAFFECTED package keeps a STALE
+`coverage-summary.json` from a previous run. The ratchet graded that stale file
+against baseline and reported a phantom regression (e.g. "packages/orchestrator
+lines dropped from 85.52% to 83.5%"), blocking pushes on fresh clones and
+headless agent sandboxes. `--allow-missing` only skips packages whose coverage
+is absent, not stale-but-present ones.
+
+Fix: add a unit-testable `pruneCoverageSummaries()` export (plus a `--clean`
+CLI mode) to `scripts/coverage-ratchet.mjs` that deletes stale
+`coverage-summary.json` files, and call it in `.husky/pre-push` BEFORE the
+`--affected` coverage run. Afterwards only re-measured packages have a summary
+(graded); unaffected packages have none (skipped under `--allow-missing`),
+restoring the invariant "measured this run <=> file present". CI's flagless,
+whole-repo authoritative ratchet path is unchanged.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -75,6 +75,12 @@ if [ "$AFFECTED_OK" = "1" ]; then
 
   # Affected-scoped typecheck and coverage (base = origin/main, dependents included).
   pnpm exec turbo run typecheck --affected
+  # Prune STALE coverage-summary.json before the affected run. `--affected`
+  # regenerates coverage only for changed packages; an unaffected package keeps a
+  # stale summary from a previous run that the ratchet would grade as a phantom
+  # regression (#939). Removing them first makes "measured this run <=> file
+  # present" hold, so the --allow-missing skip below is correct by construction.
+  node scripts/coverage-ratchet.mjs --clean
   # Cap turbo concurrency to 2 packages-at-a-time. Without this, filesystem/sqlite/HTTP-heavy
   # tests flake under compound parallel load (Phase 2 raises this cap after test isolation).
   pnpm exec turbo run test:coverage --affected --concurrency=2

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -6,10 +6,11 @@
  * Usage:
  *   node scripts/coverage-ratchet.mjs                  # check mode (CI, full/authoritative)
  *   node scripts/coverage-ratchet.mjs --allow-missing  # check mode, skip packages with no fresh coverage (pre-push)
+ *   node scripts/coverage-ratchet.mjs --clean          # delete stale coverage-summary.json before an --affected run (pre-push)
  *   node scripts/coverage-ratchet.mjs --update          # update baselines
  */
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -58,6 +59,43 @@ function readCoverage(pkgKey) {
     console.warn(`  Warning: could not read coverage for ${pkgKey} -- skipping`);
     return null;
   }
+}
+
+/**
+ * Delete any coverage-summary.json files left on disk for the given packages.
+ *
+ * This is the load-bearing half of the pre-push freshness fix (#939). The
+ * partial `--allow-missing` mode is only correct if "not measured this run"
+ * truly means "no coverage file present": `turbo run test:coverage --affected`
+ * regenerates coverage ONLY for affected packages, but an UNAFFECTED package
+ * keeps a STALE coverage-summary.json from a previous run. `evaluateCoverage`
+ * cannot tell fresh from stale — it grades whatever is on disk — so that stale
+ * file gets graded against baseline and reports a phantom regression, blocking
+ * pushes on fresh clones / headless agent sandboxes.
+ *
+ * Running this BEFORE the `--affected` coverage run removes every summary, so
+ * afterwards only packages the run actually re-measured have a file (graded)
+ * and unaffected packages have none (null -> skipped under `--allow-missing`).
+ * That restores the invariant "measured this run <=> file present" and makes
+ * `--allow-missing` correct by construction, without per-package special-casing.
+ *
+ * Idempotent: absent files are left alone (`existsSync` guard + `force`), so a
+ * fresh clone with no coverage dirs at all is a no-op.
+ *
+ * @param {Record<string, string>} packages  pkgKey -> coverage-summary.json path (relative to rootDir)
+ * @param {string} rootDir  repo root the paths resolve against
+ * @returns {string[]} pkgKeys whose stale summary was removed
+ */
+export function pruneCoverageSummaries(packages = PACKAGES, rootDir = ROOT) {
+  const removed = [];
+  for (const pkgKey of Object.keys(packages)) {
+    const absPath = join(rootDir, packages[pkgKey]);
+    if (existsSync(absPath)) {
+      rmSync(absPath, { force: true });
+      removed.push(pkgKey);
+    }
+  }
+  return removed;
 }
 
 function loadBaselines() {
@@ -134,7 +172,9 @@ function check({ allowMissing = false } = {}) {
 
   if (failures > 0) {
     console.error(`\n${failures} coverage regression(s) detected.`);
-    console.error('If coverage intentionally decreased, run: node scripts/coverage-ratchet.mjs --update');
+    console.error(
+      'If coverage intentionally decreased, run: node scripts/coverage-ratchet.mjs --update'
+    );
     process.exit(1);
   }
 
@@ -158,12 +198,13 @@ function check({ allowMissing = false } = {}) {
  * - new package       -> adopt
  * - package missing this run -> keep the committed value (transient gap, no churn)
  */
-export function mergeCoverageBaselines(existing = {}, fresh = {}, tolerance = V8_VARIANCE_TOLERANCE) {
+export function mergeCoverageBaselines(
+  existing = {},
+  fresh = {},
+  tolerance = V8_VARIANCE_TOLERANCE
+) {
   const merged = {};
-  const keys = [
-    ...Object.keys(existing),
-    ...Object.keys(fresh).filter((k) => !(k in existing)),
-  ];
+  const keys = [...Object.keys(existing), ...Object.keys(fresh).filter((k) => !(k in existing))];
 
   for (const pkgKey of keys) {
     const prev = existing[pkgKey];
@@ -181,9 +222,7 @@ export function mergeCoverageBaselines(existing = {}, fresh = {}, tolerance = V8
       const a = next[metric];
       const b = prev[metric];
       out[metric] =
-        typeof a === 'number' && typeof b === 'number' && Math.abs(a - b) <= tolerance
-          ? b
-          : a;
+        typeof a === 'number' && typeof b === 'number' && Math.abs(a - b) <= tolerance ? b : a;
     }
     merged[pkgKey] = out;
   }
@@ -213,7 +252,9 @@ function update() {
   const merged = mergeCoverageBaselines(existing, fresh);
   for (const pkgKey of Object.keys(merged)) {
     const m = merged[pkgKey];
-    console.log(`  ${pkgKey}: lines=${m.lines}% branches=${m.branches}% functions=${m.functions}% statements=${m.statements}%`);
+    console.log(
+      `  ${pkgKey}: lines=${m.lines}% branches=${m.branches}% functions=${m.functions}% statements=${m.statements}%`
+    );
   }
 
   writeFileSync(BASELINES_PATH, JSON.stringify(merged, null, 2) + '\n');
@@ -226,7 +267,15 @@ const invokedDirectly =
 
 if (invokedDirectly) {
   const args = process.argv.slice(2);
-  if (args.includes('--update')) {
+  if (args.includes('--clean')) {
+    console.log('Pruning stale coverage summaries before the affected run...\n');
+    const removed = pruneCoverageSummaries();
+    if (removed.length) {
+      for (const pkgKey of removed) console.log(`  Removed stale coverage for ${pkgKey}`);
+    } else {
+      console.log('  No stale coverage summaries found.');
+    }
+  } else if (args.includes('--update')) {
     console.log('Updating coverage baselines...\n');
     update();
   } else {

--- a/tests/scripts/baseline-gating.test.mjs
+++ b/tests/scripts/baseline-gating.test.mjs
@@ -16,8 +16,15 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
-import { mergeCoverageBaselines, evaluateCoverage } from '../../scripts/coverage-ratchet.mjs';
+import {
+  mergeCoverageBaselines,
+  evaluateCoverage,
+  pruneCoverageSummaries,
+} from '../../scripts/coverage-ratchet.mjs';
 import { mergeBenchmarkBaselines } from '../../scripts/benchmark-check.mjs';
 
 test('coverage: sub-tolerance jitter keeps the committed file byte-identical', () => {
@@ -37,7 +44,9 @@ test('coverage: sub-tolerance jitter keeps the committed file byte-identical', (
 
 test('coverage: movement beyond tolerance is adopted', () => {
   const committed = { 'packages/core': { lines: 80, branches: 70, functions: 80, statements: 80 } };
-  const measured = { 'packages/core': { lines: 85, branches: 70.2, functions: 80, statements: 80 } };
+  const measured = {
+    'packages/core': { lines: 85, branches: 70.2, functions: 80, statements: 80 },
+  };
 
   const merged = mergeCoverageBaselines(committed, measured);
 
@@ -86,18 +95,145 @@ test('evaluateCoverage: with allowMissing, a missing package is skipped, present
 
 test('evaluateCoverage: with allowMissing, a present package below baseline still fails', () => {
   const baselines = { 'packages/cli': { lines: 85, branches: 75, functions: 85, statements: 85 } };
-  const coverageByPkg = { 'packages/cli': { lines: 80, branches: 75, functions: 85, statements: 85 } };
+  const coverageByPkg = {
+    'packages/cli': { lines: 80, branches: 75, functions: 85, statements: 85 },
+  };
   const { failures } = evaluateCoverage(baselines, coverageByPkg, { allowMissing: true });
   assert.equal(failures, 1); // -5% lines beyond 0.5% tolerance
 });
 
+// ---------------------------------------------------------------------------
+// #939: pre-push coverage ratchet grades a STALE summary for an unaffected
+// package. `turbo --affected` only regenerates coverage for changed packages,
+// so an unaffected package keeps a coverage-summary.json from a previous run.
+// `evaluateCoverage` can't tell fresh from stale and grades it as a phantom
+// regression. pruneCoverageSummaries deletes those stale files BEFORE the
+// affected run so "measured this run <=> file present" holds and --allow-missing
+// skips them correctly. These tests fail if pruneCoverageSummaries is missing
+// or doesn't delete on-disk summaries (revert the fix -> import/behaviour fails).
+// ---------------------------------------------------------------------------
+
+/** Read one package's coverage the way the ratchet does, returning null when absent. */
+function readSummary(root, relPath) {
+  try {
+    const total = JSON.parse(readFileSync(join(root, relPath), 'utf8')).total;
+    return {
+      lines: total.lines.pct,
+      branches: total.branches.pct,
+      functions: total.functions.pct,
+      statements: total.statements.pct,
+    };
+  } catch {
+    return null;
+  }
+}
+
+test('pruneCoverageSummaries: deletes on-disk stale summaries and is idempotent on absent ones', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ratchet-prune-'));
+  try {
+    const packages = {
+      'packages/orchestrator': 'packages/orchestrator/coverage/coverage-summary.json',
+      'packages/cli': 'packages/cli/coverage/coverage-summary.json',
+    };
+    // Only orchestrator has a leftover (stale) summary on disk.
+    const stale = join(root, packages['packages/orchestrator']);
+    mkdirSync(join(root, 'packages/orchestrator/coverage'), { recursive: true });
+    writeFileSync(stale, JSON.stringify({ total: { lines: { pct: 83.5 } } }));
+    assert.ok(existsSync(stale));
+
+    const removed = pruneCoverageSummaries(packages, root);
+
+    assert.deepEqual(removed, ['packages/orchestrator']); // only the present file
+    assert.ok(!existsSync(stale)); // stale summary is gone -> reads as "missing this run"
+
+    // Idempotent: a second prune (or a fresh clone with no coverage dirs) is a no-op.
+    assert.deepEqual(pruneCoverageSummaries(packages, root), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('#939 end-to-end: prune before an affected run stops a stale unaffected summary from being graded', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ratchet-e2e-'));
+  try {
+    const packages = {
+      'packages/orchestrator': 'packages/orchestrator/coverage/coverage-summary.json',
+      'packages/cli': 'packages/cli/coverage/coverage-summary.json',
+    };
+    const baselines = {
+      'packages/orchestrator': { lines: 85.52, branches: 80, functions: 90, statements: 85 },
+      'packages/cli': { lines: 85, branches: 75, functions: 85, statements: 85 },
+    };
+
+    // BEFORE this push: a STALE orchestrator summary sits on disk below baseline
+    // (85.52% -> 83.5%). This push only affects packages/cli.
+    mkdirSync(join(root, 'packages/orchestrator/coverage'), { recursive: true });
+    writeFileSync(
+      join(root, packages['packages/orchestrator']),
+      JSON.stringify({
+        total: {
+          lines: { pct: 83.5 },
+          branches: { pct: 80 },
+          functions: { pct: 90 },
+          statements: { pct: 85 },
+        },
+      })
+    );
+
+    // Without prune, the ratchet would grade the stale orchestrator file -> phantom fail.
+    const staleGraded = evaluateCoverage(
+      baselines,
+      {
+        'packages/orchestrator': readSummary(root, packages['packages/orchestrator']),
+        'packages/cli': null,
+      },
+      { allowMissing: true }
+    );
+    assert.equal(staleGraded.failures, 1); // demonstrates the bug the fix removes
+
+    // THE FIX: prune stale summaries, then the affected run regenerates only cli.
+    pruneCoverageSummaries(packages, root);
+    mkdirSync(join(root, 'packages/cli/coverage'), { recursive: true });
+    writeFileSync(
+      join(root, packages['packages/cli']),
+      JSON.stringify({
+        total: {
+          lines: { pct: 86 },
+          branches: { pct: 76 },
+          functions: { pct: 86 },
+          statements: { pct: 86 },
+        },
+      })
+    );
+
+    const coverageByPkg = {
+      'packages/orchestrator': readSummary(root, packages['packages/orchestrator']), // null: pruned, unaffected
+      'packages/cli': readSummary(root, packages['packages/cli']), // fresh, meets baseline
+    };
+    const { failures, skipped } = evaluateCoverage(baselines, coverageByPkg, {
+      allowMissing: true,
+    });
+
+    assert.equal(failures, 0); // no phantom regression from the stale file
+    assert.deepEqual(skipped, ['packages/orchestrator']); // unaffected -> skipped, not graded
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('benchmark: sub-threshold timing jitter keeps the committed file byte-identical', () => {
   const committed = {
-    'core/validateConfig - valid config object': { mean: 0.001601108808008122, p99: 0.0032860000000027867 },
+    'core/validateConfig - valid config object': {
+      mean: 0.001601108808008122,
+      p99: 0.0032860000000027867,
+    },
   };
   // The exact jitter that conflicted in #671 (mean move << 100% threshold).
   const measured = {
-    'core/validateConfig - valid config object': { mean: 0.0018601312616490825, p99: 0.0030699999999797 },
+    'core/validateConfig - valid config object': {
+      mean: 0.0018601312616490825,
+      p99: 0.0030699999999797,
+    },
   };
 
   const merged = mergeBenchmarkBaselines(committed, measured);
@@ -118,7 +254,7 @@ test('benchmark: a genuine regression beyond threshold is adopted', () => {
 test('benchmark: new and placeholder-zero baselines adopt fresh values', () => {
   const merged = mergeBenchmarkBaselines(
     { existing: { mean: 0, p99: 0 } },
-    { existing: { mean: 0.5, p99: 0.6 }, fresh: { mean: 0.1, p99: 0.2 } },
+    { existing: { mean: 0.5, p99: 0.6 }, fresh: { mean: 0.1, p99: 0.2 } }
   );
 
   assert.deepEqual(merged.existing, { mean: 0.5, p99: 0.6 }); // zero placeholder -> adopt


### PR DESCRIPTION
Fixes #939

## Root cause
The `pre-push` hook runs `pnpm exec turbo run test:coverage --affected` then `node scripts/coverage-ratchet.mjs --allow-missing`. `--affected` regenerates coverage **only for changed packages**, but an UNAFFECTED package keeps a **stale** `packages/<pkg>/coverage/coverage-summary.json` from a previous run. The ratchet's `readCoverage()` reads that stale (non-null) file and grades it against baseline, reporting a phantom regression (e.g. `packages/orchestrator lines dropped from 85.52% to 83.5%`). `--allow-missing` only skips packages whose coverage is **absent/unreadable** (null), not stale-but-present ones — so fresh clones and headless agent sandboxes couldn't push without `--no-verify`.

The underlying defect: freshness is invisible to the ratchet. It grades whatever `coverage-summary.json` is on disk regardless of whether *this* run produced it, so `--allow-missing` conflates "not measured this run" with "file present".

## Fix
Make "not measured this run" ⟺ "no coverage file present", so `--allow-missing` becomes correct by construction:

- Add a unit-testable `pruneCoverageSummaries(packages, rootDir)` export (plus a `--clean` CLI mode) to `scripts/coverage-ratchet.mjs` that deletes stale `coverage-summary.json` files. Idempotent (`existsSync` guard + `rmSync({ force })`), so a fresh clone with no coverage dirs is a no-op.
- Call `node scripts/coverage-ratchet.mjs --clean` in `.husky/pre-push` **before** the `--affected` coverage run. Afterwards only re-measured packages have a summary (graded); unaffected packages have none (null → skipped under `--allow-missing`).

CI's flagless, whole-repo authoritative ratchet path (the `else` branch) is unchanged.

No try/catch swallowing, no per-package special-cases, no tolerance weakening, no baseline edits.

## Regression test
`tests/scripts/baseline-gating.test.mjs` gains two tests:
1. `pruneCoverageSummaries` deletes on-disk stale summaries and is idempotent on absent ones.
2. `#939 end-to-end`: a stale unaffected summary below baseline would be graded as a failure (asserts the bug), then after prune + affected re-measure it is skipped and only the fresh package is graded (0 failures).

**Proof it catches the bug:** with the prune body neutered, tests 7 & 8 fail (`# fail 2`); with the fix restored, all 11 pass.

## Local gates (all green)
- `node --test tests/scripts/baseline-gating.test.mjs` → 11/11 pass
- pre-commit `harness ci check` arch gate → pass
- pre-push: changeset check, affected typecheck+coverage, coverage ratchet (`--clean` then `--allow-missing` — correctly skipped all unaffected packages), `generate-docs --check` → all pass