### PR TITLE
feat(outcome-eval): wire the spec-satisfaction gate into the lifecycle (autopilot + CI)

### DIFF
--- a/.changeset/wire-outcome-eval-gate.md
+++ b/.changeset/wire-outcome-eval-gate.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/intelligence': minor
+'@harness-engineering/cli': minor
+---
+
+Wire outcome-eval in as an automatic, blocking post-execution spec-satisfaction gate.
+
+- Add `harness outcome-eval-ci`: a headless, CI-runnable surface of the outcome-eval gate. It resolves the spec (explicit `--spec` or auto-discovered from the diff), the diff range, and optional captured test output; runs the `OutcomeEvaluator`; persists the `execution_outcome` node to `.harness/graph`; and turns the TypeScript-derived ship authority into an exit code — blocking (exit 1) only on a high-confidence `NOT_SATISFIED` under `--block-on blocking` (the default). Degrade-safe: no resolvable spec, no analysis provider, an empty diff, or a persistence failure yields an `INCONCLUSIVE`/advisory verdict and exit 0.
+- Enrich `OutcomeEvaluator` persistence: the `execution_outcome` node now carries the full verdict (`rationale`, `authority`, `unmetCriteria`) plus an optional `commit` sha, so a sha-keyed consumer (the pre-merge brief) can reconstruct and surface the verdict. `OutcomeEvalInput` gains an optional `commit` field; the `outcome_eval` MCP tool threads it through. All additive — a node written without a commit keeps the prior shape aside from the new verdict fields. `authority` on the node is the TS-derived value, never read from the LLM.

--- a/.gemini-extension/commands/autopilot.toml
+++ b/.gemini-extension/commands/autopilot.toml
@@ -62,7 +62,7 @@ INIT → ASSESS → PLAN → APPROVE_PLAN → EXECUTE → VERIFY → INTEGRATE �
                                                                                   │
                                                                            [next phase?]
                                                                             │           │
-                                                                         ASSESS   FINAL_REVIEW → DONE
+                                                                         ASSESS   FINAL_REVIEW → OUTCOME_EVAL → DONE
 ```
 
 ---
@@ -245,17 +245,46 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
    subagent_type: "harness-code-reviewer"
    prompt: "Final cross-phase review. Diff: git diff {startingCommit}..HEAD. Session: {sessionSlug}. Prior findings: {collected}. Focus on cross-phase coherence: naming, duplicated utilities, architectural drift. Report findings (critical / important / suggestion)."
    ```
-4. No blocking: store in `finalReview.findings`, set `"passed"` → DONE.
+4. No blocking: store in `finalReview.findings`, set `"passed"` → OUTCOME_EVAL.
 5. Blocking: ask "fix / override / stop."
    - `fix`: increment `finalReview.retryCount` (max 3). Dispatch harness-task-executor: "Fix these blocking findings: {findings with file, line, title}. Session: {sessionSlug}. Commit each fix atomically." Run `harness validate`. Re-run FINAL_REVIEW from step 1. If retryCount > 3: stop, record in `.harness/failures.md`.
-   - `override`: record rationale in `decisions[]`. Set `"overridden"` → DONE.
+   - `override`: record rationale in `decisions[]`. Set `"overridden"` → OUTCOME_EVAL.
    - `stop`: save state and exit (resumable).
+
+---
+
+### OUTCOME_EVAL
+
+The blocking post-execution **spec-satisfaction gate** — the harness's ship gate. It fires ONCE per session, after FINAL_REVIEW and before DONE, judging the WHOLE change against the spec. (It runs at the ship boundary, not per phase: a per-phase judgment would spuriously fail while later phases are still outstanding.) It runs at every rigor level — the gate is not weakened by `--fast`.
+
+1. Set `currentState: "OUTCOME_EVAL"`.
+2. **Gather the evidence (required).** Capture the cumulative change as a unified diff: `git diff {startingCommit}..HEAD`. Capture the most recent test-runner output retained from VERIFY; if none is retained, re-run the project test command and capture stdout+stderr. Resolve the head sha via `git rev-parse HEAD`.
+3. **Invoke the gate.** Call the `outcome_eval` MCP tool:
+
+   ```json
+   {
+     "specPath": "<spec path>",
+     "diff": "<git diff {startingCommit}..HEAD>",
+     "testOutput": "<captured test output>",
+     "commit": "<git rev-parse HEAD>"
+   }
+   ```
+
+   Supplying real `diff` and `testOutput` is mandatory — omitting them degrades the verdict to INCONCLUSIVE/advisory, a silent false-negative that defeats the gate. The tool persists the verdict as an `execution_outcome` node (keyed by `commit`) and returns `verdict`, `confidence`, `judgedAgainst`, `rationale`, `unmetCriteria`, and the TS-derived `authority`.
+
+4. **Honor the TS-derived authority — never the LLM.** `authority` is computed in TypeScript from `(verdict, confidence)`; read it, never recompute or override it.
+   - `authority === "advisory"` (all `SATISFIED`, all `INCONCLUSIVE`, and every `medium`/`low` `NOT_SATISFIED`): record the verdict in `finalReview` and proceed → DONE. An advisory `NOT_SATISFIED` is surfaced for human attention but does not halt.
+   - `authority === "blocking"` (a high-confidence `NOT_SATISFIED`, and ONLY that): HALT before DONE. Report `unmetCriteria` and ask "fix / override / stop."
+     - `fix`: increment `finalReview.retryCount` (max 3). Dispatch harness-task-executor to address the unmet criteria, run `harness validate`, then re-enter OUTCOME_EVAL. If retryCount > 3: stop, record in `.harness/failures.md`.
+     - `override`: record the rationale in `decisions[]` — the audit trail for shipping over a blocking verdict → DONE.
+     - `stop`: save state and exit (resumable).
+5. **Never block on infrastructure noise.** A provider failure, a missing/unjudgable spec, or an absent `ANTHROPIC_API_KEY` degrades to `INCONCLUSIVE`/advisory and proceeds — surface the degradation to the human, but do not halt.
 
 ---
 
 ### DONE
 
-1. Present: total phases, tasks, retries, time, `finalReview.status` + findings count, any overridden findings.
+1. Present: total phases, tasks, retries, time, `finalReview.status` + findings count, any overridden findings, and the OUTCOME_EVAL verdict (`verdict` / `confidence` / `authority`, plus any recorded override).
 2. Ask "Create a PR? (yes / no)." When creating the PR, include a bare closing line `Closes #<N>` where `<N>` is the issue number from the roadmap row's `External-ID`. The keyword MUST sit IMMEDIATELY before the ref — no intervening words (`Closes #<N>`, never `Closes roadmap #<N>`), or GitHub will not link/close the issue and roadmap auto-done will skip the row.
 3. Write final handoff to `{sessionDir}/handoff.json`. Append learnings to `.harness/learnings.md`. Call `promoteSessionLearnings(projectPath, sessionSlug)`. If learnings count > 30, suggest `harness learnings prune`.
 4. If `docs/roadmap.md` exists: call `manage_roadmap update` to set feature done. Skip if not found.
@@ -275,7 +304,7 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
 6. **INTEGRATE** — Resolve integration tier, dispatch harness-integration, verify system wiring, knowledge materialization, and documentation per tier.
 7. **REVIEW** — Dispatch harness-code-reviewer, fix blocking findings.
 8. **PHASE_COMPLETE** — Summarize (including integration report), sync roadmap, loop to ASSESS for next phase or proceed to FINAL_REVIEW.
-9. **FINAL_REVIEW → DONE** — Cross-phase review, offer PR creation, write final handoff.
+9. **FINAL_REVIEW → OUTCOME_EVAL → DONE** — Cross-phase review, then the blocking spec-satisfaction gate (halt on a high-confidence NOT_SATISFIED), offer PR creation, write final handoff.
 
 ---
 
@@ -292,7 +321,8 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
 
 - **No reimplementing delegated skills.** Writing planning/execution/verification/review/integration logic → STOP. Delegate via `subagent_type`.
 - **No executing without plan approval.** Every plan passes APPROVE_PLAN. No exceptions.
-- **No skipping VERIFY, INTEGRATE, or REVIEW.** Human can override findings; steps cannot be skipped. INTEGRATE may be skipped only via explicit "skip" choice with decision recorded in `decisions[]`.
+- **No skipping VERIFY, INTEGRATE, REVIEW, or OUTCOME_EVAL.** Human can override findings; steps cannot be skipped. INTEGRATE may be skipped only via explicit "skip" choice with decision recorded in `decisions[]`.
+- **Ship authority for OUTCOME_EVAL is derived in TypeScript, never read from the LLM.** Read `authority` off the verdict; do not recompute or override it. A high-confidence `NOT_SATISFIED` (`authority: "blocking"`) HALTS before DONE — shipping over it requires an explicit `override` recorded in `decisions[]`. Every other verdict is advisory.
 - **No infinite retries.** EXECUTE budget: 3 attempts. FINAL_REVIEW: 3 cycles. If exhausted, stop and surface.
 - **No modifying state files manually.** If corrupted, start fresh.
 
