### PR TITLE
fix(cli): fail closed when block-no-verify cannot read stdin

### DIFF
--- a/.changeset/hook-stdin-fail-closed.md
+++ b/.changeset/hook-stdin-fail-closed.md
@@ -1,0 +1,24 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): block-no-verify hook must fail CLOSED when it cannot read stdin
+
+`block-no-verify` read its payload with `readFileSync(0)` and treated _any_
+throw as "no input", exiting 0 (allow). On a pipe that fd is non-blocking, so a
+read issued before the writer has filled the pipe throws `EAGAIN` — and the
+guard silently stopped enforcing while still reporting success. That is how
+`git commit --no-verify` could pass a hook that CI showed as green; it surfaced
+as an intermittent `expected +0 to be 2` on the macOS runner (run 30671939046).
+Issue #619 addressed the symptom by changing how the _test_ fed stdin, leaving
+the fail-open seam in the hook itself.
+
+Stdin reading moves to a shared `readHookStdin()` helper that retries while the
+pipe reports `EAGAIN` (bounded, 5s) and reports read success separately from
+read content. The hook now distinguishes the two cases that were conflated: a
+read that _failed_ means the guard is blind and it exits 2 (blocked), while a
+read that _succeeded and returned nothing_ is a legitimate empty invocation and
+stays fail-open, as do malformed JSON and a missing `tool_input`.
+
+Note: `protect-config.js` and `sentinel-pre.js` are also blocking guards with
+the same fail-open read seam and are tracked separately.

--- a/packages/cli/src/hooks/block-no-verify.js
+++ b/packages/cli/src/hooks/block-no-verify.js
@@ -4,18 +4,27 @@
 // Blocks git commands that use --no-verify to skip hooks.
 // Exit codes: 0 = allow, 2 = block
 
-import { readFileSync } from 'node:fs';
 import process from 'node:process';
 
