### PR TITLE
feat(parallelization): owned-files declaration overlap forecasting (#601)

### DIFF
--- a/.changeset/owned-files-declaration.md
+++ b/.changeset/owned-files-declaration.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/core': patch
+'@harness-engineering/types': patch
+---
+
+Define the `owns:[paths]` owned-files declaration on plan tasks (#601). Adds a cheap, deterministic, graph-free pre-execution conflict forecast: `forecastOwnershipConflicts` and glob-aware `pathsOverlap` (via minimatch) flag task pairs whose declared owned paths overlap and so may conflict if run in parallel. `buildTaskGraph`/`planParallelization` now compute footprint overlap glob-aware and surface an `ownershipForecast` field on `ParallelizationPlan`. Fully additive — absent `owns` preserves current behavior.

--- a/.changeset/owned-files-declaration.md
+++ b/.changeset/owned-files-declaration.md
@@ -1,6 +1,7 @@
 ---
 '@harness-engineering/core': patch
 '@harness-engineering/types': patch
+'@harness-engineering/cli': patch
 ---
 
 Define the `owns:[paths]` owned-files declaration on plan tasks (#601). Adds a cheap, deterministic, graph-free pre-execution conflict forecast: `forecastOwnershipConflicts` and glob-aware `pathsOverlap` (via minimatch) flag task pairs whose declared owned paths overlap and so may conflict if run in parallel. `buildTaskGraph`/`planParallelization` now compute footprint overlap glob-aware and surface an `ownershipForecast` field on `ParallelizationPlan`. Fully additive — absent `owns` preserves current behavior.

--- a/.claude-plugin/agents/harness-planner.md
+++ b/.claude-plugin/agents/harness-planner.md
@@ -281,7 +281,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -352,7 +352,7 @@ One sentence.
 
 **Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast. All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/.claude-plugin/agents/harness-planner.md
+++ b/.claude-plugin/agents/harness-planner.md
@@ -281,7 +281,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -350,9 +350,9 @@ One sentence.
 
 ### Task 1: <descriptive name>
 
-**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts
+**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input. Both feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/.claude-plugin/agents/harness-task-executor.md
+++ b/.claude-plugin/agents/harness-task-executor.md
@@ -162,7 +162,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/.claude-plugin/agents/harness-task-executor.md
+++ b/.claude-plugin/agents/harness-task-executor.md
@@ -162,7 +162,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files` and `dependsOn` (from the plan's task headers) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`).
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/.cursor-plugin/agents/harness-planner.md
+++ b/.cursor-plugin/agents/harness-planner.md
@@ -280,7 +280,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -351,7 +351,7 @@ One sentence.
 
 **Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast. All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/.cursor-plugin/agents/harness-planner.md
+++ b/.cursor-plugin/agents/harness-planner.md
@@ -280,7 +280,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -349,9 +349,9 @@ One sentence.
 
 ### Task 1: <descriptive name>
 
-**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts
+**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input. Both feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/.cursor-plugin/agents/harness-task-executor.md
+++ b/.cursor-plugin/agents/harness-task-executor.md
@@ -161,7 +161,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files` and `dependsOn` (from the plan's task headers) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`).
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/.cursor-plugin/agents/harness-task-executor.md
+++ b/.cursor-plugin/agents/harness-task-executor.md
@@ -161,7 +161,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/.gemini-extension/commands/autopilot.toml
+++ b/.gemini-extension/commands/autopilot.toml
@@ -141,7 +141,7 @@ On return: read `planPath` from `{sessionDir}/handoff.json`. Complexity override
    }
    ```
 
-   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`, and `ownershipForecast`. Forwarding each task's `owns` lets the cheap deterministic owns-overlap check (#601) contribute implicit edges to the wave DAG and surface any overlapping ownership pairs in `ownershipForecast`. Omit `owns` for tasks that declare none — it stays a no-op.
+   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`, and `ownershipForecast`. Forwarding each task's `owns` lets the cheap deterministic owns-overlap check contribute implicit edges to the wave DAG and surface any overlapping ownership pairs in `ownershipForecast`. Omit `owns` for tasks that declare none — it stays a no-op.
 
 2. **If `cyclic` is non-empty:** STOP. Surface the cycle and route back to PLAN/APPROVE_PLAN (a dependency cycle is a plan defect). Do not dispatch.
 

--- a/.gemini-extension/commands/autopilot.toml
+++ b/.gemini-extension/commands/autopilot.toml
@@ -131,17 +131,17 @@ On return: read `planPath` from `{sessionDir}/handoff.json`. Complexity override
 
 **Pre-dispatch: plan parallelization (standard automatic parallelism).** Before dispatching tasks, decide the safe parallel structure. This is orchestration, not reimplementation — autopilot chooses HOW to dispatch; the persona agents still do the work.
 
-1. Collect the phase's tasks with their `files` and `dependsOn` (from the plan's task headers). Call the `plan_parallelization` MCP tool:
+1. Collect the phase's tasks with their `files`, `dependsOn`, and `owns` (from the plan's task headers — `owns` comes from the optional `**Owns:**` line). Call the `plan_parallelization` MCP tool:
 
    ```json
    {
      "path": "<project-root>",
-     "tasks": [{ "id": "task-1", "files": ["..."], "dependsOn": [] }],
+     "tasks": [{ "id": "task-1", "files": ["..."], "dependsOn": [], "owns": ["src/api/**"] }],
      "depth": 1
    }
    ```
 
-   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`.
+   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`, and `ownershipForecast`. Forwarding each task's `owns` lets the cheap deterministic owns-overlap check (#601) contribute implicit edges to the wave DAG and surface any overlapping ownership pairs in `ownershipForecast`. Omit `owns` for tasks that declare none — it stays a no-op.
 
 2. **If `cyclic` is non-empty:** STOP. Surface the cycle and route back to PLAN/APPROVE_PLAN (a dependency cycle is a plan defect). Do not dispatch.
 

--- a/.gemini-extension/commands/execution.toml
+++ b/.gemini-extension/commands/execution.toml
@@ -156,7 +156,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/.gemini-extension/commands/execution.toml
+++ b/.gemini-extension/commands/execution.toml
@@ -156,7 +156,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files` and `dependsOn` (from the plan's task headers) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`).
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/.gemini-extension/commands/planning.toml
+++ b/.gemini-extension/commands/planning.toml
@@ -276,7 +276,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -345,9 +345,9 @@ One sentence.
 
 ### Task 1: <descriptive name>
 
-**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts
+**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input. Both feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/.gemini-extension/commands/planning.toml
+++ b/.gemini-extension/commands/planning.toml
@@ -276,7 +276,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -347,7 +347,7 @@ One sentence.
 
 **Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast. All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/agents/skills/claude-code/harness-autopilot/SKILL.md
+++ b/agents/skills/claude-code/harness-autopilot/SKILL.md
@@ -120,7 +120,7 @@ On return: read `planPath` from `{sessionDir}/handoff.json`. Complexity override
    }
    ```
 
-   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`, and `ownershipForecast`. Forwarding each task's `owns` lets the cheap deterministic owns-overlap check (#601) contribute implicit edges to the wave DAG and surface any overlapping ownership pairs in `ownershipForecast`. Omit `owns` for tasks that declare none — it stays a no-op.
+   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`, and `ownershipForecast`. Forwarding each task's `owns` lets the cheap deterministic owns-overlap check contribute implicit edges to the wave DAG and surface any overlapping ownership pairs in `ownershipForecast`. Omit `owns` for tasks that declare none — it stays a no-op.
 
 2. **If `cyclic` is non-empty:** STOP. Surface the cycle and route back to PLAN/APPROVE_PLAN (a dependency cycle is a plan defect). Do not dispatch.
 

--- a/agents/skills/claude-code/harness-autopilot/SKILL.md
+++ b/agents/skills/claude-code/harness-autopilot/SKILL.md
@@ -110,17 +110,17 @@ On return: read `planPath` from `{sessionDir}/handoff.json`. Complexity override
 
 **Pre-dispatch: plan parallelization (standard automatic parallelism).** Before dispatching tasks, decide the safe parallel structure. This is orchestration, not reimplementation — autopilot chooses HOW to dispatch; the persona agents still do the work.
 
-1. Collect the phase's tasks with their `files` and `dependsOn` (from the plan's task headers). Call the `plan_parallelization` MCP tool:
+1. Collect the phase's tasks with their `files`, `dependsOn`, and `owns` (from the plan's task headers — `owns` comes from the optional `**Owns:**` line). Call the `plan_parallelization` MCP tool:
 
    ```json
    {
      "path": "<project-root>",
-     "tasks": [{ "id": "task-1", "files": ["..."], "dependsOn": [] }],
+     "tasks": [{ "id": "task-1", "files": ["..."], "dependsOn": [], "owns": ["src/api/**"] }],
      "depth": 1
    }
    ```
 
-   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`.
+   It returns a `ParallelizationPlan`: `waves[]` (each `{ tasks, severity, firing, analysisLevel }`), `serialized[]`, `cyclic[]`, `narration`, and `ownershipForecast`. Forwarding each task's `owns` lets the cheap deterministic owns-overlap check (#601) contribute implicit edges to the wave DAG and surface any overlapping ownership pairs in `ownershipForecast`. Omit `owns` for tasks that declare none — it stays a no-op.
 
 2. **If `cyclic` is non-empty:** STOP. Surface the cycle and route back to PLAN/APPROVE_PLAN (a dependency cycle is a plan defect). Do not dispatch.
 

