### PR TITLE
feat(pre-commit): rationale per skip + capped allowlist (#529)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -29,6 +29,15 @@ fi
 # guardrail stays visibly named — roadmap #529) AND passed to `ci check` via
 # "$SKIP". Editing this list updates the warnings and the actual skip together;
 # they cannot drift.
+#
+# CAP (roadmap #529): this is a CLOSED, documented allowlist — it cannot silently
+# grow. Every category is enumerated with its rationale in
+# .husky/pre-commit-skip-allowlist.md, and
+# packages/cli/tests/hooks/pre-commit-skip-allowlist.test.ts FAILS if this SKIP
+# set, the per-category `case` rationale arms below, and that allowlist doc ever
+# diverge. Adding a skip is therefore a visible, reviewed three-way edit (this
+# list + a rationale arm + the allowlist doc), never a silent one-token append.
+#
 # NOTE (#529 follow-up, resolved in #965): the STRENGTH-003 skip-list auditor now
 # resolves this `--skip "$SKIP"` variable form — it finds the matching `SKIP="a,b,c"`
 # assignment in this file and audits that list — so review-time coverage of the skip
@@ -46,7 +55,28 @@ old_ifs=$IFS
 IFS=,
 set -f
 for cat in $SKIP; do
-  echo "⚠ pre-commit: '$cat' check SKIPPED (deferred to CI) — see roadmap #529" >&2
+  # One rationale arm per category: WHY it is deferred + WHERE it runs instead
+  # (so the gap is named, not just numbered — roadmap #529). Every category in
+  # $SKIP MUST have an explicit arm; the `*` arm names an UNDOCUMENTED skip so a
+  # new category can never pass silently. Keep the arms in sync with
+  # .husky/pre-commit-skip-allowlist.md (the allowlist test enforces both).
+  case "$cat" in
+    entropy)
+      why="drift/dead-code graph walk, too slow per-commit; runs in CI (harness ci check)" ;;
+    docs)
+      why="doc-drift analysis, graph-dependent; runs in CI + PR doc-drift advisory" ;;
+    perf)
+      why="complexity/coupling graph walk, slow + already arch-baselined locally; runs in CI" ;;
+    security)
+      why="whole-tree static security scan, slow per-commit; runs in CI + security ledger" ;;
+    deps)
+      why="dependency/supply-chain health, slow; runs in CI" ;;
+    phase-gate)
+      why="spec/impl phase gate, needs CLI phase context; runs in CI + 'harness check-phase-gate'" ;;
+    *)
+      why="UNDOCUMENTED skip — add it to .husky/pre-commit-skip-allowlist.md with a rationale" ;;
+  esac
+  echo "⚠ pre-commit: skipping '$cat' check (deferred) — $why" >&2
 done
 set +f
 IFS=$old_ifs

--- a/.husky/pre-commit-skip-allowlist.md
+++ b/.husky/pre-commit-skip-allowlist.md
@@ -1,0 +1,47 @@
+# Pre-commit `--skip` allowlist
+
+`.husky/pre-commit` runs `harness ci check --skip "$SKIP"`. `$SKIP` is a **closed,
+documented allowlist** of check categories that are deliberately deferred out of the
+per-commit gate. This file is the reviewed source of that decision: it names every
+skipped category, why it is deferred, and where it runs instead.
+
+## Why this file exists (roadmap #529)
+
+Deferring a slow check from commit-time is fine on its own. The failure mode is the
+_cumulative silence_ — "every gap was once a known issue, then background noise, then
+invisible." Two mechanisms keep the gaps named and the list capped:
+
+1. **Visible at commit time.** The hook emits one `stderr` warning per skipped category,
+   each carrying the rationale below, so a committer always sees which guardrails are
+   inactive and why.
+2. **Capped against silent growth.** `packages/cli/tests/hooks/pre-commit-skip-allowlist.test.ts`
+   fails if the hook's `SKIP` set, its per-category rationale `case` arms, and the table
+   below ever diverge. Adding a skip is therefore a visible, reviewed change across all
+   three, never a silent one-token append to `SKIP`.
+
+All six categories below run in CI via `harness ci check --skip arch`
+(`.github/workflows/harness.yml`) — the mirror image of the local gate, which runs `arch`,
+`validate`, and `traceability` and defers the rest. Between the two, every category runs
+exactly once.
+
+## Allowlist
+
+| Category     | Where it runs instead                                | Why it is deferred from pre-commit                                                                                           |
+| ------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `entropy`    | CI (`harness ci check`)                              | Drift & dead-code detection walks the whole dependency/knowledge graph — too slow to run on every commit.                    |
+| `docs`       | CI (`harness ci check`) + PR doc-drift advisory      | Doc-drift analysis depends on graph state and is advisory-grade; the PR advisory job already surfaces it before merge.       |
+| `perf`       | CI (`harness ci check`)                              | Complexity/coupling analysis is another full-graph walk, and its violations are already arch-baselined by the local gate.    |
+| `security`   | CI (`harness ci check`) + security ledger            | The static security scan reads every source file in the tree — too slow per-commit; CI and the ledger cover it before merge. |
+| `deps`       | CI (`harness ci check`)                              | Dependency / supply-chain health is slow and registry-facing — inappropriate for a fast local commit gate.                   |
+| `phase-gate` | CI (`harness ci check`) + `harness check-phase-gate` | The spec↔implementation phase gate needs CLI-level phase context the fast local gate does not set up, and is phase-specific. |
+
+## Changing the list
+
+To add, remove, or rename a skip, edit **all three** in the same PR:
+
+1. the `SKIP="..."` assignment in `.husky/pre-commit`,
+2. the matching rationale `case` arm in `.husky/pre-commit` (`why=...`), and
+3. the table row above (with a real rationale + where-it-runs-instead).
+
+The allowlist test enforces that these three stay in sync, so the reviewer sees the gap
+being named — that is the entire point of the cap.

