### PR TITLE
fix(orchestrator): kill codex process group on stopSession (fixes flaky CI)

### DIFF
--- a/.changeset/codex-killtree-process-group.md
+++ b/.changeset/codex-killtree-process-group.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): kill codex's whole process group on stopSession/timeout
+
+The codex child was spawned without its own process group, so `stopSession`'s
+`SIGKILL` reached only the direct child. A grandchild it spawned (or, in the unit
+test, a shell's `sleep`) survived and kept the stdout pipe open, so draining hung
+past the stage deadline — surfacing as a flaky 10s test timeout in
+`codex.test.ts > stopSession …` on Linux CI (macOS reaped the grandchild, hiding
+the gap). The child is now spawned `detached` (its own group) and both the
+wall-clock timeout and `stopSession` kill the whole group via `process.kill(-pid)`
+(POSIX; Windows falls back to a direct child kill). A stage-deadline abort now
+reliably terminates codex and everything it started.

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -241,12 +241,17 @@ export class CodexBackend implements AgentBackend {
       env: process.env,
       // stdin from /dev/null: codex exec otherwise blocks reading additional input.
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Own process GROUP (POSIX) so a kill can take down codex AND any grandchild
+      // it spawned. Without this, killing only the direct child leaves a grandchild
+      // holding the stdout pipe open, and draining hangs past the stage deadline —
+      // see killTree.
+      detached: process.platform !== 'win32',
     });
 
     let timedOut = false;
     const killTimer = setTimeout(() => {
       timedOut = true;
-      child.kill('SIGKILL');
+      this.killTree(child);
     }, this.timeoutMs);
     // Register the live child so stopSession (invoked by the runner on a stage
     // abort) can terminate it — see activeChildren.
@@ -368,12 +373,38 @@ export class CodexBackend implements AgentBackend {
     const active = this.activeChildren.get(session.sessionId);
     if (active !== undefined) {
       clearTimeout(active.killTimer);
-      if (active.child.exitCode === null && active.child.signalCode === null) {
-        active.child.kill('SIGKILL');
-      }
+      this.killTree(active.child);
       this.activeChildren.delete(session.sessionId);
     }
     return Ok(undefined);
+  }
+
+  /**
+   * SIGKILL the child AND its process group, so a grandchild codex spawned (or, in
+   * tests, a shell's `sleep`) can't survive and keep the stdout pipe open — which
+   * would hang the drain past a stage deadline (observed as a 10s test timeout on
+   * Linux CI, where an un-grouped kill leaves the grandchild running; macOS reaped
+   * it, hiding the gap). The child is spawned `detached`, so it leads its own group
+   * and `process.kill(-pid)` targets the whole tree. Best-effort: an already-exited
+   * child (ESRCH) is a no-op; Windows (no real process groups / SIGKILL) falls back
+   * to a direct child kill.
+   */
+  private killTree(child: ChildProcess): void {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    const pid = child.pid;
+    if (pid !== undefined && process.platform !== 'win32') {
+      try {
+        process.kill(-pid, 'SIGKILL');
+        return;
+      } catch {
+        // Group gone or never grouped — fall through to a direct child kill.
+      }
+    }
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // Already exited — nothing to terminate.
+    }
   }
 
   async healthCheck(): Promise<Result<void, AgentError>> {


### PR DESCRIPTION
## Problem

`build-and-test` is flaky-failing on Linux CI (and reds `main`) on:

```
codex.test.ts > CodexBackend > stopSession kills the live child … — Test timed out in 10000ms
```

The codex child is spawned **without its own process group**, so `stopSession`'s `SIGKILL` reaches only the direct child. A grandchild it spawned (or, in the test fixture, a shell's `sleep 30`) **survives and keeps the stdout pipe open**, so draining the turn hangs past the stage deadline — a 10s test timeout on Linux (macOS reaps the grandchild, which is why it passes there and locally).

This is a pre-existing issue on `main`, independent of #980/#981 (which fail on this same inherited flake).

## Fix

Spawn codex `detached` (its own process group) and, on both the wall-clock timeout and `stopSession`, SIGKILL the **whole group** via `process.kill(-pid, 'SIGKILL')` (POSIX; Windows falls back to a direct child kill; already-exited is a no-op). A stage-deadline abort now reliably terminates codex and anything it started.

## Verify

`codex.test.ts` passes in ~1.6s (the `stopSession` drain completes immediately instead of hanging). Merging this greens `main`; #980/#981 go green on re-run/rebase.