### PR TITLE
feat(ci): alarm when main's CI goes red (#987)

### DIFF
--- a/.github/workflows/main-health.yml
+++ b/.github/workflows/main-health.yml
@@ -1,0 +1,71 @@
+name: Main Health Alarm
+
+# Watches `main`'s CI and says so when it goes red.
+#
+# Issue #987: `build-and-test` was red on `main` for eight days and nothing
+# noticed, because nothing watched `main` itself — the failure was only found by
+# someone stumbling into it from a PR. This is the watcher.
+#
+# Two triggers on purpose:
+#   - `workflow_run`: reacts within minutes of each `main` CI run finishing, so
+#     a green -> red transition (and the red -> green all-clear) is timely.
+#   - `schedule`: a daily heartbeat. It is the arm that catches the silent
+#     failures — a renamed workflow file, a revoked permission, or a `main`
+#     that stopped receiving pushes entirely. The `workflow_run` arm can never
+#     detect "no runs at all", because it only fires when a run happens.
+#
+# Where the alarm lands: the script opens/updates a labelled tracking issue
+# (`main-health-alarm`) and writes a step summary on EVERY run. A failing job
+# alone would be no better than the red `main` it is reporting on — the whole
+# point of #987 is that a red check nobody reads is silence.
+#
+# No step-level `continue-on-error` anywhere: this job is *meant* to go red when
+# `main` is red, and red when it could not tell (exit 3). An abstaining health
+# check must never look like a pass.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # Daily at 07:00 UTC
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: 'Consecutive decisive failures required to alarm'
+        required: false
+        default: '2'
+
+permissions:
+  actions: read # read the CI workflow's run history
+  contents: read
+  issues: write # upsert the tracking issue
+
+# Never cancel an in-flight alarm delivery: a cancelled run could drop the
+# green -> red notification (or the all-clear) on the floor. Serialize instead.
+concurrency:
+  group: main-health
+  cancel-in-progress: false
+
+jobs:
+  main-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      # No `pnpm install`: the check is a dependency-free node script, so the
+      # watcher cannot be taken down by an install failure in the thing it
+      # watches.
+      - name: Check main CI health
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          MAIN_HEALTH_WORKFLOW: ci.yml
+          MAIN_HEALTH_BRANCH: main
+          MAIN_HEALTH_THRESHOLD: ${{ inputs.threshold || '2' }}
+        run: node scripts/main-health-check.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,6 +387,37 @@ pnpm clean
 > (fresh clone / detached HEAD) pre-push falls back to the full unscoped gate.
 > See ADR `docs/knowledge/decisions/0075-affected-scoped-pre-push.md`.
 
+### Main-branch health alarm
+
+`.github/workflows/main-health.yml` watches `main`'s own CI so a red `main` cannot
+go unnoticed again (issue #987: `build-and-test` was red for eight days and the
+only thing that found it was a contributor triaging their own PR). It runs on a
+daily schedule **and** after every `main` run of `CI` completes, and calls
+`scripts/main-health-check.mjs`.
+
+- **Health rule (deliberately quiet):** `main` is unhealthy when the most recent
+  **2** _decisive_ runs both failed (`MAIN_HEALTH_THRESHOLD`). Decisive excludes
+  `cancelled`/`skipped` — CI runs with `cancel-in-progress: true`, so rapid
+  merges leave cancelled runs that say nothing about health. The louder
+  "most-recent-run-failed" rule would alarm on every flake, and a flaky alarm is
+  a muted alarm.
+- **Where the alarm lands:** a labelled tracking issue (`main-health-alarm`),
+  upserted — opened on green → red, **edited in place** while still red (never a
+  second issue, never a nightly comment), and commented + closed as an all-clear
+  on red → green. A step summary is written on every run regardless of verdict.
+- **Denominator discipline:** if fewer decisive runs than the threshold can be
+  resolved (renamed workflow file, API error, missing permission, quiet branch),
+  the check exits `3` INDETERMINATE and reports "abstained — not a pass". It
+  never reports healthy on an empty denominator, and it neither opens nor closes
+  an alarm in that state.
+- **Exit codes:** `0` healthy · `1` internal error · `2` unhealthy (alarm
+  raised) · `3` indeterminate · `4` alarm undelivered (verdict known, the issue
+  write failed). Full rationale is in the script header.
+- Logic is covered by `tests/scripts/main-health-check.test.mjs` with a fake
+  `gh`, so the tests never touch the network. Run
+  `node scripts/main-health-check.mjs --dry-run` locally to see the verdict
+  without writing anything.
+
 ### Git Workflow and Commit Conventions
 
 We use **Conventional Commits** for clear, machine-readable commit messages:

