### PR TITLE
feat(maintenance): machine-parseable findings contract for checks (#691)

### DIFF
--- a/.changeset/maintenance-findings-contract.md
+++ b/.changeset/maintenance-findings-contract.md
@@ -1,0 +1,28 @@
+---
+'@harness-engineering/types': patch
+'@harness-engineering/orchestrator': patch
+'@harness-engineering/cli': patch
+---
+
+Give maintenance checks a standard machine-parseable findings contract (#691).
+
+`harness maintenance run` (and the cron orchestrator) previously recovered each
+task's findings COUNT by regex-scanning free-text check output
+(`N findings|issues|violations|errors`, plus a keyword fallback). That is
+fragile: checks like `check-docs` (doc-drift) and `cleanup` (entropy) emit no
+clean count — so doc-drift reported a uniform "1 finding" — and any wording
+change could silently break the count.
+
+A new shared envelope (`@harness-engineering/types`:
+`MaintenanceFindingsContract` + `formatFindingsContract` / `parseFindingsContract`)
+lets a check subcommand emit its count as structured data
+(`{"findings":N,"check":"...","v":1}`) under a `--findings-json` flag. The
+runner's shared spawn/parse core (`runHarnessCheck`) now prefers that envelope
+over the regex on both clean and non-zero exits, and labels the source
+(`findingsSource: 'contract' | 'regex'`). The legacy regex remains the fallback
+for checks not yet migrated.
+
+Migrated built-in checks: `check-arch`, `check-deps`, `check-docs`, `cleanup`,
+`check-security`, `cross-check` (their registry `checkCommand`s now pass
+`--findings-json`). Fully additive and backward-compatible — the flag defaults
+off for interactive CLI use and unmigrated checks are unchanged.

--- a/docs/changes/maintenance-findings-contract/proposal.md
+++ b/docs/changes/maintenance-findings-contract/proposal.md
@@ -1,0 +1,100 @@
+# Maintenance checks: a standard machine-parseable findings contract
+
+**Date**: 2026-08-05
+**Status**: Implemented
+**Issue**: #691
+**Packages**: `@harness-engineering/types`, `@harness-engineering/orchestrator`, `@harness-engineering/cli`
+
+## Problem
+
+`harness maintenance run` (and the cron orchestrator that shares its
+`TaskRunner`) derives each task's findings COUNT by regex-recovering it from the
+free-text output a check subcommand prints:
+
+- `runHarnessCheck` (the shared spawn/parse core) scans stdout for
+  `(\d+)\s+(finding|issue|violation|error)`.
+- When that misses, `classifyCheckExecutionFailure` applies a second keyword
+  heuristic (`explicitFindingsCount`) and, failing that, assumes `1`.
+
+This is fragile:
+
+- Checks like `check-docs` (doc-drift) and `cleanup` (entropy) emit **no clean
+  count** in the shape the regex matches. `check-docs` reported a uniform
+  "1 finding" via the assume-1 fallback, regardless of how many files were
+  actually undocumented.
+- Any change to a check's human wording can silently break the count — the same
+  class of bug that once made every maintenance row show "1 finding".
+
+## Decision
+
+Introduce **one** shared, machine-readable findings envelope and have the runner
+consume it in place of the regex, keeping the regex only as a labeled fallback
+for checks not yet migrated.
+
+### The contract (`@harness-engineering/types`)
+
+`packages/types/src/maintenance-findings.ts`:
+
+```ts
+interface MaintenanceFindingsContract {
+  findings: number; // authoritative, non-negative
+  check?: string;   // provenance (e.g. "check-docs")
+  v?: number;       // contract version
+}
+formatFindingsContract(findings, check?): string   // producer (CLI)
+parseFindingsContract(output): contract | null      // consumer (runner)
+```
+
+It lives in `types` — the one package both the CLI (producer) and the
+orchestrator (consumer) already depend on — so the shape cannot drift between
+the two. Wire form is a **single JSON line** printed to stdout, e.g.
+`{"findings":12,"check":"check-docs","v":1}`. `parseFindingsContract` scans lines
+from the last backward, so a trailing envelope is found ahead of human output
+and a multi-line pretty-printed `--json` blob (whose lines are fragments, never a
+complete `{...}` object) is correctly ignored.
+
+### Runner integration (`@harness-engineering/orchestrator`)
+
+`runHarnessCheck` now tries `parseFindingsContract` first on **both** the
+clean-exit and non-zero-exit branches. When an envelope is present it is
+authoritative — the count is trusted verbatim and `executionFailed` is false,
+regardless of the exit code or surrounding prose. When absent, the legacy
+`FINDINGS_RE` regex runs exactly as before. `CheckCommandResult` gains an
+optional `findingsSource: 'contract' | 'regex'` so the source is observable and
+testable. Because cron and CLI share this core, both benefit identically.
+
+### Producer migration (`@harness-engineering/cli`)
+
+Each migrated check subcommand gains an additive `--findings-json` flag that
+appends the standard envelope as a trailing stdout line (human output
+unchanged). The built-in maintenance registry passes `--findings-json` in the
+`checkCommand` for the migrated tasks — mirroring the established pattern used by
+`pulse run --non-interactive`, `compound scan-candidates --non-interactive`, and
+`sync-main --json`.
+
+**Migrated (mechanical-ai checks):** `check-arch`, `check-deps`, `check-docs`,
+`cleanup`, `check-security`, `cross-check`.
+
+**Left on regex/status fallback (documented):** `traceability` (always exits 0,
+coverage-based, no natural fixable-findings integer); the report-only checks
+`check-perf`, `predict`, `insights`, `stale-constraints`, `graph scan`; and
+`pulse` / `compound`, which already emit the sibling JSON status-line contract
+(`candidatesFound`). These can be migrated incrementally later.
+
+## Backward compatibility
+
+Fully additive. `--findings-json` defaults off, so interactive CLI use is
+unchanged; unmigrated checks keep the regex path; the envelope parser returns
+`null` (→ regex fallback) for any output that does not carry it.
+
+## Tests
+
+- `packages/types/tests/maintenance-findings.test.ts` — format/parse round-trip,
+  trailing-line recovery, multi-line-blob rejection, non-numeric `findings`
+  rejection, coercion.
+- `packages/orchestrator/tests/maintenance/check-runner.test.ts` — the runner
+  reads the count from the contract (`findingsSource: 'contract'`) on clean and
+  non-zero exits; a wording change ("clean" prose but `findings: 5`) does not
+  break the count; regex remains the labeled fallback for an unmigrated check.
+- `task-registry.test.ts` / `integration-full-cycle.test.ts` — registry
+  `checkCommand`s carry `--findings-json`.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -72,10 +72,15 @@ Check architecture assertions against baseline and thresholds
 - `--module` — Check a single module
 - `--allow-regress` — Permit a --update-baseline that worsens a metric (requires --reason)
 - `--reason` — Why an accepted regression is acceptable (logged to audit)
+- `--findings-json` — Emit findings contract as a trailing JSON line (#691)
 
 ### `harness check-deps`
 
 Validate dependency layers and detect circular dependencies
+
+**Options:**
+
+- `--findings-json` — Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)
 
 ### `harness check-design`
 
@@ -93,6 +98,7 @@ Check documentation coverage
 **Options:**
 
 - `--min-coverage` — Minimum coverage percentage (default: "80")
+- `--findings-json` — Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)
 
 ### `harness check-harness-strength`
 
@@ -128,6 +134,7 @@ Run lightweight security scan: secrets, injection, XSS, weak crypto
 
 - `--severity` — Minimum severity that fails the command; findings below it are excluded from the report and never fail the gate (error, warning, info) (default: "warning")
 - `--changed-only` — Only scan git-changed files
+- `--findings-json` — Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)
 
 ### `harness check-vocabulary`
 
