### PR TITLE
feat(pre-commit): make skipped ci-check categories visible (#529)

### DIFF
--- a/.changeset/strength-003-resolve-skip-var.md
+++ b/.changeset/strength-003-resolve-skip-var.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(harness-strength): STRENGTH-003 resolves a variable skip list (`--skip "$SKIP"`)
+
+The skip-list auditor matched only a literal `--skip a,b,c`, so a hook using the drift-free
+`SKIP="a,b,c"` + `--skip "$SKIP"` single-source form went unaudited — silencing the review-time
+signal that flags a growing/hollow local gate. The matcher now captures quoted/bare/variable
+tokens and, for a `$VAR`/`${VAR}` reference, resolves the matching `VAR="a,b,c"` assignment in
+the same file (unresolvable → skipped gracefully). Literal-match path unchanged.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -29,15 +29,27 @@ fi
 # guardrail stays visibly named — roadmap #529) AND passed to `ci check` via
 # "$SKIP". Editing this list updates the warnings and the actual skip together;
 # they cannot drift.
-# NOTE (#529 follow-up): the STRENGTH-003 skip-list auditor matches only a LITERAL
-# `--skip a,b,c` and does not resolve this `--skip "$SKIP"` variable, so its
-# static/review-time signal no longer scans this line. The per-commit warnings below
-# cover the committer; teaching STRENGTH-003 to resolve a `SKIP=` assignment would
-# restore review-time coverage of the list GROWING — tracked as a follow-up.
+# NOTE (#529 follow-up, resolved in #965): the STRENGTH-003 skip-list auditor now
+# resolves this `--skip "$SKIP"` variable form — it finds the matching `SKIP="a,b,c"`
+# assignment in this file and audits that list — so review-time coverage of the skip
+# list GROWING is restored alongside the drift-free single-source `$SKIP` form. The
+# per-commit warnings below still cover the committer at commit time.
 SKIP="entropy,docs,perf,security,deps,phase-gate"
-for cat in $(echo "$SKIP" | tr ',' ' '); do
-  echo "⚠ pre-commit: '$cat' check SKIPPED (deferred to CI/pre-push) — see roadmap #529" >&2
+# Comma-split without invoking `tr` and without globbing the categories. `IFS=,`
+# makes the unquoted `$SKIP` expansion split on commas only (not the whitespace a
+# `$(echo … | tr ',' ' ')` split would need); `set -f` disables pathname expansion
+# so a category value that happened to contain a glob metacharacter (`*`, `?`)
+# cannot expand against the cwd — word-splitting and globbing are SEPARATE steps, so
+# IFS alone would still let each split word glob. Save/restore both IFS and the glob
+# flag so the rest of the hook keeps default splitting + globbing. POSIX, dash-safe.
+old_ifs=$IFS
+IFS=,
+set -f
+for cat in $SKIP; do
+  echo "⚠ pre-commit: '$cat' check SKIPPED (deferred to CI) — see roadmap #529" >&2
 done
+set +f
+IFS=$old_ifs
 
 if ! node packages/cli/dist/bin/harness.js ci check --skip "$SKIP" >/tmp/harness-pre-commit.log 2>&1; then
   cat /tmp/harness-pre-commit.log

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -24,7 +24,22 @@ if [ -f .husky/ensure-node-pin.sh ]; then
   . .husky/ensure-node-pin.sh
 fi
 
-if ! node packages/cli/dist/bin/harness.js ci check --skip entropy,docs,perf,security,deps,phase-gate >/tmp/harness-pre-commit.log 2>&1; then
+# Single source of truth for the skipped check categories: the SAME value is
+# both looped over below (one stderr warning per category, so each disabled
+# guardrail stays visibly named — roadmap #529) AND passed to `ci check` via
+# "$SKIP". Editing this list updates the warnings and the actual skip together;
+# they cannot drift.
+# NOTE (#529 follow-up): the STRENGTH-003 skip-list auditor matches only a LITERAL
+# `--skip a,b,c` and does not resolve this `--skip "$SKIP"` variable, so its
+# static/review-time signal no longer scans this line. The per-commit warnings below
+# cover the committer; teaching STRENGTH-003 to resolve a `SKIP=` assignment would
+# restore review-time coverage of the list GROWING — tracked as a follow-up.
+SKIP="entropy,docs,perf,security,deps,phase-gate"
+for cat in $(echo "$SKIP" | tr ',' ' '); do
+  echo "⚠ pre-commit: '$cat' check SKIPPED (deferred to CI/pre-push) — see roadmap #529" >&2
+done
+
+if ! node packages/cli/dist/bin/harness.js ci check --skip "$SKIP" >/tmp/harness-pre-commit.log 2>&1; then
   cat /tmp/harness-pre-commit.log
   echo ""
   echo "✗ Commit blocked: harness ci check failed (see output above)."

--- a/docs/changes/pre-commit-skip-visibility/REVIEW.md
+++ b/docs/changes/pre-commit-skip-visibility/REVIEW.md
@@ -1,0 +1,24 @@
+# Phase review record — pre-commit skip visibility (#529)
+
+Produced by the harness autopilot lifecycle; each phase owned by a dedicated persona agent.
+
+## VERIFY — `harness-verifier` → **PASS**
+
+Independent, evidence-based verification against the spec's EARS criteria 1–4 and all plan
+constraints (ran the loop with split streams, checked file mode, ran both regression suites).
+All four criteria PASS; `pre-commit-cicheck-gate.e2e.test.ts` 2/2, `strength-003-skip-list.test.ts` 6/6.
+
+## REVIEW — `harness-code-reviewer` → **Approve (Comment)**
+
+No blocking issues. Verified single-source-of-truth holds, dash-safe portability, the "deferred
+to CI" message is accurate (CI runs all six categories), and the `cat` loop-var / `cat` command
+coexist safely.
+
+**Non-blocking follow-up (folded):** the `--skip "$SKIP"` variable form silences STRENGTH-003's
+literal-list static auditor — the review-time signal that catches the skip list _growing_. The
+runtime warnings cover the committer but not the reviewer's audience. Documented inline in the
+hook (see the `#529 follow-up` NOTE) and tracked as a follow-up issue to teach STRENGTH-003 to
+resolve a `SKIP=` assignment.
+
+Nits (non-actionable): loop var `cat` naming; six warning lines/commit is a mild alarm-fatigue risk
+(the spec's deliberate A-over-C choice).

--- a/docs/changes/pre-commit-skip-visibility/plans/2026-07-22-phase-1-skip-visibility-plan.md
+++ b/docs/changes/pre-commit-skip-visibility/plans/2026-07-22-phase-1-skip-visibility-plan.md
@@ -1,0 +1,170 @@
+# Plan: Make pre-commit skipped checks visible
+
+**Date:** 2026-07-22 | **Spec:** `docs/changes/pre-commit-skip-visibility/proposal.md` | **Tasks:** 5 | **Time:** ~18 min | **Integration Tier:** small
+
+## Goal
+
+When the `.husky/pre-commit` hook runs, each of the six `--skip` categories is named on its own `stderr` line, derived from a single source-of-truth list, with the actual `ci check` command, skip set, exit behavior, and file mode all unchanged.
+
+## Observable Truths (Acceptance Criteria)
+
+1. WHEN the hook's gate block runs, the system SHALL emit exactly one `stderr` line per category in the `--skip` list (six lines: `entropy`, `docs`, `perf`, `security`, `deps`, `phase-gate`), each line naming that category. (Spec criterion 1)
+2. The warning lines SHALL be written to `stderr` (`>&2`) only — `stdout` of the hook SHALL NOT contain them, so piped/captured stdout is unaffected. (Spec criterion 2)
+3. The effective `ci check` invocation SHALL remain byte-identical in behavior: `--skip entropy,docs,perf,security,deps,phase-gate`, same command, same fail-closed `exit 1` on nonzero. A passing commit still passes; a blocked commit still blocks. (Spec criterion 3)
+4. The warned categories and the `--skip` argument SHALL be the same shell value (one `SKIP` variable), so they cannot drift. (Spec criterion 4)
+5. The file SHALL retain mode `100755` (`git ls-files -s .husky/pre-commit` reports `100755`).
+6. All existing comments in the file — especially the `#726` tee-exit-code note (lines 6–12) and the node-pin note (lines 14–22) — SHALL be preserved verbatim.
+7. Regression guards stay green: `pre-commit-cicheck-gate.e2e.test.ts` and `strength-003-skip-list.test.ts` pass.
+
+## File Map
+
+- MODIFY `.husky/pre-commit` — insert a `SKIP` assignment + per-category `stderr` warning loop immediately before the `ci check` invocation (current line 27), and change that invocation to consume `"$SKIP"`. No other files.
+
+_Confirmed via grep: the literal `entropy,docs,perf,security,deps,phase-gate` also appears in `docs/roadmap*`, `docs/changes/*/proposal.md`, and three harness-strength **test fixtures** (`strength-003-skip-list.test.ts:23`, `auditor.test.ts:72`, and planning docs). Those fixtures are self-contained strings, NOT reads of the real hook, so editing `.husky/pre-commit` does not touch them. Do not edit them (spec: edit ONLY `.husky/pre-commit`)._
+
+## Current-state evidence (verified 2026-07-22)
+
+- `.husky/pre-commit` is mode `100755` (`git ls-files -s .husky/pre-commit` → `100755`).
+- Lines 1–12: comment header incl. the load-bearing `#726` tee note. Lines 14–25: node-pin note + `if [ -f .husky/ensure-node-pin.sh ]; then . …; fi`. Line 26: blank. **Line 27:** `if ! node packages/cli/dist/bin/harness.js ci check --skip entropy,docs,perf,security,deps,phase-gate >/tmp/harness-pre-commit.log 2>&1; then`. Lines 28–38: fail-closed body + `exit 1`. Line 39: `cat /tmp/harness-pre-commit.log`. Line 40: `npx lint-staged`. Lines 42–77: plugin-artifact + roadmap-regen blocks.
+- Precise insertion point: **between line 26 (blank) and line 27 (the `if ! node … ci check …` line)** — the warnings must print before the gate runs.
+
+## Uncertainties
+
+- **[DECISION — see Task 3 checkpoint] STRENGTH-003 runtime silencing.** `harness-strength` rule STRENGTH-003 detects oversized skip lists via `/--skip[= ]+([\w,-]+)/`, which only matches a **literal** comma-list. Moving the invocation to `--skip "$SKIP"` means the rule no longer matches the real hook at audit time, so its warning-severity finding goes silent. This breaks **no test** (its unit test uses a self-contained fixture) and blocks nothing (severity `warning`, not in the pre-commit skip set). The new per-commit runtime warnings are strictly louder than the static audit finding, so the visibility goal is over-satisfied — but this is a conscious side effect the executor must accept. Fallback documented in Task 3.
+- **[ASSUMPTION] e2e producer-rewrite stays valid.** `pre-commit-cicheck-gate.e2e.test.ts` rewrites the producer with `/node packages\/cli\/dist\/bin\/harness\.js ci check[^>|]*/`. `--skip "$SKIP"` introduces no `>` or `|`, so the match still spans to the `>` redirect. Verified by reading the test; re-verified by running it in Task 4.
+- **[ASSUMPTION] Loop variable `cat` is safe.** `cat` is used later as a command (`cat /tmp/…`). In POSIX sh, a shell **variable** named `cat` and the **command** `cat` occupy separate namespaces; `$cat` (the loop var) never shadows the `cat` command. The user-specified idiom `for cat in …` is retained.
+
+## TDD note (shell hook)
+
+This change edits a single POSIX-sh git hook and the spec constrains edits to **only** `.husky/pre-commit` — no new test file may be added. The pre-existing `pre-commit-cicheck-gate.e2e.test.ts` is the regression guard for the gate's structure; the per-category stderr output is verified by an executable runtime check in Task 3 (write-the-check-first, observe-it-fail-then-pass), which substitutes for a unit test here.
+
+## Tasks
+
+### Task 1: Capture the current stderr baseline (proves the "before" state)
+
+**Depends on:** none | **Files:** none (read-only verification)
+
+1. From the repo root, run the isolated gate-preamble to confirm that **today** the skip categories produce **zero** stderr lines. Run:
+   ```sh
+   sh -c 'set -e
+   if [ -f .husky/ensure-node-pin.sh ]; then . .husky/ensure-node-pin.sh; fi
+   true' 2>/tmp/skipwarn-before.err 1>/dev/null || true
+   grep -c "SKIPPED" /tmp/skipwarn-before.err || echo "0 (expected: 0 before change)"
+   ```
+2. Confirm output is `0` — no per-category warnings exist yet. This is the failing pre-state the change must flip.
+3. Record file mode for later comparison: `git ls-files -s .husky/pre-commit` → confirm prefix `100755`.
+4. No commit (read-only).
+
+### Task 2: Insert the `SKIP` variable + per-category stderr warning loop, and point the invocation at `"$SKIP"`
+
+**Depends on:** Task 1 | **Files:** `.husky/pre-commit`
+
+1. Open `.husky/pre-commit`. Locate line 27 (the `if ! node packages/cli/dist/bin/harness.js ci check --skip entropy,docs,perf,security,deps,phase-gate >/tmp/harness-pre-commit.log 2>&1; then` line). **Do not touch lines 1–25** (all comments and the node-pin block stay verbatim).
+2. Immediately **before** that `if ! …` line (i.e. after the blank line 26), insert:
+   ```sh
+   # Single source of truth for the skipped check categories: the SAME value is
+   # both looped over below (one stderr warning per category, so each disabled
+   # guardrail stays visibly named — roadmap #529) AND passed to `ci check` via
+   # "$SKIP". Editing this list updates the warnings and the actual skip together;
+   # they cannot drift.
+   SKIP="entropy,docs,perf,security,deps,phase-gate"
+   for cat in $(echo "$SKIP" | tr ',' ' '); do
+     echo "⚠ pre-commit: '$cat' check SKIPPED (deferred to CI/pre-push) — see roadmap #529" >&2
+   done
+   ```
+3. Change ONLY the `--skip` argument on the invocation line from the literal to the variable, leaving everything else byte-identical:
+   ```sh
+   if ! node packages/cli/dist/bin/harness.js ci check --skip "$SKIP" >/tmp/harness-pre-commit.log 2>&1; then
+   ```
+   (The redirect `>/tmp/harness-pre-commit.log 2>&1`, the `if ! …; then`, the body, and the fail-closed `exit 1` are unchanged.)
+4. Constraints to honor while editing: POSIX sh only — no bashisms (no arrays, no `set -o pipefail`, no `${PIPESTATUS[…]}`); the `for cat in $(echo "$SKIP" | tr ',' ' ')` idiom is dash-portable. Warnings go to `stderr` (`>&2`) only. Keep the `#726` tee note and node-pin note intact. Do not alter the shebang/mode.
+5. Run: `node packages/cli/dist/bin/harness.js validate` — confirm it still exits 0.
+6. Do NOT commit yet (verification first — Task 3).
+
+### Task 3: Verify runtime stderr output, stdout cleanliness, and unchanged pass/block behavior `[checkpoint:human-verify]` `[checkpoint:decision]`
+
+**Depends on:** Task 2 | **Files:** none (verification of `.husky/pre-commit`)
+
+1. **Six named warnings on stderr, in order.** Run the warning preamble in isolation and inspect stderr:
+   ```sh
+   SKIP="entropy,docs,perf,security,deps,phase-gate"
+   for cat in $(echo "$SKIP" | tr ',' ' '); do
+     echo "⚠ pre-commit: '$cat' check SKIPPED (deferred to CI/pre-push) — see roadmap #529" >&2
+   done 2>/tmp/skipwarn-after.err 1>/tmp/skipwarn-after.out
+   grep -c "SKIPPED" /tmp/skipwarn-after.err   # expect: 6
+   grep -oE "'(entropy|docs|perf|security|deps|phase-gate)'" /tmp/skipwarn-after.err  # expect all six, once each
+   wc -c /tmp/skipwarn-after.out               # expect: 0  (nothing on stdout)
+   ```
+   Confirm: exactly 6 stderr lines, each naming a distinct category, and stdout is empty (criteria 1 + 2).
+2. **Effective invocation unchanged.** Confirm the variable expands to the original literal:
+   ```sh
+   SKIP="entropy,docs,perf,security,deps,phase-gate"; printf '%s\n' "--skip $SKIP"
+   # expect: --skip entropy,docs,perf,security,deps,phase-gate
+   ```
+3. **Pass/block behavior unchanged (real hook).** In a scratch state with a trivial staged change, run a real commit and observe: on a clean tree the commit proceeds (gate passes) and the six warnings appear on stderr; if `harness ci check` would fail, the `Commit blocked` path and `exit 1` still fire. (The dedicated fail-closed proof is the e2e test run in Task 4 — no need to force a real arch regression here.)
+4. **File mode preserved.** Run `git ls-files -s .husky/pre-commit` → confirm `100755` (criterion 5).
+5. **Comments preserved.** `git diff .husky/pre-commit` — confirm the diff is purely additive around line 27 (new `SKIP=`/loop block + the `--skip "$SKIP"` swap) and that lines 1–25 and the `#726` note are untouched (criterion 6).
+6. `[checkpoint:decision]` **STRENGTH-003 side effect.** Confirm the accepted approach: moving to `--skip "$SKIP"` silences the STRENGTH-003 static audit finding on the real hook (no test breaks; runtime warnings compensate). Present the fallback and stop for confirmation:
+   - **A) (recommended, matches spec)** Keep `--skip "$SKIP"` — true single source of truth (criterion 4), STRENGTH-003 goes silent, no test breaks.
+   - **B) (fallback)** Keep the literal `--skip entropy,…` on the invocation line unchanged and let the loop read the separate `SKIP` literal — preserves STRENGTH-003 but introduces two copies that CAN drift (violates criterion 4).
+     Recommend **A** (the spec's criterion 4 and the executor notes explicitly call for a single derived list).
+7. `[checkpoint:human-verify]` Show the six-line stderr output and the `git diff` to the human; wait for confirmation before committing.
+8. Run: `node packages/cli/dist/bin/harness.js validate`.
+
+### Task 4: Run the affected regression tests
+
+**Depends on:** Task 3 | **Files:** none (test execution)
+
+1. Run the pre-commit gate e2e (proves the `[^>|]*` producer-rewrite still matches `--skip "$SKIP"` and the fail-closed gate still blocks):
+   ```sh
+   npx vitest run packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts
+   ```
+   Expect all cases pass (BLOCKS on nonzero, ALLOWS on zero).
+2. Run the STRENGTH-003 unit test (proves the rule's self-contained fixtures are unaffected by the real-hook edit):
+   ```sh
+   npx vitest run packages/core/src/harness-strength/rules/strength-003-skip-list.test.ts
+   ```
+   Expect pass.
+3. If either fails, return to Task 2 — do not proceed.
+4. No commit (test run only).
+
+### Task 5: Commit the change
+
+**Depends on:** Task 4 | **Files:** `.husky/pre-commit`
+
+1. Stage only the hook: `git add .husky/pre-commit`.
+2. Confirm no unintended files staged: `git status --porcelain` shows only `.husky/pre-commit`.
+3. Run: `node packages/cli/dist/bin/harness.js validate`.
+4. Commit:
+
+   ```
+   feat(pre-commit): name each skipped ci-check category on stderr (#529)
+
+   Derive the six skipped categories from a single SKIP variable that feeds
+   both a per-category stderr warning loop and the ci-check --skip argument,
+   so the disabled guardrails stay visibly named at commit time and cannot
+   drift from the actual skip set. Effective invocation, exit behavior, and
+   file mode unchanged. POSIX-sh (dash-safe); #726 tee note preserved.
+   ```
+
+5. If a pre-commit hook reformats or blocks, resolve, re-`git add .husky/pre-commit`, and re-commit.
+
+## Sequencing / parallelism
+
+Strictly sequential: Task 1 (baseline) → Task 2 (edit) → Task 3 (verify + decision) → Task 4 (regression tests) → Task 5 (commit). All tasks touch or gate on the same single file; no parallel waves.
+
+## Traceability
+
+| Observable truth              | Delivered by                                   |
+| ----------------------------- | ---------------------------------------------- |
+| 1 (six named stderr lines)    | Task 2 (loop), Task 3 step 1                   |
+| 2 (stderr only, stdout clean) | Task 2 (`>&2`), Task 3 step 1                  |
+| 3 (invocation/exit unchanged) | Task 2 step 3, Task 3 steps 2–3, Task 4 step 1 |
+| 4 (single source of truth)    | Task 2 (`SKIP` feeds both), Task 3 step 6      |
+| 5 (mode 100755)               | Task 1 step 3, Task 3 step 4                   |
+| 6 (comments preserved)        | Task 2 step 1/4, Task 3 step 5                 |
+| 7 (regression guards green)   | Task 4                                         |
+
+## Notes
+
+- Per the operating rule "commit only when the user asks," Task 5's commit runs only on the user's go-ahead; this planning pass writes the plan document but does not commit it.

--- a/docs/changes/pre-commit-skip-visibility/proposal.md
+++ b/docs/changes/pre-commit-skip-visibility/proposal.md
@@ -1,0 +1,72 @@
+# Spec: Make pre-commit skipped checks visible
+
+**Status:** approved (autonomous — single-phase, low-complexity)
+**Roadmap:** #529 (`Audit and cap the pre-commit --skip list`)
+**Keywords:** pre-commit, ci-check, skip-list, visibility, stderr, fail-closed
+
+## Problem
+
+`.husky/pre-commit` runs `harness ci check --skip entropy,docs,perf,security,deps,phase-gate`
+(line 27). Six check categories are **silently** disabled at commit time. Each skip may be
+individually justified (the checks are slow, or run later at pre-push), but the _cumulative
+silence_ is the failure pattern the roadmap item cites: "every gap was once a known issue.
+Then it became background noise. Then it became invisible." A developer committing has no
+signal that six categories of guardrail are inactive.
+
+### Boundary
+
+- **In scope:** make the six skips _visibly named_ at commit time.
+- **Out of scope:** re-enabling any skipped check, moving checks to pre-push, or changing the
+  `--skip` set. Visibility only — behavior of the checks themselves is unchanged.
+
+## Approaches considered
+
+|            | A) One stderr warning line per skipped category                   | B) Move slow checks to pre-push, drop the skip                    | C) Single summary warning naming all six                                                           |
+| ---------- | ----------------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **How**    | For each skipped category, `echo "…" >&2` before the ci-check run | Delete `--skip`, add the categories to the pre-push gauntlet      | One `echo` listing all six categories                                                              |
+| **Pros**   | Each gap stays individually named; minimal, reversible            | Actually closes the gaps                                          | Least output noise                                                                                 |
+| **Cons**   | Doesn't close the gaps (visibility only)                          | Large behavior change; slows every push; out of this item's scope | A blob is easier to stop reading than per-line names — weaker against the "invisible" failure mode |
+| **Risk**   | Low                                                               | Medium–High                                                       | Low                                                                                                |
+| **Effort** | Low                                                               | Medium                                                            | Low                                                                                                |
+
+**Chosen: A.** The roadmap item explicitly frames this as a _visibility_ fix ("emit a
+one-line stderr warning per skipped category so the gaps remain visibly named"), not a
+re-enablement. Per-line naming is what defeats the "becomes invisible" pattern — a reader
+scanning commit output sees each disabled gate by name. B is a real but separate decision
+(behavior change) that YAGNI cuts from this scope. C loses the per-gate naming that is the point.
+
+## User story
+
+As a developer committing to this repo, I want each pre-commit check that is being skipped to
+be named on stderr, so that the set of temporarily-disabled guardrails never silently grows
+invisible.
+
+## Success criteria (EARS)
+
+1. WHEN the pre-commit hook runs, the system SHALL emit exactly one `stderr` line per category
+   in the `--skip` list, each line naming that category.
+2. The warnings SHALL go to `stderr` (`>&2`), never `stdout`, so piped/captured stdout is
+   unaffected.
+3. The system SHALL NOT change the `--skip` set, the `ci check` invocation, or the hook's
+   exit behavior (a passing commit still passes; a blocked commit still blocks).
+4. The skip list in the warnings SHALL stay in sync with the actual `--skip` argument (single
+   source of truth — the warnings are derived from the same list, not a hand-copied duplicate
+   that can drift).
+
+## Implementation Order
+
+### Phase 1: Emit per-category skip warnings <!-- complexity: low -->
+
+Edit **only** `.husky/pre-commit`. Derive the category list from the `--skip` argument (one
+source of truth) and, immediately before the `ci check` invocation, loop over it emitting one
+`>&2` warning per category. No change to the `--skip` value, the `ci check` command, or exit
+handling. Verify by running the hook and confirming six named warning lines on stderr and
+unchanged pass/block behavior.
+
+## Notes for the executor
+
+- The hook is POSIX `sh` (may be dash under husky) — no bashisms (`set -o pipefail`, arrays).
+  A `for cat in $(echo "$SKIP" | tr ',' ' ')` loop is portable.
+- Keep the existing comments (the #726 tee-exit-code note is load-bearing documentation — do
+  not delete it as collateral).
+- Do not alter the file mode (it must stay executable, `100755`).

--- a/packages/core/src/harness-strength/rules/strength-003-skip-list.test.ts
+++ b/packages/core/src/harness-strength/rules/strength-003-skip-list.test.ts
@@ -32,6 +32,52 @@ describe('STRENGTH-003 oversized --skip list', () => {
     expect('severity' in f).toBe(false);
   });
 
+  it('resolves a `SKIP="…"` assignment referenced by `--skip "$SKIP"` (variable form)', () => {
+    // The drift-free single-source hook pattern (roadmap #529 / #965): the skip list
+    // lives in a `SKIP="…"` assignment and is passed as `--skip "$SKIP"`. The auditor
+    // must resolve the variable and audit the assigned categories, not go silent.
+    const findings = strength003SkipList.detect(
+      ctx({
+        preCommit:
+          'SKIP="entropy,docs,perf,security,deps,phase-gate"\n' +
+          'node harness ci check --skip "$SKIP" >/tmp/log 2>&1\n',
+      })
+    );
+    expect(findings).toHaveLength(1);
+    const f = findings[0]!;
+    expect(f.id).toBe('STRENGTH-003');
+    // The finding points at the `--skip "$SKIP"` line, not the assignment.
+    expect(f.line).toBe(2);
+    // Same six categories as the literal form, resolved from the assignment.
+    expect(f.message).toMatch(/6/);
+    expect(f.message).toContain('entropy, docs, perf, security, deps, phase-gate');
+  });
+
+  it('resolves the unquoted `--skip $SKIP` and `${SKIP}` variable forms', () => {
+    for (const ref of ['$SKIP', '${SKIP}', '"${SKIP}"']) {
+      const findings = strength003SkipList.detect(
+        ctx({ preCommit: `SKIP='a,b,c,d'\nharness ci check --skip ${ref}\n` })
+      );
+      expect(findings).toHaveLength(1);
+      expect(findings[0]!.message).toMatch(/4/);
+    }
+  });
+
+  it('falls back gracefully when `--skip "$SKIP"` has no matching assignment', () => {
+    // No `SKIP=` assignment in the file → the variable is unresolvable. The auditor
+    // must not crash and must emit no finding (nothing to audit).
+    expect(() =>
+      strength003SkipList.detect(
+        ctx({ preCommit: 'harness ci check --skip "$SKIP" >/tmp/log 2>&1\n' })
+      )
+    ).not.toThrow();
+    expect(
+      strength003SkipList.detect(
+        ctx({ preCommit: 'harness ci check --skip "$SKIP" >/tmp/log 2>&1\n' })
+      )
+    ).toEqual([]);
+  });
+
   it('passes when 2 or fewer categories are skipped', () => {
     expect(
       strength003SkipList.detect(ctx({ preCommit: 'harness ci check --skip entropy,docs\n' }))

--- a/packages/core/src/harness-strength/rules/strength-003-skip-list.ts
+++ b/packages/core/src/harness-strength/rules/strength-003-skip-list.ts
@@ -11,9 +11,49 @@ import type { ProjectContext, StrengthFinding, StrengthRule } from '../types';
  * and flag when count > 2 AND the matched line has no inline `#` comment after the
  * skip value (the comment is treated as the author's justification). Absent
  * `--skip` is a pass (discipline holds), not "not evaluable".
+ *
+ * Two forms of the skip argument are supported (#965), so the drift-free
+ * single-source `SKIP="…"` + `--skip "$SKIP"` hook pattern (roadmap #529) stays
+ * under review-time coverage:
+ *   1. Literal:  `--skip a,b,c`  (also `--skip "a,b,c"` / `--skip 'a,b,c'`)
+ *   2. Variable: `--skip "$SKIP"` / `--skip $SKIP` / `--skip "${SKIP}"` — resolved
+ *      by finding the matching `SKIP="a,b,c"` (or `SKIP='a,b,c'` / `SKIP=a,b,c`)
+ *      assignment in the same file and auditing that value.
+ * A `--skip "$VAR"` with no matching assignment in the file falls back gracefully
+ * (treated as unresolvable → no finding, no crash).
  */
 
-const SKIP_RE = /--skip[= ]+([\w,-]+)/;
+// Captures the skip ARGUMENT token: a double-quoted run, a single-quoted run, or a
+// bare (unquoted) run of non-whitespace. The token may be a literal category list
+// or a shell-variable reference — resolveSkipCategories() disambiguates.
+const SKIP_RE = /--skip[= ]+("[^"]*"|'[^']*'|\S+)/;
+
+// A bare or braced variable reference: $SKIP or ${SKIP}.
+const VAR_REF_RE = /^\$\{?(\w+)\}?$/;
+
+/**
+ * Resolve the raw `--skip` argument token to a category list.
+ * - Literal token (optionally quoted) → its comma-split categories.
+ * - Variable reference ($VAR / ${VAR}, optionally quoted) → the value of the
+ *   matching `VAR=…` assignment in the same file, or `null` if none is found.
+ */
+function resolveSkipCategories(rawToken: string, fileContent: string): string[] | null {
+  let tok = rawToken;
+  if ((tok.startsWith('"') && tok.endsWith('"')) || (tok.startsWith("'") && tok.endsWith("'"))) {
+    tok = tok.slice(1, -1);
+  }
+  const varRef = VAR_REF_RE.exec(tok);
+  if (varRef) {
+    const varName = varRef[1]!;
+    // Find `VAR="a,b,c"`, `VAR='a,b,c'`, or `VAR=a,b,c` at the start of a line.
+    const assignRe = new RegExp(`^\\s*${varName}=(?:"([^"]*)"|'([^']*)'|([\\w,-]+))`, 'm');
+    const am = assignRe.exec(fileContent);
+    if (!am) return null;
+    const value = am[1] ?? am[2] ?? am[3] ?? '';
+    return value.split(',').filter(Boolean);
+  }
+  return tok.split(',').filter(Boolean);
+}
 
 export const strength003SkipList: StrengthRule = {
   id: 'STRENGTH-003',
@@ -29,7 +69,9 @@ export const strength003SkipList: StrengthRule = {
       const line = lines[i]!;
       const m = SKIP_RE.exec(line);
       if (!m) continue;
-      const categories = m[1]!.split(',').filter(Boolean);
+      const categories = resolveSkipCategories(m[1]!, ctx.preCommit);
+      // Unresolvable variable (no matching assignment in the file) → skip gracefully.
+      if (categories === null) continue;
       if (categories.length <= 2) continue;
       // Inline justification: a `#` SHELL COMMENT appearing after the --skip
       // value. The `#` must sit at a comment boundary (start-of-segment or


### PR DESCRIPTION
Closes #529. **The first item this session taken end-to-end through the actual harness autopilot lifecycle** — every phase owned by a dedicated persona agent, with a document produced at each step (not hand-cranked).

## The change
Six ci-check categories were silently disabled at commit time (`--skip entropy,docs,perf,security,deps,phase-gate`). Now each is named on stderr, derived from a single `SKIP` variable that also feeds `--skip "$SKIP"` — single source of truth, cannot drift.

```diff
+SKIP="entropy,docs,perf,security,deps,phase-gate"
+for cat in $(echo "$SKIP" | tr ',' ' '); do
+  echo "⚠ pre-commit: '$cat' check SKIPPED (deferred to CI/pre-push) — see roadmap #529" >&2
+done
 if ! node …/harness.js ci check --skip "$SKIP" >/tmp/… 2>&1; then
```

POSIX-sh (dash-safe), stderr-only, mode `100755` + all comments preserved, ci-check behavior byte-identical.

## Produced through the lifecycle (artifacts in `docs/changes/pre-commit-skip-visibility/`)
| Phase | Agent | Output |
|---|---|---|
| Brainstorming | (driver) | `proposal.md` — problem, 3 approaches weighed, chosen (A) with rationale, EARS criteria |
| PLAN | `harness-planner` | `plans/2026-07-22-phase-1-…-plan.md` — 5 tasks; surfaced the STRENGTH-003 tension as a checkpoint |
| EXECUTE | `harness-task-executor` | the `.husky/pre-commit` edit; self-verified 6 stderr lines, constraints held |
| VERIFY | `harness-verifier` | **PASS** — independent, ran the hook + both regression suites (2/2, 6/6) |
| REVIEW | `harness-code-reviewer` | **Approve (Comment)** — verified portability/accuracy; 1 non-blocking finding (folded) |

## Reviewer's non-blocking finding (folded)
The `--skip "$SKIP"` variable form silences **STRENGTH-003**'s literal-list static auditor — the *review-time* signal that catches the skip list **growing** (whereas the runtime warnings reach the committer). Documented inline in the hook; enhancement tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)