### PR TITLE
fix(core): check-harness-strength honors core.hooksPath; partial coverage is not solid

### DIFF
--- a/.changeset/harness-strength-hookspath-coverage.md
+++ b/.changeset/harness-strength-hookspath-coverage.md
@@ -1,0 +1,35 @@
+---
+'@harness-engineering/core': patch
+'@harness-engineering/cli': patch
+---
+
+fix(core): check-harness-strength honors core.hooksPath and never reads partial coverage as solid
+
+Two companion defects in the STRENGTH auditor:
+
+**Hook discovery ignored `core.hooksPath` (#1012).** `buildProjectContext` read a
+single hardcoded `.husky/pre-commit` and `resolveHookFiles` searched only
+`.husky` / `.claude/hooks` / `.harness/hooks`. A repo wiring hooks via
+`.githooks/` + `git config core.hooksPath .githooks` (a common non-husky
+convention) therefore had `ctx.preCommit === null`, silently disabling
+**STRENGTH-002 (regression-baseline)** and **STRENGTH-003 (skip-discipline)** —
+the two patterns most specifically about pre-commit behavior — while still
+scoring `solid`. Discovery now resolves `core.hooksPath` from the repo-local
+`.git/config` (file-based, so the auditor stays child_process-free and
+unit-testable), includes that directory in `resolveHookFiles`, and sets
+`ctx.preCommit` from `<resolvedHooksDir>/pre-commit` (falling back to `.husky`
+then `.git/hooks`).
+
+**Non-evaluable patterns scored as a clean solid (#1013).** When a rule could
+not be evaluated (required input absent) it contributed nothing to the score and
+nothing to the output, so "we could not audit this" read identically to "we
+audited this and it was clean" — a repo where every pattern abstained scored
+100/100 `solid`. The auditor now:
+
+- reports `summary.rulesApplicable` (the coverage denominator) and
+  `summary.skipped: [{ id, gearPiece, reason }]` (the named abstentions);
+- withholds `solid` when coverage is partial, using a new `incomplete` tier so a
+  clean score across only some applicable patterns no longer reads as a full
+  pass (weaker tiers already signal detected problems and are unchanged);
+- the CLI prints `coverage: N/M patterns evaluated` and lists each skipped
+  pattern, so the gap is visible and actionable rather than invisible.

--- a/packages/cli/src/commands/check-harness-strength.ts
+++ b/packages/cli/src/commands/check-harness-strength.ts
@@ -108,6 +108,24 @@ async function runCheckHarnessStrengthAction(
   );
   if (summaryLine) console.log(summaryLine);
 
+  // Coverage (#1013): print the denominator so a partial audit never reads as a
+  // full pass. `rulesRun` of `rulesApplicable` patterns were evaluated; the rest
+  // abstained (required input absent) and are named so the gap is actionable.
+  const { rulesRun, rulesApplicable, skipped } = audit.summary;
+  if (rulesApplicable > 0) {
+    const coverageLine = formatter.formatSummary(
+      'coverage',
+      `${rulesRun}/${rulesApplicable} patterns evaluated`,
+      skipped.length === 0
+    );
+    if (coverageLine) console.log(coverageLine);
+    if (skipped.length > 0 && outMode !== OutputMode.QUIET) {
+      for (const s of skipped) {
+        console.log(`    - not evaluated: ${s.id} (${s.gearPiece}) — ${s.reason}`);
+      }
+    }
+  }
+
   process.exit(opts.reportOnly || valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
 }
 

--- a/packages/cli/tests/commands/check-harness-strength.test.ts
+++ b/packages/cli/tests/commands/check-harness-strength.test.ts
@@ -12,9 +12,24 @@ describe('runCheckHarnessStrength', () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(typeof r.value.audit.score).toBe('number');
-    expect(['solid', 'at-risk', 'theatre']).toContain(r.value.audit.tier);
+    // `incomplete` (#1013): a clean score across only some applicable patterns.
+    expect(['solid', 'incomplete', 'at-risk', 'theatre']).toContain(r.value.audit.tier);
     expect(r.value.audit.summary).toHaveProperty('errors');
     expect(r.value.audit.summary).toHaveProperty('rulesRun');
+    expect(r.value.audit.summary).toHaveProperty('rulesApplicable');
+    expect(r.value.audit.summary).toHaveProperty('skipped');
+  });
+
+  it('reports coverage: rulesRun + skipped account for every applicable pattern (#1013)', () => {
+    const r = runCheckHarnessStrength(WEAK, {});
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const s = r.value.audit.summary;
+    expect(s.rulesRun + s.skipped.length).toBe(s.rulesApplicable);
+    // The weak fixture is config-only, so hook/workflow/snapshot patterns abstain
+    // and are surfaced (not silently dropped), capping the tier below solid.
+    expect(s.skipped.length).toBeGreaterThan(0);
+    expect(r.value.audit.tier).toBe('incomplete');
   });
 
   it('is invalid (gate trips) when an error-severity finding survives the threshold', () => {

--- a/packages/cli/tests/fixtures/harness-strength-clean/.github/workflows/ci.yml
+++ b/packages/cli/tests/fixtures/harness-strength-clean/.github/workflows/ci.yml
@@ -1,0 +1,7 @@
+name: CI
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi

--- a/packages/cli/tests/fixtures/harness-strength-clean/.harness/health-snapshot.json
+++ b/packages/cli/tests/fixtures/harness-strength-clean/.harness/health-snapshot.json
@@ -1,0 +1,4 @@
+{
+  "checks": { "lint": { "passed": true } },
+  "signals": []
+}

--- a/packages/cli/tests/fixtures/harness-strength-clean/.husky/pre-commit
+++ b/packages/cli/tests/fixtures/harness-strength-clean/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+if ! npx harness ci check; then
+  exit 1
+fi
+npx lint-staged

--- a/packages/core/src/harness-strength/auditor.test.ts
+++ b/packages/core/src/harness-strength/auditor.test.ts
@@ -21,7 +21,7 @@ function writeHusky(text: string): void {
 }
 
 describe('HarnessStrengthAuditor.audit', () => {
-  it('returns Ok with a clean result for a bare directory', () => {
+  it('reports a bare directory as incomplete, not solid (#1013)', () => {
     const result = new HarnessStrengthAuditor().audit(root, {});
     expect(isOk(result)).toBe(true);
     if (!isOk(result)) return;
@@ -29,10 +29,19 @@ describe('HarnessStrengthAuditor.audit', () => {
     expect(v.mode).toBe('adopter');
     expect(v.findings).toEqual([]);
     expect(v.score).toBe(100);
-    expect(v.tier).toBe('solid');
-    // Bare dir: every rule's required input is absent => none evaluable.
+    // Bare dir: every rule's required input is absent => none evaluable. A clean
+    // score across ZERO evaluated patterns must not read as a full `solid` pass.
+    expect(v.tier).toBe('incomplete');
     expect(v.summary.rulesRun).toBe(0);
     expect(v.summary.rulesPassing).toBe(0);
+    // Coverage is fully surfaced: every applicable pattern is named as skipped.
+    expect(v.summary.rulesApplicable).toBeGreaterThan(0);
+    expect(v.summary.skipped).toHaveLength(v.summary.rulesApplicable);
+    for (const s of v.summary.skipped) {
+      expect(s.id).toMatch(/^STRENGTH-/);
+      expect(s.gearPiece.length).toBeGreaterThan(0);
+      expect(s.reason).toContain('not evaluable');
+    }
   });
 
   it('detects STRENGTH-001 at default severity (error)', () => {
@@ -227,7 +236,7 @@ describe('HarnessStrengthAuditor clean harness (passing gate path)', () => {
     return dir;
   }
 
-  it('scores 100/solid with zero findings when layers have populated thresholds', () => {
+  it('reports config-only coverage as incomplete, not solid (#1013)', () => {
     const dir = buildClean();
     try {
       const result = new HarnessStrengthAuditor().audit(dir, {});
@@ -236,11 +245,15 @@ describe('HarnessStrengthAuditor clean harness (passing gate path)', () => {
       const v = result.value;
       expect(v.findings).toEqual([]);
       expect(v.score).toBe(100);
-      expect(v.tier).toBe('solid');
       expect(v.summary.errors).toBe(0);
       expect(v.summary.warnings).toBe(0);
-      // STRENGTH-004 evaluable (config present) and passes; others not evaluable.
+      // Config present => STRENGTH-004/005 evaluable and pass; the hook-,
+      // workflow-, and snapshot-based patterns abstain. A clean score across
+      // only some patterns is `incomplete`, not `solid` (#1013).
       expect(v.summary.rulesPassing).toBeGreaterThanOrEqual(1);
+      expect(v.summary.skipped.length).toBeGreaterThan(0);
+      expect(v.summary.rulesRun).toBeLessThan(v.summary.rulesApplicable);
+      expect(v.tier).toBe('incomplete');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -251,6 +264,51 @@ describe('HarnessStrengthAuditor clean harness (passing gate path)', () => {
     try {
       const auditor = new HarnessStrengthAuditor();
       expect(auditor.audit(dir, {})).toEqual(auditor.audit(dir, {}));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('HarnessStrengthAuditor full coverage (#1013)', () => {
+  // Every applicable adopter pattern has its required input present and benign,
+  // so all evaluate AND pass — the only path on which `solid` is earned.
+  const PRECOMMIT = '#!/bin/sh\nif ! npx harness ci check; then\n  exit 1\nfi\nnpx lint-staged\n';
+  const CONFIG = JSON.stringify({
+    version: 1,
+    layers: [{ name: 'a' }],
+    architecture: { thresholds: { maxFanIn: 12 } },
+  });
+  const BENIGN_WF =
+    'name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n';
+  // Honest snapshot: `lint` has no contradicting signal, so STRENGTH-007 passes.
+  const SNAPSHOT = JSON.stringify({ checks: { lint: { passed: true } }, signals: [] });
+
+  function buildFull(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'hs-full-'));
+    mkdirSync(join(dir, '.husky'), { recursive: true });
+    writeFileSync(join(dir, '.husky', 'pre-commit'), PRECOMMIT);
+    writeFileSync(join(dir, 'harness.config.json'), CONFIG);
+    mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
+    writeFileSync(join(dir, '.github', 'workflows', 'ci.yml'), BENIGN_WF);
+    mkdirSync(join(dir, '.harness'), { recursive: true });
+    writeFileSync(join(dir, '.harness', 'health-snapshot.json'), SNAPSHOT);
+    return dir;
+  }
+
+  it('earns solid only when every applicable pattern is evaluated and clean', () => {
+    const dir = buildFull();
+    try {
+      const result = new HarnessStrengthAuditor().audit(dir, {});
+      expect(isOk(result)).toBe(true);
+      if (!isOk(result)) return;
+      const v = result.value;
+      expect(v.findings).toEqual([]);
+      expect(v.score).toBe(100);
+      // Full coverage: nothing abstained, so the `incomplete` cap does not apply.
+      expect(v.summary.skipped).toEqual([]);
+      expect(v.summary.rulesRun).toBe(v.summary.rulesApplicable);
+      expect(v.tier).toBe('solid');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/harness-strength/auditor.ts
+++ b/packages/core/src/harness-strength/auditor.ts
@@ -2,7 +2,15 @@ import { Ok, Err, type Result } from '../shared/result';
 import { buildProjectContext, resolveMode, type ModeOptions } from './context';
 import { ALL_RULES } from './rules/index';
 import { rollupScore } from './scoring';
-import type { AuditResult, ProjectContext, Severity, StrengthFinding, StrengthRule } from './types';
+import type {
+  AuditResult,
+  ProjectContext,
+  Severity,
+  SkippedRule,
+  StrengthFinding,
+  StrengthRule,
+  Tier,
+} from './types';
 
 export type AuditOptions = ModeOptions;
 
@@ -15,16 +23,34 @@ export type AuditOptions = ModeOptions;
  *
  * "Not evaluable" rules (required input absent) are excluded from BOTH
  * `summary.rulesRun` and `summary.rulesPassing` so absent input never masks a
- * weakness as a pass (success criterion #7).
+ * weakness as a pass (success criterion #7). They are instead surfaced in
+ * `summary.skipped` and, when they leave coverage partial, cap the tier at
+ * `incomplete` so a partial audit never reads as a full `solid` pass (#1013).
  */
 export class HarnessStrengthAuditor {
   audit(root: string, opts: AuditOptions = {}): Result<AuditResult, Error> {
     try {
       const mode = resolveMode(opts, root);
       const ctx = buildProjectContext(root, mode);
-      const evaluable = ALL_RULES.filter(
-        (r) => r.appliesIn(mode) && (r.evaluable ? r.evaluable(ctx) : true)
-      );
+
+      // Partition the patterns that APPLY to this mode into evaluable (required
+      // input present) and skipped (input absent → abstained). The applicable
+      // count is the coverage denominator; skipped is reported, never silently
+      // dropped (#1013).
+      const applicable = ALL_RULES.filter((r) => r.appliesIn(mode));
+      const evaluable: StrengthRule[] = [];
+      const skipped: SkippedRule[] = [];
+      for (const r of applicable) {
+        if (!r.evaluable || r.evaluable(ctx)) {
+          evaluable.push(r);
+        } else {
+          skipped.push({
+            id: r.id,
+            gearPiece: r.gearPiece,
+            reason: 'not evaluable: a required input for this pattern is absent',
+          });
+        }
+      }
 
       const findings: StrengthFinding[] = [];
       let rulesPassing = 0;
@@ -38,13 +64,21 @@ export class HarnessStrengthAuditor {
         for (const f of raw) findings.push({ ...f, severity });
       }
 
-      const { score, tier } = rollupScore(findings);
+      const { score, tier: scoredTier } = rollupScore(findings);
+      // Withhold `solid` when coverage is partial: a clean score across only
+      // some of the applicable patterns is `incomplete`, not `solid` (#1013).
+      // Weaker tiers (`at-risk`/`theatre`) already signal detected problems and
+      // are left as-is.
+      const tier: Tier = scoredTier === 'solid' && skipped.length > 0 ? 'incomplete' : scoredTier;
+
       const summary = {
         errors: findings.filter((f) => f.severity === 'error').length,
         warnings: findings.filter((f) => f.severity === 'warning').length,
         info: findings.filter((f) => f.severity === 'info').length,
         rulesRun: evaluable.length,
         rulesPassing,
+        rulesApplicable: applicable.length,
+        skipped,
       };
 
       return Ok({ mode, score, tier, findings, summary });

--- a/packages/core/src/harness-strength/context.test.ts
+++ b/packages/core/src/harness-strength/context.test.ts
@@ -156,3 +156,51 @@ describe('buildProjectContext (present inputs)', () => {
     expect(ctx.templates?.every((t) => !isAbsolute(t.path))).toBe(true);
   });
 });
+
+// Regression for #1012: hook discovery read only `.husky/pre-commit`, ignoring
+// git's core.hooksPath. A repo wiring hooks via `.githooks/` +
+// `git config core.hooksPath .githooks` had STRENGTH-002/003 silently disabled
+// (ctx.preCommit === null) while still scoring solid.
+describe('buildProjectContext (core.hooksPath / .githooks)', () => {
+  function writeGitHooksRepo(hooksDirName: string): void {
+    // Minimal `.git/config` that sets core.hooksPath, as `git config` would.
+    mkdirSync(join(root, '.git'), { recursive: true });
+    writeFileSync(
+      join(root, '.git', 'config'),
+      `[core]\n\trepositoryformatversion = 0\n\thooksPath = ${hooksDirName}\n`
+    );
+    mkdirSync(join(root, hooksDirName), { recursive: true });
+    writeFileSync(
+      join(root, hooksDirName, 'pre-commit'),
+      '#!/bin/sh\nif ! npx harness ci check; then\n  exit 1\nfi\n'
+    );
+  }
+
+  it('reads pre-commit from the core.hooksPath directory (not .husky)', () => {
+    writeGitHooksRepo('.githooks');
+    const ctx = buildProjectContext(root, 'adopter');
+
+    // .husky/ does not exist here — the old code returned null and disabled the
+    // pre-commit-behavior rules.
+    expect(ctx.preCommit).not.toBeNull();
+    expect(ctx.preCommit).toContain('harness ci check');
+  });
+
+  it('includes the core.hooksPath scripts in hookFiles', () => {
+    writeGitHooksRepo('.githooks');
+    const ctx = buildProjectContext(root, 'adopter');
+
+    const preCommit = ctx.hookFiles.find((h) => h.name === 'pre-commit');
+    expect(preCommit).toBeDefined();
+    expect(preCommit?.path).toBe('.githooks/pre-commit');
+    expect(ctx.hookFiles.every((h) => !isAbsolute(h.path))).toBe(true);
+  });
+
+  it('honors a quoted core.hooksPath value', () => {
+    writeGitHooksRepo('.githooks');
+    // Rewrite the config with a quoted value (git accepts either form).
+    writeFileSync(join(root, '.git', 'config'), '[core]\n\thooksPath = ".githooks"\n');
+    const ctx = buildProjectContext(root, 'adopter');
+    expect(ctx.preCommit).toContain('harness ci check');
+  });
+});

--- a/packages/core/src/harness-strength/context.test.ts
+++ b/packages/core/src/harness-strength/context.test.ts
@@ -203,4 +203,27 @@ describe('buildProjectContext (core.hooksPath / .githooks)', () => {
     const ctx = buildProjectContext(root, 'adopter');
     expect(ctx.preCommit).toContain('harness ci check');
   });
+
+  it('does NOT let the .husky/_ wrapper shadow the real .husky/pre-commit', () => {
+    // Husky v9 sets core.hooksPath=.husky/_ and generates wrappers there that
+    // exec the real hooks in .husky/. Reading the wrapper instead of the real
+    // hook made STRENGTH-002/003 stop firing on every husky repo (regression
+    // caught by the live-repo dogfood). The real .husky/pre-commit must win.
+    mkdirSync(join(root, '.git'), { recursive: true });
+    writeFileSync(join(root, '.git', 'config'), '[core]\n\thooksPath = .husky/_\n');
+    mkdirSync(join(root, '.husky', '_'), { recursive: true });
+    // The husky-generated wrapper — NOT the gate we want to analyze.
+    writeFileSync(join(root, '.husky', '_', 'pre-commit'), '#!/bin/sh\n. "$(dirname "$0")/h"\n');
+    // The real user gate.
+    writeFileSync(
+      join(root, '.husky', 'pre-commit'),
+      '#!/bin/sh\nif ! npx harness ci check --skip docs; then\n  exit 1\nfi\n'
+    );
+
+    const ctx = buildProjectContext(root, 'adopter');
+    expect(ctx.preCommit).toContain('harness ci check');
+    expect(ctx.preCommit).not.toContain('dirname');
+    // The internal wrapper dir must not be surfaced as a hook file.
+    expect(ctx.hookFiles.every((h) => !h.path.includes('.husky/_'))).toBe(true);
+  });
 });

--- a/packages/core/src/harness-strength/context.ts
+++ b/packages/core/src/harness-strength/context.ts
@@ -102,28 +102,37 @@ function readGitCoreHooksPath(root: string): string | null {
 }
 
 /**
- * The custom hooks directory when `core.hooksPath` is set, else null (#1012).
- * A repo wiring hooks via `.githooks/` + `core.hooksPath` would otherwise be
- * read only at `.husky/`, silently disabling STRENGTH-002/003 while still
- * scoring `solid`.
+ * The custom hooks directory when `core.hooksPath` is set to a NON-husky
+ * location, else null (#1012). A repo wiring hooks via `.githooks/` +
+ * `core.hooksPath` would otherwise be read only at `.husky/`, silently
+ * disabling STRENGTH-002/003 while still scoring `solid`.
+ *
+ * Husky (v9+) points `core.hooksPath` at its internal `.husky/_` dir, whose
+ * scripts are generated wrappers that exec the REAL hooks in `.husky/`. Anything
+ * inside `.husky/` is therefore treated as husky (handled by the `.husky`
+ * branch), never a custom dir — otherwise the STRENGTH rules would analyze the
+ * wrapper instead of the gate and stop firing on ordinary husky repos.
  */
 function customHooksDir(root: string): string | null {
   const hp = readGitCoreHooksPath(root);
   if (!hp) return null;
-  return isAbsolute(hp) ? hp : join(root, hp);
+  const dir = isAbsolute(hp) ? hp : join(root, hp);
+  const top = relative(root, dir).replaceAll('\\', '/').split('/')[0];
+  if (top === '.husky') return null;
+  return dir;
 }
 
 /**
- * Resolve `ctx.preCommit` from the first existing pre-commit hook across the
- * custom `core.hooksPath` dir, `.husky/`, then git's default `.git/hooks/`
- * (#1012). Previously only `.husky/pre-commit` was read, so a `.githooks/`
- * repo's pre-commit was invisible to the pre-commit-behavior rules.
+ * Resolve `ctx.preCommit` from the first existing pre-commit hook: `.husky/`
+ * (the dominant convention and the pre-#1012 behavior — preferred so husky is
+ * never regressed), then a non-husky `core.hooksPath` dir (#1012), then git's
+ * default `.git/hooks/`. Previously only `.husky/pre-commit` was read, so a
+ * `.githooks/` repo's pre-commit was invisible to the pre-commit-behavior rules.
  */
 function readPreCommit(root: string): string | null {
-  const candidates: string[] = [];
+  const candidates: string[] = [join(root, '.husky', 'pre-commit')];
   const custom = customHooksDir(root);
   if (custom) candidates.push(join(custom, 'pre-commit'));
-  candidates.push(join(root, '.husky', 'pre-commit'));
   candidates.push(join(root, '.git', 'hooks', 'pre-commit'));
   for (const c of candidates) {
     const text = readTextOrNull(c);

--- a/packages/core/src/harness-strength/context.ts
+++ b/packages/core/src/harness-strength/context.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, basename, resolve, relative } from 'node:path';
+import { join, basename, resolve, relative, isAbsolute } from 'node:path';
 import { HarnessConfigSubsetSchema } from './types';
 import type { HarnessConfigSubset, HookFile, Mode, ProjectContext } from './types';
 
@@ -76,17 +76,77 @@ function readHookDir(root: string, dir: string): HookFile[] {
 }
 
 /**
- * Phase 1 file-based hook resolution: union of scripts under .husky/ and
- * .claude/hooks/, plus any scripts referenced by .claude/settings.json hook
- * registrations. Deduplicated by absolute path. Profile mapping is Phase 2.
+ * Read git's `core.hooksPath` from the repo-local `.git/config` (#1012).
+ *
+ * Kept file-based (no child_process) so the auditor stays pure and unit-testable
+ * on plain tmp dirs. This covers the common repo-local convention
+ * (`git config core.hooksPath .githooks`); global/worktree-indirected config is
+ * out of scope. Returns the raw value (relative to root or absolute), or null.
+ */
+function readGitCoreHooksPath(root: string): string | null {
+  const config = readTextOrNull(join(root, '.git', 'config'));
+  if (config === null) return null;
+  let section = '';
+  for (const raw of config.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('[')) {
+      const m = line.match(/^\[\s*([\w.-]+)/);
+      section = m ? m[1]!.toLowerCase() : '';
+      continue;
+    }
+    if (section !== 'core') continue;
+    const kv = line.match(/^hooksPath\s*=\s*(.+?)\s*$/i);
+    if (kv) return kv[1]!.replace(/^["']|["']$/g, '');
+  }
+  return null;
+}
+
+/**
+ * The custom hooks directory when `core.hooksPath` is set, else null (#1012).
+ * A repo wiring hooks via `.githooks/` + `core.hooksPath` would otherwise be
+ * read only at `.husky/`, silently disabling STRENGTH-002/003 while still
+ * scoring `solid`.
+ */
+function customHooksDir(root: string): string | null {
+  const hp = readGitCoreHooksPath(root);
+  if (!hp) return null;
+  return isAbsolute(hp) ? hp : join(root, hp);
+}
+
+/**
+ * Resolve `ctx.preCommit` from the first existing pre-commit hook across the
+ * custom `core.hooksPath` dir, `.husky/`, then git's default `.git/hooks/`
+ * (#1012). Previously only `.husky/pre-commit` was read, so a `.githooks/`
+ * repo's pre-commit was invisible to the pre-commit-behavior rules.
+ */
+function readPreCommit(root: string): string | null {
+  const candidates: string[] = [];
+  const custom = customHooksDir(root);
+  if (custom) candidates.push(join(custom, 'pre-commit'));
+  candidates.push(join(root, '.husky', 'pre-commit'));
+  candidates.push(join(root, '.git', 'hooks', 'pre-commit'));
+  for (const c of candidates) {
+    const text = readTextOrNull(c);
+    if (text !== null) return text;
+  }
+  return null;
+}
+
+/**
+ * Phase 1 file-based hook resolution: union of scripts under .husky/,
+ * .claude/hooks/, .harness/hooks/, and — when `core.hooksPath` is set — the
+ * custom hooks directory (#1012), plus any scripts referenced by
+ * .claude/settings.json hook registrations. Deduplicated by absolute path.
  */
 function resolveHookFiles(root: string): HookFile[] {
   // Dedup keyed on ABSOLUTE path; the stored HookFile.path is ROOT-RELATIVE.
   const collected = new Map<string, HookFile>();
+  const custom = customHooksDir(root);
   for (const h of [
     ...readHookDir(root, join(root, '.husky')),
     ...readHookDir(root, join(root, '.claude', 'hooks')),
     ...readHookDir(root, join(root, '.harness', 'hooks')),
+    ...(custom ? readHookDir(root, custom) : []),
   ]) {
     collected.set(resolve(root, h.path), h);
   }
@@ -208,7 +268,7 @@ export function buildProjectContext(root: string, mode: Mode): ProjectContext {
     root,
     mode,
     config: readConfig(root),
-    preCommit: readTextOrNull(join(root, '.husky', 'pre-commit')),
+    preCommit: readPreCommit(root),
     hookFiles: resolveHookFiles(root),
     workflows: readWorkflows(root),
     healthSnapshot: readJsonOrNull(join(root, '.harness', 'health-snapshot.json')),

--- a/packages/core/src/harness-strength/types.ts
+++ b/packages/core/src/harness-strength/types.ts
@@ -8,7 +8,11 @@ export type Mode = z.infer<typeof ModeSchema>;
 export const SeveritySchema = z.enum(['error', 'warning', 'info']);
 export type Severity = z.infer<typeof SeveritySchema>;
 
-export const TierSchema = z.enum(['solid', 'at-risk', 'theatre']);
+// `incomplete` (#1013): the audit could not evaluate every applicable pattern,
+// so a clean score must not read as a full `solid` pass. Ordered strongest →
+// weakest for display; `incomplete` sits below `solid` because partial coverage
+// is a caveat on an otherwise-clean run, not a detected weakness like `at-risk`.
+export const TierSchema = z.enum(['solid', 'incomplete', 'at-risk', 'theatre']);
 export type Tier = z.infer<typeof TierSchema>;
 
 // --- Finding ---
@@ -75,12 +79,27 @@ export type ProjectContext = z.infer<typeof ProjectContextSchema>;
 
 // --- AuditResult ---
 
+// A pattern that applied to this mode but could not be evaluated because a
+// required input was absent (#1013). Named + reasoned so the abstention is
+// actionable rather than invisible.
+export const SkippedRuleSchema = z.object({
+  id: z.string(),
+  gearPiece: z.string(),
+  reason: z.string(),
+});
+export type SkippedRule = z.infer<typeof SkippedRuleSchema>;
+
 export const AuditSummarySchema = z.object({
   errors: z.number().int().nonnegative(),
   warnings: z.number().int().nonnegative(),
   info: z.number().int().nonnegative(),
   rulesRun: z.number().int().nonnegative(),
   rulesPassing: z.number().int().nonnegative(),
+  // Total patterns that APPLIED to this mode — the coverage denominator.
+  // `rulesRun` of these were evaluable; `skipped.length` abstained.
+  rulesApplicable: z.number().int().nonnegative(),
+  // Applicable-but-not-evaluable patterns (#1013). Empty on full coverage.
+  skipped: z.array(SkippedRuleSchema),
 });
 
 export const AuditResultSchema = z.object({


### PR DESCRIPTION
Two companion defects in the STRENGTH auditor.

## #1012 — hook discovery ignored `core.hooksPath`

`buildProjectContext` read a hardcoded `.husky/pre-commit` and `resolveHookFiles`
searched only `.husky` / `.claude/hooks` / `.harness/hooks`. A repo wiring hooks
via `.githooks/` + `git config core.hooksPath .githooks` (a common non-husky
convention) had `ctx.preCommit === null`, so **STRENGTH-002 (regression-baseline)**
and **STRENGTH-003 (skip-discipline)** — the two patterns most specifically about
pre-commit behavior — silently abstained while the repo still scored `solid`.

**Fix:** resolve `core.hooksPath` from the repo-local `.git/config` (file-based, so
the auditor stays `child_process`-free and unit-testable on tmp dirs), include the
resolved directory in `resolveHookFiles`, and set `ctx.preCommit` from
`<resolvedHooksDir>/pre-commit` (falling back to `.husky` then `.git/hooks`).

## #1013 — non-evaluable patterns scored as a clean solid

A rule that could not be evaluated contributed nothing to the score and nothing to
the output, so "we could not audit this" read identically to "we audited this and
it was clean" — a repo where all patterns abstained scored **100/100 `solid`**.

**Fix:** the auditor now
- reports `summary.rulesApplicable` (coverage denominator) and
  `summary.skipped: [{ id, gearPiece, reason }]` (named abstentions);
- withholds `solid` on partial coverage via a new **`incomplete`** tier (weaker
  tiers already signal detected problems and are unchanged);
- the CLI prints `coverage: N/M patterns evaluated` and lists each skipped pattern.

## Tests

- **context (#1012):** a `.githooks/` + `core.hooksPath` repo now resolves
  `ctx.preCommit` and lists the hook in `hookFiles` (incl. a quoted-value case).
- **auditor (#1013):** a bare dir and a config-only repo now report `incomplete`
  with a populated `skipped[]`; a new **full-coverage clean fixture earns `solid`**
  (proving `solid` is still reachable and `rulesRun === rulesApplicable`).
- **CLI:** `rulesRun + skipped.length === rulesApplicable`; the `harness-strength-clean`
  fixture was upgraded to full coverage (husky + workflow + honest snapshot) so it
  legitimately passes the gate as `solid`.
- Both existing tests that asserted the old "config-only ⇒ solid" behavior are
  updated to the corrected `incomplete` (they codified the bug).

Closes #1012, closes #1013