### PR TITLE
feat(roadmap): adopter-facing install-hook for aggregate regeneration

### DIFF
--- a/.changeset/adopter-roadmap-hook-installer.md
+++ b/.changeset/adopter-roadmap-hook-installer.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Add `harness roadmap install-hook` — an adopter-facing installer for the roadmap
+aggregate-regeneration git hook (#688).
+
+Projects that shard their roadmap (`docs/roadmap.d/`) keep the generated
+`docs/roadmap.md` aggregate fresh with a `pre-commit` step that runs `harness
+roadmap regen`. This command installs that step into an adopter's own hook,
+composing safely with an existing husky (`.husky/pre-commit`) or raw
+`.git/hooks/pre-commit` setup. It is idempotent (a fenced managed block is
+replaced in place, never duplicated, and never clobbers the adopter's own hook
+steps) and degrades gracefully when the project is not sharded (skips unless
+`--force`). CI (`harness validate`) remains the authoritative freshness contract;
+this hook is a local developer convenience.

--- a/.changeset/adopter-roadmap-hook-installer.md
+++ b/.changeset/adopter-roadmap-hook-installer.md
@@ -1,5 +1,6 @@
 ---
 '@harness-engineering/cli': patch
+'@harness-engineering/core': patch
 ---
 
 Add `harness roadmap install-hook` — an adopter-facing installer for the roadmap
@@ -14,3 +15,7 @@ replaced in place, never duplicated, and never clobbers the adopter's own hook
 steps) and degrades gracefully when the project is not sharded (skips unless
 `--force`). CI (`harness validate`) remains the authoritative freshness contract;
 this hook is a local developer convenience.
+
+The `@harness-engineering/core` bump is the read-source invariant-R allowlist
+entry for the new command (the generated hook block names `docs/roadmap.md` as a
+git path, not a content read); no runtime behavior changes in core.

--- a/docs/changes/adopter-roadmap-hook-installer/proposal.md
+++ b/docs/changes/adopter-roadmap-hook-installer/proposal.md
@@ -1,0 +1,78 @@
+# Adopter-facing git-hook installer for roadmap aggregate regeneration
+
+**Keywords:** roadmap, sharding, git-hooks, husky, pre-commit, aggregate-regen, adopter-tooling
+
+## Overview
+
+Follow-up from #684 (roadmap sharding). When a project shards its roadmap
+(`docs/roadmap.d/<slug>.md` + a generated `merge=ours` aggregate at
+`docs/roadmap.md`), the aggregate must be regenerated whenever a shard changes so
+it never drifts. This repo does that with a `.husky/pre-commit` step that runs
+`harness roadmap regen` and re-stages `docs/roadmap.md`. Adopters who shard their
+roadmap want the same local convenience, but harness ships no adopter-facing way
+to install that hook.
+
+This change adds `harness roadmap install-hook`: an idempotent installer that
+wires the regen step into an adopter's `pre-commit` hook, composing safely with
+an existing husky or raw `.git/hooks` setup.
+
+### Goals
+
+1. One command installs a `pre-commit` hook that runs `harness roadmap regen` and
+   re-stages `docs/roadmap.md` when any `docs/roadmap.d/` shard is staged.
+2. Compose safely with the adopter's existing setup — husky (`.husky/pre-commit`)
+   or raw `.git/hooks/pre-commit` — never clobbering their own hook steps.
+3. Idempotent: re-running replaces the managed block in place (fenced by markers)
+   and is a no-op when nothing changed.
+4. Degrade gracefully when the project is not sharded (`docs/roadmap.d/` absent):
+   skip with a clear message, unless `--force` is used to pre-provision.
+
+### Out of Scope
+
+- Wiring the installer into `harness init` (opt-in for new projects) — a follow-up
+  once the standalone command has proven out.
+- A `post-merge` hook installer. The pre-commit path is the primary drift source;
+  merges are already covered by the CI aggregate-drift check.
+- Changing the freshness contract. **CI (`harness validate`) remains the
+  authoritative, portable freshness mechanism** (read-source invariant R means a
+  missed regen only yields a stale cosmetic aggregate, never wrong tooling). This
+  hook is a local developer convenience, per the sharding guide.
+
+## Decisions
+
+| #   | Decision                                                                       | Rationale                                                                                                  |
+| --- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | -------------------- |
+| D1  | New `harness roadmap install-hook` subcommand (not a flag on `hooks init`)     | `harness hooks` manages Claude Code tool-use hooks, which cannot fire on `git commit`; this is a GIT hook  |
+| D2  | Fenced managed block (`# >>> … >>>` / `# <<< … <<<`) merged into the hook      | Idempotent replace-in-place; never duplicates and never clobbers the adopter's own hook steps              |
+| D3  | `--mechanism auto` picks husky when `.husky/` exists, else raw `.git/hooks`    | Matches whatever the adopter already uses; `--mechanism husky                                              | git` forces a choice |
+| D4  | Guarded regen (`git diff --cached … grep docs/roadmap.d`) + fail-closed        | No-op unless a shard is staged; a regen failure blocks the commit rather than committing a stale aggregate |
+| D5  | Skip-with-warning when not sharded; `--force` installs anyway                  | Graceful degradation; `--force` lets an adopter pre-provision before `harness roadmap shard`               |
+| D6  | Default regen command `npx harness roadmap regen`, overridable via `--command` | Resolves the local CLI bin in an adopter repo; override supports pnpm/yarn or a pinned path                |
+
+## Technical Design
+
+`packages/cli/src/commands/roadmap/install-hook.ts`:
+
+- `runRoadmapInstallHook(opts)` — resolves the git repo, detects sharding,
+  resolves the mechanism + hook path (`git rev-parse --git-path hooks` for
+  worktree/submodule correctness, falling back to `.git/hooks`), merges the
+  managed block, writes it, and `chmod +x`es the hook (best-effort on non-POSIX).
+- `mergeHookContent(existing, block)` — the pure idempotent merge: fresh file →
+  shebang + block (`created`); existing managed block → replace in place
+  (`updated` / `unchanged`); adopter hook with no managed block → append
+  (`updated`, preserving their steps).
+- `buildRegenBlock(command)` — the fenced, guarded, fail-closed shell block.
+- `createRoadmapInstallHookCommand()` — Commander wrapper with `--cwd`,
+  `--mechanism`, `--command`, `--force`, `--format {human,json}`; registered in
+  `roadmap/index.ts`.
+
+## Success Criteria
+
+1. `harness roadmap install-hook` in a sharded repo writes an executable
+   `pre-commit` hook containing the guarded regen block; a real `git commit` that
+   stages a shard regenerates and re-stages `docs/roadmap.md`.
+2. Re-running is idempotent (`unchanged`) and never duplicates the block.
+3. An existing husky / `.git/hooks` `pre-commit` keeps its own steps; the block is
+   appended, not substituted.
+4. In an unsharded repo the command skips gracefully (writes nothing) and
+   `--force` installs anyway.

