### PR TITLE
feat(templates): graduate pre-merge-brief to adopter template + ruleset

### DIFF
--- a/.changeset/init-template-named-fallback.md
+++ b/.changeset/init-template-named-fallback.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Make `harness init --template <name>` actually render standalone named templates.
+`init` passes the `--template` value in as `level`, but `resolveTemplate` only
+matched an adoption-level scaffold (`template.json.level`), so named templates
+whose `template.json` declares no `level` (`ci-pre-merge-brief`, and even the
+documented `orchestrator` example) failed with `Template not found for level: <name>`.
+`resolveTemplate` now falls back to matching by template `name` when no level
+matches, rendering that template standalone — honoring an explicit `extends` but
+never dragging in the basic-level scaffold. `init` also supplies the
+`runner`/`blockOn`/`baseBranch` defaults the `ci-pre-merge-brief` workflow needs
+under strict-mode Handlebars. Level-based `init` is unchanged.

--- a/.changeset/pre-merge-brief-adopter-template.md
+++ b/.changeset/pre-merge-brief-adopter-template.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Graduate the pre-merge brief to an adopter-facing artifact. `harness init` can
+now render the opt-in `ci-pre-merge-brief` template — a GitHub Actions workflow
+that runs `harness review-ci` then upserts the senior-facing `harness
+pre-merge-brief` sticky PR comment (diff, review verdict, Signal status,
+outcome-eval, and "worth your eyes") — plus a matching branch-protection ruleset
+for the eventual acknowledgment gate. Mirrors how `ci-required-review` graduated:
+a discoverable, opt-in named template directory rendered by the existing
+`TemplateEngine` (no engine change). Every brief section degrades independently,
+so the workflow runs in a plain adopter CI without a daemon or signal providers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ harness-engineering/
 │   ├── skills/cursor/        # 741 skills (mirrored from claude-code for platform parity)
 │   ├── skills/templates/     # Shared discipline template (Evidence Requirements, Red Flags, Rationalizations to Reject)
 │   └── personas/             # 16 personas (adversarial-reviewer, architecture-enforcer, code-reviewer, codebase-health-analyst, documentation-maintainer, entropy-cleaner, frontend-races-reviewer, graph-maintainer, harness-pm, parallel-coordinator, performance-guardian, planner, security-reviewer, task-executor, typescript-strict-reviewer, verifier)
-├── templates/                 # 19 project scaffolding templates (language bases + framework overlays: Express, NestJS, Next.js, FastAPI, Django, Gin, Axum, Spring Boot, React Vite, Vue, and more) — plus the opt-in `ci-required-review` template that `harness init` renders into a GitHub Actions workflow + branch-protection ruleset wiring the `harness review-ci` required check
+├── templates/                 # 19 project scaffolding templates (language bases + framework overlays: Express, NestJS, Next.js, FastAPI, Django, Gin, Axum, Spring Boot, React Vite, Vue, and more) — plus the opt-in `ci-required-review` template that `harness init` renders into a GitHub Actions workflow + branch-protection ruleset wiring the `harness review-ci` required check, and the opt-in `ci-pre-merge-brief` template that renders a workflow + ruleset posting the senior-facing `harness pre-merge-brief` sticky PR comment
 ├── examples/                  # Progressive tutorial examples
 │   ├── hello-world/          # Basic adoption level
 │   ├── task-api/             # Intermediate adoption level

