### PR TITLE
feat(cli): add --severity flag to validate and check-perf

### DIFF
--- a/.changeset/validate-check-perf-severity.md
+++ b/.changeset/validate-check-perf-severity.md
@@ -1,0 +1,22 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Add a real `--severity <error|warning|info>` flag to `harness validate` and
+`harness check-perf`, mirroring `harness check-security`.
+
+Persona CI workflows pass a persona-declared `--severity <level>` to their
+command steps, but only `check-security` accepted the flag — `validate` and
+`check-perf` hard-errored on it despite both already carrying a per-finding
+severity model. Both commands now honor the threshold: when `--severity` is set,
+findings below it are excluded from BOTH the report and the pass/fail verdict
+(the command fails only when a finding at or above the threshold exists);
+findings below the threshold never fail the gate.
+
+Default behavior is unchanged. When `--severity` is omitted, every finding is
+still reported and the verdict fails only on error-severity findings (for
+`validate`, the hard checks that carry no explicit severity continue to fail as
+before) — warnings and info are reported but never flip the verdict.
+
+Widening the persona generator's flag whitelist so personas can declare these
+thresholds is a follow-up; this change is the command capability only.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -130,6 +130,7 @@ Run performance checks: structural complexity, coupling, and size budgets
 - `--structural` — Run structural complexity checks only
 - `--coupling` — Run coupling metric checks only
 - `--size` — Run size budget checks only
+- `--severity` — Minimum severity that fails the command; when set, violations below it are excluded from the report and never fail the gate (error, warning, info)
 
 ### `harness check-phase-gate`
 
@@ -649,6 +650,7 @@ Run all validation checks
 - `--agent-configs` — Validate agent configs (CLAUDE.md, hooks, skills) via agnix or built-in fallback rules
 - `--strict` — Treat warnings as errors (applies to --agent-configs)
 - `--agnix-bin` — Override the agnix binary path discovered on PATH
+- `--severity` — Minimum severity that fails the command; when set, findings below it are excluded from the report and never fail the gate (error, warning, info)
 
 ### `harness verify`
 

--- a/packages/cli/src/commands/check-perf.ts
+++ b/packages/cli/src/commands/check-perf.ts
@@ -30,11 +30,31 @@ function resolveConfiguredEntryPoints(configPath?: string): string[] | undefined
   return undefined;
 }
 
+type PerfSeverity = 'error' | 'warning' | 'info';
+
+const SEVERITY_RANK: Record<PerfSeverity, number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+};
+
+function severityRank(severity: string): number {
+  return SEVERITY_RANK[severity as PerfSeverity] ?? 0;
+}
+
 interface CheckPerfOptions {
   structural?: boolean;
   size?: boolean;
   coupling?: boolean;
   configPath?: string;
+  /**
+   * Minimum severity that fails the command. When set, violations below the
+   * threshold are excluded from BOTH the report and the pass/fail verdict —
+   * the same contract as `check-security --severity`. When omitted, behavior
+   * is unchanged from before the flag existed: every violation is reported and
+   * only error-severity violations fail the gate.
+   */
+  severity?: PerfSeverity;
 }
 
 interface CheckPerfResult {
@@ -141,17 +161,31 @@ export async function runCheckPerf(
     }
   }
 
