### PR TITLE
feat(eslint-plugin): add no-process-exit rule

### DIFF
--- a/.changeset/no-process-exit.md
+++ b/.changeset/no-process-exit.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/eslint-plugin': patch
+---
+
+Add no-process-exit ESLint rule.

--- a/docs/reference/eslint-rules.md
+++ b/docs/reference/eslint-rules.md
@@ -616,3 +616,17 @@ spawn('node', ['script.js'], {
 ---
 
 _Last Updated: 2026-04-18_
+| `no-process-exit` | Security | `error` | No |
+| `no-process-env-in-spawn` | Security | `error` | No |
+
+**Note:** The `recommended` config enables the architecture, boundary, documentation, cross-platform, and most test/performance rules. Performance rules (`no-nested-loops-in-critical`, `no-sync-io-in-async`, `no-unbounded-array-chains`) are set to `warn` severity. To customize severity:
+
+```js
+'@harness-engineering/no-nested-loops-in-critical': 'warn',
+'@harness-engineering/no-sync-io-in-async': 'warn',
+'@harness-engineering/no-unbounded-array-chains': 'warn',
+```
+
+---
+
+_Last Updated: 2026-04-18_

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -14,6 +14,7 @@ import noHardcodedTestCount from './no-hardcoded-test-count';
 import noLayerViolation from './no-layer-violation';
 import noNestedLoopsInCritical from './no-nested-loops-in-critical';
 import noProcessEnvInSpawn from './no-process-env-in-spawn';
+import noProcessExit from './no-process-exit';
 import noSkippedTests from './no-skipped-tests';
 import noSpreadInVariadic from './no-spread-in-variadic';
 import noSyncIoInAsync from './no-sync-io-in-async';
@@ -39,6 +40,7 @@ export const rules: Record<string, TSESLint.RuleModule<string, unknown[]>> = {
   'no-layer-violation': noLayerViolation,
   'no-nested-loops-in-critical': noNestedLoopsInCritical,
   'no-process-env-in-spawn': noProcessEnvInSpawn,
+  'no-process-exit': noProcessExit,
   'no-skipped-tests': noSkippedTests,
   'no-spread-in-variadic': noSpreadInVariadic,
   'no-sync-io-in-async': noSyncIoInAsync,

--- a/packages/eslint-plugin/src/rules/no-process-exit.ts
+++ b/packages/eslint-plugin/src/rules/no-process-exit.ts
@@ -1,0 +1,42 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/harness-engineering/eslint-plugin/blob/main/docs/rules/${name}.md`
+);
+
+type MessageIds = 'noProcessExit';
+
+export default createRule<[], MessageIds>({
+  name: 'no-process-exit',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow direct process.exit() calls that bypass graceful shutdown.',
+    },
+    messages: {
+      noProcessExit:
+        'Direct process.exit() call — use graceful shutdown instead to allow pending async cleanup.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Check for process.exit() and process.exit(1) calls
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'process' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'exit'
+        ) {
+          context.report({
+            node,
+            messageId: 'noProcessExit',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/rules/no-process-exit.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-process-exit.test.ts
@@ -1,0 +1,37 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { describe, it, afterAll } from 'vitest';
+import rule from '../../src/rules/no-process-exit';
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-process-exit', rule, {
+  valid: [
+    // Regular function calls
+    { code: `console.log('hello');` },
+    { code: `someFunction();` },
+    // Non-call member access like process.env
+    { code: `process.env;` },
+    { code: `process.pid;` },
+    // Other unrelated member calls
+    { code: `foo.exit();` },
+    { code: `bar.process.exit();` },
+    // Bare exit call (not related to process)
+    { code: `exit(1);` },
+  ],
+  invalid: [
+    // process.exit()
+    {
+      code: `process.exit();`,
+      errors: [{ messageId: 'noProcessExit' }],
+    },
+    // process.exit(1)
+    {
+      code: `process.exit(1);`,
+      errors: [{ messageId: 'noProcessExit' }],
+    },
+  ],
+});


### PR DESCRIPTION
New ESLint rule `no-process-exit` for @harness-engineering/eslint-plugin — flags direct `process.exit(...)` calls in source that bypass graceful shutdown.

**Produced fully autonomously by the local/hybrid orchestrator pipeline** (Claude design/plan/review + local qwen3-coder:30b execute/verify via codex-exec): rule + RuleTester test + reference-doc entry + changeset. Passed the enforced gates (typecheck + lint + test, spec-vs-diff outcome-eval) and the full pre-push gauntlet (changeset check, whole-tree format:check). Committed + pushed by the orchestrator's deterministic ship; only `gh pr create` needed the keyring token (detached-process env).