### PR TITLE
chore(roadmap): mark shipped dependency migrations #298/#299 done

### DIFF
--- a/docs/roadmap.d/migrate-to-google-genai-sdk.md
+++ b/docs/roadmap.d/migrate-to-google-genai-sdk.md
@@ -6,9 +6,9 @@ order: 4
 
 ### Migrate to @google/genai SDK
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** Migrate from deprecated @google/generative-ai@0.24.1 to @google/genai@2.x in packages/orchestrator and packages/intelligence; upstream has stopped publishing the old package
+- **Summary:** DELIVERED (commit eb801b788, "chore(orchestrator): migrate to @google/genai 2.x SDK"; CHANGELOG a6f7cd3). packages/orchestrator gemini backend imports @google/genai (package.json: @google/genai@^2.0.4); the deprecated @google/generative-ai is fully removed. GeminiBackend public API unchanged. Row was stale — completed via a commit whose PR number differs from External-ID #298, so auto-done never fired.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —

--- a/docs/roadmap.d/upgrade-hono-node-server-to-v2.md
+++ b/docs/roadmap.d/upgrade-hono-node-server-to-v2.md
@@ -6,9 +6,9 @@ order: 5
 
 ### Upgrade @hono/node-server to v2
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** Major version bump from @hono/node-server@1.19.x to v2.x in packages/dashboard; audit breaking changes and relax pnpm.overrides "@hono/node-server" pin
+- **Summary:** DELIVERED (commit 0ca37f4cf, "chore(deps): upgrade @hono/node-server to v2.0.4"). packages/dashboard runs on @hono/node-server v2 and the pnpm.overrides pin is relaxed to ">=2.0.10" (package.json). Row was stale — completed via a deps commit whose PR number differs from External-ID #299, so auto-done never fired.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1102,9 +1102,9 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Migrate to @google/genai SDK
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** Migrate from deprecated @google/generative-ai@0.24.1 to @google/genai@2.x in packages/orchestrator and packages/intelligence; upstream has stopped publishing the old package
+- **Summary:** DELIVERED (commit eb801b788, "chore(orchestrator): migrate to @google/genai 2.x SDK"; CHANGELOG a6f7cd3). packages/orchestrator gemini backend imports @google/genai (package.json: @google/genai@^2.0.4); the deprecated @google/generative-ai is fully removed. GeminiBackend public API unchanged. Row was stale — completed via a commit whose PR number differs from External-ID #298, so auto-done never fired.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —
@@ -1113,9 +1113,9 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Upgrade @hono/node-server to v2
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** Major version bump from @hono/node-server@1.19.x to v2.x in packages/dashboard; audit breaking changes and relax pnpm.overrides "@hono/node-server" pin
+- **Summary:** DELIVERED (commit 0ca37f4cf, "chore(deps): upgrade @hono/node-server to v2.0.4"). packages/dashboard runs on @hono/node-server v2 and the pnpm.overrides pin is relaxed to ">=2.0.10" (package.json). Row was stale — completed via a deps commit whose PR number differs from External-ID #299, so auto-done never fired.
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —


### PR DESCRIPTION
## What

Two more stale roadmap rows corrected to **done**. Both dependency migrations already shipped, but auto-done never fired because each row's External-ID is the *issue* number while the *merge commit/PR* differs.

| Row | What | Evidence |
|-----|------|----------|
| #298 | Migrate to `@google/genai` 2.x SDK | commit `eb801b788` (CHANGELOG `a6f7cd3`); `packages/orchestrator` gemini backend imports `@google/genai`, `package.json` has `@google/genai@^2.0.4`, deprecated `@google/generative-ai` fully removed |
| #299 | Upgrade `@hono/node-server` to v2 | commit `0ca37f4cf`; `pnpm.overrides` pin relaxed to `>=2.0.10`, dashboard runs on hono v2 |

Roadmap-accuracy correction only — no source changes.

Found during a follow-up roadmap sweep after PR #1040 (which cleared the analogous stale ESLint-rule rows #223/#224). The recurring cause is the External-ID/merge-PR number mismatch that suppresses auto-done.

Closes #298
Closes #299