### PR TITLE
fix(config): reserve co-tenant namespaces so harness.config.json stops warning on shared keys

### DIFF
--- a/.changeset/config-reserve-cotenant-namespaces.md
+++ b/.changeset/config-reserve-cotenant-namespaces.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(config): reserve co-tenant namespaces so harness.config.json stops warning on shared keys
+
+`harness.config.json` is in practice a **shared file**: sibling tools read their
+own top-level namespace out of it (e.g. Canary reads `canary` directly). Since
+the stripped-key warning landed (#862), harness warned on that live, load-bearing
+block — `⚠ harness.config.json: ignored unknown key 'canary'`. The warning is
+correct from harness's point of view and **actively harmful in effect**: the
+obvious way to silence it is to delete the key, which silently resets the
+co-tenant's gate configuration (#982).
+
+The dropped-key detector now recognizes reserved co-tenant namespaces at the
+**root** and never reports them: an explicit allow-list (`canary`) plus the
+`x-*` extension convention for tools harness has not been told about. The
+reservation is root-only and narrow — a genuinely-unknown root key
+(`frobnicate`) is still reported, and a `canary` key **mis-nested** under a known
+section (`entropy.canary`) is still caught, since only the root is co-tenant
+space.
+
+Addresses ask (1) of #982. Asks (2) pin the publisher's own smoke test and (3)
+the release-cadence / `stable` dist-tag / config-migration policy are distribution
+decisions left to the maintainers.

--- a/packages/cli/src/config/stripped-keys.test.ts
+++ b/packages/cli/src/config/stripped-keys.test.ts
@@ -58,6 +58,31 @@ describe('collectStrippedKeys — schema-aware dropped-key detection', () => {
     expect(misnested[0]).not.toHaveProperty('suggestion');
   });
 
+  // #982: harness.config.json is a shared file; co-tenant tools read their own
+  // top-level namespace out of it. Warning on those keys is harmful — deleting
+  // the key to silence the warning silently resets the co-tenant's config.
+  it('does NOT report a reserved co-tenant namespace at the root (canary)', () => {
+    const raw = { version: 1, canary: { guardian: { block: ['diff-coverage'] } } };
+    expect(collectStrippedKeys(HarnessConfigSchema, raw)).toEqual([]);
+  });
+
+  it('does NOT report a root-level x-* extension namespace', () => {
+    const raw = { version: 1, 'x-myteam': { anything: true } };
+    expect(collectStrippedKeys(HarnessConfigSchema, raw)).toEqual([]);
+  });
+
+  it('still reports a genuinely unknown root key (allow-list stays narrow)', () => {
+    const raw = { version: 1, frobnicate: { enabled: true } };
+    expect(collectStrippedKeys(HarnessConfigSchema, raw)).toEqual([{ path: 'frobnicate' }]);
+  });
+
+  it('still reports a "canary" key that is mis-nested, not a root co-tenant namespace', () => {
+    // Only the ROOT is co-tenant space; `canary` under a known section is a real
+    // strip (and exactly the kind of mis-nesting the warning exists to catch).
+    const raw = { version: 1, entropy: { canary: {} } };
+    expect(collectStrippedKeys(HarnessConfigSchema, raw)).toEqual([{ path: 'entropy.canary' }]);
+  });
+
   it('formats a warning line that names the stripped path', () => {
     const lines = formatStrippedKeyWarnings([{ path: 'entropy.analyze' }]);
     expect(lines).toEqual(["⚠ harness.config.json: ignored unknown key 'entropy.analyze'"]);
@@ -105,6 +130,17 @@ describe('loadConfig — non-fatal stripped-key warning wiring (#862)', () => {
   it('emits no warning for a config whose extras live under a passthrough section', () => {
     const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     const p = writeConfig({ version: 1, security: { enabled: true, customFoo: { bar: 1 } } });
+
+    const result = loadConfig(p);
+
+    expect(result.ok).toBe(true);
+    const output = stderr.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).not.toContain('ignored unknown key');
+  });
+
+  it('emits no warning for a co-tenant namespace block (canary) (#982)', () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const p = writeConfig({ version: 1, canary: { guardian: { block: ['diff-coverage'] } } });
 
     const result = loadConfig(p);
 

--- a/packages/cli/src/config/stripped-keys.ts
+++ b/packages/cli/src/config/stripped-keys.ts
@@ -34,6 +34,23 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Top-level namespaces that `harness.config.json` reserves for co-tenant tools
+ * (#982). The file is in practice a SHARED file: sibling tools read their own
+ * namespace directly out of it (e.g. Canary reads `canary`). Warning on these
+ * load-bearing keys is actively harmful — the obvious way to silence the warning
+ * is to delete the key, which silently resets the co-tenant's config. harness
+ * does not own these keys and must not police them.
+ *
+ * Reserved: an explicit allow-list of known co-tenants, plus the `x-*` extension
+ * convention for anything harness has not been told about.
+ */
+const RESERVED_COTENANT_NAMESPACES = new Set(['canary']);
+
+function isReservedCotenantKey(key: string): boolean {
+  return RESERVED_COTENANT_NAMESPACES.has(key) || key.startsWith('x-');
+}
+
+/**
  * Case-insensitive Levenshtein distance, capped for short identifiers.
  */
 function editDistance(a: string, b: string): number {
@@ -156,6 +173,10 @@ function walkObject(def: ZodDef, value: unknown, prefix: string, out: StrippedKe
     if (child) {
       walk(child, value[key], childPath, out);
     } else if (!passthrough) {
+      // A reserved co-tenant namespace at the ROOT is another tool's config, not
+      // a dropped harness key — never report it (#982). Only the root is
+      // co-tenant space; a `canary` nested elsewhere is still a real strip.
+      if (prefix === '' && isReservedCotenantKey(key)) continue;
       // `strict` would already have failed the top-level parse, so any key we
       // reach here under a non-passthrough object was strip-dropped. Passthrough
       // extras are intentionally kept and are never reported.


### PR DESCRIPTION
Addresses **ask (1)** of #982 — "reserve co-tenant config namespaces (highest
impact, smallest change)".

## Why

`harness.config.json` is in practice a **shared file**: sibling tools read their
own top-level namespace out of it (Canary reads `canary` directly —
`canary/ts/src/guardian/pr-check.ts`). Since the stripped-key warning landed
(#862), harness warns on that live, load-bearing block:

```
⚠ harness.config.json: ignored unknown key 'canary'
```

The warning is correct from harness's point of view and **actively harmful in
effect**: the obvious way to make it go away is to delete the key, which silently
resets a consumer's guardian gate.

## Fix

The dropped-key detector now recognizes reserved co-tenant namespaces at the
**root** and never reports them:
- an explicit allow-list (`canary`), and
- the `x-*` extension convention for tools harness has not been told about.

The reservation is deliberately **root-only and narrow**:
- a genuinely-unknown root key (`frobnicate`) is still reported;
- a `canary` key **mis-nested** under a known section (`entropy.canary`) is still
  caught — only the root is co-tenant space.

## Tests

Added unit + `loadConfig` integration tests: `canary` and `x-*` at the root emit
no warning; `frobnicate` and `entropy.canary` still do. Revert-and-fail verified
(without the reservation, the co-tenant cases report `{ path: 'canary' }`).

## Not in this PR (maintainer decisions)

#982 also asks to (2) pin the publisher's own `smoke-test.yml` like a consumer and
(3) adopt a release cadence + `stable` dist-tag + config-schema migrations. Those
are distribution-policy decisions (which pin idiom, cadence, support window) that
belong to the maintainers rather than a mechanical fix — see the issue for a
proposed approach. This PR does **not** close #982.