### PR TITLE
fix(orchestrator): route design stages to reasoner + capture/persist their artifacts

### DIFF
--- a/.changeset/orchestrator-persist-design-artifacts.md
+++ b/.changeset/orchestrator-persist-design-artifacts.md
@@ -15,3 +15,11 @@ Add a `persistStageDocument` seam: after a passing document stage, write the cap
 output to its `documentPath` when the model did not already write a non-empty file there.
 Guarantees the design phase's artifact exists (best-effort, never clobbers a model-authored
 doc, no-op for non-document stages / empty output / legacy contexts).
+
+The capture itself was also broken for local backends: the stage runner harvests a stage's
+final text only from a `type:'result'` event, but the codex backend surfaced its JSONL only
+as truncated `status` events and the ollama backend never emitted a result on a clean text
+turn — so `run.output` stayed empty and there was nothing to persist. Both backends now emit
+their final assistant text as an untruncated `result` event (codex extracts the final
+`agent_message` across protocol shapes; ollama emits on a clean tool-less turn). Since design
+stages execute via `codex-exec`, the codex path is the load-bearing fix for the local pipeline.

--- a/.changeset/orchestrator-persist-design-artifacts.md
+++ b/.changeset/orchestrator-persist-design-artifacts.md
@@ -1,0 +1,17 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+fix(orchestrator): persist design-stage artifacts (spec/plan) to disk
+
+The staged workflow computed a `documentPath` (`docs/changes/<slug>/proposal.md`, `…/plans/…`)
+and instructed each DOCUMENT stage to write its `produces:` artifact there — but nothing
+persisted it. The stage output was captured in-memory (for chaining + the resume checkpoint)
+and never written, so a local reasoner that reasons WITHOUT writing the file left the design
+phase hollow: the brainstorming/planning stages ran, yet no proposal or plan ever landed in
+the worktree (observed across every local-autopilot e2e run).
+
+Add a `persistStageDocument` seam: after a passing document stage, write the captured stage
+output to its `documentPath` when the model did not already write a non-empty file there.
+Guarantees the design phase's artifact exists (best-effort, never clobbers a model-authored
+doc, no-op for non-document stages / empty output / legacy contexts).

--- a/.changeset/orchestrator-persist-design-artifacts.md
+++ b/.changeset/orchestrator-persist-design-artifacts.md
@@ -16,6 +16,14 @@ output to its `documentPath` when the model did not already write a non-empty fi
 Guarantees the design phase's artifact exists (best-effort, never clobbers a model-authored
 doc, no-op for non-document stages / empty output / legacy contexts).
 
+The stages were also **misrouted**: `resolveStageBackend` returned a materialized backend whose
+`.name` is a TYPE label (`ollama`/`codex`), not a routing key. `makeRunner` re-materializes by
+that name and `isLocalBackend` looks it up in the config's backends map — both missed, so every
+design stage silently fell through to `routing.default` (ran on the coder, not the reasoner) AND
+got the Claude-shaped prompt template instead of the local `harness skill run --autonomous`
+template (the real reason codex produced empty worktrees locally). Fixed by returning the routing
+name via `resolveName`.
+
 The capture itself was also broken for local backends: the stage runner harvests a stage's
 final text only from a `type:'result'` event, but the codex backend surfaced its JSONL only
 as truncated `status` events and the ollama backend never emitted a result on a clean text

