### PR TITLE
fix(roadmap): resolve writeback shards by frontmatter slug + stamp last_synced (#1036, #1037)

### DIFF
--- a/.changeset/roadmap-writeback-slug-fix.md
+++ b/.changeset/roadmap-writeback-slug-fix.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/core': patch
+---
+
+Fix two roadmap-sync writeback bugs that silently corrupted GitHub sync in sharded mode.
+
+- **#1036 (writeback aborted on title-slug ≠ frontmatter-slug):** `applyRoadmapDiff`
+  addresses each shard by `slugifyFeatureName(feature.name)`, but a shard's real file
+  identity is its frontmatter `slug` — frequently a hand-shortened / length-truncated
+  form of the title. For rows where the two diverge, the writeback ENOENT'd and aborted
+  the _entire_ batch, dropping every external-ID backfill and the `last_synced` stamp,
+  and (worst case) re-creating a duplicate tracker issue on the next run. `ShardStore`
+  now resolves the real shard by name-slug when the direct path misses, so `patchFeature`
+  / `removeFeature` address the correct file without aborting.
+- **#1037 (`last_synced` never stamped on success):** `fullSync` never wrote
+  `last_synced` on a clean apply — `applyRoadmapDiff`'s frontmatter branch only fires
+  when before/after frontmatter differ (never here) and is a no-op in sharded mode — so
+  `_meta.md` drifted arbitrarily stale even with zero errors. Added a `stampLastSynced`
+  store operation (writes `_meta.md` in sharded mode, the aggregate frontmatter in
+  monolith mode) and `fullSync` now stamps it on every successful non-dry-run writeback.

--- a/docs/roadmap.d/bug-roadmap-harness-roadmap-sync-never-stamps-last-synced-on-success.md
+++ b/docs/roadmap.d/bug-roadmap-harness-roadmap-sync-never-stamps-last-synced-on-success.md
@@ -7,7 +7,7 @@ order: 31
 ### bug(roadmap): harness roadmap sync never stamps last_synced on success
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** .changeset/roadmap-writeback-slug-fix.md
 - **Summary:** `fullSync` (packages/core/src/roadmap/sync-engine.ts) pushes, pulls, and writes back changed rows, but never sets `roadmap.frontmatter.lastSynced`. Because `applyRoadmapDiff` only writes frontmatter when it differs, a successful `harness roadmap sync --apply` leaves `_meta.md`'s `last_synced` untouched — so the field stays stale even though a sync just completed. This is the exact "`last_synced` 22 days behind `last_manual_edit`" symptom the sync command's own docstring cites as its reason for existing, and it undermines the human-always-wins staleness heuristic and any observability keyed on last_synced. Confirmed live 2026-08-04: `--apply` reported 104 patches / 0 errors yet `last_synced` remained at the pre-run value (manually corrected afterward). **Fix:** stamp `frontmatter.lastSynced = now` in `fullSync` before writeback (guard against `Date.now()` in test seams as elsewhere), and cover it with a test asserting last_synced advances on a no-op-diff successful sync.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.d/bug-roadmap-sync-writeback-resolves-shards-by-title-slug-not-frontmatter-slug-silently-aborting-the-whole-batch.md
+++ b/docs/roadmap.d/bug-roadmap-sync-writeback-resolves-shards-by-title-slug-not-frontmatter-slug-silently-aborting-the-whole-batch.md
@@ -7,7 +7,7 @@ order: 30
 ### bug(roadmap): sync writeback resolves shards by title-slug not frontmatter slug, silently aborting the whole batch
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** .changeset/roadmap-writeback-slug-fix.md
 - **Summary:** `applyRoadmapDiff` (packages/core/src/roadmap/store/apply-diff.ts) keys every shard by `slugifyFeatureName(feature.name)`, but the sharded store's real identity is the frontmatter `slug` — which `load()` enforces to equal the filename base, and which is frequently a hand-shortened or length-truncated form of the title. For the 22 shards (of 104) where `slugify(title) !== frontmatter.slug` (e.g. filename `lmlm-wire-engine-to-operator-surfaces` vs `slugify("LMLM Phases 4–9: wire the engine to operator surfaces")`), `patchFeature`/`addFeature`/`removeFeature` open `{slugify(title)}.md`, hit ENOENT, and `applyRoadmapDiff` **returns Err on the first failure — aborting the entire writeback batch**. Impact observed live during a full `roadmap sync --apply` (2026-08-04): all 11 external-ID backfills were dropped, `last_synced` was never stamped, and — most dangerously — a create path would have persisted the new issue on GitHub while failing to write its `externalId` back locally, so the next run recreates it (duplicate issues). **Fix:** resolve shards by the loaded feature's frontmatter slug (carry it on `RoadmapFeature` or index `before`/`after` by it), OR make the writeback collect per-shard errors instead of aborting on the first. Add a regression test with a shard whose title-slug ≠ frontmatter-slug. Workaround used on 2026-08-04: hand-backfill External-IDs so `changedFeatureNames` is empty and the buggy path is never entered.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -212,7 +212,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### bug(roadmap): sync writeback resolves shards by title-slug not frontmatter slug, silently aborting the whole batch
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** .changeset/roadmap-writeback-slug-fix.md
 - **Summary:** `applyRoadmapDiff` (packages/core/src/roadmap/store/apply-diff.ts) keys every shard by `slugifyFeatureName(feature.name)`, but the sharded store's real identity is the frontmatter `slug` — which `load()` enforces to equal the filename base, and which is frequently a hand-shortened or length-truncated form of the title. For the 22 shards (of 104) where `slugify(title) !== frontmatter.slug` (e.g. filename `lmlm-wire-engine-to-operator-surfaces` vs `slugify("LMLM Phases 4–9: wire the engine to operator surfaces")`), `patchFeature`/`addFeature`/`removeFeature` open `{slugify(title)}.md`, hit ENOENT, and `applyRoadmapDiff` **returns Err on the first failure — aborting the entire writeback batch**. Impact observed live during a full `roadmap sync --apply` (2026-08-04): all 11 external-ID backfills were dropped, `last_synced` was never stamped, and — most dangerously — a create path would have persisted the new issue on GitHub while failing to write its `externalId` back locally, so the next run recreates it (duplicate issues). **Fix:** resolve shards by the loaded feature's frontmatter slug (carry it on `RoadmapFeature` or index `before`/`after` by it), OR make the writeback collect per-shard errors instead of aborting on the first. Add a regression test with a shard whose title-slug ≠ frontmatter-slug. Workaround used on 2026-08-04: hand-backfill External-IDs so `changedFeatureNames` is empty and the buggy path is never entered.
 - **Blockers:** —
 - **Plan:** —
@@ -223,7 +223,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### bug(roadmap): harness roadmap sync never stamps last_synced on success
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** .changeset/roadmap-writeback-slug-fix.md
 - **Summary:** `fullSync` (packages/core/src/roadmap/sync-engine.ts) pushes, pulls, and writes back changed rows, but never sets `roadmap.frontmatter.lastSynced`. Because `applyRoadmapDiff` only writes frontmatter when it differs, a successful `harness roadmap sync --apply` leaves `_meta.md`'s `last_synced` untouched — so the field stays stale even though a sync just completed. This is the exact "`last_synced` 22 days behind `last_manual_edit`" symptom the sync command's own docstring cites as its reason for existing, and it undermines the human-always-wins staleness heuristic and any observability keyed on last_synced. Confirmed live 2026-08-04: `--apply` reported 104 patches / 0 errors yet `last_synced` remained at the pre-run value (manually corrected afterward). **Fix:** stamp `frontmatter.lastSynced = now` in `fullSync` before writeback (guard against `Date.now()` in test seams as elsewhere), and cover it with a test asserting last_synced advances on a no-op-diff successful sync.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/core/src/roadmap/store/factory.ts
+++ b/packages/core/src/roadmap/store/factory.ts
@@ -166,5 +166,8 @@ function withAggregateRegen(
     // section stays fresh.
     patchAssignmentHistory: async (history: AssignmentRecord[]) =>
       regen(await base.patchAssignmentHistory(history)),
+    // Writes _meta.md in sharded mode (last_synced) → regenerate so the aggregate's
+    // frontmatter reflects the fresh stamp (#1037).
+    stampLastSynced: async (timestamp: string) => regen(await base.stampLastSynced(timestamp)),
   };
 }