@@ -321,6 +351,7 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
 - Every plan approval is recorded in `decisions[]` (auto or manual)
 - Retry budget (3 attempts) is enforced — exhausted retries surface to user, never silently continue
 - FINAL_REVIEW runs on `startingCommit..HEAD` diff and catches cross-phase coherence issues
+- OUTCOME_EVAL runs at the ship boundary on the full `startingCommit..HEAD` change; a high-confidence `NOT_SATISFIED` halts before DONE and its verdict persists as an `execution_outcome` node
 - State is persisted to `autopilot-state.json` after every state transition — re-invocation resumes correctly
 - `harness validate` passes after every phase
 

--- a/.github/workflows/required-review.yml
+++ b/.github/workflows/required-review.yml
@@ -56,6 +56,25 @@ jobs:
         # degrades to floor-only if ANTHROPIC_API_KEY is unset. --json writes the
         # verdict artifact the pre-merge-brief step reuses (no second review run).
         run: node packages/cli/dist/bin/harness.js review-ci --runner claude --block-on request-changes --diff "origin/${{ github.base_ref }}...HEAD" --json /tmp/review.json
+      - name: Run outcome-eval spec-satisfaction gate
+        # Post-execution SHIP GATE (the first blocking spec-satisfaction gate).
+        # Judges the PR's change against its spec and persists the
+        # execution_outcome node — keyed by `git rev-parse HEAD` — that the
+        # pre-merge-brief step below consumes (no --commit: both this step and the
+        # brief default to `git rev-parse HEAD`, so the sha matches in-workspace).
+        #
+        # WIRED NON-BLOCKING FIRST (mirrors the required-review dogfood posture):
+        # continue-on-error keeps even a blocking verdict from failing the PR
+        # during bake-in. --block-on blocking makes the command exit 1 ONLY on a
+        # high-confidence NOT_SATISFIED (authority is DERIVED in TypeScript, never
+        # from the LLM); promote it to a required check only after it proves
+        # stable. Degrade-safe: no spec in the diff, or no ANTHROPIC_API_KEY,
+        # yields an INCONCLUSIVE/advisory verdict and exit 0.
+        if: always()
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: node packages/cli/dist/bin/harness.js outcome-eval-ci --diff "origin/${{ github.base_ref }}...HEAD" --block-on blocking --out /tmp/outcome.json
       - name: Post senior pre-merge brief
         # Dogfood (spec #569, D4/D5): compose the senior-facing brief from the
         # review verdict above + live signals + outcome-eval, and upsert it as a

--- a/agents/skills/claude-code/harness-autopilot/SKILL.md
+++ b/agents/skills/claude-code/harness-autopilot/SKILL.md
@@ -41,7 +41,7 @@ INIT → ASSESS → PLAN → APPROVE_PLAN → EXECUTE → VERIFY → INTEGRATE �
                                                                                   │
                                                                            [next phase?]
                                                                             │           │
-                                                                         ASSESS   FINAL_REVIEW → DONE
+                                                                         ASSESS   FINAL_REVIEW → OUTCOME_EVAL → DONE
 ```
 
 ---
@@ -224,17 +224,46 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
    subagent_type: "harness-code-reviewer"
    prompt: "Final cross-phase review. Diff: git diff {startingCommit}..HEAD. Session: {sessionSlug}. Prior findings: {collected}. Focus on cross-phase coherence: naming, duplicated utilities, architectural drift. Report findings (critical / important / suggestion)."
    ```
-4. No blocking: store in `finalReview.findings`, set `"passed"` → DONE.
+4. No blocking: store in `finalReview.findings`, set `"passed"` → OUTCOME_EVAL.
 5. Blocking: ask "fix / override / stop."
    - `fix`: increment `finalReview.retryCount` (max 3). Dispatch harness-task-executor: "Fix these blocking findings: {findings with file, line, title}. Session: {sessionSlug}. Commit each fix atomically." Run `harness validate`. Re-run FINAL_REVIEW from step 1. If retryCount > 3: stop, record in `.harness/failures.md`.
-   - `override`: record rationale in `decisions[]`. Set `"overridden"` → DONE.
+   - `override`: record rationale in `decisions[]`. Set `"overridden"` → OUTCOME_EVAL.
    - `stop`: save state and exit (resumable).
+
+---
+
+### OUTCOME_EVAL
+
+The blocking post-execution **spec-satisfaction gate** — the harness's ship gate. It fires ONCE per session, after FINAL_REVIEW and before DONE, judging the WHOLE change against the spec. (It runs at the ship boundary, not per phase: a per-phase judgment would spuriously fail while later phases are still outstanding.) It runs at every rigor level — the gate is not weakened by `--fast`.
+
+1. Set `currentState: "OUTCOME_EVAL"`.
+2. **Gather the evidence (required).** Capture the cumulative change as a unified diff: `git diff {startingCommit}..HEAD`. Capture the most recent test-runner output retained from VERIFY; if none is retained, re-run the project test command and capture stdout+stderr. Resolve the head sha via `git rev-parse HEAD`.
+3. **Invoke the gate.** Call the `outcome_eval` MCP tool:
+
+   ```json
+   {
+     "specPath": "<spec path>",
+     "diff": "<git diff {startingCommit}..HEAD>",
+     "testOutput": "<captured test output>",
+     "commit": "<git rev-parse HEAD>"
+   }
+   ```
+
+   Supplying real `diff` and `testOutput` is mandatory — omitting them degrades the verdict to INCONCLUSIVE/advisory, a silent false-negative that defeats the gate. The tool persists the verdict as an `execution_outcome` node (keyed by `commit`) and returns `verdict`, `confidence`, `judgedAgainst`, `rationale`, `unmetCriteria`, and the TS-derived `authority`.
+
+4. **Honor the TS-derived authority — never the LLM.** `authority` is computed in TypeScript from `(verdict, confidence)`; read it, never recompute or override it.
+   - `authority === "advisory"` (all `SATISFIED`, all `INCONCLUSIVE`, and every `medium`/`low` `NOT_SATISFIED`): record the verdict in `finalReview` and proceed → DONE. An advisory `NOT_SATISFIED` is surfaced for human attention but does not halt.
+   - `authority === "blocking"` (a high-confidence `NOT_SATISFIED`, and ONLY that): HALT before DONE. Report `unmetCriteria` and ask "fix / override / stop."
+     - `fix`: increment `finalReview.retryCount` (max 3). Dispatch harness-task-executor to address the unmet criteria, run `harness validate`, then re-enter OUTCOME_EVAL. If retryCount > 3: stop, record in `.harness/failures.md`.
+     - `override`: record the rationale in `decisions[]` — the audit trail for shipping over a blocking verdict → DONE.
+     - `stop`: save state and exit (resumable).
+5. **Never block on infrastructure noise.** A provider failure, a missing/unjudgable spec, or an absent `ANTHROPIC_API_KEY` degrades to `INCONCLUSIVE`/advisory and proceeds — surface the degradation to the human, but do not halt.
 
 ---
 
 ### DONE
 
-1. Present: total phases, tasks, retries, time, `finalReview.status` + findings count, any overridden findings.
+1. Present: total phases, tasks, retries, time, `finalReview.status` + findings count, any overridden findings, and the OUTCOME_EVAL verdict (`verdict` / `confidence` / `authority`, plus any recorded override).
 2. Ask "Create a PR? (yes / no)." When creating the PR, include a bare closing line `Closes #<N>` where `<N>` is the issue number from the roadmap row's `External-ID`. The keyword MUST sit IMMEDIATELY before the ref — no intervening words (`Closes #<N>`, never `Closes roadmap #<N>`), or GitHub will not link/close the issue and roadmap auto-done will skip the row.
 3. Write final handoff to `{sessionDir}/handoff.json`. Append learnings to `.harness/learnings.md`. Call `promoteSessionLearnings(projectPath, sessionSlug)`. If learnings count > 30, suggest `harness learnings prune`.
 4. If `docs/roadmap.md` exists: call `manage_roadmap update` to set feature done. Skip if not found.