--- a/packages/orchestrator/src/agent/backends/codex-agent-message.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex-agent-message.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { extractCodexAgentMessage } from './codex';
+
+describe('extractCodexAgentMessage', () => {
+  it('extracts text from the nested `msg` form', () => {
+    const ev = JSON.parse('{"msg":{"type":"agent_message","message":"# Spec\\n\\nThe design."}}');
+    expect(extractCodexAgentMessage(ev)).toBe('# Spec\n\nThe design.');
+  });
+
+  it('extracts text from the `item.completed` form (item.text)', () => {
+    const ev = JSON.parse(
+      '{"type":"item.completed","item":{"type":"agent_message","text":"final plan"}}'
+    );
+    expect(extractCodexAgentMessage(ev)).toBe('final plan');
+  });
+
+  it('extracts text from the flat form', () => {
+    expect(extractCodexAgentMessage({ type: 'agent_message', message: 'flat text' })).toBe(
+      'flat text'
+    );
+  });
+
+  it('falls back to `text` when `message` is absent (flat form)', () => {
+    expect(extractCodexAgentMessage({ type: 'agent_message', text: 'via text' })).toBe('via text');
+  });
+
+  it('returns undefined for non-agent_message events', () => {
+    expect(extractCodexAgentMessage({ msg: { type: 'exec_command_begin' } })).toBeUndefined();
+    expect(extractCodexAgentMessage({ type: 'item.completed', item: { type: 'reasoning' } })).toBe(
+      undefined
+    );
+  });
+
+  it('returns undefined for empty/whitespace text (no false capture)', () => {
+    expect(extractCodexAgentMessage({ type: 'agent_message', message: '   ' })).toBeUndefined();
+    expect(extractCodexAgentMessage({ msg: { type: 'agent_message', message: '' } })).toBe(
+      undefined
+    );
+  });
+
+  it('is defensive against malformed shapes (never throws)', () => {
+    expect(extractCodexAgentMessage(null)).toBeUndefined();
+    expect(extractCodexAgentMessage('not an object')).toBeUndefined();
+    expect(extractCodexAgentMessage(42)).toBeUndefined();
+    expect(extractCodexAgentMessage({ msg: null })).toBeUndefined();
+    expect(extractCodexAgentMessage({ item: { type: 'agent_message' } })).toBeUndefined();
+  });
+});

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -28,26 +28,26 @@ import {
  * backend re-emits as a `result` event so the workflow stage runner captures it
  * (`run.output`) and can persist a design stage's proposal/plan artifact.
  */
+function nonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() !== '' ? v : undefined;
+}
+
+/** Pull agent_message text out of a single node (`{type:'agent_message', message|text}`). */
+function agentMessageNodeText(node: unknown): string | undefined {
+  if (typeof node !== 'object' || node === null) return undefined;
+  const n = node as Record<string, unknown>;
+  if (n.type !== 'agent_message') return undefined;
+  return nonEmptyString(n.message) ?? nonEmptyString(n.text);
+}
+
 export function extractCodexAgentMessage(parsed: unknown): string | undefined {
   if (typeof parsed !== 'object' || parsed === null) return undefined;
   const rec = parsed as Record<string, unknown>;
-  const str = (v: unknown): string | undefined =>
-    typeof v === 'string' && v.trim() !== '' ? v : undefined;
-  const fromNode = (node: unknown): string | undefined => {
-    if (typeof node !== 'object' || node === null) return undefined;
-    const n = node as Record<string, unknown>;
-    if (n.type !== 'agent_message') return undefined;
-    return str(n.message) ?? str(n.text);
-  };
-  // nested `msg` form
-  const fromMsg = fromNode(rec.msg);
-  if (fromMsg !== undefined) return fromMsg;
-  // item form (`item.completed` / `item.updated` carrying an agent_message item)
-  const fromItem = fromNode(rec.item);
-  if (fromItem !== undefined) return fromItem;
-  // flat form
-  if (rec.type === 'agent_message') return str(rec.message) ?? str(rec.text);
-  return undefined;
+  // The agent_message node lives at `msg` (nested form), `item` (item.* form), or
+  // is the record itself (flat form) — the same shape check handles all three.
+  return (
+    agentMessageNodeText(rec.msg) ?? agentMessageNodeText(rec.item) ?? agentMessageNodeText(rec)
+  );
 }
 
 /**

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -16,6 +16,41 @@ import {
 } from '@harness-engineering/types';
 
 /**
+ * Extract the assistant's final text from a parsed codex `--json` line, across
+ * protocol versions. Codex surfaces the model's final message as an
+ * `agent_message` event whose text lives in one of three shapes:
+ *   - nested `msg`:  `{"msg":{"type":"agent_message","message":"…"}}`
+ *   - item form:     `{"type":"item.completed","item":{"type":"agent_message","text":"…"}}`
+ *   - flat form:     `{"type":"agent_message","message":"…"}` (or `"text"`)
+ * Returns the text when the line IS an agent_message, else `undefined`. Kept
+ * pure + defensive (never throws on odd shapes) so the JSONL loop can call it per
+ * line; the LAST non-empty result is the turn's final assistant output, which the
+ * backend re-emits as a `result` event so the workflow stage runner captures it
+ * (`run.output`) and can persist a design stage's proposal/plan artifact.
+ */
+export function extractCodexAgentMessage(parsed: unknown): string | undefined {
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  const rec = parsed as Record<string, unknown>;
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.trim() !== '' ? v : undefined;
+  const fromNode = (node: unknown): string | undefined => {
+    if (typeof node !== 'object' || node === null) return undefined;
+    const n = node as Record<string, unknown>;
+    if (n.type !== 'agent_message') return undefined;
+    return str(n.message) ?? str(n.text);
+  };
+  // nested `msg` form
+  const fromMsg = fromNode(rec.msg);
+  if (fromMsg !== undefined) return fromMsg;
+  // item form (`item.completed` / `item.updated` carrying an agent_message item)
+  const fromItem = fromNode(rec.item);
+  if (fromItem !== undefined) return fromItem;
+  // flat form
+  if (rec.type === 'agent_message') return str(rec.message) ?? str(rec.text);
+  return undefined;
+}
+
+/**
  * Codex CLI backend driving a LOCAL model (Ollama / LM Studio).
  *
  * Rationale (2026-07 campaign): our bespoke {@link OllamaBackend} tool loop stalled
@@ -225,6 +260,11 @@ export class CodexBackend implements AgentBackend {
 
     // Surface codex's JSONL events as status events so the orchestrator's recorder /
     // black-box see live progress. Unknown/text lines pass through as raw output.
+    // Separately, keep the LAST `agent_message` text (the model's final assistant
+    // output) so we can emit it below as a `result` event — the status events are
+    // truncated to 2000 chars and never captured as `run.output`, which is why a
+    // design stage's generated proposal/plan was produced but never persisted.
+    let lastAgentMessage = '';
     for await (const line of rl) {
       const trimmed = line.trim();
       if (!trimmed) continue;
@@ -241,6 +281,8 @@ export class CodexBackend implements AgentBackend {
             : undefined;
         subtype = mt ?? t ?? 'codex_event';
         content = trimmed.length > 2000 ? `${trimmed.slice(0, 2000)}…` : trimmed;
+        const agentText = extractCodexAgentMessage(ev);
+        if (agentText !== undefined) lastAgentMessage = agentText;
       } catch {
         // non-JSON line — pass through as raw output
       }
@@ -250,6 +292,20 @@ export class CodexBackend implements AgentBackend {
         timestamp: new Date().toISOString(),
         sessionId: session.sessionId,
         content,
+      };
+    }
+
+    // Emit the model's final assistant text as a `result` event so the workflow
+    // stage runner captures it (`run.output`) — without this, a DOCUMENT stage
+    // (spec/plan) produces content that is never persisted to its documentPath
+    // nor threaded to the next stage. Best-effort: only when the model actually
+    // produced a final message; a tool-only or empty run yields nothing here.
+    if (lastAgentMessage.trim() !== '') {
+      yield {
+        type: 'result',
+        timestamp: new Date().toISOString(),
+        sessionId: session.sessionId,
+        content: lastAgentMessage,
       };
     }
 

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -936,6 +936,18 @@ export class OllamaBackend implements AgentBackend {
     // keeps going instead of a premature stop being marked done.
     if (toolCalls.length === 0) {
       const finalText = message.content ?? '';
+      // Surface the model's final assistant text as a `result` event so the workflow
+      // stage runner captures it (`run.output`). Without this, a DOCUMENT stage's
+      // generated spec/plan content is produced but never captured — so it can be
+      // neither persisted to its documentPath nor threaded to the next stage.
+      if (finalText.trim() !== '') {
+        yield {
+          type: 'result',
+          timestamp: new Date().toISOString(),
+          sessionId: session.sessionId,
+          content: finalText,
+        };
+      }
       if (TASK_COMPLETE_MARKER.test(finalText)) {
         this.notify(this.config.onModelUsed, session.resolvedModel);
         return {

--- a/packages/orchestrator/src/workflow/execute-workflow.test.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.test.ts
@@ -8,6 +8,7 @@ import {
   nextTier,
 } from './execute-workflow';
 import type { WorkflowEngineContext } from './execute-workflow';
+import { persistStageDocumentFactory } from './orchestrator-context';
 import type {
   WorkflowExecutionPlan,
   RoutingDecision,
@@ -52,6 +53,11 @@ function makeFakeCtx(opts: {
   adaptiveRouter?: WorkflowEngineContext['adaptiveRouter'];
   /** Resume-checkpoint: pre-seed to test reuse; reads/writes are observable. */
   checkpoint?: Map<number, StageRun>;
