### PR TITLE
chore(roadmap): mark shipped ESLint rules #223/#224 done

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1346,13 +1346,9 @@ Search for community skills on the @harness-skills registry
 - `--trigger` — Filter by trigger type (e.g., manual, automatic)
 - `--registry` — Use a custom npm registry URL
 
-### `harness skill validate [skill-name]`
+### `harness skill validate`
 
-Validate skill.yaml files and SKILL.md structure
-
-**Arguments:**
-
-- `skill-name` (optional) — Validate only this skill (fails if it is not found)
+Validate all skill.yaml files and SKILL.md structure
 
 ## Snapshot Commands
 

--- a/docs/roadmap.d/eslint-rule-no-hardcoded-test-count.md
+++ b/docs/roadmap.d/eslint-rule-no-hardcoded-test-count.md
@@ -6,9 +6,9 @@ order: 3
 
 ### ESLint Rule: no-hardcoded-test-count
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** New ESLint rule to flag magic-number `toHaveLength(N)` assertions in test files where N matches a registry/array size. Fragile to additions — 2 recurring gotchas in learnings where tool count assertions broke on every new tool. Suggest dynamic `TOOL_DEFINITIONS.length` references.
+- **Summary:** DELIVERED (PR #871, merged). New ESLint rule flags magic-number `toHaveLength(N)` assertions in test files where N matches a registry/array size; suggests dynamic `.length` references. Rule implemented at packages/eslint-plugin/src/rules/no-hardcoded-test-count.ts, registered as an 'error' in the recommended config, tests passing. Row was stale — auto-done did not fire because External-ID #224 is the issue number while the merge PR was #871.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —

--- a/docs/roadmap.d/eslint-rule-no-undefined-optional-assignment.md
+++ b/docs/roadmap.d/eslint-rule-no-undefined-optional-assignment.md
@@ -6,9 +6,9 @@ order: 2
 
 ### ESLint Rule: no-undefined-optional-assignment
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** New ESLint rule to flag `{ optionalField: valueOrUndefined }` assignments that fail with `exactOptionalPropertyTypes`. 5 recurring gotchas in learnings. Suggest conditional spread `...(val !== undefined && { field: val })` instead.
+- **Summary:** DELIVERED (PR #834, merged). New ESLint rule flags `{ optionalField: valueOrUndefined }` assignments that fail with `exactOptionalPropertyTypes`; suggests conditional spread `...(val !== undefined && { field: val })`. Rule implemented at packages/eslint-plugin/src/rules/no-undefined-optional-assignment.ts, registered in the plugin, 13 passing tests. Row was stale — auto-done did not fire because External-ID #223 is the issue number while the merge PR was #834.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1080,9 +1080,9 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### ESLint Rule: no-undefined-optional-assignment
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** New ESLint rule to flag `{ optionalField: valueOrUndefined }` assignments that fail with `exactOptionalPropertyTypes`. 5 recurring gotchas in learnings. Suggest conditional spread `...(val !== undefined && { field: val })` instead.
+- **Summary:** DELIVERED (PR #834, merged). New ESLint rule flags `{ optionalField: valueOrUndefined }` assignments that fail with `exactOptionalPropertyTypes`; suggests conditional spread `...(val !== undefined && { field: val })`. Rule implemented at packages/eslint-plugin/src/rules/no-undefined-optional-assignment.ts, registered in the plugin, 13 passing tests. Row was stale — auto-done did not fire because External-ID #223 is the issue number while the merge PR was #834.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —
@@ -1091,9 +1091,9 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### ESLint Rule: no-hardcoded-test-count
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** New ESLint rule to flag magic-number `toHaveLength(N)` assertions in test files where N matches a registry/array size. Fragile to additions — 2 recurring gotchas in learnings where tool count assertions broke on every new tool. Suggest dynamic `TOOL_DEFINITIONS.length` references.
+- **Summary:** DELIVERED (PR #871, merged). New ESLint rule flags magic-number `toHaveLength(N)` assertions in test files where N matches a registry/array size; suggests dynamic `.length` references. Rule implemented at packages/eslint-plugin/src/rules/no-hardcoded-test-count.ts, registered as an 'error' in the recommended config, tests passing. Row was stale — auto-done did not fire because External-ID #224 is the issue number while the merge PR was #871.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —


### PR DESCRIPTION
## What

Corrects two stale roadmap rows to **done**. Both ESLint rules were already implemented, registered, and tested — but auto-done never fired because each row's External-ID is the *issue* number while the *merge PR* was numbered differently (a known recurring roadmap-sync gap).

| Row | Rule | Shipped in |
|-----|------|-----------|
| #223 | `no-undefined-optional-assignment` | PR #834 |
| #224 | `no-hardcoded-test-count` | PR #871 |

Verified: both rules exist under `packages/eslint-plugin/src/rules/`, are registered in the plugin (`no-hardcoded-test-count` as `error` in the recommended config), and their tests pass (26 tests green).

## Also included

- Regenerated `docs/reference/cli-commands.md` — pre-existing drift on `main` that the pre-push docs-freshness gate required to push. Reflects an already-landed `harness skill validate` help-text change; no behavior change.

## Why no code

This is a roadmap-accuracy correction only — the work was already delivered. Part of a sweep clearing simple/already-done roadmap items.