### PR TITLE
fix(orchestrator): support reasoningEffort 'none' for local coder models

### DIFF
--- a/.changeset/codex-reasoning-effort-none.md
+++ b/.changeset/codex-reasoning-effort-none.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/orchestrator': patch
+'@harness-engineering/types': patch
+---
+
+fix(orchestrator): support `reasoningEffort: 'none'` so the codex backend can drive local coder models
+
+The codex backend passed `-c model_reasoning_effort` only for `'low' | 'medium' | 'high'`,
+and omitting it fell through to codex's own default — which still sends a reasoning
+request. Newer ollama builds REJECT a reasoning request for a model that does not
+support one, rather than ignoring it: `"qwen3-coder:30b" does not support thinking`
+(`invalid_request_error`). That failed EVERY codex turn against such a model (0 tokens,
+0 turns), silently breaking the entire codex-drives-local-coder path.
+
+`reasoningEffort: 'none'` is now a first-class value (type, Zod schema, and the codex
+argv builder). It emits `model_reasoning_effort="none"`, which tells codex to omit the
+reasoning field entirely. Verified against ollama `qwen3-coder:30b`: `low` and omission
+both fail the turn; `none` completes it cleanly.

--- a/packages/orchestrator/src/agent/backends/codex.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.test.ts
@@ -134,6 +134,13 @@ exit 0`);
       expect(fs.readFileSync(argfile, 'utf8')).toContain('model_reasoning_effort="low"');
       await drive(new CodexBackend({ model: 'm', command: cmd }), SESSION);
       expect(fs.readFileSync(argfile, 'utf8')).not.toContain('model_reasoning_effort');
+      // `'none'` is a real, distinct value (NOT omission): it makes codex send
+      // `model_reasoning_effort="none"`, which tells codex to OMIT the reasoning
+      // field from the request. Required for local ollama coder models that reject a
+      // reasoning request outright (`qwen3-coder:30b` → "does not support thinking");
+      // codex's own default (effort omitted) still sends one, so omission is NOT a fix.
+      await drive(new CodexBackend({ model: 'm', command: cmd, reasoningEffort: 'none' }), SESSION);
+      expect(fs.readFileSync(argfile, 'utf8')).toContain('model_reasoning_effort="none"');
     }
   );
 

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -84,8 +84,15 @@ export interface CodexBackendOptions {
    * A hands-on coder (e.g. qwen3-coder) wants `'low'` — minimal deliberation, spend
    * the budget on edits + gate iteration, not a long think. Design/reasoning phases
    * route to a separate thinking backend, not this one. Omit to use codex's default.
+   *
+   * `'none'` makes codex OMIT the reasoning field from the request. Required for
+   * local ollama (`--oss`) coder models that do not support reasoning at all: newer
+   * ollama rejects the request outright (`"qwen3-coder:30b" does not support
+   * thinking`, invalid_request_error) rather than ignoring it, which fails EVERY
+   * turn (0 tokens, 0 turns). Note codex's DEFAULT (effort omitted) still sends a
+   * reasoning request, so `'none'` — not omission — is the fix for such models.
    */
-  reasoningEffort?: 'low' | 'medium' | 'high';
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   /**
    * MCP servers to expose to the codex-driven model, injected per-invocation via
    * `-c mcp_servers.<name>.…` overrides (NOT written to the user's global
@@ -142,7 +149,7 @@ export class CodexBackend implements AgentBackend {
   private localProvider: 'ollama' | 'lmstudio';
   private timeoutMs: number;
   private mcpServers: McpServerSpec[];
-  private reasoningEffort?: 'low' | 'medium' | 'high';
+  private reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   /**
    * Live codex subprocess per active session, so {@link stopSession} can kill it
    * when the workflow aborts a stage (its wall-clock deadline). Without this, the

--- a/packages/orchestrator/src/workflow/schema.ts
+++ b/packages/orchestrator/src/workflow/schema.ts
@@ -208,7 +208,7 @@ export const BackendDefSchema = z.discriminatedUnion('type', [
       localProvider: z.enum(['ollama', 'lmstudio']).optional(),
       command: z.string().optional(),
       timeoutMs: z.number().int().positive().optional(),
-      reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+      reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
       mcpServers: z.array(McpServerSpecSchema).optional(),
       capabilities: BackendCapabilitiesSchema.optional(),
     })

--- a/packages/types/src/orchestrator.ts
+++ b/packages/types/src/orchestrator.ts
@@ -526,8 +526,11 @@ export interface CodexBackendDef {
   /**
    * Reasoning effort for the driven model (`-c model_reasoning_effort`). A hands-on
    * coder wants `'low'`; omit to use codex's default. Design phases route elsewhere.
+   * `'none'` makes codex omit the reasoning field entirely — required for local
+   * (ollama `--oss`) coder models that reject a reasoning request outright (e.g.
+   * `qwen3-coder:30b` → "does not support thinking"); codex's own default sends one.
    */
-  reasoningEffort?: 'low' | 'medium' | 'high';
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   /**
    * MCP servers exposed to the codex-driven local model, injected per-invocation via
    * `-c mcp_servers.<name>.…` (never written to the user's global `~/.codex/config.toml`).


### PR DESCRIPTION
## Problem

The codex backend drives local ollama coder models via `codex exec --oss`. It passed `-c model_reasoning_effort` only for `'low' | 'medium' | 'high'`, and **omitting** the option fell through to codex's own default — which *still sends a reasoning request*.

Newer ollama builds **reject** a reasoning request for a model that doesn't support one, instead of ignoring it:

```
"qwen3-coder:30b" does not support thinking   (invalid_request_error)
```

This failed **every** codex turn against such a model — 0 tokens, 0 turns — silently breaking the entire codex-drives-local-coder execution path. (It worked in older ollama, which ignored the field.)

## Fix

`reasoningEffort: 'none'` is now a first-class value across the type (`@harness-engineering/types`), the Zod config schema, and the codex argv builder. It emits `model_reasoning_effort="none"`, telling codex to **omit the reasoning field** from the request.

## Verification

Ran `codex exec` against ollama `qwen3-coder:30b` three ways:

| reasoningEffort | result |
|---|---|
| `low` | ❌ fails every turn ("does not support thinking") |
| omitted (codex default) | ❌ also fails — codex still sends a reasoning request |
| **`none`** | ✅ turn completes, zero errors |

Note: **omission is not a fix** — `'none'` is required. Added a regression test asserting `reasoningEffort: 'none'` → `model_reasoning_effort="none"` in the spawned argv. Full codex suite green (28), orchestrator + types typecheck clean.