### PR TITLE
feat(cli): move first-run telemetry notice to stdout (#559)

### DIFF
--- a/.changeset/telemetry-consent-stdout.md
+++ b/.changeset/telemetry-consent-stdout.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Move the first-run telemetry privacy notice from stderr to stdout so it is visible in IDE sessions where stderr is hidden, and reword it to truthfully describe what is collected (skill name/outcome/duration/phases, OS/Node/harness versions, a random install ID, and — when configured — git user.name and project/team names). The once-only first-run marker behavior and all telemetry send behavior are unchanged.

--- a/.harness/hooks/telemetry-reporter.js
+++ b/.harness/hooks/telemetry-reporter.js
@@ -17,8 +17,11 @@ const POSTHOG_BATCH_URL = 'https://app.posthog.com/batch';
 const MAX_ATTEMPTS = 3;
 const TIMEOUT_MS = 5000;
 
-const FIRST_RUN_NOTICE = `Harness collects anonymous usage analytics to improve the tool.
-No personal information is sent. Disable with:
+const FIRST_RUN_NOTICE = `Harness collects usage analytics to improve the tool: which skills run,
+their outcome, duration, and phases reached, plus your OS, Node, and harness
+versions. Events are keyed by a random install ID; when configured, your git
+user.name and project/team names are also included. No source code, file
+contents, or command arguments are sent. Opt out with:
   DO_NOT_TRACK=1  or  harness.config.json \u2192 telemetry.enabled: false\n`;
 
 // --- Helpers ---
@@ -241,7 +244,11 @@ function showFirstRunNotice(cwd) {
   const flagFile = join(cwd, '.harness', '.telemetry-notice-shown');
   if (existsSync(flagFile)) return;
 
-  process.stderr.write(FIRST_RUN_NOTICE);
+  // Written to stdout (not stderr) so the consent notice is visible in IDE
+  // sessions where stderr is often hidden. The notice is plain prose, never
+  // JSON, so it cannot be mistaken for a hook's structured-output protocol;
+  // callers that spawn this hook ignore its stdout entirely.
+  process.stdout.write(FIRST_RUN_NOTICE);
 
   try {
     mkdirSync(join(cwd, '.harness'), { recursive: true });

--- a/docs/changes/telemetry-consent-stdout/proposal.md
+++ b/docs/changes/telemetry-consent-stdout/proposal.md
@@ -1,0 +1,45 @@
+# Strengthen telemetry consent surface (stdout notice)
+
+**Roadmap item:** `strengthen-telemetry-consent-surface`
+**External-ID:** github:Intense-Visions/harness-engineering#559
+**Keywords:** telemetry, consent, first-run-notice, privacy, posthog, stdout
+
+## Overview
+
+`packages/cli/src/hooks/telemetry-reporter.js` shows a one-time first-run privacy
+notice before it sends adoption telemetry to PostHog. The notice was written to
+**stderr**, which is frequently hidden in IDE-hosted agent sessions, so the
+consent surface was weaker than the real data flow (a live PostHog ingest).
+
+This change makes the notice visible and truthful. It does **not** change when or
+whether telemetry is sent.
+
+### Problem
+
+1. The notice went to `process.stderr.write`, invisible in most IDE sessions.
+2. The wording ("No personal information is sent") understated the actual data
+   flow: the PostHog `distinct_id` defaults to the git `user.name`
+   (`identity.alias ?? installId`), and `project`/`team` names are also included
+   when configured.
+
+### Goals
+
+1. Write the first-run notice to **stdout** so adopters see it. The notice is
+   plain prose (never JSON), and the only caller that spawns this hook
+   (`flushTelemetryBackground` in `command-telemetry.ts`) uses
+   `stdio: ['pipe', 'ignore', 'ignore']`, so stdout is never consumed as a
+   structured-output protocol. Diagnostic log lines stay on stderr.
+2. Preserve the once-only behavior: the notice writes a
+   `.harness/.telemetry-notice-shown` marker and only prints on the first run.
+3. Reword the notice to truthfully enumerate what is collected (skill
+   name/outcome/duration/phases, OS/Node/harness versions, a random install ID,
+   and — when configured — git user.name and project/team names) and how to opt
+   out (`DO_NOT_TRACK=1` or `harness.config.json → telemetry.enabled: false`).
+
+### Non-goals
+
+- **No `telemetry.consented` opt-in gate.** Gating the PostHog batch send on a new
+  consent flag is a genuine privacy-policy decision — it would stop telemetry for
+  existing installs until they opt in. That is deferred as a human decision (see
+  the roadmap item's "optionally add" note), not implemented here.
+- No change to the transport, batching, cursor, or consent-resolution logic.

--- a/docs/roadmap.d/strengthen-telemetry-consent-surface.md
+++ b/docs/roadmap.d/strengthen-telemetry-consent-surface.md
@@ -7,7 +7,7 @@ order: 3
 ### Strengthen telemetry consent surface
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/telemetry-consent-stdout/proposal.md
 - **Summary:** `packages/cli/src/hooks/telemetry-reporter.js` prints first-run privacy notice to stderr. In IDE sessions stderr is often invisible — adopters technically opted in by installing the plugin but the consent surface is weak. Move the notice to stdout. Optionally add a `harness.config.json` `telemetry.consented: true` field that the adopter must set before first batch send. The PostHog ingest is real (1319 dogfood records over 80 days); the consent surface should match the data flow. Source: Pass 5 #3.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -550,7 +550,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Strengthen telemetry consent surface
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/telemetry-consent-stdout/proposal.md
 - **Summary:** `packages/cli/src/hooks/telemetry-reporter.js` prints first-run privacy notice to stderr. In IDE sessions stderr is often invisible — adopters technically opted in by installing the plugin but the consent surface is weak. Move the notice to stdout. Optionally add a `harness.config.json` `telemetry.consented: true` field that the adopter must set before first batch send. The PostHog ingest is real (1319 dogfood records over 80 days); the consent surface should match the data flow. Source: Pass 5 #3.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/hooks/telemetry-reporter.js
+++ b/packages/cli/src/hooks/telemetry-reporter.js
@@ -17,8 +17,11 @@ const POSTHOG_BATCH_URL = 'https://app.posthog.com/batch';
 const MAX_ATTEMPTS = 3;
 const TIMEOUT_MS = 5000;
 
-const FIRST_RUN_NOTICE = `Harness collects anonymous usage analytics to improve the tool.
-No personal information is sent. Disable with:
+const FIRST_RUN_NOTICE = `Harness collects usage analytics to improve the tool: which skills run,
+their outcome, duration, and phases reached, plus your OS, Node, and harness
+versions. Events are keyed by a random install ID; when configured, your git
+user.name and project/team names are also included. No source code, file
+contents, or command arguments are sent. Opt out with:
   DO_NOT_TRACK=1  or  harness.config.json \u2192 telemetry.enabled: false\n`;
 
 // --- Helpers ---
@@ -241,7 +244,11 @@ function showFirstRunNotice(cwd) {
   const flagFile = join(cwd, '.harness', '.telemetry-notice-shown');
   if (existsSync(flagFile)) return;
 
-  process.stderr.write(FIRST_RUN_NOTICE);
+  // Written to stdout (not stderr) so the consent notice is visible in IDE
+  // sessions where stderr is often hidden. The notice is plain prose, never
+  // JSON, so it cannot be mistaken for a hook's structured-output protocol;
+  // callers that spawn this hook ignore its stdout entirely.
+  process.stdout.write(FIRST_RUN_NOTICE);
 
   try {
     mkdirSync(join(cwd, '.harness'), { recursive: true });

--- a/packages/cli/tests/hooks/telemetry-reporter.test.ts
+++ b/packages/cli/tests/hooks/telemetry-reporter.test.ts
@@ -10,7 +10,7 @@ function runHook(
   stdinData: string,
   cwd: string,
   env?: Record<string, string>
-): { exitCode: number; stderr: string } {
+): { exitCode: number; stdout: string; stderr: string } {
   // Sanitize telemetry opt-out vars from the inherited base env so each test
   // fully controls telemetry state via the explicit `env` arg. The global test
   // setup sets DO_NOT_TRACK=1 by default (to keep telemetry export from making
@@ -31,6 +31,7 @@ function runHook(
   });
   return {
     exitCode: result.status ?? (result.signal ? 0 : 1),
+    stdout: result.stdout ?? '',
     stderr: result.stderr ?? '',
   };
 }
@@ -89,14 +90,16 @@ describe('telemetry-reporter', { timeout: 60000 }, () => {
     const result = runHook(STDIN_INPUT, tmpDir, { DO_NOT_TRACK: '1' });
     expect(result.exitCode).toBe(0);
     // Should not show first-run notice
-    expect(result.stderr).not.toContain('anonymous usage analytics');
+    expect(result.stdout).not.toContain('usage analytics');
+    expect(result.stderr).not.toContain('usage analytics');
   });
 
   it('exits 0 without HTTP when HARNESS_TELEMETRY_OPTOUT=1', () => {
     writeAdoptionJsonl(tmpDir, [SAMPLE_RECORD]);
     const result = runHook(STDIN_INPUT, tmpDir, { HARNESS_TELEMETRY_OPTOUT: '1' });
     expect(result.exitCode).toBe(0);
-    expect(result.stderr).not.toContain('anonymous usage analytics');
+    expect(result.stdout).not.toContain('usage analytics');
+    expect(result.stderr).not.toContain('usage analytics');
   });
 
   it('exits 0 without HTTP when telemetry.enabled is false in config', () => {
@@ -107,17 +110,20 @@ describe('telemetry-reporter', { timeout: 60000 }, () => {
     );
     const result = runHook(STDIN_INPUT, tmpDir);
     expect(result.exitCode).toBe(0);
-    expect(result.stderr).not.toContain('anonymous usage analytics');
+    expect(result.stdout).not.toContain('usage analytics');
+    expect(result.stderr).not.toContain('usage analytics');
   });
 
   // --- First-run notice ---
 
-  it('shows first-run notice when flag file does not exist', () => {
+  it('shows first-run notice on stdout when flag file does not exist', () => {
     writeAdoptionJsonl(tmpDir, [SAMPLE_RECORD]);
     const result = runHook(STDIN_INPUT, tmpDir);
     expect(result.exitCode).toBe(0);
-    expect(result.stderr).toContain('anonymous usage analytics');
-    expect(result.stderr).toContain('DO_NOT_TRACK=1');
+    // The consent notice must go to stdout (visible in IDE sessions), not stderr.
+    expect(result.stdout).toContain('usage analytics');
+    expect(result.stdout).toContain('DO_NOT_TRACK=1');
+    expect(result.stderr).not.toContain('usage analytics');
     // Flag file should be created
     expect(existsSync(join(tmpDir, '.harness', '.telemetry-notice-shown'))).toBe(true);
   });
@@ -128,7 +134,8 @@ describe('telemetry-reporter', { timeout: 60000 }, () => {
     writeFileSync(join(tmpDir, '.harness', '.telemetry-notice-shown'), 'shown');
     const result = runHook(STDIN_INPUT, tmpDir);
     expect(result.exitCode).toBe(0);
-    expect(result.stderr).not.toContain('anonymous usage analytics');
+    expect(result.stdout).not.toContain('usage analytics');
+    expect(result.stderr).not.toContain('usage analytics');
   });
 
   // --- Install ID ---


### PR DESCRIPTION
## What

Moves the first-run telemetry **privacy notice** in `packages/cli/src/hooks/telemetry-reporter.js` from **stderr → stdout**, so adopters actually see it. In IDE-hosted agent sessions stderr is frequently hidden, which made the consent surface weaker than the real PostHog data flow.

## Why it is safe (no data-send behavior changed)

- The notice is **plain prose, never JSON**, so it cannot be mistaken for a hook's structured-output protocol.
- The only caller that spawns this hook, `flushTelemetryBackground` in `command-telemetry.ts`, uses `stdio: ['pipe', 'ignore', 'ignore']` — the hook's **stdout is explicitly ignored**, not parsed. No hook in the repo writes to stdout as a protocol channel; stderr remains the log convention.
- Diagnostic log lines (`[telemetry-reporter] …`) stay on **stderr**.
- The once-only `.harness/.telemetry-notice-shown` marker behavior is preserved: first run prints, subsequent runs are silent.

## Wording fix (truthfulness)

The old notice said *"No personal information is sent"*, but the PostHog `distinct_id` defaults to the git `user.name` (`identity.alias ?? installId`) and `project`/`team` names are also sent when configured. The notice now truthfully enumerates what is collected (skill name/outcome/duration/phases, OS/Node/harness versions, a random install ID, and — when configured — git user.name and project/team names) and that no source code, file contents, or command arguments are sent. The opt-out line (`DO_NOT_TRACK=1` / `harness.config.json → telemetry.enabled: false`) is unchanged.

## Deferred: consent-gate is a human decision

This PR **deliberately does not** add the `telemetry.consented` opt-in gate. Gating the PostHog batch send on a new opt-in flag is a genuine privacy-policy decision — it would **stop telemetry for existing installs until they opt in**. That should be an explicit human call, not bundled into a visibility fix. Recommended as a follow-up decision.

## Verification

- Manual two-run test in a temp dir: run 1 prints the notice on **stdout** (stderr only has the send log), run 2 is silent on stdout; the marker file is created.
- `vitest tests/hooks/telemetry-reporter.test.ts` — 17/17 pass (added an assertion that the notice targets stdout, not stderr; helper now captures stdout).
- `tsc --noEmit` (cli) clean after build; `eslint src/hooks/telemetry-reporter.js` clean.
- The tracked dogfood copy `.harness/hooks/telemetry-reporter.js` (byte-identical to src, used by this repo and shipped via plugin install) was synced to match.

Changeset: `@harness-engineering/cli` patch.

Closes #559