### PR TITLE
fix(review): stop the security floor tier flagging secret references as hardcoded secrets

### DIFF
--- a/.changeset/security-secret-reference-suppression.md
+++ b/.changeset/security-secret-reference-suppression.md
@@ -1,0 +1,25 @@
+---
+'@harness-engineering/core': patch
+---
+
+Stop the security review flagging secret **references** as hardcoded secrets.
+
+Both the deterministic secret rules (`SEC-SEC-*`) and the heuristic review-tier
+secret detector match assignment shapes like `TOKEN="..."`. When the right-hand
+side is a variable or expression reference rather than a literal, nothing is
+embedded in source — the real value is resolved at runtime — so a
+"Hardcoded secret or API key detected" finding there is a false positive.
+
+The detectors now extract the matched value and suppress the finding when it is
+composed solely of references:
+
+- shell/env variables: `$NAME`, `${NAME}`, `${NAME:-default}`
+- CI expressions: `${{ secrets.X }}`, `${{ env.X }}`, `${{ vars.X }}`, and any
+  `${{ ... }}`
+
+This mis-fired on essentially every pull request touching a CI workflow file
+(e.g. `GH_TOKEN="$AUTOAPPROVE_PAT"`, `TOKEN: "${{ secrets.FOO }}"`), and in
+floor-only review mode it produced a blocking request-changes verdict. Genuine
+hardcoded literals — including values with a variable-only prefix such as
+`"${PREFIX}sk-live-..."` — are still detected. The shared reference check lives
+in `security/secret-reference.ts` so both detection tiers benefit.

--- a/packages/core/src/review/agents/security-agent.ts
+++ b/packages/core/src/review/agents/security-agent.ts
@@ -1,5 +1,6 @@
 import type { ContextBundle, ReviewFinding, ReviewAgentDescriptor } from '../types';
 import { makeFindingId } from '../constants';
