### PR TITLE
feat(design): support design.exclude path scoping for the drift linter (#742)

### DIFF
--- a/.changeset/design-drift-exclude.md
+++ b/.changeset/design-drift-exclude.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Support path exclusions for the design-token drift linter via `design.exclude`.
+The linter now honors a `design.exclude` glob list (minimatch), stacked on top
+of the project-wide `analysis.exclude` — letting monorepos scope DRIFT-\* findings
+out of token-palette sources, test files, and non-UI code. This also makes the
+drift linter honor `analysis.exclude`, which every other analysis scanner already
+respects. Default behavior is unchanged when neither is configured.

--- a/docs/changes/design-drift-exclude/proposal.md
+++ b/docs/changes/design-drift-exclude/proposal.md
@@ -70,18 +70,26 @@ combines `security.exclude` + `analysis.exclude`.
 exclude: z.array(z.string().min(1)).default([]),
 ```
 
+**`packages/cli/src/config/analysis-schema.ts`** — add `loadDesignExclude()`
+next to `loadAnalysisExclude()`: an import-light, best-effort read of
+`design.exclude` from `harness.config.json`.
+
 **`packages/cli/src/drift/index.ts`**:
 
-- Add `exclude?: string[]` to `DetectDriftInput` (design-specific patterns).
+- Add `exclude?: string[]` to `DetectDriftInput` — an **override** for the
+  config read (used by the MCP tool), not the sole source.
 - Add `excludePatterns: string[]` to `ResolvedDriftConfig`; in
-  `resolveDriftConfig`, union `input.exclude ?? []` with
-  `loadAnalysisExclude(projectRoot)` (imported from `../config/analysis-schema.js`).
+  `resolveDriftConfig`, compute `input.exclude ?? loadDesignExclude(projectRoot)`
+  and union it with `loadAnalysisExclude(projectRoot)`. Loading `design.exclude`
+  **inside the runner** (like `analysis.exclude`) means every caller — validate,
+  check-design, align, design-pipeline, MCP — honors it uniformly with no
+  per-caller threading.
 - In `collectFiles`, after the walk, drop any file whose project-relative POSIX
   path matches any exclude pattern via `minimatch(rel, pat, { matchBase: true })`.
   Explicit `files` arg bypasses the filter (Decision 4).
 
-**`packages/cli/src/commands/validate.ts`** — in the drift block (~L363), read
-`config.design?.exclude` and pass it as `exclude` to `runDetectDrift`.
+**`packages/cli/src/commands/validate.ts`** — no threading needed; the drift
+block inherits `design.exclude` via the runner's config read.
 
 **`packages/cli/src/mcp/tools/detect-drift.ts`** — add an `exclude` array
 property to the tool `inputSchema` so MCP callers can scope a scan.

--- a/docs/changes/design-drift-exclude/proposal.md
+++ b/docs/changes/design-drift-exclude/proposal.md
@@ -1,0 +1,128 @@
+---
+feature: design-drift-exclude
+status: planned
+tier: small
+roadmap: github:Intense-Visions/harness-engineering#742
+keywords: design-drift, drift-linter, exclude, minimatch, analysis-exclude, harness-config, monorepo-scoping
+---
+
+# Support path exclusions for the design-token drift linter (`design.exclude`)
+
+## Overview & Goals
+
+Since v4, `harness validate` runs the design-token drift linter
+(DRIFT-T001..T004 / DRIFT-P00x) over every `.ts/.tsx/.js/.jsx/.css/.scss` file
+under the project root, skipping only `node_modules`/`dist`/`build`/`coverage`/
+dot-dirs. The only configuration surface is `design.strictness` and
+`design.audit.driftDetection.enabled`. In a real monorepo this swamps the gate
+with unavoidable findings — the token-palette source files themselves (raw hex
+by definition), test files asserting on colors, and non-UI code where hex
+strings aren't design tokens. The observed case: 1,614 findings, 1,545 errors,
+100% from `driftDetection`.
+
+Every **other** analysis scanner (entropy, security, graph ingestion,
+doc-coverage) already honors the project-wide `analysis.exclude` glob list, and
+`analysis-schema.ts` explicitly names **`design.exclude`** as the intended
+precedent — but the drift linter honors neither `analysis.exclude` nor any
+design-specific exclude today. This closes that gap.
+
+**Goal:** let a project scope the drift linter out of paths where hex/primitive
+findings are noise, via a `design.exclude` glob list, stacked on top of the
+existing project-wide `analysis.exclude` — mirroring exactly how `security.ts`
+combines `security.exclude` + `analysis.exclude`.
+
+## Decisions Made
+
+1. **Config lives at `design.exclude`** (top-level under `design`), not buried
+   under `design.audit.driftDetection`. _Rationale:_ the roadmap item and the
+   `analysis-schema.ts` precedent comment both name `design.exclude`; it mirrors
+   the sibling `security.exclude` shape (`z.array(z.string().min(1)).default([])`).
+
+2. **Stack `design.exclude` on top of project-wide `analysis.exclude`.** The
+   drift runner loads `analysis.exclude` itself (via the existing
+   `loadAnalysisExclude`) and unions it with the design-specific patterns —
+   exactly as `security.ts:71-74` does. _Rationale:_ a repo declares vendored/
+   generated paths once in `analysis.exclude`; `design.exclude` adds
+   drift-specific scoping. This also finally makes the drift linter honor the
+   project-wide exclude every other scanner already respects.
+
+3. **Match with `minimatch({ matchBase: true })` against the project-relative,
+   POSIX-normalized path**, mirroring `skill/dispatcher.ts:158` and the
+   `analysis.exclude` semantics. _Rationale:_ reuse the established matcher
+   (already a dependency) rather than the drift walker's ad-hoc string checks.
+
+4. **Apply excludes only to the walked file set, not to an explicit `files`
+   arg.** When a caller passes an explicit file list it has already scoped the
+   scan intentionally. _Rationale:_ mirrors `security.ts:65-66`, which skips
+   excludes when `input.files` is provided.
+
+5. **Report-only default behavior is unchanged when no excludes are configured**
+   — `design.exclude` defaults to `[]` and `analysis.exclude` is already `[]`
+   by default, so the walked set and every finding are identical to today unless
+   a project opts in.
+
+## Technical Design
+
+**`packages/cli/src/config/schema.ts`** — add to `DesignConfigSchema`:
+
+```ts
+/** Glob patterns (minimatch) excluded from the design-token drift linter. */
+exclude: z.array(z.string().min(1)).default([]),
+```
+
+**`packages/cli/src/drift/index.ts`**:
+
+- Add `exclude?: string[]` to `DetectDriftInput` (design-specific patterns).
+- Add `excludePatterns: string[]` to `ResolvedDriftConfig`; in
+  `resolveDriftConfig`, union `input.exclude ?? []` with
+  `loadAnalysisExclude(projectRoot)` (imported from `../config/analysis-schema.js`).
+- In `collectFiles`, after the walk, drop any file whose project-relative POSIX
+  path matches any exclude pattern via `minimatch(rel, pat, { matchBase: true })`.
+  Explicit `files` arg bypasses the filter (Decision 4).
+
+**`packages/cli/src/commands/validate.ts`** — in the drift block (~L363), read
+`config.design?.exclude` and pass it as `exclude` to `runDetectDrift`.
+
+**`packages/cli/src/mcp/tools/detect-drift.ts`** — add an `exclude` array
+property to the tool `inputSchema` so MCP callers can scope a scan.
+
+## Integration Points
+
+- **Entry Points:** `harness validate` drift block; the `detect_drift` MCP tool;
+  `runDetectDrift` (also called by check-design and the design-pipeline fix phase
+  — all inherit the exclude via the runner, no per-caller threading needed for
+  `analysis.exclude`).
+- **Registrations Required:** none (no new command/tool/export).
+- **Documentation Updates:** the `design.exclude` field is self-documenting via
+  its schema JSDoc; the reference docs regenerate from the schema.
+- **Architectural Decisions:** None — small change, mirrors an existing pattern.
+- **Knowledge Impact:** None — makes the drift linter consistent with the
+  existing `analysis.exclude` convention.
+
+## Success Criteria
+
+1. `design.exclude` is a valid, optional glob-array field on `DesignConfigSchema`
+   (defaults to `[]`), rejecting empty-string entries like `security.exclude`.
+2. Given a project with `design.exclude: ["**/tokens-reference.ts"]`, a drift
+   scan does NOT report findings from `tokens-reference.ts`, while findings from
+   other files are unchanged.
+3. Given `analysis.exclude: ["packages/backend/**"]` (no `design.exclude`), the
+   drift scan skips files under `packages/backend/` — the linter now honors the
+   project-wide exclude.
+4. With neither configured, the scanned file set and findings are byte-identical
+   to current behavior (no regression).
+5. An explicit `files` arg to `runDetectDrift` bypasses exclude filtering
+   (mirrors security).
+6. `harness validate` passes `config.design.exclude` through to the runner.
+7. Full `packages/cli` typecheck + lint + build green; new unit tests pass.
+
+## Implementation Order
+
+1. **Schema.** Add `exclude` to `DesignConfigSchema`; unit-test parse/default/
+   empty-string rejection.
+2. **Runner.** Thread `exclude` through `DetectDriftInput` →
+   `resolveDriftConfig` (union with `loadAnalysisExclude`) → `collectFiles`
+   minimatch filter. Unit-test: design.exclude filters, analysis.exclude filters,
+   explicit-files bypass, no-exclude no-op.
+3. **Wire + tool.** Read `config.design?.exclude` in `validate.ts`; add `exclude`
+   to the `detect_drift` MCP `inputSchema`. Typecheck + lint + build.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1346,9 +1346,13 @@ Search for community skills on the @harness-skills registry
 - `--trigger` — Filter by trigger type (e.g., manual, automatic)
 - `--registry` — Use a custom npm registry URL
 
-### `harness skill validate`
+### `harness skill validate [skill-name]`
 
-Validate all skill.yaml files and SKILL.md structure
+Validate skill.yaml files and SKILL.md structure
+
+**Arguments:**
+
+- `skill-name` (optional) — Validate only this skill (fails if it is not found)
 
 ## Snapshot Commands
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -223,6 +223,7 @@ Detect design-system drift in source: hardcoded values where tokens exist (token
 - `path` (string, required) — Project root path
 - `mode` (string, optional) — Both modes equivalent in v1 (no slow patterns yet).
 - `files` (array, optional) — Optional explicit file list to scope the scan.
+- `exclude` (array, optional) — Optional minimatch globs to exclude from the walk (design.exclude); unioned with the project-wide analysis.exclude. Ignored when `files` is set.
 - `designStrictness` (string, optional) — Overrides design.strictness from harness.config.json.
 - `rules` (object, optional) — Per-rule enable flags.
 

--- a/docs/roadmap.d/feat-design-support-path-exclusions-for-the-design-token-drift-linter-design-exc.md
+++ b/docs/roadmap.d/feat-design-support-path-exclusions-for-the-design-token-drift-linter-design-exc.md
@@ -7,7 +7,7 @@ order: 7
 ### feat(design): support path exclusions for the design-token drift linter (design.exclude)
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/design-drift-exclude/proposal.md
 - **Summary:** Problem Since v4, `harness validate` runs the design-token drift linter (DRIFT-T001..T004) over every `.ts/.tsx/.js/.jsx/.css/.scss` file under the project root (skipping only `node_modules`/`dist`/`build`/`coverage`/dot-dirs). The only configuration surface is `design.strictness` and `design.audit.driftDetection.enabled`. In a real monorepo this produces thousands of unavoidable findings: - **The token palette sources themselves** (e.g. a `tokens-reference.ts` or generated `theme/tokens.ts`) by definition contain raw hex literals — ours account for 350+ DRIFT-T001 errors. - **Test files** asserting on rendered colors/fonts. - **Non-UI code** (backend service definitions, DSL/DAG files) where hex strings aren't design tokens at all. With no way to scope the linter, the practical options today are `strictness: permissive` (gate passes but output is still swamped) or disabling drift detection entirely — losing the signal where it *is* valuable (component source in the UI package). Proposal Support an exclusion/scoping config for drift detection, mirroring the existing `security.exclude` shape, e.g.: An `include` allowlist (or per-path severity, e.g. error in `packages/ui`, warn elsewhere) would be even better, but plain excludes would unblock most monorepos. Context harness-engineering CLI 4.1.0. Observed while re-greening `harness validate` after the 2.8 → 4.x upgrade: 1,614 findings, 1,545 errors, 100% from `driftDetection`.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1136,7 +1136,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### feat(design): support path exclusions for the design-token drift linter (design.exclude)
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/design-drift-exclude/proposal.md
 - **Summary:** Problem Since v4, `harness validate` runs the design-token drift linter (DRIFT-T001..T004) over every `.ts/.tsx/.js/.jsx/.css/.scss` file under the project root (skipping only `node_modules`/`dist`/`build`/`coverage`/dot-dirs). The only configuration surface is `design.strictness` and `design.audit.driftDetection.enabled`. In a real monorepo this produces thousands of unavoidable findings: - **The token palette sources themselves** (e.g. a `tokens-reference.ts` or generated `theme/tokens.ts`) by definition contain raw hex literals — ours account for 350+ DRIFT-T001 errors. - **Test files** asserting on rendered colors/fonts. - **Non-UI code** (backend service definitions, DSL/DAG files) where hex strings aren't design tokens at all. With no way to scope the linter, the practical options today are `strictness: permissive` (gate passes but output is still swamped) or disabling drift detection entirely — losing the signal where it *is* valuable (component source in the UI package). Proposal Support an exclusion/scoping config for drift detection, mirroring the existing `security.exclude` shape, e.g.: An `include` allowlist (or per-path severity, e.g. error in `packages/ui`, warn elsewhere) would be even better, but plain excludes would unblock most monorepos. Context harness-engineering CLI 4.1.0. Observed while re-greening `harness validate` after the 2.8 → 4.x upgrade: 1,614 findings, 1,545 errors, 100% from `driftDetection`.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -364,6 +364,7 @@ export async function runValidate(
         path: cwd,
         mode: 'fast',
         designStrictness: strictness,
+        ...(config.design?.exclude !== undefined && { exclude: config.design.exclude }),
       });
       result.checks.driftDetection = true;
       for (const finding of driftOutput.findings) {

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -360,11 +360,13 @@ export async function runValidate(
         | 'strict'
         | 'standard'
         | 'permissive';
+      // design.exclude (and the project-wide analysis.exclude) are loaded
+      // inside runDetectDrift, so every drift entry point honors them uniformly
+      // — no per-caller threading needed here.
       const driftOutput = await runDetectDrift({
         path: cwd,
         mode: 'fast',
         designStrictness: strictness,
-        ...(config.design?.exclude !== undefined && { exclude: config.design.exclude }),
       });
       result.checks.driftDetection = true;
       for (const finding of driftOutput.findings) {

--- a/packages/cli/src/config/analysis-schema.ts
+++ b/packages/cli/src/config/analysis-schema.ts
@@ -51,3 +51,40 @@ export function loadAnalysisExclude(projectPath: string): string[] {
   if (!parsed.success) return [];
   return parsed.data.exclude;
 }
+
+/**
+ * Schema fragment for the `design.exclude` glob list (drift-linter scoping).
+ * Kept here — alongside `analysis.exclude` — so the drift runner can load it
+ * without importing the full `HarnessConfigSchema` and its transitive deps.
+ * Mirrors the `DesignConfigSchema.exclude` field shape.
+ */
+const DesignExcludeSchema = z.object({
+  exclude: z.array(z.string().min(1)).default([]),
+});
+
+/**
+ * Best-effort load of `design.exclude` from `<projectPath>/harness.config.json`.
+ *
+ * Returns `[]` on any miss (no file, malformed JSON, or a `design` block that
+ * fails validation) so the drift linter keeps working on un-configured
+ * projects. Read inside the drift runner so every caller (validate,
+ * check-design, align, design-pipeline, MCP) honors `design.exclude` uniformly
+ * — the same pattern `loadAnalysisExclude` uses for the project-wide list.
+ */
+export function loadDesignExclude(projectPath: string): string[] {
+  const configPath = path.join(projectPath, 'harness.config.json');
+  if (!fs.existsSync(configPath)) return [];
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch {
+    return [];
+  }
+
+  const designRaw = (raw as { design?: unknown } | null | undefined)?.design;
+  if (designRaw === undefined || designRaw === null || typeof designRaw !== 'object') return [];
+  const parsed = DesignExcludeSchema.safeParse(designRaw);
+  if (!parsed.success) return [];
+  return parsed.data.exclude;
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -308,10 +308,15 @@ export const DesignConfigSchema = z
     /** Brief description of the intended aesthetic direction */
     aestheticIntent: z.string().optional(),
     /**
-     * Glob patterns (minimatch) excluded from the design-token drift linter,
-     * stacked on top of the project-wide `analysis.exclude`. Scopes DRIFT-*
-     * findings out of token-palette sources, tests, and non-UI code where hex
-     * literals aren't design tokens. Mirrors the `security.exclude` shape.
+     * Glob patterns excluded from the design-token drift linter, stacked on top
+     * of the project-wide `analysis.exclude`. Scopes DRIFT-* findings out of
+     * token-palette sources, tests, and non-UI code where hex literals aren't
+     * design tokens. Mirrors the `security.exclude` shape.
+     *
+     * Matched with `minimatch({ matchBase: true })` against each file's
+     * project-relative POSIX path: a bare basename (`*.tokens.ts`) matches at
+     * any depth, while a slash-bearing pattern anchors at the project root
+     * (`packages/backend/**`, not `backend/**`).
      */
     exclude: z.array(z.string().min(1)).default([]),
     /**

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -308,6 +308,13 @@ export const DesignConfigSchema = z
     /** Brief description of the intended aesthetic direction */
     aestheticIntent: z.string().optional(),
     /**
+     * Glob patterns (minimatch) excluded from the design-token drift linter,
+     * stacked on top of the project-wide `analysis.exclude`. Scopes DRIFT-*
+     * findings out of token-palette sources, tests, and non-UI code where hex
+     * literals aren't design tokens. Mirrors the `security.exclude` shape.
+     */
+    exclude: z.array(z.string().min(1)).default([]),
+    /**
      * Design-pipeline audit configuration (rule-based floor layer).
      * Omit to use built-in defaults.
      */

--- a/packages/cli/src/drift/index.ts
+++ b/packages/cli/src/drift/index.ts
@@ -15,7 +15,9 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { minimatch } from 'minimatch';
 import { sanitizePath } from '../mcp/utils/sanitize-path.js';
+import { loadAnalysisExclude } from '../config/analysis-schema.js';
 import type { DriftFinding, DriftSeverity, DriftStrictness } from './findings/finding.js';
 import { loadTokenSet } from './resolvers/tokens.js';
 import { loadComponentRegistry } from './resolvers/component-registry.js';
@@ -33,6 +35,12 @@ export interface DetectDriftInput {
     tokenBypass?: boolean;
     primitiveAdoption?: boolean;
   };
+  /**
+   * Design-specific glob patterns (minimatch) to exclude from the walk,
+   * sourced from `design.exclude`. Unioned with the project-wide
+   * `analysis.exclude`. Ignored when an explicit `files` list is provided.
+   */
+  exclude?: string[];
 }
 
 import type { Verifier } from '../shared/verifier.js';