--- a/docs/changes/audit-precommit-skip-list/proposal.md
+++ b/docs/changes/audit-precommit-skip-list/proposal.md
@@ -1,0 +1,91 @@
+# Spec: Audit and cap the pre-commit `--skip` list
+
+**Status:** approved (autonomous — single-phase, low-complexity)
+**Roadmap:** #529 (`Audit and cap the pre-commit --skip list`)
+**Keywords:** pre-commit, ci-check, skip-list, allowlist, rationale, cap
+
+## Problem
+
+`.husky/pre-commit` runs `harness ci check --skip "$SKIP"` where
+`SKIP="entropy,docs,perf,security,deps,phase-gate"` — six check categories deferred out of
+the commit-time gate. A prior change (#964) already emits one stderr warning per skipped
+category, but each warning was **generic** ("check SKIPPED (deferred to CI) — see roadmap
+#529"); it did not say _why_ a category is deferred or _where_ it runs instead. And the list
+itself had no cap: a seventh token appended to `SKIP` would sail through unless a reviewer
+happened to notice, which is exactly the failure the roadmap item names — "every gap was once
+a known issue, then background noise, then invisible."
+
+### Boundary
+
+- **In scope:** (1) make each skip's rationale visible at commit time; (2) cap the list with a
+  checked-in, documented allowlist + a test that fails on divergence; (3) document each
+  rationale (why deferred, where it runs).
+- **Out of scope:** re-enabling any skipped check, moving checks between pre-commit / pre-push
+  / CI, or changing _which_ categories are skipped. Visibility + cap only — behavior of the
+  checks is unchanged.
+
+## Where the skipped checks actually run
+
+CI runs `harness ci check --json --skip arch` (`.github/workflows/harness.yml`) — the mirror
+image of the local gate. The local gate runs `arch`, `validate`, `traceability` and defers the
+other six; CI runs those six and defers `arch` (whose baseline is a local concern). Between the
+two, every category runs exactly once. This symmetry is what makes each deferral safe and gives
+every rationale a concrete "runs instead in CI" answer.
+
+## Approaches considered
+
+|            | A) Enrich warnings + checked-in allowlist doc + divergence test                                   | B) Rely on the existing STRENGTH-003 heuristic auditor | C) Move the six checks into pre-commit (no skip)         |
+| ---------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------- |
+| **How**    | `case` arm per category + `.husky/pre-commit-skip-allowlist.md` + a test asserting hook⇄doc agree | Lean on STRENGTH-003 flagging >2 skips w/o inline `#`  | Delete `--skip`, add the six to the commit gate          |
+| **Pros**   | Hard failure on silent growth; each gap named with rationale                                      | No new files                                           | Actually closes the gaps                                 |
+| **Cons**   | One reference doc to maintain (test keeps it honest)                                              | Warning-level only, no rationale, not a commit/CI gate | Large behavior change; slows every commit — out of scope |
+| **Risk**   | Low                                                                                               | Low but insufficient                                   | High                                                     |
+| **Effort** | Low                                                                                               | None                                                   | Medium                                                   |
+
+**Chosen: A.** The roadmap item asks for _visibility + a cap_, not re-architecting the gate.
+STRENGTH-003 (B) is a useful review-time heuristic and is retained, but it is advisory
+(warning severity, not a blocking gate) and carries no per-category rationale — so it does not
+by itself satisfy "documented allowlist that can't silently grow." C is a real but separate
+decision that YAGNI cuts from this scope.
+
+## User story
+
+As a developer committing to this repo, I want each deferred pre-commit check named _with its
+rationale_ at commit time, and the set of deferrals capped by a reviewed allowlist, so the
+disabled guardrails never silently grow invisible.
+
+## Success criteria (EARS)
+
+1. WHEN the pre-commit hook runs, the system SHALL emit exactly one stderr line per category in
+   `$SKIP`, each naming the category AND a short rationale (why deferred + where it runs).
+2. The system SHALL keep a checked-in reference (`.husky/pre-commit-skip-allowlist.md`) that
+   enumerates every skipped category with its rationale and where it runs instead.
+3. The system SHALL fail a test WHEN the hook's `SKIP` set, its per-category rationale arms, and
+   the allowlist doc diverge — so adding/removing a skip is a visible, reviewed change.
+4. The system SHALL NOT change the `--skip` set, the `ci check` invocation, or the hook's
+   pass/block exit behavior.
+5. The skip warnings and the audited list SHALL derive from one source (`$SKIP`), not a
+   hand-copied duplicate that can drift.
+
+## Implementation Order
+
+### Phase 1: Rationale + allowlist cap <!-- complexity: low -->
+
+1. Replace the generic warning loop in `.husky/pre-commit` with a POSIX `case "$cat"` block
+   mapping each category to a one-line rationale; keep the single-source `$SKIP` loop and the
+   `*` fallback arm that loudly names an undocumented category.
+2. Add `.husky/pre-commit-skip-allowlist.md` — the reviewed reference table (category / where it
+   runs / why deferred) plus a "changing the list" checklist.
+3. Add `packages/cli/tests/hooks/pre-commit-skip-allowlist.test.ts` asserting three-way
+   agreement (SKIP ⇄ case arms ⇄ allowlist table), non-empty rationale per row, and that the
+   hook still passes `--skip "$SKIP"`.
+
+## Notes for the executor
+
+- The hook is POSIX `sh` (may be dash under husky) — `case`/`esac` is portable; no arrays or
+  `set -o pipefail`.
+- Keep the load-bearing comments (the #726 tee-exit-code note, the #910 node-pin note, the #965
+  STRENGTH-003 note) — do not delete them as collateral.
+- Do not alter the hook's file mode (must stay executable, `100755`).
+- `docs/reference/` is auto-generated by `generate-docs.mjs`; the allowlist lives in `.husky/`
+  (next to the hook it governs) so a docs regen cannot overwrite it.

