### PR TITLE
feat(dashboard): role-shaped front doors (presentation-only non-technical lanes)

### DIFF
--- a/.changeset/role-shaped-dashboard-lanes.md
+++ b/.changeset/role-shaped-dashboard-lanes.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/dashboard': minor
+---
+
+Add role-shaped front doors to the dashboard: a presentation-only `role`
+preference (`dev` | `pm-ba` | `client`) that scopes the sidebar and picks a
+per-role default landing route.
+
+- `dev` (default) is unchanged — every page, lands on Signals.
+- `pm-ba` sees Roadmap, Work in Flight, live agents/streams, and the proposal
+  review queue, landing on Roadmap.
+- `client` sees a curated, read-only pair — Roadmap and Traceability — landing
+  on Roadmap.
+
+The role resolves from a persisted client preference, else the
+`HARNESS_DASHBOARD_ROLE` server default, else `dev`, and can be switched from a
+lane selector in the sidebar. This is a navigation convenience, **not a
+security boundary**: a viewer can still reach any surface by typing its route.
+Real per-role authorization is left as a documented seam at the orchestrator
+proxy, pending multi-user hosting and authenticated sessions.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-06T00:33:47.296Z",
-  "updatedFrom": "18f2180",
+  "updatedAt": "2026-08-06T10:54:50.081Z",
+  "updatedFrom": "a42b4f2fb",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -321,7 +321,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 215854,
+      "value": 216580,
       "violationIds": [
         "14c3c7cf4350a3212158ff69554ef83629eb26d75ffaf4d24bbded2841aa58ad",
         "4d6965066aaca1a3553a39fac1fb531ec9ecb47395a5a4420adbd066d367c3b6",
@@ -337,7 +337,7 @@
       ]
     },
     "dependency-depth": {
-      "value": 548,
+      "value": 559,
       "violationIds": []
     }
   }

--- a/packages/dashboard/src/client/components/layout/ThreadSidebar.tsx
+++ b/packages/dashboard/src/client/components/layout/ThreadSidebar.tsx
@@ -6,7 +6,8 @@ import {
   selectSidebarSections,
   useThreadStore,
 } from '../../stores/threadStore';
-import { SYSTEM_PAGES } from '../../types/thread';
+import { useRole } from '../../hooks/useRole';
+import { DASHBOARD_ROLES, ROLE_LANES, isDashboardRole, pagesForRole } from '../../types/roles';
 import { Sigil } from '../NeonAI/Sigil';
 import { SidebarSection } from '../sidebar/SidebarSection';
 import { SystemNavItem } from '../sidebar/SystemNavItem';