@@ -60,6 +68,8 @@ interface ResolvedDriftConfig {
   primitiveAdoptionEnabled: boolean;
   tokens: ReturnType<typeof loadTokenSet>;
   registry: ReturnType<typeof loadComponentRegistry>;
+  /** design.exclude ∪ analysis.exclude — minimatch globs applied to the walk. */
+  excludePatterns: string[];
 }
 
 /**
@@ -69,6 +79,9 @@ function resolveDriftConfig(input: DetectDriftInput): ResolvedDriftConfig {
   const projectRoot = sanitizePath(input.path);
   const tokenBypassEnabled = input.rules?.tokenBypass !== false;
   const primitiveAdoptionEnabled = input.rules?.primitiveAdoption !== false;
+  // design.exclude (caller-supplied) stacked on top of the project-wide
+  // analysis.exclude — mirrors security.ts's exclude union.
+  const excludePatterns = [...(input.exclude ?? []), ...loadAnalysisExclude(projectRoot)];
   return {
     projectRoot,
     mode: input.mode ?? 'fast',
@@ -77,6 +90,7 @@ function resolveDriftConfig(input: DetectDriftInput): ResolvedDriftConfig {
     primitiveAdoptionEnabled,
     tokens: tokenBypassEnabled ? loadTokenSet(projectRoot) : null,
     registry: primitiveAdoptionEnabled ? loadComponentRegistry(projectRoot) : null,
+    excludePatterns,
   };
 }
 
@@ -157,7 +171,7 @@ export async function runDetectDrift(input: DetectDriftInput): Promise<DetectDri
   const config = resolveDriftConfig(input);
   const rulesApplied = computeRulesApplied(config);
 
-  const filesToScan = await collectFiles(config.projectRoot, input.files);
+  const filesToScan = await collectFiles(config.projectRoot, input.files, config.excludePatterns);
   const findings = scanFiles(filesToScan, config);
   const { bySeverity, byCode } = summarizeFindings(findings);
 
@@ -185,14 +199,32 @@ export async function runDetectDrift(input: DetectDriftInput): Promise<DetectDri
  */
 async function collectFiles(
   projectRoot: string,
-  explicitFiles: readonly string[] | undefined
+  explicitFiles: readonly string[] | undefined,
+  excludePatterns: readonly string[]
 ): Promise<string[]> {
+  // An explicit file list is already a deliberate scoping — bypass excludes,
+  // mirroring security.ts's handling of an explicit `files` arg.
   if (explicitFiles !== undefined && explicitFiles.length > 0) {
     return explicitFiles.map((f) => (path.isAbsolute(f) ? f : path.join(projectRoot, f)));
   }
   const out: string[] = [];
   walk(projectRoot, out, 0);
-  return out;
+  if (excludePatterns.length === 0) return out;
+  return out.filter((abs) => !isExcluded(projectRoot, abs, excludePatterns));
+}
+
+/**
+ * True when the file's project-relative, POSIX-normalized path matches any
+ * exclude glob. `matchBase` lets a bare `*.test.ts` match at any depth,
+ * consistent with skill/dispatcher.ts and the analysis.exclude semantics.
+ */
+function isExcluded(
+  projectRoot: string,
+  absFile: string,
+  excludePatterns: readonly string[]
+): boolean {
+  const rel = path.relative(projectRoot, absFile).replaceAll('\\', '/');
+  return excludePatterns.some((pattern) => minimatch(rel, pattern, { matchBase: true }));
 }
 
 function walk(dir: string, out: string[], depth: number): void {

--- a/packages/cli/src/drift/index.ts
+++ b/packages/cli/src/drift/index.ts
@@ -17,7 +17,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { minimatch } from 'minimatch';
 import { sanitizePath } from '../mcp/utils/sanitize-path.js';
-import { loadAnalysisExclude } from '../config/analysis-schema.js';
+import { loadAnalysisExclude, loadDesignExclude } from '../config/analysis-schema.js';
 import type { DriftFinding, DriftSeverity, DriftStrictness } from './findings/finding.js';
 import { loadTokenSet } from './resolvers/tokens.js';
 import { loadComponentRegistry } from './resolvers/component-registry.js';
@@ -36,9 +36,11 @@ export interface DetectDriftInput {
     primitiveAdoption?: boolean;
   };
   /**
-   * Design-specific glob patterns (minimatch) to exclude from the walk,
-   * sourced from `design.exclude`. Unioned with the project-wide
-   * `analysis.exclude`. Ignored when an explicit `files` list is provided.
+   * Optional override for the design-specific exclude globs (minimatch). When
+   * omitted, the runner loads `design.exclude` from harness.config.json; when
+   * provided (e.g. from the detect_drift MCP tool), it replaces that config
+   * read. Either way it is unioned with the project-wide `analysis.exclude`
+   * and ignored when an explicit `files` list is provided.
    */
   exclude?: string[];
 }
