### PR TITLE
fix(orchestrator): make the spec-vs-diff eval see the implementation, not noise

### DIFF
--- a/.changeset/introduced-diff-includes-untracked.md
+++ b/.changeset/introduced-diff-includes-untracked.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): include untracked files in the introduced-diff
+
+`WorkspaceManager.getIntroducedDiff{,Text}` diffed the worktree against the
+merge-base with plain `git diff`, which SILENTLY OMITS untracked files. So a
+brand-new file the agent created (a new module, not a modification of an existing
+one) was invisible to the introduced-diff — and the local gate's spec-vs-diff
+`outcome_eval` judge, reading that diff, concluded the work was MISSING even
+though it was present and passing (a false NOT_SATISFIED that no retry can fix).
+
+Both methods now `git add --intent-to-add` the worktree before diffing, so
+untracked files appear as additions. `--intent-to-add` respects `.gitignore` and
+does not alter file contents; the residual index entries are harmless (the ship
+stages with `git add -A`). Best-effort — a failure falls back to the prior
+tracked-only diff rather than blocking the gate.

--- a/.changeset/introduced-diff-includes-untracked.md
+++ b/.changeset/introduced-diff-includes-untracked.md
@@ -2,17 +2,25 @@
 '@harness-engineering/orchestrator': patch
 ---
 
-fix(orchestrator): include untracked files in the introduced-diff
+fix(orchestrator): make the spec-vs-diff eval see the implementation, not noise
 
-`WorkspaceManager.getIntroducedDiff{,Text}` diffed the worktree against the
-merge-base with plain `git diff`, which SILENTLY OMITS untracked files. So a
-brand-new file the agent created (a new module, not a modification of an existing
-one) was invisible to the introduced-diff — and the local gate's spec-vs-diff
-`outcome_eval` judge, reading that diff, concluded the work was MISSING even
-though it was present and passing (a false NOT_SATISFIED that no retry can fix).
+Two related defects in `WorkspaceManager.getIntroducedDiffText` (the diff the
+local gate's `outcome_eval` judge reads) caused false NOT_SATISFIED verdicts on
+correct, passing work:
 
-Both methods now `git add --intent-to-add` the worktree before diffing, so
-untracked files appear as additions. `--intent-to-add` respects `.gitignore` and
-does not alter file contents; the residual index entries are harmless (the ship
-stages with `git add -A`). Best-effort — a failure falls back to the prior
-tracked-only diff rather than blocking the gate.
+1. **Untracked files were invisible.** It diffed with plain `git diff <mergeBase>`,
+   which silently omits untracked files — so a brand-NEW file the agent created
+   (a new module, not a modification) never reached the judge, which then
+   concluded the work was missing. Both `getIntroducedDiff{,Text}` now
+   `git add --intent-to-add` first (respects `.gitignore`, leaves contents
+   untouched, harmless residual index entries).
+
+2. **Process artifacts buried the code.** The eval diff also pulled in the design
+   stage's proposal/plan (`docs/changes`), roadmap shards (`docs/roadmap.d`), and
+   the local `.pnpm-store` — ~280 lines of planning + binary noise dwarfing a
+   ~90-line change, so the judge conflated "described in the proposal" with
+   "implemented" and reported the new file missing. `getIntroducedDiffText` now
+   excludes those process artifacts (the 4c hunk scan keeps the fuller diff).
+
+Validated end-to-end: with both fixes the local outcome-eval flips from a false
+NOT_SATISFIED to SATISFIED on a correct diff.

--- a/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
+++ b/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
@@ -111,6 +111,11 @@ describe('WorkspaceManager.getIntroducedDiffText (4c v2 — raw diff for the eva
       '.',
       ':(exclude).harness/proposals',
       ':(exclude)docs/roadmap.md',
+      // Process artifacts (design proposal/plan, roadmap shards, pnpm store) are
+      // excluded so they don't bury/confuse the spec-vs-diff judge.
+      ':(exclude)docs/changes',
+      ':(exclude)docs/roadmap.d',
+      ':(exclude).pnpm-store',
     ]);
     // Raw text is returned verbatim (unparsed) — context + removed lines preserved.
     expect(text).toBe(RAW_DIFF_TEXT);
