### PR TITLE
feat(skill): per-skill capability declarations + wired validation (#558)

### DIFF
--- a/.changeset/per-skill-capabilities.md
+++ b/.changeset/per-skill-capabilities.md
@@ -1,0 +1,13 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Add per-skill `capabilities:` declarations to skill.yaml (#558).
+
+Skills now declare a capability envelope — `{ tools, network, filesystem }` —
+derived mechanically from the existing `tools:` list. `harness skill validate`
+enforces it: every harness-authored skill must declare `capabilities`, and any
+declared envelope must stay consistent with the skill's `tools:` (drift, e.g.
+adding `WebFetch` without `network: true`, fails validation). All 89
+harness-authored skills are seeded. This ships the declaration + validation
+layer; runtime bounds-enforcement is a follow-up.

--- a/.gemini-extension/commands/architecture-advisor.toml
+++ b/.gemini-extension/commands/architecture-advisor.toml
@@ -545,6 +545,14 @@ state:
   files:
     - docs/architecture/
 depends_on: []
+capabilities:
+  tools:
+    - Read
+    - Glob
+    - Grep
+    - Bash
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/audit-strength.toml
+++ b/.gemini-extension/commands/audit-strength.toml
@@ -262,6 +262,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Grep
+    - Glob
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/audit.toml
+++ b/.gemini-extension/commands/audit.toml
@@ -327,6 +327,14 @@ addresses:
     weight: 0.3
   - signal: dead-code
     weight: 0.3
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/autopilot.toml
+++ b/.gemini-extension/commands/autopilot.toml
@@ -432,6 +432,16 @@ depends_on:
   - harness-execution
   - harness-verification
   - harness-code-review
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/brainstorming.toml
+++ b/.gemini-extension/commands/brainstorming.toml
@@ -538,6 +538,17 @@ depends_on:
   - harness-planning
   - harness-autopilot
   - harness-soundness-review
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/catalog-retrospective.toml
+++ b/.gemini-extension/commands/catalog-retrospective.toml
@@ -192,6 +192,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/code-review.toml
+++ b/.gemini-extension/commands/code-review.toml
@@ -920,6 +920,15 @@ addresses:
     weight: 0.5
   - signal: high-coupling
     weight: 0.4
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/codebase-cleanup.toml
+++ b/.gemini-extension/commands/codebase-cleanup.toml
@@ -332,6 +332,14 @@ addresses:
     weight: 0.8
   - signal: drift
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/compound.toml
+++ b/.gemini-extension/commands/compound.toml
@@ -238,6 +238,16 @@ keywords:
   - playbook
   - bug-track
   - knowledge-track
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/debugging.toml
+++ b/.gemini-extension/commands/debugging.toml
@@ -497,6 +497,16 @@ addresses:
     weight: 0.5
   - signal: anomaly-outlier
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/dependency-health.toml
+++ b/.gemini-extension/commands/dependency-health.toml
@@ -267,6 +267,14 @@ addresses:
     weight: 0.6
   - signal: articulation-point
     weight: 0.5
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/docs-pipeline.toml
+++ b/.gemini-extension/commands/docs-pipeline.toml
@@ -567,6 +567,16 @@ depends_on:
   - align-documentation
   - validate-context-engineering
   - harness-knowledge-mapper
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/execution.toml
+++ b/.gemini-extension/commands/execution.toml
@@ -603,6 +603,17 @@ state:
     - .harness/learnings.md
 depends_on:
   - harness-verification
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/hotspot-detector.toml
+++ b/.gemini-extension/commands/hotspot-detector.toml
@@ -249,6 +249,14 @@ addresses:
     weight: 0.7
   - signal: articulation-point
     weight: 0.8
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/ideate.toml
+++ b/.gemini-extension/commands/ideate.toml
@@ -368,6 +368,16 @@ keywords:
   - impact-confidence-effort
   - strategic-anchor
   - compound-engineering
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/impact-analysis.toml
+++ b/.gemini-extension/commands/impact-analysis.toml
@@ -264,6 +264,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/integration.toml
+++ b/.gemini-extension/commands/integration.toml
@@ -648,6 +648,18 @@ state:
     - .harness/sessions/*/integration-updates.json
 depends_on:
   - harness-verification
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+    - manage_state
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/integrity.toml
+++ b/.gemini-extension/commands/integrity.toml
@@ -255,6 +255,14 @@ addresses:
     weight: 0.7
   - signal: dead-code
     weight: 0.5
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/knowledge-pipeline.toml
+++ b/.gemini-extension/commands/knowledge-pipeline.toml
@@ -372,6 +372,16 @@ state:
     - .harness/knowledge/staged/pipeline-staged.jsonl
     - .harness/knowledge/gaps.md
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/maintenance-pipeline.toml
+++ b/.gemini-extension/commands/maintenance-pipeline.toml
@@ -236,6 +236,12 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/onboarding.toml
+++ b/.gemini-extension/commands/onboarding.toml
@@ -351,6 +351,13 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/perf.toml
+++ b/.gemini-extension/commands/perf.toml
@@ -351,6 +351,16 @@ depends_on:
 addresses:
   - signal: perf-regression
     weight: 0.8
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/planning.toml
+++ b/.gemini-extension/commands/planning.toml
@@ -605,6 +605,16 @@ state:
 depends_on:
   - harness-verification
   - harness-soundness-review
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - emit_interaction
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/pulse.toml
+++ b/.gemini-extension/commands/pulse.toml
@@ -218,6 +218,16 @@ keywords:
   - read-side
   - smart-metrics
   - strategy-seeding
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/refactoring.toml
+++ b/.gemini-extension/commands/refactoring.toml
@@ -274,6 +274,16 @@ addresses:
     metric: couplingRatio
     threshold: 0.5
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/release-readiness.toml
+++ b/.gemini-extension/commands/release-readiness.toml
@@ -799,6 +799,16 @@ depends_on:
   - enforce-architecture
   - harness-diagnostics
   - harness-parallel-agents
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/roadmap-pilot.toml
+++ b/.gemini-extension/commands/roadmap-pilot.toml
@@ -354,6 +354,17 @@ depends_on:
   - harness-brainstorming
   - harness-autopilot
   - harness-roadmap
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/roadmap.toml
+++ b/.gemini-extension/commands/roadmap.toml
@@ -748,6 +748,16 @@ phases:
 state:
   persistent: false
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/rollback.toml
+++ b/.gemini-extension/commands/rollback.toml
@@ -197,6 +197,16 @@ state:
   persistent: false
 depends_on:
   - outcome-eval
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/security-scan.toml
+++ b/.gemini-extension/commands/security-scan.toml
@@ -230,6 +230,14 @@ depends_on: []
 addresses:
   - signal: security-findings
     hard: true
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/skill-authoring.toml
+++ b/.gemini-extension/commands/skill-authoring.toml
@@ -559,6 +559,16 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/soundness-review.toml
+++ b/.gemini-extension/commands/soundness-review.toml
@@ -1227,6 +1227,16 @@ addresses:
     weight: 0.6
   - signal: circular-deps
     weight: 0.5
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/strategy.toml
+++ b/.gemini-extension/commands/strategy.toml
@@ -228,6 +228,16 @@ keywords:
   - upstream-grounding
   - compound-engineering
   - rumelt
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/supply-chain-audit.toml
+++ b/.gemini-extension/commands/supply-chain-audit.toml
@@ -368,6 +368,16 @@ depends_on:
 addresses:
   - signal: security-findings
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Grep
+    - Glob
+    - WebFetch
+  network: true
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/tdd.toml
+++ b/.gemini-extension/commands/tdd.toml
@@ -291,6 +291,16 @@ related_skills:
 addresses:
   - signal: low-coverage
     weight: 0.9
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/test-advisor.toml
+++ b/.gemini-extension/commands/test-advisor.toml
@@ -319,6 +319,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/verification.toml
+++ b/.gemini-extension/commands/verification.toml
@@ -464,6 +464,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - emit_interaction
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/verify.toml
+++ b/.gemini-extension/commands/verify.toml
@@ -233,6 +233,13 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/.gemini-extension/commands/workflow-audit.toml
+++ b/.gemini-extension/commands/workflow-audit.toml
@@ -368,6 +368,14 @@ depends_on: []
 addresses:
   - signal: security-findings
     weight: 0.4
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write
 
 </execution_context>
 

--- a/agents/skills/claude-code/harness-accessibility/skill.yaml
+++ b/agents/skills/claude-code/harness-accessibility/skill.yaml
@@ -73,3 +73,13 @@ stack_signals:
   - frontend
 depends_on:
   - harness-design-system
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-api-design/skill.yaml
+++ b/agents/skills/claude-code/harness-api-design/skill.yaml
@@ -80,3 +80,13 @@ related_skills:
   - graphql-resolver-pattern
   - graphql-pagination-patterns
   - trpc-router-composition
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-architecture-advisor/skill.yaml
+++ b/agents/skills/claude-code/harness-architecture-advisor/skill.yaml
@@ -50,3 +50,11 @@ state:
   files:
     - docs/architecture/
 depends_on: []
+capabilities:
+  tools:
+    - Read
+    - Glob
+    - Grep
+    - Bash
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-audit-harness-strength/skill.yaml
+++ b/agents/skills/claude-code/harness-audit-harness-strength/skill.yaml
@@ -52,3 +52,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Grep
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-audit/skill.yaml
+++ b/agents/skills/claude-code/harness-audit/skill.yaml
@@ -79,3 +79,11 @@ addresses:
     weight: 0.3
   - signal: dead-code
     weight: 0.3
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-auth/skill.yaml
+++ b/agents/skills/claude-code/harness-auth/skill.yaml
@@ -86,3 +86,14 @@ related_skills:
   - owasp-auth-patterns
   - owasp-csrf-protection
   - next-auth-patterns
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-autopilot/skill.yaml
+++ b/agents/skills/claude-code/harness-autopilot/skill.yaml
@@ -68,3 +68,13 @@ depends_on:
   - harness-execution
   - harness-verification
   - harness-code-review
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-brainstorming/skill.yaml
+++ b/agents/skills/claude-code/harness-brainstorming/skill.yaml
@@ -55,3 +55,14 @@ depends_on:
   - harness-planning
   - harness-autopilot
   - harness-soundness-review
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-caching/skill.yaml
+++ b/agents/skills/claude-code/harness-caching/skill.yaml
@@ -77,3 +77,13 @@ depends_on: []
 related_skills:
   - resilience-rate-limiting
   - resilience-fallback-pattern
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-catalog-retrospective/skill.yaml
+++ b/agents/skills/claude-code/harness-catalog-retrospective/skill.yaml
@@ -46,3 +46,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-chaos/skill.yaml
+++ b/agents/skills/claude-code/harness-chaos/skill.yaml
@@ -73,3 +73,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-code-review/skill.yaml
+++ b/agents/skills/claude-code/harness-code-review/skill.yaml
@@ -67,3 +67,12 @@ addresses:
     weight: 0.5
   - signal: high-coupling
     weight: 0.4
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-codebase-cleanup/skill.yaml
+++ b/agents/skills/claude-code/harness-codebase-cleanup/skill.yaml
@@ -71,3 +71,11 @@ addresses:
     weight: 0.8
   - signal: drift
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-compliance/skill.yaml
+++ b/agents/skills/claude-code/harness-compliance/skill.yaml
@@ -79,3 +79,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-compound/skill.yaml
+++ b/agents/skills/claude-code/harness-compound/skill.yaml
@@ -58,3 +58,13 @@ keywords:
   - playbook
   - bug-track
   - knowledge-track
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-containerization/skill.yaml
+++ b/agents/skills/claude-code/harness-containerization/skill.yaml
@@ -86,3 +86,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-data-pipeline/skill.yaml
+++ b/agents/skills/claude-code/harness-data-pipeline/skill.yaml
@@ -82,3 +82,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-data-validation/skill.yaml
+++ b/agents/skills/claude-code/harness-data-validation/skill.yaml
@@ -81,3 +81,13 @@ related_skills:
   - zod-object-patterns
   - zod-error-handling
   - ts-type-guards
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-database/skill.yaml
+++ b/agents/skills/claude-code/harness-database/skill.yaml
@@ -93,3 +93,13 @@ related_skills:
   - prisma-migrations
   - drizzle-schema-definition
   - drizzle-migrations
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-debugging/skill.yaml
+++ b/agents/skills/claude-code/harness-debugging/skill.yaml
@@ -54,3 +54,13 @@ addresses:
     weight: 0.5
   - signal: anomaly-outlier
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-dependency-health/skill.yaml
+++ b/agents/skills/claude-code/harness-dependency-health/skill.yaml
@@ -52,3 +52,11 @@ addresses:
     weight: 0.6
   - signal: articulation-point
     weight: 0.5
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-deployment/skill.yaml
+++ b/agents/skills/claude-code/harness-deployment/skill.yaml
@@ -78,3 +78,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-design-craft/skill.yaml
+++ b/agents/skills/claude-code/harness-design-craft/skill.yaml
@@ -55,3 +55,13 @@ state:
 depends_on:
   - harness-design
   - harness-design-system
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-design-mobile/skill.yaml
+++ b/agents/skills/claude-code/harness-design-mobile/skill.yaml
@@ -71,3 +71,13 @@ stack_signals:
 depends_on:
   - harness-design-system
   - harness-design
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-design-pipeline/skill.yaml
+++ b/agents/skills/claude-code/harness-design-pipeline/skill.yaml
@@ -68,3 +68,13 @@ depends_on:
   - audit-component-anatomy
   - audit-brand-compliance
   - harness-design-craft
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-design-system/skill.yaml
+++ b/agents/skills/claude-code/harness-design-system/skill.yaml
@@ -81,3 +81,13 @@ related_skills:
   - design-naming-conventions
   - design-brand-consistency
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-design-web/skill.yaml
+++ b/agents/skills/claude-code/harness-design-web/skill.yaml
@@ -81,3 +81,13 @@ related_skills:
 depends_on:
   - harness-design-system
   - harness-design
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-design/skill.yaml
+++ b/agents/skills/claude-code/harness-design/skill.yaml
@@ -81,3 +81,13 @@ related_skills:
   - design-design-critique
 depends_on:
   - harness-design-system
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-diagnostics/skill.yaml
+++ b/agents/skills/claude-code/harness-diagnostics/skill.yaml
@@ -71,3 +71,13 @@ stack_signals:
   - typescript
   - rust
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+    - Edit
+    - Write
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-docs-pipeline/skill.yaml
+++ b/agents/skills/claude-code/harness-docs-pipeline/skill.yaml
@@ -71,3 +71,13 @@ depends_on:
   - align-documentation
   - validate-context-engineering
   - harness-knowledge-mapper
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-dx/skill.yaml
+++ b/agents/skills/claude-code/harness-dx/skill.yaml
@@ -77,3 +77,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-e2e/skill.yaml
+++ b/agents/skills/claude-code/harness-e2e/skill.yaml
@@ -91,3 +91,14 @@ related_skills:
   - test-playwright-patterns
   - test-playwright-setup
   - test-msw-pattern
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-event-driven/skill.yaml
+++ b/agents/skills/claude-code/harness-event-driven/skill.yaml
@@ -83,3 +83,13 @@ related_skills:
   - events-pubsub-pattern
   - events-kafka-patterns
   - events-outbox-pattern
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-execution/skill.yaml
+++ b/agents/skills/claude-code/harness-execution/skill.yaml
@@ -65,3 +65,14 @@ state:
     - .harness/learnings.md
 depends_on:
   - harness-verification
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-feature-flags/skill.yaml
+++ b/agents/skills/claude-code/harness-feature-flags/skill.yaml
@@ -75,3 +75,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-git-workflow/skill.yaml
+++ b/agents/skills/claude-code/harness-git-workflow/skill.yaml
@@ -48,3 +48,10 @@ stack_signals:
   - github
   - gitlab
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-hotspot-detector/skill.yaml
+++ b/agents/skills/claude-code/harness-hotspot-detector/skill.yaml
@@ -55,3 +55,11 @@ addresses:
     weight: 0.7
   - signal: articulation-point
     weight: 0.8
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-i18n-process/skill.yaml
+++ b/agents/skills/claude-code/harness-i18n-process/skill.yaml
@@ -60,3 +60,10 @@ stack_signals:
   - backend
   - mobile
 depends_on: []
+capabilities:
+  tools:
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read

--- a/agents/skills/claude-code/harness-i18n-workflow/skill.yaml
+++ b/agents/skills/claude-code/harness-i18n-workflow/skill.yaml
@@ -74,3 +74,13 @@ stack_signals:
   - frontend
 depends_on:
   - harness-i18n
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-i18n/skill.yaml
+++ b/agents/skills/claude-code/harness-i18n/skill.yaml
@@ -78,3 +78,13 @@ stack_signals:
   - backend
   - mobile
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-ideate/skill.yaml
+++ b/agents/skills/claude-code/harness-ideate/skill.yaml
@@ -64,3 +64,13 @@ keywords:
   - impact-confidence-effort
   - strategic-anchor
   - compound-engineering
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-impact-analysis/skill.yaml
+++ b/agents/skills/claude-code/harness-impact-analysis/skill.yaml
@@ -46,3 +46,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-incident-response/skill.yaml
+++ b/agents/skills/claude-code/harness-incident-response/skill.yaml
@@ -79,3 +79,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-infrastructure-as-code/skill.yaml
+++ b/agents/skills/claude-code/harness-infrastructure-as-code/skill.yaml
@@ -88,3 +88,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-integration-test/skill.yaml
+++ b/agents/skills/claude-code/harness-integration-test/skill.yaml
@@ -74,3 +74,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-integration/skill.yaml
+++ b/agents/skills/claude-code/harness-integration/skill.yaml
@@ -63,3 +63,15 @@ state:
     - .harness/sessions/*/integration-updates.json
 depends_on:
   - harness-verification
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+    - manage_state
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-integrity/skill.yaml
+++ b/agents/skills/claude-code/harness-integrity/skill.yaml
@@ -54,3 +54,11 @@ addresses:
     weight: 0.7
   - signal: dead-code
     weight: 0.5
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-knowledge-mapper/skill.yaml
+++ b/agents/skills/claude-code/harness-knowledge-mapper/skill.yaml
@@ -51,3 +51,12 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-knowledge-pipeline/skill.yaml
+++ b/agents/skills/claude-code/harness-knowledge-pipeline/skill.yaml
@@ -58,3 +58,13 @@ state:
     - .harness/knowledge/staged/pipeline-staged.jsonl
     - .harness/knowledge/gaps.md
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-load-testing/skill.yaml
+++ b/agents/skills/claude-code/harness-load-testing/skill.yaml
@@ -80,3 +80,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-maintenance-pipeline/skill.yaml
+++ b/agents/skills/claude-code/harness-maintenance-pipeline/skill.yaml
@@ -41,3 +41,9 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-ml-ops/skill.yaml
+++ b/agents/skills/claude-code/harness-ml-ops/skill.yaml
@@ -83,3 +83,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-mobile-patterns/skill.yaml
+++ b/agents/skills/claude-code/harness-mobile-patterns/skill.yaml
@@ -93,3 +93,14 @@ related_skills:
   - mobile-navigation-pattern
   - mobile-network-patterns
   - mobile-storage-patterns
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-mutation-test/skill.yaml
+++ b/agents/skills/claude-code/harness-mutation-test/skill.yaml
@@ -71,3 +71,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-observability/skill.yaml
+++ b/agents/skills/claude-code/harness-observability/skill.yaml
@@ -84,3 +84,14 @@ related_skills:
   - otel-tracing-pattern
   - otel-metrics-pattern
   - otel-logging-pattern
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-onboarding/skill.yaml
+++ b/agents/skills/claude-code/harness-onboarding/skill.yaml
@@ -32,3 +32,10 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-parallel-agents/skill.yaml
+++ b/agents/skills/claude-code/harness-parallel-agents/skill.yaml
@@ -35,3 +35,13 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-perf-tdd/skill.yaml
+++ b/agents/skills/claude-code/harness-perf-tdd/skill.yaml
@@ -69,3 +69,13 @@ stack_signals:
 depends_on:
   - harness-tdd
   - harness-perf
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-perf/skill.yaml
+++ b/agents/skills/claude-code/harness-perf/skill.yaml
@@ -55,3 +55,13 @@ depends_on:
 addresses:
   - signal: perf-regression
     weight: 0.8
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-planning/skill.yaml
+++ b/agents/skills/claude-code/harness-planning/skill.yaml
@@ -63,3 +63,13 @@ state:
 depends_on:
   - harness-verification
   - harness-soundness-review
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-pre-commit-review/skill.yaml
+++ b/agents/skills/claude-code/harness-pre-commit-review/skill.yaml
@@ -51,3 +51,11 @@ stack_signals:
   - vitest
 depends_on:
   - harness-code-review
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-product-spec/skill.yaml
+++ b/agents/skills/claude-code/harness-product-spec/skill.yaml
@@ -73,3 +73,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-property-test/skill.yaml
+++ b/agents/skills/claude-code/harness-property-test/skill.yaml
@@ -72,3 +72,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-pulse/skill.yaml
+++ b/agents/skills/claude-code/harness-pulse/skill.yaml
@@ -59,3 +59,13 @@ keywords:
   - read-side
   - smart-metrics
   - strategy-seeding
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-refactoring/skill.yaml
+++ b/agents/skills/claude-code/harness-refactoring/skill.yaml
@@ -49,3 +49,13 @@ addresses:
     metric: couplingRatio
     threshold: 0.5
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-release-readiness/skill.yaml
+++ b/agents/skills/claude-code/harness-release-readiness/skill.yaml
@@ -59,3 +59,13 @@ depends_on:
   - enforce-architecture
   - harness-diagnostics
   - harness-parallel-agents
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-repo-hygiene/skill.yaml
+++ b/agents/skills/claude-code/harness-repo-hygiene/skill.yaml
@@ -48,3 +48,10 @@ related_skills:
 metadata:
   author: Bri Stevenski
   upstream: "https://github.com/Intense-Visions/harness-engineering"
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-resilience/skill.yaml
+++ b/agents/skills/claude-code/harness-resilience/skill.yaml
@@ -82,3 +82,14 @@ related_skills:
   - resilience-retry-pattern
   - resilience-bulkhead-pattern
   - resilience-fallback-pattern
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-roadmap-pilot/skill.yaml
+++ b/agents/skills/claude-code/harness-roadmap-pilot/skill.yaml
@@ -53,3 +53,14 @@ depends_on:
   - harness-brainstorming
   - harness-autopilot
   - harness-roadmap
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-roadmap/skill.yaml
+++ b/agents/skills/claude-code/harness-roadmap/skill.yaml
@@ -45,3 +45,13 @@ phases:
 state:
   persistent: false
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-rollback/skill.yaml
+++ b/agents/skills/claude-code/harness-rollback/skill.yaml
@@ -50,3 +50,13 @@ state:
   persistent: false
 depends_on:
   - outcome-eval
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-router/skill.yaml
+++ b/agents/skills/claude-code/harness-router/skill.yaml
@@ -45,3 +45,10 @@ depends_on: []
 addresses:
   - signal: high-complexity
     weight: 0.3
+capabilities:
+  tools:
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read

--- a/agents/skills/claude-code/harness-secrets/skill.yaml
+++ b/agents/skills/claude-code/harness-secrets/skill.yaml
@@ -77,3 +77,12 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-security-review/skill.yaml
+++ b/agents/skills/claude-code/harness-security-review/skill.yaml
@@ -87,3 +87,13 @@ related_skills:
   - security-zero-trust-principles
   - security-audit-log-design
   - security-injection-families
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-security-scan/skill.yaml
+++ b/agents/skills/claude-code/harness-security-scan/skill.yaml
@@ -52,3 +52,11 @@ depends_on: []
 addresses:
   - signal: security-findings
     hard: true
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-skill-authoring/skill.yaml
+++ b/agents/skills/claude-code/harness-skill-authoring/skill.yaml
@@ -34,3 +34,13 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-soundness-review/skill.yaml
+++ b/agents/skills/claude-code/harness-soundness-review/skill.yaml
@@ -55,3 +55,13 @@ addresses:
     weight: 0.6
   - signal: circular-deps
     weight: 0.5
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-sql-review/skill.yaml
+++ b/agents/skills/claude-code/harness-sql-review/skill.yaml
@@ -82,3 +82,14 @@ related_skills:
   - drizzle-performance-patterns
   - prisma-raw-queries
   - drizzle-query-builder
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-state-management/skill.yaml
+++ b/agents/skills/claude-code/harness-state-management/skill.yaml
@@ -39,3 +39,12 @@ related_skills:
   - state-zustand-slices
   - redux-slice-pattern
   - state-context-pattern
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-strategy/skill.yaml
+++ b/agents/skills/claude-code/harness-strategy/skill.yaml
@@ -52,3 +52,13 @@ keywords:
   - upstream-grounding
   - compound-engineering
   - rumelt
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-supply-chain-audit/skill.yaml
+++ b/agents/skills/claude-code/harness-supply-chain-audit/skill.yaml
@@ -55,3 +55,13 @@ depends_on:
 addresses:
   - signal: security-findings
     weight: 0.6
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Grep
+    - Glob
+    - WebFetch
+  network: true
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-tdd/skill.yaml
+++ b/agents/skills/claude-code/harness-tdd/skill.yaml
@@ -58,3 +58,13 @@ related_skills:
 addresses:
   - signal: low-coverage
     weight: 0.9
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-test-advisor/skill.yaml
+++ b/agents/skills/claude-code/harness-test-advisor/skill.yaml
@@ -49,3 +49,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-test-data/skill.yaml
+++ b/agents/skills/claude-code/harness-test-data/skill.yaml
@@ -75,3 +75,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-ux-copy/skill.yaml
+++ b/agents/skills/claude-code/harness-ux-copy/skill.yaml
@@ -90,3 +90,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-verification/skill.yaml
+++ b/agents/skills/claude-code/harness-verification/skill.yaml
@@ -47,3 +47,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-verify/skill.yaml
+++ b/agents/skills/claude-code/harness-verify/skill.yaml
@@ -42,3 +42,10 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-visual-regression/skill.yaml
+++ b/agents/skills/claude-code/harness-visual-regression/skill.yaml
@@ -79,3 +79,14 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+  network: false
+  filesystem: read-write

--- a/agents/skills/claude-code/harness-workflow-audit/skill.yaml
+++ b/agents/skills/claude-code/harness-workflow-audit/skill.yaml
@@ -59,3 +59,11 @@ depends_on: []
 addresses:
   - signal: security-findings
     weight: 0.4
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-audit-harness-strength/skill.yaml
+++ b/agents/skills/codex/harness-audit-harness-strength/skill.yaml
@@ -52,3 +52,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Grep
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-audit/skill.yaml
+++ b/agents/skills/codex/harness-audit/skill.yaml
@@ -79,3 +79,11 @@ addresses:
     weight: 0.3
   - signal: dead-code
     weight: 0.3
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-catalog-retrospective/skill.yaml
+++ b/agents/skills/codex/harness-catalog-retrospective/skill.yaml
@@ -46,3 +46,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-compound/skill.yaml
+++ b/agents/skills/codex/harness-compound/skill.yaml
@@ -58,3 +58,13 @@ keywords:
   - playbook
   - bug-track
   - knowledge-track
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-design-craft/skill.yaml
+++ b/agents/skills/codex/harness-design-craft/skill.yaml
@@ -55,3 +55,13 @@ state:
 depends_on:
   - harness-design
   - harness-design-system
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-design-pipeline/skill.yaml
+++ b/agents/skills/codex/harness-design-pipeline/skill.yaml
@@ -68,3 +68,13 @@ depends_on:
   - audit-component-anatomy
   - audit-brand-compliance
   - harness-design-craft
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-ideate/skill.yaml
+++ b/agents/skills/codex/harness-ideate/skill.yaml
@@ -64,3 +64,13 @@ keywords:
   - impact-confidence-effort
   - strategic-anchor
   - compound-engineering
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-integration/skill.yaml
+++ b/agents/skills/codex/harness-integration/skill.yaml
@@ -63,3 +63,15 @@ state:
     - .harness/sessions/*/integration-updates.json
 depends_on:
   - harness-verification
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+    - manage_state
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-knowledge-pipeline/skill.yaml
+++ b/agents/skills/codex/harness-knowledge-pipeline/skill.yaml
@@ -58,3 +58,13 @@ state:
     - .harness/knowledge/staged/pipeline-staged.jsonl
     - .harness/knowledge/gaps.md
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-pulse/skill.yaml
+++ b/agents/skills/codex/harness-pulse/skill.yaml
@@ -59,3 +59,13 @@ keywords:
   - read-side
   - smart-metrics
   - strategy-seeding
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-repo-hygiene/skill.yaml
+++ b/agents/skills/codex/harness-repo-hygiene/skill.yaml
@@ -48,3 +48,10 @@ related_skills:
 metadata:
   author: Bri Stevenski
   upstream: "https://github.com/Intense-Visions/harness-engineering"
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/codex/harness-router/skill.yaml
+++ b/agents/skills/codex/harness-router/skill.yaml
@@ -45,3 +45,10 @@ depends_on: []
 addresses:
   - signal: high-complexity
     weight: 0.3
+capabilities:
+  tools:
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read

--- a/agents/skills/codex/harness-strategy/skill.yaml
+++ b/agents/skills/codex/harness-strategy/skill.yaml
@@ -52,3 +52,13 @@ keywords:
   - upstream-grounding
   - compound-engineering
   - rumelt
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-audit-harness-strength/skill.yaml
+++ b/agents/skills/cursor/harness-audit-harness-strength/skill.yaml
@@ -52,3 +52,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Grep
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-audit/skill.yaml
+++ b/agents/skills/cursor/harness-audit/skill.yaml
@@ -79,3 +79,11 @@ addresses:
     weight: 0.3
   - signal: dead-code
     weight: 0.3
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-catalog-retrospective/skill.yaml
+++ b/agents/skills/cursor/harness-catalog-retrospective/skill.yaml
@@ -46,3 +46,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-compound/skill.yaml
+++ b/agents/skills/cursor/harness-compound/skill.yaml
@@ -58,3 +58,13 @@ keywords:
   - playbook
   - bug-track
   - knowledge-track
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-design-craft/skill.yaml
+++ b/agents/skills/cursor/harness-design-craft/skill.yaml
@@ -55,3 +55,13 @@ state:
 depends_on:
   - harness-design
   - harness-design-system
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-design-pipeline/skill.yaml
+++ b/agents/skills/cursor/harness-design-pipeline/skill.yaml
@@ -68,3 +68,13 @@ depends_on:
   - audit-component-anatomy
   - audit-brand-compliance
   - harness-design-craft
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-ideate/skill.yaml
+++ b/agents/skills/cursor/harness-ideate/skill.yaml
@@ -64,3 +64,13 @@ keywords:
   - impact-confidence-effort
   - strategic-anchor
   - compound-engineering
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-integration/skill.yaml
+++ b/agents/skills/cursor/harness-integration/skill.yaml
@@ -63,3 +63,15 @@ state:
     - .harness/sessions/*/integration-updates.json
 depends_on:
   - harness-verification
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+    - manage_state
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-knowledge-pipeline/skill.yaml
+++ b/agents/skills/cursor/harness-knowledge-pipeline/skill.yaml
@@ -58,3 +58,13 @@ state:
     - .harness/knowledge/staged/pipeline-staged.jsonl
     - .harness/knowledge/gaps.md
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-pulse/skill.yaml
+++ b/agents/skills/cursor/harness-pulse/skill.yaml
@@ -59,3 +59,13 @@ keywords:
   - read-side
   - smart-metrics
   - strategy-seeding
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-repo-hygiene/skill.yaml
+++ b/agents/skills/cursor/harness-repo-hygiene/skill.yaml
@@ -48,3 +48,10 @@ related_skills:
 metadata:
   author: Bri Stevenski
   upstream: "https://github.com/Intense-Visions/harness-engineering"
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/cursor/harness-router/skill.yaml
+++ b/agents/skills/cursor/harness-router/skill.yaml
@@ -45,3 +45,10 @@ depends_on: []
 addresses:
   - signal: high-complexity
     weight: 0.3
+capabilities:
+  tools:
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read

--- a/agents/skills/cursor/harness-strategy/skill.yaml
+++ b/agents/skills/cursor/harness-strategy/skill.yaml
@@ -52,3 +52,13 @@ keywords:
   - upstream-grounding
   - compound-engineering
   - rumelt
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-audit-harness-strength/skill.yaml
+++ b/agents/skills/gemini-cli/harness-audit-harness-strength/skill.yaml
@@ -52,3 +52,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Grep
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-audit/skill.yaml
+++ b/agents/skills/gemini-cli/harness-audit/skill.yaml
@@ -79,3 +79,11 @@ addresses:
     weight: 0.3
   - signal: dead-code
     weight: 0.3
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-catalog-retrospective/skill.yaml
+++ b/agents/skills/gemini-cli/harness-catalog-retrospective/skill.yaml
@@ -46,3 +46,11 @@ state:
   persistent: false
   files: []
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-compound/skill.yaml
+++ b/agents/skills/gemini-cli/harness-compound/skill.yaml
@@ -58,3 +58,13 @@ keywords:
   - playbook
   - bug-track
   - knowledge-track
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-design-craft/skill.yaml
+++ b/agents/skills/gemini-cli/harness-design-craft/skill.yaml
@@ -55,3 +55,13 @@ state:
 depends_on:
   - harness-design
   - harness-design-system
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-design-pipeline/skill.yaml
+++ b/agents/skills/gemini-cli/harness-design-pipeline/skill.yaml
@@ -68,3 +68,13 @@ depends_on:
   - audit-component-anatomy
   - audit-brand-compliance
   - harness-design-craft
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-ideate/skill.yaml
+++ b/agents/skills/gemini-cli/harness-ideate/skill.yaml
@@ -64,3 +64,13 @@ keywords:
   - impact-confidence-effort
   - strategic-anchor
   - compound-engineering
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-integration/skill.yaml
+++ b/agents/skills/gemini-cli/harness-integration/skill.yaml
@@ -63,3 +63,15 @@ state:
     - .harness/sessions/*/integration-updates.json
 depends_on:
   - harness-verification
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - emit_interaction
+    - manage_state
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-knowledge-pipeline/skill.yaml
+++ b/agents/skills/gemini-cli/harness-knowledge-pipeline/skill.yaml
@@ -58,3 +58,13 @@ state:
     - .harness/knowledge/staged/pipeline-staged.jsonl
     - .harness/knowledge/gaps.md
 depends_on: []
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-pulse/skill.yaml
+++ b/agents/skills/gemini-cli/harness-pulse/skill.yaml
@@ -59,3 +59,13 @@ keywords:
   - read-side
   - smart-metrics
   - strategy-seeding
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-repo-hygiene/skill.yaml
+++ b/agents/skills/gemini-cli/harness-repo-hygiene/skill.yaml
@@ -48,3 +48,10 @@ related_skills:
 metadata:
   author: Bri Stevenski
   upstream: "https://github.com/Intense-Visions/harness-engineering"
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Glob
+  network: false
+  filesystem: read-write

--- a/agents/skills/gemini-cli/harness-router/skill.yaml
+++ b/agents/skills/gemini-cli/harness-router/skill.yaml
@@ -45,3 +45,10 @@ depends_on: []
 addresses:
   - signal: high-complexity
     weight: 0.3
+capabilities:
+  tools:
+    - Read
+    - Glob
+    - Grep
+  network: false
+  filesystem: read

--- a/agents/skills/gemini-cli/harness-strategy/skill.yaml
+++ b/agents/skills/gemini-cli/harness-strategy/skill.yaml
@@ -52,3 +52,13 @@ keywords:
   - upstream-grounding
   - compound-engineering
   - rumelt
+capabilities:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+  network: false
+  filesystem: read-write

--- a/docs/changes/per-skill-capabilities/proposal.md
+++ b/docs/changes/per-skill-capabilities/proposal.md
@@ -1,0 +1,91 @@
+# Per-Skill Capability Declarations
+
+**Roadmap item:** `add-per-skill-capability-declarations`
+**Keywords:** skill.yaml, capabilities, tools, network, filesystem, bounds-enforcement, skill-validation
+
+## Overview
+
+Skills are markdown + YAML. Each `skill.yaml` already declares a `tools:` list
+(e.g. `tools: [Bash, Read, Write, Edit, Glob, Grep]`), but nothing declares the
+capability envelope a skill needs — whether it touches the network, whether it
+writes the filesystem or only reads it. Without that surface, there is no place
+for a future orchestrator/daemon to bound a skill to what it declared.
+
+This change adds a `capabilities:` manifest to `skill.yaml` and a validation
+that enforces it today. It is the **declaration + validation** layer. Runtime
+bounds-enforcement (an orchestrator actually blocking a skill that exceeds its
+envelope) is a deliberate follow-up (see Non-Goals).
+
+### Problem
+
+The article's gear #4 ("bounded, observable, reversible") applies at the
+orchestrator-workspace grain today, and only when the daemon is running. At the
+skill grain there is nothing: a skill's markdown can direct the agent to take
+any action the user permitted Claude Code. The first prerequisite for bounding a
+skill is a machine-readable statement of what it should be allowed to do — and
+that statement must be validated, or it rots into a comment.
+
+## Design
+
+### Schema
+
+`SkillCapabilitiesSchema` (in `packages/cli/src/skill/schema.ts`):
+
+```yaml
+capabilities:
+  tools: [Bash, Read, Write, Edit, Glob, Grep] # mirrors the skill's tools:
+  network: false # WebFetch/WebSearch present?
+  filesystem: read-write # none | read | read-write
+```
+
+The field is **optional** in the schema (backward compatible; third-party and
+knowledge skills without it still parse), and added as
+`capabilities: SkillCapabilitiesSchema.optional()` on `SkillMetadataSchema`.
+
+### Derivation from `tools:`
+
+`deriveCapabilities(tools)` maps the existing `tools:` list to an envelope
+mechanically, so the 89 harness-authored skills are seeded rather than
+hand-authored:
+
+- `filesystem = 'read-write'` if any mutating tool (`Write`, `Edit`,
+  `MultiEdit`, `NotebookEdit`, `Bash`) is present — a shell can create and
+  delete files, so `Bash` counts as read-write. Else `'read'` if any read-only
+  tool (`Read`, `Glob`, `Grep`) is present. Else `'none'`.
+- `network = true` if any network tool (`WebFetch`, `WebSearch`) is present.
+- `tools` mirrors the declared list verbatim, so the envelope is self-contained
+  for a future enforcer that never re-reads the skill body.
+
+### The wired check (teeth)
+
+`harness skill validate` (and the vitest suite that runs it in CI) enforces two
+rules via `validateSkillEntry`:
+
+1. **Presence** — every harness-authored skill (reserved `harness-` name
+   prefix) MUST declare `capabilities`. A missing declaration fails validation.
+2. **Consistency** — any skill that declares `capabilities` must keep it
+   consistent with its `tools:` list. `capabilityDriftErrors(tools, declared)`
+   flags a tool-set mismatch, a wrong `network`, or a wrong `filesystem`. So
+   adding `WebFetch` to `tools` without setting `network: true`, or listing a
+   tool the envelope omits, fails.
+
+This is what makes the primitive non-dormant: it runs today, in
+`harness skill validate` and in CI, and fails on a missing or drifted
+declaration.
+
+### Seeding
+
+All 89 `agents/skills/claude-code/harness-*/skill.yaml` files are seeded with
+their derived envelope. The four platform trees (`claude-code`, `gemini-cli`,
+`codex`, `cursor`) are hardlinks of the same inode, so seeding once populates
+all four. The `gemini-cli` command tomls embed the full `skill.yaml`, so their
+plugin artifacts are regenerated (content-only; no file-set change).
+
+## Non-Goals (follow-up)
+
+- **Runtime bounds-enforcement.** This change does not make the
+  orchestrator/daemon block a skill from exceeding its declared capabilities.
+  That requires orchestrator work and is the next item on this thread.
+- **Per-tool network/filesystem scoping** (allowed hosts, path allowlists).
+  The envelope is coarse (`boolean` / three-level enum) by design; finer grain
+  can extend the schema later without breaking existing declarations.

--- a/docs/roadmap.d/add-per-skill-capability-declarations.md
+++ b/docs/roadmap.d/add-per-skill-capability-declarations.md
@@ -7,7 +7,7 @@ order: 2
 ### Add per-skill capability declarations
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** [docs/changes/per-skill-capabilities/proposal.md](../changes/per-skill-capabilities/proposal.md)
 - **Summary:** Skills are markdown files; the agent reads them and may take any action the user permitted Claude Code. No skill manifest declares "this skill needs Bash + Edit + WebFetch and nothing else." Add a `capabilities:` manifest field to skill.yaml declaring tool/network/file requirements. The orchestrator/agent enforces it as bounds. Closes the article's gear #4 ("bounded, observable, reversible") at the skill grain — currently it only applies at the orchestrator-workspace grain, and only when the daemon is running. Source: Pass 6 #5.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -539,7 +539,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Add per-skill capability declarations
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** [docs/changes/per-skill-capabilities/proposal.md](../changes/per-skill-capabilities/proposal.md)
 - **Summary:** Skills are markdown files; the agent reads them and may take any action the user permitted Claude Code. No skill manifest declares "this skill needs Bash + Edit + WebFetch and nothing else." Add a `capabilities:` manifest field to skill.yaml declaring tool/network/file requirements. The orchestrator/agent enforces it as bounds. Closes the article's gear #4 ("bounded, observable, reversible") at the skill grain — currently it only applies at the orchestrator-workspace grain, and only when the daemon is running. Source: Pass 6 #5.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/skill/validate.ts
+++ b/packages/cli/src/commands/skill/validate.ts
@@ -2,7 +2,11 @@ import { Command } from 'commander';
 import * as fs from 'fs';
 import * as path from 'path';
 import { parse } from 'yaml';
-import { SkillMetadataSchema } from '../../skill/schema';
+import {
+  SkillMetadataSchema,
+  capabilityDriftErrors,
+  type SkillCapabilities,
+} from '../../skill/schema';
 import { logger } from '../../output/logger';
 import { ExitCode } from '../../utils/errors';
 import { resolveProjectSkillsDir, resolveSkillsDir } from '../../utils/paths';
@@ -58,6 +62,46 @@ function validateSkillMd(
   }
 }
 
+/**
+ * Harness-authored skills are the ones the harness itself ships and is
+ * accountable for. They carry the reserved `harness-` name prefix, so the
+ * capabilities envelope is mandatory for them; third-party/community skills may
+ * still declare it (and are checked for consistency when they do) but are not
+ * required to.
+ */
+export function isHarnessAuthoredSkill(name: string): boolean {
+  return name.startsWith('harness-');
+}
+
+/**
+ * Enforce the per-skill capability declaration (#558):
+ *
+ * - Every harness-authored skill MUST declare `capabilities`.
+ * - Any skill that declares `capabilities` must keep it consistent with its
+ *   `tools:` list (derived network/filesystem/tool-set).
+ *
+ * This is the wired half of the declaration layer: it runs in `harness skill
+ * validate` and in CI, and fails on a missing or drifted declaration. Runtime
+ * bounds-enforcement (blocking a skill that exceeds its envelope) is deferred.
+ */
+function validateCapabilities(
+  name: string,
+  meta: { tools?: string[] | undefined; capabilities?: SkillCapabilities | undefined },
+  errors: string[]
+): void {
+  if (!meta.capabilities) {
+    if (isHarnessAuthoredSkill(name)) {
+      errors.push(
+        `${name}/skill.yaml: harness-authored skill must declare capabilities (derive from tools; run \`harness skill validate\` for the expected values)`
+      );
+    }
+    return;
+  }
+  for (const drift of capabilityDriftErrors(meta.tools ?? [], meta.capabilities)) {
+    errors.push(`${name}/skill.yaml: ${drift}`);
+  }
+}
+
 export function validateSkillEntry(name: string, skillsDir: string, errors: string[]): boolean {
   const skillDir = path.join(skillsDir, name);
   const yamlPath = path.join(skillDir, 'skill.yaml');
@@ -75,6 +119,7 @@ export function validateSkillEntry(name: string, skillsDir: string, errors: stri
       return false;
     }
     validateSkillMd(name, path.join(skillDir, 'SKILL.md'), result.data.type, errors);
+    validateCapabilities(name, result.data, errors);
     return true;
   } catch (e) {
     errors.push(`${name}: parse error — ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/cli/src/skill/schema.ts
+++ b/packages/cli/src/skill/schema.ts
@@ -68,6 +68,88 @@ export const SkillContextBudgetSchema = z.object({
   priority: z.number().int().min(1).max(5).default(3),
 });
 
+/** Filesystem-access levels a skill may declare, from least to most authority. */
+export const FILESYSTEM_LEVELS = ['none', 'read', 'read-write'] as const;
+export type FilesystemLevel = (typeof FILESYSTEM_LEVELS)[number];
+
+// Tool → capability classification. Kept here (not in the check) so both the
+// derivation used to seed skill.yaml and the consistency check that guards it
+// read from a single source of truth.
+const FS_WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Bash']);
+const FS_READ_TOOLS = new Set(['Read', 'Glob', 'Grep']);
+const NETWORK_TOOLS = new Set(['WebFetch', 'WebSearch']);
+
+/**
+ * A skill's declared capability envelope — the tool/network/filesystem surface
+ * it is allowed to touch. Declaration + validation layer only; runtime
+ * bounds-enforcement (an orchestrator actually blocking a skill that exceeds
+ * this) is a follow-up. `tools` mirrors the skill's `tools:` list so the
+ * envelope is self-contained for a future enforcer that never re-reads the
+ * skill body.
+ */
+export const SkillCapabilitiesSchema = z.object({
+  tools: z.array(z.string()).default([]),
+  network: z.boolean(),
+  filesystem: z.enum(FILESYSTEM_LEVELS),
+});
+export type SkillCapabilities = z.infer<typeof SkillCapabilitiesSchema>;
+
+/**
+ * Mechanically derive the capability envelope from a skill's `tools:` list.
+ *
+ * - `filesystem` is `read-write` when any mutating tool (Write/Edit/Bash/…) is
+ *   present, `read` when only read-only tools (Read/Glob/Grep) are, else `none`.
+ *   Bash counts as read-write: a shell can create and delete files.
+ * - `network` is true when a network tool (WebFetch/WebSearch) is present.
+ * - `tools` is the declared list verbatim.
+ *
+ * This is the seed used to populate `capabilities:` and the reference the
+ * consistency check compares against, so the two never drift.
+ */
+export function deriveCapabilities(tools: readonly string[]): SkillCapabilities {
+  const filesystem: FilesystemLevel = tools.some((t) => FS_WRITE_TOOLS.has(t))
+    ? 'read-write'
+    : tools.some((t) => FS_READ_TOOLS.has(t))
+      ? 'read'
+      : 'none';
+  return {
+    tools: [...tools],
+    network: tools.some((t) => NETWORK_TOOLS.has(t)),
+    filesystem,
+  };
+}
+
+/**
+ * Compare a declared capability envelope against what its `tools:` list implies
+ * and return one message per inconsistency (empty when consistent). This is the
+ * teeth: a skill that adds `WebFetch` to `tools` but not `network: true`, or
+ * lists tools its capabilities omit, fails validation.
+ */
+export function capabilityDriftErrors(
+  tools: readonly string[],
+  declared: SkillCapabilities
+): string[] {
+  const derived = deriveCapabilities(tools);
+  const errors: string[] = [];
+
+  const declaredTools = new Set(declared.tools);
+  const skillTools = new Set(tools);
+  const mismatched =
+    declaredTools.size !== skillTools.size || [...skillTools].some((t) => !declaredTools.has(t));
+  if (mismatched) {
+    errors.push(
+      `capabilities.tools [${[...declaredTools].sort().join(', ')}] must match the skill's tools [${[...skillTools].sort().join(', ')}]`
+    );
+  }
+  if (declared.network !== derived.network) {
+    errors.push(`capabilities.network must be ${derived.network} (derived from tools)`);
+  }
+  if (declared.filesystem !== derived.filesystem) {
+    errors.push(`capabilities.filesystem must be "${derived.filesystem}" (derived from tools)`);
+  }
+  return errors;
+}
+
 export const SkillAddressSchema = z.object({
   signal: z.string(),
   hard: z.boolean().optional(),
@@ -121,6 +203,7 @@ export const SkillMetadataSchema = z
       .optional(),
     addresses: z.array(SkillAddressSchema).default([]),
     context_budget: SkillContextBudgetSchema.optional(),
+    capabilities: SkillCapabilitiesSchema.optional(),
   })
   .superRefine((data, ctx) => {
     if (data.type === 'knowledge') {

--- a/packages/cli/tests/commands/skill-validate.test.ts
+++ b/packages/cli/tests/commands/skill-validate.test.ts
@@ -210,6 +210,85 @@ escalate here
     });
   });
 
