### PR TITLE
feat(orchestrator): language-aware local-dispatch verify gate

### DIFF
--- a/.changeset/local-dispatch-lang-aware-verify.md
+++ b/.changeset/local-dispatch-lang-aware-verify.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/orchestrator': minor
+---
+
+Make the local-dispatch enforced verify gate language-aware.
+
+The local gate's default verify runner shelled out to `pnpm -w run …`
+unconditionally, so verification failed environmentally for every non-JS
+workspace (pnpm absent / no `package.json`) and blocked the dispatch for a
+reason unrelated to the change under test. A new pure ecosystem detector
+(`detectEcosystem` / `detectEcosystemFromFiles`) classifies a workspace from the
+lockfiles/manifests present — pnpm/npm/yarn (node), uv/poetry/pipenv/pip
+(python), cargo (rust), go, bundler (ruby), maven/gradle (java) — in a
+deterministic priority order, and returns both the dependency-install command
+(for scaffolding a matching `hooks.afterCreate`) and the ordered verify command
+set. The verify runner now dispatches a non-node workspace to its own toolchain
+(e.g. `pytest`, `cargo test`, `go test ./...`) while preserving the existing
+pnpm-scoped, changed-package behavior for node workspaces. An unrecognized
+workspace remains a clean pass (nothing to check). Every choice stays overridable
+via config.

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -24,6 +24,12 @@ export * from './tracker/adapters/roadmap';
 export * from './tracker/extensions/linear';
 export * from './workspace/manager';
 export * from './workspace/hooks';
+// Language-aware workspace ecosystem detector — the single source of truth mapping
+// a workspace's lockfiles/manifests to its dependency-install + verify command set.
+// Consumed by the local enforced gate (verify) and available to `harness init` so a
+// matching `hooks.afterCreate` install command can be scaffolded per ecosystem.
+export { detectEcosystem, detectEcosystemFromFiles, ECOSYSTEM_RULES } from './workspace/ecosystem';
+export type { Ecosystem, EcosystemId } from './workspace/ecosystem';
 // Backend implementations are internal — use Orchestrator's factory methods instead.
 // Re-exporting only the mock backend for test consumers.
 export * from './agent/backends/mock';

--- a/packages/orchestrator/src/orchestrator.default-verify-runner.test.ts
+++ b/packages/orchestrator/src/orchestrator.default-verify-runner.test.ts
@@ -53,6 +53,23 @@ describe('defaultLocalVerifyRunner (B4)', () => {
     expect(r.ok).toBe(false);
     expect(r.output).toContain('typecheck failed');
   });
