### PR TITLE
fix(dashboard): drop inaccurate 'read-only' wording on client lane; keep role seed on 503

### DIFF
--- a/.changeset/client-lane-not-read-only.md
+++ b/.changeset/client-lane-not-read-only.md
@@ -1,0 +1,21 @@
+---
+'@harness-engineering/dashboard': patch
+---
+
+Correct the `client` dashboard lane wording and stop dropping the role seed on
+the identity-failure path (follow-up to #1132).
+
+The `client` lane was described as "read-only", but the lanes are
+presentation-only and enforce no authorization — the lane defaults to `/s/roadmap`,
+where a live **Claim** write action (`POST /api/actions/roadmap/claim`) ships.
+The "read-only" wording implied an access guarantee that is not enforced, so it
+is dropped from the lane description and the surrounding comments (client `roles.ts`
+and shared `roles.ts`); the "presentation-only, not a security boundary" caveat
+is kept and reinforced. No behavior change — the Claim button is intentionally
+not hidden by role (that would be half-authorization, which #1132 deliberately
+avoided).
+
+`GET /api/identity` now returns the `role` preference (from
+`HARNESS_DASHBOARD_ROLE`) even on the 503 identity-resolution-failure path, and
+the client `useRole` hook reads the body regardless of status, so an operator's
+role seed is no longer silently dropped when GitHub identity cannot be resolved.

--- a/packages/dashboard/src/client/hooks/useRole.tsx
+++ b/packages/dashboard/src/client/hooks/useRole.tsx
@@ -43,7 +43,9 @@ export function RoleProvider({ children }: { children: ReactNode }) {
     if (storedRole !== null) return; // client preference wins; skip the fetch
     let cancelled = false;
     fetch('/api/identity')
-      .then((res) => (res.ok ? res.json() : null))
+      // The server attaches the role seed even on the 503 identity-failure path,
+      // so parse the body regardless of status to avoid dropping it.
+      .then((res) => res.json().catch(() => null))
       .then((data: { role?: unknown } | null) => {
         if (cancelled) return;
         if (data && isDashboardRole(data.role)) setRoleState(data.role);

--- a/packages/dashboard/src/client/types/roles.ts
+++ b/packages/dashboard/src/client/types/roles.ts
@@ -45,7 +45,10 @@ export interface RoleLane {
  * - `dev`    — every page, lands on Signals (unchanged default experience).
  * - `pm-ba`  — Roadmap, Work in Flight, live agents/streams, and the proposal
  *              review queue: author intent, watch agents, adjudicate.
- * - `client` — a curated, read-only pair: Roadmap plus Traceability.
+ * - `client` — a curated pair for progress and traceability: Roadmap plus
+ *              Traceability. Presentation-only, like every lane: it does not
+ *              enforce read-only access (a Claim write action still ships on
+ *              the Roadmap page).
  */
 export const ROLE_LANES: Record<DashboardRole, RoleLane> = {
   dev: {
@@ -65,7 +68,7 @@ export const ROLE_LANES: Record<DashboardRole, RoleLane> = {
   client: {
     role: 'client',
     label: 'Client',
-    description: 'A curated, read-only view of progress and traceability.',
+    description: 'A curated view of progress and traceability.',
     pages: ['roadmap', 'traceability'],
     defaultRoute: '/s/roadmap',
   },

--- a/packages/dashboard/src/server/routes/actions.ts
+++ b/packages/dashboard/src/server/routes/actions.ts
@@ -470,11 +470,14 @@ async function handleClaim(c: Context, ctx: ServerContext): Promise<Response> {
 
 async function handleIdentity(c: Context): Promise<Response> {
   const identity = await resolveIdentity();
+  // The presentation-only role preference (default `dev`) rides along even when
+  // identity resolution fails, so an operator's `HARNESS_DASHBOARD_ROLE` seed
+  // isn't silently dropped on the 503 path.
+  const role = resolveRole();
   if (!identity) {
-    return c.json({ error: 'Could not resolve GitHub identity' }, 503);
+    return c.json({ error: 'Could not resolve GitHub identity', role }, 503);
   }
-  // Attach the presentation-only role preference (default `dev`).
-  return c.json({ ...identity, role: resolveRole() });
+  return c.json({ ...identity, role });
 }
 
 export function buildActionsRouter(ctx: ServerContext): Hono {

--- a/packages/dashboard/src/shared/roles.ts
+++ b/packages/dashboard/src/shared/roles.ts
@@ -14,7 +14,8 @@
  * - `dev`    — the full operator surface (default; unchanged behavior).
  * - `pm-ba`  — product / business-analyst lane: author intent, watch agents,
  *              adjudicate at decision points.
- * - `client` — a curated, read-only lane.
+ * - `client` — a curated lane for progress and traceability (presentation-only,
+ *              like every lane — not a read-only access guarantee).
  */
 export type DashboardRole = 'dev' | 'pm-ba' | 'client';
 

--- a/packages/dashboard/tests/client/types/roles.test.ts
+++ b/packages/dashboard/tests/client/types/roles.test.ts
@@ -54,7 +54,7 @@ describe('role → visible-pages mapping', () => {
     expect(pages).not.toContain('local-models');
   });
 
-  it('client sees only the curated read-only pair', () => {
+  it('client sees only the curated pair', () => {
     const pages = pagesForRole('client').map((e) => e.page);
     expect(pages).toEqual(['roadmap', 'traceability']);
   });

--- a/packages/dashboard/tests/server/routes/actions-claim.test.ts
+++ b/packages/dashboard/tests/server/routes/actions-claim.test.ts
@@ -297,9 +297,14 @@ describe('GET /api/identity', () => {
     const { resolveIdentity } = await import('../../../src/server/identity');
     vi.mocked(resolveIdentity).mockResolvedValueOnce(null);
 
+    const { resolveRole } = await import('../../../src/server/identity');
+    vi.mocked(resolveRole).mockReturnValueOnce('client');
+
     const res = await app.request('/api/identity');
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.error).toBeDefined();
+    // The role seed rides along even on failure so it isn't silently dropped.
+    expect(body.role).toBe('client');
   });
 });


### PR DESCRIPTION
## What

Post-merge follow-up to #1132 (role-shaped dashboard lanes). Two small, low-risk fixes.

### 1. Drop the inaccurate "read-only" wording on the `client` lane (the finding)

The `client` navigation lane was described as **read-only** (`packages/dashboard/src/client/types/roles.ts` lane `description` + comments, and the shared `packages/dashboard/src/shared/roles.ts` comment). But the lanes are **presentation-only and enforce no authorization** — the `client` lane lands on `/s/roadmap`, where a live **Claim** write action (`POST /api/actions/roadmap/claim`) ships. So "read-only" implied an access guarantee that isn't enforced.

- Removed "read-only" from the lane `description` -> now `'A curated view of progress and traceability.'`
- Aligned the surrounding comments in both `client/types/roles.ts` and `shared/roles.ts`, keeping (and reinforcing) the "presentation-only, not a security boundary" caveat.
- Updated the one test title that used the "read-only" phrasing.

**This is a wording fix only.** The Claim button is deliberately **not** hidden by role — that would introduce half-authorization, which #1132 intentionally avoided. No behavior change.

### 2. Keep the role seed on the identity-failure path (reviewer suggestion #2)

`GET /api/identity` previously returned `role` only on success; on the 503 identity-resolution-failure path the operator's `HARNESS_DASHBOARD_ROLE` seed was silently dropped. The client `useRole` hook also gated on `res.ok`, so even a returned role would have been discarded.

- Server (`actions.ts`): `role` (from `resolveRole()`) now rides along on the 503 body too.
- Client (`useRole.tsx`): parses the body regardless of HTTP status, so the seed survives an identity-resolution failure.

## Testing

- `packages/dashboard`: full vitest suite green (918 tests), `tsc --noEmit` clean, `eslint src` clean, server + client builds succeed.
- Added a 503-path assertion that `role` rides along; retitled the client-lane test.

## Changeset

`@harness-engineering/dashboard` patch.