--- a/docs/changes/adopter-roadmap-hook-installer/proposal.md
+++ b/docs/changes/adopter-roadmap-hook-installer/proposal.md
@@ -41,10 +41,10 @@ an existing husky or raw `.git/hooks` setup.
 ## Decisions
 
 | #   | Decision                                                                       | Rationale                                                                                                  |
-| --- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | -------------------- |
+| --- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
 | D1  | New `harness roadmap install-hook` subcommand (not a flag on `hooks init`)     | `harness hooks` manages Claude Code tool-use hooks, which cannot fire on `git commit`; this is a GIT hook  |
 | D2  | Fenced managed block (`# >>> … >>>` / `# <<< … <<<`) merged into the hook      | Idempotent replace-in-place; never duplicates and never clobbers the adopter's own hook steps              |
-| D3  | `--mechanism auto` picks husky when `.husky/` exists, else raw `.git/hooks`    | Matches whatever the adopter already uses; `--mechanism husky                                              | git` forces a choice |
+| D3  | `--mechanism auto` picks husky when `.husky/` exists, else raw `.git/hooks`    | Matches whatever the adopter already uses; `--mechanism husky` / `--mechanism git` forces a choice         |
 | D4  | Guarded regen (`git diff --cached … grep docs/roadmap.d`) + fail-closed        | No-op unless a shard is staged; a regen failure blocks the commit rather than committing a stale aggregate |
 | D5  | Skip-with-warning when not sharded; `--force` installs anyway                  | Graceful degradation; `--force` lets an adopter pre-provision before `harness roadmap shard`               |
 | D6  | Default regen command `npx harness roadmap regen`, overridable via `--command` | Resolves the local CLI bin in an adopter repo; override supports pnpm/yarn or a pinned path                |