+  describe('capabilities enforcement (#558)', () => {
+    const behavioralMd = `# Skill
+## When to Use
+x
+## Process
+x
+## Harness Integration
+x
+## Success Criteria
+x
+## Examples
+x
+## Rationalizations to Reject
+x
+## Gates
+x
+## Escalation
+x
+`;
+
+    const harnessYaml = (extra: string) => `name: harness-thing
+version: "1.0.0"
+description: A harness skill
+triggers: [manual]
+platforms: [claude-code]
+tools: [Bash, Read, Write]
+type: rigid
+${extra}`;
+
+    it('requires harness-authored skills to declare capabilities', () => {
+      writeSkill('harness-thing', harnessYaml(''), behavioralMd);
+      const errors: string[] = [];
+      validateSkillEntry('harness-thing', tempDir, errors);
+      expect(errors.some((e) => e.includes('must declare capabilities'))).toBe(true);
+    });
+
+    it('does not require non-harness skills to declare capabilities', () => {
+      writeSkill(
+        'third-party-thing',
+        harnessYaml('').replace('harness-thing', 'third-party-thing'),
+        behavioralMd
+      );
+      const errors: string[] = [];
+      validateSkillEntry('third-party-thing', tempDir, errors);
+      expect(errors.some((e) => e.includes('capabilities'))).toBe(false);
+    });
+
+    it('passes when a harness skill declares a consistent envelope', () => {
+      writeSkill(
+        'harness-thing',
+        harnessYaml(`capabilities:
+  tools: [Bash, Read, Write]
+  network: false
+  filesystem: read-write
+`),
+        behavioralMd
+      );
+      const errors: string[] = [];
+      validateSkillEntry('harness-thing', tempDir, errors);
+      expect(errors.some((e) => e.includes('capabilities'))).toBe(false);
+    });
+
+    it('flags a drifted capabilities envelope', () => {
+      writeSkill(
+        'harness-thing',
+        harnessYaml(`capabilities:
+  tools: [Bash, Read, Write]
+  network: true
+  filesystem: read
+`),
+        behavioralMd
+      );
+      const errors: string[] = [];
+      validateSkillEntry('harness-thing', tempDir, errors);
+      expect(errors.some((e) => e.includes('capabilities.network'))).toBe(true);
+      expect(errors.some((e) => e.includes('capabilities.filesystem'))).toBe(true);
+    });
+  });
+
   describe('createValidateCommand', () => {
     it('creates command with correct name', () => {
       const cmd = createValidateCommand();

--- a/packages/cli/tests/skill/capabilities.test.ts
+++ b/packages/cli/tests/skill/capabilities.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SkillMetadataSchema,
+  SkillCapabilitiesSchema,
+  FILESYSTEM_LEVELS,
+  deriveCapabilities,
+  capabilityDriftErrors,
+} from '../../src/skill/schema';
+
+describe('deriveCapabilities', () => {
+  it('marks filesystem read-write when a mutating tool is present', () => {
+    expect(deriveCapabilities(['Read', 'Write']).filesystem).toBe('read-write');
+    expect(deriveCapabilities(['Edit']).filesystem).toBe('read-write');
+    // Bash counts as read-write: a shell can create and delete files.
+    expect(deriveCapabilities(['Bash', 'Read']).filesystem).toBe('read-write');
+  });
+
+  it('marks filesystem read when only read-only tools are present', () => {
+    expect(deriveCapabilities(['Read', 'Glob', 'Grep']).filesystem).toBe('read');
+  });
+
+  it('marks filesystem none when no filesystem tools are present', () => {
+    expect(deriveCapabilities([]).filesystem).toBe('none');
+    expect(deriveCapabilities(['WebFetch']).filesystem).toBe('none');
+  });
+
+  it('sets network true only when a network tool is present', () => {
+    expect(deriveCapabilities(['WebFetch']).network).toBe(true);
+    expect(deriveCapabilities(['WebSearch', 'Read']).network).toBe(true);
+    expect(deriveCapabilities(['Bash', 'Read', 'Write']).network).toBe(false);
+  });
+
+  it('mirrors the tools list verbatim', () => {
+    const tools = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'];
+    expect(deriveCapabilities(tools).tools).toEqual(tools);
+  });
+
+  const toolCombos: string[][] = [[], ['Read'], ['Bash'], ['WebFetch'], ['Read', 'Edit']];
+  it.each(toolCombos)('always produces a valid filesystem level for %j', (...tools) => {
+    expect(FILESYSTEM_LEVELS).toContain(deriveCapabilities(tools).filesystem);
+  });
+});
+
+describe('capabilityDriftErrors', () => {
+  it('returns no errors when the declaration matches the derived envelope', () => {
+    const tools = ['Bash', 'Read', 'Write'];
+    expect(capabilityDriftErrors(tools, deriveCapabilities(tools))).toEqual([]);
+  });
+
+  it('flags a tool-set mismatch', () => {
+    const errors = capabilityDriftErrors(['Bash', 'Read'], {
+      tools: ['Bash'],
+      network: false,
+      filesystem: 'read-write',
+    });
+    expect(errors.some((e) => e.includes('capabilities.tools'))).toBe(true);
+  });
+
+  it('flags a network mismatch', () => {
+    const errors = capabilityDriftErrors(['Read'], {
+      tools: ['Read'],
+      network: true,
+      filesystem: 'read',
+    });
+    expect(errors.some((e) => e.includes('capabilities.network'))).toBe(true);
+  });
+
+  it('flags a filesystem mismatch', () => {
+    const errors = capabilityDriftErrors(['Read', 'Write'], {
+      tools: ['Read', 'Write'],
+      network: false,
+      filesystem: 'read',
+    });
+    expect(errors.some((e) => e.includes('capabilities.filesystem'))).toBe(true);
+  });
+});
+
+describe('SkillCapabilitiesSchema', () => {
+  it('rejects an invalid filesystem level', () => {
+    expect(() =>
+      SkillCapabilitiesSchema.parse({ tools: [], network: false, filesystem: 'write-only' })
+    ).toThrow();
+  });
+
+  it('requires network and filesystem', () => {
+    expect(() => SkillCapabilitiesSchema.parse({ tools: ['Read'] })).toThrow();
+  });
+});
+
+describe('SkillMetadataSchema — capabilities field', () => {
+  const validBase = {
+    name: 'test-skill',
+    version: '1.0.0',
+    description: 'A test skill',
+    triggers: ['manual'],
+    platforms: ['claude-code'],
+    tools: ['Read', 'Write'],
+    type: 'rigid' as const,
+  };
+
+  it('accepts a skill with a capabilities envelope', () => {
+    const result = SkillMetadataSchema.parse({
+      ...validBase,
+      capabilities: { tools: ['Read', 'Write'], network: false, filesystem: 'read-write' },
+    });
+    expect(result.capabilities?.filesystem).toBe('read-write');
+  });
+
+  it('leaves capabilities optional for backward compatibility', () => {
+    const result = SkillMetadataSchema.parse(validBase);
+    expect(result.capabilities).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/skill/harness-capabilities-seed.test.ts
+++ b/packages/cli/tests/skill/harness-capabilities-seed.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse } from 'yaml';
+import {
+  SkillMetadataSchema,
+  capabilityDriftErrors,
+  deriveCapabilities,
+} from '../../src/skill/schema';
+import { isHarnessAuthoredSkill } from '../../src/commands/skill/validate';
+
+/**
+ * Wired enforcement for #558: the harness's own skills must ship a consistent
+ * `capabilities:` envelope. This runs against the real `agents/skills/claude-code`
+ * tree in CI, so a harness skill that adds a tool without updating capabilities
+ * (or drops the declaration entirely) fails here.
+ */
+function findSkillsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(dir, 'agents', 'skills', 'claude-code');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate agents/skills/claude-code from test');
+}
+
+const skillsDir = findSkillsDir();
+const harnessSkills = fs
+  .readdirSync(skillsDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && isHarnessAuthoredSkill(d.name))
+  .map((d) => d.name)
+  .sort();
+
+describe('harness-authored skill capabilities (#558)', () => {
+  it('finds harness-authored skills to check', () => {
+    // Dynamic count — never hardcode. Guards against a resolution regression
+    // silently checking nothing.
+    expect(harnessSkills.length).toBeGreaterThan(0);
+  });
+
+  it.each(harnessSkills)('%s declares a capabilities envelope', (name) => {
+    const raw = fs.readFileSync(path.join(skillsDir, name, 'skill.yaml'), 'utf-8');
+    const parsed = SkillMetadataSchema.safeParse(parse(raw));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.capabilities).toBeDefined();
+  });
+
+  it.each(harnessSkills)('%s capabilities are consistent with its tools', (name) => {
+    const raw = fs.readFileSync(path.join(skillsDir, name, 'skill.yaml'), 'utf-8');
+    const parsed = SkillMetadataSchema.safeParse(parse(raw));
+    expect(parsed.success).toBe(true);
+    if (!parsed.success || !parsed.data.capabilities) return;
+    const drift = capabilityDriftErrors(parsed.data.tools ?? [], parsed.data.capabilities);
+    expect(drift, `${name}: ${drift.join('; ')}`).toEqual([]);
+    // The declared envelope equals what derivation would produce from tools.
+    expect(parsed.data.capabilities).toEqual(deriveCapabilities(parsed.data.tools ?? []));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `capabilities:` manifest to `skill.yaml` declaring the tool/network/filesystem envelope each skill needs, and enforces it in `harness skill validate`. This ships the **declaration + validation** layer only — runtime bounds-enforcement (an orchestrator actually blocking a skill that exceeds its envelope) is a deliberate follow-up.

The field is genuinely WIRED, not a dormant primitive: a validation runs today (in `harness skill validate` and in CI via vitest) that fails on a missing or inconsistent declaration.

## Changes

- **Schema** (`packages/cli/src/skill/schema.ts`): new `SkillCapabilitiesSchema { tools: string[]; network: boolean; filesystem: 'none' | 'read' | 'read-write' }`, added as an optional `capabilities` field on `SkillMetadataSchema` (backward compatible — existing skills and third-party skills without it still parse).
- **Derivation**: `deriveCapabilities(tools)` maps the existing `tools:` list to an envelope mechanically — `Write`/`Edit`/`Bash` → `filesystem: read-write`, `Read`/`Glob`/`Grep` → `read`, `WebFetch`/`WebSearch` → `network: true`. This is how the 89 harness skills are seeded rather than hand-authored.
- **Wired check (the teeth)** (`validateSkillEntry`): (1) every harness-authored skill — reserved `harness-` name prefix — MUST declare `capabilities`, and (2) any declared envelope must stay consistent with its `tools:` list. `capabilityDriftErrors()` flags a tool-set mismatch, wrong `network`, or wrong `filesystem`. Adding `WebFetch` to `tools` without `network: true`, or a missing declaration, fails validation. Verified by deliberately breaking a declaration.
- **Seed**: all 89 `agents/skills/claude-code/harness-*/skill.yaml` seeded with their derived envelope; the four platform mirrors kept in parity; the gemini command tomls (which embed `skill.yaml`) regenerated.
- Spec: `docs/changes/per-skill-capabilities/proposal.md`; roadmap shard linked.

## Testing

- [x] `pnpm build` passes
- [x] `pnpm test` passes (new `capabilities.test.ts` + `harness-capabilities-seed.test.ts`, extended `skill-validate.test.ts`; platform-parity green; full skills package 27716 tests pass)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `harness skill validate` reports zero capability errors across the real tree; fails as designed on injected drift/missing declarations
- [x] `generate:plugin:check` green (no plugin-artifact drift)

## Follow-up (out of scope)

Runtime bounds-enforcement — the orchestrator/daemon actually blocking a skill from exceeding its declared capabilities — requires orchestrator work and is the next item on this thread. This PR establishes the declared, validated surface it will read.

Closes #558