### PR TITLE
feat(skills): promote injection + ARIA domain skills to load-bearing checks

### DIFF
--- a/.changeset/domain-skills-load-bearing.md
+++ b/.changeset/domain-skills-load-bearing.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/cli': patch
+---
+
+Promote two domain skills from advisory prose to load-bearing mechanical checks. `owasp-injection-prevention` gains `SEC-INJ-004`, which flags Prisma `$queryRawUnsafe`/`$executeRawUnsafe` called with interpolated or concatenated input (enforced by `harness-security-scan`). `a11y-aria-patterns` gains a new `AriaScanner` (`A11Y-014` aria-hidden on a focusable element, `A11Y-042` positive tabindex), invoked by `harness-accessibility`. Both checks fire only on statically-decidable values to keep false positives near zero. The CSRF, rate-limiting, and idempotency-key skills remain advisory — a low-false-positive mechanical check is not achievable for them without framework-aware data-flow analysis.

--- a/.claude-plugin/agents/harness-codebase-health-analyst.md
+++ b/.claude-plugin/agents/harness-codebase-health-analyst.md
@@ -1193,7 +1193,7 @@ Phase 4: ENFORCE
 ## Harness Integration
 
 - **`harness check-security`** — CLI command that invokes this skill's scanner.
-- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine.
+- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine. Its injection rule set (`SEC-INJ-*`) is the load-bearing enforcement of the `owasp-injection-prevention` domain skill's concrete anti-patterns — `eval`/`Function`, SQL string concatenation, command injection, and Prisma `$queryRawUnsafe`/`$executeRawUnsafe` called with interpolated input. Deep injection classes that need data-flow (NoSQL operator injection, second-order injection) are intentionally out of scope for this mechanical scan and belong to `/harness:security-review`.
 - **`harness.config.json`** — Security section configures severity threshold and file exclusions.
 - **codebase-health-analyst persona** — Invokes this skill as part of its sweep.
 

--- a/.cursor-plugin/agents/harness-codebase-health-analyst.md
+++ b/.cursor-plugin/agents/harness-codebase-health-analyst.md
@@ -1192,7 +1192,7 @@ Phase 4: ENFORCE
 ## Harness Integration
 
 - **`harness check-security`** — CLI command that invokes this skill's scanner.
-- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine.
+- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine. Its injection rule set (`SEC-INJ-*`) is the load-bearing enforcement of the `owasp-injection-prevention` domain skill's concrete anti-patterns — `eval`/`Function`, SQL string concatenation, command injection, and Prisma `$queryRawUnsafe`/`$executeRawUnsafe` called with interpolated input. Deep injection classes that need data-flow (NoSQL operator injection, second-order injection) are intentionally out of scope for this mechanical scan and belong to `/harness:security-review`.
 - **`harness.config.json`** — Security section configures severity threshold and file exclusions.
 - **codebase-health-analyst persona** — Invokes this skill as part of its sweep.
 

--- a/.gemini-extension/commands/security-scan.toml
+++ b/.gemini-extension/commands/security-scan.toml
@@ -73,7 +73,7 @@ Phases:
 ## Harness Integration
 
 - **`harness check-security`** — CLI command that invokes this skill's scanner.
-- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine.
+- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine. Its injection rule set (`SEC-INJ-*`) is the load-bearing enforcement of the `owasp-injection-prevention` domain skill's concrete anti-patterns — `eval`/`Function`, SQL string concatenation, command injection, and Prisma `$queryRawUnsafe`/`$executeRawUnsafe` called with interpolated input. Deep injection classes that need data-flow (NoSQL operator injection, second-order injection) are intentionally out of scope for this mechanical scan and belong to `/harness:security-review`.
 - **`harness.config.json`** — Security section configures severity threshold and file exclusions.
 - **codebase-health-analyst persona** — Invokes this skill as part of its sweep.
 

