### PR TITLE
feat(cli): require ADR for operational policy changes (check-operational-drift) (#565)

### DIFF
--- a/.changeset/check-operational-drift.md
+++ b/.changeset/check-operational-drift.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Add `harness check-operational-drift`: a diff-based check that flags changes to operational-policy surfaces (hook profiles, `.husky/**`, the pre-commit `--skip` list, and `harness.config.json` threshold fields) that lack a corresponding ADR under `docs/knowledge/decisions/`. Advisory by default; configurable to blocking via `operationalPolicy` config or `--strict`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,24 @@ jobs:
       # Dogfood the shipped semantic-vocabulary gate against harness's own config.
       - run: node packages/cli/dist/bin/harness.js check-vocabulary
 
+      # The operational-drift check is diff-based, so it needs the PR base commit
+      # reachable. The build-and-test checkout above is shallow (fetch-depth 1),
+      # so fetch the base branch to make origin/<base_ref> resolvable — the same
+      # pattern required-review.yml uses for its diff range.
+      - name: Fetch PR base for operational-drift diff
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      # ADVISORY (non-blocking): dogfood check-operational-drift on the PR diff.
+      # Surfaces gate-softening operational changes (hook profiles, harness.config
+      # thresholds, the pre-commit --skip list, .husky/**) that land without an
+      # accompanying ADR under docs/knowledge/decisions/. Runs in default mode
+      # (NO --strict) so a missing ADR reports in the job log but exits 0 and
+      # never fails the PR. Promote to --strict later to make it blocking.
+      - name: check-operational-drift (advisory)
+        if: github.event_name == 'pull_request'
+        run: node packages/cli/dist/bin/harness.js check-operational-drift --base origin/${{ github.event.pull_request.base.ref }}
+
   # Regenerate auto-generated baselines on main after merge to prevent drift.
   # Downloads coverage from the test job to avoid running the full test suite twice.
   refresh-baselines:

--- a/docs/changes/require-adr-operational-policy/proposal.md
+++ b/docs/changes/require-adr-operational-policy/proposal.md
@@ -102,3 +102,24 @@ ADR a non-zero exit. This matches the graduated-enforcement posture of the other
 - Config file changed but no watched threshold field touched → pass.
 - Config base undiffable → whole-file fallback flag.
 - Git-seam tests for base-ref resolution and changed-file collection.
+
+## Integration points
+
+The command is dogfooded as an **advisory** step in the `build-and-test` job of
+`.github/workflows/ci.yml`, alongside the existing `check-vocabulary` /
+`check-arch` invocations. It is guarded to `pull_request` events only (the check
+is diff-based and needs a base), and runs in default mode — **no `--strict`** —
+so a missing ADR is surfaced in the job log but exits 0 and never fails the PR:
+
+```yaml
+- name: check-operational-drift (advisory)
+  if: github.event_name == 'pull_request'
+  run: node packages/cli/dist/bin/harness.js check-operational-drift --base origin/${{ github.event.pull_request.base.ref }}
+```
+
+Because the `build-and-test` checkout is shallow, a preceding
+`git fetch origin ${{ github.event.pull_request.base.ref }}` step (same
+`pull_request`-only guard) makes `origin/<base_ref>` resolvable for the diff —
+the same base-fetch pattern `required-review.yml` uses. Promote the step to
+`--strict` (or set `operationalPolicy.severity: "blocking"`) once it has proven
+stable on real PRs to make a missing ADR blocking.

--- a/docs/changes/require-adr-operational-policy/proposal.md
+++ b/docs/changes/require-adr-operational-policy/proposal.md
@@ -1,0 +1,104 @@
+---
+title: Require ADR for Operational Policy Changes
+status: draft
+milestone: v5.0 — Trust & Security Model
+roadmap_ref: github:Intense-Visions/harness-engineering#565
+priority: P2
+keywords:
+  [
+    operational-policy,
+    adr,
+    check-operational-drift,
+    hook-profiles,
+    thresholds,
+    skip-list,
+    baseline-policy,
+    diff-check,
+  ]
+---
+
+# Require ADR for Operational Policy Changes
+
+## Overview and Goals
+
+Operational policy — hook profiles, the pre-commit `--skip` list, `harness.config.json`
+threshold values, and baseline-update policy — is load-bearing: each of these
+controls how loudly a gate fires, or whether it fires at all. Yet these surfaces
+accumulate silently in ordinary commits, with no ADR-grade record of the decision
+to soften (or harden) them. The pre-commit auto-baseline behavior (Pass 1 #1)
+entered the codebase exactly this way — a gate was softened without a documented
+decision.
+
+This change adds `harness check-operational-drift`: a diff-based check that FLAGS
+when a change touches an operational-policy surface WITHOUT a corresponding ADR in
+`docs/knowledge/decisions/` in the same diff. It forces "we silently softened a
+gate" to surface as a deliberate ADR.
+
+## Why a new command (not extending `enforce-architecture`)
+
+`harness enforce-architecture` answers a different question (layer boundaries,
+import direction, module size) over the _code graph_. Operational drift is a
+_diff-vs-ADR correspondence_ check with its own base-ref resolution, config-field
+diffing, and advisory severity model. Bolting that onto the architecture command
+would overload a cohesive command with an unrelated axis. A focused
+`check-operational-drift` mirrors the existing `check-*` command family
+(`check-docs`, `check-security`, …), registers cleanly via `_registry.ts`, and
+composes into CI independently.
+
+## Operational-policy surfaces watched
+
+The watch list is documented and config-overridable via `operationalPolicy` in
+`harness.config.json`. Defaults:
+
+- `.husky/**` — all git hook scripts. This also covers the pre-commit `--skip`
+  list, which lives as a `SKIP="…"` assignment inside `.husky/pre-commit`.
+- `packages/cli/src/hooks/profiles.ts` — the hook profile tiers
+  (minimal / standard / strict).
+- `harness.config.json` threshold fields — field-level, not whole-file. The
+  default watched sub-trees are:
+  - `architecture.thresholds`
+  - `performance.complexity.thresholds`
+  - `performance.coupling.thresholds`
+  - `security.strict`
+  - `security.rules`
+
+### Config threshold diffing (scope)
+
+For `harness.config.json` the check does **field-level** diffing: it reads the
+file at the base ref (`git show <base>:harness.config.json`) and at the working
+tree, then deep-compares each watched dotted sub-tree. Only a change to a watched
+threshold sub-tree flags — an unrelated edit (e.g. `name`) does not. If the base
+version cannot be read (new file, unreadable ref), the check **falls back to
+flagging the whole file** and says so in the finding.
+
+## ADR correspondence
+
+A "corresponding ADR" is any file added or modified under
+`docs/knowledge/decisions/` (config: `operationalPolicy.adrDir`) in the same diff.
+If one is present, the operational change passes. ADRs there follow the existing
+`NNNN-slug.md` naming convention.
+
+## Base ref
+
+Like the other diff-based checks, the base defaults to the merge-base of `HEAD`
+with the default branch (resolved from `origin/HEAD`, falling back to `main`).
+`--base <ref>` overrides. Changed files are the union of the tracked diff
+(base → working tree) and untracked files, so the check works both in CI
+(committed PR diff) and locally (an ADR staged alongside the operational change).
+
+## Severity
+
+Advisory by default: findings are reported and the command exits 0. Set
+`operationalPolicy.severity: "blocking"` (or pass `--strict`) to make a missing
+ADR a non-zero exit. This matches the graduated-enforcement posture of the other
+`check-*` commands and lets teams adopt the check in report-only mode first.
+
+## Testing
+
+- Operational change (hook profile / `.husky` / config threshold) **with** an ADR
+  in the same diff → pass.
+- Operational change **without** an ADR → flag.
+- Unrelated change (no operational surface) → pass.
+- Config file changed but no watched threshold field touched → pass.
+- Config base undiffable → whole-file fallback flag.
+- Git-seam tests for base-ref resolution and changed-file collection.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -106,6 +106,15 @@ Mechanically audit this project's harness setup against the 7 strength patterns
 - `--adopter` — Force adopter mode
 - `--report-only` — Always exit 0 regardless of findings
 
+### `harness check-operational-drift`
+
+Flag operational-policy changes (hooks, thresholds, --skip list) that lack a corresponding ADR
+
+**Options:**
+
+- `--base` — Base git ref to diff against (default: merge-base with default branch)
+- `--strict` — Treat a missing ADR as blocking (non-zero exit), overriding config
+
 ### `harness check-perf`
 
 Run performance checks: structural complexity, coupling, and size budgets
@@ -664,6 +673,26 @@ Run an agent task
 - `--timeout` — Timeout in milliseconds (default: "300000")
 - `--persona` — Run a persona by name
 - `--trigger` — Trigger context (auto, on_pr, on_commit, manual) (default: "auto")
+
+## Black-box Commands
+
+Inspect durable per-run orchestrator flight records (provenance, verdicts, tool-use)
+
+### `harness black-box list`
+
+List recorded runs, newest first
+
+**Options:**
+
+- `--dir` — Black-box directory (default: ".harness/black-box")
+
+### `harness black-box show <runId>`
+
+Show provenance, verdicts, convergence, and tool-use for a run
+
+**Options:**
+
+- `--dir` — Black-box directory (default: ".harness/black-box")
 
 ## Ci Commands
 

--- a/docs/roadmap.d/require-adr-for-operational-policy-changes.md
+++ b/docs/roadmap.d/require-adr-for-operational-policy-changes.md
@@ -7,7 +7,7 @@ order: 5
 ### Require ADR for operational policy changes
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** [docs/changes/require-adr-operational-policy/proposal.md](../changes/require-adr-operational-policy/proposal.md)
 - **Summary:** ADRs in `docs/knowledge/decisions/` capture architectural decisions. Changes to hook profiles, threshold values, `--skip` lists, and baseline-update policies are also load-bearing — and they accumulate silently in commits without ADR-grade artifacts. Add a `harness:check-operational-drift` check (or extend the existing `harness:enforce-architecture`) that flags PRs touching `.husky/`, `harness.config.json` thresholds, the pre-commit `--skip` list, or `packages/cli/src/hooks/profiles.ts` without a corresponding ADR. Forces the "we silently softened a gate" decision to surface as a deliberate ADR-grade record. Closes the surface where Pass 1 #1 (pre-commit auto-baseline) entered the codebase without a documented decision in the first place. Source: Pass 7 final-pass synthesis.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -572,7 +572,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Require ADR for operational policy changes
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** [docs/changes/require-adr-operational-policy/proposal.md](../changes/require-adr-operational-policy/proposal.md)
 - **Summary:** ADRs in `docs/knowledge/decisions/` capture architectural decisions. Changes to hook profiles, threshold values, `--skip` lists, and baseline-update policies are also load-bearing — and they accumulate silently in commits without ADR-grade artifacts. Add a `harness:check-operational-drift` check (or extend the existing `harness:enforce-architecture`) that flags PRs touching `.husky/`, `harness.config.json` thresholds, the pre-commit `--skip` list, or `packages/cli/src/hooks/profiles.ts` without a corresponding ADR. Forces the "we silently softened a gate" decision to surface as a deliberate ADR-grade record. Closes the surface where Pass 1 #1 (pre-commit auto-baseline) entered the codebase without a documented decision in the first place. Source: Pass 7 final-pass synthesis.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -9,12 +9,14 @@ import { createAgentCommand } from './agent';
 import { createAlignDesignSystemCommand } from './align-design-system';
 import { createAuditProtectedCommand } from './audit-protected';
 import { createBackfillSkillProvenanceCommand } from './backfill-skill-provenance';
+import { createBlackBoxCommand } from './orchestrator-black-box';
 import { createBlueprintCommand } from './blueprint';
 import { createCheckArchCommand } from './check-arch';
 import { createCheckDepsCommand } from './check-deps';
 import { createCheckDesignCommand } from './check-design';
 import { createCheckDocsCommand } from './check-docs';
 import { createCheckHarnessStrengthCommand } from './check-harness-strength';
+import { createCheckOperationalDriftCommand } from './check-operational-drift';
 import { createCheckPerfCommand } from './check-perf';
 import { createCheckPhaseGateCommand } from './check-phase-gate';
 import { createCheckSecurityCommand } from './check-security';
@@ -101,12 +103,14 @@ export const commandCreators: Array<() => Command> = [
   createAlignDesignSystemCommand,
   createAuditProtectedCommand,
   createBackfillSkillProvenanceCommand,
+  createBlackBoxCommand,
   createBlueprintCommand,
   createCheckArchCommand,
   createCheckDepsCommand,
   createCheckDesignCommand,
   createCheckDocsCommand,
   createCheckHarnessStrengthCommand,
+  createCheckOperationalDriftCommand,
   createCheckPerfCommand,
   createCheckPhaseGateCommand,
   createCheckSecurityCommand,

--- a/packages/cli/src/commands/check-operational-drift.test.ts
+++ b/packages/cli/src/commands/check-operational-drift.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { resolveBaseRef, collectChangedFiles, type RunGit } from './check-operational-drift';
+
+/**
+ * Command-layer git-seam contract for `harness check-operational-drift`. The
+ * detection logic is covered in operational-drift.test.ts; here we pin the git
+ * interaction (base-ref resolution precedence + changed-file collection) using an
+ * injected `runGit` so no real subprocess runs.
+ */
+
+/** Build a fake `runGit` from an argv[0..n] → output map; throws for unmapped calls. */
+function fakeGit(responses: Record<string, string | (() => string)>): RunGit {
+  return (args: string[]) => {
+    const key = args.join(' ');
+    const hit = responses[key];
+    if (hit === undefined) throw new Error(`unmapped git call: ${key}`);
+    return typeof hit === 'function' ? hit() : hit;
+  };
+}
+
+describe('resolveBaseRef', () => {
+  it('returns an explicit --base verbatim without touching git', () => {
+    const runGit = fakeGit({});
+    expect(resolveBaseRef({ base: 'abc123', runGit })).toBe('abc123');
+  });
+
+  it('resolves the merge-base with the default branch from origin/HEAD', () => {
+    const runGit = fakeGit({
+      'symbolic-ref refs/remotes/origin/HEAD': 'refs/remotes/origin/develop',
+      'merge-base HEAD origin/develop': 'basesha',
+    });
+    expect(resolveBaseRef({ runGit })).toBe('basesha');
+  });
+
+  it('falls back to main when origin/HEAD is absent', () => {
+    const runGit = fakeGit({
+      'symbolic-ref refs/remotes/origin/HEAD': (() => {
+        throw new Error('no ref');
+      }) as unknown as string,
+      'merge-base HEAD origin/main': 'mainbase',
+    });
+    expect(resolveBaseRef({ runGit })).toBe('mainbase');
+  });
+
+  it('falls back to HEAD when no merge-base can be resolved', () => {
+    const throwing = (() => {
+      throw new Error('fail');
+    }) as unknown as string;
+    const runGit = fakeGit({
+      'symbolic-ref refs/remotes/origin/HEAD': throwing,
+      'merge-base HEAD origin/main': throwing,
+      'merge-base HEAD main': throwing,
+    });
+    expect(resolveBaseRef({ runGit })).toBe('HEAD');
+  });
+});
+
+describe('collectChangedFiles', () => {
+  it('unions tracked diff and untracked files, normalizing separators', () => {
+    const runGit = fakeGit({
+      'diff --name-only base': 'packages/cli/src/hooks/profiles.ts\nharness.config.json',
+      'ls-files --others --exclude-standard': 'docs/knowledge/decisions/0100-new.md',
+    });
+    const files = collectChangedFiles('base', runGit);
+    expect(files).toContain('packages/cli/src/hooks/profiles.ts');
+    expect(files).toContain('harness.config.json');
+    expect(files).toContain('docs/knowledge/decisions/0100-new.md');
+    // Three distinct paths across the two git calls.
+    const expectedCount = new Set([
+      'packages/cli/src/hooks/profiles.ts',
+      'harness.config.json',
+      'docs/knowledge/decisions/0100-new.md',
+    ]).size;
+    expect(files).toHaveLength(expectedCount);
+  });
+
+  it('de-duplicates a path that appears in both tracked and untracked output', () => {
+    const runGit = fakeGit({
+      'diff --name-only base': '.husky/pre-commit',
+      'ls-files --others --exclude-standard': '.husky/pre-commit',
+    });
+    expect(collectChangedFiles('base', runGit)).toEqual(['.husky/pre-commit']);
+  });
+
+  it('tolerates a failing diff and still returns untracked files', () => {
+    const runGit: RunGit = (args) => {
+      if (args[0] === 'diff') throw new Error('bad ref');
+      if (args[0] === 'ls-files') return 'docs/knowledge/decisions/0101-x.md';
+      throw new Error('unexpected');
+    };
+    expect(collectChangedFiles('HEAD', runGit)).toEqual(['docs/knowledge/decisions/0101-x.md']);
+  });
+});

--- a/packages/cli/src/commands/check-operational-drift.ts
+++ b/packages/cli/src/commands/check-operational-drift.ts
@@ -1,0 +1,289 @@
+import { Command } from 'commander';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import type { Result } from '@harness-engineering/core';
+import { Ok } from '@harness-engineering/core';
+import { resolveConfig } from '../config/loader';
+import { OutputMode } from '../output/formatter';
+import { resolveOutputMode } from '../utils/output';
+import { logger } from '../output/logger';
+import { CLIError, ExitCode } from '../utils/errors';
+import {
+  DEFAULT_OPERATIONAL_DRIFT_POLICY,
+  changedThresholdPaths,
+  detectOperationalDrift,
+  normalizeRel,
+  type OperationalDriftFinding,
+  type OperationalDriftPolicy,
+  type OperationalDriftSeverity,
+} from './operational-drift';
+
+/**
+ * Injectable git seam. Returns trimmed stdout of `git <args>`; throws on
+ * non-zero exit. Real implementation uses `execFileSync` (no shell) so tests can
+ * stub it without spawning a process and callers cannot inject shell metachars.
+ */
+export type RunGit = (args: string[]) => string;
+
+const defaultRunGit: RunGit = (args) =>
+  execFileSync('git', args, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+    .toString()
+    .trim();
+
+/**
+ * Resolve the base ref to diff against.
+ * - Explicit `--base <ref>` wins.
+ * - Otherwise the default branch is read from `origin/HEAD`
+ *   (`git symbolic-ref refs/remotes/origin/HEAD`), defaulting to `main`, and the
+ *   base is the merge-base of HEAD and that branch — the same PR-diff semantics
+ *   the other diff-based checks use.
+ * - If merge-base resolution fails (shallow/CI checkout), fall back to the branch
+ *   ref itself, then to `HEAD` (an empty diff — nothing to flag).
+ */
+export function resolveBaseRef(opts: { base?: string | undefined; runGit: RunGit }): string {
+  if (opts.base) return opts.base;
+  const { runGit } = opts;
+  let branch = 'main';
+  try {
+    const ref = runGit(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+    const m = ref.match(/origin\/(.+)$/);
+    if (m?.[1]) branch = m[1];
+  } catch {
+    // No origin/HEAD symbolic ref — keep the `main` default.
+  }
+  const candidates = [`origin/${branch}`, branch];
+  for (const candidate of candidates) {
+    try {
+      return runGit(['merge-base', 'HEAD', candidate]);
+    } catch {
+      // Try the next candidate ref.
+    }
+  }
+  return 'HEAD';
+}
+
+/**
+ * Union of tracked changes (base → working tree) and untracked files, so the
+ * check works both in CI (committed PR diff) and locally (staged/unstaged/new
+ * files) — an ADR staged alongside an operational change is seen either way.
+ */
+export function collectChangedFiles(base: string, runGit: RunGit): string[] {
+  const set = new Set<string>();
+  try {
+    for (const f of runGit(['diff', '--name-only', base]).split('\n')) {
+      if (f.trim()) set.add(normalizeRel(f.trim()));
+    }
+  } catch {
+    // No diff available (e.g. base === HEAD or bad ref) — leave set as-is.
+  }
+  try {
+    for (const f of runGit(['ls-files', '--others', '--exclude-standard']).split('\n')) {
+      if (f.trim()) set.add(normalizeRel(f.trim()));
+    }
+  } catch {
+    // Untracked enumeration is best-effort.
+  }
+  return [...set];
+}
+
+/** Read and JSON-parse a file's contents at a git ref; `undefined` on any failure. */
+function readJsonAtRef(ref: string, relPath: string, runGit: RunGit): unknown {
+  try {
+    const raw = runGit(['show', `${ref}:${relPath}`]);
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read and JSON-parse a working-tree file; `undefined` on any failure. */
+function readJsonFromDisk(cwd: string, relPath: string): unknown {
+  try {
+    const full = path.resolve(cwd, relPath);
+    if (!existsSync(full)) return undefined;
+    return JSON.parse(readFileSync(full, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+}
+
+export interface CheckOperationalDriftOptions {
+  cwd?: string;
+  configPath?: string;
+  base?: string;
+  /** Force blocking severity regardless of config (equivalent to `severity: 'blocking'`). */
+  strict?: boolean;
+  runGit?: RunGit;
+}
+
+export interface CheckOperationalDriftResult {
+  /** true = no operational change, OR an operational change accompanied by an ADR. */
+  valid: boolean;
+  /** true = operational change with no corresponding ADR (the drift condition). */
+  flagged: boolean;
+  severity: OperationalDriftSeverity;
+  base: string;
+  operationalChanges: OperationalDriftFinding[];
+  adrFiles: string[];
+}
+
+/**
+ * Resolve the effective policy by layering the (optional) `operationalPolicy`
+ * config block over the built-in defaults.
+ */
+function resolvePolicy(
+  raw: Partial<OperationalDriftPolicy> | undefined,
+  strictFlag: boolean | undefined
+): OperationalDriftPolicy {
+  const merged: OperationalDriftPolicy = {
+    ...DEFAULT_OPERATIONAL_DRIFT_POLICY,
+    ...(raw ?? {}),
+  };
+  if (strictFlag) merged.severity = 'blocking';
+  return merged;
+}
+
+export async function runCheckOperationalDrift(
+  options: CheckOperationalDriftOptions
+): Promise<Result<CheckOperationalDriftResult, CLIError>> {
+  const cwd = options.cwd ?? process.cwd();
+  const runGit = options.runGit ?? defaultRunGit;
+
+  const configResult = resolveConfig(options.configPath);
+  if (!configResult.ok) return configResult;
+  const rawPolicy = (configResult.value as { operationalPolicy?: Partial<OperationalDriftPolicy> })
+    .operationalPolicy;
+  const policy = resolvePolicy(rawPolicy, options.strict);
+
+  const base = resolveBaseRef({ base: options.base, runGit });
+
+  if (!policy.enabled) {
+    return Ok({
+      valid: true,
+      flagged: false,
+      severity: policy.severity,
+      base,
+      operationalChanges: [],
+      adrFiles: [],
+    });
+  }
+
+  const changedFiles = collectChangedFiles(base, runGit);
+
+  // Field-level threshold diff for the config file, only if it actually changed.
+  const configFile = normalizeRel(policy.configFile);
+  const configChanged = changedFiles.includes(configFile);
+  let changedConfigPaths: string[] = [];
+  let configUndiffable = false;
+  if (configChanged) {
+    const baseConfig = readJsonAtRef(base, policy.configFile, runGit);
+    const headConfig = readJsonFromDisk(cwd, policy.configFile);
+    if (baseConfig === undefined || headConfig === undefined) {
+      // Could not read one side — fall back to flagging the whole file.
+      configUndiffable = true;
+    } else {
+      changedConfigPaths = changedThresholdPaths(
+        baseConfig,
+        headConfig,
+        policy.configThresholdPaths
+      );
+    }
+  }
+
+  const detection = detectOperationalDrift({
+    changedFiles,
+    policy,
+    changedConfigPaths,
+    configUndiffable,
+  });
+
+  return Ok({
+    valid: !detection.flagged,
+    flagged: detection.flagged,
+    severity: policy.severity,
+    base,
+    operationalChanges: detection.operationalChanges,
+    adrFiles: detection.adrFiles,
+  });
+}
+
+function printResult(result: CheckOperationalDriftResult): void {
+  if (result.operationalChanges.length === 0) {
+    console.log('✓ No operational-policy surfaces changed against ' + result.base);
+    return;
+  }
+
+  console.log(`Operational-policy surfaces changed against ${result.base}:`);
+  for (const finding of result.operationalChanges) {
+    console.log(`  - ${finding.surface}: ${finding.detail}`);
+  }
+
+  if (result.adrFiles.length > 0) {
+    console.log('\nCorresponding ADR(s) found in the same diff:');
+    for (const adr of result.adrFiles) {
+      console.log(`  - ${adr}`);
+    }
+    console.log('\n✓ Operational change is documented by an ADR.');
+    return;
+  }
+
+  const label = result.severity === 'blocking' ? '✗' : '⚠';
+  console.log(
+    `\n${label} No ADR found under docs/knowledge/decisions/ for these operational-policy changes.`
+  );
+  console.log(
+    '  Operational policy (hook profiles, thresholds, the pre-commit --skip list, baseline\n' +
+      '  policy) is load-bearing. Add an ADR recording this decision, e.g.:'
+  );
+  console.log('    docs/knowledge/decisions/NNNN-<slug>.md');
+  if (result.severity === 'advisory') {
+    console.log(
+      '\n  (advisory — not blocking; set operationalPolicy.severity=blocking to enforce)'
+    );
+  }
+}
+
+export function createCheckOperationalDriftCommand(): Command {
+  const command = new Command('check-operational-drift')
+    .description(
+      'Flag operational-policy changes (hooks, thresholds, --skip list) that lack a corresponding ADR'
+    )
+    .option(
+      '--base <ref>',
+      'Base git ref to diff against (default: merge-base with default branch)'
+    )
+    .option('--strict', 'Treat a missing ADR as blocking (non-zero exit), overriding config')
+    .action(async (opts, cmd) => {
+      const globalOpts = cmd.optsWithGlobals();
+      const mode = resolveOutputMode(globalOpts);
+
+      const result = await runCheckOperationalDrift({
+        configPath: globalOpts.config,
+        base: opts.base,
+        strict: opts.strict,
+      });
+
+      if (!result.ok) {
+        if (mode === OutputMode.JSON) {
+          console.log(JSON.stringify({ error: result.error.message }));
+        } else {
+          logger.error(result.error.message);
+        }
+        process.exit(result.error.exitCode);
+      }
+
+      if (mode === OutputMode.JSON) {
+        console.log(JSON.stringify(result.value, null, 2));
+      } else if (mode !== OutputMode.QUIET) {
+        printResult(result.value);
+      }
+
+      // Advisory by default: a flagged change reports but still exits 0.
+      // Blocking severity (config or --strict) exits non-zero on a flag.
+      const shouldFail = result.value.flagged && result.value.severity === 'blocking';
+      process.exit(shouldFail ? ExitCode.VALIDATION_FAILED : ExitCode.SUCCESS);
+    });
+
+  return command;
+}

--- a/packages/cli/src/commands/operational-drift.test.ts
+++ b/packages/cli/src/commands/operational-drift.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_OPERATIONAL_DRIFT_POLICY,
+  changedThresholdPaths,
+  deepEqual,
+  detectOperationalDrift,
+  getByPath,
+  normalizeRel,
+  type OperationalDriftPolicy,
+} from './operational-drift';
+
+/**
+ * Contract for the pure operational-drift detection (roadmap #565). Exercises the
+ * three required fixtures — operational change + ADR in the same diff → pass;
+ * operational change without ADR → flag; unrelated change → pass — plus the
+ * field-level config-threshold diffing and the whole-file fallback.
+ */
+
+const policy: OperationalDriftPolicy = { ...DEFAULT_OPERATIONAL_DRIFT_POLICY };
+
+describe('normalizeRel', () => {
+  it('converts backslashes to forward slashes', () => {
+    expect(normalizeRel('a\\b\\c')).toBe('a/b/c');
+  });
+});
+
+describe('getByPath / deepEqual', () => {
+  it('resolves nested dotted paths and returns undefined for missing', () => {
+    const obj = { a: { b: { c: 15 } } };
+    expect(getByPath(obj, 'a.b.c')).toBe(15);
+    expect(getByPath(obj, 'a.b.x')).toBeUndefined();
+    expect(getByPath(obj, 'a.z.c')).toBeUndefined();
+  });
+
+  it('is order-insensitive for object keys but order-sensitive for arrays', () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+    expect(deepEqual({ x: { y: [1, 2] } }, { x: { y: [1, 2] } })).toBe(true);
+  });
+});
+
+describe('changedThresholdPaths', () => {
+  it('reports only the threshold sub-trees that actually differ', () => {
+    const base = {
+      architecture: { thresholds: { complexity: { max: 15 } } },
+      security: { strict: false },
+    };
+    const head = {
+      architecture: { thresholds: { complexity: { max: 20 } } }, // softened
+      security: { strict: false }, // unchanged
+    };
+    const paths = ['architecture.thresholds', 'security.strict'];
+    const changed = changedThresholdPaths(base, head, paths);
+    expect(changed).toEqual(['architecture.thresholds']);
+    // Dynamic count assertion (no hardcoded literal count).
+    const expectedChangedCount = paths.filter(
+      (p) => JSON.stringify(getByPath(base, p)) !== JSON.stringify(getByPath(head, p))
+    ).length;
+    expect(changed).toHaveLength(expectedChangedCount);
+  });
+
+  it('detects adding or removing a threshold block', () => {
+    const base = { security: {} };
+    const head = { security: { strict: true } };
+    expect(changedThresholdPaths(base, head, ['security.strict'])).toEqual(['security.strict']);
+  });
+});
+
+describe('detectOperationalDrift', () => {
+  it('flags an operational change (hook profile) with no ADR', () => {
+    const changedFiles = ['packages/cli/src/hooks/profiles.ts', 'packages/cli/src/index.ts'];
+    const result = detectOperationalDrift({ changedFiles, policy, changedConfigPaths: [] });
+    expect(result.flagged).toBe(true);
+    expect(result.adrFiles).toHaveLength(0);
+    expect(result.operationalChanges).toHaveLength(1);
+    expect(result.operationalChanges[0]?.surface).toBe('packages/cli/src/hooks/profiles.ts');
+  });
+
+  it('passes when an operational change is accompanied by an ADR in the same diff', () => {
+    const opFiles = ['.husky/pre-commit'];
+    const adrFiles = ['docs/knowledge/decisions/0099-soften-precommit.md'];
+    const changedFiles = [...opFiles, ...adrFiles];
+    const result = detectOperationalDrift({ changedFiles, policy, changedConfigPaths: [] });
+    expect(result.flagged).toBe(false);
+    expect(result.adrFiles).toEqual(adrFiles);
+    // One finding per watched operational file.
+    expect(result.operationalChanges).toHaveLength(opFiles.length);
+  });
+
+  it('passes for an unrelated change (no operational surface touched)', () => {
+    const changedFiles = ['packages/cli/src/commands/check-docs.ts', 'README.md'];
+    const result = detectOperationalDrift({ changedFiles, policy, changedConfigPaths: [] });
+    expect(result.flagged).toBe(false);
+    expect(result.operationalChanges).toHaveLength(0);
+  });
+
+  it('flags a config threshold field change with no ADR (field-level)', () => {
+    const changedFiles = ['harness.config.json'];
+    const changedConfigPaths = ['architecture.thresholds'];
+    const result = detectOperationalDrift({ changedFiles, policy, changedConfigPaths });
+    expect(result.flagged).toBe(true);
+    expect(result.operationalChanges).toHaveLength(changedConfigPaths.length);
+    expect(result.operationalChanges[0]?.surface).toBe(
+      'harness.config.json:architecture.thresholds'
+    );
+  });
+
+  it('does NOT flag a config change whose watched threshold fields are untouched', () => {
+    // config file is in the diff, but changedConfigPaths is empty (e.g. only `name` changed)
+    const changedFiles = ['harness.config.json'];
+    const result = detectOperationalDrift({ changedFiles, policy, changedConfigPaths: [] });
+    expect(result.flagged).toBe(false);
+    expect(result.operationalChanges).toHaveLength(0);
+  });
+
+  it('falls back to flagging the whole config file when the base is undiffable', () => {
+    const changedFiles = ['harness.config.json'];
+    const result = detectOperationalDrift({
+      changedFiles,
+      policy,
+      changedConfigPaths: [],
+      configUndiffable: true,
+    });
+    expect(result.flagged).toBe(true);
+    expect(result.operationalChanges).toHaveLength(1);
+    expect(result.operationalChanges[0]?.surface).toBe('harness.config.json');
+  });
+
+  it('matches the pre-commit --skip list via the .husky glob', () => {
+    // The --skip list lives as SKIP="…" inside .husky/pre-commit, covered by `.husky/**`.
+    const changedFiles = ['.husky/pre-commit'];
+    const result = detectOperationalDrift({ changedFiles, policy, changedConfigPaths: [] });
+    expect(result.flagged).toBe(true);
+    expect(result.operationalChanges.map((f) => f.surface)).toContain('.husky/pre-commit');
+  });
+});

--- a/packages/cli/src/commands/operational-drift.ts
+++ b/packages/cli/src/commands/operational-drift.ts
@@ -1,0 +1,210 @@
+// packages/cli/src/commands/operational-drift.ts
+//
+// Pure detection logic for `harness check-operational-drift` (roadmap #565).
+//
+// Operational policy — hook profiles, the pre-commit `--skip` list, config
+// threshold values, and baseline-update policy — is load-bearing but tends to
+// accumulate silently in commits without an ADR-grade record. This module
+// answers one question against a diff: did a watched operational-policy surface
+// change WITHOUT a corresponding ADR being added or modified in the same diff?
+//
+// Everything here is pure (no git, no fs). The command layer
+// (`check-operational-drift.ts`) supplies the changed-file list and the
+// base/head config objects; these functions decide what is flagged. That split
+// keeps the detection fully unit-testable without spawning git.
+
+import { minimatch } from 'minimatch';
+
+export type OperationalDriftSeverity = 'advisory' | 'blocking';
+
+/**
+ * Resolved operational-policy watch configuration. Every field is
+ * config-overridable via `operationalPolicy` in `harness.config.json`; the
+ * defaults below encode the surfaces named in roadmap #565.
+ */
+export interface OperationalDriftPolicy {
+  /** When false, the check is a no-op (always passes). */
+  enabled: boolean;
+  /**
+   * `advisory` (default): findings are reported but the command exits 0.
+   * `blocking`: an operational change with no ADR exits non-zero.
+   */
+  severity: OperationalDriftSeverity;
+  /** Directory (repo-relative) where ADRs live; a change here satisfies the requirement. */
+  adrDir: string;
+  /**
+   * Glob patterns (repo-relative, forward-slash) whose changed files are treated
+   * as operational-policy changes. `.husky/**` covers hook scripts AND the
+   * pre-commit `--skip` list (which is a `SKIP="…"` assignment inside
+   * `.husky/pre-commit`).
+   */
+  watchedPaths: string[];
+  /** The config file whose threshold fields are watched (repo-relative). */
+  configFile: string;
+  /**
+   * Dotted JSON paths inside {@link configFile} whose sub-tree is threshold /
+   * skip-list policy. A change to any of these sub-trees is an operational
+   * change. Field-level (not whole-file) so unrelated config edits do not flag.
+   */
+  configThresholdPaths: string[];
+}
+
+/**
+ * Defaults for the surfaces named in roadmap #565:
+ * - `.husky/**` — hook scripts + the pre-commit `--skip` list.
+ * - `packages/cli/src/hooks/profiles.ts` — hook profile tiers.
+ * - `harness.config.json` threshold sub-trees — architecture / performance
+ *   budgets and the security gate strictness.
+ */
+export const DEFAULT_OPERATIONAL_DRIFT_POLICY: OperationalDriftPolicy = {
+  enabled: true,
+  severity: 'advisory',
+  adrDir: 'docs/knowledge/decisions',
+  watchedPaths: ['.husky/**', 'packages/cli/src/hooks/profiles.ts'],
+  configFile: 'harness.config.json',
+  configThresholdPaths: [
+    'architecture.thresholds',
+    'performance.complexity.thresholds',
+    'performance.coupling.thresholds',
+    'security.strict',
+    'security.rules',
+  ],
+};
+
+/** A single operational-policy surface that changed in the diff. */
+export interface OperationalDriftFinding {
+  /** The surface identifier, e.g. `.husky/pre-commit` or `harness.config.json:architecture.thresholds`. */
+  surface: string;
+  /** Human-readable explanation of what changed. */
+  detail: string;
+}
+
+/** Normalize a path to forward slashes so glob/prefix matching is platform-stable. */
+export function normalizeRel(p: string): string {
+  return p.replaceAll('\\', '/');
+}
+
+/** Resolve a dotted path (`a.b.c`) inside a parsed-JSON object; `undefined` if absent. */
+export function getByPath(obj: unknown, dottedPath: string): unknown {
+  const segments = dottedPath.split('.');
+  let cursor: unknown = obj;
+  for (const segment of segments) {
+    if (cursor === null || typeof cursor !== 'object') return undefined;
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+}
+
+/** Deep array equality (order-sensitive), used by {@link deepEqual}. */
+function arraysEqual(a: unknown[], b: unknown[]): boolean {
+  return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+}
+
+/** Deep plain-object equality (key-order-insensitive), used by {@link deepEqual}. */
+function objectsEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  return aKeys.every(
+    (key) => Object.prototype.hasOwnProperty.call(b, key) && deepEqual(a[key], b[key])
+  );
+}
+
+/**
+ * Order-insensitive deep equality for parsed-JSON values (objects, arrays,
+ * primitives). Object key order does not matter; array order does.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+
+  const aArr = Array.isArray(a);
+  if (aArr !== Array.isArray(b)) return false;
+  return aArr
+    ? arraysEqual(a as unknown[], b as unknown[])
+    : objectsEqual(a as Record<string, unknown>, b as Record<string, unknown>);
+}
+
+/**
+ * Compare the watched threshold sub-trees between two parsed configs and return
+ * the dotted paths that differ. `undefined` on either side is compared like any
+ * value, so adding or removing a threshold block is detected too.
+ */
+export function changedThresholdPaths(
+  baseConfig: unknown,
+  headConfig: unknown,
+  paths: string[]
+): string[] {
+  return paths.filter((p) => !deepEqual(getByPath(baseConfig, p), getByPath(headConfig, p)));
+}
+
+/** Result of a pure detection pass over a diff. */
+export interface OperationalDriftDetection {
+  /** Watched operational-policy surfaces that changed. */
+  operationalChanges: OperationalDriftFinding[];
+  /** ADR files added/modified in the same diff (repo-relative, normalized). */
+  adrFiles: string[];
+  /** True when an operational change occurred with NO corresponding ADR. */
+  flagged: boolean;
+}
+
+/**
+ * Decide, from a diff's changed-file list and a pre-computed set of changed
+ * config-threshold paths, which operational-policy surfaces changed and whether
+ * a corresponding ADR is present.
+ *
+ * "Corresponding ADR" = any added/modified file under `policy.adrDir` in the
+ * same diff. If one is present, operational changes pass.
+ */
+export function detectOperationalDrift(input: {
+  changedFiles: string[];
+  policy: OperationalDriftPolicy;
+  /** Dotted config-threshold paths that changed (from {@link changedThresholdPaths}). */
+  changedConfigPaths: string[];
+  /**
+   * True when the config file changed but its base version could not be read to
+   * diff fields (e.g. new file, or unreadable base). Falls back to flagging the
+   * whole file, as documented in the proposal.
+   */
+  configUndiffable?: boolean;
+}): OperationalDriftDetection {
+  const { policy } = input;
+  const changed = input.changedFiles.map(normalizeRel);
+  const operationalChanges: OperationalDriftFinding[] = [];
+
+  // 1) Glob-watched paths (hook scripts, profiles, the --skip list in .husky).
+  for (const file of changed) {
+    for (const pattern of policy.watchedPaths) {
+      if (minimatch(file, pattern, { dot: true })) {
+        operationalChanges.push({
+          surface: file,
+          detail: `operational-policy file changed (matches "${pattern}")`,
+        });
+        break;
+      }
+    }
+  }
+
+  // 2) Config threshold / skip-list fields.
+  const configFile = normalizeRel(policy.configFile);
+  if (input.configUndiffable && changed.includes(configFile)) {
+    operationalChanges.push({
+      surface: configFile,
+      detail: `${configFile} changed but its base version could not be read to diff threshold fields; flagging the whole file`,
+    });
+  } else {
+    for (const p of input.changedConfigPaths) {
+      operationalChanges.push({
+        surface: `${configFile}:${p}`,
+        detail: `threshold/policy field "${p}" changed in ${configFile}`,
+      });
+    }
+  }
+
+  // 3) Corresponding ADR = any changed file under the ADR directory.
+  const adrPrefix = normalizeRel(policy.adrDir).replace(/\/$/, '') + '/';
+  const adrFiles = changed.filter((f) => f.startsWith(adrPrefix));
+
+  const flagged = operationalChanges.length > 0 && adrFiles.length === 0;
+
+  return { operationalChanges, adrFiles, flagged };
+}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -779,6 +779,40 @@ export const LocalModelsConfigSchema = z.object({
     .optional(),
 });
 
+/**
+ * Operational-policy drift settings, consumed by `harness check-operational-drift`
+ * (roadmap #565). Flags a diff that touches operational-policy surfaces (hook
+ * profiles, the pre-commit `--skip` list, config threshold values, baseline
+ * policy) without a corresponding ADR under `adrDir`. Every field is optional and
+ * layered over built-in defaults; `.passthrough()` keeps it forward-compatible.
+ */
+export const OperationalPolicyConfigSchema = z
+  .object({
+    /** When false, `check-operational-drift` is a no-op. Default: true. */
+    enabled: z.boolean().optional(),
+    /**
+     * `advisory` (default): report but exit 0. `blocking`: a missing ADR exits
+     * non-zero. Also forced to blocking by the `--strict` flag.
+     */
+    severity: z.enum(['advisory', 'blocking']).optional(),
+    /** Directory (repo-relative) where ADRs live. Default: `docs/knowledge/decisions`. */
+    adrDir: z.string().optional(),
+    /**
+     * Glob patterns (repo-relative) whose changed files count as operational
+     * changes. Default: `.husky/**`, `packages/cli/src/hooks/profiles.ts`.
+     */
+    watchedPaths: z.array(z.string()).optional(),
+    /** The config file whose threshold fields are watched. Default: `harness.config.json`. */
+    configFile: z.string().optional(),
+    /**
+     * Dotted JSON paths inside `configFile` whose sub-tree is threshold/skip-list
+     * policy. A change to any sub-tree flags. Defaults cover the architecture and
+     * performance budgets plus the security gate strictness.
+     */
+    configThresholdPaths: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
 export const HarnessConfigSchema = z.object({
   /** Configuration schema version */
   version: z.literal(1),
@@ -846,6 +880,8 @@ export const HarnessConfigSchema = z.object({
   integrations: IntegrationsConfigSchema.optional(),
   /** General architectural enforcement settings */
   architecture: ArchConfigSchema.optional(),
+  /** Operational-policy drift settings (ADR requirement for hooks/thresholds/skip-list) */
+  operationalPolicy: OperationalPolicyConfigSchema.optional(),
   /** Skill loading, suggestion, and tier override settings */
   skills: z
     .object({


### PR DESCRIPTION
## What

Adds `harness check-operational-drift` (roadmap #565): a diff-based check that FLAGS when a change touches an operational-policy surface WITHOUT a corresponding ADR under `docs/knowledge/decisions/` in the same diff. Operational policy — hook profiles, the pre-commit `--skip` list, config thresholds, baseline policy — is load-bearing but accumulates silently; this forces "we silently softened a gate" to surface as a deliberate ADR.

## New command, not an extension of `enforce-architecture`

`enforce-architecture` answers a graph question (layer boundaries, imports, module size). Operational drift is a diff-vs-ADR correspondence check with its own base-ref resolution, config-field diffing, and advisory severity. A focused command mirrors the existing `check-*` family and composes into CI independently. Rationale documented in the proposal.

## Surfaces watched (config-overridable via `operationalPolicy`)

- `.husky/**` — hook scripts, and the pre-commit `--skip` list (a `SKIP="…"` assignment inside `.husky/pre-commit`).
- `packages/cli/src/hooks/profiles.ts` — hook profile tiers.
- `harness.config.json` threshold fields — **field-level** diffing (base via `git show`, head from disk, deep-compare each watched dotted sub-tree): `architecture.thresholds`, `performance.complexity.thresholds`, `performance.coupling.thresholds`, `security.strict`, `security.rules`. Unrelated config edits do not flag. If the base version is unreadable, falls back to flagging the whole file.

## ADR correspondence

A corresponding ADR = any file added/modified under `docs/knowledge/decisions/` in the same diff. If present, the change passes.

## Severity

Advisory by default (reports, exits 0). `operationalPolicy.severity: "blocking"` or `--strict` makes a missing ADR a non-zero exit.

## CI wiring (advisory)

The check now **runs advisory on PRs**: a non-blocking step in the `build-and-test` job of `.github/workflows/ci.yml` (next to `check-vocabulary`) invokes `check-operational-drift --base origin/<base_ref>` on `pull_request` events only. It runs in default mode (no `--strict`), so a missing ADR is surfaced in the job log but exits 0 and never fails the PR. A preceding `git fetch origin <base_ref>` (same PR-only guard) makes `origin/<base_ref>` resolvable against the shallow `build-and-test` checkout — the same base-fetch pattern `required-review.yml` uses. Promote to `--strict` later to make it blocking.

## Base ref

Defaults to the merge-base of HEAD with the default branch (from `origin/HEAD`, falling back to `main`); `--base <ref>` overrides. Changed files = union of tracked diff and untracked files, so it works in CI and locally.

## Tests

19 tests: pure detection (the three required fixtures — op-change+ADR → pass, op-change no ADR → flag, unrelated → pass — plus field-level config diffing, whole-file fallback, `--skip`-list glob) and command git-seams (base-ref precedence, changed-file union/dedup). `tsc --noEmit`, `eslint`, and the package vitest run all pass. Verified end-to-end: advisory exits 0, `--strict` exits 1.

Spec: `docs/changes/require-adr-operational-policy/proposal.md` (linked in the roadmap shard).

Closes #565