--- a/docs/guides/roadmap-sharding.md
+++ b/docs/guides/roadmap-sharding.md
@@ -96,6 +96,33 @@ shards and **warns when the committed `docs/roadmap.md` has drifted**
 harness roadmap regen
 ```
 
+### Optional: install the local regen hook in your repo
+
+The `.husky/pre-commit` regen step above is this repo's own hook. Adopters get the
+same local convenience with a one-shot installer:
+
+```bash
+harness roadmap install-hook
+```
+
+This wires a guarded regen step into your `pre-commit` hook — when any
+`docs/roadmap.d/` shard is staged it runs `harness roadmap regen` and re-stages
+`docs/roadmap.md` (blocking the commit if regen fails). It is idempotent and
+composes safely with an existing hook:
+
+- `--mechanism auto` (default) writes to `.husky/pre-commit` when a `.husky/`
+  directory exists, otherwise to raw `.git/hooks/pre-commit`. Force a choice with
+  `--mechanism husky` or `--mechanism git`.
+- Re-running replaces its own fenced block in place (never duplicated) and never
+  clobbers your other hook steps.
+- It skips gracefully when the repo is not sharded yet (no `docs/roadmap.d/`);
+  pass `--force` to pre-provision before `harness roadmap shard`.
+- `--command <cmd>` overrides the embedded regen invocation (default `npx harness
+roadmap regen`) for pnpm/yarn or a pinned CLI path.
+
+Like all local git hooks this is per-developer and bypassable — **CI (`harness
+validate`) remains the authoritative freshness contract**, not this hook.
+
 ### Optional: regenerate-on-push CI (auto-fix instead of fail-on-drift)
 
 Teams that prefer CI to _fix_ drift rather than fail on it can add a small workflow

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1170,6 +1170,18 @@ Run a pulse: query configured adapters, sanitize, assemble single-page report
 
 Roadmap management
 
+### `harness roadmap install-hook`
+
+Install a git pre-commit hook that regenerates docs/roadmap.md from the docs/roadmap.d shards
+
+**Options:**
+
+- `--cwd` — Project root (defaults to the current working directory)
+- `--mechanism` — Hook mechanism: "auto" (default), "husky", or "git" (raw .git/hooks) (default: "auto")
+- `--command` — Regen command the hook runs (default: "npx harness roadmap regen")
+- `--force` — Install even when the project is not sharded (no docs/roadmap.d)
+- `--format` — Output format: "human" (default) or "json" (single JSON object for CI consumers) (default: "human")
+
 ### `harness roadmap migrate`
 
 Migrate the project roadmap to a different storage mode

--- a/docs/roadmap.d/adopter-facing-git-hook-installer-for-roadmap-aggregate-regeneration.md
+++ b/docs/roadmap.d/adopter-facing-git-hook-installer-for-roadmap-aggregate-regeneration.md
@@ -7,7 +7,7 @@ order: 10
 ### Adopter-facing git-hook installer for roadmap aggregate regeneration
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/adopter-roadmap-hook-installer/proposal.md
 - **Summary:** Follow-up from #684 (roadmap sharding). Deferred by design from Phase 6 rollout. #684 ships sharding with the **CI aggregate-drift check** (`harness validate`) as the portable adopter freshness contract, plus the local `.husky/{pre-commit,post-merge}` regen hooks for this repo (dev convenience). **Not** shipped: an installer that sets up the regen git-hooks in an *adopter's* repo. Rationale: harness installs no git hooks today, and a general installer must compose with arbitrary adopter husky/`.git/hooks` setups — its own scoped piece of work. The CI drift-check already keeps adopters correct (invariant R means a missed regen only yields a stale *cosmetic* aggregate, never wrong tooling). **Scope if pursued:** - Decide mechanism (husky vs raw `.git/hooks` vs a `harness hooks install` command) and composition with existing adopter hooks. - Wire into `harness init` (opt-in) for new projects; a one-shot install for existing adopters who run `harness roadmap shard`. - Keep it optional — CI drift-check remains the authoritative freshness mechanism. See ADR 0050 (read-source invariant R) and docs/guides/roadmap-sharding.md.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -313,7 +313,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Adopter-facing git-hook installer for roadmap aggregate regeneration
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/adopter-roadmap-hook-installer/proposal.md
 - **Summary:** Follow-up from #684 (roadmap sharding). Deferred by design from Phase 6 rollout. #684 ships sharding with the **CI aggregate-drift check** (`harness validate`) as the portable adopter freshness contract, plus the local `.husky/{pre-commit,post-merge}` regen hooks for this repo (dev convenience). **Not** shipped: an installer that sets up the regen git-hooks in an *adopter's* repo. Rationale: harness installs no git hooks today, and a general installer must compose with arbitrary adopter husky/`.git/hooks` setups — its own scoped piece of work. The CI drift-check already keeps adopters correct (invariant R means a missed regen only yields a stale *cosmetic* aggregate, never wrong tooling). **Scope if pursued:** - Decide mechanism (husky vs raw `.git/hooks` vs a `harness hooks install` command) and composition with existing adopter hooks. - Wire into `harness init` (opt-in) for new projects; a one-shot install for existing adopters who run `harness roadmap shard`. - Keep it optional — CI drift-check remains the authoritative freshness mechanism. See ADR 0050 (read-source invariant R) and docs/guides/roadmap-sharding.md.
 - **Blockers:** —
 - **Plan:** —
@@ -561,7 +561,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Add harness mcp list-capabilities CLI for adopter audit
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** [docs/changes/mcp-list-capabilities/proposal.md](../changes/mcp-list-capabilities/proposal.md)
 - **Summary:** MCP server has 101 tool files (`packages/cli/src/mcp/tools/`). Per-tool `trustedOutput` flag exists but per-tool capability declarations don't. Adopters have no easy way to audit what their agent can do via MCP. Add `harness mcp list-capabilities --by-permission` CLI command that surfaces each tool's read/write/exec scope, network access, and trust tag. Source: Pass 6 #3.
 - **Blockers:** —
 - **Plan:** —
@@ -1033,7 +1033,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Semantic-Vocabulary CI Gate
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/semantic-vocabulary-ci-gate/proposal.md
 - **Summary:** Add a harness analog of Spec Kitty's test_no_legacy_terminology architectural test: a CI gate that fails when deprecated or renamed canonical terms reappear in skills/docs, protecting the glossary and naming-craft investment from vocabulary drift over time. Adapted from Spec Kitty's semantic-terminology architectural test. Adoption #8 from docs/research/spec-kitty-comparison-analysis.md [SPECKITTY-8]
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/roadmap/index.ts
+++ b/packages/cli/src/commands/roadmap/index.ts
@@ -3,6 +3,7 @@ import { createRoadmapMigrateCommand } from './migrate';
 import { createRoadmapShardCommand } from './shard';
 import { createRoadmapUnshardCommand } from './unshard';
 import { createRoadmapRegenCommand } from './regen';
+import { createRoadmapInstallHookCommand } from './install-hook';
 import { createRoadmapReconcileCommand } from './reconcile';
 import { createRoadmapSyncCommand } from './sync';
 import { createRoadmapReferencedIssuesCommand } from './referenced-issues';
@@ -14,6 +15,7 @@ export function createRoadmapCommand(): Command {
   roadmap.addCommand(createRoadmapShardCommand());
   roadmap.addCommand(createRoadmapUnshardCommand());
   roadmap.addCommand(createRoadmapRegenCommand());
+  roadmap.addCommand(createRoadmapInstallHookCommand());
   roadmap.addCommand(createRoadmapReconcileCommand());
   roadmap.addCommand(createRoadmapSyncCommand());
   roadmap.addCommand(createRoadmapReferencedIssuesCommand());

--- a/packages/cli/src/commands/roadmap/install-hook.test.ts
+++ b/packages/cli/src/commands/roadmap/install-hook.test.ts
@@ -1,0 +1,254 @@
+// packages/cli/src/commands/roadmap/install-hook.test.ts
+//
+// Adopter-facing git-hook installer for roadmap aggregate regeneration (#688).
+//
+// Covers the pure merge core (idempotent, non-clobbering), the end-to-end
+// installer against a real temp git repo (husky + raw .git/hooks, graceful
+// no-op when unsharded), and a real `git commit` proving the installed hook
+// fires the regen step only when a shard is staged.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  HOOK_BLOCK_BEGIN,
+  HOOK_BLOCK_END,
+  DEFAULT_REGEN_COMMAND,
+  buildRegenBlock,
+  mergeHookContent,
+  runRoadmapInstallHook,
+} from './install-hook';
+
+function mkTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'harness-install-hook-'));
+}
+
+/** Minimal sharded roadmap so the installer treats the repo as sharded. */
+function seedShards(cwd: string): void {
+  const shardDir = path.join(cwd, 'docs', 'roadmap.d');
+  fs.mkdirSync(shardDir, { recursive: true });
+  fs.writeFileSync(path.join(shardDir, '_meta.md'), '---\nproject: demo\nmilestones: []\n---\n');
+  fs.writeFileSync(
+    path.join(shardDir, 'sample.md'),
+    '---\nslug: "sample"\n---\n\n### Sample\n\n- **Status:** planned\n'
+  );
+}
+
+function initGitRepo(cwd: string): void {
+  execFileSync('git', ['init', '-q'], { cwd });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd });
+}
+
+describe('mergeHookContent', () => {
+  const block = buildRegenBlock(DEFAULT_REGEN_COMMAND);
+
+  it('creates a fresh POSIX hook (shebang + block) when no file exists', () => {
+    const { content, action } = mergeHookContent(null, block);
+    expect(action).toBe('created');
+    expect(content.startsWith(`#!/bin/sh\n`)).toBe(true);
+    expect(content).toContain(HOOK_BLOCK_BEGIN);
+    expect(content).toContain(HOOK_BLOCK_END);
+  });
+
+  it('treats an effectively-empty file as a fresh hook', () => {
+    const { content, action } = mergeHookContent('   \n  ', block);
+    expect(action).toBe('created');
+    expect(content.startsWith(`#!/bin/sh\n`)).toBe(true);
+  });
+
+  it('appends to an existing adopter hook without clobbering its steps', () => {
+    const existing = '#!/bin/sh\nnpm run lint-staged\n';
+    const { content, action } = mergeHookContent(existing, block);
+    expect(action).toBe('updated');
+    expect(content).toContain('npm run lint-staged');
+    expect(content).toContain(HOOK_BLOCK_BEGIN);
+    // Adopter content must precede the managed block.
+    expect(content.indexOf('npm run lint-staged')).toBeLessThan(content.indexOf(HOOK_BLOCK_BEGIN));
+  });
+
+  it('replaces a previously-managed block in place, preserving surrounding steps', () => {
+    const first = mergeHookContent('#!/bin/sh\necho before\n', block).content;
+    // Add an adopter step AFTER the managed block, then re-merge with a new command.
+    const withTrailer = `${first}echo after\n`;
+    const newBlock = buildRegenBlock('pnpm harness roadmap regen');
+    const { content, action } = mergeHookContent(withTrailer, newBlock);
+    expect(action).toBe('updated');
+    expect(content).toContain('echo before');
+    expect(content).toContain('echo after');
+    expect(content).toContain('pnpm harness roadmap regen');
+    expect(content).not.toContain(DEFAULT_REGEN_COMMAND);
+    // Still exactly one managed block.
+    expect(content.split(HOOK_BLOCK_BEGIN).length - 1).toBe(1);
+  });
+
+  it('is idempotent — re-merging identical content reports unchanged', () => {
+    const once = mergeHookContent('#!/bin/sh\n', block).content;
+    const { content, action } = mergeHookContent(once, block);
+    expect(action).toBe('unchanged');
+    expect(content).toBe(once);
+  });
+});
+
+describe('buildRegenBlock', () => {
+  it('embeds the guard, the regen command, and a fail-closed exit', () => {
+    const block = buildRegenBlock('npx harness roadmap regen');
+    expect(block).toContain("grep -qE '^docs/roadmap\\.d/'");
+    expect(block).toContain('npx harness roadmap regen');
+    expect(block).toContain('git add docs/roadmap.md');
+    expect(block).toContain('exit 1');
+  });
+});
+
+describe('runRoadmapInstallHook', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkTmp();
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('errors when the directory is not a git repository', async () => {
+    seedShards(cwd);
+    const result = await runRoadmapInstallHook({ cwd });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/not a git repository/i);
+  });
+
+  it('installs an executable raw .git/hooks/pre-commit and is idempotent', async () => {
+    initGitRepo(cwd);
+    seedShards(cwd);
+
+    const first = await runRoadmapInstallHook({ cwd });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    expect(first.value.mechanism).toBe('git');
+    expect(first.value.action).toBe('created');
+    expect(first.value.sharded).toBe(true);
+
+    const hookContent = fs.readFileSync(first.value.hookPath, 'utf-8');
+    expect(hookContent).toContain(HOOK_BLOCK_BEGIN);
+    expect(hookContent).toContain(DEFAULT_REGEN_COMMAND);
+    // Executable bit set (POSIX).
+    expect(fs.statSync(first.value.hookPath).mode & 0o111).not.toBe(0);
+
+    const second = await runRoadmapInstallHook({ cwd });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.value.action).toBe('unchanged');
+    expect(second.value.hookPath).toBe(first.value.hookPath);
+  });
+
+  it('auto-detects husky and writes .husky/pre-commit when .husky exists', async () => {
+    initGitRepo(cwd);
+    seedShards(cwd);
+    fs.mkdirSync(path.join(cwd, '.husky'), { recursive: true });
+
+    const result = await runRoadmapInstallHook({ cwd });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.mechanism).toBe('husky');
+    expect(result.value.hookPath).toBe(path.join(cwd, '.husky', 'pre-commit'));
+    expect(fs.existsSync(result.value.hookPath)).toBe(true);
+  });
+
+  it('preserves an adopter husky hook when appending the block', async () => {
+    initGitRepo(cwd);
+    seedShards(cwd);
+    const huskyHook = path.join(cwd, '.husky', 'pre-commit');
+    fs.mkdirSync(path.dirname(huskyHook), { recursive: true });
+    fs.writeFileSync(huskyHook, `#!/bin/sh\nnpx lint-staged\n`);
+
+    const result = await runRoadmapInstallHook({ cwd, mechanism: 'husky' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.action).toBe('updated');
+    const content = fs.readFileSync(huskyHook, 'utf-8');
+    expect(content).toContain('npx lint-staged');
+    expect(content).toContain(HOOK_BLOCK_BEGIN);
+  });
+
+  it('respects an explicit --command override', async () => {
+    initGitRepo(cwd);
+    seedShards(cwd);
+    const result = await runRoadmapInstallHook({ cwd, command: 'pnpm exec harness roadmap regen' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const content = fs.readFileSync(result.value.hookPath, 'utf-8');
+    expect(content).toContain('pnpm exec harness roadmap regen');
+    expect(content).not.toContain(DEFAULT_REGEN_COMMAND);
+  });
+
+  it('degrades gracefully when the project is not sharded (skips, writes nothing)', async () => {
+    initGitRepo(cwd);
+    const result = await runRoadmapInstallHook({ cwd });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.action).toBe('skipped');
+    expect(result.value.sharded).toBe(false);
+    expect(fs.existsSync(result.value.hookPath)).toBe(false);
+  });
+
+  it('installs anyway with --force when not sharded (pre-provision)', async () => {
+    initGitRepo(cwd);
+    const result = await runRoadmapInstallHook({ cwd, force: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.action).toBe('created');
+    expect(result.value.sharded).toBe(false);
+    expect(fs.existsSync(result.value.hookPath)).toBe(true);
+  });
+});
+
+describe('installed hook fires on commit', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkTmp();
+    initGitRepo(cwd);
+    seedShards(cwd);
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('regenerates + re-stages the aggregate only when a shard is staged', async () => {
+    // Use a deterministic, quote-free sentinel regen script (no external CLI
+    // needed) that stands in for `harness roadmap regen`: it writes the
+    // aggregate, then the block `git add`s it. Proves the hook is installed,
+    // executable, guarded, and re-stages the aggregate through a real commit.
+    fs.writeFileSync(
+      path.join(cwd, 'regen.sh'),
+      `#!/bin/sh\nprintf REGENERATED > docs/roadmap.md\n`
+    );
+    const install = await runRoadmapInstallHook({
+      cwd,
+      mechanism: 'git',
+      command: 'sh ./regen.sh',
+    });
+    expect(install.ok).toBe(true);
+
+    // Commit that DOES stage a shard → hook fires, aggregate committed.
+    execFileSync('git', ['add', 'docs/roadmap.d/sample.md'], { cwd });
+    execFileSync('git', ['commit', '-q', '-m', 'add shard'], { cwd });
+    const committed = execFileSync('git', ['show', 'HEAD:docs/roadmap.md'], {
+      cwd,
+      encoding: 'utf-8',
+    });
+    expect(committed).toContain('REGENERATED');
+
+    // Commit that does NOT touch a shard → guard is a no-op, no regen.
+    fs.rmSync(path.join(cwd, 'docs', 'roadmap.md'));
+    fs.writeFileSync(path.join(cwd, 'other.txt'), 'hi\n');
+    execFileSync('git', ['add', 'other.txt'], { cwd });
+    execFileSync('git', ['commit', '-q', '-m', 'unrelated'], { cwd });
+    expect(fs.existsSync(path.join(cwd, 'docs', 'roadmap.md'))).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/roadmap/install-hook.ts
+++ b/packages/cli/src/commands/roadmap/install-hook.ts
@@ -1,0 +1,299 @@
+import { Command } from 'commander';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Ok, Err } from '@harness-engineering/core';
+import type { Result } from '@harness-engineering/core';
+import { logger } from '../../output/logger';
+import { CLIError, ExitCode } from '../../utils/errors';
+
+/**
+ * Adopter-facing installer for the roadmap aggregate-regeneration git hook.
+ *
+ * This repo keeps `docs/roadmap.md` (a generated `merge=ours` aggregate) fresh
+ * with a `.husky/pre-commit` step that runs `harness roadmap regen` whenever a
+ * `docs/roadmap.d/` shard is staged. Adopters who shard their roadmap want the
+ * same drift-prevention, but harness installs no git hooks for them today — the
+ * portable freshness contract is the CI aggregate-drift check (`harness
+ * validate`). This command adds the missing *local* convenience: it wires the
+ * regen step into an adopter's `pre-commit` hook, composing safely with an
+ * existing husky or raw `.git/hooks` setup.
+ *
+ * It is intentionally a GIT hook, not a Claude Code agent hook (`harness hooks
+ * init` / profiles.ts register tool-use hooks, which cannot fire on `git
+ * commit`).
+ */
+
+/** Fence markers delimiting the managed block, so re-runs replace (never duplicate) it. */
+export const HOOK_BLOCK_BEGIN =
+  '# >>> harness roadmap regen (managed by `harness roadmap install-hook`) >>>';
+export const HOOK_BLOCK_END =
+  '# <<< harness roadmap regen (managed by `harness roadmap install-hook`) <<<';
+
+/** Default regen invocation written into an adopter hook (resolves the local CLI bin). */
+export const DEFAULT_REGEN_COMMAND = 'npx harness roadmap regen';
+
+export type HookMechanism = 'husky' | 'git';
+export type InstallHookAction = 'created' | 'updated' | 'unchanged' | 'skipped';
+
+export interface RoadmapInstallHookOptions {
+  /** Project root (defaults to the current working directory). */
+  cwd?: string;
+  /** Hook mechanism: `auto` picks husky when `.husky/` exists, otherwise raw `.git/hooks`. */
+  mechanism?: 'auto' | HookMechanism;
+  /** Shell command the hook runs to regenerate the aggregate. */
+  command?: string;
+  /** Install even when the project is not sharded (no `docs/roadmap.d/`). */
+  force?: boolean;
+  /** Output format: human-readable (default) or a single JSON object for CI. */
+  format?: 'human' | 'json';
+}
+
+/** Summary of an install-hook run. */
+export interface InstallHookReport {
+  /** Which hook surface was written. */
+  mechanism: HookMechanism;
+  /** Absolute path to the hook file that was written (or would have been). */
+  hookPath: string;
+  /** What happened to the hook file. */
+  action: InstallHookAction;
+  /** Whether the project is sharded (`docs/roadmap.d/` present). */
+  sharded: boolean;
+  /** The regen command embedded in the hook block. */
+  command: string;
+}
+
+/** Build the managed hook block (markers + guarded regen) for `regenCommand`. */
+export function buildRegenBlock(regenCommand: string): string {
+  return [
+    HOOK_BLOCK_BEGIN,
+    '# Regenerate docs/roadmap.md from the docs/roadmap.d/ shards when a shard is',
+    '# staged, so the committed aggregate never drifts. Safe no-op when no shard is',
+    '# staged. Managed by `harness roadmap install-hook` — edits inside this block',
+    '# are overwritten on the next run.',
+    "if git diff --cached --name-only | grep -qE '^docs/roadmap\\.d/'; then",
+    `  if ! ${regenCommand}; then`,
+    `    echo "Commit blocked: '${regenCommand}' failed; refusing to commit a stale docs/roadmap.md" >&2`,
+    '    exit 1',
+    '  fi',
+    '  git add docs/roadmap.md',
+    'fi',
+    HOOK_BLOCK_END,
+  ].join('\n');
+}
+
+/**
+ * Idempotently merge `block` into an existing hook file's `existing` content.
+ *
+ * - No file yet (`existing === null`) or an effectively-empty file: create a
+ *   fresh POSIX hook (shebang + block).
+ * - A previously managed block (markers present): replace it in place, keeping
+ *   everything around it untouched. Identical content reports `unchanged`.
+ * - An adopter hook with no managed block: append the block, never clobbering
+ *   the adopter's own steps.
+ */
+export function mergeHookContent(
+  existing: string | null,
+  block: string
+): { content: string; action: InstallHookAction } {
+  if (existing === null || existing.trim() === '') {
+    return { content: `#!/bin/sh\n${block}\n`, action: 'created' };
+  }
+
+  const begin = existing.indexOf(HOOK_BLOCK_BEGIN);
+  if (begin !== -1) {
+    const endMarker = existing.indexOf(HOOK_BLOCK_END);
+    // Guard against a truncated/corrupted block missing its END marker: fall
+    // back to appending a fresh block rather than mangling the file.
+    if (endMarker !== -1 && endMarker >= begin) {
+      const endLineBreak = existing.indexOf('\n', endMarker);
+      const head = existing.slice(0, begin);
+      const tail = endLineBreak === -1 ? '' : existing.slice(endLineBreak);
+      const content = `${head}${block}${tail}`;
+      return { content, action: content === existing ? 'unchanged' : 'updated' };
+    }
+  }
+
+  const separator = existing.endsWith('\n') ? '' : '\n';
+  return { content: `${existing}${separator}\n${block}\n`, action: 'updated' };
+}
+
+/**
+ * Resolve the directory git uses for hooks in `cwd`. Prefers `git rev-parse
+ * --git-path hooks` so it is correct in linked worktrees and submodules (where
+ * `.git` is a file, not a directory); falls back to `<cwd>/.git/hooks`.
+ */
+function resolveGitHooksDir(cwd: string): string {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+      cwd,
+      encoding: 'utf-8',
+    }).trim();
+    return path.isAbsolute(out) ? out : path.join(cwd, out);
+  } catch {
+    return path.join(cwd, '.git', 'hooks');
+  }
+}
+
+/** True if `cwd` looks like a git repository (`.git` present as dir or gitdir file). */
+function isGitRepo(cwd: string): boolean {
+  return fs.existsSync(path.join(cwd, '.git'));
+}
+
+/**
+ * Install (or refresh) the roadmap-regen pre-commit hook. Idempotent: re-running
+ * replaces the managed block in place and reports `unchanged` when nothing moved.
+ * Degrades gracefully when the project is not sharded (skips unless `--force`).
+ */
+export async function runRoadmapInstallHook(
+  opts: RoadmapInstallHookOptions = {}
+): Promise<Result<InstallHookReport, CLIError>> {
+  const cwd = opts.cwd ?? process.cwd();
+  const command = opts.command?.trim() || DEFAULT_REGEN_COMMAND;
+  const requested = opts.mechanism ?? 'auto';
+  const force = Boolean(opts.force);
+
+  if (!isGitRepo(cwd)) {
+    return Err(
+      new CLIError(
+        'Not a git repository (no .git found); cannot install a git hook.',
+        ExitCode.ERROR
+      )
+    );
+  }
+
+  const sharded = fs.existsSync(path.join(cwd, 'docs', 'roadmap.d'));
+
+  // Resolve the mechanism. `auto` prefers husky when the adopter already uses it.
+  const huskyDir = path.join(cwd, '.husky');
+  const mechanism: HookMechanism =
+    requested === 'auto' ? (fs.existsSync(huskyDir) ? 'husky' : 'git') : requested;
+
+  const hookPath =
+    mechanism === 'husky'
+      ? path.join(huskyDir, 'pre-commit')
+      : path.join(resolveGitHooksDir(cwd), 'pre-commit');
+
+  // Graceful degradation: nothing to protect until the roadmap is sharded.
+  // `--force` still installs (useful to pre-provision before `harness roadmap shard`).
+  if (!sharded && !force) {
+    return Ok({ mechanism, hookPath, action: 'skipped', sharded, command });
+  }
+
+  const existing = fs.existsSync(hookPath) ? fs.readFileSync(hookPath, 'utf-8') : null;
+  const block = buildRegenBlock(command);
+  const { content, action } = mergeHookContent(existing, block);
+
+  if (action !== 'unchanged') {
+    fs.mkdirSync(path.dirname(hookPath), { recursive: true });
+    fs.writeFileSync(hookPath, content);
+  }
+  // A raw `.git/hooks` hook must be executable; husky sources its files but the
+  // execute bit is harmless there. chmod every run so a pre-existing non-exec
+  // hook is fixed too. Best-effort: a filesystem without POSIX modes must not fail.
+  try {
+    fs.chmodSync(hookPath, 0o755);
+  } catch {
+    // Non-POSIX filesystem — nothing to do.
+  }
+
+  return Ok({ mechanism, hookPath, action, sharded, command });
+}
+
+/** Print the human-readable summary of an install-hook run. */
+function printReport(report: InstallHookReport, cwd: string): void {
+  const rel = path.relative(cwd, report.hookPath).replaceAll('\\', '/');
+
+  if (report.action === 'skipped') {
+    logger.warn(
+      `Project is not sharded (docs/roadmap.d not found) — skipped hook install. ` +
+        `Run 'harness roadmap shard' first, or re-run with --force to pre-provision.`
+    );
+    return;
+  }
+
+  const verb =
+    report.action === 'created'
+      ? 'Created'
+      : report.action === 'updated'
+        ? 'Updated'
+        : 'Already up to date:';
+  logger.success(`${verb} ${report.mechanism} pre-commit hook at ${rel}`);
+  logger.info(`Hook runs: ${report.command}`);
+  if (!report.sharded) {
+    logger.warn('Project is not sharded yet — the hook is a no-op until docs/roadmap.d/ exists.');
+  }
+}
+
+/** Emit an error in the requested format (JSON object or human log) and exit. */
+function failInstallHook(message: string, format: 'human' | 'json', exitCode: number): never {
+  if (format === 'json') {
+    console.log(JSON.stringify({ ok: false, error: message }));
+  } else {
+    logger.error(message);
+  }
+  process.exit(exitCode);
+}
+
+interface InstallHookCliOptions {
+  cwd?: string;
+  mechanism?: string;
+  command?: string;
+  force?: boolean;
+  format?: string;
+}
+
+/** The `harness roadmap install-hook` action body, extracted for clarity + testability. */
+export async function runInstallHookAction(options: InstallHookCliOptions): Promise<void> {
+  const format: 'human' | 'json' = options.format === 'json' ? 'json' : 'human';
+  const mechanism = options.mechanism ?? 'auto';
+
+  if (!['auto', 'husky', 'git'].includes(mechanism)) {
+    failInstallHook(
+      `Invalid --mechanism: ${mechanism}. Must be one of: auto, husky, git`,
+      format,
+      ExitCode.ERROR
+    );
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const result = await runRoadmapInstallHook({
+    cwd,
+    mechanism: mechanism as 'auto' | HookMechanism,
+    ...(options.command ? { command: options.command } : {}),
+    force: Boolean(options.force),
+    format,
+  });
+
+  if (!result.ok) {
+    failInstallHook(result.error.message, format, result.error.exitCode);
+  }
+
+  if (format === 'json') {
+    console.log(JSON.stringify({ ok: true, ...result.value }));
+  } else {
+    printReport(result.value, cwd);
+  }
+}
+
+/** Commander wrapper for `harness roadmap install-hook`. */
+export function createRoadmapInstallHookCommand(): Command {
+  return new Command('install-hook')
+    .description(
+      'Install a git pre-commit hook that regenerates docs/roadmap.md from the docs/roadmap.d shards'
+    )
+    .option('--cwd <dir>', 'Project root (defaults to the current working directory)')
+    .option(
+      '--mechanism <mechanism>',
+      'Hook mechanism: "auto" (default), "husky", or "git" (raw .git/hooks)',
+      'auto'
+    )
+    .option('--command <command>', 'Regen command the hook runs', DEFAULT_REGEN_COMMAND)
+    .option('--force', 'Install even when the project is not sharded (no docs/roadmap.d)', false)
+    .option(
+      '--format <fmt>',
+      'Output format: "human" (default) or "json" (single JSON object for CI consumers)',
+      'human'
+    )
+    .action(runInstallHookAction);
+}

--- a/packages/core/src/validation/roadmap-read-source.ts
+++ b/packages/core/src/validation/roadmap-read-source.ts
@@ -46,6 +46,11 @@ export const ROADMAP_READ_ALLOWLIST: readonly string[] = [
   'packages/cli/src/commands/roadmap/unshard.ts',
   'packages/cli/src/commands/roadmap/migrate.ts',
   'packages/cli/src/commands/roadmap/migrate-lock.ts',
+  // Adopter-facing git-hook installer: writes a pre-commit hook whose generated
+  // shell block names `docs/roadmap.md` (git add + fail message) — a path in a
+  // shell string, not a content parse-read; the hook shells out to `harness
+  // roadmap regen`, which goes through the store.
+  'packages/cli/src/commands/roadmap/install-hook.ts',
   // Read-only auto-triage: parses items to score dispatchability (report +
   // --brainstorm); never writes roadmap.md. Same parse pattern as its peer
   // roadmap commands above (shard/regen), and default-off behind roadmap.autoTriage.


### PR DESCRIPTION
## Summary

Adds `harness roadmap install-hook` — an adopter-facing installer that wires the roadmap aggregate-regeneration step into an adopter's git `pre-commit` hook. Projects that shard their roadmap (`docs/roadmap.d/`) keep the generated `docs/roadmap.md` aggregate fresh via a pre-commit `harness roadmap regen`; this repo did that with its own `.husky/pre-commit`, but there was no adopter-facing way to install the equivalent. This closes that gap.

## What it does

- New subcommand `harness roadmap install-hook` (registered in `packages/cli/src/commands/roadmap/index.ts`, implemented in `install-hook.ts`).
- Writes a guarded, fail-closed regen block into the adopter's `pre-commit` hook: when any `docs/roadmap.d/` shard is staged, it runs the regen command and re-stages `docs/roadmap.md`, blocking the commit if regen fails (never commits a stale aggregate). Safe no-op when no shard is staged.
- **Composes safely with existing hooks.** `--mechanism auto` (default) writes `.husky/pre-commit` when a `.husky/` dir exists, else raw `.git/hooks/pre-commit` (`--mechanism husky|git` forces a choice). The managed block is fenced by markers, so re-running replaces it in place — never duplicated, never clobbering the adopter's own hook steps.
- **Idempotent.** Re-run reports `unchanged` when nothing moved.
- **Degrades gracefully.** Skips with a clear message when the project is not sharded (no `docs/roadmap.d/`); `--force` installs anyway to pre-provision. `--command` overrides the embedded regen invocation (default `npx harness roadmap regen`). `--format json` for CI consumers.
- Distinct from `harness hooks` (Claude Code tool-use hooks, which cannot fire on `git commit`) — this is a real GIT hook.

CI (`harness validate`) remains the authoritative freshness contract; this hook is a local developer convenience.

## Tests

`packages/cli/src/commands/roadmap/install-hook.test.ts` (14 tests): the pure idempotent merge (create / append-preserving / replace-in-place / unchanged), end-to-end install against a real temp git repo (raw `.git/hooks` + husky auto-detect, executable bit, `--command` override), graceful skip when unsharded + `--force`, and a real `git commit` proving the installed hook regenerates and re-stages the aggregate only when a shard is staged.

## Notes

- The `@harness-engineering/core` change is a single read-source invariant-R allowlist entry for the new command (its generated hook block names `docs/roadmap.md` as a git path, not a content read); no runtime behavior change in core.
- Docs: adopter section added to `docs/guides/roadmap-sharding.md`; proposal at `docs/changes/adopter-roadmap-hook-installer/proposal.md`; CLI reference regenerated; changeset added; roadmap shard `Spec` field updated.

Closes #688
