### PR TITLE
docs+config: validated local-execution setup (guide, config, triage) + restore ship cruft-removal

### DIFF
--- a/.changeset/restore-ship-scratch-removal.md
+++ b/.changeset/restore-ship-scratch-removal.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+fix(orchestrator): remove scratch cruft (not just add-exclude) before ship
+
+Restores the ship-time scratch-file removal that was orphaned when the tidiness
+guardrails landed without their follow-up commit. Excluding cruft from `git add`
+is insufficient — the eval diff's `git add --intent-to-add` had already marked it,
+and lint-staged's pre-commit stash then fails ("Entry not uptodate. Cannot
+merge"), blocking the ship. `markUntrackedIntentToAdd` no longer marks scratch
+files, and the ship physically removes them (index + disk) before committing.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -181,6 +181,16 @@ approve/reject, and known limitations.
 
 **Best for:** Operators running an opt-in, self-managing local model pool
 
+### [Local-Model Execution](./local-execution.md)
+
+Run autonomous **contained** engineering/maintenance tasks on local models,
+on-device and safely: the validated coder/reasoner/judge setup, the
+`local-eligible` task-fit triage checklist, operating rules (scoped queue,
+enforced gates, bounded retries, fresh-server bursts), hardware notes, and the
+hybrid escalation variant.
+
+**Best for:** Operators evaluating or running local-model execution of scoped tasks
+
 ## How to Use These Guides
 
 1. **Start with Getting Started** if you're new to Harness Engineering