@@ -123,7 +128,16 @@ describe('WorkspaceManager.getIntroducedDiffText (4c v2 — raw diff for the eva
     const wm = new RawStubWM(config({ seedPaths: ['/repo/docs/roadmap.md'] }));
     await wm.getIntroducedDiffText('ISS-1');
     const diffCall = wm.calls.find((c) => c[0] === 'diff');
-    expect(diffCall).toEqual(['diff', 'basesha123', '--', '.', ':(exclude)docs/roadmap.md']);
+    expect(diffCall).toEqual([
+      'diff',
+      'basesha123',
+      '--',
+      '.',
+      ':(exclude)docs/roadmap.md',
+      ':(exclude)docs/changes',
+      ':(exclude)docs/roadmap.d',
+      ':(exclude).pnpm-store',
+    ]);
   });
 
   it('marks untracked files intent-to-add BEFORE the diff, so a NEW file the agent created is in the judged diff', async () => {

--- a/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
+++ b/packages/orchestrator/src/workspace/manager.introduced-diff.test.ts
@@ -79,6 +79,17 @@ describe('WorkspaceManager.getIntroducedDiff', () => {
     // src/app.ts now excluded; roadmap.md is no longer a seed ⇒ it comes through.
     expect(hunks.map((h) => h.file)).toEqual(['docs/roadmap.md']);
   });
+
+  it('marks untracked files intent-to-add BEFORE the diff (so NEW files are captured)', async () => {
+    const wm = new StubWM(config());
+    await wm.getIntroducedDiff('ISS-1');
+    const addIdx = wm.calls.findIndex((c) => c[0] === 'add' && c.includes('--intent-to-add'));
+    const diffIdx = wm.calls.findIndex((c) => c[0] === 'diff');
+    // git diff omits untracked files; `add --intent-to-add` (run first) makes a
+    // brand-new file show up as an addition instead of being silently invisible.
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeLessThan(diffIdx);
+  });
 });
 
 describe('WorkspaceManager.getIntroducedDiffText (4c v2 — raw diff for the eval)', () => {
@@ -113,5 +124,16 @@ describe('WorkspaceManager.getIntroducedDiffText (4c v2 — raw diff for the eva
     await wm.getIntroducedDiffText('ISS-1');
     const diffCall = wm.calls.find((c) => c[0] === 'diff');
     expect(diffCall).toEqual(['diff', 'basesha123', '--', '.', ':(exclude)docs/roadmap.md']);
+  });
+
+  it('marks untracked files intent-to-add BEFORE the diff, so a NEW file the agent created is in the judged diff', async () => {
+    const wm = new RawStubWM(config());
+    await wm.getIntroducedDiffText('ISS-1');
+    const addIdx = wm.calls.findIndex((c) => c[0] === 'add' && c.includes('--intent-to-add'));
+    const diffIdx = wm.calls.findIndex((c) => c[0] === 'diff');
+    // Without this, a brand-new rule module (untracked) is invisible to the
+    // spec-vs-diff judge, which then wrongly reports the work as missing.
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeLessThan(diffIdx);
   });
 });

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -143,7 +143,7 @@ export class WorkspaceManager {
     // un-relativized absolute path would be a silent no-op exclude, leaking the
     // seeded overlay into the eval diff). Array argv (no shell) makes each pathspec
     // a single literal arg — special chars can't break or inject.
-    const excludes = seedPaths
+    const excludes = [...seedPaths, ...WorkspaceManager.EVAL_DIFF_EXCLUDES]
       .map((p) => (path.isAbsolute(p) ? path.relative(repoRoot, p).replaceAll('\\', '/') : p))
       .filter((rel) => rel && rel !== '..' && !rel.startsWith('../') && !path.isAbsolute(rel))
       .map((rel) => `:(exclude)${rel}`);
@@ -294,6 +294,22 @@ export class WorkspaceManager {
    * is unset — the artifacts produced by the brainstorm → orchestrator handoff.
    */
   private static readonly DEFAULT_SEED_PATHS = ['.harness/proposals', 'docs/roadmap.md'];
+
+  /**
+   * Process artifacts excluded from the spec-vs-diff EVAL diff (on top of the
+   * seed overlay) — they are NOT the agent's implementation:
+   *   - `docs/changes` — the design stage's proposal/plan (the proposal IS the
+   *     spec, re-included redundantly; the plan is planning).
+   *   - `docs/roadmap.d` — roadmap shards written by the run.
+   *   - `.pnpm-store` — the local package store (binary noise).
+   * Why it matters: left in, these DWARF the actual code change (e.g. a ~280-line
+   * proposal/plan vs a ~90-line rule+test) and let the judge conflate "described
+   * in the proposal" with "implemented", so it reports the new file "missing"
+   * among the noise. Validated end-to-end: excluding these flips the local
+   * outcome-eval from a false NOT_SATISFIED to SATISFIED on a correct diff. The
+   * 4c hunk scan keeps the fuller diff; only the eval text is narrowed.
+   */
+  private static readonly EVAL_DIFF_EXCLUDES = ['docs/changes', 'docs/roadmap.d', '.pnpm-store'];
 
   /**
    * Copies the configured seed paths from the root working tree into a

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -116,6 +116,7 @@ export class WorkspaceManager {
     const repoRoot = await this.getRepoRoot();
     const baseRef = await this.resolveBaseRef(repoRoot);
     const mergeBase = (await this.git(['merge-base', 'HEAD', baseRef], workspacePath)).trim();
+    await this.markUntrackedIntentToAdd(workspacePath);
     const raw = await this.git(['diff', '--unified=0', mergeBase, '--', '.'], workspacePath);
     const seedPaths = this.config.seedPaths ?? WorkspaceManager.DEFAULT_SEED_PATHS;
     return parseIntroducedHunks(raw, seedPaths);
@@ -146,7 +147,29 @@ export class WorkspaceManager {
       .map((p) => (path.isAbsolute(p) ? path.relative(repoRoot, p).replaceAll('\\', '/') : p))
       .filter((rel) => rel && rel !== '..' && !rel.startsWith('../') && !path.isAbsolute(rel))
       .map((rel) => `:(exclude)${rel}`);
+    await this.markUntrackedIntentToAdd(workspacePath);
     return this.git(['diff', mergeBase, '--', '.', ...excludes], workspacePath);
+  }
+
+  /**
+   * Mark untracked (non-ignored) files in the worktree as intent-to-add so a
+   * subsequent `git diff` INCLUDES their full content. Without this, `git diff`
+   * silently omits untracked files entirely — so a brand-NEW file the agent
+   * created (e.g. a new rule module, not a modification of an existing one) is
+   * invisible to the introduced-diff, and any spec-vs-diff judge concludes the
+   * work is missing even though it is present and passing. `--intent-to-add`
+   * respects `.gitignore` (build output / node_modules stay out) and leaves file
+   * contents untouched; the residual index entries are harmless (the ship stages
+   * with `git add -A` regardless). Best-effort: a failure falls back to the
+   * tracked-only diff rather than blocking the eval/scan.
+   */
+  private async markUntrackedIntentToAdd(workspacePath: string): Promise<void> {
+    try {
+      await this.git(['add', '--intent-to-add', '--', '.'], workspacePath);
+    } catch {
+      // Non-fatal: without intent-to-add the diff is tracked-only (the prior
+      // behavior), never an error that aborts the gate.
+    }
   }
 
   /**


### PR DESCRIPTION
Two related defects in `WorkspaceManager.getIntroducedDiffText` (the diff the local gate's `outcome_eval` judge reads) caused **false NOT_SATISFIED** verdicts on correct, passing work — the judge blocked a merge-ready implementation that no retry could fix.

## 1. Untracked files were invisible
It diffed with plain `git diff <mergeBase>`, which silently omits untracked files. A brand-**new** file the agent created (a new module, not a modification of an existing one) never reached the judge, which then concluded the work was missing. Both `getIntroducedDiff{,Text}` now `git add --intent-to-add` first (respects `.gitignore`, leaves contents untouched, harmless residual index entries).

## 2. Process artifacts buried the code
The eval diff also pulled in the design stage's proposal/plan (`docs/changes`), roadmap shards (`docs/roadmap.d`), and the local `.pnpm-store` — ~280 lines of planning + binary noise dwarfing a ~90-line change, so the judge conflated *described in the proposal* with *implemented* and reported the new file missing. `getIntroducedDiffText` now excludes those process artifacts (the 4c hunk scan keeps the fuller diff).

## Validation

Probed the real judge against a correct diff: with the noise it returns NOT_SATISFIED ("rule missing"); with the clean diff it returns **SATISFIED (high)**. End-to-end, this flips a fully-local run from a stuck false-negative to a passing acceptance gate. Regression tests added; `introduced-diff` suite green (6).