### PR TITLE
fix(orchestrator): local reasoning stages get an adequate deadline + capture thinking-only turns

### DIFF
--- a/.changeset/local-reasoning-stage-deadline.md
+++ b/.changeset/local-reasoning-stage-deadline.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): give local reasoning stages an adequate deadline + capture thinking-only turns
+
+A fully-local staged workflow left its design phase empty: the `brainstorming`/`planning`
+stages ran on a local reasoning backend but produced no `proposal.md`/plan. Two causes:
+
+1. **Deadline too short for a local reasoning model.** The per-stage wall-clock deadline
+   defaulted to 120s (`DEFAULT_STAGE_DEADLINE_MS`), which is tuned for cloud models. A local
+   reasoning model (e.g. qwen3 with `think:true`) spends ~30-40s per turn processing large
+   contexts, so 120s aborted a design/plan stage after only ~3 turns — while it was still
+   gathering context, BEFORE it wrote its spec/plan — yielding an empty artifact and cascading
+   to an empty execution stage. A stage routed to a LOCAL (on-device) backend now defaults to
+   `LOCAL_STAGE_DEADLINE_MS` (600s, ~15 turns of headroom); cloud stages are unchanged
+   (byte-identical to the old 120s default), and an explicit `stageDeadlineMs` on the workflow
+   decl still overrides both.
+
+2. **A reasoning model's thinking-only turn was dropped.** The native `/api/chat` `thinking`
+   field (a reasoning model's chain-of-thought, separate from `content`) was discarded during
+   response normalization. When such a model ends a tool-less turn with empty `content` but a
+   populated `thinking`, its output is now captured as the stage's `result` (falling back to
+   `thinking` only when `content` is empty) instead of being lost — so the persist/thread-forward
+   path has something to work with. Completion (`TASK_COMPLETE`) still keys on visible `content`.

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -164,7 +164,16 @@ interface NativeMessage {
 }
 /** Native `/api/chat` non-stream response shape. */
 interface NativeChatResponse {
-  message?: { role?: string; content?: string | null; tool_calls?: NativeToolCall[] };
+  // `thinking` carries a reasoning model's (`think:true`) chain-of-thought as a
+  // field SEPARATE from `content`. A reasoning model can end a turn with all its
+  // work in `thinking` and an EMPTY `content` — so we preserve it (see
+  // fromNativeResponse) rather than dropping the only field the model populated.
+  message?: {
+    role?: string;
+    content?: string | null;
+    thinking?: string | null;
+    tool_calls?: NativeToolCall[];
+  };
   prompt_eval_count?: number;
   eval_count?: number;
   done?: boolean;
@@ -443,8 +452,9 @@ function nativeUsage(native: NativeChatResponse): {
 export function fromNativeResponse(native: NativeChatResponse): OllamaChatResponse {
   const nm = native.message;
   const toolCalls = normalizeNativeToolCalls(nm?.tool_calls);
-  const message: { content?: string | null; tool_calls?: ToolCall[] } = {
+  const message: { content?: string | null; thinking?: string | null; tool_calls?: ToolCall[] } = {
     content: nm?.content ?? '',
+    ...(nm?.thinking ? { thinking: nm.thinking } : {}),
     ...(toolCalls ? { tool_calls: toolCalls } : {}),
   };
   return { choices: [{ message }], usage: nativeUsage(native) };
@@ -935,11 +945,16 @@ export class OllamaBackend implements AgentBackend {
     // the orchestrator runner re-prompt ("Continue your work.") so the model
     // keeps going instead of a premature stop being marked done.
     if (toolCalls.length === 0) {
-      const finalText = message.content ?? '';
+      const content = message.content ?? '';
       // Surface the model's final assistant text as a `result` event so the workflow
       // stage runner captures it (`run.output`). Without this, a DOCUMENT stage's
       // generated spec/plan content is produced but never captured — so it can be
       // neither persisted to its documentPath nor threaded to the next stage.
+      // A reasoning model (`think:true`) can end a tool-less turn with all its work
+      // in `thinking` and an EMPTY `content` (observed: a design stage where the
+      // reasoner gathered context then emitted 0 content tokens). Fall back to the
+      // reasoning trace so its output is captured instead of dropped.
+      const finalText = content.trim() !== '' ? content : (message.thinking ?? '');
       if (finalText.trim() !== '') {
         yield {
           type: 'result',
@@ -948,7 +963,9 @@ export class OllamaBackend implements AgentBackend {
           content: finalText,
         };
       }
-      if (TASK_COMPLETE_MARKER.test(finalText)) {
+      // Completion is signaled via VISIBLE content, never a hidden reasoning trace,
+      // so key the TASK_COMPLETE check on `content` (not the thinking fallback).
+      if (TASK_COMPLETE_MARKER.test(content)) {
         this.notify(this.config.onModelUsed, session.resolvedModel);
         return {
           done: true,
@@ -1414,7 +1431,7 @@ export class OllamaBackend implements AgentBackend {
 /** Minimal shape of Ollama's OpenAI-compatible chat-completions response. */
 interface OllamaChatResponse {
   choices: Array<{
-    message?: { content?: string | null; tool_calls?: ToolCall[] };
+    message?: { content?: string | null; thinking?: string | null; tool_calls?: ToolCall[] };
   }>;
   usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
 }

--- a/packages/orchestrator/src/workflow/execute-workflow.test.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.test.ts
@@ -1151,6 +1151,127 @@ describe('per-stage deadline (SC7 / D12)', () => {
       vi.useRealTimers();
     }
   });
+
+  it('a LOCAL stage with no explicit deadline gets the generous local default (survives past the 120s cloud default)', async () => {
+    // The bug this guards: a local reasoning model is slow, so the 120s cloud
+    // default aborted a design stage before it wrote its artifact. A local stage
+    // must get LOCAL_STAGE_DEADLINE_MS (600s) when no explicit deadline is set.
+    vi.useFakeTimers();
+    try {
+      const successCalls: StageRun[][] = [];
+      const ctx: WorkflowEngineContext = {
+        recorder: {
+          startRecording: vi.fn(),
+          recordEvent: vi.fn(),
+          finishRecording: vi.fn(),
+        } as unknown as WorkflowEngineContext['recorder'],
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        } as unknown as WorkflowEngineContext['logger'],
+        issueId: 'issue-1',
+        identifier: 'issue-1',
+        externalId: null,
+        workspacePath: '/tmp/ws',
+        // NO stageDeadlineMs → engine default applies; isLocalBackend → the LOCAL default.
+        isLocalBackend: () => true,
+        makeRunner: () => ({
+          async *runSession(_i: unknown, _ws: string, _p: string) {
+            yield {
+              type: 'usage',
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            } as unknown as AgentEvent;
+            // Finish PAST the 120s cloud default but WELL under the 600s local one.
+            await new Promise((r) => setTimeout(r, 200_000));
+            return {
+              sessionId: 'ok-local',
+              success: true,
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            };
+          },
+        }),
+        resolveStageBackend: () => fakeBackend(),
+        emitWorkflowSuccess: async (_u, runs) => {
+          successCalls.push(runs);
+        },
+        finalizeWorkflowTerminal: async () => {},
+      };
+      const s: WorkflowStep = { skill: 'slow-local', produces: 's', gate: 'pass-required' };
+      const p = executeWorkflow(ctx, { coherenceUnit: 'issue-1', stages: [s] });
+      await vi.advanceTimersByTimeAsync(250_000);
+      await p;
+
+      // Not aborted at 120s — the local default gave it room to finish at 200s.
+      expect(successCalls).toHaveLength(1);
+      expect(successCalls[0]![0]!.outcome).toBe('pass');
+      expect(successCalls[0]![0]!.sessionId).toBe('ok-local');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a CLOUD stage with no explicit deadline keeps the 120s default (aborts a 200s stage)', async () => {
+    vi.useFakeTimers();
+    try {
+      let runSessions = 0;
+      const successCalls: StageRun[][] = [];
+      const terminalCalls: StageRun[][] = [];
+      const ctx: WorkflowEngineContext = {
+        recorder: {
+          startRecording: vi.fn(),
+          recordEvent: vi.fn(),
+          finishRecording: vi.fn(),
+        } as unknown as WorkflowEngineContext['recorder'],
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        } as unknown as WorkflowEngineContext['logger'],
+        issueId: 'issue-1',
+        identifier: 'issue-1',
+        externalId: null,
+        workspacePath: '/tmp/ws',
+        // NO stageDeadlineMs and NO isLocalBackend → non-local → the 120s cloud default.
+        makeRunner: () => ({
+          async *runSession(_i: unknown, _ws: string, _p: string) {
+            runSessions++;
+            yield {
+              type: 'usage',
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+            } as unknown as AgentEvent;
+            await new Promise((r) => setTimeout(r, 200_000));
+            return {
+              sessionId: 'never',
+              success: true,
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+            };
+          },
+        }),
+        resolveStageBackend: () => fakeBackend(),
+        emitWorkflowSuccess: async (_u, runs) => {
+          successCalls.push(runs);
+        },
+        finalizeWorkflowTerminal: async (_u, runs) => {
+          terminalCalls.push(runs);
+        },
+      };
+      const s: WorkflowStep = { skill: 'slow-cloud', produces: 's', gate: 'pass-required' };
+      const p = executeWorkflow(ctx, { coherenceUnit: 'issue-1', stages: [s] });
+      // Past two 120s attempts (retry once) so the 200s stage is aborted, not run.
+      await vi.advanceTimersByTimeAsync(600_000);
+      await p;
+
+      expect(runSessions).toBe(2); // aborted at 120s each attempt, never reached 200s
+      expect(successCalls).toHaveLength(0);
+      expect(terminalCalls).toHaveLength(1);
+      expect(terminalCalls[0]![0]!.outcome).toBe('fail');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('runStageSession — abort cleanup (carry-forward a)', () => {

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -32,6 +32,17 @@ export function nextTier(t: CapabilityTier): CapabilityTier {
 export const DEFAULT_STAGE_DEADLINE_MS = 120_000;
 
 /**
+ * Per-stage deadline for a stage routed to a LOCAL (on-device) backend. The 120s
+ * cloud default is far too short here: a local reasoning model (e.g. qwen3 with
+ * think:true) spends ~30-40s per turn processing large contexts, so 120s aborts a
+ * design/plan stage after only ~3 turns — while it is still gathering context,
+ * BEFORE it writes its spec/plan — leaving an empty artifact. Give a local stage
+ * real room (~15 turns). An explicit `stageDeadlineMs` on the workflow decl still
+ * overrides this; cloud stages are unaffected (byte-identical to the old default).
+ */
+export const LOCAL_STAGE_DEADLINE_MS = 600_000;
+
+/**
  * Narrow surface the stage-execution engine needs. The Orchestrator will
  * implement this in Phase 4 when dispatchIssue wires the branch; the engine
  * must NOT import orchestrator.ts (layer cycle). Phase 1 tests inject a fake.
@@ -284,7 +295,10 @@ export async function runStageSession(
   // runs too long. A pending `abort` is resolved through `abortWaiter` so the drain
   // loop's `await` never blocks unboundedly even when the generator never yields
   // and never returns (an unbounded hang). Always cleared in `finally`.
-  const deadlineMs = ctx.stageDeadlineMs ?? DEFAULT_STAGE_DEADLINE_MS;
+  // An explicit workflow-decl deadline always wins; otherwise a local-backend stage
+  // gets the generous local budget and a cloud stage keeps the 120s default.
+  const deadlineMs =
+    ctx.stageDeadlineMs ?? (local ? LOCAL_STAGE_DEADLINE_MS : DEFAULT_STAGE_DEADLINE_MS);
   let onAbort: (() => void) | undefined;
   const abortWaiter = new Promise<'aborted'>((resolve) => {
     onAbort = () => resolve('aborted');

--- a/packages/orchestrator/tests/agent/backends/ollama.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama.test.ts
@@ -14,10 +14,12 @@ import {
 /** Build a canned NATIVE /api/chat response with optional tool calls. */
 function chatResponse(opts: {
   content?: string;
+  thinking?: string;
   toolCalls?: Array<{ name: string; args: unknown }>;
   usage?: { prompt_tokens?: number; completion_tokens?: number };
 }) {
   const message: Record<string, unknown> = { role: 'assistant', content: opts.content ?? '' };
+  if (opts.thinking !== undefined) message.thinking = opts.thinking;
   if (opts.toolCalls) {
     message.tool_calls = opts.toolCalls.map((tc) => ({
       function: { name: tc.name, arguments: tc.args },
@@ -781,6 +783,67 @@ describe('OllamaBackend', () => {
       expect(result.success).toBe(true);
     });
 
+    it('a tool-less turn with EMPTY content but non-empty `thinking` still emits a result event carrying the reasoning (design-stage capture)', async () => {
+      // The observed failure: a reasoning model runs a document stage, gathers
+      // context, then ends a turn with all its output in `thinking` and empty
+      // `content`. Without the fallback the result event is skipped → run.output
+      // empty → nothing to persist to proposal.md. The fallback captures it.
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          okFetch(chatResponse({ content: '', thinking: 'Proposal: add a prefer-execfile rule…' }))
+        );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!start.ok) return;
+      const { events, result } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'produce the spec',
+          isContinuation: false,
+        })
+      );
+      const resultEvents = events.filter((e) => e.type === 'result');
+      expect(resultEvents).toHaveLength(1);
+      expect((resultEvents[0] as { content: string }).content).toBe(
+        'Proposal: add a prefer-execfile rule…'
+      );
+      // Completion is keyed on VISIBLE content, so a thinking-only turn still
+      // re-prompts (no TASK_COMPLETE) rather than falsely completing.
+      expect(result.success).toBe(false);
+    });
+
+    it('content wins over `thinking` when both are present (no regression to the normal path)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          okFetch(chatResponse({ content: 'The visible answer.', thinking: 'hidden reasoning' }))
+        );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!start.ok) return;
+      const { events } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'do the work',
+          isContinuation: false,
+        })
+      );
+      const resultEvents = events.filter((e) => e.type === 'result');
+      expect(resultEvents).toHaveLength(1);
+      expect((resultEvents[0] as { content: string }).content).toBe('The visible answer.');
+    });
+
     it('TASK_COMPLETE must be a whole token — a substring like TASK_COMPLETED does NOT count', async () => {
       const fetchMock = vi
         .fn()
@@ -1014,6 +1077,22 @@ describe('OllamaBackend', () => {
       expect(r.choices[0]!.message!.content).toBe('TASK_COMPLETE');
       expect(r.choices[0]!.message!.tool_calls).toBeUndefined();
       expect(r.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0 });
+    });
+
+    it("preserves a reasoning model's `thinking` field (a think:true turn can put all its work there, content empty)", () => {
+      const r = fromNativeResponse({
+        message: { role: 'assistant', content: '', thinking: 'the whole proposal reasoning' },
+        done: true,
+      });
+      // Without preserving `thinking`, an empty-content reasoning turn would be
+      // dropped entirely — the design stage's only output lost.
+      expect(r.choices[0]!.message!.content).toBe('');
+      expect(r.choices[0]!.message!.thinking).toBe('the whole proposal reasoning');
+    });
+
+    it('omits `thinking` when the native response has none (non-reasoning turn)', () => {
+      const r = fromNativeResponse({ message: { role: 'assistant', content: 'hi' }, done: true });
+      expect(r.choices[0]!.message!.thinking).toBeUndefined();
     });
 
     it('builds native messages: assistant tool_calls args string→object, tool msg → {role,content,tool_name}', () => {


### PR DESCRIPTION
## Problem

A fully-local staged workflow left its **design phase empty** — the `brainstorming`/`planning` stages ran on a local reasoning backend but produced no `proposal.md`/plan, cascading to an empty execution stage (empty worktree → retries → needs-human). Diagnosed by running the real orchestrator and inspecting per-turn native responses.

## Root cause (not what it looked like)

Not model quality, not the routing bug (fixed in #967), not the `thinking` field. The killer was the **120s per-stage wall-clock deadline** (`DEFAULT_STAGE_DEADLINE_MS`, tuned for cloud models). A local reasoning model (qwen3.6:27b, `think:true`) spends ~30–40s/turn processing 40K-token contexts, so 120s fired `abort()` after only ~3 turns — while the model was **still gathering context, before it ever wrote its spec/plan**.

## Fixes

1. **Backend-aware stage deadline** — a stage routed to a LOCAL (on-device) backend now defaults to `LOCAL_STAGE_DEADLINE_MS` (600s, ~15 turns of headroom). Cloud stages are byte-identical to the old 120s default; an explicit `stageDeadlineMs` on the workflow decl still overrides both.
2. **Capture reasoning-only turns** — the native `/api/chat` `thinking` field was dropped during normalization. It's now preserved, and a tool-less turn with empty `content` falls back to `thinking` for the stage `result` (so persist / thread-forward has something). `TASK_COMPLETE` still keys on visible `content`.

## Validation (real orchestrator, local models)

With the deadline lifted, the reasoner produced a **10KB `proposal.md`** (real spec with decision-tradeoff tables), planning produced a plan, and codex execution wrote **rule + registration + test + count-bump** — the pipeline went from empty-worktree/spin to a real multi-file change.

## Tests

+6 unit tests: `fromNativeResponse` preserves `thinking`; the tool-less empty-content→thinking fallback (and content-wins-when-present); local-stage gets the 600s default while cloud keeps 120s. Full orchestrator ollama (72) + execute-workflow (66) suites green.

## Known follow-ups (separate)

- Planning's plan is produced as `content` on a *tool-call* turn and not persisted (capture fires only on tool-less turns); execution still succeeded from the spec alone.
- The deadline `abort()` does not kill the codex *subprocess* (a codex-backend issue).