--- a/scripts/main-health-check.mjs
+++ b/scripts/main-health-check.mjs
@@ -1,0 +1,545 @@
+#!/usr/bin/env node
+/**
+ * Scheduled health alarm for `main`'s CI.
+ *
+ * Driven by issue #987: `build-and-test` was red on `main` for eight days and
+ * nothing noticed. Every PR inherited the red check, and the real cost was not
+ * the broken test — it was that a permanently-red required check trains
+ * contributors to read red as normal, so the next genuine regression in that
+ * job lands invisibly. Nothing in the repo watched `main` itself; the failure
+ * was only ever found by someone stumbling into it from a PR.
+ *
+ * What it does
+ * ------------
+ * 1. Reads the recent `push`-triggered runs of the CI workflow on `main`.
+ * 2. Applies a deliberately quiet health rule (below).
+ * 3. Alarms on a *transition* only — opens a tracking issue on green -> red,
+ *    updates that same issue while it stays red (never opens a second one),
+ *    and comments + closes it as an all-clear on red -> green.
+ * 4. Writes a step summary on EVERY run regardless of verdict, so the check
+ *    always shows its own working.
+ *
+ * The health rule, and why it is the quiet one
+ * -------------------------------------------
+ * `main` is unhealthy when the most recent N *decisive* runs all failed
+ * (N = 2 by default, `MAIN_HEALTH_THRESHOLD`). The louder alternative —
+ * "the most recent run failed" — alarms on any single flake, and an alarm that
+ * fires on flakes is an alarm people mute. Two consecutive failures is already
+ * far inside the eight-day window this exists to close, and a genuinely broken
+ * `main` fails every run, so the quieter rule loses nothing real.
+ *
+ * "Decisive" excludes `cancelled` and `skipped` runs. CI sets
+ * `cancel-in-progress: true`, so rapid merges leave a trail of cancelled runs
+ * that say nothing about `main`'s health; counting them as failures would
+ * manufacture streaks out of merge cadence alone.
+ *
+ * Denominator discipline
+ * ----------------------
+ * If fewer than N decisive runs can be resolved — wrong workflow filename,
+ * API error, missing permission, or simply a quiet window — the check exits
+ * INDETERMINATE (3). It never reports healthy. A health check that examined
+ * nothing has abstained, not confirmed health, and the whole point of #987 is
+ * that a green-looking gate which verified nothing is worse than no gate.
+ *
+ * Exit codes
+ * ----------
+ *   0  HEALTHY        — the most recent decisive runs are not a failing streak.
+ *   1  INTERNAL_ERROR — unexpected exception; verdict unknown.
+ *   2  UNHEALTHY      — failing streak met the threshold; alarm raised/updated.
+ *   3  INDETERMINATE  — fewer than `threshold` decisive runs resolved (zero
+ *                       runs, bad workflow name, API/permission failure).
+ *                       Explicitly NOT a pass.
+ *   4  ALARM_UNDELIVERED — verdict computed but the issue upsert failed, so the
+ *                       alarm did not reach a human. Fails loudly rather than
+ *                       letting silence read as health.
+ *
+ * Usage:
+ *   node scripts/main-health-check.mjs [--dry-run]
+ *
+ * Env:
+ *   GH_TOKEN                 required for the `gh` calls
+ *   GITHUB_REPOSITORY        owner/repo (default: Intense-Visions/harness-engineering)
+ *   MAIN_HEALTH_WORKFLOW     workflow filename (default: ci.yml)
+ *   MAIN_HEALTH_BRANCH       branch to watch (default: main)
+ *   MAIN_HEALTH_THRESHOLD    consecutive decisive failures to alarm (default: 2)
+ *   MAIN_HEALTH_LOOKBACK     runs to fetch (default: 30)
+ *   GITHUB_STEP_SUMMARY      appended to when present
+ */
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Exit codes. Documented in the module header; asserted in tests. */
+export const EXIT = {
+  HEALTHY: 0,
+  INTERNAL_ERROR: 1,
+  UNHEALTHY: 2,
+  INDETERMINATE: 3,
+  ALARM_UNDELIVERED: 4,
+};
+
+/** Marker embedded in the alarm issue body so the issue is identifiable by grep as well as by label. */
+export const ALARM_MARKER = '<!-- main-health-alarm:v1 -->';
+
+/** Label that makes the alarm issue findable without relying on the search index. */
+export const ALARM_LABEL = 'main-health-alarm';
+
+/**
+ * Conclusions that say something about `main`'s health. `cancelled` and
+ * `skipped` are deliberately absent — see the header.
+ */
+const DECISIVE_CONCLUSIONS = new Set(['success', 'failure', 'timed_out', 'startup_failure']);
+
+/**
+ * Keep only runs that carry a health signal, newest first.
+ *
+ * @param {Array<{status?: string, conclusion?: string, created_at?: string}>} runs
+ * @returns {Array<object>} decisive runs, newest first
+ */
+export function selectDecisiveRuns(runs) {
+  return (Array.isArray(runs) ? runs : [])
+    .filter((r) => r && r.status === 'completed' && DECISIVE_CONCLUSIONS.has(r.conclusion))
+    .slice()
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+}
+
+/**
+ * Apply the health rule to a run list.
+ *
+ * @param {Array<object>} runs raw workflow runs (any order)
+ * @param {{threshold?: number}} [opts]
+ * @returns {{
+ *   state: 'healthy'|'unhealthy'|'indeterminate',
+ *   threshold: number,
+ *   decisiveCount: number,
+ *   failingStreak: number,
+ *   latest: object|null,
+ *   streakRuns: Array<object>,
+ *   reason: string,
+ * }}
+ */
+export function evaluateHealth(runs, opts = {}) {
+  const threshold = Math.max(1, Number(opts.threshold ?? 2));
+  const decisive = selectDecisiveRuns(runs);
+
+  if (decisive.length < threshold) {
+    return {
+      state: 'indeterminate',
+      threshold,
+      decisiveCount: decisive.length,
+      failingStreak: 0,
+      latest: decisive[0] ?? null,
+      streakRuns: [],
+      reason:
+        decisive.length === 0
+          ? 'Zero decisive runs resolved — nothing was inspected, so health is unknown (not healthy).'
+          : `Only ${decisive.length} decisive run(s) resolved; the rule needs ${threshold} to decide.`,
+    };
+  }
+
+  let failingStreak = 0;
+  for (const run of decisive) {
+    if (run.conclusion === 'success') break;
+    failingStreak += 1;
+  }
+
+  const unhealthy = failingStreak >= threshold;
+  return {
+    state: unhealthy ? 'unhealthy' : 'healthy',
+    threshold,
+    decisiveCount: decisive.length,
+    failingStreak,
+    latest: decisive[0] ?? null,
+    streakRuns: decisive.slice(0, failingStreak),
+    reason: unhealthy
+      ? `The ${failingStreak} most recent decisive run(s) failed (threshold ${threshold}).`
+      : failingStreak === 0
+        ? 'The most recent decisive run succeeded.'
+        : `Only ${failingStreak} consecutive failure(s); below the alarm threshold of ${threshold} (treated as a flake).`,
+  };
+}
+
+/**
+ * Decide what to do about the alarm issue, given the verdict and whether an
+ * alarm issue is already open. This is the transition rule: notify on change,
+ * stay quiet otherwise.
+ *
+ * @param {'healthy'|'unhealthy'|'indeterminate'} state
+ * @param {boolean} hasOpenAlarm
+ * @returns {'open'|'update'|'resolve'|'none'}
+ */
+export function decideAction(state, hasOpenAlarm) {
+  if (state === 'unhealthy') return hasOpenAlarm ? 'update' : 'open';
+  if (state === 'healthy') return hasOpenAlarm ? 'resolve' : 'none';
+  // Indeterminate: the check cannot see `main`, so it must not close a live
+  // alarm (that would fake an all-clear) and must not open one either.
+  return 'none';
+}
+
+/** @param {object|null} run */
+function runLine(run) {
+  if (!run) return '_none_';
+  return `[${run.created_at ?? '?'} — ${run.conclusion ?? '?'}](${run.html_url ?? '#'})`;
+}
+
+/**
+ * Body of the tracking issue. Rewritten (not appended to) on every update so
+ * the issue always shows current state rather than a scroll of nightly noise.
+ *
+ * @param {ReturnType<typeof evaluateHealth>} verdict
+ * @param {{repo: string, workflow: string, branch: string, runUrl?: string}} ctx
+ * @returns {string}
+ */
+export function renderIssueBody(verdict, ctx) {
+  const streak = verdict.streakRuns.map((r) => `- ${runLine(r)} — ${r.display_title ?? ''}`);
+  return [
+    ALARM_MARKER,
+    `## \`${ctx.branch}\` CI is red`,
+    '',
+    `The **${verdict.failingStreak}** most recent decisive runs of \`${ctx.workflow}\` on ` +
+      `\`${ctx.branch}\` failed. Alarm threshold is ${verdict.threshold} consecutive failures.`,
+    '',
+    '### Failing runs (newest first)',
+    ...(streak.length ? streak : ['- _none recorded_']),
+    '',
+    '### Why this issue exists',
+    '',
+    'Every PR inherits a red `main`. Two costs, and the second is the expensive one:',
+    'a broken PR cannot be told apart from the ambient failure, and a permanently-red',
+    'required check teaches contributors to read red as normal — so the next real',
+    'regression in that job lands unnoticed. See #987.',
+    '',
+    '### What closes this',
+    '',
+    `A green run of \`${ctx.workflow}\` on \`${ctx.branch}\`. The scheduled check closes this`,
+    'issue automatically with an all-clear comment; do not close it by hand while',
+    '`main` is still red.',
+    '',
+    '---',
+    '',
+    `_Maintained by \`.github/workflows/main-health.yml\` (\`scripts/main-health-check.mjs\`)._`,
+    ctx.runUrl ? `_Last updated by [this run](${ctx.runUrl})._` : '',
+  ]
+    .filter((l) => l !== '')
+    .join('\n');
+}
+
+/**
+ * The step summary, written on every run — healthy, unhealthy, or abstained.
+ * Silence is the failure mode being fixed, so the check always says what it
+ * looked at and how many runs it resolved.
+ *
+ * @param {ReturnType<typeof evaluateHealth>} verdict
+ * @param {'open'|'update'|'resolve'|'none'} action
+ * @param {{repo: string, workflow: string, branch: string, issueNumber?: number|null}} ctx
+ * @returns {string}
+ */
+export function renderSummary(verdict, action, ctx) {
+  const badge = {
+    healthy: '✅ HEALTHY',
+    unhealthy: '🚨 UNHEALTHY',
+    indeterminate: '❓ INDETERMINATE (abstained — not a pass)',
+  }[verdict.state];
+
+  const actionText = {
+    open: 'Opened a tracking issue (green → red transition).',
+    update: 'Updated the existing tracking issue (still red — no new notification).',
+    resolve: 'Commented an all-clear and closed the tracking issue (red → green transition).',
+    none:
+      verdict.state === 'indeterminate'
+        ? 'No issue action: the check could not see `main`, so it neither alarms nor clears.'
+        : 'No issue action: steady state, nothing changed.',
+  }[action];
+
+  return [
+    `## main CI health: ${badge}`,
+    '',
+    `| | |`,
+    `| --- | --- |`,
+    `| Repo | \`${ctx.repo}\` |`,
+    `| Workflow | \`${ctx.workflow}\` on \`${ctx.branch}\` |`,
+    `| Decisive runs resolved | **${verdict.decisiveCount}** (threshold ${verdict.threshold}) |`,
+    `| Consecutive failures | **${verdict.failingStreak}** |`,
+    `| Latest decisive run | ${runLine(verdict.latest)} |`,
+    `| Tracking issue | ${ctx.issueNumber ? `#${ctx.issueNumber}` : '_none_'} |`,
+    '',
+    `**Verdict:** ${verdict.reason}`,
+    '',
+    `**Alarm:** ${actionText}`,
+    '',
+    '_Decisive = a completed run concluding success / failure / timed_out / startup_failure._',
+    '_`cancelled` and `skipped` runs are excluded: CI cancels in-progress runs on rapid_',
+    '_merges, and counting those as failures would invent streaks out of merge cadence._',
+  ].join('\n');
+}
+
+/* ------------------------------------------------------------------ *
+ * Everything below is I/O. The pure logic above is what tests cover. *
+ * ------------------------------------------------------------------ */
+
+/**
+ * Invoke `gh`. Injectable so tests never touch the network.
+ *
+ * @param {string[]} args
+ * @returns {string} stdout
+ */
+function ghExec(args) {
+  return execFileSync('gh', args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/**
+ * @param {{gh: (args: string[]) => string, repo: string, workflow: string, branch: string, lookback: number}} deps
+ * @returns {Array<object>} raw runs
+ * @throws when the API call fails or returns an unusable shape (caller maps this to INDETERMINATE)
+ */
+export function fetchRuns(deps) {
+  const { gh, repo, workflow, branch, lookback } = deps;
+  const path =
+    `/repos/${repo}/actions/workflows/${workflow}/runs` +
+    `?branch=${encodeURIComponent(branch)}&event=push&per_page=${lookback}`;
+  const raw = gh(['api', path]);
+  const parsed = JSON.parse(raw);
+  if (!parsed || !Array.isArray(parsed.workflow_runs)) {
+    throw new Error(`Unexpected response shape from ${path} (no workflow_runs array).`);
+  }
+  return parsed.workflow_runs;
+}
+
+/**
+ * Find the currently-open alarm issue, if any. Looked up by label rather than
+ * by search query: `gh search` is index-backed and lags, and a lagging lookup
+ * is exactly how an upsert turns into a nightly duplicate.
+ *
+ * @param {{gh: (args: string[]) => string, repo: string}} deps
+ * @returns {{number: number}|null}
+ */
+export function findOpenAlarmIssue(deps) {
+  const { gh, repo } = deps;
+  let raw;
+  try {
+    raw = gh([
+      'issue',
+      'list',
+      '--repo',
+      repo,
+      '--label',
+      ALARM_LABEL,
+      '--state',
+      'open',
+      '--limit',
+      '10',
+      '--json',
+      'number,title',
+    ]);
+  } catch {
+    // The label may not exist yet on a first run; that is indistinguishable
+    // from "no open alarm", and both mean the same thing here.
+    return null;
+  }
+  const issues = JSON.parse(raw || '[]');
+  if (!Array.isArray(issues) || issues.length === 0) return null;
+  // Lowest number = the original incident issue if a human opened extras.
+  return issues.slice().sort((a, b) => a.number - b.number)[0];
+}
+
+/** Create the alarm label if it is missing. Idempotent. */
+function ensureLabel(gh, repo) {
+  try {
+    gh([
+      'label',
+      'create',
+      ALARM_LABEL,
+      '--repo',
+      repo,
+      '--color',
+      'B60205',
+      '--description',
+      'Automated alarm: main branch CI health',
+      '--force',
+    ]);
+  } catch {
+    // Label creation needs write scope we may not have on a fork; the issue
+    // upsert still works without the label, it just loses the fast lookup.
+  }
+}
+
+/**
+ * Deliver the alarm. Returns true when the intended side effect landed.
+ *
+ * @param {{
+ *   gh: (args: string[]) => string,
+ *   repo: string, workflow: string, branch: string, runUrl?: string,
+ *   action: 'open'|'update'|'resolve'|'none',
+ *   verdict: ReturnType<typeof evaluateHealth>,
+ *   issue: {number: number}|null,
+ *   dryRun?: boolean,
+ * }} args
+ * @returns {{delivered: boolean, issueNumber: number|null, error?: string}}
+ */
+export function deliverAlarm(args) {
+  const { gh, repo, action, verdict, issue, dryRun } = args;
+  const ctx = {
+    repo,
+    workflow: args.workflow,
+    branch: args.branch,
+    runUrl: args.runUrl,
+  };
+
+  if (action === 'none') return { delivered: true, issueNumber: issue?.number ?? null };
+  if (dryRun) {
+    console.log(`[dry-run] would ${action} the alarm issue`);
+    return { delivered: true, issueNumber: issue?.number ?? null };
+  }
+
+  try {
+    if (action === 'open') {
+      ensureLabel(gh, repo);
+      const url = gh([
+        'issue',
+        'create',
+        '--repo',
+        repo,
+        '--title',
+        `🚨 ${args.branch} CI is red (${verdict.failingStreak} consecutive failures)`,
+        '--body',
+        renderIssueBody(verdict, ctx),
+        '--label',
+        ALARM_LABEL,
+      ]).trim();
+      const num = Number(url.split('/').pop());
+      return { delivered: true, issueNumber: Number.isFinite(num) ? num : null };
+    }
+
+    if (action === 'update') {
+      // Edit the body in place instead of commenting: a nightly comment on a
+      // long-running outage is how an alarm gets muted.
+      gh([
+        'issue',
+        'edit',
+        String(issue.number),
+        '--repo',
+        repo,
+        '--body',
+        renderIssueBody(verdict, ctx),
+      ]);
+      return { delivered: true, issueNumber: issue.number };
+    }
+
+    // resolve
+    gh([
+      'issue',
+      'comment',
+      String(issue.number),
+      '--repo',
+      repo,
+      '--body',
+      `✅ All clear — \`${args.workflow}\` is green again on \`${args.branch}\`.\n\n` +
+        `Latest decisive run: ${runLine(verdict.latest)}\n\n` +
+        `_Closed automatically by \`.github/workflows/main-health.yml\`._`,
+    ]);
+    gh(['issue', 'close', String(issue.number), '--repo', repo, '--reason', 'completed']);
+    return { delivered: true, issueNumber: issue.number };
+  } catch (err) {
+    return {
+      delivered: false,
+      issueNumber: issue?.number ?? null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function writeSummary(text) {
+  console.log(text);
+  const target = process.env.GITHUB_STEP_SUMMARY;
+  if (!target) return;
+  try {
+    appendFileSync(target, `${text}\n`);
+  } catch (err) {
+    console.error(`Could not write the step summary: ${String(err)}`);
+  }
+}
+
+function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const repo = process.env.GITHUB_REPOSITORY || 'Intense-Visions/harness-engineering';
+  const workflow = process.env.MAIN_HEALTH_WORKFLOW || 'ci.yml';
+  const branch = process.env.MAIN_HEALTH_BRANCH || 'main';
+  const threshold = Number(process.env.MAIN_HEALTH_THRESHOLD || 2);
+  const lookback = Number(process.env.MAIN_HEALTH_LOOKBACK || 30);
+  const runUrl =
+    process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : undefined;
+
+  let runs;
+  try {
+    runs = fetchRuns({ gh: ghExec, repo, workflow, branch, lookback });
+  } catch (err) {
+    // A failed fetch is an abstention, never a pass: the check saw nothing.
+    const verdict = evaluateHealth([], { threshold });
+    verdict.reason = `Could not resolve any runs: ${err instanceof Error ? err.message : String(err)}`;
+    writeSummary(renderSummary(verdict, 'none', { repo, workflow, branch, issueNumber: null }));
+    console.error(
+      `INDETERMINATE: the health check resolved zero runs and therefore verified nothing.\n` +
+        `Check that \`${workflow}\` still exists, that the token can read Actions, and that\n` +
+        `\`${branch}\` is the right branch. Exiting ${EXIT.INDETERMINATE}.`
+    );
+    process.exit(EXIT.INDETERMINATE);
+  }
+
+  const verdict = evaluateHealth(runs, { threshold });
+  const openIssue = verdict.state === 'indeterminate' ? null : findOpenAlarmIssue({ gh: ghExec, repo });
+  const action = decideAction(verdict.state, Boolean(openIssue));
+  const delivery = deliverAlarm({
+    gh: ghExec,
+    repo,
+    workflow,
+    branch,
+    runUrl,
+    action,
+    verdict,
+    issue: openIssue,
+    dryRun,
+  });
+
+  writeSummary(
+    renderSummary(verdict, action, { repo, workflow, branch, issueNumber: delivery.issueNumber })
+  );
+
+  if (!delivery.delivered) {
+    console.error(
+      `ALARM UNDELIVERED: verdict is ${verdict.state} but the issue ${action} failed: ${delivery.error}\n` +
+        `Failing loudly — an undelivered alarm must not read as health. Exiting ${EXIT.ALARM_UNDELIVERED}.`
+    );
+    process.exit(EXIT.ALARM_UNDELIVERED);
+  }
+
+  if (verdict.state === 'indeterminate') {
+    console.error(
+      `INDETERMINATE: resolved ${verdict.decisiveCount} decisive run(s), fewer than the ` +
+        `threshold of ${threshold}. Nothing was confirmed. Exiting ${EXIT.INDETERMINATE}.`
+    );
+    process.exit(EXIT.INDETERMINATE);
+  }
+
+  if (verdict.state === 'unhealthy') {
+    console.error(`UNHEALTHY: ${verdict.reason} Exiting ${EXIT.UNHEALTHY}.`);
+    process.exit(EXIT.UNHEALTHY);
+  }
+
+  console.log(`HEALTHY: ${verdict.reason}`);
+  process.exit(EXIT.HEALTHY);
+}
+
+// Only run the gate when invoked as a script; importing exposes the pure
+// helpers to tests without side effects.
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`INTERNAL ERROR: ${err instanceof Error ? err.stack : String(err)}`);
+    process.exit(EXIT.INTERNAL_ERROR);
+  }
+}

--- a/tests/scripts/main-health-check.test.mjs
+++ b/tests/scripts/main-health-check.test.mjs
@@ -1,0 +1,397 @@
+/**
+ * Tests for the `main` CI health alarm (issue #987).
+ *
+ * These cover the three properties that make the alarm trustworthy:
+ *
+ *   1. The quiet rule — one failure is a flake, N consecutive failures is an
+ *      outage — and `cancelled` runs never count either way (CI cancels
+ *      in-progress runs on rapid merges).
+ *   2. Transition-only notification — open on green -> red, edit in place while
+ *      still red (never a second issue), all-clear on red -> green.
+ *   3. Denominator discipline — resolving fewer decisive runs than the rule
+ *      needs is INDETERMINATE, never healthy. A check that examined nothing
+ *      has abstained.
+ *
+ * `gh` is injected as a fake, so nothing here touches the network.
+ * Run with: node --test tests/scripts/
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EXIT,
+  ALARM_LABEL,
+  ALARM_MARKER,
+  selectDecisiveRuns,
+  evaluateHealth,
+  decideAction,
+  renderSummary,
+  renderIssueBody,
+  fetchRuns,
+  findOpenAlarmIssue,
+  deliverAlarm,
+} from '../../scripts/main-health-check.mjs';
+
+/** @param {string} conclusion @param {string} date */
+function run(conclusion, date, extra = {}) {
+  return {
+    status: 'completed',
+    conclusion,
+    created_at: date,
+    html_url: `https://example.test/${date}`,
+    display_title: `commit at ${date}`,
+    ...extra,
+  };
+}
+
+/** Records the `gh` argv it was called with and replays canned stdout. */
+function fakeGh(responses = {}) {
+  const calls = [];
+  const gh = (args) => {
+    calls.push(args);
+    for (const [key, value] of Object.entries(responses)) {
+      if (args.join(' ').includes(key)) {
+        if (value instanceof Error) throw value;
+        return value;
+      }
+    }
+    return '';
+  };
+  gh.calls = calls;
+  return gh;
+}
+
+// --------------------------------------------------------------------------
+// Exit-code contract
+// --------------------------------------------------------------------------
+
+test('main-health: exit codes are distinct and INDETERMINATE is not zero', () => {
+  const codes = Object.values(EXIT);
+  assert.equal(new Set(codes).size, codes.length, 'exit codes must be unique');
+  assert.equal(EXIT.HEALTHY, 0);
+  assert.notEqual(EXIT.INDETERMINATE, EXIT.HEALTHY);
+  assert.notEqual(EXIT.INDETERMINATE, EXIT.UNHEALTHY);
+  assert.ok(EXIT.INDETERMINATE > 0, 'abstaining must never be reported as success');
+});
+
+// --------------------------------------------------------------------------
+// Decisive-run selection
+// --------------------------------------------------------------------------
+
+test('main-health: cancelled and skipped runs are not health signals', () => {
+  const decisive = selectDecisiveRuns([
+    run('cancelled', '2026-07-27T00:00:00Z'),
+    run('skipped', '2026-07-26T00:00:00Z'),
+    run('failure', '2026-07-25T00:00:00Z'),
+    { status: 'in_progress', conclusion: null, created_at: '2026-07-28T00:00:00Z' },
+  ]);
+  assert.equal(decisive.length, 1);
+  assert.equal(decisive[0].conclusion, 'failure');
+});
+
+test('main-health: decisive runs are ordered newest first regardless of input order', () => {
+  const decisive = selectDecisiveRuns([
+    run('failure', '2026-07-20T00:00:00Z'),
+    run('success', '2026-07-25T00:00:00Z'),
+    run('failure', '2026-07-23T00:00:00Z'),
+  ]);
+  assert.deepEqual(
+    decisive.map((r) => r.created_at),
+    ['2026-07-25T00:00:00Z', '2026-07-23T00:00:00Z', '2026-07-20T00:00:00Z']
+  );
+});
+
+test('main-health: timed_out and startup_failure count as failures', () => {
+  const verdict = evaluateHealth([
+    run('timed_out', '2026-07-27T00:00:00Z'),
+    run('startup_failure', '2026-07-26T00:00:00Z'),
+    run('success', '2026-07-25T00:00:00Z'),
+  ]);
+  assert.equal(verdict.state, 'unhealthy');
+  assert.equal(verdict.failingStreak, 2);
+});
+
+// --------------------------------------------------------------------------
+// The quiet rule
+// --------------------------------------------------------------------------
+
+test('main-health: a single failure after a green run is a flake, not an alarm', () => {
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('success', '2026-07-26T00:00:00Z'),
+    run('success', '2026-07-25T00:00:00Z'),
+  ]);
+  assert.equal(verdict.state, 'healthy');
+  assert.equal(verdict.failingStreak, 1);
+  assert.match(verdict.reason, /flake/);
+});
+
+test('main-health: two consecutive failures trip the alarm', () => {
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+    run('success', '2026-07-25T00:00:00Z'),
+  ]);
+  assert.equal(verdict.state, 'unhealthy');
+  assert.equal(verdict.failingStreak, 2);
+  assert.equal(verdict.streakRuns.length, 2);
+});
+
+test('main-health: cancelled runs interleaved in a red streak do not break it', () => {
+  // The real #987 shape: concurrency-cancelled runs sit between real failures.
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('cancelled', '2026-07-26T12:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+    run('success', '2026-07-22T00:00:00Z'),
+  ]);
+  assert.equal(verdict.state, 'unhealthy');
+  assert.equal(verdict.failingStreak, 2);
+});
+
+test('main-health: a green most-recent run is healthy even with older failures', () => {
+  const verdict = evaluateHealth([
+    run('success', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+    run('failure', '2026-07-25T00:00:00Z'),
+  ]);
+  assert.equal(verdict.state, 'healthy');
+  assert.equal(verdict.failingStreak, 0);
+});
+
+test('main-health: the threshold is configurable and a strictly quieter rule alarms later', () => {
+  const runs = [
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+    run('success', '2026-07-25T00:00:00Z'),
+  ];
+  assert.equal(evaluateHealth(runs, { threshold: 2 }).state, 'unhealthy');
+  assert.equal(evaluateHealth(runs, { threshold: 3 }).state, 'healthy');
+});
+
+// --------------------------------------------------------------------------
+// Denominator discipline
+// --------------------------------------------------------------------------
+
+test('main-health: zero runs is INDETERMINATE, never healthy', () => {
+  const verdict = evaluateHealth([]);
+  assert.equal(verdict.state, 'indeterminate');
+  assert.equal(verdict.decisiveCount, 0);
+  assert.match(verdict.reason, /Zero decisive runs/);
+});
+
+test('main-health: a run list of only cancelled runs resolves zero and abstains', () => {
+  const verdict = evaluateHealth([
+    run('cancelled', '2026-07-27T00:00:00Z'),
+    run('cancelled', '2026-07-26T00:00:00Z'),
+  ]);
+  assert.equal(verdict.state, 'indeterminate');
+  assert.equal(verdict.decisiveCount, 0);
+});
+
+test('main-health: fewer decisive runs than the threshold abstains rather than guessing', () => {
+  const verdict = evaluateHealth([run('failure', '2026-07-27T00:00:00Z')], { threshold: 2 });
+  assert.equal(verdict.state, 'indeterminate');
+  assert.match(verdict.reason, /needs 2/);
+});
+
+test('main-health: a malformed API response throws so the caller can abstain', () => {
+  const gh = fakeGh({ 'actions/workflows': '{"not_what_we_expected": true}' });
+  assert.throws(
+    () => fetchRuns({ gh, repo: 'o/r', workflow: 'ci.yml', branch: 'main', lookback: 5 }),
+    /workflow_runs/
+  );
+});
+
+test('main-health: an API failure propagates rather than resolving as empty-and-healthy', () => {
+  const gh = fakeGh({ 'actions/workflows': new Error('gh: HTTP 404 Not Found') });
+  assert.throws(
+    () => fetchRuns({ gh, repo: 'o/r', workflow: 'nope.yml', branch: 'main', lookback: 5 }),
+    /404/
+  );
+});
+
+test('main-health: the run query is scoped to push events on the watched branch', () => {
+  const gh = fakeGh({ 'actions/workflows': '{"workflow_runs": []}' });
+  fetchRuns({ gh, repo: 'o/r', workflow: 'ci.yml', branch: 'main', lookback: 30 });
+  assert.equal(gh.calls[0][0], 'api');
+  const path = gh.calls[0][1];
+  assert.match(path, /\/repos\/o\/r\/actions\/workflows\/ci\.yml\/runs/);
+  assert.match(path, /branch=main/);
+  assert.match(path, /event=push/);
+  assert.match(path, /per_page=30/);
+});
+
+// --------------------------------------------------------------------------
+// Transition-only alarming
+// --------------------------------------------------------------------------
+
+test('main-health: green -> red opens an issue; still-red only updates it', () => {
+  assert.equal(decideAction('unhealthy', false), 'open');
+  assert.equal(decideAction('unhealthy', true), 'update');
+});
+
+test('main-health: red -> green resolves; steady green does nothing', () => {
+  assert.equal(decideAction('healthy', true), 'resolve');
+  assert.equal(decideAction('healthy', false), 'none');
+});
+
+test('main-health: an abstaining check never opens nor closes an alarm', () => {
+  assert.equal(decideAction('indeterminate', false), 'none');
+  assert.equal(decideAction('indeterminate', true), 'none');
+});
+
+test('main-health: an already-open alarm is edited in place, not duplicated', () => {
+  const gh = fakeGh();
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+  ]);
+  const result = deliverAlarm({
+    gh,
+    repo: 'o/r',
+    workflow: 'ci.yml',
+    branch: 'main',
+    action: 'update',
+    verdict,
+    issue: { number: 42 },
+  });
+  assert.equal(result.delivered, true);
+  assert.equal(result.issueNumber, 42);
+  const verbs = gh.calls.map((c) => c.slice(0, 2).join(' '));
+  assert.ok(verbs.includes('issue edit'), 'should edit the existing issue');
+  assert.ok(!verbs.includes('issue create'), 'must never open a second alarm issue');
+  assert.ok(!verbs.includes('issue comment'), 'must not nag with a comment every run');
+});
+
+test('main-health: opening an alarm labels it and returns the parsed issue number', () => {
+  const gh = fakeGh({ 'issue create': 'https://github.com/o/r/issues/1234\n' });
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+  ]);
+  const result = deliverAlarm({
+    gh,
+    repo: 'o/r',
+    workflow: 'ci.yml',
+    branch: 'main',
+    action: 'open',
+    verdict,
+    issue: null,
+  });
+  assert.equal(result.issueNumber, 1234);
+  const create = gh.calls.find((c) => c[0] === 'issue' && c[1] === 'create');
+  assert.ok(create.includes(ALARM_LABEL), 'alarm issue must carry the lookup label');
+});
+
+test('main-health: resolving comments an all-clear and then closes', () => {
+  const gh = fakeGh();
+  const verdict = evaluateHealth([
+    run('success', '2026-07-28T00:00:00Z'),
+    run('success', '2026-07-27T00:00:00Z'),
+  ]);
+  deliverAlarm({
+    gh,
+    repo: 'o/r',
+    workflow: 'ci.yml',
+    branch: 'main',
+    action: 'resolve',
+    verdict,
+    issue: { number: 42 },
+  });
+  const verbs = gh.calls.map((c) => c.slice(0, 2).join(' '));
+  assert.deepEqual(verbs, ['issue comment', 'issue close']);
+});
+
+test('main-health: a failed issue upsert reports undelivered rather than swallowing it', () => {
+  const gh = fakeGh({ 'issue edit': new Error('HTTP 403: Resource not accessible') });
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+  ]);
+  const result = deliverAlarm({
+    gh,
+    repo: 'o/r',
+    workflow: 'ci.yml',
+    branch: 'main',
+    action: 'update',
+    verdict,
+    issue: { number: 42 },
+  });
+  assert.equal(result.delivered, false);
+  assert.match(result.error, /403/);
+});
+
+test('main-health: a dry run performs no writes', () => {
+  const gh = fakeGh();
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+  ]);
+  deliverAlarm({
+    gh,
+    repo: 'o/r',
+    workflow: 'ci.yml',
+    branch: 'main',
+    action: 'open',
+    verdict,
+    issue: null,
+    dryRun: true,
+  });
+  assert.deepEqual(gh.calls, []);
+});
+
+test('main-health: the open alarm is found by label and the lowest number wins', () => {
+  const gh = fakeGh({ 'issue list': '[{"number": 90, "title": "b"}, {"number": 42, "title": "a"}]' });
+  const found = findOpenAlarmIssue({ gh, repo: 'o/r' });
+  assert.equal(found.number, 42);
+  assert.ok(gh.calls[0].includes('--label'));
+  assert.ok(gh.calls[0].includes(ALARM_LABEL));
+});
+
+test('main-health: a missing label reads as no open alarm rather than crashing', () => {
+  const gh = fakeGh({ 'issue list': new Error('could not find any label named main-health-alarm') });
+  assert.equal(findOpenAlarmIssue({ gh, repo: 'o/r' }), null);
+});
+
+// --------------------------------------------------------------------------
+// Reporting — the summary must exist and show its denominator every run
+// --------------------------------------------------------------------------
+
+test('main-health: the summary states the denominator on every verdict', () => {
+  const ctx = { repo: 'o/r', workflow: 'ci.yml', branch: 'main', issueNumber: null };
+  for (const runs of [
+    [run('success', '2026-07-28T00:00:00Z'), run('success', '2026-07-27T00:00:00Z')],
+    [run('failure', '2026-07-28T00:00:00Z'), run('failure', '2026-07-27T00:00:00Z')],
+    [],
+  ]) {
+    const verdict = evaluateHealth(runs);
+    const summary = renderSummary(verdict, decideAction(verdict.state, false), ctx);
+    assert.match(summary, /Decisive runs resolved \| \*\*\d+\*\*/);
+    assert.match(summary, /Verdict:/);
+  }
+});
+
+test('main-health: an abstained summary is not labelled as a pass', () => {
+  const summary = renderSummary(evaluateHealth([]), 'none', {
+    repo: 'o/r',
+    workflow: 'ci.yml',
+    branch: 'main',
+    issueNumber: null,
+  });
+  assert.match(summary, /INDETERMINATE/);
+  assert.match(summary, /not a pass/);
+  assert.ok(!/HEALTHY/.test(summary.split('\n')[0]), 'the headline must not read healthy');
+});
+
+test('main-health: the issue body carries the marker, the streak, and the #987 rationale', () => {
+  const verdict = evaluateHealth([
+    run('failure', '2026-07-27T00:00:00Z'),
+    run('failure', '2026-07-26T00:00:00Z'),
+  ]);
+  const body = renderIssueBody(verdict, { repo: 'o/r', workflow: 'ci.yml', branch: 'main' });
+  assert.ok(body.startsWith(ALARM_MARKER));
+  assert.match(body, /2026-07-27T00:00:00Z/);
+  assert.match(body, /#987/);
+});


### PR DESCRIPTION
Closes the last checkbox on #987: _"Consider why 8 days of red `main` produced no alert — a scheduled main-health check, or a notification on `main` CI failure, would have surfaced this without someone stumbling into it from a PR."_

**Scope note:** this PR does **not** touch the failing `codex.test.ts` test. That is #987's own scope. This is only the watcher.

## What lands

| File | Why |
| --- | --- |
| `.github/workflows/main-health.yml` | scheduled + post-CI watcher |
| `scripts/main-health-check.mjs` | the whole rule, dependency-free |
| `tests/scripts/main-health-check.test.mjs` | 28 tests, fake `gh`, no network |
| `AGENTS.md` | documented alongside the pre-push gate note |

No changeset: nothing under `packages/*/src` or a package manifest changed, so `check-changesets` does not require one.

## Design decisions

### 1. Signal source and the health rule — the quiet one

Reads `GET /repos/{repo}/actions/workflows/ci.yml/runs?branch=main&event=push`.

**`main` is unhealthy when the most recent 2 _decisive_ runs both failed** (`MAIN_HEALTH_THRESHOLD`), not when the most recent run failed. The louder rule alarms on any single flake, and an alarm that fires on flakes is an alarm people mute — which is the exact failure mode #987 describes from the other direction (a red check that trains people to read red as normal). Two consecutive failures is still deep inside the eight-day window this exists to close, and a genuinely broken `main` fails *every* run, so the quieter rule loses nothing real.

**"Decisive" excludes `cancelled` and `skipped`.** CI runs `cancel-in-progress: true`, so rapid merges leave a trail of cancelled runs. `main`'s real history right now interleaves them with the failures:

```
2026-07-27T20:52  failure
2026-07-24T20:57  cancelled   <- says nothing about health
2026-07-24T21:07  failure
2026-07-23T19:31  cancelled   <- says nothing about health
2026-07-23T19:31  failure
```

Counting cancellations as failures would manufacture streaks out of merge cadence; counting them as successes would break real streaks. They are excluded from the denominator entirely. `timed_out` and `startup_failure` do count as failures.

### 2. Where the alarm lands

A **labelled tracking issue** (`main-health-alarm`), plus a **step summary on every run regardless of verdict**. A failing job alone would be no better than the red `main` it reports on — a red check nobody reads *is* the silence being fixed.

The issue is looked up **by label, not by `gh search`**. Search is index-backed and lags, and a lagging lookup is precisely how an upsert becomes a nightly duplicate.

### 3. Alarm on transition, not every run

| verdict | open alarm issue? | action |
| --- | --- | --- |
| unhealthy | no | **open** the tracking issue (green → red) |
| unhealthy | yes | **edit the body in place** — no comment, no second issue |
| healthy | yes | **comment all-clear + close** (red → green) |
| healthy | no | nothing |
| indeterminate | either | **nothing** — see below |

Still-red runs rewrite the body rather than appending a comment: a nightly comment on a long outage is how an alarm gets muted. The all-clear is deliberate — a watcher that only ever shouts is one people learn to filter.

### 4. Denominator discipline

If fewer decisive runs than the threshold can be resolved — renamed workflow file, API error, revoked `actions: read`, or a genuinely quiet branch — the check exits **3 INDETERMINATE** and the summary headline reads `❓ INDETERMINATE (abstained — not a pass)`. It never reports healthy on an empty denominator, and in that state it neither opens an alarm nor **closes a live one** (closing would fake an all-clear out of blindness).

Exit codes, all documented in the script header:

| code | meaning |
| --- | --- |
| `0` | HEALTHY |
| `1` | INTERNAL_ERROR — verdict unknown |
| `2` | UNHEALTHY — alarm raised/updated |
| `3` | INDETERMINATE — fewer than `threshold` decisive runs resolved. Explicitly not a pass |
| `4` | ALARM_UNDELIVERED — verdict computed, the issue write failed. Fails loudly so silence cannot read as health |

### 5. No step-level `continue-on-error`

None anywhere, and no job-level one either. This job is *meant* to go red when `main` is red, and red when it could not tell. The issue is the durable channel; the red job is the immediate one.

Two triggers on purpose: `workflow_run` on `CI` completion reacts within minutes of a transition, and the daily `schedule` is the arm that catches the silent failures — a renamed workflow, a revoked permission, or a `main` that stopped receiving pushes. The `workflow_run` arm structurally *cannot* detect "no runs at all", because it only fires when a run happens.

The workflow runs **no `pnpm install`** — the check is a dependency-free node script, so the watcher cannot be taken down by an install failure in the thing it watches.

## Proof

### Proof 1 — real repo state, reports `main` unhealthy right now

```
$ GITHUB_REPOSITORY=Intense-Visions/harness-engineering node scripts/main-health-check.mjs --dry-run
[dry-run] would open the alarm issue
## main CI health: 🚨 UNHEALTHY

| | |
| --- | --- |
| Repo | `Intense-Visions/harness-engineering` |
| Workflow | `ci.yml` on `main` |
| Decisive runs resolved | **19** (threshold 2) |
| Consecutive failures | **8** |
| Latest decisive run | [2026-07-27T20:52:05Z — failure](https://github.com/Intense-Visions/harness-engineering/actions/runs/30304409747) |
| Tracking issue | _none_ |

**Verdict:** The 8 most recent decisive run(s) failed (threshold 2).

**Alarm:** Opened a tracking issue (green → red transition).
EXIT=2
```

19 decisive runs resolved, 8 consecutive failures. That is the expected result and the proof the rule works — it was not loosened to make anything go green.

### Proof 2 — simulated healthy history reports healthy and does not alarm

Fake `gh` on `PATH` returning `success / cancelled / success`:

```
## main CI health: ✅ HEALTHY

| Decisive runs resolved | **2** (threshold 2) |
| Consecutive failures | **0** |
| Latest decisive run | [2026-07-28T00:00:00Z — success](https://x/1) |

**Verdict:** The most recent decisive run succeeded.
**Alarm:** No issue action: steady state, nothing changed.
HEALTHY: The most recent decisive run succeeded.
EXIT=0
```

Note the cancelled run was dropped from the denominator (3 runs in, 2 decisive), and **no `gh issue` write was attempted at all**.

### Proof 3 — zero runs takes the distinct non-zero exit

Fake `gh` returning `{"workflow_runs": []}`:

```
## main CI health: ❓ INDETERMINATE (abstained — not a pass)

| Decisive runs resolved | **0** (threshold 2) |
| Latest decisive run | _none_ |

**Verdict:** Zero decisive runs resolved — nothing was inspected, so health is unknown (not healthy).
**Alarm:** No issue action: the check could not see `main`, so it neither alarms nor clears.
INDETERMINATE: resolved 0 decisive run(s), fewer than the threshold of 2. Nothing was confirmed. Exiting 3.
EXIT=3
```

Exit `3`, distinct from both `0` and `2`.

### Tests

28 tests, all mocking `gh` — nothing touches the network. They cover the quiet rule (1 failure = flake, 2 = outage), cancelled-run exclusion including the real interleaved `main` shape, the four transitions, upsert-never-duplicates (asserts `issue create` and `issue comment` are *not* called on an update), abstention on zero/thin/malformed/failed-API responses, undelivered-alarm reporting, and that the summary always prints its denominator.

## Gates

| gate | result |
| --- | --- |
| `pnpm build` | pass (12/12) |
| `pnpm typecheck` | pass (20/20) |
| `pnpm lint` | pass (11/11) |
| `pnpm format:check` | pass |
| `pnpm test` | pass (24/24 tasks; cli 4966 tests) |
| `node --test tests/scripts/*.test.mjs` | pass — 53 tests (25 pre-existing + 28 new) |
| pre-commit hooks | pass |

`build-and-test` is **already red on `main`** (#987) and will be red here too. This change adds zero TypeScript and the full local suite is green, so it cannot be the cause — that failure is CI-environment-coupled, which is consistent with #987's own diagnosis.

Pre-existing, not introduced: `npx eslint scripts/*.mjs` reports `no-undef` on `process`/`console` because the root eslint config declares node globals only for `.ts`/`.mts`. `scripts/check-changesets.mjs` reports 25 of the same errors on untouched `main`. `pnpm lint` (turbo) only lints `packages/*/src`, so `scripts/` is not in any gate. Left alone rather than widening this PR's scope to the eslint config.

## Worth porting to consumer repos?

**Yes — the blind spot is not specific to this repo.** Nothing about the rule is harness-specific: it is ~150 lines of logic over the Actions runs API plus an issue upsert. Two things make it portable rather than a copy-paste: the workflow name, branch, and threshold are all env-driven, and the script has no dependencies (no `pnpm install` step to port).

The natural home is the `ci-required-review` template in `templates/`, which already renders a workflow + branch-protection wiring at `harness init` — a `ci-main-health` sibling would put the watcher in every scaffolded repo by default. Consumer repos are *more* exposed than this one, not less: they have fewer contributors opening PRs, so there are fewer chances for someone to stumble into a red `main` the way #987 was found.

One caveat before porting: the transition rule assumes the alarm issue is the only state store. A repo where humans hand-close the alarm issue while `main` is still red will get a fresh issue on the next run (correct, if noisy) — the issue body says not to do that.

Refs #987
