### PR TITLE
fix(graph): Windows-safe per-test timeout for #940 extractor integration test

### DIFF
--- a/.changeset/graph-windows-extractor-timeout.md
+++ b/.changeset/graph-windows-extractor-timeout.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/graph': patch
+---
+
+fix(graph): give the #940 extractor integration test a Windows-safe per-test timeout
+
+The `binds extractor governs/documents edges to materialized code-scanner file
+nodes (#940)` case is the only test in this suite that runs the full
+`CodeIngestor.ingest` filesystem materialization on top of the extractor pass.
+That IO is markedly slower on the `windows-latest` runner and intermittently
+blew the suite's default 30s budget there (ubuntu and macOS finish the same
+test well inside it), turning `main` red on Windows alone (#992).
+
+The fix scopes a larger 120s budget to this one IO-heavy test rather than
+raising the global `testTimeout` — a genuine hang in any other test still
+surfaces at the default 30s deadline. The assertion the test makes
+(path-based `file:${relativePath}` node IDs, the thing #940 fixed) is left
+untouched, so Windows path handling stays covered rather than skipped.

--- a/packages/graph/tests/ingest/extractors/integration.test.ts
+++ b/packages/graph/tests/ingest/extractors/integration.test.ts
@@ -97,6 +97,13 @@ describe('Code Signal Extractors — End-to-End', () => {
   // Regression for #940: extractor `governs`/`documents` edges must target the
   // SAME path-based file-node ID the code scanner materializes
   // (`file:${relativePath}`), not a hash-based `file:<hash>` that never resolves.
+  //
+  // Per-test timeout (#992): this is the only case here that runs the full
+  // `CodeIngestor.ingest` filesystem materialization on top of the extractor
+  // pass. That IO is markedly slower on the windows-latest runner and blew the
+  // default 30s budget there (ubuntu/macOS finish well inside it). The larger
+  // budget is scoped to this one IO-heavy test — not a global `testTimeout`
+  // bump — so a genuine hang elsewhere still surfaces at the default deadline.
   it('binds extractor governs/documents edges to materialized code-scanner file nodes (#940)', async () => {
     // Materialize the canonical path-based file nodes first (as `graph scan` does).
     const codeIngestor = new CodeIngestor(store);
@@ -138,7 +145,7 @@ describe('Code Signal Extractors — End-to-End', () => {
     // Sanity: we actually exercised governs edges (from test-descriptions).
     expect(checkedEdges).toBeGreaterThan(0);
     expect(governsChecked).toBeGreaterThan(0);
-  });
+  }, 120_000);
 
   it('covers all 6 languages across extractors', async () => {
     const runner = createExtractionRunner();


### PR DESCRIPTION
## What

Scopes a **120s per-test timeout** to the single IO-heavy case in
`packages/graph/tests/ingest/extractors/integration.test.ts` — the `#940`
`governs`/`documents`-edge regression test — so it stops timing out on the
`windows-latest` runner.

## Why

`#940`'s test is the only case in that suite that runs the full
`CodeIngestor.ingest` filesystem materialization *on top of* the extractor
pass. That IO is markedly slower on Windows: the suite reports ~326s of test
time against a ~187s wall clock there, and this one test intermittently blew
the suite's default `testTimeout: 30_000`, timing out at 30000ms and turning
`main` red on Windows alone. ubuntu and macOS finish the same test well inside
the budget.

Per the issue's preferred remediation (option 2), this raises the budget **for
this test only**, with a comment naming Windows IO as the reason — not a global
`testTimeout` bump, which would mask a genuine hang elsewhere. The assertion the
test makes (path-based `file:${relativePath}` node IDs — the thing `#940` fixed,
and exactly where Windows path handling would regress) is untouched, so the test
is neither skipped on Windows nor weakened.

## Verification

This is a **Windows-only** timeout, so it cannot be reproduced on a macOS/Linux
dev box — CI on the `windows-latest` runner is the authoritative check. Raising
a per-test timeout cannot make a currently-passing test fail; the test already
passes on ubuntu/macOS (verified locally on Node 22) and on the latest `main`
Windows run.

Closes #992