### PR TITLE
fix(review): stop the security floor tier emitting fabricated criticals (prose SQL, test fixtures, comment bodies)

### DIFF
--- a/.changeset/security-agent-sql-prose-fp.md
+++ b/.changeset/security-agent-sql-prose-fp.md
@@ -1,0 +1,34 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(review): stop the SQL-injection heuristic firing on prose that uses a SQL keyword as a word
+
+The security review agent's CWE-89 heuristic reported a **critical** SQL-injection
+finding for a `commander` help string:
+
+```
+'never create a ticket for a row lacking an externalId (report the skip instead) — ' +
+```
+
+There is no SQL there. The pattern matches case-insensitively, so the ordinary
+English word "create" whole-word-matched the `CREATE` keyword, and the literal is
+followed by `+`. Whole-word matching already spared inflected forms
+("created"/"updated"); the bare stem was the hole. This is the same class of
+false positive as issue #657 — whose string-boundary fix was necessary but not
+sufficient — and it produced a `critical` finding with `trustScore: 49` on a PR
+containing no database code at all.
+
+A statement keyword alone is not evidence of SQL. Real queries pair one with a
+**structural companion** token (`SELECT … FROM`, `INSERT INTO`, `UPDATE … SET`,
+`DELETE FROM`, `CREATE`/`ALTER`/`DROP TABLE`, `… JOIN`, `… VALUES`); prose
+essentially never does. Both the concatenation and template-literal alternatives
+now require a keyword **and** a companion inside the same literal.
+
+Every genuine injection shape still fires (verified by parametrized tests for
+`INSERT INTO`, `UPDATE … SET`, `DELETE FROM`, and an interpolated
+`SELECT … JOIN … WHERE`), and the prose class is gone — including a regression
+test pinned to the verbatim line that blocked the PR. The pre-existing
+nested-quote blind spot (`"INSERT INTO t VALUES ('" + name + "')"`, which the
+`[^"']` class cannot span) is now documented as a known limitation rather than
+left implicit; it was not introduced by this change.

--- a/.changeset/security-agent-sql-prose-fp.md
+++ b/.changeset/security-agent-sql-prose-fp.md
@@ -2,33 +2,46 @@
 '@harness-engineering/core': patch
 ---
 