--- a/docs/guides/local-execution.md
+++ b/docs/guides/local-execution.md
@@ -1,0 +1,112 @@
+# Local-Model Execution (Operator Guide)
+
+Run autonomous **contained** engineering/maintenance tasks on **local models**, on-device, with no cloud calls — safely. This is the validated setup, operating rules, and task-fit envelope from an extended evaluation of local execution on this repo.
+
+> **TL;DR.** For **contained** tasks (a new lint rule, a small helper, a focused config change, a well-repro'd bugfix, doc/test upkeep) the local pipeline is useful **and safe** today: the enforced gates mean it either produces acceptable work or blocks/retries/escalates — it **never silently ships broken or spec-violating code**. For **complex logic** or **lights-out high-volume autonomy**, it is not there yet (model-capability ceiling + local GPU limits) — escalate those to a stronger model or a human.
+
+---
+
+## Why it's safe even when the model is imperfect
+
+The orchestrator enforces two gates **independently of the model**, after the staged workflow:
+
+1. **Mechanical gate** — typecheck + lint + the full test suite of every touched package (no `--no-verify`).
+2. **Spec-vs-diff outcome-eval** — a reasoner-as-judge compares the change to the spec; a high-confidence `NOT_SATISFIED` blocks.
+
+A block re-dispatches with the failure threaded back; retry exhaustion halts to **needs-human**. So the open question is _throughput_ (how often it lands clean), never _safety_.
+
+---
+
+## The task-fit envelope — `local-eligible` triage checklist
+
+Route a task to local execution only if **all** of these hold. Otherwise escalate to a stronger model or a human.
+
+- [ ] **Single concern, contained blast radius** — one feature/fix in one area; not a cross-module refactor.
+- [ ] **Clear, testable acceptance** — you can state what "done" looks like and it's checkable by tests.
+- [ ] **Pattern to follow** — there's an existing example in the repo to mirror (a sibling rule, a similar handler).
+- [ ] **Bounded new logic** — no non-trivial algorithm, subtle type/AST narrowing, or deep cross-file reasoning. (This is the hard ceiling: the local coder does simple `MemberExpression`-shaped logic well, but stalls on multi-form AST detection.)
+- [ ] **Minimal collateral wiring** — if it needs fiddly multi-site registration (a barrel/index, several configs), first make that **auto-derived** (see "Reduce collateral surface"); a weak coder reliably fumbles precise multi-file edits.
+- [ ] **Well-specified** — a short, concrete work item (the design stage produces a real spec, but a vague ask amplifies drift).
+
+**Good fits:** new ESLint rule with a single AST pattern; a focused bugfix with a repro; a small utility + its test; adding a doc entry; a mechanical, pattern-following change.
+**Escalate:** complex algorithms; type-system/AST subtlety; cross-cutting refactors; anything security-sensitive or architecture-defining.
+
+---
+
+## The validated configuration
+
+Three roles, each on the model that suits it:
+
+| Role         | Stage(s)                                             | Backend / model                                                 | Why                                                                                                                                          |
+| ------------ | ---------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Coder**    | execution, verification                              | **Codex** driving **qwen3-coder:30b** (`reasoningEffort: none`) | Codex's edit + self-verify + retry loop converges where a bare tool-loop stalls; `none` is required (the model rejects a reasoning request). |
+| **Reasoner** | design, planning, review (`cognitiveMode: thinking`) | **qwen3.6:27b**, reasoning ON                                   | Writes the spec/plan the coder builds against; the `<think>` trace helps design.                                                             |
+| **Judge**    | settle-gate outcome-eval                             | **gpt-oss:20b** (fast, non-reasoning)                           | ~8s spec-vs-diff verdict; a reasoning model is unusable on `/v1`; more independent than the coder judging itself.                            |
+
+The complete, copy-paste config lives at **`templates/orchestrator/harness.orchestrator.local.md`**. Key points:
+
+- `routing.default: codex-exec` (fully-local); `routing.modes.thinking: reasoner`; `routing.intelligence.sel: judge`.
+- Curated MCP tool allowlist (~a dozen lifecycle tools), not the full ~99-tool flood, which makes a local model over-explore.
+- A staged `local-full-workflow` (design → plan → execute → verify → review) with the gates enforced at settle.
+- `escalation.maxLocalStageRetries: 4`, then halt to needs-human.
+
+---
+
+## Operating rules (do these)
+
+1. **Scope the queue.** The orchestrator picks every `planned`/`in-progress` row by Status. Point `tracker.filePath` at a **curated `local-eligible` queue** (e.g. `.harness/local-queue.roadmap.md`), not your whole roadmap. Add only tasks that pass the checklist above, and **name each row `local-<slug>`** — the staged `local-full-workflow` matches on the `local-` identifier prefix, so the prefix is what enrolls a task in the full design→…→review lifecycle.
+2. **Gates on, always.** Never `--no-verify`. The gates are the safety layer.
+3. **Fresh model server per session.** Long multi-hour runs degrade the local model server (model-swapping starves the coder → empty executions). `brew services restart ollama` (or equivalent) before a run; prefer **short supervised bursts** over lights-out all-day.
+4. **Bound and escalate.** `maxLocalStageRetries: 3–5`, then needs-human (or, in the hybrid variant, hand off to the cloud backend). Don't grind for hours.
+5. **Reduce collateral surface.** Where a task class needs fiddly multi-site edits, eliminate the edit via generation (see below) — it converts coin-flips into reliable passes.
+
+### Reduce collateral surface (the highest-leverage reliability move)
+
+The single biggest reliability win in the evaluation was making a required multi-site edit **unnecessary**: e.g. the ESLint rule **barrel is auto-generated** from the rule files (a rule's basename is its name, its default export is the rule), so adding a rule is a single self-contained file drop — no barrel edit to fumble. Apply the same principle wherever local tasks must touch a shared index/config/registry.
+
+---
+
+## Running it (this repo)
+
+```bash
+# 1. Fresh model server (avoids multi-hour degradation)
+brew services restart ollama
+
+# 2. Ensure the models are present
+ollama list        # expect: qwen3-coder:30b, qwen3.6:27b, gpt-oss:20b
+
+# 3. Launch the orchestrator against the local config + curated queue
+node packages/cli/dist/bin/harness.js orchestrator run \
+  --workflow templates/orchestrator/harness.orchestrator.local.md --headless
+```
+
+Supervise the run; each unit goes design → plan → execute → verify → review → gate → ship (a PR). On a block it retries with feedback; on exhaustion it halts to needs-human. (When dogfooding this repo, point the config's harness MCP server at the built dist — `node packages/cli/dist/bin/harness-mcp.js` — so it reflects local changes; adopters use the installed `harness-mcp`.)
+
+---
+
+## Hardware notes
+
+64 GB works, but the reasoner + coder can't co-reside, so they swap — which is what degrades long runs. Two ways to remove that wall:
+
+- **More VRAM** so both models stay resident.
+- **Coder-only local** — drop the local reasoner and route design/judge to a cheap cloud call (or the hybrid backend), so nothing swaps.
+
+On 64 GB strictly local: prefer short bursts + a fresh server restart per session.
+
+---
+
+## Hybrid variant (widens the envelope with ~zero extra work)
+
+Add the cloud backend as an **escalation target**: local handles `local-eligible` tasks; anything classified complex (or that exhausts local retries) routes to the cloud backend instead of a human. You keep on-device economics for the bulk of small tasks and get frontier capability exactly where local stalls. It's a routing change, not new machinery: set `routing.default: primary` (or route only complex tiers to it) in the config.
+
+> Not recommended: NVMe **weight-streaming** engines (running a frontier MoE from disk) for the execution loop — at ~0.5–7 tok/s they're 10–100× too slow for turn-heavy agentic coding. They may fit a rare, latency-tolerant single-shot call (a design decision, a judge verdict), not the loop.
+
+---
+
+## What the evaluation actually showed
+
+- The pipeline mechanics, gates, and reasoner-as-judge are **sound and validated end-to-end** — a clean run produced a correct rule + matching test + appended doc, passed both gates (`SATISFIED`), and reached ship.
+- Most early "local can't do this" turned out to be **harness bugs, not model limits** — each was fixed (stage deadlines, the codex reasoning request, the eval diff hiding new files / drowning in noise, process-group kill on abort, barrel auto-discovery, scratch-cruft handling).
+- The residual walls are real but **specific**: (a) the coder's **capability ceiling** on complex logic, (b) **per-run tidiness variance** (mitigated by guardrails + surface reduction), and (c) **local GPU degradation** over multi-hour runs. None block _safe, scoped, supervised_ use today.
+
+**Bottom line:** use it now for scoped, gated, supervised contained maintenance; escalate complex work; revisit lights-out autonomy when the executor and hardware improve.

--- a/harness.orchestrator.local.md
+++ b/harness.orchestrator.local.md
@@ -1,7 +1,20 @@
 ---
+# ─────────────────────────────────────────────────────────────────────────────
+# LOCAL-EXECUTION orchestrator config — the validated, fully-local setup for
+# autonomous CONTAINED maintenance/engineering tasks (on-device, NO cloud calls).
+# The enforced gates make it SAFE: it blocks/retries/escalates and NEVER ships
+# broken or spec-violating work. Full operator guide, task-fit envelope, operating
+# rules, hardware notes, and the hybrid variant: docs/guides/local-execution.md.
+#
+# SCOPE IT: the orchestrator picks every planned/in-progress row by Status, so
+# `tracker.filePath` points at a CURATED local-eligible QUEUE (only contained
+# tasks — see the triage checklist in the guide), NOT your whole roadmap. Complex
+# logic / cross-module refactors are above the local coder's ceiling — keep them
+# out, or use the hybrid variant to escalate them to `primary`.
+# ─────────────────────────────────────────────────────────────────────────────
 tracker:
   kind: roadmap
-  filePath: docs/roadmap.md
+  filePath: .harness/local-queue.roadmap.md
   activeStates: [planned, in-progress]
   terminalStates: [done]
 polling:
@@ -9,239 +22,197 @@ polling:
 workspace:
   root: .harness/workspaces
 hooks:
-  afterCreate: null
+  # Install deps AND build the CLI so the worktree's pre-commit gate
+  # (`harness ci check`) actually RUNS — the ship commits/pushes THROUGH the real
+  # gates (no --no-verify). Adopters on other ecosystems substitute their install.
+  afterCreate: 'pnpm install --prefer-offline && pnpm --filter @harness-engineering/cli... run build'
   beforeRun: null
   afterRun: null
   beforeRemove: null
   timeoutMs: 60000
 agent:
-  # Named backend definitions (Spec 2). See docs/guides/multi-backend-routing.md.
-  # `capabilities` (tier/cost/privacy/context) let AMR compare backends and select a
-  # capability tier per dispatch — a backend without one is invisible to tier selection.
   backends:
+    # Cloud backend — present ONLY for the hybrid variant to escalate to; kept OUT
+    # of `routing` below so this config is fully-local by default.
     primary:
       type: claude
       command: claude
       capabilities:
         { tier: strong, costPer1kTokens: 15, privacyClass: shared-cloud, contextWindow: 200000 }
-    # Local backend for autonomous execution of simple tasks.
-    # `model` accepts a string OR a prefer-and-fallback array — first
-    # match wins after a `/v1/models` probe.
+
+    # Direct-ollama coder for quick-fix/diagnostic (single-shot) routes. Curated
+    # MCP tool allowlist — NOT the full ~99-tool flood, which makes a local model
+    # over-explore. Precise agentic-coding sampling (not ollama's hot default).
     local:
       type: ollama
-      # Ollama's OpenAI-compatible API lives under /v1 (the resolver probes
-      # `${endpoint}/models`). Names must match `ollama list` exactly.
       endpoint: http://127.0.0.1:11434/v1
-      # Prefer-and-fallback: first name present in /v1/models wins. Coder model
-      # first (local routes are quick-fix/diagnostic), general model as fallback.
-      # Quote the names — the ':tag' colon otherwise breaks YAML flow parsing.
-      model: ['qwen2.5-coder:7b', 'gemma3n:e4b']
-      # Qwen3 reasons by default; Ollama /v1 ignores reasoning:false, so disable it
+      model: ['qwen3-coder:30b']
       disableReasoning: true
+      temperature: 0.6
+      topP: 0.95
+      topK: 20
+      numCtx: 65536
       capabilities:
-        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
-      # Optional: give the local agent tools from MCP servers, merged with its
-      # built-in bash/read_file/write_file. Tools are namespaced `<server>__<tool>`;
-      # a server that fails to start is skipped (never breaks the dispatch). Default
-      # (unset) = built-ins only. See docs/guides/multi-backend-routing.md#mcp-tools.
-      # mcpServers:
-      #   - name: context7        # live library docs — stop coding from stale memory
-      #     command: npx
-      #     args: ['-y', '@upstash/context7-mcp']
-      #   - name: harness          # code_search / ask_graph / review_changes /
-      #     command: harness-mcp    # outcome_eval, run against the agent's workspace
-      #     tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]
-      #                             # narrow harness's ~95 tools to the read-oriented set
-      #                             # so a local model isn't flooded (omit tools = all).
-    # Local REASONING backend for the DESIGN phases of a staged workflow
-    # (cognitiveMode: thinking). A larger reasoning model (qwen3:32b) with
-    # reasoning LEFT ON — the design stages benefit from the <think> trace, so
-    # unlike the `local` coder we do NOT set disableReasoning. routing.modes.thinking
-    # points here (see routing.modes below).
+        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 65536 }
+      mcpServers:
+        - name: context7
+          command: npx
+          args: ['-y', '@upstash/context7-mcp']
+        - name: harness
+          command: harness-mcp # dogfooding this repo? use: node packages/cli/dist/bin/harness-mcp.js
+          tools:
+            [
+              manage_roadmap,
+              code_search,
+              code_outline,
+              ask_graph,
+              gather_context,
+              find_context_for,
+              review_changes,
+              run_code_review,
+              run_ci_checks,
+              outcome_eval,
+              acceptance_eval,
+              spec_craft,
+              test_craft,
+            ]
+
+    # CODER (execution + verification) — Codex driving the local coder. Codex's
+    # edit + self-verify + retry loop converges where a bare tool-loop stalls.
+    # `reasoningEffort: none` is REQUIRED: qwen3-coder does not support thinking and
+    # current ollama rejects a reasoning request outright ("does not support
+    # thinking"), zeroing the coder; codex's DEFAULT still sends one, so `none` (not
+    # omission) is the fix. routing.default points here.
+    codex-exec:
+      type: codex
+      model: ['qwen3-coder:30b']
+      localProvider: ollama
+      reasoningEffort: none
+      mcpServers:
+        - name: context7
+          command: npx
+          args: ['-y', '@upstash/context7-mcp']
+        - name: harness
+          command: harness-mcp # dogfooding this repo? use: node packages/cli/dist/bin/harness-mcp.js
+          tools: [code_search, code_outline, ask_graph, gather_context, review_changes]
+
+    # REASONER (design + planning + review — cognitiveMode: thinking). Thinking
+    # model with reasoning LEFT ON; writes the spec/plan the coder builds against.
     reasoner:
       type: ollama
       endpoint: http://127.0.0.1:11434/v1
-      model: ['qwen3:32b']
-      # Reasoning stays ON for design (thinking) stages — this is the reasoner.
+      model: ['qwen3.6:27b']
       disableReasoning: false
       capabilities:
-        { tier: strong, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
-  # Routing — controls WHICH backend handles each use case.
+        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 65536 }
+
+    # JUDGE (the settle-gate outcome-eval / spec-vs-diff verdict). A FAST
+    # NON-reasoning model — a reasoning model is unusable on /v1 (empty content or
+    # multi-minute stalls). gpt-oss:20b returns a correct verdict in ~8s and is more
+    # INDEPENDENT than the coder judging its own work.
+    judge:
+      type: ollama
+      endpoint: http://127.0.0.1:11434/v1
+      model: ['gpt-oss:20b', 'qwen3-coder:30b']
+      disableReasoning: true
+      capabilities:
+        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
+
   routing:
-    default: primary
+    # Fully-local: execution/verification → codex-exec. `primary` (claude) is kept
+    # OUT of routing. HYBRID variant: set `default: primary` (or route only complex
+    # tiers to it) to escalate hard work — see the guide.
+    default: codex-exec
     quick-fix: local
     diagnostic: local
-    # Per-phase routing: a staged workflow's DESIGN stages (cognitiveMode: thinking)
-    # route here — to the local reasoner — while its execution stages carry no
-    # cognitiveMode and fall to routing.default. See the `workflows:` decl below.
+    # Per-phase: design/plan/review stages carry `cognitiveMode: thinking` → reasoner;
+    # execution/verify carry none → routing.default.
     modes:
       thinking: reasoner
-    # Route the intelligence pipeline (sel/pesl) to the local backend.
+    # Analysis/judge layer (outcome-eval at the enforced gate) → the fast judge.
     intelligence:
-      sel: local
-      pesl: local
-    # AMR (Adaptive Model Routing) — opt-in; its PRESENCE flips dispatch from the
-    # identity/default chain to complexity-aware tier selection. trivial/simple →
-    # local (fast, free); moderate/complex → claude (no `standard` backend, so a
-    # `standard` requirement resolves to the cheapest backend at-or-above it =
-    # primary). The always-on baseline-relative security-defect feeder climbs a
-    # unit's tier after `escalationThreshold` consecutive quality failures
-    # (strong-capped, then hard-fails to a human). Budget cap + LLM acceptance-eval
-    # are available opt-ins (docs/guides/adaptive-model-routing.md) — left off here.
-    policy:
-      complexityTierMatrix: { trivial: fast, simple: fast, moderate: standard, complex: strong }
-      escalationThreshold: 2
-  # Escalation — controls WHETHER a tier dispatches at all (orthogonal to routing).
+      sel: judge
+  # Bound the loop, then escalate — never grind forever. Exhaustion → needs-human
+  # (or, in the hybrid variant, hand off to primary).
   escalation:
+    maxLocalStageRetries: 4
     alwaysHuman: [full-exploration]
-    autoExecute: [quick-fix, diagnostic]
-    primaryExecute: [guided-change]
-    signalGated: []
-    diagnosticRetryBudget: 1
   maxConcurrentAgents: 1
-  maxTurns: 10
-  maxRetryBackoffMs: 5000
-  maxConcurrentAgentsByState: {}
-  globalCooldownMs: 60000
-  maxRequestsPerMinute: 50
-  maxRequestsPerSecond: 1
-  # Default limits based on Anthropic Tier 3. Adjust according to your account tier.
-  # Tier 1: 40k ITPM / 10k OTPM
-  # Tier 2: 200k ITPM / 40k OTPM
-  # Tier 3: 400k ITPM / 80k OTPM
-  # Tier 4: 1m ITPM / 200k OTPM
-  maxInputTokensPerMinute: 400000
-  maxOutputTokensPerMinute: 80000
-  turnTimeoutMs: 300000
-  readTimeoutMs: 30000
-  stallTimeoutMs: 60000
-# Staged workflows (per-phase routing). A matched unit is dispatched as ONE
-# multi-stage run on a single worktree instead of chained skill invocations:
-# the DESIGN stages carry `cognitiveMode: thinking` and route to
-# routing.modes.thinking (the local `reasoner`); the EXECUTION stages carry no
-# cognitiveMode and fall to routing.default. Each stage's prior output threads
-# to the next over the text channel (expects/produces). A local-endpoint routed
-# stage renders the `harness skill run <skill> --autonomous` indirection prompt
-# automatically. `workflowFor` only returns a plan for a decl with >= 2 stages.
+
+# Staged local workflow — the real lifecycle as discrete, persona-routed stages.
+# design/plan/review carry cognitiveMode: thinking (→ reasoner); execution/verify
+# fall to routing.default (→ codex-exec). After review the orchestrator ENFORCES
+# the gates: mechanical (typecheck+lint+test) + spec-vs-diff outcome-eval; a
+# high-confidence NOT_SATISFIED blocks + re-dispatches with the failure threaded
+# back. match identifierPrefix 'local-' — name local-eligible queue rows 'local-<slug>' (see the guide).
 workflows:
   - name: local-full-workflow
-    match: { identifierPrefix: 'LOCAL-' }
+    match: { identifierPrefix: 'local-' }
     stages:
-      - { skill: harness-brainstorming, cognitiveMode: thinking, produces: spec }
-      - { skill: harness-planning, cognitiveMode: thinking, expects: spec, produces: plan }
+      - { skill: harness-brainstorming, cognitiveMode: thinking, produces: spec, checkpoint: true }
+      - {
+          skill: harness-planning,
+          cognitiveMode: thinking,
+          expects: spec,
+          produces: plan,
+          checkpoint: true,
+        }
       - { skill: harness-execution, expects: plan, produces: impl }
       - { skill: harness-verification, expects: impl, produces: verify }
+      - { skill: harness-code-review, cognitiveMode: thinking, expects: impl, produces: review }
+
+# Intelligence pipeline off by default (the enforced outcome-eval gate builds its
+# provider from the judge backend directly — see the guide). Enable for AMR.
 intelligence:
-  enabled: true
-  requestTimeoutMs: 180000
+  enabled: false
 server:
-  port: 8080
-localModels:
-  enabled: true
-  pool:
-    diskBudgetGb: 100
-    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google, openai, zai-org, THUDM, moonshotai]
-    allowedFamilies: []
-  refresh:
-    intervalMs: 86400000
-    proposalThreshold: 5
-    jitterMs: 600000
-  installer:
-    backend: ollama
-    ollamaEndpoint: http://127.0.0.1:11434
-# Built-in maintenance tasks run on cron when `maintenance.enabled: true`.
-# Notable housekeeping tasks: `main-sync` (every 15 min) fast-forwards the
-# orchestrator's local default branch from origin so files read from `cwd`
-# (e.g., docs/roadmap.md, harness.orchestrator.md) stay current. Sync is
-# fast-forward-only — never destructive — and skips with a structured
-# warning event if the working tree is dirty, the branch is wrong, or the
-# local default has diverged. Disable all maintenance via `maintenance.enabled: false`.
-#
-# Per-task Run Now (since 2026-05-09): the dashboard Maintenance page renders
-# a Run Now button on every row of the schedule table. The previous single-
-# button affordance (which always triggered `project-health`) has been
-# removed. Each button is disabled while a `maintenance:started` event is in
-# flight for that task ID and re-enables on the matching `maintenance:completed`
-# or `maintenance:error` event.
-maintenance:
-  enabled: true
+  enabled: false
 ---
 
-# Prompt Template (Local Backend — bootstrap shim)
+# Prompt Template (local single-agent fallback)
 
-You are a local agent with `bash`, `read`, `write`, `grep`, and `find`. You do
-NOT have `/harness:*` slash commands or harness MCP tools. You run the REAL
-harness workflow skills by reading them over bash — this template carries no
-methodology of its own.
+This body is used ONLY for a unit that does NOT match a staged `workflows:` decl
+(the staged path renders its own per-stage prompts). You are an autonomous agent
+working exactly as a real harness session would. In addition to bash/read/write
+you have the harness MCP toolset (namespaced `harness__*` on the ollama path; on
+the codex path, use codex's own edit/patch + the injected read tools) — USE the
+real tools when a skill calls for them instead of approximating with bash.
 
 ## Issue: {{ issue.title }}
 
 **Identifier:** {{ issue.identifier }}
 **Description:** {{ issue.description }}
 
-## How to run a harness skill (the indirection rule)
-
-To run any harness workflow skill, execute it over bash and follow its output
-**verbatim**:
+## Run a harness skill (the indirection rule)
 
 ```bash
 harness skill run <skill-name> --autonomous --path .
 ```
 
-`harness skill run` prints the skill's full instructions (the same content the
-primary backend gets from a `/harness:*` slash command) to stdout as a plain CLI
-read. `--autonomous` prepends the headless-decider preamble: you do the full
-analysis at full rigor but YOU decide every fork and record it in the spec — you
-never pause for a human.
+`harness skill run` prints the skill's full instructions to stdout; `--autonomous`
+means YOU decide every fork at full rigor and never pause for a human. Whenever a
+skill's output says to run `/harness:X`, run `harness skill run harness-X
+--autonomous` instead.
 
-**Redirect rule.** Whenever a skill's output instructs you to run `/harness:X`,
-instead run `harness skill run harness-X --autonomous`. Slash commands are
-unavailable on this backend; the skill-run indirection is their equivalent.
+## Editing existing files: surgical edits only, never rewrite a whole file
 
-## Full-workflow entry sequence
-
-Run these in order, each via `harness skill run <name> --autonomous --path .`,
-following each skill's output before moving on:
-
-1. `harness-brainstorming` — runs at full rigor (≥2 approaches, YAGNI, persona
-   council, soundness), but YOU decide the forks (autonomous) and record each
-   decision in the spec.
-2. `harness-planning`
-3. `harness-execution` (or `harness-tdd` for test-driven work)
-4. `harness-verification`
-5. `harness-code-review`
-
-Run `harness skill list` to see the full roster of available skills.
-
-> **Staged dispatch (per-phase routing).** When a unit matches `local-full-workflow`
-> (frontmatter), design stages (`cognitiveMode: thinking`) route to the local reasoner and execution stages to `routing.default`, chained automatically for you.
+Change only the exact lines that must change; APPEND to existing docs/lists (never
+regenerate a shared file from scratch — that drops other entries); never leave
+backup/scratch files (`*.bak`, `temp_*`). Actually RUN any test you author and
+confirm it passes against your implementation.
 
 ## Gates (enforced by the harness, not just by you)
 
-The orchestrator INDEPENDENTLY enforces `harness validate` plus the
-verify/outcome-eval gates against your branch after you exit — you cannot ship
-past a red gate. Reach a green state: run `harness validate` and the project's
-own typecheck/lint/test yourself and fix every failure before shipping. A run
-that cannot reach green is halted and re-dispatched rather than shipped, and
-escalated to a human if the retry budget is exhausted.
+The orchestrator INDEPENDENTLY enforces `harness validate` plus typecheck + lint +
+the full test suite, and a spec-vs-diff outcome-eval, against your branch — you
+cannot ship past a red gate. Reach a green state yourself (run `harness validate`
+and the project's typecheck/lint/test and fix every failure); a run that can't is
+halted and re-dispatched, and escalated to a human when the retry budget is
+exhausted.
 
 ## Ship (only after the gates are green)
 
-- Create a topic branch if you are still on `main`/`master`
-  (e.g. `feat/{{ issue.identifier }}`).
-- Stage your changes and create a descriptive commit (Conventional Commits style).
-- Push the branch with `git push -u origin HEAD`.
-- Open a pull request with `gh pr create`. Use a HEREDOC for the body:
-
-  ```bash
-  gh pr create --title "<title>" --body "$(cat <<'EOF'
-  ## Summary
-
-  <body content with real newlines>
-  EOF
-  )"
-  ```
-
-- Report the PR URL as your final output, then stop.
+Create a topic branch, commit (Conventional Commits), `git push -u origin HEAD`,
+open a PR with `gh pr create`, report the PR URL, then stop.
 
 Attempt Number: {{ attempt }}

--- a/packages/orchestrator/src/workspace/manager.ship.test.ts
+++ b/packages/orchestrator/src/workspace/manager.ship.test.ts
@@ -112,13 +112,19 @@ describe('WorkspaceManager.shipWorkspace (D4)', () => {
     expect(result.value.branch).toBe('orchestrator/iss-1');
     expect(result.value.prUrl).toBe('https://github.com/o/r/pull/42');
 
-    // Sequence: add -A → commit → switch -c (slash-prefixed) → push -u → gh pr create.
+    // Sequence: rm/clean scratch cruft → add -A → commit → switch -c → push -u → gh pr create.
+    // Agent scratch/backup cruft is physically removed (index + disk) BEFORE staging,
+    // so it never lands in the PR and can't break lint-staged's pre-commit stash.
+    const rmCruft = wm.gitCalls.find((c) => c[0] === 'rm' && c.includes('--cached'));
+    const cleanCruft = wm.gitCalls.find((c) => c[0] === 'clean');
+    expect(rmCruft).toContain(':(glob)**/*.bak');
+    expect(cleanCruft).toContain(':(glob)**/temp_*');
     const add = wm.gitCalls.find((c) => c[0] === 'add');
-    // Stages everything under the worktree EXCEPT agent scratch/backup cruft, so a
-    // coder's leftover `*.bak`/`temp_*` files never land in the PR.
-    expect(add?.slice(0, 4)).toEqual(['add', '-A', '--', '.']);
-    expect(add).toContain(':(exclude,glob)**/*.bak');
-    expect(add).toContain(':(exclude,glob)**/temp_*');
+    expect(add).toEqual(['add', '-A']);
+    // Cleanup precedes staging.
+    expect(wm.gitCalls.findIndex((c) => c[0] === 'clean')).toBeLessThan(
+      wm.gitCalls.findIndex((c) => c[0] === 'add')
+    );
     const commit = wm.gitCalls.find((c) => c[0] === 'commit');
     // Commit runs THROUGH the real pre-commit gate (no --no-verify) — the worktree
     // builds the CLI so `harness ci check` runs; a block feeds back for remediation.

--- a/packages/orchestrator/src/workspace/manager.ts
+++ b/packages/orchestrator/src/workspace/manager.ts
@@ -169,10 +169,41 @@ export class WorkspaceManager {
    */
   private async markUntrackedIntentToAdd(workspacePath: string): Promise<void> {
     try {
-      await this.git(['add', '--intent-to-add', '--', '.'], workspacePath);
+      // Exclude scratch/backup cruft: intent-to-adding it would both surface it in
+      // the eval diff AND leave an index entry that later makes lint-staged's
+      // pre-commit stash fail ("not uptodate, cannot merge") at ship time.
+      const scratch = WorkspaceManager.SCRATCH_GLOBS.map((g) => `:(exclude,glob)${g}`);
+      await this.git(['add', '--intent-to-add', '--', '.', ...scratch], workspacePath);
     } catch {
       // Non-fatal: without intent-to-add the diff is tracked-only (the prior
       // behavior), never an error that aborts the gate.
+    }
+  }
+
+  /**
+   * Physically remove agent scratch/backup cruft ({@link SCRATCH_GLOBS}) from the
+   * worktree before a ship commit. Clears the index entry (in case it was marked
+   * intent-to-add) THEN deletes the on-disk file, so: (a) the cruft never lands in
+   * the PR, and (b) lint-staged's pre-commit stash can't fail on an intent-to-add
+   * cruft file ("Entry … not uptodate. Cannot merge."). Glob pathspecs, tolerant
+   * of no match; best-effort — a failure never blocks the ship.
+   */
+  private async removeScratchFiles(workspacePath: string): Promise<void> {
+    const scratch = WorkspaceManager.SCRATCH_GLOBS.map((g) => `:(glob)${g}`);
+    try {
+      // Un-index any staged/intent-to-add cruft so `git clean` can then remove it.
+      await this.git(
+        ['rm', '-rf', '--cached', '--ignore-unmatch', '--', ...scratch],
+        workspacePath
+      );
+    } catch {
+      // no match / nothing staged — fine.
+    }
+    try {
+      // Delete the (now-untracked) cruft from disk.
+      await this.git(['clean', '-fq', '--', ...scratch], workspacePath);
+    } catch {
+      // nothing to clean — fine.
     }
   }
 
@@ -603,16 +634,19 @@ export class WorkspaceManager {
         }
       }
 
+      // 0. Physically remove agent scratch/backup cruft (*.bak/temp_*/…) BEFORE
+      //    staging: it must not land in the PR, and a lingering intent-to-add mark
+      //    on it (from the eval diff's `git add -N`) otherwise makes lint-staged's
+      //    pre-commit stash fail ("not uptodate, cannot merge"). Removal (not just
+      //    add-exclusion) is what actually unblocks the commit.
+      await this.removeScratchFiles(workspacePath);
+
       // 1. Commit the accumulated uncommitted work — but only if the tree is
       //    dirty. A `git commit` on a clean tree exits non-zero; probing
       //    porcelain status first keeps a no-op commit from failing the flow.
       const status = (await this.git(['status', '--porcelain'], workspacePath)).trim();
       if (status.length > 0) {
-        // Stage everything EXCEPT agent scratch/backup cruft, so a coder's leftover
-        // `*.bak`/`temp_*` files never land in the PR (glob pathspec excludes; they
-        // stay untracked on disk, harmless). Mirrors the eval-diff's SCRATCH_GLOBS.
-        const scratchExcludes = WorkspaceManager.SCRATCH_GLOBS.map((g) => `:(exclude,glob)${g}`);
-        await this.git(['add', '-A', '--', '.', ...scratchExcludes], workspacePath);
+        await this.git(['add', '-A'], workspacePath);
         // Commit THROUGH the real pre-commit gate (no --no-verify): the autonomous
         // ship must not bypass the gates a human push hits — it fixes what they flag,
         // like a real session. The worktree's `afterCreate` builds the CLI so

--- a/templates/orchestrator/harness.orchestrator.local.md
+++ b/templates/orchestrator/harness.orchestrator.local.md
@@ -1,7 +1,20 @@
 ---
+# ─────────────────────────────────────────────────────────────────────────────
+# LOCAL-EXECUTION orchestrator config — the validated, fully-local setup for
+# autonomous CONTAINED maintenance/engineering tasks (on-device, NO cloud calls).
+# The enforced gates make it SAFE: it blocks/retries/escalates and NEVER ships
+# broken or spec-violating work. Full operator guide, task-fit envelope, operating
+# rules, hardware notes, and the hybrid variant: docs/guides/local-execution.md.
+#
+# SCOPE IT: the orchestrator picks every planned/in-progress row by Status, so
+# `tracker.filePath` points at a CURATED local-eligible QUEUE (only contained
+# tasks — see the triage checklist in the guide), NOT your whole roadmap. Complex
+# logic / cross-module refactors are above the local coder's ceiling — keep them
+# out, or use the hybrid variant to escalate them to `primary`.
+# ─────────────────────────────────────────────────────────────────────────────
 tracker:
   kind: roadmap
-  filePath: docs/roadmap.md
+  filePath: .harness/local-queue.roadmap.md
   activeStates: [planned, in-progress]
   terminalStates: [done]
 polling:
@@ -9,239 +22,197 @@ polling:
 workspace:
   root: .harness/workspaces
 hooks:
-  afterCreate: null
+  # Install deps AND build the CLI so the worktree's pre-commit gate
+  # (`harness ci check`) actually RUNS — the ship commits/pushes THROUGH the real
+  # gates (no --no-verify). Adopters on other ecosystems substitute their install.
+  afterCreate: 'pnpm install --prefer-offline && pnpm --filter @harness-engineering/cli... run build'
   beforeRun: null
   afterRun: null
   beforeRemove: null
   timeoutMs: 60000
 agent:
-  # Named backend definitions (Spec 2). See docs/guides/multi-backend-routing.md.
-  # `capabilities` (tier/cost/privacy/context) let AMR compare backends and select a
-  # capability tier per dispatch — a backend without one is invisible to tier selection.
   backends:
+    # Cloud backend — present ONLY for the hybrid variant to escalate to; kept OUT
+    # of `routing` below so this config is fully-local by default.
     primary:
       type: claude
       command: claude
       capabilities:
         { tier: strong, costPer1kTokens: 15, privacyClass: shared-cloud, contextWindow: 200000 }
-    # Local backend for autonomous execution of simple tasks.
-    # `model` accepts a string OR a prefer-and-fallback array — first
-    # match wins after a `/v1/models` probe.
+
+    # Direct-ollama coder for quick-fix/diagnostic (single-shot) routes. Curated
+    # MCP tool allowlist — NOT the full ~99-tool flood, which makes a local model
+    # over-explore. Precise agentic-coding sampling (not ollama's hot default).
     local:
       type: ollama
-      # Ollama's OpenAI-compatible API lives under /v1 (the resolver probes
-      # `${endpoint}/models`). Names must match `ollama list` exactly.
       endpoint: http://127.0.0.1:11434/v1
-      # Prefer-and-fallback: first name present in /v1/models wins. Coder model
-      # first (local routes are quick-fix/diagnostic), general model as fallback.
-      # Quote the names — the ':tag' colon otherwise breaks YAML flow parsing.
-      model: ['qwen2.5-coder:7b', 'gemma3n:e4b']
-      # Qwen3 reasons by default; Ollama /v1 ignores reasoning:false, so disable it
+      model: ['qwen3-coder:30b']
       disableReasoning: true
+      temperature: 0.6
+      topP: 0.95
+      topK: 20
+      numCtx: 65536
       capabilities:
-        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
-      # Optional: give the local agent tools from MCP servers, merged with its
-      # built-in bash/read_file/write_file. Tools are namespaced `<server>__<tool>`;
-      # a server that fails to start is skipped (never breaks the dispatch). Default
-      # (unset) = built-ins only. See docs/guides/multi-backend-routing.md#mcp-tools.
-      # mcpServers:
-      #   - name: context7        # live library docs — stop coding from stale memory
-      #     command: npx
-      #     args: ['-y', '@upstash/context7-mcp']
-      #   - name: harness          # code_search / ask_graph / review_changes /
-      #     command: harness-mcp    # outcome_eval, run against the agent's workspace
-      #     tools: [code_search, ask_graph, review_changes, outcome_eval, gather_context]
-      #                             # narrow harness's ~95 tools to the read-oriented set
-      #                             # so a local model isn't flooded (omit tools = all).
-    # Local REASONING backend for the DESIGN phases of a staged workflow
-    # (cognitiveMode: thinking). A larger reasoning model (qwen3:32b) with
-    # reasoning LEFT ON — the design stages benefit from the <think> trace, so
-    # unlike the `local` coder we do NOT set disableReasoning. routing.modes.thinking
-    # points here (see routing.modes below).
+        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 65536 }
+      mcpServers:
+        - name: context7
+          command: npx
+          args: ['-y', '@upstash/context7-mcp']
+        - name: harness
+          command: harness-mcp # dogfooding this repo? use: node packages/cli/dist/bin/harness-mcp.js
+          tools:
+            [
+              manage_roadmap,
+              code_search,
+              code_outline,
+              ask_graph,
+              gather_context,
+              find_context_for,
+              review_changes,
+              run_code_review,
+              run_ci_checks,
+              outcome_eval,
+              acceptance_eval,
+              spec_craft,
+              test_craft,
+            ]
+
+    # CODER (execution + verification) — Codex driving the local coder. Codex's
+    # edit + self-verify + retry loop converges where a bare tool-loop stalls.
+    # `reasoningEffort: none` is REQUIRED: qwen3-coder does not support thinking and
+    # current ollama rejects a reasoning request outright ("does not support
+    # thinking"), zeroing the coder; codex's DEFAULT still sends one, so `none` (not
+    # omission) is the fix. routing.default points here.
+    codex-exec:
+      type: codex
+      model: ['qwen3-coder:30b']
+      localProvider: ollama
+      reasoningEffort: none
+      mcpServers:
+        - name: context7
+          command: npx
+          args: ['-y', '@upstash/context7-mcp']
+        - name: harness
+          command: harness-mcp # dogfooding this repo? use: node packages/cli/dist/bin/harness-mcp.js
+          tools: [code_search, code_outline, ask_graph, gather_context, review_changes]
+
+    # REASONER (design + planning + review — cognitiveMode: thinking). Thinking
+    # model with reasoning LEFT ON; writes the spec/plan the coder builds against.
     reasoner:
       type: ollama
       endpoint: http://127.0.0.1:11434/v1
-      model: ['qwen3:32b']
-      # Reasoning stays ON for design (thinking) stages — this is the reasoner.
+      model: ['qwen3.6:27b']
       disableReasoning: false
       capabilities:
-        { tier: strong, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
-  # Routing — controls WHICH backend handles each use case.
+        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 65536 }
+
+    # JUDGE (the settle-gate outcome-eval / spec-vs-diff verdict). A FAST
+    # NON-reasoning model — a reasoning model is unusable on /v1 (empty content or
+    # multi-minute stalls). gpt-oss:20b returns a correct verdict in ~8s and is more
+    # INDEPENDENT than the coder judging its own work.
+    judge:
+      type: ollama
+      endpoint: http://127.0.0.1:11434/v1
+      model: ['gpt-oss:20b', 'qwen3-coder:30b']
+      disableReasoning: true
+      capabilities:
+        { tier: fast, costPer1kTokens: 0, privacyClass: on-device, contextWindow: 32768 }
+
   routing:
-    default: primary
+    # Fully-local: execution/verification → codex-exec. `primary` (claude) is kept
+    # OUT of routing. HYBRID variant: set `default: primary` (or route only complex
+    # tiers to it) to escalate hard work — see the guide.
+    default: codex-exec
     quick-fix: local
     diagnostic: local
-    # Per-phase routing: a staged workflow's DESIGN stages (cognitiveMode: thinking)
-    # route here — to the local reasoner — while its execution stages carry no
-    # cognitiveMode and fall to routing.default. See the `workflows:` decl below.
+    # Per-phase: design/plan/review stages carry `cognitiveMode: thinking` → reasoner;
+    # execution/verify carry none → routing.default.
     modes:
       thinking: reasoner
-    # Route the intelligence pipeline (sel/pesl) to the local backend.
+    # Analysis/judge layer (outcome-eval at the enforced gate) → the fast judge.
     intelligence:
-      sel: local
-      pesl: local
-    # AMR (Adaptive Model Routing) — opt-in; its PRESENCE flips dispatch from the
-    # identity/default chain to complexity-aware tier selection. trivial/simple →
-    # local (fast, free); moderate/complex → claude (no `standard` backend, so a
-    # `standard` requirement resolves to the cheapest backend at-or-above it =
-    # primary). The always-on baseline-relative security-defect feeder climbs a
-    # unit's tier after `escalationThreshold` consecutive quality failures
-    # (strong-capped, then hard-fails to a human). Budget cap + LLM acceptance-eval
-    # are available opt-ins (docs/guides/adaptive-model-routing.md) — left off here.
-    policy:
-      complexityTierMatrix: { trivial: fast, simple: fast, moderate: standard, complex: strong }
-      escalationThreshold: 2
-  # Escalation — controls WHETHER a tier dispatches at all (orthogonal to routing).
+      sel: judge
+  # Bound the loop, then escalate — never grind forever. Exhaustion → needs-human
+  # (or, in the hybrid variant, hand off to primary).
   escalation:
+    maxLocalStageRetries: 4
     alwaysHuman: [full-exploration]
-    autoExecute: [quick-fix, diagnostic]
-    primaryExecute: [guided-change]
-    signalGated: []
-    diagnosticRetryBudget: 1
   maxConcurrentAgents: 1
-  maxTurns: 10
-  maxRetryBackoffMs: 5000
-  maxConcurrentAgentsByState: {}
-  globalCooldownMs: 60000
-  maxRequestsPerMinute: 50
-  maxRequestsPerSecond: 1
-  # Default limits based on Anthropic Tier 3. Adjust according to your account tier.
-  # Tier 1: 40k ITPM / 10k OTPM
-  # Tier 2: 200k ITPM / 40k OTPM
-  # Tier 3: 400k ITPM / 80k OTPM
-  # Tier 4: 1m ITPM / 200k OTPM
-  maxInputTokensPerMinute: 400000
-  maxOutputTokensPerMinute: 80000
-  turnTimeoutMs: 300000
-  readTimeoutMs: 30000
-  stallTimeoutMs: 60000
-# Staged workflows (per-phase routing). A matched unit is dispatched as ONE
-# multi-stage run on a single worktree instead of chained skill invocations:
-# the DESIGN stages carry `cognitiveMode: thinking` and route to
-# routing.modes.thinking (the local `reasoner`); the EXECUTION stages carry no
-# cognitiveMode and fall to routing.default. Each stage's prior output threads
-# to the next over the text channel (expects/produces). A local-endpoint routed
-# stage renders the `harness skill run <skill> --autonomous` indirection prompt
-# automatically. `workflowFor` only returns a plan for a decl with >= 2 stages.
+
+# Staged local workflow — the real lifecycle as discrete, persona-routed stages.
+# design/plan/review carry cognitiveMode: thinking (→ reasoner); execution/verify
+# fall to routing.default (→ codex-exec). After review the orchestrator ENFORCES
+# the gates: mechanical (typecheck+lint+test) + spec-vs-diff outcome-eval; a
+# high-confidence NOT_SATISFIED blocks + re-dispatches with the failure threaded
+# back. match identifierPrefix 'local-' — name local-eligible queue rows 'local-<slug>' (see the guide).
 workflows:
   - name: local-full-workflow
-    match: { identifierPrefix: 'LOCAL-' }
+    match: { identifierPrefix: 'local-' }
     stages:
-      - { skill: harness-brainstorming, cognitiveMode: thinking, produces: spec }
-      - { skill: harness-planning, cognitiveMode: thinking, expects: spec, produces: plan }
+      - { skill: harness-brainstorming, cognitiveMode: thinking, produces: spec, checkpoint: true }
+      - {
+          skill: harness-planning,
+          cognitiveMode: thinking,
+          expects: spec,
+          produces: plan,
+          checkpoint: true,
+        }
       - { skill: harness-execution, expects: plan, produces: impl }
       - { skill: harness-verification, expects: impl, produces: verify }
+      - { skill: harness-code-review, cognitiveMode: thinking, expects: impl, produces: review }
+
+# Intelligence pipeline off by default (the enforced outcome-eval gate builds its
+# provider from the judge backend directly — see the guide). Enable for AMR.
 intelligence:
-  enabled: true
-  requestTimeoutMs: 180000
+  enabled: false
 server:
-  port: 8080
-localModels:
-  enabled: true
-  pool:
-    diskBudgetGb: 100
-    allowedOrgs: [Qwen, deepseek-ai, meta-llama, google, openai, zai-org, THUDM, moonshotai]
-    allowedFamilies: []
-  refresh:
-    intervalMs: 86400000
-    proposalThreshold: 5
-    jitterMs: 600000
-  installer:
-    backend: ollama
-    ollamaEndpoint: http://127.0.0.1:11434
-# Built-in maintenance tasks run on cron when `maintenance.enabled: true`.
-# Notable housekeeping tasks: `main-sync` (every 15 min) fast-forwards the
-# orchestrator's local default branch from origin so files read from `cwd`
-# (e.g., docs/roadmap.md, harness.orchestrator.md) stay current. Sync is
-# fast-forward-only — never destructive — and skips with a structured
-# warning event if the working tree is dirty, the branch is wrong, or the
-# local default has diverged. Disable all maintenance via `maintenance.enabled: false`.
-#
-# Per-task Run Now (since 2026-05-09): the dashboard Maintenance page renders
-# a Run Now button on every row of the schedule table. The previous single-
-# button affordance (which always triggered `project-health`) has been
-# removed. Each button is disabled while a `maintenance:started` event is in
-# flight for that task ID and re-enables on the matching `maintenance:completed`
-# or `maintenance:error` event.
-maintenance:
-  enabled: true
+  enabled: false
 ---
 
-# Prompt Template (Local Backend — bootstrap shim)
+# Prompt Template (local single-agent fallback)
 
-You are a local agent with `bash`, `read`, `write`, `grep`, and `find`. You do
-NOT have `/harness:*` slash commands or harness MCP tools. You run the REAL
-harness workflow skills by reading them over bash — this template carries no
-methodology of its own.
+This body is used ONLY for a unit that does NOT match a staged `workflows:` decl
+(the staged path renders its own per-stage prompts). You are an autonomous agent
+working exactly as a real harness session would. In addition to bash/read/write
+you have the harness MCP toolset (namespaced `harness__*` on the ollama path; on
+the codex path, use codex's own edit/patch + the injected read tools) — USE the
+real tools when a skill calls for them instead of approximating with bash.
 
 ## Issue: {{ issue.title }}
 
 **Identifier:** {{ issue.identifier }}
 **Description:** {{ issue.description }}
 
-## How to run a harness skill (the indirection rule)
-
-To run any harness workflow skill, execute it over bash and follow its output
-**verbatim**:
+## Run a harness skill (the indirection rule)
 
 ```bash
 harness skill run <skill-name> --autonomous --path .
 ```
 
-`harness skill run` prints the skill's full instructions (the same content the
-primary backend gets from a `/harness:*` slash command) to stdout as a plain CLI
-read. `--autonomous` prepends the headless-decider preamble: you do the full
-analysis at full rigor but YOU decide every fork and record it in the spec — you
-never pause for a human.
+`harness skill run` prints the skill's full instructions to stdout; `--autonomous`
+means YOU decide every fork at full rigor and never pause for a human. Whenever a
+skill's output says to run `/harness:X`, run `harness skill run harness-X
+--autonomous` instead.
 
-**Redirect rule.** Whenever a skill's output instructs you to run `/harness:X`,
-instead run `harness skill run harness-X --autonomous`. Slash commands are
-unavailable on this backend; the skill-run indirection is their equivalent.
+## Editing existing files: surgical edits only, never rewrite a whole file
 
-## Full-workflow entry sequence
-
-Run these in order, each via `harness skill run <name> --autonomous --path .`,
-following each skill's output before moving on:
-
-1. `harness-brainstorming` — runs at full rigor (≥2 approaches, YAGNI, persona
-   council, soundness), but YOU decide the forks (autonomous) and record each
-   decision in the spec.
-2. `harness-planning`
-3. `harness-execution` (or `harness-tdd` for test-driven work)
-4. `harness-verification`
-5. `harness-code-review`
-
-Run `harness skill list` to see the full roster of available skills.
-
-> **Staged dispatch (per-phase routing).** When a unit matches `local-full-workflow`
-> (frontmatter), design stages (`cognitiveMode: thinking`) route to the local reasoner and execution stages to `routing.default`, chained automatically for you.
+Change only the exact lines that must change; APPEND to existing docs/lists (never
+regenerate a shared file from scratch — that drops other entries); never leave
+backup/scratch files (`*.bak`, `temp_*`). Actually RUN any test you author and
+confirm it passes against your implementation.
 
 ## Gates (enforced by the harness, not just by you)
 
-The orchestrator INDEPENDENTLY enforces `harness validate` plus the
-verify/outcome-eval gates against your branch after you exit — you cannot ship
-past a red gate. Reach a green state: run `harness validate` and the project's
-own typecheck/lint/test yourself and fix every failure before shipping. A run
-that cannot reach green is halted and re-dispatched rather than shipped, and
-escalated to a human if the retry budget is exhausted.
+The orchestrator INDEPENDENTLY enforces `harness validate` plus typecheck + lint +
+the full test suite, and a spec-vs-diff outcome-eval, against your branch — you
+cannot ship past a red gate. Reach a green state yourself (run `harness validate`
+and the project's typecheck/lint/test and fix every failure); a run that can't is
+halted and re-dispatched, and escalated to a human when the retry budget is
+exhausted.
 
 ## Ship (only after the gates are green)
 
-- Create a topic branch if you are still on `main`/`master`
-  (e.g. `feat/{{ issue.identifier }}`).
-- Stage your changes and create a descriptive commit (Conventional Commits style).
-- Push the branch with `git push -u origin HEAD`.
-- Open a pull request with `gh pr create`. Use a HEREDOC for the body:
-
-  ```bash
-  gh pr create --title "<title>" --body "$(cat <<'EOF'
-  ## Summary
-
-  <body content with real newlines>
-  EOF
-  )"
-  ```
-
-- Report the PR URL as your final output, then stop.
+Create a topic branch, commit (Conventional Commits), `git push -u origin HEAD`,
+open a PR with `gh pr create`, report the PR URL, then stop.
 
 Attempt Number: {{ attempt }}


### PR DESCRIPTION
## What

Captures the validated **local-model execution** setup so it can be run and evaluated repeatably, and restores a fix that was orphaned when #995 merged without its follow-up commit.

### 1. Restore the ship scratch-cruft removal (bugfix)
#995 merged with only its first commit — main had the `add`-exclude cruft handling that is **insufficient**: the eval diff's `git add --intent-to-add` marks the cruft, and lint-staged's pre-commit stash then fails ("Entry not uptodate. Cannot merge"), blocking the ship. Restores `removeScratchFiles` (physically removes cruft from index + disk before commit) and stops `markUntrackedIntentToAdd` from marking scratch files.

### 2. Operator guide — `docs/guides/local-execution.md`
The validated **coder / reasoner / judge** setup, the **`local-eligible` task-fit triage checklist**, operating rules (scoped queue, gates-on, bounded retries, fresh-server bursts), hardware notes, the hybrid escalation variant, and the effectiveness findings. Linked in the guides index.

### 3. Updated `harness.orchestrator.local.md` (template + byte-identical root copy)
Brought to the validated config: **codex-exec** coder (`reasoningEffort: none`), **qwen3.6** reasoner, **gpt-oss** judge, fully-local routing (`default: codex-exec`, `modes.thinking: reasoner`, `intelligence.sel: judge`), the 5-stage `local-full-workflow`, and `maxLocalStageRetries: 4`. (Replaces the stale pre-validation template — a 7B coder with no codex/judge split and a wrong "no MCP tools" premise.)

## Verified
- Config **parses through the real `WorkflowLoader`** (the path `orchestrator run` uses) — caught + fixed an invalid `match` key.
- template-lint 36/36, cli templates 152, orchestrator loader/manager green; the two config copies byte-identical.

## How to run (evaluate)
Curate `.harness/local-queue.roadmap.md` with contained tasks named `local-<slug>`, then `orchestrator run --workflow templates/orchestrator/harness.orchestrator.local.md --headless`. See the guide.