### PR TITLE
fix(orchestrator): stage-deadline abort terminates the codex subprocess

### DIFF
--- a/.changeset/codex-stage-abort-kills-subprocess.md
+++ b/.changeset/codex-stage-abort-kills-subprocess.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): a stage-deadline abort now actually terminates the codex subprocess
+
+When a staged workflow aborts a stage at its wall-clock deadline, the runner calls
+`backend.stopSession`. The codex backend's `stopSession` was a no-op and its spawned
+`codex exec` child was referenced only inside `runTurn`, so an aborted codex stage kept
+running to codex's own 30-minute cap — a stage deadline could not stop the work (observed:
+a local verification stage ran ~20 min past its deadline). The codex backend now tracks the
+live child per session and `stopSession` SIGKILLs it, mirroring how the ollama backend
+cancels its in-flight request on abort.

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -154,6 +154,45 @@ exit 3`);
     expect(result.error).toMatch(/wall-clock cap/);
   });
 
+  itPosix(
+    'stopSession kills the live child so a stage-deadline abort actually terminates codex',
+    async () => {
+      // Fixture: emit one line, then sleep far longer than the test timeout. The
+      // backend's own timeoutMs is huge (mimicking the 30-min default), so if
+      // stopSession does NOT kill the child, draining blocks on the sleep and the
+      // test times out — reproducing the bug where a stage deadline could not stop codex.
+      const cmd = fakeCodex(`echo '{"type":"session.created"}'
+sleep 30`);
+      const b = new CodexBackend({ model: 'm', command: cmd, timeoutMs: 30 * 60_000 });
+      const gen = b.runTurn(SESSION, {
+        sessionId: SESSION.sessionId,
+        prompt: 'do x',
+      } as TurnParams);
+      // Pull the first event so the child is spawned + registered in activeChildren.
+      await gen.next();
+      // The runner invokes stopSession when a stage's wall-clock deadline aborts.
+      const stopped = await b.stopSession(SESSION);
+      expect(stopped.ok).toBe(true);
+      // Draining now completes promptly (child SIGKILLed) instead of hanging on sleep 30.
+      let result: TurnResult | undefined;
+      for (;;) {
+        const n = await gen.next();
+        if (n.done) {
+          result = n.value;
+          break;
+        }
+      }
+      expect(result!.success).toBe(false); // killed by signal → non-zero exit
+    },
+    10_000
+  );
+
+  it('stopSession is a safe no-op for a session with no live child', async () => {
+    const b = new CodexBackend({ model: 'm' });
+    const r = await b.stopSession(SESSION);
+    expect(r.ok).toBe(true);
+  });
+
   it('healthCheck returns Err for a non-existent codex binary', async () => {
     const b = new CodexBackend({ model: 'm', command: '/definitely/not/codex-xyz' });
     const r = await b.healthCheck();

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import * as readline from 'node:readline';
 import { randomUUID } from 'node:crypto';
 import {
@@ -143,6 +143,17 @@ export class CodexBackend implements AgentBackend {
   private timeoutMs: number;
   private mcpServers: McpServerSpec[];
   private reasoningEffort?: 'low' | 'medium' | 'high';
+  /**
+   * Live codex subprocess per active session, so {@link stopSession} can kill it
+   * when the workflow aborts a stage (its wall-clock deadline). Without this, the
+   * runner's abort only invokes the (previously no-op) `stopSession` while the
+   * detached codex process kept running to its own 30-min cap — a stage's deadline
+   * could not actually terminate the work.
+   */
+  private readonly activeChildren = new Map<
+    string,
+    { child: ChildProcess; killTimer: NodeJS.Timeout }
+  >();
 
   constructor(options: CodexBackendOptions = {}) {
     this.command = options.command ?? 'codex';
@@ -230,6 +241,9 @@ export class CodexBackend implements AgentBackend {
       timedOut = true;
       child.kill('SIGKILL');
     }, this.timeoutMs);
+    // Register the live child so stopSession (invoked by the runner on a stage
+    // abort) can terminate it — see activeChildren.
+    this.activeChildren.set(session.sessionId, { child, killTimer });
 
     let spawnError = '';
     child.on('error', (err) => {
@@ -311,6 +325,9 @@ export class CodexBackend implements AgentBackend {
 
     await exited;
     clearTimeout(killTimer);
+    // Normal completion — drop the session's live-child registration (the abort
+    // path clears it in stopSession instead).
+    this.activeChildren.delete(session.sessionId);
 
     if (spawnError !== '') {
       return {
@@ -336,7 +353,19 @@ export class CodexBackend implements AgentBackend {
     };
   }
 
-  async stopSession(_session: AgentSession): Promise<Result<void, AgentError>> {
+  async stopSession(session: AgentSession): Promise<Result<void, AgentError>> {
+    // The runner calls this when a stage is aborted (its wall-clock deadline).
+    // Kill the live codex subprocess so the deadline actually terminates the work
+    // instead of letting codex run to its own 30-min cap. SIGKILL: codex ignores
+    // gentler signals mid-run, and its stdio-piped MCP children exit on stdin EOF.
+    const active = this.activeChildren.get(session.sessionId);
+    if (active !== undefined) {
+      clearTimeout(active.killTimer);
+      if (active.child.exitCode === null && active.child.signalCode === null) {
+        active.child.kill('SIGKILL');
+      }
+      this.activeChildren.delete(session.sessionId);
+    }
     return Ok(undefined);
   }
 


### PR DESCRIPTION
## Problem

When a staged workflow aborts a stage at its wall-clock deadline, the runner calls `backend.stopSession()` (via `runSession`'s `finally`). The **codex** backend's `stopSession` was a **no-op**, and its spawned `codex exec` child was referenced only inside `runTurn` — so an aborted codex stage kept running to codex's own **30-minute** cap. A stage's deadline could not actually stop the work.

Observed during local e2e validation: a codex **verification** stage ran **~20 minutes past** its 600s deadline (`consumeTurn` drives `runTurn` via manual `.next()`, so the abandoned backend generator's cleanup never runs, and `stopSession` did nothing).

## Fix

Track the live child process per session (`activeChildren`), and have `stopSession` SIGKILL it — mirroring how the **ollama** backend cancels its in-flight request on abort. Normal completion clears the registration; the abort path clears it in `stopSession`.

- SIGKILL because codex ignores gentler signals mid-run; its stdio-piped MCP children exit on stdin EOF.
- The backend's own 30-min `timeoutMs` kill-timer is unchanged (backstop); this makes the **stage** deadline effective.

## Tests

- `stopSession kills the live child…` (POSIX): a fixture that emits a line then `sleep 30` with a 30-min backend timeout — draining after `stopSession` completes promptly instead of hanging, proving the child was killed (would time out if not).
- `stopSession is a safe no-op for a session with no live child`.
- Full codex suite green (35).

## Context

Follow-up to #968 (which fixed the local-reasoning-stage deadline). Together: local design/plan stages get enough time to produce artifacts, and codex execution/verification stages that overrun are now actually bounded by the deadline — closing the "converge or halt, don't spin" guarantee for the local pipeline.