### PR TITLE
fix(orchestrator): deflake privacy-boundary escalation test on slow CI runners

### DIFF
--- a/packages/orchestrator/src/agent/adaptive-router.privacy-boundary.test.ts
+++ b/packages/orchestrator/src/agent/adaptive-router.privacy-boundary.test.ts
@@ -170,9 +170,15 @@ describe('PrivacyNoMatch → routing:no-tier-match steward escalation (finding #
     const handled = await i.handleRoutingFailure(ISSUE, new PrivacyNoMatch('no compliant backend'));
 
     expect(handled).toBe(true); // boundary claimed it — the generic transport path must NOT also run
-    for (let n = 0; n < 50 && queued.filter((q) => q.issueId === ISSUE.id).length === 0; n++) {
-      await new Promise((r) => setTimeout(r, 5));
-    }
+    // Wait for the escalation to be queued. The push happens on an async path,
+    // so a fixed short poll (previously 50×5ms = 250ms) is fragile on slow /
+    // loaded CI runners (observed flaking Windows-only, where the file's git
+    // execSync setup alone runs ~16s/test). vi.waitFor gives a generous budget
+    // without masking a genuine no-queue bug — that still times out and fails.
+    await vi.waitFor(() => expect(queued.filter((q) => q.issueId === ISSUE.id).length).toBeGreaterThan(0), {
+      timeout: 5000,
+      interval: 10,
+    });
     const escs = queued.filter((q) => q.issueId === ISSUE.id);
     expect(escs).toHaveLength(1);
     expect(escs[0]!.type).toBe('needs-human');
@@ -194,9 +200,15 @@ describe('PrivacyNoMatch → routing:no-tier-match steward escalation (finding #
     );
 
     expect(handled).toBe(true);
-    for (let n = 0; n < 50 && queued.filter((q) => q.issueId === ISSUE.id).length === 0; n++) {
-      await new Promise((r) => setTimeout(r, 5));
-    }
+    // Wait for the escalation to be queued. The push happens on an async path,
+    // so a fixed short poll (previously 50×5ms = 250ms) is fragile on slow /
+    // loaded CI runners (observed flaking Windows-only, where the file's git
+    // execSync setup alone runs ~16s/test). vi.waitFor gives a generous budget
+    // without masking a genuine no-queue bug — that still times out and fails.
+    await vi.waitFor(() => expect(queued.filter((q) => q.issueId === ISSUE.id).length).toBeGreaterThan(0), {
+      timeout: 5000,
+      interval: 10,
+    });
     expect(queued.filter((q) => q.issueId === ISSUE.id)).toHaveLength(1);
   });
 


### PR DESCRIPTION
## What

Main's Windows CI lane (`build-and-test (windows-latest, 22)`) went red on `@harness-engineering/orchestrator#test`: a single test in `adaptive-router.privacy-boundary.test.ts` failed with `expected [] to have a length of 1 but got +0`.

## Root cause

The `PrivacyNoMatch → routing:no-tier-match` escalation tests waited for the **async** escalation push with a hand-rolled fixed poll (`50×5ms` = 250ms). On a slow/loaded runner that budget is too tight — the file's per-test `git init && git commit` `execSync` setup alone runs ~16s on the Windows runner (file total ~64s), and the escalation simply had not been queued within 250ms. It reproduces Windows-only because that runner is the slowest; the three sibling tests share the pattern and only the borderline one tripped.

## Fix

Replace the hand-rolled poll with `vi.waitFor` on a 5s budget (10ms interval) in both affected tests. Semantics are preserved — a genuine no-queue regression still fails (it times out), so this hardens timing **without** masking a real defect.

## Verification

- Targeted file green locally under Node 22 (4/4).
- Full pre-push gauntlet passed (build, typecheck, lint, coverage, docs freshness). Never used `--no-verify`.