--- a/docs/changes/pre-merge-brief-adopter-template/proposal.md
+++ b/docs/changes/pre-merge-brief-adopter-template/proposal.md
@@ -1,0 +1,73 @@
+# Graduate pre-merge-brief to an adopter template + ruleset
+
+## Problem
+
+The senior-facing pre-merge brief (`harness pre-merge-brief`) runs today only on
+harness's own dogfood — as a step inside the required-review dogfood workflow.
+Adopters who install `@harness-engineering/cli` have the command but no
+first-class, `harness init`-rendered artifact wiring it into their CI. The
+required-review gate already made this jump: it graduated from a dogfood workflow
+to a discoverable, opt-in `ci-required-review` template. The pre-merge brief
+should follow the same path so adopters can opt in with one `harness init` render
+and a documented, admin-applied ruleset for the eventual gate.
+
+## Approach
+
+Mirror the `ci-required-review` graduation exactly. Ship a standalone,
+discoverable named template directory, rendered by the existing `TemplateEngine`
+with no engine or schema change:
+
+- `templates/ci-pre-merge-brief/pre-merge-brief.yml.hbs` — a `pull_request`
+  workflow whose single `pre-merge-brief` job runs `harness review-ci --out`
+  (continue-on-error) then `harness pre-merge-brief --from … --comment`, upserting
+  a single sticky senior-facing PR comment.
+- `templates/ci-pre-merge-brief/pre-merge-brief.ruleset.json` — a GitHub ruleset
+  marking the `pre-merge-brief` check as a required status check, targeting
+  `~DEFAULT_BRANCH`. Applied manually by a repo admin (deferred), for the eventual
+  acknowledgment gate.
+- `templates/ci-pre-merge-brief/template.json` — registers the directory as the
+  opt-in named template `ci-pre-merge-brief` (no `level`/`framework`), so
+  `TemplateEngine.listTemplates()` discovers it and `harness init` can render it.
+- `templates/ci-pre-merge-brief/README.md` — adopter documentation (generic; no
+  harness-internal roadmap/PR/issue numbers).
+
+The template variables (`runner`, `blockOn`, `baseBranch`) and the GitHub-Actions
+`${{ … }}` per-line escaping match the `ci-required-review` template so the two
+stay maintainable together.
+
+## Why it is safe for a plain adopter CI
+
+`harness pre-merge-brief` has no daemon, signal-provider, or agent-runner
+dependency. Every section (diff, review verdict, Signal status, outcome-eval,
+guardian, "worth your eyes") degrades independently to an "unavailable" line when
+its input is absent, and the command always exits 0. All dependencies are bundled
+in the published CLI. The brief is informational; gating on the review verdict
+remains the `ci-required-review` template's job (this workflow's `review-ci` step
+is `continue-on-error`).
+
+## Known limitation (out of scope)
+
+The review-verdict section is fed by handing the `review-ci --out` artifact to
+`pre-merge-brief --from`. At present `review-ci --out` writes the bare verdict
+object, while `pre-merge-brief`'s `readReview` expects a `{ verdict: … }`-wrapped
+`CiReviewResult`; when the shapes do not match, the review section renders
+"unavailable" and every other section still populates. Aligning that
+producer/consumer artifact contract is a separate change to the two commands and
+is intentionally not bundled into this template graduation.
+
+## Acceptance criteria
+
+1. A new `templates/ci-pre-merge-brief/` directory ships the workflow template,
+   ruleset, `template.json`, and README.
+2. `TemplateEngine.listTemplates()` discovers `ci-pre-merge-brief` as a named
+   template with no `level`/`framework` (proven by test).
+3. Rendering `pre-merge-brief.yml.hbs` with `runner`/`blockOn`/`baseBranch`
+   produces valid YAML whose `pre-merge-brief` job: runs `review-ci --out`
+   (continue-on-error) and `pre-merge-brief --from … --comment`; diffs
+   `origin/${{ github.base_ref }}...HEAD`; declares `contents: read` +
+   `pull-requests: write`; and preserves every `${{ … }}` expression verbatim
+   (no `\{{` artifact).
+4. The workflow job name and the ruleset's `required_status_checks[].context`
+   are the identical literal `pre-merge-brief` (proven by test).
+5. The rendered/shipped template and README contain no harness-internal
+   roadmap/PR/issue numbers.