+
+  it('language-aware: a non-node (Go) workspace runs the Go toolchain, not pnpm', async () => {
+    // A workspace detected as Go must NOT shell `pnpm` (the historical
+    // environmental false-red). `go` is absent in most CI images, so the runner
+    // shelling a real `go build` → an ENOENT/exec error → RED gate carrying the
+    // Go command. The assertion is that the FAILURE names the detected toolchain
+    // (`go ...`), never `pnpm`, proving the ecosystem dispatch fired.
+    fs.writeFileSync(path.join(tmp, 'go.mod'), 'module example.com/x\n\ngo 1.22\n');
+    const r = await defaultLocalVerifyRunner(tmp);
+    // Either `go` is installed and the trivial module builds/vets/tests clean
+    // (ok:true), or `go` is absent and the gate is red on a `go` command — never
+    // on pnpm. Both outcomes prove pnpm was not invoked for a non-node workspace.
+    if (!r.ok) {
+      expect(r.output).toContain('go ');
+      expect(r.output).not.toContain('pnpm');
+    }
+  });
 });
 
 /**

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -49,6 +49,7 @@ import { RoadmapTrackerAdapter } from './tracker/adapters/roadmap';
 import { GitHubIssuesIssueTrackerAdapter } from './tracker/adapters/github-issues-issue-tracker';
 import { WorkspaceManager } from './workspace/manager';
 import { WorkspaceHooks } from './workspace/hooks';
+import { detectEcosystem } from './workspace/ecosystem';
 import { AgentRunner } from './agent/runner';
 import { PromptRenderer } from './prompt/renderer';
 // Spec 2 SC30 / Task 11: backend class imports moved to
@@ -240,14 +241,18 @@ export function normalizeHarnessCommand(command: string[]): string[] {
 export { truncateGateOutput } from './workflow/gate-feedback';
 
 /**
- * local-backend-full-workflow Phase 2 (Option C): the production default verify
- * runner for the local enforced gate. It runs the project's own mechanical gate
- * (typecheck + lint + test) over `workspacePath` via `pnpm -w run <script>` for
- * whichever of `typecheck`/`lint`/`test` the workspace's package.json declares,
- * short-circuiting on the first red gate. Adopter-portable: it only runs the
- * scripts that exist, and a missing package.json / no scripts → a passing gate
- * (nothing to check). Fully self-contained; tests inject a fake via the
- * `verifyRunner` seam so this concrete detector is never exercised in unit tests.
+ * The production default verify runner for the local enforced gate. It is
+ * language-aware: {@link detectEcosystem} classifies the workspace by the
+ * lockfiles/manifests present, and the runner executes THAT ecosystem's verify
+ * command set, short-circuiting on the first red gate. For a node workspace it
+ * runs the project's own scripts (typecheck + lint + test) via `pnpm run`, scoped
+ * to the changed packages; for a Python/Rust/Go/Ruby/Java workspace it runs that
+ * toolchain's commands (e.g. `pytest`, `cargo test`, `go test ./...`) at the root
+ * so verify no longer fails ENVIRONMENTALLY for non-JS adopters. Adopter-portable:
+ * the node path only runs the scripts that exist, and an unrecognized workspace /
+ * missing package.json → a passing gate (nothing to check). Fully self-contained;
+ * tests inject a fake via the `verifyRunner` seam so this concrete detector is
+ * never exercised in unit tests.
  */
 export function changedWorkspacePackages(porcelain: string): string[] {
   const dirs = new Set<string>();
@@ -314,13 +319,16 @@ export async function defaultLocalVerifyRunner(
   const pathMod = await import('node:path');
 
   // Manual Promise wrapper around execFile (avoids promisify's overloaded typing).
-  const run = (args: string[]): Promise<{ ok: boolean; output: string }> =>
+  // Generalized over the binary so the gate is language-aware: the node path binds
+  // it to `pnpm`, a non-node ecosystem binds it to its own toolchain (cargo, go,
+  // pytest, …). Nothing here hardcodes a package manager.
+  const runCmd = (bin: string, args: string[]): Promise<{ ok: boolean; output: string }> =>
     new Promise((resolve) => {
-      // S2: bound each verify step (typecheck/lint/test) with the same wall-clock
-      // limit as the acceptance command — a wedged or watch-mode script must not hang
-      // the settle/tick forever. A timeout (Node sets `killed:true`) is a gate FAIL.
+      // S2: bound each verify step with the same wall-clock limit as the acceptance
+      // command — a wedged or watch-mode script must not hang the settle/tick
+      // forever. A timeout (Node sets `killed:true`) is a gate FAIL.
       cp.execFile(
-        'pnpm',
+        bin,
         args,
         { cwd: workspacePath, maxBuffer: 32 * 1024 * 1024, timeout: LOCAL_GATE_TIMEOUT_MS },
         (error, stdout, stderr) => {
@@ -329,7 +337,7 @@ export async function defaultLocalVerifyRunner(
             const suffix = timedOut ? ` (TIMED OUT after ${LOCAL_GATE_TIMEOUT_MS}ms)` : '';
             resolve({
               ok: false,
-              output: `${args.join(' ')} failed${suffix}:\n${stdout ?? ''}\n${stderr ?? error.message}`,
+              output: `${[bin, ...args].join(' ')} failed${suffix}:\n${stdout ?? ''}\n${stderr ?? error.message}`,
             });
           } else {
             resolve({ ok: true, output: '' });
@@ -337,6 +345,29 @@ export async function defaultLocalVerifyRunner(
         }
       );
     });
+
+  // Language-aware gate: detect the workspace ecosystem from its lockfiles /
+  // manifests and, for a NON-node ecosystem, run THAT toolchain's verify commands
+  // at the workspace root, in order, short-circuiting on the first failure. This
+  // is the fix for the environmental false-red: a Python/Rust/Go/… workspace no
+  // longer has `pnpm -w run …` (absent binary, no package.json) shelled at it. The
+  // node path below is preserved byte-for-byte for JS adopters (pnpm-scoped,
+  // package.json-script-probing), and an unrecognized workspace falls through to
+  // it (where a missing package.json is a clean pass — nothing to check).
+  const ecosystem = detectEcosystem(workspacePath);
+  if (ecosystem !== null && ecosystem.language !== 'node') {
+    for (const cmd of ecosystem.verifyCommands) {
+      const parts = cmd.split(/\s+/).filter((p) => p.length > 0);
+      const bin = parts[0];
+      if (bin === undefined) continue;
+      const result = await runCmd(bin, parts.slice(1));
+      if (!result.ok) return result;
+    }
+    return { ok: true, output: '' };
+  }
+
+  // NODE (or unrecognized) path — unchanged pnpm-scoped behavior.
+  const run = (args: string[]): Promise<{ ok: boolean; output: string }> => runCmd('pnpm', args);
 
   const readPkg = (dir: string): { name?: string; scripts: Record<string, string> } => {
     try {

--- a/packages/orchestrator/src/workspace/ecosystem.test.ts
+++ b/packages/orchestrator/src/workspace/ecosystem.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  detectEcosystem,
+  detectEcosystemFromFiles,
+  ECOSYSTEM_RULES,
+  type EcosystemId,
+} from './ecosystem.js';
+
+/**
+ * Guards the language-aware workspace detector that feeds the local enforced gate.
+ * Before this, verify shelled `pnpm -w run …` unconditionally and failed
+ * ENVIRONMENTALLY for every non-JS workspace. The matcher is pure (files → descriptor)
+ * so the priority order + fallback are asserted directly; a thin fs wrapper is
+ * exercised against real fixture directories, one per ecosystem.
+ */
+describe('detectEcosystemFromFiles (pure matcher)', () => {
+  const cases: ReadonlyArray<{ files: string[]; id: EcosystemId; pm: string }> = [
+    { files: ['pnpm-lock.yaml', 'package.json'], id: 'node-pnpm', pm: 'pnpm' },
+    { files: ['package-lock.json', 'package.json'], id: 'node-npm', pm: 'npm' },
+    { files: ['npm-shrinkwrap.json'], id: 'node-npm', pm: 'npm' },
+    { files: ['yarn.lock', 'package.json'], id: 'node-yarn', pm: 'yarn' },
+    { files: ['package.json'], id: 'node-npm', pm: 'npm' },
+    { files: ['uv.lock', 'pyproject.toml'], id: 'python-uv', pm: 'uv' },
+    { files: ['poetry.lock', 'pyproject.toml'], id: 'python-poetry', pm: 'poetry' },
+    { files: ['Pipfile.lock'], id: 'python-pipenv', pm: 'pipenv' },
+    { files: ['Pipfile'], id: 'python-pipenv', pm: 'pipenv' },
+    { files: ['requirements.txt'], id: 'python-pip', pm: 'pip' },
+    { files: ['pyproject.toml'], id: 'python-pip', pm: 'pip' },
+    { files: ['Cargo.toml'], id: 'rust-cargo', pm: 'cargo' },
+    { files: ['Cargo.lock'], id: 'rust-cargo', pm: 'cargo' },
+    { files: ['go.mod'], id: 'go', pm: 'go' },
+    { files: ['go.sum'], id: 'go', pm: 'go' },
+    { files: ['Gemfile'], id: 'ruby-bundler', pm: 'bundler' },
+    { files: ['pom.xml'], id: 'java-maven', pm: 'maven' },
+    { files: ['build.gradle'], id: 'java-gradle', pm: 'gradle' },
+    { files: ['build.gradle.kts'], id: 'java-gradle', pm: 'gradle' },
+  ];
+
+  for (const { files, id, pm } of cases) {
+    it(`[${files.join(', ')}] → ${id}`, () => {
+      const eco = detectEcosystemFromFiles(files);
+      expect(eco?.id).toBe(id);
+      expect(eco?.packageManager).toBe(pm);
+      expect(eco?.installCommand.length).toBeGreaterThan(0);
+      expect(eco?.verifyCommands.length).toBeGreaterThan(0);
+    });
+  }
+
+  it('returns null when no recognized marker is present (clean fallback)', () => {
+    expect(detectEcosystemFromFiles(['README.md', 'LICENSE', 'src'])).toBeNull();
+    expect(detectEcosystemFromFiles([])).toBeNull();
+  });
+
+  it('node wins over a co-present non-node manifest (harness JS-default bias)', () => {
+    // A polyglot repo carrying a package.json for tooling still bootstraps as node.
+    const eco = detectEcosystemFromFiles(['pyproject.toml', 'package.json']);
+    expect(eco?.language).toBe('node');
+  });
+
+  it('a lockfile pins its package manager over a looser sibling manifest', () => {
+    // uv.lock beats poetry.lock beats a bare pyproject.toml — most specific wins.
+    expect(detectEcosystemFromFiles(['uv.lock', 'poetry.lock', 'pyproject.toml'])?.id).toBe(
+      'python-uv'
+    );
+    expect(detectEcosystemFromFiles(['poetry.lock', 'pyproject.toml'])?.id).toBe('python-poetry');
+  });
+
+  it('accepts a Set as well as an array (no re-copy needed)', () => {
+    expect(detectEcosystemFromFiles(new Set(['Cargo.toml']))?.id).toBe('rust-cargo');
+  });
+
+  it('non-node verify commands are whitespace-splittable (no shell required)', () => {
+    for (const rule of ECOSYSTEM_RULES) {
+      if (rule.ecosystem.language === 'node') continue;
+      for (const cmd of rule.ecosystem.verifyCommands) {
+        expect(cmd.trim()).toBe(cmd);
+        expect(cmd.split(/\s+/).filter(Boolean).length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('detectEcosystem (filesystem wrapper)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-ecosystem-'));
+  });
+  afterEach(() => {
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  const write = (name: string): void => fs.writeFileSync(path.join(tmp, name), '');
+
+  it('detects a Python (uv) fixture directory', () => {
+    write('uv.lock');
+    write('pyproject.toml');
+    const eco = detectEcosystem(tmp);
+    expect(eco?.id).toBe('python-uv');
+    expect(eco?.installCommand).toBe('uv sync');
+    expect(eco?.verifyCommands).toContain('uv run pytest');
+  });
+
+  it('detects a Rust (cargo) fixture directory', () => {
+    write('Cargo.toml');
+    const eco = detectEcosystem(tmp);
+    expect(eco?.id).toBe('rust-cargo');
+    expect(eco?.verifyCommands).toEqual(['cargo build', 'cargo test']);
+  });
+
+  it('detects a Go fixture directory', () => {
+    write('go.mod');
+    write('go.sum');
+    expect(detectEcosystem(tmp)?.id).toBe('go');
+  });
+
+  it('detects a node (pnpm) fixture directory', () => {
+    write('pnpm-lock.yaml');
+    write('package.json');
+    expect(detectEcosystem(tmp)?.id).toBe('node-pnpm');
+  });
+
+  it('an empty workspace directory → null (nothing to detect)', () => {
+    expect(detectEcosystem(tmp)).toBeNull();
+  });
+
+  it('an unreadable/absent path → null (graceful degradation, no throw)', () => {
+    expect(detectEcosystem(path.join(tmp, 'does-not-exist'))).toBeNull();
+  });
+});

--- a/packages/orchestrator/src/workspace/ecosystem.ts
+++ b/packages/orchestrator/src/workspace/ecosystem.ts
@@ -1,0 +1,263 @@
+import * as fs from 'node:fs';
+
+/**
+ * Language-aware workspace ecosystem detector.
+ *
+ * The local enforced gate (the mechanical verify that BLOCKS a dispatch) and the
+ * workspace bootstrap step were both JS/pnpm-baked: verify shelled out to
+ * `pnpm -w run …` unconditionally. For any non-JS workspace (Python, Rust, Go,
+ * Ruby, Java, …) that fails ENVIRONMENTALLY — pnpm is absent or there is no
+ * package.json — so the gate blocks every dispatch for a reason that has nothing
+ * to do with the change under test.
+ *
+ * This module is the single, language-agnostic source of truth: given a
+ * workspace it detects the ecosystem from the lockfiles/manifests present and
+ * returns BOTH the dependency-install command (what a matching `hooks.afterCreate`
+ * should scaffold) AND the ordered verify command set (what the enforced gate
+ * should run). It hardcodes no package manager in orchestrator control flow — the
+ * commands live in one declarative table here and every choice remains overridable
+ * via config.
+ *
+ * The core matcher is PURE: it takes the set of filenames present at the workspace
+ * root and returns a descriptor. A thin filesystem wrapper does the single
+ * directory read and delegates, so the matching logic is unit-testable without
+ * touching disk.
+ */
+
+export type EcosystemId =
+  | 'node-pnpm'
+  | 'node-npm'
+  | 'node-yarn'
+  | 'python-uv'
+  | 'python-poetry'
+  | 'python-pipenv'
+  | 'python-pip'
+  | 'rust-cargo'
+  | 'go'
+  | 'ruby-bundler'
+  | 'java-maven'
+  | 'java-gradle';
+
+export interface Ecosystem {
+  /** Stable identifier — language family + package manager / toolchain. */
+  id: EcosystemId;
+  /** Human-readable language family (node / python / rust / go / ruby / java). */
+  language: string;
+  /** Package manager or build tool (pnpm, npm, yarn, uv, poetry, cargo, go, …). */
+  packageManager: string;
+  /**
+   * Command that installs the workspace's dependencies from a clean checkout —
+   * the value a matching `hooks.afterCreate` should scaffold so the agent's fresh
+   * worktree is not missing its deps when the gate runs.
+   */
+  installCommand: string;
+  /**
+   * Ordered mechanical verify steps (the ecosystem's build / typecheck / lint /
+   * test analogues). The gate runs them in order and short-circuits on the first
+   * failure. Each entry is a whole command line split on whitespace at execution
+   * time — no shell is involved, so nothing here may rely on shell features.
+   * Kept to each toolchain's ALWAYS-PRESENT commands (e.g. `go vet`, `cargo test`)
+   * rather than optional add-ons (mypy, ruff, clippy) so a stock checkout does not
+   * red the gate on a merely-missing linter; adopters add those via config.
+   */
+  verifyCommands: readonly string[];
+}
+
+/**
+ * One detector rule: if ANY of `markers` is present at the workspace root, the
+ * workspace IS `ecosystem`. Rules are evaluated in array order and the FIRST
+ * match wins, so the array order encodes the detection priority.
+ */
+interface EcosystemRule {
+  markers: readonly string[];
+  ecosystem: Ecosystem;
+}
+
+/**
+ * Detection rules in deterministic priority order (first match wins).
+ *
+ * Node is checked before every other family: the harness's own default is JS and
+ * a polyglot repo that carries a `package.json` for tooling should still bootstrap
+ * as node unless it is unambiguously another ecosystem. Within a family the more
+ * specific lockfile precedes the looser manifest (e.g. `uv.lock` before
+ * `poetry.lock` before a bare `pyproject.toml`) so a lockfile always pins the
+ * package manager it belongs to. Every entry stays overridable via config.
+ */
+export const ECOSYSTEM_RULES: readonly EcosystemRule[] = [
+  {
+    markers: ['pnpm-lock.yaml'],
+    ecosystem: {
+      id: 'node-pnpm',
+      language: 'node',
+      packageManager: 'pnpm',
+      installCommand: 'pnpm install',
+      verifyCommands: ['pnpm -w run typecheck', 'pnpm -w run lint', 'pnpm -w run test'],
+    },
+  },
+  {
+    markers: ['package-lock.json', 'npm-shrinkwrap.json'],
+    ecosystem: {
+      id: 'node-npm',
+      language: 'node',
+      packageManager: 'npm',
+      installCommand: 'npm install',
+      verifyCommands: ['npm run typecheck', 'npm run lint', 'npm run test'],
+    },
+  },
+  {
+    markers: ['yarn.lock'],
+    ecosystem: {
+      id: 'node-yarn',
+      language: 'node',
+      packageManager: 'yarn',
+      installCommand: 'yarn install',
+      verifyCommands: ['yarn run typecheck', 'yarn run lint', 'yarn run test'],
+    },
+  },
+  {
+    // Bare manifest, no lockfile → default the node package manager to npm (the
+    // one every Node install ships with).
+    markers: ['package.json'],
+    ecosystem: {
+      id: 'node-npm',
+      language: 'node',
+      packageManager: 'npm',
+      installCommand: 'npm install',
+      verifyCommands: ['npm run typecheck', 'npm run lint', 'npm run test'],
+    },
+  },
+  {
+    markers: ['uv.lock'],
+    ecosystem: {
+      id: 'python-uv',
+      language: 'python',
+      packageManager: 'uv',
+      installCommand: 'uv sync',
+      verifyCommands: ['uv run pytest'],
+    },
+  },
+  {
+    markers: ['poetry.lock'],
+    ecosystem: {
+      id: 'python-poetry',
+      language: 'python',
+      packageManager: 'poetry',
+      installCommand: 'poetry install',
+      verifyCommands: ['poetry run pytest'],
+    },
+  },
+  {
+    markers: ['Pipfile.lock', 'Pipfile'],
+    ecosystem: {
+      id: 'python-pipenv',
+      language: 'python',
+      packageManager: 'pipenv',
+      installCommand: 'pipenv install --dev',
+      verifyCommands: ['pipenv run pytest'],
+    },
+  },
+  {
+    markers: ['requirements.txt'],
+    ecosystem: {
+      id: 'python-pip',
+      language: 'python',
+      packageManager: 'pip',
+      installCommand: 'pip install -r requirements.txt',
+      verifyCommands: ['pytest'],
+    },
+  },
+  {
+    // A `pyproject.toml` with no lockfile above → an editable install of the
+    // project itself is the closest package-manager-agnostic bootstrap.
+    markers: ['pyproject.toml'],
+    ecosystem: {
+      id: 'python-pip',
+      language: 'python',
+      packageManager: 'pip',
+      installCommand: 'pip install .',
+      verifyCommands: ['pytest'],
+    },
+  },
+  {
+    markers: ['Cargo.lock', 'Cargo.toml'],
+    ecosystem: {
+      id: 'rust-cargo',
+      language: 'rust',
+      packageManager: 'cargo',
+      installCommand: 'cargo fetch',
+      verifyCommands: ['cargo build', 'cargo test'],
+    },
+  },
+  {
+    markers: ['go.sum', 'go.mod'],
+    ecosystem: {
+      id: 'go',
+      language: 'go',
+      packageManager: 'go',
+      installCommand: 'go mod download',
+      verifyCommands: ['go build ./...', 'go vet ./...', 'go test ./...'],
+    },
+  },
+  {
+    markers: ['Gemfile.lock', 'Gemfile'],
+    ecosystem: {
+      id: 'ruby-bundler',
+      language: 'ruby',
+      packageManager: 'bundler',
+      installCommand: 'bundle install',
+      verifyCommands: ['bundle exec rake'],
+    },
+  },
+  {
+    markers: ['pom.xml'],
+    ecosystem: {
+      id: 'java-maven',
+      language: 'java',
+      packageManager: 'maven',
+      installCommand: 'mvn --batch-mode dependency:go-offline',
+      verifyCommands: ['mvn --batch-mode test'],
+    },
+  },
+  {
+    markers: ['build.gradle', 'build.gradle.kts', 'settings.gradle', 'settings.gradle.kts'],
+    ecosystem: {
+      id: 'java-gradle',
+      language: 'java',
+      packageManager: 'gradle',
+      installCommand: './gradlew dependencies',
+      verifyCommands: ['./gradlew test'],
+    },
+  },
+];
+
+/**
+ * PURE core: pick the ecosystem for a workspace from the set of filenames present
+ * at its root. Returns the FIRST rule (in {@link ECOSYSTEM_RULES} priority order)
+ * for which any marker is present, or `null` when nothing is recognized. Never
+ * touches the filesystem, so it is fully unit-testable.
+ */
+export function detectEcosystemFromFiles(files: Iterable<string>): Ecosystem | null {
+  const present = files instanceof Set ? files : new Set(files);
+  for (const rule of ECOSYSTEM_RULES) {
+    if (rule.markers.some((marker) => present.has(marker))) {
+      return rule.ecosystem;
+    }
+  }
+  return null;
+}
+
+/**
+ * Filesystem wrapper around {@link detectEcosystemFromFiles}: read the workspace
+ * root's directory entries ONCE and delegate to the pure matcher. Returns `null`
+ * when the directory cannot be read (a missing/uninitialized workspace has no
+ * detectable ecosystem) so callers degrade gracefully rather than throwing.
+ */
+export function detectEcosystem(workspacePath: string): Ecosystem | null {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(workspacePath);
+  } catch {
+    return null;
+  }
+  return detectEcosystemFromFiles(entries);
+}


### PR DESCRIPTION
## Problem

The local-dispatch enforced verify gate baked in JS/pnpm. Its default verify runner shelled out to \`pnpm -w run …\` unconditionally, so verification failed **environmentally** for every non-JS adopter (Python/Rust/Go/Ruby/Java): pnpm is absent or there is no \`package.json\`, so the gate blocked *every* dispatch for a reason unrelated to the change under test.

## Change

A single, language-agnostic **ecosystem detector** (\`packages/orchestrator/src/workspace/ecosystem.ts\`) is the source of truth mapping a workspace to its toolchain:

- **Pure core** \`detectEcosystemFromFiles(files)\` — classifies by the lockfiles/manifests present, in a deterministic priority order (most-specific lockfile wins; node checked first as the harness default). Never touches disk.
- **fs wrapper** \`detectEcosystem(workspacePath)\` — one directory read, delegates to the pure core, returns \`null\` on an unreadable/empty workspace (graceful degradation).
- Each descriptor returns **both** the dependency-**install** command (for scaffolding a matching \`hooks.afterCreate\`) and the ordered **verify** command set.

### Ecosystem coverage
| Language | Detected package managers |
|---|---|
| node | pnpm, npm, yarn (+ bare \`package.json\`) |
| python | uv, poetry, pipenv, pip (\`requirements.txt\` / \`pyproject.toml\`) |
| rust | cargo |
| go | go modules |
| ruby | bundler |
| java | maven, gradle |

### Wiring
\`defaultLocalVerifyRunner\` now detects the ecosystem and, for a **non-node** workspace, runs that toolchain's verify commands at the workspace root (e.g. \`pytest\`, \`cargo test\`, \`go test ./...\`), short-circuiting on the first failure. **Node** workspaces keep the existing pnpm-scoped, changed-package, package.json-script-probing behavior byte-for-byte. An unrecognized workspace remains a clean pass (nothing to check). Every command stays overridable via config; verify commands are kept to each toolchain's always-present commands so a stock checkout doesn't red the gate on a merely-missing optional linter.

## Tests
- \`ecosystem.test.ts\` — pure matcher (every ecosystem, priority order, node-wins tie-break, lockfile-pins-PM, null fallback) + fs wrapper against real fixture dirs per ecosystem.
- \`orchestrator.default-verify-runner.test.ts\` — a non-node (Go) workspace dispatches to the Go toolchain, never pnpm.
- Full orchestrator suite: 2480 passing.

## Follow-up (out of scope here)
- \`harness init\` scaffolding a matching \`afterCreate\` install command from the detector, and a loud warn when neither install nor verify is configured.
- The local stage-prompt's self-verify prose still names \`pnpm --filter …\`; making it ecosystem-aware needs a renderer variable and is left for a focused change.