### PR TITLE
fix(cli): guard two Windows-only test assertions blocking the fleet

### DIFF
--- a/.changeset/windows-test-parity-hotfix.md
+++ b/.changeset/windows-test-parity-hotfix.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix two Windows-only CI test failures that block the fleet on `windows-latest`:
+
+- `roadmap install-hook`: the exec-bit assertion now skips on Windows, matching
+  the `process.platform !== 'win32'` guard around `chmodSync` (git for Windows
+  honors the hook regardless of mode).
+- `outcome-eval-ci` `resolveSpecPath`: the expected path is now built with
+  `path.join` instead of a hard-coded POSIX string, so it matches the native
+  separator the implementation returns.
+
+Both are test-only corrections; runtime behavior is unchanged.

--- a/packages/cli/src/commands/roadmap/install-hook.test.ts
+++ b/packages/cli/src/commands/roadmap/install-hook.test.ts
@@ -135,8 +135,12 @@ describe('runRoadmapInstallHook', () => {
     const hookContent = fs.readFileSync(first.value.hookPath, 'utf-8');
     expect(hookContent).toContain(HOOK_BLOCK_BEGIN);
     expect(hookContent).toContain(DEFAULT_REGEN_COMMAND);
-    // Executable bit set (POSIX).
-    expect(fs.statSync(first.value.hookPath).mode & 0o111).not.toBe(0);
+    // Executable bit set (POSIX). Skipped on Windows, where chmod is a
+    // deliberate no-op (git for Windows honors the hook regardless of mode) —
+    // matching the platform guard in runRoadmapInstallHook.
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(first.value.hookPath).mode & 0o111).not.toBe(0);
+    }
 
     const second = await runRoadmapInstallHook({ cwd });
     expect(second.ok).toBe(true);

--- a/packages/cli/tests/commands/outcome-eval-ci.test.ts
+++ b/packages/cli/tests/commands/outcome-eval-ci.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import path from 'node:path';
 import type { OutcomeVerdict } from '@harness-engineering/intelligence';
 import {
   deriveExitCode,
@@ -66,8 +67,10 @@ describe('resolveSpecPath', () => {
     const runGit = vi
       .fn()
       .mockReturnValue('src/a.ts\ndocs/changes/my-feature/proposal.md\nREADME.md');
+    // resolveSpecPath returns a native path (path.join), so build the
+    // expectation the same way — on Windows the separator is a backslash.
     expect(resolveSpecPath({ range: 'r', cwd: '/repo', runGit })).toBe(
-      '/repo/docs/changes/my-feature/proposal.md'
+      path.join('/repo', 'docs/changes/my-feature/proposal.md')
     );
   });
 


### PR DESCRIPTION
## Problem

Every open PR shows `mergeStateStatus=BLOCKED` because `main` itself is red on `build-and-test (windows-latest, 22)`. Two test-only assertions fail on Windows:

1. **`packages/cli/src/commands/roadmap/install-hook.test.ts`** — asserts the pre-commit hook has POSIX exec bits. Since the chmod hotfix (#1092) correctly guards `chmodSync` behind `process.platform !== 'win32'` (git for Windows honors the hook regardless of mode), the exec bits are never set on Windows and the assertion fails. The test wasn't guarded to match.
2. **`packages/cli/tests/commands/outcome-eval-ci.test.ts`** — `resolveSpecPath` returns a native path via `path.join`, but the test hard-coded a POSIX `/repo/...` expectation, so on Windows `\repo\...` !== `/repo/...`.

## Fix

Both are **test-only** corrections — runtime behavior is unchanged:

- Skip the exec-bit assertion on Windows, mirroring the production platform guard.
- Build the expected spec path with `path.join` so it matches the native separator.

## Verification

```
Test Files  2 passed (2)
     Tests  33 passed (33)
```
(Node 22, macOS.)

Once merged, `main` goes green on Windows and unblocks the rest of the open fleet.