### PR TITLE
fix(roadmap): guard install-hook chmodSync with a platform check

### DIFF
--- a/.changeset/install-hook-chmod-guard.md
+++ b/.changeset/install-hook-chmod-guard.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Guard the `chmodSync` in `harness roadmap install-hook` with a `process.platform !== 'win32'` check (regression from the initial install-hook landing) so the platform-parity gate passes and Windows adopters don't hit a chmod error.

--- a/packages/cli/src/commands/roadmap/install-hook.ts
+++ b/packages/cli/src/commands/roadmap/install-hook.ts
@@ -190,11 +190,15 @@ export async function runRoadmapInstallHook(
   }
   // A raw `.git/hooks` hook must be executable; husky sources its files but the
   // execute bit is harmless there. chmod every run so a pre-existing non-exec
-  // hook is fixed too. Best-effort: a filesystem without POSIX modes must not fail.
-  try {
-    fs.chmodSync(hookPath, 0o755);
-  } catch {
-    // Non-POSIX filesystem — nothing to do.
+  // hook is fixed too. Guarded: chmod is a POSIX-mode no-op on Windows (git for
+  // Windows honors the hook regardless), and best-effort so a filesystem without
+  // POSIX modes must not fail.
+  if (process.platform !== 'win32') {
+    try {
+      fs.chmodSync(hookPath, 0o755);
+    } catch {
+      // Non-POSIX filesystem — nothing to do.
+    }
   }
 
   return Ok({ mechanism, hookPath, action, sharded, command });


### PR DESCRIPTION
## What
The `harness roadmap install-hook` command (landed in #1078) called `fs.chmodSync` on the git hook **without a platform guard**. The repo's `tests/platform-parity.test.ts` ("no unguarded fs.chmodSync calls") requires a `process.platform !== 'win32'` guard within 5 lines of any `chmodSync` — so this failed `build-and-test` on **every PR branched from main** after #1078 merged.

Wrapped the call in `if (process.platform !== 'win32')` (chmod is a POSIX-mode no-op on Windows anyway; git-for-Windows honors the hook regardless; still best-effort try/catch for non-POSIX filesystems).

## Why it matters
This is the fleet-wide `build-and-test` red across the open PRs — not a docs-freshness issue. Merging this greens the `platform-parity` step for every PR once they merge main.

## Verified
- `tests/platform-parity.test.ts` chmodSync check: green.
- install-hook behavior tests: 14/14 pass (guard is a no-op on this platform, install still works).
- Changeset added (`@harness-engineering/cli` patch).

Fixes the regression from #1078.