### PR TITLE
feat(adoption): failure-reason categorization for adoption.jsonl (#564)

### DIFF
--- a/.changeset/adoption-failure-category.md
+++ b/.changeset/adoption-failure-category.md
@@ -1,0 +1,30 @@
+---
+'@harness-engineering/types': minor
+'@harness-engineering/core': minor
+'@harness-engineering/intelligence': minor
+'@harness-engineering/cli': minor
+---
+
+Add failure-reason categorization to `.harness/metrics/adoption.jsonl`.
+
+Adoption records previously captured `outcome: completed | failed | abandoned` —
+the _what_ of a skill run without the _why_. A new optional `failureCategory`
+field records the reason a run did not complete, drawn from a small closed
+taxonomy (`FailureCategory`): `prerequisite-missing`, `gate-rejected`,
+`user-cancelled`, `timeout`, `dependency-failure`, `agent-error`, and
+`inconclusive`.
+
+The category is derived by the adoption-tracker hook at the failure/gate points
+already present in the skill-event stream: an `error` event's `failureType` is
+mapped through a keyword table (defaulting to `agent-error`), and a failed
+`gate_result` yields `gate-rejected`. It is only emitted when a reason is
+determinable — completed runs and reason-less abandonments carry no category, so
+the field is never guessed.
+
+The field is optional and additive: records written before it existed still
+parse, and the reader drops any unrecognized value. Downstream consumers now use
+it — the skill-effectiveness scorer (`detectFailingSkills`) reports a
+per-skill `failureCategories` breakdown, and the catalog retrospective adds a
+per-skill breakdown, a catalog-wide `failureCategoryTotals`, and a rendered
+"Failure categories" section — so failing skills can be grouped by _why_ they
+fail, not just how often.

--- a/packages/cli/src/hooks/adoption-tracker.js
+++ b/packages/cli/src/hooks/adoption-tracker.js
@@ -32,7 +32,9 @@ function isAdoptionEnabled(cwd) {
 /** Read the cursor offset for events.jsonl processing. */
 function readEventsCursor(cwd) {
   try {
-    const data = JSON.parse(readFileSync(join(cwd, '.harness', 'metrics', ADOPTION_CURSOR_FILE), 'utf-8'));
+    const data = JSON.parse(
+      readFileSync(join(cwd, '.harness', 'metrics', ADOPTION_CURSOR_FILE), 'utf-8')
+    );
     return typeof data.offset === 'number' ? data.offset : 0;
   } catch {
     return 0;
@@ -85,6 +87,57 @@ function deriveOutcome(events) {
   if (hasHandoff || hasFinalPhase) return 'completed';
   if (hasError) return 'failed';
   return 'abandoned';
+}
+
+/**
+ * Failure-reason taxonomy (keep in sync with FAILURE_CATEGORIES in
+ * @harness-engineering/types). Each rule maps a keyword pattern found in an
+ * error event's `failureType` to a category; the first match wins.
+ */
+const FAILURE_CATEGORY_RULES = [
+  [/timeout|timed[-_ ]?out|deadline/i, 'timeout'],
+  [/cancel|abort|interrupt|user[-_ ]?stop|declin/i, 'user-cancelled'],
+  [/prereq|prerequisite|precondition|not[-_ ]?found|missing/i, 'prerequisite-missing'],
+  [/depend|upstream|blocked|blocker/i, 'dependency-failure'],
+  [/gate|reject|verify|unsatisf|not[-_ ]?satisf|outcome/i, 'gate-rejected'],
+  [/inconclusive|unknown|indeterminate/i, 'inconclusive'],
+];
+
+/** Map a free-form failureType string to a closed FailureCategory. */
+function classifyFailureType(failureType) {
+  if (typeof failureType === 'string' && failureType) {
+    for (const [pattern, category] of FAILURE_CATEGORY_RULES) {
+      if (pattern.test(failureType)) return category;
+    }
+  }
+  // A recorded error with no more specific signal is a generic agent error.
+  return 'agent-error';
+}
+
+/**
+ * Derive the failure category for a run, or undefined when it does not apply.
+ *
+ * - Completed runs never carry a category.
+ * - An explicit `error` event is the most specific signal: its `failureType`
+ *   is mapped through the keyword table (defaulting to `agent-error`).
+ * - Otherwise a failed `gate_result` (passed === false) is a `gate-rejected`.
+ * - A run that merely stopped (abandoned) with no error and no failed gate has
+ *   no determinable reason, so the field is omitted rather than guessed.
+ */
+function deriveFailureCategory(events, outcome) {
+  if (outcome === 'completed') return undefined;
+
+  const errorEvent = events.find((e) => e.type === 'error');
+  if (errorEvent) {
+    return classifyFailureType(errorEvent.data && errorEvent.data.failureType);
+  }
+
+  const gateRejected = events.some(
+    (e) => e.type === 'gate_result' && e.data && e.data.passed === false
+  );
+  if (gateRejected) return 'gate-rejected';
+
+  return undefined;
 }
 
 /** Derive phases reached from phase_transition events. */
@@ -149,14 +202,19 @@ function groupBySkill(events) {
 function buildRecord(skill, events, allEvents, sessionId) {
   // Use all events for this skill (including non-relevant) for timing
   const allSkillEvents = allEvents.filter((e) => e.skill === skill);
-  return {
+  const outcome = deriveOutcome(events);
+  const record = {
     skill,
     session: sessionId,
     startedAt: allSkillEvents[0]?.timestamp ?? events[0].timestamp,
     duration: deriveDuration(allSkillEvents.length > 0 ? allSkillEvents : events),
-    outcome: deriveOutcome(events),
+    outcome,
     phasesReached: derivePhasesReached(events),
   };
+  // Additive, optional: only present when a reason is determinable.
+  const failureCategory = deriveFailureCategory(events, outcome);
+  if (failureCategory) record.failureCategory = failureCategory;
+  return record;
 }
 
 function main() {

--- a/packages/cli/tests/hooks/adoption-tracker.test.ts
+++ b/packages/cli/tests/hooks/adoption-tracker.test.ts
@@ -136,6 +136,96 @@ describe('adoption-tracker', { timeout: 60000 }, () => {
     expect((records[0] as Record<string, unknown>).outcome).toBe('failed');
   });
 
+  it('does not emit failureCategory on a completed run', () => {
+    writeEventsJsonl(tmpDir, SAMPLE_EVENTS);
+    const result = runHook(JSON.stringify({ session_id: 'test' }), tmpDir);
+    expect(result.exitCode).toBe(0);
+    const record = readAdoptionRecords(tmpDir)[0] as Record<string, unknown>;
+    expect(record.outcome).toBe('completed');
+    expect(record).not.toHaveProperty('failureCategory');
+  });
+
+  it('classifies an error failureType into a failureCategory', () => {
+    const events = [
+      {
+        timestamp: '2026-04-09T10:00:00.000Z',
+        skill: 'harness-execution',
+        type: 'phase_transition',
+        summary: 'Starting PREPARE',
+        data: { from: 'init', to: 'PREPARE' },
+      },
+      {
+        timestamp: '2026-04-09T10:05:00.000Z',
+        skill: 'harness-execution',
+        type: 'error',
+        summary: 'Run exceeded the time budget',
+        data: { failureType: 'execution timed-out' },
+      },
+    ];
+    writeEventsJsonl(tmpDir, events);
+    const result = runHook(JSON.stringify({ session_id: 'test' }), tmpDir);
+    expect(result.exitCode).toBe(0);
+    const record = readAdoptionRecords(tmpDir)[0] as Record<string, unknown>;
+    expect(record.outcome).toBe('failed');
+    expect(record.failureCategory).toBe('timeout');
+  });
+
+  it('defaults an unrecognized error failureType to agent-error', () => {
+    const events = [
+      {
+        timestamp: '2026-04-09T10:00:00.000Z',
+        skill: 'harness-execution',
+        type: 'error',
+        summary: 'Something broke',
+        data: { failureType: 'kaboom' },
+      },
+    ];
+    writeEventsJsonl(tmpDir, events);
+    runHook(JSON.stringify({ session_id: 'test' }), tmpDir);
+    const record = readAdoptionRecords(tmpDir)[0] as Record<string, unknown>;
+    expect(record.failureCategory).toBe('agent-error');
+  });
+
+  it('derives gate-rejected from a failed gate_result when no error is present', () => {
+    const events = [
+      {
+        timestamp: '2026-04-09T10:00:00.000Z',
+        skill: 'harness-verify',
+        type: 'phase_transition',
+        summary: 'Starting VERIFY',
+        data: { from: 'init', to: 'VERIFY' },
+      },
+      {
+        timestamp: '2026-04-09T10:05:00.000Z',
+        skill: 'harness-verify',
+        type: 'gate_result',
+        summary: 'gate failed',
+        data: { passed: false },
+      },
+    ];
+    writeEventsJsonl(tmpDir, events);
+    runHook(JSON.stringify({ session_id: 'test' }), tmpDir);
+    const record = readAdoptionRecords(tmpDir)[0] as Record<string, unknown>;
+    expect(record.failureCategory).toBe('gate-rejected');
+  });
+
+  it('omits failureCategory for an abandoned run with no error or failed gate', () => {
+    const events = [
+      {
+        timestamp: '2026-04-09T10:00:00.000Z',
+        skill: 'harness-planning',
+        type: 'phase_transition',
+        summary: 'Starting SCOPE',
+        data: { from: 'init', to: 'SCOPE' },
+      },
+    ];
+    writeEventsJsonl(tmpDir, events);
+    runHook(JSON.stringify({ session_id: 'test' }), tmpDir);
+    const record = readAdoptionRecords(tmpDir)[0] as Record<string, unknown>;
+    expect(record.outcome).toBe('abandoned');
+    expect(record).not.toHaveProperty('failureCategory');
+  });
+
   it('derives outcome=abandoned when no handoff, no final phase, no error', () => {
     const events = [
       {

--- a/packages/core/src/adoption/reader.ts
+++ b/packages/core/src/adoption/reader.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { SkillInvocationRecord } from '@harness-engineering/types';
+import { FAILURE_CATEGORIES, type SkillInvocationRecord } from '@harness-engineering/types';
+
+const FAILURE_CATEGORY_SET = new Set<string>(FAILURE_CATEGORIES);
 
 /**
  * Parses a single JSONL line into a SkillInvocationRecord.
@@ -20,6 +22,12 @@ function parseLine(line: string, lineNumber: number): SkillInvocationRecord | nu
         `[harness adoption] Skipping malformed JSONL line ${lineNumber}: missing required fields\n`
       );
       return null;
+    }
+    // Back-compat: `failureCategory` is optional and additive. Records written
+    // before it existed simply lack it; drop an unrecognized value rather than
+    // letting it leak into typed consumers.
+    if (parsed.failureCategory !== undefined && !FAILURE_CATEGORY_SET.has(parsed.failureCategory)) {
+      delete parsed.failureCategory;
     }
     return parsed as SkillInvocationRecord;
   } catch {

--- a/packages/core/src/adoption/retrospective.ts
+++ b/packages/core/src/adoption/retrospective.ts
@@ -35,6 +35,12 @@ export interface SkillRetroStat {
   lastUsed: string;
   /** Whole days between lastUsed and the reference "now". */
   daysSinceLastUse: number;
+  /**
+   * This skill's non-completed runs tallied by `FailureCategory` (only observed
+   * keys present). Empty when no non-completed run carried a category. Lets the
+   * retrospective show *why* a skill fails, not just how often.
+   */
+  failureCategories: Record<string, number>;
 }
 
 /** Telemetry-coverage context: how much of the catalog emits any signal at all. */
@@ -73,6 +79,12 @@ export interface RetrospectiveReport {
   abandonedMidWorkflow: SkillRetroStat[];
   /** Ever-invoked skills quiet for at least inactiveDaysThreshold days. */
   staleSkills: SkillRetroStat[];
+  /**
+   * Catalog-wide tally of non-completed runs by `FailureCategory` (only observed
+   * keys present). Answers "why is the catalog failing overall" across every
+   * skill. Empty when no record carried a failure category.
+   */
+  failureCategoryTotals: Record<string, number>;
   /** Telemetry-coverage context across the catalog. */
   coverage: RetrospectiveCoverage;
 }
@@ -97,6 +109,17 @@ function resolveNowMs(records: SkillInvocationRecord[], now?: Date): number {
   return latest === Number.NEGATIVE_INFINITY ? Date.now() : latest;
 }
 
+/** Tally the `failureCategory` field across a set of records (skips absent). */
+function tallyFailureCategories(records: SkillInvocationRecord[]): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const record of records) {
+    if (record.failureCategory) {
+      totals[record.failureCategory] = (totals[record.failureCategory] ?? 0) + 1;
+    }
+  }
+  return totals;
+}
+
 function buildStat(skill: string, records: SkillInvocationRecord[], nowMs: number): SkillRetroStat {
   const invocations = records.length;
   const failures = records.filter((r) => r.outcome === 'failed').length;
@@ -113,6 +136,7 @@ function buildStat(skill: string, records: SkillInvocationRecord[], nowMs: numbe
     abandonedMidWorkflow: abandoned,
     lastUsed,
     daysSinceLastUse,
+    failureCategories: tallyFailureCategories(records),
   };
 }
 
@@ -206,6 +230,7 @@ export function getCatalogRetrospectiveReport(
     topFailing,
     abandonedMidWorkflow,
     staleSkills,
+    failureCategoryTotals: tallyFailureCategories(records),
     coverage: computeCoverage(new Set(bySkill.keys()), options.catalogSkills),
   };
 }
@@ -246,6 +271,19 @@ function renderOverview(report: RetrospectiveReport): string {
   return lines.join('\n');
 }
 
+function renderFailureCategories(totals: Record<string, number>): string {
+  const entries = Object.entries(totals).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  if (entries.length === 0) {
+    return '### Failure categories\n\n_No categorized failures recorded._\n';
+  }
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  const header = '| Category | Count | Share |\n| -------- | ----- | ----- |';
+  const rows = entries
+    .map(([category, count]) => `| \`${category}\` | ${count} | ${formatRate(count / total)} |`)
+    .join('\n');
+  return `### Failure categories\n\n${header}\n${rows}\n`;
+}
+
 function staleEmptyNote(report: RetrospectiveReport): string {
   const base = `No ever-invoked skill is inactive ≥${report.inactiveDaysThreshold} days.`;
   if (report.windowDays < report.inactiveDaysThreshold) {
@@ -269,6 +307,7 @@ export function renderRetrospectiveMarkdown(report: RetrospectiveReport): string
       report.abandonedMidWorkflow,
       'No abandoned-mid-workflow runs recorded.'
     ),
+    renderFailureCategories(report.failureCategoryTotals),
     renderStatSection(
       `Stale skills (inactive ≥${report.inactiveDaysThreshold} days)`,
       report.staleSkills,

--- a/packages/core/tests/adoption/reader.test.ts
+++ b/packages/core/tests/adoption/reader.test.ts
@@ -95,6 +95,52 @@ describe('readAdoptionRecords', () => {
     stderrSpy.mockRestore();
   });
 
+  it('preserves a valid failureCategory field', () => {
+    const record = {
+      skill: 'harness-execution',
+      session: 'sess-fc',
+      startedAt: '2026-04-09T10:00:00.000Z',
+      duration: 1000,
+      outcome: 'failed',
+      phasesReached: ['prepare'],
+      failureCategory: 'gate-rejected',
+    };
+    fs.writeFileSync(adoptionFile, JSON.stringify(record) + '\n');
+    const records = readAdoptionRecords(tmpDir);
+    expect(records[0]!.failureCategory).toBe('gate-rejected');
+  });
+
+  it('drops an unrecognized failureCategory value', () => {
+    const record = {
+      skill: 'harness-execution',
+      session: 'sess-bad',
+      startedAt: '2026-04-09T10:00:00.000Z',
+      duration: 1000,
+      outcome: 'failed',
+      phasesReached: [],
+      failureCategory: 'not-a-real-category',
+    };
+    fs.writeFileSync(adoptionFile, JSON.stringify(record) + '\n');
+    const records = readAdoptionRecords(tmpDir);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.failureCategory).toBeUndefined();
+  });
+
+  it('parses back-compat records that lack failureCategory', () => {
+    const record = {
+      skill: 'harness-brainstorming',
+      session: 'sess-old',
+      startedAt: '2026-04-09T10:00:00.000Z',
+      duration: 1000,
+      outcome: 'failed',
+      phasesReached: [],
+    };
+    fs.writeFileSync(adoptionFile, JSON.stringify(record) + '\n');
+    const records = readAdoptionRecords(tmpDir);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.failureCategory).toBeUndefined();
+  });
+
   it('skips blank lines without warning', () => {
     const valid = {
       skill: 'harness-brainstorming',

--- a/packages/core/tests/adoption/retrospective.test.ts
+++ b/packages/core/tests/adoption/retrospective.test.ts
@@ -166,4 +166,37 @@ describe('renderRetrospectiveMarkdown', () => {
     const md = renderRetrospectiveMarkdown(report);
     expect(md).toContain('shorter than the threshold');
   });
+
+  it('renders a failure-categories section from category totals', () => {
+    const records = [
+      makeRecord({ skill: 'alpha', outcome: 'failed', failureCategory: 'gate-rejected' }),
+      makeRecord({ skill: 'beta', outcome: 'failed', failureCategory: 'gate-rejected' }),
+      makeRecord({ skill: 'beta', outcome: 'failed', failureCategory: 'timeout' }),
+    ];
+    const report = getCatalogRetrospectiveReport(records, { now: NOW });
+    expect(report.failureCategoryTotals).toEqual({ 'gate-rejected': 2, timeout: 1 });
+    const md = renderRetrospectiveMarkdown(report);
+    expect(md).toContain('### Failure categories');
+    expect(md).toContain('`gate-rejected`');
+  });
+
+  it('notes when no categorized failures exist', () => {
+    const report = getCatalogRetrospectiveReport([makeRecord({ skill: 'alpha' })], { now: NOW });
+    expect(report.failureCategoryTotals).toEqual({});
+    const md = renderRetrospectiveMarkdown(report);
+    expect(md).toContain('No categorized failures recorded.');
+  });
+});
+
+describe('getCatalogRetrospectiveReport failure categories', () => {
+  it('tallies failureCategory per skill on the stat rows', () => {
+    const records = [
+      makeRecord({ skill: 'alpha', outcome: 'failed', failureCategory: 'timeout' }),
+      makeRecord({ skill: 'alpha', outcome: 'failed', failureCategory: 'timeout' }),
+      makeRecord({ skill: 'alpha', outcome: 'completed' }),
+    ];
+    const report = getCatalogRetrospectiveReport(records, { now: NOW });
+    const alpha = report.topInvoked.find((s) => s.skill === 'alpha')!;
+    expect(alpha.failureCategories).toEqual({ timeout: 2 });
+  });
 });

--- a/packages/intelligence/src/effectiveness/skill-scorer.ts
+++ b/packages/intelligence/src/effectiveness/skill-scorer.ts
@@ -26,6 +26,8 @@ interface SkillCounts {
   completed: number;
   failed: number;
   abandonedMidWorkflow: number;
+  /** Non-completed runs tallied by FailureCategory (only observed keys present). */
+  failureCategories: Record<string, number>;
 }
 
 /**
@@ -42,6 +44,28 @@ function isAbandonedMidWorkflow(record: SkillInvocationRecord): boolean {
   return record.outcome !== 'completed' && record.phasesReached.length > 0;
 }
 
+function emptyCounts(): SkillCounts {
+  return {
+    invocations: 0,
+    completed: 0,
+    failed: 0,
+    abandonedMidWorkflow: 0,
+    failureCategories: {},
+  };
+}
+
+/** Fold a single record's outcome and failure category into the running counts. */
+function tallyRecord(counts: SkillCounts, record: SkillInvocationRecord): void {
+  counts.invocations += 1;
+  if (record.outcome === 'completed') counts.completed += 1;
+  else if (record.outcome === 'failed') counts.failed += 1;
+  if (isAbandonedMidWorkflow(record)) counts.abandonedMidWorkflow += 1;
+  const category = record.failureCategory;
+  if (category) {
+    counts.failureCategories[category] = (counts.failureCategories[category] ?? 0) + 1;
+  }
+}
+
 /**
  * Traverse the records once and tally per-skill outcome counts. Records whose
  * `skill` is missing or empty are ignored.
@@ -56,13 +80,10 @@ function gatherCounts(records: SkillInvocationRecord[]): Map<string, SkillCounts
     if (typeof skill !== 'string' || skill.length === 0) continue;
     let counts = map.get(skill);
     if (!counts) {
-      counts = { invocations: 0, completed: 0, failed: 0, abandonedMidWorkflow: 0 };
+      counts = emptyCounts();
       map.set(skill, counts);
     }
-    counts.invocations += 1;
-    if (record.outcome === 'completed') counts.completed += 1;
-    else if (record.outcome === 'failed') counts.failed += 1;
-    if (isAbandonedMidWorkflow(record)) counts.abandonedMidWorkflow += 1;
+    tallyRecord(counts, record);
   }
   return map;
 }
@@ -142,6 +163,7 @@ export function detectFailingSkills(
       failed: counts.failed,
       failureRate,
       smoothedSuccessRate: smoothedSuccessRate(counts),
+      failureCategories: { ...counts.failureCategories },
     });
   }
 

--- a/packages/intelligence/src/effectiveness/types.ts
+++ b/packages/intelligence/src/effectiveness/types.ts
@@ -106,6 +106,13 @@ export interface FailingSkill {
   failureRate: number;
   /** Laplace-smoothed success rate in [0, 1]. */
   smoothedSuccessRate: number;
+  /**
+   * Count of this skill's non-completed runs by `FailureCategory`, keyed by the
+   * category string. Only categories that actually occurred appear (no zero
+   * entries). Empty when no non-completed run carried a category — e.g. records
+   * predate the field. Lets callers see *why* a skill fails, not just that it does.
+   */
+  failureCategories: Record<string, number>;
 }
 
 /**

--- a/packages/intelligence/tests/effectiveness/skill-scorer.test.ts
+++ b/packages/intelligence/tests/effectiveness/skill-scorer.test.ts
@@ -129,6 +129,26 @@ describe('detectFailingSkills', () => {
     expect(failing[0].smoothedSuccessRate).toBeCloseTo(1 / 3, 5);
   });
 
+  it('groups failing skills by failureCategory', () => {
+    const records = [
+      makeRecord({ skill: 'a', outcome: 'failed', failureCategory: 'gate-rejected' }),
+      makeRecord({ skill: 'a', outcome: 'failed', failureCategory: 'gate-rejected' }),
+      makeRecord({ skill: 'a', outcome: 'failed', failureCategory: 'timeout' }),
+    ];
+    const failing = detectFailingSkills(records);
+    expect(failing).toHaveLength(1);
+    expect(failing[0].failureCategories).toEqual({ 'gate-rejected': 2, timeout: 1 });
+  });
+
+  it('returns an empty failureCategories map for uncategorized failures', () => {
+    const records = [
+      makeRecord({ skill: 'a', outcome: 'failed' }),
+      makeRecord({ skill: 'a', outcome: 'failed' }),
+    ];
+    const failing = detectFailingSkills(records);
+    expect(failing[0].failureCategories).toEqual({});
+  });
+
   it('honours custom thresholds', () => {
     const records = [
       makeRecord({ skill: 'a', outcome: 'failed' }),

--- a/packages/types/src/adoption.ts
+++ b/packages/types/src/adoption.ts
@@ -1,4 +1,49 @@
 /**
+ * Closed taxonomy of *why* a skill invocation did not complete. Recorded on
+ * `SkillInvocationRecord.failureCategory` so downstream consumers (the
+ * skill-effectiveness scorer and the catalog retrospective) can distinguish
+ * failure reasons instead of treating every non-completed run as undifferentiated
+ * noise.
+ *
+ * The categories are intentionally small and mutually exclusive:
+ * - `prerequisite-missing` — a required precondition/input was absent (e.g. a
+ *   missing spec, config, or upstream artifact) so the skill could not start.
+ * - `gate-rejected` — a mechanical or evaluative gate returned a failing verdict
+ *   (a failed `gate_result`, or an outcome/verify evaluation that was not
+ *   satisfied).
+ * - `user-cancelled` — a human aborted, interrupted, or declined to continue.
+ * - `timeout` — the run exceeded a time budget / deadline.
+ * - `dependency-failure` — an upstream dependency or blocking skill failed,
+ *   leaving this run unable to proceed.
+ * - `agent-error` — an unclassified execution error the agent hit (the default
+ *   for a recorded error with no more specific signal).
+ * - `inconclusive` — the run stopped without a determinable pass/fail verdict.
+ */
+export type FailureCategory =
+  | 'prerequisite-missing'
+  | 'gate-rejected'
+  | 'user-cancelled'
+  | 'timeout'
+  | 'dependency-failure'
+  | 'agent-error'
+  | 'inconclusive';
+
+/**
+ * The full closed set of {@link FailureCategory} values, in a stable order.
+ * Exported so producers and consumers can validate against a single source of
+ * truth. Keep in sync with the derivation table in the adoption-tracker hook.
+ */
+export const FAILURE_CATEGORIES: readonly FailureCategory[] = [
+  'prerequisite-missing',
+  'gate-rejected',
+  'user-cancelled',
+  'timeout',
+  'dependency-failure',
+  'agent-error',
+  'inconclusive',
+];
+
+/**
  * A single skill invocation record stored in adoption.jsonl.
  * One line per invocation, appended by the adoption-tracker hook.
  */
@@ -19,6 +64,13 @@ export interface SkillInvocationRecord {
   tier?: number;
   /** How the skill was triggered. Absent when not derivable from events. */
   trigger?: string;
+  /**
+   * Why a non-completed run stopped. Absent for completed runs and for
+   * non-completed runs whose reason cannot be determined from the event stream
+   * (the reason is genuinely unknown rather than guessed). Optional and additive:
+   * records written before this field existed still parse.
+   */
+  failureCategory?: FailureCategory;
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -85,7 +85,13 @@ export type {
 export type { UsageRecord, ModelPricing, DailyUsage, SessionUsage } from './usage';
 
 // --- Adoption Telemetry ---
-export type { SkillInvocationRecord, SkillAdoptionSummary, AdoptionSnapshot } from './adoption';
+export type {
+  SkillInvocationRecord,
+  SkillAdoptionSummary,
+  AdoptionSnapshot,
+  FailureCategory,
+} from './adoption';
+export { FAILURE_CATEGORIES } from './adoption';
 
 // --- Session State ---
 export { SESSION_SECTION_NAMES } from './session-state';

--- a/packages/types/tests/index.test.ts
+++ b/packages/types/tests/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { Ok, Err, isOk, isErr, STANDARD_COGNITIVE_MODES } from '../src/index.js';
+import {
+  Ok,
+  Err,
+  isOk,
+  isErr,
+  STANDARD_COGNITIVE_MODES,
+  FAILURE_CATEGORIES,
+} from '../src/index.js';
 
 describe('Result helpers', () => {
   it('Ok creates a successful result', () => {
@@ -48,5 +55,20 @@ describe('STANDARD_COGNITIVE_MODES', () => {
     expect(STANDARD_COGNITIVE_MODES).toContain('advisory-guide');
     expect(STANDARD_COGNITIVE_MODES).toContain('meticulous-verifier');
     expect(STANDARD_COGNITIVE_MODES).toHaveLength(6);
+  });
+});
+
+describe('FAILURE_CATEGORIES', () => {
+  it('is a closed, deduplicated taxonomy of the expected categories', () => {
+    expect([...FAILURE_CATEGORIES]).toEqual([
+      'prerequisite-missing',
+      'gate-rejected',
+      'user-cancelled',
+      'timeout',
+      'dependency-failure',
+      'agent-error',
+      'inconclusive',
+    ]);
+    expect(new Set(FAILURE_CATEGORIES).size).toBe(FAILURE_CATEGORIES.length);
   });
 });


### PR DESCRIPTION
## Summary

Extends `.harness/metrics/adoption.jsonl` with **failure-reason categorization**. Adoption records previously captured `outcome: completed | failed | abandoned` — the *what* of a skill run, not the *why*. This adds an optional `failureCategory` field so the skill-effectiveness scorer and the catalog retrospective can distinguish *why* a skill run failed instead of treating every non-completed run as undifferentiated noise.

Closes #564.

## Taxonomy

A small, closed, mutually-exclusive `FailureCategory` enum (defined and exported from `@harness-engineering/types`, `FAILURE_CATEGORIES`):

| Category | Meaning |
| --- | --- |
| `prerequisite-missing` | A required precondition/input was absent (missing spec, config, upstream artifact) so the skill could not start. |
| `gate-rejected` | A mechanical or evaluative gate returned a failing verdict (failed `gate_result`, or an outcome/verify evaluation not satisfied). |
| `user-cancelled` | A human aborted, interrupted, or declined to continue. |
| `timeout` | The run exceeded a time budget / deadline. |
| `dependency-failure` | An upstream dependency or blocking skill failed. |
| `agent-error` | An unclassified execution error (the default for a recorded error with no more specific signal). |
| `inconclusive` | The run stopped without a determinable pass/fail verdict. |

The taxonomy is drawn from the roadmap shard and reconciled with the actual failure/gate signals already present in the skill-event stream.

## Where it is emitted

The `adoption-tracker` Stop hook (`packages/cli/src/hooks/adoption-tracker.js`) derives the category at the **existing** failure/gate points — no new emission plumbing, no MCP/command schema change:

- An `error` event is the most specific signal: its `failureType` string is mapped through a keyword table (defaulting to `agent-error`).
- Otherwise a failed `gate_result` (`passed === false`) yields `gate-rejected`.
- Completed runs and reason-less abandonments carry **no** category — the field is omitted rather than guessed, so it is never fabricated.

## Where it is consumed (not dormant)

- **Skill-effectiveness scorer** (`packages/intelligence`): `FailingSkill` now carries a per-skill `failureCategories` breakdown, so failing skills can be grouped by *why* they fail.
- **Catalog retrospective** (`packages/core`): `SkillRetroStat` gains a per-skill `failureCategories` map, the report gains a catalog-wide `failureCategoryTotals`, and the rendered Markdown gains a **"Failure categories"** section.

## Back-compat

`failureCategory` is optional and additive:
- Records written before this field existed still parse.
- The reader (`readAdoptionRecords`) drops any unrecognized value rather than leaking it into typed consumers.
- No change to the `outcome` field or any existing consumer's behavior.

## Tests

- Enum shape/closedness (`@harness-engineering/types`).
- Emission at representative failure points: error→category mapping, unknown→`agent-error`, failed gate→`gate-rejected`, no category on completed, omitted for reason-less abandonment (`adoption-tracker.test.ts`).
- Back-compat parse: records lacking the field, valid value preserved, unrecognized value dropped (`reader.test.ts`).
- Consumption: scorer per-skill grouping; retrospective per-skill + catalog-wide totals + rendered section.

Full pre-push gauntlet green (build, lint, typecheck, coverage ratchet, `generate-docs --check`, `generate:plugin:check`).