@@ -14,6 +15,8 @@ import { ThreadListItem } from '../sidebar/ThreadListItem';
 
 export function ThreadSidebar() {
   const navigate = useNavigate();
+  const { role, setRole } = useRole();
+  const rolePages = useMemo(() => pagesForRole(role), [role]);
   const threads = useThreadStore((s) => s.threads);
   const sidebarSections = useMemo(
     () => selectSidebarSections({ threads } as Parameters<typeof selectSidebarSections>[0]),
@@ -111,7 +114,7 @@ export function ThreadSidebar() {
 
           <SidebarSection label="System">
             <div className="flex flex-col gap-0.5 px-1">
-              {SYSTEM_PAGES.map((entry) => (
+              {rolePages.map((entry) => (
                 <SystemNavItem
                   key={entry.page}
                   page={entry.page}
@@ -121,6 +124,30 @@ export function ThreadSidebar() {
               ))}
             </div>
           </SidebarSection>
+        </div>
+
+        {/* Lane switcher — presentation-only role preference. */}
+        <div className="border-t border-white/[0.06] px-3 py-2.5">
+          <label
+            htmlFor="role-lane"
+            className="mb-1 block text-[8px] font-bold uppercase tracking-[0.2em] text-neutral-muted/70"
+          >
+            Lane
+          </label>
+          <select
+            id="role-lane"
+            value={role}
+            onChange={(e) => {
+              if (isDashboardRole(e.target.value)) setRole(e.target.value);
+            }}
+            className="w-full rounded-lg border border-white/[0.08] bg-white/[0.04] px-2 py-1.5 text-[11px] font-medium text-neutral-text hover:bg-white/[0.08] focus:outline-none focus:ring-1 focus:ring-primary-500/40 transition-colors"
+          >
+            {DASHBOARD_ROLES.map((r) => (
+              <option key={r} value={r} className="bg-neutral-surface text-neutral-text">
+                {ROLE_LANES[r].label}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
     </aside>

--- a/packages/dashboard/src/client/hooks/useRole.tsx
+++ b/packages/dashboard/src/client/hooks/useRole.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { DEFAULT_ROLE, isDashboardRole, type DashboardRole } from '../types/roles';
+
+/**
+ * Presentation-only dashboard role.
+ *
+ * Resolution order: a persisted client preference (localStorage) wins; else the
+ * server's `/api/identity` role (env-configured default); else `dev`. Switching
+ * lanes persists the choice locally. This is not a security boundary — it only
+ * selects which navigation lane the client renders.
+ */
+const STORAGE_KEY = 'harness.dashboard.role';
+
+interface RoleContextValue {
+  role: DashboardRole;
+  /** Persist and apply a new lane. */
+  setRole: (role: DashboardRole) => void;
+  /** True once the initial role has been resolved (storage or identity fetch). */
+  ready: boolean;
+}
+
+const RoleContext = createContext<RoleContextValue>({
+  role: DEFAULT_ROLE,
+  setRole: () => {},
+  ready: true,
+});
+
+function readStoredRole(): DashboardRole | null {
+  if (typeof localStorage === 'undefined') return null;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return isDashboardRole(stored) ? stored : null;
+}
+
+export function RoleProvider({ children }: { children: ReactNode }) {
+  const storedRole = readStoredRole();
+  const [role, setRoleState] = useState<DashboardRole>(storedRole ?? DEFAULT_ROLE);
+  // A stored preference is authoritative and already resolved; otherwise we
+  // wait for the identity fetch before reporting ready so role-aware landing
+  // can honor the server-configured default on first load.
+  const [ready, setReady] = useState<boolean>(storedRole !== null);
+
+  useEffect(() => {
+    if (storedRole !== null) return; // client preference wins; skip the fetch
+    let cancelled = false;
+    fetch('/api/identity')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { role?: unknown } | null) => {
+        if (cancelled) return;
+        if (data && isDashboardRole(data.role)) setRoleState(data.role);
+      })
+      .catch(() => {
+        // Identity unavailable — keep the default lane.
+      })
+      .finally(() => {
+        if (!cancelled) setReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [storedRole]);
+
+  const setRole = (next: DashboardRole) => {
+    setRoleState(next);
+    setReady(true);
+    if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, next);
+  };
+
+  return <RoleContext.Provider value={{ role, setRole, ready }}>{children}</RoleContext.Provider>;
+}
+
+export const useRole = () => useContext(RoleContext);

--- a/packages/dashboard/src/client/main.tsx
+++ b/packages/dashboard/src/client/main.tsx
@@ -4,7 +4,20 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
 import { ChatLayout } from './components/layout/ChatLayout';
 import { ThreadRoute, SystemRoute } from './components/layout/ThreadView';
 import { ProjectPulseProvider } from './hooks/useProjectPulse';
+import { RoleProvider, useRole } from './hooks/useRole';
+import { defaultRouteForRole } from './types/roles';
 import './index.css';
+
+/**
+ * Role-aware home: redirect `/` to the current role's default landing route.
+ * Waits for the role to resolve so an env-configured lane lands correctly on
+ * first load; developers (the default) still land on Signals.
+ */
+function RoleHome() {
+  const { role, ready } = useRole();
+  if (!ready) return null;
+  return <Navigate to={defaultRouteForRole(role)} replace />;
+}
 
 // Legacy route redirects: map old domain-prefixed and flat routes to /s/:page
 const LEGACY_REDIRECTS: Array<{ from: string; to: string }> = [
@@ -52,23 +65,26 @@ if (root) {
   createRoot(root).render(
     <StrictMode>
       <ProjectPulseProvider>
-        <BrowserRouter>
-          <ChatLayout>
-            <Routes>
-              {/* Core chat-first routes */}
-              {/* Spec 534 — dashboard opens on the signal layer.
-                  Chat remains reachable via the sidebar "New Chat" button and /t/:threadId. */}
-              <Route path="/" element={<Navigate to="/s/signals" replace />} />
-              <Route path="/t/:threadId" element={<ThreadRoute />} />
-              <Route path="/s/:systemPage" element={<SystemRoute />} />
+        <RoleProvider>
+          <BrowserRouter>
+            <ChatLayout>
+              <Routes>
+                {/* Core chat-first routes */}
+                {/* The dashboard opens on the current role's default landing
+                    route (Signals for developers). Chat remains reachable via
+                    the sidebar "New Chat" button and /t/:threadId. */}
+                <Route path="/" element={<RoleHome />} />
+                <Route path="/t/:threadId" element={<ThreadRoute />} />
+                <Route path="/s/:systemPage" element={<SystemRoute />} />
 
-              {/* Legacy redirects */}
-              {LEGACY_REDIRECTS.map(({ from, to }) => (
-                <Route key={from} path={from} element={<Navigate to={to} replace />} />
-              ))}
-            </Routes>
-          </ChatLayout>
-        </BrowserRouter>
+                {/* Legacy redirects */}
+                {LEGACY_REDIRECTS.map(({ from, to }) => (
+                  <Route key={from} path={from} element={<Navigate to={to} replace />} />
+                ))}
+              </Routes>
+            </ChatLayout>
+          </BrowserRouter>
+        </RoleProvider>
       </ProjectPulseProvider>
     </StrictMode>
   );

--- a/packages/dashboard/src/client/types/roles.ts
+++ b/packages/dashboard/src/client/types/roles.ts
@@ -1,0 +1,97 @@
+/**
+ * Client role → navigation-lane mapping.
+ *
+ * Groups the flat {@link SYSTEM_PAGES} registry into per-role lanes and picks a
+ * default landing route per role. This is PRESENTATION-ONLY: it decides which
+ * system pages the sidebar renders and where a role lands by default. It does
+ * NOT prevent a viewer from reaching a page they can still hand-type the route
+ * for — real per-role authorization is a server concern that arrives with
+ * multi-user hosting and authenticated sessions.
+ */
+import { SYSTEM_PAGES, type SystemPage } from './thread';
+import {
+  DASHBOARD_ROLES,
+  DEFAULT_ROLE,
+  coerceRole,
+  isDashboardRole,
+  type DashboardRole,
+} from '../../shared/roles';
+
+export { DASHBOARD_ROLES, DEFAULT_ROLE, coerceRole, isDashboardRole };
+export type { DashboardRole };
+
+/** One entry of the {@link SYSTEM_PAGES} registry. */
+export type SystemPageEntry = (typeof SYSTEM_PAGES)[number];
+
+/** A navigation lane for one role. */
+export interface RoleLane {
+  role: DashboardRole;
+  /** Short human label for the lane (used by the lane switcher). */
+  label: string;
+  /** One-line description of who the lane is for. */
+  description: string;
+  /**
+   * Ordered allowlist of system pages visible in this lane, or `null` to mean
+   * "every page" (the developer lane — unchanged from the flat registry).
+   */
+  pages: readonly SystemPage[] | null;
+  /** Route this role lands on from `/`. */
+  defaultRoute: string;
+}
+
+/**
+ * Per-role lanes.
+ *
+ * - `dev`    — every page, lands on Signals (unchanged default experience).
+ * - `pm-ba`  — Roadmap, Work in Flight, live agents/streams, and the proposal
+ *              review queue: author intent, watch agents, adjudicate.
+ * - `client` — a curated, read-only pair: Roadmap plus Traceability.
+ */
+export const ROLE_LANES: Record<DashboardRole, RoleLane> = {
+  dev: {
+    role: 'dev',
+    label: 'Developer',
+    description: 'Full dashboard — every signal, panel, and operator surface.',
+    pages: null,
+    defaultRoute: '/s/signals',
+  },
+  'pm-ba': {
+    role: 'pm-ba',
+    label: 'PM / BA',
+    description: 'Author intent, watch agents, and adjudicate at decision points.',
+    pages: ['roadmap', 'kanban', 'orchestrator', 'streams', 'proposals'],
+    defaultRoute: '/s/roadmap',
+  },
+  client: {
+    role: 'client',
+    label: 'Client',
+    description: 'A curated, read-only view of progress and traceability.',
+    pages: ['roadmap', 'traceability'],
+    defaultRoute: '/s/roadmap',
+  },
+};
+
+/** The lane for a role, defaulting to the developer lane for unknown input. */
+export function laneForRole(role: DashboardRole): RoleLane {
+  return ROLE_LANES[role] ?? ROLE_LANES[DEFAULT_ROLE];
+}
+
+/**
+ * The ordered list of {@link SYSTEM_PAGES} entries visible in a role's lane.
+ * Developer sees the full registry in its canonical order; other lanes see
+ * their allowlist in the order declared on the lane. Unknown page ids in a
+ * lane allowlist are skipped.
+ */
+export function pagesForRole(role: DashboardRole): SystemPageEntry[] {
+  const lane = laneForRole(role);
+  if (lane.pages === null) return [...SYSTEM_PAGES];
+  const byPage = new Map<SystemPage, SystemPageEntry>(SYSTEM_PAGES.map((e) => [e.page, e]));
+  return lane.pages
+    .map((page) => byPage.get(page))
+    .filter((entry): entry is SystemPageEntry => entry !== undefined);
+}
+
+/** The default landing route for a role. */
+export function defaultRouteForRole(role: DashboardRole): string {
+  return laneForRole(role).defaultRoute;
+}

--- a/packages/dashboard/src/server/identity.ts
+++ b/packages/dashboard/src/server/identity.ts
@@ -1,7 +1,8 @@
 import { execFile } from 'node:child_process';
-import type { IdentityResponse } from '../shared/types';
+import type { ResolvedIdentity } from '../shared/types';
+import { coerceRole, type DashboardRole } from '../shared/roles';
 
-let pending: Promise<IdentityResponse | null> | null = null;
+let pending: Promise<ResolvedIdentity | null> | null = null;
 
 function execAsync(cmd: string, args: string[]): Promise<string> {
   return new Promise<string>((resolve, reject) => {
@@ -15,7 +16,7 @@ function execAsync(cmd: string, args: string[]): Promise<string> {
   });
 }
 
-async function resolveFromGithubApi(): Promise<IdentityResponse | null> {
+async function resolveFromGithubApi(): Promise<ResolvedIdentity | null> {
   const token = process.env['GITHUB_TOKEN'];
   if (!token) return null;
   try {
@@ -35,7 +36,7 @@ async function resolveFromGithubApi(): Promise<IdentityResponse | null> {
   return null;
 }
 
-async function resolveFromGhCli(): Promise<IdentityResponse | null> {
+async function resolveFromGhCli(): Promise<ResolvedIdentity | null> {
   try {
     const login = await execAsync('gh', ['api', 'user', '--jq', '.login']);
     if (login) return { username: login, source: 'gh-cli' };
@@ -45,7 +46,7 @@ async function resolveFromGhCli(): Promise<IdentityResponse | null> {
   return null;
 }
 
-async function resolveFromGitConfig(): Promise<IdentityResponse | null> {
+async function resolveFromGitConfig(): Promise<ResolvedIdentity | null> {
   try {
     const name = await execAsync('git', ['config', 'user.name']);
     if (name) return { username: name, source: 'git-config' };
@@ -55,7 +56,7 @@ async function resolveFromGitConfig(): Promise<IdentityResponse | null> {
   return null;
 }
 
-async function resolveInner(): Promise<IdentityResponse | null> {
+async function resolveInner(): Promise<ResolvedIdentity | null> {
   return (
     (await resolveFromGithubApi()) ?? (await resolveFromGhCli()) ?? (await resolveFromGitConfig())
   );
@@ -66,7 +67,7 @@ async function resolveInner(): Promise<IdentityResponse | null> {
  * Waterfall: GitHub API -> gh CLI -> git config. Cached for server lifetime.
  * Concurrent calls share the same in-flight promise to avoid redundant API calls.
  */
-export async function resolveIdentity(): Promise<IdentityResponse | null> {
+export async function resolveIdentity(): Promise<ResolvedIdentity | null> {
   if (!pending) {
     pending = resolveInner();
   }
@@ -76,4 +77,17 @@ export async function resolveIdentity(): Promise<IdentityResponse | null> {
 /** Clear cached identity (for testing). */
 export function clearIdentityCache(): void {
   pending = null;
+}
+
+/**
+ * Resolve the dashboard `role` preference from the environment.
+ *
+ * Reads `HARNESS_DASHBOARD_ROLE` and validates it against the known roles,
+ * defaulting to `dev` when unset or invalid. This is a PRESENTATION-ONLY
+ * preference (it selects the client's navigation lane); it is not a security
+ * boundary and is intentionally not cached, so an operator can change lanes by
+ * restarting with a different value.
+ */
+export function resolveRole(): DashboardRole {
+  return coerceRole(process.env['HARNESS_DASHBOARD_ROLE']);
 }

--- a/packages/dashboard/src/server/orchestrator-proxy.ts
+++ b/packages/dashboard/src/server/orchestrator-proxy.ts
@@ -13,6 +13,21 @@ import { isBadPort } from '@harness-engineering/core';
 import { ORCHESTRATOR_PORT } from '../shared/constants';
 
 /**
+ * AUTHORIZATION SEAM (not yet implemented).
+ *
+ * The dashboard exposes a presentation-only `role` preference (`dev` | `pm-ba`
+ * | `client`) that selects which navigation lane the client renders. It is NOT
+ * a security boundary: a viewer in a restricted lane can still hand-type any
+ * `/s/:page` route or call any API prefix below directly.
+ *
+ * Real per-role enforcement — rejecting requests to surfaces a role is not
+ * permitted to reach — belongs here, at the proxy, keyed off an authenticated
+ * session rather than a client-supplied preference. That work depends on
+ * multi-user hosting and server-side sessions and is intentionally deferred;
+ * this comment marks where the check would attach once those land.
+ */
+
+/**
  * Route prefixes that belong to the orchestrator.
  * Order matches vite.config.ts — more-specific prefixes first.
  */

--- a/packages/dashboard/src/server/routes/actions.ts
+++ b/packages/dashboard/src/server/routes/actions.ts
@@ -12,7 +12,7 @@ import {
 } from '@harness-engineering/core';
 import type { Roadmap, RoadmapFeature, FeatureStatus } from '@harness-engineering/types';
 import type { ServerContext } from '../context';
-import { resolveIdentity } from '../identity';
+import { resolveIdentity, resolveRole } from '../identity';
 import { gatherSecurity } from '../gather/security';
 import { gatherPerf } from '../gather/perf';
 import { gatherArch } from '../gather/arch';
@@ -473,7 +473,8 @@ async function handleIdentity(c: Context): Promise<Response> {
   if (!identity) {
     return c.json({ error: 'Could not resolve GitHub identity' }, 503);
   }
-  return c.json(identity);
+  // Attach the presentation-only role preference (default `dev`).
+  return c.json({ ...identity, role: resolveRole() });
 }
 
 export function buildActionsRouter(ctx: ServerContext): Hono {

--- a/packages/dashboard/src/shared/roles.ts
+++ b/packages/dashboard/src/shared/roles.ts
@@ -1,0 +1,35 @@
+/**
+ * Dashboard role taxonomy — shared by server (identity/preference resolution)
+ * and client (role-scoped navigation lanes).
+ *
+ * A role is a PRESENTATION preference, not a security boundary. It selects
+ * which navigation lane the dashboard renders for a viewer; it does not, on
+ * its own, prevent a viewer from reaching any surface (see the client router
+ * and the orchestrator proxy for where real, session-backed authorization
+ * would eventually live).
+ */
+
+/**
+ * Front-door lanes:
+ * - `dev`    — the full operator surface (default; unchanged behavior).
+ * - `pm-ba`  — product / business-analyst lane: author intent, watch agents,
+ *              adjudicate at decision points.
+ * - `client` — a curated, read-only lane.
+ */
+export type DashboardRole = 'dev' | 'pm-ba' | 'client';
+
+/** All roles, in canonical order. */
+export const DASHBOARD_ROLES: readonly DashboardRole[] = ['dev', 'pm-ba', 'client'] as const;
+
+/** The role assumed when none is configured or a stored value is invalid. */
+export const DEFAULT_ROLE: DashboardRole = 'dev';
+
+/** Type guard: is `value` one of the known dashboard roles? */
+export function isDashboardRole(value: unknown): value is DashboardRole {
+  return typeof value === 'string' && (DASHBOARD_ROLES as readonly string[]).includes(value);
+}
+
+/** Coerce any input to a valid role, falling back to {@link DEFAULT_ROLE}. */
+export function coerceRole(value: unknown): DashboardRole {
+  return isDashboardRole(value) ? value : DEFAULT_ROLE;
+}

--- a/packages/dashboard/src/shared/types.ts
+++ b/packages/dashboard/src/shared/types.ts
@@ -1,5 +1,6 @@
 import type { FeatureStatus } from '@harness-engineering/core';
 import type { AdoptionSnapshot, SkillAdoptionSummary } from '@harness-engineering/types';
+import type { DashboardRole } from './roles';
 export type { FeatureStatus, AdoptionSnapshot, SkillAdoptionSummary };
 
 /** Health check response shape */
@@ -143,10 +144,25 @@ export const CONFLICT_TOAST_TEMPLATE = (conflictedWith: string | null): string =
 
 // --- Identity types ---
 
-/** GET /api/identity response body */
-export interface IdentityResponse {
+/**
+ * The resolved GitHub identity (username + how it was resolved). This is the
+ * output of the server-side identity waterfall and carries no preferences.
+ */
+export interface ResolvedIdentity {
   username: string;
   source: 'github-api' | 'gh-cli' | 'git-config';
+}
+
+/**
+ * GET /api/identity response body: the resolved identity plus the viewer's
+ * dashboard `role` preference.
+ *
+ * `role` is PRESENTATION-ONLY — it selects the navigation lane the client
+ * renders, not what the viewer is permitted to reach. It is not a security
+ * boundary.
+ */
+export interface IdentityResponse extends ResolvedIdentity {
+  role: DashboardRole;
 }
 
 // --- Health types ---

--- a/packages/dashboard/tests/client/types/roles.test.ts
+++ b/packages/dashboard/tests/client/types/roles.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { SYSTEM_PAGES, type SystemPage } from '../../../src/client/types/thread';
+import {
+  DASHBOARD_ROLES,
+  DEFAULT_ROLE,
+  ROLE_LANES,
+  coerceRole,
+  defaultRouteForRole,
+  isDashboardRole,
+  laneForRole,
+  pagesForRole,
+  type DashboardRole,
+} from '../../../src/client/types/roles';
+
+const ALL_PAGES = new Set<SystemPage>(SYSTEM_PAGES.map((e) => e.page));
+
+describe('dashboard role taxonomy', () => {
+  it('exposes exactly three roles with dev as the default', () => {
+    expect([...DASHBOARD_ROLES]).toEqual(['dev', 'pm-ba', 'client']);
+    expect(DEFAULT_ROLE).toBe('dev');
+  });
+
+  it('isDashboardRole accepts known roles and rejects everything else', () => {
+    expect(isDashboardRole('dev')).toBe(true);
+    expect(isDashboardRole('pm-ba')).toBe(true);
+    expect(isDashboardRole('client')).toBe(true);
+    expect(isDashboardRole('admin')).toBe(false);
+    expect(isDashboardRole('')).toBe(false);
+    expect(isDashboardRole(null)).toBe(false);
+    expect(isDashboardRole(undefined)).toBe(false);
+    expect(isDashboardRole(42)).toBe(false);
+  });
+
+  it('coerceRole passes through valid roles and defaults invalid ones', () => {
+    expect(coerceRole('pm-ba')).toBe('pm-ba');
+    expect(coerceRole('client')).toBe('client');
+    expect(coerceRole('nope')).toBe('dev');
+    expect(coerceRole(undefined)).toBe('dev');
+  });
+});
+
+describe('role → visible-pages mapping', () => {
+  it('dev sees the entire flat registry in canonical order', () => {
+    const pages = pagesForRole('dev').map((e) => e.page);
+    expect(pages).toEqual(SYSTEM_PAGES.map((e) => e.page));
+  });
+
+  it('pm-ba sees the author/watch/adjudicate lane and nothing more', () => {
+    const pages = pagesForRole('pm-ba').map((e) => e.page);
+    expect(pages).toEqual(['roadmap', 'kanban', 'orchestrator', 'streams', 'proposals']);
+    // Operator-only surfaces are excluded.
+    expect(pages).not.toContain('tokens');
+    expect(pages).not.toContain('webhooks');
+    expect(pages).not.toContain('local-models');
+  });
+
+  it('client sees only the curated read-only pair', () => {
+    const pages = pagesForRole('client').map((e) => e.page);
+    expect(pages).toEqual(['roadmap', 'traceability']);
+  });
+
+  it('every lane allowlist references pages that exist in the registry', () => {
+    for (const role of DASHBOARD_ROLES) {
+      const lane = ROLE_LANES[role];
+      if (lane.pages === null) continue;
+      for (const page of lane.pages) {
+        expect(ALL_PAGES.has(page)).toBe(true);
+      }
+      // A non-dev lane is a strict, non-empty subset of the full registry.
+      expect(lane.pages.length).toBeGreaterThan(0);
+      expect(lane.pages.length).toBeLessThan(SYSTEM_PAGES.length);
+    }
+  });
+
+  it('pagesForRole returns entries with intact label and route', () => {
+    const [first] = pagesForRole('client');
+    expect(first?.page).toBe('roadmap');
+    expect(first?.label).toBe('Roadmap');
+    expect(first?.route).toBe('/s/roadmap');
+  });
+
+  it('falls back to the developer lane for an unknown role', () => {
+    const unknown = 'ghost' as unknown as DashboardRole;
+    expect(laneForRole(unknown)).toBe(ROLE_LANES.dev);
+    expect(pagesForRole(unknown).map((e) => e.page)).toEqual(SYSTEM_PAGES.map((e) => e.page));
+  });
+});
+
+describe('default landing per role', () => {
+  it('lands each role on its lane default', () => {
+    expect(defaultRouteForRole('dev')).toBe('/s/signals');
+    expect(defaultRouteForRole('pm-ba')).toBe('/s/roadmap');
+    expect(defaultRouteForRole('client')).toBe('/s/roadmap');
+  });
+
+  it('every default route points at a page inside that role lane', () => {
+    for (const role of DASHBOARD_ROLES) {
+      const route = defaultRouteForRole(role);
+      const landingPage = route.replace('/s/', '') as SystemPage;
+      const lanePages = pagesForRole(role).map((e) => e.page);
+      expect(lanePages).toContain(landingPage);
+    }
+  });
+
+  it('falls back to the developer landing for an unknown role', () => {
+    const unknown = 'ghost' as unknown as DashboardRole;
+    expect(defaultRouteForRole(unknown)).toBe('/s/signals');
+  });
+});

--- a/packages/dashboard/tests/server/identity-role.test.ts
+++ b/packages/dashboard/tests/server/identity-role.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { resolveRole } from '../../src/server/identity';
+
+const origEnv = { ...process.env };
+
+describe('resolveRole', () => {
+  beforeEach(() => {
+    process.env = { ...origEnv };
+    delete process.env['HARNESS_DASHBOARD_ROLE'];
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+  });
+
+  it('defaults to dev when unset', () => {
+    expect(resolveRole()).toBe('dev');
+  });
+
+  it('returns a valid configured role', () => {
+    process.env['HARNESS_DASHBOARD_ROLE'] = 'pm-ba';
+    expect(resolveRole()).toBe('pm-ba');
+    process.env['HARNESS_DASHBOARD_ROLE'] = 'client';
+    expect(resolveRole()).toBe('client');
+  });
+
+  it('falls back to dev for an unrecognized value', () => {
+    process.env['HARNESS_DASHBOARD_ROLE'] = 'superuser';
+    expect(resolveRole()).toBe('dev');
+  });
+
+  it('falls back to dev for an empty value', () => {
+    process.env['HARNESS_DASHBOARD_ROLE'] = '';
+    expect(resolveRole()).toBe('dev');
+  });
+
+  it('re-reads the environment on each call (not cached)', () => {
+    process.env['HARNESS_DASHBOARD_ROLE'] = 'client';
+    expect(resolveRole()).toBe('client');
+    process.env['HARNESS_DASHBOARD_ROLE'] = 'pm-ba';
+    expect(resolveRole()).toBe('pm-ba');
+  });
+});

--- a/packages/dashboard/tests/server/routes/actions-claim.test.ts
+++ b/packages/dashboard/tests/server/routes/actions-claim.test.ts
@@ -36,6 +36,7 @@ vi.mock('../../../src/server/gather/anomalies', () => ({
 }));
 vi.mock('../../../src/server/identity', () => ({
   resolveIdentity: vi.fn().mockResolvedValue({ username: 'testuser', source: 'git-config' }),
+  resolveRole: vi.fn().mockReturnValue('dev'),
 }));
 
 const CLAIMABLE_ROADMAP = `---
@@ -280,11 +281,16 @@ describe('GET /api/identity', () => {
     const { resolveIdentity } = await import('../../../src/server/identity');
     vi.mocked(resolveIdentity).mockResolvedValueOnce({ username: 'octocat', source: 'github-api' });
 
+    const { resolveRole } = await import('../../../src/server/identity');
+    vi.mocked(resolveRole).mockReturnValueOnce('pm-ba');
+
     const res = await app.request('/api/identity');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.username).toBe('octocat');
     expect(body.source).toBe('github-api');
+    // The presentation-only role preference rides along on the identity payload.
+    expect(body.role).toBe('pm-ba');
   });
 
   it('returns 503 when identity resolution fails', async () => {


### PR DESCRIPTION
## Summary

Adds **role-shaped front doors** to the dashboard: a presentation-only `role` preference that scopes the sidebar to a per-role navigation lane and picks a per-role default landing route. Non-technical users (PM/BA, client) get a focused door into the existing surfaces without a terminal; the developer experience is unchanged.

Implements roadmap item #711 ("role-shaped dashboard front doors — non-technical lanes"), Full-lifecycle reach track.

## What shipped

- **`shared/roles.ts`** — role taxonomy (`dev | pm-ba | client`), `DEFAULT_ROLE`, and validation (`isDashboardRole`, `coerceRole`). Shared by server and client (no layering violation).
- **Server** — `resolveRole()` reads `HARNESS_DASHBOARD_ROLE` (validated, defaults `dev`); `GET /api/identity` now carries `role` alongside the resolved username. `IdentityResponse` split from a preference-free `ResolvedIdentity`.
- **Client** — `useRole` provider (localStorage preference → `/api/identity` → `dev`), a role→lane mapping (`pagesForRole` / `defaultRouteForRole`), a role-scoped sidebar with a lane switcher, and a role-aware `/` redirect.

### Lanes shipped

| Role | Visible system pages | Default landing |
|------|----------------------|-----------------|
| `dev` (default) | all pages (unchanged) | `/s/signals` |
| `pm-ba` | Roadmap, Work in Flight, Orchestrator, Streams, Proposals | `/s/roadmap` |
| `client` | Roadmap, Traceability (read-only) | `/s/roadmap` |

## Tests

- `tests/client/types/roles.test.ts` — role→visible-pages mapping (dev = full registry; pm-ba lane; client read-only pair; lane allowlists reference real pages; default-landing-per-role; unknown-role fallback).
- `tests/server/identity-role.test.ts` — `resolveRole` env parsing/validation/defaulting.
- Updated the `/api/identity` route test to assert the role rides along.
- Full dashboard suite green (918 tests, 129 files); typecheck + lint clean; server & client build succeed.

## Design decision (autonomous — for review)

**Scope chosen: smallest coherent slice — presentation-only role filter. Explicitly NOT a security boundary in v1.**

- **Role taxonomy.** Three roles: `dev` (full operator surface, unchanged default), `pm-ba` (author intent, watch agents, adjudicate at decision points), `client` (curated read-only). Modeled as a *preference*, not part of resolved identity — the GitHub-identity waterfall is untouched; role is a separate, env-seeded, client-overridable preference. Resolution precedence: persisted client preference → server `HARNESS_DASHBOARD_ROLE` default → `dev`.
- **Per-lane page scope.** The flat `SYSTEM_PAGES` registry is grouped into per-role lanes via a pure mapping module. `dev` keeps the full registry in canonical order; `pm-ba` and `client` get explicit, ordered allowlists. The mapping is the load-bearing, fully-unit-tested artifact; the sidebar/router just consume it.
- **PRESENTATION-ONLY — not a security boundary (deliberate).** The role scopes what the sidebar renders and where each role lands. It does **not** stop a viewer from reaching a page: a `client` can still hand-type `/s/health` and the `SystemRoute` will render it, and every `/api/*` prefix remains directly callable. This is called out in the changeset, in the `role` type docs, and as an explicit **authorization seam** documented at `orchestrator-proxy.ts` where real, session-keyed enforcement would attach. No authz logic was implemented.
- **Cross-deps / deferred.** Real per-role enforcement depends on multi-user hosting + authenticated sessions (**#124**) — deferred by design, seam left in place. Adjacent non-technical-authoring work (**#714**) can build on the `pm-ba` lane and the `role` seam. Per repo policy, no internal issue numbers appear in shipped source/changeset/comments — the caveat is described in prose there; the cross-refs live here in the PR only.
- **Arch baseline.** Wiring the new shared module into 4 files raised `dependency-depth` (548→559); accepted via `check-arch --update-baseline --allow-regress --reason`. The 12 pre-existing cyclomatic-complexity findings are identical on clean `origin/main` and unrelated to this change.

## Caveat worth a reviewer's eyes

The lane switcher persists to `localStorage`, so a client-set preference wins over the server default on that browser. That is intended for a presentation-only v1 (any user can pick any lane) but is exactly why this must not be mistaken for access control until #124 lands.
