### PR TITLE
test(orchestrator): POSIX-guard codex fakeCodex-spawn tests (green Windows CI)

### DIFF
--- a/.changeset/codex-test-windows-skip-no-release.md
+++ b/.changeset/codex-test-windows-skip-no-release.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Test-only: POSIX-guard the three `CodexBackend` tests that spawn a `#!/bin/sh` `fakeCodex` stand-in (`it.skipIf(win32)`). Node's shell-less `child_process.spawn` can launch only a real `.exe` on Windows — not a shebang script or a `.cmd` (EINVAL) — so these fixture-spawn tests are POSIX-only, matching the repo's existing bash-hook e2e `skipIf(win32)` convention. Greens `build-and-test (windows-latest)`. No runtime change.

--- a/.prettierignore
+++ b/.prettierignore
@@ -47,3 +47,4 @@ packages/core/tests/fixtures/code-nav/syntax-error.ts
 .changeset/repo-shape-orchestrator-comment-no-release.md
 .changeset/workflow-audit-orchestrator-comment-no-release.md
 .changeset/stagedecision-jsdoc-comment-no-release.md
+.changeset/codex-test-windows-skip-no-release.md

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -15,6 +15,18 @@ function fakeCodex(body: string): string {
   return p;
 }
 
+/**
+ * The {@link fakeCodex} stand-in is a POSIX `#!/bin/sh` script. `CodexBackend`
+ * launches it with a shell-less `child_process.spawn`, which on Windows can
+ * execute only a real `.exe` — a shebang script is not honored, and a `.cmd`
+ * throws `EINVAL` without `shell: true` (Node's CVE-2024-27980 fix, present in
+ * the pinned Node 22). So the tests that spawn this fixture run on POSIX only.
+ * (Matches the repo's existing bash-hook e2e `skipIf(win32)` convention; a real
+ * `codex.exe` on Windows is exercised by the healthCheck/no-model paths, which
+ * do not depend on a script stand-in.)
+ */
+const itPosix = it.skipIf(process.platform === 'win32');
+
 async function drive(
   b: CodexBackend,
   session: AgentSession
@@ -79,7 +91,7 @@ describe('CodexBackend', () => {
     expect(b.name).toBe('codex');
   });
 
-  it('runTurn streams JSONL events and reports success on exit 0', async () => {
+  itPosix('runTurn streams JSONL events and reports success on exit 0', async () => {
     const cmd = fakeCodex(`echo '{"type":"session.created"}'
 echo '{"msg":{"type":"item.completed"}}'
 echo 'plain text line'
@@ -95,7 +107,7 @@ exit 0`);
     expect(subtypes).toContain('codex:codex_output'); // non-JSON line
   });
 
-  it('runTurn reports success:false + error on a non-zero exit', async () => {
+  itPosix('runTurn reports success:false + error on a non-zero exit', async () => {
     const cmd = fakeCodex(`echo '{"type":"error"}'
 exit 3`);
     const b = new CodexBackend({ model: 'm', command: cmd });
@@ -104,7 +116,7 @@ exit 3`);
     expect(result.error).toMatch(/exited with code 3/);
   });
 
-  it('runTurn kills + fails when the session exceeds the wall-clock cap', async () => {
+  itPosix('runTurn kills + fails when the session exceeds the wall-clock cap', async () => {
     const cmd = fakeCodex(`sleep 10`);
     const b = new CodexBackend({ model: 'm', command: cmd, timeoutMs: 150 });
     const { result } = await drive(b, SESSION);


### PR DESCRIPTION
## Summary

Greens `build-and-test (windows-latest)`, which has been red on `main` (and on every PR — non-blocking, `main` has no required checks) since the codex backend landed.

## Root cause

Three `CodexBackend` tests (`runTurn streams JSONL…`, `…non-zero exit`, `…wall-clock cap`) spawn a `fakeCodex` stand-in written as a `#!/bin/sh` script. `CodexBackend.runTurn` launches `this.command` with a **shell-less** `child_process.spawn`. On Windows that can execute only a real `.exe`:
- a shebang script is not honored (no `/bin/sh`, no shebang support), and
- a `.cmd`/`.bat` throws `EINVAL` without `shell: true` (Node's CVE-2024-27980 fix, present in the pinned Node 22).

So the POSIX shell-script fixture cannot be spawned on Windows by construction. A cross-platform fixture isn't achievable — a test can't ship a compiled `.exe`, and the backend intentionally spawns shell-less (changing that to `shell: true` would be a production behavior/quoting change for a non-Windows feature).

## Fix

Guard exactly those three fixture-spawn tests with `itPosix = it.skipIf(process.platform === 'win32')`, with a documenting comment. The other tests (`name`, no-model, `getModel`, `healthCheck`) don't depend on a script stand-in and continue to run on all platforms. Matches the repo's existing bash-hook e2e `skipIf(win32)` convention. Test-only — no runtime change (empty no-release changeset).

## Verification

- macOS: **13/13 pass** (unchanged).
- Simulated `win32` (predicate forced true): **10 pass, 3 skip, 0 fail** → suite green.
- Full pre-commit (arch gate) + pre-push gauntlet green.