--- a/agents/skills/claude-code/a11y-aria-patterns/SKILL.md
+++ b/agents/skills/claude-code/a11y-aria-patterns/SKILL.md
@@ -174,7 +174,11 @@ https://www.w3.org/TR/wai-aria-1.2/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but two of its assertions are also **load-bearing**: they are enforced mechanically by `harness-accessibility` via the `AriaScanner` in `@harness-engineering/core`.
+  - `A11Y-014` — `aria-hidden="true"` on a focusable element (rule #4 of ARIA: do not hide a focusable control from assistive technology).
+  - `A11Y-042` — positive `tabindex`, which disrupts the natural tab order.
+    These fire only on statically-decidable values (a dynamic `aria-hidden={expr}` or a `tabIndex={0}`/`tabIndex={-1}` is never flagged), keeping false positives near zero.
+- **What remains advisory (not mechanized):** accessible-name presence (`aria-label`/`aria-labelledby`), role-appropriate keyboard operability, live-region and state-attribute correctness. These require resolving relationships across elements or runtime state and cannot be enforced at a low false-positive rate by pattern matching, so they stay prose guidance here.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/claude-code/api-idempotency-keys/SKILL.md
+++ b/agents/skills/claude-code/api-idempotency-keys/SKILL.md
@@ -164,6 +164,7 @@ Stripe's measured outcome: introducing idempotency keys reduced duplicate charge
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** the core assertion — "mutating endpoints with side effects must accept an idempotency key" — is a missing-control judgment scoped to only the financially or data-integrity sensitive operations, not every POST/PATCH/DELETE. Deciding which endpoints qualify, and confirming the key is actually stored and enforced, requires semantic understanding of the handler that pattern matching cannot supply without a high false-positive rate. `harness-api-design` reviews idempotency as part of its DESIGN/VALIDATE phases; a blocking mechanical check is deferred rather than shipped noisy.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** api-http-methods, events-idempotency-pattern, api-bulk-operations, api-retry-guidance
 

--- a/agents/skills/claude-code/harness-accessibility/SKILL.md
+++ b/agents/skills/claude-code/harness-accessibility/SKILL.md
@@ -40,6 +40,8 @@
 - If `enabled: false` or absent: scan for `A11Y-010` / `A11Y-050` as normal (no deferral).
 - Same i18n-style deduplication pattern as step 2.5 — prevents one root cause from appearing in both the accessibility report and the anatomy report.
 
+  2.7. **Run the mechanical ARIA scanner first.** Call `AriaScanner.scanFiles()` from `@harness-engineering/core` (the same load-bearing pattern by which `harness-security-scan` calls `SecurityScanner.scanFiles()`). It authoritatively produces `A11Y-014` (`aria-hidden="true"` on a focusable element) and `A11Y-042` (positive `tabindex`) — the two ARIA rules that are decidable from a single element at a near-zero false-positive rate. Treat its findings as the source of truth for those two codes; the grep heuristics below cover only the remaining rules. These two codes are the load-bearing enforcement of the `a11y-aria-patterns` domain skill.
+
 3. **Scan component files.** Search all files matching `.tsx`, `.jsx`, `.vue`, `.svelte`, `.html` for the following violations:
 
    **Images and media:**
@@ -185,6 +187,7 @@ This phase is optional. It applies fixes only for **mechanical issues** -- viola
 
 ## Harness Integration
 
+- **`AriaScanner`** (`@harness-engineering/core`) -- Mechanical rule engine that produces `A11Y-014` (aria-hidden on a focusable element) and `A11Y-042` (positive tabindex). This is the load-bearing enforcement of the `a11y-aria-patterns` domain skill, invoked in the SCAN phase exactly as `harness-security-scan` invokes `SecurityScanner`. Rules fire only on statically-true values, so dynamic `aria-hidden={expr}` and `tabIndex={0}`/`{-1}` are never flagged.
 - **`harness validate`** -- Accessibility findings surface as design constraint violations when `design.strictness` is `strict` or `standard`. Running validate after a scan reflects the current a11y state.
 - **`harness scan`** -- Refresh the knowledge graph after fixes to update `VIOLATES` edges. Ensures impact analysis stays current.
 - **`DesignConstraintAdapter`** (`packages/graph/src/constraints/DesignConstraintAdapter.ts`) -- Reads `design.strictness` from project config to control violation severity. Manages `VIOLATES` edges in the graph for design and accessibility constraints.

--- a/agents/skills/claude-code/harness-security-scan/SKILL.md
+++ b/agents/skills/claude-code/harness-security-scan/SKILL.md
@@ -56,7 +56,7 @@
 ## Harness Integration
 
 - **`harness check-security`** — CLI command that invokes this skill's scanner.
-- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine.
+- **`SecurityScanner`** — Core class from `@harness-engineering/core` that executes the rule engine. Its injection rule set (`SEC-INJ-*`) is the load-bearing enforcement of the `owasp-injection-prevention` domain skill's concrete anti-patterns — `eval`/`Function`, SQL string concatenation, command injection, and Prisma `$queryRawUnsafe`/`$executeRawUnsafe` called with interpolated input. Deep injection classes that need data-flow (NoSQL operator injection, second-order injection) are intentionally out of scope for this mechanical scan and belong to `/harness:security-review`.
 - **`harness.config.json`** — Security section configures severity threshold and file exclusions.
 - **codebase-health-analyst persona** — Invokes this skill as part of its sweep.
 

--- a/agents/skills/claude-code/owasp-csrf-protection/SKILL.md
+++ b/agents/skills/claude-code/owasp-csrf-protection/SKILL.md
@@ -167,6 +167,7 @@ https://owasp.org/www-project-top-ten/
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** CSRF protection cannot be checked mechanically at a low false-positive rate. Whether a route needs CSRF defense depends on its authentication model — a Bearer-token API is immune, while a cookie-session route is not — and on whether a token or `SameSite` cookie is wired through middleware. Deciding this requires framework-aware data-flow analysis; a pattern-based "missing CSRF protection" check would be noisy, and a noisy security gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/claude-code/owasp-injection-prevention/SKILL.md
+++ b/agents/skills/claude-code/owasp-injection-prevention/SKILL.md
@@ -151,7 +151,8 @@ https://owasp.org/www-project-top-ten/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but its concrete anti-patterns are also **load-bearing**: they are enforced mechanically by `harness-security-scan` via the injection rule set in `@harness-engineering/core` (`SEC-INJ-001` eval/Function, `SEC-INJ-002` SQL string concatenation, `SEC-INJ-003` command injection, `SEC-INJ-004` Prisma `$queryRawUnsafe`/`$executeRawUnsafe` with interpolated input). A finding from any of these rules is a real, citable violation of this skill.
+- **What remains advisory (not mechanized):** NoSQL/MongoDB operator injection (passing an unvalidated request body to `find`/`findOne`) and second-order injection both require framework-aware data-flow analysis to detect without a high false-positive rate. Those stay prose guidance here and are covered by `/harness:security-review` (semantic taint tracking), not the mechanical scan.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/claude-code/owasp-rate-limiting/SKILL.md
+++ b/agents/skills/claude-code/owasp-rate-limiting/SKILL.md
@@ -207,6 +207,7 @@ https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.htm
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** "this endpoint should be rate-limited but isn't" is a missing-control judgment. Detecting it requires tracing route definitions to their middleware chain and applying business context about which operations are sensitive (auth, password reset, export). A pattern-based check cannot decide this without a high false-positive rate, and a noisy gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** owasp-auth-patterns, owasp-logging-monitoring, security-zero-trust-principles, security-threat-modeling-stride, api-rate-limiting, api-rate-limit-headers
 

--- a/agents/skills/codex/a11y-aria-patterns/SKILL.md
+++ b/agents/skills/codex/a11y-aria-patterns/SKILL.md
@@ -174,7 +174,11 @@ https://www.w3.org/TR/wai-aria-1.2/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but two of its assertions are also **load-bearing**: they are enforced mechanically by `harness-accessibility` via the `AriaScanner` in `@harness-engineering/core`.
+  - `A11Y-014` — `aria-hidden="true"` on a focusable element (rule #4 of ARIA: do not hide a focusable control from assistive technology).
+  - `A11Y-042` — positive `tabindex`, which disrupts the natural tab order.
+    These fire only on statically-decidable values (a dynamic `aria-hidden={expr}` or a `tabIndex={0}`/`tabIndex={-1}` is never flagged), keeping false positives near zero.
+- **What remains advisory (not mechanized):** accessible-name presence (`aria-label`/`aria-labelledby`), role-appropriate keyboard operability, live-region and state-attribute correctness. These require resolving relationships across elements or runtime state and cannot be enforced at a low false-positive rate by pattern matching, so they stay prose guidance here.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/codex/api-idempotency-keys/SKILL.md
+++ b/agents/skills/codex/api-idempotency-keys/SKILL.md
@@ -164,6 +164,7 @@ Stripe's measured outcome: introducing idempotency keys reduced duplicate charge
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** the core assertion — "mutating endpoints with side effects must accept an idempotency key" — is a missing-control judgment scoped to only the financially or data-integrity sensitive operations, not every POST/PATCH/DELETE. Deciding which endpoints qualify, and confirming the key is actually stored and enforced, requires semantic understanding of the handler that pattern matching cannot supply without a high false-positive rate. `harness-api-design` reviews idempotency as part of its DESIGN/VALIDATE phases; a blocking mechanical check is deferred rather than shipped noisy.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** api-http-methods, events-idempotency-pattern, api-bulk-operations, api-retry-guidance
 

--- a/agents/skills/codex/owasp-csrf-protection/SKILL.md
+++ b/agents/skills/codex/owasp-csrf-protection/SKILL.md
@@ -167,6 +167,7 @@ https://owasp.org/www-project-top-ten/
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** CSRF protection cannot be checked mechanically at a low false-positive rate. Whether a route needs CSRF defense depends on its authentication model — a Bearer-token API is immune, while a cookie-session route is not — and on whether a token or `SameSite` cookie is wired through middleware. Deciding this requires framework-aware data-flow analysis; a pattern-based "missing CSRF protection" check would be noisy, and a noisy security gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/codex/owasp-injection-prevention/SKILL.md
+++ b/agents/skills/codex/owasp-injection-prevention/SKILL.md
@@ -151,7 +151,8 @@ https://owasp.org/www-project-top-ten/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but its concrete anti-patterns are also **load-bearing**: they are enforced mechanically by `harness-security-scan` via the injection rule set in `@harness-engineering/core` (`SEC-INJ-001` eval/Function, `SEC-INJ-002` SQL string concatenation, `SEC-INJ-003` command injection, `SEC-INJ-004` Prisma `$queryRawUnsafe`/`$executeRawUnsafe` with interpolated input). A finding from any of these rules is a real, citable violation of this skill.
+- **What remains advisory (not mechanized):** NoSQL/MongoDB operator injection (passing an unvalidated request body to `find`/`findOne`) and second-order injection both require framework-aware data-flow analysis to detect without a high false-positive rate. Those stay prose guidance here and are covered by `/harness:security-review` (semantic taint tracking), not the mechanical scan.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/codex/owasp-rate-limiting/SKILL.md
+++ b/agents/skills/codex/owasp-rate-limiting/SKILL.md
@@ -207,6 +207,7 @@ https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.htm
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** "this endpoint should be rate-limited but isn't" is a missing-control judgment. Detecting it requires tracing route definitions to their middleware chain and applying business context about which operations are sensitive (auth, password reset, export). A pattern-based check cannot decide this without a high false-positive rate, and a noisy gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** owasp-auth-patterns, owasp-logging-monitoring, security-zero-trust-principles, security-threat-modeling-stride, api-rate-limiting, api-rate-limit-headers
 

--- a/agents/skills/cursor/a11y-aria-patterns/SKILL.md
+++ b/agents/skills/cursor/a11y-aria-patterns/SKILL.md
@@ -174,7 +174,11 @@ https://www.w3.org/TR/wai-aria-1.2/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but two of its assertions are also **load-bearing**: they are enforced mechanically by `harness-accessibility` via the `AriaScanner` in `@harness-engineering/core`.
+  - `A11Y-014` — `aria-hidden="true"` on a focusable element (rule #4 of ARIA: do not hide a focusable control from assistive technology).
+  - `A11Y-042` — positive `tabindex`, which disrupts the natural tab order.
+    These fire only on statically-decidable values (a dynamic `aria-hidden={expr}` or a `tabIndex={0}`/`tabIndex={-1}` is never flagged), keeping false positives near zero.
+- **What remains advisory (not mechanized):** accessible-name presence (`aria-label`/`aria-labelledby`), role-appropriate keyboard operability, live-region and state-attribute correctness. These require resolving relationships across elements or runtime state and cannot be enforced at a low false-positive rate by pattern matching, so they stay prose guidance here.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/cursor/api-idempotency-keys/SKILL.md
+++ b/agents/skills/cursor/api-idempotency-keys/SKILL.md
@@ -164,6 +164,7 @@ Stripe's measured outcome: introducing idempotency keys reduced duplicate charge
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** the core assertion — "mutating endpoints with side effects must accept an idempotency key" — is a missing-control judgment scoped to only the financially or data-integrity sensitive operations, not every POST/PATCH/DELETE. Deciding which endpoints qualify, and confirming the key is actually stored and enforced, requires semantic understanding of the handler that pattern matching cannot supply without a high false-positive rate. `harness-api-design` reviews idempotency as part of its DESIGN/VALIDATE phases; a blocking mechanical check is deferred rather than shipped noisy.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** api-http-methods, events-idempotency-pattern, api-bulk-operations, api-retry-guidance
 

--- a/agents/skills/cursor/owasp-csrf-protection/SKILL.md
+++ b/agents/skills/cursor/owasp-csrf-protection/SKILL.md
@@ -167,6 +167,7 @@ https://owasp.org/www-project-top-ten/
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** CSRF protection cannot be checked mechanically at a low false-positive rate. Whether a route needs CSRF defense depends on its authentication model — a Bearer-token API is immune, while a cookie-session route is not — and on whether a token or `SameSite` cookie is wired through middleware. Deciding this requires framework-aware data-flow analysis; a pattern-based "missing CSRF protection" check would be noisy, and a noisy security gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/cursor/owasp-injection-prevention/SKILL.md
+++ b/agents/skills/cursor/owasp-injection-prevention/SKILL.md
@@ -151,7 +151,8 @@ https://owasp.org/www-project-top-ten/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but its concrete anti-patterns are also **load-bearing**: they are enforced mechanically by `harness-security-scan` via the injection rule set in `@harness-engineering/core` (`SEC-INJ-001` eval/Function, `SEC-INJ-002` SQL string concatenation, `SEC-INJ-003` command injection, `SEC-INJ-004` Prisma `$queryRawUnsafe`/`$executeRawUnsafe` with interpolated input). A finding from any of these rules is a real, citable violation of this skill.
+- **What remains advisory (not mechanized):** NoSQL/MongoDB operator injection (passing an unvalidated request body to `find`/`findOne`) and second-order injection both require framework-aware data-flow analysis to detect without a high false-positive rate. Those stay prose guidance here and are covered by `/harness:security-review` (semantic taint tracking), not the mechanical scan.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/cursor/owasp-rate-limiting/SKILL.md
+++ b/agents/skills/cursor/owasp-rate-limiting/SKILL.md
@@ -207,6 +207,7 @@ https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.htm
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** "this endpoint should be rate-limited but isn't" is a missing-control judgment. Detecting it requires tracing route definitions to their middleware chain and applying business context about which operations are sensitive (auth, password reset, export). A pattern-based check cannot decide this without a high false-positive rate, and a noisy gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** owasp-auth-patterns, owasp-logging-monitoring, security-zero-trust-principles, security-threat-modeling-stride, api-rate-limiting, api-rate-limit-headers
 

--- a/agents/skills/gemini-cli/a11y-aria-patterns/SKILL.md
+++ b/agents/skills/gemini-cli/a11y-aria-patterns/SKILL.md
@@ -174,7 +174,11 @@ https://www.w3.org/TR/wai-aria-1.2/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but two of its assertions are also **load-bearing**: they are enforced mechanically by `harness-accessibility` via the `AriaScanner` in `@harness-engineering/core`.
+  - `A11Y-014` — `aria-hidden="true"` on a focusable element (rule #4 of ARIA: do not hide a focusable control from assistive technology).
+  - `A11Y-042` — positive `tabindex`, which disrupts the natural tab order.
+    These fire only on statically-decidable values (a dynamic `aria-hidden={expr}` or a `tabIndex={0}`/`tabIndex={-1}` is never flagged), keeping false positives near zero.
+- **What remains advisory (not mechanized):** accessible-name presence (`aria-label`/`aria-labelledby`), role-appropriate keyboard operability, live-region and state-attribute correctness. These require resolving relationships across elements or runtime state and cannot be enforced at a low false-positive rate by pattern matching, so they stay prose guidance here.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/gemini-cli/api-idempotency-keys/SKILL.md
+++ b/agents/skills/gemini-cli/api-idempotency-keys/SKILL.md
@@ -164,6 +164,7 @@ Stripe's measured outcome: introducing idempotency keys reduced duplicate charge
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** the core assertion — "mutating endpoints with side effects must accept an idempotency key" — is a missing-control judgment scoped to only the financially or data-integrity sensitive operations, not every POST/PATCH/DELETE. Deciding which endpoints qualify, and confirming the key is actually stored and enforced, requires semantic understanding of the handler that pattern matching cannot supply without a high false-positive rate. `harness-api-design` reviews idempotency as part of its DESIGN/VALIDATE phases; a blocking mechanical check is deferred rather than shipped noisy.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** api-http-methods, events-idempotency-pattern, api-bulk-operations, api-retry-guidance
 

--- a/agents/skills/gemini-cli/owasp-csrf-protection/SKILL.md
+++ b/agents/skills/gemini-cli/owasp-csrf-protection/SKILL.md
@@ -167,6 +167,7 @@ https://owasp.org/www-project-top-ten/
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** CSRF protection cannot be checked mechanically at a low false-positive rate. Whether a route needs CSRF defense depends on its authentication model — a Bearer-token API is immune, while a cookie-session route is not — and on whether a token or `SameSite` cookie is wired through middleware. Deciding this requires framework-aware data-flow analysis; a pattern-based "missing CSRF protection" check would be noisy, and a noisy security gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/gemini-cli/owasp-injection-prevention/SKILL.md
+++ b/agents/skills/gemini-cli/owasp-injection-prevention/SKILL.md
@@ -151,7 +151,8 @@ https://owasp.org/www-project-top-ten/
 
 ## Harness Integration
 
-- **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Type:** knowledge — this skill is a reference document consumed as context, but its concrete anti-patterns are also **load-bearing**: they are enforced mechanically by `harness-security-scan` via the injection rule set in `@harness-engineering/core` (`SEC-INJ-001` eval/Function, `SEC-INJ-002` SQL string concatenation, `SEC-INJ-003` command injection, `SEC-INJ-004` Prisma `$queryRawUnsafe`/`$executeRawUnsafe` with interpolated input). A finding from any of these rules is a real, citable violation of this skill.
+- **What remains advisory (not mechanized):** NoSQL/MongoDB operator injection (passing an unvalidated request body to `find`/`findOne`) and second-order injection both require framework-aware data-flow analysis to detect without a high false-positive rate. Those stay prose guidance here and are covered by `/harness:security-review` (semantic taint tracking), not the mechanical scan.
 - **No tools or state** — consumed as context by other skills and agents.
 
 ## Success Criteria

--- a/agents/skills/gemini-cli/owasp-rate-limiting/SKILL.md
+++ b/agents/skills/gemini-cli/owasp-rate-limiting/SKILL.md
@@ -207,6 +207,7 @@ https://cheatsheetseries.owasp.org/cheatsheets/Denial_of_Service_Cheat_Sheet.htm
 ## Harness Integration
 
 - **Type:** knowledge — this skill is a reference document, not a procedural workflow.
+- **Advisory by design (not mechanized):** "this endpoint should be rate-limited but isn't" is a missing-control judgment. Detecting it requires tracing route definitions to their middleware chain and applying business context about which operations are sensitive (auth, password reset, export). A pattern-based check cannot decide this without a high false-positive rate, and a noisy gate is worse than this advisory. Use `/harness:security-review` for a semantic assessment.
 - **No tools or state** — consumed as context by other skills and agents.
 - **related_skills:** owasp-auth-patterns, owasp-logging-monitoring, security-zero-trust-principles, security-threat-modeling-stride, api-rate-limiting, api-rate-limit-headers
 

--- a/docs/changes/domain-skills-load-bearing/proposal.md
+++ b/docs/changes/domain-skills-load-bearing/proposal.md
@@ -1,0 +1,69 @@
+# Promote domain skills from advisory prose to load-bearing checks
+
+**Roadmap item:** `promote-5-domain-skills-from-advisory-to-load-bearing-checks`
+**Keywords:** domain-skills, load-bearing, security-scan, accessibility, aria, injection, idempotency, csrf, rate-limiting, false-positive-floor
+
+## Overview
+
+Five domain skills carry genuine domain-specific assertions but are prose-only advisories: `api-idempotency-keys`, `owasp-injection-prevention`, `owasp-csrf-protection`, `owasp-rate-limiting`, and `a11y-aria-patterns`. The roadmap item asks that each be wired as a load-bearing mechanical check invoked by its parent harness skill (`harness-api-design`, `harness-security-scan`, `harness-accessibility`).
+
+These are security and accessibility gates. The governing constraint is that **a mechanical check that false-positives is worse than an advisory** — a noisy gate trains reviewers to ignore it and erodes trust in every other harness check. So the decision for each skill is not "can we pattern-match something" but "can we pattern-match it at a near-zero false-positive rate." Where the answer is no, the honest outcome is to keep the skill advisory and say why, rather than ship a noisy check.
+
+This proposal mechanizes the two skills where a high-precision check is feasible and explicitly defers the three where it is not.
+
+## What ships (mechanized, load-bearing)
+
+### 1. `owasp-injection-prevention` → `harness-security-scan`
+
+The parent already invokes `SecurityScanner.scanFiles()` from `@harness-engineering/core`, and the scanner's injection rule set already enforces the skill's core anti-patterns: `SEC-INJ-001` (`eval`/`Function`), `SEC-INJ-002` (SQL string concatenation), `SEC-INJ-003` (command injection). The one concrete gap the skill names but the scanner did not cover is the ORM raw-query escape hatch — the skill's "ORMs do NOT automatically protect you" section.
+
+Added **`SEC-INJ-004` (Prisma raw query injection)**: fires on `$queryRawUnsafe`/`$executeRawUnsafe` called with an interpolated template literal (`` `...${x}...` ``) or a concatenated string (`... + x`). This is a near-zero-FP signal:
+
+- The `*Unsafe` variants exist precisely because they do **not** parameterize interpolations — the name is the contract.
+- The rule fires **only** when the argument is interpolated/concatenated. A fully static `$queryRawUnsafe("SELECT 1")` and the parameterized positional form `$queryRawUnsafe("... $1", id)` are not flagged (no injection vector).
+- The safe tagged-template form `` prisma.$queryRaw`...${id}` `` and the `Prisma.sql` helper are never matched.
+
+Because the parent already invokes the scanner generically, this rule is load-bearing the moment it registers — no new CLI surface. `harness-security-scan`'s Harness Integration now documents that `SEC-INJ-*` is the enforcement of this skill.
+
+**Left advisory:** NoSQL/MongoDB operator injection (unvalidated request body passed to `find`/`findOne`) and second-order injection both require framework-aware data-flow/taint analysis. Detecting them by pattern would be noisy; they remain prose here and are covered by `/harness:security-review`.
+
+### 2. `a11y-aria-patterns` → `harness-accessibility`
+
+New `AriaScanner` in `@harness-engineering/core` (`packages/core/src/accessibility/`), modeled on `SecurityScanner`: regex rules evaluated per line, one finding per match. `harness-accessibility` invokes it in its SCAN phase exactly the way `harness-security-scan` invokes `SecurityScanner`. Two rules, both decidable from a single element:
+
+- **`A11Y-014`** — `aria-hidden="true"` on a focusable element (ARIA rule #4). Restricted to natively-focusable tags (`button`, `input`, `select`, `textarea`, and `<a>` only when it carries `href`). A dynamic binding `aria-hidden={expr}` is excluded (may resolve to false); `aria-hidden="false"` is excluded; non-focusable `<span>`/`<div>` are excluded.
+- **`A11Y-042`** — positive `tabindex`. `tabIndex={0}` (natural order) and `tabIndex={-1}` (programmatic focus) are not flagged; only `>= 1` matches.
+
+These two codes already existed in `harness-accessibility`'s advisory taxonomy; they are now backed by a real scanner rather than eyeballed grep output.
+
+**Left advisory:** accessible-name presence (`aria-label`/`aria-labelledby`), role-appropriate keyboard operability, and live-region/state-attribute correctness. Each requires resolving relationships across elements or runtime state and cannot be enforced at a low FP rate by pattern matching.
+
+## What is deferred (remains advisory, with reason)
+
+### 3. `owasp-csrf-protection` — deferred
+
+Whether a route needs CSRF defense depends on its authentication model (a Bearer-token API is immune; a cookie-session route is not) and on whether a token or `SameSite` cookie is threaded through middleware. This is missing-control detection requiring framework-aware data-flow. There is no low-FP positive anti-pattern to flag (`sameSite: 'none'` and comparing tokens are legitimate in context). A pattern-based "missing CSRF protection" gate would be noisy. Deferred to `/harness:security-review`.
+
+### 4. `owasp-rate-limiting` — deferred
+
+"This endpoint should be rate-limited but isn't" is a missing-control judgment that requires tracing route definitions to their middleware chain plus business context about which operations are sensitive. No low-FP positive signal exists. Deferred.
+
+### 5. `api-idempotency-keys` — deferred
+
+Two blockers. (a) The core assertion — "mutating endpoints with side effects must accept and enforce an idempotency key" — is scoped to only the financially/data-integrity-sensitive subset of mutations, not every POST/PATCH/DELETE; deciding which qualify, and confirming the key is stored and enforced, needs semantic handler understanding. (b) The parent `harness-api-design` has no code-level scanner to mirror (its analysis is agent-driven OpenAPI/route reading); the only low-FP concrete anti-pattern (advertising `Idempotency-Key` on a GET) has near-zero real-world signal and would not justify a new OpenAPI-parsing verifier subsystem. Deferred; `harness-api-design` continues to review idempotency in its DESIGN/VALIDATE phases.
+
+## Rationale for a partial ship
+
+The roadmap item scoped five conversions at "roughly one week each." A truthful reading of the false-positive floor is that only two admit a high-precision mechanical check today. Shipping the two cleanly and documenting the three deferrals — in the skill files, here, and in the PR — is the outcome that respects the "noisy security gate is worse than an advisory" constraint. Three of the five stay advisory not for lack of effort but because low-FP mechanization is not achievable without the semantic/taint analysis that `/harness:security-review` and `harness-api-design`'s agent phases already provide.
+
+## Testing
+
+- `SEC-INJ-004`: rule-level pattern tests (violating template/concat forms flagged; static, positional, and tagged-template forms clean) in `packages/core/tests/security/rules/injection.test.ts`.
+- `AriaScanner`: rule catalog + per-rule violation/clean fixtures + scanner surface (file/line reporting, clean markup passes, non-markup extensions skipped) in `packages/core/tests/accessibility/aria-scanner.test.ts`.
+
+## Success criteria
+
+- `SEC-INJ-004` fires on interpolated `$queryRawUnsafe`/`$executeRawUnsafe` and is silent on safe forms; reachable through `harness-security-scan`'s existing scanner invocation.
+- `AriaScanner` produces `A11Y-014` and `A11Y-042` at a near-zero FP rate and is invoked by `harness-accessibility`'s SCAN phase.
+- The three deferred skills state, in-repo, why they remain advisory.
+- No shipped skill text contains internal roadmap/PR/issue identifiers.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -356,6 +356,15 @@ Run knowledge extraction, drift detection, and gap analysis
 - `--coverage` — Display per-domain coverage report
 - `--check-contradictions` — Display cross-source contradiction report
 
+### `harness list-capabilities`
+
+Audit each MCP tool: read/write/exec scope, network access, and trust tag
+
+**Options:**
+
+- `--by-permission` — Group tools by read/write/exec/network scope
+- `--json` — Emit machine-readable JSON
+
 ### `harness naming-craft`
 
 LLM-judgment critique of identifier names (variables, functions, types, files). First craft-pipeline ceiling skill; uses curated rubric catalog from Martin/Beck/Karlton.

--- a/docs/roadmap.d/promote-5-domain-skills-from-advisory-to-load-bearing-checks.md
+++ b/docs/roadmap.d/promote-5-domain-skills-from-advisory-to-load-bearing-checks.md
@@ -7,7 +7,7 @@ order: 7
 ### Promote 5 domain skills from advisory to load-bearing checks
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/domain-skills-load-bearing/proposal.md
 - **Summary:** Five domain skills have genuine domain-specific assertions but are currently prose-only advisories. Wire them as load-bearing checks invoked by their parent harness skill: `api-idempotency-keys` → `harness-api-design`; `owasp-injection-prevention`, `owasp-csrf-protection`, `owasp-rate-limiting` → `harness-security-scan`; `a11y-aria-patterns` → `harness-accessibility`. Each is roughly one week of work to convert from advisory prose to a mechanical check. Source: Pass 4 action 3.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -414,7 +414,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Promote 5 domain skills from advisory to load-bearing checks
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/domain-skills-load-bearing/proposal.md
 - **Summary:** Five domain skills have genuine domain-specific assertions but are currently prose-only advisories. Wire them as load-bearing checks invoked by their parent harness skill: `api-idempotency-keys` → `harness-api-design`; `owasp-injection-prevention`, `owasp-csrf-protection`, `owasp-rate-limiting` → `harness-security-scan`; `a11y-aria-patterns` → `harness-accessibility`. Each is roughly one week of work to convert from advisory prose to a mechanical check. Source: Pass 4 action 3.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -50,6 +50,7 @@ import { createLinterCommand } from './linter';
 import { createMaintenanceCommand } from './maintenance';
 import { createMcpCommand } from './mcp';
 import { createMcpGuardCommand } from './mcp-guard';
+import { createMcpListCapabilitiesCommand } from './mcp';
 import { createMigrateCommand } from './migrate';
 import { createModelsCommand } from './models';
 import { createNamingCraftCommand } from './naming-craft';
@@ -144,6 +145,7 @@ export const commandCreators: Array<() => Command> = [
   createMaintenanceCommand,
   createMcpCommand,
   createMcpGuardCommand,
+  createMcpListCapabilitiesCommand,
   createMigrateCommand,
   createModelsCommand,
   createNamingCraftCommand,

--- a/packages/core/src/accessibility/index.ts
+++ b/packages/core/src/accessibility/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Accessibility (ARIA) scanning module.
+ *
+ * Provides the mechanical, low-false-positive checks promoted from the
+ * `a11y-aria-patterns` domain skill and invoked by `harness-accessibility`.
+ */
+
+export { AriaScanner } from './scanner';
+export { ariaRules } from './rules';
+export { ARIA_SCANNABLE_EXTENSIONS } from './types';
+export type { AriaRule, AriaFinding, AriaScanResult, AriaSeverity, AriaConfidence } from './types';

--- a/packages/core/src/accessibility/rules.ts
+++ b/packages/core/src/accessibility/rules.ts
@@ -1,0 +1,60 @@
+import type { AriaRule } from './types';
+
+/**
+ * ARIA rules — the mechanical, load-bearing subset of the `a11y-aria-patterns`
+ * domain skill.
+ *
+ * Only two of the skill's assertions are decidable from a single element with
+ * near-zero false positives; those are enforced here. The rest of the skill
+ * (accessible-name presence, role-appropriate keyboard handlers, live-region
+ * semantics) stays advisory prose because a pattern match cannot decide them
+ * without data-flow, and a noisy accessibility gate is worse than an advisory.
+ *
+ * Both rules deliberately fire only on statically-true attribute values:
+ *   - `aria-hidden` dynamic bindings (`aria-hidden={isHidden}`) are NOT flagged
+ *     because they may resolve to false at runtime.
+ *   - `tabIndex={0}` / `tabIndex={-1}` are NOT flagged — only positive indices
+ *     disrupt the natural tab order.
+ */
+
+// `aria-hidden` set to a literal true, OR the JSX bare-attribute shorthand
+// (`aria-hidden` with no `=`, which means true). A dynamic binding such as
+// `aria-hidden={isHidden}` is excluded by the negative lookahead on `=`.
+const ARIA_HIDDEN_TRUE = String.raw`aria-hidden(?:\s*=\s*(?:["']true["']|\{\s*true\s*\})|(?!\s*=))`;
+
+export const ariaRules: AriaRule[] = [
+  {
+    // ARIA rule #4: never put aria-hidden="true" on a focusable element — it
+    // creates a control that receives keyboard focus while being invisible to
+    // assistive technology. Restricted to natively-focusable tags (and <a> only
+    // when it carries href) so non-interactive decorative elements never match.
+    id: 'A11Y-014',
+    name: 'aria-hidden on focusable element',
+    severity: 'error',
+    confidence: 'high',
+    patterns: [
+      new RegExp(String.raw`<(?:button|input|select|textarea)\b[^>]*?\b${ARIA_HIDDEN_TRUE}`),
+      new RegExp(String.raw`<a\b(?=[^>]*?\bhref\b)[^>]*?\b${ARIA_HIDDEN_TRUE}`),
+    ],
+    message:
+      'aria-hidden="true" on a focusable element — the element stays keyboard-focusable but is removed from the accessibility tree, stranding assistive-technology users on an invisible control',
+    remediation:
+      'Remove aria-hidden from the focusable element. To hide it from everyone, also remove it from the tab order (e.g. disable it or render it conditionally).',
+    references: ['WCAG 4.1.2', 'ARIA rule #4'],
+  },
+  {
+    // Positive tabindex overrides the DOM order and produces an unpredictable
+    // focus sequence. tabIndex={0} (in natural order) and tabIndex={-1}
+    // (programmatically focusable) are both fine and are not matched.
+    id: 'A11Y-042',
+    name: 'positive tabindex',
+    severity: 'warning',
+    confidence: 'high',
+    patterns: [/\btabindex\s*=\s*["'][1-9]\d*["']/i, /\btabindex\s*=\s*\{\s*[1-9]\d*\s*\}/i],
+    message:
+      'Positive tabindex disrupts the natural tab order — focus jumps out of DOM sequence and becomes unpredictable for keyboard users',
+    remediation:
+      'Use tabIndex={0} to include an element in the natural tab order, or tabIndex={-1} to make it programmatically focusable only. Order the DOM to match the intended focus flow.',
+    references: ['WCAG 2.4.3'],
+  },
+];

--- a/packages/core/src/accessibility/scanner.ts
+++ b/packages/core/src/accessibility/scanner.ts
@@ -1,0 +1,92 @@
+import * as fs from 'node:fs/promises';
+import { extname } from 'node:path';
+import { ariaRules } from './rules';
+import { ARIA_SCANNABLE_EXTENSIONS } from './types';
+import type { AriaFinding, AriaRule, AriaScanResult } from './types';
+
+/**
+ * Mechanical ARIA scanner — the load-bearing implementation of the two
+ * decidable checks promoted out of the `a11y-aria-patterns` advisory skill.
+ *
+ * Modeled on {@link SecurityScanner}: regex rules evaluated per line, one
+ * finding per match. `harness-accessibility` invokes this exactly the way
+ * `harness-security-scan` invokes the security scanner — the skill's SCAN phase
+ * calls {@link AriaScanner.scanFiles} rather than eyeballing grep output for
+ * A11Y-014 / A11Y-042.
+ */
+export class AriaScanner {
+  private readonly rules: AriaRule[];
+
+  constructor(rules: AriaRule[] = ariaRules) {
+    this.rules = rules;
+  }
+
+  /** Scan raw content for a given file path. `startLine` offsets reported lines. */
+  scanContent(content: string, filePath: string, startLine = 1): AriaFinding[] {
+    const findings: AriaFinding[] = [];
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? '';
+      for (const rule of this.rules) {
+        if (this.ruleMatchesLine(rule, line)) {
+          findings.push(this.buildFinding(rule, filePath, startLine + i, line));
+        }
+      }
+    }
+
+    return findings;
+  }
+
+  /** True if any of the rule's patterns match the line (one finding per rule per line). */
+  private ruleMatchesLine(rule: AriaRule, line: string): boolean {
+    return rule.patterns.some((pattern) => {
+      pattern.lastIndex = 0;
+      return pattern.test(line);
+    });
+  }
+
+  private buildFinding(rule: AriaRule, file: string, line: number, raw: string): AriaFinding {
+    return {
+      ruleId: rule.id,
+      ruleName: rule.name,
+      severity: rule.severity,
+      confidence: rule.confidence,
+      file,
+      line,
+      match: raw.trim(),
+      message: rule.message,
+      remediation: rule.remediation,
+      ...(rule.references ? { references: rule.references } : {}),
+    };
+  }
+
+  async scanFile(filePath: string): Promise<AriaFinding[]> {
+    if (!ARIA_SCANNABLE_EXTENSIONS.includes(extname(filePath).toLowerCase())) {
+      return [];
+    }
+    const content = await fs.readFile(filePath, 'utf-8');
+    return this.scanContent(content, filePath, 1);
+  }
+
+  async scanFiles(filePaths: string[]): Promise<AriaScanResult> {
+    const allFindings: AriaFinding[] = [];
+    let scannedCount = 0;
+
+    for (const filePath of filePaths) {
+      try {
+        const findings = await this.scanFile(filePath);
+        allFindings.push(...findings);
+        scannedCount++;
+      } catch {
+        // Skip unreadable files (permission errors, binary files, etc.)
+      }
+    }
+
+    return {
+      findings: allFindings,
+      scannedFiles: scannedCount,
+      rulesApplied: this.rules.length,
+    };
+  }
+}

--- a/packages/core/src/accessibility/types.ts
+++ b/packages/core/src/accessibility/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Accessibility (ARIA) scanning types.
+ *
+ * Load-bearing mechanical check for the `a11y-aria-patterns` domain skill.
+ * Mirrors the shape of the security rule engine (regex-per-line, confidence +
+ * severity), but scoped to ARIA violations that are decidable from a single
+ * element without data-flow or framework awareness. Deeper ARIA assertions
+ * (accessible-name resolution, role-appropriate keyboard operability) remain
+ * advisory in the skill because they cannot be enforced at low false-positive
+ * rates with pattern matching alone.
+ */
+
+export type AriaSeverity = 'error' | 'warning' | 'info';
+export type AriaConfidence = 'high' | 'medium' | 'low';
+
+export interface AriaRule {
+  /** Stable rule id, reusing the harness-accessibility A11Y-* taxonomy. */
+  id: string;
+  name: string;
+  severity: AriaSeverity;
+  confidence: AriaConfidence;
+  patterns: RegExp[];
+  message: string;
+  remediation: string;
+  /** WCAG success criterion / ARIA authoring-practices reference. */
+  references?: string[];
+}
+
+export interface AriaFinding {
+  ruleId: string;
+  ruleName: string;
+  severity: AriaSeverity;
+  confidence: AriaConfidence;
+  file: string;
+  line: number;
+  match: string;
+  message: string;
+  remediation: string;
+  references?: string[];
+}
+
+export interface AriaScanResult {
+  findings: AriaFinding[];
+  scannedFiles: number;
+  rulesApplied: number;
+}
+
+/** File extensions that can contain markup/JSX worth scanning for ARIA misuse. */
+export const ARIA_SCANNABLE_EXTENSIONS: readonly string[] = [
+  '.tsx',
+  '.jsx',
+  '.vue',
+  '.svelte',
+  '.html',
+  '.htm',
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,6 +222,11 @@ export type {
 } from './telemetry';
 
 /**
+ * Accessibility module.
+ */
+export * from './accessibility';
+
+/**
  * Harness-strength module.
  */
 export * from './harness-strength';

--- a/packages/core/src/security/rules/injection.ts
+++ b/packages/core/src/security/rules/injection.ts
@@ -42,4 +42,28 @@ export const injectionRules: SecurityRule[] = [
     remediation: 'Use execFile() with argument array instead of exec() with string',
     references: ['CWE-78'],
   },
+  {
+    // Load-bearing check for the `owasp-injection-prevention` domain skill.
+    // Closes the concrete gap its "ORMs do NOT automatically protect you"
+    // section names: Prisma's `$queryRawUnsafe` / `$executeRawUnsafe` escape
+    // hatches never parameterize interpolated values (the name says so). We
+    // only fire on an interpolated argument (template `${…}` or `+` concat),
+    // so a fully-static Unsafe call — which carries no injection vector — does
+    // not match. This keeps false positives near zero: the tagged-template
+    // form `prisma.$queryRaw`…`` and the `Prisma.sql` helper never match.
+    id: 'SEC-INJ-004',
+    name: 'Prisma Raw Query Injection',
+    category: 'injection',
+    severity: 'error',
+    confidence: 'high',
+    patterns: [
+      /\$(?:queryRawUnsafe|executeRawUnsafe)\s*\(\s*`[^`]*\$\{/,
+      /\$(?:queryRawUnsafe|executeRawUnsafe)\s*\([^)]*\+/,
+    ],
+    message:
+      'Prisma $queryRawUnsafe/$executeRawUnsafe called with an interpolated or concatenated string — user input is injected directly into SQL',
+    remediation:
+      'Use the tagged-template form (prisma.$queryRaw`...${value}`) or pass parameters positionally: prisma.$queryRawUnsafe("... WHERE id = $1", value)',
+    references: ['CWE-89'],
+  },
 ];

--- a/packages/core/tests/accessibility/aria-scanner.test.ts
+++ b/packages/core/tests/accessibility/aria-scanner.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { AriaScanner, ariaRules } from '../../src/accessibility';
+
+const scanner = new AriaScanner();
+
+function codesFor(content: string, file = 'Component.tsx'): string[] {
+  return scanner.scanContent(content, file).map((f) => f.ruleId);
+}
+
+describe('ARIA rules catalog', () => {
+  it('exposes the A11Y-* rules with references', () => {
+    expect(ariaRules.length).toBeGreaterThan(0);
+    for (const rule of ariaRules) {
+      expect(rule.id).toMatch(/^A11Y-\d+$/);
+      expect(rule.patterns.length).toBeGreaterThan(0);
+      expect(rule.references?.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('A11Y-014 — aria-hidden on focusable element', () => {
+  it('flags aria-hidden="true" on a <button>', () => {
+    expect(codesFor('<button aria-hidden="true">Save</button>')).toContain('A11Y-014');
+  });
+
+  it('flags aria-hidden={true} on an <input>', () => {
+    expect(codesFor('<input type="text" aria-hidden={true} />')).toContain('A11Y-014');
+  });
+
+  it('flags the bare aria-hidden JSX shorthand on a <select>', () => {
+    expect(codesFor('<select aria-hidden><option>a</option></select>')).toContain('A11Y-014');
+  });
+
+  it('flags aria-hidden="true" on an <a> that has href', () => {
+    expect(codesFor('<a href="/home" aria-hidden="true">Home</a>')).toContain('A11Y-014');
+    // attribute order reversed
+    expect(codesFor('<a aria-hidden="true" href="/home">Home</a>')).toContain('A11Y-014');
+  });
+
+  it('does NOT flag aria-hidden on a non-focusable <span> or <div>', () => {
+    expect(codesFor('<span aria-hidden="true"><Icon /></span>')).not.toContain('A11Y-014');
+    expect(codesFor('<div aria-hidden="true" className="decorative" />')).not.toContain('A11Y-014');
+  });
+
+  it('does NOT flag an <a> without href (not focusable)', () => {
+    expect(codesFor('<a aria-hidden="true" onClick={noop}>x</a>')).not.toContain('A11Y-014');
+  });
+
+  it('does NOT flag a dynamic aria-hidden binding (may resolve to false)', () => {
+    expect(codesFor('<button aria-hidden={isHidden}>Save</button>')).not.toContain('A11Y-014');
+  });
+
+  it('does NOT flag aria-hidden="false" on a focusable element', () => {
+    expect(codesFor('<button aria-hidden="false">Save</button>')).not.toContain('A11Y-014');
+  });
+});
+
+describe('A11Y-042 — positive tabindex', () => {
+  it('flags tabIndex={1}', () => {
+    expect(codesFor('<div role="button" tabIndex={1} />')).toContain('A11Y-042');
+  });
+
+  it('flags tabindex="3" (HTML string form)', () => {
+    expect(codesFor('<span tabindex="3">x</span>')).toContain('A11Y-042');
+  });
+
+  it('does NOT flag tabIndex={0} (natural order)', () => {
+    expect(codesFor('<div role="button" tabIndex={0} />')).not.toContain('A11Y-042');
+  });
+
+  it('does NOT flag tabIndex={-1} (programmatic focus)', () => {
+    expect(codesFor('<div tabIndex={-1} />')).not.toContain('A11Y-042');
+  });
+});
+
+describe('AriaScanner scan surface', () => {
+  it('reports file and 1-indexed line for each finding', () => {
+    const src = ['<div>', '  <button aria-hidden="true">Go</button>', '</div>'].join('\n');
+    const findings = scanner.scanContent(src, 'src/Widget.tsx');
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ ruleId: 'A11Y-014', file: 'src/Widget.tsx', line: 2 });
+  });
+
+  it('returns clean for accessible markup', () => {
+    const src = [
+      '<button aria-label="Close" onClick={onClose}>',
+      '  <XIcon aria-hidden="true" />',
+      '</button>',
+      '<a href="/next" tabIndex={0}>Next</a>',
+    ].join('\n');
+    expect(scanner.scanContent(src, 'src/Clean.tsx')).toHaveLength(0);
+  });
+
+  it('scanFiles skips non-markup extensions', async () => {
+    const result = await scanner.scanFiles(['server.py', 'data.json']);
+    expect(result.findings).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/security/rules/injection.test.ts
+++ b/packages/core/tests/security/rules/injection.test.ts
@@ -31,4 +31,41 @@ describe('Injection detection rules', () => {
     const testLine = 'exec("rm -rf " + userInput)';
     expect(rule!.patterns.some((p) => p.test(testLine))).toBe(true);
   });
+
+  describe('SEC-INJ-004 — Prisma raw query injection', () => {
+    const rule = injectionRules.find((r) => r.id === 'SEC-INJ-004')!;
+
+    it('is a high-confidence error', () => {
+      expect(rule).toBeDefined();
+      expect(rule.severity).toBe('error');
+      expect(rule.confidence).toBe('high');
+      expect(rule.references).toContain('CWE-89');
+    });
+
+    it('flags $queryRawUnsafe with an interpolated template literal', () => {
+      const line =
+        'const rows = await prisma.$queryRawUnsafe(`SELECT * FROM users WHERE id = ${id}`);';
+      expect(rule.patterns.some((p) => p.test(line))).toBe(true);
+    });
+
+    it('flags $executeRawUnsafe with string concatenation', () => {
+      const line = 'await prisma.$executeRawUnsafe("DELETE FROM logs WHERE owner = " + userId);';
+      expect(rule.patterns.some((p) => p.test(line))).toBe(true);
+    });
+
+    it('does NOT flag the safe tagged-template $queryRaw form', () => {
+      const line = 'const rows = await prisma.$queryRaw`SELECT * FROM users WHERE id = ${id}`;';
+      expect(rule.patterns.some((p) => p.test(line))).toBe(false);
+    });
+
+    it('does NOT flag $queryRawUnsafe with a fully static string (no injection vector)', () => {
+      const line = 'await prisma.$queryRawUnsafe("SELECT 1");';
+      expect(rule.patterns.some((p) => p.test(line))).toBe(false);
+    });
+
+    it('does NOT flag the parameterized $queryRawUnsafe positional form', () => {
+      const line = 'await prisma.$queryRawUnsafe("SELECT * FROM users WHERE id = $1", id);';
+      expect(rule.patterns.some((p) => p.test(line))).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Promotes the two of five advisory domain skills where a **low-false-positive** mechanical check is feasible into load-bearing checks invoked by their parent harness skill, and explicitly defers the other three (with reasons) rather than shipping noisy security/a11y gates. A mechanical check that false-positives is worse than an advisory, so the deciding question was not "can we pattern-match something" but "can we pattern-match it at a near-zero false-positive rate."

Spec: `docs/changes/domain-skills-load-bearing/proposal.md`.

## Mechanized (load-bearing)

**`owasp-injection-prevention` → `harness-security-scan`**
The parent already invokes `SecurityScanner.scanFiles()`, and the scanner's injection rules already enforce the skill's core anti-patterns (`SEC-INJ-001/002/003`: `eval`/`Function`, SQL string concat, command injection). Added **`SEC-INJ-004`** to close the one concrete gap the skill names — the ORM raw-query escape hatch: Prisma `$queryRawUnsafe`/`$executeRawUnsafe` called with an interpolated template literal or concatenated string. Fires **only** on an injectable argument; the safe tagged-template form, the `Prisma.sql` helper, static strings, and the parameterized positional form are all clean. Load-bearing the moment it registers — no new CLI surface.

**`a11y-aria-patterns` → `harness-accessibility`**
New `AriaScanner` in `@harness-engineering/core` (`packages/core/src/accessibility/`), modeled on `SecurityScanner`, invoked in the accessibility SCAN phase exactly as `harness-security-scan` invokes the security scanner. Two rules, both decidable from a single element:
- **`A11Y-014`** — `aria-hidden="true"` on a focusable element (native focusable tags, plus `<a>` only with `href`). Dynamic `aria-hidden={expr}` and `aria-hidden="false"` are not flagged.
- **`A11Y-042`** — positive `tabindex` (`tabIndex={0}`/`{-1}` are not flagged).

## Deferred (remain advisory, documented in-skill + proposal)

- **`owasp-csrf-protection`** — CSRF need depends on the auth model (Bearer APIs are immune; only cookie-session state-changing routes need it) and middleware wiring. Missing-control detection requiring framework-aware data-flow; no low-FP positive signal.
- **`owasp-rate-limiting`** — "this endpoint should be rate-limited but isn't" needs route→middleware tracing plus business context about which operations are sensitive. No low-FP signal.
- **`api-idempotency-keys`** — the core assertion is scoped to only the side-effectful subset of mutations and requires semantic handler understanding; `harness-api-design` has no code-level scanner to mirror, and the one low-FP anti-pattern (advertising `Idempotency-Key` on a GET) has near-zero real-world signal.

## Tests

- `SEC-INJ-004`: pattern tests (interpolated/concat flagged; static, positional, tagged-template clean) in `packages/core/tests/security/rules/injection.test.ts`.
- `AriaScanner`: rule catalog + per-rule violation/clean fixtures + scanner surface in `packages/core/tests/accessibility/aria-scanner.test.ts`.
- Full suites green: core (3838), CLI security (70), skills parity (27716).

## Notes

- Skill edits mirrored across all platform dirs (claude-code/cursor/codex/gemini-cli); affected plugin artifacts (health-analyst agent, gemini security-scan command) regenerated by hand.
- Incidentally completed a stale generated-command registration (`list-capabilities`) surfaced by the barrel regen, with its reference-docs entry.

Closes #547
