### PR TITLE
fix(cli): generated hook commands resolve the main checkout, not the worktree cwd

### DIFF
--- a/.changeset/hook-generator-worktree-paths.md
+++ b/.changeset/hook-generator-worktree-paths.md
@@ -8,7 +8,7 @@ fix(cli): generated hook commands resolve the main checkout, not the worktree cw
 commands of the form `node "$(git rev-parse --show-toplevel)/.harness/hooks/<name>.js"`.
 That form has two production failure modes (seen in real repos, 2026-07-31):
 
-1. **Linked worktree.** `--show-toplevel` returns the *worktree* root, where the
+1. **Linked worktree.** `--show-toplevel` returns the _worktree_ root, where the
    machine-local, gitignored `.harness/` does not exist → `MODULE_NOT_FOUND` on
    every tool call. Because the failure is non-blocking, the verify-bypass
    blocker and quality gate **silently stop protecting worktree sessions** —

--- a/.changeset/hook-generator-worktree-paths.md
+++ b/.changeset/hook-generator-worktree-paths.md
@@ -1,0 +1,32 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): generated hook commands resolve the main checkout, not the worktree cwd
+
+`harness hooks init` and `harness hooks add` generated settings.json hook
+commands of the form `node "$(git rev-parse --show-toplevel)/.harness/hooks/<name>.js"`.
+That form has two production failure modes (seen in real repos, 2026-07-31):
+
+1. **Linked worktree.** `--show-toplevel` returns the *worktree* root, where the
+   machine-local, gitignored `.harness/` does not exist → `MODULE_NOT_FOUND` on
+   every tool call. Because the failure is non-blocking, the verify-bypass
+   blocker and quality gate **silently stop protecting worktree sessions** —
+   gates report as hook errors instead of running. With agent-per-worktree
+   workflows, most agent work goes ungated.
+2. **Non-repo cwd.** `git rev-parse` fails and spams
+   `fatal: not a git repository` on every tool call.
+
+Both generators now share a `buildHookCommand(name)` helper that emits:
+
+```sh
+g="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || exit 0; f="$(dirname "$g")/.harness/hooks/<name>.js"; [ -f "$f" ] || exit 0; exec node "$f"
+```
+
+`--git-common-dir` resolves to the **main** checkout even from a linked
+worktree, so gates run (and protect) against the main repo's `.harness`; the
+`|| exit 0` guards make the hook a silent no-op outside a repo or on a machine
+without `.harness`; and `exec node` preserves the hook's blocking exit code (2).
+
+Already-onboarded repos keep the old pattern until they re-run `harness hooks
+init` — a `harness doctor` migration check is worth a follow-up.

--- a/packages/cli/src/commands/hooks/add.ts
+++ b/packages/cli/src/commands/hooks/add.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import { HOOK_SCRIPTS } from '../../hooks/profiles';
 import { supportFilesFor } from '../../hooks/support-files';
 import { logger } from '../../output/logger';
