### PR TITLE
fix(cli): doctor resolves slash-command references instead of counting files

### DIFF
--- a/.changeset/doctor-resolve-slash-command-refs.md
+++ b/.changeset/doctor-resolve-slash-command-refs.md
@@ -1,0 +1,26 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): doctor resolves slash-command references instead of counting files
+
+`harness doctor` reported `✓ Slash commands installed (N commands)` by counting
+files in the output directory and never checking whether the `@`-references
+inside them resolve. On a machine where the CLI had been upgraded (2.8.0 →
+10.1.0) and the old install directory removed, every one of 51 commands pointed
+at a `SKILL.md` that no longer existed — and doctor was green for ~10 days
+(#1009). A slash command with a dangling `@` still runs, returning its wrapper
+with the skill body silently absent, so doctor was the only surface that could
+catch it.
+
+The check now resolves rather than counts: for each generated command it
+extracts the absolute `@`-referenced skill assets, verifies they exist, and
+reports `N commands, M resolvable`. When `M < N` it fails, names the first dead
+reference, and points at the fix — `harness generate-slash-commands` — which
+regenerates against the current install. A command with no `@`-refs (e.g. Gemini
+inlines the SKILL body) is self-contained and counts as resolvable.
+
+This also closes the "silent for 10 days" surface behind #1010: an upgrade that
+leaves generated commands pointing at the previous version's path is now
+detectable and actionable rather than invisible (`harness update` already offers
+regeneration post-upgrade).

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -37,12 +37,64 @@ function checkNodeVersion(): CheckResult {
   };
 }
 
