### PR TITLE
docs(readme): lead with the article's binary holiday question

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![pnpm](https://img.shields.io/badge/maintained%20with-pnpm-cc00ff.svg)](https://pnpm.io/)
 
-**Mechanical constraints for AI agents. Ship faster without the chaos.**
+**If your senior engineer goes on holiday for two weeks and your agents keep shipping — do you trust what comes out the other side?**
+
+Harness Engineering is the gear list that makes the answer _yes_. The framing is Ajey Gore's, from ["The Solo Climb"](https://ajeygore.in/content/the-solo-climb): shipping with agents unsupervised isn't a prompt problem, it's an equipment problem. The article names the gear you need before that holiday is safe. Here is each piece — and what harness ships for it.
+
+## The Gears
+
+1. **Specs you operate from** — the input the agent works from, the source the eval checks against, and the artifact the team reviews when something breaks. harness both authors and polices them: `brainstorming` and `spec-craft` produce specs and ADRs, and `acceptance-eval` refuses a spec that lacks measurable, testable acceptance criteria.
+
+2. **A test suite the team trusts enough to ship on** — green means ship, red means don't. harness doesn't write your tests, but it makes them load-bearing: `test-advisor` selects the tests a change actually needs and audits coverage gaps, and the `verify` gate runs test/lint/typecheck as a single hard pass/fail.
+
+3. **An eval suite for "did it solve the right problem"** — the layer above the unit tests that catches the change which passes every test and still does the wrong thing. harness ships `outcome-eval`, a blocking post-execution gate that judges the diff against the spec's acceptance criteria before the change is allowed to ship.
+
+4. **A sandboxed environment the agent can operate in** — bounded, observable, reversible, so a mistake's blast radius never reaches the user. harness covers this partly: isolated git worktrees bound the work, session search and `insights` make it observable, and the `rollback` skill proposes a full-context revert when a shipped change fails. It orchestrates your environment rather than providing the sandbox itself.
+
+5. **Gates that actually gate** — the build either goes to production or it doesn't; no soft gates that warn and wave you through. This is the core of harness: architectural boundaries enforced by ESLint, CI checks that fail the build, a `block-no-verify` hook that refuses `--no-verify`, and phase gates that won't advance on a failed checkpoint.
+
+6. **Agent-of-agent review** — one agent writes, another reviews, a third runs the tests. harness ships a multi-phase `code-review` pipeline that fans work out to parallel persona reviewers (architecture, security, TypeScript-strict, frontend-races, adversarial) and supports peer review between agents.
 
 ## Why This Exists
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **If your senior engineer goes on holiday for two weeks and your agents keep shipping — do you trust what comes out the other side?**
 
-Harness Engineering is the gear list that makes the answer _yes_. The framing is Ajey Gore's, from ["The Solo Climb"](https://ajeygore.in/content/the-solo-climb): shipping with agents unsupervised isn't a prompt problem, it's an equipment problem. The article names the gear you need before that holiday is safe. Here is each piece — and what harness ships for it.
+Harness Engineering is the gear list that makes the answer _yes_. The framing draws on a growing body of work on harness engineering — Ajey Gore's ["The Solo Climb"](https://ajeygore.in/content/the-solo-climb) and ["The Anatomy of an AI-Native Org"](https://ajeygore.in/content/the-anatomy-of-an-ai-native-org), OpenAI's ["Harness engineering"](https://openai.com/index/harness-engineering/), and Martin Fowler's ["Harness engineering for coding agents"](https://martinfowler.com/articles/harness-engineering.html) — distilled to one question: shipping with agents unsupervised isn't a prompt problem, it's an equipment problem. The holiday test is Gore's; _The Solo Climb_ names the gear you need before that holiday is safe. Here is each piece — and what harness ships for it.
 
 ## The Gears
 

--- a/docs/roadmap.d/invert-readme-lede-to-lead-with-the-article-s-binary-question.md
+++ b/docs/roadmap.d/invert-readme-lede-to-lead-with-the-article-s-binary-question.md
@@ -7,7 +7,7 @@ order: 0
 ### Invert README lede to lead with the article's binary question
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** Direct docs change — see [README.md](../../README.md) lede + "The Gears" section.
 - **Summary:** `README.md:7-19` opens with feature copy: "Mechanical constraints for AI agents. Ship faster without the chaos." Compare against what an article-aligned adopter weighs hardest. Rewrite the top 20% to lead with: "If your senior engineer goes on holiday for two weeks and your agents keep shipping — do you trust what comes out the other side? This tool is the gear list that makes the answer yes." Then walk through the 7 pieces and what the tool ships for each. Today the README sells features; article-readers buy outcomes. Source: Pass 2 #8, Pass 3 #9.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -585,7 +585,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Invert README lede to lead with the article's binary question
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** Direct docs change — see [README.md](../../README.md) lede + "The Gears" section.
 - **Summary:** `README.md:7-19` opens with feature copy: "Mechanical constraints for AI agents. Ship faster without the chaos." Compare against what an article-aligned adopter weighs hardest. Rewrite the top 20% to lead with: "If your senior engineer goes on holiday for two weeks and your agents keep shipping — do you trust what comes out the other side? This tool is the gear list that makes the answer yes." Then walk through the 7 pieces and what the tool ships for each. Today the README sells features; article-readers buy outcomes. Source: Pass 2 #8, Pass 3 #9.
 - **Blockers:** —
 - **Plan:** —


### PR DESCRIPTION
## What

Inverts the top of `README.md` so it leads with the binary framing instead of feature copy, and credits the sources of "harness engineering" collectively rather than attributing the concept to a single article.

**Before:** opened with the tagline _"Mechanical constraints for AI agents. Ship faster without the chaos."_ followed straight into feature sections.

**After:** opens with the holiday test —

> **If your senior engineer goes on holiday for two weeks and your agents keep shipping — do you trust what comes out the other side?**

— positions harness as "the gear list that makes the answer yes," then walks the gears the article names, each mapped to what harness actually ships.

## Why

Article-aligned adopters buy outcomes, not features. Leading with the trust question frames every downstream feature as an answer to it. Harness engineering is an amalgamation of a growing body of work, not one person's idea — so the lede now credits that body of work collectively instead of over-crediting a single article.

## Sources

The lede now attributes the framing to a shared body of work on harness engineering, with the holiday-test phrasing still credited specifically to Gore:

- Ajey Gore, ["The Solo Climb"](https://ajeygore.in/content/the-solo-climb) — the holiday test and the gear list.
- Ajey Gore, ["The Anatomy of an AI-Native Org"](https://ajeygore.in/content/the-anatomy-of-an-ai-native-org) — the org-shape framing.
- OpenAI, ["Harness engineering: leveraging Codex in an agent-first world"](https://openai.com/index/harness-engineering/) — the Constraints / Observability / Feedback-Loops pillars.
- Martin Fowler / Birgitta Böckeler, ["Harness engineering for coding agents"](https://martinfowler.com/articles/harness-engineering.html) — the term's canonical treatment.

## Notes

- The article names **six** gears (specs, a trusted test suite, an eval suite, a sandboxed env, gates that actually gate, agent-of-agent review). The roadmap summary said "7 pieces" — that was an error; this PR walks the six the article actually lists.
- Gear 4 (sandboxed environment) is described as **partial** — harness orchestrates isolation/observability/reversibility rather than providing the sandbox itself. Every other claim maps to a shipped skill/hook.
- Docs-only: no changeset. Everything below the lede is unchanged.
- Roadmap `Spec:` field updated in place.

Closes #553