--- a/docs/roadmap.d/graduate-pre-merge-brief-to-adopter-template-ruleset.md
+++ b/docs/roadmap.d/graduate-pre-merge-brief-to-adopter-template-ruleset.md
@@ -7,7 +7,7 @@ order: 14
 ### Graduate pre-merge-brief to adopter template + ruleset
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/pre-merge-brief-adopter-template/proposal.md
 - **Summary:** Follow-up to the senior accountability surface (#569, D5): ship the adopter-facing pre-merge-brief as a templates/ci/*.yml.hbs rendered by `harness init`, plus a ruleset for the eventual gate. Deferred so the brief's Markdown format bakes on dogfood PRs before adopters are locked in — mirrors how required-review graduated. Natural companion to fully extracting signal providers into shared core.
 - **Blockers:** Build senior-engineer accountability surface for PR push
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -739,7 +739,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Graduate pre-merge-brief to adopter template + ruleset
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/pre-merge-brief-adopter-template/proposal.md
 - **Summary:** Follow-up to the senior accountability surface (#569, D5): ship the adopter-facing pre-merge-brief as a templates/ci/*.yml.hbs rendered by `harness init`, plus a ruleset for the eventual gate. Deferred so the brief's Markdown format bakes on dogfood PRs before adopters are locked in — mirrors how required-review graduated. Natural companion to fully extracting signal providers into shared core.
 - **Blockers:** Build senior-engineer accountability surface for PR push
 - **Plan:** —

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -130,6 +130,13 @@ async function scaffoldProject(
   const renderResult = engine.render(resolveResult.value, {
     projectName: name,
     level: level ?? '',
+    // Defaults for named-template variables (the ci-pre-merge-brief workflow).
+    // Handlebars compiles in strict mode, so these must be present for any
+    // template that references them; templates that don't simply ignore them.
+    // Adopters edit the rendered workflow to change runner/block-on/base branch.
+    runner: 'claude',
+    blockOn: 'request-changes',
+    baseBranch: 'main',
     ...(options.framework !== undefined && { framework: options.framework }),
     ...(language !== undefined && { language }),
   });

--- a/packages/cli/src/templates/engine.ts
+++ b/packages/cli/src/templates/engine.ts
@@ -15,6 +15,12 @@ export interface TemplateContext {
   pythonMinVersion?: string;
   javaGroupId?: string;
   rustEdition?: string;
+  // Named-template variables (currently the ci-pre-merge-brief workflow). The
+  // engine compiles Handlebars in strict mode, so any template that references
+  // these must have them supplied by the caller (see commands/init.ts).
+  runner?: string;
+  blockOn?: string;
+  baseBranch?: string;
 }
 
 interface TemplateFile {
@@ -207,14 +213,38 @@ export class TemplateEngine {
       return Err(new Error('Level is required for TypeScript/JavaScript templates'));
     }
 
+    // Primary: an adoption-level scaffold (template.json `level` === level).
     const levelDir = this.findTemplateDir(level, 'level');
-    if (!levelDir) return Err(new Error(`Template not found for level: ${level}`));
+    if (levelDir) return this.resolveTemplateDir(levelDir, level, framework);
 
-    const metaPath = path.join(levelDir, 'template.json');
+    // Named-template fallback: `harness init --template <name>` passes the
+    // template name in as `level`. When no adoption-level template matches, try
+    // resolving a standalone named template (e.g. `orchestrator`,
+    // `ci-pre-merge-brief`) by its `name`. It renders on its own — honoring an
+    // explicit `extends` if the template declares one, but never dragging in the
+    // basic-level scaffold. This is what makes `--template <name>` reachable.
+    const namedDir = this.findTemplateDir(level, 'name');
+    if (namedDir) return this.resolveTemplateDir(namedDir, level, framework);
+
+    return Err(new Error(`Template not found for level: ${level}`));
+  }
+
+  /**
+   * Resolve a single template directory into a ResolvedTemplate: its own files,
+   * optionally merged over the files of a declared `extends` base, then an
+   * optional framework overlay. Shared by the adoption-level path and the
+   * named-template (`--template <name>`) fallback in resolveTemplate.
+   */
+  private resolveTemplateDir(
+    dir: string,
+    sourceName: string,
+    framework?: string
+  ): Result<ResolvedTemplate, Error> {
+    const metaPath = path.join(dir, 'template.json');
     const metaRaw = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
     const metaResult = TemplateMetadataSchema.safeParse(metaRaw);
     if (!metaResult.success)
-      return Err(new Error(`Invalid template.json in ${level}: ${metaResult.error.message}`));
+      return Err(new Error(`Invalid template.json in ${sourceName}: ${metaResult.error.message}`));
 
     const metadata = metaResult.data;
     let files: TemplateFile[] = [];
@@ -224,8 +254,8 @@ export class TemplateEngine {
       if (fs.existsSync(baseDir)) files = this.collectFiles(baseDir, metadata.extends);
     }
 
-    const levelFiles = this.collectFiles(levelDir, level);
-    files = this.mergeFileLists(files, levelFiles);
+    const ownFiles = this.collectFiles(dir, sourceName);
+    files = this.mergeFileLists(files, ownFiles);
 
     let overlayMetadata: TemplateMetadata | undefined;
     if (framework) {

--- a/packages/cli/tests/templates/ci-pre-merge-brief.test.ts
+++ b/packages/cli/tests/templates/ci-pre-merge-brief.test.ts
@@ -126,4 +126,42 @@ describe('ci-pre-merge-brief template', () => {
     expect(ci!.level).toBeUndefined();
     expect(ci!.framework).toBeUndefined();
   });
+
+  it('resolves + renders through the real init path (`--template ci-pre-merge-brief`)', () => {
+    // `harness init --template ci-pre-merge-brief` passes the template name in as
+    // `level` (commands/init.ts). This is the exact resolution call init makes,
+    // and is what proves the workflow is emitted into an adopter repo — the
+    // hand-built engine.render() test above never exercises resolveTemplate.
+    const engine = new TemplateEngine(TEMPLATES);
+    const resolved = engine.resolveTemplate('ci-pre-merge-brief', undefined, 'typescript');
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+
+    // Named standalone template: no `extends`, so ONLY its own files resolve —
+    // the pre-merge-brief workflow, ruleset, and README, and no basic/base
+    // level-scaffold files (e.g. harness.config.json / AGENTS.md) leak in.
+    const paths = resolved.value.files.map((f) => f.relativePath).sort();
+    expect(paths).toEqual(
+      ['README.md', 'pre-merge-brief.ruleset.json', 'pre-merge-brief.yml.hbs'].sort()
+    );
+
+    // Render with the same defaults commands/init.ts supplies. Strict-mode
+    // Handlebars would throw if a referenced var were missing.
+    const rendered = engine.render(resolved.value, {
+      projectName: 'demo',
+      level: '',
+      runner: 'claude',
+      blockOn: 'request-changes',
+      baseBranch: 'main',
+    });
+    expect(rendered.ok).toBe(true);
+    if (!rendered.ok) return;
+
+    // The `.hbs` is stripped: `harness init --template ci-pre-merge-brief` emits
+    // the runnable `pre-merge-brief.yml` workflow.
+    const wf = rendered.value.files.find((f) => f.relativePath === 'pre-merge-brief.yml');
+    expect(wf).toBeDefined();
+    expect(wf!.content).toContain('name: pre-merge-brief');
+    expect(wf!.content).toContain('--runner claude');
+  });
 });

--- a/packages/cli/tests/templates/ci-pre-merge-brief.test.ts
+++ b/packages/cli/tests/templates/ci-pre-merge-brief.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import { TemplateEngine, type TemplateContext } from '../../src/templates/engine';
+
+const TEMPLATES = path.resolve(__dirname, '..', '..', '..', '..', 'templates');
+const CI_DIR = path.join(TEMPLATES, 'ci-pre-merge-brief');
+
+describe('ci-pre-merge-brief template', () => {
+  it('ruleset required-check context matches the workflow job name', () => {
+    // Parse the RAW .hbs: the literal `name: pre-merge-brief` and the quoted
+    // Handlebars tokens are valid YAML, so the job name is stable on the raw file.
+    const wf = yaml.parse(fs.readFileSync(path.join(CI_DIR, 'pre-merge-brief.yml.hbs'), 'utf-8'));
+    const jobName = wf.jobs['pre-merge-brief'].name;
+
+    const ruleset = JSON.parse(
+      fs.readFileSync(path.join(CI_DIR, 'pre-merge-brief.ruleset.json'), 'utf-8')
+    );
+    const checks = ruleset.rules.find((r: { type: string }) => r.type === 'required_status_checks')
+      .parameters.required_status_checks;
+    const contexts = checks.map((c: { context: string }) => c.context);
+
+    expect(jobName).toBe('pre-merge-brief');
+    expect(contexts).toContain(jobName);
+  });
+
+  it('renders the workflow with substituted runner/blockOn/baseBranch into valid YAML', () => {
+    const engine = new TemplateEngine(TEMPLATES);
+    const resolved = {
+      metadata: {
+        name: 'ci-pre-merge-brief',
+        description: 'x',
+        version: 1 as const,
+        mergeStrategy: { json: 'deep-merge' as const, files: 'overlay-wins' as const },
+      },
+      files: [
+        {
+          relativePath: 'pre-merge-brief.yml.hbs',
+          absolutePath: path.join(CI_DIR, 'pre-merge-brief.yml.hbs'),
+          isHandlebars: true,
+          sourceTemplate: 'ci-pre-merge-brief',
+        },
+      ],
+    };
+    // TemplateContext does not declare runner/blockOn/baseBranch, but Handlebars
+    // renders by key regardless of the TS interface — cast the extra keys in.
+    const result = engine.render(resolved, {
+      projectName: 'demo',
+      runner: 'claude',
+      blockOn: 'request-changes',
+      baseBranch: 'main',
+    } as unknown as TemplateContext);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The engine strips `.hbs`, so the rendered file is `pre-merge-brief.yml`.
+    const wf = result.value.files.find((f) => f.relativePath === 'pre-merge-brief.yml');
+    expect(wf).toBeDefined();
+
+    const parsed = yaml.parse(wf!.content); // throws if invalid YAML
+    const job = parsed.jobs['pre-merge-brief'];
+    expect(job.name).toBe('pre-merge-brief');
+
+    // The review step runs review-ci with substituted runner/block-on and writes
+    // the artifact the brief step consumes via `--out`.
+    const reviewStep = job.steps.find(
+      (s: { run?: string }) => typeof s.run === 'string' && s.run.includes('review-ci')
+    );
+    expect(reviewStep.run).toContain('--runner claude');
+    expect(reviewStep.run).toContain('--block-on request-changes');
+    expect(reviewStep.run).toContain('--out /tmp/review.json');
+    // A blocking verdict must not fail the informational brief job.
+    expect(reviewStep['continue-on-error']).toBe(true);
+
+    // The brief step composes + upserts the sticky comment, reusing the artifact.
+    const briefStep = job.steps.find(
+      (s: { run?: string }) => typeof s.run === 'string' && s.run.includes('pre-merge-brief')
+    );
+    expect(briefStep.run).toContain('--from /tmp/review.json');
+    expect(briefStep.run).toContain('--comment');
+
+    expect(parsed.on.pull_request.branches).toContain('main');
+
+    // Both harness steps must diff against the PR's real base via the runtime
+    // `github.base_ref` expression, NOT the CLI's origin/HEAD fallback (which can
+    // silently review the wrong/empty diff on a pull_request event).
+    expect(reviewStep.run).toContain('--diff "origin/${{ github.base_ref }}...HEAD"');
+    expect(briefStep.run).toContain('--diff "origin/${{ github.base_ref }}...HEAD"');
+
+    // A step fetches the PR base so origin/${{ github.base_ref }} resolves.
+    const fetchStep = job.steps.find(
+      (s: { run?: string }) => typeof s.run === 'string' && s.run.includes('git fetch origin')
+    );
+    expect(fetchStep).toBeDefined();
+    expect(fetchStep.run).toContain('git fetch origin ${{ github.base_ref }}');
+
+    // The brief upserts a sticky PR comment, so it needs pull-requests: write;
+    // review-ci itself only reads the diff.
+    expect(parsed.permissions['contents']).toBe('read');
+    expect(parsed.permissions['pull-requests']).toBe('write');
+
+    // GitHub `${{ secrets.X }}` expressions survived Handlebars verbatim, including
+    // the GITHUB_TOKEN the brief posts its comment with:
+    expect(wf!.content).toContain('${{ secrets.ANTHROPIC_API_KEY }}');
+    expect(job.env.ANTHROPIC_API_KEY).toBe('${{ secrets.ANTHROPIC_API_KEY }}');
+    expect(job.env.GH_TOKEN).toBe('${{ secrets.GITHUB_TOKEN }}');
+
+    // An escaped GH expression and a substituted Handlebars var coexist on one
+    // line (the review step has a literal ${{ github.base_ref }} AND a real
+    // {{runner}} -> claude substitution). Proves the per-line escaping is correct.
+    expect(reviewStep.run).toContain('${{ github.base_ref }}');
+    expect(reviewStep.run).toContain('--runner claude');
+
+    // No stray escaping artifact leaked into the output:
+    expect(wf!.content).not.toContain('\\{{');
+  });
+
+  it('is discoverable as a named template (not a level scaffold)', () => {
+    const engine = new TemplateEngine(TEMPLATES);
+    const list = engine.listTemplates();
+    expect(list.ok).toBe(true);
+    if (!list.ok) return;
+    const ci = list.value.find((t) => t.name === 'ci-pre-merge-brief');
+    expect(ci).toBeDefined();
+    expect(ci!.level).toBeUndefined();
+    expect(ci!.framework).toBeUndefined();
+  });
+});

--- a/templates/ci-pre-merge-brief/README.md
+++ b/templates/ci-pre-merge-brief/README.md
@@ -1,0 +1,101 @@
+# `ci-pre-merge-brief` — opt-in senior pre-merge brief
+
+This template wires the built-in `harness pre-merge-brief` command into a GitHub
+Actions workflow that composes a single **senior-facing accountability brief**
+and upserts it as a sticky comment on every pull request. It is an opt-in,
+discoverable template (rendered by `harness init`); it is not part of any level
+scaffold, and it is independent of the `ci-required-review` template — you can
+adopt either, both, or neither.
+
+## What it renders
+
+| File                           | Purpose                                                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `pre-merge-brief.yml`          | A `pull_request` workflow whose single job runs `harness review-ci` then `harness pre-merge-brief --comment`.   |
+| `pre-merge-brief.ruleset.json` | A GitHub repository ruleset that marks the workflow's check as a required status check (for the eventual gate). |
+
+## What the brief contains
+
+The upserted comment (one sticky comment per PR, updated in place) assembles, in
+order: a **diff summary**, the **review verdict**, a point-in-time **Signal
+status** snapshot, the **outcome-eval** result, and a derived **"Worth your
+eyes"** section (the union of blocking findings, warn/alert signals, unmet
+outcome criteria, and flagged guardian diff-coverage records).
+
+Every section degrades **independently**: a missing or unavailable input renders
+an "unavailable / not configured" line rather than failing the job. The workflow
+always exits 0 — the brief is informational; blocking a merge on the review
+verdict is the `ci-required-review` template's job.
+
+## The binding contract
+
+The workflow job's `name:` is the literal string **`pre-merge-brief`**, and the
+ruleset's `required_status_checks[].context` is the same literal
+**`pre-merge-brief`**. GitHub matches required checks by this name. **Do not
+rename one without the other** — if they drift, the ruleset will require a check
+that never reports and every PR will be blocked indefinitely.
+
+## Template variables
+
+`harness init` renders `pre-merge-brief.yml.hbs` with three Handlebars variables.
+The engine compiles in strict mode, so all three must be supplied:
+
+| Variable     | Default           | Meaning                                                             |
+| ------------ | ----------------- | ------------------------------------------------------------------- |
+| `runner`     | `claude`          | Which review runner `review-ci` uses for the LLM tier of the brief. |
+| `blockOn`    | `request-changes` | The `review-ci` block-on level (does not fail the brief job).       |
+| `baseBranch` | _(required)_      | The PR base branch the workflow triggers on.                        |
+
+> GitHub Actions `${{ ... }}` expressions in the template are emitted verbatim
+> (escaped past Handlebars); only `runner`, `blockOn`, and `baseBranch` are
+> substituted.
+
+## Applying the ruleset (deferred — run once, by a repo admin)
+
+The ruleset is **not** applied automatically by this template or by any CI. It
+exists for the **eventual acknowledgment gate** — the point at which "the brief
+was posted" (and, later, acknowledged) becomes a required merge condition. Until
+you opt in, the workflow simply posts the brief and never blocks a merge.
+
+After the workflow has run at least once on a PR (so the `pre-merge-brief` check
+is known to GitHub), a repository admin applies the ruleset with the GitHub CLI:
+
+```sh
+gh api repos/{owner}/{repo}/rulesets --input pre-merge-brief.ruleset.json
+```
+
+Replace `{owner}/{repo}` with your repository. The ruleset targets the default
+branch (`~DEFAULT_BRANCH`), which is the portable choice across forks and renames.
+
+## Per-runner secrets
+
+Set these as repository **Actions secrets**. The workflow exposes all of them as
+environment variables; the runner you select reads the one it needs. The
+heuristic floor of `review-ci` runs regardless; the LLM tier is secret-gated and
+**degrades gracefully** (skips the LLM pass) when its secret is absent.
+
+| `runner`                                    | Secret env var(s)                                                                                         |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `claude`                                    | `ANTHROPIC_API_KEY`                                                                                       |
+| `antigravity` (and the superseded `gemini`) | `GEMINI_API_KEY` _(unverified for CI — selecting antigravity without a working secret yields floor-only)_ |
+| `codex`                                     | `OPENAI_API_KEY`                                                                                          |
+| `local`                                     | `HARNESS_LOCAL_ENDPOINT`, `HARNESS_LOCAL_MODEL` — **no API key; secret-free and cost-free**               |
+
+The brief posts its sticky comment through the GitHub CLI using the built-in
+`GITHUB_TOKEN` (exposed as `GH_TOKEN`); no additional secret is required for
+comment posting.
+
+## Notes
+
+- The workflow diffs `origin/${{ github.base_ref }}...HEAD` (the PR's real base,
+  resolved at runtime), with `fetch-depth: 0` and an explicit
+  `git fetch origin ${{ github.base_ref }}` step so the base ref is reachable.
+- The `review-ci` step is `continue-on-error: true`: a blocking verdict feeds the
+  brief's review section but never fails the brief job. Pair this template with
+  `ci-required-review` if you want the verdict to actually gate the merge.
+- The **review-verdict section** is composed from the `review-ci --out` artifact
+  handed to `pre-merge-brief --from`. If that artifact is unavailable the section
+  renders "unavailable" and every other section still populates.
+- The workflow installs `@harness-engineering/cli@latest`. Pin it to a specific
+  released version in the rendered workflow once you have validated the brief, for
+  reproducible CI runs.

--- a/templates/ci-pre-merge-brief/pre-merge-brief.ruleset.json
+++ b/templates/ci-pre-merge-brief/pre-merge-brief.ruleset.json
@@ -1,0 +1,20 @@
+{
+  "name": "pre-merge-brief",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [{ "context": "pre-merge-brief" }]
+      }
+    }
+  ]
+}

