### PR TITLE
fix(orchestrator): capture a local stage's document when emitted as content on a tool-call turn

### DIFF
--- a/.changeset/capture-document-content-on-tool-turns.md
+++ b/.changeset/capture-document-content-on-tool-turns.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): capture a local stage's document when it's emitted as content on a tool-call turn
+
+A local planning stage produced its plan as assistant `content` on a turn that also called a
+tool (a final read), then never wrote it to a file — so the plan was neither persisted to its
+`documentPath` nor threaded to the next stage. The ollama backend only surfaced a `result`
+event on a clean tool-less turn, so content produced alongside a tool call was lost.
+
+The backend now captures assistant `content` as a `result` on any turn (tool-call turns
+included), keeping the LONGEST content of the turn-loop (the workflow harvest is last-wins, so
+a monotonic-longest guard makes `run.output` settle on the largest artifact rather than a
+later, chattier line). The `thinking`-trace fallback now applies only when NO content was
+produced the entire turn-loop. `TASK_COMPLETE` still keys on visible content.

--- a/packages/orchestrator/src/agent/backends/ollama.ts
+++ b/packages/orchestrator/src/agent/backends/ollama.ts
@@ -203,6 +203,14 @@ export interface OllamaSession extends AgentSession {
   mcpClients: Client[];
   /** Resolved `num_ctx` for this session (override | min(modelMax, cap) | default). */
   numCtx: number;
+  /**
+   * Length of the longest assistant `content` captured as a `result` event so far
+   * this turn-loop. The workflow harvest is last-wins, so emitting a content result
+   * only when it beats this makes `run.output` settle on the LARGEST artifact the
+   * model produced — even when that artifact appeared on a tool-call turn and was
+   * never written to a file. `0` ⇒ no content captured yet (⇒ salvage `thinking`).
+   */
+  longestResultLen: number;
 }
 
 /**
@@ -760,6 +768,7 @@ export class OllamaBackend implements AgentBackend {
       mcpToolMap: new Map(),
       mcpClients: [],
       numCtx: DEFAULT_AUTO_CTX,
+      longestResultLen: 0,
     };
 
     const specs = this.config.mcpServers ?? [];
@@ -929,14 +938,32 @@ export class OllamaBackend implements AgentBackend {
     }
 
     const toolCalls = message.tool_calls ?? [];
+    const content = message.content ?? '';
 
     // Append the assistant turn (with its tool_calls, if any) to the
     // conversation before executing tools, mirroring the OpenAI protocol.
     session.messages.push({
       role: 'assistant',
-      content: message.content ?? '',
+      content,
       ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
     });
+
+    // Surface the model's substantive CONTENT as a `result` event so the workflow
+    // stage runner captures it (`run.output`) — on tool-call turns too, whenever it
+    // is the LONGEST content this turn-loop. A DOCUMENT stage can emit its spec/plan
+    // as assistant content on a turn that ALSO calls a tool (e.g. a final read) and
+    // then never write_file it; capturing only clean tool-less turns lost that
+    // artifact. The harvest is last-wins, so the monotonic-longest guard makes
+    // `run.output` settle on the largest artifact, not a later, chattier line.
+    if (content.trim() !== '' && content.length > session.longestResultLen) {
+      session.longestResultLen = content.length;
+      yield {
+        type: 'result',
+        timestamp: new Date().toISOString(),
+        sessionId: session.sessionId,
+        content,
+      };
+    }
 
     // No tool calls → the model stopped calling tools. This is a clean, done
     // turn ONLY when the final message signals completion via TASK_COMPLETE;
@@ -945,23 +972,19 @@ export class OllamaBackend implements AgentBackend {
     // the orchestrator runner re-prompt ("Continue your work.") so the model
     // keeps going instead of a premature stop being marked done.
     if (toolCalls.length === 0) {
-      const content = message.content ?? '';
-      // Surface the model's final assistant text as a `result` event so the workflow
-      // stage runner captures it (`run.output`). Without this, a DOCUMENT stage's
-      // generated spec/plan content is produced but never captured — so it can be
-      // neither persisted to its documentPath nor threaded to the next stage.
-      // A reasoning model (`think:true`) can end a tool-less turn with all its work
-      // in `thinking` and an EMPTY `content` (observed: a design stage where the
-      // reasoner gathered context then emitted 0 content tokens). Fall back to the
-      // reasoning trace so its output is captured instead of dropped.
-      const finalText = content.trim() !== '' ? content : (message.thinking ?? '');
-      if (finalText.trim() !== '') {
-        yield {
-          type: 'result',
-          timestamp: new Date().toISOString(),
-          sessionId: session.sessionId,
-          content: finalText,
-        };
+      // A reasoning model (`think:true`) can end a turn with all its work in
+      // `thinking` and an EMPTY `content`. If NO content was captured this whole
+      // turn-loop, salvage the reasoning trace so the output isn't dropped.
+      if (session.longestResultLen === 0) {
+        const thinking = message.thinking ?? '';
+        if (thinking.trim() !== '') {
+          yield {
+            type: 'result',
+            timestamp: new Date().toISOString(),
+            sessionId: session.sessionId,
+            content: thinking,
+          };
+        }
       }
       // Completion is signaled via VISIBLE content, never a hidden reasoning trace,
       // so key the TASK_COMPLETE check on `content` (not the thinking fallback).

--- a/packages/orchestrator/tests/agent/backends/ollama.test.ts
+++ b/packages/orchestrator/tests/agent/backends/ollama.test.ts
@@ -844,6 +844,46 @@ describe('OllamaBackend', () => {
       expect((resultEvents[0] as { content: string }).content).toBe('The visible answer.');
     });
 
+    it('captures a DOCUMENT emitted as content on a TOOL-CALL turn, and a shorter later turn does not clobber it (longest-wins)', async () => {
+      // The observed gap: a planning stage produced its plan as assistant content on a
+      // turn that ALSO called a tool, then never write_file'd it — only clean tool-less
+      // turns were captured, so the plan was lost. Now tool-call-turn content is captured,
+      // and the monotonic-longest guard keeps run.output on the largest artifact.
+      const longPlan = `PLAN\n${'step '.repeat(120)}`; // ~600 chars
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          okFetch(
+            chatResponse({
+              content: longPlan,
+              toolCalls: [{ name: 'bash', args: { command: 'echo hi' } }],
+            })
+          )
+        )
+        .mockResolvedValueOnce(okFetch(chatResponse({ content: 'Done.\nTASK_COMPLETE' })));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const backend = new OllamaBackend(baseConfig);
+      const start = await backend.startSession({
+        workspacePath: workspace,
+        permissionMode: 'full',
+      });
+      if (!start.ok) return;
+      const { events, result } = await drain(
+        backend.runTurn(start.value, {
+          sessionId: start.value.sessionId,
+          prompt: 'produce the plan',
+          isContinuation: false,
+        })
+      );
+      const resultEvents = events.filter((e) => e.type === 'result');
+      // Only the long plan is captured; the short final wrap-up is not longer, so it
+      // does not emit a result — last-wins harvest therefore keeps the plan.
+      expect(resultEvents).toHaveLength(1);
+      expect((resultEvents[0] as { content: string }).content).toBe(longPlan);
+      expect(result.success).toBe(true); // TASK_COMPLETE on the second turn
+    });
+
     it('TASK_COMPLETE must be a whole token — a substring like TASK_COMPLETED does NOT count', async () => {
       const fetchMock = vi
         .fn()


### PR DESCRIPTION
## Problem

With the design phase now producing artifacts (#968), the **planning** stage surfaced the next gap: it produced its plan as assistant `content` on a turn that **also called a tool** (a final read), then never `write_file`'d it. The ollama backend only emitted a `result` event on a clean **tool-less** turn, so content produced alongside a tool call was dropped — the plan was neither persisted to its `documentPath` nor threaded to the next stage. (Execution still succeeded from the spec alone, but the plan was lost.)

## Fix

Capture assistant `content` as a `result` on **any** turn (tool-call turns included), keeping the **longest** content of the turn-loop:
- The workflow harvest is last-wins, so a monotonic-longest guard (`session.longestResultLen`) makes `run.output` settle on the largest artifact rather than a later, chattier line.
- The `thinking`-trace fallback (from #968) now applies only when **no** content was produced the entire turn-loop.
- `TASK_COMPLETE` still keys on visible `content`.

The existing `persistStageDocument` seam then writes the captured plan to its `documentPath`.

## Tests

- New: a document emitted as content on a tool-call turn is captured, and a shorter later (tool-less) turn does not clobber it (longest-wins). Existing thinking-fallback / content-wins tests updated to the refined semantics.
- Full ollama suite green (73).

## Context

Third in the local-pipeline convergence series: #968 (design deadline) → #969 (codex stage abort) → this (plan capture). Together the local design→plan phases now reliably produce and persist their artifacts.