### PR TITLE
fix: unblock the arch gate on main (#1087) + burn-hud forecast-weight corollary

### DIFF
--- a/.changeset/unblock-arch-gate-complexity.md
+++ b/.changeset/unblock-arch-gate-complexity.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Reduce `parseFencedJson` complexity in `docs-craft/phases/critique.ts` past the
+arch gate's new-code threshold (cyclomaticComplexity 12 > 10), which was blocking
+all commits on `main` (#1087). Fence-stripping and object-narrowing are extracted
+to `stripJsonFence` and `asJsonObject`, leaving the parser as try/catch plus two
+calls. Behaviour is unchanged and the `SEC-DES-001` ignore comment is retained,
+now pointing at `asJsonObject` where the shape gate lives.

--- a/.gemini-extension/commands/burn-hud.toml
+++ b/.gemini-extension/commands/burn-hud.toml
@@ -65,6 +65,19 @@ This law is not theoretical. Both real failures of the reference implementation 
 
 In both cases the denominator was non-zero and the arithmetic was correct. Zero-denominator checks caught neither. Only reconciliation against ground truth did.
 
+#### Corollary: a forecast may only escalate in proportion to the evidence behind it
+
+Incurred spend is a fact and may always raise the alarm. A projection is evidence whose weight grows with the week, and must earn severity gradually.
+
+The reference implementation shipped this wrong too, in the opposite direction from the failures above. It derived status from `max(projected, used)`, so 2% of budget spent in a week's first three hours extrapolated to 118% and fired `CRITICAL`. The warning then read "5.8M used this week ... 108% of your weekly budget" — self-contradictory on its face, which teaches the reader to discount every future alarm. **An alarm that fires on noise is worse than no alarm**, because it spends the credibility the real one depends on.
+
+Two mechanisms, and both are needed:
+
+- **Shrink the forecast toward the trailing baseline** in proportion to how much of the week has not yet happened. Early on, the best available estimate of where the week lands is "a normal week". Report the raw extrapolation alongside the blended figure — quietly adjusting a number the user reads daily is its own kind of untrustworthiness, even when the adjustment is the statistically sound one.
+- **Cap how far a low-confidence forecast may escalate** (e.g. low → no escalation, medium → at most the second tier, high → any tier). With no baseline there is nothing to shrink toward, so this cap carries the load alone.
+
+Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ verdict on thin evidence, and withhold an _alarming_ verdict built on a thin _forecast_ — but never withhold one built on spend already incurred.
+
 ---
 
 ### Phase 1: INSTALL — Wire It Up Without Breaking Anything
@@ -117,6 +130,11 @@ In both cases the denominator was non-zero and the arithmetic was correct. Zero-
    - Empty store → status must be `NO_DATA` ("blind, not clear"), never `0% — fine`.
 
 3. **Confirm the reminders fire.** With an elevated status the post-turn hook must warn; at `OK` or `EARLY` it must stay silent, or it becomes wallpaper.
+
+4. **Test both directions of the forecast asymmetry**, because muting noise and muting a real alarm are the same edit if done carelessly:
+   - Small spend a few hours into the week, whose linear extrapolation exceeds the budget → must **not** escalate, and must not print an exhaustion date.
+   - Spend already past the budget a few hours into the week → **must** escalate to the top tier regardless of forecast confidence.
+     A change that satisfies only the first is a muted alarm, not a fixed one.
 
 **Gate G6/G7.**
 
@@ -180,30 +198,33 @@ Escalate to the user rather than guessing:
 
 ## Red Flags
 
-| Signal                                                         | Why it is a stop                                                                                           |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| "It says 3% so we're fine" with no calibration on record       | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number. |
-| Status flipped to a much lower figure with no behaviour change | Suspect record loss or a window change, not a quiet week.                                                  |
-| `files_rescanned: 1` alongside a suddenly small record total   | The exact signature of fingerprints outliving their records. Force a rebuild.                              |
-| Adjusting the budget so the HUD agrees with `/usage`           | This hides a window error behind a fudged ceiling. Fix the window instead.                                 |
-| Calibrating within hours of a reset                            | Whole-percent rounding makes this near-useless. Wait for mid-week.                                         |
-| A green statusline the user disputes                           | Diagnose before defending the number.                                                                      |
-| Installing on a platform without POSIX locking                 | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                         |
+| Signal                                                                  | Why it is a stop                                                                                                                                     |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It says 3% so we're fine" with no calibration on record                | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number.                                           |
+| Status flipped to a much lower figure with no behaviour change          | Suspect record loss or a window change, not a quiet week.                                                                                            |
+| `files_rescanned: 1` alongside a suddenly small record total            | The exact signature of fingerprints outliving their records. Force a rebuild.                                                                        |
+| Adjusting the budget so the HUD agrees with `/usage`                    | This hides a window error behind a fudged ceiling. Fix the window instead.                                                                           |
+| Calibrating within hours of a reset                                     | Whole-percent rounding makes this near-useless. Wait for mid-week.                                                                                   |
+| A green statusline the user disputes                                    | Diagnose before defending the number.                                                                                                                |
+| An alarm firing in the first hours of a week on a small absolute spend  | The forecast rests on almost no week. Verify the projection is shrunk and confidence-capped before believing it.                                     |
+| A warning quoting a projected percentage beside a small absolute figure | Self-contradictory on its face ("5.8M used ... 108% of budget"), which trains the reader to discount later alarms. Lead with what is actually spent. |
+| Installing on a platform without POSIX locking                          | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                                                                   |
 
 ## Rationalizations to Reject
 
-| Rationalization                                                    | Reality                                                                                                                                                                                                             |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                       |
-| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                   |
-| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                          |
-| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store. |
-| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                     |
-| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                    |
-| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                        |
-| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                  |
-| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                            |
-| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                 |
+| Rationalization                                                    | Reality                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                                                 |
+| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                                             |
+| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                                                    |
+| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store.                           |
+| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                                               |
+| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                                              |
+| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                                                  |
+| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                                            |
+| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                                                      |
+| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                                           |
+| "The projection says 120%, so warn now"                            | A projection is not spend. Early in the week it is an extrapolation from hours, and escalating on it burns the credibility the real alarm depends on. Cap what a low-confidence forecast may escalate to; let incurred spend escalate freely. |
 
 ## Examples
 

--- a/agents/skills/claude-code/burn-hud/SKILL.md
+++ b/agents/skills/claude-code/burn-hud/SKILL.md
@@ -51,6 +51,19 @@ This law is not theoretical. Both real failures of the reference implementation 
 
 In both cases the denominator was non-zero and the arithmetic was correct. Zero-denominator checks caught neither. Only reconciliation against ground truth did.
 
+#### Corollary: a forecast may only escalate in proportion to the evidence behind it
+
+Incurred spend is a fact and may always raise the alarm. A projection is evidence whose weight grows with the week, and must earn severity gradually.
+
+The reference implementation shipped this wrong too, in the opposite direction from the failures above. It derived status from `max(projected, used)`, so 2% of budget spent in a week's first three hours extrapolated to 118% and fired `CRITICAL`. The warning then read "5.8M used this week ... 108% of your weekly budget" — self-contradictory on its face, which teaches the reader to discount every future alarm. **An alarm that fires on noise is worse than no alarm**, because it spends the credibility the real one depends on.
+
+Two mechanisms, and both are needed:
+
+- **Shrink the forecast toward the trailing baseline** in proportion to how much of the week has not yet happened. Early on, the best available estimate of where the week lands is "a normal week". Report the raw extrapolation alongside the blended figure — quietly adjusting a number the user reads daily is its own kind of untrustworthiness, even when the adjustment is the statistically sound one.
+- **Cap how far a low-confidence forecast may escalate** (e.g. low → no escalation, medium → at most the second tier, high → any tier). With no baseline there is nothing to shrink toward, so this cap carries the load alone.
+
+Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ verdict on thin evidence, and withhold an _alarming_ verdict built on a thin _forecast_ — but never withhold one built on spend already incurred.
+
 ---
 
 ### Phase 1: INSTALL — Wire It Up Without Breaking Anything
@@ -103,6 +116,11 @@ In both cases the denominator was non-zero and the arithmetic was correct. Zero-
    - Empty store → status must be `NO_DATA` ("blind, not clear"), never `0% — fine`.
 
 3. **Confirm the reminders fire.** With an elevated status the post-turn hook must warn; at `OK` or `EARLY` it must stay silent, or it becomes wallpaper.
+
+4. **Test both directions of the forecast asymmetry**, because muting noise and muting a real alarm are the same edit if done carelessly:
+   - Small spend a few hours into the week, whose linear extrapolation exceeds the budget → must **not** escalate, and must not print an exhaustion date.
+   - Spend already past the budget a few hours into the week → **must** escalate to the top tier regardless of forecast confidence.
+     A change that satisfies only the first is a muted alarm, not a fixed one.
 
 **Gate G6/G7.**
 
@@ -166,30 +184,33 @@ Escalate to the user rather than guessing:
 
 ## Red Flags
 
-| Signal                                                         | Why it is a stop                                                                                           |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| "It says 3% so we're fine" with no calibration on record       | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number. |
-| Status flipped to a much lower figure with no behaviour change | Suspect record loss or a window change, not a quiet week.                                                  |
-| `files_rescanned: 1` alongside a suddenly small record total   | The exact signature of fingerprints outliving their records. Force a rebuild.                              |
-| Adjusting the budget so the HUD agrees with `/usage`           | This hides a window error behind a fudged ceiling. Fix the window instead.                                 |
-| Calibrating within hours of a reset                            | Whole-percent rounding makes this near-useless. Wait for mid-week.                                         |
-| A green statusline the user disputes                           | Diagnose before defending the number.                                                                      |
-| Installing on a platform without POSIX locking                 | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                         |
+| Signal                                                                  | Why it is a stop                                                                                                                                     |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It says 3% so we're fine" with no calibration on record                | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number.                                           |
+| Status flipped to a much lower figure with no behaviour change          | Suspect record loss or a window change, not a quiet week.                                                                                            |
+| `files_rescanned: 1` alongside a suddenly small record total            | The exact signature of fingerprints outliving their records. Force a rebuild.                                                                        |
+| Adjusting the budget so the HUD agrees with `/usage`                    | This hides a window error behind a fudged ceiling. Fix the window instead.                                                                           |
+| Calibrating within hours of a reset                                     | Whole-percent rounding makes this near-useless. Wait for mid-week.                                                                                   |
+| A green statusline the user disputes                                    | Diagnose before defending the number.                                                                                                                |
+| An alarm firing in the first hours of a week on a small absolute spend  | The forecast rests on almost no week. Verify the projection is shrunk and confidence-capped before believing it.                                     |
+| A warning quoting a projected percentage beside a small absolute figure | Self-contradictory on its face ("5.8M used ... 108% of budget"), which trains the reader to discount later alarms. Lead with what is actually spent. |
+| Installing on a platform without POSIX locking                          | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                                                                   |
 
 ## Rationalizations to Reject
 
-| Rationalization                                                    | Reality                                                                                                                                                                                                             |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                       |
-| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                   |
-| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                          |
-| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store. |
-| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                     |
-| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                    |
-| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                        |
-| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                  |
-| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                            |
-| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                 |
+| Rationalization                                                    | Reality                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                                                 |
+| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                                             |
+| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                                                    |
+| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store.                           |
+| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                                               |
+| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                                              |
+| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                                                  |
+| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                                            |
+| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                                                      |
+| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                                           |
+| "The projection says 120%, so warn now"                            | A projection is not spend. Early in the week it is an extrapolation from hours, and escalating on it burns the credibility the real alarm depends on. Cap what a low-confidence forecast may escalate to; let incurred spend escalate freely. |
 
 ## Examples
 

--- a/agents/skills/codex/burn-hud/SKILL.md
+++ b/agents/skills/codex/burn-hud/SKILL.md
@@ -51,6 +51,19 @@ This law is not theoretical. Both real failures of the reference implementation 
 
 In both cases the denominator was non-zero and the arithmetic was correct. Zero-denominator checks caught neither. Only reconciliation against ground truth did.
 
+#### Corollary: a forecast may only escalate in proportion to the evidence behind it
+
+Incurred spend is a fact and may always raise the alarm. A projection is evidence whose weight grows with the week, and must earn severity gradually.
+
+The reference implementation shipped this wrong too, in the opposite direction from the failures above. It derived status from `max(projected, used)`, so 2% of budget spent in a week's first three hours extrapolated to 118% and fired `CRITICAL`. The warning then read "5.8M used this week ... 108% of your weekly budget" — self-contradictory on its face, which teaches the reader to discount every future alarm. **An alarm that fires on noise is worse than no alarm**, because it spends the credibility the real one depends on.
+
+Two mechanisms, and both are needed:
+
+- **Shrink the forecast toward the trailing baseline** in proportion to how much of the week has not yet happened. Early on, the best available estimate of where the week lands is "a normal week". Report the raw extrapolation alongside the blended figure — quietly adjusting a number the user reads daily is its own kind of untrustworthiness, even when the adjustment is the statistically sound one.
+- **Cap how far a low-confidence forecast may escalate** (e.g. low → no escalation, medium → at most the second tier, high → any tier). With no baseline there is nothing to shrink toward, so this cap carries the load alone.
+
+Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ verdict on thin evidence, and withhold an _alarming_ verdict built on a thin _forecast_ — but never withhold one built on spend already incurred.
+
 ---
 
 ### Phase 1: INSTALL — Wire It Up Without Breaking Anything
@@ -103,6 +116,11 @@ In both cases the denominator was non-zero and the arithmetic was correct. Zero-
    - Empty store → status must be `NO_DATA` ("blind, not clear"), never `0% — fine`.
 
 3. **Confirm the reminders fire.** With an elevated status the post-turn hook must warn; at `OK` or `EARLY` it must stay silent, or it becomes wallpaper.
+
+4. **Test both directions of the forecast asymmetry**, because muting noise and muting a real alarm are the same edit if done carelessly:
+   - Small spend a few hours into the week, whose linear extrapolation exceeds the budget → must **not** escalate, and must not print an exhaustion date.
+   - Spend already past the budget a few hours into the week → **must** escalate to the top tier regardless of forecast confidence.
+     A change that satisfies only the first is a muted alarm, not a fixed one.
 
 **Gate G6/G7.**
 
@@ -166,30 +184,33 @@ Escalate to the user rather than guessing:
 
 ## Red Flags
 
-| Signal                                                         | Why it is a stop                                                                                           |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| "It says 3% so we're fine" with no calibration on record       | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number. |
-| Status flipped to a much lower figure with no behaviour change | Suspect record loss or a window change, not a quiet week.                                                  |
-| `files_rescanned: 1` alongside a suddenly small record total   | The exact signature of fingerprints outliving their records. Force a rebuild.                              |
-| Adjusting the budget so the HUD agrees with `/usage`           | This hides a window error behind a fudged ceiling. Fix the window instead.                                 |
-| Calibrating within hours of a reset                            | Whole-percent rounding makes this near-useless. Wait for mid-week.                                         |
-| A green statusline the user disputes                           | Diagnose before defending the number.                                                                      |
-| Installing on a platform without POSIX locking                 | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                         |
+| Signal                                                                  | Why it is a stop                                                                                                                                     |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It says 3% so we're fine" with no calibration on record                | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number.                                           |
+| Status flipped to a much lower figure with no behaviour change          | Suspect record loss or a window change, not a quiet week.                                                                                            |
+| `files_rescanned: 1` alongside a suddenly small record total            | The exact signature of fingerprints outliving their records. Force a rebuild.                                                                        |
+| Adjusting the budget so the HUD agrees with `/usage`                    | This hides a window error behind a fudged ceiling. Fix the window instead.                                                                           |
+| Calibrating within hours of a reset                                     | Whole-percent rounding makes this near-useless. Wait for mid-week.                                                                                   |
+| A green statusline the user disputes                                    | Diagnose before defending the number.                                                                                                                |
+| An alarm firing in the first hours of a week on a small absolute spend  | The forecast rests on almost no week. Verify the projection is shrunk and confidence-capped before believing it.                                     |
+| A warning quoting a projected percentage beside a small absolute figure | Self-contradictory on its face ("5.8M used ... 108% of budget"), which trains the reader to discount later alarms. Lead with what is actually spent. |
+| Installing on a platform without POSIX locking                          | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                                                                   |
 
 ## Rationalizations to Reject
 
-| Rationalization                                                    | Reality                                                                                                                                                                                                             |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                       |
-| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                   |
-| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                          |
-| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store. |
-| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                     |
-| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                    |
-| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                        |
-| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                  |
-| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                            |
-| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                 |
+| Rationalization                                                    | Reality                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                                                 |
+| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                                             |
+| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                                                    |
+| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store.                           |
+| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                                               |
+| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                                              |
+| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                                                  |
+| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                                            |
+| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                                                      |
+| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                                           |
+| "The projection says 120%, so warn now"                            | A projection is not spend. Early in the week it is an extrapolation from hours, and escalating on it burns the credibility the real alarm depends on. Cap what a low-confidence forecast may escalate to; let incurred spend escalate freely. |
 
 ## Examples
 

--- a/agents/skills/cursor/burn-hud/SKILL.md
+++ b/agents/skills/cursor/burn-hud/SKILL.md
@@ -51,6 +51,19 @@ This law is not theoretical. Both real failures of the reference implementation 
 
 In both cases the denominator was non-zero and the arithmetic was correct. Zero-denominator checks caught neither. Only reconciliation against ground truth did.
 
+#### Corollary: a forecast may only escalate in proportion to the evidence behind it
+
+Incurred spend is a fact and may always raise the alarm. A projection is evidence whose weight grows with the week, and must earn severity gradually.
+
+The reference implementation shipped this wrong too, in the opposite direction from the failures above. It derived status from `max(projected, used)`, so 2% of budget spent in a week's first three hours extrapolated to 118% and fired `CRITICAL`. The warning then read "5.8M used this week ... 108% of your weekly budget" — self-contradictory on its face, which teaches the reader to discount every future alarm. **An alarm that fires on noise is worse than no alarm**, because it spends the credibility the real one depends on.
+
+Two mechanisms, and both are needed:
+
+- **Shrink the forecast toward the trailing baseline** in proportion to how much of the week has not yet happened. Early on, the best available estimate of where the week lands is "a normal week". Report the raw extrapolation alongside the blended figure — quietly adjusting a number the user reads daily is its own kind of untrustworthiness, even when the adjustment is the statistically sound one.
+- **Cap how far a low-confidence forecast may escalate** (e.g. low → no escalation, medium → at most the second tier, high → any tier). With no baseline there is nothing to shrink toward, so this cap carries the load alone.
+
+Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ verdict on thin evidence, and withhold an _alarming_ verdict built on a thin _forecast_ — but never withhold one built on spend already incurred.
+
 ---
 
 ### Phase 1: INSTALL — Wire It Up Without Breaking Anything
@@ -103,6 +116,11 @@ In both cases the denominator was non-zero and the arithmetic was correct. Zero-
    - Empty store → status must be `NO_DATA` ("blind, not clear"), never `0% — fine`.
 
 3. **Confirm the reminders fire.** With an elevated status the post-turn hook must warn; at `OK` or `EARLY` it must stay silent, or it becomes wallpaper.
+
+4. **Test both directions of the forecast asymmetry**, because muting noise and muting a real alarm are the same edit if done carelessly:
+   - Small spend a few hours into the week, whose linear extrapolation exceeds the budget → must **not** escalate, and must not print an exhaustion date.
+   - Spend already past the budget a few hours into the week → **must** escalate to the top tier regardless of forecast confidence.
+     A change that satisfies only the first is a muted alarm, not a fixed one.
 
 **Gate G6/G7.**
 
@@ -166,30 +184,33 @@ Escalate to the user rather than guessing:
 
 ## Red Flags
 
-| Signal                                                         | Why it is a stop                                                                                           |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| "It says 3% so we're fine" with no calibration on record       | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number. |
-| Status flipped to a much lower figure with no behaviour change | Suspect record loss or a window change, not a quiet week.                                                  |
-| `files_rescanned: 1` alongside a suddenly small record total   | The exact signature of fingerprints outliving their records. Force a rebuild.                              |
-| Adjusting the budget so the HUD agrees with `/usage`           | This hides a window error behind a fudged ceiling. Fix the window instead.                                 |
-| Calibrating within hours of a reset                            | Whole-percent rounding makes this near-useless. Wait for mid-week.                                         |
-| A green statusline the user disputes                           | Diagnose before defending the number.                                                                      |
-| Installing on a platform without POSIX locking                 | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                         |
+| Signal                                                                  | Why it is a stop                                                                                                                                     |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It says 3% so we're fine" with no calibration on record                | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number.                                           |
+| Status flipped to a much lower figure with no behaviour change          | Suspect record loss or a window change, not a quiet week.                                                                                            |
+| `files_rescanned: 1` alongside a suddenly small record total            | The exact signature of fingerprints outliving their records. Force a rebuild.                                                                        |
+| Adjusting the budget so the HUD agrees with `/usage`                    | This hides a window error behind a fudged ceiling. Fix the window instead.                                                                           |
+| Calibrating within hours of a reset                                     | Whole-percent rounding makes this near-useless. Wait for mid-week.                                                                                   |
+| A green statusline the user disputes                                    | Diagnose before defending the number.                                                                                                                |
+| An alarm firing in the first hours of a week on a small absolute spend  | The forecast rests on almost no week. Verify the projection is shrunk and confidence-capped before believing it.                                     |
+| A warning quoting a projected percentage beside a small absolute figure | Self-contradictory on its face ("5.8M used ... 108% of budget"), which trains the reader to discount later alarms. Lead with what is actually spent. |
+| Installing on a platform without POSIX locking                          | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                                                                   |
 
 ## Rationalizations to Reject
 
-| Rationalization                                                    | Reality                                                                                                                                                                                                             |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                       |
-| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                   |
-| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                          |
-| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store. |
-| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                     |
-| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                    |
-| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                        |
-| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                  |
-| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                            |
-| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                 |
+| Rationalization                                                    | Reality                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                                                 |
+| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                                             |
+| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                                                    |
+| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store.                           |
+| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                                               |
+| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                                              |
+| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                                                  |
+| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                                            |
+| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                                                      |
+| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                                           |
+| "The projection says 120%, so warn now"                            | A projection is not spend. Early in the week it is an extrapolation from hours, and escalating on it burns the credibility the real alarm depends on. Cap what a low-confidence forecast may escalate to; let incurred spend escalate freely. |
 
 ## Examples
 

--- a/agents/skills/gemini-cli/burn-hud/SKILL.md
+++ b/agents/skills/gemini-cli/burn-hud/SKILL.md
@@ -51,6 +51,19 @@ This law is not theoretical. Both real failures of the reference implementation 
 
 In both cases the denominator was non-zero and the arithmetic was correct. Zero-denominator checks caught neither. Only reconciliation against ground truth did.
 
+#### Corollary: a forecast may only escalate in proportion to the evidence behind it
+
+Incurred spend is a fact and may always raise the alarm. A projection is evidence whose weight grows with the week, and must earn severity gradually.
+
+The reference implementation shipped this wrong too, in the opposite direction from the failures above. It derived status from `max(projected, used)`, so 2% of budget spent in a week's first three hours extrapolated to 118% and fired `CRITICAL`. The warning then read "5.8M used this week ... 108% of your weekly budget" — self-contradictory on its face, which teaches the reader to discount every future alarm. **An alarm that fires on noise is worse than no alarm**, because it spends the credibility the real one depends on.
+
+Two mechanisms, and both are needed:
+
+- **Shrink the forecast toward the trailing baseline** in proportion to how much of the week has not yet happened. Early on, the best available estimate of where the week lands is "a normal week". Report the raw extrapolation alongside the blended figure — quietly adjusting a number the user reads daily is its own kind of untrustworthiness, even when the adjustment is the statistically sound one.
+- **Cap how far a low-confidence forecast may escalate** (e.g. low → no escalation, medium → at most the second tier, high → any tier). With no baseline there is nothing to shrink toward, so this cap carries the load alone.
+
+Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ verdict on thin evidence, and withhold an _alarming_ verdict built on a thin _forecast_ — but never withhold one built on spend already incurred.
+
 ---
 
 ### Phase 1: INSTALL — Wire It Up Without Breaking Anything
@@ -103,6 +116,11 @@ In both cases the denominator was non-zero and the arithmetic was correct. Zero-
    - Empty store → status must be `NO_DATA` ("blind, not clear"), never `0% — fine`.
 
 3. **Confirm the reminders fire.** With an elevated status the post-turn hook must warn; at `OK` or `EARLY` it must stay silent, or it becomes wallpaper.
+
+4. **Test both directions of the forecast asymmetry**, because muting noise and muting a real alarm are the same edit if done carelessly:
+   - Small spend a few hours into the week, whose linear extrapolation exceeds the budget → must **not** escalate, and must not print an exhaustion date.
+   - Spend already past the budget a few hours into the week → **must** escalate to the top tier regardless of forecast confidence.
+     A change that satisfies only the first is a muted alarm, not a fixed one.
 
 **Gate G6/G7.**
 
@@ -166,30 +184,33 @@ Escalate to the user rather than guessing:
 
 ## Red Flags
 
-| Signal                                                         | Why it is a stop                                                                                           |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| "It says 3% so we're fine" with no calibration on record       | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number. |
-| Status flipped to a much lower figure with no behaviour change | Suspect record loss or a window change, not a quiet week.                                                  |
-| `files_rescanned: 1` alongside a suddenly small record total   | The exact signature of fingerprints outliving their records. Force a rebuild.                              |
-| Adjusting the budget so the HUD agrees with `/usage`           | This hides a window error behind a fudged ceiling. Fix the window instead.                                 |
-| Calibrating within hours of a reset                            | Whole-percent rounding makes this near-useless. Wait for mid-week.                                         |
-| A green statusline the user disputes                           | Diagnose before defending the number.                                                                      |
-| Installing on a platform without POSIX locking                 | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                         |
+| Signal                                                                  | Why it is a stop                                                                                                                                     |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It says 3% so we're fine" with no calibration on record                | An uncalibrated percentage is meaningless. Check for a budget and calibration before repeating any number.                                           |
+| Status flipped to a much lower figure with no behaviour change          | Suspect record loss or a window change, not a quiet week.                                                                                            |
+| `files_rescanned: 1` alongside a suddenly small record total            | The exact signature of fingerprints outliving their records. Force a rebuild.                                                                        |
+| Adjusting the budget so the HUD agrees with `/usage`                    | This hides a window error behind a fudged ceiling. Fix the window instead.                                                                           |
+| Calibrating within hours of a reset                                     | Whole-percent rounding makes this near-useless. Wait for mid-week.                                                                                   |
+| A green statusline the user disputes                                    | Diagnose before defending the number.                                                                                                                |
+| An alarm firing in the first hours of a week on a small absolute spend  | The forecast rests on almost no week. Verify the projection is shrunk and confidence-capped before believing it.                                     |
+| A warning quoting a projected percentage beside a small absolute figure | Self-contradictory on its face ("5.8M used ... 108% of budget"), which trains the reader to discount later alarms. Lead with what is actually spent. |
+| Installing on a platform without POSIX locking                          | Unsynchronised scans corrupt the store, and a corrupt store reports green. Refuse.                                                                   |
 
 ## Rationalizations to Reject
 
-| Rationalization                                                    | Reality                                                                                                                                                                                                             |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                       |
-| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                   |
-| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                          |
-| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store. |
-| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                     |
-| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                    |
-| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                        |
-| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                  |
-| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                            |
-| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                 |
+| Rationalization                                                    | Reality                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The numbers look plausible, so calibration can wait"              | Plausible is exactly how both failures presented. The 81× understatement looked like a quiet week; the 85% record loss looked like 3% of budget. Reconcile or report nothing.                                                                 |
+| "The denominator is non-zero, so the reading is sound"             | Both real failures had non-zero denominators and correct arithmetic. Zero-denominator checks catch _no data_; they cannot catch _wrong window_ or _partial data_.                                                                             |
+| "Weekday is enough — the exact reset time hardly matters"          | A time-of-day error shifts the window by hours; combined with the wrong weekday it produced an 81× error. Set weekday, time, and timezone.                                                                                                    |
+| "Atomic writes are in place, so a record-count check is redundant" | Atomic writes prevent _new_ corruption; they do not detect _existing_ loss. The count header is what makes fingerprints and records fail together instead of the fingerprints silently vouching for a gutted store.                           |
+| "Scanning after every turn keeps it fresh"                         | That frequency caused the write race. Usage cannot move meaningfully inside a minute; throttle.                                                                                                                                               |
+| "Just set a budget from the trailing median"                       | A self-referential budget drifts with behaviour and never maps to the real ceiling. It is a fallback for _no calibration yet_, not a substitute.                                                                                              |
+| "The promo ends eventually; no need to record a date"              | An unrecorded expiry is a budget that under-warns silently from that day on.                                                                                                                                                                  |
+| "Tests are overkill for a personal statusline"                     | The tool's entire job is not lying about usage, and it lied twice.                                                                                                                                                                            |
+| "The pooled percentage is fine, so we're fine"                     | Per-model limits are separate and can be fully spent while the pooled bar looks healthy.                                                                                                                                                      |
+| "The user is probably misreading it"                               | They caught both real failures before the tool did. Diagnose first.                                                                                                                                                                           |
+| "The projection says 120%, so warn now"                            | A projection is not spend. Early in the week it is an extrapolation from hours, and escalating on it burns the credibility the real alarm depends on. Cap what a low-confidence forecast may escalate to; let incurred spend escalate freely. |
 
 ## Examples
 

--- a/packages/cli/src/docs-craft/phases/critique.ts
+++ b/packages/cli/src/docs-craft/phases/critique.ts
@@ -82,16 +82,24 @@ function buildPrompt(input: CritiqueInput): string {
   ].join('\n');
 }
 
-function parseFencedJson(raw: string): Record<string, unknown> | null {
+/** Strip an optional ```json fence, returning the trimmed payload. */
+function stripJsonFence(raw: string): string {
   const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = (match?.[1] ?? raw).trim();
+  return (match?.[1] ?? raw).trim();
+}
+
+/** Narrow parsed JSON to a plain object, rejecting null/arrays/primitives. */
+function asJsonObject(parsed: unknown): Record<string, unknown> | null {
+  if (parsed === null || typeof parsed !== 'object') return null;
+  return parsed as Record<string, unknown>;
+}
+
+function parseFencedJson(raw: string): Record<string, unknown> | null {
+  const body = stripJsonFence(raw);
   if (body === 'null') return null;
   try {
-    // harness-ignore SEC-DES-001: parses LLM model output; typeof check below gates shape, downstream callers re-validate fields
-    const parsed: unknown = JSON.parse(body);
-    return parsed !== null && typeof parsed === 'object'
-      ? (parsed as Record<string, unknown>)
-      : null;
+    // harness-ignore SEC-DES-001: parses LLM model output; asJsonObject gates shape, downstream callers re-validate fields
+    return asJsonObject(JSON.parse(body));
   } catch {
     return null;
   }

--- a/packages/core/tests/roadmap/reconcile.test.ts
+++ b/packages/core/tests/roadmap/reconcile.test.ts
@@ -39,6 +39,23 @@ function roadmap(features: RoadmapFeature[]): Roadmap {
   };
 }
 
+/** Apply `mutate` to the first feature matching `slug`, in place. */
+function patchFeatureInPlace(
+  roadmap: Roadmap,
+  slug: string,
+  mutate: (
+    feature: Roadmap['milestones'][number]['features'][number]
+  ) => Roadmap['milestones'][number]['features'][number]
+): void {
+  for (const m of roadmap.milestones) {
+    const idx = m.features.findIndex((f) => slugifyFeatureName(f.name) === slug);
+    if (idx >= 0) {
+      m.features[idx] = mutate(m.features[idx]!);
+      return;
+    }
+  }
+}
+
 /**
  * In-memory store that actually applies mutations to a held `Roadmap` (so a
  * second reconcile pass sees the persisted state) and records each op so tests
@@ -56,13 +73,7 @@ function inMemoryStore(initial: Roadmap) {
   const store: RoadmapStore = {
     load: async () => Ok(structuredClone(current)),
     patchFeature: async (slug, mutate) => {
-      for (const m of current.milestones) {
-        const idx = m.features.findIndex((f) => slugifyFeatureName(f.name) === slug);
-        if (idx >= 0) {
-          m.features[idx] = mutate(m.features[idx]!);
-          break;
-        }
-      }
+      patchFeatureInPlace(current, slug, mutate);
       calls.patchFeature.push(slug);
       return Ok(undefined);
     },


### PR DESCRIPTION
Resolves #1087.

Rebased onto latest main. Two independent things, in separate commits.

> **Note for review:** this PR shrank after rebasing. It previously also carried a module-size baseline bump and a docs catalog-count fix — main has since absorbed both, so neither is here any more. It now touches **no baseline** and accepts no one else's regression. The macOS CI failure it originally hit was the unguarded `chmodSync` from #1078, which @chadtowle fixed independently in #1092; my duplicate fix was discarded.

## 1. Unblock the arch gate (#1087) — `3c61ebe39`

The pre-commit arch gate was failing on `main`, blocking **every** commit including markdown-only ones. Found while trying to commit a docs change containing no TypeScript.

Two NEW complexity breaches, fixed by extraction rather than by moving a baseline, because both functions were genuinely doing more than one thing:

| Breach | Fix |
|---|---|
| `functionLength=53 > 50` in `inMemoryStore` (`packages/core/tests/roadmap/reconcile.test.ts`) | The find-and-mutate loop over milestones lifts to `patchFeatureInPlace`, leaving the test fake a flat list of stubs |
| `cyclomaticComplexity=12 > 10` in `parseFencedJson` (`packages/cli/src/docs-craft/phases/critique.ts`) | Fence-stripping and object-narrowing lift to `stripJsonFence` / `asJsonObject`, leaving the parser as try/catch plus two calls |

The `SEC-DES-001` ignore comment on `parseFencedJson` is retained, with its reference updated to `asJsonObject` — that is where the shape gate now lives, so the comment stays true.

Behaviour is unchanged: `reconcile.test.ts` passes 10/10 and both packages typecheck.

## 2. burn-hud forecast-weight corollary — `969267bba`

The skill merged in #1046 documented two false-green failures. This adds the **opposite** failure mode: a false alarm.

The reference implementation derived status from `max(projected, used)`, so 2% of budget spent in a week's first three hours extrapolated to 118% and fired `CRITICAL`:

> 🔴 Burn CRITICAL — 5.8M used this week, 308.8M projected by reset. That is 108% of your weekly budget at this pace.

Self-contradictory on its face — and that is the damage. **An alarm that fires on noise is worse than no alarm**, because it spends the credibility the real one depends on.

A second, related failure is folded in: the *projected* percentage also occupied the statusline's headline slot, so `87% of budget` was read as 87% consumed when actual spend was 7%. A forecast must never sit where a reader will take it for a measurement.

The skill previously encoded the confidence asymmetry only in the *reassuring* direction ("withhold a green on thin evidence"), which is exactly how a HUD built to this skill would still produce the noise. The corollary states both required mechanisms:

- **Shrink the forecast toward the trailing baseline** in proportion to how much of the week has not yet happened, and report the raw extrapolation alongside it — quietly adjusting a number the user reads daily is its own kind of untrustworthiness.
- **Cap how far a low-confidence forecast may escalate** (low → none, medium → second tier, high → any).

And it is explicit that **incurred spend always escalates**, so muting noise cannot mute a real blowout. Phase 4 now requires *both* directions be tested, because muting noise and muting a real alarm are the same edit done carelessly.

Verified against the implementation: `CRITICAL` → `EARLY`, forecast 353M → 236M (1.01× the 4-week median) on 2% of budget spent, exhaustion timestamp withheld rather than dressed in false precision.

Identical across all four platform dirs; the generated `gemini-cli` command artifact is regenerated to match.

## 3. Changeset — `78a4c2bbd`

Required by the pre-push gate for the `@harness-engineering/cli` change. Behaviour-preserving extraction, so `patch`.

## Verification

- `agents/skills` vitest suite passes
- parity across all four platform dirs re-confirmed after prettier
- changeset gate: `Changeset check OK. Covered: @harness-engineering/cli`
- generated-docs gate passes
- arch gate passes per commit
- up to date with `origin/main` at time of push

No hooks bypassed.

## Two traps worth documenting for the next contributor

Both cost me real time and both present as opaque failures:

1. **After rebasing onto newer main, rebuild before running gates.** A stale `packages/core/dist` makes `generate:plugin:all` fail with `does not provide an export named 'archiveDoneShardsForProject'`. The pre-commit hook runs that generator with output suppressed, so it surfaces only as `husky - pre-commit script failed (code 1)` with no cause.

2. **Same for `generate-docs`.** Regenerating with a stale CLI build makes the generator emit an outdated command set and **delete valid documentation** — observed at -82 lines, dropping `check-operational-drift` and `--findings-json`.

## Unrelated observation

The arch gate now reports a **new** breach from main's own code, currently `warn` rather than `fail`:

```
! [complexity] NEW: cyclomaticComplexity=13 in runOutcomeEvalCi (threshold: 10)
    packages/cli/src/commands/outcome-eval-ci.ts
```

Not blocking today, but it is the same pattern as #1087 and will start blocking commits if anything tips it over. Not touched here — flagging for whoever owns `wire-outcome-eval-gate`.
