### PR TITLE
fix(graph): test-description extractor emits path-based file: IDs so governs edges resolve (#940)

### DIFF
--- a/.changeset/graph-extractor-path-based-file-ids.md
+++ b/.changeset/graph-extractor-path-based-file-ids.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/graph': patch
+---
+
+fix(graph): test-description extractor emits path-based `file:` IDs so `governs` edges resolve (#940)
+
+The business-signal / test-description extractor ingest minted hash-based `file:<hash>`
+IDs for its edge targets and node `location.fileId`, while the code scanner materializes
+file nodes with path-based IDs (`file:<relativePath>`). The two schemes never matched, so
+every `governs`/`documents` edge from an `extracted:*` node dangled by construction (e.g.
+529 dangling edges in one repo). `ExtractionRunner` now emits the canonical
+`file:${record.filePath}` ID for both the node location and the edge target; because the
+runner already passes each extractor a repo-relative, POSIX-normalized path identical to
+`CodeIngestor`'s, these IDs are byte-identical and the edges bind to the real file nodes.

--- a/packages/graph/src/ingest/extractors/ExtractionRunner.ts
+++ b/packages/graph/src/ingest/extractors/ExtractionRunner.ts
@@ -2,7 +2,6 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { GraphStore } from '../../store/GraphStore.js';
 import type { IngestResult, GraphNode, GraphEdge, EdgeType } from '../../types.js';
-import { hash } from '../ingestUtils.js';
 import { DEFAULT_SKIP_DIRS } from '../skip-dirs.js';
 import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
 
@@ -159,7 +158,10 @@ export class ExtractionRunner {
       name: record.name,
       path: record.filePath,
       location: {
-        fileId: `file:${hash(record.filePath)}`,
+        // Use the canonical path-based file-node ID (matching CodeIngestor's
+        // `file:${relativePath}` convention) so this record binds to the real,
+        // materialized file node instead of a dangling `file:<hash>` target (#940).
+        fileId: `file:${record.filePath}`,
         startLine: record.line,
         endLine: record.line,
       },
@@ -176,8 +178,10 @@ export class ExtractionRunner {
 
     store.addNode(node);
 
-    // Create edge to source file node
-    const fileNodeId = `file:${hash(record.filePath)}`;
+    // Create edge to source file node. Target the canonical path-based file-node
+    // ID (`file:${relativePath}`, same as CodeIngestor) so this `governs`/`documents`
+    // edge resolves to a materialized file node rather than dangling (#940).
+    const fileNodeId = `file:${record.filePath}`;
     const edgeType = EXTRACTOR_EDGE_TYPE[record.extractor] ?? 'documents';
     const edge: GraphEdge = {
       from: record.id,

--- a/packages/graph/tests/ingest/extractors/integration.test.ts
+++ b/packages/graph/tests/ingest/extractors/integration.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'os';
 import { GraphStore } from '../../../src/store/GraphStore.js';
 import { createExtractionRunner } from '../../../src/ingest/extractors/index.js';
+import { CodeIngestor } from '../../../src/ingest/CodeIngestor.js';
 import type { ExtractionRecord } from '../../../src/ingest/extractors/types.js';
 
 const FIXTURE_DIR = path.resolve(__dirname, '../../../__fixtures__/extractor-project');
@@ -91,6 +92,52 @@ describe('Code Signal Extractors — End-to-End', () => {
     const result = await runner.run(FIXTURE_DIR, store, tmpDir);
 
     expect(result.edgesAdded).toBeGreaterThan(0);
+  });
+
+  // Regression for #940: extractor `governs`/`documents` edges must target the
+  // SAME path-based file-node ID the code scanner materializes
+  // (`file:${relativePath}`), not a hash-based `file:<hash>` that never resolves.
+  it('binds extractor governs/documents edges to materialized code-scanner file nodes (#940)', async () => {
+    // Materialize the canonical path-based file nodes first (as `graph scan` does).
+    const codeIngestor = new CodeIngestor(store);
+    await codeIngestor.ingest(FIXTURE_DIR);
+
+    // Then run the business-signal extractors (as `graph ingest --all` does).
+    const runner = createExtractionRunner();
+    await runner.run(FIXTURE_DIR, store, tmpDir);
+
+    // Every edge that originates from an `extracted:` node must resolve to a real
+    // file node — no dangling targets.
+    const extractedNodes = [
+      ...store.findNodes({ type: 'business_rule' }),
+      ...store.findNodes({ type: 'business_term' }),
+      ...store.findNodes({ type: 'business_process' }),
+    ].filter((n) => n.metadata.source === 'code-extractor');
+    expect(extractedNodes.length).toBeGreaterThan(0);
+
+    let checkedEdges = 0;
+    let governsChecked = 0;
+    for (const node of extractedNodes) {
+      const outEdges = store.getEdges({ from: node.id });
+      const fileEdges = outEdges.filter((e) => e.type === 'governs' || e.type === 'documents');
+      for (const edge of fileEdges) {
+        checkedEdges++;
+        if (edge.type === 'governs') governsChecked++;
+
+        // The edge target must be the canonical path-based file-node ID.
+        expect(edge.to).toBe(`file:${node.path}`);
+        expect(edge.to).not.toMatch(/^file:[0-9a-f]{8,}$/);
+
+        // And it must resolve to a real, materialized file node (no dangle).
+        const target = store.getNode(edge.to);
+        expect(target, `dangling edge target ${edge.to} from ${node.id}`).not.toBeNull();
+        expect(target!.type).toBe('file');
+      }
+    }
+
+    // Sanity: we actually exercised governs edges (from test-descriptions).
+    expect(checkedEdges).toBeGreaterThan(0);
+    expect(governsChecked).toBeGreaterThan(0);
   });
 
   it('covers all 6 languages across extractors', async () => {


### PR DESCRIPTION
Fixes #940.

## Root cause
After `harness graph scan` + `harness graph ingest --all`, `graph status` reported large batches of **dangling `governs` edges** (529 in one repo). Each originated from an `extracted:test-descriptions:<hash>` node and targeted a `file:<hash>` node that was never materialized.

The cause was an ID-scheme mismatch. The code scanner (`CodeIngestor`) materializes file nodes with **path-based** IDs:

```ts
const relativePath = path.relative(rootDir, filePath).replace(/\\/g, '/');
const fileId = `file:${relativePath}`;   // e.g. file:tests/guardian/test_cli.py
```

but the business-signal / test-description extractor ingest (`ExtractionRunner.persistRecord`) minted **hash-based** IDs for both the node `location.fileId` and its `governs`/`documents` edge target:

```ts
fileId: `file:${hash(record.filePath)}`;      // e.g. file:5b16029f
const fileNodeId = `file:${hash(record.filePath)}`;
```

The two schemes can never match, so every extractor edge dangled by construction.

## Fix
`ExtractionRunner` now emits the canonical path-based `file:${record.filePath}` ID for both the node location and the edge target, and the now-unused `hash` import is dropped.

This is byte-identical to `CodeIngestor`'s scheme: the runner passes each extractor a repo-relative, POSIX-normalized path (`path.relative(projectDir, filePath).replaceAll('\\', '/')`) — the same computation `CodeIngestor` uses — and every extractor stores that argument verbatim as `record.filePath`. So the edges now bind to the real, materialized file nodes instead of dangling.

## Regression test
`packages/graph/tests/ingest/extractors/integration.test.ts` — new test *"binds extractor governs/documents edges to materialized code-scanner file nodes (#940)"*: runs `CodeIngestor.ingest` then the extractors against the shared fixture project, and asserts every `governs`/`documents` edge from an `extracted:*` node (a) equals `file:${node.path}`, (b) does not match a `file:<hash>` shape, and (c) resolves to a real `file` node in the store.

Proven: without the fix the test fails (`expected 'file:5b16029f' to be 'file:AuthTest.java'`); with the fix it passes.

## Verification
- `@harness-engineering/graph` full suite: 898 tests pass (73 files)
- `tsc --noEmit` clean
- pre-commit arch gate + eslint + prettier passed; pre-push gauntlet (format:check, typecheck, coverage ratchet, generate-docs --check) all green