+import { isReferenceOnlySecretValue } from '../../security/secret-reference';
 
 export const SECURITY_DESCRIPTOR: ReviewAgentDescriptor = {
   domain: 'security',
@@ -18,11 +19,29 @@ export const SECURITY_DESCRIPTOR: ReviewAgentDescriptor = {
 /** Patterns that indicate dangerous eval/Function usage. */
 const EVAL_PATTERN = /\beval\s*\(|new\s+Function\s*\(/;
 
-/** Patterns that indicate hardcoded secrets. */
+/**
+ * Patterns that indicate hardcoded secrets. Group 1 captures the candidate
+ * secret VALUE so `detectHardcodedSecrets` can tell a literal from a
+ * variable/expression reference (`$VAR`, `${{ secrets.X }}`) — see
+ * `isReferenceOnlySecretValue`.
+ */
 const SECRET_PATTERNS = [
-  /(?:api[_-]?key|secret|password|token|private[_-]?key)\s*=\s*["'][^"']{8,}/i,
-  /["'](?:sk|pk|api|key|secret|token|password)[-_][a-zA-Z0-9]{10,}["']/i,
+  /(?:api[_-]?key|secret|password|token|private[_-]?key)\s*=\s*["']([^"']{8,})/i,
+  /["']((?:sk|pk|api|key|secret|token|password)[-_][a-zA-Z0-9]{10,})["']/i,
 ];
+
+/**
+ * Return the captured secret VALUE for the first matching pattern, or `null`
+ * when no pattern matches. An empty string is a valid (matched-but-empty) value
+ * distinct from `null` (no match).
+ */
+function matchSecretValue(text: string): string | null {
+  for (const pattern of SECRET_PATTERNS) {
+    const m = pattern.exec(text);
+    if (m) return m[1] ?? '';
+  }
+  return null;
+}
 
 /**
  * Pattern for SQL string concatenation.
@@ -347,8 +366,12 @@ function detectHardcodedSecrets(bundle: ContextBundle): ReviewFinding[] {
       const line = lines[i]!;
       if (codeFile && isCommentLine(line)) continue;
       const codePart = codeFile ? stripTrailingLineComment(line) : line;
-      const matched = SECRET_PATTERNS.some((p) => p.test(codePart));
-      if (!matched) continue;
+      const value = matchSecretValue(codePart);
+      if (value === null) continue;
+      // A `$VAR` / `${{ secrets.X }}` reference is resolved at runtime, not
+      // embedded in source — flagging it as a hardcoded literal mis-fires on
+      // essentially every CI workflow line that wires a secret into an env var.
+      if (isReferenceOnlySecretValue(value)) continue;
       findings.push(makeSecretFinding(cf.path, i + 1));
     }
   }

--- a/packages/core/src/security/scanner.ts
+++ b/packages/core/src/security/scanner.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import { minimatch } from 'minimatch';
 import { RuleRegistry } from './rules/registry';
 import { resolveRuleSeverity } from './config';
+import { isReferenceOnlySecretValue, extractQuotedSecretValue } from './secret-reference';
 import { detectStack } from './stack-detector';
 import { secretRules } from './rules/secrets';
 import { injectionRules } from './rules/injection';
@@ -158,7 +159,16 @@ export class SecurityScanner {
   ): SecurityFinding | null {
     for (const pattern of rule.patterns) {
       pattern.lastIndex = 0; // Reset regex lastIndex for global/sticky patterns
-      if (!pattern.test(line)) continue;
+      const match = pattern.exec(line);
+      if (!match) continue;
+      // Secret rules match assignment shapes like `TOKEN="..."`. When the value
+      // is a variable/expression reference (`$VAR`, `${{ secrets.X }}`) rather
+      // than a literal, nothing is embedded in source — the secret is resolved
+      // at runtime — so a "hardcoded secret" finding here is a false positive.
+      if (rule.category === 'secrets') {
+        const value = extractQuotedSecretValue(match[0]);
+        if (value !== null && isReferenceOnlySecretValue(value)) continue;
+      }
       return {
         ruleId: rule.id,
         ruleName: rule.name,

--- a/packages/core/src/security/secret-reference.ts
+++ b/packages/core/src/security/secret-reference.ts
@@ -1,0 +1,60 @@
+/**
+ * A "hardcoded secret" finding is only genuine when the matched value is a
+ * literal. Both the deterministic secret rules (SEC-SEC-*) and the heuristic
+ * review-tier secret detector match assignment shapes like `TOKEN="..."`, and
+ * both mis-fire when the right-hand side is a *reference* rather than a literal:
+ *
+ *  - a shell/env variable: `$NAME`, `${NAME}`, `${NAME:-default}`
+ *  - a CI expression: `${{ secrets.X }}`, `${{ env.X }}`, `${{ vars.X }}`, or
+ *    any `${{ ... }}`
+ *
+ * These reference forms appear on essentially every CI workflow line that wires
+ * a secret into an env var (`GH_TOKEN="$AUTOAPPROVE_PAT"`,
+ * `TOKEN: "${{ secrets.FOO }}"`). Nothing is embedded in source there — the real
+ * secret is resolved at runtime from the environment or the CI secret store — so
+ * reporting it as a leaked literal is a false positive that blocks unrelated PRs.
+ * This module decides whether an extracted value is reference-only.
+ */
+
+// CI expression: `${{ ... }}` (secrets / env / vars / anything). The inner
+// class excludes braces so the whole `${{ … }}` is consumed as one token rather
+// than leaving a stray `}` behind.
+const CI_EXPRESSION = /\$\{\{[^{}]*\}\}/g;
+// Shell/env brace form: `${NAME}`, `${NAME:-default}`, `${NAME#glob}`, …
+const SHELL_BRACE_VAR = /\$\{[^{}]*\}/g;
+// Shell/env bare form: `$NAME`.
+const SHELL_BARE_VAR = /\$[A-Za-z_][A-Za-z0-9_]*/g;
+
+/**
+ * True when `value` (the extracted right-hand side of a secret-shaped
+ * assignment) carries no literal secret material — i.e. it is composed solely of
+ * variable/expression references plus surrounding punctuation and whitespace.
+ *
+ * Order matters: `${{ … }}` is stripped before `${ … }` so the CI-expression
+ * form is consumed whole rather than leaving a stray `{ … }`. After every
+ * reference form is removed, a genuine literal leaves alphanumeric residue
+ * (`sk-ant-...` → `skant...`), whereas a pure reference leaves none. A partial
+ * literal such as `prefix-${VAR}` deliberately keeps its `prefix` residue and is
+ * therefore NOT treated as reference-only — the conservative choice keeps real
+ * secret detection intact.
+ */
+export function isReferenceOnlySecretValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed === '') return false;
+  const withoutRefs = trimmed
+    .replace(CI_EXPRESSION, '')
+    .replace(SHELL_BRACE_VAR, '')
+    .replace(SHELL_BARE_VAR, '');
+  return !/[A-Za-z0-9]/.test(withoutRefs);
+}
+
+/**
+ * Extract the quoted value from a matched secret assignment, e.g.
+ * `TOKEN="$AUTOAPPROVE_PAT"` → `$AUTOAPPROVE_PAT`. Returns `null` when the match
+ * carries no quoted value, so callers treat unquoted/bare-token matches (which
+ * the reference forms never produce) as literals rather than suppressing them.
+ */
+export function extractQuotedSecretValue(matchText: string): string | null {
+  const m = /['"]([^'"]*)['"]/.exec(matchText);
+  return m ? (m[1] ?? '') : null;
+}

--- a/packages/core/tests/review/agents/security-agent.test.ts
+++ b/packages/core/tests/review/agents/security-agent.test.ts
@@ -489,6 +489,83 @@ describe('runSecurityAgent()', () => {
     expect(runSecurityAgent(bundle).length).toBe(1);
   });
 
+  // ---- reference-vs-literal guard: a matched value that is a shell/env var
+  // or a CI expression is resolved at runtime, not embedded in source, so it
+  // must NOT be flagged as a hardcoded secret. This mis-fired on essentially
+  // every PR touching a workflow file (e.g. GH_TOKEN="$AUTOAPPROVE_PAT"). ----
+
+  it('does NOT flag a CI expression value in a workflow file', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: '.github/workflows/ci.yml',
+          content: 'AUTOAPPROVE_PAT: "${{ secrets.BASELINE_AUTOAPPROVE_PAT }}"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('does NOT flag a shell variable reference assigned to a token', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: '.github/workflows/ci.yml',
+          content: 'GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('does NOT flag a ${VAR} brace reference assigned to a token', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'deploy/run.sh',
+          content: 'export API_KEY="${DEPLOY_API_KEY}"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('STILL flags a genuine hardcoded literal (guard must not over-suppress)', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'src/config.ts',
+          content: 'const API_KEY = "sk-ant-api03-REALLOOKINGKEY0123456789abcdef";',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    const findings = runSecurityAgent(bundle);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.cweId).toBe('CWE-798');
+  });
+
+  it('STILL flags a literal with a variable-only PREFIX — a partial reference is not reference-only', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'deploy/run.sh',
+          content: 'export API_KEY="${PREFIX}sk-live-0123456789abcdef"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(1);
+  });
+
   // ---- guards are code-scoped: test-markers and comment syntax are JS/TS
   // conventions, so they must not suppress findings in non-code files ----
 

--- a/packages/core/tests/security/rules/secrets.test.ts
+++ b/packages/core/tests/security/rules/secrets.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { secretRules } from '../../../src/security/rules/secrets';
+import { SecurityScanner } from '../../../src/security/scanner';
 
 describe('Secret detection rules', () => {
   it('exports multiple rules', () => {
@@ -37,5 +38,36 @@ describe('Secret detection rules', () => {
     const rule = secretRules.find((r) => r.id === 'SEC-SEC-002');
     const envRead = 'const key = process.env.API_KEY;';
     expect(rule!.patterns.some((p) => p.test(envRead))).toBe(false);
+  });
+});
+
+// The scanner suppresses secret findings whose value is a variable/expression
+// reference rather than a literal — the SEC-SEC-002 pattern still matches the
+// assignment shape, but a runtime-resolved reference is not a hardcoded leak.
+describe('SecurityScanner secret reference suppression', () => {
+  const scanner = new SecurityScanner();
+
+  function scan(line: string, file = 'deploy/run.sh') {
+    return scanner.scanContent(line, file).filter((f) => f.category === 'secrets');
+  }
+
+  it('does not flag a CI expression assigned to a token', () => {
+    expect(scan('TOKEN: "${{ secrets.BASELINE_AUTOAPPROVE_PAT }}"')).toHaveLength(0);
+  });
+
+  it('does not flag a shell $VAR assigned to a token', () => {
+    expect(scan('GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review --approve')).toHaveLength(0);
+  });
+
+  it('does not flag a ${VAR} brace reference assigned to a token', () => {
+    expect(scan('export API_KEY="${DEPLOY_API_KEY}"')).toHaveLength(0);
+  });
+
+  it('STILL flags a genuine hardcoded literal', () => {
+    expect(scan('const API_KEY = "sk-live-abc123def456ghi789";').length).toBeGreaterThan(0);
+  });
+
+  it('STILL flags a literal with a variable-only prefix', () => {
+    expect(scan('export API_KEY="${PREFIX}sk-live-abc123def456"').length).toBeGreaterThan(0);
   });
 });

--- a/packages/core/tests/security/secret-reference.test.ts
+++ b/packages/core/tests/security/secret-reference.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isReferenceOnlySecretValue,
+  extractQuotedSecretValue,
+} from '../../src/security/secret-reference';
+
+describe('isReferenceOnlySecretValue', () => {
+  it.each([
+    ['$AUTOAPPROVE_PAT', 'shell bare var'],
+    ['${DEPLOY_API_KEY}', 'shell brace var'],
+    ['${NAME:-default}', 'shell brace var with default'],
+    ['${{ secrets.BASELINE_AUTOAPPROVE_PAT }}', 'CI secrets expression'],
+    ['${{ env.MY_ENV }}', 'CI env expression'],
+    ['${{ vars.MY_VAR }}', 'CI vars expression'],
+    ['${{ secrets.A }}-${{ secrets.B }}', 'two CI expressions joined by punctuation'],
+    ['  $TOKEN  ', 'reference with surrounding whitespace'],
+  ])('treats %s (%s) as reference-only', (value) => {
+    expect(isReferenceOnlySecretValue(value)).toBe(true);
+  });
+
+  it.each([
+    ['sk-ant-api03-REALLOOKINGKEY0123456789abcdef', 'literal API key'],
+    ['hunter2hunter2', 'literal password'],
+    ['${PREFIX}sk-live-abc123', 'partial: reference + literal residue'],
+    ['prefix-${VAR}', 'partial: literal prefix + reference'],
+    ['', 'empty string'],
+    ['   ', 'whitespace only'],
+  ])('treats %s (%s) as NOT reference-only', (value) => {
+    expect(isReferenceOnlySecretValue(value)).toBe(false);
+  });
+});
+
+describe('extractQuotedSecretValue', () => {
+  it('extracts a double-quoted value', () => {
+    expect(extractQuotedSecretValue('TOKEN="$AUTOAPPROVE_PAT"')).toBe('$AUTOAPPROVE_PAT');
+  });
+
+  it('extracts a single-quoted value', () => {
+    expect(extractQuotedSecretValue("API_KEY='sk-live-abc'")).toBe('sk-live-abc');
+  });
+
+  it('returns null when the match carries no quoted value', () => {
+    expect(extractQuotedSecretValue('postgres://user:pass@host')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

The security review's secret detectors flag **variable/expression references** as hardcoded secrets. Both the heuristic review-tier detector (`runSecurityAgent`, `validatedBy: 'heuristic'`) and the deterministic secret rules (`SEC-SEC-*`) match assignment shapes like `TOKEN="..."` and treat the right-hand side as a literal even when it is a reference resolved at runtime.

This mis-fires on essentially every pull request that touches a CI workflow file, e.g.:

```yaml
GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve
TOKEN: "${{ secrets.BASELINE_AUTOAPPROVE_PAT }}"
```

In floor-only review mode (no LLM tier) the finding becomes a blocking `request-changes`, blocking unrelated PRs.

## Fix

A shared helper (`packages/core/src/security/secret-reference.ts`) decides whether an extracted secret value is composed solely of references:

- shell/env variables: `$NAME`, `${NAME}`, `${NAME:-default}`
- CI expressions: `${{ secrets.X }}`, `${{ env.X }}`, `${{ vars.X }}`, and any `${{ ... }}`

Both detection tiers extract the matched value and suppress the finding when it is reference-only:

- **Heuristic tier** (`review/agents/security-agent.ts`): `SECRET_PATTERNS` now capture the value; `detectHardcodedSecrets` skips reference-only matches.
- **Deterministic tier** (`security/scanner.ts`): for `secrets`-category rules, the matched quoted value is checked and skipped when reference-only.

Genuine literals are still detected, including values with a variable-only prefix (`"${PREFIX}sk-live-..."`) — a partial literal is conservatively treated as a real secret so detection is never weakened.

## Tests

- `secret-reference.test.ts` — unit coverage of the reference/literal decision and value extraction.
- `security-agent.test.ts` — the exact workflow lines (`GH_TOKEN="$AUTOAPPROVE_PAT"`, `${{ secrets.X }}`, `${VAR}`) produce no finding; a real `sk-ant-api03-...` literal and a variable-prefixed literal still fire.
- `secrets.test.ts` — same suppression/retention verified through the `SecurityScanner` deterministic path.

All 1037 core security + review tests pass.