-fix(review): stop the SQL-injection heuristic firing on prose that uses a SQL keyword as a word
+fix(review): stop the security floor tier emitting fabricated criticals (#984)
 
-The security review agent's CWE-89 heuristic reported a **critical** SQL-injection
-finding for a `commander` help string:
+The no-LLM security floor was reporting blocking `critical` findings for strings
+that cannot reach any sink. Three false-positive classes, all observed on real PRs:
 
-```
-'never create a ticket for a row lacking an externalId (report the skip instead) — ' +
-```
+- **Prose using a SQL keyword as an English word.** A `commander` help string —
+  `'never create a ticket for a row lacking an externalId … ' +` — was reported
+  as critical CWE-89 because "create" whole-word-matches `CREATE` and the
+  literal is followed by `+`. Same class as issue #657, whose string-boundary
+  fix was necessary but not sufficient.
+- **Test fixtures.** A test proving a detector fires must contain the vulnerable
+  shape as data, so any PR touching a security test self-flagged.
+- **Comment bodies.** A JSDoc documenting the shape a rule detects necessarily
+  contains it; the rule's own JSDoc was reported as a critical CWE-89.
 
-There is no SQL there. The pattern matches case-insensitively, so the ordinary
-English word "create" whole-word-matched the `CREATE` keyword, and the literal is
-followed by `+`. Whole-word matching already spared inflected forms
-("created"/"updated"); the bare stem was the hole. This is the same class of
-false positive as issue #657 — whose string-boundary fix was necessary but not
-sufficient — and it produced a `critical` finding with `trustScore: 49` on a PR
-containing no database code at all.
+The fixes:
 
-A statement keyword alone is not evidence of SQL. Real queries pair one with a
-**structural companion** token (`SELECT … FROM`, `INSERT INTO`, `UPDATE … SET`,
-`DELETE FROM`, `CREATE`/`ALTER`/`DROP TABLE`, `… JOIN`, `… VALUES`); prose
-essentially never does. Both the concatenation and template-literal alternatives
-now require a keyword **and** a companion inside the same literal.
+- **SQL: ordered statement shapes.** A statement keyword alone is not evidence
+  of SQL. The pattern now requires an ordered shape (`SELECT … FROM`,
+  `INSERT INTO`, `UPDATE … SET`, `DELETE FROM`, `CREATE/ALTER/DROP TABLE`,
+  `UNION SELECT`) inside a concatenated string literal or an interpolated
+  template literal. The vocabulary deliberately mirrors `SQL_QUERY_SHAPE` in
+  `finding-integrity.ts`, so nothing the floor emits is downgraded by the
+  Phase 5.75 integrity invariant (#989) — one definition of "looks like SQL",
+  not two. The template alternative does not require a closing backtick, so the
+  opening line of a multi-line template query still fires.
+- **Comment-only lines are skipped; comment PREFIXES are not.** `/**/ eval(x)`,
+  `*/ eval(x)`, and generator members (`*run() { … }`) execute and are scanned;
+  a trailing `//` comment is stripped without truncating at a URL's `://`.
+- **Guards are code-scoped.** Test-file markers (`.test.`, `.spec.`, …) and JS
+  comment syntax apply only to files with code extensions, so `.env.test.local`
+  and a key in a Markdown bullet are still scanned. The secrets detector keeps
+  its deliberately wider file scope.
 
-Every genuine injection shape still fires (verified by parametrized tests for
-`INSERT INTO`, `UPDATE … SET`, `DELETE FROM`, and an interpolated
-`SELECT … JOIN … WHERE`), and the prose class is gone — including a regression
-test pinned to the verbatim line that blocked the PR. The pre-existing
-nested-quote blind spot (`"INSERT INTO t VALUES ('" + name + "')"`, which the
-`[^"']` class cannot span) is now documented as a known limitation rather than
-left implicit; it was not introduced by this change.
+Known, test-pinned limitations (a heuristic floor, not a proof of absence): a
+SQL shape split across concatenated literals or lines does not fire (loosening
+to line level would resurrect the prose class), nested quotes are not spanned
+(pre-existing), and a bare clause fragment (`` `WHERE id = ${id}` ``) no longer
+fires. The LLM review tier above the floor covers those shapes.
+
+50 tests pin both directions — every guard has a must-fire case proving it
+cannot over-suppress, plus a cross-layer test asserting detector output
+survives `enforceFindingIntegrity` undowngraded.

--- a/packages/core/src/review/agents/security-agent.ts
+++ b/packages/core/src/review/agents/security-agent.ts
@@ -108,10 +108,10 @@ const CODE_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mt
  *
  * Same reasoning as the docs/config exclusion above, one step further: a test
  * that proves a detector FIRES must contain the vulnerable shape as **data**.
- * This file's own suite necessarily holds `"SELECT * FROM users WHERE id = " +
- * userId` and `const API_KEY = "sk-1234…"` as fixtures — scanning them reports
- * `critical` findings for strings that are the test's whole point, and any PR
- * touching a security test self-flags.
+ * This file's own suite necessarily holds concatenated `SELECT … FROM` query
+ * strings and `sk-…`-style fixture keys — scanning them reports `critical`
+ * findings for strings that are the test's whole point, and any PR touching a
+ * security test self-flags.
  *
  * The trade-off is explicit and bounded: test code is not part of the shipped
  * attack surface (it is not published, not deployed, and takes no untrusted
@@ -159,9 +159,10 @@ function isScannableSourceFile(path: string): boolean {
  * injection shape it detects (`"SELECT … FROM t WHERE id = " + userId`), was
  * itself reported as a `critical` CWE-89 finding.
  *
- * A comment PREFIX is not enough: `/**\/ eval(x)`, `*\/ eval(x)` (the line
- * closing a block comment), and generator members (`*run() { … }`) all begin
- * with comment-ish tokens yet execute. So a line counts as a comment only when
+ * A comment PREFIX is not enough: an eval call behind a `/**\/` or `*\/`
+ * prefix (the line closing a block comment), and generator members
+ * (`*run() { … }`), all begin with comment-ish tokens yet execute. So a line
+ * counts as a comment only when
  * (a) it opens with `//`, or (b) it opens with `/*`, `*\/`, or a JSDoc-body `*`
  * followed by whitespace/EOL, AND nothing but whitespace follows the block
  * close (if any) on the same line.
@@ -315,7 +316,7 @@ function detectEvalUsage(bundle: ContextBundle): ReviewFinding[] {
  * source-pattern detectors: it does not gate on `isCodeFile`. A hardcoded key in
  * a `.env.example`, a shell script or any other non-`.ts` file is a genuine leak,
  * so restricting this detector to `.ts`/`.js` would lose real coverage rather
- * than noise. The asymmetry is the point — `eval(`, backtick-`exec(` and SQL
+ * than noise. The asymmetry is the point — eval, backtick-exec and SQL
  * concatenation are code constructs; a leaked credential is not.
  *
  * Scope caveat, measured rather than assumed: `SECRET_PATTERNS` key off an

--- a/packages/core/src/review/agents/security-agent.ts
+++ b/packages/core/src/review/agents/security-agent.ts
@@ -29,30 +29,55 @@ const SECRET_PATTERNS = [
  *
  * The SQL keyword must sit **inside a quoted string literal or template literal**
  * that is actually being concatenated or interpolated — not merely appear as a
- * bare token somewhere on the line. A bare-keyword pattern (the previous
+ * bare token somewhere on the line. A bare-keyword pattern (the original
  * `KEYWORD … + word`) matched arithmetic-style prose such as the markdown heading
  * `UPDATE (medium + large tiers)`, producing a `critical` CWE-89 false positive
- * that hard-blocked unrelated PRs (issue #657). Requiring a string boundary
- * adjacent to the concatenation keeps the genuine
- * `"SELECT … WHERE id = " + userId` injection shape firing while ignoring prose.
+ * that hard-blocked unrelated PRs (issue #657).
+ *
+ * The string-boundary fix for #657 was not enough on its own, because the match
+ * is **case-insensitive**: an ordinary English sentence inside a concatenated
+ * string literal still fired whenever it used a SQL keyword as a normal word.
+ * A `commander` help string —
+ * `'never create a ticket for a row lacking an externalId … ' +` — was reported
+ * as a critical CWE-89 SQL injection purely because "create" whole-word-matches
+ * `CREATE` and the literal is followed by `+`. (Whole-word matching already
+ * spared inflected forms like "created"/"updated"; the bare stem was the hole.)
+ *
+ * So a keyword alone is not evidence of SQL. Real queries pair a statement
+ * keyword with a **structural companion** token (`SELECT … FROM`,
+ * `INSERT INTO`, `UPDATE … SET`, `DELETE FROM`, `CREATE/ALTER/DROP TABLE`,
+ * `… JOIN`, `… VALUES`), whereas prose essentially never does. Requiring both
+ * inside the same literal keeps every genuine injection shape firing and drops
+ * the prose class of false positives.
  *
  * Alternatives:
- *  1. A quoted string literal containing a SQL keyword, immediately followed by
- *     `+` concatenation (`"SELECT … " + userId`, `'DELETE FROM t WHERE id = ' + id`).
- *  2. A template literal that both contains a SQL keyword and an `${…}`
- *     interpolation, in either order.
+ *  1. A quoted string literal containing a SQL keyword AND a companion token,
+ *     immediately followed by `+` concatenation
+ *     (`"SELECT … WHERE id = " + userId`, `'DELETE FROM t WHERE id = ' + id`).
+ *  2. A template literal containing an `${…}` interpolation, a SQL keyword, and
+ *     a companion token, in any order.
+ *
+ * Known limitation (pre-dates the companion-token change): the `[^"']` class
+ * cannot span a nested quote, so a query that embeds the opposite quote
+ * character — `"INSERT INTO t VALUES ('" + name + "')"` — is not matched. This
+ * heuristic is a floor, not a proof of absence; the LLM review tier is what
+ * catches the shapes it misses.
  */
 const SQL_KEYWORDS = 'SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER';
 const SQL_TEMPLATE_KEYWORDS = 'SELECT|INSERT|UPDATE|DELETE|WHERE';
+/**
+ * Structural tokens that co-occur with a statement keyword in real SQL but not
+ * in prose. Requiring one alongside the keyword is what separates a query from
+ * an English sentence that happens to say "create" or "update".
+ */
+const SQL_COMPANIONS = 'FROM|INTO|WHERE|VALUES|SET|TABLE|JOIN';
 const SQL_CONCAT_PATTERN = new RegExp(
-  // 1. quoted string literal containing a SQL keyword, then a `+` concatenation
-  `["'][^"']*\\b(?:${SQL_KEYWORDS})\\b[^"']*["']\\s*\\+` +
+  // 1. quoted string literal holding a SQL keyword AND a companion, then a `+`
+  `["'](?=[^"']*\\b(?:${SQL_KEYWORDS})\\b)(?=[^"']*\\b(?:${SQL_COMPANIONS})\\b)[^"']*["']\\s*\\+` +
     '|' +
-    // 2a. template literal: `${…}` interpolation followed by a SQL keyword
-    `\`[^\`]*\\$\\{[^}]*\\}[^\`]*\\b(?:${SQL_TEMPLATE_KEYWORDS})\\b` +
-    '|' +
-    // 2b. template literal: a SQL keyword followed by an `${…}` interpolation
-    `\`[^\`]*\\b(?:${SQL_TEMPLATE_KEYWORDS})\\b[^\`]*\\$\\{`,
+    // 2. template literal holding an interpolation, a SQL keyword, AND a companion
+    `\`(?=[^\`]*\\$\\{)(?=[^\`]*\\b(?:${SQL_TEMPLATE_KEYWORDS})\\b)` +
+    `(?=[^\`]*\\b(?:${SQL_COMPANIONS})\\b)[^\`]*\``,
   'i'
 );
 

--- a/packages/core/src/review/agents/security-agent.ts
+++ b/packages/core/src/review/agents/security-agent.ts
@@ -91,9 +91,52 @@ const SHELL_EXEC_PATTERN = /(?:exec|execSync|spawn|spawnSync)\s*\(\s*`[^`]*\$\{/
  */
 const CODE_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts'];
 
+/**
+ * Test files, which the source-pattern detectors deliberately skip.
+ *
+ * Same reasoning as the docs/config exclusion above, one step further: a test
+ * that proves a detector FIRES must contain the vulnerable shape as **data**.
+ * This file's own suite necessarily holds `"SELECT * FROM users WHERE id = " +
+ * userId` and `const API_KEY = "sk-1234…"` as fixtures — scanning them reports
+ * `critical` findings for strings that are the test's whole point, and any PR
+ * touching a security test self-flags.
+ *
+ * The trade-off is explicit and bounded: test code is not part of the shipped
+ * attack surface (it is not published, not deployed, and takes no untrusted
+ * input), so a concatenated query or a fake key inside a `*.test.ts` fixture is
+ * not a vulnerability. Real sinks live in `src/`, which is still scanned. This
+ * narrows PRECISION-losing noise, not coverage of production code.
+ */
+const TEST_FILE_MARKERS = ['.test.', '.spec.', '/__tests__/', '/__fixtures__/'];
+
+/** True when `path` is test code, whose fixtures hold vulnerable shapes as data. */
+function isTestFile(path: string): boolean {
+  const normalized = path.replace(/\\/g, '/');
+  return TEST_FILE_MARKERS.some((marker) => normalized.includes(marker));
+}
+
 /** True when `path` is a code file the source-pattern heuristics should scan. */
 function isCodeFile(path: string): boolean {
-  return CODE_FILE_EXTENSIONS.some((ext) => path.endsWith(ext));
+  if (!CODE_FILE_EXTENSIONS.some((ext) => path.endsWith(ext))) return false;
+  return !isTestFile(path);
+}
+
+/**
+ * True when `line` is a comment rather than executable code.
+ *
+ * A SQL string inside a `//` line comment or a `*` JSDoc body is documentation —
+ * it cannot reach a database. The rule's own JSDoc, which documents the genuine
+ * injection shape it detects (`"SELECT … WHERE id = " + userId`), was itself
+ * reported as a `critical` CWE-89 finding. Skipping comment lines costs no
+ * coverage of executable code.
+ *
+ * Line-oriented like the detectors it serves: it recognizes `//`, `/*`, `*` and
+ * `*\/` openers, so a SQL literal on a continuation line of a block comment that
+ * does not start with `*` is still scanned. That is the conservative direction —
+ * it can only over-scan, never under-scan.
+ */
+function isCommentLine(line: string): boolean {
+  return /^\s*(?:\/\/|\/\*|\*\/|\*)/.test(line);
 }
 
 function makeEvalFinding(file: string, lineNum: number, line: string): ReviewFinding {
@@ -204,6 +247,7 @@ function detectEvalUsage(bundle: ContextBundle): ReviewFinding[] {
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
+      if (isCommentLine(line)) continue;
       if (!EVAL_PATTERN.test(line)) continue;
       findings.push(makeEvalFinding(cf.path, i + 1, line));
     }
@@ -211,12 +255,35 @@ function detectEvalUsage(bundle: ContextBundle): ReviewFinding[] {
   return findings;
 }
 
+/**
+ * Secret detection deliberately keeps a WIDER file scope than the three
+ * source-pattern detectors: it does not gate on `isCodeFile`. A hardcoded key in
+ * a `.env.example`, a shell script or any other non-`.ts` file is a genuine leak,
+ * so restricting this detector to `.ts`/`.js` would lose real coverage rather
+ * than noise. The asymmetry is the point — `eval(`, backtick-`exec(` and SQL
+ * concatenation are code constructs; a leaked credential is not.
+ *
+ * Scope caveat, measured rather than assumed: `SECRET_PATTERNS` key off an
+ * assignment shape (`<name> = "<value>"`), so a dotenv/shell line IS matched
+ * while a YAML mapping (`apiKey: "..."`) is NOT. The wider file scope is
+ * therefore real but narrower than "all config files" — do not read this comment
+ * as a claim that YAML secrets are covered. Tests pin both directions.
+ *
+ * What it does share with them is the two precision guards: test fixtures hold
+ * fake keys as data, and a documented example key in a JSDoc body is not a
+ * secret. Both are skipped.
+ */
 function detectHardcodedSecrets(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   for (const cf of bundle.changedFiles) {
+    if (isTestFile(cf.path)) continue;
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
+      // `isCommentLine` catches whole-line and JSDoc-body comments; the
+      // `codePart` slice additionally strips a trailing `//` comment from an
+      // otherwise-executable line.
+      if (isCommentLine(line)) continue;
       const codePart = line.includes('//') ? line.slice(0, line.indexOf('//')) : line;
       const matched = SECRET_PATTERNS.some((p) => p.test(codePart));
       if (!matched) continue;
@@ -233,6 +300,7 @@ function detectSqlInjection(bundle: ContextBundle): ReviewFinding[] {
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
+      if (isCommentLine(line)) continue;
       if (!SQL_CONCAT_PATTERN.test(line)) continue;
       findings.push(makeSqlFinding(cf.path, i + 1, line));
     }
@@ -247,6 +315,7 @@ function detectCommandInjection(bundle: ContextBundle): ReviewFinding[] {
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
+      if (isCommentLine(line)) continue;
       if (!SHELL_EXEC_PATTERN.test(line)) continue;
       findings.push(makeCommandFinding(cf.path, i + 1, line));
     }

--- a/packages/core/src/review/agents/security-agent.ts
+++ b/packages/core/src/review/agents/security-agent.ts
@@ -43,41 +43,53 @@ const SECRET_PATTERNS = [
  * `CREATE` and the literal is followed by `+`. (Whole-word matching already
  * spared inflected forms like "created"/"updated"; the bare stem was the hole.)
  *
- * So a keyword alone is not evidence of SQL. Real queries pair a statement
- * keyword with a **structural companion** token (`SELECT … FROM`,
- * `INSERT INTO`, `UPDATE … SET`, `DELETE FROM`, `CREATE/ALTER/DROP TABLE`,
- * `… JOIN`, `… VALUES`), whereas prose essentially never does. Requiring both
- * inside the same literal keeps every genuine injection shape firing and drops
- * the prose class of false positives.
+ * So a keyword alone is not evidence of SQL. Real queries carry an **ordered
+ * statement shape** (`SELECT … FROM`, `INSERT INTO`, `UPDATE … SET`,
+ * `DELETE FROM`, `CREATE/ALTER/DROP TABLE`, `UNION SELECT`), whereas prose
+ * essentially never does. The shape vocabulary deliberately mirrors
+ * `SQL_QUERY_SHAPE` in `finding-integrity.ts` so that every finding this
+ * detector emits carries evidence the integrity invariant accepts — an
+ * unordered keyword-pair match here would produce findings (e.g. bare
+ * `SELECT … WHERE` with no `FROM`) that Phase 5.75 immediately downgrades.
  *
  * Alternatives:
- *  1. A quoted string literal containing a SQL keyword AND a companion token,
+ *  1. A quoted string literal containing an ordered statement shape,
  *     immediately followed by `+` concatenation
- *     (`"SELECT … WHERE id = " + userId`, `'DELETE FROM t WHERE id = ' + id`).
- *  2. A template literal containing an `${…}` interpolation, a SQL keyword, and
- *     a companion token, in any order.
+ *     (`"SELECT … FROM t WHERE id = " + userId`, `'DELETE FROM t WHERE id = ' + id`).
+ *  2. A template literal containing an `${…}` interpolation and an ordered
+ *     statement shape. No closing backtick is required, so the opening line of
+ *     a multi-line template query still fires.
  *
- * Known limitation (pre-dates the companion-token change): the `[^"']` class
- * cannot span a nested quote, so a query that embeds the opposite quote
- * character — `"INSERT INTO t VALUES ('" + name + "')"` — is not matched. This
- * heuristic is a floor, not a proof of absence; the LLM review tier is what
- * catches the shapes it misses.
+ * Known limitations (documented, pinned by must-miss tests, and caught by the
+ * LLM review tier above this floor — a heuristic floor is not a proof of absence):
+ *  - Nested quotes: the `[^"']` class cannot span the opposite quote character,
+ *    so `"INSERT INTO t VALUES ('" + name + "')"` is not matched (pre-existing).
+ *  - Split literals: a query whose shape spans multiple concatenated literals
+ *    (`"SELECT " + cols + " FROM users"`) or multiple lines does not fire.
+ *    Loosening the shape to line level would resurrect the prose class this
+ *    change exists to kill (concatenated CLI help strings).
+ *  - Query fragments: a lone clause in a template (`` `WHERE id = ${id}` ``)
+ *    no longer fires; the integrity invariant downgraded those anyway unless a
+ *    query API appeared on the same line.
  */
-const SQL_KEYWORDS = 'SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER';
-const SQL_TEMPLATE_KEYWORDS = 'SELECT|INSERT|UPDATE|DELETE|WHERE';
-/**
- * Structural tokens that co-occur with a statement keyword in real SQL but not
- * in prose. Requiring one alongside the keyword is what separates a query from
- * an English sentence that happens to say "create" or "update".
- */
-const SQL_COMPANIONS = 'FROM|INTO|WHERE|VALUES|SET|TABLE|JOIN';
+const sqlStatementShapes = (gap: string): string =>
+  [
+    `\\bSELECT\\b${gap}\\bFROM\\b`,
+    `\\bINSERT\\s+INTO\\b`,
+    `\\bUPDATE\\b${gap}\\bSET\\b`,
+    `\\bDELETE\\s+FROM\\b`,
+    `\\bDROP\\s+(?:TABLE|DATABASE|SCHEMA|INDEX|VIEW)\\b`,
+    `\\bALTER\\s+TABLE\\b`,
+    `\\bCREATE\\s+(?:TABLE|DATABASE|SCHEMA|INDEX|VIEW|TEMP)\\b`,
+    `\\bUNION\\s+(?:ALL\\s+)?SELECT\\b`,
+  ].join('|');
 const SQL_CONCAT_PATTERN = new RegExp(
-  // 1. quoted string literal holding a SQL keyword AND a companion, then a `+`
-  `["'](?=[^"']*\\b(?:${SQL_KEYWORDS})\\b)(?=[^"']*\\b(?:${SQL_COMPANIONS})\\b)[^"']*["']\\s*\\+` +
+  // 1. quoted string literal holding an ordered statement shape, then a `+`
+  `["'][^"']*(?:${sqlStatementShapes('[^"\']*?')})[^"']*["']\\s*\\+` +
     '|' +
-    // 2. template literal holding an interpolation, a SQL keyword, AND a companion
-    `\`(?=[^\`]*\\$\\{)(?=[^\`]*\\b(?:${SQL_TEMPLATE_KEYWORDS})\\b)` +
-    `(?=[^\`]*\\b(?:${SQL_COMPANIONS})\\b)[^\`]*\``,
+    // 2. template literal holding an interpolation and an ordered statement
+    //    shape (closing backtick optional: multi-line queries open here)
+    `\`(?=[^\`]*\\$\\{)[^\`]*(?:${sqlStatementShapes('[^`]*?')})`,
   'i'
 );
 
@@ -109,34 +121,77 @@ const CODE_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mt
  */
 const TEST_FILE_MARKERS = ['.test.', '.spec.', '/__tests__/', '/__fixtures__/'];
 
-/** True when `path` is test code, whose fixtures hold vulnerable shapes as data. */
+/**
+ * True when `path` is test code, whose fixtures hold vulnerable shapes as data.
+ *
+ * The markers are substrings, so this is only meaningful for paths that already
+ * passed `hasCodeExtension` — a bare substring check would also swallow
+ * `.env.test.local` or `config.test.json`, which are live config files whose
+ * secrets are exactly what the secrets detector exists to catch.
+ */
 function isTestFile(path: string): boolean {
   const normalized = path.replace(/\\/g, '/');
   return TEST_FILE_MARKERS.some((marker) => normalized.includes(marker));
 }
 
-/** True when `path` is a code file the source-pattern heuristics should scan. */
-function isCodeFile(path: string): boolean {
-  if (!CODE_FILE_EXTENSIONS.some((ext) => path.endsWith(ext))) return false;
-  return !isTestFile(path);
+/** True when `path` has a JS/TS source extension. */
+function hasCodeExtension(path: string): boolean {
+  return CODE_FILE_EXTENSIONS.some((ext) => path.endsWith(ext));
 }
 
 /**
- * True when `line` is a comment rather than executable code.
+ * True when `path` is non-test source code the source-pattern heuristics scan.
+ *
+ * Named for what it means, not what it checks: the sibling `bug-agent.ts` has
+ * an `isCodeFile` helper with extension-only semantics, and reusing that name
+ * here (with a test-file exclusion baked in) invited silent divergence when
+ * detector patterns get copied between the agent files.
+ */
+function isScannableSourceFile(path: string): boolean {
+  return hasCodeExtension(path) && !isTestFile(path);
+}
+
+/**
+ * True when `line` is comment-only — nothing executable can be on it.
  *
  * A SQL string inside a `//` line comment or a `*` JSDoc body is documentation —
  * it cannot reach a database. The rule's own JSDoc, which documents the genuine
- * injection shape it detects (`"SELECT … WHERE id = " + userId`), was itself
- * reported as a `critical` CWE-89 finding. Skipping comment lines costs no
- * coverage of executable code.
+ * injection shape it detects (`"SELECT … FROM t WHERE id = " + userId`), was
+ * itself reported as a `critical` CWE-89 finding.
  *
- * Line-oriented like the detectors it serves: it recognizes `//`, `/*`, `*` and
- * `*\/` openers, so a SQL literal on a continuation line of a block comment that
- * does not start with `*` is still scanned. That is the conservative direction —
- * it can only over-scan, never under-scan.
+ * A comment PREFIX is not enough: `/**\/ eval(x)`, `*\/ eval(x)` (the line
+ * closing a block comment), and generator members (`*run() { … }`) all begin
+ * with comment-ish tokens yet execute. So a line counts as a comment only when
+ * (a) it opens with `//`, or (b) it opens with `/*`, `*\/`, or a JSDoc-body `*`
+ * followed by whitespace/EOL, AND nothing but whitespace follows the block
+ * close (if any) on the same line.
+ *
+ * Residual over-skip, deliberately accepted: a rare expression-continuation
+ * line shaped like `* factor;` reads as a JSDoc body and is skipped. That can
+ * in principle under-scan, so the guard is a strong floor, not a guarantee —
+ * the LLM tier scans whole files, comments included.
  */
 function isCommentLine(line: string): boolean {
-  return /^\s*(?:\/\/|\/\*|\*\/|\*)/.test(line);
+  const t = line.trimStart();
+  if (t.startsWith('//')) return true;
+  const opensComment = t.startsWith('/*') || t.startsWith('*/') || /^\*(?:\s|$)/.test(t);
+  if (!opensComment) return false;
+  const close = t.indexOf('*/', t.startsWith('/*') ? 2 : 0);
+  if (close === -1) return true; // the whole line stays inside the comment
+  return t.slice(close + 2).trim() === ''; // code after the close ⇒ executable
+}
+
+/**
+ * Strip a trailing `//` line comment so its text is not scanned as code.
+ *
+ * The naive `indexOf('//')` truncated at the `//` inside `https://`-style URLs,
+ * silently hiding anything after a URL on the same line from the secrets
+ * detector (`const url = "https://…"; const password = "…"` never fired).
+ * A `//` preceded by `:` is a protocol separator, not a comment opener.
+ */
+function stripTrailingLineComment(line: string): string {
+  const m = /(?<!:)\/\//.exec(line);
+  return m ? line.slice(0, m.index) : line;
 }
 
 function makeEvalFinding(file: string, lineNum: number, line: string): ReviewFinding {
@@ -243,12 +298,12 @@ function makeCommandFinding(file: string, lineNum: number, line: string): Review
 function detectEvalUsage(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   for (const cf of bundle.changedFiles) {
-    if (!isCodeFile(cf.path)) continue;
+    if (!isScannableSourceFile(cf.path)) continue;
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
       if (isCommentLine(line)) continue;
-      if (!EVAL_PATTERN.test(line)) continue;
+      if (!EVAL_PATTERN.test(stripTrailingLineComment(line))) continue;
       findings.push(makeEvalFinding(cf.path, i + 1, line));
     }
   }
@@ -269,22 +324,28 @@ function detectEvalUsage(bundle: ContextBundle): ReviewFinding[] {
  * therefore real but narrower than "all config files" — do not read this comment
  * as a claim that YAML secrets are covered. Tests pin both directions.
  *
- * What it does share with them is the two precision guards: test fixtures hold
+ * What it does share with them is the two precision guards — test fixtures hold
  * fake keys as data, and a documented example key in a JSDoc body is not a
- * secret. Both are skipped.
+ * secret — but ONLY for files with a code extension. `.test.`/`.spec.` are
+ * code-naming conventions and `//`/`*` are JS comment syntax; applied to the
+ * detector's wider file scope they would skip `.env.test.local` (live staging
+ * creds by convention) and a key pasted into a Markdown `*` bullet.
+ *
+ * Residual, deliberately accepted: a REAL credential pasted into a `*.test.ts`
+ * is skipped along with the fixtures. The git-history exposure is identical to
+ * one in `src/`, but there is no mechanical way to tell it from the fake keys
+ * that security tests must contain — that judgment belongs to the LLM tier.
  */
 function detectHardcodedSecrets(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   for (const cf of bundle.changedFiles) {
-    if (isTestFile(cf.path)) continue;
+    const codeFile = hasCodeExtension(cf.path);
+    if (codeFile && isTestFile(cf.path)) continue;
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
-      // `isCommentLine` catches whole-line and JSDoc-body comments; the
-      // `codePart` slice additionally strips a trailing `//` comment from an
-      // otherwise-executable line.
-      if (isCommentLine(line)) continue;
-      const codePart = line.includes('//') ? line.slice(0, line.indexOf('//')) : line;
+      if (codeFile && isCommentLine(line)) continue;
+      const codePart = codeFile ? stripTrailingLineComment(line) : line;
       const matched = SECRET_PATTERNS.some((p) => p.test(codePart));
       if (!matched) continue;
       findings.push(makeSecretFinding(cf.path, i + 1));
@@ -296,12 +357,12 @@ function detectHardcodedSecrets(bundle: ContextBundle): ReviewFinding[] {
 function detectSqlInjection(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   for (const cf of bundle.changedFiles) {
-    if (!isCodeFile(cf.path)) continue;
+    if (!isScannableSourceFile(cf.path)) continue;
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
       if (isCommentLine(line)) continue;
-      if (!SQL_CONCAT_PATTERN.test(line)) continue;
+      if (!SQL_CONCAT_PATTERN.test(stripTrailingLineComment(line))) continue;
       findings.push(makeSqlFinding(cf.path, i + 1, line));
     }
   }
@@ -311,12 +372,12 @@ function detectSqlInjection(bundle: ContextBundle): ReviewFinding[] {
 function detectCommandInjection(bundle: ContextBundle): ReviewFinding[] {
   const findings: ReviewFinding[] = [];
   for (const cf of bundle.changedFiles) {
-    if (!isCodeFile(cf.path)) continue;
+    if (!isScannableSourceFile(cf.path)) continue;
     const lines = cf.content.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
       if (isCommentLine(line)) continue;
-      if (!SHELL_EXEC_PATTERN.test(line)) continue;
+      if (!SHELL_EXEC_PATTERN.test(stripTrailingLineComment(line))) continue;
       findings.push(makeCommandFinding(cf.path, i + 1, line));
     }
   }

--- a/packages/core/tests/review/agents/security-agent.test.ts
+++ b/packages/core/tests/review/agents/security-agent.test.ts
@@ -187,6 +187,77 @@ describe('runSecurityAgent()', () => {
     expect(sql[0]!.severity).toBe('critical');
   });
 
+  // A SQL keyword used as an ordinary English word inside a concatenated string
+  // literal is not SQL. The match is case-insensitive, so "create"/"update"/
+  // "select"/"delete" in prose whole-word-matched the keyword list; the #657
+  // string-boundary fix did not cover it. A real query pairs the keyword with a
+  // structural companion (FROM/INTO/WHERE/SET/VALUES/TABLE/JOIN) — prose does not.
+  it('does not flag a commander help string that uses "create" as prose', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/commands/roadmap/sync.ts',
+          // Verbatim: this exact line was reported as a critical CWE-89
+          // SQL-injection finding and hard-blocked a PR.
+          content:
+            "'never create a ticket for a row lacking an externalId (report the skip instead) — ' +",
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    const findings = runSecurityAgent(bundle);
+    expect(findings.some((f) => f.title.toLowerCase().includes('sql'))).toBe(false);
+  });
+
+  it.each([
+    ["'the operator must select a milestone before continuing, ' +", 'select'],
+    ["'this will delete every row that is no longer referenced, ' +", 'delete'],
+    ["'we update the label only when the status actually moved, ' +", 'update'],
+    ["'drop the stale entry and continue, ' +", 'drop'],
+  ])('does not flag prose using %s as an English word', (content) => {
+    const bundle = makeBundle({
+      changedFiles: [{ path: 'src/prose.ts', content, reason: 'changed', lines: 1 }],
+    });
+    const findings = runSecurityAgent(bundle);
+    expect(findings.some((f) => f.title.toLowerCase().includes('sql'))).toBe(false);
+  });
+
+  it('does not flag a template literal whose prose uses a SQL keyword as a word', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/log.ts',
+          content: 'logger.info(`Would create ${planned.length} ticket(s) for this run.`);',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    const findings = runSecurityAgent(bundle);
+    expect(findings.some((f) => f.title.toLowerCase().includes('sql'))).toBe(false);
+  });
+
+  // NOTE: inputs deliberately avoid embedding the opposite quote character.
+  // The `[^"']` character class cannot span a nested quote, so
+  // `"INSERT INTO t VALUES ('" + name + "')"` is missed — a PRE-EXISTING
+  // limitation of this heuristic (verified against the pattern before the
+  // companion-token change), not a regression from it.
+  it.each([
+    ['const q = "INSERT INTO audit (actor) VALUES (" + actorId + ")";', 'INSERT INTO'],
+    ['const q = "UPDATE users SET active = " + flag;', 'UPDATE SET'],
+    ['const q = "DELETE FROM sessions WHERE id = " + id;', 'DELETE FROM'],
+    ['const q = `SELECT * FROM t JOIN u ON u.id = t.id WHERE t.k = ${k}`;', 'SELECT JOIN'],
+  ])('still flags genuine SQL: %s', (content) => {
+    const bundle = makeBundle({
+      changedFiles: [{ path: 'src/db3.ts', content, reason: 'changed', lines: 1 }],
+    });
+    const findings = runSecurityAgent(bundle);
+    const sql = findings.filter((f) => f.title.toLowerCase().includes('sql'));
+    expect(sql.length).toBeGreaterThanOrEqual(1);
+    expect(sql[0]!.cweId).toBe('CWE-89');
+  });
+
   it('still flags a template literal query with interpolation (issue #657)', () => {
     const bundle = makeBundle({
       changedFiles: [

--- a/packages/core/tests/review/agents/security-agent.test.ts
+++ b/packages/core/tests/review/agents/security-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { runSecurityAgent, SECURITY_DESCRIPTOR } from '../../../src/review/agents/security-agent';
+import { enforceFindingIntegrity } from '../../../src/review/finding-integrity';
 import type { ContextBundle } from '../../../src/review/types';
 
 function makeBundle(overrides: Partial<ContextBundle> = {}): ContextBundle {
@@ -486,5 +487,183 @@ describe('runSecurityAgent()', () => {
       ],
     });
     expect(runSecurityAgent(bundle).length).toBe(1);
+  });
+
+  // ---- guards are code-scoped: test-markers and comment syntax are JS/TS
+  // conventions, so they must not suppress findings in non-code files ----
+
+  it('STILL flags a key in .env.test.local — test-file markers only apply to code files', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: '.env.test.local',
+          content: 'API_KEY="sk-live-0123456789abcdef0123456789abcdef"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(1);
+  });
+
+  it('STILL flags a key in a Markdown `*` bullet — JS comment syntax only applies to code files', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'docs/runbook.md',
+          content: '* API_KEY = "sk-live-0123456789abcdef0123456789abcdef"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(1);
+  });
+
+  it('STILL flags a secret after a URL on the same line — protocol `//` is not a comment', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/client.ts',
+          content: 'const url = "https://api.example.com"; const password = "hunter2hunter2";',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    const findings = runSecurityAgent(bundle);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.cweId).toBe('CWE-798');
+  });
+
+  // ---- comment skip is comment-ONLY lines: a comment prefix must not hide
+  // executable code (issue #984 follow-up — the old prefix check let a
+  // uniform `/**/ ` prefix silence all four detectors) ----
+
+  it.each([
+    ['/**/ eval(userInput);', 'block-comment prefix'],
+    ['*/ eval(userInput);', 'code after a block-comment close'],
+    ['/* istanbul ignore next */ eval(userInput);', 'inline pragma before code'],
+    ['  *run() { return eval(this.expr); }', 'generator member (not JSDoc)'],
+  ])('STILL flags eval on an executable line: %s (%s)', (content) => {
+    const bundle = makeBundle({
+      changedFiles: [{ path: 'src/sneaky.ts', content, reason: 'changed', lines: 1 }],
+    });
+    const findings = runSecurityAgent(bundle);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.cweId).toBe('CWE-94');
+  });
+
+  it('does not flag eval mentioned in a trailing // comment on an executable line', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/safe.ts',
+          content: 'safeCall(input); // never use eval(input) here',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  // ---- the SQL/eval/exec detectors skip test files (pins the
+  // isScannableSourceFile semantics that isTestFile alone does not cover) ----
+
+  it('does not flag SQL or eval fixtures inside a test file', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/db/__tests__/query.test.ts',
+          content: [
+            'const q = "SELECT * FROM users WHERE id = " + userId;',
+            'const r = eval(userInput);',
+          ].join('\n'),
+          reason: 'changed',
+          lines: 2,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  // ---- ordered statement shapes (aligned with finding-integrity's
+  // SQL_QUERY_SHAPE so nothing this detector emits gets downgraded) ----
+
+  it('does not flag a template literal whose prose uses "where" as a word', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/log2.ts',
+          content: 'logger.info(`this is where ${x} lives`);',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('flags the opening line of a multi-line template query (no closing backtick needed)', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/db4.ts',
+          content: [
+            'const q = `SELECT * FROM users WHERE id = ${userId} AND',
+            '  status = ${status}`;',
+          ].join('\n'),
+          reason: 'changed',
+          lines: 2,
+        },
+      ],
+    });
+    const sql = runSecurityAgent(bundle).filter((f) => f.cweId === 'CWE-89');
+    expect(sql.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Known limitations, pinned so a future change to them is a conscious one
+  // (see the SQL_CONCAT_PATTERN JSDoc): a shape split across literals or lines
+  // does not fire — loosening to line level would resurrect the prose FP class
+  // (concatenated CLI help strings) that #984 exists to kill.
+  it.each([
+    ['const q = "SELECT " + cols + " FROM users";', 'shape split across literals'],
+    ['const q = "SELECT id, name " +', 'multi-line concat, keyword line'],
+    ['  "FROM users WHERE id = " + userId;', 'multi-line concat, companion line'],
+    ['const q = `WHERE id = ${id}`;', 'bare clause fragment (integrity would downgrade)'],
+  ])('documented miss (does not fire): %s (%s)', (content) => {
+    const bundle = makeBundle({
+      changedFiles: [{ path: 'src/db5.ts', content, reason: 'changed', lines: 1 }],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  // ---- cross-layer invariant: the detector's SQL vocabulary is a subset of
+  // finding-integrity's SQL_QUERY_SHAPE, so nothing the floor emits is
+  // immediately downgraded by Phase 5.75 (two definitions of "looks like SQL"
+  // must not drift apart again) ----
+
+  it('every SQL finding the detector emits survives enforceFindingIntegrity undowngraded', () => {
+    const genuineShapes = [
+      'const q = "SELECT * FROM users WHERE id = " + userId;',
+      'const q = "INSERT INTO audit (actor) VALUES (" + actorId + ")";',
+      'const q = "UPDATE users SET active = " + flag;',
+      'const q = "DELETE FROM sessions WHERE id = " + id;',
+      'const q = `SELECT * FROM t JOIN u ON u.id = t.id WHERE t.k = ${k}`;',
+    ];
+    for (const content of genuineShapes) {
+      const bundle = makeBundle({
+        changedFiles: [{ path: 'src/db6.ts', content, reason: 'changed', lines: 1 }],
+      });
+      const emitted = runSecurityAgent(bundle).filter((f) => f.cweId === 'CWE-89');
+      expect(emitted.length).toBeGreaterThanOrEqual(1);
+      // Confidence reconciliation (heuristic ⇒ capped at medium) is expected;
+      // what must never happen is an evidence/class downgrade or drop.
+      const { findings, report } = enforceFindingIntegrity(emitted);
+      expect(report.downgraded).toBe(0);
+      expect(report.dropped).toBe(0);
+      expect(findings[0]!.severity).toBe('critical');
+    }
   });
 });

--- a/packages/core/tests/review/agents/security-agent.test.ts
+++ b/packages/core/tests/review/agents/security-agent.test.ts
@@ -415,4 +415,76 @@ describe('runSecurityAgent()', () => {
     const findings = runSecurityAgent(bundle);
     expect(findings.length).toBe(0);
   });
+
+  // ---- precision guards: test fixtures and comment bodies (issue #984) ----
+  // The secrets detector deliberately keeps a WIDER file scope than the three
+  // source-pattern detectors (a key in a .yml IS a leak), so it is guarded by
+  // isTestFile + isCommentLine rather than isCodeFile. These lock that asymmetry.
+
+  it('does not flag a fake key in a test fixture', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'packages/core/tests/review/agents/security-agent.test.ts',
+          content: 'const API_KEY = "sk-live-0123456789abcdef0123456789abcdef";',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('does not flag an example key documented in a JSDoc body', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/config.ts',
+          content: [
+            '/**',
+            ' * Set it like this:',
+            ' * const API_KEY = "sk-live-0123456789abcdef0123456789abcdef";',
+            ' */',
+            'export const KEY = process.env.API_KEY;',
+          ].join('\n'),
+          reason: 'changed',
+          lines: 5,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('STILL flags a real hardcoded key in source (guards must not over-suppress)', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/config.ts',
+          content: 'const API_KEY = "sk-live-0123456789abcdef0123456789abcdef";',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    const findings = runSecurityAgent(bundle);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.severity).toBe('critical');
+  });
+
+  // Non-code coverage is real but assignment-shaped: SECRET_PATTERNS key off
+  // `<name> = "<value>"`, so a shell/env/dotenv form is caught while a YAML
+  // `apiKey: "..."` is NOT (documented as a known gap in the PR, not fixed here).
+  it('STILL flags a hardcoded key in a non-code file — secrets keep the wider scope', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'deploy/.env.example',
+          content: 'API_KEY="sk-live-0123456789abcdef0123456789abcdef"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #984.

## What this fixes

`review-ci`'s floor tier was emitting **blocking `critical` security findings for strings that cannot reach any sink**. Two distinct false-positive classes, both observed on real PRs:

1. **Prose that uses a SQL keyword as an English word.** A `commander` help string — `'never create a ticket for a row lacking an externalId … ' +` — was reported as `critical` CWE-89 SQL injection, purely because "create" whole-word-matches `CREATE` and the literal is followed by `+`. Whole-word matching already spared inflected forms ("created"/"updated"); the bare stem was the hole.
2. **Fixtures and documentation.** A test that proves a detector *fires* must contain the vulnerable shape as data, and a JSDoc documenting the shape a rule detects necessarily contains it too. Both were scanned, so **any PR touching a security test or its docs self-flagged** — including this file's own JSDoc, reported as a critical CWE-89.

## The fix, per detector

- **SQL:** a statement keyword alone is not evidence of SQL. Real queries pair one with a **structural companion** (`SELECT … FROM`, `INSERT INTO`, `UPDATE … SET`, `DELETE FROM`, `… TABLE/JOIN/VALUES`); prose essentially never does. Requiring both inside the same literal keeps every genuine injection shape firing and drops the prose class.
- **eval / shell / SQL:** already gated on `isCodeFile`; now also skip **comment lines** (`//`, `/*`, `*` JSDoc bodies).
- **Secrets — the fourth detector, which had neither guard:** now skips test files and comment bodies.

### One deliberate asymmetry

The secrets detector still does **not** gate on `isCodeFile`. A credential in a dotenv or shell file is a real leak, whereas `eval(`, backtick-`exec(` and SQL concatenation are code constructs. Restricting it would lose coverage, not noise.

**Scope caveat, measured rather than assumed:** `SECRET_PATTERNS` key off an assignment shape (`<name> = "<value>"`), so a dotenv/shell line **is** matched while a YAML mapping (`apiKey: "..."`) is **not**. I wrote a comment claiming YAML coverage, the test written to prove it failed, and I corrected the comment rather than the expectation. The wider file scope is real but narrower than "all config files" — that YAML gap is pre-existing and left for its own issue rather than widened inside a false-positive PR.

## Tests — both directions

35 passing in `security-agent.test.ts`, including four new cases pinning that the guards **cannot over-suppress**:

- a fake key in a test fixture → no finding
- an example key in a JSDoc body → no finding
- a real hardcoded key in `src/` → **still `critical`**
- a real key in a non-code file (`.env.example`) → **still fires**

## Why this matters beyond the noise

The floor tier runs when `ANTHROPIC_API_KEY` is unset, so the tier least able to sanity-check itself was publishing `critical` / `confidence: high` findings carrying `validatedBy: heuristic` and `trustScore: 56`. One fabricated critical costs more than ten missed real ones, because the next genuine CWE-89 gets waved through as "probably that string-concat thing again."

#984 also suggests two structural hardenings **not** done here: an invariant that a finding claiming a vulnerability class must carry evidence consistent with that class, and reconciling `confidence` with `validatedBy`/`trustScore`. Worth doing separately; this PR fixes the detectors.

## Provenance

Both commits were originally authored on the `roadmap sync` branch (#983) while investigating why that PR's `required-review` gate was red. Mixing a review-engine change into a roadmap-CLI PR was a packaging mistake, so they were moved here and #983 was force-pushed back to roadmap-only scope (no reviews had been submitted, so nothing was invalidated). #983 is unaffected and independently green apart from the gate this PR fixes.
