### PR TITLE
feat(check-arch): require --allow-regress --reason to worsen a baseline (#530)

### DIFF
--- a/.changeset/check-arch-allow-regress.md
+++ b/.changeset/check-arch-allow-regress.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/cli': minor
+---
+
+feat(check-arch): require `--allow-regress --reason` to update a baseline that worsens a metric (#530)
+
+`harness check-arch --update-baseline` previously accepted regressions silently — a worsened
+complexity/coupling/module-size value could be baked into the baseline with no record. Now,
+when an update would WORSEN any metric versus the current baseline (beyond the configured
+regression tolerance), it is rejected unless the caller passes `--allow-regress --reason "…"`.
+The accepted regression (categories, before→after, delta, commit, reason) is appended to
+`.harness/audit.log`, forcing the decision into the open. A first-capture (no baseline) or a
+non-worsening update is unaffected.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -70,6 +70,8 @@ Check architecture assertions against baseline and thresholds
 
 - `--update-baseline` — Capture current state as new baseline
 - `--module` — Check a single module
+- `--allow-regress` — Permit a --update-baseline that worsens a metric (requires --reason)
+- `--reason` — Why an accepted regression is acceptable (logged to audit)
 
 ### `harness check-deps`
 

--- a/packages/cli/src/commands/check-arch.ts
+++ b/packages/cli/src/commands/check-arch.ts
@@ -20,6 +20,7 @@ import { logger } from '../output/logger';
 import { CLIError, ExitCode } from '../utils/errors';
 import { execSync } from 'node:child_process';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 interface CheckArchOptions {
   cwd?: string;
@@ -27,6 +28,10 @@ interface CheckArchOptions {
   updateBaseline?: boolean;
   json?: boolean;
   module?: string;
+  /** Permit a `--update-baseline` that WORSENS a metric (else such an update is rejected). */
+  allowRegress?: boolean;
+  /** Human reason for an accepted regression; required with `--allow-regress`, logged to audit. */
+  reason?: string;
 }
 
 export interface CheckArchResult {
@@ -58,6 +63,37 @@ function getCommitHash(cwd: string): string {
 function filterByModule(results: MetricResult[], modulePath: string): MetricResult[] {
   const normalized = modulePath.replace(/\/+$/, '');
   return results.filter((r) => r.scope === normalized || r.scope.startsWith(normalized + '/'));
+}
+
+/**
+ * Append an accepted arch-baseline regression to `.harness/audit.log` (#530) so the
+ * decision to worsen a metric is durable and reviewable. Best-effort — a logging failure
+ * must not block an otherwise-authorized update (the reason was still supplied on the CLI).
+ */
+function appendArchRegressionAudit(
+  cwd: string,
+  reason: string,
+  regressions: ArchDiffResult['regressions']
+): void {
+  try {
+    const dir = path.join(cwd, '.harness');
+    fs.mkdirSync(dir, { recursive: true });
+    const entry = {
+      timestamp: new Date().toISOString(),
+      event: 'arch-baseline-regression-accepted',
+      commit: getCommitHash(cwd),
+      reason,
+      regressions: regressions.map((r) => ({
+        category: r.category,
+        from: r.baselineValue,
+        to: r.currentValue,
+        delta: r.delta,
+      })),
+    };
+    fs.appendFileSync(path.join(dir, 'audit.log'), JSON.stringify(entry) + '\n');
+  } catch {
+    // Best-effort audit — never block the update on a logging failure.
+  }
 }
 
 /**
@@ -146,6 +182,34 @@ export async function runCheckArch(
 
   // --update-baseline mode
   if (options.updateBaseline) {
+    // #530: a baseline update that WORSENS a metric must be an explicit, recorded
+    // decision — not a silent rewrite. Diff the new results against the CURRENT
+    // baseline; if that update would regress any category, reject it unless the
+    // caller passed `--allow-regress --reason "…"`, and log the acceptance to the
+    // audit trail. No existing baseline ⇒ nothing to worsen (first capture).
+    const existingBaseline = manager.load();
+    if (existingBaseline) {
+      const regressions = diff(results, existingBaseline, {
+        regressionTolerance: archConfig.regressionTolerance,
+      }).regressions;
+      if (regressions.length > 0) {
+        const summary = regressions
+          .map((r) => `  - ${r.category}: ${r.baselineValue} → ${r.currentValue} (+${r.delta})`)
+          .join('\n');
+        if (!options.allowRegress || !options.reason || options.reason.trim() === '') {
+          return Err(
+            new CLIError(
+              `Refusing to update the baseline: it WORSENS ${regressions.length} metric(s):\n${summary}\n\n` +
+                `A regression must be an explicit decision. Re-run with:\n` +
+                `  harness check-arch --update-baseline --allow-regress --reason "<why this regression is accepted>"\n` +
+                `The reason is recorded in .harness/audit.log.`,
+              ExitCode.ERROR
+            )
+          );
+        }
+        appendArchRegressionAudit(cwd, options.reason, regressions);
+      }
+    }
     const commitHash = getCommitHash(cwd);
     // Merge into the existing baseline so categories absent from `results`
     // (e.g. silent collector failures) are not silently dropped (issue #268).
@@ -255,6 +319,11 @@ export function createCheckArchCommand(): Command {
     .description('Check architecture assertions against baseline and thresholds')
     .option('--update-baseline', 'Capture current state as new baseline')
     .option('--module <path>', 'Check a single module')
+    .option(
+      '--allow-regress',
+      'Permit a --update-baseline that worsens a metric (requires --reason)'
+    )
+    .option('--reason <text>', 'Why an accepted regression is acceptable (logged to audit)')
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const mode = resolveOutputMode(globalOpts);
@@ -265,6 +334,8 @@ export function createCheckArchCommand(): Command {
         updateBaseline: opts.updateBaseline,
         json: globalOpts.json,
         module: opts.module,
+        allowRegress: opts.allowRegress,
+        reason: opts.reason,
       });
 
       if (!result.ok) {

--- a/packages/cli/tests/commands/check-arch.test.ts
+++ b/packages/cli/tests/commands/check-arch.test.ts
@@ -268,6 +268,93 @@ describe('check-arch command', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
+    // #530: a --update-baseline that WORSENS a metric must be an explicit, recorded
+    // decision (--allow-regress --reason), not a silent rewrite.
+    async function seedRegressingWorkspace(): Promise<{ tmpDir: string; configPath: string }> {
+      const fs = await import('node:fs');
+      const os = await import('node:os');
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-arch-530-'));
+      const configPath = path.join(tmpDir, 'harness.config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ version: 1, architecture: { enabled: true } }));
+      const codePath = path.join(tmpDir, 'code.ts');
+      // Small file → capture a low module-size baseline.
+      fs.writeFileSync(codePath, `export const x = 1;\n`);
+      await runCheckArch({ cwd: tmpDir, configPath, updateBaseline: true });
+      // Grow the file substantially → the next scan worsens module-size well beyond
+      // any regression tolerance.
+      const bloat = Array.from({ length: 60 }, (_, i) => `export const v${i} = ${i};`).join('\n');
+      fs.writeFileSync(codePath, `${bloat}\n`);
+      return { tmpDir, configPath };
+    }
+
+    it('registers --allow-regress and --reason options', () => {
+      const opts = createCheckArchCommand().options.map((o) => o.long);
+      expect(opts).toContain('--allow-regress');
+      expect(opts).toContain('--reason');
+    });
+
+    it('rejects a regressing --update-baseline without --allow-regress (#530)', async () => {
+      const fs = await import('node:fs');
+      const { tmpDir, configPath } = await seedRegressingWorkspace();
+      const result = await runCheckArch({ cwd: tmpDir, configPath, updateBaseline: true });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toMatch(/WORSENS/);
+        expect(result.error.message).toMatch(/--allow-regress --reason/);
+      }
+      // No audit entry written on a rejected update.
+      expect(fs.existsSync(path.join(tmpDir, '.harness', 'audit.log'))).toBe(false);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('rejects --allow-regress without a --reason (#530)', async () => {
+      const fs = await import('node:fs');
+      const { tmpDir, configPath } = await seedRegressingWorkspace();
+      const result = await runCheckArch({
+        cwd: tmpDir,
+        configPath,
+        updateBaseline: true,
+        allowRegress: true,
+      });
+      expect(result.ok).toBe(false);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('accepts a regressing update with --allow-regress --reason and logs it to audit.log (#530)', async () => {
+      const fs = await import('node:fs');
+      const { tmpDir, configPath } = await seedRegressingWorkspace();
+      const result = await runCheckArch({
+        cwd: tmpDir,
+        configPath,
+        updateBaseline: true,
+        allowRegress: true,
+        reason: 'accepted for the migration in #999',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.baselineUpdated).toBe(true);
+      const auditPath = path.join(tmpDir, '.harness', 'audit.log');
+      expect(fs.existsSync(auditPath)).toBe(true);
+      const entry = JSON.parse(fs.readFileSync(auditPath, 'utf-8').trim().split('\n')[0]);
+      expect(entry.event).toBe('arch-baseline-regression-accepted');
+      expect(entry.reason).toBe('accepted for the migration in #999');
+      expect(entry.regressions.length).toBeGreaterThan(0);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('a non-regressing --update-baseline still works without --allow-regress (#530)', async () => {
+      const fs = await import('node:fs');
+      const os = await import('node:os');
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-arch-530-ok-'));
+      const configPath = path.join(tmpDir, 'harness.config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ version: 1, architecture: { enabled: true } }));
+      await runCheckArch({ cwd: tmpDir, configPath, updateBaseline: true });
+      // Re-capture with no change — no regression, so no flag needed.
+      const result = await runCheckArch({ cwd: tmpDir, configPath, updateBaseline: true });
+      expect(result.ok).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, '.harness', 'audit.log'))).toBe(false);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
     it('reports correct exit code mapping: 0=pass, 1=regression, 2=config-error', async () => {
       // Exit code 2 for config error
       const configError = await runCheckArch({


### PR DESCRIPTION
Closes #530.

## Problem
`harness check-arch --update-baseline` silently accepted regressions. A worsened complexity / coupling / module-size / dep-depth value could be baked into the baseline with **no record and no friction** — exactly the kind of quiet quality erosion baselines are meant to prevent.

## Change
When `--update-baseline` would **worsen** any metric versus the current baseline (beyond the configured `regressionTolerance`), it is now **rejected**:

```
Refusing to update the baseline: it WORSENS 1 metric(s):
  - module-size: 20 → 60 (+40)

A regression must be an explicit decision. Re-run with:
  harness check-arch --update-baseline --allow-regress --reason "<why this regression is accepted>"
The reason is recorded in .harness/audit.log.
```

With `--allow-regress --reason "…"`, the update proceeds and the acceptance is appended to `.harness/audit.log`:

```json
{"timestamp":"…","event":"arch-baseline-regression-accepted","commit":"…","reason":"…","regressions":[{"category":"module-size","from":20,"to":60,"delta":40}]}
```

- A **first capture** (no baseline yet) and any **non-worsening** update are unaffected — no flag needed.
- `--reason` is required with `--allow-regress` (an empty reason is rejected).
- Audit logging is best-effort — a logging failure never blocks an authorized update.

## Tests
5 new cases: flag registration, reject-without-flag, reject-allow-regress-without-reason, accept-with-reason + audit.log written, and non-regressing update still works. 24 check-arch tests pass. Reference docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)