--- a/agents/skills/claude-code/harness-execution/SKILL.md
+++ b/agents/skills/claude-code/harness-execution/SKILL.md
@@ -135,7 +135,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files` and `dependsOn` (from the plan's task headers) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`).
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/agents/skills/claude-code/harness-execution/SKILL.md
+++ b/agents/skills/claude-code/harness-execution/SKILL.md
@@ -135,7 +135,7 @@ RMH005 (`harness validate`).
 
 Before the per-task loop, decide the safe parallel structure so independent tasks dispatch concurrently by default (no human typing "in parallel").
 
-1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast (#601) add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
+1. Collect this run's tasks with their `files`, `dependsOn`, and optional `owns` (from the plan's task headers — `owns` comes from the `**Owns:**` line) and call the `plan_parallelization` MCP tool (`{ path, tasks, depth: 1 }`). It returns `ParallelizationPlan` (`waves[]`, `serialized[]`, `cyclic[]`, `narration`, `ownershipForecast`). Forwarding `owns` lets the deterministic owns-overlap forecast add implicit DAG edges and surface overlapping-ownership pairs in `ownershipForecast`; omit it for tasks that declare none.
 2. If `cyclic` is non-empty, STOP and escalate (dependency cycle = plan defect). Do not execute.
 3. Emit `narration` (announce-and-proceed — do not pause).
 4. Run `serialized` tasks first (serially, in order — cross-bucket prerequisites), then process `waves` **in array order** (topologically sorted; do not reorder, do not key off `firing` alone).

