### PR TITLE
fix(core): make arch baseline byte-stable to stop merge-conflict churn

### DIFF
--- a/.changeset/stabilize-arch-baseline.md
+++ b/.changeset/stabilize-arch-baseline.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/core': patch
+---
+
+Make the architecture baseline file (`.harness/arch/baselines.json`) a pure
+function of its metrics, eliminating spurious merge-conflict churn.
+
+`ArchBaselineManager.update` now preserves the `updatedAt`/`updatedFrom` stamps
+when a refresh does not actually change any metric, and `capture` sorts each
+category's `violationIds`. A no-op regeneration therefore produces a
+byte-identical file, so a PR that moves no metric never touches the baseline —
+and no longer conflicts with `main` on every merge. (The `merge=ours` git
+attribute only resolves this file for _local_ merges; GitHub's server-side merge
+cannot run a custom driver, so any diff here surfaces as a conflict there.)
+Genuine metric changes still bump the stamps and update the values as before.

--- a/packages/core/src/architecture/baseline-manager.ts
+++ b/packages/core/src/architecture/baseline-manager.ts
@@ -5,6 +5,32 @@ import { ArchBaselineSchema } from './types';
 import type { ArchBaseline, MetricResult, CategoryBaseline } from './types';
 
 /**
+ * Deep-equality for two baseline metric maps, treating each category's
+ * `violationIds` as a set (order-insensitive) so a reordering alone does not
+ * count as a change. Used to decide whether a baseline refresh actually moved
+ * any metric — if not, the volatile stamps are preserved to keep the file
+ * byte-stable.
+ */
+function metricsEqual(
+  a: Record<string, CategoryBaseline>,
+  b: Record<string, CategoryBaseline>
+): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const key of keys) {
+    const ca = a[key];
+    const cb = b[key];
+    if (!ca || !cb) return false;
+    if (ca.value !== cb.value) return false;
+    if (ca.violationIds.length !== cb.violationIds.length) return false;
+    const setA = new Set(ca.violationIds);
+    for (const id of cb.violationIds) {
+      if (!setA.has(id)) return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Manages architecture baselines stored on disk.
  *
  * Baselines are stored at `.harness/arch/baselines.json` relative to the project root.
@@ -40,9 +66,12 @@ export class ArchBaselineManager {
       }
     }
 
-    // Deduplicate violationIds per category
+    // Deduplicate and sort violationIds per category. Sorting makes the stored
+    // order a deterministic function of the set (not of collection order), so
+    // an unchanged set always serializes to identical bytes — a prerequisite
+    // for the byte-stable no-op regen below.
     for (const baseline of Object.values(metrics)) {
-      baseline.violationIds = [...new Set(baseline.violationIds)];
+      baseline.violationIds = [...new Set(baseline.violationIds)].sort();
     }
 
     return {
@@ -96,6 +125,17 @@ export class ArchBaselineManager {
     const existing = this.load();
     if (existing) {
       fresh.metrics = { ...existing.metrics, ...fresh.metrics };
+      // Keep the committed file a pure function of the metrics: only bump the
+      // volatile `updatedAt`/`updatedFrom` stamps when the metrics actually
+      // changed. A no-op regen then produces a byte-identical file, so PRs that
+      // don't move any metric never touch baselines.json — which stops the
+      // spurious merge-conflict churn on this generated file (the `merge=ours`
+      // attribute only resolves LOCAL merges; GitHub's server-side merge cannot
+      // run it, so any diff here shows as a conflict there).
+      if (metricsEqual(existing.metrics, fresh.metrics)) {
+        fresh.updatedAt = existing.updatedAt;
+        fresh.updatedFrom = existing.updatedFrom;
+      }
     }
     this.save(fresh);
     return fresh;

--- a/packages/core/tests/architecture/baseline-manager.test.ts
+++ b/packages/core/tests/architecture/baseline-manager.test.ts
@@ -259,5 +259,58 @@ describe('ArchBaselineManager', () => {
       const loaded = manager.load();
       expect(loaded!.metrics['coupling']!.value).toBe(1);
     });
+
+    // Stabilization: a re-run whose metrics are unchanged must not churn the
+    // volatile stamps, so the committed file stays byte-identical and does not
+    // spuriously conflict across branches.
+    it('preserves updatedAt/updatedFrom (byte-stable) when metrics are unchanged', () => {
+      const results: MetricResult[] = [
+        {
+          category: 'complexity',
+          scope: 'project',
+          value: 2,
+          violations: [
+            { id: 'cx-1', file: 'a.ts', detail: 'd', severity: 'warning' },
+            { id: 'cx-2', file: 'b.ts', detail: 'd', severity: 'warning' },
+          ],
+        },
+      ];
+      manager.update(results, 'commit-1');
+      const first = readFileSync(join(tmpDir, '.harness', 'arch', 'baselines.json'), 'utf-8');
+
+      // Same metrics, different commit hash + a reordered violation list.
+      manager.update(
+        [
+          {
+            category: 'complexity',
+            scope: 'project',
+            value: 2,
+            violations: [
+              { id: 'cx-2', file: 'b.ts', detail: 'd', severity: 'warning' },
+              { id: 'cx-1', file: 'a.ts', detail: 'd', severity: 'warning' },
+            ],
+          },
+        ],
+        'commit-2-different'
+      );
+      const second = readFileSync(join(tmpDir, '.harness', 'arch', 'baselines.json'), 'utf-8');
+      expect(second).toBe(first);
+    });
+
+    it('bumps updatedAt/updatedFrom when a metric actually changes', () => {
+      manager.update(
+        [{ category: 'complexity', scope: 'project', value: 2, violations: [] }],
+        'commit-1'
+      );
+      const before = manager.load()!;
+      manager.update(
+        [{ category: 'complexity', scope: 'project', value: 5, violations: [] }],
+        'commit-2'
+      );
+      const after = manager.load()!;
+      expect(after.metrics['complexity']!.value).toBe(5);
+      expect(after.updatedFrom).toBe('commit-2');
+      expect(after.updatedFrom).not.toBe(before.updatedFrom);
+    });
   });
 });


### PR DESCRIPTION
## Problem

`.harness/arch/baselines.json` conflicts on nearly every open PR. Root cause is two-fold:

1. **Volatile stamps.** `ArchBaselineManager.update` rewrites `updatedAt` (a timestamp) and `updatedFrom` (a commit hash) on *every* regeneration, so the file changes even when no metric moved.
2. **Non-deterministic ordering.** `violationIds` are stored in collection order, so two regens of the same set can differ.

The `merge=ours` git attribute is declared for this file, but that only resolves **local** merges — GitHub's server-side merge cannot run a custom merge driver, so any diff surfaces as a **CONFLICTING** status on the PR. With the recent merge flurry (each refreshing `main`'s baseline), every open PR re-conflicted on each merge.

## Fix

Make the committed file a **pure function of its metrics**:

- `update()` preserves `updatedAt`/`updatedFrom` when the metrics are unchanged (order-insensitive comparison of values + violationId sets).
- `capture()` sorts `violationIds`.

A no-op regeneration now produces a **byte-identical** file, so a PR that moves no metric never touches the baseline — and can't conflict on it. Genuine metric changes still bump the stamps and update the values exactly as before.

## Tests

+2 regression tests: a metric-neutral re-run (different commit hash, reordered violations) is byte-identical; a real metric change still bumps `updatedFrom` and the value. Full core suite green.

Once merged, metric-neutral PRs stop conflicting on the arch baseline.