-  const hasErrors = violations.some((v) => v.severity === 'error');
-  const errorCount = violations.filter((v) => v.severity === 'error').length;
-  const warningCount = violations.filter((v) => v.severity === 'warning').length;
-  const infoCount = violations.filter((v) => v.severity === 'info').length;
+  // `--severity` (when provided) bounds BOTH the reported violations and the
+  // pass/fail verdict, mirroring `check-security`: the command fails only when a
+  // violation at or above the requested threshold exists, and violations below it
+  // are excluded from the report and never fail the gate. When the flag is
+  // OMITTED, behavior is unchanged from before the flag existed — every violation
+  // is reported and the verdict fails only on error-severity violations.
+  // Defaulting the threshold to 'error' would preserve the verdict but would
+  // silently drop warning/info violations from the default report; keeping the
+  // omitted path unfiltered preserves the existing report too.
+  const threshold = options.severity;
+  const reported = threshold
+    ? violations.filter((v) => severityRank(v.severity) >= SEVERITY_RANK[threshold])
+    : violations;
+  const valid = threshold ? reported.length === 0 : !reported.some((v) => v.severity === 'error');
+
+  const errorCount = reported.filter((v) => v.severity === 'error').length;
+  const warningCount = reported.filter((v) => v.severity === 'warning').length;
+  const infoCount = reported.filter((v) => v.severity === 'info').length;
 
   return Ok({
-    valid: !hasErrors,
-    violations,
+    valid,
+    violations: reported,
     stats: {
       filesAnalyzed: report.complexity?.stats.filesAnalyzed ?? 0,
-      violationCount: violations.length,
+      violationCount: reported.length,
       errorCount,
       warningCount,
       infoCount,
@@ -160,7 +194,7 @@ export async function runCheckPerf(
 }
 
 async function runCheckPerfAction(
-  opts: { structural?: boolean; coupling?: boolean; size?: boolean },
+  opts: { structural?: boolean; coupling?: boolean; size?: boolean; severity?: PerfSeverity },
   globalOpts: { json?: boolean; quiet?: boolean; verbose?: boolean }
 ): Promise<void> {
   const mode: OutputModeType = globalOpts.json
@@ -177,6 +211,7 @@ async function runCheckPerfAction(
     ...(opts.structural !== undefined && { structural: opts.structural }),
     ...(opts.coupling !== undefined && { coupling: opts.coupling }),
     ...(opts.size !== undefined && { size: opts.size }),
+    ...(opts.severity !== undefined && { severity: opts.severity }),
   });
 
   if (!result.ok) {
@@ -211,6 +246,17 @@ export function createCheckPerfCommand(): Command {
     .option('--structural', 'Run structural complexity checks only')
     .option('--coupling', 'Run coupling metric checks only')
     .option('--size', 'Run size budget checks only')
+    .option(
+      '--severity <level>',
+      'Minimum severity that fails the command; when set, violations below it are excluded from the report and never fail the gate (error, warning, info)'
+    )
+    .hook('preAction', (thisCommand) => {
+      const severity = thisCommand.opts().severity;
+      if (severity !== undefined && !['error', 'warning', 'info'].includes(severity)) {
+        logger.error(`Invalid severity: "${severity}". Must be one of: error, warning, info`);
+        process.exit(ExitCode.ERROR);
+      }
+    })
     .action(async (opts, cmd) => {
       await runCheckPerfAction(opts, cmd.optsWithGlobals());
     });

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -28,6 +28,14 @@ import { runAudit as runComponentAnatomyAudit } from '../mcp/tools/audit-anatomy
 import { runDetectDrift } from '../mcp/tools/detect-drift';
 import { runAuditBrand } from '../mcp/tools/audit-brand';
 
+type ValidateSeverity = 'error' | 'warning' | 'info';
+
+const SEVERITY_RANK: Record<ValidateSeverity, number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+};
+
 interface ValidateOptions {
   cwd?: string;
   configPath?: string;
@@ -37,6 +45,15 @@ interface ValidateOptions {
   agentConfigs?: boolean;
   strict?: boolean;
   agnixBin?: string;
+  /**
+   * Minimum severity that fails the command. When set, aggregated findings
+   * below the threshold are excluded from BOTH the report and the pass/fail
+   * verdict — the same contract as `check-security --severity`. When omitted,
+   * behavior is unchanged: every finding is reported and the verdict fails on
+   * the hard checks (which carry no explicit severity and are treated as
+   * error-level) and on error-severity findings, while warnings never fail.
+   */
+  severity?: ValidateSeverity;
 }
 
 interface ValidateResult {
@@ -459,6 +476,24 @@ export async function runValidate(
     }
   }
 
+  // `--severity` (when provided) bounds BOTH the reported findings and the
+  // pass/fail verdict, mirroring `check-security`: validation fails only when a
+  // finding at or above the requested threshold exists, and findings below it are
+  // excluded from the report and never fail the gate. When the flag is OMITTED,
+  // behavior is unchanged — the per-check `result.valid` accumulated above (hard
+  // checks and error-severity findings fail; warnings are reported but never
+  // flip the verdict) stands as-is. Several hard checks (agentsMap, knowledgeMap,
+  // pulseConfig, solutionsDir) push findings with no explicit severity; they are
+  // hard failures, so they rank as error-level for threshold comparison.
+  if (options.severity) {
+    const thresholdRank = SEVERITY_RANK[options.severity];
+    const filtered = result.issues.filter(
+      (issue) => SEVERITY_RANK[issue.severity ?? 'error'] >= thresholdRank
+    );
+    result.issues = filtered;
+    result.valid = filtered.length === 0;
+  }
+
   return Ok(result);
 }
 
@@ -495,6 +530,17 @@ export function createValidateCommand(): Command {
     )
     .option('--strict', 'Treat warnings as errors (applies to --agent-configs)')
     .option('--agnix-bin <path>', 'Override the agnix binary path discovered on PATH')
+    .option(
+      '--severity <level>',
+      'Minimum severity that fails the command; when set, findings below it are excluded from the report and never fail the gate (error, warning, info)'
+    )
+    .hook('preAction', (thisCommand) => {
+      const severity = thisCommand.opts().severity;
+      if (severity !== undefined && !['error', 'warning', 'info'].includes(severity)) {
+        logger.error(`Invalid severity: "${severity}". Must be one of: error, warning, info`);
+        process.exit(ExitCode.ERROR);
+      }
+    })
     .action(async (opts, cmd) => runValidateAction(opts, cmd.optsWithGlobals()));
   return command;
 }
@@ -514,6 +560,7 @@ async function runValidateAction(
     agentConfigs: opts.agentConfigs === true,
     strict: opts.strict === true,
     ...(typeof opts.agnixBin === 'string' && { agnixBin: opts.agnixBin }),
+    ...(typeof opts.severity === 'string' && { severity: opts.severity as ValidateSeverity }),
   });
 
   if (!result.ok) {

--- a/packages/cli/tests/commands/check-perf.test.ts
+++ b/packages/cli/tests/commands/check-perf.test.ts
@@ -475,4 +475,145 @@ describe('check-perf command', () => {
       }
     });
   });
