### PR TITLE
fix(orchestrator): unload the coder before the reasoner unstick call (free the GPU)

### DIFF
--- a/.changeset/unstick-unload-peer-model.md
+++ b/.changeset/unstick-unload-peer-model.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): unload the coder before the reasoner unstick call (free the GPU)
+
+On a single-GPU box the coder (codex's execution model) and the reasoner can't both be
+resident. The unstick's reasoner call must swap the coder out, and in a run that swap is
+starved past its budget — Ollama serves one request at a time and the just-finished coder
+is still resident — so the advisory timed out and was skipped every time (observed cx4–cx7),
+never reaching the coder. The provider path itself is correct (verified in isolation); the
+failure is purely GPU contention at the moment the advisory fires.
+
+Before the reasoner call, explicitly unload the execution model from Ollama
+(`/api/generate` with `keep_alive: 0`) so the reasoner loads into free VRAM with nothing to
+evict; codex reloads the coder on the next dispatch. Best-effort and never throws.

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -110,6 +110,7 @@ import {
   findUndocumentedAdditions,
   formatUndocumentedReason,
 } from './workflow/doc-coverage-gate';
+import { resolvePeerUnloadFromConfig } from './workflow/peer-unload';
 import {
   shouldRequestUnstickAdvice,
   buildUnstickPrompt,
@@ -3314,6 +3315,25 @@ export class Orchestrator extends EventEmitter {
   }
 
   /**
+   * Unload the coder (execution model) from Ollama so the reasoner unstick call has a
+   * free GPU (see {@link resolvePeerUnloadTarget}). Best-effort and never throws — a
+   * miss just leaves the coder resident and the reasoner call takes its chances.
+   */
+  private async unloadPeerModelBestEffort(): Promise<void> {
+    try {
+      const target = resolvePeerUnloadFromConfig(this.config.agent);
+      if (target === undefined) return;
+      await fetch(target.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: target.model, keep_alive: 0 }),
+      });
+    } catch {
+      // Best-effort: an unload failure must never block the advisory.
+    }
+  }
+
+  /**
    * Reasoner unstick advisory: when the local executor has STALLED (repeated gate
    * failures with retry budget left), ask the thinking model to diagnose the failure
    * and prescribe a concrete fix, returning a preamble to prepend to the coder's next
@@ -3334,6 +3354,11 @@ export class Orchestrator extends EventEmitter {
     }
     const resolved = this.resolveReasonerProvider();
     if (resolved === undefined) return undefined;
+    // Free the GPU before the reasoner call: on a single-GPU box the just-finished
+    // coder is still resident, and swapping it out under load starves the reasoner
+    // request past its budget (cx4–cx7: advisory timed out + skipped every time).
+    // Explicitly unload the coder so the reasoner loads into free VRAM. Best-effort.
+    await this.unloadPeerModelBestEffort();
     try {
       let diffText = '';
       try {

--- a/packages/orchestrator/src/workflow/peer-unload.test.ts
+++ b/packages/orchestrator/src/workflow/peer-unload.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePeerUnloadTarget, resolvePeerUnloadFromConfig } from './peer-unload';
+
+describe('resolvePeerUnloadTarget', () => {
+  it('derives the /api/generate URL from the reasoner /v1 endpoint + coder model', () => {
+    expect(
+      resolvePeerUnloadTarget({
+        reasonerEndpoint: 'http://127.0.0.1:11434/v1',
+        executionModel: 'qwen3-coder:30b',
+      })
+    ).toEqual({ url: 'http://127.0.0.1:11434/api/generate', model: 'qwen3-coder:30b' });
+  });
+
+  it('uses the first model of a prefer-fallback array', () => {
+    expect(
+      resolvePeerUnloadTarget({
+        reasonerEndpoint: 'http://127.0.0.1:11434/v1/',
+        executionModel: ['qwen3-coder:30b', 'fallback'],
+      })?.model
+    ).toBe('qwen3-coder:30b');
+  });
+
+  it('strips a trailing slash with no /v1 suffix', () => {
+    expect(
+      resolvePeerUnloadTarget({ reasonerEndpoint: 'http://host:11434/', executionModel: 'm' })?.url
+    ).toBe('http://host:11434/api/generate');
+  });
+
+  it('returns undefined when the endpoint or model is missing', () => {
+    expect(resolvePeerUnloadTarget({ executionModel: 'm' })).toBeUndefined();
+    expect(resolvePeerUnloadTarget({ reasonerEndpoint: 'http://x/v1' })).toBeUndefined();
+    expect(
+      resolvePeerUnloadTarget({ reasonerEndpoint: 'http://x/v1', executionModel: [] })
+    ).toBeUndefined();
+    expect(resolvePeerUnloadTarget({ reasonerEndpoint: '', executionModel: 'm' })).toBeUndefined();
+  });
+});
+
+describe('resolvePeerUnloadFromConfig', () => {
+  const config = {
+    routing: { default: 'codex-exec', modes: { thinking: 'reasoner' } },
+    backends: {
+      reasoner: { type: 'ollama', endpoint: 'http://127.0.0.1:11434/v1', model: 'qwen3.6:27b' },
+      'codex-exec': { type: 'codex', model: ['qwen3-coder:30b'] },
+    },
+  };
+
+  it('derives the target from the thinking-reasoner endpoint + default-backend model', () => {
+    expect(resolvePeerUnloadFromConfig(config)).toEqual({
+      url: 'http://127.0.0.1:11434/api/generate',
+      model: 'qwen3-coder:30b',
+    });
+  });
+
+  it('handles array-form routing.default / modes.thinking', () => {
+    expect(
+      resolvePeerUnloadFromConfig({
+        routing: { default: ['codex-exec'], modes: { thinking: ['reasoner'] } },
+        backends: config.backends,
+      })?.model
+    ).toBe('qwen3-coder:30b');
+  });
+
+  it('returns undefined when the reasoner backend has no endpoint', () => {
+    expect(
+      resolvePeerUnloadFromConfig({
+        routing: { default: 'codex-exec', modes: { thinking: 'claudeish' } },
+        backends: { claudeish: { type: 'claude' }, 'codex-exec': { type: 'codex', model: 'm' } },
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when routing/backends are absent', () => {
+    expect(resolvePeerUnloadFromConfig({})).toBeUndefined();
+    expect(resolvePeerUnloadFromConfig({ routing: {} })).toBeUndefined();
+  });
+});

--- a/packages/orchestrator/src/workflow/peer-unload.ts
+++ b/packages/orchestrator/src/workflow/peer-unload.ts
@@ -1,0 +1,86 @@
+/**
+ * Peer-model unload for the reasoner unstick advisory.
+ *
+ * On a single-GPU box the coder (codex's execution model) and the reasoner cannot both
+ * be resident, so the unstick's reasoner call must swap the coder out. In isolation that
+ * swap is fast (~30s), but IN A RUN the reasoner request is repeatedly starved past its
+ * budget (Ollama serves one request at a time; the just-finished coder is still resident
+ * and the swap contends) — observed cx4–cx7: the advisory timed out and was skipped every
+ * time, so the escalation never reached the coder.
+ *
+ * Fix: right before the reasoner call, explicitly UNLOAD the coder from Ollama
+ * (`/api/generate` with `keep_alive: 0`) so the GPU is free and the reasoner loads
+ * cleanly with nothing to evict. Best-effort — codex reloads the coder on the next
+ * dispatch. This helper resolves the (url, model) target from config; the caller fires
+ * the request and swallows any error.
+ */
+
+/** Resolve the Ollama unload target — the coder model + the `/api/generate` URL. */
+export function resolvePeerUnloadTarget(opts: {
+  /** The reasoner (thinking) backend's OpenAI-compatible endpoint, e.g. `…:11434/v1`. */
+  reasonerEndpoint?: string | undefined;
+  /** The execution (routing.default) backend's model — the coder to unload. */
+  executionModel?: string | string[] | undefined;
+}): { url: string; model: string } | undefined {
+  const { reasonerEndpoint, executionModel } = opts;
+  if (reasonerEndpoint === undefined || reasonerEndpoint === '') return undefined;
+  const model = Array.isArray(executionModel) ? executionModel[0] : executionModel;
+  if (model === undefined || model === '') return undefined;
+  const base = reasonerEndpoint.replace(/\/v1\/?$/, '').replace(/\/$/, '');
+  return { url: `${base}/api/generate`, model };
+}
+
+/** The slices of agent config the unload target is derived from (accepts `AgentConfig`). */
+export interface PeerUnloadConfig {
+  routing?: unknown;
+  backends?: unknown;
+}
+
+/** Pick the first entry of a `string | string[]`-ish name field. */
+function firstName(v: unknown): string | undefined {
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v) && typeof v[0] === 'string') return v[0];
+  return undefined;
+}
+
+/** Read a string-valued property from an unknown object, else undefined. */
+function strProp(obj: unknown, key: string): string | undefined {
+  if (obj && typeof obj === 'object' && key in obj) {
+    const v = (obj as Record<string, unknown>)[key];
+    if (typeof v === 'string') return v;
+  }
+  return undefined;
+}
+
+/** Read a backend def by name from an unknown `backends` map. */
+function backend(backends: unknown, name: string | undefined): unknown {
+  if (name === undefined || !backends || typeof backends !== 'object') return undefined;
+  return (backends as Record<string, unknown>)[name];
+}
+
+/**
+ * Navigate agent config → the unload target: the reasoner (thinking) backend supplies the
+ * Ollama endpoint, the execution (routing.default) backend supplies the coder model.
+ * Pure and defensive (routing/backends are `unknown`), so the orchestrator method stays a
+ * thin fetch wrapper and this navigation is unit-tested.
+ */
+export function resolvePeerUnloadFromConfig(
+  config: PeerUnloadConfig
+): { url: string; model: string } | undefined {
+  const routing =
+    config.routing && typeof config.routing === 'object'
+      ? (config.routing as Record<string, unknown>)
+      : {};
+  const modes =
+    routing.modes && typeof routing.modes === 'object'
+      ? (routing.modes as Record<string, unknown>)
+      : {};
+  const reasonerDef = backend(config.backends, firstName(modes.thinking));
+  const reasonerEndpoint = strProp(reasonerDef, 'endpoint');
+  const execDef = backend(config.backends, firstName(routing.default));
+  const executionModel =
+    execDef && typeof execDef === 'object' && 'model' in execDef
+      ? (execDef as { model?: string | string[] }).model
+      : undefined;
+  return resolvePeerUnloadTarget({ reasonerEndpoint, executionModel });
+}


