### PR TITLE
feat: Semantic-Vocabulary CI Gate (#605)

### DIFF
--- a/.changeset/semantic-vocabulary-check.md
+++ b/.changeset/semantic-vocabulary-check.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Add the `harness check-vocabulary` command — a config-driven, adopter-facing semantic-vocabulary gate. It reads a `vocabulary` block from the project's `harness.config.json` (deprecated → canonical term rules, plus `paths`/`exclude` globs) and fails when a deprecated or renamed canonical term reappears in Markdown prose, reporting the file, line, deprecated term, and suggested canonical replacement. The pure scanner strips fenced/inline code, matches case-insensitively on word boundaries, and honors per-rule `allow` exemptions; `--json` output is supported and the gate passes trivially when disabled or ruleless. Harness dogfoods it via its own five seed rules wired into CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
 
       - run: pnpm test:platform-parity
 
+      # Dogfood the shipped semantic-vocabulary gate against harness's own config.
+      - run: node packages/cli/dist/bin/harness.js check-vocabulary
+
   # Regenerate auto-generated baselines on main after merge to prevent drift.
   # Downloads coverage from the test job to avoid running the full test suite twice.
   refresh-baselines:

--- a/docs/changes/semantic-vocabulary-ci-gate/proposal.md
+++ b/docs/changes/semantic-vocabulary-ci-gate/proposal.md
@@ -1,0 +1,156 @@
+# Semantic-Vocabulary CI Gate
+
+**Keywords:** vocabulary-drift, glossary, naming-craft, terminology-gate, deprecated-terms, canonical-terms, adopter-facing, check-command, skills, docs, prose-scan
+
+## Overview
+
+A harness analog of Spec Kitty's `test_no_legacy_terminology.py`, rebuilt as a
+**shipped, adopter-facing CLI command** — `harness check-vocabulary`. It fails when a
+deprecated or renamed canonical term reappears in an adopter's skill or doc prose,
+protecting a glossary and naming-craft investment from vocabulary drift over time.
+Once a term is renamed, the gate keeps the old spelling from creeping back in, and
+points the author at the canonical replacement with the exact file and line.
+
+Harness is a framework that adopters install in their own projects, so its checks
+must ship as `harness check-*` commands that read the adopter's
+`harness.config.json` — not as harness-repo-internal tests wired into harness's own
+`ci.yml`. This gate follows the same shape as `check-docs`, `check-security`, and
+`check-arch`: it reads a config block, scans the configured surfaces, prints
+findings, supports `--json`, and exits non-zero on any violation. Harness itself
+**dogfoods** the command through its own `vocabulary` config block, wired into
+harness CI as `node packages/cli/dist/bin/harness.js check-vocabulary`.
+
+### Goals
+
+1. A pure, unit-testable scanner (`packages/cli/src/vocabulary/scanner.ts`) that
+   ships in `@harness-engineering/cli`, finds deprecated terms in Markdown prose,
+   and reports `{file, line, deprecated, canonical, reason?, excerpt}`.
+2. A `vocabulary` config block in the harness config schema — the extension point —
+   with `enabled`, `rules` (`{deprecated, canonical, reason?, allow?}`), and
+   `paths` / `exclude` globs (sensible defaults).
+3. A `harness check-vocabulary` command mirroring `check-docs`: `resolveConfig`,
+   scan, per-violation reporting, `--json`, exit `VALIDATION_FAILED` on any finding.
+4. Low false-positive by construction: prose-only matching (fenced code blocks and
+   inline code stripped), case-insensitive word-boundary matching, per-rule allow
+   exemptions, and default exclusion of historical/archival surfaces.
+5. Harness dogfoods the shipped command via its own five seed rules + a CI step.
+
+### Non-Goals
+
+- A general natural-language style linter or spell-checker.
+- Enforcing vocabulary in source-code identifiers (naming-craft critiques those).
+- Auto-fixing / rewriting offending prose (the gate reports; the author edits).
+- A harness-repo-internal vitest suite wired into harness's own CI (the rejected
+  first design — it shipped nothing to adopters).
+
+## Assumptions
+
+- **The gate must stay green on `main`.** Each of harness's five seed rules'
+  deprecated forms has zero occurrences across the in-scope Markdown surfaces. New
+  rules must clear the same bar (or the offenders must be fixed) before landing.
+- **Markdown prose is the canonical vocabulary surface.** Skills
+  (`agents/skills/**`) and docs (`docs/**`) are where terminology is authored and
+  read; scanning them catches drift where it matters without the false-positive
+  risk of scanning code.
+- **Historical surfaces legitimately reference old/external vocabulary.** ADRs,
+  change proposals (this proposal cites the deprecated terms), and research
+  analyses are excluded by default rather than exempted line-by-line.
+
+## Decisions
+
+| #   | Decision                                                                                                          | Rationale                                                                                                                                                                                                  |
+| --- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Ship as a `harness check-vocabulary` CLI command reading `harness.config.json`, not a harness-internal test**   | Harness is a framework adopters install; its checks must run in _their_ projects against _their_ config. A repo-internal vitest test ships nothing to adopters. Mirrors the established `check-*` pattern. |
+| 2   | **Config-driven `vocabulary` block** (`enabled`, `rules`, `paths`, `exclude`) as the extension point              | Adopters register their own renames declaratively in JSON. `allow` regex sources + `reason` are expressible in JSON so the whole rule set is data, no code changes to extend.                              |
+| 3   | **Pure scanner module in `packages/cli/src/vocabulary/`** so it ships and stays unit-testable                     | `scanText` is pure and sync (fixture-testable); `scanFiles`/`resolveScanFiles` do I/O via the `glob` dependency for portability across adopter Node versions.                                              |
+| 4   | **Prose-only matching** — strip fenced (` ``` `/`~~~`) and inline `` `code` `` before matching                    | A deprecated spelling inside a code sample or identifier is not vocabulary drift. Stripping code removes the dominant false-positive source while preserving original line numbers.                        |
+| 5   | **Case-insensitive, word-boundary matching; interior whitespace matches any run of whitespace**                   | "codebase" must never match a "code base" rule as a substring; "code base" (or a line-wrapped variant) must still be caught. Word boundaries + `\s+` normalization give both.                              |
+| 6   | **Trivial pass when `enabled: false` or `rules` is empty (including an absent block)**                            | The gate is inert until an adopter opts in with rules, so it is safe to ship on by default and safe to run in any project.                                                                                 |
+| 7   | **Seed harness's own config with the five closed-compound / branch-name rules; wire the shipped command into CI** | Dogfooding proves the command works end-to-end against a real config, and the five rules carry real value (they catch the drift) while keeping harness's baseline green.                                   |
+
+## Technical Design
+
+### Module layout
+
+```
+packages/cli/src/
+  vocabulary/scanner.ts              # pure scanner: types + scanText/scanFiles/resolveScanFiles/formatViolations
+  config/schema.ts                   # VocabularyConfigSchema + VocabularyRuleSchema, wired into HarnessConfigSchema
+  commands/check-vocabulary.ts       # the `harness check-vocabulary` command (mirrors check-docs)
+  commands/_registry.ts              # registers createCheckVocabularyCommand
+packages/cli/tests/
+  commands/check-vocabulary.test.ts  # scanner unit tests + command tests
+  fixtures/semantic-vocabulary/      # deprecated/clean samples + enabled/clean/disabled/empty configs
+```
+
+### Config block
+
+```jsonc
+"vocabulary": {
+  "enabled": true,               // default true; false ⇒ trivial pass
+  "rules": [                     // default []; empty ⇒ trivial pass
+    { "deprecated": "sub-agent", "canonical": "subagent", "reason": "closed compound", "allow": ["..."] }
+  ],
+  "paths":   ["agents/skills/**/*.md", "docs/**/*.md"],          // default
+  "exclude": ["**/node_modules/**", "docs/knowledge/decisions/**",
+              "docs/changes/**", "docs/research/**", "docs/roadmap-archive.md"] // default
+}
+```
+
+### Algorithm
+
+1. The command calls `resolveConfig`, reads the `vocabulary` block (defaulting an
+   absent block through the schema). If disabled or ruleless, it returns a trivial
+   `valid: true, skipped: true` result.
+2. `resolveScanFiles(root, {include, exclude})` expands `paths` via `glob` with
+   `ignore: exclude`, de-dupes, and sorts.
+3. For each file, `scanText` splits into lines, `stripCode` blanks fenced-block and
+   inline-code content (line indices preserved), then each rule's word-boundary
+   matcher runs against the stripped prose. A hit is skipped if any `allow` regex
+   (compiled case-insensitively) matches the original line.
+4. The command prints an actionable `file:line — "x" is deprecated; use "y"` block
+   (or JSON with `--json`) and exits `VALIDATION_FAILED` when any violation exists.
+
+### Seeded rules (harness dogfood)
+
+| Deprecated      | Canonical     | Reason                                        |
+| --------------- | ------------- | --------------------------------------------- |
+| `sub-agent`     | `subagent`    | canonical closed compound                     |
+| `sub-task`      | `subtask`     | canonical closed compound                     |
+| `code base`     | `codebase`    | canonical closed compound                     |
+| `green field`   | `greenfield`  | canonical closed compound                     |
+| `master branch` | `main branch` | default branch is `main`; `master` is retired |
+
+Each deprecated form has zero in-scope occurrences — so the gate is immediately
+green and immediately useful.
+
+## Integration Points
+
+- **CLI:** `harness check-vocabulary` (registered in `_registry.ts`), shipped in
+  `@harness-engineering/cli`.
+- **Config schema:** `VocabularyConfigSchema` on `HarnessConfigSchema.vocabulary`.
+- **Harness CI:** `.github/workflows/ci.yml` runs the shipped command
+  (`node packages/cli/dist/bin/harness.js check-vocabulary`) next to the other
+  gates — dogfooding, not a bespoke vitest step.
+- **Adopters:** add a `vocabulary` block to their own `harness.config.json` and run
+  `harness check-vocabulary` in their CI.
+
+## Success Criteria
+
+1. `harness check-vocabulary` passes on harness's own repo with the five seed rules.
+2. A deprecated term added to a scanned Markdown file fails the gate with the file,
+   line, and suggested canonical term.
+3. Clean prose and canonical spellings pass; deprecated spellings inside code blocks
+   / inline code do not trip the gate.
+4. `--json` emits a machine-readable result; disabled/ruleless config passes trivially.
+5. The rule set is extended by adding one object to `vocabulary.rules` in config —
+   no scanner or command changes required.
+
+## Implementation Order
+
+1. Pure scanner + types (`packages/cli/src/vocabulary/scanner.ts`).
+2. `VocabularyConfigSchema` in `packages/cli/src/config/schema.ts`.
+3. `check-vocabulary` command + registry registration.
+4. Fixtures + tests (scanner unit + command).
+5. Harness dogfood: `vocabulary` block in `harness.config.json` + CI step.
+6. Regenerate reference docs; verify green baseline, typecheck, lint.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -669,6 +669,26 @@ Run an agent task
 - `--persona` — Run a persona by name
 - `--trigger` — Trigger context (auto, on_pr, on_commit, manual) (default: "auto")
 
+## Black-box Commands
+
+Inspect durable per-run orchestrator flight records (provenance, verdicts, tool-use)
+
+### `harness black-box list`
+
+List recorded runs, newest first
+
+**Options:**
+
+- `--dir` — Black-box directory (default: ".harness/black-box")
+
+### `harness black-box show <runId>`
+
+Show provenance, verdicts, convergence, and tool-use for a run
+
+**Options:**
+
+- `--dir` — Black-box directory (default: ".harness/black-box")
+
 ## Ci Commands
 
 CI/CD integration commands

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -129,6 +129,10 @@ Run lightweight security scan: secrets, injection, XSS, weak crypto
 - `--severity` — Minimum severity that fails the command; findings below it are excluded from the report and never fail the gate (error, warning, info) (default: "warning")
 - `--changed-only` — Only scan git-changed files
 
+### `harness check-vocabulary`
+
+Fail when deprecated or renamed canonical terms reappear in skills/docs prose
+
 ### `harness cleanup`
 
 Detect entropy issues (doc drift, dead code, patterns)

--- a/docs/roadmap.d/semantic-vocabulary-ci-gate.md
+++ b/docs/roadmap.d/semantic-vocabulary-ci-gate.md
@@ -7,7 +7,7 @@ order: 8
 ### Semantic-Vocabulary CI Gate
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/semantic-vocabulary-ci-gate/proposal.md
 - **Summary:** Add a harness analog of Spec Kitty's test_no_legacy_terminology architectural test: a CI gate that fails when deprecated or renamed canonical terms reappear in skills/docs, protecting the glossary and naming-craft investment from vocabulary drift over time. Adapted from Spec Kitty's semantic-terminology architectural test. Adoption #8 from docs/research/spec-kitty-comparison-analysis.md [SPECKITTY-8]
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1022,7 +1022,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Semantic-Vocabulary CI Gate
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/semantic-vocabulary-ci-gate/proposal.md
 - **Summary:** Add a harness analog of Spec Kitty's test_no_legacy_terminology architectural test: a CI gate that fails when deprecated or renamed canonical terms reappear in skills/docs, protecting the glossary and naming-craft investment from vocabulary drift over time. Adapted from Spec Kitty's semantic-terminology architectural test. Adoption #8 from docs/research/spec-kitty-comparison-analysis.md [SPECKITTY-8]
 - **Blockers:** —
 - **Plan:** —

--- a/harness.config.json
+++ b/harness.config.json
@@ -307,6 +307,36 @@
       "budgets": {}
     }
   },
+  "vocabulary": {
+    "enabled": true,
+    "rules": [
+      {
+        "deprecated": "sub-agent",
+        "canonical": "subagent",
+        "reason": "harness/Anthropic canonical spelling is the closed compound \"subagent\""
+      },
+      {
+        "deprecated": "sub-task",
+        "canonical": "subtask",
+        "reason": "canonical spelling is the closed compound \"subtask\""
+      },
+      {
+        "deprecated": "code base",
+        "canonical": "codebase",
+        "reason": "canonical spelling is the closed compound \"codebase\""
+      },
+      {
+        "deprecated": "green field",
+        "canonical": "greenfield",
+        "reason": "canonical spelling is the closed compound \"greenfield\""
+      },
+      {
+        "deprecated": "master branch",
+        "canonical": "main branch",
+        "reason": "the default branch is \"main\"; \"master\" is the retired name"
+      }
+    ]
+  },
   "roadmap": {
     "tracker": {
       "kind": "github",

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -9,6 +9,7 @@ import { createAgentCommand } from './agent';
 import { createAlignDesignSystemCommand } from './align-design-system';
 import { createAuditProtectedCommand } from './audit-protected';
 import { createBackfillSkillProvenanceCommand } from './backfill-skill-provenance';
+import { createBlackBoxCommand } from './orchestrator-black-box';
 import { createBlueprintCommand } from './blueprint';
 import { createCheckArchCommand } from './check-arch';
 import { createCheckDepsCommand } from './check-deps';
@@ -18,6 +19,7 @@ import { createCheckHarnessStrengthCommand } from './check-harness-strength';
 import { createCheckPerfCommand } from './check-perf';
 import { createCheckPhaseGateCommand } from './check-phase-gate';
 import { createCheckSecurityCommand } from './check-security';
+import { createCheckVocabularyCommand } from './check-vocabulary';
 import { createCICommand } from './ci';
 import { createCleanupCommand } from './cleanup';
 import { createCleanupSessionsCommand } from './cleanup-sessions';
@@ -101,6 +103,7 @@ export const commandCreators: Array<() => Command> = [
   createAlignDesignSystemCommand,
   createAuditProtectedCommand,
   createBackfillSkillProvenanceCommand,
+  createBlackBoxCommand,
   createBlueprintCommand,
   createCheckArchCommand,
   createCheckDepsCommand,
@@ -110,6 +113,7 @@ export const commandCreators: Array<() => Command> = [
   createCheckPerfCommand,
   createCheckPhaseGateCommand,
   createCheckSecurityCommand,
+  createCheckVocabularyCommand,
   createCICommand,
   createCleanupCommand,
   createCleanupSessionsCommand,

--- a/packages/cli/src/commands/check-vocabulary.ts
+++ b/packages/cli/src/commands/check-vocabulary.ts
@@ -1,0 +1,128 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import type { Result } from '@harness-engineering/core';
+import { Ok } from '@harness-engineering/core';
+import { resolveConfig } from '../config/loader';
+import { VocabularyConfigSchema } from '../config/schema';
+import { scanFiles, resolveScanFiles, formatViolations } from '../vocabulary/scanner';
+import type { Violation } from '../vocabulary/scanner';
+import { OutputFormatter, OutputMode } from '../output/formatter';
+import type { OutputModeType } from '../output/formatter';
+import { resolveOutputMode } from '../utils/output';
+import { logger } from '../output/logger';
+import { CLIError, ExitCode } from '../utils/errors';
+
+interface CheckVocabularyOptions {
+  cwd?: string;
+  configPath?: string;
+}
+
+interface CheckVocabularyResult {
+  valid: boolean;
+  /** True when the gate was inert (disabled or no rules) and passed trivially. */
+  skipped: boolean;
+  filesScanned: number;
+  rulesApplied: number;
+  violations: Violation[];
+}
+
+export async function runCheckVocabulary(
+  options: CheckVocabularyOptions
+): Promise<Result<CheckVocabularyResult, CLIError>> {
+  const cwd = options.cwd ?? process.cwd();
+
+  const configResult = resolveConfig(options.configPath);
+  if (!configResult.ok) {
+    return configResult;
+  }
+
+  // Fill defaults (paths/exclude) even when the `vocabulary` block is omitted, so
+  // an absent block behaves like an enabled-but-ruleless gate: it passes trivially.
+  const vocab = VocabularyConfigSchema.parse(configResult.value.vocabulary ?? {});
+
+  // Trivial pass: gate disabled, or no rules to enforce.
+  if (!vocab.enabled || vocab.rules.length === 0) {
+    return Ok({
+      valid: true,
+      skipped: true,
+      filesScanned: 0,
+      rulesApplied: vocab.rules.length,
+      violations: [],
+    });
+  }
+
+  const root = path.resolve(cwd);
+  const scan = { include: vocab.paths, exclude: vocab.exclude };
+  const scanned = await resolveScanFiles(root, scan);
+  const violations = await scanFiles(root, scan, vocab.rules);
+
+  return Ok({
+    valid: violations.length === 0,
+    skipped: false,
+    filesScanned: scanned.length,
+    rulesApplied: vocab.rules.length,
+    violations,
+  });
+}
+
+function printCheckVocabularyResult(
+  value: CheckVocabularyResult,
+  formatter: OutputFormatter,
+  mode: OutputModeType
+): void {
+  if (value.skipped) {
+    if (mode !== OutputMode.QUIET) {
+      console.log(formatter.formatSummary('Semantic vocabulary', 'no rules — skipped', true));
+    }
+    return;
+  }
+
+  console.log(
+    formatter.formatSummary(
+      'Semantic vocabulary',
+      value.valid
+        ? `${value.filesScanned} files, ${value.rulesApplied} rules — clean`
+        : `${value.violations.length} violation(s)`,
+      value.valid
+    )
+  );
+
+  if (!value.valid) {
+    console.log(
+      '\nDeprecated canonical terms found — replace with the suggested canonical term\n' +
+        '(or add an exemption to the `vocabulary` block in harness.config.json):\n'
+    );
+    console.log(formatViolations(value.violations));
+  }
+}
+
+export function createCheckVocabularyCommand(): Command {
+  const command = new Command('check-vocabulary')
+    .description('Fail when deprecated or renamed canonical terms reappear in skills/docs prose')
+    .action(async (_opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const mode = resolveOutputMode(globalOpts);
+      const formatter = new OutputFormatter(mode);
+
+      const result = await runCheckVocabulary({ configPath: globalOpts.config });
+
+      if (!result.ok) {
+        if (mode === OutputMode.JSON) {
+          console.log(JSON.stringify({ error: result.error.message }));
+        } else {
+          logger.error(result.error.message);
+        }
+        process.exit(result.error.exitCode);
+      }
+
+      if (mode === OutputMode.JSON) {
+        console.log(JSON.stringify(result.value, null, 2));
+      } else if (mode !== OutputMode.QUIET) {
+        printCheckVocabularyResult(result.value, formatter, mode);
+      }
+
+      process.exit(result.value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
+    });
+
+  return command;
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -441,6 +441,60 @@ export const IntegrationsConfigSchema = z.object({
 });
 
 /**
+ * Schema for a single semantic-vocabulary rule (`vocabulary.rules[]`).
+ *
+ * Each rule maps a deprecated / renamed term to its canonical replacement. The
+ * `harness check-vocabulary` gate fails when the deprecated form reappears in
+ * scanned Markdown prose (fenced code blocks and inline code are ignored), and
+ * points the author at the canonical term with the exact file and line.
+ */
+export const VocabularyRuleSchema = z.object({
+  /** The deprecated / renamed term that must no longer appear in prose. */
+  deprecated: z.string().min(1),
+  /** The canonical term to suggest in its place. */
+  canonical: z.string().min(1),
+  /** Why the term was deprecated — shown in the failure message. */
+  reason: z.string().min(1).optional(),
+  /**
+   * Optional regex sources (compiled case-insensitively) that exempt a
+   * legitimate occurrence on a matching line. Use sparingly.
+   */
+  allow: z.array(z.string().min(1)).optional(),
+});
+
+/**
+ * Schema for the semantic-vocabulary CI gate (`vocabulary`).
+ *
+ * A config-driven, adopter-facing gate: `harness check-vocabulary` scans the
+ * configured Markdown surfaces and fails when a deprecated / renamed canonical
+ * term reappears in prose, protecting a glossary or naming investment from
+ * vocabulary drift. When `enabled` is false or `rules` is empty the gate passes
+ * trivially. Omit the block entirely to leave the gate inert.
+ *
+ * `paths` / `exclude` default to authored-prose surfaces (skills + docs) while
+ * skipping archival/historical ones (ADRs, change proposals, research) that
+ * legitimately quote old or external vocabulary.
+ */
+export const VocabularyConfigSchema = z.object({
+  /** Whether the vocabulary gate is enabled (default: true). */
+  enabled: z.boolean().default(true),
+  /** Deprecated → canonical term mappings. Empty ⇒ the gate passes trivially. */
+  rules: z.array(VocabularyRuleSchema).default([]),
+  /** Glob patterns of Markdown surfaces to scan (default: skills + docs prose). */
+  paths: z.array(z.string().min(1)).default(['agents/skills/**/*.md', 'docs/**/*.md']),
+  /** Glob patterns to skip (default: archival/historical surfaces + node_modules). */
+  exclude: z
+    .array(z.string().min(1))
+    .default([
+      '**/node_modules/**',
+      'docs/knowledge/decisions/**',
+      'docs/changes/**',
+      'docs/research/**',
+      'docs/roadmap-archive.md',
+    ]),
+});
+
+/**
  * The main Harness configuration schema.
  */
 /**
@@ -836,6 +890,8 @@ export const HarnessConfigSchema = z.object({
   phaseGates: PhaseGatesConfigSchema.optional(),
   /** Design system consistency settings */
   design: DesignConfigSchema.optional(),
+  /** Semantic-vocabulary CI gate settings (`harness check-vocabulary`) */
+  vocabulary: VocabularyConfigSchema.optional(),
   /** Shared configuration for craft-pipeline ceiling skills (LLM-judgment) */
   craft: CraftConfigSchema.optional(),
   /** Internationalization (i18n) settings */
@@ -947,6 +1003,11 @@ export type HarnessConfig = z.infer<typeof HarnessConfigSchema>;
  * Type for design-specific configuration.
  */
 export type DesignConfig = z.infer<typeof DesignConfigSchema>;
+
+/**
+ * Type for semantic-vocabulary gate configuration.
+ */
+export type VocabularyConfig = z.infer<typeof VocabularyConfigSchema>;
 
 /**
  * Type for i18n-specific configuration.

--- a/packages/cli/src/vocabulary/scanner.ts
+++ b/packages/cli/src/vocabulary/scanner.ts
@@ -1,0 +1,181 @@
+// Semantic-vocabulary scanner — the pure engine behind `harness check-vocabulary`,
+// the adopter-facing gate that fails when a deprecated or renamed canonical term
+// reappears in an adopter's skills/docs prose, guarding a glossary or naming
+// investment from vocabulary drift over time.
+//
+// Ships in @harness-engineering/cli so any project that adopts harness can run it
+// against its own `harness.config.json` `vocabulary` block. The rule set and scan
+// scope come from config; this module is pure logic so it can be unit-tested
+// against fixtures independent of any real repo.
+//
+// Design constraints (low false-positive by construction):
+//   - Prose-only: fenced code blocks (``` / ~~~) and inline code spans (`...`) are
+//     stripped before matching, so a legitimate identifier mention never trips the
+//     gate. Line numbers are preserved against the original file.
+//   - Word-boundary matching, case-insensitive by default — "codebase" never
+//     matches the "code base" rule, and a substring inside a larger word is ignored.
+//   - Per-rule `allow` regex sources let a rule exempt a known-legitimate context.
+
+import { readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { glob } from 'glob';
+
+/** One deprecated → canonical vocabulary mapping. */
+export interface VocabularyRule {
+  /** The deprecated / renamed term that must no longer appear in prose. */
+  readonly deprecated: string;
+  /** The canonical term to suggest in its place. */
+  readonly canonical: string;
+  /** Why the term was deprecated — shown in the failure message. */
+  readonly reason?: string | undefined;
+  /**
+   * Optional regex sources that exempt a legitimate occurrence. If any matches the
+   * line (original, pre-strip), the hit on that line is not reported. Compiled
+   * case-insensitively. Use sparingly. Sourced from config as plain strings so the
+   * rule set is fully expressible in JSON.
+   */
+  readonly allow?: readonly string[] | undefined;
+}
+
+/** What files the gate scans and which surfaces it deliberately skips. */
+export interface ScanConfig {
+  /** Glob patterns (relative to root) of files to scan. */
+  readonly include: readonly string[];
+  /**
+   * Glob patterns (relative to root) to exclude. Historical/archival/competitor
+   * surfaces (ADRs, change deltas, research analyses) legitimately reference old
+   * or external vocabulary and must not be treated as drift.
+   */
+  readonly exclude: readonly string[];
+}
+
+/** A single deprecated-term occurrence found by the scanner. */
+export interface Violation {
+  /** Repo-relative, forward-slash-normalized path. */
+  readonly file: string;
+  /** 1-based line number in the original file. */
+  readonly line: number;
+  readonly deprecated: string;
+  readonly canonical: string;
+  readonly reason?: string;
+  /** The matched line, trimmed, for context in the failure message. */
+  readonly excerpt: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build a case-insensitive, word-boundary-anchored matcher for a term. Interior
+ * whitespace in a multi-word term matches any run of whitespace so "code   base"
+ * (or a wrapped line normalized to a single space) is still caught.
+ */
+function buildMatcher(deprecated: string): RegExp {
+  const pattern = escapeRegExp(deprecated).replace(/\\?\s+/g, '\\s+');
+  return new RegExp(`\\b${pattern}\\b`, 'i');
+}
+
+/** Compile a rule's `allow` sources into case-insensitive matchers (once per scan). */
+function compileAllow(allow: readonly string[] | undefined): RegExp[] {
+  return (allow ?? []).map((src) => new RegExp(src, 'i'));
+}
+
+/**
+ * Strip Markdown code from a line array while preserving indices (each stripped
+ * line becomes '' so line numbers still line up with the original file).
+ *   - Fenced blocks: everything between matching ``` or ~~~ fences (inclusive).
+ *   - Inline code: `...` spans within a surviving line.
+ */
+function stripCode(lines: readonly string[]): string[] {
+  const out: string[] = [];
+  let fence: string | null = null;
+
+  for (const raw of lines) {
+    const fenceMatch = /^\s*(`{3,}|~{3,})/.exec(raw);
+    if (fence) {
+      // Inside a fenced block: blank the line; close if the fence char repeats.
+      out.push('');
+      if (fenceMatch && fenceMatch[1]!.startsWith(fence[0]!)) fence = null;
+      continue;
+    }
+    if (fenceMatch) {
+      out.push('');
+      fence = fenceMatch[1]!;
+      continue;
+    }
+    // Not fenced: drop inline-code spans, keep the rest of the prose.
+    out.push(raw.replace(/`[^`]*`/g, ' '));
+  }
+
+  return out;
+}
+
+/** Scan already-loaded text (used by unit tests and by {@link scanFiles}). */
+export function scanText(
+  file: string,
+  content: string,
+  rules: readonly VocabularyRule[]
+): Violation[] {
+  const original = content.split('\n');
+  const prose = stripCode(original);
+  const violations: Violation[] = [];
+
+  for (const rule of rules) {
+    const matcher = buildMatcher(rule.deprecated);
+    const allow = compileAllow(rule.allow);
+    for (let i = 0; i < prose.length; i++) {
+      if (!matcher.test(prose[i]!)) continue;
+      const originalLine = original[i]!;
+      if (allow.some((re) => re.test(originalLine))) continue;
+      violations.push({
+        file,
+        line: i + 1,
+        deprecated: rule.deprecated,
+        canonical: rule.canonical,
+        ...(rule.reason !== undefined && { reason: rule.reason }),
+        excerpt: originalLine.trim(),
+      });
+    }
+  }
+
+  return violations;
+}
+
+/** Resolve the configured globs to a de-duplicated, sorted list of absolute files. */
+export async function resolveScanFiles(root: string, scan: ScanConfig): Promise<string[]> {
+  const matches = await glob([...scan.include], {
+    cwd: root,
+    absolute: true,
+    ignore: [...scan.exclude],
+    nodir: true,
+  });
+  return [...new Set(matches)].sort();
+}
+
+/** Scan every configured file under `root` and return all violations. */
+export async function scanFiles(
+  root: string,
+  scan: ScanConfig,
+  rules: readonly VocabularyRule[]
+): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  for (const absPath of await resolveScanFiles(root, scan)) {
+    const rel = relative(root, absPath).replaceAll('\\', '/');
+    violations.push(...scanText(rel, readFileSync(resolve(absPath), 'utf-8'), rules));
+  }
+  return violations;
+}
+
+/** Render violations as a human-readable, actionable failure message. */
+export function formatViolations(violations: readonly Violation[]): string {
+  return violations
+    .map((v) => {
+      const because = v.reason ? ` (${v.reason})` : '';
+      return (
+        `  ${v.file}:${v.line} — "${v.deprecated}" is deprecated; use "${v.canonical}"` +
+        `${because}\n    ${v.excerpt}`
+      );
+    })
+    .join('\n');
+}

--- a/packages/cli/tests/commands/check-vocabulary.test.ts
+++ b/packages/cli/tests/commands/check-vocabulary.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import {
+  createCheckVocabularyCommand,
+  runCheckVocabulary,
+} from '../../src/commands/check-vocabulary';
+import {
+  scanText,
+  scanFiles,
+  formatViolations,
+  type VocabularyRule,
+} from '../../src/vocabulary/scanner';
+
+const FIXTURES = path.join(__dirname, '../fixtures/semantic-vocabulary');
+
+const SAMPLE_RULES: readonly VocabularyRule[] = [
+  { deprecated: 'sub-agent', canonical: 'subagent', reason: 'closed compound' },
+  { deprecated: 'green field', canonical: 'greenfield', reason: 'closed compound' },
+  { deprecated: 'master branch', canonical: 'main branch', reason: 'default branch is main' },
+];
+
+describe('semantic-vocabulary scanner', () => {
+  it('flags a deprecated term in prose with the suggested canonical term', () => {
+    const v = scanText('x.md', 'We spun up a sub-agent for this.', SAMPLE_RULES);
+    expect(v.map((x) => x.deprecated)).toEqual(['sub-agent']);
+    expect(v[0]).toMatchObject({ deprecated: 'sub-agent', canonical: 'subagent', line: 1 });
+  });
+
+  it('reports the correct 1-based line number', () => {
+    const content = 'line one\nline two has a sub-agent here\nline three';
+    const v = scanText('x.md', content, SAMPLE_RULES);
+    expect(v.map((x) => x.line)).toEqual([2]);
+  });
+
+  it('passes clean prose that uses the canonical term', () => {
+    const v = scanText('x.md', 'We spun up a subagent on the main branch.', SAMPLE_RULES);
+    expect(v).toEqual([]);
+  });
+
+  it('does not match a canonical closed compound as a substring', () => {
+    // "codebase" must not trip a "code base" rule via substring.
+    const rules = [{ deprecated: 'code base', canonical: 'codebase', reason: 'r' }];
+    expect(scanText('x.md', 'The codebase is large.', rules)).toEqual([]);
+  });
+
+  it('ignores deprecated terms inside fenced code blocks and inline code', () => {
+    const content = ['```', 'const x = "sub-agent";', '```', 'inline `sub-agent` too'].join('\n');
+    expect(scanText('x.md', content, SAMPLE_RULES)).toEqual([]);
+  });
+
+  it('honors per-rule allow exemptions (regex source strings)', () => {
+    const rules: VocabularyRule[] = [
+      { deprecated: 'sub-agent', canonical: 'subagent', reason: 'r', allow: ['quoting legacy'] },
+    ];
+    expect(scanText('x.md', 'quoting legacy sub-agent term', rules)).toEqual([]);
+  });
+
+  it('formats violations into an actionable message', () => {
+    const v = scanText('docs/x.md', 'a sub-agent', SAMPLE_RULES);
+    const msg = formatViolations(v);
+    expect(msg).toContain('docs/x.md:1');
+    expect(msg).toContain('use "subagent"');
+  });
+
+  it('detects every deprecated term in the deprecated fixture, and none in the clean fixture', async () => {
+    const dirty = await scanFiles(
+      FIXTURES,
+      { include: ['deprecated-sample.md'], exclude: [] },
+      SAMPLE_RULES
+    );
+    // Every sample rule appears exactly once in prose; code/inline are ignored.
+    expect(dirty.map((v) => v.deprecated).sort()).toEqual(
+      SAMPLE_RULES.map((r) => r.deprecated).sort()
+    );
+
+    const clean = await scanFiles(
+      FIXTURES,
+      { include: ['clean-sample.md'], exclude: [] },
+      SAMPLE_RULES
+    );
+    expect(clean).toEqual([]);
+  });
+});
+
+describe('runCheckVocabulary command', () => {
+  it('fails and reports violations for a deprecated fixture', async () => {
+    const result = await runCheckVocabulary({
+      cwd: FIXTURES,
+      configPath: path.join(FIXTURES, 'enabled-config.json'),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.valid).toBe(false);
+      expect(result.value.skipped).toBe(false);
+      expect(result.value.violations.map((v) => v.deprecated).sort()).toEqual(
+        SAMPLE_RULES.map((r) => r.deprecated).sort()
+      );
+    }
+  });
+
+  it('passes for clean prose using canonical terms', async () => {
+    const result = await runCheckVocabulary({
+      cwd: FIXTURES,
+      configPath: path.join(FIXTURES, 'clean-config.json'),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.valid).toBe(true);
+      expect(result.value.violations).toEqual([]);
+    }
+  });
+
+  it('passes trivially (skipped) when the gate is disabled', async () => {
+    const result = await runCheckVocabulary({
+      cwd: FIXTURES,
+      configPath: path.join(FIXTURES, 'disabled-config.json'),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.valid).toBe(true);
+      expect(result.value.skipped).toBe(true);
+    }
+  });
+
+  it('passes trivially (skipped) when there are no rules', async () => {
+    const result = await runCheckVocabulary({
+      cwd: FIXTURES,
+      configPath: path.join(FIXTURES, 'empty-rules-config.json'),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.valid).toBe(true);
+      expect(result.value.skipped).toBe(true);
+    }
+  });
+
+  it('returns an error when the config cannot be resolved', async () => {
+    const result = await runCheckVocabulary({
+      configPath: '/nonexistent/harness.config.json',
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('createCheckVocabularyCommand', () => {
+  it('creates a command named check-vocabulary', () => {
+    const cmd = createCheckVocabularyCommand();
+    expect(cmd.name()).toBe('check-vocabulary');
+  });
+});

--- a/packages/cli/tests/fixtures/semantic-vocabulary/clean-config.json
+++ b/packages/cli/tests/fixtures/semantic-vocabulary/clean-config.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "vocabulary": {
+    "enabled": true,
+    "rules": [
+      { "deprecated": "sub-agent", "canonical": "subagent", "reason": "closed compound" },
+      { "deprecated": "green field", "canonical": "greenfield", "reason": "closed compound" },
+      {
+        "deprecated": "master branch",
+        "canonical": "main branch",
+        "reason": "default branch is main"
+      }
+    ],
+    "paths": ["clean-sample.md"],
+    "exclude": []
+  }
+}

--- a/packages/cli/tests/fixtures/semantic-vocabulary/clean-sample.md
+++ b/packages/cli/tests/fixtures/semantic-vocabulary/clean-sample.md
@@ -1,0 +1,5 @@
+# Clean sample
+
+We spun up a subagent to handle the subtask on the main branch.
+
+The codebase is large, and this was a greenfield effort.

--- a/packages/cli/tests/fixtures/semantic-vocabulary/deprecated-sample.md
+++ b/packages/cli/tests/fixtures/semantic-vocabulary/deprecated-sample.md
@@ -1,0 +1,12 @@
+# Deprecated sample
+
+We spun up a sub-agent to handle the work on the master branch.
+
+This project started as a green field effort.
+
+```ts
+// code inside a fence mentions a sub-agent but must be ignored
+const label = 'sub-agent';
+```
+
+Inline `sub-agent` in code span is also ignored.

--- a/packages/cli/tests/fixtures/semantic-vocabulary/disabled-config.json
+++ b/packages/cli/tests/fixtures/semantic-vocabulary/disabled-config.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "vocabulary": {
+    "enabled": false,
+    "rules": [{ "deprecated": "sub-agent", "canonical": "subagent", "reason": "closed compound" }],
+    "paths": ["deprecated-sample.md"],
+    "exclude": []
+  }
+}

--- a/packages/cli/tests/fixtures/semantic-vocabulary/empty-rules-config.json
+++ b/packages/cli/tests/fixtures/semantic-vocabulary/empty-rules-config.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "vocabulary": {
+    "enabled": true,
+    "rules": [],
+    "paths": ["deprecated-sample.md"],
+    "exclude": []
+  }
+}

--- a/packages/cli/tests/fixtures/semantic-vocabulary/enabled-config.json
+++ b/packages/cli/tests/fixtures/semantic-vocabulary/enabled-config.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "vocabulary": {
+    "enabled": true,
+    "rules": [
+      { "deprecated": "sub-agent", "canonical": "subagent", "reason": "closed compound" },
+      { "deprecated": "green field", "canonical": "greenfield", "reason": "closed compound" },
+      {
+        "deprecated": "master branch",
+        "canonical": "main branch",
+        "reason": "default branch is main"
+      }
+    ],
+    "paths": ["deprecated-sample.md"],
+    "exclude": []
+  }
+}


### PR DESCRIPTION
## Semantic-Vocabulary CI Gate (#605) — shipped `harness check-vocabulary`

Reworked from a harness-repo-internal vitest test into an **adopter-facing CLI command**. Harness is a framework adopters install in their own projects, so its checks must ship as `harness check-*` commands that read the adopter's `harness.config.json` — not as tests wired into harness's own `ci.yml`. Harness now dogfoods the same shipped command.

### What ships
- **`harness check-vocabulary`** (`packages/cli/src/commands/check-vocabulary.ts`) — mirrors `check-docs`: `resolveConfig` → scan → per-violation report (`file:line — "x" is deprecated; use "y"`), `--json` support, exits `VALIDATION_FAILED` on any finding, `SUCCESS` otherwise.
- **Pure scanner** (`packages/cli/src/vocabulary/scanner.ts`) — strips fenced/inline code, case-insensitive word-boundary matching, per-rule `allow` exemptions, forward-slash-normalized paths. Unit-testable in isolation.
- **`vocabulary` config block** (`packages/cli/src/config/schema.ts`):
  ```jsonc
  "vocabulary": {
    "enabled": true,                    // false ⇒ trivial pass
    "rules": [ { "deprecated": "sub-agent", "canonical": "subagent", "reason": "...", "allow": ["..."] } ], // [] ⇒ trivial pass
    "paths":   ["agents/skills/**/*.md", "docs/**/*.md"],            // defaults
    "exclude": ["**/node_modules/**", "docs/knowledge/decisions/**", "docs/changes/**", "docs/research/**", "docs/roadmap-archive.md"] // defaults (archival surfaces)
  }
  ```

### Dogfooding
- Harness's own `harness.config.json` seeds 5 rules: `sub-agent→subagent`, `sub-task→subtask`, `code base→codebase`, `green field→greenfield`, `master branch→main branch` (each verified with zero in-scope occurrences).
- CI runs the shipped command (`node packages/cli/dist/bin/harness.js check-vocabulary`) alongside the other gates in `.github/workflows/ci.yml` — no bespoke vitest step.

### Verification
- Live: `harness check-vocabulary` → `Semantic vocabulary: 3423 files, 5 rules — clean` (exit 0); `--json` emits `{ valid: true, skipped: false, filesScanned: 3423, rulesApplied: 5, violations: [] }`.
- Tests (`packages/cli/tests/commands/check-vocabulary.test.ts`, 14 passing): deprecated→finding with canonical, clean→pass, `allow` respected, code blocks ignored, disabled/empty-rules→trivial pass, ported scanner unit tests. Config suite: 190 passing.
- `tsc --noEmit`, eslint, full pre-push suite + doc-freshness all green. Changeset + regenerated `docs/reference/cli-commands.md` included.

Spec: `docs/changes/semantic-vocabulary-ci-gate/proposal.md` (rewritten for the adopter-facing design). Roadmap shard `Spec:` line updated.

Closes #605