--- a/packages/core/src/roadmap/store/monolith-store.ts
+++ b/packages/core/src/roadmap/store/monolith-store.ts
@@ -162,6 +162,12 @@ export class MonolithStore implements RoadmapStore {
     return this.write(roadmap);
   }
 
+  // Monolith keeps `lastSynced` in the aggregate frontmatter, so stamping it is a
+  // whole-file rewrite via `patchFrontmatter` (#1037).
+  async stampLastSynced(timestamp: string): Promise<Result<void>> {
+    return this.patchFrontmatter((fm) => ({ ...fm, lastSynced: timestamp }));
+  }
+
   private async write(roadmap: Roadmap): Promise<Result<void>> {
     // Data-loss guard (#839): a whole-file rewrite serializes only the fields the
     // model captures, silently dropping hand-authored content the parser does not

--- a/packages/core/src/roadmap/store/roadmap-store.ts
+++ b/packages/core/src/roadmap/store/roadmap-store.ts
@@ -70,4 +70,14 @@ export interface RoadmapStore {
    * (never a feature shard).
    */
   patchAssignmentHistory(history: AssignmentRecord[]): Promise<Result<void>>;
+  /**
+   * Stamp the roadmap-level `lastSynced` timestamp on a successful sync (#1037).
+   * A distinct operation from {@link patchFrontmatter} (a deliberate no-op in
+   * sharded mode to protect the single-shard write invariant): `lastSynced` lives
+   * in `_meta.md` in sharded mode, so it needs a real write there — the shard
+   * backend rewrites only `_meta.md` (never a feature shard); monolith rewrites the
+   * whole file. Callers invoke this after a successful writeback so the aggregate's
+   * `last_synced` reflects when the sync actually ran.
+   */
+  stampLastSynced(timestamp: string): Promise<Result<void>>;
 }

--- a/packages/core/src/roadmap/store/shard-store.ts
+++ b/packages/core/src/roadmap/store/shard-store.ts
@@ -13,6 +13,7 @@ import type {
   RoadmapMeta,
 } from './roadmap-store';
 import type { FileIO } from './monolith-store';
+import { slugifyFeatureName } from './monolith-store';
 import { parseShard, serializeShard } from './shard';
 import { parseMeta, serializeMeta } from './meta';
 import { assembleRoadmap } from './assembler';
@@ -120,18 +121,56 @@ export class ShardStore implements RoadmapStore {
     return Ok(assembleRoadmap(read.value.shards, read.value.meta));
   }
 
-  async patchFeature(slug: string, mutate: FeatureMutation): Promise<Result<void>> {
-    const path = joinPath(this.shardDir, `${slug}.md`);
-    let content: string;
+  /**
+   * Resolve the on-disk shard addressed by a diff-supplied `slug`. `applyRoadmapDiff`
+   * computes the slug as `slugifyFeatureName(feature.name)`, but a shard's real file
+   * identity is its frontmatter `slug` — frequently a hand-shortened / length-truncated
+   * form of the title, so the two diverge for many rows (#1036). Try the direct
+   * `{slug}.md` first (the common case where they match); on a miss, scan the shard dir
+   * for the shard whose feature name slugifies to `slug` and address it by its real
+   * frontmatter slug. Returns the resolved path + parsed shard, or `Err` when no shard
+   * matches (a genuinely absent row) or the directory/shard fails to read/parse.
+   *
+   * Prior to this the slug mismatch surfaced as an ENOENT that aborted the whole
+   * writeback batch — silently dropping every external-ID backfill and, worst case,
+   * re-creating a duplicate tracker issue on the next run.
+   */
+  private async resolveShard(slug: string): Promise<Result<{ path: string; shard: Shard }>> {
+    const direct = joinPath(this.shardDir, `${slug}.md`);
+    let directContent: string | null = null;
     try {
-      content = await this.io.readFile(path);
-    } catch (err) {
-      return Err(new Error(`patchFeature: shard "${slug}" not found: ${(err as Error).message}`));
+      directContent = await this.io.readFile(direct);
+    } catch {
+      // Not addressable by the diff slug as a filename — fall through to the
+      // name-slug scan below (the title-slug ≠ frontmatter-slug case, #1036).
     }
-    const parsed = parseShard(content);
-    if (!parsed.ok) return parsed;
+    if (directContent !== null) {
+      const parsed = parseShard(directContent);
+      if (!parsed.ok) return parsed;
+      return Ok({ path: direct, shard: parsed.value });
+    }
 
-    const updated: Shard = { ...parsed.value, feature: mutate(parsed.value.feature) };
+    const read = await readShardDir(this.shardDir, this.io);
+    if (!read.ok) return read;
+    for (const shard of read.value.shards) {
+      if (slugifyFeatureName(shard.feature.name) === slug) {
+        return Ok({ path: joinPath(this.shardDir, `${shard.slug}.md`), shard });
+      }
+    }
+    return Err(
+      new Error(
+        `shard "${slug}" not found: no file named "${slug}.md" and no row whose name ` +
+          `slugifies to it in ${this.shardDir}`
+      )
+    );
+  }
+
+  async patchFeature(slug: string, mutate: FeatureMutation): Promise<Result<void>> {
+    const resolved = await this.resolveShard(slug);
+    if (!resolved.ok) return Err(new Error(`patchFeature: ${resolved.error.message}`));
+    const { path, shard } = resolved.value;
+
+    const updated: Shard = { ...shard, feature: mutate(shard.feature) };
     return this.writeShard(path, updated);
   }
 
@@ -157,11 +196,16 @@ export class ShardStore implements RoadmapStore {
   }
 
   async removeFeature(slug: string): Promise<Result<void>> {
-    const path = joinPath(this.shardDir, `${slug}.md`);
+    // Resolve the real file first so a title-slug ≠ frontmatter-slug row (#1036)
+    // deletes the correct shard instead of ENOENT-ing on the diff slug.
+    const resolved = await this.resolveShard(slug);
+    if (!resolved.ok) return Err(new Error(`removeFeature: ${resolved.error.message}`));
     try {
-      await this.io.deleteFile(path);
+      await this.io.deleteFile(resolved.value.path);
     } catch (err) {
-      return Err(new Error(`removeFeature: shard "${slug}" not found: ${(err as Error).message}`));
+      return Err(
+        new Error(`removeFeature: failed to delete shard "${slug}": ${(err as Error).message}`)
+      );
     }
     return Ok(undefined);
   }
@@ -193,6 +237,35 @@ export class ShardStore implements RoadmapStore {
     const parsed = parseMeta(content);
     if (!parsed.ok) return parsed;
     const updated = { ...parsed.value, assignmentHistory: history };
+    try {
+      await this.io.writeFile(metaPath, serializeMeta(updated));
+    } catch (err) {
+      return Err(new Error(`Failed to write ${metaPath}: ${(err as Error).message}`));
+    }
+    return Ok(undefined);
+  }
+
+  // `lastSynced` is roadmap-level and lives in `_meta.md` in sharded mode (the
+  // aggregate's frontmatter is regenerated from it), so — unlike `patchFrontmatter`,
+  // which no-ops here to keep per-feature writes off `_meta` — stamping it must
+  // genuinely rewrite `_meta.md`. No feature shard is touched, so ordinary status
+  // edits still stay off this path (#1037).
+  async stampLastSynced(timestamp: string): Promise<Result<void>> {
+    const metaPath = joinPath(this.shardDir, META_FILE);
+    let content: string;
+    try {
+      content = await this.io.readFile(metaPath);
+    } catch (err) {
+      return Err(
+        new Error(`Failed to read ${META_FILE} in ${this.shardDir}: ${(err as Error).message}`)
+      );
+    }
+    const parsed = parseMeta(content);
+    if (!parsed.ok) return parsed;
+    const updated: RoadmapMeta = {
+      ...parsed.value,
+      frontmatter: { ...parsed.value.frontmatter, lastSynced: timestamp },
+    };
     try {
       await this.io.writeFile(metaPath, serializeMeta(updated));
     } catch (err) {

--- a/packages/core/src/roadmap/sync-engine.ts
+++ b/packages/core/src/roadmap/sync-engine.ts
@@ -416,11 +416,23 @@ export async function fullSync(
     // Merge results (surface a writeback failure under the '*' envelope)
     const writebackErrors =
       persisted && !persisted.ok ? [{ featureOrId: '*', error: persisted.error }] : [];
+
+    // Stamp `last_synced` on a successful non-dry-run writeback (#1037). Previously
+    // nothing on this path ever wrote it — `applyRoadmapDiff`'s frontmatter branch
+    // only fires when before/after frontmatter differ (it never does here) and is a
+    // no-op in sharded mode anyway — so `_meta.md` drifted arbitrarily stale ("22
+    // days behind") even when every patch applied cleanly. A dry run writes nothing;
+    // a failed writeback leaves the prior stamp untouched.
+    let stampErrors: { featureOrId: string; error: Error }[] = [];
+    if (!dryRun && persisted && persisted.ok) {
+      const stamped = await store.stampLastSynced(new Date().toISOString());
+      if (!stamped.ok) stampErrors = [{ featureOrId: '*', error: stamped.error }];
+    }
     return {
       created: pushResult.created,
       updated: pushResult.updated,
       assignmentChanges: pullResult.assignmentChanges,
-      errors: [...pushResult.errors, ...pullResult.errors, ...writebackErrors],
+      errors: [...pushResult.errors, ...pullResult.errors, ...writebackErrors, ...stampErrors],
       dryRun,
       planned: {
         creates: pushResult.planned.creates,

--- a/packages/core/tests/roadmap/reconcile.test.ts
+++ b/packages/core/tests/roadmap/reconcile.test.ts
@@ -84,6 +84,10 @@ function inMemoryStore(initial: Roadmap) {
       calls.patchAssignmentHistory.push(structuredClone(history));
       return Ok(undefined);
     },
+    stampLastSynced: async (timestamp) => {
+      current.frontmatter = { ...current.frontmatter, lastSynced: timestamp };
+      return Ok(undefined);
+    },
   };
   return {
     store,

--- a/packages/core/tests/roadmap/store/apply-diff.test.ts
+++ b/packages/core/tests/roadmap/store/apply-diff.test.ts
@@ -53,6 +53,10 @@ function spyStore() {
       calls.push({ op: 'history', slug: '*' });
       return Ok(undefined);
     },
+    stampLastSynced: async () => {
+      calls.push({ op: 'stamp', slug: '*' });
+      return Ok(undefined);
+    },
   };
   return { store, calls };
 }
@@ -158,6 +162,7 @@ describe('applyRoadmapDiff', () => {
       removeFeature: async () => Ok(undefined),
       patchFrontmatter: async () => Ok(undefined),
       patchAssignmentHistory: async () => Ok(undefined),
+      stampLastSynced: async () => Ok(undefined),
     };
     const r = await applyRoadmapDiff(store, before, after);
     expect(r.ok).toBe(false);

--- a/packages/core/tests/roadmap/store/shard-store.test.ts
+++ b/packages/core/tests/roadmap/store/shard-store.test.ts
@@ -6,7 +6,7 @@ import { assembleRoadmap } from '../../../src/roadmap/store/assembler';
 import { serializeShard } from '../../../src/roadmap/store/shard';
 import { serializeMeta } from '../../../src/roadmap/store/meta';
 import { serializeRoadmap } from '../../../src/roadmap/serialize';
-import { ASSEMBLER_SHARDS, ASSEMBLER_META } from './fixtures';
+import { ASSEMBLER_SHARDS, ASSEMBLER_META, feat } from './fixtures';
 
 const SHARD_DIR = '/repo/docs/roadmap.d';
 
@@ -197,6 +197,65 @@ describe('ShardStore', () => {
     expect(r.ok).toBe(false);
     expect(writes).toHaveLength(0);
     expect(files.get(`${SHARD_DIR}/a-feature.md`)).toBe(before);
+  });
+
+  // #1036: a shard's real file identity is its frontmatter `slug` (often a
+  // hand-shortened / length-truncated form of the title), so
+  // `slugifyFeatureName(name)` — the key `applyRoadmapDiff` addresses it by —
+  // frequently differs. Before the fix that mismatch ENOENT'd and aborted the
+  // whole writeback batch. patchFeature must resolve the real shard by name-slug.
+  it('patchFeature() resolves a shard whose title-slug ≠ frontmatter slug (#1036)', async () => {
+    const { io, files, writes } = makeShardIO();
+    const mismatched = {
+      slug: 'short-id',
+      milestone: 'MVP Release',
+      order: 30,
+      feature: feat('A Much Longer Feature Title That Was Hand Shortened', 'planned'),
+    };
+    files.set(`${SHARD_DIR}/short-id.md`, serializeShard(mismatched));
+    const store = new ShardStore({ shardDir: SHARD_DIR, io });
+
+    // The diff addresses the row by slugifyFeatureName(name), NOT the frontmatter slug.
+    const diffSlug = 'a-much-longer-feature-title-that-was-hand-shortened';
+    expect(diffSlug).not.toBe(mismatched.slug);
+    const r = await store.patchFeature(diffSlug, (f) => ({
+      ...f,
+      externalId: 'github:owner/repo#9',
+    }));
+    expect(r.ok).toBe(true);
+    // It rewrote the REAL shard file, not a slugify-named phantom (no ENOENT abort).
+    expect(writes.map(basename)).toEqual(['short-id.md']);
+    expect(files.get(`${SHARD_DIR}/short-id.md`)).toContain('github:owner/repo#9');
+    expect(files.has(`${SHARD_DIR}/${diffSlug}.md`)).toBe(false);
+  });
+
+  it('removeFeature() resolves a shard whose title-slug ≠ frontmatter slug (#1036)', async () => {
+    const { io, files, deletes } = makeShardIO();
+    const mismatched = {
+      slug: 'trunc',
+      milestone: 'MVP Release',
+      order: 31,
+      feature: feat('Yet Another Long Title Kept Under A Short Slug', 'planned'),
+    };
+    files.set(`${SHARD_DIR}/trunc.md`, serializeShard(mismatched));
+    const store = new ShardStore({ shardDir: SHARD_DIR, io });
+
+    const diffSlug = 'yet-another-long-title-kept-under-a-short-slug';
+    const r = await store.removeFeature(diffSlug);
+    expect(r.ok).toBe(true);
+    expect(deletes).toEqual([`${SHARD_DIR}/trunc.md`]);
+    expect(files.has(`${SHARD_DIR}/trunc.md`)).toBe(false);
+  });
+
+  // #1037: last_synced lives in _meta.md in sharded mode. Stamping it must
+  // genuinely rewrite _meta.md (patchFrontmatter no-ops here) — and touch no shard.
+  it('stampLastSynced() rewrites ONLY _meta.md with the new timestamp (#1037)', async () => {
+    const { io, files, writes } = makeShardIO();
+    const store = new ShardStore({ shardDir: SHARD_DIR, io });
+    const r = await store.stampLastSynced('2027-01-01T00:00:00.000Z');
+    expect(r.ok).toBe(true);
+    expect(writes).toEqual([`${SHARD_DIR}/_meta.md`]);
+    expect(files.get(`${SHARD_DIR}/_meta.md`)).toContain('last_synced: "2027-01-01T00:00:00.000Z"');
   });
 });
 

--- a/packages/core/tests/roadmap/sync-engine.test.ts
+++ b/packages/core/tests/roadmap/sync-engine.test.ts
@@ -748,4 +748,85 @@ describe('fullSync()', () => {
       'github:owner/repo#1'
     );
   });
+
+  // #1037: `--apply` succeeds with zero errors yet `last_synced` used to stay stale
+  // (the "22 days behind" symptom). A successful writeback must stamp it.
+  it('stamps last_synced on a successful monolith writeback (#1037)', async () => {
+    const roadmap = makeRoadmap([makeFeature({ name: 'Stamp Me' })]);
+    writeRoadmap(roadmap);
+    const adapter = mockAdapter({ fetchAllTickets: vi.fn(async () => Ok([])) });
+
+    const result = await fullSync(tmpDir, adapter, CONFIG);
+    expect(result.errors).toHaveLength(0);
+
+    const raw = fs.readFileSync(roadmapPath, 'utf-8');
+    const stamped = /last_synced:\s*(.+)/.exec(raw)?.[1]?.trim();
+    expect(stamped).toBeDefined();
+    // The stale seed value ('2026-04-01T00:00:00Z') must have been overwritten.
+    expect(stamped).not.toContain('2026-04-01T00:00:00Z');
+    expect(Date.parse(stamped!.replace(/['"]/g, ''))).toBeGreaterThan(
+      Date.parse('2026-04-01T00:00:00Z')
+    );
+  });
+
+  it('stamps last_synced in _meta.md on a successful sharded writeback (#1037)', async () => {
+    const roadmap = makeRoadmap([makeFeature({ name: 'Sharded Stamp' })]);
+    const { shards, meta } = roadmapToShards(roadmap);
+    const shardDir = path.join(tmpDir, 'docs', 'roadmap.d');
+    fs.mkdirSync(shardDir, { recursive: true });
+    for (const shard of shards) {
+      fs.writeFileSync(path.join(shardDir, `${shard.slug}.md`), serializeShard(shard), 'utf-8');
+    }
+    fs.writeFileSync(path.join(shardDir, '_meta.md'), serializeMeta(meta), 'utf-8');
+
+    const adapter = mockAdapter({ fetchAllTickets: vi.fn(async () => Ok([])) });
+    const result = await fullSync(tmpDir, adapter, CONFIG);
+    expect(result.errors).toHaveLength(0);
+
+    const metaRaw = fs.readFileSync(path.join(shardDir, '_meta.md'), 'utf-8');
+    const stamped = /last_synced:\s*"?([^"\n]+)"?/.exec(metaRaw)?.[1]?.trim();
+    expect(stamped).toBeDefined();
+    expect(Date.parse(stamped!)).toBeGreaterThan(Date.parse('2026-04-01T00:00:00Z'));
+  });
+
+  // #1036: a shard whose frontmatter slug is a hand-shortened form of the title
+  // (slugify(name) !== slug). The externalId backfill addresses it by slugify(name);
+  // before the fix that ENOENT'd and aborted the ENTIRE writeback batch — dropping
+  // the backfill and risking a duplicate issue on the next run. It must patch cleanly.
+  it('backfills externalId on a title-slug ≠ frontmatter-slug shard without aborting (#1036)', async () => {
+    const shardDir = path.join(tmpDir, 'docs', 'roadmap.d');
+    fs.mkdirSync(shardDir, { recursive: true });
+    // Hand-write a shard whose file identity ('short') diverges from slugify(name).
+    const longName = 'A Very Long Feature Name Needing A Ticket';
+    const shard = {
+      slug: 'short',
+      milestone: 'M1',
+      order: 0,
+      feature: makeFeature({ name: longName }),
+    };
+    fs.writeFileSync(path.join(shardDir, 'short.md'), serializeShard(shard), 'utf-8');
+    const meta = {
+      frontmatter: {
+        project: 'test',
+        version: 1,
+        lastSynced: '2026-04-01T00:00:00Z',
+        lastManualEdit: '2026-04-01T00:00:00Z',
+      },
+      milestones: ['M1'],
+    };
+    fs.writeFileSync(path.join(shardDir, '_meta.md'), serializeMeta(meta), 'utf-8');
+
+    const adapter = mockAdapter({ fetchAllTickets: vi.fn(async () => Ok([])) });
+    const result = await fullSync(tmpDir, adapter, CONFIG);
+
+    // No batch abort: writeback succeeded (no '*' envelope error) and the ticket was created.
+    expect(result.errors).toHaveLength(0);
+    expect(result.created).toHaveLength(1);
+    // The externalId was persisted to the REAL shard file, not a slugify-named phantom.
+    const persisted = fs.readFileSync(path.join(shardDir, 'short.md'), 'utf-8');
+    expect(persisted).toContain('github:owner/repo#1');
+    expect(
+      fs.existsSync(path.join(shardDir, `${'a-very-long-feature-name-needing-a-ticket'}.md`))
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes two roadmap-sync writeback bugs in `@harness-engineering/core` that silently corrupted GitHub sync in sharded mode. Both live in the same subsystem (`packages/core/src/roadmap/store` + `sync-engine.ts`).

### #1036 (P1) — writeback resolved shards by title-slug, not frontmatter slug

`applyRoadmapDiff` addresses each shard by `slugifyFeatureName(feature.name)`, but a shard's real file identity is its frontmatter `slug` — frequently a hand-shortened / length-truncated form of the title. For the rows where `slugify(title) !== frontmatter.slug`, `ShardStore.patchFeature` / `removeFeature` opened `{slugify(title)}.md`, hit ENOENT, and `applyRoadmapDiff` returned `Err` on the first failure — **aborting the entire writeback batch**, silently dropping every external-ID backfill and the `last_synced` stamp, and (worst case) leaving a freshly-created GitHub issue with no local `externalId` → a duplicate on the next run.

**Fix:** `ShardStore` now resolves the real shard by name-slug when the direct `{slug}.md` path misses (`resolveShard`): it scans the shard dir for the row whose feature name slugifies to the requested slug and addresses it by its true frontmatter slug. `patchFeature` / `removeFeature` route through it, so a title-slug ≠ frontmatter-slug row patches cleanly with no ENOENT and no batch abort. Matching shards keep their fast direct-path behavior. Store parity and the single-shard-write invariants are untouched (the loaded `Roadmap` is unchanged).

### #1037 (P2) — fullSync never stamped last_synced on success

`fullSync` pushed, pulled, and wrote back changed rows but never wrote `last_synced`: `applyRoadmapDiff`'s frontmatter branch only fires when before/after frontmatter differ (never the case here) and is a no-op in sharded mode anyway. So `_meta.md`'s `last_synced` drifted arbitrarily stale even on a clean `--apply` with zero errors (the "22 days behind" symptom).

**Fix:** added a dedicated `stampLastSynced(timestamp)` store operation — it rewrites `_meta.md` in sharded mode (where `last_synced` actually lives) and the aggregate frontmatter in monolith mode, distinct from the deliberately-no-op `patchFrontmatter`. `fullSync` now stamps it on every successful non-dry-run writeback (dry runs write nothing; a failed writeback leaves the prior stamp untouched). The sharded decorator regenerates the aggregate after the stamp so `roadmap.md` stays fresh.

## Tests

Six new regression tests (all green), plus the existing roadmap suite stays green (517 passed / 1 skipped):

- `shard-store.test.ts`: `patchFeature` / `removeFeature` resolve a shard whose title-slug ≠ frontmatter slug (#1036); `stampLastSynced` rewrites only `_meta.md` (#1037).
- `sync-engine.test.ts`: `fullSync` backfills externalId on a title-slug ≠ frontmatter-slug shard without aborting (#1036); stamps `last_synced` on a successful monolith writeback and in `_meta.md` on a successful sharded writeback (#1037).

Verification: `@harness-engineering/core` roadmap tests green, `tsc --noEmit` clean, `eslint src` clean, full pre-push gauntlet passed.

Closes #1036
Closes #1037
