### PR TITLE
test(lmlm): lock in live HF candidate-discovery → recommender wiring; fix stale comments

### DIFF
--- a/.changeset/lmlm-live-candidate-wiring-verified.md
+++ b/.changeset/lmlm-live-candidate-wiring-verified.md
@@ -1,0 +1,24 @@
+---
+'@harness-engineering/orchestrator': patch
+'@harness-engineering/local-models': patch
+---
+
+Correct stale LMLM candidate-discovery documentation and lock in the
+live-discovery → recommender wiring with regression tests.
+
+The live-HuggingFace → `RankerCandidate` parser (`parseHfModelToCandidates`),
+the fail-soft discovery function (`discoverCandidates`), and the orchestrator
+glue (`refreshCandidatesLive` → `seedRecommender`, wired at the CLI composition
+root and fired on startup + the operator Refresh button) are all in place — the
+autonomous swap-proposal loop consumes discovered candidates, so it is live, not
+inert. Three source comments (`Orchestrator.modelRecommender`,
+`startRefreshScheduler`, and `createNativeRecommender`) still asserted the
+parser "was never built" and that the recommender is "seeded with an empty
+candidate set"; those claims contradicted the shipped code and are corrected.
+
+Adds orchestrator integration tests covering the previously-untested glue:
+`refreshCandidatesLive` re-seeds the recommender with discovered,
+allowlist-filtered candidates and the recommender ranks them (proving the loop
+is live), plus the three fail-closed branches — discovery throws, discovery
+yields nothing installable, and no orgs approved — each keeping the standing
+frozen candidates. No runtime behavior change.

--- a/packages/local-models/src/recommender/native.ts
+++ b/packages/local-models/src/recommender/native.ts
@@ -2,12 +2,12 @@
  * Native recommender seam (Phase 6).
  *
  * The scheduler needs a single `recommend(hardware)` call that turns the
