### PR TITLE
docs(roadmap): track PR #1115 follow-ups (#1128, #1129)

### DIFF
--- a/docs/roadmap.d/init-scaffold-ecosystem-install-command.md
+++ b/docs/roadmap.d/init-scaffold-ecosystem-install-command.md
@@ -1,0 +1,16 @@
+---
+slug: "init-scaffold-ecosystem-install-command"
+milestone: "Intake"
+order: 32
+---
+
+### init: scaffold ecosystem-matched install command + warn when neither install nor verify is configured
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-up to #1115 (lang-aware local-dispatch, #1002). The ecosystem detector (`packages/orchestrator/src/workspace/ecosystem.ts`) already exposes each ecosystem's INSTALL command alongside verify, but only verify is wired. Wire `harness init` to scaffold a matching `hooks.afterCreate` install command from the detected ecosystem, and warn loudly when a workspace has neither an install nor a verify command resolvable.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P2
+- **External-ID:** github:Intense-Visions/harness-engineering#1128

--- a/docs/roadmap.d/local-dispatch-ecosystem-aware-self-verify-prose.md
+++ b/docs/roadmap.d/local-dispatch-ecosystem-aware-self-verify-prose.md
@@ -1,0 +1,16 @@
+---
+slug: "local-dispatch-ecosystem-aware-self-verify-prose"
+milestone: "Intake"
+order: 33
+---
+
+### local dispatch: make the self-verify stage-prompt prose ecosystem-aware
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-up to #1115 (#1002). #1115 made the enforced verify GATE ecosystem-aware, but the local stage-prompt's self-verify PROSE still hardcodes `pnpm --filter …`. Make the self-verify guidance render the detected ecosystem's verify commands; per #1115 this needs a strict-variables renderer change so the prompt accepts the ecosystem-derived command set.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P2
+- **External-ID:** github:Intense-Visions/harness-engineering#1129

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,6 +242,28 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** P2
 - **External-ID:** github:Intense-Visions/harness-engineering#1037
 
+### init: scaffold ecosystem-matched install command + warn when neither install nor verify is configured
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-up to #1115 (lang-aware local-dispatch, #1002). The ecosystem detector (`packages/orchestrator/src/workspace/ecosystem.ts`) already exposes each ecosystem's INSTALL command alongside verify, but only verify is wired. Wire `harness init` to scaffold a matching `hooks.afterCreate` install command from the detected ecosystem, and warn loudly when a workspace has neither an install nor a verify command resolvable.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P2
+- **External-ID:** github:Intense-Visions/harness-engineering#1128
+
+### local dispatch: make the self-verify stage-prompt prose ecosystem-aware
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-up to #1115 (#1002). #1115 made the enforced verify GATE ecosystem-aware, but the local stage-prompt's self-verify PROSE still hardcodes `pnpm --filter …`. Make the self-verify guidance render the detected ecosystem's verify commands; per #1115 this needs a strict-variables renderer change so the prompt accepts the ecosystem-derived command set.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P2
+- **External-ID:** github:Intense-Visions/harness-engineering#1129
+
 ## v5.0 — Enforcement Hardening
 
 ### Audit and cap the pre-commit --skip list
@@ -728,7 +750,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Honor persona-declared triggers — emit and commit persona CI workflows and scheduled jobs
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/honor-persona-triggers/proposal.md
 - **Summary:** Persona YAMLs (agents/personas/\*.yaml) declare on_pr/on_commit/scheduled(cron) triggers and outputs.ci-workflow: true, and a generator exists (packages/cli/src/persona/generators/ci-workflow.ts), but — verified 2026-06 — NO generated persona workflow is committed and nothing honors the triggers; they are dead declarations. Make them real: run the persona CI-workflow generator and commit the resulting .github/workflows/ so declared triggers actually fire, plus a check that fails when a persona's declared trigger has no committed workflow (drift guard, mirrors generate:plugin:check). First consumer: the new harness-pm persona (#566) auto-runs acceptance-eval on PRs touching docs/changes/\*\* — closing the manual-only gap for the upstream acceptance-criteria gate. Also lights up the currently-dormant declarations on codebase-health-analyst (dependency-health, hotspot-detector, cleanup-dead-code — weekly sweep), performance-guardian (perf), entropy-cleaner (cleanup), graph-maintainer, and security-reviewer (on_pr deep OWASP/threat-model review beyond CI's lightweight security-scan). Today the project's strongest gear is opt-in; this makes it load-bearing without a human remembering to invoke each persona. Recommended priority: P1.
 - **Blockers:** —
 - **Plan:** —


### PR DESCRIPTION
Roadmap-hygiene: adds two planned shards tracking the follow-ups identified in PR #1115 (lang-aware local-dispatch, #1002), and regenerates the aggregate.

## New shards (both `planned`, Intake milestone, P2)

- **`init-scaffold-ecosystem-install-command.md`** (#1128) — Wire `harness init` to scaffold a matching `hooks.afterCreate` install command from the detected ecosystem (the detector in `packages/orchestrator/src/workspace/ecosystem.ts` already exposes INSTALL alongside verify, but only verify is wired), and warn loudly when a workspace has neither an install nor a verify command resolvable.
- **`local-dispatch-ecosystem-aware-self-verify-prose.md`** (#1129) — #1115 made the enforced verify GATE ecosystem-aware, but the local stage-prompt's self-verify PROSE still hardcodes `pnpm --filter …`. Make the self-verify guidance render the detected ecosystem's verify commands (needs a strict-variables renderer change).

## Aggregate

`docs/roadmap.md` regenerated via `harness roadmap regen` from the shards. Both rows now appear under the Intake milestone.

Docs-only change; no changeset required.