### PR TITLE
feat(orchestrator): make the local enforced gate's outcome-eval actually fire

### DIFF
--- a/.changeset/local-outcome-eval-gate.md
+++ b/.changeset/local-outcome-eval-gate.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+feat(orchestrator): the local enforced gate's outcome-eval now actually fires
+
+The staged local gate (`runLocalWorkflowGate`) already had a blocking
+spec-vs-diff `outcome-eval` step — the harness's own verifier judgment — but it
+silently no-op'd on every fully-local run for two reasons, so a diff that passes
+the tests yet contradicts the spec shipped anyway:
+
+1. **No provider.** The eval provider came only from `resolveComplexityProvider`,
+   which builds nothing unless `intelligence.enabled` is true. A fully-local run
+   leaves the intelligence pipeline off, so the provider was `undefined` → skip.
+   Now, for the local caller, it falls back to the reasoner via the startup-derived
+   analysis env (`HARNESS_ANALYSIS_*`, from the thinking-mode backend) — the same
+   `OpenAICompatibleAnalysisProvider` the intelligence factory would build — so the
+   gate judges on-device without the full pipeline.
+
+2. **No spec.** The step keyed on `issue.spec`, but the local model rarely
+   registers the roadmap Spec field. It now falls back to the conventional
+   `docs/changes/<slug>/proposal.md` the design stage writes, and no-ops only when
+   neither a spec file nor a provider resolves.
+
+This is the right layer for the judgment: an **orchestrator-run gate**, not a
+model-invoked MCP tool — codex cannot call MCP tools (it shell-execs the names),
+so the verify-stage prompt instruction to run `outcome_eval` was inert and is
+removed. A high-confidence `NOT_SATISFIED` blocks and re-dispatches, exactly like
+the Claude/AMR path.

--- a/packages/orchestrator/src/orchestrator.local-gate.test.ts
+++ b/packages/orchestrator/src/orchestrator.local-gate.test.ts
@@ -632,6 +632,37 @@ describe('runLocalWorkflowGate — outcome-eval (Task 7 / SC4)', () => {
     const result = await gate(orch)(withSpec(), tmpDir, 'local');
     expect(result.ok).toBe(true);
   });