@@ -254,7 +283,7 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
 6. **INTEGRATE** — Resolve integration tier, dispatch harness-integration, verify system wiring, knowledge materialization, and documentation per tier.
 7. **REVIEW** — Dispatch harness-code-reviewer, fix blocking findings.
 8. **PHASE_COMPLETE** — Summarize (including integration report), sync roadmap, loop to ASSESS for next phase or proceed to FINAL_REVIEW.
-9. **FINAL_REVIEW → DONE** — Cross-phase review, offer PR creation, write final handoff.
+9. **FINAL_REVIEW → OUTCOME_EVAL → DONE** — Cross-phase review, then the blocking spec-satisfaction gate (halt on a high-confidence NOT_SATISFIED), offer PR creation, write final handoff.
 
 ---
 
@@ -271,7 +300,8 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
 
 - **No reimplementing delegated skills.** Writing planning/execution/verification/review/integration logic → STOP. Delegate via `subagent_type`.
 - **No executing without plan approval.** Every plan passes APPROVE_PLAN. No exceptions.
-- **No skipping VERIFY, INTEGRATE, or REVIEW.** Human can override findings; steps cannot be skipped. INTEGRATE may be skipped only via explicit "skip" choice with decision recorded in `decisions[]`.
+- **No skipping VERIFY, INTEGRATE, REVIEW, or OUTCOME_EVAL.** Human can override findings; steps cannot be skipped. INTEGRATE may be skipped only via explicit "skip" choice with decision recorded in `decisions[]`.
+- **Ship authority for OUTCOME_EVAL is derived in TypeScript, never read from the LLM.** Read `authority` off the verdict; do not recompute or override it. A high-confidence `NOT_SATISFIED` (`authority: "blocking"`) HALTS before DONE — shipping over it requires an explicit `override` recorded in `decisions[]`. Every other verdict is advisory.
 - **No infinite retries.** EXECUTE budget: 3 attempts. FINAL_REVIEW: 3 cycles. If exhausted, stop and surface.
 - **No modifying state files manually.** If corrupted, start fresh.
 
@@ -300,6 +330,7 @@ Persist findings to `{sessionDir}/phase-{N}-review.json`. No blocking → PHASE_
 - Every plan approval is recorded in `decisions[]` (auto or manual)
 - Retry budget (3 attempts) is enforced — exhausted retries surface to user, never silently continue
 - FINAL_REVIEW runs on `startingCommit..HEAD` diff and catches cross-phase coherence issues
+- OUTCOME_EVAL runs at the ship boundary on the full `startingCommit..HEAD` change; a high-confidence `NOT_SATISFIED` halts before DONE and its verdict persists as an `execution_outcome` node
 - State is persisted to `autopilot-state.json` after every state transition — re-invocation resumes correctly
 - `harness validate` passes after every phase
 

--- a/docs/changes/wire-outcome-eval-gate/proposal.md
+++ b/docs/changes/wire-outcome-eval-gate/proposal.md
@@ -1,0 +1,86 @@
+# Wire outcome-eval into the lifecycle as an automatic spec-satisfaction gate
+
+## Overview
+
+`outcome-eval` is the harness's first blocking post-execution spec-satisfaction
+gate: it reads a spec's acceptance section, the change diff, and test output and
+emits a confidence-rated `OutcomeVerdict` (`SATISFIED | NOT_SATISFIED |
+INCONCLUSIVE`) whose ship `authority` is DERIVED in TypeScript from
+`(verdict, confidence)` — a high-confidence `NOT_SATISFIED` is `blocking`, every
+other verdict is `advisory`. Until now nothing invoked it automatically: it was
+absent from `.husky/`, from `.github/workflows/`, and from the harness-autopilot
+loop. Its blocking authority only bit when a human or agent chose to run it.
+
+This change wires it in at the two lifecycle points where "did the
+implementation satisfy its spec?" must be answered automatically:
+
+- **the harness-autopilot ship boundary** (skill instruction), and
+- **pre-merge CI** (a headless CLI entrypoint invoked from the required-review
+  workflow, whose persisted verdict the pre-merge brief consumes).
+
+## User-Visible Behavior
+
+- A new `harness outcome-eval-ci` command runs the gate headlessly: it resolves
+  the spec (explicit `--spec` or auto-discovered from the diff), the diff range,
+  and optional captured test output; runs the `OutcomeEvaluator`; persists the
+  `execution_outcome` node to `.harness/graph`; and exits non-zero ONLY when
+  `--block-on blocking` (the default) and the TS-derived `authority` is
+  `blocking` (a high-confidence `NOT_SATISFIED`). Every other verdict exits 0.
+- The command is degrade-safe: no spec in the diff, no analysis provider, an
+  empty diff, or a persistence failure yields an `INCONCLUSIVE`/advisory verdict
+  and exit 0 — it never throws and never blocks on infrastructure noise.
+- `harness-autopilot` gains an `OUTCOME_EVAL` state between `FINAL_REVIEW` and
+  `DONE`. It gathers the full `startingCommit..HEAD` diff plus test output,
+  invokes the `outcome_eval` MCP tool, and HALTS before `DONE` on a blocking
+  verdict (offering fix / override / stop); an advisory verdict proceeds. The
+  verdict persists as an `execution_outcome` node.
+- The persisted `execution_outcome` node now carries the FULL verdict
+  (`rationale`, `authority`, `unmetCriteria`) plus an optional `commit` sha, so a
+  sha-keyed consumer (the pre-merge brief) can reconstruct and surface the
+  verdict without re-running the judge.
+- The `required-review` dogfood workflow runs `outcome-eval-ci` (non-blocking
+  during bake-in) before the pre-merge-brief step, so the brief surfaces the
+  outcome-eval result.
+
+## Success Criteria
+
+1. `harness outcome-eval-ci` exists and is registered in the CLI command
+   registry.
+2. The gate honors the TS-derived authority: a high-confidence `NOT_SATISFIED`
+   (`authority: "blocking"`) with `--block-on blocking` exits 1; every other
+   verdict, and any `--block-on none` invocation, exits 0. Authority is read off
+   the verdict, never recomputed from the LLM.
+3. The gate is degrade-safe: no resolvable spec, a thrown evaluator, or a graph
+   persistence failure resolves to an advisory verdict and exit 0 (never blocks
+   on infrastructure noise).
+4. The persisted `execution_outcome` node includes `rationale`, `authority`,
+   `unmetCriteria`, and — when supplied — `commit`, additively (a node written
+   without a commit is byte-identical to the prior shape aside from the new
+   verdict fields).
+5. `harness-autopilot` documents an `OUTCOME_EVAL` gate at the ship boundary
+   that halts on a blocking verdict and honors the TS-derived authority, kept in
+   parity across all platform skill copies.
+6. `required-review.yml` invokes `outcome-eval-ci` before the pre-merge-brief
+   step, keyed to the same head sha the brief looks up.
+7. Tests cover the gate firing and honoring the verdict authority (blocking →
+   exit 1; advisory / `--block-on none` → exit 0), the degradation paths, and
+   the enriched persistence.
+8. No new `harness validate` findings; layer rules and lint pass; no internal
+   roadmap/PR/issue references leak into shipped skill text.
+
+## Implementation Order
+
+### Phase 1: Persistence + CLI gate + wiring
+
+<!-- complexity: medium -->
+
+Enrich the `OutcomeEvaluator` persistence (full verdict + optional `commit`),
+thread `commit` through the `outcome_eval` MCP tool, add the `outcome-eval-ci`
+command and register it, wire the autopilot `OUTCOME_EVAL` state, and add the
+`required-review.yml` step. Cover with unit tests.
+
+## References
+
+- Closes github:Intense-Visions/harness-engineering#662
+- Upstream twin: `acceptance-eval` (pre-execution spec-measurability gate).
+- Consumer unblocked: the pre-merge brief (surfaces the outcome-eval result).

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -394,6 +394,21 @@ LLM-judgment critique of identifier names (variables, functions, types, files). 
 - `--max-files` — Cap file count (default: 100)
 - `--max-identifiers-per-file` — Cap per-file identifier sampling (default: 15)
 
