### PR TITLE
ci(#664): advisory PR jobs for design-token + doc drift

### DIFF
--- a/.github/workflows/pr-advisory-checks.yml
+++ b/.github/workflows/pr-advisory-checks.yml
@@ -1,0 +1,150 @@
+name: PR Advisory Checks
+
+# Roadmap #664 — Auto-wire standalone drift and audit pipelines on PRs.
+#
+# Runs the LIGHTWEIGHT, CLI-runnable harness validators on PRs and surfaces
+# their findings. Every job here is ADVISORY (non-blocking): the validator
+# steps run under `continue-on-error: true`, so a finding is reported in the
+# job log but never flips the PR's required-check status. Blocking is opt-in
+# and out of scope for this workflow.
+#
+# Only validators that run UNAIDED via `node packages/cli/dist/bin/harness.js`
+# — no API key, no agent runner, no network, no pre-built knowledge graph —
+# are wired here. The full LLM-judgment pipelines (design-pipeline /
+# docs-pipeline / design-craft) and the network+agent-driven skills
+# (supply-chain-audit, test-advisor) need the `required-review.yml`
+# `harness review-ci` agent-runtime pattern and are intentionally NOT wired.
+# See docs/changes/auto-wire-drift-audit-pr-jobs/proposal.md.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Design-token drift (detect-design-drift rule floor).
+  #
+  # `align-design-system --dry-run` invokes detect-design-drift internally and
+  # reports DRIFT-T*/DRIFT-P* findings WITHOUT writing any files (report-only,
+  # exit 0). It is purely rule-based (regex + TS-compiler JSX parsing over
+  # design-system/tokens.json + DESIGN.md) — no LLM, no graph, no network.
+  # Scoped to the PR's changed UI/token files via `-f`.
+  # ---------------------------------------------------------------------------
+  design-drift:
+    name: Design-token drift (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so origin/<base> is a usable diff base.
+          fetch-depth: 0
+
+      - name: Detect changed UI/token files
+        id: changes
+        run: |
+          git fetch origin "${{ github.base_ref }}" >/dev/null 2>&1 || true
+          CHANGED="$(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" || true)"
+          FILES="$(printf '%s\n' "$CHANGED" | grep -E '\.(ts|tsx|js|jsx|css|scss)$' || true)"
+          if [ -n "$FILES" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            # Space-join for a single -f invocation; persist via a heredoc.
+            {
+              echo "files<<EOF"
+              printf '%s\n' "$FILES"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Changed UI/token files:"
+            printf '%s\n' "$FILES"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No UI/token files changed — skipping design-drift."
+          fi
+
+      - uses: pnpm/action-setup@v5
+        if: steps.changes.outputs.run == 'true'
+
+      - uses: actions/setup-node@v6
+        if: steps.changes.outputs.run == 'true'
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+        if: steps.changes.outputs.run == 'true'
+
+      - run: pnpm build
+        if: steps.changes.outputs.run == 'true'
+
+      - name: detect-design-drift (advisory, report-only)
+        if: steps.changes.outputs.run == 'true'
+        continue-on-error: true
+        run: |
+          # xargs feeds the changed files as -f args; --dry-run guarantees
+          # report-only (no source is modified). Advisory: continue-on-error
+          # means a finding never fails the PR.
+          printf '%s\n' "${{ steps.changes.outputs.files }}" \
+            | xargs node packages/cli/dist/bin/harness.js align-design-system --dry-run -f
+
+  # ---------------------------------------------------------------------------
+  # Documentation drift (detect-doc-drift).
+  #
+  # The detect-doc-drift skill's Phase 1 runs `harness check-docs` (doc
+  # coverage, exit 0) and `harness cleanup --type drift` (AST-based stale/
+  # renamed-symbol detection via EntropyAnalyzer, exit 1 on findings). Both are
+  # self-contained — no LLM, no network, no pre-built knowledge graph — so they
+  # run unaided. `cleanup` exits non-zero when it finds drift, so the step runs
+  # under continue-on-error to keep the job advisory.
+  # ---------------------------------------------------------------------------
+  doc-drift:
+    name: Documentation drift (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed docs/source files
+        id: changes
+        run: |
+          git fetch origin "${{ github.base_ref }}" >/dev/null 2>&1 || true
+          CHANGED="$(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" || true)"
+          FILES="$(printf '%s\n' "$CHANGED" | grep -E '\.(ts|tsx|js|jsx|md|mdx)$|(^|/)docs/|(^|/)AGENTS\.md$' || true)"
+          if [ -n "$FILES" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Changed docs/source files detected — running doc-drift."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No docs/source files changed — skipping doc-drift."
+          fi
+
+      - uses: pnpm/action-setup@v5
+        if: steps.changes.outputs.run == 'true'
+
+      - uses: actions/setup-node@v6
+        if: steps.changes.outputs.run == 'true'
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+        if: steps.changes.outputs.run == 'true'
+
+      - run: pnpm build
+        if: steps.changes.outputs.run == 'true'
+
+      - name: check-docs coverage (advisory)
+        if: steps.changes.outputs.run == 'true'
+        continue-on-error: true
+        run: node packages/cli/dist/bin/harness.js check-docs
+
+      - name: detect-doc-drift (advisory)
+        if: steps.changes.outputs.run == 'true'
+        continue-on-error: true
+        run: node packages/cli/dist/bin/harness.js cleanup --type drift

--- a/docs/changes/auto-wire-drift-audit-pr-jobs/proposal.md
+++ b/docs/changes/auto-wire-drift-audit-pr-jobs/proposal.md
@@ -1,0 +1,56 @@
+# Auto-wire standalone drift and audit pipelines on PRs (#664)
+
+## Problem
+
+Several high-value harness checks run nowhere on PRs. Roadmap #664 asks for
+PR-scoped, path-filtered, **advisory (non-blocking)** CI jobs that run the
+lightweight, CLI-runnable validators and surface their findings.
+
+The item explicitly warns that the full LLM-judgment pipelines
+(`design-pipeline`, `docs-pipeline`, `design-craft`) need an **agent runner**
+(the `required-review.yml` `harness review-ci` pattern), not plain GitHub
+Actions. Only validators that run **unaided** — no API key, no agent runner, no
+network, no pre-built knowledge graph — belong in a stock Actions workflow.
+
+## What was wired
+
+A dedicated workflow, `.github/workflows/pr-advisory-checks.yml`, keyed on
+`pull_request` to `main`. Each job path-gates itself by diffing the PR against
+`origin/${{ github.base_ref }}` (mirroring `required-review.yml` /
+`changeset-check`: `fetch-depth: 0` + base-ref fetch) and skips cleanly when no
+relevant file changed. All validator steps run under `continue-on-error: true`,
+so findings are surfaced in the log but never flip the PR status (advisory by
+default; blocking is opt-in and out of scope).
+
+| Validator                                    | Job                                                                                     | Command                                            | Why it runs unaided                                                                                                                                                                                                                                                                                                                | Local run                                                                                              |
+| -------------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **detect-design-drift** (design-token drift) | `design-drift`, gated on `**/*.{ts,tsx,js,jsx,css,scss}`                                | `align-design-system --dry-run -f <changed files>` | `align-design-system --dry-run` invokes detect-design-drift internally and reports DRIFT-T*/DRIFT-P* findings **report-only** (0 files modified). Purely rule-based: regex + TS-compiler JSX parsing over `design-system/tokens.json` + `DESIGN.md`. No LLM, no graph, no network.                                                 | exit 0, 303 suggestions repo-wide; 2 suggestions when scoped to one changed file                       |
+| **detect-doc-drift** (doc drift)             | `doc-drift`, gated on docs/source (`**/*.{ts,tsx,js,jsx,md,mdx}`, `docs/`, `AGENTS.md`) | `check-docs` + `cleanup --type drift`              | The detect-doc-drift skill's Phase 1 runs exactly these two commands. `check-docs` (doc coverage) exits 0; `cleanup --type drift` does AST-based stale/renamed-symbol detection via `EntropyAnalyzer` (not the `.harness/graph`) and exits 1 on findings — handled by `continue-on-error`. No LLM, no network, no pre-built graph. | `check-docs` exit 0 (89.0% coverage); `cleanup --type drift` exit 1 with stale/renamed-symbol findings |
+
+`check-design` (which would cover design-drift more richly) was **not** used
+because it composes `design-craft`, an LLM-judgment critique that needs an agent
+runtime. The `align-design-system --dry-run` path is the rule-based drift floor
+the item asked for ("run ONLY the rule-based drift portion").
+
+## What was deferred (agent-runtime required)
+
+| Validator                                          | Why deferred                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **supply-chain-audit** (6-factor dependency risk)  | No CLI command exists (`harness supply-chain-audit` is not registered). The skill is an agent-driven process that fetches the npm registry (`registry.npmjs.org`) and the GitHub API per dependency to score maintainer concentration, maintenance status, etc. It needs **network access + agent orchestration**, so it cannot run unaided via `harness.js`. `check-deps` exists but only validates architectural layers / circular deps — it is not the supply-chain audit. |
+| **test-advisor** (test-strategy / coverage advice) | No CLI command exists. The skill drives MCP tools (`canary_probe`, `query_graph`, `get_impact`, `get_relationships`, `canary_recommend_framework`) that require a **pre-built knowledge graph** (`.harness/graph/`, which is git-ignored and absent on a fresh CI checkout) plus an **MCP/agent runtime**. Not runnable unaided.                                                                                                                                              |
+
+Both deferred validators need the agent-runtime work (the `required-review.yml`
+`harness review-ci` runner pattern) before they can be wired — which is the
+constraint #664 itself flags.
+
+## Verification
+
+- Both wired commands were run locally against this repo via
+  `node packages/cli/dist/bin/harness.js …` and produce findings without any
+  API key, agent runner, network, or pre-built graph.
+- `align-design-system --dry-run` writes no source files (verified: clean
+  `git status` after the run).
+- The workflow YAML parses cleanly (`yaml.parse`); both jobs carry the correct
+  `continue-on-error` advisory steps and `on.pull_request.branches: [main]`.
+- CI itself cannot be exercised locally; job/step `if:` gating and the
+  changed-file path filters were reviewed by hand.

--- a/docs/roadmap.d/auto-wire-standalone-drift-and-audit-pipelines-on-prs.md
+++ b/docs/roadmap.d/auto-wire-standalone-drift-and-audit-pipelines-on-prs.md
@@ -7,7 +7,7 @@ order: 12
 ### Auto-wire standalone drift and audit pipelines on PRs
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/auto-wire-drift-audit-pr-jobs/proposal.md
 - **Summary:** Several high-value checks have no owning persona, so the persona-trigger work (above) does not cover them, and — verified 2026-06 — none runs automatically on PRs: detect-design-drift / design-pipeline (design-system drift), detect-doc-drift / docs-pipeline (doc drift; only a lightweight slice runs today inside the entropy check in harness.yml), supply-chain-audit (6-factor dependency risk), and test-advisor (test-strategy/coverage advice). Add PR-scoped CI jobs (path-filtered where sensible: design-drift on UI/token paths, supply-chain-audit on dependency-manifest changes, doc-drift on docs/source changes, test-advisor on test/source changes) that run these and surface findings, advisory-by-default with opt-in blocking. Note the agent-runtime constraint: the full LLM-judgment pipelines need an agent runner (the required-review.yml 'harness review-ci' pattern), not just the lightweight CLI validators GitHub Actions can run unaided. Recommended priority: P2.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -717,7 +717,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Auto-wire standalone drift and audit pipelines on PRs
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/auto-wire-drift-audit-pr-jobs/proposal.md
 - **Summary:** Several high-value checks have no owning persona, so the persona-trigger work (above) does not cover them, and — verified 2026-06 — none runs automatically on PRs: detect-design-drift / design-pipeline (design-system drift), detect-doc-drift / docs-pipeline (doc drift; only a lightweight slice runs today inside the entropy check in harness.yml), supply-chain-audit (6-factor dependency risk), and test-advisor (test-strategy/coverage advice). Add PR-scoped CI jobs (path-filtered where sensible: design-drift on UI/token paths, supply-chain-audit on dependency-manifest changes, doc-drift on docs/source changes, test-advisor on test/source changes) that run these and surface findings, advisory-by-default with opt-in blocking. Note the agent-runtime constraint: the full LLM-judgment pipelines need an agent runner (the required-review.yml 'harness review-ci' pattern), not just the lightweight CLI validators GitHub Actions can run unaided. Recommended priority: P2.
 - **Blockers:** —
 - **Plan:** —


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-advisory-checks.yml` — PR-scoped, path-gated, **advisory (non-blocking)** CI jobs that run the lightweight, CLI-runnable harness validators and surface findings. All validator steps run under `continue-on-error: true`, so a finding is reported in the log but never flips the PR status. Only validators that run **unaided** (no API key, no agent runner, no network, no pre-built graph) via `node packages/cli/dist/bin/harness.js` are wired.

Each job gates itself on the PR diff against `origin/${{ github.base_ref }}` (`fetch-depth: 0` + base-ref fetch, mirroring `required-review.yml` / `changeset-check`) and skips cleanly when no relevant file changed.

## Wired validators (run unaided — proven locally)

| Validator | Job | Command | Local run |
| --- | --- | --- | --- |
| **detect-design-drift** (design-token drift) | `design-drift`, gated on `**/*.{ts,tsx,js,jsx,css,scss}` | `align-design-system --dry-run -f <changed files>` (rule floor, report-only) | exit 0; 303 suggestions repo-wide, 2 when scoped to one file; 0 files modified |
| **detect-doc-drift** (doc drift) | `doc-drift`, gated on docs/source | `check-docs` + `cleanup --type drift` (AST-based, via EntropyAnalyzer) | `check-docs` exit 0 (89.0% coverage); `cleanup --type drift` exit 1 with stale/renamed-symbol findings (advisory via continue-on-error) |

`check-design` was deliberately **not** used for design-drift because it composes `design-craft` (LLM-judgment, agent-required); `align-design-system --dry-run` is the rule-based drift floor #664 asked for.

## Deferred validators (agent-runtime required — per #664's own constraint)

- **supply-chain-audit** — no CLI command exists; the skill fetches the npm registry + GitHub API per dependency and needs network access + agent orchestration. (`check-deps` only validates layer/circular-dep rules — not the supply-chain audit.)
- **test-advisor** — no CLI command exists; the skill drives MCP tools (`canary_probe`, `query_graph`, `get_impact`, …) needing a pre-built knowledge graph (`.harness/graph/`, git-ignored / absent on fresh CI) and an MCP runtime.

Both need the `required-review.yml` `harness review-ci` agent-runner pattern before they can be wired.

## Verification

- Both wired commands run locally against this repo without any API key, agent runner, network, or pre-built graph.
- `align-design-system --dry-run` writes no source files (clean `git status` after run).
- Workflow YAML parses cleanly (`yaml.parse`); both jobs carry correct `continue-on-error` advisory steps.
- CI can't run locally; `if:` gating and path filters reviewed by hand.

Spec: `docs/changes/auto-wire-drift-audit-pr-jobs/proposal.md`

Closes #664
