### PR TITLE
feat(orchestrator): local verify stage calls outcome_eval (impl-vs-spec judgment)

### DIFF
--- a/.changeset/local-verify-outcome-eval.md
+++ b/.changeset/local-verify-outcome-eval.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+feat(orchestrator): local verify stage delegates impl-vs-spec judgment to outcome_eval
+
+A staged local workflow's verify stage was told to run `run_code_review` /
+`run_ci_checks` — "do the tests pass?" — but nothing checked whether the
+implementation actually SATISFIES the spec. That let a diff whose behavior
+contradicts the spec through (observed: a rule whose own test marked a
+spec-invalid case as valid; tests were internally consistent but wrong).
+
+The LOCAL verify-stage prompt now instructs `harness__outcome_eval` with the
+spec path, the accumulated `git diff`, and the test output — an LLM judge (the
+reasoner, via the local analysis provider) that reads the spec's acceptance
+criteria and emits SATISFIED / NOT_SATISFIED, where a high-confidence
+NOT_SATISFIED is blocking and its `unmetCriteria` are folded into the findings.
+A new `specPath` render variable exposes the design spec's path; only the LOCAL
+verify branch references it (the default template and other stages are
+unchanged).

--- a/packages/orchestrator/src/workflow/local-stage-prompt.test.ts
+++ b/packages/orchestrator/src/workflow/local-stage-prompt.test.ts
@@ -18,6 +18,7 @@ const RENDER_BAG = {
   produces: 'artifact.md',
   documentPath: '',
   reviewStage: '',
+  specPath: 'docs/changes/iss-1/proposal.md',
   priorEntries: [] as Array<{ name: string; output: string }>,
 };
 
@@ -77,6 +78,31 @@ describe('stage-prompt templates thread the produces variable (SC5)', () => {
     await expect(renderer.render(LOCAL_STAGE_PROMPT_TEMPLATE, RENDER_BAG)).resolves.toContain(
       'artifact.md'
     );
+  });
+
+  it('a VERIFY stage is told to run outcome_eval with the spec path (impl-vs-spec judgment)', async () => {
+    const renderer = new PromptRenderer();
+    const rendered = await renderer.render(LOCAL_STAGE_PROMPT_TEMPLATE, {
+      ...RENDER_BAG,
+      produces: 'verify',
+      reviewStage: 'verify',
+      specPath: 'docs/changes/iss-1/proposal.md',
+    });
+    // NOT_SATISFIED + the spec path are unique to the verify block (the bare
+    // `harness__outcome_eval` token also appears in the intro tool list, so it is
+    // not a reliable marker of the instruction).
+    expect(rendered).toContain('docs/changes/iss-1/proposal.md');
+    expect(rendered).toContain('NOT_SATISFIED');
+  });
+
+  it('a REVIEW stage does NOT get the verify-only outcome_eval instruction', async () => {
+    const renderer = new PromptRenderer();
+    const rendered = await renderer.render(LOCAL_STAGE_PROMPT_TEMPLATE, {
+      ...RENDER_BAG,
+      produces: 'review',
+      reviewStage: 'review',
+    });
+    expect(rendered).not.toContain('NOT_SATISFIED');
   });
 });
 

--- a/packages/orchestrator/src/workflow/local-stage-prompt.ts
+++ b/packages/orchestrator/src/workflow/local-stage-prompt.ts
@@ -45,6 +45,9 @@ Writing this document to \`{{ documentPath }}\` (and registering it) IS completi
 {% elsif reviewStage != '' %}
 ## This stage is a REVIEW/CHECK — run the tools, commit NOTHING
 Review the accumulated diff with \`harness__run_code_review\` and \`harness__review_changes\` (and \`harness__run_ci_checks\` for a verify stage) and report the findings as your stage output — correctness, missed cases, and any stray/scratch files that should not ship. Do NOT write or commit any review/report file (no \`review.md\`), and do NOT modify code here: your findings are FEEDBACK carried to the next stage, not a committed artifact.
+{% if reviewStage == 'verify' %}
+Then run \`harness__outcome_eval\` to judge whether the implementation actually SATISFIES the spec's acceptance criteria — a stronger check than "tests pass", and the one that catches a diff whose behavior contradicts the spec (e.g. a test case whose expectation is wrong per the spec). Pass all three required inputs from this session: \`specPath: "{{ specPath }}"\`, the accumulated \`git diff\`, and the test-runner output (omitting any degrades the verdict to advisory). A high-confidence \`NOT_SATISFIED\` is a real blocker: fold its \`unmetCriteria\` into your findings verbatim so the execution stage fixes exactly those.
+{% endif %}
 {% else %}
 The skill will instruct you to WRITE the implementation ({{ produces }}): do the work to completion and PRODUCE it before stopping — reading the instructions is NOT completing the stage.
 

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -350,6 +350,10 @@ function renderStagePromptFactory(
     // run tools, commit nothing), CODE (impl → write code + self-verify).
     const documentPath = documentStagePath(produces, issue.identifier);
     const reviewStage = REVIEW_ARTIFACTS.has(produces) ? produces : '';
+    // The design stage's spec path, so a VERIFY stage can point `outcome_eval` at
+    // it (judge impl-vs-spec via the reasoner). Always computed; only the LOCAL
+    // verify branch references it.
+    const specPath = documentStagePath('spec', issue.identifier);
     // Per-phase routing: pick the LOCAL-indirection template for a local-endpoint
     // routed backend, else the byte-identical default (SC-LOCAL/SC3). The variable
     // bag is identical for both templates (strictVariables — no new required var).
@@ -371,6 +375,8 @@ function renderStagePromptFactory(
         documentPath,
         // Non-empty ⇒ REVIEW stage: run review/check tools, commit no report file.
         reviewStage,
+        // The design spec's path — a verify stage points `outcome_eval` at it.
+        specPath,
         priorEntries,
       }
     );


### PR DESCRIPTION
The verify stage ran run_code_review/run_ci_checks ('do tests pass?') but never
checked whether the impl SATISFIES the spec — letting a diff that contradicts the
spec through. The LOCAL verify prompt now calls harness__outcome_eval with the
spec path + git diff + test output (the reasoner judges via the local analysis
provider); a high-confidence NOT_SATISFIED is blocking. New specPath render var,
referenced only by the LOCAL verify branch.