+
+  it('spec-fallback: issue.spec=null but a conventional docs/changes/<slug>/proposal.md exists → outcome-eval STILL runs and blocks', async () => {
+    // The local design stage writes the proposal at the convention but the model
+    // usually does not set the roadmap Spec field. The gate must find it anyway.
+    const orch = newOrch({ local: LOCAL_BACKEND }, 'local', async () => ({ ok: true, output: '' }));
+    stubDiffText(orch, 'diff --git a/x b/x\n+broke it');
+    stubProvider(orch, {
+      verdict: 'NOT_SATISFIED',
+      confidence: 'high',
+      rationale: 'r',
+      unmetCriteria: [],
+    });
+    const proposal = path.join(tmpDir, 'docs', 'changes', 'ISS-1', 'proposal.md');
+    fs.mkdirSync(path.dirname(proposal), { recursive: true });
+    fs.writeFileSync(proposal, '# Feature\n\n## Success Criteria\n\n- must debounce 300ms\n');
+    const result = await gate(orch)({ ...ISSUE, spec: null } as unknown as Issue, tmpDir, 'local');
+    expect(result.ok).toBe(false);
+  });
+
+  it('spec-fallback: issue.spec=null and no conventional proposal → outcome-eval skipped (gate green, unchanged)', async () => {
+    const orch = newOrch({ local: LOCAL_BACKEND }, 'local', async () => ({ ok: true, output: '' }));
+    stubDiffText(orch, 'diff --git a/x b/x\n+ok');
+    stubProvider(orch, {
+      verdict: 'NOT_SATISFIED',
+      confidence: 'high',
+      rationale: 'r',
+      unmetCriteria: [],
+    });
+    const result = await gate(orch)({ ...ISSUE, spec: null } as unknown as Issue, tmpDir, 'local');
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('workflowGates provider routing (SC6, Phase 3)', () => {
@@ -670,6 +701,44 @@ describe('workflowGates provider routing (SC6, Phase 3)', () => {
     evalProvider(orch)('amr');
     expect(selSpy).toHaveBeenCalled();
     expect(primSpy).not.toHaveBeenCalled();
+  });
+
+  it('local caller + no intelligence provider + HARNESS_ANALYSIS_BASE_URL set → reasoner env provider (gate works with intelligence off)', () => {
+    const orch = newOrchWithGates({ local: LOCAL_BACKEND }, 'local', undefined);
+    // Simulate intelligence.enabled=false (no SEL provider built).
+    (orch as unknown as { resolveComplexityProvider: () => unknown }).resolveComplexityProvider =
+      () => undefined;
+    const saved = {
+      base: process.env.HARNESS_ANALYSIS_BASE_URL,
+      model: process.env.HARNESS_ANALYSIS_MODEL,
+    };
+    try {
+      process.env.HARNESS_ANALYSIS_BASE_URL = 'http://127.0.0.1:11434/v1';
+      process.env.HARNESS_ANALYSIS_MODEL = 'qwen3.6:27b';
+      const provider = evalProvider(orch)('local');
+      expect(provider).not.toBeUndefined();
+      expect((provider as { constructor: { name: string } }).constructor.name).toBe(
+        'OpenAICompatibleAnalysisProvider'
+      );
+    } finally {
+      if (saved.base === undefined) delete process.env.HARNESS_ANALYSIS_BASE_URL;
+      else process.env.HARNESS_ANALYSIS_BASE_URL = saved.base;
+      if (saved.model === undefined) delete process.env.HARNESS_ANALYSIS_MODEL;
+      else process.env.HARNESS_ANALYSIS_MODEL = saved.model;
+    }
+  });
+
+  it('local caller + no intelligence provider + no analysis env → undefined (degrades, unchanged)', () => {
+    const orch = newOrchWithGates({ local: LOCAL_BACKEND }, 'local', undefined);
+    (orch as unknown as { resolveComplexityProvider: () => unknown }).resolveComplexityProvider =
+      () => undefined;
+    const saved = process.env.HARNESS_ANALYSIS_BASE_URL;
+    try {
+      delete process.env.HARNESS_ANALYSIS_BASE_URL;
+      expect(evalProvider(orch)('local')).toBeUndefined();
+    } finally {
+      if (saved !== undefined) process.env.HARNESS_ANALYSIS_BASE_URL = saved;
+    }
   });
 });
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -17,7 +17,11 @@ import { RoutingError } from '@harness-engineering/types';
 import type { Issue, IssueTrackerClient } from '@harness-engineering/core';
 import { writeTaint, SecurityScanner } from '@harness-engineering/core';
 import { hasIntroducedSecurityDefect, outcomeVerdictToQualityFail } from './agent/quality-verdict';
-import { IntelligencePipeline, OutcomeEvaluator } from '@harness-engineering/intelligence';
+import {
+  IntelligencePipeline,
+  OutcomeEvaluator,
+  OpenAICompatibleAnalysisProvider,
+} from '@harness-engineering/intelligence';
 import type {
   EnrichedSpec,
   AnalysisProvider,
@@ -122,7 +126,7 @@ import {
   type UnstickAdvice,
 } from './workflow/unstick-advisory';
 import { workflowFor } from './workflow/workflow-for';
-import { buildWorkflowContext } from './workflow/orchestrator-context';
+import { buildWorkflowContext, documentStagePath } from './workflow/orchestrator-context';
 import { executeWorkflow } from './workflow/execute-workflow';
 import { buildRoutingUseCase } from './agent/use-case-builder';
 import { applyAnalysisEnv } from './agent/analysis-env';
@@ -3090,22 +3094,22 @@ export class Orchestrator extends EventEmitter {
         return { ok: false, reason: docCoverage.output };
       }
 
-      // 2. Outcome evaluation (SC4): when a spec is present, run the SAME
-      //    OutcomeEvaluator engine the Claude/AMR path uses — un-gated from the
-      //    AMR-active + `acceptanceEval.enabled` requirements (D2: local always
-      //    evaluates when a spec exists). Read the eval model from the AMR
-      //    policy when configured, else default. A high-confidence NOT_SATISFIED
+      // 2. Outcome evaluation (SC4): run the SAME OutcomeEvaluator engine the
+      //    Claude/AMR path uses — un-gated from the AMR-active + `acceptanceEval.
+      //    enabled` requirements (D2: local always evaluates when a spec exists).
+      //    `evaluateOutcomeCore` resolves the spec from the roadmap Spec field OR
+      //    the conventional docs/changes/<slug>/proposal.md the design stage wrote
+      //    (the local model rarely registers the Spec field), and no-ops when
+      //    neither a spec nor a provider resolves. A high-confidence NOT_SATISFIED
       //    → `'quality-fail'` → block (same authority as the Claude path).
-      if (issue.spec !== null) {
-        const model = this.config.agent.routing?.policy?.acceptanceEval?.model;
-        const evalClass = await this.evaluateOutcomeCore(issue, workspacePath, model, 'local');
-        if (evalClass === 'quality-fail') {
-          return {
-            ok: false,
-            reason:
-              'outcome-eval returned a high-confidence NOT_SATISFIED verdict: the implementation does not satisfy the spec.',
-          };
-        }
+      const model = this.config.agent.routing?.policy?.acceptanceEval?.model;
+      const evalClass = await this.evaluateOutcomeCore(issue, workspacePath, model, 'local');
+      if (evalClass === 'quality-fail') {
+        return {
+          ok: false,
+          reason:
+            'outcome-eval returned a high-confidence NOT_SATISFIED verdict: the implementation does not satisfy the spec.',
+        };
       }
       return { ok: true };
     } catch (err) {
@@ -3214,7 +3218,31 @@ export class Orchestrator extends EventEmitter {
     if (caller === 'local' && this.config.agent.routing?.workflowGates === 'primary') {
       return this.resolvePrimaryOutcomeEvalProvider() ?? this.resolveComplexityProvider();
     }
-    return this.resolveComplexityProvider();
+    const intelligenceProvider = this.resolveComplexityProvider();
+    if (intelligenceProvider !== undefined) return intelligenceProvider;
+    // The outcome-eval gate is a distinct concern from the intelligence PIPELINE
+    // (CML/PESL). A fully-local run wants the gate's spec-vs-diff judgment even with
+    // `intelligence.enabled: false`, so fall back to the reasoner provider derived at
+    // startup (HARNESS_ANALYSIS_*, see analysis-env). Local caller only — the AMR
+    // path keeps its configured provider.
+    return caller === 'local' ? this.resolveLocalAnalysisEnvProvider() : undefined;
+  }
+
+  /**
+   * The reasoner `AnalysisProvider` from the startup-derived analysis env
+   * ({@link applyAnalysisEnv}). Lets the local outcome-eval gate judge on-device
+   * without the full intelligence pipeline. Undefined when no analysis endpoint is
+   * configured (⇒ the gate degrades to advisory, exactly as before).
+   */
+  private resolveLocalAnalysisEnvProvider(): AnalysisProvider | undefined {
+    const baseUrl = process.env.HARNESS_ANALYSIS_BASE_URL?.trim();
+    if (baseUrl === undefined || baseUrl === '') return undefined;
+    const model = process.env.HARNESS_ANALYSIS_MODEL?.trim();
+    return new OpenAICompatibleAnalysisProvider({
+      apiKey: process.env.HARNESS_ANALYSIS_API_KEY?.trim() || 'ollama',
+      baseUrl,
+      ...(model ? { defaultModel: model } : {}),
+    });
   }
 
   /**
@@ -3407,7 +3435,16 @@ export class Orchestrator extends EventEmitter {
     model: string | undefined,
     caller: 'amr' | 'local'
   ): Promise<'quality-fail' | undefined> {
-    if (issue.spec === null) return undefined;
+    // Prefer the roadmap-registered Spec; fall back to the conventional
+    // docs/changes/<slug>/proposal.md the local design stage writes — the local
+    // model often does not register the Spec field, so keying only on `issue.spec`
+    // silently skips the gate on every local run. Skip only when neither resolves to
+    // a real file on disk (no spec to judge against).
+    const specRel = issue.spec ?? documentStagePath('spec', issue.identifier);
+    if (specRel === '') return undefined;
+    const specPath = path.join(workspacePath, specRel);
+    const { existsSync } = await import('node:fs');
+    if (!existsSync(specPath)) return undefined;
     const provider = this.resolveOutcomeEvalProvider(caller);
     if (provider === undefined) return undefined;
     try {
@@ -3417,7 +3454,7 @@ export class Orchestrator extends EventEmitter {
         ...(model !== undefined ? { model } : {}),
       });
       const verdict = await evaluator.evaluate({
-        specPath: path.join(workspacePath, issue.spec),
+        specPath,
         diff,
         // No captured test output at the single-agent-exit seam — intentionally
         // omitted (the evaluator judges diff-vs-spec and treats absent test output

--- a/packages/orchestrator/src/workflow/local-stage-prompt.test.ts
+++ b/packages/orchestrator/src/workflow/local-stage-prompt.test.ts
@@ -18,7 +18,6 @@ const RENDER_BAG = {
   produces: 'artifact.md',
   documentPath: '',
   reviewStage: '',
-  specPath: 'docs/changes/iss-1/proposal.md',
   priorEntries: [] as Array<{ name: string; output: string }>,
 };
 
@@ -80,29 +79,18 @@ describe('stage-prompt templates thread the produces variable (SC5)', () => {
     );
   });
 
-  it('a VERIFY stage is told to run outcome_eval with the spec path (impl-vs-spec judgment)', async () => {
+  it('a VERIFY stage does not tell the model to invoke outcome_eval (the orchestrator gate runs it)', async () => {
+    // outcome_eval moved from a model instruction (unworkable — codex cannot call
+    // MCP tools, it shell-execs the name) to a deterministic orchestrator gate step.
+    // The verify prompt must NOT tell the model to run it.
     const renderer = new PromptRenderer();
     const rendered = await renderer.render(LOCAL_STAGE_PROMPT_TEMPLATE, {
       ...RENDER_BAG,
       produces: 'verify',
       reviewStage: 'verify',
-      specPath: 'docs/changes/iss-1/proposal.md',
-    });
-    // NOT_SATISFIED + the spec path are unique to the verify block (the bare
-    // `harness__outcome_eval` token also appears in the intro tool list, so it is
-    // not a reliable marker of the instruction).
-    expect(rendered).toContain('docs/changes/iss-1/proposal.md');
-    expect(rendered).toContain('NOT_SATISFIED');
-  });
-
-  it('a REVIEW stage does NOT get the verify-only outcome_eval instruction', async () => {
-    const renderer = new PromptRenderer();
-    const rendered = await renderer.render(LOCAL_STAGE_PROMPT_TEMPLATE, {
-      ...RENDER_BAG,
-      produces: 'review',
-      reviewStage: 'review',
     });
     expect(rendered).not.toContain('NOT_SATISFIED');
+    expect(rendered).toContain('orchestrator independently runs');
   });
 });
 

--- a/packages/orchestrator/src/workflow/local-stage-prompt.ts
+++ b/packages/orchestrator/src/workflow/local-stage-prompt.ts
@@ -44,10 +44,7 @@ Your output is **{{ produces }}**: a concise, concrete markdown document. Write 
 Writing this document to \`{{ documentPath }}\` (and registering it) IS completing the stage.
 {% elsif reviewStage != '' %}
 ## This stage is a REVIEW/CHECK — run the tools, commit NOTHING
-Review the accumulated diff with \`harness__run_code_review\` and \`harness__review_changes\` (and \`harness__run_ci_checks\` for a verify stage) and report the findings as your stage output — correctness, missed cases, and any stray/scratch files that should not ship. Do NOT write or commit any review/report file (no \`review.md\`), and do NOT modify code here: your findings are FEEDBACK carried to the next stage, not a committed artifact.
-{% if reviewStage == 'verify' %}
-Then run \`harness__outcome_eval\` to judge whether the implementation actually SATISFIES the spec's acceptance criteria — a stronger check than "tests pass", and the one that catches a diff whose behavior contradicts the spec (e.g. a test case whose expectation is wrong per the spec). Pass all three required inputs from this session: \`specPath: "{{ specPath }}"\`, the accumulated \`git diff\`, and the test-runner output (omitting any degrades the verdict to advisory). A high-confidence \`NOT_SATISFIED\` is a real blocker: fold its \`unmetCriteria\` into your findings verbatim so the execution stage fixes exactly those.
-{% endif %}
+Review the accumulated diff with \`harness__run_code_review\` and \`harness__review_changes\` (and \`harness__run_ci_checks\` for a verify stage) and report the findings as your stage output — correctness, missed cases, and any stray/scratch files that should not ship. Do NOT write or commit any review/report file (no \`review.md\`), and do NOT modify code here: your findings are FEEDBACK carried to the next stage, not a committed artifact. (The orchestrator independently runs a spec-vs-diff \`outcome_eval\` at the enforced gate, so you do NOT need to invoke it here.)
 {% else %}
 The skill will instruct you to WRITE the implementation ({{ produces }}): do the work to completion and PRODUCE it before stopping — reading the instructions is NOT completing the stage.
 

--- a/packages/orchestrator/src/workflow/orchestrator-context.ts
+++ b/packages/orchestrator/src/workflow/orchestrator-context.ts
@@ -273,7 +273,7 @@ const REVIEW_ARTIFACTS = new Set(['review', 'verify']);
  * convention (not an invented `docs/autopilot/`), made explicit because the model
  * needs it. `<slug>` is the sanitized item identifier.
  */
-function documentStagePath(produces: string, identifier: string): string {
+export function documentStagePath(produces: string, identifier: string): string {
   const slug = identifier.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'item';
   if (produces === 'spec') return `docs/changes/${slug}/proposal.md`;
   if (produces === 'plan') return `docs/changes/${slug}/plans/${slug}-plan.md`;
@@ -350,10 +350,6 @@ function renderStagePromptFactory(
     // run tools, commit nothing), CODE (impl → write code + self-verify).
     const documentPath = documentStagePath(produces, issue.identifier);
     const reviewStage = REVIEW_ARTIFACTS.has(produces) ? produces : '';
-    // The design stage's spec path, so a VERIFY stage can point `outcome_eval` at
-    // it (judge impl-vs-spec via the reasoner). Always computed; only the LOCAL
-    // verify branch references it.
-    const specPath = documentStagePath('spec', issue.identifier);
     // Per-phase routing: pick the LOCAL-indirection template for a local-endpoint
     // routed backend, else the byte-identical default (SC-LOCAL/SC3). The variable
     // bag is identical for both templates (strictVariables — no new required var).
@@ -375,8 +371,6 @@ function renderStagePromptFactory(
         documentPath,
         // Non-empty ⇒ REVIEW stage: run review/check tools, commit no report file.
         reviewStage,
-        // The design spec's path — a verify stage points `outcome_eval` at it.
-        specPath,
         priorEntries,
       }
     );


### PR DESCRIPTION
## The real fix

Probing the last e2e revealed the reasoner-as-judge stack's activation was blocked by a fundamental issue: **codex can't call MCP tools** — qwen3-coder emits tool calls as text (`<function=…>`) that codex doesn't parse, so the model shell-execs `harness__outcome_eval` → `command not found`. So prompting the model to call `outcome_eval` (#975) was never going to work.

But it turns out the orchestrator's staged gate (`runLocalWorkflowGate`) **already has** a blocking spec-vs-diff `outcome-eval` step — the harness's own verifier judgment, orchestrator-run (not model-invoked). It just **silently no-op'd on every fully-local run** for two reasons:

1. **No provider** — the eval provider came only from `resolveComplexityProvider`, which builds nothing unless `intelligence.enabled` is true. Fully-local runs leave the pipeline off → `undefined` → skip. Now the local caller falls back to the reasoner via the startup-derived `HARNESS_ANALYSIS_*` env (the same `OpenAICompatibleAnalysisProvider` the intelligence factory builds).
2. **No spec** — the step keyed on `issue.spec`, which the local model rarely registers on the roadmap. Now it falls back to the conventional `docs/changes/<slug>/proposal.md` the design stage writes; no-ops only when neither a spec file nor a provider resolves.

This is the right layer — an **orchestrator-run gate**, deterministic and model-agnostic. A high-confidence `NOT_SATISFIED` blocks + re-dispatches, exactly like the Claude/AMR path. The inert `outcome_eval` prompt instruction from #975 is removed.

## Builds on
#973 (local analysis provider) and #974 (reasoner analysis env) — those are exactly the foundation this uses. #975's model-instruction approach is superseded.

## Tests
- Provider fallback: no-intelligence + `HARNESS_ANALYSIS_BASE_URL` set → reasoner provider; absent → undefined (degrade).
- Spec fallback: `issue.spec=null` + conventional proposal exists → outcome-eval runs + blocks; absent → skipped (gate green).
- Verify prompt no longer instructs `outcome_eval`.
- **Full orchestrator suite green (2440 passed).**