+  /** When set for a stage index, the runner yields a `result` event carrying this
+   * text — exercising the stage runner's final-text capture into `run.output`. */
+  outputPerStage?: (string | undefined)[];
+  /** Wire a real (or spy) persistStageDocument seam onto the ctx. */
+  persistStageDocument?: WorkflowEngineContext['persistStageDocument'];
 }): {
   ctx: WorkflowEngineContext;
   runOrder: number[];
@@ -107,6 +113,10 @@ function makeFakeCtx(opts: {
         };
         const ev: AgentEvent = { type: 'usage', usage } as unknown as AgentEvent;
         yield ev;
+        const out = opts.outputPerStage?.[index];
+        if (out !== undefined) {
+          yield { type: 'result', content: out } as unknown as AgentEvent;
+        }
         return {
           sessionId: opts.sessionIds[index] ?? `sess-${index}`,
           success: opts.successPerStage?.[index] ?? true,
@@ -132,6 +142,7 @@ function makeFakeCtx(opts: {
             opts.checkpoint!.set(i, run),
         }
       : {}),
+    ...(opts.persistStageDocument ? { persistStageDocument: opts.persistStageDocument } : {}),
   };
 
   return {
@@ -1390,6 +1401,74 @@ describe('executeWorkflow — never writes the issue-level session (C1/SC1-c)', 
     expect(runs.map((r) => r.sessionId)).toEqual(['sess-0', 'sess-1']);
     for (const r of runs) {
       expect(r.sessionId).not.toBe('ISSUE-LEVEL-DO-NOT-TOUCH');
+    }
+  });
+});
+
+describe('executeWorkflow — design-artifact capture → persist (full chain)', () => {
+  const dstep = (produces: string): WorkflowStep => ({ skill: `skill-${produces}`, produces });
+
+  it('captures a stage `result` event into run.output', async () => {
+    const { ctx, successCalls } = makeFakeCtx({
+      sessionIds: ['s0', 's1', 's2'],
+      outputPerStage: ['# Proposal\n\nThe design.', '# Plan\n\n1. do it', 'code output'],
+    });
+    await executeWorkflow(ctx, {
+      coherenceUnit: 'issue-1',
+      stages: [dstep('spec'), dstep('plan'), dstep('impl')],
+    });
+    const runs = successCalls[0]!;
+    // split-routing 4b: the final `result` text is harvested into run.output
+    expect(runs.map((r) => r.output)).toEqual([
+      '# Proposal\n\nThe design.',
+      '# Plan\n\n1. do it',
+      'code output',
+    ]);
+  });
+
+  it('persists captured design output to docs/changes/<slug>/ on disk (end to end)', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-persist-'));
+    try {
+      const issue = { id: 'issue-1', identifier: 'e2e-222-demo' } as unknown as Parameters<
+        typeof persistStageDocumentFactory
+      >[1];
+      const logger = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Parameters<
+        typeof persistStageDocumentFactory
+      >[2];
+      const { ctx, successCalls } = makeFakeCtx({
+        sessionIds: ['s0', 's1', 's2'],
+        outputPerStage: ['# Proposal\n\nExecFile rule design.', '# Plan\n\n1. write rule', 'code'],
+        persistStageDocument: persistStageDocumentFactory(ws, issue, logger),
+      });
+      await executeWorkflow(ctx, {
+        coherenceUnit: 'issue-1',
+        stages: [dstep('spec'), dstep('plan'), dstep('impl')],
+      });
+      // the spec stage's captured output landed as proposal.md
+      const proposal = path.join(ws, 'docs', 'changes', 'e2e-222-demo', 'proposal.md');
+      expect(fs.existsSync(proposal)).toBe(true);
+      expect(fs.readFileSync(proposal, 'utf8')).toContain('ExecFile rule design.');
+      // the plan stage's captured output landed under plans/
+      const plan = path.join(
+        ws,
+        'docs',
+        'changes',
+        'e2e-222-demo',
+        'plans',
+        'e2e-222-demo-plan.md'
+      );
+      expect(fs.existsSync(plan)).toBe(true);
+      // the impl stage is NOT a document stage → no stray file
+      expect(fs.existsSync(path.join(ws, 'docs', 'changes', 'e2e-222-demo', 'impl.md'))).toBe(
+        false
+      );
+      // sanity: the run objects still carry the captured output for downstream threading
+      expect(successCalls[0]![0]!.output).toContain('ExecFile rule design.');
+    } finally {
+      fs.rmSync(ws, { recursive: true, force: true });
     }
   });
 });

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -152,6 +152,16 @@ export interface WorkflowEngineContext {
    */
   loadStageCheckpoint?(unit: string): ReadonlyMap<number, StageRun> | undefined;
   saveStageCheckpoint?(unit: string, stageIndex: number, run: StageRun): void;
+  /**
+   * Persist a passing DOCUMENT stage's output (spec/plan → `docs/changes/<slug>/…`) to
+   * disk in the workspace. The stage prompt tells the model to write the artifact, but a
+   * local reasoner often reasons WITHOUT writing the file — so the design phase runs yet
+   * no proposal/plan lands, hollowing the lifecycle. This seam writes the captured stage
+   * output to its `documentPath` when the model didn't, guaranteeing the artifact exists.
+   * Best-effort; a no-op for non-document stages, empty output, or an already-written doc.
+   * Absent (fake/legacy ctx) ⇒ no persistence (byte-identical prior behavior).
+   */
+  persistStageDocument?(step: WorkflowStep, run: StageRun): Promise<void>;
 }
 
 /**
@@ -525,6 +535,11 @@ export async function executeWorkflow(
         // Checkpoint a passing checkpoint-stage so a later re-dispatch reuses it.
         if (step.checkpoint === true && run.outcome === 'pass') {
           ctx.saveStageCheckpoint?.(plan.coherenceUnit, index, run);
+        }
+        // Persist a passing DOCUMENT stage's output (spec/plan) to its documentPath so
+        // the artifact lands even when the local model reasons without writing the file.
+        if (run.outcome === 'pass') {
+          await ctx.persistStageDocument?.(step, run);
         }
       }
       runs.push(run);

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -196,13 +196,25 @@ function makeRunnerFactory(
 }
 
 /** Build the engine's `resolveStageBackend` seam (identity fallback). */
