### PR TITLE
fix(orchestrator): larger deadline for local DOCUMENT stages (spec/plan)

### DIFF
--- a/.changeset/local-document-stage-deadline.md
+++ b/.changeset/local-document-stage-deadline.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): give local DOCUMENT stages a larger deadline than other local stages
+
+A local DOCUMENT stage (produces `spec`/`plan`) runs on the reasoning backend, which
+faithfully follows the skill's multi-phase process and over-explores — gathering context
+across many turns before writing its artifact. The flat 600s local deadline
+(`LOCAL_STAGE_DEADLINE_MS`) could guillotine it mid-exploration, so the captured output was
+a narration fragment rather than a finished spec/plan. Document stages now default to
+`LOCAL_DOCUMENT_STAGE_DEADLINE_MS` (1200s) while execution/verify/review keep 600s; an
+explicit `stageDeadlineMs` on the workflow decl still overrides, and cloud stages are
+unchanged.

--- a/packages/orchestrator/src/workflow/execute-workflow.test.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.test.ts
@@ -1272,6 +1272,125 @@ describe('per-stage deadline (SC7 / D12)', () => {
       vi.useRealTimers();
     }
   });
+
+  it('a LOCAL DOCUMENT stage (spec/plan) gets the larger document deadline (survives past the 600s local default)', async () => {
+    // The reasoning backend over-explores a design/plan stage; 600s can guillotine it
+    // mid-exploration. A document stage must get LOCAL_DOCUMENT_STAGE_DEADLINE_MS.
+    vi.useFakeTimers();
+    try {
+      const successCalls: StageRun[][] = [];
+      const ctx: WorkflowEngineContext = {
+        recorder: {
+          startRecording: vi.fn(),
+          recordEvent: vi.fn(),
+          finishRecording: vi.fn(),
+        } as unknown as WorkflowEngineContext['recorder'],
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        } as unknown as WorkflowEngineContext['logger'],
+        issueId: 'issue-1',
+        identifier: 'issue-1',
+        externalId: null,
+        workspacePath: '/tmp/ws',
+        isLocalBackend: () => true,
+        makeRunner: () => ({
+          async *runSession(_i: unknown, _ws: string, _p: string) {
+            yield {
+              type: 'usage',
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            } as unknown as AgentEvent;
+            // Finish PAST the 600s local default but under the 1200s document default.
+            await new Promise((r) => setTimeout(r, 800_000));
+            return {
+              sessionId: 'ok-doc',
+              success: true,
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            };
+          },
+        }),
+        resolveStageBackend: () => fakeBackend(),
+        emitWorkflowSuccess: async (_u, runs) => {
+          successCalls.push(runs);
+        },
+        finalizeWorkflowTerminal: async () => {},
+      };
+      const s: WorkflowStep = { skill: 'brainstorm', produces: 'spec', gate: 'pass-required' };
+      const p = executeWorkflow(ctx, { coherenceUnit: 'issue-1', stages: [s] });
+      await vi.advanceTimersByTimeAsync(900_000);
+      await p;
+
+      // Not aborted at 600s — the document deadline gave it room to finish at 800s.
+      expect(successCalls).toHaveLength(1);
+      expect(successCalls[0]![0]!.outcome).toBe('pass');
+      expect(successCalls[0]![0]!.sessionId).toBe('ok-doc');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a LOCAL NON-document stage (produces impl) keeps the 600s local default (aborts an 800s stage)', async () => {
+    vi.useFakeTimers();
+    try {
+      let runSessions = 0;
+      const successCalls: StageRun[][] = [];
+      const terminalCalls: StageRun[][] = [];
+      const ctx: WorkflowEngineContext = {
+        recorder: {
+          startRecording: vi.fn(),
+          recordEvent: vi.fn(),
+          finishRecording: vi.fn(),
+        } as unknown as WorkflowEngineContext['recorder'],
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        } as unknown as WorkflowEngineContext['logger'],
+        issueId: 'issue-1',
+        identifier: 'issue-1',
+        externalId: null,
+        workspacePath: '/tmp/ws',
+        isLocalBackend: () => true,
+        makeRunner: () => ({
+          async *runSession(_i: unknown, _ws: string, _p: string) {
+            runSessions++;
+            yield {
+              type: 'usage',
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+            } as unknown as AgentEvent;
+            await new Promise((r) => setTimeout(r, 800_000));
+            return {
+              sessionId: 'never',
+              success: true,
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+            };
+          },
+        }),
+        resolveStageBackend: () => fakeBackend(),
+        emitWorkflowSuccess: async (_u, runs) => {
+          successCalls.push(runs);
+        },
+        finalizeWorkflowTerminal: async (_u, runs) => {
+          terminalCalls.push(runs);
+        },
+      };
+      const s: WorkflowStep = { skill: 'execute', produces: 'impl', gate: 'pass-required' };
+      const p = executeWorkflow(ctx, { coherenceUnit: 'issue-1', stages: [s] });
+      // Past two 600s attempts (retry once) so the 800s stage is aborted, not run.
+      await vi.advanceTimersByTimeAsync(2_000_000);
+      await p;
+
+      expect(runSessions).toBe(2); // aborted at 600s each attempt, never reached 800s
+      expect(successCalls).toHaveLength(0);
+      expect(terminalCalls).toHaveLength(1);
+      expect(terminalCalls[0]![0]!.outcome).toBe('fail');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('runStageSession — abort cleanup (carry-forward a)', () => {

--- a/packages/orchestrator/src/workflow/execute-workflow.ts
+++ b/packages/orchestrator/src/workflow/execute-workflow.ts
@@ -43,6 +43,16 @@ export const DEFAULT_STAGE_DEADLINE_MS = 120_000;
 export const LOCAL_STAGE_DEADLINE_MS = 600_000;
 
 /**
+ * Per-stage deadline for a LOCAL DOCUMENT stage (produces `spec`/`plan`). These run
+ * on the reasoning backend, which faithfully follows the skill's multi-phase process
+ * (explore → analyze → write) and over-explores: gathering context across many turns
+ * before producing the artifact. 600s can guillotine it mid-exploration — capturing a
+ * narration fragment instead of a finished spec/plan. Give document stages more room
+ * so the reasoner reaches the write. Execution/verify/review keep LOCAL_STAGE_DEADLINE_MS.
+ */
+export const LOCAL_DOCUMENT_STAGE_DEADLINE_MS = 1_200_000;
+
+/**
  * Narrow surface the stage-execution engine needs. The Orchestrator will
  * implement this in Phase 4 when dispatchIssue wires the branch; the engine
  * must NOT import orchestrator.ts (layer cycle). Phase 1 tests inject a fake.
@@ -296,9 +306,14 @@ export async function runStageSession(
   // loop's `await` never blocks unboundedly even when the generator never yields
   // and never returns (an unbounded hang). Always cleared in `finally`.
   // An explicit workflow-decl deadline always wins; otherwise a local-backend stage
-  // gets the generous local budget and a cloud stage keeps the 120s default.
-  const deadlineMs =
-    ctx.stageDeadlineMs ?? (local ? LOCAL_STAGE_DEADLINE_MS : DEFAULT_STAGE_DEADLINE_MS);
+  // gets the generous local budget — larger still for a DOCUMENT stage (spec/plan),
+  // whose reasoning backend over-explores before writing — and a cloud stage keeps
+  // the 120s default.
+  const isDocumentStage = step.produces === 'spec' || step.produces === 'plan';
+  const localDeadlineMs = isDocumentStage
+    ? LOCAL_DOCUMENT_STAGE_DEADLINE_MS
+    : LOCAL_STAGE_DEADLINE_MS;
+  const deadlineMs = ctx.stageDeadlineMs ?? (local ? localDeadlineMs : DEFAULT_STAGE_DEADLINE_MS);
   let onAbort: (() => void) | undefined;
   const abortWaiter = new Promise<'aborted'>((resolve) => {
     onAbort = () => resolve('aborted');


### PR DESCRIPTION
## Problem

Follow-up to #968. A full local-pipeline run showed the reasoning backend **over-exploring** a design/plan stage — faithfully following the skill's multi-phase process (explore → analyze → write), gathering context across 17+ turns before writing. The flat 600s local deadline (`LOCAL_STAGE_DEADLINE_MS`) guillotined it **mid-exploration**, so the captured "spec" was a narration fragment (`"Now I have full context. Let me follow the brainstorming skill phases... Let me also check the roadmap"`) rather than a finished document.

Chosen approach (keep the faithful skill-run process, give it more room): document stages get a larger deadline.

## Fix

`LOCAL_DOCUMENT_STAGE_DEADLINE_MS = 1_200_000` for local stages that produce `spec`/`plan`. Execution/verify/review keep `LOCAL_STAGE_DEADLINE_MS` (600s, enough for the coder). An explicit `stageDeadlineMs` on the workflow decl still overrides; cloud stages unchanged.

## Tests

- A local DOCUMENT stage (`produces: spec`) survives past 600s (finishes at 800s) — gets the 1200s deadline.
- A local NON-document stage (`produces: impl`) still aborts at 600s.
- Full execute-workflow suite green (68).

## Context

Fourth in the local-pipeline convergence series: #968 (deadline) → #969 (codex abort) → #970 (plan capture) → this (document-stage headroom). Addresses the reasoner-over-exploration wall surfaced by an all-fixes e2e run.