### PR TITLE
fix(orchestrator): outcome-eval judge = dedicated fast backend, not the reasoner

### DIFF
--- a/.changeset/fast-eval-judge-backend.md
+++ b/.changeset/fast-eval-judge-backend.md
@@ -1,0 +1,17 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): let the outcome-eval judge be a dedicated fast backend
+
+The local outcome-eval gate (the reasoner-as-judge) derived its analysis endpoint/
+model from the THINKING-mode backend — the reasoner. But a reasoning model (qwen3)
+is unusable as the judge on the OpenAI `/v1` endpoint: reasoning cannot be disabled
+there, so a small token budget returns empty content and a large one stalls for
+minutes. (Fast non-reasoning models judge the same spec-vs-diff correctly in ~8s.)
+
+`deriveAnalysisEnv` now prefers `routing.intelligence.sel` — the already-designated
+analysis/SEL-layer backend — over `routing.modes.thinking`, falling back to the
+thinking backend only when no analysis backend is configured. So an operator points
+`routing.intelligence.sel` at a fast non-reasoning backend to judge quickly, while
+the reasoner keeps doing design (where thinking-on and slow is fine).

--- a/packages/orchestrator/src/agent/analysis-env.ts
+++ b/packages/orchestrator/src/agent/analysis-env.ts
@@ -36,7 +36,14 @@ export interface AnalysisEnv {
  * point the eval provider at, so the tools degrade exactly as before.
  */
 export function deriveAnalysisEnv(config: WorkflowConfig): AnalysisEnv | null {
-  const name = firstBackendName(config.agent?.routing?.modes?.thinking);
+  const routing = config.agent?.routing;
+  // Prefer the SEL / analysis-layer backend (`routing.intelligence.sel`) — the
+  // designated judge, which SHOULD be a FAST NON-REASONING model: a reasoning model
+  // like qwen3 is unusable on the OpenAI `/v1` endpoint (reasoning can't be disabled,
+  // so it either stalls for minutes or returns empty content). Fall back to the
+  // thinking-mode backend so an unconfigured run still has a judge (slow but present).
+  const name =
+    firstBackendName(routing?.intelligence?.sel) ?? firstBackendName(routing?.modes?.thinking);
   if (name === undefined) return null;
 
   const def = config.agent?.backends?.[name] as { endpoint?: unknown; model?: unknown } | undefined;

--- a/packages/orchestrator/tests/agent/analysis-env.test.ts
+++ b/packages/orchestrator/tests/agent/analysis-env.test.ts
@@ -28,6 +28,27 @@ describe('deriveAnalysisEnv', () => {
     });
   });
 
+  it('PREFERS the SEL/analysis backend (routing.intelligence.sel) over the thinking backend', () => {
+    // The eval judge should be a fast non-reasoning model, not the slow reasoner.
+    const env = deriveAnalysisEnv(
+      config({
+        routing: { modes: { thinking: 'reasoner' }, intelligence: { sel: 'judge' } },
+        backends: {
+          reasoner,
+          judge: { type: 'ollama', endpoint: 'http://127.0.0.1:11434/v1', model: ['gpt-oss:20b'] },
+        },
+      })
+    );
+    expect(env?.HARNESS_ANALYSIS_MODEL).toBe('gpt-oss:20b');
+  });
+
+  it('falls back to the thinking backend when routing.intelligence.sel is absent', () => {
+    const env = deriveAnalysisEnv(
+      config({ routing: { modes: { thinking: 'reasoner' } }, backends: { reasoner } })
+    );
+    expect(env?.HARNESS_ANALYSIS_MODEL).toBe('qwen3.6:27b');
+  });
+
   it('accepts a scalar model and a prefer-list thinking value (uses the first name)', () => {
     const env = deriveAnalysisEnv(
       config({


### PR DESCRIPTION
## Why

Validating the reasoner-as-judge gate (#976) surfaced a model-selection problem: the eval derived its analysis endpoint/model from the THINKING-mode backend (the reasoner), but a **reasoning model is unusable as a `/v1` judge** — reasoning can't be disabled on the OpenAI-compatible endpoint, so:
- small `max_tokens` → **empty content** (all budget on hidden `<think>`)
- large `max_tokens` → **stalls 4+ minutes** → timeout

A targeted probe confirmed fast non-reasoning models judge the *same* spec-vs-diff correctly and quickly:
- **gpt-oss:20b** → `NOT_SATISFIED`, names the missing cases, **8.3s**
- **qwen2.5-coder:7b** → correct, 9.6s
- qwen3.6:27b (reasoner) → timeout / empty

## What

`deriveAnalysisEnv` now prefers **`routing.intelligence.sel`** — the already-designated analysis/SEL-layer backend — over `routing.modes.thinking`, falling back to the thinking backend only when no analysis backend is configured. So an operator points `routing.intelligence.sel` at a fast non-reasoning backend to judge quickly, while the reasoner keeps doing *design* (where thinking-on is fine).

This closes the reasoner-as-judge loop: design→build→**judge (fast, on-device)**→gate.

## Tests
- `deriveAnalysisEnv` prefers `routing.intelligence.sel` over `modes.thinking`; falls back when absent. (+2)
- Full analysis-env suite green.

Builds on #973/#974/#976.