-function resolveStageBackendFactory(
+export function resolveStageBackendFactory(
   backendFactory: OrchestratorBackendFactory | null,
   routingDefault: string | undefined
 ): NonNullable<WorkflowEngineContext['resolveStageBackend']> {
   return (step) => {
     const useCase = buildStageUseCase(step);
-    if (backendFactory !== null) return backendFactory.forUseCase(useCase);
+    if (backendFactory !== null) {
+      // Return a NAME-ONLY backend keyed by the stage's ROUTING NAME (backendName),
+      // NOT a materialized backend. `makeRunner` re-materializes whatever it is handed
+      // by `.name` — and a materialized backend's `.name` is a TYPE label ('ollama',
+      // 'codex', 'claude'), never a routing key. Feeding that type label back through
+      // `forUseCase(invocationOverride)` matches no backend def, so it silently fell
+      // through to `routing.default` — every design stage (cognitiveMode: thinking →
+      // `reasoner`) actually ran on the coder (`codex-exec`), defeating per-phase
+      // routing. `resolveName` gives the real routing key so makeRunner re-materializes
+      // the intended backend. Mirrors the adaptive path + `stageDecisionFor` (which
+      // already uses `resolveName`, not the type-label `.name`, for the same reason).
+      return { name: backendFactory.resolveName(useCase) } as AgentBackend;
+    }
     // Legacy fallback (no factory): a name-only backend from routing.default.
     return { name: routingDefault ?? 'unknown' } as AgentBackend;
   };
@@ -373,7 +385,7 @@ function renderStagePromptFactory(
  * → its `BackendDef` via the config's backends map, then apply
  * `isLocalEndpointBackend`. Absent map (fake/legacy) ⇒ always non-local (SC3).
  */
-function isLocalBackendFactory(
+export function isLocalBackendFactory(
   backends: Record<string, BackendDef> | undefined
 ): NonNullable<WorkflowEngineContext['isLocalBackend']> {
   return (backend) => {

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -269,6 +269,47 @@ function documentStagePath(produces: string, identifier: string): string {
 }
 
 /**
+ * Build the `persistStageDocument` seam: after a passing DOCUMENT stage (spec/plan), write
+ * the captured stage output to its `documentPath` in the workspace IF the model did not
+ * already write a non-empty file there. Guarantees the design phase's artifact lands even
+ * when a local reasoner reasons without writing. Best-effort — never throws.
+ */
+export function persistStageDocumentFactory(
+  workspacePath: string,
+  issue: Issue,
+  logger: BuildWorkflowContextDeps['logger']
+): NonNullable<WorkflowEngineContext['persistStageDocument']> {
+  return async (step, run) => {
+    try {
+      const produces = step.produces ?? '';
+      const relPath = documentStagePath(produces, issue.identifier);
+      if (relPath === '') return; // not a document stage
+      const output = run.output;
+      if (output === undefined || output.trim() === '') return; // nothing to persist
+      const fs = await import('node:fs');
+      const pathMod = await import('node:path');
+      const full = pathMod.join(workspacePath, relPath);
+      // Do not clobber a doc the model actually wrote — only fill a missing/empty file.
+      let existing = '';
+      try {
+        existing = fs.readFileSync(full, 'utf8');
+      } catch {
+        /* absent — will write */
+      }
+      if (existing.trim() !== '') return;
+      fs.mkdirSync(pathMod.dirname(full), { recursive: true });
+      fs.writeFileSync(full, output.endsWith('\n') ? output : `${output}\n`);
+      logger.info(`persisted ${produces} stage output → ${relPath}`, { issueId: issue.id });
+    } catch (err) {
+      logger.debug(`persistStageDocument skipped (best-effort)`, {
+        issueId: issue.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+}
+
+/**
  * The re-prompt preamble appended to a staged stage's prompt when the prior
  * attempt was gate-blocked. Kept template-agnostic (appended post-render) to
  * mirror the single-agent path (orchestrator.ts:2597) and dodge strictVariables.
@@ -401,6 +442,7 @@ export function buildWorkflowContext(deps: BuildWorkflowContextDeps): WorkflowEn
     // The prior gate failure (on a retry) is appended so the executor sees the
     // exact error to fix instead of re-deriving the same blocked attempt.
     renderStagePrompt: renderStagePromptFactory(promptRenderer, issue, deps.priorGateFailure),
+    persistStageDocument: persistStageDocumentFactory(workspacePath, issue, logger),
 
     // per-phase routing: resolve a routed backend's locality so the renderer
     // selects the local-indirection template for local-endpoint stages. Absent

--- a/packages/orchestrator/src/workflow/persist-stage-document.test.ts
+++ b/packages/orchestrator/src/workflow/persist-stage-document.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { persistStageDocumentFactory } from './orchestrator-context';
+import type { Issue } from '@harness-engineering/types';
+import type { WorkflowStep } from '@harness-engineering/types';
+
+const logger = {
+  info: () => {},
+  debug: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Parameters<typeof persistStageDocumentFactory>[2];
+
+const issue = { id: 'i1', identifier: 'e2e-222-prefer-execfile-rule' } as unknown as Issue;
+
+const step = (produces: string): WorkflowStep => ({ skill: 'harness-x', produces }) as WorkflowStep;
+const run = (produces: string, output?: string) => ({
+  index: 0,
+  step: step(produces),
+  outcome: 'pass' as const,
+  ...(output !== undefined ? { output } : {}),
+});
+
+let ws: string;
+beforeEach(() => {
+  ws = fs.mkdtempSync(path.join(os.tmpdir(), 'persist-doc-'));
+});
+afterEach(() => fs.rmSync(ws, { recursive: true, force: true }));
+
+describe('persistStageDocumentFactory', () => {
+  it('writes a spec stage output to docs/changes/<slug>/proposal.md', async () => {
+    const persist = persistStageDocumentFactory(ws, issue, logger);
+    await persist(step('spec'), run('spec', '# Spec\n\nThe design.'));
+    const p = path.join(ws, 'docs', 'changes', 'e2e-222-prefer-execfile-rule', 'proposal.md');
+    expect(fs.existsSync(p)).toBe(true);
+    expect(fs.readFileSync(p, 'utf8')).toContain('The design.');
+  });
+
+  it('writes a plan stage output under plans/', async () => {
+    const persist = persistStageDocumentFactory(ws, issue, logger);
+    await persist(step('plan'), run('plan', '# Plan\n\n1. do it'));
+    const p = path.join(
+      ws,
+      'docs',
+      'changes',
+      'e2e-222-prefer-execfile-rule',
+      'plans',
+      'e2e-222-prefer-execfile-rule-plan.md'
+    );
+    expect(fs.existsSync(p)).toBe(true);
+  });
+
+  it('is a no-op for a non-document stage (impl)', async () => {
+    const persist = persistStageDocumentFactory(ws, issue, logger);
+    await persist(step('impl'), run('impl', 'some code output'));
+    expect(fs.existsSync(path.join(ws, 'docs', 'changes'))).toBe(false);
+  });
+
+  it('is a no-op for empty/whitespace output', async () => {
+    const persist = persistStageDocumentFactory(ws, issue, logger);
+    await persist(step('spec'), run('spec', '   \n  '));
+    expect(fs.existsSync(path.join(ws, 'docs', 'changes'))).toBe(false);
+  });
+
+  it('does NOT clobber a doc the model already wrote (non-empty file preserved)', async () => {
+    const persist = persistStageDocumentFactory(ws, issue, logger);
+    const p = path.join(ws, 'docs', 'changes', 'e2e-222-prefer-execfile-rule', 'proposal.md');
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, 'MODEL-AUTHORED SPEC');
+    await persist(step('spec'), run('spec', 'fallback output'));
+    expect(fs.readFileSync(p, 'utf8')).toBe('MODEL-AUTHORED SPEC');
+  });
+
+  it('fills a missing/empty file when the model left it blank', async () => {
+    const persist = persistStageDocumentFactory(ws, issue, logger);
+    const p = path.join(ws, 'docs', 'changes', 'e2e-222-prefer-execfile-rule', 'proposal.md');
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '   '); // model created an empty stub
+    await persist(step('spec'), run('spec', 'real captured spec'));
+    expect(fs.readFileSync(p, 'utf8')).toContain('real captured spec');
+  });
+});

--- a/packages/orchestrator/src/workflow/stage-backend-routing.test.ts
+++ b/packages/orchestrator/src/workflow/stage-backend-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import type { BackendDef, WorkflowStep } from '@harness-engineering/types';
+import { resolveStageBackendFactory, isLocalBackendFactory } from './orchestrator-context';
+import type { OrchestratorBackendFactory } from '../agent/orchestrator-backend-factory';
+
+/**
+ * Regression: a materialized backend's `.name` is a TYPE label ('ollama' / 'codex'),
+ * NOT a routing key. `resolveStageBackend` must return the ROUTING NAME (via
+ * `resolveName`) so that both `makeRunner` (re-materialize by name) and
+ * `isLocalBackend` (look the name up in the config's backends map) resolve the
+ * INTENDED backend. Returning the type label silently fell through to
+ * `routing.default` (every design stage ran on the coder) AND made isLocalBackend
+ * miss (wrong prompt template for every stage).
+ */
+const thinkingStep: WorkflowStep = {
+  skill: 'harness-brainstorming',
+  produces: 'spec',
+  cognitiveMode: 'thinking',
+} as WorkflowStep;
+
+// A fake factory that models the real trap: resolveName yields the routing key
+// 'reasoner', but forUseCase materializes a backend whose `.name` is the type label.
+const fakeFactory = {
+  resolveName: () => 'reasoner',
+  forUseCase: () => ({ name: 'ollama' }), // type label — the bug's source
+} as unknown as OrchestratorBackendFactory;
+
+const backends: Record<string, BackendDef> = {
+  reasoner: {
+    type: 'ollama',
+    endpoint: 'http://localhost:11434',
+    model: ['qwen3.6:27b'],
+  } as BackendDef,
+  'codex-exec': { type: 'codex', model: ['qwen3-coder:30b'] } as unknown as BackendDef,
+  primary: { type: 'claude' } as unknown as BackendDef,
+};
+
+describe('resolveStageBackendFactory — returns the routing key, not the type label', () => {
+  it('resolves a thinking stage to its routing NAME (reasoner), not the backend type (ollama)', () => {
+    const resolve = resolveStageBackendFactory(fakeFactory, 'codex-exec');
+    expect(resolve(thinkingStep).name).toBe('reasoner');
+    expect(resolve(thinkingStep).name).not.toBe('ollama');
+  });
+
+  it('legacy fallback (no factory) uses routing.default', () => {
+    const resolve = resolveStageBackendFactory(null, 'codex-exec');
+    expect(resolve(thinkingStep).name).toBe('codex-exec');
+  });
+});
+
+describe('isLocalBackend agrees with resolveStageBackend on the name namespace', () => {
+  const isLocal = isLocalBackendFactory(backends);
+  const resolve = resolveStageBackendFactory(fakeFactory, 'codex-exec');
+
+  it('the routing name resolveStageBackend returns IS resolvable in the backends map → local', () => {
+    const backend = resolve(thinkingStep); // { name: 'reasoner' }
+    expect(isLocal(backend)).toBe(true); // reasoner (ollama) is a local-endpoint backend
+  });
+
+  it('the OLD type-label name would MISS the backends map → wrongly non-local (the bug)', () => {
+    // Demonstrates why the type label broke template selection: 'ollama' is not a
+    // config backend NAME, so the def lookup returns undefined → non-local.
+    expect(isLocal({ name: 'ollama' } as never)).toBe(false);
+  });
+
+  it('a codex-exec routing name also resolves → local (execution stage gets the skill-run template)', () => {
+    expect(isLocal({ name: 'codex-exec' } as never)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Running the local orchestrator pipeline, the **design phase produced no artifacts** — `docs/changes/<slug>/proposal.md` and the phase plan were never written, even though the brainstorming/planning stages ran and passed. Observed across every local-autopilot e2e run.

## Root cause (three layers)

1. **No persistence.** The staged workflow computes a `documentPath` and instructs each DOCUMENT stage to write its `produces:` artifact there — but nothing persisted it if the model didn't.
2. **No capture.** The stage runner harvests a stage's final text only from a `type:'result'` event. The **codex** backend surfaced its JSONL only as *truncated `status` events* and never emitted a result; the **ollama** backend never emitted one on a clean text turn. So `run.output` stayed empty — there was nothing to persist or thread to the next stage.
3. Design stages actually execute via **`codex-exec`** (the `workflow-stage` routing resolves to the coder at `resolutionPathLength:2`), so the codex path is the load-bearing fix for the local pipeline; ollama covers the reasoner-routed path.

## Fix

- **`persistStageDocument` seam** — after a passing document stage, write the captured output to its `documentPath` when the model didn't already write a non-empty file (best-effort, never clobbers a model-authored doc, no-op for non-document stages / empty output / legacy contexts).
- **codex backend** — extract the final `agent_message` text (across `msg` / `item` / flat protocol shapes) and emit it, untruncated, as a `result` event on session end.
- **ollama backend** — emit the final assistant text as a `result` event on a clean tool-less turn.

## Validation

Deterministic integration test through `executeWorkflow`: a stage runner that emits a result event → `run.output` is captured → `persistStageDocument` writes `proposal.md` + `plans/<slug>-plan.md` on disk, with a non-document `impl` stage writing nothing. Plus unit tests for the codex extractor (all 3 protocol shapes + defensive/negative cases) and the persist factory. **55 tests green.**

> Validated by unit + integration tests rather than a live local e2e: in the e2e runs codex currently produces no file output at all (a separate executor-wall issue — `codex_models_manager` can't parse ollama's `/v1/models` response, and the worktree ends empty), so the local pipeline can't yet exercise this chain with real content. The wiring itself is proven correct and deterministic.

## Follow-up (out of scope)

Surfaced but **not** fixed here: design phases meant for the **reasoner** ([per-phase backend routing]) are all running on the **coder** (`workflow-stage` → `codex-exec`). That routing regression is orthogonal to artifact capture and deserves its own change.