--- a/templates/ci-pre-merge-brief/pre-merge-brief.yml.hbs
+++ b/templates/ci-pre-merge-brief/pre-merge-brief.yml.hbs
@@ -1,0 +1,69 @@
+# Rendered by `harness init` (ci-pre-merge-brief template).
+# The job name below ("pre-merge-brief") is the check name bound as REQUIRED
+# by pre-merge-brief.ruleset.json. Keep them identical.
+#
+# NOTE ON ESCAPING: GitHub Actions expressions ($\{{ ... }}) collide with the
+# Handlebars template engine under its strict compile mode, which provides no
+# raw/literal block helper. Each GH expression below therefore escapes the
+# opening braces per-line (a backslash before the mustache: $\{{ ... }}) so
+# Handlebars emits them verbatim (the rendered output is the literal
+# dollar-double-brace form GitHub Actions evaluates at runtime). A future editor
+# must NOT "fix" these by removing the backslash — that breaks the render.
+# Only the runner and blockOn mustaches are real template vars (substituted);
+# baseBranch is real too, but the diff range uses the RUNTIME github.base_ref.
+name: Pre-merge Brief
+
+on:
+  pull_request:
+    branches: ['{{baseBranch}}']
+
+# The brief upserts a single sticky senior-facing PR comment, so the job needs
+# pull-requests: write. review-ci itself only reads the diff.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pre-merge-brief:
+    name: pre-merge-brief
+    runs-on: ubuntu-latest
+    env:
+      # review-ci's heuristic floor runs regardless of runner. The LLM tier only
+      # activates when its secret is present, degrading gracefully otherwise.
+      ANTHROPIC_API_KEY: $\{{ secrets.ANTHROPIC_API_KEY }}
+      GEMINI_API_KEY: $\{{ secrets.GEMINI_API_KEY }}
+      OPENAI_API_KEY: $\{{ secrets.OPENAI_API_KEY }}
+      HARNESS_LOCAL_ENDPOINT: $\{{ secrets.HARNESS_LOCAL_ENDPOINT }}
+      HARNESS_LOCAL_MODEL: $\{{ secrets.HARNESS_LOCAL_MODEL }}
+      # The brief posts its sticky comment through the GitHub CLI.
+      GH_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the PR base branch is reachable for the diff range.
+          fetch-depth: 0
+      - name: Fetch PR base branch
+        # actions/checkout leaves origin/HEAD unresolved on pull_request events,
+        # which would make the diff range fall back to origin/main...HEAD (wrong or
+        # empty diff if the PR base is not main). Fetch the real base so the
+        # explicit origin/$\{{ github.base_ref }}...HEAD range below resolves.
+        run: git fetch origin $\{{ github.base_ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm install -g @harness-engineering/cli@latest
+      - name: Review the diff (feeds the brief's review section)
+        # continue-on-error: a blocking verdict must NOT fail the brief job. The
+        # brief is informational; gating on the verdict is the ci-required-review
+        # template's job. --out writes the verdict artifact the brief step reuses,
+        # so review runs once. The runner/block-on values are substituted; the GH
+        # expression is preserved verbatim (see escaping note at top of file).
+        continue-on-error: true
+        run: harness review-ci --runner {{runner}} --block-on {{blockOn}} --diff "origin/$\{{ github.base_ref }}...HEAD" --out /tmp/review.json
+      - name: Post the senior pre-merge brief
+        # Compose the brief (diff summary, review verdict, Signal status,
+        # outcome-eval, and a derived "Worth your eyes") and upsert it as a single
+        # sticky PR comment (upsert by hidden marker). Every section degrades
+        # independently, so a missing input renders "unavailable" and never fails
+        # the job. Reuses the review-ci artifact above (no second review run).
+        run: harness pre-merge-brief --from /tmp/review.json --diff "origin/$\{{ github.base_ref }}...HEAD" --comment

--- a/templates/ci-pre-merge-brief/template.json
+++ b/templates/ci-pre-merge-brief/template.json
@@ -1,0 +1,5 @@
+{
+  "name": "ci-pre-merge-brief",
+  "description": "Opt-in GitHub Actions pre-merge brief: renders a workflow that runs `harness pre-merge-brief` to upsert a senior-facing sticky PR comment (diff, review verdict, signals, outcome-eval, \"worth your eyes\"), plus a matching branch-protection ruleset for the eventual acknowledgment gate.",
+  "version": 1
+}


### PR DESCRIPTION
## What

Graduates the senior-facing **pre-merge brief** from a harness-only dogfood step into an **adopter-facing artifact**, mirroring how `ci-required-review` graduated: a standalone, discoverable, opt-in named template directory rendered by the `TemplateEngine`.

New `templates/ci-pre-merge-brief/`:

| File | Purpose |
| --- | --- |
| `pre-merge-brief.yml.hbs` | `pull_request` workflow whose single `pre-merge-brief` job runs `harness review-ci --out` (continue-on-error) then `harness pre-merge-brief --from … --comment`, upserting one sticky senior-facing PR comment. |
| `pre-merge-brief.ruleset.json` | Branch-protection ruleset marking the `pre-merge-brief` check required (admin-applied, deferred) for the eventual acknowledgment gate. |
| `template.json` | Registers the dir as the opt-in named template `ci-pre-merge-brief` (no `level`/`framework`), so `harness init` can render it. |
| `README.md` | Adopter documentation (generic — no internal roadmap/PR/issue numbers). |

## Update: now actually `init`-renderable (wiring fix)

The template was discoverable via `listTemplates()` but **not renderable** by `harness init`. `init --template <name>` passes the name in as `level`, and `resolveTemplate` matched only adoption-level scaffolds (`template.json.level`). Since `ci-pre-merge-brief` (and even the documented `orchestrator` example) declare no `level`, `harness init --template ci-pre-merge-brief` failed with `Template not found for level: ci-pre-merge-brief` — nothing emitted the workflow into an adopter repo. (`level` is a fixed enum of `basic|intermediate|advanced`, so a config-only `level: "<name>"` was not possible.)

Fix (minimal, backward-compatible):

- `resolveTemplate` now falls back to matching by template **`name`** when no `level` matches, rendering that template **standalone** — honoring an explicit `extends` but never dragging in the basic-level scaffold.
- `init` supplies the `runner`/`blockOn`/`baseBranch` defaults (`claude` / `request-changes` / `main`) the workflow needs under strict-mode Handlebars.

Verified end-to-end: `harness init --template ci-pre-merge-brief` now emits `pre-merge-brief.yml`, `pre-merge-brief.ruleset.json`, and `README.md` (plus `init`'s standard `.github/workflows/ci.yml` + roadmap + MCP config) with **no** basic/base scaffold files. The same fix also makes the sibling `ci-required-review` template init-renderable (same three vars, same name fallback). Level-based `init` is unchanged; adds a `@harness-engineering/cli` patch changeset.

## How it mirrors required-review

- Same directory-as-named-template model (`template.json` with `name`, no `level`/`framework`), discovered via `TemplateEngine.listTemplates()` and now resolved via the shared name fallback.
- Same three template variables (`runner`, `blockOn`, `baseBranch`) and the same per-line `$\{{ … }}` Handlebars escaping for GitHub Actions expressions.
- Same job-name ⇄ ruleset-context binding contract (both the literal `pre-merge-brief`), asserted by test.
- Bundled into the published CLI the same way (build copies `templates/` into `dist/templates`, shipped via `files: ["dist"]`).

## Why it is safe in a plain adopter CI

`harness pre-merge-brief` has no daemon / signal-provider / agent-runner dependency. Every section (diff, review verdict, Signal status, outcome-eval, guardian, "worth your eyes") degrades **independently** to an "unavailable" line, and the command always exits 0. The `review-ci` step is `continue-on-error` — gating on the verdict remains `ci-required-review`'s job.

## Known limitation (documented, out of scope)

`review-ci --out` writes the bare verdict object, while `pre-merge-brief`'s `readReview` expects a `{ verdict: … }`-wrapped `CiReviewResult`. When the shapes don't match the review section renders "unavailable" and every other section still populates. Aligning that producer/consumer artifact contract is a separate change to the two commands, deliberately not bundled into this template graduation.

## Tests

`packages/cli/tests/templates/ci-pre-merge-brief.test.ts` asserts discoverability, valid rendered YAML, both harness steps + flags, runtime `github.base_ref` diff range, `contents: read` + `pull-requests: write`, verbatim `${{ … }}` survival, and job-name⇄ruleset-context binding. A new case drives the **real init resolution path** — `engine.resolveTemplate('ci-pre-merge-brief', undefined, 'typescript')` — asserting it resolves to only its own files and renders the `pre-merge-brief.yml` workflow (proving `harness init --template` would emit it). Dynamic assertions (no hardcoded counts).

- cli template + init tests pass (230 across the template + init suites).
- `tsc --noEmit` clean; `eslint src` clean.

Spec: `docs/changes/pre-merge-brief-adopter-template/proposal.md`

Closes #732