- * operator's candidate set into a hardware-aware ranking each tick. Phase 2's
- * live-HF candidate parser (arbitrary HF model → `RankerCandidate` with
- * `sizeB`/`quant` extracted from the GGUF manifest) was never built, so this
- * seam takes the candidate list **explicitly** (frozen-snapshot- or
- * config-derived) rather than discovering brand-new HF models autonomously —
- * autonomous discovery is deferred to the Phase 2 recommender completion.
+ * operator's candidate set into a hardware-aware ranking each tick. This seam
+ * takes the candidate list **explicitly** (frozen-snapshot- or config-derived,
+ * or the live-discovered set) rather than fetching HF itself — discovery is a
+ * separate composed step (`../candidates/discover.ts` → `parseHfModelToCandidates`,
+ * wired by the orchestrator's `refreshCandidatesLive`), keeping this ranking path
+ * pure and free of per-call network I/O.
  *
  * The recommender is degradation-first (S4/O4):
  *  - The benchmark snapshot loads via `loadFrozenSnapshot` (the offline

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -789,8 +789,9 @@ export class Orchestrator extends EventEmitter {
   /**
    * LMLM Phase 7: the hardware-aware recommender bound at scheduler start. Reused
    * by `GET /api/v1/local-models/recommendations`. Null when LMLM is disabled (no
-   * pool → scheduler never armed). Ranks the (currently empty) candidate set —
-   * see the Phase 2 candidate-parser gap noted on `startRefreshScheduler`.
+   * pool → scheduler never armed). Seeded from the bundled frozen snapshot at
+   * scheduler start and re-seeded with live HuggingFace candidates by
+   * `refreshCandidatesLive` (startup + operator Refresh) — see `seedRecommender`.
    */
   private modelRecommender: ReturnType<typeof createNativeRecommender> | null = null;
   /**
@@ -4429,12 +4430,12 @@ export class Orchestrator extends EventEmitter {
    * pool. No-op when LMLM is disabled (`modelPool` null). Each tick runs
    * hardware→recommend→reconcile(D12 drift)→diff→emit→score-writeback.
    *
-   * NOTE (deferred): the recommender is seeded with an empty candidate set —
-   * Phase 2's live-HF→RankerCandidate parser was never built, so autonomous
-   * swap-proposal discovery is out of scope here (flagged concern). The tick
-   * still performs F10 drift reconciliation, O1 logging, and re-ranks/dedups
-   * whatever candidates are supplied — the wiring is complete and candidate
-   * breadth is the only piece deferred to the Phase 2 recommender.
+   * The recommender is seeded here from the bundled frozen snapshot (offline-safe,
+   * deterministic) filtered to the operator's org/family allowlist. Live HF
+   * candidate discovery then runs in the background on startup (and on the operator
+   * Refresh button) via `refreshCandidatesLive`, which swaps in a fresh recommender
+   * over the discovered set so the tick and `GET /recommendations` emit real,
+   * up-to-date swap proposals.
    */
   private startRefreshScheduler(): void {
     if (this.modelPool === null) return;

--- a/packages/orchestrator/tests/integration/orchestrator-model-pool.test.ts
+++ b/packages/orchestrator/tests/integration/orchestrator-model-pool.test.ts
@@ -17,6 +17,8 @@ import {
   type PoolFilesystem,
   type PoolState,
   type RemoteModelInfo,
+  type FrozenCandidate,
+  type RankerCandidate,
 } from '@harness-engineering/local-models';
 import type {
   WorkflowConfig,
@@ -671,6 +673,187 @@ describe('Orchestrator LMLM Phase 7 — drain liveness on refresh tick (P7-SUG-D
 
     expect(evicts.map((e) => e.name)).toEqual(['qwen2.5:32b']);
     expect(manager.listPendingEvictions()).toHaveLength(0);
+
+    await orch.stop();
+  });
+});
+
+// ── Live HF candidate discovery → recommender wiring ───────────────────────────
+//
+// The parser (`parseHfModelToCandidates`) and the fail-soft discovery function
+// (`discoverCandidates`) are unit-tested in local-models. These tests cover the
+// orchestrator glue that turns the loop from wired-but-inert to LIVE:
+// `refreshCandidatesLive` runs the injected discovery seam, filters to the
+// operator allowlist, and re-seeds the recommender that `GET /recommendations`
+// and the scheduler tick consume. Also covers the fail-closed branches.
+
+/** Structural access to the private `refreshCandidatesLive`, bound to `orch`. */
+function refreshLiveOf(
+  orch: Orchestrator
+): (signal?: AbortSignal) => Promise<{ source: 'frozen' | 'live'; count: number }> {
+  return (
+    orch as unknown as {
+      refreshCandidatesLive(signal?: AbortSignal): Promise<{
+        source: 'frozen' | 'live';
+        count: number;
+      }>;
+    }
+  ).refreshCandidatesLive.bind(orch);
+}
+
+/** Structural access to the private `candidateSourceState` snapshot. */
+function candidateSourceOf(orch: Orchestrator): { source: 'frozen' | 'live'; count: number } {
+  return (orch as unknown as { candidateSourceState: { source: 'frozen' | 'live'; count: number } })
+    .candidateSourceState;
+}
+
+/** Structural access to the private `recommenderCandidates` held set. */
+function heldCandidatesOf(orch: Orchestrator): readonly RankerCandidate[] {
+  return (orch as unknown as { recommenderCandidates: readonly RankerCandidate[] })
+    .recommenderCandidates;
+}
+
+function startSchedulerOf(orch: Orchestrator): void {
+  (orch as unknown as { startRefreshScheduler(): void }).startRefreshScheduler();
+}
+
+function makeOrchestratorWithDiscovery(
+  discoverCandidates: () => Promise<{ candidates: FrozenCandidate[]; warnings: string[] }>
+): Orchestrator {
+  return new Orchestrator(makeConfig(localModelsWithHardware()), 'Prompt', {
+    tracker: makeMockTracker(),
+    backend: new MockBackend(),
+    execFileFn: noopExecFile,
+    schedulerTimer: noopTimer,
+    discoverCandidates,
+  });
+}
+
+describe('Orchestrator LMLM — live HF candidate discovery wiring', () => {
+  const LIVE_CANDIDATES: FrozenCandidate[] = [
+    {
+      hfRepoId: 'Qwen/Qwen3-4B-GGUF',
+      ollamaName: 'qwen3:4b',
+      family: 'qwen3',
+      sizeB: 4,
+      quant: 'Q4_K_M',
+    },
+    {
+      hfRepoId: 'Qwen/Qwen3-1.7B-GGUF',
+      ollamaName: 'qwen3:1.7b',
+      family: 'qwen3',
+      sizeB: 1.7,
+      quant: 'Q4_K_M',
+    },
+    // Dropped by selectCandidates: org not in the operator allowlist (['Qwen']).
+    {
+      hfRepoId: 'meta-llama/Llama-3.2-3B-GGUF',
+      ollamaName: 'llama3.2:3b',
+      family: 'llama3',
+      sizeB: 3,
+      quant: 'Q4_K_M',
+    },
+  ];
+
+  it('re-seeds the recommender with discovered, allowlist-filtered candidates and ranks them', async () => {
+    const orch = makeOrchestratorWithDiscovery(async () => ({
+      candidates: LIVE_CANDIDATES,
+      warnings: [],
+    }));
+
+    const result = await refreshLiveOf(orch)();
+
+    // The out-of-allowlist Llama repo is filtered out; two Qwen candidates seed the recommender.
+    expect(result).toEqual({ source: 'live', count: 2 });
+    expect(candidateSourceOf(orch)).toEqual({ source: 'live', count: 2 });
+    expect(
+      heldCandidatesOf(orch)
+        .map((c) => c.hfRepoId)
+        .sort()
+    ).toEqual(['Qwen/Qwen3-1.7B-GGUF', 'Qwen/Qwen3-4B-GGUF']);
+
+    // The now-live recommender actually consumes the discovered set — proving the
+    // loop is live, not inert. GET /recommendations and the scheduler tick call this same binding.
+    const recommend = recommenderOf(orch);
+    expect(recommend).not.toBeNull();
+    const ranking = await recommend!(await detectHardwareOf(orch)());
+    const rankedRepos = (ranking.ranked as Array<{ hfRepoId: string }>).map((r) => r.hfRepoId);
+    expect(rankedRepos).toContain('Qwen/Qwen3-4B-GGUF');
+    expect(rankedRepos).not.toContain('meta-llama/Llama-3.2-3B-GGUF');
+
+    await orch.stop();
+  });
+
+  it('keeps the current (frozen) candidates when live discovery throws (fail-closed)', async () => {
+    const orch = makeOrchestratorWithDiscovery(async () => {
+      throw new Error('HF unreachable');
+    });
+    // Seed the recommender from the frozen snapshot first (as scheduler start does).
+    setModelPool(orch, (await makeSeededPool([REPLACES])).manager);
+    startSchedulerOf(orch);
+    const seeded = candidateSourceOf(orch);
+    expect(seeded.source).toBe('frozen');
+    expect(seeded.count).toBeGreaterThan(0);
+
+    const result = await refreshLiveOf(orch)();
+
+    // A discovery failure must not clear or replace the standing frozen candidates.
+    expect(result).toEqual(seeded);
+    expect(candidateSourceOf(orch)).toEqual(seeded);
+
+    await orch.stop();
+  });
+
+  it('keeps the current candidates when live discovery yields nothing installable', async () => {
+    // All discovered repos are outside the operator allowlist → selection empties them.
+    const orch = makeOrchestratorWithDiscovery(async () => ({
+      candidates: [
+        {
+          hfRepoId: 'meta-llama/Llama-3.2-3B-GGUF',
+          ollamaName: 'llama3.2:3b',
+          sizeB: 3,
+          quant: 'Q4_K_M',
+        },
+      ],
+      warnings: ['org list failed'],
+    }));
+    setModelPool(orch, (await makeSeededPool([REPLACES])).manager);
+    startSchedulerOf(orch);
+    const seeded = candidateSourceOf(orch);
+
+    const result = await refreshLiveOf(orch)();
+
+    expect(result).toEqual(seeded);
+    expect(candidateSourceOf(orch)).toEqual(seeded);
+
+    await orch.stop();
+  });
+
+  it('is a no-op that keeps frozen candidates when no orgs are approved', async () => {
+    let discoverCalled = false;
+    const orch = new Orchestrator(
+      makeConfig({
+        ...localModelsWithHardware(),
+        pool: { diskBudgetGb: 100, allowedOrgs: [], allowedFamilies: [] },
+      }),
+      'Prompt',
+      {
+        tracker: makeMockTracker(),
+        backend: new MockBackend(),
+        execFileFn: noopExecFile,
+        schedulerTimer: noopTimer,
+        discoverCandidates: async () => {
+          discoverCalled = true;
+          return { candidates: LIVE_CANDIDATES, warnings: [] };
+        },
+      }
+    );
+
+    const result = await refreshLiveOf(orch)();
+
+    // Empty allowlist short-circuits before any network/discovery work.
+    expect(discoverCalled).toBe(false);
+    expect(result).toEqual(candidateSourceOf(orch));
 
     await orch.stop();
   });


### PR DESCRIPTION
## Summary

Roadmap item #997 ("LMLM live-HF candidate discovery") turned out to be **already implemented and wired** — delivered by #785 (live discovery on startup + operator Refresh button) plus follow-ups. The parser (`parseHfModelToCandidates`), the fail-soft `discoverCandidates`, the orchestrator glue (`refreshCandidatesLive` → `seedRecommender`), the CLI composition-root wiring (`orchestrator run` injects the real `discoverCandidates`), and the operator Refresh route all exist. The autonomous swap-proposal loop **consumes** discovered candidates today — it is live, not inert.

This PR closes the two real gaps that remained:

1. **Stale, contradictory documentation.** Three source comments still claimed the recommender is "seeded with an empty candidate set" and the live-HF parser "was never built" — directly contradicting the shipped code. Corrected on `Orchestrator.modelRecommender`, `startRefreshScheduler`, and `createNativeRecommender`.

2. **Untested orchestrator glue.** The `discoverCandidates` unit tests and the GET /recommendations route test existed, but the orchestrator seam that ties them together (`refreshCandidatesLive` → re-seed) had no direct coverage. Added 4 integration tests:
   - live discovery re-seeds the recommender with allowlist-filtered candidates, and the recommender **ranks** them (proves the loop is live);
   - fail-closed when discovery **throws** (keeps standing frozen candidates);
   - fail-closed when discovery **yields nothing installable**;
   - no-op short-circuit (no discovery call) when **no orgs are approved**.

No runtime behavior change.

## Test plan
- `vitest run tests/integration/orchestrator-model-pool.test.ts` — 22 passed (18 existing + 4 new)
- `pnpm build`, repo `typecheck`, package `lint` — green
- Full pre-push gauntlet (test:coverage, coverage-ratchet, generate-docs --check, docs:build) — green

## Note for the roadmap
Recommend marking #997 done; its substantive deliverable shipped in #785. This PR verifies and documents that fact.