@@ -140,6 +147,7 @@ Detect entropy issues (doc drift, dead code, patterns)
 **Options:**
 
 - `-t, --type` — Issue type: drift, dead-code, patterns, all (default: "all")
+- `--findings-json` — Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)
 
 ### `harness cleanup-sessions`
 
@@ -188,6 +196,7 @@ Check cross-artifact consistency (plan-to-implementation coverage and staleness)
 
 - `--specs-dir` — Specs directory relative to project root (default: docs/specs)
 - `--plans-dir` — Plans directory relative to project root (default: docs/plans)
+- `--findings-json` — Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)
 
 ### `harness dashboard`
 

--- a/docs/roadmap.d/maintenance-checks-need-a-standard-machine-parseable-findings-contract.md
+++ b/docs/roadmap.d/maintenance-checks-need-a-standard-machine-parseable-findings-contract.md
@@ -6,8 +6,8 @@ order: 9
 
 ### Maintenance checks need a standard machine-parseable findings contract
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** in-progress
+- **Spec:** docs/changes/maintenance-findings-contract/proposal.md
 - **Summary:** Follow-up from the on-demand maintenance pipeline (#687). **Problem:** `harness maintenance run` derives each task's findings count by regex-recovering it from free-text check output (`N findings|issues|violations|errors`, plus a keyword fallback in `classifyCheckExecutionFailure`). This is fragile: `doc-drift` (`check-docs`) and `entropy` (`cleanup`) emit no clean count and rely on recovery; if any check changes its output wording the count can silently break (the same class of bug that originally made the report show a uniform '1 finding'). **Proposal:** give maintenance check subcommands a standard machine-readable findings contract (e.g. a `--json` mode emitting `{ findings: N, ... }`) and have the runner consume that instead of regex-recovering from prose. Cross-cutting across ~18 check commands — deserves its own spec. **Scope note:** deliberately deferred from #687 to avoid scope creep; the regex recovery is the documented stopgap.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1157,8 +1157,8 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Maintenance checks need a standard machine-parseable findings contract
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** in-progress
+- **Spec:** docs/changes/maintenance-findings-contract/proposal.md
 - **Summary:** Follow-up from the on-demand maintenance pipeline (#687). **Problem:** `harness maintenance run` derives each task's findings count by regex-recovering it from free-text check output (`N findings|issues|violations|errors`, plus a keyword fallback in `classifyCheckExecutionFailure`). This is fragile: `doc-drift` (`check-docs`) and `entropy` (`cleanup`) emit no clean count and rely on recovery; if any check changes its output wording the count can silently break (the same class of bug that originally made the report show a uniform '1 finding'). **Proposal:** give maintenance check subcommands a standard machine-readable findings contract (e.g. a `--json` mode emitting `{ findings: N, ... }`) and have the runner consume that instead of regex-recovering from prose. Cross-cutting across ~18 check commands — deserves its own spec. **Scope note:** deliberately deferred from #687 to avoid scope creep; the regex recovery is the documented stopgap.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/check-arch.ts
+++ b/packages/cli/src/commands/check-arch.ts
@@ -14,6 +14,7 @@ import type {
   MetricResult,
   Violation,
 } from '@harness-engineering/core';
+import { formatFindingsContract } from '@harness-engineering/types';
 import { findConfigFile, loadConfig } from '../config/loader';
 import { OutputFormatter, OutputMode, type OutputModeType } from '../output/formatter';
 import { logger } from '../output/logger';
@@ -314,6 +315,15 @@ function printArchResult(
   if (output) console.log(output);
 }
 
+/** #691: emit the findings contract (new + threshold violations + regressions)
+ * when `--findings-json` is set. Extracted so the action stays under the
+ * complexity/length arch thresholds. */
+function maybeEmitArchFindings(findingsJson: boolean | undefined, value: CheckArchResult): void {
+  if (findingsJson) {
+    console.log(formatFindingsContract(buildArchIssues(value).length, 'check-arch'));
+  }
+}
+
 export function createCheckArchCommand(): Command {
   const command = new Command('check-arch')
     .description('Check architecture assertions against baseline and thresholds')
@@ -324,6 +334,7 @@ export function createCheckArchCommand(): Command {
       'Permit a --update-baseline that worsens a metric (requires --reason)'
     )
     .option('--reason <text>', 'Why an accepted regression is acceptable (logged to audit)')
+    .option('--findings-json', 'Emit findings contract as a trailing JSON line (#691)')
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const mode = resolveOutputMode(globalOpts);
@@ -355,6 +366,7 @@ export function createCheckArchCommand(): Command {
       }
 
       printArchResult(value, mode, formatter);
+      maybeEmitArchFindings(opts.findingsJson, value);
       process.exit(value.passed ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
     });
 

--- a/packages/cli/src/commands/check-deps.ts
+++ b/packages/cli/src/commands/check-deps.ts
@@ -9,6 +9,7 @@ import {
   TypeScriptParser,
 } from '@harness-engineering/core';
 import type { LayerConfig } from '@harness-engineering/core';
+import { formatFindingsContract } from '@harness-engineering/types';
 import { resolveConfig } from '../config/loader';
 import { OutputFormatter, OutputMode, type OutputModeType } from '../output/formatter';
 import { logger } from '../output/logger';
@@ -111,12 +112,15 @@ export async function runCheckDeps(
   return Ok(result);
 }
 
-async function runCheckDepsAction(globalOpts: {
-  config?: string;
-  json?: boolean;
-  verbose?: boolean;
-  quiet?: boolean;
-}): Promise<void> {
+async function runCheckDepsAction(
+  globalOpts: {
+    config?: string;
+    json?: boolean;
+    verbose?: boolean;
+    quiet?: boolean;
+  },
+  localOpts: { findingsJson?: boolean } = {}
+): Promise<void> {
   const mode: OutputModeType = globalOpts.json
     ? OutputMode.JSON
     : globalOpts.quiet
@@ -162,14 +166,23 @@ async function runCheckDepsAction(globalOpts: {
     console.log(output);
   }
 
+  // #691: findings = layer violations + circular dependencies.
+  if (localOpts.findingsJson) {
+    console.log(formatFindingsContract(issues.length, 'check-deps'));
+  }
+
   process.exit(result.value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
 }
 
 export function createCheckDepsCommand(): Command {
   const command = new Command('check-deps')
     .description('Validate dependency layers and detect circular dependencies')
-    .action(async (_opts, cmd) => {
-      await runCheckDepsAction(cmd.optsWithGlobals());
+    .option(
+      '--findings-json',
+      'Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)'
+    )
+    .action(async (opts, cmd) => {
+      await runCheckDepsAction(cmd.optsWithGlobals(), { findingsJson: opts.findingsJson });
     });
 
   return command;

--- a/packages/cli/src/commands/check-docs.ts
+++ b/packages/cli/src/commands/check-docs.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import * as path from 'path';
 import type { Result } from '@harness-engineering/core';
 import { Ok, Err } from '@harness-engineering/core';
+import { formatFindingsContract } from '@harness-engineering/types';
 import { checkDocCoverage, validateKnowledgeMap } from '@harness-engineering/core';
 import { resolveConfig } from '../config/loader';
 import { OutputFormatter, OutputMode } from '../output/formatter';
@@ -130,6 +131,10 @@ export function createCheckDocsCommand(): Command {
   const command = new Command('check-docs')
     .description('Check documentation coverage')
     .option('--min-coverage <percent>', 'Minimum coverage percentage', '80')
+    .option(
+      '--findings-json',
+      'Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)'
+    )
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const mode = resolveOutputMode(globalOpts);
@@ -156,6 +161,12 @@ export function createCheckDocsCommand(): Command {
         console.log(JSON.stringify(result.value, null, 2));
       } else if (mode !== OutputMode.QUIET) {
         printCheckDocsResult(result.value, mode, formatter);
+      }
+
+      // #691: findings = undocumented files + broken knowledge-map links.
+      if (opts.findingsJson) {
+        const findings = result.value.undocumented.length + result.value.brokenLinks.length;
+        console.log(formatFindingsContract(findings, 'check-docs'));
       }
 
       process.exit(result.value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);

--- a/packages/cli/src/commands/check-security.ts
+++ b/packages/cli/src/commands/check-security.ts
@@ -9,6 +9,7 @@ import {
   parseSecurityConfig,
 } from '@harness-engineering/core';
 import type { SecurityFinding, SecuritySeverity } from '@harness-engineering/core';
+import { formatFindingsContract } from '@harness-engineering/types';
 import { OutputFormatter, OutputMode, type OutputModeType } from '../output/formatter';
 import { logger } from '../output/logger';
 import { ExitCode } from '../utils/errors';
@@ -131,7 +132,7 @@ export async function runCheckSecurity(
 }
 
 async function runCheckSecurityAction(
-  opts: { severity: SecuritySeverity; changedOnly?: boolean },
+  opts: { severity: SecuritySeverity; changedOnly?: boolean; findingsJson?: boolean },
   globalOpts: { json?: boolean; quiet?: boolean; verbose?: boolean }
 ): Promise<void> {
   const mode: OutputModeType = globalOpts.json
@@ -172,6 +173,11 @@ async function runCheckSecurityAction(
     console.log(output);
   }
 
+  // #691: findings = security findings at or above the requested severity.
+  if (opts.findingsJson) {
+    console.log(formatFindingsContract(result.value.findings.length, 'check-security'));
+  }
+
   process.exit(result.value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
 }
 
@@ -191,6 +197,10 @@ export function createCheckSecurityCommand(): Command {
       }
     })
     .option('--changed-only', 'Only scan git-changed files')
+    .option(
+      '--findings-json',
+      'Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)'
+    )
     .action(async (opts, cmd) => {
       await runCheckSecurityAction(opts, cmd.optsWithGlobals());
     });

--- a/packages/cli/src/commands/cleanup.ts
+++ b/packages/cli/src/commands/cleanup.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import * as path from 'path';
 import type { Result, EntropyConfig, DriftConfig } from '@harness-engineering/core';
 import { Ok, Err, EntropyAnalyzer } from '@harness-engineering/core';
+import { formatFindingsContract } from '@harness-engineering/types';
 import { resolveConfig } from '../config/loader';
 import { OutputFormatter, OutputMode } from '../output/formatter';
 import { resolveOutputMode } from '../utils/output';
@@ -153,6 +154,10 @@ export function createCleanupCommand(): Command {
   const command = new Command('cleanup')
     .description('Detect entropy issues (doc drift, dead code, patterns)')
     .option('-t, --type <type>', 'Issue type: drift, dead-code, patterns, all', 'all')
+    .option(
+      '--findings-json',
+      'Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)'
+    )
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       const mode = resolveOutputMode(globalOpts);
@@ -179,6 +184,11 @@ export function createCleanupCommand(): Command {
         console.log(JSON.stringify(result.value, null, 2));
       } else if (mode !== OutputMode.QUIET || result.value.totalIssues > 0) {
         printCleanupResult(result.value, formatter);
+      }
+
+      // #691: findings = total entropy issues (drift + dead code + patterns).
+      if (opts.findingsJson) {
+        console.log(formatFindingsContract(result.value.totalIssues, 'cleanup'));
       }
 
       process.exit(result.value.totalIssues === 0 ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);

--- a/packages/cli/src/commands/cross-check.ts
+++ b/packages/cli/src/commands/cross-check.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import * as path from 'path';
 import chalk from 'chalk';
+import { formatFindingsContract } from '@harness-engineering/types';
 import { runCrossCheck } from './validate-cross-check';
 import { OutputMode, type OutputModeType } from '../output/formatter';
 import { ExitCode } from '../utils/errors';
@@ -11,6 +12,7 @@ interface CrossCheckCommandOptions {
   json?: boolean;
   verbose?: boolean;
   quiet?: boolean;
+  findingsJson?: boolean;
 }
 
 interface CrossCheckValue {
@@ -53,6 +55,10 @@ async function runCrossCheckCommand(options: CrossCheckCommandOptions): Promise<
 
   const { warnings } = result.value;
   emitCrossCheckResult(result.value, mode);
+  // #691: findings = cross-artifact consistency warnings.
+  if (options.findingsJson) {
+    console.log(formatFindingsContract(warnings, 'cross-check'));
+  }
   process.exit(warnings === 0 ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
 }
 
@@ -94,6 +100,10 @@ export function createCrossCheckCommand(): Command {
     .description('Check cross-artifact consistency (plan-to-implementation coverage and staleness)')
     .option('--specs-dir <path>', 'Specs directory relative to project root (default: docs/specs)')
     .option('--plans-dir <path>', 'Plans directory relative to project root (default: docs/plans)')
+    .option(
+      '--findings-json',
+      'Emit the machine-readable maintenance findings contract ({ findings: N }) as a trailing stdout line (#691)'
+    )
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
       await runCrossCheckCommand({
@@ -102,6 +112,7 @@ export function createCrossCheckCommand(): Command {
         json: globalOpts.json,
         verbose: globalOpts.verbose,
         quiet: globalOpts.quiet,
+        findingsJson: opts.findingsJson,
       });
     });
 }

--- a/packages/orchestrator/src/maintenance/check-runner.ts
+++ b/packages/orchestrator/src/maintenance/check-runner.ts
@@ -10,6 +10,7 @@
 
 import { execFile as nodeExecFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { parseFindingsContract } from '@harness-engineering/types';
 import type { CheckCommandResult } from './task-runner';
 
 /**
@@ -32,7 +33,10 @@ export const MAINTENANCE_CHECK_MAX_BUFFER = 64 * 1024 * 1024;
  */
 export const MAINTENANCE_CHECK_TIMEOUT_MS = 300_000;
 
-/** Primary findings-count parser ("45 issues", "3 findings", …). */
+/** Legacy findings-count parser ("45 issues", "3 findings", …). Used ONLY as a
+ * fallback for checks that have not yet emitted the machine-readable findings
+ * contract ({@link parseFindingsContract}); migrated checks are read from the
+ * contract and never touch this regex (#691). */
 const FINDINGS_RE = /(\d+)\s+(?:finding|issue|violation|error)/i;
 
 const nodeExecFileAsync = promisify(nodeExecFile);
@@ -81,6 +85,10 @@ export function isCheckTimeoutError(e: ExecFileError): boolean {
  * Spawn a resolved harness check invocation and classify its result into a
  * {@link CheckCommandResult}. Behavior (shared by cron + CLI):
  *
+ *   - findings contract present (#691) → the machine-readable envelope
+ *     (`{ findings: N, ... }`) wins over everything below, on BOTH a clean and a
+ *     non-zero exit (`findingsSource: 'contract'`). A migrated check reports its
+ *     count as structured data, so no wording change can break it.
  *   - clean exit, parseable count → `{ findings: N }` (or 0 on a parse-miss; a
  *     check that ran and said nothing is clean, not "1 finding").
  *   - non-zero exit WITH a parseable count → real findings (`executionFailed:
@@ -111,9 +119,29 @@ export async function runHarnessCheck(
       maxBuffer,
     });
     const text = String(stdout);
+    // Prefer the machine-readable findings contract (#691): a migrated check
+    // emits `{ findings: N, ... }` and we trust that count verbatim, immune to
+    // any wording change in the surrounding human output. Regex is the labeled
+    // fallback for checks not yet emitting the contract.
+    const contract = parseFindingsContract(text);
+    if (contract) {
+      return {
+        passed: contract.findings === 0,
+        findings: contract.findings,
+        output: text,
+        executionFailed: false,
+        findingsSource: 'contract',
+      };
+    }
     const m = text.match(FINDINGS_RE);
     const findings = m ? parseInt(m[1]!, 10) : 0;
-    return { passed: findings === 0, findings, output: text, executionFailed: false };
+    return {
+      passed: findings === 0,
+      findings,
+      output: text,
+      executionFailed: false,
+      findingsSource: 'regex',
+    };
   } catch (err) {
     const e = err as ExecFileError;
     let output = [e.stdout, e.stderr]
@@ -132,13 +160,33 @@ export async function runHarnessCheck(
       return { passed: false, findings: 0, output, executionFailed: true };
     }
 
+    // A migrated check that found issues exits non-zero but STILL emits the
+    // contract (#691). The envelope proves the check ran and reported N — trust
+    // it over both the regex and the executionFailed classification below.
+    const contract = parseFindingsContract(output);
+    if (contract) {
+      return {
+        passed: contract.findings === 0,
+        findings: contract.findings,
+        output,
+        executionFailed: false,
+        findingsSource: 'contract',
+      };
+    }
+
     const m = output.match(FINDINGS_RE);
     if (m) {
       // Non-zero exit WITH a parseable count: the check ran and found issues.
-      return { passed: false, findings: parseInt(m[1]!, 10), output, executionFailed: false };
+      return {
+        passed: false,
+        findings: parseInt(m[1]!, 10),
+        output,
+        executionFailed: false,
+        findingsSource: 'regex',
+      };
     }
     // Non-zero exit / spawn error with NO parseable count: could not produce a
     // usable result (ENOENT, unknown subcommand, crash). Flag executionFailed.
-    return { passed: false, findings: 0, output, executionFailed: true };
+    return { passed: false, findings: 0, output, executionFailed: true, findingsSource: 'regex' };
   }
 }

--- a/packages/orchestrator/src/maintenance/task-registry.ts
+++ b/packages/orchestrator/src/maintenance/task-registry.ts
@@ -17,7 +17,10 @@ export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
     description: 'Detect and fix architecture violations',
     schedule: '0 2 * * *',
     branch: 'harness-maint/arch-fixes',
-    checkCommand: ['check-arch'],
+    // `--findings-json` emits the standard machine-readable findings contract
+    // (#691); the runner consumes `{ findings: N }` instead of regex-recovering
+    // the count from prose.
+    checkCommand: ['check-arch', '--findings-json'],
     fixSkill: 'harness-arch-fix',
   },
   {
@@ -26,7 +29,7 @@ export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
     description: 'Detect and fix dependency violations',
     schedule: '0 2 * * *',
     branch: 'harness-maint/dep-fixes',
-    checkCommand: ['check-deps'],
+    checkCommand: ['check-deps', '--findings-json'],
     fixSkill: 'harness-dep-fix',
   },
   {
@@ -35,7 +38,7 @@ export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
     description: 'Detect and fix documentation drift',
     schedule: '0 3 * * *',
     branch: 'harness-maint/doc-fixes',
-    checkCommand: ['check-docs'],
+    checkCommand: ['check-docs', '--findings-json'],
     fixSkill: 'harness-doc-fix',
   },
   {
@@ -44,7 +47,7 @@ export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
     description: 'Detect and fix security findings',
     schedule: '0 1 * * *',
     branch: 'harness-maint/security-fixes',
-    checkCommand: ['check-security'],
+    checkCommand: ['check-security', '--findings-json'],
     fixSkill: 'harness-security-fix',
   },
   {
@@ -53,7 +56,7 @@ export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
     description: 'Detect and fix codebase entropy',
     schedule: '0 3 * * *',
     branch: 'harness-maint/entropy-fixes',
-    checkCommand: ['cleanup'],
+    checkCommand: ['cleanup', '--findings-json'],
     fixSkill: 'harness-entropy-fix',
   },
   {
@@ -77,7 +80,9 @@ export const BUILT_IN_TASKS: readonly TaskDefinition[] = [
     // WITHOUT running the full `harness validate` suite. It prints a parseable
     // `Cross-check: N issues` line and exits 0 (clean) / 1 (N issues), so the
     // maintenance runner reports real results instead of an honest `failure`.
-    checkCommand: ['cross-check'],
+    // `--findings-json` additionally emits the machine-readable findings contract
+    // (#691) so the count is read from `{ findings: N }`, not the prose line.
+    checkCommand: ['cross-check', '--findings-json'],
     fixSkill: 'harness-cross-check-fix',
   },
 

--- a/packages/orchestrator/src/maintenance/task-runner.ts
+++ b/packages/orchestrator/src/maintenance/task-runner.ts
@@ -35,6 +35,15 @@ export interface CheckCommandResult {
    * that predate this field.
    */
   executionFailed?: boolean;
+  /**
+   * How `findings` was derived (#691). `'contract'` means the check emitted the
+   * standard machine-readable findings envelope (`{ findings: N, ... }`) and the
+   * runner consumed THAT — the robust, wording-independent path. `'regex'` means
+   * the count was recovered by scanning free-text output — the legacy fallback,
+   * kept for checks not yet migrated to the contract. Omitted for runners (e.g.
+   * `CheckScriptRunner`) that don't distinguish the two.
+   */
+  findingsSource?: 'contract' | 'regex';
 }
 
 /**

--- a/packages/orchestrator/tests/maintenance/check-runner.test.ts
+++ b/packages/orchestrator/tests/maintenance/check-runner.test.ts
@@ -8,6 +8,7 @@ import {
   type RunHarnessCheckOptions,
 } from '../../src/maintenance/check-runner';
 import { classifyCheckExecutionFailure } from '../../src/maintenance/task-runner';
+import { formatFindingsContract } from '@harness-engineering/types';
 
 /** An execFile stub that RESOLVES with the given stdout (clean run). */
 function resolveWith(stdout: string): ExecFileAsyncFn {
@@ -115,6 +116,61 @@ describe('runHarnessCheck — shared cron+CLI spawn/parse/timeout core', () => {
     // The marker is appended after the partial output, yet classification still
     // resolves to `unrunnable` (timeout wins ahead of explicitFindingsCount).
     expect(classifyCheckExecutionFailure(r.output).kind).toBe('unrunnable');
+  });
+
+  // --- #691: machine-readable findings contract preferred over regex ---
+
+  it('clean exit WITH the findings contract → count from contract, source=contract', async () => {
+    const r = await runHarnessCheck(SPAWN, '/repo', {
+      execFileAsync: resolveWith(
+        `Documentation coverage: 62%\n${formatFindingsContract(3, 'check-docs')}\n`
+      ),
+    });
+    expect(r.findings).toBe(3);
+    expect(r.passed).toBe(false);
+    expect(r.executionFailed).toBe(false);
+    expect(r.findingsSource).toBe('contract');
+  });
+
+  it('contract with findings:0 → passed, source=contract (a migrated clean check)', async () => {
+    const r = await runHarnessCheck(SPAWN, '/repo', {
+      execFileAsync: resolveWith(`${formatFindingsContract(0, 'cleanup')}\n`),
+    });
+    expect(r.findings).toBe(0);
+    expect(r.passed).toBe(true);
+    expect(r.findingsSource).toBe('contract');
+  });
+
+  it('non-zero exit WITH the contract → real findings, NOT executionFailed, source=contract', async () => {
+    const r = await runHarnessCheck(SPAWN, '/repo', {
+      execFileAsync: rejectWith({
+        stdout: `Entropy issues: 8\n${formatFindingsContract(8, 'cleanup')}`,
+        code: 1,
+      }),
+    });
+    expect(r.findings).toBe(8);
+    expect(r.executionFailed).toBe(false);
+    expect(r.findingsSource).toBe('contract');
+  });
+
+  it('a wording change does NOT break a migrated check: prose says "clean" but contract says 5', async () => {
+    // The prose carries no `N issues` token the regex could match — and even
+    // reads as clean — yet the contract is authoritative, so the count is 5.
+    const r = await runHarnessCheck(SPAWN, '/repo', {
+      execFileAsync: resolveWith(
+        `No problems detected. Everything looks great!\n${formatFindingsContract(5, 'check-arch')}`
+      ),
+    });
+    expect(r.findings).toBe(5);
+    expect(r.findingsSource).toBe('contract');
+  });
+
+  it('regex remains the labeled fallback for an unmigrated check (no contract line)', async () => {
+    const r = await runHarnessCheck(SPAWN, '/repo', {
+      execFileAsync: resolveWith('Found 45 issues\n'),
+    });
+    expect(r.findings).toBe(45);
+    expect(r.findingsSource).toBe('regex');
   });
 
   it('empty command output on success-with-buffer is stringified safely', async () => {

--- a/packages/orchestrator/tests/maintenance/integration-full-cycle.test.ts
+++ b/packages/orchestrator/tests/maintenance/integration-full-cycle.test.ts
@@ -103,8 +103,12 @@ describe('Integration: full maintenance cycle', () => {
       // Trigger evaluation at 2am when arch-violations is due
       await scheduler.evaluate(new Date('2026-04-17T02:00:00'));
 
-      // Verify the full pipeline executed
-      expect(checkRunner.run).toHaveBeenCalledWith(['check-arch'], '/test/project');
+      // Verify the full pipeline executed (#691: arch-violations now runs the
+      // check with --findings-json to emit the machine-readable findings contract).
+      expect(checkRunner.run).toHaveBeenCalledWith(
+        ['check-arch', '--findings-json'],
+        '/test/project'
+      );
       expect(agentDispatcher.dispatch).toHaveBeenCalledWith(
         'harness-arch-fix',
         'harness-maint/arch-fixes',

--- a/packages/orchestrator/tests/maintenance/task-registry.test.ts
+++ b/packages/orchestrator/tests/maintenance/task-registry.test.ts
@@ -81,7 +81,8 @@ describe('task-registry', () => {
       expect(t.type).toBe('mechanical-ai');
       expect(t.schedule).toBe('0 2 * * *');
       expect(t.branch).toBe('harness-maint/arch-fixes');
-      expect(t.checkCommand).toEqual(['check-arch']);
+      // #691: emits the machine-readable findings contract via --findings-json.
+      expect(t.checkCommand).toEqual(['check-arch', '--findings-json']);
     });
 
     it('dep-violations: daily 2am, mechanical-ai', () => {
@@ -89,7 +90,7 @@ describe('task-registry', () => {
       expect(t.type).toBe('mechanical-ai');
       expect(t.schedule).toBe('0 2 * * *');
       expect(t.branch).toBe('harness-maint/dep-fixes');
-      expect(t.checkCommand).toEqual(['check-deps']);
+      expect(t.checkCommand).toEqual(['check-deps', '--findings-json']);
     });
 
     it('doc-drift: daily 3am, mechanical-ai', () => {
@@ -130,7 +131,8 @@ describe('task-registry', () => {
       // staleness) via the `validate_cross_check` core (`runCrossCheck`) WITHOUT
       // running the full `harness validate` suite. Emits a parseable
       // `Cross-check: N issues` line so the runner reports real results.
-      expect(t.checkCommand).toEqual(['cross-check']);
+      // #691: also emits the machine-readable findings contract via --findings-json.
+      expect(t.checkCommand).toEqual(['cross-check', '--findings-json']);
     });
 
     it('every built-in checkCommand uses a real CLI subcommand, not an MCP tool name', () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -251,6 +251,14 @@ export type {
   OsvGuardConfig,
 } from './maintenance';
 
+// --- Maintenance findings contract (#691) ---
+export {
+  MAINTENANCE_FINDINGS_CONTRACT_VERSION,
+  formatFindingsContract,
+  parseFindingsContract,
+} from './maintenance-findings';
+export type { MaintenanceFindingsContract } from './maintenance-findings';
+
 // --- Auth (Hermes Phase 0) ---
 export {
   TokenScopeSchema,

--- a/packages/types/src/maintenance-findings.ts
+++ b/packages/types/src/maintenance-findings.ts
@@ -1,0 +1,113 @@
+// packages/types/src/maintenance-findings.ts
+//
+// The standard machine-parseable findings contract for maintenance checks (#691).
+//
+// `harness maintenance run` (and the cron orchestrator) historically recovered
+// each task's findings COUNT by regex-scanning free-text check output
+// (`N findings|issues|violations|errors`, plus a keyword fallback in
+// `classifyCheckExecutionFailure`). That is fragile: checks like `check-docs`
+// (doc-drift) and `cleanup` (entropy) emit no clean count, and a wording change
+// silently breaks the count.
+//
+// This module defines ONE shared envelope so a check subcommand can emit its
+// finding count as structured data and the runner can consume THAT instead of
+// regex. It lives in `@harness-engineering/types` — the one package both the CLI
+// (which EMITS the envelope from check subcommands) and the orchestrator (which
+// PARSES it in `runHarnessCheck`) already depend on — so the shape cannot drift
+// between producer and consumer.
+//
+// Wire form: a single JSON line printed to stdout, e.g.
+//   {"findings":12,"check":"check-docs","v":1}
+// Emitting it as one self-contained line (never pretty-printed across lines)
+// keeps it recoverable by a last-line-first scan that tolerates surrounding
+// human output, mirroring the sibling `parseStatusLine` status contract.
+
+/** Current version of the maintenance findings contract envelope. Bump only on
+ * a breaking shape change; parsers tolerate an absent or unknown `v`. */
+export const MAINTENANCE_FINDINGS_CONTRACT_VERSION = 1;
+
+/**
+ * The standard machine-readable findings envelope a maintenance check subcommand
+ * emits (under `--findings-json`) and the maintenance runner consumes in place
+ * of regex-recovering a count from prose (#691).
+ */
+export interface MaintenanceFindingsContract {
+  /** Non-negative count of findings the check surfaced (0 = clean). This is the
+   * authoritative count — the runner trusts it over any regex recovery. */
+  findings: number;
+  /** Optional provenance: the check subcommand that produced the envelope
+   * (e.g. `'check-docs'`). Advisory only; used for debugging/observability. */
+  check?: string;
+  /** Contract version ({@link MAINTENANCE_FINDINGS_CONTRACT_VERSION}) for
+   * forward-compatibility. */
+  v?: number;
+}
+
+/**
+ * Format a {@link MaintenanceFindingsContract} as the single-line JSON string a
+ * check subcommand prints to stdout. `findings` is coerced to a non-negative
+ * integer so a producer can pass a raw `.length` without worrying about sign or
+ * fractional inputs.
+ */
+export function formatFindingsContract(findings: number, check?: string): string {
+  const envelope: MaintenanceFindingsContract = {
+    findings: normalizeFindings(findings),
+    v: MAINTENANCE_FINDINGS_CONTRACT_VERSION,
+  };
+  if (check) envelope.check = check;
+  return JSON.stringify(envelope);
+}
+
+/**
+ * Parse the findings contract from a check's captured stdout. Scans lines from
+ * the LAST backward for a single-line JSON object carrying a numeric `findings`
+ * field, so a trailing envelope is found ahead of any earlier human output (and
+ * a multi-line pretty-printed `--json` blob — whose lines are fragments, never a
+ * complete `{...}` object — is correctly ignored). Returns `null` when no
+ * envelope is present, which is the signal for the runner to fall back to the
+ * legacy regex recovery.
+ */
+export function parseFindingsContract(output: string): MaintenanceFindingsContract | null {
+  if (!output) return null;
+  const lines = output
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  // Scan from the LAST line backward so a trailing envelope wins over earlier
+  // output; the first line that parses into a valid envelope is authoritative.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const contract = parseContractLine(lines[i]!);
+    if (contract) return contract;
+  }
+  return null;
+}
+
+/**
+ * Parse a single candidate line into a {@link MaintenanceFindingsContract}, or
+ * `null` when it is not a JSON object carrying a numeric `findings` field (the
+ * caller then keeps scanning earlier lines). The numeric requirement is what
+ * distinguishes the envelope from an unrelated JSON line — e.g. check-security's
+ * `--json` blob whose `findings` is an ARRAY is rejected, not misread.
+ */
+function parseContractLine(line: string): MaintenanceFindingsContract | null {
+  if (!line.startsWith('{') || !line.endsWith('}')) return null;
+  let rec: Record<string, unknown>;
+  try {
+    // Safe cast: a string that starts with `{`, ends with `}`, and parses is
+    // always a JSON object (arrays start with `[`, primitives never match).
+    rec = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (typeof rec.findings !== 'number' || !Number.isFinite(rec.findings)) return null;
+  const contract: MaintenanceFindingsContract = { findings: normalizeFindings(rec.findings) };
+  if (typeof rec.check === 'string') contract.check = rec.check;
+  if (typeof rec.v === 'number') contract.v = rec.v;
+  return contract;
+}
+
+/** Coerce an arbitrary numeric finding count into a non-negative integer. */
+function normalizeFindings(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.trunc(n));
+}

--- a/packages/types/tests/maintenance-findings.test.ts
+++ b/packages/types/tests/maintenance-findings.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAINTENANCE_FINDINGS_CONTRACT_VERSION,
+  formatFindingsContract,
+  parseFindingsContract,
+} from '../src/maintenance-findings';
+
+describe('formatFindingsContract', () => {
+  it('emits a single-line JSON envelope with findings, check, and version', () => {
+    const line = formatFindingsContract(12, 'check-docs');
+    expect(line).not.toContain('\n');
+    expect(JSON.parse(line)).toEqual({
+      findings: 12,
+      check: 'check-docs',
+      v: MAINTENANCE_FINDINGS_CONTRACT_VERSION,
+    });
+  });
+
+  it('omits check when not provided', () => {
+    const parsed = JSON.parse(formatFindingsContract(0));
+    expect(parsed.findings).toBe(0);
+    expect(parsed.check).toBeUndefined();
+  });
+
+  it('coerces negative / fractional / non-finite counts to a non-negative integer', () => {
+    expect(JSON.parse(formatFindingsContract(-5)).findings).toBe(0);
+    expect(JSON.parse(formatFindingsContract(3.9)).findings).toBe(3);
+    expect(JSON.parse(formatFindingsContract(Number.NaN)).findings).toBe(0);
+  });
+});
+
+describe('parseFindingsContract', () => {
+  it('round-trips a formatted envelope', () => {
+    const parsed = parseFindingsContract(formatFindingsContract(7, 'cleanup'));
+    expect(parsed).toEqual({
+      findings: 7,
+      check: 'cleanup',
+      v: MAINTENANCE_FINDINGS_CONTRACT_VERSION,
+    });
+  });
+
+  it('finds the envelope as a trailing line after human output', () => {
+    const output = [
+      'Documentation coverage: 62.0%',
+      '  - src/foo.ts',
+      formatFindingsContract(3, 'check-docs'),
+    ].join('\n');
+    expect(parseFindingsContract(output)?.findings).toBe(3);
+  });
+
+  it('returns null when no envelope line is present (regex-fallback signal)', () => {
+    expect(parseFindingsContract('Validation passed\n45 issues found')).toBeNull();
+    expect(parseFindingsContract('')).toBeNull();
+  });
+
+  it('parses a bare envelope with no check / version fields', () => {
+    expect(parseFindingsContract('{"findings":2}')).toEqual({ findings: 2 });
+  });
+
+  it('ignores a { … } line that is not valid JSON', () => {
+    expect(parseFindingsContract('{not valid json}')).toBeNull();
+  });
+
+  it('ignores a multi-line pretty-printed --json blob (fragments are not complete objects)', () => {
+    const blob = JSON.stringify({ valid: false, findings: [{ a: 1 }] }, null, 2);
+    expect(parseFindingsContract(blob)).toBeNull();
+  });
+
+  it('rejects a JSON line whose findings field is not a number', () => {
+    expect(parseFindingsContract('{"findings":[1,2,3]}')).toBeNull();
+    expect(parseFindingsContract('{"findings":"3"}')).toBeNull();
+  });
+
+  it('scans backward and returns the LAST envelope when several are present', () => {
+    const output = [formatFindingsContract(1), formatFindingsContract(9)].join('\n');
+    expect(parseFindingsContract(output)?.findings).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary

`harness maintenance run` (and the cron orchestrator that shares its `TaskRunner`) derived each task's findings COUNT by regex-recovering it from free-text check output (`N findings|issues|violations|errors`, plus an assume-1 keyword fallback in `classifyCheckExecutionFailure`). That is fragile: `check-docs` (doc-drift) and `cleanup` (entropy) emit no clean count — so doc-drift reported a uniform "1 finding" — and any wording change could silently break the count.

This gives maintenance checks a standard machine-readable findings contract and has the runner consume THAT instead of regex.

## What changed

**Shared contract (`@harness-engineering/types` — the one package both producer and consumer already depend on, so the shape can't drift):**
- `MaintenanceFindingsContract` (`{ findings, check?, v? }`) + `formatFindingsContract` / `parseFindingsContract` in `maintenance-findings.ts`.
- Wire form: a single JSON line on stdout, e.g. `{"findings":12,"check":"check-docs","v":1}`. Parsed last-line-first, so it tolerates surrounding human output and ignores multi-line `--json` blobs.

**Runner (`@harness-engineering/orchestrator`):**
- `runHarnessCheck` now prefers the envelope over the regex on BOTH clean and non-zero exits; the envelope is authoritative (a migrated check that found issues exits non-zero but still reports N via the contract).
- Regex is the labeled fallback; `CheckCommandResult.findingsSource: 'contract' | 'regex'` makes the source observable.
- Cron and CLI share this core, so both benefit identically.

**Producer (`@harness-engineering/cli`):**
- Additive `--findings-json` flag on `check-arch`, `check-deps`, `check-docs`, `cleanup`, `check-security`, `cross-check`.
- Built-in maintenance registry passes `--findings-json` for those tasks — same pattern as `pulse run --non-interactive` / `sync-main --json`.

**Migrated vs left on fallback:**
- Migrated (all mechanical-ai checks): `check-arch`, `check-deps`, `check-docs`, `cleanup`, `check-security`, `cross-check`.
- Left on regex/status fallback (documented in the spec): `traceability` (always exits 0, coverage-based); report-only `check-perf` / `predict` / `insights` / `stale-constraints` / `graph scan`; `pulse` / `compound` (already emit the sibling `candidatesFound` status contract). Incrementally migratable later.

## Backward compatibility

Fully additive. `--findings-json` defaults off (interactive CLI unchanged); unmigrated checks keep the regex path; `parseFindingsContract` returns `null` → regex fallback for any output without the envelope. No change to `harness maintenance run` behavior.

## Tests

- `packages/types/tests/maintenance-findings.test.ts` — format/parse round-trip, trailing-line recovery, multi-line-blob rejection, non-numeric `findings` rejection, coercion.
- `packages/orchestrator/tests/maintenance/check-runner.test.ts` — runner reads the count from the contract (`findingsSource: 'contract'`) on clean and non-zero exits; a wording change ("clean" prose but `findings: 5`) does not break the count; regex remains the labeled fallback for an unmigrated check.
- `task-registry.test.ts` / `integration-full-cycle.test.ts` — registry `checkCommand`s carry `--findings-json`.

Spec: `docs/changes/maintenance-findings-contract/proposal.md`

Closes #691