+### `harness outcome-eval-ci`
+
+Run the post-execution spec-satisfaction gate (outcome-eval) for CI: judge the change against its spec and block (exit 1) only on a high-confidence NOT_SATISFIED
+
+**Options:**
+
+- `--spec` — spec markdown to judge against (default: auto-discover from the diff)
+- `--diff` — git range (default: origin/<base>...HEAD)
+- `--test-output` — file with captured test-runner output (default: none)
+- `--block-on` — blocking | none (default: "blocking")
+- `--model` — model override for the outcome-eval LLM call
+- `--commit` — head sha to stamp on the persisted node (default: git rev-parse HEAD)
+- `--comment` — post the verdict as a comment on the current branch's PR via gh
+- `--out` — write the verdict JSON artifact to a file (use the global --json to stream it to stdout instead)
+
 ### `harness pre-merge-brief`
 
 Compose a senior-facing pre-merge PR brief (diff, review, signals, outcome, "worth your eyes")

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -623,6 +623,7 @@ Post-execution LLM-judgment: did the implementation actually satisfy its spec? R
 - `testOutput` (string, required) — Captured test-runner stdout+stderr. Required: empty/unparseable output is tolerated but degrades the verdict toward INCONCLUSIVE/advisory.
 - `model` (string, optional) — Optional model override for the outcome-eval LLM call
 - `path` (string, optional) — Project root used to resolve the knowledge graph (default: cwd)
+- `commit` (string, optional) — Optional head commit sha of the change under judgment. Persisted onto the execution_outcome node so a sha-keyed consumer (e.g. the pre-merge brief) can look the verdict up. Omitting it is safe (additive).
 
 ### `plan_parallelization`
 

--- a/docs/roadmap.d/wire-outcome-eval-into-the-lifecycle-as-an-automatic-spec-satisfaction-gate.md
+++ b/docs/roadmap.d/wire-outcome-eval-into-the-lifecycle-as-an-automatic-spec-satisfaction-gate.md
@@ -6,8 +6,8 @@ order: 10
 
 ### Wire outcome-eval into the lifecycle as an automatic spec-satisfaction gate
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** in-progress
+- **Spec:** docs/changes/wire-outcome-eval-gate/proposal.md
 - **Summary:** outcome-eval is the harness's first blocking post-execution spec-satisfaction gate, but nothing invokes it automatically — verified 2026-06 it is absent from .husky/, .github/workflows/, AND the harness-autopilot VERIFY/INTEGRATE/REVIEW loop. Its blocking authority (high-confidence NOT_SATISFIED) only bites when a human or agent chooses to run /harness:outcome-eval or mcp**harness**outcome_eval. Wire it in: (a) call outcome_eval in harness-autopilot after REVIEW (post-execution, before PHASE_COMPLETE), gathering diff+testOutput from the session and halting on a blocking verdict; (b) add a pre-merge CI job (sibling to .github/workflows/required-review.yml) that runs it on PRs and surfaces the verdict, blocking only on high-confidence NOT_SATISFIED. This makes the #1-gap gate actually load-bearing and unblocks the assumptions baked into #569 (pre-merge-brief surfaces 'outcome-eval result when available'), #533 (post-merge rollback on failed eval), and #552 (Holiday Confidence KPI measures 'outcome-eval passed'). Recommended priority: P1.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -561,7 +561,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Add harness mcp list-capabilities CLI for adopter audit
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** [docs/changes/mcp-list-capabilities/proposal.md](../changes/mcp-list-capabilities/proposal.md)
 - **Summary:** MCP server has 101 tool files (`packages/cli/src/mcp/tools/`). Per-tool `trustedOutput` flag exists but per-tool capability declarations don't. Adopters have no easy way to audit what their agent can do via MCP. Add `harness mcp list-capabilities --by-permission` CLI command that surfaces each tool's read/write/exec scope, network access, and trust tag. Source: Pass 6 #3.
 - **Blockers:** —
 - **Plan:** —
@@ -705,8 +705,8 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Wire outcome-eval into the lifecycle as an automatic spec-satisfaction gate
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** in-progress
+- **Spec:** docs/changes/wire-outcome-eval-gate/proposal.md
 - **Summary:** outcome-eval is the harness's first blocking post-execution spec-satisfaction gate, but nothing invokes it automatically — verified 2026-06 it is absent from .husky/, .github/workflows/, AND the harness-autopilot VERIFY/INTEGRATE/REVIEW loop. Its blocking authority (high-confidence NOT_SATISFIED) only bites when a human or agent chooses to run /harness:outcome-eval or mcp**harness**outcome_eval. Wire it in: (a) call outcome_eval in harness-autopilot after REVIEW (post-execution, before PHASE_COMPLETE), gathering diff+testOutput from the session and halting on a blocking verdict; (b) add a pre-merge CI job (sibling to .github/workflows/required-review.yml) that runs it on PRs and surfaces the verdict, blocking only on high-confidence NOT_SATISFIED. This makes the #1-gap gate actually load-bearing and unblocks the assumptions baked into #569 (pre-merge-brief surfaces 'outcome-eval result when available'), #533 (post-merge rollback on failed eval), and #552 (Holiday Confidence KPI measures 'outcome-eval passed'). Recommended priority: P1.
 - **Blockers:** —
 - **Plan:** —
@@ -1033,7 +1033,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Semantic-Vocabulary CI Gate
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/semantic-vocabulary-ci-gate/proposal.md
 - **Summary:** Add a harness analog of Spec Kitty's test_no_legacy_terminology architectural test: a CI gate that fails when deprecated or renamed canonical terms reappear in skills/docs, protecting the glossary and naming-craft investment from vocabulary drift over time. Adapted from Spec Kitty's semantic-terminology architectural test. Adoption #8 from docs/research/spec-kitty-comparison-analysis.md [SPECKITTY-8]
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -57,6 +57,7 @@ import { createModelsCommand } from './models';
 import { createNamingCraftCommand } from './naming-craft';
 import { createNotificationsCommand } from './notifications';
 import { createOrchestratorCommand } from './orchestrator';
+import { createOutcomeEvalCiCommand } from './outcome-eval-ci';
 import { createPerfCommand } from './perf';
 import { createPersonaCommand } from './persona';
 import { createPredictCommand } from './predict';
