### PR TITLE
fix(cli): protect-config and sentinel-pre must fail CLOSED on unreadable stdin

### DIFF
--- a/.changeset/hook-stdin-fail-closed-guards.md
+++ b/.changeset/hook-stdin-fail-closed-guards.md
@@ -1,0 +1,24 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): protect-config and sentinel-pre must fail CLOSED when they cannot read stdin
+
+Both are blocking `PreToolUse` guards that read their payload with
+`readFileSync(0)` and treated _any_ throw as "no input", exiting 0 (allow) —
+the same fail-open seam already fixed in `block-no-verify`. On a pipe fd 0 is
+non-blocking, so a read issued before the writer has filled the pipe throws
+`EAGAIN`: the guard went blind and waved the command through while still
+reporting success — a bypass hiding behind a green check (#993). For
+`protect-config` that means a protected linter/formatter config could be edited
+unverified; for `sentinel-pre` it means taint enforcement silently switched off
+mid-session.
+
+Both now read stdin through the shared `readHookStdin()` helper, which retries
+while the pipe reports `EAGAIN` (bounded, 5s) and reports read success
+separately from read content. A read that _failed_ means the guard is blind and
+it exits 2 (blocked); a read that _succeeded and returned nothing_ stays
+fail-open, as do malformed JSON and (for `protect-config`) a missing
+`file_path`. Regression tests drive a real read failure by opening a directory
+as fd 0 (`EISDIR`) — closing fd 0 does not work because Node substitutes
+`/dev/null`, which reads as empty rather than failing.

--- a/packages/cli/src/hooks/protect-config.js
+++ b/packages/cli/src/hooks/protect-config.js
@@ -10,9 +10,10 @@
 //     potentially unprotected config edit.
 // Exit codes: 0 = allow, 2 = block
 
-import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import process from 'node:process';
+
+import { readHookStdin } from './read-hook-stdin.js';
 
 // Protected config file patterns
 const PROTECTED_PATTERNS = [
@@ -35,13 +36,21 @@ function isProtected(filePath) {
 }
 
 function main() {
-  let raw;
-  try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
-    process.stderr.write('[protect-config] Could not read stdin — allowing (fail-open)\n');
-    process.exit(0);
+  const stdin = readHookStdin();
+  if (!stdin.ok) {
+    // Fail CLOSED. On a pipe, fd 0 is non-blocking and a read issued before the
+    // writer has filled it throws EAGAIN; treating that as "no input" and
+    // exiting 0 let a config edit through unverified while the check still
+    // reported success (#993, same seam as block-no-verify). A guard that
+    // cannot read the edit it is guarding must not vouch for it.
+    process.stderr.write(
+      `BLOCKED: protect-config could not read hook input (${stdin.error.code ?? stdin.error.message}); ` +
+        'refusing to allow a potentially unprotected config edit unverified.\n'
+    );
+    process.exit(2);
   }
+
+  const raw = stdin.data;
 
   if (!raw.trim()) {
     process.stderr.write('[protect-config] Empty stdin — allowing (fail-open)\n');

--- a/packages/cli/src/hooks/sentinel-pre.js
+++ b/packages/cli/src/hooks/sentinel-pre.js
@@ -18,6 +18,8 @@ import { readFileSync, unlinkSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import process from 'node:process';
 
+import { readHookStdin } from './read-hook-stdin.js';
+
 // Destructive tool patterns blocked during taint.
 // Keep in sync with DESTRUCTIVE_BASH exported from @harness-engineering/core injection-patterns.ts.
 const DESTRUCTIVE_BASH = [
@@ -40,19 +42,25 @@ function isOutsideWorkspace(filePath, workspaceRoot) {
   return !realResolved.startsWith(workspaceRoot);
 }
 
-/** Read stdin (fd 0) and parse it as JSON. Returns null when it should exit-0. */
+/**
+ * Read stdin (fd 0) and parse it as JSON.
+ *
+ * Returns `{ blind: true }` when the read genuinely FAILED (the guard is blind
+ * and must fail closed), `{ input: null }` for a legitimately empty or malformed
+ * payload (benign — fail open), or `{ input }` on success. Distinguishing a
+ * failed read from an empty one is the whole point: conflating them let a tool
+ * call through unverified during a tainted session whenever the stdin pipe
+ * hiccuped, while the check still reported success (#993, same seam as
+ * block-no-verify).
+ */
 function readStdinJson() {
-  let raw;
+  const stdin = readHookStdin();
+  if (!stdin.ok) return { blind: true, error: stdin.error };
+  if (!stdin.data.trim()) return { input: null };
   try {
-    raw = readFileSync(0, 'utf-8');
+    return { input: JSON.parse(stdin.data) };
   } catch {
-    return null;
-  }
-  if (!raw.trim()) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
+    return { input: null };
   }
 }
 
@@ -114,7 +122,18 @@ function enforceTaint(toolName, toolInput, workspaceRoot) {
 }
 
 async function main() {
-  const input = readStdinJson();
+  const result = readStdinJson();
+  if (result.blind) {
+    // Fail CLOSED: a taint guard that cannot read the tool call it is guarding
+    // must not wave it through. Exiting 0 here would silently disable Sentinel
+    // during a tainted session on the exact EAGAIN pipe race #993 describes.
+    process.stderr.write(
+      `BLOCKED by Sentinel: could not read hook input (${result.error.code ?? result.error.message}); ` +
+        'refusing to allow the tool call unverified during a possibly-tainted session.\n'
+    );
+    process.exit(2);
+  }
+  const input = result.input;
   if (input === null) {
     process.exit(0);
   }

--- a/packages/cli/tests/hooks/protect-config.test.ts
+++ b/packages/cli/tests/hooks/protect-config.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { closeSync, mkdtempSync, openSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 const HOOK_PATH = resolve(__dirname, '../../src/hooks/protect-config.js');
 
@@ -141,5 +143,31 @@ describe('protect-config', () => {
     });
     const { exitCode } = runHook(input);
     expect(exitCode).toBe(2);
+  });
+
+  // Regression for #993: the hook used to treat ANY stdin read failure as "no
+  // input" and exit 0, so a transient EAGAIN on the pipe silently waved a
+  // protected-config edit through while the check stayed green. A blind guard
+  // must block. POSIX-only: the fd/pipe shape does not reproduce on Windows.
+  const onPosix = process.platform === 'win32' ? describe.skip : describe;
+
+  onPosix('stdin read failure (fail closed)', () => {
+    it('blocks when the stdin read itself fails', () => {
+      // A directory opens fine but errors (EISDIR) on read — a read that
+      // genuinely failed, unlike /dev/null which reads 0 bytes successfully.
+      // Node substitutes /dev/null for a closed fd 0, so closing it won't do.
+      const dirFd = openSync(mkdtempSync(join(tmpdir(), 'protect-config-stdin-')), 'r');
+      try {
+        const result = spawnSync('node', [HOOK_PATH], {
+          stdio: [dirFd, 'pipe', 'pipe'],
+          encoding: 'utf-8',
+          timeout: 60000,
+        });
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain('could not read hook input');
+      } finally {
+        closeSync(dirFd);
+      }
+    });
   });
 });

--- a/packages/cli/tests/hooks/sentinel-pre.test.ts
+++ b/packages/cli/tests/hooks/sentinel-pre.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { closeSync, mkdtempSync, openSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const HOOK_PATH = resolve(__dirname, '../../src/hooks/sentinel-pre.js');
+
+function runHook(stdinData: string): { exitCode: number; stderr: string } {
+  // Pass stdin directly via spawnSync's `input` option (issue 619): the previous
+  // `cat <file> | node` pipe intermittently delivered empty/partial stdin under
+  // v8 coverage, tripping the hooks' fail-open path. macOS CI is the gate.
+  const result = spawnSync('node', [HOOK_PATH], {
+    input: stdinData,
+    encoding: 'utf-8',
+    timeout: 60000,
+    // Run outside any tainted session so the baseline cases exercise the
+    // allow path rather than a taint block.
+    cwd: mkdtempSync(join(tmpdir(), 'sentinel-pre-cwd-')),
+  });
+  return {
+    exitCode: result.status ?? 1,
+    stderr: result.stderr ?? '',
+  };
+}
+
+describe('sentinel-pre', () => {
+  it('allows a normal tool call when the session is not tainted', () => {
+    const input = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      session_id: 'no-taint-session',
+    });
+    const { exitCode } = runHook(input);
+    expect(exitCode).toBe(0);
+  });
+
+  it('fails open on malformed JSON', () => {
+    const { exitCode } = runHook('not json at all');
+    expect(exitCode).toBe(0);
+  });
+
+  it('fails open on empty stdin', () => {
+    const { exitCode } = runHook('');
+    expect(exitCode).toBe(0);
+  });
+
+  // Regression for #993: sentinel-pre used to treat ANY stdin read failure as
+  // "no input" and exit 0, so a transient EAGAIN on the pipe silently disabled
+  // taint enforcement during a tainted session while the check stayed green. A
+  // blind guard must block. POSIX-only: the fd/pipe shape does not reproduce on
+  // Windows.
+  const onPosix = process.platform === 'win32' ? describe.skip : describe;
+
+  onPosix('stdin read failure (fail closed)', () => {
+    it('blocks when the stdin read itself fails', () => {
+      // A directory opens fine but errors (EISDIR) on read — a read that
+      // genuinely failed, unlike /dev/null which reads 0 bytes successfully.
+      // Node substitutes /dev/null for a closed fd 0, so closing it won't do.
+      const dirFd = openSync(mkdtempSync(join(tmpdir(), 'sentinel-pre-stdin-')), 'r');
+      try {
+        const result = spawnSync('node', [HOOK_PATH], {
+          stdio: [dirFd, 'pipe', 'pipe'],
+          encoding: 'utf-8',
+          timeout: 60000,
+        });
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain('could not read hook input');
+      } finally {
+        closeSync(dirFd);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

`protect-config.js` and `sentinel-pre.js` are both blocking `PreToolUse` guards
that read their payload with `readFileSync(0)` and treated **any** throw as "no
input", exiting 0 (allow). This is the same fail-open seam already fixed in
`block-no-verify.js` under `fix/hook-stdin-fail-closed`.

On a pipe, fd 0 is non-blocking, so a read issued before the writer has filled
the pipe throws `EAGAIN`. The guard went blind and waved the command through
**while still reporting success** — a bypass hiding behind a green check
(#993):

- `protect-config`: a protected linter/formatter config could be edited unverified.
- `sentinel-pre`: taint enforcement silently switched off mid-session.

## Fix

Both now read stdin through the shared `readHookStdin()` helper (introduced by
the `block-no-verify` fix), which retries while the pipe reports `EAGAIN`
(bounded, 5s) and reports read **success** separately from read **content**:

- read **failed** → the guard is blind → **exit 2 (block)**.
- read **succeeded and returned nothing** → legitimate empty invocation → stays fail-open.
- malformed JSON, and (for `protect-config`) a missing `file_path`, keep their existing behavior.

## Tests

- New regression tests in `protect-config.test.ts` and a new `sentinel-pre.test.ts`
  drive a **real** read failure by opening a directory as fd 0 (`EISDIR`) — closing
  fd 0 does not work because Node substitutes `/dev/null`, which reads as empty
  rather than failing. Same harness the `block-no-verify` fix used.
- Verified all three hook suites pass (45/45) on Node 22, and confirmed the
  revert-and-fail protocol: with the old fail-open behavior the new test fails
  (`expected +0 to be 2`); with the fix it passes.

Closes #993