### PR TITLE
fix(graph): link @req annotations after requirement nodes exist (#949 follow-up)

### DIFF
--- a/.changeset/req-scan-ordering-949.md
+++ b/.changeset/req-scan-ordering-949.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/graph': patch
+'@harness-engineering/cli': patch
+---
+
+Fix `@req` scan ordering (follow-up to #949): `harness graph scan` ingested code (which extracts `@req` annotations) BEFORE `RequirementIngestor` created the requirement nodes, so on a single `scan` every annotation logged "references non-existent requirement" and no `verified_by` edge formed — it only worked via the two-step `scan` then `ingest --all` workaround. `CodeIngestor.ingest` now accepts a `{ skipRequirementAnnotations }` option and exposes `linkRequirementAnnotations()`; `runScan` defers annotation linking until after requirement nodes exist. Convention-based requirement linking (which needs file nodes) is unaffected.

--- a/packages/cli/src/commands/graph/scan.ts
+++ b/packages/cli/src/commands/graph/scan.ts
@@ -16,9 +16,12 @@ export async function runScan(
   const store = new GraphStore();
   const start = Date.now();
 
-  // Code ingestion (honors `ingest.*` config from harness.config.json)
+  // Code ingestion (honors `ingest.*` config from harness.config.json).
+  // Defer @req-annotation linking: requirement nodes do not exist yet, so annotations
+  // must be linked AFTER RequirementIngestor runs, otherwise no verified_by edges form (#949).
   const ingestOptions = loadIngestOptions(projectPath);
-  await new CodeIngestor(store, ingestOptions).ingest(projectPath);
+  const codeIngestor = new CodeIngestor(store, ingestOptions);
+  await codeIngestor.ingest(projectPath, { skipRequirementAnnotations: true });
   new TopologicalLinker(store).link();
 
   // Knowledge ingestion
@@ -28,6 +31,10 @@ export async function runScan(
   // Requirement ingestion (spec traceability)
   const specsDir = path.join(projectPath, 'docs', 'changes');
   await new RequirementIngestor(store).ingestSpecs(specsDir);
+
+  // Link @req annotations now that requirement nodes exist (#949). Runs after
+  // RequirementIngestor so annotations resolve to real requirement nodes.
+  await codeIngestor.linkRequirementAnnotations(projectPath);
 
   // Git ingestion (may fail if not a git repo)
   try {

--- a/packages/cli/tests/commands/graph/scan-req-annotation.test.ts
+++ b/packages/cli/tests/commands/graph/scan-req-annotation.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runScan } from '../../../src/commands/graph/scan';
+
+/**
+ * #949 (follow-up): `harness graph scan` ingests code BEFORE requirement specs,
+ * so `@req` annotations must be linked AFTER requirement nodes exist. Before the
+ * fix the annotation pass ran inline during code ingestion — before any
+ * requirement node existed — so every annotation logged "references non-existent
+ * requirement" and no `verified_by` edge was created on a single `scan` (it only
+ * worked via the two-step `scan` then `ingest --all` workaround). This guards the
+ * production wiring: annotation linking now runs after RequirementIngestor.
+ */
+describe('runScan @req annotation linking (#949)', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'runscan-req-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('creates a verified_by edge from an @req annotation to the annotated file', async () => {
+    // A spec so RequirementIngestor mints requirement nodes.
+    const featureDir = path.join(tmp, 'docs', 'changes', 'auth-feature');
+    fs.mkdirSync(featureDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(featureDir, 'proposal.md'),
+      [
+        '# Auth Feature',
+        '',
+        '## Success Criteria',
+        '',
+        '1. When a user logs in, the system shall return a token',
+        '',
+      ].join('\n')
+    );
+
+    // A source file annotated with @req against that requirement.
+    const srcDir = path.join(tmp, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(srcDir, 'auth.test.ts'),
+      [
+        '// @req auth-feature#1',
+        'describe("auth", () => {',
+        '  it("logs in", () => {});',
+        '});',
+        '',
+      ].join('\n')
+    );
+
+    await runScan(tmp);
+
+    // Load the persisted graph and assert the annotation edge exists and resolves
+    // to the path-based file node the code scanner materialized.
+    const { GraphStore } = await import('@harness-engineering/graph');
+    const store = new GraphStore();
+    await store.load(path.join(tmp, '.harness', 'graph'));
+
+    const annotationEdges = store
+      .getEdges({ type: 'verified_by' })
+      .filter((e) => e.metadata?.method === 'annotation');
+
+    expect(annotationEdges.length).toBeGreaterThanOrEqual(1);
+    expect(annotationEdges.some((e) => e.to === 'file:src/auth.test.ts')).toBe(true);
+  });
+});

--- a/packages/graph/src/ingest/CodeIngestor.ts
+++ b/packages/graph/src/ingest/CodeIngestor.ts
@@ -208,7 +208,10 @@ export class CodeIngestor {
     this.respectGitignore = options.respectGitignore ?? true;
   }
 
-  async ingest(rootDir: string): Promise<IngestResult> {
+  async ingest(
+    rootDir: string,
+    opts: { skipRequirementAnnotations?: boolean } = {}
+  ): Promise<IngestResult> {
     const start = Date.now();
     const errors: string[] = [];
     let nodesAdded = 0;
@@ -248,14 +251,20 @@ export class CodeIngestor {
       }
     }
 
-    // Third pass: extract @req annotations and create verified_by edges (reuses cached content)
-    for (const filePath of files) {
-      try {
-        const content = contentCache.get(filePath);
-        if (content === undefined) continue;
-        edgesAdded += this.extractReqAnnotationsForFile(filePath, content, rootDir);
-      } catch {
-        // Skip errors in third pass
+    // Third pass: extract @req annotations and create verified_by edges (reuses cached content).
+    // Callers that ingest code BEFORE requirement nodes exist (the scan/ingest pipeline) pass
+    // `skipRequirementAnnotations` and instead call linkRequirementAnnotations() after
+    // RequirementIngestor.ingestSpecs() — otherwise every annotation references a not-yet-created
+    // requirement and no verified_by edge forms (#949).
+    if (!opts.skipRequirementAnnotations) {
+      for (const filePath of files) {
+        try {
+          const content = contentCache.get(filePath);
+          if (content === undefined) continue;
+          edgesAdded += this.extractReqAnnotationsForFile(filePath, content, rootDir);
+        } catch {
+          // Skip errors in third pass
+        }
       }
     }
 
@@ -267,6 +276,32 @@ export class CodeIngestor {
       errors,
       durationMs: Date.now() - start,
     };
+  }
+
+  /**
+   * Link `@req` annotations to requirement nodes, creating `verified_by` edges.
+   *
+   * A pass separate from {@link ingest} because it depends on requirement nodes
+   * already existing in the store. In the scan/ingest pipeline code is ingested
+   * before specs, so annotations must be linked AFTER RequirementIngestor.ingestSpecs()
+   * has run — otherwise every annotation references a not-yet-created requirement and no
+   * edge forms (#949). Re-reads file contents, since ingest()'s content cache is per-call
+   * and not retained.
+   *
+   * @returns the number of `verified_by` edges added.
+   */
+  async linkRequirementAnnotations(rootDir: string): Promise<number> {
+    const files = await this.findSourceFiles(rootDir);
+    let edgesAdded = 0;
+    for (const filePath of files) {
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        edgesAdded += this.extractReqAnnotationsForFile(filePath, content, rootDir);
+      } catch {
+        // Skip unreadable files
+      }
+    }
+    return edgesAdded;
   }
 
   private async processFile(


### PR DESCRIPTION
## Summary

Follow-up to #949 / #950 (the `.mjs`/`.cjs` ingest fix, now merged). This addresses the **secondary bug** noted in #949: the `@req` scan-ordering problem.

`harness graph scan` ingests code — which extracts `@req` annotations via `CodeIngestor`'s third pass — **before** `RequirementIngestor.ingestSpecs()` creates the requirement nodes. So on a single `scan`, every annotation logged `@req annotation references non-existent requirement` and **no `verified_by` edge formed**. It only worked via the two-step workaround `harness graph scan .` then `harness graph ingest --all` (the latter `store.load()`s persisted requirement nodes first).

## Root cause

Ordering, with a genuine mutual dependency that rules out a naive swap:
- `CodeIngestor` pass-3 (`extractReqAnnotationsForFile`) needs **requirement** nodes to exist.
- `RequirementIngestor`'s convention-based linking needs **file** nodes from `CodeIngestor`.

So requirement ingestion can't simply run first. The fix is the issue's suggested **post-ingest annotation-linking pass**.

## Fix

- `packages/graph` — `CodeIngestor.ingest` accepts `{ skipRequirementAnnotations }` (default off, so **all existing callers/tests are unchanged**) and exposes a new `linkRequirementAnnotations(rootDir)` pass.
- `packages/cli` — `runScan` ingests code with `skipRequirementAnnotations: true`, runs `RequirementIngestor.ingestSpecs`, then calls `linkRequirementAnnotations` — so annotations resolve to real requirement nodes while convention-based linking still sees file nodes.

## Regression test

`packages/cli/tests/commands/graph/scan-req-annotation.test.ts` drives the real `runScan` on a temp project (a spec + an `@req`-annotated source file), loads the persisted graph, and asserts the annotation `verified_by` edge exists and resolves to the path-based file node. Proven to **fail without the reorder** (0 edges) and pass with it.

## Verification

- New test passes; existing `CodeIngestor` `@req`/ingest suites unchanged (18 tests green); graph + cli typecheck clean.
- Full pre-commit (arch gate) + pre-push gauntlet (affected typecheck/coverage, coverage ratchet, docs freshness) green.

Fixes the `@req`-ordering half of #949.