--- a/agents/skills/claude-code/harness-planning/SKILL.md
+++ b/agents/skills/claude-code/harness-planning/SKILL.md
@@ -256,7 +256,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -327,7 +327,7 @@ One sentence.
 
 **Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast. All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/agents/skills/claude-code/harness-planning/SKILL.md
+++ b/agents/skills/claude-code/harness-planning/SKILL.md
@@ -256,7 +256,7 @@ Report progress: `**[Phase 2/4]** DECOMPOSE — mapping file structure and creat
 ### Phase 3: SEQUENCE — Order Tasks and Identify Dependencies
 
 1. **Order by dependency.** Types before implementations. Implementations before integrations. Integration tasks (tagged `category: "integration"`) after all implementation tasks. Tests alongside implementations (same task, TDD style).
-2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`.
+2. **Identify parallel opportunities and record dependency edges.** Tasks touching different subsystems with no shared state can run in parallel. Record each task's real dependencies as `dependsOn` (the task IDs it must follow) in the task header `**Depends on:**` line, and keep the task's `**Files:**` list accurate — together these are exactly the edges `plan_parallelization` consumes (explicit `dependsOn` unioned with file-overlap edges) to build the wave DAG at execution time. A task with no dependencies records `**Depends on:** none`. Optionally, add an `**Owns:**` line listing glob paths a task claims ownership of (e.g. `src/api/**`); it feeds the cheap, deterministic, graph-free `owns`-overlap forecast in `plan_parallelization` (roadmap #601) — two tasks whose owned globs overlap are flagged in `ownershipForecast` and gain an implicit DAG edge, alongside the file-overlap edges. `Owns` is OPTIONAL: a task with no distinct ownership just omits it.
 3. **Number tasks sequentially.** Use `Task 1`, `Task 2`, etc. Dependencies reference task numbers.
 4. **Estimate total time.** Sum 2-5 minutes per task. If total exceeds available time, identify a milestone boundary for pausing.
 
@@ -325,9 +325,9 @@ One sentence.
 
 ### Task 1: <descriptive name>
 
-**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts
+**Depends on:** none | **Files:** path/to/file.ts, path/to/file.test.ts | **Owns:** path/to/\*\*
 
-<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input. Both feed `plan_parallelization` during execution. -->
+<!-- `Depends on` lists the task IDs this task must follow (its `dependsOn` edges); `Files` is the independence-checking input; `Owns` (optional) lists glob paths this task claims, feeding the deterministic owns-overlap forecast (#601). All three feed `plan_parallelization` during execution. -->
 
 1. Create test file with exact test code
 2. Run test — observe failure

--- a/docs/changes/owned-files-declaration/proposal.md
+++ b/docs/changes/owned-files-declaration/proposal.md
@@ -1,0 +1,105 @@
+---
+feature: owned-files-declaration
+status: draft
+created: 2026-08-04
+roadmap: owned-files-declaration-in-plans-tasks
+external-id: github:Intense-Visions/harness-engineering#601
+keywords:
+  - owned-files
+  - owns-paths
+  - parallel-execution
+  - conflict-forecasting
+  - glob-overlap
+  - task-independence
+---
+
+# Owned-Files Declaration in Plans/Tasks (#601)
+
+## Overview
+
+The standardize-parallel-execution feature scaffolded an `owns?: string[]` field on
+`PlanTask` but explicitly deferred its semantics to this roadmap item: it read `owns`
+entries only as exact strings and named #601 as the owner of the actual authoring and
+overlap meaning (`packages/types/src/plan-task.ts`, and the non-goal in
+`docs/changes/standardize-parallel-execution/proposal.md`).
+
+This change **defines** `owns:[paths]` as an owned-files declaration: each task declares
+the source paths/globs it claims. Two tasks whose owned paths overlap may conflict if run
+in parallel. From that we derive a **cheap, deterministic, graph-free** pre-execution
+conflict forecast — a near-free parallel-safety guardrail that runs alongside the heavier
+graph-based independence analysis (`check_task_independence` / `ConflictPredictor`), not
+in place of it.
+
+Adapted from Spec Kitty's per-work-package owned-files frontmatter
+(`docs/research/spec-kitty-comparison-analysis.md`, adoption SPECKITTY-4).
+
+## Decisions
+
+1. **Glob-aware overlap, not exact-string.** `owns` entries are globs (`src/api/**`), so
+   overlap must be glob-aware. Two patterns overlap when either matches the other treated
+   as a literal path (symmetric double-`minimatch`, `{ dot: true }`). This reduces to
+   equality for two concrete paths (preserving prior file-overlap behavior), matches a
+   covering glob against a path it contains, and — via globstar — treats a narrower glob
+   nested under a broader one as overlapping. Disjoint directory globs
+   (`src/api/**` vs `src/web/**`) do not overlap.
+
+2. **Reuse `minimatch`, already a `@harness-engineering/core` dependency.** No new
+   dependency; mirrors existing glob usage in `constraints/layers.ts` and
+   `security/scanner.ts`.
+
+3. **Additive and backward-compatible.** Absent `owns` = current behavior, exactly. The
+   forecast is advisory: it never removes waves or forces serialization on its own. It is
+   surfaced as a new `ownershipForecast` field on `ParallelizationPlan`.
+
+4. **Schema is the parse boundary.** `PlanTask` reaches the planner as validated JSON
+   through `PlanTaskSchema` (Zod) and the MCP `plan_parallelization` tool — there is no
+   separate plan-markdown task-header parser in the repo. `owns` parsing therefore lives
+   in the strict schema (already present), which this change documents as the owned-files
+   declaration rather than a placeholder consumed field.
+
+## Technical Design
+
+- **`packages/core/src/parallelization/ownership.ts`** (new):
+  - `pathsOverlap(a, b): boolean` — symmetric glob-aware overlap via `minimatch`.
+  - `forecastOwnershipConflicts(tasks): OwnershipConflict[]` — deterministic pairwise
+    scan; only pairs where **both** tasks declare `owns` are considered; each flagged pair
+    lists every overlapping `(ownedByA, ownedByB)` pattern pair in stable order.
+  - Types `OwnershipConflict`, `OwnershipOverlap`.
+
+- **`packages/core/src/parallelization/plan.ts`** (edit): `footprintOf` now returns the
+  union of `files` + `owns` as match patterns, and `shareFootprint` uses `pathsOverlap`
+  instead of exact `Set` membership — so the task DAG (`buildTaskGraph`) gains an implicit
+  edge when an `owns` glob covers another task's file. `planParallelization` populates a
+  new required `ownershipForecast: OwnershipConflict[]` field on `ParallelizationPlan`.
+
+- **`packages/types/src/plan-task.ts`** (edit): doc comment updated to define `owns` as
+  the owned-files declaration (#601) rather than a deferred consumed field.
+
+- **`packages/cli/src/mcp/tools/parallelization.ts`** (edit): tool description updated to
+  document `ownershipForecast` and glob-aware overlap. The returned plan (serialized JSON)
+  carries the forecast automatically — no input-schema change.
+
+## Integration Points
+
+- **`plan_parallelization` (MCP tool / `planParallelization`)** — primary pre-execution
+  conflict-forecasting path. Now emits `ownershipForecast` and builds a glob-aware DAG.
+- **`check_task_independence` / `ConflictPredictor`** — unchanged (graph-based, file
+  driven). The owned-files forecast runs _alongside_ it as the cheap deterministic layer.
+- **`@harness-engineering/core` public API** — exports `forecastOwnershipConflicts`,
+  `pathsOverlap`, and the two types.
+
+## Success Criteria
+
+- Two tasks with overlapping `owns` globs are flagged (both in `ownershipForecast` and as
+  a `buildTaskGraph` edge); disjoint globs are not; absent `owns` is a no-op.
+- Existing exact file-overlap behavior is preserved (concrete-path overlap unchanged).
+- No new dependency; source lints, typechecks, and all parallelization/plan-task tests
+  pass.
+
+## Implementation Order
+
+1. `ownership.ts` — `pathsOverlap` + `forecastOwnershipConflicts` + types.
+2. Wire glob-aware overlap into `plan.ts` (`footprintOf` / `shareFootprint`) and add
+   `ownershipForecast` to `ParallelizationPlan`.
+3. Export from `packages/core/src/index.ts`; document `owns` in types + MCP tool.
+4. Tests: `ownership.test.ts`, extend `plan.test.ts`.

--- a/docs/changes/owned-files-declaration/proposal.md
+++ b/docs/changes/owned-files-declaration/proposal.md
@@ -88,6 +88,25 @@ Adapted from Spec Kitty's per-work-package owned-files frontmatter
 - **`@harness-engineering/core` public API** — exports `forecastOwnershipConflicts`,
   `pathsOverlap`, and the two types.
 
+## Skill-Layer Wiring (producers + consumers)
+
+Core defines and forecasts `owns`, but the primitive is only end-to-end once the skill
+layer both produces and forwards it:
+
+- **Planning produces `owns`.** `harness-planning` documents an optional `**Owns:**`
+  task-header field (next to `**Files:**` / `**Depends on:**`). It lists glob paths a
+  task claims (e.g. `src/api/**`) and feeds the deterministic `owns`-overlap forecast.
+  Optional: a task with no distinct ownership omits it.
+- **Autopilot / execution forward `owns`.** `harness-autopilot` (EXECUTE) and
+  `harness-execution` collect each task's `owns` from its header and include it in the
+  `plan_parallelization` payload (`{ id, files, dependsOn, owns }`), so the forecast
+  contributes implicit DAG edges and surfaces `ownershipForecast` at dispatch time.
+
+This closes the producer→consumer gap: plan authoring emits `**Owns:**` →
+autopilot/execution forward `owns` → `plan_parallelization` runs the glob-aware
+overlap forecast. Skill markdown only; core logic is unchanged. Platform variants
+(codex/cursor/gemini-cli) inherit via symlink to the `claude-code` sources.
+
 ## Success Criteria
 
 - Two tasks with overlapping `owns` globs are flagged (both in `ownershipForecast` and as

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1346,9 +1346,13 @@ Search for community skills on the @harness-skills registry
 - `--trigger` — Filter by trigger type (e.g., manual, automatic)
 - `--registry` — Use a custom npm registry URL
 
-### `harness skill validate`
+### `harness skill validate [skill-name]`
 
-Validate all skill.yaml files and SKILL.md structure
+Validate skill.yaml files and SKILL.md structure
+
+**Arguments:**
+
+- `skill-name` (optional) — Validate only this skill (fails if it is not found)
 
 ## Snapshot Commands
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -625,7 +625,7 @@ Post-execution LLM-judgment: did the implementation actually satisfy its spec? R
 
 ### `plan_parallelization`
 
-Plan safe parallel execution for a set of plan tasks. Builds a task DAG from dependsOn plus file/owns overlap, wave-groups it, annotates each wave with conflict severity and a firing decision, and returns a ParallelizationPlan (waves, serialized, cyclic, narration).
+Plan safe parallel execution for a set of plan tasks. Builds a task DAG from dependsOn plus glob-aware file/owns overlap, wave-groups it, annotates each wave with conflict severity and a firing decision, and returns a ParallelizationPlan (waves, serialized, cyclic, ownershipForecast, narration). ownershipForecast is a cheap deterministic list of task pairs whose declared owns:[paths] overlap.
 
 **Parameters:**
 

--- a/docs/roadmap.d/owned-files-declaration-in-plans-tasks.md
+++ b/docs/roadmap.d/owned-files-declaration-in-plans-tasks.md
@@ -7,7 +7,7 @@ order: 4
 ### Owned-Files Declaration in Plans/Tasks
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/owned-files-declaration/proposal.md
 - **Summary:** Add an owns:[paths] field to harness plan tasks declaring the source files each task owns, enabling cheap deterministic pre-execution conflict forecasting alongside the heavier graph-based independence check (check_task_independence). A near-free parallel-safety guardrail. Adapted from Spec Kitty's per-work-package owned-files frontmatter. Adoption #4 from docs/research/spec-kitty-comparison-analysis.md [SPECKITTY-4]
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -888,7 +888,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Owned-Files Declaration in Plans/Tasks
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/owned-files-declaration/proposal.md
 - **Summary:** Add an owns:[paths] field to harness plan tasks declaring the source files each task owns, enabling cheap deterministic pre-execution conflict forecasting alongside the heavier graph-based independence check (check_task_independence). A near-free parallel-safety guardrail. Adapted from Spec Kitty's per-work-package owned-files frontmatter. Adoption #4 from docs/research/spec-kitty-comparison-analysis.md [SPECKITTY-4]
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/mcp/tools/parallelization.ts
+++ b/packages/cli/src/mcp/tools/parallelization.ts
@@ -6,7 +6,7 @@ import { sanitizePath } from '../utils/sanitize-path.js';
 export const planParallelizationDefinition = {
   name: 'plan_parallelization',
   description:
-    'Plan safe parallel execution for a set of plan tasks. Builds a task DAG from dependsOn plus file/owns overlap, wave-groups it, annotates each wave with conflict severity and a firing decision, and returns a ParallelizationPlan (waves, serialized, cyclic, narration).',
+    'Plan safe parallel execution for a set of plan tasks. Builds a task DAG from dependsOn plus glob-aware file/owns overlap, wave-groups it, annotates each wave with conflict severity and a firing decision, and returns a ParallelizationPlan (waves, serialized, cyclic, ownershipForecast, narration). ownershipForecast is a cheap deterministic list of task pairs whose declared owns:[paths] overlap.',
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -258,6 +258,8 @@ export type {
   FiringDecision,
   WaveSeverity,
 } from './parallelization/plan';
+export { forecastOwnershipConflicts, pathsOverlap } from './parallelization/ownership';
+export type { OwnershipConflict, OwnershipOverlap } from './parallelization/ownership';
 
 /**
  * Proposals module.

--- a/packages/core/src/parallelization/ownership.ts
+++ b/packages/core/src/parallelization/ownership.ts
@@ -1,0 +1,93 @@
+import { minimatch } from 'minimatch';
+import type { PlanTask } from '@harness-engineering/types';
+
+/**
+ * Owned-files declaration overlap forecasting (roadmap #601).
+ *
+ * A task's `owns:[paths]` field declares the source paths/globs a task claims.
+ * Two tasks whose owned paths overlap may conflict if dispatched in parallel.
+ * This module provides the cheap, deterministic, graph-free forecast — a
+ * near-free parallel-safety guardrail that runs alongside the heavier
+ * graph-based independence analysis (check_task_independence).
+ */
+
+// Enable dot so an owned glob like `src/**` also covers dotfiles under it.
+const MATCH_OPTS = { dot: true } as const;
+
+/**
+ * True when two path patterns could match a common path — i.e. their owned
+ * footprints overlap. Symmetric and deterministic.
+ *
+ * A bare path is a trivial glob, so this reduces to string equality for two
+ * concrete paths, matches a concrete path against a covering glob (e.g.
+ * `src/api/**` vs `src/api/users.ts`), and — via globstar — treats a narrower
+ * glob nested under a broader one as overlapping (e.g. `src/**` vs
+ * `src/api/**`). Two disjoint globs (`src/api/**` vs `src/web/**`) do not
+ * overlap.
+ */
+export function pathsOverlap(a: string, b: string): boolean {
+  if (a === b) return true;
+  // Test each pattern as a literal string against the other treated as a glob.
+  return minimatch(a, b, MATCH_OPTS) || minimatch(b, a, MATCH_OPTS);
+}
+
+/** A single overlapping pair of owned patterns between two tasks. */
+export interface OwnershipOverlap {
+  /** The owned pattern contributed by taskA. */
+  readonly ownedByA: string;
+  /** The owned pattern contributed by taskB. */
+  readonly ownedByB: string;
+}
+
+/** A forecast that two tasks' owned paths overlap (potential parallel conflict). */
+export interface OwnershipConflict {
+  readonly taskA: string;
+  readonly taskB: string;
+  /** Every overlapping (ownedByA, ownedByB) pattern pair. Never empty. */
+  readonly overlaps: readonly OwnershipOverlap[];
+}
+
+/**
+ * Every overlapping (ownedByA, ownedByB) pattern pair between two owned-path
+ * lists, in stable (ownsA × ownsB) declaration order.
+ */
+function overlappingPatternPairs(
+  ownsA: readonly string[],
+  ownsB: readonly string[]
+): OwnershipOverlap[] {
+  const overlaps: OwnershipOverlap[] = [];
+  for (const ownedByA of ownsA) {
+    for (const ownedByB of ownsB) {
+      if (pathsOverlap(ownedByA, ownedByB)) overlaps.push({ ownedByA, ownedByB });
+    }
+  }
+  return overlaps;
+}
+
+/**
+ * Deterministic pre-execution forecast of parallel conflicts implied by
+ * `owns:[paths]` declarations.
+ *
+ * For every unordered task pair where BOTH tasks declare `owns`, flag the pair
+ * when any owned pattern of one overlaps any owned pattern of the other.
+ * Tasks without `owns` (or with an empty `owns`) contribute nothing — absent
+ * declarations preserve current behavior exactly (no-op).
+ *
+ * Output order is stable: pairs follow input order, and each pair's `overlaps`
+ * follow (ownsA × ownsB) declaration order.
+ */
+export function forecastOwnershipConflicts(tasks: readonly PlanTask[]): OwnershipConflict[] {
+  const conflicts: OwnershipConflict[] = [];
+  const declaring = tasks.filter((t) => (t.owns ?? []).length > 0);
+
+  for (let i = 0; i < declaring.length; i++) {
+    const a = declaring[i]!;
+    for (let j = i + 1; j < declaring.length; j++) {
+      const b = declaring[j]!;
+      const overlaps = overlappingPatternPairs(a.owns!, b.owns!);
+      if (overlaps.length > 0) conflicts.push({ taskA: a.id, taskB: b.id, overlaps });
+    }
+  }
+
+  return conflicts;
+}

--- a/packages/core/src/parallelization/plan.ts
+++ b/packages/core/src/parallelization/plan.ts
@@ -2,6 +2,8 @@ import type { ConflictPrediction, ConflictSeverity } from '@harness-engineering/
 import type { PlanTask } from '@harness-engineering/types';
 import { findParallelGroups } from '../review/parallel-groups';
 import type { GraphNode } from '../review/types';
+import { forecastOwnershipConflicts, pathsOverlap } from './ownership';
+import type { OwnershipConflict } from './ownership';
 
 /** Per-wave firing decision (Phase 1: basic derivation; Phase 2 refines). */
 export type FiringDecision = 'auto-dispatch' | 'confirm' | 'serialize';
@@ -29,6 +31,13 @@ export interface ParallelizationPlan {
   serialized: string[];
   /** Dependency cycles (blocking). Disjoint from `waves` and `serialized`. */
   cyclic: string[];
+  /**
+   * Cheap deterministic `owns:[paths]` overlap forecast (roadmap #601): task
+   * pairs whose declared owned paths overlap and so may conflict if run in
+   * parallel. Empty when no tasks declare overlapping `owns`. Advisory —
+   * additive alongside the conflict-driven waves/serialized channels.
+   */
+  ownershipForecast: OwnershipConflict[];
   /** Human-readable DAG summary for announce-and-proceed. */
   narration: string;
 }
@@ -46,18 +55,31 @@ export interface PlanTaskValidation {
   warnings: string[];
 }
 
-/** Union of a task's declared file touches and owned globs (exact-string set). */
-function footprintOf(task: PlanTask): Set<string> {
-  const files = task.files || [];
-  const owns = task.owns || [];
-  return new Set<string>([...files, ...owns]);
+/**
+ * Union of a task's declared file touches and owned globs, as match patterns.
+ * A concrete file path is a trivial glob, so files and `owns` entries are
+ * compared uniformly by {@link shareFootprint}.
+ */
+function footprintOf(task: PlanTask): string[] {
+  return [...(task.files || []), ...(task.owns || [])];
 }
 
-/** True when two footprints share at least one exact entry. */
-function shareFootprint(a: Set<string> | undefined, b: Set<string> | undefined): boolean {
+/**
+ * True when two footprints share at least one overlapping path/glob.
+ *
+ * Uses glob-aware overlap (roadmap #601), so an `owns` glob (`src/api/**`)
+ * overlaps a concrete path it covers (`src/api/users.ts`). For two concrete
+ * paths this reduces to string equality, preserving prior file-overlap behavior.
+ */
+function shareFootprint(
+  a: readonly string[] | undefined,
+  b: readonly string[] | undefined
+): boolean {
   if (!a || !b) return false;
-  for (const item of a) {
-    if (b.has(item)) return true;
+  for (const pa of a) {
+    for (const pb of b) {
+      if (pathsOverlap(pa, pb)) return true;
+    }
   }
   return false;
 }
@@ -384,6 +406,7 @@ export function planParallelization(input: PlanParallelizationInput): Paralleliz
     waves,
     serialized,
     cyclic,
+    ownershipForecast: forecastOwnershipConflicts(tasks),
     narration: narrate(waves, reasons, serialized, cyclic, nodes),
   };
 }

--- a/packages/core/tests/parallelization/ownership.test.ts
+++ b/packages/core/tests/parallelization/ownership.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import type { PlanTask } from '@harness-engineering/types';
+import { forecastOwnershipConflicts, pathsOverlap } from '../../src/parallelization/ownership';
+
+describe('pathsOverlap()', () => {
+  it('treats identical concrete paths as overlapping', () => {
+    expect(pathsOverlap('src/api/users.ts', 'src/api/users.ts')).toBe(true);
+  });
+
+  it('treats distinct concrete paths as disjoint', () => {
+    expect(pathsOverlap('src/api/users.ts', 'src/api/orders.ts')).toBe(false);
+  });
+
+  it('matches a covering glob against a concrete path it contains', () => {
+    expect(pathsOverlap('src/api/**', 'src/api/users.ts')).toBe(true);
+    expect(pathsOverlap('src/api/users.ts', 'src/api/**')).toBe(true);
+  });
+
+  it('treats a narrower glob nested under a broader glob as overlapping', () => {
+    expect(pathsOverlap('src/**', 'src/api/**')).toBe(true);
+  });
+
+  it('treats disjoint directory globs as non-overlapping', () => {
+    expect(pathsOverlap('src/api/**', 'src/web/**')).toBe(false);
+  });
+
+  it('does not let a single-star glob cross directory boundaries', () => {
+    expect(pathsOverlap('src/*.ts', 'src/api/handler.ts')).toBe(false);
+  });
+
+  it('matches dotfiles under a globstar (dot option enabled)', () => {
+    expect(pathsOverlap('src/**', 'src/.eslintrc.js')).toBe(true);
+  });
+});
+
+describe('forecastOwnershipConflicts()', () => {
+  it('flags a pair whose owned globs overlap', () => {
+    const tasks: PlanTask[] = [
+      { id: 'a', files: [], owns: ['src/api/**'] },
+      { id: 'b', files: [], owns: ['src/api/users.ts'] },
+    ];
+    const conflicts = forecastOwnershipConflicts(tasks);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({ taskA: 'a', taskB: 'b' });
+    expect(conflicts[0]!.overlaps).toEqual([
+      { ownedByA: 'src/api/**', ownedByB: 'src/api/users.ts' },
+    ]);
+  });
+
+  it('does not flag tasks whose owned paths are disjoint', () => {
+    const tasks: PlanTask[] = [
+      { id: 'a', files: [], owns: ['src/api/**'] },
+      { id: 'b', files: [], owns: ['src/web/**'] },
+    ];
+    expect(forecastOwnershipConflicts(tasks)).toEqual([]);
+  });
+
+  it('is a no-op when tasks declare no owns (absent field preserves behavior)', () => {
+    const tasks: PlanTask[] = [
+      { id: 'a', files: ['src/api/users.ts'] },
+      { id: 'b', files: ['src/api/users.ts'] },
+    ];
+    expect(forecastOwnershipConflicts(tasks)).toEqual([]);
+  });
+
+  it('skips a pair when only one side declares owns', () => {
+    const tasks: PlanTask[] = [
+      { id: 'a', files: [], owns: ['src/api/**'] },
+      { id: 'b', files: ['src/api/users.ts'] },
+    ];
+    expect(forecastOwnershipConflicts(tasks)).toEqual([]);
+  });
+
+  it('reports every overlapping pattern pair for a flagged pair', () => {
+    const tasks: PlanTask[] = [
+      { id: 'a', files: [], owns: ['src/api/**', 'src/shared/**'] },
+      { id: 'b', files: [], owns: ['src/api/users.ts', 'src/shared/log.ts'] },
+    ];
+    const conflicts = forecastOwnershipConflicts(tasks);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]!.overlaps).toEqual([
+      { ownedByA: 'src/api/**', ownedByB: 'src/api/users.ts' },
+      { ownedByA: 'src/shared/**', ownedByB: 'src/shared/log.ts' },
+    ]);
+  });
+
+  it('flags across three tasks pairwise and preserves input order', () => {
+    const tasks: PlanTask[] = [
+      { id: 'a', files: [], owns: ['src/api/**'] },
+      { id: 'b', files: [], owns: ['src/web/**'] },
+      { id: 'c', files: [], owns: ['src/api/handler.ts'] },
+    ];
+    const conflicts = forecastOwnershipConflicts(tasks);
+    expect(conflicts.map((c) => [c.taskA, c.taskB])).toEqual([['a', 'c']]);
+  });
+});

--- a/packages/core/tests/parallelization/plan.test.ts
+++ b/packages/core/tests/parallelization/plan.test.ts
@@ -55,6 +55,24 @@ describe('buildTaskGraph()', () => {
     const b = nodes.find((n) => n.id === 'b')!;
     expect(b.dependsOn.filter((d) => d === 'a')).toHaveLength(1);
   });
+
+  it('adds an implicit edge when an owns glob covers another task file (#601)', () => {
+    const nodes = buildTaskGraph([
+      { id: 'a', files: [], owns: ['src/api/**'] },
+      { id: 'b', files: ['src/api/users.ts'] },
+    ]);
+    const b = nodes.find((n) => n.id === 'b')!;
+    expect(b.dependsOn).toContain('a');
+  });
+
+  it('does not add an edge for disjoint owns globs (#601)', () => {
+    const nodes = buildTaskGraph([
+      { id: 'a', files: [], owns: ['src/api/**'] },
+      { id: 'b', files: [], owns: ['src/web/**'] },
+    ]);
+    const b = nodes.find((n) => n.id === 'b')!;
+    expect(b.dependsOn).not.toContain('a');
+  });
 });
 
 describe('validatePlanTasks()', () => {
@@ -191,6 +209,30 @@ describe('planParallelization()', () => {
     expect(plan.waves.map((w) => w.tasks)).toEqual([['a'], ['b']]);
     expect(plan.cyclic).toEqual([]);
     expect(plan.narration).toContain('Wave 1');
+  });
+
+  it('surfaces an owns-glob overlap in ownershipForecast (#601)', () => {
+    const tasks = [
+      { id: 'a', files: [], owns: ['src/api/**'] },
+      { id: 'b', files: [], owns: ['src/api/users.ts'] },
+    ];
+    const plan = planParallelization({ tasks, conflicts: noConflicts(['a', 'b']) });
+    expect(plan.ownershipForecast).toEqual([
+      {
+        taskA: 'a',
+        taskB: 'b',
+        overlaps: [{ ownedByA: 'src/api/**', ownedByB: 'src/api/users.ts' }],
+      },
+    ]);
+  });
+
+  it('leaves ownershipForecast empty when no owns declared (#601)', () => {
+    const tasks = [
+      { id: 'a', files: ['shared.ts'] },
+      { id: 'b', files: ['shared.ts'] },
+    ];
+    const plan = planParallelization({ tasks, conflicts: noConflicts(['a', 'b']) });
+    expect(plan.ownershipForecast).toEqual([]);
   });
 
   it('separates file-overlapping tasks across waves (Truth #4)', () => {

--- a/packages/types/src/plan-task.ts
+++ b/packages/types/src/plan-task.ts
@@ -5,9 +5,10 @@ import { z } from 'zod';
  * parallelization planning.
  *
  * `dependsOn` is the explicit dependency edge (task ids) introduced by the
- * standardize-parallel-execution feature. `owns` is READ if present but
- * OWNED/DEFINED by roadmap #601 — do not treat its presence here as this
- * feature adopting `owns:[paths]` authoring.
+ * standardize-parallel-execution feature. `owns` is the owned-files declaration
+ * defined by roadmap #601: path globs a task claims ownership of, consumed for
+ * cheap deterministic pre-execution parallel-conflict forecasting (glob overlap
+ * between two tasks' owned paths implies a potential parallel conflict).
  */
 export const PlanTaskSchema = z
   .object({
@@ -17,7 +18,7 @@ export const PlanTaskSchema = z
     files: z.array(z.string()),
     /** Ids of tasks that must complete before this one (explicit DAG edges). */
     dependsOn: z.array(z.string()).optional(),
-    /** Path globs the task claims ownership of. Consumed if present; defined by #601. */
+    /** Path globs the task claims ownership of (owned-files declaration, #601). */
     owns: z.array(z.string()).optional(),
   })
   .strict();


### PR DESCRIPTION
## What

Defines the `owns:[paths]` **owned-files declaration** on plan tasks (roadmap #601) and derives a cheap, deterministic, graph-free pre-execution parallel-conflict forecast — a near-free guardrail that runs *alongside* the heavier graph-based `check_task_independence` / `ConflictPredictor`, not in place of it.

The predecessor `standardize-parallel-execution` feature scaffolded `owns?: string[]` but read it only as exact strings and explicitly deferred the authoring/overlap semantics to this item. This change fills that gap **and wires it end-to-end** so the primitive is no longer inert.

## Changes

### Core (forecast — the consumer's engine)

- **`packages/core/src/parallelization/ownership.ts`** (new)
  - `pathsOverlap(a, b)` — glob-aware overlap via `minimatch` (`{ dot: true }`), symmetric double-match. Reduces to equality for two concrete paths; matches a covering glob (`src/api/**`) against a path it contains (`src/api/users.ts`); treats a narrower glob nested under a broader one as overlapping; disjoint dir globs do not overlap.
  - `forecastOwnershipConflicts(tasks)` — deterministic pairwise scan over tasks that **both** declare `owns`; returns each flagged pair with every overlapping `(ownedByA, ownedByB)` pattern pair.
- **`packages/core/src/parallelization/plan.ts`** — `footprintOf`/`shareFootprint` now compute footprint overlap glob-aware (files + owns), so `buildTaskGraph` gains an implicit DAG edge when an `owns` glob covers another task's file. `planParallelization` surfaces a new `ownershipForecast` field on `ParallelizationPlan`.
- **`packages/types/src/plan-task.ts`** — documents `owns` as the #601 owned-files declaration.
- **`packages/cli/src/mcp/tools/parallelization.ts`** — tool description documents `ownershipForecast` + glob-aware overlap (returned JSON carries it automatically; no input-schema change).

### Skill-layer wiring (producers + consumers — makes `owns` flow)

Core alone left `owns` inert: nothing told plan authors to declare it, and autopilot forwarded only `files`+`dependsOn` to `plan_parallelization`. This PR closes both ends:

- **`harness-planning`** now documents an optional `**Owns:**` task-header field (next to `**Files:**` / `**Depends on:**`) — glob paths a task claims, feeding the deterministic owns-overlap forecast. Updates the parallel-opportunities guidance, the example task header, and the inline `plan_parallelization` comment.
- **`harness-autopilot`** (EXECUTE) and **`harness-execution`** now collect each task's `owns` from its header and forward `{ id, files, dependsOn, owns }` to `plan_parallelization`, so the forecast contributes implicit DAG edges and surfaces `ownershipForecast` at dispatch time.
- Regenerated the affected plugin artifacts (`harness-planner` / `harness-task-executor` agent defs for claude + cursor; `planning` / `execution` / `autopilot` gemini commands).

End-to-end flow: **plan authoring emits `**Owns:**` → autopilot/execution forward `owns` → `plan_parallelization` runs the glob-aware overlap forecast.**

- Spec: `docs/changes/owned-files-declaration/proposal.md` (now records the skill-layer wiring); roadmap shard linked.

## Backward compatibility

Fully additive — **absent `owns` = current behavior, exactly**. Concrete-path file overlap is unchanged (glob overlap reduces to equality). The forecast is advisory: it never removes waves or forces serialization on its own. `**Owns:**` is optional; a task with no distinct ownership omits it.

## Tests

- New `packages/core/tests/parallelization/ownership.test.ts` — `pathsOverlap` (equal / covering glob / nested glob / disjoint dirs / single-star boundary / dotfiles) and `forecastOwnershipConflicts` (overlap flagged, disjoint not, absent no-op, one-sided skip, multi-overlap, pairwise order).
- Extended `plan.test.ts` — glob-covering DAG edge, disjoint no-edge, `ownershipForecast` populated / empty.
- Skills suite (27,674 tests) green; all parallelization + plan-task tests pass; full pre-push suite green.

Closes #601