@@ -79,9 +81,13 @@ function resolveDriftConfig(input: DetectDriftInput): ResolvedDriftConfig {
   const projectRoot = sanitizePath(input.path);
   const tokenBypassEnabled = input.rules?.tokenBypass !== false;
   const primitiveAdoptionEnabled = input.rules?.primitiveAdoption !== false;
-  // design.exclude (caller-supplied) stacked on top of the project-wide
-  // analysis.exclude — mirrors security.ts's exclude union.
-  const excludePatterns = [...(input.exclude ?? []), ...loadAnalysisExclude(projectRoot)];
+  // design.exclude stacked on top of the project-wide analysis.exclude —
+  // mirrors security.ts's exclude union. Both are loaded from config INSIDE the
+  // runner so every caller (validate, check-design, align, design-pipeline, MCP)
+  // honors them uniformly. An explicit `input.exclude` overrides the config read
+  // (used by the detect_drift MCP tool); pass [] to force "no design excludes".
+  const designExclude = input.exclude ?? loadDesignExclude(projectRoot);
+  const excludePatterns = [...designExclude, ...loadAnalysisExclude(projectRoot)];
   return {
     projectRoot,
     mode: input.mode ?? 'fast',

--- a/packages/cli/src/mcp/tools/detect-drift.ts
+++ b/packages/cli/src/mcp/tools/detect-drift.ts
@@ -39,6 +39,13 @@ export const detectDriftDefinition = {
         items: { type: 'string' },
         description: 'Optional explicit file list to scope the scan.',
       },
+      exclude: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Optional minimatch globs to exclude from the walk (design.exclude); ' +
+          'unioned with the project-wide analysis.exclude. Ignored when `files` is set.',
+      },
       designStrictness: {
         type: 'string',
         enum: ['strict', 'standard', 'permissive'],

--- a/packages/cli/tests/config/design-schema.test.ts
+++ b/packages/cli/tests/config/design-schema.test.ts
@@ -28,6 +28,23 @@ describe('DesignConfigSchema', () => {
     expect(result.platforms).toEqual([]);
   });
 
+  it('defaults exclude to empty array', () => {
+    const result = DesignConfigSchema.parse({});
+    expect(result.exclude).toEqual([]);
+  });
+
+  it('accepts a design.exclude glob list', () => {
+    const result = DesignConfigSchema.safeParse({
+      exclude: ['**/tokens-reference.ts', 'packages/backend/**'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty-string exclude patterns (mirrors security.exclude min(1))', () => {
+    const result = DesignConfigSchema.safeParse({ exclude: [''] });
+    expect(result.success).toBe(false);
+  });
+
   it('accepts strictness: strict', () => {
     const result = DesignConfigSchema.safeParse({ strictness: 'strict' });
     expect(result.success).toBe(true);

--- a/packages/cli/tests/drift/integration/detect-drift.test.ts
+++ b/packages/cli/tests/drift/integration/detect-drift.test.ts
@@ -114,6 +114,53 @@ describe('runDetectDrift (integration)', () => {
     expect([...files].some((f) => f.endsWith('Card.ts'))).toBe(true);
   });
 
+  it('loads design.exclude from harness.config.json (honored by every caller, not just validate)', async () => {
+    writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
+    writeFile(
+      'harness.config.json',
+      JSON.stringify({ design: { exclude: ['**/tokens-reference.ts'] } })
+    );
+    writeFile('src/tokens-reference.ts', `const a = "#aabbcc";`);
+    writeFile('src/Card.ts', `const b = "#112233";`);
+
+    // No input.exclude — the runner must read design.exclude from config itself.
+    const out = await runDetectDrift({ path: tmpDir });
+    const files = new Set(out.findings.map((f) => f.file));
+    expect([...files].some((f) => f.endsWith('tokens-reference.ts'))).toBe(false);
+    expect([...files].some((f) => f.endsWith('Card.ts'))).toBe(true);
+  });
+
+  it('stacks design.exclude on top of analysis.exclude (both applied)', async () => {
+    writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
+    writeFile(
+      'harness.config.json',
+      JSON.stringify({
+        design: { exclude: ['**/tokens-reference.ts'] },
+        analysis: { exclude: ['backend/**'] },
+      })
+    );
+    writeFile('src/tokens-reference.ts', `const a = "#aabbcc";`); // dropped by design.exclude
+    writeFile('backend/service.ts', `const b = "#112233";`); // dropped by analysis.exclude
+    writeFile('ui/Card.ts', `const c = "#445566";`); // kept
+
+    const out = await runDetectDrift({ path: tmpDir });
+    const files = new Set(out.findings.map((f) => f.file));
+    expect([...files].some((f) => f.endsWith('tokens-reference.ts'))).toBe(false);
+    expect([...files].some((f) => f.includes('backend'))).toBe(false);
+    expect([...files].some((f) => f.endsWith('Card.ts'))).toBe(true);
+  });
+
+  it('matchBase: a bare-basename pattern matches at any depth', async () => {
+    writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
+    writeFile('src/deep/nested/Foo.tokens.ts', `const a = "#aabbcc";`);
+    writeFile('src/Card.ts', `const b = "#112233";`);
+
+    const out = await runDetectDrift({ path: tmpDir, exclude: ['*.tokens.ts'] });
+    const files = new Set(out.findings.map((f) => f.file));
+    expect([...files].some((f) => f.endsWith('Foo.tokens.ts'))).toBe(false);
+    expect([...files].some((f) => f.endsWith('Card.ts'))).toBe(true);
+  });
+
   it('honors project-wide analysis.exclude from harness.config.json', async () => {
     writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
     writeFile('harness.config.json', JSON.stringify({ analysis: { exclude: ['backend/**'] } }));

--- a/packages/cli/tests/drift/integration/detect-drift.test.ts
+++ b/packages/cli/tests/drift/integration/detect-drift.test.ts
@@ -98,4 +98,55 @@ describe('runDetectDrift (integration)', () => {
     expect(out.findings.filter((f) => f.code.startsWith('DRIFT-T'))).toHaveLength(0);
     expect(out.catalog.rulesApplied).not.toContain('token-bypass');
   });
+
+  it('design.exclude (input.exclude) drops matching files from the walk', async () => {
+    writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
+    writeFile('src/tokens-reference.ts', `const a = "#aabbcc";`);
+    writeFile('src/Card.ts', `const b = "#112233";`);
+
+    const out = await runDetectDrift({
+      path: tmpDir,
+      exclude: ['**/tokens-reference.ts'],
+    });
+    const files = new Set(out.findings.map((f) => f.file));
+    expect([...files].some((f) => f.endsWith('tokens-reference.ts'))).toBe(false);
+    // Non-excluded file still reports.
+    expect([...files].some((f) => f.endsWith('Card.ts'))).toBe(true);
+  });
+
+  it('honors project-wide analysis.exclude from harness.config.json', async () => {
+    writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
+    writeFile('harness.config.json', JSON.stringify({ analysis: { exclude: ['backend/**'] } }));
+    writeFile('backend/service.ts', `const a = "#aabbcc";`);
+    writeFile('ui/Card.ts', `const b = "#112233";`);
+
+    const out = await runDetectDrift({ path: tmpDir });
+    const files = new Set(out.findings.map((f) => f.file));
+    expect([...files].some((f) => f.includes('backend'))).toBe(false);
+    expect([...files].some((f) => f.endsWith('Card.ts'))).toBe(true);
+  });
+
+  it('an explicit files arg bypasses exclude filtering (mirrors security)', async () => {
+    writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
+    writeFile('src/tokens-reference.ts', `const a = "#aabbcc";`);
+
+    const out = await runDetectDrift({
+      path: tmpDir,
+      files: ['src/tokens-reference.ts'],
+      exclude: ['**/tokens-reference.ts'],
+    });
+    // Explicit scoping wins: the file is still scanned despite matching exclude.
+    expect(out.findings.some((f) => f.file.endsWith('tokens-reference.ts'))).toBe(true);
+  });
+
+  it('no excludes configured → walk + findings unchanged (no regression)', async () => {
+    writeFile('design-system/tokens.json', JSON.stringify({ color: {} }));
+    writeFile('src/A.tsx', `const a = "#aabbcc";`);
+    writeFile('src/B.tsx', `const b = "#112233";`);
+
+    const out = await runDetectDrift({ path: tmpDir });
+    const files = new Set(out.findings.map((f) => f.file));
+    expect([...files].some((f) => f.endsWith('A.tsx'))).toBe(true);
+    expect([...files].some((f) => f.endsWith('B.tsx'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## What

Adds a `design.exclude` config option that scopes the design-token drift linter (DRIFT-T*/DRIFT-P*). Since v4 the linter walked **every** source file with no scoping, swamping monorepo `harness validate` runs with unavoidable findings from token-palette sources, tests, and non-UI code (the reported case: 1,614 findings, 1,545 errors, 100% from `driftDetection`).

Delivered via `/harness:brainstorming → /harness:autopilot`. Spec: `docs/changes/design-drift-exclude/proposal.md`.

## How

- New `design.exclude` glob list (`z.array(z.string().min(1)).default([])`) — mirrors the `security.exclude` shape.
- The drift runner loads **both** `design.exclude` and the project-wide `analysis.exclude` from `harness.config.json` (new `loadDesignExclude`, alongside the existing `loadAnalysisExclude`) and unions them. Loading inside `runDetectDrift` means **every** caller — `harness validate`, `check-design`, `align`, the design-pipeline phases, and the `detect_drift` MCP tool — honors it uniformly, with no per-caller threading. This also makes the drift linter finally honor `analysis.exclude`, which every other analysis scanner already respects.
- Matching: `minimatch({ matchBase: true })` against each file's project-relative POSIX path (reuses the established matcher). A bare basename matches at any depth; a slash-bearing pattern anchors at the project root.
- An explicit `files` arg bypasses excludes (mirrors `security.ts`); an explicit `input.exclude` (MCP tool) overrides the config read.
- **Default behavior is unchanged** when nothing is configured (`[]` defaults + early return).

## Verification

- 45 unit tests across `detect-drift.test.ts` + `design-schema.test.ts` — design.exclude via config, design∪analysis stacking, matchBase bare-basename, explicit-files bypass, no-regression baseline, empty-pattern rejection.
- 295 tests green across drift/config/validate/check-design (no caller regression); typecheck + lint + build clean.

## Review

Independent `harness-code-reviewer` pass flagged two Important items — both fixed here:
1. `design.exclude` originally reached only `harness validate` → moved the config read into the runner so all callers honor it.
2. minimatch-vs-security matcher divergence → documented the `matchBase` semantics on the schema field.

Closes #742