@@ -153,6 +154,7 @@ export const commandCreators: Array<() => Command> = [
   createNamingCraftCommand,
   createNotificationsCommand,
   createOrchestratorCommand,
+  createOutcomeEvalCiCommand,
   createPerfCommand,
   createPersonaCommand,
   createPredictCommand,

--- a/packages/cli/src/commands/outcome-eval-ci.ts
+++ b/packages/cli/src/commands/outcome-eval-ci.ts
@@ -1,0 +1,381 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { Command, Option } from 'commander';
+import type { OutcomeVerdict } from '@harness-engineering/intelligence';
+import { resolveAnalysisProvider } from '../mcp/utils/analysis-provider';
+import { resolveDiffRange, type RunGit } from './review-ci';
+import { logger } from '../output/logger';
+
+/**
+ * `harness outcome-eval-ci` — the headless, CI-runnable surface of the
+ * post-execution spec-satisfaction gate (outcome-eval). It is to `outcome_eval`
+ * what `review-ci` is to the interactive review skill: it resolves the change
+ * (spec + diff + test output), runs the intelligence-package `OutcomeEvaluator`,
+ * persists the `execution_outcome` node to the project graph (so a sha-keyed
+ * consumer such as the pre-merge brief can look the verdict up), and turns the
+ * TS-DERIVED ship authority into a process exit code.
+ *
+ * Authority is NEVER read from the LLM — the evaluator computes it via
+ * `deriveAuthority(verdict, confidence)` and this command only reads
+ * `verdict.authority`. The gate blocks (exit 1) iff `--block-on blocking`
+ * (the default) and `authority === 'blocking'` (a high-confidence
+ * NOT_SATISFIED); every other verdict is advisory and exits 0. The whole path
+ * is degrade-safe: a missing spec, missing provider, empty diff, or persistence
+ * failure resolves to an INCONCLUSIVE/advisory verdict and exit 0 — it never
+ * throws and never blocks on infrastructure noise.
+ */
+
+/** The valid `--block-on` levels: block on a blocking verdict, or never. */
+export type OutcomeBlockOn = 'blocking' | 'none';
+export const OUTCOME_BLOCK_ON_LEVELS: OutcomeBlockOn[] = ['blocking', 'none'];
+
+const defaultRunGit: RunGit = (args) =>
+  execFileSync('git', args, { encoding: 'utf-8' }).toString().trim();
+
+/** The evaluator seam — the subset of `OutcomeEvaluator` this command drives. */
+export interface OutcomeEvaluatorLike {
+  evaluate(input: {
+    specPath: string;
+    diff: string;
+    testOutput: string;
+    commit?: string;
+  }): Promise<OutcomeVerdict>;
+}
+
+/**
+ * Resolve the spec path to judge against.
+ *
+ * - An explicit `--spec` is used verbatim.
+ * - Otherwise, auto-discover a `docs/changes/<slug>/proposal.md` among the
+ *   files changed in the diff range (the harness's own change-spec convention).
+ *   The first match wins.
+ * - Returns `undefined` when no spec can be resolved — the degradation path
+ *   (an advisory INCONCLUSIVE verdict; the gate never blocks a spec-less PR).
+ */
+export function resolveSpecPath(opts: {
+  specPath?: string | undefined;
+  range: string;
+  cwd: string;
+  runGit: RunGit;
+}): string | undefined {
+  if (opts.specPath) return opts.specPath;
+  let names: string[];
+  try {
+    names = opts.runGit(['diff', '--name-only', opts.range]).split('\n');
+  } catch {
+    return undefined;
+  }
+  const match = names
+    .map((n) => n.trim())
+    .find((n) => /^docs\/changes\/[^/]+\/proposal\.md$/.test(n));
+  return match ? path.join(opts.cwd, match) : undefined;
+}
+
+/**
+ * The degradation verdict used when there is nothing judgable (no spec). It is
+ * INCONCLUSIVE/low → advisory via the SAME authority rule the evaluator uses,
+ * so the gate can never block a change that carries no spec.
+ */
+function noSpecVerdict(): OutcomeVerdict {
+  return {
+    verdict: 'INCONCLUSIVE',
+    confidence: 'low',
+    rationale:
+      'No spec (docs/changes/<slug>/proposal.md) was found for this change; ' +
+      'the outcome gate has nothing judgable and degrades to an advisory verdict.',
+    judgedAgainst: 'overview',
+    unmetCriteria: [],
+    authority: 'advisory',
+  };
+}
+
+/**
+ * Build the real `OutcomeEvaluator` bound to the project graph store, returning
+ * BOTH the evaluator and the store so the caller can persist the store after
+ * evaluation without reaching into a private field.
+ */
+async function buildEvaluator(
+  cwd: string,
+  model?: string
+): Promise<{ evaluator: OutcomeEvaluatorLike; store: unknown }> {
+  const { OutcomeEvaluator } = await import('@harness-engineering/intelligence');
+  const { GraphStore } = await import('@harness-engineering/graph');
+  const provider = await resolveAnalysisProvider(model);
+  const store = new GraphStore();
+  // Load the existing graph so persistence is additive; a missing graph leaves
+  // the store empty (the outcome node is still written and saved below).
+  try {
+    await store.load(path.join(cwd, '.harness', 'graph'));
+  } catch {
+    // degrade-safe: an unloadable graph is treated as empty.
+  }
+  const evaluator = new OutcomeEvaluator(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (provider ?? unconfiguredProvider()) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store as any,
+    model !== undefined ? { model } : {}
+  ) as unknown as OutcomeEvaluatorLike;
+  return { evaluator, store };
+}
+
+/**
+ * A provider whose analyze() always rejects — used only when no real provider
+ * is configured, so the evaluator degrades to INCONCLUSIVE/advisory rather than
+ * throwing. Mirrors the MCP tool's degrade seam.
+ */
+function unconfiguredProvider(): { analyze: () => Promise<never> } {
+  return {
+    analyze: () =>
+      Promise.reject(
+        new Error('No analysis provider configured (set ANTHROPIC_API_KEY). Degrading.')
+      ),
+  };
+}
+
+/**
+ * Persist the graph store to `.harness/graph` so the freshly-written
+ * execution_outcome node survives for a later reader (e.g. the pre-merge
+ * brief). Degrade-safe: a save failure is logged and swallowed — the verdict
+ * (and the gate) are unaffected.
+ */
+async function persistGraph(store: unknown, cwd: string): Promise<void> {
+  const maybe = store as { save?: (dir: string) => Promise<void> };
+  if (typeof maybe.save !== 'function') return;
+  try {
+    await maybe.save(path.join(cwd, '.harness', 'graph'));
+  } catch {
+    logger.warn('outcome-eval-ci: graph persistence failed; the verdict above is unaffected.');
+  }
+}
+
+export interface OutcomeEvalCiOptions {
+  cwd?: string | undefined;
+  specPath?: string | undefined;
+  diffRange?: string | undefined;
+  testOutputPath?: string | undefined;
+  blockOn?: OutcomeBlockOn | undefined;
+  model?: string | undefined;
+  commit?: string | undefined;
+  // Injected seams for tests (default to the real implementations):
+  runGit?: RunGit;
+  resolveRaw?: (range: string, cwd: string, runGit: RunGit) => string;
+  readTestOutput?: (p: string) => string;
+  /** Provide an evaluator + its store directly (tests); else the real one is built. */
+  makeEvaluator?: (cwd: string, model?: string) => Promise<OutcomeEvaluatorLike>;
+  /** The store to persist after evaluation (tests); real path saves the graph. */
+  store?: unknown;
+}
+
+export interface OutcomeEvalCiResult {
+  verdict: OutcomeVerdict;
+  exitCode: number;
+}
+
+/**
+ * Map a verdict + `--block-on` level to the gate exit code. Pure: the ONLY
+ * place the TS-derived authority becomes a pass/fail decision.
+ */
+export function deriveExitCode(verdict: OutcomeVerdict, blockOn: OutcomeBlockOn): number {
+  return blockOn === 'blocking' && verdict.authority === 'blocking' ? 1 : 0;
+}
+
+/** Resolve the raw diff for the range; degrade-safe ('' on any failure). */
+function resolveDiff(
+  opts: OutcomeEvalCiOptions,
+  range: string,
+  cwd: string,
+  runGit: RunGit
+): string {
+  const resolveRaw = opts.resolveRaw ?? ((r, _c, g) => g(['diff', r]));
+  try {
+    return resolveRaw(range, cwd, runGit);
+  } catch {
+    return '';
+  }
+}
+
+/** Read captured test output from the given path; degrade-safe ('' otherwise). */
+function resolveTestOutput(opts: OutcomeEvalCiOptions): string {
+  if (!opts.testOutputPath) return '';
+  try {
+    return (opts.readTestOutput ?? ((p) => readFileSync(p, 'utf-8')))(opts.testOutputPath);
+  } catch {
+    return '';
+  }
+}
+
+/** Build the evaluator + the store to persist, honoring the test seams. */
+async function resolveEvaluator(
+  opts: OutcomeEvalCiOptions,
+  cwd: string
+): Promise<{ evaluator: OutcomeEvaluatorLike; store: unknown }> {
+  if (opts.makeEvaluator) {
+    return { evaluator: await opts.makeEvaluator(cwd, opts.model), store: opts.store };
+  }
+  return buildEvaluator(cwd, opts.model);
+}
+
+/**
+ * Pure orchestration for `outcome-eval-ci`: resolve spec + diff + test output,
+ * run the evaluator, persist, and derive the exit code. Contains NO
+ * `process.exit`, so it stays unit-testable. Never throws — every failure
+ * degrades to an advisory verdict (exit 0).
+ */
+export async function runOutcomeEvalCi(opts: OutcomeEvalCiOptions): Promise<OutcomeEvalCiResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const runGit = opts.runGit ?? defaultRunGit;
+  const blockOn = opts.blockOn ?? 'blocking';
+  const range = resolveDiffRange({
+    ...(opts.diffRange ? { range: opts.diffRange } : {}),
+    cwd,
+    runGit,
+  });
+
+  const specPath = resolveSpecPath({ specPath: opts.specPath, range, cwd, runGit });
+  if (!specPath) {
+    const verdict = noSpecVerdict();
+    return { verdict, exitCode: deriveExitCode(verdict, blockOn) };
+  }
+
+  const diff = resolveDiff(opts, range, cwd, runGit);
+  const testOutput = resolveTestOutput(opts);
+  const commit = opts.commit ?? safeHeadSha(runGit);
+
+  try {
+    const { evaluator, store } = await resolveEvaluator(opts, cwd);
+    const verdict = await evaluator.evaluate({
+      specPath,
+      diff,
+      testOutput,
+      ...(commit ? { commit } : {}),
+    });
+    // Persist the store so the freshly-written execution_outcome node survives
+    // for a later reader (e.g. the pre-merge brief). Degrade-safe.
+    if (store !== undefined) await persistGraph(store, cwd);
+    return { verdict, exitCode: deriveExitCode(verdict, blockOn) };
+  } catch {
+    // Fail closed on the SAFE side: any unexpected error degrades to advisory.
+    return { verdict: noSpecVerdict(), exitCode: 0 };
+  }
+}
+
+/** Best-effort `git rev-parse HEAD`; undefined on failure (never throws). */
+function safeHeadSha(runGit: RunGit): string | undefined {
+  try {
+    return runGit(['rev-parse', 'HEAD']);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Render the verdict as a Markdown PR-comment body. Pure (no I/O). */
+export function buildOutcomeBody(verdict: OutcomeVerdict): string {
+  const icon =
+    verdict.verdict === 'SATISFIED' ? '✅' : verdict.authority === 'blocking' ? '🛑' : '💬';
+  const out: string[] = [
+    `## ${icon} harness outcome-eval — ${verdict.verdict}`,
+    '',
+    `**Confidence:** \`${verdict.confidence}\`  •  **Authority:** \`${verdict.authority}\`` +
+      `  •  **Judged against:** \`${verdict.judgedAgainst}\``,
+  ];
+  if (verdict.rationale) out.push('', verdict.rationale);
+  if (verdict.unmetCriteria.length) {
+    out.push('', '### Unmet criteria', ...verdict.unmetCriteria.map((c) => `- ${c}`));
+  }
+  out.push(
+    '',
+    '<sub>Posted by `harness outcome-eval-ci`. Ship authority is derived in TypeScript ' +
+      'from (verdict, confidence); a high-confidence NOT_SATISFIED blocks. The exit code is authoritative.</sub>'
+  );
+  return out.join('\n');
+}
+
+/** Seam for delivering the verdict to a PR — real impl shells out to `gh`. */
+export type PostOutcome = (verdict: OutcomeVerdict) => void;
+
+const defaultPostOutcome: PostOutcome = (verdict) => {
+  execFileSync('gh', ['pr', 'comment', '--body-file', '-'], {
+    input: buildOutcomeBody(verdict),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  });
+};
+
+/**
+ * Emit the result: print the terminal summary (or stream the verdict JSON to
+ * stdout when `--json` is set without `--out`), optionally write the JSON
+ * artifact, and optionally post it to the PR. No `process.exit` here.
+ */
+export function emitOutcomeEvalCi(
+  result: OutcomeEvalCiResult,
+  opts: { jsonPath?: string | boolean | undefined; comment?: boolean | undefined },
+  writeFile: (p: string, d: string) => void = (p, d) => writeFileSync(p, d),
+  log: (m: string) => void = (m) => process.stdout.write(m + '\n'),
+  postOutcome: PostOutcome = defaultPostOutcome
+): void {
+  const serialized = JSON.stringify(result.verdict, null, 2);
+  const jsonToStdout = opts.jsonPath === true;
+  if (!jsonToStdout) log(buildOutcomeBody(result.verdict));
+  if (typeof opts.jsonPath === 'string') writeFile(opts.jsonPath, serialized);
+  else if (jsonToStdout) log(serialized);
+  if (opts.comment) {
+    try {
+      postOutcome(result.verdict);
+    } catch (err) {
+      logger.warn(
+        `outcome-eval-ci: failed to post PR comment (${err instanceof Error ? err.message : String(err)}). ` +
+          'The verdict above is authoritative; the exit code still reflects the gate.'
+      );
+    }
+  }
+}
+
+/** Build the top-level `harness outcome-eval-ci` command. */
+export function createOutcomeEvalCiCommand(): Command {
+  return new Command('outcome-eval-ci')
+    .description(
+      'Run the post-execution spec-satisfaction gate (outcome-eval) for CI: judge the ' +
+        'change against its spec and block (exit 1) only on a high-confidence NOT_SATISFIED'
+    )
+    .option(
+      '--spec <path>',
+      'spec markdown to judge against (default: auto-discover from the diff)'
+    )
+    .option('--diff <range>', 'git range (default: origin/<base>...HEAD)')
+    .option('--test-output <path>', 'file with captured test-runner output (default: none)')
+    .addOption(
+      new Option('--block-on <level>', OUTCOME_BLOCK_ON_LEVELS.join(' | '))
+        .choices(OUTCOME_BLOCK_ON_LEVELS)
+        .default('blocking')
+    )
+    .option('--model <model>', 'model override for the outcome-eval LLM call')
+    .option(
+      '--commit <sha>',
+      'head sha to stamp on the persisted node (default: git rev-parse HEAD)'
+    )
+    .option('--comment', "post the verdict as a comment on the current branch's PR via gh")
+    .option(
+      '--out <path>',
+      'write the verdict JSON artifact to a file (use the global --json to stream it to stdout instead)'
+    )
+    .action(async (opts: Record<string, unknown>, cmd: Command) => {
+      const result = await runOutcomeEvalCi({
+        specPath: opts.spec as string | undefined,
+        diffRange: opts.diff as string | undefined,
+        testOutputPath: opts.testOutput as string | undefined,
+        blockOn: opts.blockOn as OutcomeBlockOn | undefined,
+        model: opts.model as string | undefined,
+        commit: opts.commit as string | undefined,
+      });
+      const streamJson = cmd.optsWithGlobals().json === true;
+      emitOutcomeEvalCi(result, {
+        jsonPath: typeof opts.out === 'string' ? opts.out : streamJson ? true : undefined,
+        comment: opts.comment as boolean | undefined,
+      });
+      // process.exit is confined to the commander action so the pure functions
+      // above remain testable; the exit code reflects the TS-derived authority.
+      process.exit(result.exitCode);
+    });
+}

--- a/packages/cli/src/mcp/tools/outcome-eval.ts
+++ b/packages/cli/src/mcp/tools/outcome-eval.ts
@@ -42,6 +42,13 @@ export interface OutcomeEvalToolInput {
   model?: string;
   /** Project root used to resolve the knowledge graph (default: cwd). */
   path?: string;
+  /**
+   * Optional head commit sha of the change under judgment. When supplied it is
+   * persisted onto the `execution_outcome` node's metadata so a sha-keyed
+   * consumer (e.g. the pre-merge brief) can look the verdict up. Additive:
+   * omitting it leaves the persisted node byte-identical to prior behaviour.
+   */
+  commit?: string;
 }
 
 export const outcomeEvalDefinition = {
@@ -82,6 +89,13 @@ export const outcomeEvalDefinition = {
       path: {
         type: 'string',
         description: 'Project root used to resolve the knowledge graph (default: cwd)',
+      },
+      commit: {
+        type: 'string',
+        description:
+          'Optional head commit sha of the change under judgment. Persisted onto the ' +
+          'execution_outcome node so a sha-keyed consumer (e.g. the pre-merge brief) can ' +
+          'look the verdict up. Omitting it is safe (additive).',
       },
     },
     required: ['specPath', 'diff', 'testOutput'],
@@ -160,6 +174,7 @@ export async function handleOutcomeEval(input: OutcomeEvalToolInput): Promise<To
       specPath: input.specPath,
       diff: input.diff,
       testOutput: input.testOutput,
+      ...(typeof input.commit === 'string' && input.commit !== '' ? { commit: input.commit } : {}),
       ...(guardian.length > 0 ? { guardian } : {}),
     });
 

--- a/packages/cli/tests/commands/outcome-eval-ci.test.ts
+++ b/packages/cli/tests/commands/outcome-eval-ci.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { OutcomeVerdict } from '@harness-engineering/intelligence';
+import {
+  deriveExitCode,
+  resolveSpecPath,
+  runOutcomeEvalCi,
+  buildOutcomeBody,
+  emitOutcomeEvalCi,
+  type OutcomeEvaluatorLike,
+} from '../../src/commands/outcome-eval-ci';
+
+/** A minimal verdict factory. */
+function verdict(overrides: Partial<OutcomeVerdict> = {}): OutcomeVerdict {
+  return {
+    verdict: 'SATISFIED',
+    confidence: 'high',
+    rationale: 'ok',
+    judgedAgainst: 'success-criteria',
+    unmetCriteria: [],
+    authority: 'advisory',
+    ...overrides,
+  };
+}
+
+/** An evaluator seam that returns a fixed verdict and records its input. */
+function stubEvaluator(v: OutcomeVerdict): {
+  evaluator: OutcomeEvaluatorLike;
+  calls: Array<{ specPath: string; diff: string; testOutput: string; commit?: string }>;
+} {
+  const calls: Array<{ specPath: string; diff: string; testOutput: string; commit?: string }> = [];
+  return {
+    calls,
+    evaluator: {
+      evaluate: async (input) => {
+        calls.push(input);
+        return v;
+      },
+    },
+  };
+}
+
+describe('deriveExitCode — the TS authority becomes the gate', () => {
+  it('blocks (exit 1) on a blocking verdict when --block-on blocking', () => {
+    expect(deriveExitCode(verdict({ authority: 'blocking' }), 'blocking')).toBe(1);
+  });
+
+  it('does not block an advisory verdict', () => {
+    expect(deriveExitCode(verdict({ authority: 'advisory' }), 'blocking')).toBe(0);
+  });
+
+  it('never blocks when --block-on none, even on a blocking verdict', () => {
+    expect(deriveExitCode(verdict({ authority: 'blocking' }), 'none')).toBe(0);
+  });
+});
+
+describe('resolveSpecPath', () => {
+  it('uses an explicit spec verbatim (no git call)', () => {
+    const runGit = vi.fn();
+    expect(
+      resolveSpecPath({ specPath: 'docs/x/proposal.md', range: 'r', cwd: '/repo', runGit })
+    ).toBe('docs/x/proposal.md');
+    expect(runGit).not.toHaveBeenCalled();
+  });
+
+  it('auto-discovers a docs/changes/<slug>/proposal.md from the diff', () => {
+    const runGit = vi
+      .fn()
+      .mockReturnValue('src/a.ts\ndocs/changes/my-feature/proposal.md\nREADME.md');
+    expect(resolveSpecPath({ range: 'r', cwd: '/repo', runGit })).toBe(
+      '/repo/docs/changes/my-feature/proposal.md'
+    );
+  });
+
+  it('returns undefined when no spec is in the diff (degradation path)', () => {
+    const runGit = vi.fn().mockReturnValue('src/a.ts\nsrc/b.ts');
+    expect(resolveSpecPath({ range: 'r', cwd: '/repo', runGit })).toBeUndefined();
+  });
+
+  it('returns undefined when git fails (degradation path)', () => {
+    const runGit = vi.fn(() => {
+      throw new Error('no git');
+    });
+    expect(resolveSpecPath({ range: 'r', cwd: '/repo', runGit })).toBeUndefined();
+  });
+});
+
+describe('runOutcomeEvalCi — the gate fires and honors the verdict authority', () => {
+  const baseOpts = {
+    cwd: '/repo',
+    diffRange: 'main...HEAD',
+    specPath: 'docs/changes/f/proposal.md',
+    runGit: vi.fn().mockReturnValue('abc123'),
+    resolveRaw: () => 'diff --git a/x b/x\n+content',
+  };
+
+  it('exits 1 on a high-confidence NOT_SATISFIED (blocking)', async () => {
+    const { evaluator } = stubEvaluator(
+      verdict({ verdict: 'NOT_SATISFIED', confidence: 'high', authority: 'blocking' })
+    );
+    const store = { save: vi.fn().mockResolvedValue(undefined) };
+    const res = await runOutcomeEvalCi({
+      ...baseOpts,
+      makeEvaluator: async () => evaluator,
+      store,
+    });
+    expect(res.exitCode).toBe(1);
+    expect(res.verdict.authority).toBe('blocking');
+    // Persistence still happens on a blocking verdict.
+    expect(store.save).toHaveBeenCalledOnce();
+  });
+
+  it('exits 0 on an advisory NOT_SATISFIED (medium confidence)', async () => {
+    const { evaluator } = stubEvaluator(
+      verdict({ verdict: 'NOT_SATISFIED', confidence: 'medium', authority: 'advisory' })
+    );
+    const res = await runOutcomeEvalCi({
+      ...baseOpts,
+      makeEvaluator: async () => evaluator,
+      store: { save: vi.fn().mockResolvedValue(undefined) },
+    });
+    expect(res.exitCode).toBe(0);
+  });
+
+  it('never blocks when --block-on none even on a blocking verdict', async () => {
+    const { evaluator } = stubEvaluator(verdict({ authority: 'blocking' }));
+    const res = await runOutcomeEvalCi({
+      ...baseOpts,
+      blockOn: 'none',
+      makeEvaluator: async () => evaluator,
+      store: { save: vi.fn().mockResolvedValue(undefined) },
+    });
+    expect(res.exitCode).toBe(0);
+  });
+
+  it('threads the resolved diff, test output, and commit into the evaluator', async () => {
+    const stub = stubEvaluator(verdict());
+    await runOutcomeEvalCi({
+      ...baseOpts,
+      commit: 'deadbeef',
+      testOutputPath: '/tmp/tests.txt',
+      readTestOutput: () => 'PASS 10 tests',
+      makeEvaluator: async () => stub.evaluator,
+      store: { save: vi.fn().mockResolvedValue(undefined) },
+    });
+    expect(stub.calls[0]).toMatchObject({
+      specPath: 'docs/changes/f/proposal.md',
+      diff: 'diff --git a/x b/x\n+content',
+      testOutput: 'PASS 10 tests',
+      commit: 'deadbeef',
+    });
+  });
+
+  it('degrades to advisory (exit 0) when no spec can be resolved — never blocks a spec-less PR', async () => {
+    const res = await runOutcomeEvalCi({
+      cwd: '/repo',
+      diffRange: 'main...HEAD',
+      runGit: vi.fn().mockReturnValue('src/only.ts'),
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.verdict.verdict).toBe('INCONCLUSIVE');
+    expect(res.verdict.authority).toBe('advisory');
+  });
+
+  it('degrades to advisory (exit 0) when the evaluator throws — never blocks on infra noise', async () => {
+    const throwing: OutcomeEvaluatorLike = {
+      evaluate: async () => {
+        throw new Error('provider exploded');
+      },
+    };
+    const res = await runOutcomeEvalCi({
+      ...baseOpts,
+      makeEvaluator: async () => throwing,
+      store: { save: vi.fn() },
+    });
+    expect(res.exitCode).toBe(0);
+    expect(res.verdict.authority).toBe('advisory');
+  });
+
+  it('swallows a persistence failure — the verdict and gate are unaffected', async () => {
+    const { evaluator } = stubEvaluator(verdict({ authority: 'blocking' }));
+    const store = {
+      save: vi.fn().mockRejectedValue(new Error('disk full')),
+    };
+    const res = await runOutcomeEvalCi({
+      ...baseOpts,
+      makeEvaluator: async () => evaluator,
+      store,
+    });
+    expect(res.exitCode).toBe(1);
+    expect(store.save).toHaveBeenCalledOnce();
+  });
+});
+
+describe('buildOutcomeBody', () => {
+  it('renders a blocking verdict with the unmet criteria', () => {
+    const body = buildOutcomeBody(
+      verdict({
+        verdict: 'NOT_SATISFIED',
+        confidence: 'high',
+        authority: 'blocking',
+        rationale: 'the 404 branch is missing',
+        unmetCriteria: ['404 path unimplemented'],
+      })
+    );
+    expect(body).toContain('harness outcome-eval — NOT_SATISFIED');
+    expect(body).toContain('`blocking`');
+    expect(body).toContain('- 404 path unimplemented');
+    expect(body).toContain('the 404 branch is missing');
+  });
+
+  it('renders a satisfied verdict without an unmet-criteria section', () => {
+    const body = buildOutcomeBody(verdict());
+    expect(body).toContain('SATISFIED');
+    expect(body).not.toContain('### Unmet criteria');
+  });
+});
+
+describe('emitOutcomeEvalCi', () => {
+  it('streams verdict JSON to stdout and suppresses the summary when jsonPath === true', () => {
+    const logs: string[] = [];
+    emitOutcomeEvalCi(
+      { verdict: verdict(), exitCode: 0 },
+      { jsonPath: true },
+      () => {},
+      (m) => logs.push(m)
+    );
+    expect(logs).toHaveLength(1);
+    expect(JSON.parse(logs[0]).verdict).toBe('SATISFIED');
+  });
+
+  it('writes the JSON artifact to a path and prints the human summary', () => {
+    const writes: Array<[string, string]> = [];
+    const logs: string[] = [];
+    emitOutcomeEvalCi(
+      { verdict: verdict(), exitCode: 0 },
+      { jsonPath: '/tmp/out.json' },
+      (p, d) => writes.push([p, d]),
+      (m) => logs.push(m)
+    );
+    expect(writes[0][0]).toBe('/tmp/out.json');
+    expect(logs.join('\n')).toContain('harness outcome-eval');
+  });
+
+  it('posts a PR comment when comment=true, degrading a post failure to a warning', () => {
+    const post = vi.fn(() => {
+      throw new Error('gh missing');
+    });
+    expect(() =>
+      emitOutcomeEvalCi(
+        { verdict: verdict(), exitCode: 0 },
+        { comment: true },
+        () => {},
+        () => {},
+        post
+      )
+    ).not.toThrow();
+    expect(post).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/intelligence/src/outcome-eval/evaluator.ts
+++ b/packages/intelligence/src/outcome-eval/evaluator.ts
@@ -192,9 +192,12 @@ export class OutcomeEvaluator {
    *   included for human readability only.
    * - taskType: OMITTED. The outcome-eval judge has no task categorization, and
    *   asserting a false 'feature' would mislead specialization analytics (SUG-2).
-   * - metadata: verdict-specific signal carried through the connector's
-   *   additive pass-through (verdict/confidence/judgedAgainst/source) so the
-   *   true 3-valued verdict is durable on the node (Truth 3).
+   * - metadata: the full verdict carried through the connector's additive
+   *   pass-through (verdict/confidence/judgedAgainst/rationale/authority/
+   *   unmetCriteria/source, plus commit when supplied) so the true 3-valued
+   *   verdict is durable and self-describing on the node (Truth 3) and a
+   *   sha-keyed consumer can reconstruct the OutcomeVerdict. `authority` is a
+   *   copy of the TS-derived value, never trusted from the LLM.
    */
   private toExecutionOutcome(verdict: OutcomeVerdict, input: OutcomeEvalInput): ExecutionOutcome {
     const timestamp = new Date().toISOString();
@@ -215,6 +218,18 @@ export class OutcomeEvaluator {
         confidence: verdict.confidence,
         judgedAgainst: verdict.judgedAgainst,
         source: 'outcome-eval',
+        // The full verdict, carried additively so the node is a faithful,
+        // self-describing record and a consumer (e.g. the pre-merge brief's
+        // findOutcomeVerdict) can reconstruct the OutcomeVerdict without
+        // re-running the judge. `authority` here is the TS-derived value from
+        // the verdict — it is a copy of the computed authority, never trusted
+        // from the LLM. `unmetCriteria` mirrors failureReasons additively
+        // (failureReasons is a reserved/core key the consumer does not read).
+        rationale: verdict.rationale,
+        authority: verdict.authority,
+        unmetCriteria: verdict.unmetCriteria,
+        // Head sha (when supplied) lets a sha-keyed consumer match this node.
+        ...(input.commit !== undefined && input.commit !== '' ? { commit: input.commit } : {}),
       },
     };
   }

--- a/packages/intelligence/src/outcome-eval/types.ts
+++ b/packages/intelligence/src/outcome-eval/types.ts
@@ -27,6 +27,14 @@ export interface OutcomeEvalInput {
   /** Pre-resolved judgment section; otherwise the section-resolver runs. */
   specSection?: string;
   /**
+   * Head commit sha of the change under judgment. Persisted onto the
+   * `execution_outcome` node's metadata (`commit`) so downstream consumers
+   * (e.g. the pre-merge brief) can look the verdict up by sha. Optional and
+   * additive: absent leaves the persisted node byte-identical to no-commit
+   * wiring.
+   */
+  commit?: string;
+  /**
    * Advisory guardian diff-coverage records read from `.harness/analyses/`
    * (#914). Absent/empty leaves the verdict byte-identical to no guardian
    * wiring; when present, a deterministic one-line signal is appended to the

--- a/packages/intelligence/tests/outcome-eval/persistence.integration.test.ts
+++ b/packages/intelligence/tests/outcome-eval/persistence.integration.test.ts
@@ -68,6 +68,47 @@ describe('OutcomeEvaluator persistence — real GraphStore + effectiveness score
     expect(computePersonaEffectiveness(store)).toEqual([]);
   });
 
+  it('persists the FULL verdict (rationale/authority/unmetCriteria) + commit so a sha-keyed consumer can reconstruct it', async () => {
+    const store = new GraphStore();
+    const p = writeSpec(SPEC);
+    await new OutcomeEvaluator(
+      provider({
+        verdict: 'NOT_SATISFIED',
+        confidence: 'high',
+        rationale: 'the 404 branch is missing',
+        unmetCriteria: ['404 path unimplemented'],
+      }),
+      store
+    ).evaluate({ specPath: p, diff: 'd', testOutput: 't', commit: 'deadbeef' });
+
+    const nodes = store.findNodes({ type: 'execution_outcome' });
+    expect(nodes).toHaveLength(1);
+    const m = nodes[0].metadata;
+    // The node is a faithful, self-describing record of the verdict.
+    expect(m.verdict).toBe('NOT_SATISFIED');
+    expect(m.confidence).toBe('high');
+    expect(m.rationale).toBe('the 404 branch is missing');
+    expect(m.unmetCriteria).toEqual(['404 path unimplemented']);
+    // authority is the TS-derived value (high NOT_SATISFIED => blocking), copied
+    // onto the node — NEVER read from the LLM payload.
+    expect(m.authority).toBe('blocking');
+    // The head sha lets a sha-keyed consumer (pre-merge brief) match this node.
+    expect(m.commit).toBe('deadbeef');
+  });
+
+  it('omits commit from metadata when none is supplied (additive, byte-identical to no-commit wiring)', async () => {
+    const store = new GraphStore();
+    const p = writeSpec(SPEC);
+    await new OutcomeEvaluator(
+      provider({ verdict: 'SATISFIED', confidence: 'high', rationale: 'ok', unmetCriteria: [] }),
+      store
+    ).evaluate({ specPath: p, diff: 'd', testOutput: 't' });
+
+    const m = store.findNodes({ type: 'execution_outcome' })[0].metadata;
+    expect('commit' in m).toBe(false);
+    expect(m.authority).toBe('advisory'); // SATISFIED => advisory
+  });
+
   it('scorer surfaces a persona-attributed execution_outcome linked to a seeded system node', () => {
     const store = new GraphStore();
     store.addNode({ id: 'module:api', type: 'module', name: 'api', metadata: {} });


### PR DESCRIPTION
## What & why

`outcome-eval` is the harness's first blocking post-execution spec-satisfaction gate, but nothing invoked it automatically — it was absent from the autopilot loop and from CI, so its blocking authority (a high-confidence `NOT_SATISFIED`) only bit when a human chose to run it. This wires it in at the two lifecycle points where "did the implementation satisfy its spec?" must be answered automatically.

Spec: `docs/changes/wire-outcome-eval-gate/proposal.md`.

## Changes

- **`harness outcome-eval-ci` (new CLI command)** — the headless, CI-runnable surface of the gate (mirrors `review-ci`). Resolves the spec (explicit `--spec` or auto-discovered from the diff), the diff range, and optional captured test output; runs `OutcomeEvaluator`; persists the `execution_outcome` node to `.harness/graph`; and turns the **TypeScript-derived** ship authority into an exit code — blocking (exit 1) only on a high-confidence `NOT_SATISFIED` under `--block-on blocking` (the default). Degrade-safe: no resolvable spec / no provider / empty diff / persistence failure → `INCONCLUSIVE`/advisory verdict, exit 0.

- **harness-autopilot gate** — new `OUTCOME_EVAL` state at the ship boundary (`FINAL_REVIEW → OUTCOME_EVAL → DONE`). It judges the full `startingCommit..HEAD` change against the spec via the `outcome_eval` MCP tool and **HALTS before DONE** on a high-confidence `NOT_SATISFIED` (offering fix / override / stop); every other verdict is advisory. Placed at the ship boundary, not per phase, because a per-phase judgment would spuriously fail on partial work.

- **`required-review.yml`** — runs `outcome-eval-ci` (non-blocking dogfood, mirroring the required-review posture) before the pre-merge-brief step, keyed to the same `git rev-parse HEAD` the brief looks up — so the brief now surfaces a real outcome-eval verdict.

- **Enriched persistence** — the `execution_outcome` node now carries the full verdict (`rationale`, `authority`, `unmetCriteria`) plus an optional `commit` sha, so a sha-keyed consumer (the pre-merge brief) can reconstruct and surface it. `OutcomeEvalInput` gains an optional `commit`; the `outcome_eval` MCP tool threads it through. All additive; `authority` on the node is the TS-derived value, never read from the LLM.

## Authority discipline

Ship authority is derived in TypeScript via `deriveAuthority(verdict, confidence)` and is never read from the LLM. `outcome-eval-ci` only reads `verdict.authority`; the autopilot gate does the same. Blocking iff `NOT_SATISFIED` + `high` confidence.

## Notes / deviations

- The roadmap suggested a *sibling* pre-merge CI job. I instead added the `outcome-eval-ci` step **inside** `required-review.yml` (before the brief): a separate workflow runs in an isolated workspace and its persisted graph would be invisible to the brief, whereas co-locating the step lets the brief consume the verdict — closing the loop this item was meant to unblock.

## Tests

New/extended coverage: the gate fires and honors the verdict authority (blocking → exit 1; advisory / `--block-on none` → exit 0), the degradation paths (no spec, thrown evaluator, persistence failure), and the enriched persistence (full verdict + `commit`, additive when absent). `tsc`, `eslint`, arch/complexity, plugin-drift, and doc-freshness checks are green.

Closes #662