+
+  // `--severity` mirrors `check-security`: the flag bounds BOTH the report and
+  // the pass/fail verdict. When omitted, behavior is unchanged (report all,
+  // fail only on error). When set, findings below the threshold are excluded
+  // from the report and never fail the gate.
+  describe('severity threshold', () => {
+    const WARNING_ONLY = {
+      ok: true as const,
+      value: {
+        complexity: {
+          violations: [],
+          stats: { filesAnalyzed: 4, violationCount: 0, errorCount: 0, warningCount: 0 },
+        },
+        coupling: {
+          violations: [
+            {
+              tier: 2,
+              severity: 'warning',
+              metric: 'afferent-coupling',
+              file: 'src/hub.ts',
+              value: 30,
+              threshold: 20,
+              message: 'High afferent coupling',
+            },
+          ],
+          stats: { violationCount: 1, warningCount: 1 },
+        },
+        sizeBudget: { violations: [] },
+      },
+    };
+
+    const MIXED = {
+      ok: true as const,
+      value: {
+        complexity: {
+          violations: [
+            {
+              tier: 1,
+              severity: 'error',
+              metric: 'cc',
+              file: 'a.ts',
+              function: 'f',
+              value: 20,
+              threshold: 10,
+              message: 'too complex',
+            },
+            {
+              tier: 3,
+              severity: 'info',
+              metric: 'lines-of-code',
+              file: 'c.ts',
+              function: 'g',
+              value: 100,
+              threshold: 80,
+              message: 'long',
+            },
+          ],
+          stats: { filesAnalyzed: 6, violationCount: 2, errorCount: 1, warningCount: 0 },
+        },
+        coupling: {
+          violations: [
+            {
+              tier: 2,
+              severity: 'warning',
+              metric: 'coupling',
+              file: 'b.ts',
+              value: 15,
+              threshold: 10,
+              message: 'high coupling',
+            },
+          ],
+          stats: { violationCount: 1, warningCount: 1 },
+        },
+        sizeBudget: { violations: [] },
+      },
+    };
+
+    it('default (no --severity): a warning-only run stays valid and reports the warning', async () => {
+      mockAnalyze.mockResolvedValue(WARNING_ONLY);
+      const result = await runCheckPerf('/tmp/test', {});
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Unchanged default behavior: warnings are reported and never fail.
+      expect(result.value.valid).toBe(true);
+      expect(result.value.violations).toHaveLength(1);
+      expect(result.value.stats.warningCount).toBe(1);
+    });
+
+    it('does NOT fail --severity error on a warning-only run and drops it from the report', async () => {
+      mockAnalyze.mockResolvedValue(WARNING_ONLY);
+      const result = await runCheckPerf('/tmp/test', { severity: 'error' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(true);
+      expect(result.value.violations).toHaveLength(0);
+      expect(result.value.stats.warningCount).toBe(0);
+    });
+
+    it('DOES fail --severity error when an error violation exists', async () => {
+      mockAnalyze.mockResolvedValue(MIXED);
+      const result = await runCheckPerf('/tmp/test', { severity: 'error' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(false);
+      // Only the error survives the filter; warning + info are excluded.
+      expect(result.value.violations).toHaveLength(1);
+      expect(result.value.violations[0].severity).toBe('error');
+      expect(result.value.stats.errorCount).toBe(1);
+      expect(result.value.stats.warningCount).toBe(0);
+      expect(result.value.stats.infoCount).toBe(0);
+    });
+
+    it('fails --severity warning when a warning is at/above the threshold', async () => {
+      mockAnalyze.mockResolvedValue(WARNING_ONLY);
+      const result = await runCheckPerf('/tmp/test', { severity: 'warning' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Under threshold=warning the warning now fails the gate.
+      expect(result.value.valid).toBe(false);
+      expect(result.value.violations).toHaveLength(1);
+      expect(result.value.stats.warningCount).toBe(1);
+    });
+
+    it('--severity warning keeps error+warning but excludes info from report and verdict', async () => {
+      mockAnalyze.mockResolvedValue(MIXED);
+      const result = await runCheckPerf('/tmp/test', { severity: 'warning' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(false);
+      expect(result.value.violations).toHaveLength(2);
+      expect(result.value.stats.errorCount).toBe(1);
+      expect(result.value.stats.warningCount).toBe(1);
+      expect(result.value.stats.infoCount).toBe(0);
+    });
+
+    it('registers the --severity option on the command', () => {
+      const cmd = createCheckPerfCommand();
+      const opt = cmd.options.find((o) => o.long === '--severity');
+      expect(opt).toBeDefined();
+    });
+  });
 });

--- a/packages/cli/tests/commands/validate.test.ts
+++ b/packages/cli/tests/commands/validate.test.ts
@@ -492,4 +492,125 @@ describe('validate command', () => {
       expect(anatomyIssue?.message).toContain('boom: parser crashed');
     });
   });
+
+  // `--severity` mirrors `check-security`: when provided, the flag bounds BOTH
+  // the reported findings and the pass/fail verdict. When omitted, behavior is
+  // unchanged (hard checks + error-severity findings fail; warnings are reported
+  // but never flip the verdict).
+  describe('severity threshold', () => {
+    // Produces a single warning-severity component-anatomy finding, on an
+    // otherwise-clean project, so the aggregated issue set is exactly one
+    // warning.
+    function mockWarningFinding(): void {
+      vi.mocked(runComponentAnatomyAudit).mockResolvedValueOnce({
+        findings: [
+          {
+            code: 'ANAT-D000',
+            severity: 'warn',
+            file: 'src/Tabs.tsx',
+            line: null,
+            componentType: 'Tabs',
+            message: 'JSDoc anatomy declaration diverges from convention',
+            evidence: { snippet: '' },
+            rule: { id: 'ANAT-D000', source: 'convention/divergence' },
+            fix: { kind: 'manual', description: 'Update JSDoc or convention' },
+          },
+        ],
+        summary: {
+          totalFiles: 1,
+          durationMs: 5,
+          bySeverity: { error: 0, warn: 1, info: 0 },
+          byCode: { 'ANAT-D000': 1 },
+        },
+        catalog: { conventionsApplied: ['Tabs'], patternsApplied: [] },
+        meta: { mode: 'fast', deferredToA11y: 0 },
+      } as never);
+    }
+
+    it('default (no --severity): a warning-only run stays valid and reports the warning', async () => {
+      mockWarningFinding();
+      const result = await runValidate({ cwd: '/tmp/test' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Unchanged default behavior: the warning is reported but never fails.
+      expect(result.value.valid).toBe(true);
+      const warn = result.value.issues.find((i) => i.check === 'componentAnatomy');
+      expect(warn?.severity).toBe('warning');
+    });
+
+    it('--severity error: excludes the warning from the report and stays valid', async () => {
+      mockWarningFinding();
+      const result = await runValidate({ cwd: '/tmp/test', severity: 'error' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(true);
+      expect(result.value.issues).toHaveLength(0);
+    });
+
+    it('--severity warning: the warning now fails the gate and is reported', async () => {
+      mockWarningFinding();
+      const result = await runValidate({ cwd: '/tmp/test', severity: 'warning' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(false);
+      expect(result.value.issues).toHaveLength(1);
+      expect(result.value.issues[0].severity).toBe('warning');
+    });
+
+    it('--severity error: an error finding still fails and survives the filter', async () => {
+      vi.mocked(runComponentAnatomyAudit).mockResolvedValueOnce({
+        findings: [
+          {
+            code: 'ANAT-D001',
+            severity: 'error',
+            file: 'src/Button.tsx',
+            line: 14,
+            componentType: 'Button',
+            message: 'Button is missing required slot: content',
+            evidence: { snippet: '' },
+            rule: { id: 'ANAT-D001', source: 'APG/button' },
+            fix: { kind: 'manual', description: 'Add a children/content prop' },
+          },
+        ],
+        summary: {
+          totalFiles: 1,
+          durationMs: 5,
+          bySeverity: { error: 1, warn: 0, info: 0 },
+          byCode: { 'ANAT-D001': 1 },
+        },
+        catalog: { conventionsApplied: ['Button'], patternsApplied: [] },
+        meta: { mode: 'fast', deferredToA11y: 0 },
+      } as never);
+
+      const result = await runValidate({ cwd: '/tmp/test', severity: 'error' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.valid).toBe(false);
+      expect(result.value.issues).toHaveLength(1);
+      expect(result.value.issues[0].severity).toBe('error');
+    });
+
+    it('--severity error: a hard check with no explicit severity is treated as error and fails', async () => {
+      vi.mocked(validateAgentsMap).mockResolvedValueOnce({
+        ok: false,
+        error: { message: 'AGENTS.md not found', suggestions: [] },
+      } as never);
+
+      const result = await runValidate({ cwd: '/tmp/test', severity: 'error' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // No explicit severity on the agentsMap finding, but it is a hard failure,
+      // so it ranks as error-level and fails under `--severity error`.
+      expect(result.value.valid).toBe(false);
+      const issue = result.value.issues.find((i) => i.check === 'agentsMap');
+      expect(issue).toBeDefined();
+    });
+  });
+
+  describe('createValidateCommand --severity', () => {
+    it('registers the --severity option', () => {
+      const cmd = createValidateCommand();
+      expect(cmd.options.find((o) => o.long === '--severity')).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds a real `--severity <error|warning|info>` flag to `harness validate` and `harness check-perf`, mirroring the existing pattern in `harness check-security`.

## Why

Persona CI workflows pass a persona-declared `--severity <level>` to their command steps, but only `check-security` accepted the flag — `validate` and `check-perf` hard-errored with "unknown option" despite both already carrying a per-finding severity model. This extends genuine `--severity` support so a persona's declared severity threshold is honored by those checks too.

## Contract (mirrors check-security)

When `--severity` is set:
- Findings are ranked via a `SEVERITY_RANK` map (`error > warning > info`).
- Findings below the threshold are excluded from **both** the report and the pass/fail verdict.
- The command fails only when a finding **at or above** the threshold exists; lower-severity findings never fail the gate.

## Default behavior (flag omitted) — unchanged

- `check-perf`: every violation is reported; the verdict fails only on `error`-severity violations. (Defaulting the threshold to `error` would have preserved the verdict but silently dropped warning/info violations from the default report, so the omitted path stays unfiltered to preserve the existing report too.)
- `validate`: every finding is reported; the accumulated per-check verdict stands (hard checks and error-severity findings fail; warnings are reported but never flip the verdict). Hard checks that carry no explicit severity (agentsMap, knowledgeMap, pulseConfig, solutionsDir) are hard failures and rank as error-level for threshold comparison.

Invalid `--severity` values exit with an error, consistent with `check-security`.

## Scope

This PR is **only the command capability**. Widening the persona generator's flag whitelist so personas can declare these thresholds for `validate`/`check-perf` is the intended **next-step follow-up PR** and is deliberately not included here. `check-deps`/`check-docs` are untouched (no severity concept).

## Tests

- Added severity-threshold unit tests to both commands (below-threshold does not fail; at/above threshold fails; default behavior unchanged; option registered).
- Full CLI suite green (5532 tests).

## Verification against the built CLI

`node packages/cli/dist/bin/harness.js validate --severity error` and `check-perf --severity error` no longer error on the flag. On this repo, `validate --json` reports 368 findings (71 warning + 297 error) by default; `--severity error` returns 297 (warnings excluded from report **and** verdict); `--severity warning` returns all 368. Invalid values exit 2.

A changeset (`@harness-engineering/cli` minor) and regenerated reference docs are included.