### PR TITLE
fix(cli): skill validate scans the working tree, honours its argument, reports the denominator

### DIFF
--- a/.changeset/skill-validate-working-tree.md
+++ b/.changeset/skill-validate-working-tree.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(cli): skill validate scans the working tree, honours its argument, reports the denominator
+
+`harness skill validate` resolved its skills directory with `resolveSkillsDir()`,
+which walks up from the CLI's own install location and therefore scanned the
+**installed bundle** (`<cli>/dist/agents/skills/...`), not the working tree. When
+authoring a skill in a checkout of this repo the validator could not see it, so
+it reported neither pass nor fail — its silence read as approval, and
+`harness-skill-authoring`'s "no skill ships without validation passing" gate
+could be satisfied while the validator had never looked at the file (#1011).
+
+Three fixes:
+
+- **Scan the working tree when inside a harness checkout.** Resolution now prefers
+  `resolveProjectSkillsDir()` (the `agents/skills/` above cwd), falling back to
+  the bundle otherwise, so a newly authored skill is actually validated.
+- **Honour the skill-name argument.** `harness skill validate <name>` validates
+  just that skill and fails if it is not found, instead of ignoring the argument
+  and validating the whole catalog.
+- **Report the denominator.** Output now says `Validated N skill(s) in <dir>`
+  (and the `--json` payload carries `skillsDir` + `scanned`), so "no errors" is
+  distinguishable from "nothing checked".

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1346,9 +1346,13 @@ Search for community skills on the @harness-skills registry
 - `--trigger` — Filter by trigger type (e.g., manual, automatic)
 - `--registry` — Use a custom npm registry URL
 
-### `harness skill validate`
+### `harness skill validate [skill-name]`
 
-Validate all skill.yaml files and SKILL.md structure
+Validate skill.yaml files and SKILL.md structure
+
+**Arguments:**
+
+- `skill-name` (optional) — Validate only this skill (fails if it is not found)
 
 ## Snapshot Commands
 

--- a/packages/cli/src/commands/skill/validate.ts
+++ b/packages/cli/src/commands/skill/validate.ts
@@ -5,7 +5,7 @@ import { parse } from 'yaml';
 import { SkillMetadataSchema } from '../../skill/schema';
 import { logger } from '../../output/logger';
 import { ExitCode } from '../../utils/errors';
-import { resolveSkillsDir } from '../../utils/paths';
+import { resolveProjectSkillsDir, resolveSkillsDir } from '../../utils/paths';
 
 const BEHAVIORAL_REQUIRED_SECTIONS = [
   '## When to Use',
@@ -82,41 +82,105 @@ export function validateSkillEntry(name: string, skillsDir: string, errors: stri
   }
 }
 
+export interface SkillValidationResult {
+  /** The directory that was scanned, or null when none exists. */
+  skillsDir: string | null;
+  /** How many skills were actually examined (the denominator). */
+  scanned: number;
+  /** Of the scanned skills, how many had a parseable skill.yaml. */
+  validated: number;
+  errors: string[];
+  /** Set when a requested skill name was not present in `skillsDir`. */
+  notFound?: string;
+}
+
+/**
+ * Resolve the skills directory to validate and run the checks (#1011).
+ *
+ * Prefers the working-tree `agents/skills/` when invoked inside a harness
+ * checkout, falling back to the installed CLI bundle otherwise. Previously this
+ * always scanned the bundle (`<cli>/dist/agents/skills/...`), so a skill authored
+ * in a checkout was never examined — the validator's silence read as approval,
+ * and `harness-skill-authoring`'s "no skill ships without validation passing"
+ * gate could be satisfied without the file ever being looked at.
+ */
+export function runSkillValidation(
+  // `| undefined` (not just `?`) so callers may pass through an unset optional
+  // under exactOptionalPropertyTypes.
+  opts: { cwd?: string | undefined; skillName?: string | undefined } = {}
+): SkillValidationResult {
+  const skillsDir = resolveProjectSkillsDir(opts.cwd) ?? resolveSkillsDir();
+
+  if (!fs.existsSync(skillsDir)) {
+    return { skillsDir: null, scanned: 0, validated: 0, errors: [] };
+  }
+
+  const allEntries = fs
+    .readdirSync(skillsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  // Honour the skill-name argument: validate just that skill and fail if it is
+  // not present, rather than silently validating everything else (#1011).
+  if (opts.skillName && !allEntries.includes(opts.skillName)) {
+    return { skillsDir, scanned: 0, validated: 0, errors: [], notFound: opts.skillName };
+  }
+  const entries = opts.skillName ? [opts.skillName] : allEntries;
+
+  const errors: string[] = [];
+  let validated = 0;
+  for (const name of entries) {
+    if (validateSkillEntry(name, skillsDir, errors)) validated++;
+  }
+
+  return { skillsDir, scanned: entries.length, validated, errors };
+}
+
 export function createValidateCommand(): Command {
   return new Command('validate')
-    .description('Validate all skill.yaml files and SKILL.md structure')
-    .action(async (_opts, cmd) => {
+    .description('Validate skill.yaml files and SKILL.md structure')
+    .argument('[skill-name]', 'Validate only this skill (fails if it is not found)')
+    .action(async (skillName: string | undefined, _opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
-      const skillsDir = resolveSkillsDir();
+      const result = runSkillValidation({ skillName });
 
-      if (!fs.existsSync(skillsDir)) {
-        logger.info('No skills directory found.');
+      if (result.skillsDir === null) {
+        if (globalOpts.json) {
+          logger.raw({ skillsDir: null, scanned: 0, validated: 0, errors: [] });
+        } else {
+          logger.info('No skills directory found.');
+        }
         process.exit(ExitCode.SUCCESS);
         return;
       }
 
-      const entries = fs
-        .readdirSync(skillsDir, { withFileTypes: true })
-        .filter((d) => d.isDirectory())
-        .map((d) => d.name);
-
-      const errors: string[] = [];
-      let validated = 0;
-
-      for (const name of entries) {
-        if (validateSkillEntry(name, skillsDir, errors)) validated++;
+      if (result.notFound) {
+        if (globalOpts.json) {
+          logger.raw({ ...result });
+        } else {
+          logger.error(`Skill not found: ${result.notFound} (searched ${result.skillsDir})`);
+        }
+        process.exit(ExitCode.ERROR);
+        return;
       }
 
       if (globalOpts.json) {
-        logger.raw({ validated, errors });
-      } else if (errors.length > 0) {
-        logger.error(`Validation failed with ${errors.length} error(s):`);
-        for (const err of errors) console.error(`  - ${err}`);
+        logger.raw({
+          skillsDir: result.skillsDir,
+          scanned: result.scanned,
+          validated: result.validated,
+          errors: result.errors,
+        });
+      } else if (result.errors.length > 0) {
+        logger.error(
+          `Validation failed with ${result.errors.length} error(s) across ${result.scanned} skill(s) in ${result.skillsDir}:`
+        );
+        for (const err of result.errors) console.error(`  - ${err}`);
         process.exit(ExitCode.ERROR);
-      } else {
-        if (!globalOpts.quiet) {
-          logger.success(`All ${validated} skill(s) validated successfully.`);
-        }
+      } else if (!globalOpts.quiet) {
+        // Report the denominator so "no errors" is distinguishable from
+        // "nothing checked" (#1011).
+        logger.success(`Validated ${result.scanned} skill(s) in ${result.skillsDir}.`);
       }
       process.exit(ExitCode.SUCCESS);
     });

--- a/packages/cli/tests/commands/skill/validate-skill.test.ts
+++ b/packages/cli/tests/commands/skill/validate-skill.test.ts
@@ -102,3 +102,90 @@ describe('skill validate — knowledge skill sections', () => {
     fs.rmSync(tmpDir, { recursive: true });
   });
 });
+
+// Regression for #1011: `harness skill validate` scanned the installed CLI
+// bundle, not the working tree — so a skill authored in a checkout was never
+// examined and the validator's silence read as approval. It also ignored the
+// skill-name argument and never reported the denominator.
+describe('runSkillValidation — working-tree resolution (#1011)', () => {
+  /** Build a `<root>/agents/skills/claude-code/` tree the way a checkout looks. */
+  function makeProject(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-validate-wt-'));
+    fs.mkdirSync(path.join(root, 'agents', 'skills', 'claude-code'), { recursive: true });
+    return root;
+  }
+
+  function writeKnowledgeSkill(root: string, name: string, opts: { withInstructions: boolean }) {
+    const dir = path.join(root, 'agents', 'skills', 'claude-code', name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'skill.yaml'),
+      [
+        `name: ${name}`,
+        "version: '1.0.0'",
+        'description: A working-tree skill under authoring',
+        'type: knowledge',
+        'tier: 3',
+        'cognitive_mode: advisory-guide',
+        'triggers: [manual]',
+        'platforms: [claude-code]',
+        'tools: []',
+        'state: { persistent: false, files: [] }',
+        'depends_on: []',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      opts.withInstructions
+        ? `# ${name}\n\n## Instructions\n\nDo the thing.`
+        : `# ${name}\n\n## Details\n\nNo instructions section.`
+    );
+  }
+
+  it('scans the working-tree skills when run inside a checkout', async () => {
+    const root = makeProject();
+    writeKnowledgeSkill(root, 'authored-skill', { withInstructions: true });
+
+    const { runSkillValidation } = await import('../../../src/commands/skill/validate.js');
+    const result = runSkillValidation({ cwd: root });
+
+    // The dir scanned must be the working tree, not the installed bundle.
+    expect(result.skillsDir).toBe(path.join(root, 'agents', 'skills', 'claude-code'));
+    expect(result.scanned).toBe(1);
+    expect(result.errors).toEqual([]);
+
+    fs.rmSync(root, { recursive: true });
+  });
+
+  it('actually validates a newly authored skill (its break is reported, not ignored)', async () => {
+    const root = makeProject();
+    writeKnowledgeSkill(root, 'broken-authored-skill', { withInstructions: false });
+
+    const { runSkillValidation } = await import('../../../src/commands/skill/validate.js');
+    const result = runSkillValidation({ cwd: root });
+
+    expect(result.scanned).toBe(1);
+    expect(result.errors.some((e) => e.includes('broken-authored-skill'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('## Instructions'))).toBe(true);
+
+    fs.rmSync(root, { recursive: true });
+  });
+
+  it('honours the skill-name argument and fails when it is not found', async () => {
+    const root = makeProject();
+    writeKnowledgeSkill(root, 'present-skill', { withInstructions: true });
+
+    const { runSkillValidation } = await import('../../../src/commands/skill/validate.js');
+
+    const found = runSkillValidation({ cwd: root, skillName: 'present-skill' });
+    expect(found.scanned).toBe(1);
+    expect(found.notFound).toBeUndefined();
+    expect(found.errors).toEqual([]);
+
+    const missing = runSkillValidation({ cwd: root, skillName: 'no-such-skill' });
+    expect(missing.notFound).toBe('no-such-skill');
+    expect(missing.scanned).toBe(0);
+
+    fs.rmSync(root, { recursive: true });
+  });
+});


### PR DESCRIPTION
## What

`harness skill validate` now resolves its skills directory to the **working
tree** when run inside a harness checkout, honours a `<skill-name>` argument, and
reports how many skills it actually examined.

## Why (#1011)

Resolution used `resolveSkillsDir()`, which walks up from the CLI's own install
location and therefore scanned the **installed bundle**
(`<cli>/dist/agents/skills/...`), not the working tree. When authoring a skill in
a checkout the validator could not see it, so it reported neither pass nor fail —
its silence read as approval. `harness-skill-authoring`'s Iron Law ("No skill
ships without validation passing") and its Gate could both be satisfied while the
validator had never looked at the new file. It also ignored the skill-name
argument and never reported a denominator, so "no errors" was indistinguishable
from "nothing checked".

## Fix

- **Working tree first:** prefer `resolveProjectSkillsDir()` (the `agents/skills/`
  above cwd), falling back to the bundle — so a newly authored skill is actually
  validated.
- **Honour the argument:** `harness skill validate <name>` validates just that
  skill and fails if it is not found.
- **Report the denominator:** `Validated N skill(s) in <dir>` (and `--json` now
  carries `skillsDir` + `scanned`).

Selection + run logic is extracted into a testable `runSkillValidation({ cwd,
skillName })`.

## Tests

New `runSkillValidation` suite builds a working-tree `agents/skills/claude-code/`
and asserts:
- it scans the working tree (not the bundle) — `skillsDir` points into the checkout;
- **a newly authored broken skill's break is reported, not ignored** (the core regression);
- the skill-name argument validates just that skill and fails (`notFound`) when absent.

Revert-and-fail verified: with bundle-only resolution the three working-tree tests
fail; with the fix they pass. Regenerated `docs/reference/cli-commands.md` for the
new argument.

Closes #1011