-function countCommandFiles(dir: string, ext: string): number {
+/** Extract absolute `@`-referenced paths from a generated command file. */
+function extractCommandRefs(content: string): string[] {
+  return (
+    content
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('@'))
+      .map((line) => line.slice(1).trim())
+      // Only path-like references. Generated skill assets are embedded as absolute
+      // paths (e.g. `@/…/dist/agents/skills/…/SKILL.md`); an `@mention` in prose is
+      // not a path and must not be resolved.
+      .filter((ref) => path.isAbsolute(ref))
+  );
+}
+
+interface CommandDirResolution {
+  total: number;
+  resolvable: number;
+  // `| undefined` (not just `?`) so it may be returned explicitly under
+  // exactOptionalPropertyTypes.
+  firstDangling?: string | undefined;
+}
+
+/**
+ * Resolve a slash-command directory (#1009): count command files AND how many
+ * have every `@`-referenced skill asset present on disk. A command with no
+ * `@`-refs is self-contained (e.g. Gemini inlines the SKILL body) and counts as
+ * resolvable. Counting files alone reported `✓ installed` while every reference
+ * dangled — a slash command with a dead `@` still runs, returning its wrapper
+ * with the skill body silently absent, so `doctor` was the only surface that
+ * could catch it and it reported green.
+ */
+function resolveCommandDir(dir: string, ext: string): CommandDirResolution {
+  let files: string[];
   try {
-    return fs.readdirSync(dir).filter((f) => f.endsWith(ext)).length;
+    files = fs.readdirSync(dir).filter((f) => f.endsWith(ext));
   } catch {
-    return 0;
+    return { total: 0, resolvable: 0 };
   }
+
+  let resolvable = 0;
+  let firstDangling: string | undefined;
+  for (const file of files) {
+    let content: string;
+    try {
+      content = fs.readFileSync(path.join(dir, file), 'utf-8');
+    } catch {
+      firstDangling ??= path.join(dir, file);
+      continue;
+    }
+    const missing = extractCommandRefs(content).find((ref) => !fs.existsSync(ref));
+    if (missing) {
+      firstDangling ??= missing;
+    } else {
+      resolvable++;
+    }
+  }
+  return { total: files.length, resolvable, firstDangling };
 }
 
 function checkSlashCommands(): CheckResult[] {
@@ -62,19 +114,33 @@ function checkSlashCommands(): CheckResult[] {
   ];
 
   return platforms.map(({ name, dir, ext, client }) => {
-    const count = countCommandFiles(dir, ext);
-    if (count > 0) {
+    const { total, resolvable, firstDangling } = resolveCommandDir(dir, ext);
+    if (total === 0) {
       return {
         name: `slash-commands-${client}`,
-        status: 'pass' as const,
-        message: `Slash commands installed -> ${dir} (${count} commands)`,
+        status: 'fail' as const,
+        message: `No slash commands found for ${name}`,
+        fix: 'Run: harness setup',
+      };
+    }
+    if (resolvable < total) {
+      // The failure #1010 describes: a CLI upgrade leaves generated commands
+      // pointing at the previous version's install path. Report the denominator
+      // and the first dead reference so it is self-evident, and name the fix.
+      return {
+        name: `slash-commands-${client}`,
+        status: 'fail' as const,
+        message:
+          `Slash commands installed -> ${dir} (${total} commands, ${resolvable} resolvable) — ` +
+          `${total - resolvable} reference a SKILL.md that does not exist (e.g. ${firstDangling}). ` +
+          `A CLI upgrade leaves generated commands pointing at the old version's path.`,
+        fix: 'Run: harness generate-slash-commands (regenerates against the current install)',
       };
     }
     return {
       name: `slash-commands-${client}`,
-      status: 'fail' as const,
-      message: `No slash commands found for ${name}`,
-      fix: 'Run: harness setup',
+      status: 'pass' as const,
+      message: `Slash commands installed -> ${dir} (${total} commands, ${resolvable} resolvable)`,
     };
   });
 }

--- a/packages/cli/tests/commands/doctor.test.ts
+++ b/packages/cli/tests/commands/doctor.test.ts
@@ -144,6 +144,44 @@ describe('runDoctor', () => {
     expect(slashChecks.every((c) => c.fix !== undefined)).toBe(true);
   });
 
+  // Regression for #1009/#1010: doctor counted command files but never resolved
+  // their `@`-references, so it reported `✓ installed` while every command
+  // pointed at a SKILL.md removed by a CLI upgrade. The check must resolve, not
+  // count.
+  it('fails when a command references a SKILL.md that no longer resolves (#1009/#1010)', () => {
+    mockAllHealthy('/tmp/project');
+    // One generated Claude command references a SKILL.md under a now-removed
+    // versioned install path — the exact shape a CLI upgrade leaves behind.
+    const danglingRef = '/old/cli/2.8.0/dist/agents/skills/claude-code/init/SKILL.md';
+    mockReadFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+      const s = String(p);
+      if (s.endsWith('init.md')) return `# Init\n\n@${danglingRef}\n`;
+      return '{}';
+    });
+    const existsMap = buildExistsMap('/tmp/project');
+    mockExistsSync.mockImplementation((p: fs.PathLike) =>
+      String(p) === danglingRef ? false : (existsMap[String(p)] ?? false)
+    );
+
+    const result = runDoctor('/tmp/project');
+    const claudeSlash = result.checks.find((c) => c.name === 'slash-commands-claude-code');
+
+    expect(claudeSlash!.status).toBe('fail');
+    expect(claudeSlash!.message).toContain('2 commands, 1 resolvable');
+    expect(claudeSlash!.message).toContain(danglingRef);
+    expect(claudeSlash!.fix).toContain('generate-slash-commands');
+  });
+
+  it('reports the resolvable denominator on a healthy install (#1009)', () => {
+    mockAllHealthy('/tmp/project');
+
+    const result = runDoctor('/tmp/project');
+    const claudeSlash = result.checks.find((c) => c.name === 'slash-commands-claude-code');
+
+    expect(claudeSlash!.status).toBe('pass');
+    expect(claudeSlash!.message).toContain('2 commands, 2 resolvable');
+  });
+
   it('passes MCP check when harness entry exists in .mcp.json', () => {
     mockAllHealthy('/tmp/project');
 


### PR DESCRIPTION
## What

`harness doctor`'s slash-command check now **resolves** each generated command's
`@`-referenced skill assets instead of merely counting files, and reports
`N commands, M resolvable`.

## Why (#1009)

`checkSlashCommands` counted files in the output directory and never opened them
to check whether the `@`-references inside resolved. On a machine where the CLI
had been upgraded (2.8.0 → 10.1.0) and the old install directory removed, **51 of
51 commands pointed at a `SKILL.md` that no longer existed — and doctor was green
for ~10 days**. A slash command with a dangling `@` still runs: it returns its
wrapper with the skill body silently absent, so doctor was the only surface that
could catch it, and it reported `✓ installed`.

## Fix

For each generated command, extract the absolute `@`-referenced skill assets,
verify they exist, and report the denominator:

- `M === N` → pass: `N commands, M resolvable`.
- `M < N` → **fail**, naming the first dead reference and the fix:
  `harness generate-slash-commands` (regenerates against the current install).
- A command with no `@`-refs (e.g. Gemini inlines the SKILL body) is
  self-contained and counts as resolvable.

## #1010

This also closes the "silent for 10 days" surface behind #1010: an upgrade that
leaves generated commands pointing at the previous version's path is now
**detectable and actionable** rather than invisible. `harness update` already
offers regeneration post-upgrade (`offerRegeneration()`); doctor now catches the
case where an upgrade happened by another route (mise/npm directly).

## Tests

- New regression test mocks a command whose single `@`-ref points at a removed
  versioned install path → doctor fails with `2 commands, 1 resolvable`, names
  the dead reference, and points at `generate-slash-commands`.
- New test asserts the resolvable denominator on a healthy install.
- Verified revert-and-fail: with the old count-only behavior the regression test
  fails (`expected 'pass' to be 'fail'`); with the fix it passes.

Closes #1009