--- a/docs/roadmap.d/audit-and-cap-the-pre-commit-skip-list.md
+++ b/docs/roadmap.d/audit-and-cap-the-pre-commit-skip-list.md
@@ -7,7 +7,7 @@ order: 3
 ### Audit and cap the pre-commit --skip list
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/audit-precommit-skip-list/proposal.md
 - **Summary:** `.husky/pre-commit:4` silently skips `entropy,docs,perf,security,deps,phase-gate` — six categories disabled at commit time. The skips may be justified individually, but the cumulative silence is the article's failure pattern #2: "every gap was once a known issue. Then it became background noise. Then it became invisible." Either move slow checks to pre-push with no auto-skip, or emit a one-line stderr warning per skipped category so the gaps remain visibly named. Source: Pass 1 #4.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,7 +236,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Audit and cap the pre-commit --skip list
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/audit-precommit-skip-list/proposal.md
 - **Summary:** `.husky/pre-commit:4` silently skips `entropy,docs,perf,security,deps,phase-gate` — six categories disabled at commit time. The skips may be justified individually, but the cumulative silence is the article's failure pattern #2: "every gap was once a known issue. Then it became background noise. Then it became invisible." Either move slow checks to pre-push with no auto-skip, or emit a one-line stderr warning per skipped category so the gaps remain visibly named. Source: Pass 1 #4.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/tests/hooks/pre-commit-skip-allowlist.test.ts