+import { readHookStdin } from './read-hook-stdin.js';
+
 function main() {
-  let raw = '';
-  try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
-    // No stdin or read error — fail open
-    process.exit(0);
+  const stdin = readHookStdin();
+  if (!stdin.ok) {
+    // Fail CLOSED. A guard that cannot read the command it is guarding must not
+    // vouch for it — exiting 0 here is what let --no-verify through whenever the
+    // stdin pipe hiccuped, while CI still went green.
+    process.stderr.write(
+      `BLOCKED: could not read hook input (${stdin.error.code ?? stdin.error.message}); ` +
+        'refusing to allow the command unverified.\n'
+    );
+    process.exit(2);
   }
 
+  const raw = stdin.data;
+
+  // A successful read of nothing is a real "no payload" invocation, not a
+  // blind hook — that stays fail-open.
   if (!raw.trim()) {
     process.exit(0);
   }

--- a/packages/cli/src/hooks/read-hook-stdin.js
+++ b/packages/cli/src/hooks/read-hook-stdin.js
@@ -1,0 +1,60 @@
+// read-hook-stdin.js — resilient stdin reader shared by PreToolUse hooks.
+//
+// Why this exists: `readFileSync(0)` on a pipe can throw EAGAIN when the writer
+// hasn't filled the pipe yet — the fd is non-blocking and the read simply isn't
+// ready. Hooks that treated that throw as "no input" failed OPEN, so a guard
+// like block-no-verify silently stopped enforcing under CI load while still
+// reporting success (issue #619 patched the test, not this seam).
+//
+// The distinction that matters to a caller: a read that FAILED is not the same
+// as a read that succeeded and returned nothing. The former means the hook is
+// blind and must not vouch for the command; the latter is a legitimate
+// "hook invoked with no payload" and stays fail-open.
+
+import { Buffer } from 'node:buffer';
+import { readSync } from 'node:fs';
+
+const CHUNK_BYTES = 64 * 1024;
+const EAGAIN_DEADLINE_MS = 5000;
+const EAGAIN_BACKOFF_MS = 5;
+
+/** Synchronously sleep without spinning the CPU. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Read all of stdin, retrying while the pipe reports EAGAIN.
+ *
+ * @returns {{ ok: true, data: string } | { ok: false, error: Error }}
+ *   `ok: false` means the read genuinely failed and the caller is blind.
+ *   `ok: true` with `data: ''` means stdin was legitimately empty.
+ */
+export function readHookStdin() {
+  const chunks = [];
+  const buf = Buffer.alloc(CHUNK_BYTES);
+  const deadline = Date.now() + EAGAIN_DEADLINE_MS;
+
+  for (;;) {
+    let bytesRead;
+    try {
+      bytesRead = readSync(0, buf, 0, CHUNK_BYTES, null);
+    } catch (err) {
+      // Pipe not ready yet — the writer is still catching up. Retry until the
+      // deadline rather than mistaking backpressure for end-of-input.
+      if (err.code === 'EAGAIN') {
+        if (Date.now() >= deadline) return { ok: false, error: err };
+        sleepSync(EAGAIN_BACKOFF_MS);
+        continue;
+      }
+      // EOF is how some platforms signal a closed tty rather than a 0-byte read.
+      if (err.code === 'EOF') break;
+      return { ok: false, error: err };
+    }
+
+    if (bytesRead === 0) break;
+    chunks.push(Buffer.from(buf.subarray(0, bytesRead)));
+  }
+
+  return { ok: true, data: Buffer.concat(chunks).toString('utf-8') };
+}

--- a/packages/cli/tests/hooks/block-no-verify.test.ts
+++ b/packages/cli/tests/hooks/block-no-verify.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { closeSync, mkdtempSync, openSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 const HOOK_PATH = resolve(__dirname, '../../src/hooks/block-no-verify.js');
 
@@ -89,6 +91,51 @@ describe('block-no-verify', () => {
   it('fails open on empty stdin', () => {
     const { exitCode } = runHook('');
     expect(exitCode).toBe(0);
+  });
+
+  // Regression: the hook used to treat ANY stdin read failure as "no input" and
+  // exit 0, so a transient EAGAIN on the pipe silently disabled the guard while
+  // CI stayed green (macOS runner, run 30671939046). A blind guard must block.
+  // POSIX-only: both cases need a real pipe/fd shape that Windows shells and
+  // fd redirection don't reproduce. The bug manifested on the macOS runner.
+  const onPosix = process.platform === 'win32' ? describe.skip : describe;
+
+  onPosix('stdin read failure (fail closed)', () => {
+    it('blocks when the stdin read itself fails', () => {
+      // A directory opens fine but errors (EISDIR) on read — a read that
+      // genuinely failed, unlike /dev/null which reads 0 bytes successfully.
+      // Node substitutes /dev/null for a closed fd 0, so closing it won't do.
+      const dirFd = openSync(mkdtempSync(join(tmpdir(), 'hook-stdin-')), 'r');
+      try {
+        const result = spawnSync('node', [HOOK_PATH], {
+          stdio: [dirFd, 'pipe', 'pipe'],
+          encoding: 'utf-8',
+          timeout: 60000,
+        });
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain('could not read hook input');
+      } finally {
+        closeSync(dirFd);
+      }
+    });
+
+    it('still reads the full payload when the writer is slow', () => {
+      // Feed stdin from a pipe that delivers late — the shape that produced the
+      // spurious EAGAIN. The guard must wait for the payload, not fail open.
+      const command = JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'git push --no-verify' },
+      });
+      const result = spawnSync(
+        'bash',
+        [
+          '-c',
+          `sleep 0.4; printf '%s' ${JSON.stringify(command)} | node ${JSON.stringify(HOOK_PATH)}`,
+        ],
+        { encoding: 'utf-8', timeout: 60000 }
+      );
+      expect(result.status).toBe(2);
+    });
   });
 
   describe('argv-token boundary (issue #285)', () => {


### PR DESCRIPTION
Fixes the macOS half of the current `main` breakage (run [30671939046](https://github.com/Intense-Visions/harness-engineering/actions/runs/30671939046)). The Windows half is filed separately as #992.

## The bug is not the flaky test

`block-no-verify` read its payload with `readFileSync(0)` and treated **any** throw as "no input", exiting 0 — allow:

```js
try { raw = readFileSync(0, 'utf-8'); }
catch { process.exit(0); }   // ← guard silently stops enforcing
```

On a pipe, fd 0 is non-blocking, so a read issued before the writer has filled the pipe throws `EAGAIN`. When that happened the guard went blind and waved the command through **while still reporting success**. That is a `--no-verify` bypass hiding behind a green check — the CI failure (`expected +0 to be 2`) was the symptom that made it visible, not the defect itself.

Issue #619 already hit this once and fixed it by changing how the *test* fed stdin (see the comment at the top of the test file). The test went green; the fail-open seam in the hook was never touched. Worth being precise about the exposure: this is intermittent and load-dependent, so "we haven't seen a bypass" isn't evidence one didn't occur — the failure mode is silent by construction.

## The fix

Stdin reading moves to a shared `readHookStdin()` helper that retries while the pipe reports `EAGAIN` (bounded, 5s) and — the key change — **reports read success separately from read content**. That lets the hook tell apart two cases it was conflating:

| Case | Before | After |
|---|---|---|
| Read **failed** (`EAGAIN` exhausted, `EISDIR`, …) | exit 0 — allow | **exit 2 — block** |
| Read succeeded, returned nothing | exit 0 — allow | exit 0 — allow (unchanged) |
| Malformed JSON | exit 0 | exit 0 (unchanged) |
| Missing `tool_input` | exit 0 | exit 0 (unchanged) |

A guard that cannot read the command it is guarding must not vouch for it. Legitimately-empty invocations stay fail-open, so this doesn't turn ordinary no-payload calls into blocks.

## Regression test

The new test drives a **real** read failure rather than waiting for `EAGAIN` to recur: it opens a directory as fd 0, which reads `EISDIR`. Two notes for reviewers:

- Closing fd 0 does **not** work — Node substitutes `/dev/null`, which reads as empty rather than failing, so the test would pass against the broken hook. I hit this and corrected it.
- **Verified the test actually catches the bug**: reverted the hook, re-ran, and confirmed it fails with `expected +0 to be 2`. It is a real guard, not a test that merely passes.

The companion "slow writer" case is a sanity check, not the guard — `EAGAIN` doesn't reproduce deterministically on demand. Both new cases are POSIX-only; Windows shells don't reproduce the fd shape and the bug is pipe-specific.

## Verification

Run locally on macOS, Node 22 (repo pin):

- `block-no-verify.test.ts` — 16/16 pass
- `packages/cli` full suite — **455 files / 4968 tests pass**
- `lint` (exit 0), `typecheck` (exit 0), `build` (12/12 tasks)

One earlier full-suite run reported 2 failures, both `Timeout waiting for worker to respond` under load with different tests each time — vitest worker flakes, not assertion failures; clean on re-run. Flagging rather than burying it.

## Follow-up

`protect-config.js` and `sentinel-pre.js` are blocking guards with the identical fail-open seam, filed as #993 with the helper ready to adopt. Not fixed here to keep this PR scoped to what's breaking `main`.