-import { resolveHookSourceDir } from './init';
+import { buildHookCommand, resolveHookSourceDir } from './init';
 
 const ALIASES: Record<string, string[]> = {
   sentinel: ['sentinel-pre', 'sentinel-post'],
@@ -25,7 +25,7 @@ function readJson(p: string): JsonObject {
 
 function registerHook(s: JsonObject, ev: string, matcher: string, name: string): void {
   if (!s.hooks[ev]) s.hooks[ev] = [];
-  const cmd = `node "$(git rev-parse --show-toplevel)/.harness/hooks/${name}.js"`;
+  const cmd = buildHookCommand(name);
   if (!s.hooks[ev].some((e: JsonObject) => e.hooks?.some((h: JsonObject) => h.command === cmd))) {
     s.hooks[ev].push({ matcher, hooks: [{ type: 'command', command: cmd }] });
   }

--- a/packages/cli/src/commands/hooks/init.ts
+++ b/packages/cli/src/commands/hooks/init.ts
@@ -37,6 +37,42 @@ export function resolveHookSourceDir(): string {
 }
 
 /**
+ * Build the settings.json `command` for a hook script.
+ *
+ * The generated command must resolve `.harness/hooks/<name>.js` against the
+ * MAIN checkout, not the current working directory, and must never spam or
+ * silently drop protection when that file is unreachable (#990). The previous
+ * `node "$(git rev-parse --show-toplevel)/.harness/hooks/<name>.js"` form had
+ * two production failure modes:
+ *
+ *   1. In a linked git worktree, `--show-toplevel` returns the *worktree* root,
+ *      where the machine-local, gitignored `.harness/` does not exist —
+ *      `MODULE_NOT_FOUND` on every tool call. Because the failure is
+ *      non-blocking, the verify-bypass blocker and quality gate silently stop
+ *      protecting worktree sessions (gates report as hook errors instead of
+ *      running). With agent-per-worktree workflows, most agent work goes ungated.
+ *   2. In a non-repo cwd, `git rev-parse` fails and spams
+ *      `fatal: not a git repository` on every tool call.
+ *
+ * The fix:
+ *   - `--git-common-dir` resolves to the MAIN checkout's `.git` even from a
+ *     linked worktree, so `dirname` of it is the main repo root → gates run
+ *     (and protect) in worktrees against the main repo's `.harness`.
+ *   - `|| exit 0` and `[ -f "$f" ] || exit 0` make the hook a silent no-op
+ *     outside a repo, or on a machine without `.harness`, instead of spamming.
+ *   - `exec node` replaces the shell so the hook's blocking exit code (2) still
+ *     propagates to Claude Code.
+ */
+export function buildHookCommand(name: string): string {
+  return (
+    `g="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || exit 0; ` +
+    `f="$(dirname "$g")/.harness/hooks/${name}.js"; ` +
+    `[ -f "$f" ] || exit 0; ` +
+    `exec node "$f"`
+  );
+}
+
+/**
  * Build the hooks object for .claude/settings.json based on profile.
  */
 export function buildSettingsHooks(
@@ -59,7 +95,7 @@ export function buildSettingsHooks(
       hooks: [
         {
           type: 'command',
-          command: `node "$(git rev-parse --show-toplevel)/.harness/hooks/${script.name}.js"`,
+          command: buildHookCommand(script.name),
         },
       ],
     });

--- a/packages/cli/tests/commands/hooks.test.ts
+++ b/packages/cli/tests/commands/hooks.test.ts
@@ -4,7 +4,12 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { createHooksCommand } from '../../src/commands/hooks/index';
-import { initHooks, buildSettingsHooks, mergeSettings } from '../../src/commands/hooks/init';
+import {
+  initHooks,
+  buildSettingsHooks,
+  buildHookCommand,
+  mergeSettings,
+} from '../../src/commands/hooks/init';
 import { listHooks } from '../../src/commands/hooks/list';
 import { removeHooks } from '../../src/commands/hooks/remove';
 import { addHooks } from '../../src/commands/hooks/add';
@@ -51,6 +56,93 @@ describe('buildSettingsHooks', () => {
     expect(hooks.Stop[0].hooks[0].command).toContain('adoption-tracker.js');
     expect(hooks.Stop[1].hooks[0].command).toContain('telemetry-reporter.js');
     expect(hooks.Stop[2].hooks[0].command).toContain('cost-tracker.js');
+  });
+});
+
+// Regression for #990: the generated command used
+// `node "$(git rev-parse --show-toplevel)/.harness/hooks/<name>.js"`, which
+// (1) pointed at the *worktree* root in a linked worktree — where machine-local
+// `.harness/` does not exist — so gates silently stopped protecting worktree
+// sessions, and (2) spammed `fatal: not a git repository` in a non-repo cwd.
+// The command must resolve against the MAIN checkout and be a silent no-op when
+// `.harness` is unreachable, while still propagating the hook's exit code.
+describe('buildHookCommand (#990)', () => {
+  const hasGit = spawnSync('git', ['--version']).status === 0;
+  // POSIX shell semantics; the command uses `sh`-style `$(...)`, `||`, `[ -f ]`.
+  const onPosix = process.platform === 'win32' || !hasGit ? describe.skip : describe;
+
+  it('does not embed the worktree-fragile --show-toplevel form', () => {
+    const cmd = buildHookCommand('block-no-verify');
+    expect(cmd).not.toContain('--show-toplevel');
+    expect(cmd).toContain('--git-common-dir');
+    expect(cmd).toContain('.harness/hooks/block-no-verify.js');
+    // Guards + exec so it no-ops silently off-repo and still propagates exit 2.
+    expect(cmd).toContain('|| exit 0');
+    expect(cmd).toContain('exec node');
+  });
+
+  onPosix('shell behavior', () => {
+    let tmpRoot: string;
+    let mainRepo: string;
+
+    function git(cwd: string, ...args: string[]) {
+      const r = spawnSync('git', args, { cwd, encoding: 'utf-8' });
+      if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+      return r.stdout;
+    }
+
+    beforeEach(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hookcmd-'));
+      mainRepo = path.join(tmpRoot, 'main');
+      fs.mkdirSync(mainRepo, { recursive: true });
+      git(mainRepo, 'init', '-q');
+      git(mainRepo, 'config', 'user.email', 'test@example.com');
+      git(mainRepo, 'config', 'user.name', 'Test');
+      git(mainRepo, 'commit', '-q', '--allow-empty', '-m', 'init');
+      // A probe hook that blocks (exit 2), installed only in the MAIN checkout's
+      // machine-local .harness/ — exactly the layout that breaks --show-toplevel.
+      const hooksDir = path.join(mainRepo, '.harness', 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'probe.js'), 'process.exit(2);\n');
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    const run = (cwd: string) =>
+      spawnSync('sh', ['-c', buildHookCommand('probe')], { cwd, encoding: 'utf-8' });
+
+    it('runs the main-checkout hook and propagates its blocking exit code', () => {
+      const r = run(mainRepo);
+      expect(r.status).toBe(2);
+    });
+
+    it('still resolves the MAIN checkout hook from a linked worktree', () => {
+      const wt = path.join(tmpRoot, 'wt');
+      git(mainRepo, 'worktree', 'add', '-q', wt, 'HEAD');
+      // The worktree has no .harness/ of its own — the old --show-toplevel form
+      // would MODULE_NOT_FOUND here and the gate would silently stop running.
+      expect(fs.existsSync(path.join(wt, '.harness'))).toBe(false);
+      const r = run(wt);
+      expect(r.status).toBe(2);
+    });
+
+    it('is a silent no-op (exit 0, no stderr spam) outside any repo', () => {
+      const nonRepo = path.join(tmpRoot, 'not-a-repo');
+      fs.mkdirSync(nonRepo, { recursive: true });
+      const r = run(nonRepo);
+      expect(r.status).toBe(0);
+      expect(r.stderr).not.toMatch(/not a git repository/);
+    });
+
+    it('is a silent no-op when the repo has no .harness hook file', () => {
+      const bare = path.join(tmpRoot, 'bare-repo');
+      fs.mkdirSync(bare, { recursive: true });
+      git(bare, 'init', '-q');
+      const r = run(bare);
+      expect(r.status).toBe(0);
+    });
   });
 });
 
@@ -426,9 +518,7 @@ describe('addHooks', () => {
     const preCommands = settings.hooks.PreToolUse.flatMap((e: any) =>
       e.hooks.map((h: any) => h.command)
     );
-    expect(preCommands).toContain(
-      'node "$(git rev-parse --show-toplevel)/.harness/hooks/sentinel-pre.js"'
-    );
+    expect(preCommands).toContain(buildHookCommand('sentinel-pre'));
   });
 
   it('adds a single hook by name', () => {


### PR DESCRIPTION
## What

`harness hooks init` and `harness hooks add` generated settings.json hook
commands of the form:

```sh
node "$(git rev-parse --show-toplevel)/.harness/hooks/<name>.js"
```

Both generators now share a `buildHookCommand(name)` helper that emits a
worktree-safe, no-repo-safe command instead.

## Why (#990)

Two production failure modes, both seen in real repos:

1. **Linked worktree.** `--show-toplevel` returns the *worktree* root, where the
   machine-local, gitignored `.harness/` does not exist → `MODULE_NOT_FOUND` on
   every tool call. Because the failure is non-blocking, the verify-bypass
   blocker and quality gate **silently stop protecting worktree sessions**. With
   agent-per-worktree workflows, most agent work goes ungated.
2. **Non-repo cwd.** `git rev-parse` fails and spams `fatal: not a git repository`
   on every tool call.

## Fix

```sh
g="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || exit 0; f="$(dirname "$g")/.harness/hooks/<name>.js"; [ -f "$f" ] || exit 0; exec node "$f"
```

- `--git-common-dir` resolves to the **main** checkout even from a linked worktree → gates run (and protect) against the main repo's `.harness`.
- `|| exit 0` guards → silent no-op outside a repo or on a machine without `.harness`, instead of spamming.
- `exec node` → the hook's blocking exit code (2) still propagates.

## Tests

New `buildHookCommand (#990)` suite in `hooks.test.ts` spins up a real git repo,
a **linked worktree**, a **non-repo** dir, and a **bare repo with no hook file**,
and asserts the generated command:
- runs the main-checkout hook and propagates exit 2 (both from the main checkout and from the worktree);
- is a silent exit-0 no-op off-repo and when the hook file is absent, with no `not a git repository` spam.

Directly demonstrated old-vs-new: in a linked worktree the old form exits 1
(`MODULE_NOT_FOUND` — gate silently broken) while the new form exits 2; in a
non-repo dir the old form spams and exits 1 while the new form is a silent exit 0.

Follow-up worth filing: a `harness doctor` migration check so already-onboarded
repos that still carry the old pattern get flagged (they keep it until they
re-run `harness hooks init`).

Closes #990