+++ b/packages/cli/tests/hooks/pre-commit-skip-allowlist.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * CAP for the pre-commit `--skip` list (roadmap #529).
+ *
+ * `.husky/pre-commit` defers six `harness ci check` categories out of the local
+ * commit gate. Each deferral may be individually justified, but the cumulative,
+ * silent growth of that list is the failure this test guards against: "every gap
+ * was once a known issue, then background noise, then invisible."
+ *
+ * The skip list is a CLOSED, documented allowlist expressed in THREE places that
+ * must agree:
+ *   1. the `SKIP="a,b,c"` assignment actually passed to `ci check`,
+ *   2. one per-category rationale `case` arm (the stderr warning shown at commit
+ *      time), and
+ *   3. the reviewed reference table in `.husky/pre-commit-skip-allowlist.md`.
+ *
+ * This test fails if those three ever diverge. So a skip can never grow silently:
+ * adding one forces a visible, reviewed edit across the hook AND the allowlist doc
+ * (with a real rationale), which a reviewer sees. That is the entire cap.
+ */
+
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error('Could not locate monorepo root (pnpm-workspace.yaml not found)');
+    }
+    dir = parent;
+  }
+}
+
+const repoRoot = findRepoRoot(path.dirname(fileURLToPath(import.meta.url)));
+const HOOK_PATH = path.join(repoRoot, '.husky', 'pre-commit');
+const ALLOWLIST_PATH = path.join(repoRoot, '.husky', 'pre-commit-skip-allowlist.md');
+
+const hook = fs.readFileSync(HOOK_PATH, 'utf-8');
+const allowlistDoc = fs.readFileSync(ALLOWLIST_PATH, 'utf-8');
+
+/** The literal `SKIP="a,b,c"` assignment that is passed to `ci check`. */
+function parseSkipAssignment(src: string): string[] {
+  const m = /^\s*SKIP="([^"]*)"/m.exec(src);
+  if (!m) throw new Error('Could not find a `SKIP="..."` assignment in .husky/pre-commit');
+  return m[1]!
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** The category labels of the per-category rationale `case "$cat" in ... esac` block. */
+function parseCaseArmCategories(src: string): string[] {
+  const start = src.indexOf('case "$cat" in');
+  if (start === -1) throw new Error('Could not find the `case "$cat" in` rationale block');
+  const end = src.indexOf('esac', start);
+  if (end === -1) throw new Error('Could not find the closing `esac` of the rationale block');
+  const block = src.slice(start, end);
+  // Arm labels sit on their own line as `<category>)` — the `*` fallback arm is
+  // intentionally excluded (it exists to name an UNDOCUMENTED category loudly).
+  const arms: string[] = [];
+  const armRe = /^[ \t]*([a-z][a-z-]+)\)\s*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = armRe.exec(block)) !== null) arms.push(m[1]!);
+  return arms;
+}
+
+/** Category names + their rationale cells from the allowlist reference table. */
+function parseAllowlistRows(doc: string): { category: string; rationale: string }[] {
+  const rows: { category: string; rationale: string }[] = [];
+  // A table row whose first cell is a backtick-wrapped category:
+  //   | `entropy` | ...where it runs... | ...why deferred... |
+  const rowRe = /^\|\s*`([a-z][a-z-]+)`\s*\|([^|]*)\|([^|]*)\|/gm;
+  let m: RegExpExecArray | null;
+  while ((m = rowRe.exec(doc)) !== null) {
+    rows.push({ category: m[1]!, rationale: (m[2]! + m[3]!).trim() });
+  }
+  return rows;
+}
+
+const sorted = (xs: string[]): string[] => [...xs].sort();
+
+describe('pre-commit --skip allowlist cap (#529)', () => {
+  const skipCategories = parseSkipAssignment(hook);
+  const caseArmCategories = parseCaseArmCategories(hook);
+  const allowlistRows = parseAllowlistRows(allowlistDoc);
+  const allowlistCategories = allowlistRows.map((r) => r.category);
+
+  it('parses a non-empty skip list, case-arm set, and allowlist table', () => {
+    // Guards the parsers themselves — a silent parse failure must never make the
+    // divergence assertions vacuously pass.
+    expect(skipCategories.length).toBeGreaterThan(0);
+    expect(caseArmCategories.length).toBeGreaterThan(0);
+    expect(allowlistCategories.length).toBeGreaterThan(0);
+  });
+
+  it('the SKIP set passed to `ci check` matches the per-category rationale arms', () => {
+    // Every skipped category is named + rationalized at commit time; no arm names a
+    // category that is not actually skipped.
+    expect(sorted(caseArmCategories)).toEqual(sorted(skipCategories));
+  });
+
+  it('the SKIP set matches the documented allowlist table exactly', () => {
+    // The cap: the hook's actual skip set and the reviewed reference cannot diverge.
+    // A skip added to the hook without a documented, rationalized row fails here.
+    expect(sorted(allowlistCategories)).toEqual(sorted(skipCategories));
+  });
+
+  it('every allowlisted category carries a non-empty rationale', () => {
+    for (const row of allowlistRows) {
+      expect(row.rationale.length, `rationale for '${row.category}' is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('the allowlist table has no duplicate categories', () => {
+    expect(allowlistCategories.length).toBe(new Set(allowlistCategories).size);
+  });
+
+  it('the hook passes the single-source SKIP variable to `ci check` (no hand-copied list)', () => {
+    // If the hook stopped deriving the skipped set from `$SKIP`, the warnings and
+    // the audited list could drift; this keeps them one source.
+    expect(hook).toMatch(/ci check --skip "\$SKIP"/);
+  });
+});


### PR DESCRIPTION
## What

`.husky/pre-commit` defers six `harness ci check` categories out of the commit-time gate
(`SKIP="entropy,docs,perf,security,deps,phase-gate"`). The prior change (#964) already emitted
one stderr warning per skip, but each was **generic** ("check SKIPPED — see roadmap #529") and
the list had **no cap** — a seventh token appended to `SKIP` would sail through unnoticed. This
is roadmap #529's "cumulative silence" failure mode: "every gap was once a known issue, then
background noise, then invisible."

This makes each gap **named with a rationale** and **caps the list** so it cannot silently grow.

## Changes

- **Rationale per skip** — `.husky/pre-commit` now maps each skipped category to a one-line
  rationale (WHY deferred + WHERE it runs instead) via a POSIX `case` block, still driven by the
  single-source `$SKIP` loop. A `*` fallback arm loudly names any undocumented category. Example
  line: `⚠ pre-commit: skipping 'security' check (deferred) — whole-tree static security scan, slow per-commit; runs in CI + security ledger`.
- **Checked-in allowlist** — `.husky/pre-commit-skip-allowlist.md` documents every skipped
  category, its rationale, and where it runs instead, plus a "changing the list" checklist.
- **Cap test** — `packages/cli/tests/hooks/pre-commit-skip-allowlist.test.ts` fails if the hook's
  `SKIP` set, its per-category rationale arms, and the allowlist table ever diverge. Adding a
  skip therefore becomes a visible, reviewed three-way edit — never a silent one-token append.

Behavior of the checks is unchanged: no category was re-enabled, moved, or removed. All six run
in CI via `harness ci check --skip arch` (`harness.yml`) — the mirror image of the local gate.

## The six skips (rationale)

| Category | Runs instead | Why deferred |
| --- | --- | --- |
| `entropy` | CI | Full dependency/knowledge-graph walk — too slow per-commit. |
| `docs` | CI + PR doc-drift advisory | Graph-dependent, advisory-grade; PR advisory surfaces it pre-merge. |
| `perf` | CI | Another full-graph walk; violations already arch-baselined locally. |
| `security` | CI + security ledger | Static scan reads every source file — too slow per-commit. |
| `deps` | CI | Dependency/supply-chain health is slow and registry-facing. |
| `phase-gate` | CI + `harness check-phase-gate` | Needs CLI-level phase context the fast local gate doesn't set up. |

## Testing

- New allowlist test: 6/6 pass. Negative-checked: appending a fake 7th skip fails the two
  divergence assertions as designed; restoring returns to green.
- Hook warning loop verified under `/bin/sh` (dash-safe `case`/`esac`); emits all six rationale
  lines; file mode preserved (`100755`).
- No regressions: `pre-commit-cicheck-gate.e2e.test.ts` (2/2), `strength-003-skip-list.test.ts`
  (9/9), `tsc --noEmit` clean, `generate-docs --check` fresh.

No changeset: no publishable `src/` changed (hook + docs + a test only).

Spec: `docs/changes/audit-precommit-skip-list/proposal.md`

Closes #529