### PR DESCRIPTION
Makes the reasoner unstick advisory actually **deliver** on a single-GPU box.

## Problem
The unstick advisory (escalate a stalled coder to the thinking model) was timing out and being skipped every time (cx4–cx7). Root cause, isolated to one call: the **provider path is correct** (verified in isolation — it returns a valid diagnosis in ~30s), but *in a run* the reasoner request is starved by GPU contention. On this hardware the coder (codex's 30B execution model) and the reasoner can't both be resident, Ollama serves one request at a time, and the just-finished coder is still loaded — so the reasoner's swap-in never completes within budget.

Config tuning (context caps, `max_loaded`) didn't fix it — the issue is *which model holds the GPU at the moment the advisory fires*.

## Fix
Right before the reasoner call, explicitly **unload the coder** from Ollama (`/api/generate` with `keep_alive: 0`) so the reasoner loads into free VRAM with nothing to evict. Codex reloads the coder on its next dispatch. Best-effort and never throws — a miss just leaves the coder resident and the call takes its chances (prior behavior).

## Implementation
- `resolvePeerUnloadTarget` / `resolvePeerUnloadFromConfig` (pure, unit-tested) navigate config → the `(ollama /api/generate url, coder model)` target: reasoner backend supplies the endpoint, `routing.default` backend supplies the model.
- `Orchestrator.unloadPeerModelBestEffort` is a thin fetch wrapper, called at the top of `maybeReasonerUnstickAdvisory`.
- 8 unit tests.

Validated by the local-autopilot e2e (the run watching for `unstick advisory issued` instead of `skipped`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)