### PR TITLE
fix(craft): stop code-craft / cli-ergonomics-craft / api-craft silently no-opping in default (in-session) mode

### DIFF
--- a/.changeset/fix-craft-in-session-no-op.md
+++ b/.changeset/fix-craft-in-session-no-op.md
@@ -1,0 +1,36 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Fix a silent no-op in `code-craft`, `cli-ergonomics-craft`, and `api-craft` when
+run in their default (in-session) runtime mode.
+
+The default LLM provider for the craft family is the in-session provider: rather
+than call an LLM, it records each prompt and throws a deferral sentinel so the
+host chat session can answer the prompts and feed them back through a second
+`<skill>_finalize` step. `naming-craft` already implemented this two-step
+collect → finalize flow, but the three skills above swallowed the deferral in a
+bare `catch {}` and never surfaced the collected prompts. The result was that a
+default-mode invocation returned zero findings and exited successfully — a silent
+lie that looked like a clean pass.
+
+These three skills now implement the real two-step flow, mirroring
+`naming-craft`:
+
+- Each orchestrator gains `collect<Skill>Prompts` (walks the target, builds one
+  prompt per unit/command/surface × rubric, persists run-state, and returns the
+  prompts) and `finalize<Skill>` (stitches the host's answers back into findings
+  through the same parser the inline path uses).
+- The inline entry points (`runCodeCraft`, `runCliErgonomicsCraft`,
+  `runApiCraft`) now fail loudly with guidance when handed the in-session
+  provider instead of returning an empty result.
+- Three new MCP tools — `code_craft_finalize`, `cli_ergonomics_craft_finalize`,
+  and `api_craft_finalize` — complete the flow, and the three primary tools now
+  route to the collect step in in-session mode (raising the harness MCP tool
+  count to 101).
+
+Also closes two `code-craft` discovery gaps: it now falls back to conventional
+`src/` (then `app/`) roots when a project has no `packages/` directory — so a
+single-package repo is no longer scanned as empty — and excludes `fixtures/`
+directories from the walk, matching its `cli-ergonomics-craft` and `api-craft`
+twins.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-06T10:54:50.081Z",
-  "updatedFrom": "a42b4f2fb",
+  "updatedAt": "2026-08-06T12:50:36.882Z",
+  "updatedFrom": "4cc1e4e94",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 309,
+      "value": 312,
       "violationIds": [
         "007f01231e26e527dfaa5a251c21e9a18b0abc300ad8d49258b910f878f23cdf",
         "015dadca6008b916e11c3fc7d66f1420c0baa06f714552b7ad770d761fd7ec25",
@@ -96,6 +96,7 @@
         "419a39cb804c5061655023d2390a5d486eba2cf5edf98f5e27e68a2fd4afe783",
         "422dc24e7dc8fed88521575812507be84721e3b1b2604e21d1e417c34f38a968",
         "432f245d913de81ce171107dcdf78e26ab3e1450a7e3683c423e8c9ba27fffac",
+        "4342852fc18c2b36c6753fb647bcc03612c4ce4b89c230813924ce76f056a761",
         "4469bd6136884e05febc86f0d3416404fba4bae522bca8a3a2369972dbb16c4b",
         "46c361684a59b82307f50f76b0be8d39c91b0c89c8db2d7b74d645a25916eebd",
         "47867c80d92ffe6a3a1c03ccc7fdba0107d3fd77f62ce6b30bcfd88aa06d1ce1",
@@ -155,6 +156,7 @@
         "7b18f09a2a450303874b20e9759bdac0d1960cfb3ec3182519648c4d1c25f623",
         "7baa243ac2a933607d522793ba56af71df573c79ae1b97bd24ee635d6d5866ed",
         "7c57e5529dc70cf717c2556d5054de71cc6ad6aa272fbcaef4be5e9a54211db7",
+        "7caf2390b170086fcef54a50ef4296fe15ee2ce803b8487fee999d8a0024f843",
         "7e95d1c210b561bc6e7b0638266ff0b1338010d6fa88d6ac1e81fd5e4ca9d411",
         "7ec6a8af3618b317636bde30b82e7832a68544f00d7af4886ce40c759976cb63",
         "7fcaaa19a78a7ad778e4ea42a6db2421b60dcb59d05ef91b884f8db17cf795cb",
@@ -256,6 +258,7 @@
         "ce5b302b655a4cb5997a257394d22c75d5cb98f0853bc88b1e3e30549eee21be",
         "cebc590192eaac96517596c710f8492c08d4bc4eab691acc1083782fefbe04d8",
         "cf40463a6e9901bdddc4a5554843ed8cdb8cc5548189dd7c4c5e0b6e7b2632e2",
+        "d0180f42fb8cc60b38094213f5e16e902c543ecdc6fd2ba17ce8299361444389",
         "d02a85dc576ff12b588dfa879911ec09b930c90188410c55b594ff13ea132033",
         "d05b4ea444dfda6ac796cbcd56c19b1a8304c2ff40f620c9f1f036cedd14d91a",
         "d432098418726bd991e6ec0419ad0e83689249d16b0bec2410b154db397c2d31",
@@ -321,7 +324,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 216580,
+      "value": 219615,
       "violationIds": [
         "14c3c7cf4350a3212158ff69554ef83629eb26d75ffaf4d24bbded2841aa58ad",
         "4d6965066aaca1a3553a39fac1fb531ec9ecb47395a5a4420adbd066d367c3b6",

--- a/agents/skills/claude-code/api-craft/SKILL.md
+++ b/agents/skills/claude-code/api-craft/SKILL.md
@@ -84,7 +84,8 @@ Emit `ApiCraftOutput`:
 ## Harness Integration
 
 - **`harness api-craft`** — CLI entry. `--files <glob>` / `--routes-dir <dir>` / `--spec-file <file>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__api_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__api_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__api_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueApiSurfaceFile(file, opts)` exported from `packages/cli/src/api-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single spec or route file without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; security-craft owns trust-boundary and least-authority critique; the rule-based API floor owns OpenAPI/webhook format compliance. api-craft owns the SHAPE of the API contract — resource modeling, naming, verbs, status codes, error contracts, response shapes, pagination, idempotency, and compatible evolution.

--- a/agents/skills/claude-code/cli-ergonomics-craft/SKILL.md
+++ b/agents/skills/claude-code/cli-ergonomics-craft/SKILL.md
@@ -80,10 +80,24 @@ Emit `CliErgonomicsCraftOutput`:
 ## Harness Integration
 
 - **`harness cli-ergonomics-craft`** — CLI entry. `--files <glob>` / `--commands-dir <dir>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__cli_ergonomics_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCommandFile(file, opts)` exported from `packages/cli/src/cli-ergonomics-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single command without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; docs-craft owns authored teaching prose. cli-ergonomics-craft owns the shape of the command surface — names, help structure, defaults, output contract, and destructive-action guards.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It discovers the command definitions, builds one prompt per (command, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__cli_ergonomics_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with a smaller `maxFiles`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior CLI/developer-experience engineer applying the rubric to the command: a fenced `null` block if the rubric does not apply or the command already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "a critique naming the specific command/flag/handler and a concrete suggested change" }`.
+
+**Step 3 — `mcp__harness__cli_ergonomics_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CliErgonomicsCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness cli-ergonomics-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/agents/skills/claude-code/code-craft/SKILL.md
+++ b/agents/skills/claude-code/code-craft/SKILL.md
@@ -85,10 +85,24 @@ Emit `CodeCraftOutput`:
 ## Harness Integration
 
 - **`harness code-craft`** — CLI entry. `--files <glob>` / `--packages <names...>` / `--max-files <n>` / `--max-units-per-file <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__code_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__code_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__code_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCodeInFile(file, opts)` exported from `packages/cli/src/code-craft/index.ts`. Returns `[]` for files with no substantive unit (consistent with the orchestrator's skip strategy).
 - **Naming reuse (not duplication):** identifier-level naming critique is `harness-naming-craft`'s territory. code-craft re-exports its single-file entry (`critiqueNamesInFile`) so a consumer that wants both structural and naming critique imports one module; CODE-R006 fires only on signature-shape dishonesty.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It walks the project, builds one prompt per (unit, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__code_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxUnitsPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the unit: a fenced `null` block if the rubric does not apply or the unit already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "<critique naming the specific construct and a concrete suggested revision>" }`.
+
+**Step 3 — `mcp__harness__code_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CodeCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness code-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/agents/skills/codex/api-craft/SKILL.md
+++ b/agents/skills/codex/api-craft/SKILL.md
@@ -84,7 +84,8 @@ Emit `ApiCraftOutput`:
 ## Harness Integration
 
 - **`harness api-craft`** — CLI entry. `--files <glob>` / `--routes-dir <dir>` / `--spec-file <file>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__api_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__api_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__api_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueApiSurfaceFile(file, opts)` exported from `packages/cli/src/api-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single spec or route file without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; security-craft owns trust-boundary and least-authority critique; the rule-based API floor owns OpenAPI/webhook format compliance. api-craft owns the SHAPE of the API contract — resource modeling, naming, verbs, status codes, error contracts, response shapes, pagination, idempotency, and compatible evolution.

--- a/agents/skills/codex/cli-ergonomics-craft/SKILL.md
+++ b/agents/skills/codex/cli-ergonomics-craft/SKILL.md
@@ -80,10 +80,24 @@ Emit `CliErgonomicsCraftOutput`:
 ## Harness Integration
 
 - **`harness cli-ergonomics-craft`** — CLI entry. `--files <glob>` / `--commands-dir <dir>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__cli_ergonomics_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCommandFile(file, opts)` exported from `packages/cli/src/cli-ergonomics-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single command without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; docs-craft owns authored teaching prose. cli-ergonomics-craft owns the shape of the command surface — names, help structure, defaults, output contract, and destructive-action guards.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It discovers the command definitions, builds one prompt per (command, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__cli_ergonomics_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with a smaller `maxFiles`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior CLI/developer-experience engineer applying the rubric to the command: a fenced `null` block if the rubric does not apply or the command already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "a critique naming the specific command/flag/handler and a concrete suggested change" }`.
+
+**Step 3 — `mcp__harness__cli_ergonomics_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CliErgonomicsCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness cli-ergonomics-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/agents/skills/codex/code-craft/SKILL.md
+++ b/agents/skills/codex/code-craft/SKILL.md
@@ -85,10 +85,24 @@ Emit `CodeCraftOutput`:
 ## Harness Integration
 
 - **`harness code-craft`** — CLI entry. `--files <glob>` / `--packages <names...>` / `--max-files <n>` / `--max-units-per-file <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__code_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__code_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__code_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCodeInFile(file, opts)` exported from `packages/cli/src/code-craft/index.ts`. Returns `[]` for files with no substantive unit (consistent with the orchestrator's skip strategy).
 - **Naming reuse (not duplication):** identifier-level naming critique is `harness-naming-craft`'s territory. code-craft re-exports its single-file entry (`critiqueNamesInFile`) so a consumer that wants both structural and naming critique imports one module; CODE-R006 fires only on signature-shape dishonesty.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It walks the project, builds one prompt per (unit, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__code_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxUnitsPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the unit: a fenced `null` block if the rubric does not apply or the unit already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "<critique naming the specific construct and a concrete suggested revision>" }`.
+
+**Step 3 — `mcp__harness__code_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CodeCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness code-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/agents/skills/cursor/api-craft/SKILL.md
+++ b/agents/skills/cursor/api-craft/SKILL.md
@@ -84,7 +84,8 @@ Emit `ApiCraftOutput`:
 ## Harness Integration
 
 - **`harness api-craft`** — CLI entry. `--files <glob>` / `--routes-dir <dir>` / `--spec-file <file>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__api_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__api_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__api_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueApiSurfaceFile(file, opts)` exported from `packages/cli/src/api-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single spec or route file without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; security-craft owns trust-boundary and least-authority critique; the rule-based API floor owns OpenAPI/webhook format compliance. api-craft owns the SHAPE of the API contract — resource modeling, naming, verbs, status codes, error contracts, response shapes, pagination, idempotency, and compatible evolution.

--- a/agents/skills/cursor/cli-ergonomics-craft/SKILL.md
+++ b/agents/skills/cursor/cli-ergonomics-craft/SKILL.md
@@ -80,10 +80,24 @@ Emit `CliErgonomicsCraftOutput`:
 ## Harness Integration
 
 - **`harness cli-ergonomics-craft`** — CLI entry. `--files <glob>` / `--commands-dir <dir>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__cli_ergonomics_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCommandFile(file, opts)` exported from `packages/cli/src/cli-ergonomics-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single command without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; docs-craft owns authored teaching prose. cli-ergonomics-craft owns the shape of the command surface — names, help structure, defaults, output contract, and destructive-action guards.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It discovers the command definitions, builds one prompt per (command, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__cli_ergonomics_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with a smaller `maxFiles`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior CLI/developer-experience engineer applying the rubric to the command: a fenced `null` block if the rubric does not apply or the command already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "a critique naming the specific command/flag/handler and a concrete suggested change" }`.
+
+**Step 3 — `mcp__harness__cli_ergonomics_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CliErgonomicsCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness cli-ergonomics-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/agents/skills/cursor/code-craft/SKILL.md
+++ b/agents/skills/cursor/code-craft/SKILL.md
@@ -85,10 +85,24 @@ Emit `CodeCraftOutput`:
 ## Harness Integration
 
 - **`harness code-craft`** — CLI entry. `--files <glob>` / `--packages <names...>` / `--max-files <n>` / `--max-units-per-file <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__code_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__code_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__code_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCodeInFile(file, opts)` exported from `packages/cli/src/code-craft/index.ts`. Returns `[]` for files with no substantive unit (consistent with the orchestrator's skip strategy).
 - **Naming reuse (not duplication):** identifier-level naming critique is `harness-naming-craft`'s territory. code-craft re-exports its single-file entry (`critiqueNamesInFile`) so a consumer that wants both structural and naming critique imports one module; CODE-R006 fires only on signature-shape dishonesty.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It walks the project, builds one prompt per (unit, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__code_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxUnitsPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the unit: a fenced `null` block if the rubric does not apply or the unit already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "<critique naming the specific construct and a concrete suggested revision>" }`.
+
+**Step 3 — `mcp__harness__code_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CodeCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness code-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/agents/skills/gemini-cli/api-craft/SKILL.md
+++ b/agents/skills/gemini-cli/api-craft/SKILL.md
@@ -84,7 +84,8 @@ Emit `ApiCraftOutput`:
 ## Harness Integration
 
 - **`harness api-craft`** — CLI entry. `--files <glob>` / `--routes-dir <dir>` / `--spec-file <file>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__api_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__api_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__api_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueApiSurfaceFile(file, opts)` exported from `packages/cli/src/api-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single spec or route file without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; security-craft owns trust-boundary and least-authority critique; the rule-based API floor owns OpenAPI/webhook format compliance. api-craft owns the SHAPE of the API contract — resource modeling, naming, verbs, status codes, error contracts, response shapes, pagination, idempotency, and compatible evolution.

--- a/agents/skills/gemini-cli/cli-ergonomics-craft/SKILL.md
+++ b/agents/skills/gemini-cli/cli-ergonomics-craft/SKILL.md
@@ -80,10 +80,24 @@ Emit `CliErgonomicsCraftOutput`:
 ## Harness Integration
 
 - **`harness cli-ergonomics-craft`** — CLI entry. `--files <glob>` / `--commands-dir <dir>` / `--exclude-dirs <dirs...>` / `--max-files <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__cli_ergonomics_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__cli_ergonomics_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCommandFile(file, opts)` exported from `packages/cli/src/cli-ergonomics-craft/index.ts`. Another craft skill (or an orchestrator) can critique a single command without re-walking the project.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
 - **Sibling boundaries:** copy-craft owns error-message and log prose; docs-craft owns authored teaching prose. cli-ergonomics-craft owns the shape of the command surface — names, help structure, defaults, output contract, and destructive-action guards.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It discovers the command definitions, builds one prompt per (command, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__cli_ergonomics_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with a smaller `maxFiles`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior CLI/developer-experience engineer applying the rubric to the command: a fenced `null` block if the rubric does not apply or the command already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "a critique naming the specific command/flag/handler and a concrete suggested change" }`.
+
+**Step 3 — `mcp__harness__cli_ergonomics_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CliErgonomicsCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness cli-ergonomics-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/agents/skills/gemini-cli/code-craft/SKILL.md
+++ b/agents/skills/gemini-cli/code-craft/SKILL.md
@@ -85,10 +85,24 @@ Emit `CodeCraftOutput`:
 ## Harness Integration
 
 - **`harness code-craft`** — CLI entry. `--files <glob>` / `--packages <names...>` / `--max-files <n>` / `--max-units-per-file <n>` / `--json` / `--verbose`. Exits non-zero when any `foundational`-tier finding is present.
-- **`mcp__harness__code_craft`** — MCP tool. Same input/output. Consumed by agents.
+- **`mcp__harness__code_craft`** — MCP tool. Two modes (see "In-session flow" below).
+- **`mcp__harness__code_craft_finalize`** — MCP tool that completes the in-session flow.
 - **Cross-cutting API:** `critiqueCodeInFile(file, opts)` exported from `packages/cli/src/code-craft/index.ts`. Returns `[]` for files with no substantive unit (consistent with the orchestrator's skip strategy).
 - **Naming reuse (not duplication):** identifier-level naming critique is `harness-naming-craft`'s territory. code-craft re-exports its single-file entry (`critiqueNamesInFile`) so a consumer that wants both structural and naming critique imports one module; CODE-R006 fires only on signature-shape dishonesty.
 - **Shared craft infrastructure:** `LlmProvider`, `MockLlmProvider`, `derivePriority`, and the 3-axis types all live in `packages/cli/src/shared/craft/`.
+- **LLM provider:** configured in `harness.config.json` under `craft.llm` (`{ "backend": "<name>" }` for one of `agent.backends`, or `{ "mode": "in-session" | "mock" }`). Default when nothing is set: `in-session` (host chat answers prompts via the two-step MCP flow). `HARNESS_CRAFT_LLM` overrides the file (`in-session`, `mock`, or a backend name).
+
+## In-session flow (default)
+
+When `HARNESS_CRAFT_LLM` is unset (or set to `in-session`), the MCP tool does **not** call any LLM. It walks the project, builds one prompt per (unit, rubric) pair, and returns them for the calling agent to answer with its own model. This is a two-step protocol — skipping step 3 leaves you with prompts, never findings.
+
+**Step 1 — `mcp__harness__code_craft({ path, ... })`** returns `{ "status": "collected", "runId": "<uuid>", "pendingPrompts": [{ "promptId", "systemPrompt", "userPrompt" }, ...], "projection": { "promptCount": N, "budget": 100 } }`. If `projection.promptCount > budget`, `status` is `"budget-exceeded"` and `pendingPrompts` is empty — re-invoke with smaller `maxFiles` / `maxUnitsPerFile`, or pass `promptBudget` to raise the ceiling.
+
+**Step 2** — for each pending prompt, generate the fenced-JSON response as if you were a senior engineer applying the rubric to the unit: a fenced `null` block if the rubric does not apply or the unit already clears the bar, otherwise a fenced block of `{ "tier": "foundational|polish|aspirational", "impact": "small|medium|large", "confidence": "high|medium|low", "message": "<critique naming the specific construct and a concrete suggested revision>" }`.
+
+**Step 3 — `mcp__harness__code_craft_finalize({ path, runId, responses: [{ promptId, raw }, ...] })`** parses the responses through the same validation the inline path uses and returns the standard `CodeCraftOutput`.
+
+If you want inline behavior (the skill calls an LLM directly), pass `mode: 'inline'` to step 1 and set `HARNESS_CRAFT_LLM` to a non-`in-session` provider. Running the CLI (`harness code-craft`) under the default in-session provider fails loudly with this guidance rather than returning an empty result.
 
 ## Success Criteria
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -122,7 +122,7 @@ Validate STRATEGY.md at the project root. Returns { present, valid, error? }. So
 
 ### `code_craft`
 
-LLM-judgment critique of code quality / readability — the ceiling counterpart to the rule-based code floor (entropy-cleaner for dead code / drift, enforce-architecture for boundaries + deps, complexity thresholds). Asks the ceiling questions: does the code reveal intent and read in the domain’s language, is the control flow honest, does the function tell one story at one altitude, does each abstraction earn its keep, is this as simple as it could be, does the signature keep its promise, would a senior nod or wince. Walks `packages/<pkg>/src`, extracts substantive units (functions, methods, classes) via the TS Compiler API, and critiques each against 7 seed rubrics; files with no substantive unit are skipped. A small curated exemplar set (Anthropic SDK / TanStack Query / ky / SWR / date-fns) anchors the catalog. Identifier-level naming is delegated to `naming_craft`. Emits 3-axis findings (tier x impact x confidence per ADR 0019). Structural twin of `security_craft`.
+LLM-judgment critique of code quality / readability — the ceiling counterpart to the rule-based code floor (entropy-cleaner for dead code / drift, enforce-architecture for boundaries + deps, complexity thresholds). Asks the ceiling questions: does the code reveal intent and read in the domain’s language, is the control flow honest, does the function tell one story at one altitude, does each abstraction earn its keep, is this as simple as it could be, does the signature keep its promise, would a senior nod or wince. Walks `packages/<pkg>/src` (falling back to `src`/`app` for single-package repos), extracts substantive units (functions, methods, classes) via the TS Compiler API, and critiques each against 7 seed rubrics; files with no substantive unit are skipped. A small curated exemplar set (Anthropic SDK / TanStack Query / ky / SWR / date-fns) anchors the catalog. Identifier-level naming is delegated to `naming_craft`. Emits 3-axis findings (tier x impact x confidence per ADR 0019). Structural twin of `security_craft`. In-session mode (default in Claude Code) returns prompts for the calling agent to answer; call code_craft_finalize with the responses to get findings.
 
 **Parameters:**
 
@@ -131,6 +131,18 @@ LLM-judgment critique of code quality / readability — the ceiling counterpart 
 - `packages` (array, optional) — Restrict to specific packages under packages/
 - `maxFiles` (number, optional) — Cap source-file count (default: 100)
 - `maxUnitsPerFile` (number, optional) — Cap per-file unit critique (default: 20)
+- `mode` (string, optional) — 'in-session' (default): return prompts for the calling agent to answer, then call code_craft_finalize. 'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).
+- `promptBudget` (number, optional) — Cap prompt count in in-session mode (default: 100)
+
+### `code_craft_finalize`
+
+Finalize a code_craft in-session run by submitting the calling agent's responses to the prompts collected by code_craft. Returns the standard CodeCraftOutput with findings.
+
+**Parameters:**
+
+- `path` (string, required) — Project root path used in the collect call (must match)
+- `runId` (string, required) — runId returned by the code_craft collect call
+- `responses` (array, required) — Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.
 
 ### `code_outline`
 
@@ -432,7 +444,7 @@ Parse a git diff and check for forbidden patterns, oversized files, and missing 
 
 ### `api_craft`
 
-LLM-judgment critique of API quality — the ceiling counterpart to rule-based API checks (OpenAPI-format and webhook-format compliance). Asks the ceiling questions a linter cannot: do resources model the domain rather than the implementation, is the resource naming and URL structure predictable (path vs query param), are HTTP methods honest, are status codes correct, do error responses tell the consumer what to do, are response shapes predictable and consistent, do collections paginate and filter consistently, are mutations idempotency-honest, and does the API evolve without breaking consumers. Discovers a project’s own API surface — OpenAPI/Swagger documents and route/handler definitions — and critiques each per file. 9 seed rubrics; a curated exemplar set (Stripe / Linear / GitHub / Resend / Anthropic) anchors the catalog. Emits 3-axis findings (tier x impact x confidence per ADR 0019). Structural twin of cli_ergonomics_craft.
+LLM-judgment critique of API quality — the ceiling counterpart to rule-based API checks (OpenAPI-format and webhook-format compliance). Asks the ceiling questions a linter cannot: do resources model the domain rather than the implementation, is the resource naming and URL structure predictable (path vs query param), are HTTP methods honest, are status codes correct, do error responses tell the consumer what to do, are response shapes predictable and consistent, do collections paginate and filter consistently, are mutations idempotency-honest, and does the API evolve without breaking consumers. Discovers a project’s own API surface — OpenAPI/Swagger documents and route/handler definitions — and critiques each per file. 9 seed rubrics; a curated exemplar set (Stripe / Linear / GitHub / Resend / Anthropic) anchors the catalog. Emits 3-axis findings (tier x impact x confidence per ADR 0019). Structural twin of cli_ergonomics_craft. In-session mode (default in Claude Code) returns prompts for the calling agent to answer; call api_craft_finalize with the responses to get findings.
 
 **Parameters:**
 
@@ -442,6 +454,18 @@ LLM-judgment critique of API quality — the ceiling counterpart to rule-based A
 - `specFile` (string, optional) — Explicit OpenAPI/Swagger document to critique
 - `excludeDirs` (array, optional) — Extra subdir names to skip while walking
 - `maxFiles` (number, optional) — Cap surface count (default: 60)
+- `mode` (string, optional) — 'in-session' (default): return prompts for the calling agent to answer, then call api_craft_finalize. 'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).
+- `promptBudget` (number, optional) — Cap prompt count in in-session mode (default: 100)
+
+### `api_craft_finalize`
+
+Finalize an api_craft in-session run by submitting the calling agent's responses to the prompts collected by api_craft. Returns the standard ApiCraftOutput with findings.
+
+**Parameters:**
+
+- `path` (string, required) — Project root path used in the collect call (must match)
+- `runId` (string, required) — runId returned by the api_craft collect call
+- `responses` (array, required) — Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.
 
 ### `audit_anatomy`
 
@@ -481,7 +505,7 @@ Classify a test prompt with canary and recommend a framework (deterministic, no 
 
 ### `cli_ergonomics_craft`
 
-LLM-judgment critique of CLI ergonomics quality — the ceiling counterpart to mechanical CLI checks, and the only craft skill with no rule-based floor twin (a linter can verify a flag is documented, but not whether the name is predictable or the error says what to do next). Asks the ceiling questions: are command and flag names predictable and consistent, is help text task-oriented, are errors actionable, are defaults sane and safe, is output scannable and terminal-aware, does the CLI compose (pipeable, machine-readable, honest exit codes), are destructive actions guarded. 7 seed rubrics; a small curated exemplar set (gh / cargo / ripgrep / docker / Stripe CLI) anchors the catalog. Critiques a project’s own command definitions per file. Emits 3-axis findings (tier x impact x confidence per ADR 0019). Structural twin of docs_craft.
+LLM-judgment critique of CLI ergonomics quality — the ceiling counterpart to mechanical CLI checks, and the only craft skill with no rule-based floor twin (a linter can verify a flag is documented, but not whether the name is predictable or the error says what to do next). Asks the ceiling questions: are command and flag names predictable and consistent, is help text task-oriented, are errors actionable, are defaults sane and safe, is output scannable and terminal-aware, does the CLI compose (pipeable, machine-readable, honest exit codes), are destructive actions guarded. 7 seed rubrics; a small curated exemplar set (gh / cargo / ripgrep / docker / Stripe CLI) anchors the catalog. Critiques a project’s own command definitions per file. Emits 3-axis findings (tier x impact x confidence per ADR 0019). Structural twin of docs_craft. In-session mode (default in Claude Code) returns prompts for the calling agent to answer; call cli_ergonomics_craft_finalize with the responses to get findings.
 
 **Parameters:**
 
@@ -490,6 +514,18 @@ LLM-judgment critique of CLI ergonomics quality — the ceiling counterpart to m
 - `commandsDir` (string, optional) — Directory of command definitions to critique
 - `excludeDirs` (array, optional) — Extra subdir names to skip while walking
 - `maxFiles` (number, optional) — Cap command count (default: 60)
+- `mode` (string, optional) — 'in-session' (default): return prompts for the calling agent to answer, then call cli_ergonomics_craft_finalize. 'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).
+- `promptBudget` (number, optional) — Cap prompt count in in-session mode (default: 100)
+
+### `cli_ergonomics_craft_finalize`
+
+Finalize a cli_ergonomics_craft in-session run by submitting the calling agent's responses to the prompts collected by cli_ergonomics_craft. Returns the standard CliErgonomicsCraftOutput with findings.
+
+**Parameters:**
+
+- `path` (string, required) — Project root path used in the collect call (must match)
+- `runId` (string, required) — runId returned by the cli_ergonomics_craft collect call
+- `responses` (array, required) — Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.
 
 ### `compact`
 

--- a/packages/cli/src/api-craft/index.ts
+++ b/packages/cli/src/api-craft/index.ts
@@ -18,16 +18,34 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { sanitizePath } from '../mcp/utils/sanitize-path.js';
-import { getProvider, type LlmProvider } from '../shared/craft/llm/provider.js';
+import {
+  getProvider,
+  InSessionLlmProvider,
+  type LlmProvider,
+} from '../shared/craft/llm/provider.js';
+import {
+  saveRunState,
+  loadRunState,
+  deleteRunState,
+  pruneOldRuns,
+} from '../shared/craft/runs/store.js';
 import {
   discoverApiSurfaces,
   classifyApiSurface,
   type DiscoveredApiSurface,
 } from './extract/discover.js';
-import { rubricsForKind } from './catalog/rubrics/index.js';
+import { rubricsForKind, SEED_RUBRICS } from './catalog/rubrics/index.js';
+import type { ApiSurfaceKind } from './catalog/rubrics/index.js';
 import { SEED_EXEMPLARS } from './catalog/exemplars/index.js';
-import { critiqueOne } from './phases/critique.js';
+import {
+  critiqueOne,
+  buildPrompt,
+  parseFindingFromRaw,
+  CRITIQUE_SYSTEM_PROMPT,
+} from './phases/critique.js';
 import type { ApiCraftOutput, ApiFinding } from './findings/schema.js';
+
+export type ApiCraftMode = 'inline' | 'in-session';
 
 export interface ApiCraftInput {
   path: string;
@@ -36,11 +54,53 @@ export interface ApiCraftInput {
   specFile?: string;
   excludeDirs?: string[];
   maxFiles?: number;
+  /** Two-step flow toggle. Defaults follow provider: in-session if env says so, else inline. */
+  mode?: ApiCraftMode;
   /** Test-only LLM provider override. */
   __testProvider?: LlmProvider;
 }
 
 const DEFAULT_MAX_FILES = 60;
+/** Projected-cost guard: max prompts collected before bailing. */
+const DEFAULT_PROMPT_BUDGET = 100;
+
+export interface CollectPromptsOutput {
+  status: 'collected' | 'budget-exceeded';
+  runId: string;
+  pendingPrompts: Array<{
+    promptId: string;
+    systemPrompt: string;
+    userPrompt: string;
+  }>;
+  projection: { promptCount: number; budget: number };
+  /** Populated when status='budget-exceeded'. */
+  hint?: string;
+  /** Persisted to disk under .harness/craft/runs/<runId>.json. */
+  runFile?: string;
+}
+
+export interface FinalizeApiCraftInput {
+  path: string;
+  runId: string;
+  responses: Array<{ promptId: string; raw: string }>;
+}
+
+/** Skill-specific run-state metadata persisted between collect and finalize. */
+interface ApiRunMeta {
+  projectRoot: string;
+  startedAt: number;
+  rubricsApplied: string[];
+  filesScanned: number;
+  filesSkipped: number;
+  /** Pairs every queued prompt to the data needed to build a finding. */
+  prompts: Array<{
+    promptId: string;
+    file: string;
+    relative: string;
+    kind: ApiSurfaceKind;
+    rubricId: string;
+  }>;
+}
 
 interface RunAccumulator {
   findings: ApiFinding[];
@@ -54,6 +114,14 @@ export async function runApiCraft(input: ApiCraftInput): Promise<ApiCraftOutput>
   const projectRoot = sanitizePath(input.path);
   const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
   const provider = input.__testProvider ?? getProvider();
+
+  if (provider instanceof InSessionLlmProvider) {
+    throw new Error(
+      'runApiCraft is the inline entry point; the in-session provider ' +
+        'requires the two-step flow. Call collectApiCraftPrompts(...) and ' +
+        'then finalizeApiCraft(...), or set HARNESS_CRAFT_LLM=mock for tests.'
+    );
+  }
 
   const surfaces = collectSurfaces(projectRoot, input).slice(0, maxFiles);
   const acc: RunAccumulator = {
@@ -70,6 +138,159 @@ export async function runApiCraft(input: ApiCraftInput): Promise<ApiCraftOutput>
   return {
     findings: acc.findings,
     summary: buildSummary(provider, acc, Date.now() - startedAt),
+  };
+}
+
+/**
+ * Step 1 of the two-step in-session flow. Discovers the project's API
+ * surfaces, builds one prompt per (surface, rubric) pair, persists
+ * run-state, and returns the prompts for the calling agent to answer.
+ * No LLM is called.
+ */
+export async function collectApiCraftPrompts(
+  input: ApiCraftInput & { promptBudget?: number }
+): Promise<CollectPromptsOutput> {
+  const projectRoot = sanitizePath(input.path);
+  const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
+  const budget = input.promptBudget ?? DEFAULT_PROMPT_BUDGET;
+  const runId = randomUUID();
+
+  const surfaces = collectSurfaces(projectRoot, input).slice(0, maxFiles);
+  const promptRecords: ApiRunMeta['prompts'] = [];
+  const pending: CollectPromptsOutput['pendingPrompts'] = [];
+  const rubricsApplied = new Set<string>();
+  let filesScanned = 0;
+  let filesSkipped = 0;
+
+  outer: for (const surface of surfaces) {
+    let content: string;
+    try {
+      content = fs.readFileSync(surface.file, 'utf-8');
+    } catch {
+      filesSkipped++;
+      continue;
+    }
+    filesScanned++;
+    for (const rubric of rubricsForKind(surface.kind)) {
+      rubricsApplied.add(rubric.id);
+      const promptId = `p${promptRecords.length + 1}`;
+      const userPrompt = buildPrompt({
+        file: surface.file,
+        relative: surface.relative,
+        kind: surface.kind,
+        content,
+        rubric,
+      });
+      promptRecords.push({
+        promptId,
+        file: surface.file,
+        relative: surface.relative,
+        kind: surface.kind,
+        rubricId: rubric.id,
+      });
+      pending.push({ promptId, systemPrompt: CRITIQUE_SYSTEM_PROMPT, userPrompt });
+      if (pending.length > budget) break outer;
+    }
+  }
+
+  if (pending.length > budget) {
+    return {
+      status: 'budget-exceeded',
+      runId,
+      pendingPrompts: [],
+      projection: { promptCount: pending.length, budget },
+      hint:
+        `Projected at least ${pending.length} LLM prompts (budget: ${budget}). ` +
+        'Re-invoke with smaller maxFiles, or pass promptBudget to raise the ceiling.',
+    };
+  }
+
+  const meta: ApiRunMeta = {
+    projectRoot,
+    startedAt: Date.now(),
+    rubricsApplied: [...rubricsApplied].sort(),
+    filesScanned,
+    filesSkipped,
+    prompts: promptRecords,
+  };
+  pruneOldRuns(projectRoot);
+  const { runFile } = saveRunState<ApiRunMeta>(projectRoot, {
+    v: 1,
+    runId,
+    skill: 'api-craft',
+    createdAt: Date.now(),
+    meta,
+  });
+
+  return {
+    status: 'collected',
+    runId,
+    pendingPrompts: pending,
+    projection: { promptCount: pending.length, budget },
+    runFile,
+  };
+}
+
+/**
+ * Step 2 of the two-step in-session flow. Loads run-state, applies the
+ * supplied responses through the same parser the inline path uses, and
+ * returns the final ApiCraftOutput. Deletes run-state on success.
+ */
+export async function finalizeApiCraft(input: FinalizeApiCraftInput): Promise<ApiCraftOutput> {
+  const startedAt = Date.now();
+  const projectRoot = sanitizePath(input.path);
+  const state = loadRunState<ApiRunMeta>(projectRoot, input.runId);
+  if (state === null) {
+    throw new Error(
+      `api-craft: no persisted run found for runId=${input.runId} under ${projectRoot}. ` +
+        'Run collectApiCraftPrompts first, or ensure the path matches the project root used at collection time.'
+    );
+  }
+  if (state.skill !== 'api-craft') {
+    throw new Error(
+      `api-craft: runId=${input.runId} belongs to skill ${state.skill}, not api-craft.`
+    );
+  }
+
+  const rubricById = new Map(SEED_RUBRICS.map((r) => [r.id, r]));
+  const promptById = new Map(state.meta.prompts.map((p) => [p.promptId, p]));
+  const findings: ApiFinding[] = [];
+
+  for (const response of input.responses) {
+    const promptRecord = promptById.get(response.promptId);
+    if (promptRecord === undefined) continue;
+    const rubric = rubricById.get(promptRecord.rubricId);
+    if (rubric === undefined) continue;
+    const finding = parseFindingFromRaw(response.raw, {
+      file: promptRecord.file,
+      relative: promptRecord.relative,
+      kind: promptRecord.kind,
+      rubric,
+    });
+    if (finding !== null) findings.push(finding);
+  }
+
+  deleteRunState(projectRoot, input.runId);
+
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: Date.now() - startedAt,
+      llmCalls: {
+        provider: 'in-session',
+        model: 'host-chat',
+        count: input.responses.length,
+        costUsd: 0,
+      },
+      catalog: {
+        rubricsApplied: state.meta.rubricsApplied,
+        exemplarsAvailable: SEED_EXEMPLARS.length,
+      },
+      counts: { filesScanned: state.meta.filesScanned, filesSkipped: state.meta.filesSkipped },
+      runId: input.runId,
+    },
   };
 }
 

--- a/packages/cli/src/api-craft/phases/critique.ts
+++ b/packages/cli/src/api-craft/phases/critique.ts
@@ -20,7 +20,7 @@ const MAX_CONTENT_CHARS = 8000;
 /** Fenced-JSON block extractor, hoisted so its quantifiers don't inflate the parser's complexity. */
 const FENCED_JSON = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/;
 
-const SYSTEM_PROMPT =
+export const CRITIQUE_SYSTEM_PROMPT =
   'You are a senior API designer critiquing a single API surface (an OpenAPI/Swagger document ' +
   'or a route/handler definition) against a single craft rubric. You judge the CEILING — is the ' +
   'endpoint at the right abstraction, is the HTTP verb honest, does the resource name belong in ' +
@@ -50,7 +50,20 @@ export interface CritiqueInput {
 export async function critiqueOne(input: CritiqueInput): Promise<ApiFinding | null> {
   const { file, relative, kind, rubric, provider } = input;
   const prompt = buildPrompt(input);
-  const raw = await provider.callText(prompt, { systemPrompt: SYSTEM_PROMPT });
+  const raw = await provider.callText(prompt, { systemPrompt: CRITIQUE_SYSTEM_PROMPT });
+  return parseFindingFromRaw(raw, { file, relative, kind, rubric });
+}
+
+/**
+ * Parse a raw LLM response (fenced JSON) into an ApiFinding. Returns null
+ * when the response says null / fails validation. Pure — no LLM call — so
+ * the in-session two-step flow can reuse it after the calling agent answers.
+ */
+export function parseFindingFromRaw(
+  raw: string,
+  ctx: { file: string; relative: string; kind: ApiSurfaceKind; rubric: ApiRubric }
+): ApiFinding | null {
+  const { file, relative, kind, rubric } = ctx;
   const parsed = parseFencedJson(raw);
   if (parsed === null) return null;
   if (typeof parsed !== 'object') return null;
@@ -74,7 +87,15 @@ export async function critiqueOne(input: CritiqueInput): Promise<ApiFinding | nu
   };
 }
 
-function buildPrompt(input: CritiqueInput): string {
+export interface BuildPromptInput {
+  file: string;
+  relative: string;
+  kind: ApiSurfaceKind;
+  content: string;
+  rubric: ApiRubric;
+}
+
+export function buildPrompt(input: BuildPromptInput): string {
   const { file, relative, kind, content, rubric } = input;
   const body =
     content.length > MAX_CONTENT_CHARS

--- a/packages/cli/src/cli-ergonomics-craft/index.ts
+++ b/packages/cli/src/cli-ergonomics-craft/index.ts
@@ -13,12 +13,30 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { sanitizePath } from '../mcp/utils/sanitize-path.js';
-import { getProvider, type LlmProvider } from '../shared/craft/llm/provider.js';
+import {
+  getProvider,
+  InSessionLlmProvider,
+  type LlmProvider,
+} from '../shared/craft/llm/provider.js';
+import {
+  saveRunState,
+  loadRunState,
+  deleteRunState,
+  pruneOldRuns,
+} from '../shared/craft/runs/store.js';
 import { discoverCommands, classifyCommand, type DiscoveredCommand } from './extract/discover.js';
-import { rubricsForKind } from './catalog/rubrics/index.js';
+import { rubricsForKind, SEED_RUBRICS } from './catalog/rubrics/index.js';
+import type { CommandKind } from './catalog/rubrics/index.js';
 import { SEED_EXEMPLARS } from './catalog/exemplars/index.js';
-import { critiqueOne } from './phases/critique.js';
+import {
+  critiqueOne,
+  buildPrompt,
+  parseFindingFromRaw,
+  CRITIQUE_SYSTEM_PROMPT,
+} from './phases/critique.js';
 import type { CliErgonomicsCraftOutput, CliErgonomicsFinding } from './findings/schema.js';
+
+export type CliErgonomicsCraftMode = 'inline' | 'in-session';
 
 export interface CliErgonomicsCraftInput {
   path: string;
@@ -26,11 +44,53 @@ export interface CliErgonomicsCraftInput {
   commandsDir?: string;
   excludeDirs?: string[];
   maxFiles?: number;
+  /** Two-step flow toggle. Defaults follow provider: in-session if env says so, else inline. */
+  mode?: CliErgonomicsCraftMode;
   /** Test-only LLM provider override. */
   __testProvider?: LlmProvider;
 }
 
 const DEFAULT_MAX_FILES = 60;
+/** Projected-cost guard: max prompts collected before bailing. */
+const DEFAULT_PROMPT_BUDGET = 100;
+
+export interface CollectPromptsOutput {
+  status: 'collected' | 'budget-exceeded';
+  runId: string;
+  pendingPrompts: Array<{
+    promptId: string;
+    systemPrompt: string;
+    userPrompt: string;
+  }>;
+  projection: { promptCount: number; budget: number };
+  /** Populated when status='budget-exceeded'. */
+  hint?: string;
+  /** Persisted to disk under .harness/craft/runs/<runId>.json. */
+  runFile?: string;
+}
+
+export interface FinalizeCliErgonomicsCraftInput {
+  path: string;
+  runId: string;
+  responses: Array<{ promptId: string; raw: string }>;
+}
+
+/** Skill-specific run-state metadata persisted between collect and finalize. */
+interface CliRunMeta {
+  projectRoot: string;
+  startedAt: number;
+  rubricsApplied: string[];
+  filesScanned: number;
+  filesSkipped: number;
+  /** Pairs every queued prompt to the data needed to build a finding. */
+  prompts: Array<{
+    promptId: string;
+    file: string;
+    relative: string;
+    kind: CommandKind;
+    rubricId: string;
+  }>;
+}
 
 interface RunAccumulator {
   findings: CliErgonomicsFinding[];
@@ -47,6 +107,14 @@ export async function runCliErgonomicsCraft(
   const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
   const provider = input.__testProvider ?? getProvider();
 
+  if (provider instanceof InSessionLlmProvider) {
+    throw new Error(
+      'runCliErgonomicsCraft is the inline entry point; the in-session provider ' +
+        'requires the two-step flow. Call collectCliErgonomicsCraftPrompts(...) and ' +
+        'then finalizeCliErgonomicsCraft(...), or set HARNESS_CRAFT_LLM=mock for tests.'
+    );
+  }
+
   const commands = collectCommands(projectRoot, input).slice(0, maxFiles);
   const acc: RunAccumulator = {
     findings: [],
@@ -62,6 +130,161 @@ export async function runCliErgonomicsCraft(
   return {
     findings: acc.findings,
     summary: buildSummary(provider, acc, Date.now() - startedAt),
+  };
+}
+
+/**
+ * Step 1 of the two-step in-session flow. Walks the project's command
+ * definitions, builds one prompt per (command, rubric) pair, persists
+ * run-state, and returns the prompts for the calling agent to answer.
+ * No LLM is called.
+ */
+export async function collectCliErgonomicsCraftPrompts(
+  input: CliErgonomicsCraftInput & { promptBudget?: number }
+): Promise<CollectPromptsOutput> {
+  const projectRoot = sanitizePath(input.path);
+  const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
+  const budget = input.promptBudget ?? DEFAULT_PROMPT_BUDGET;
+  const runId = randomUUID();
+
+  const commands = collectCommands(projectRoot, input).slice(0, maxFiles);
+  const promptRecords: CliRunMeta['prompts'] = [];
+  const pending: CollectPromptsOutput['pendingPrompts'] = [];
+  const rubricsApplied = new Set<string>();
+  let filesScanned = 0;
+  let filesSkipped = 0;
+
+  outer: for (const command of commands) {
+    let content: string;
+    try {
+      content = fs.readFileSync(command.file, 'utf-8');
+    } catch {
+      filesSkipped++;
+      continue;
+    }
+    filesScanned++;
+    for (const rubric of rubricsForKind(command.kind)) {
+      rubricsApplied.add(rubric.id);
+      const promptId = `p${promptRecords.length + 1}`;
+      const userPrompt = buildPrompt({
+        file: command.file,
+        relative: command.relative,
+        kind: command.kind,
+        content,
+        rubric,
+      });
+      promptRecords.push({
+        promptId,
+        file: command.file,
+        relative: command.relative,
+        kind: command.kind,
+        rubricId: rubric.id,
+      });
+      pending.push({ promptId, systemPrompt: CRITIQUE_SYSTEM_PROMPT, userPrompt });
+      if (pending.length > budget) break outer;
+    }
+  }
+
+  if (pending.length > budget) {
+    return {
+      status: 'budget-exceeded',
+      runId,
+      pendingPrompts: [],
+      projection: { promptCount: pending.length, budget },
+      hint:
+        `Projected at least ${pending.length} LLM prompts (budget: ${budget}). ` +
+        'Re-invoke with smaller maxFiles, or pass promptBudget to raise the ceiling.',
+    };
+  }
+
+  const meta: CliRunMeta = {
+    projectRoot,
+    startedAt: Date.now(),
+    rubricsApplied: [...rubricsApplied].sort(),
+    filesScanned,
+    filesSkipped,
+    prompts: promptRecords,
+  };
+  pruneOldRuns(projectRoot);
+  const { runFile } = saveRunState<CliRunMeta>(projectRoot, {
+    v: 1,
+    runId,
+    skill: 'cli-ergonomics-craft',
+    createdAt: Date.now(),
+    meta,
+  });
+
+  return {
+    status: 'collected',
+    runId,
+    pendingPrompts: pending,
+    projection: { promptCount: pending.length, budget },
+    runFile,
+  };
+}
+
+/**
+ * Step 2 of the two-step in-session flow. Loads run-state, applies the
+ * supplied responses through the same parser the inline path uses, and
+ * returns the final CliErgonomicsCraftOutput. Deletes run-state on success.
+ */
+export async function finalizeCliErgonomicsCraft(
+  input: FinalizeCliErgonomicsCraftInput
+): Promise<CliErgonomicsCraftOutput> {
+  const startedAt = Date.now();
+  const projectRoot = sanitizePath(input.path);
+  const state = loadRunState<CliRunMeta>(projectRoot, input.runId);
+  if (state === null) {
+    throw new Error(
+      `cli-ergonomics-craft: no persisted run found for runId=${input.runId} under ${projectRoot}. ` +
+        'Run collectCliErgonomicsCraftPrompts first, or ensure the path matches the project root used at collection time.'
+    );
+  }
+  if (state.skill !== 'cli-ergonomics-craft') {
+    throw new Error(
+      `cli-ergonomics-craft: runId=${input.runId} belongs to skill ${state.skill}, not cli-ergonomics-craft.`
+    );
+  }
+
+  const rubricById = new Map(SEED_RUBRICS.map((r) => [r.id, r]));
+  const promptById = new Map(state.meta.prompts.map((p) => [p.promptId, p]));
+  const findings: CliErgonomicsFinding[] = [];
+
+  for (const response of input.responses) {
+    const promptRecord = promptById.get(response.promptId);
+    if (promptRecord === undefined) continue;
+    const rubric = rubricById.get(promptRecord.rubricId);
+    if (rubric === undefined) continue;
+    const finding = parseFindingFromRaw(response.raw, {
+      file: promptRecord.file,
+      relative: promptRecord.relative,
+      kind: promptRecord.kind,
+      rubric,
+    });
+    if (finding !== null) findings.push(finding);
+  }
+
+  deleteRunState(projectRoot, input.runId);
+
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: Date.now() - startedAt,
+      llmCalls: {
+        provider: 'in-session',
+        model: 'host-chat',
+        count: input.responses.length,
+        costUsd: 0,
+      },
+      catalog: {
+        rubricsApplied: state.meta.rubricsApplied,
+        exemplarsAvailable: SEED_EXEMPLARS.length,
+      },
+      counts: { filesScanned: state.meta.filesScanned, filesSkipped: state.meta.filesSkipped },
+      runId: input.runId,
+    },
   };
 }
 

--- a/packages/cli/src/cli-ergonomics-craft/phases/critique.ts
+++ b/packages/cli/src/cli-ergonomics-craft/phases/critique.ts
@@ -11,6 +11,15 @@ import { derivePriority } from '../../shared/craft/findings/derived.js';
 
 const MAX_CONTENT_CHARS = 6000;
 
+export const CRITIQUE_SYSTEM_PROMPT =
+  'You are a senior CLI/developer-experience engineer critiquing a single command ' +
+  'definition against a single craft rubric. You judge the CEILING (are names predictable, ' +
+  'does help teach, are errors actionable, are defaults sane, is output scannable, does it ' +
+  'compose, are destructive actions guarded), not the floor (does the flag exist, does the ' +
+  'file compile) — those are handled elsewhere. Reason from the command definition source. ' +
+  'Respond ONLY with a fenced JSON block. If the rubric does not apply or the command ' +
+  'already clears this bar, return `null` (literally the word null inside the JSON block).';
+
 export interface CritiqueInput {
   file: string;
   /** Relative path from the project root for the finding's target.relative. */
@@ -24,16 +33,20 @@ export interface CritiqueInput {
 export async function critiqueOne(input: CritiqueInput): Promise<CliErgonomicsFinding | null> {
   const { file, relative, kind, rubric, provider } = input;
   const prompt = buildPrompt(input);
-  const raw = await provider.callText(prompt, {
-    systemPrompt:
-      'You are a senior CLI/developer-experience engineer critiquing a single command ' +
-      'definition against a single craft rubric. You judge the CEILING (are names predictable, ' +
-      'does help teach, are errors actionable, are defaults sane, is output scannable, does it ' +
-      'compose, are destructive actions guarded), not the floor (does the flag exist, does the ' +
-      'file compile) — those are handled elsewhere. Reason from the command definition source. ' +
-      'Respond ONLY with a fenced JSON block. If the rubric does not apply or the command ' +
-      'already clears this bar, return `null` (literally the word null inside the JSON block).',
-  });
+  const raw = await provider.callText(prompt, { systemPrompt: CRITIQUE_SYSTEM_PROMPT });
+  return parseFindingFromRaw(raw, { file, relative, kind, rubric });
+}
+
+/**
+ * Parse a raw LLM response (fenced JSON) into a CliErgonomicsFinding. Returns
+ * null when the response says null / fails validation. Pure — no LLM call — so
+ * the in-session two-step flow can reuse it after the calling agent answers.
+ */
+export function parseFindingFromRaw(
+  raw: string,
+  ctx: { file: string; relative: string; kind: CommandKind; rubric: CliRubric }
+): CliErgonomicsFinding | null {
+  const { file, relative, kind, rubric } = ctx;
   const parsed = parseFencedJson(raw);
   if (parsed === null) return null;
   if (typeof parsed !== 'object') return null;
@@ -57,7 +70,15 @@ export async function critiqueOne(input: CritiqueInput): Promise<CliErgonomicsFi
   };
 }
 
-function buildPrompt(input: CritiqueInput): string {
+export interface BuildPromptInput {
+  file: string;
+  relative: string;
+  kind: CommandKind;
+  content: string;
+  rubric: CliRubric;
+}
+
+export function buildPrompt(input: BuildPromptInput): string {
   const { file, relative, kind, content, rubric } = input;
   const body =
     content.length > MAX_CONTENT_CHARS

--- a/packages/cli/src/code-craft/extract/discover.ts
+++ b/packages/cli/src/code-craft/extract/discover.ts
@@ -29,7 +29,17 @@ const EXCLUDED_DIRS = new Set([
   'tests', // v1 excludes test files — test quality is test-craft's territory
   'test',
   '__tests__',
+  'fixtures', // test fixtures are not authored production source (twins already exclude this)
 ]);
+
+/**
+ * Fallback source roots (relative to the project root) tried, in order, when a
+ * project has no `packages/` directory. Without this a single-package repo —
+ * the common shape outside a monorepo — reports zero source files, which reads
+ * as a silent clean pass. `src` is the near-universal convention; `app` covers
+ * frameworks (Next.js App Router, some Node services) that root code there.
+ */
+const FALLBACK_SOURCE_ROOTS: ReadonlyArray<string> = ['src', 'app'];
 
 const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/i;
 
@@ -38,7 +48,11 @@ export function discoverSourceFiles(
   packagesFilter?: ReadonlyArray<string>
 ): string[] {
   const packagesDir = path.join(projectRoot, 'packages');
-  if (!fs.existsSync(packagesDir)) return [];
+  if (!fs.existsSync(packagesDir)) {
+    // Not a `packages/` monorepo — fall back to conventional single-package
+    // roots so these projects aren't silently reported as empty.
+    return discoverFallbackRoots(projectRoot);
+  }
   const out: string[] = [];
   let entries: fs.Dirent[];
   try {
@@ -53,6 +67,26 @@ export function discoverSourceFiles(
     const srcDir = path.join(packagesDir, entry.name, 'src');
     if (!fs.existsSync(srcDir)) continue;
     walk(srcDir, out);
+  }
+  return out;
+}
+
+/**
+ * Discover source under conventional single-package roots (`src`, then `app`)
+ * when the project has no `packages/` directory. Walks the first root that
+ * exists as a directory; falls back to the next only when the prior is absent.
+ */
+function discoverFallbackRoots(projectRoot: string): string[] {
+  const out: string[] = [];
+  for (const root of FALLBACK_SOURCE_ROOTS) {
+    const dir = path.join(projectRoot, root);
+    if (!fs.existsSync(dir)) continue;
+    try {
+      if (!fs.statSync(dir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    walk(dir, out);
   }
   return out;
 }

--- a/packages/cli/src/code-craft/index.ts
+++ b/packages/cli/src/code-craft/index.ts
@@ -20,13 +20,30 @@
 import * as fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { sanitizePath } from '../mcp/utils/sanitize-path.js';
-import { getProvider, type LlmProvider } from '../shared/craft/llm/provider.js';
+import {
+  getProvider,
+  InSessionLlmProvider,
+  type LlmProvider,
+} from '../shared/craft/llm/provider.js';
+import {
+  saveRunState,
+  loadRunState,
+  deleteRunState,
+  pruneOldRuns,
+} from '../shared/craft/runs/store.js';
 import { discoverSourceFiles } from './extract/discover.js';
 import { extractUnits } from './extract/units.js';
 import { SEED_RUBRICS, rubricApplies, type CodeRubric } from './catalog/rubrics/index.js';
 import { SEED_EXEMPLARS } from './catalog/exemplars/index.js';
-import { critiqueOne } from './phases/critique.js';
+import {
+  critiqueOne,
+  buildPrompt,
+  parseFindingFromRaw,
+  CRITIQUE_SYSTEM_PROMPT,
+} from './phases/critique.js';
 import type { CodeCraftOutput, CodeFinding, CodeUnit } from './findings/schema.js';
+
+export type CodeCraftMode = 'inline' | 'in-session';
 
 export interface CodeCraftInput {
   path: string;
@@ -34,12 +51,54 @@ export interface CodeCraftInput {
   packages?: string[];
   maxFiles?: number;
   maxUnitsPerFile?: number;
+  /** Two-step flow toggle. Defaults follow provider: in-session if env says so, else inline. */
+  mode?: CodeCraftMode;
   /** Test-only LLM provider override. */
   __testProvider?: LlmProvider;
 }
 
 const DEFAULT_MAX_FILES = 100;
 const DEFAULT_MAX_UNITS_PER_FILE = 20;
+/** Projected-cost guard: max prompts collected before bailing. */
+const DEFAULT_PROMPT_BUDGET = 100;
+
+export interface CollectPromptsOutput {
+  status: 'collected' | 'budget-exceeded';
+  runId: string;
+  pendingPrompts: Array<{
+    promptId: string;
+    systemPrompt: string;
+    userPrompt: string;
+  }>;
+  projection: { promptCount: number; budget: number };
+  /** Populated when status='budget-exceeded'. */
+  hint?: string;
+  /** Persisted to disk under .harness/craft/runs/<runId>.json. */
+  runFile?: string;
+}
+
+export interface FinalizeCodeCraftInput {
+  path: string;
+  runId: string;
+  responses: Array<{ promptId: string; raw: string }>;
+}
+
+/** Skill-specific run-state metadata persisted between collect and finalize. */
+interface CodeRunMeta {
+  projectRoot: string;
+  startedAt: number;
+  rubricsApplied: string[];
+  filesScanned: number;
+  filesSkippedNoUnit: number;
+  unitsDetected: number;
+  /** Pairs every queued prompt to the data needed to build a finding. */
+  prompts: Array<{
+    promptId: string;
+    file: string;
+    unit: CodeUnit;
+    rubricId: string;
+  }>;
+}
 
 interface RunAccumulator {
   findings: CodeFinding[];
@@ -55,6 +114,14 @@ export async function runCodeCraft(input: CodeCraftInput): Promise<CodeCraftOutp
   const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
   const maxUnitsPerFile = input.maxUnitsPerFile ?? DEFAULT_MAX_UNITS_PER_FILE;
   const provider = input.__testProvider ?? getProvider();
+
+  if (provider instanceof InSessionLlmProvider) {
+    throw new Error(
+      'runCodeCraft is the inline entry point; the in-session provider ' +
+        'requires the two-step flow. Call collectCodeCraftPrompts(...) and ' +
+        'then finalizeCodeCraft(...), or set HARNESS_CRAFT_LLM=mock for tests.'
+    );
+  }
 
   const candidateFiles = collectFiles(projectRoot, input).slice(0, maxFiles);
   const acc: RunAccumulator = {
@@ -92,6 +159,161 @@ export async function runCodeCraft(input: CodeCraftInput): Promise<CodeCraftOutp
         unitsDetected: acc.unitsDetected,
       },
       runId: randomUUID(),
+    },
+  };
+}
+
+/**
+ * Step 1 of the two-step in-session flow. Walks the project, builds one
+ * prompt per (unit, rubric) pair, persists run-state to disk, and returns
+ * the prompts for the calling agent to answer. No LLM is called.
+ */
+export async function collectCodeCraftPrompts(
+  input: CodeCraftInput & { promptBudget?: number }
+): Promise<CollectPromptsOutput> {
+  const projectRoot = sanitizePath(input.path);
+  const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
+  const maxUnitsPerFile = input.maxUnitsPerFile ?? DEFAULT_MAX_UNITS_PER_FILE;
+  const budget = input.promptBudget ?? DEFAULT_PROMPT_BUDGET;
+  const runId = randomUUID();
+
+  const candidateFiles = collectFiles(projectRoot, input).slice(0, maxFiles);
+  const promptRecords: CodeRunMeta['prompts'] = [];
+  const pending: CollectPromptsOutput['pendingPrompts'] = [];
+  const rubricsApplied = new Set<string>();
+  let filesScanned = 0;
+  let filesSkippedNoUnit = 0;
+  let unitsDetected = 0;
+
+  outer: for (const file of candidateFiles) {
+    let source: string;
+    try {
+      source = fs.readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    const units = extractUnits(source, file);
+    if (units.length === 0) {
+      filesSkippedNoUnit++;
+      continue;
+    }
+    filesScanned++;
+    const eligibleUnits = units.slice(0, maxUnitsPerFile);
+    unitsDetected += eligibleUnits.length;
+    for (const unit of eligibleUnits) {
+      for (const rubric of SEED_RUBRICS) {
+        if (!rubricApplies(rubric, unit.kind)) continue;
+        rubricsApplied.add(rubric.id);
+        const promptId = `p${promptRecords.length + 1}`;
+        const userPrompt = buildPrompt({ file, source, unit, rubric });
+        promptRecords.push({ promptId, file, unit, rubricId: rubric.id });
+        pending.push({ promptId, systemPrompt: CRITIQUE_SYSTEM_PROMPT, userPrompt });
+        if (pending.length > budget) break outer;
+      }
+    }
+  }
+
+  if (pending.length > budget) {
+    return {
+      status: 'budget-exceeded',
+      runId,
+      pendingPrompts: [],
+      projection: { promptCount: pending.length, budget },
+      hint:
+        `Projected at least ${pending.length} LLM prompts (budget: ${budget}). ` +
+        'Re-invoke with smaller maxFiles / maxUnitsPerFile, or pass promptBudget to raise the ceiling.',
+    };
+  }
+
+  const meta: CodeRunMeta = {
+    projectRoot,
+    startedAt: Date.now(),
+    rubricsApplied: [...rubricsApplied].sort(),
+    filesScanned,
+    filesSkippedNoUnit,
+    unitsDetected,
+    prompts: promptRecords,
+  };
+  pruneOldRuns(projectRoot);
+  const { runFile } = saveRunState<CodeRunMeta>(projectRoot, {
+    v: 1,
+    runId,
+    skill: 'code-craft',
+    createdAt: Date.now(),
+    meta,
+  });
+
+  return {
+    status: 'collected',
+    runId,
+    pendingPrompts: pending,
+    projection: { promptCount: pending.length, budget },
+    runFile,
+  };
+}
+
+/**
+ * Step 2 of the two-step in-session flow. Loads run-state, applies the
+ * supplied responses through the same parser the inline path uses, and
+ * returns the final CodeCraftOutput. Deletes the run-state file on success.
+ */
+export async function finalizeCodeCraft(input: FinalizeCodeCraftInput): Promise<CodeCraftOutput> {
+  const startedAt = Date.now();
+  const projectRoot = sanitizePath(input.path);
+  const state = loadRunState<CodeRunMeta>(projectRoot, input.runId);
+  if (state === null) {
+    throw new Error(
+      `code-craft: no persisted run found for runId=${input.runId} under ${projectRoot}. ` +
+        'Run collectCodeCraftPrompts first, or ensure the path matches the project root used at collection time.'
+    );
+  }
+  if (state.skill !== 'code-craft') {
+    throw new Error(
+      `code-craft: runId=${input.runId} belongs to skill ${state.skill}, not code-craft.`
+    );
+  }
+
+  const rubricById = new Map(SEED_RUBRICS.map((r) => [r.id, r]));
+  const promptById = new Map(state.meta.prompts.map((p) => [p.promptId, p]));
+  const findings: CodeFinding[] = [];
+
+  for (const response of input.responses) {
+    const promptRecord = promptById.get(response.promptId);
+    if (promptRecord === undefined) continue;
+    const rubric = rubricById.get(promptRecord.rubricId);
+    if (rubric === undefined) continue;
+    const finding = parseFindingFromRaw(response.raw, {
+      file: promptRecord.file,
+      unit: promptRecord.unit,
+      rubric,
+    });
+    if (finding !== null) findings.push(finding);
+  }
+
+  deleteRunState(projectRoot, input.runId);
+
+  return {
+    findings,
+    summary: {
+      phaseRun: ['critique'],
+      mode: 'fast',
+      durationMs: Date.now() - startedAt,
+      llmCalls: {
+        provider: 'in-session',
+        model: 'host-chat',
+        count: input.responses.length,
+        costUsd: 0,
+      },
+      catalog: {
+        rubricsApplied: state.meta.rubricsApplied,
+        exemplarsAvailable: SEED_EXEMPLARS.length,
+      },
+      counts: {
+        filesScanned: state.meta.filesScanned,
+        filesSkippedNoUnit: state.meta.filesSkippedNoUnit,
+        unitsDetected: state.meta.unitsDetected,
+      },
+      runId: input.runId,
     },
   };
 }

--- a/packages/cli/src/code-craft/phases/critique.ts
+++ b/packages/cli/src/code-craft/phases/critique.ts
@@ -29,7 +29,7 @@ const FENCED_JSON = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/;
  * to return `null` freely — a report full of low-value nits erodes trust faster
  * than a missed nicety.
  */
-const SYSTEM_PROMPT =
+export const CRITIQUE_SYSTEM_PROMPT =
   'You are a senior engineer critiquing a SINGLE code unit (a function, method, or class) ' +
   'against a SINGLE craft rubric. You judge the CEILING — does the code reveal intent, is the ' +
   'control flow honest, does it tell one story, does the abstraction earn its keep, is it as ' +
@@ -55,7 +55,20 @@ export interface CritiqueInput {
 export async function critiqueOne(input: CritiqueInput): Promise<CodeFinding | null> {
   const { file, unit, rubric, provider } = input;
   const prompt = buildPrompt(input);
-  const raw = await provider.callText(prompt, { systemPrompt: SYSTEM_PROMPT });
+  const raw = await provider.callText(prompt, { systemPrompt: CRITIQUE_SYSTEM_PROMPT });
+  return parseFindingFromRaw(raw, { file, unit, rubric });
+}
+
+/**
+ * Parse a raw LLM response (fenced JSON) into a CodeFinding. Returns null
+ * when the response says null / fails validation. Pure — no LLM call — so
+ * the in-session two-step flow can reuse it after the calling agent answers.
+ */
+export function parseFindingFromRaw(
+  raw: string,
+  ctx: { file: string; unit: CodeUnit; rubric: CodeRubric }
+): CodeFinding | null {
+  const { file, unit, rubric } = ctx;
   const parsed = parseFencedJson(raw);
   if (parsed === null) return null;
   if (typeof parsed !== 'object') return null;
@@ -79,7 +92,14 @@ export async function critiqueOne(input: CritiqueInput): Promise<CodeFinding | n
   };
 }
 
-function buildPrompt(input: CritiqueInput): string {
+export interface BuildPromptInput {
+  file: string;
+  source: string;
+  unit: CodeUnit;
+  rubric: CodeRubric;
+}
+
+export function buildPrompt(input: BuildPromptInput): string {
   const { file, source, unit, rubric } = input;
   const snippet = unitSource(source, unit, MAX_UNIT_CHARS);
   return [

--- a/packages/cli/src/commands/setup-mcp.ts
+++ b/packages/cli/src/commands/setup-mcp.ts
@@ -157,10 +157,13 @@ export const ALL_MCP_TOOLS: string[] = [
   'docs_craft',
   // craft-pipeline — code-craft LLM-judgment ceiling skill (code readability, per-unit critique)
   'code_craft',
+  'code_craft_finalize',
   // craft-pipeline — cli-ergonomics-craft LLM-judgment ceiling skill (CLI quality)
   'cli_ergonomics_craft',
+  'cli_ergonomics_craft_finalize',
   // craft-pipeline — api-craft LLM-judgment ceiling skill (API quality, per-surface critique)
   'api_craft',
+  'api_craft_finalize',
   // outcome-eval — post-execution spec-satisfaction verdict (tiered confidence→authority)
   'outcome_eval',
   // acceptance-eval — pre-execution acceptance-criteria measurability verdict (upstream twin of outcome_eval)

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -209,14 +209,26 @@ import { securityCraftDefinition, handleSecurityCraft } from './tools/security-c
 // craft-pipeline: docs-craft LLM-judgment skill (documentation quality, per-file critique).
 import { docsCraftDefinition, handleDocsCraft } from './tools/docs-craft.js';
 // craft-pipeline: code-craft LLM-judgment skill (code readability, per-unit critique).
-import { codeCraftDefinition, handleCodeCraft } from './tools/code-craft.js';
+import {
+  codeCraftDefinition,
+  codeCraftFinalizeDefinition,
+  handleCodeCraft,
+  handleCodeCraftFinalize,
+} from './tools/code-craft.js';
 // craft-pipeline: cli-ergonomics-craft LLM-judgment skill (CLI quality, per-command critique).
 import {
   cliErgonomicsCraftDefinition,
+  cliErgonomicsCraftFinalizeDefinition,
   handleCliErgonomicsCraft,
+  handleCliErgonomicsCraftFinalize,
 } from './tools/cli-ergonomics-craft.js';
 // craft-pipeline: api-craft LLM-judgment skill (API quality, per-surface critique).
-import { apiCraftDefinition, handleApiCraft } from './tools/api-craft.js';
+import {
+  apiCraftDefinition,
+  apiCraftFinalizeDefinition,
+  handleApiCraft,
+  handleApiCraftFinalize,
+} from './tools/api-craft.js';
 import { outcomeEvalDefinition, handleOutcomeEval } from './tools/outcome-eval.js';
 import { acceptanceEvalDefinition, handleAcceptanceEval } from './tools/acceptance-eval.js';
 // strategic-anchor: STRATEGY.md read/validate/write tools so skills don't have
@@ -349,8 +361,11 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
   securityCraftDefinition,
   docsCraftDefinition,
   codeCraftDefinition,
+  codeCraftFinalizeDefinition,
   cliErgonomicsCraftDefinition,
+  cliErgonomicsCraftFinalizeDefinition,
   apiCraftDefinition,
+  apiCraftFinalizeDefinition,
   outcomeEvalDefinition,
   acceptanceEvalDefinition,
   validateStrategyDefinition,
@@ -456,8 +471,11 @@ const TOOL_HANDLERS: Record<string, ToolHandler> = {
   security_craft: handleSecurityCraft as unknown as ToolHandler,
   docs_craft: handleDocsCraft as unknown as ToolHandler,
   code_craft: handleCodeCraft as unknown as ToolHandler,
+  code_craft_finalize: handleCodeCraftFinalize as unknown as ToolHandler,
   cli_ergonomics_craft: handleCliErgonomicsCraft as unknown as ToolHandler,
+  cli_ergonomics_craft_finalize: handleCliErgonomicsCraftFinalize as unknown as ToolHandler,
   api_craft: handleApiCraft as unknown as ToolHandler,
+  api_craft_finalize: handleApiCraftFinalize as unknown as ToolHandler,
   outcome_eval: handleOutcomeEval as unknown as ToolHandler,
   acceptance_eval: handleAcceptanceEval as unknown as ToolHandler,
   validate_strategy: handleValidateStrategy as unknown as ToolHandler,

--- a/packages/cli/src/mcp/tool-capability-declarations.ts
+++ b/packages/cli/src/mcp/tool-capability-declarations.ts
@@ -93,8 +93,11 @@ export const TOOL_CAPABILITY_DECLARATIONS: Readonly<Record<string, ToolCapabilit
   security_craft: { scopes: ['read'] }, // AST critique; "child_process" match was a rubric string
   docs_craft: { scopes: ['read'] },
   code_craft: { scopes: ['read'] }, // per-unit AST critique; returns findings, not persisted
+  code_craft_finalize: { scopes: ['read'] },
   cli_ergonomics_craft: { scopes: ['read'] },
+  cli_ergonomics_craft_finalize: { scopes: ['read'] },
   api_craft: { scopes: ['read'] }, // per-surface API critique; returns findings, not persisted
+  api_craft_finalize: { scopes: ['read'] },
   acceptance_eval: { scopes: ['read'] }, // advisory verdict; not persisted
   validate_strategy: { scopes: ['read'] },
   read_strategy: { scopes: ['read'] },

--- a/packages/cli/src/mcp/tools/api-craft.ts
+++ b/packages/cli/src/mcp/tools/api-craft.ts
@@ -1,10 +1,27 @@
 /**
- * MCP tool: `mcp__harness__api_craft`.
+ * MCP tools for api-craft (craft-pipeline):
  *
- * Wraps api-craft, the API-quality member of the craft-pipeline initiative.
+ *   `api_craft` — runs the skill. With `mode: 'in-session'` (the default in
+ *     Claude Code) it discovers API surfaces, builds prompts, persists
+ *     run-state, and returns the prompts to the calling agent without invoking
+ *     an LLM. With `mode: 'inline'` (or when HARNESS_CRAFT_LLM != 'in-session')
+ *     it runs end-to-end against whichever provider is configured.
+ *
+ *   `api_craft_finalize` — completes the in-session flow by consuming the
+ *     calling agent's responses and returning the standard ApiCraftOutput.
  */
 
-import { runApiCraft, type ApiCraftInput, type ApiCraftOutput } from '../../api-craft/index.js';
+import {
+  runApiCraft,
+  collectApiCraftPrompts,
+  finalizeApiCraft,
+  type ApiCraftInput,
+  type ApiCraftOutput,
+  type ApiCraftMode,
+  type CollectPromptsOutput,
+  type FinalizeApiCraftInput,
+} from '../../api-craft/index.js';
+import { resolveCraftLlmMode } from '../../shared/craft/llm/provider.js';
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
@@ -24,7 +41,9 @@ export const apiCraftDefinition = {
     'project’s own API surface — OpenAPI/Swagger documents and route/handler definitions — and ' +
     'critiques each per file. 9 seed rubrics; a curated exemplar set (Stripe / Linear / GitHub / ' +
     'Resend / Anthropic) anchors the catalog. Emits 3-axis findings (tier x impact x confidence ' +
-    'per ADR 0019). Structural twin of cli_ergonomics_craft.',
+    'per ADR 0019). Structural twin of cli_ergonomics_craft. ' +
+    'In-session mode (default in Claude Code) returns prompts for the calling agent to answer; ' +
+    'call api_craft_finalize with the responses to get findings.',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -48,8 +67,51 @@ export const apiCraftDefinition = {
         description: 'Extra subdir names to skip while walking',
       },
       maxFiles: { type: 'number', description: 'Cap surface count (default: 60)' },
+      mode: {
+        type: 'string',
+        enum: ['inline', 'in-session'],
+        description:
+          "'in-session' (default): return prompts for the calling agent to answer, " +
+          'then call api_craft_finalize. ' +
+          "'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).",
+      },
+      promptBudget: {
+        type: 'number',
+        description: 'Cap prompt count in in-session mode (default: 100)',
+      },
     },
     required: ['path'],
+  },
+};
+
+export const apiCraftFinalizeDefinition = {
+  name: 'api_craft_finalize',
+  description:
+    "Finalize an api_craft in-session run by submitting the calling agent's responses to the " +
+    'prompts collected by api_craft. Returns the standard ApiCraftOutput with findings.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      path: {
+        type: 'string',
+        description: 'Project root path used in the collect call (must match)',
+      },
+      runId: { type: 'string', description: 'runId returned by the api_craft collect call' },
+      responses: {
+        type: 'array',
+        description:
+          'Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.',
+        items: {
+          type: 'object',
+          properties: {
+            promptId: { type: 'string' },
+            raw: { type: 'string' },
+          },
+          required: ['promptId', 'raw'],
+        },
+      },
+    },
+    required: ['path', 'runId', 'responses'],
   },
 };
 
@@ -61,11 +123,22 @@ function fail(text: string): ToolResponse {
   return { content: [{ type: 'text', text }], isError: true };
 }
 
-export async function handleApiCraft(input: ApiCraftInput): Promise<ToolResponse> {
+function effectiveMode(input: ApiCraftInput): ApiCraftMode {
+  if (input.mode !== undefined) return input.mode;
+  return resolveCraftLlmMode() === 'in-session' ? 'in-session' : 'inline';
+}
+
+export async function handleApiCraft(
+  input: ApiCraftInput & { promptBudget?: number }
+): Promise<ToolResponse> {
   if (typeof input?.path !== 'string' || input.path.length === 0) {
     return fail(JSON.stringify({ error: 'api_craft: `path` is required' }));
   }
   try {
+    if (effectiveMode(input) === 'in-session') {
+      const result: CollectPromptsOutput = await collectApiCraftPrompts(input);
+      return ok(JSON.stringify(result, null, 2));
+    }
     const result: ApiCraftOutput = await runApiCraft(input);
     return ok(JSON.stringify(result, null, 2));
   } catch (err) {
@@ -74,5 +147,36 @@ export async function handleApiCraft(input: ApiCraftInput): Promise<ToolResponse
   }
 }
 
-export { runApiCraft } from '../../api-craft/index.js';
-export type { ApiCraftInput, ApiCraftOutput } from '../../api-craft/index.js';
+/** Validate finalize input; returns an error message or null when valid. */
+function finalizeInputError(input: FinalizeApiCraftInput): string | null {
+  if (typeof input?.path !== 'string' || input.path.length === 0) {
+    return 'api_craft_finalize: `path` is required';
+  }
+  if (typeof input?.runId !== 'string' || input.runId.length === 0) {
+    return 'api_craft_finalize: `runId` is required';
+  }
+  if (!Array.isArray(input?.responses)) {
+    return 'api_craft_finalize: `responses` must be an array';
+  }
+  return null;
+}
+
+export async function handleApiCraftFinalize(input: FinalizeApiCraftInput): Promise<ToolResponse> {
+  const validationError = finalizeInputError(input);
+  if (validationError !== null) return fail(JSON.stringify({ error: validationError }));
+  try {
+    const result = await finalizeApiCraft(input);
+    return ok(JSON.stringify(result, null, 2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return fail(JSON.stringify({ error: `api_craft_finalize failed: ${message}` }));
+  }
+}
+
+export { runApiCraft, collectApiCraftPrompts, finalizeApiCraft } from '../../api-craft/index.js';
+export type {
+  ApiCraftInput,
+  ApiCraftOutput,
+  CollectPromptsOutput,
+  FinalizeApiCraftInput,
+} from '../../api-craft/index.js';

--- a/packages/cli/src/mcp/tools/cli-ergonomics-craft.ts
+++ b/packages/cli/src/mcp/tools/cli-ergonomics-craft.ts
@@ -1,17 +1,31 @@
 /**
- * MCP tool: `mcp__harness__cli_ergonomics_craft`.
+ * MCP tools for cli-ergonomics-craft (craft-pipeline):
  *
- * Wraps cli-ergonomics-craft, the command-line-quality member of the
- * craft-pipeline initiative.
+ *   `cli_ergonomics_craft` — runs the skill. With `mode: 'in-session'` (the
+ *     default in Claude Code) it discovers command definitions, builds prompts,
+ *     persists run-state, and returns the prompts to the calling agent without
+ *     invoking an LLM. With `mode: 'inline'` (or when HARNESS_CRAFT_LLM !=
+ *     'in-session') it runs end-to-end against whichever provider is configured.
  *
- * Source: docs/changes/cli-ergonomics-craft/proposal.md (Surface area → MCP tool).
+ *   `cli_ergonomics_craft_finalize` — completes the in-session flow by consuming
+ *     the calling agent's responses and returning the standard
+ *     CliErgonomicsCraftOutput.
+ *
+ * Source: docs/changes/cli-ergonomics-craft/proposal.md (Surface area → MCP tool)
+ *   + the in-session two-step extension.
  */
 
 import {
   runCliErgonomicsCraft,
+  collectCliErgonomicsCraftPrompts,
+  finalizeCliErgonomicsCraft,
   type CliErgonomicsCraftInput,
   type CliErgonomicsCraftOutput,
+  type CliErgonomicsCraftMode,
+  type CollectPromptsOutput,
+  type FinalizeCliErgonomicsCraftInput,
 } from '../../cli-ergonomics-craft/index.js';
+import { resolveCraftLlmMode } from '../../shared/craft/llm/provider.js';
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
@@ -30,7 +44,9 @@ export const cliErgonomicsCraftDefinition = {
     'are destructive actions guarded. 7 seed rubrics; a small curated exemplar set (gh / cargo / ' +
     'ripgrep / docker / Stripe CLI) anchors the catalog. Critiques a project’s own command ' +
     'definitions per file. Emits 3-axis findings (tier x impact x confidence per ADR 0019). ' +
-    'Structural twin of docs_craft.',
+    'Structural twin of docs_craft. ' +
+    'In-session mode (default in Claude Code) returns prompts for the calling agent to answer; ' +
+    'call cli_ergonomics_craft_finalize with the responses to get findings.',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -50,8 +66,55 @@ export const cliErgonomicsCraftDefinition = {
         description: 'Extra subdir names to skip while walking',
       },
       maxFiles: { type: 'number', description: 'Cap command count (default: 60)' },
+      mode: {
+        type: 'string',
+        enum: ['inline', 'in-session'],
+        description:
+          "'in-session' (default): return prompts for the calling agent to answer, " +
+          'then call cli_ergonomics_craft_finalize. ' +
+          "'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).",
+      },
+      promptBudget: {
+        type: 'number',
+        description: 'Cap prompt count in in-session mode (default: 100)',
+      },
     },
     required: ['path'],
+  },
+};
+
+export const cliErgonomicsCraftFinalizeDefinition = {
+  name: 'cli_ergonomics_craft_finalize',
+  description:
+    "Finalize a cli_ergonomics_craft in-session run by submitting the calling agent's responses " +
+    'to the prompts collected by cli_ergonomics_craft. Returns the standard ' +
+    'CliErgonomicsCraftOutput with findings.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      path: {
+        type: 'string',
+        description: 'Project root path used in the collect call (must match)',
+      },
+      runId: {
+        type: 'string',
+        description: 'runId returned by the cli_ergonomics_craft collect call',
+      },
+      responses: {
+        type: 'array',
+        description:
+          'Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.',
+        items: {
+          type: 'object',
+          properties: {
+            promptId: { type: 'string' },
+            raw: { type: 'string' },
+          },
+          required: ['promptId', 'raw'],
+        },
+      },
+    },
+    required: ['path', 'runId', 'responses'],
   },
 };
 
@@ -63,13 +126,22 @@ function fail(text: string): ToolResponse {
   return { content: [{ type: 'text', text }], isError: true };
 }
 
+function effectiveMode(input: CliErgonomicsCraftInput): CliErgonomicsCraftMode {
+  if (input.mode !== undefined) return input.mode;
+  return resolveCraftLlmMode() === 'in-session' ? 'in-session' : 'inline';
+}
+
 export async function handleCliErgonomicsCraft(
-  input: CliErgonomicsCraftInput
+  input: CliErgonomicsCraftInput & { promptBudget?: number }
 ): Promise<ToolResponse> {
   if (typeof input?.path !== 'string' || input.path.length === 0) {
     return fail(JSON.stringify({ error: 'cli_ergonomics_craft: `path` is required' }));
   }
   try {
+    if (effectiveMode(input) === 'in-session') {
+      const result: CollectPromptsOutput = await collectCliErgonomicsCraftPrompts(input);
+      return ok(JSON.stringify(result, null, 2));
+    }
     const result: CliErgonomicsCraftOutput = await runCliErgonomicsCraft(input);
     return ok(JSON.stringify(result, null, 2));
   } catch (err) {
@@ -78,8 +150,42 @@ export async function handleCliErgonomicsCraft(
   }
 }
 
-export { runCliErgonomicsCraft } from '../../cli-ergonomics-craft/index.js';
+/** Validate finalize input; returns an error message or null when valid. */
+function finalizeInputError(input: FinalizeCliErgonomicsCraftInput): string | null {
+  if (typeof input?.path !== 'string' || input.path.length === 0) {
+    return 'cli_ergonomics_craft_finalize: `path` is required';
+  }
+  if (typeof input?.runId !== 'string' || input.runId.length === 0) {
+    return 'cli_ergonomics_craft_finalize: `runId` is required';
+  }
+  if (!Array.isArray(input?.responses)) {
+    return 'cli_ergonomics_craft_finalize: `responses` must be an array';
+  }
+  return null;
+}
+
+export async function handleCliErgonomicsCraftFinalize(
+  input: FinalizeCliErgonomicsCraftInput
+): Promise<ToolResponse> {
+  const validationError = finalizeInputError(input);
+  if (validationError !== null) return fail(JSON.stringify({ error: validationError }));
+  try {
+    const result = await finalizeCliErgonomicsCraft(input);
+    return ok(JSON.stringify(result, null, 2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return fail(JSON.stringify({ error: `cli_ergonomics_craft_finalize failed: ${message}` }));
+  }
+}
+
+export {
+  runCliErgonomicsCraft,
+  collectCliErgonomicsCraftPrompts,
+  finalizeCliErgonomicsCraft,
+} from '../../cli-ergonomics-craft/index.js';
 export type {
   CliErgonomicsCraftInput,
   CliErgonomicsCraftOutput,
+  CollectPromptsOutput,
+  FinalizeCliErgonomicsCraftInput,
 } from '../../cli-ergonomics-craft/index.js';

--- a/packages/cli/src/mcp/tools/code-craft.ts
+++ b/packages/cli/src/mcp/tools/code-craft.ts
@@ -1,12 +1,31 @@
 /**
- * MCP tool: `mcp__harness__code_craft`.
+ * MCP tools for code-craft (craft-pipeline):
  *
- * Wraps code-craft, the code-quality member of the craft-pipeline initiative.
+ *   `code_craft` — runs the skill. With `mode: 'in-session'` (the default in
+ *     Claude Code) it walks the project, builds prompts, persists run-state,
+ *     and returns the prompts to the calling agent without invoking an LLM.
+ *     With `mode: 'inline'` (or when HARNESS_CRAFT_LLM != 'in-session') it runs
+ *     end-to-end against whichever provider is configured.
  *
- * Source: docs/changes/code-craft/proposal.md (Surface area → MCP tool).
+ *   `code_craft_finalize` — completes the in-session flow by consuming the
+ *     calling agent's responses, parsing them into CodeFindings, and returning
+ *     the standard CodeCraftOutput.
+ *
+ * Source: docs/changes/code-craft/proposal.md (Surface area → MCP tool)
+ *   + the in-session two-step extension.
  */
 
-import { runCodeCraft, type CodeCraftInput, type CodeCraftOutput } from '../../code-craft/index.js';
+import {
+  runCodeCraft,
+  collectCodeCraftPrompts,
+  finalizeCodeCraft,
+  type CodeCraftInput,
+  type CodeCraftOutput,
+  type CodeCraftMode,
+  type CollectPromptsOutput,
+  type FinalizeCodeCraftInput,
+} from '../../code-craft/index.js';
+import { resolveCraftLlmMode } from '../../shared/craft/llm/provider.js';
 
 interface ToolResponse {
   content: Array<{ type: 'text'; text: string }>;
@@ -22,11 +41,14 @@ export const codeCraftDefinition = {
     'intent and read in the domain’s language, is the control flow honest, does the function ' +
     'tell one story at one altitude, does each abstraction earn its keep, is this as simple as ' +
     'it could be, does the signature keep its promise, would a senior nod or wince. Walks ' +
-    '`packages/<pkg>/src`, extracts substantive units (functions, methods, classes) via the TS ' +
-    'Compiler API, and critiques each against 7 seed rubrics; files with no substantive unit are ' +
-    'skipped. A small curated exemplar set (Anthropic SDK / TanStack Query / ky / SWR / date-fns) ' +
-    'anchors the catalog. Identifier-level naming is delegated to `naming_craft`. Emits 3-axis ' +
-    'findings (tier x impact x confidence per ADR 0019). Structural twin of `security_craft`.',
+    '`packages/<pkg>/src` (falling back to `src`/`app` for single-package repos), extracts ' +
+    'substantive units (functions, methods, classes) via the TS Compiler API, and critiques each ' +
+    'against 7 seed rubrics; files with no substantive unit are skipped. A small curated exemplar ' +
+    'set (Anthropic SDK / TanStack Query / ky / SWR / date-fns) anchors the catalog. ' +
+    'Identifier-level naming is delegated to `naming_craft`. Emits 3-axis findings ' +
+    '(tier x impact x confidence per ADR 0019). Structural twin of `security_craft`. ' +
+    'In-session mode (default in Claude Code) returns prompts for the calling agent to answer; ' +
+    'call code_craft_finalize with the responses to get findings.',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -43,8 +65,51 @@ export const codeCraftDefinition = {
       },
       maxFiles: { type: 'number', description: 'Cap source-file count (default: 100)' },
       maxUnitsPerFile: { type: 'number', description: 'Cap per-file unit critique (default: 20)' },
+      mode: {
+        type: 'string',
+        enum: ['inline', 'in-session'],
+        description:
+          "'in-session' (default): return prompts for the calling agent to answer, " +
+          'then call code_craft_finalize. ' +
+          "'inline': run end-to-end via the configured provider (HARNESS_CRAFT_LLM).",
+      },
+      promptBudget: {
+        type: 'number',
+        description: 'Cap prompt count in in-session mode (default: 100)',
+      },
     },
     required: ['path'],
+  },
+};
+
+export const codeCraftFinalizeDefinition = {
+  name: 'code_craft_finalize',
+  description:
+    "Finalize a code_craft in-session run by submitting the calling agent's responses to the " +
+    'prompts collected by code_craft. Returns the standard CodeCraftOutput with findings.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      path: {
+        type: 'string',
+        description: 'Project root path used in the collect call (must match)',
+      },
+      runId: { type: 'string', description: 'runId returned by the code_craft collect call' },
+      responses: {
+        type: 'array',
+        description:
+          'Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.',
+        items: {
+          type: 'object',
+          properties: {
+            promptId: { type: 'string' },
+            raw: { type: 'string' },
+          },
+          required: ['promptId', 'raw'],
+        },
+      },
+    },
+    required: ['path', 'runId', 'responses'],
   },
 };
 
@@ -56,11 +121,22 @@ function fail(text: string): ToolResponse {
   return { content: [{ type: 'text', text }], isError: true };
 }
 
-export async function handleCodeCraft(input: CodeCraftInput): Promise<ToolResponse> {
+function effectiveMode(input: CodeCraftInput): CodeCraftMode {
+  if (input.mode !== undefined) return input.mode;
+  return resolveCraftLlmMode() === 'in-session' ? 'in-session' : 'inline';
+}
+
+export async function handleCodeCraft(
+  input: CodeCraftInput & { promptBudget?: number }
+): Promise<ToolResponse> {
   if (typeof input?.path !== 'string' || input.path.length === 0) {
     return fail(JSON.stringify({ error: 'code_craft: `path` is required' }));
   }
   try {
+    if (effectiveMode(input) === 'in-session') {
+      const result: CollectPromptsOutput = await collectCodeCraftPrompts(input);
+      return ok(JSON.stringify(result, null, 2));
+    }
     const result: CodeCraftOutput = await runCodeCraft(input);
     return ok(JSON.stringify(result, null, 2));
   } catch (err) {
@@ -69,5 +145,42 @@ export async function handleCodeCraft(input: CodeCraftInput): Promise<ToolRespon
   }
 }
 
-export { runCodeCraft } from '../../code-craft/index.js';
-export type { CodeCraftInput, CodeCraftOutput } from '../../code-craft/index.js';
+/** Validate finalize input; returns an error message or null when valid. */
+function finalizeInputError(input: FinalizeCodeCraftInput): string | null {
+  if (typeof input?.path !== 'string' || input.path.length === 0) {
+    return 'code_craft_finalize: `path` is required';
+  }
+  if (typeof input?.runId !== 'string' || input.runId.length === 0) {
+    return 'code_craft_finalize: `runId` is required';
+  }
+  if (!Array.isArray(input?.responses)) {
+    return 'code_craft_finalize: `responses` must be an array';
+  }
+  return null;
+}
+
+export async function handleCodeCraftFinalize(
+  input: FinalizeCodeCraftInput
+): Promise<ToolResponse> {
+  const validationError = finalizeInputError(input);
+  if (validationError !== null) return fail(JSON.stringify({ error: validationError }));
+  try {
+    const result = await finalizeCodeCraft(input);
+    return ok(JSON.stringify(result, null, 2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return fail(JSON.stringify({ error: `code_craft_finalize failed: ${message}` }));
+  }
+}
+
+export {
+  runCodeCraft,
+  collectCodeCraftPrompts,
+  finalizeCodeCraft,
+} from '../../code-craft/index.js';
+export type {
+  CodeCraftInput,
+  CodeCraftOutput,
+  CollectPromptsOutput,
+  FinalizeCodeCraftInput,
+} from '../../code-craft/index.js';

--- a/packages/cli/tests/api-craft/integration.test.ts
+++ b/packages/cli/tests/api-craft/integration.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { runApiCraft, critiqueApiSurfaceFile } from '../../src/api-craft';
-import { MockLlmProvider } from '../../src/shared/craft/llm/provider';
+import {
+  runApiCraft,
+  critiqueApiSurfaceFile,
+  collectApiCraftPrompts,
+  finalizeApiCraft,
+} from '../../src/api-craft';
+import { MockLlmProvider, InSessionLlmProvider } from '../../src/shared/craft/llm/provider';
 
 const ROUTE = "router.post('/widgets', async (req, res) => { res.json({}); });";
 const OPENAPI_YAML = 'openapi: 3.0.0\ninfo:\n  title: Widgets\n  version: 1.0.0\npaths: {}\n';
@@ -136,5 +141,59 @@ describe('runApiCraft (integration)', () => {
       files: [path.join(tmpDir, 'src/routes/a.ts')],
     });
     expect(out.summary.counts.filesScanned).toBe(1);
+  });
+});
+
+// The default runtime provider is in-session (host-chat). Before the fix,
+// runApiCraft swallowed the deferral in a bare catch and returned a
+// zero-finding SUCCESS — a silent no-op. These tests pin the corrected
+// two-step collect→finalize behavior.
+describe('runApiCraft (in-session default path)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-craft-insession-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(rel: string, content: string): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  it('inline entry throws a loud guard under the in-session provider (never a silent [])', async () => {
+    writeFile('src/routes/widgets.ts', ROUTE);
+    await expect(
+      runApiCraft({ path: tmpDir, __testProvider: new InSessionLlmProvider() })
+    ).rejects.toThrow(/two-step flow/);
+  });
+
+  it('collect returns pending prompts instead of empty findings', async () => {
+    writeFile('src/routes/widgets.ts', ROUTE);
+    const collected = await collectApiCraftPrompts({ path: tmpDir });
+    expect(collected.status).toBe('collected');
+    expect(collected.pendingPrompts.length).toBeGreaterThan(0);
+    expect(collected.runId).toBeTruthy();
+  });
+
+  it('round-trips collect → finalize into real findings', async () => {
+    writeFile('src/routes/widgets.ts', ROUTE);
+    const collected = await collectApiCraftPrompts({ path: tmpDir });
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"foundational","impact":"large","confidence":"high","message":"verb dishonest"}\n```'
+          : '```json\nnull\n```',
+    }));
+    const out = await finalizeApiCraft({ path: tmpDir, runId: collected.runId, responses });
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.summary.runId).toBe(collected.runId);
+    expect(out.summary.llmCalls.provider).toBe('in-session');
+    expect(out.findings[0]!.target.relative).toBe('src/routes/widgets.ts');
   });
 });

--- a/packages/cli/tests/cli-ergonomics-craft/integration.test.ts
+++ b/packages/cli/tests/cli-ergonomics-craft/integration.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { runCliErgonomicsCraft, critiqueCommandFile } from '../../src/cli-ergonomics-craft';
-import { MockLlmProvider } from '../../src/shared/craft/llm/provider';
+import {
+  runCliErgonomicsCraft,
+  critiqueCommandFile,
+  collectCliErgonomicsCraftPrompts,
+  finalizeCliErgonomicsCraft,
+} from '../../src/cli-ergonomics-craft';
+import { MockLlmProvider, InSessionLlmProvider } from '../../src/shared/craft/llm/provider';
 
 const LEAF = "new Command('build').option('--out <f>').action(async () => {});";
 const GROUP = "new Command('db').addCommand(a).addCommand(b);";
@@ -137,5 +142,63 @@ describe('runCliErgonomicsCraft (integration)', () => {
       files: [path.join(tmpDir, 'src/commands/a.ts')],
     });
     expect(out.summary.counts.filesScanned).toBe(1);
+  });
+});
+
+// The default runtime provider is in-session (host-chat). Before the fix,
+// runCliErgonomicsCraft swallowed the deferral in a bare catch and returned a
+// zero-finding SUCCESS — a silent no-op. These tests pin the corrected
+// two-step collect→finalize behavior.
+describe('runCliErgonomicsCraft (in-session default path)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-craft-insession-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(rel: string, content: string): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  it('inline entry throws a loud guard under the in-session provider (never a silent [])', async () => {
+    writeFile('src/commands/build.ts', LEAF);
+    await expect(
+      runCliErgonomicsCraft({ path: tmpDir, __testProvider: new InSessionLlmProvider() })
+    ).rejects.toThrow(/two-step flow/);
+  });
+
+  it('collect returns pending prompts instead of empty findings', async () => {
+    writeFile('src/commands/build.ts', LEAF);
+    const collected = await collectCliErgonomicsCraftPrompts({ path: tmpDir });
+    expect(collected.status).toBe('collected');
+    expect(collected.pendingPrompts.length).toBeGreaterThan(0);
+    expect(collected.runId).toBeTruthy();
+  });
+
+  it('round-trips collect → finalize into real findings', async () => {
+    writeFile('src/commands/build.ts', LEAF);
+    const collected = await collectCliErgonomicsCraftPrompts({ path: tmpDir });
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"foundational","impact":"large","confidence":"high","message":"--out breaks --output convention"}\n```'
+          : '```json\nnull\n```',
+    }));
+    const out = await finalizeCliErgonomicsCraft({
+      path: tmpDir,
+      runId: collected.runId,
+      responses,
+    });
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.summary.runId).toBe(collected.runId);
+    expect(out.summary.llmCalls.provider).toBe('in-session');
+    expect(out.findings[0]!.target.relative).toBe('src/commands/build.ts');
   });
 });

--- a/packages/cli/tests/code-craft/discover.test.ts
+++ b/packages/cli/tests/code-craft/discover.test.ts
@@ -21,8 +21,31 @@ describe('discoverSourceFiles (code-craft)', () => {
     fs.writeFileSync(full, 'export const x = 1;\n');
   }
 
-  it('returns [] when there is no packages/ dir', () => {
+  it('returns [] when there is neither a packages/ nor a src/app/ dir', () => {
     expect(discoverSourceFiles(tmpDir)).toEqual([]);
+  });
+
+  it('falls back to src/ when packages/ is absent (single-package repo, #1089 gap)', () => {
+    writeFile('src/index.ts');
+    writeFile('src/lib/util.ts');
+    const files = discoverSourceFiles(tmpDir);
+    expect(files).toHaveLength(2);
+    expect(files.every((f) => f.includes(`${path.sep}src${path.sep}`))).toBe(true);
+  });
+
+  it('falls back to app/ when packages/ and src/ are both absent', () => {
+    writeFile('app/routes/page.ts');
+    const files = discoverSourceFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('page.ts');
+  });
+
+  it('excludes fixtures/ from the walk (#1089 gap — twins already exclude it)', () => {
+    writeFile('packages/api/src/real.ts');
+    writeFile('packages/api/src/fixtures/sample.ts');
+    const files = discoverSourceFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('real.ts');
   });
 
   it('excludes test files and build/coverage/node_modules dirs', () => {

--- a/packages/cli/tests/code-craft/integration.test.ts
+++ b/packages/cli/tests/code-craft/integration.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { runCodeCraft, critiqueCodeInFile } from '../../src/code-craft';
+import {
+  runCodeCraft,
+  critiqueCodeInFile,
+  collectCodeCraftPrompts,
+  finalizeCodeCraft,
+} from '../../src/code-craft';
 import { SEED_RUBRICS, rubricApplies } from '../../src/code-craft/catalog/rubrics';
 import { SEED_EXEMPLARS } from '../../src/code-craft/catalog/exemplars';
-import { MockLlmProvider } from '../../src/shared/craft/llm/provider';
+import { MockLlmProvider, InSessionLlmProvider } from '../../src/shared/craft/llm/provider';
 
 const RUBRICS_FOR_FUNCTION = SEED_RUBRICS.filter((r) => rubricApplies(r, 'function')).length;
 
@@ -153,5 +158,60 @@ describe('runCodeCraft (integration)', () => {
     writeFile('packages/api/src/trivial.ts', 'export const x = 1;\n');
     const findings = await critiqueCodeInFile(path.join(tmpDir, 'packages/api/src/trivial.ts'));
     expect(findings).toEqual([]);
+  });
+});
+
+// The default runtime provider is in-session (host-chat). Before the fix,
+// runCodeCraft swallowed the deferral in a bare catch and returned a
+// zero-finding SUCCESS — a silent no-op. These tests pin the corrected
+// behavior: the inline entry throws a loud guard, and the two-step
+// collect→finalize flow actually produces findings.
+describe('runCodeCraft (in-session default path)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-craft-insession-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeFile(rel: string, content: string): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  it('inline entry throws a loud guard under the in-session provider (never a silent [])', async () => {
+    writeFile('packages/api/src/classify.ts', SUBSTANTIVE_FN);
+    await expect(
+      runCodeCraft({ path: tmpDir, __testProvider: new InSessionLlmProvider() })
+    ).rejects.toThrow(/two-step flow/);
+  });
+
+  it('collect returns pending prompts instead of empty findings', async () => {
+    writeFile('packages/api/src/classify.ts', SUBSTANTIVE_FN);
+    const collected = await collectCodeCraftPrompts({ path: tmpDir });
+    expect(collected.status).toBe('collected');
+    expect(collected.pendingPrompts.length).toBeGreaterThan(0);
+    expect(collected.runId).toBeTruthy();
+  });
+
+  it('round-trips collect → finalize into real findings', async () => {
+    writeFile('packages/api/src/classify.ts', SUBSTANTIVE_FN);
+    const collected = await collectCodeCraftPrompts({ path: tmpDir });
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"foundational","impact":"large","confidence":"high","message":"invert the guard"}\n```'
+          : '```json\nnull\n```',
+    }));
+    const out = await finalizeCodeCraft({ path: tmpDir, runId: collected.runId, responses });
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.summary.runId).toBe(collected.runId);
+    expect(out.summary.llmCalls.provider).toBe('in-session');
+    expect(out.findings[0]!.target.unit).toBe('classify');
   });
 });

--- a/packages/cli/tests/mcp/server-integration.test.ts
+++ b/packages/cli/tests/mcp/server-integration.test.ts
@@ -105,7 +105,11 @@ describe('MCP Server Integration', () => {
     expect(names).toContain('plan_parallelization');
     // craft-pipeline — api-craft LLM-judgment ceiling skill (API quality)
     expect(names).toContain('api_craft');
-    expect(tools).toHaveLength(98);
+    // craft-pipeline — in-session finalize tools for the three fixed craft skills
+    expect(names).toContain('code_craft_finalize');
+    expect(names).toContain('cli_ergonomics_craft_finalize');
+    expect(names).toContain('api_craft_finalize');
+    expect(tools).toHaveLength(101);
   });
 
   it('all tool definitions have inputSchema', () => {

--- a/packages/cli/tests/mcp/server.test.ts
+++ b/packages/cli/tests/mcp/server.test.ts
@@ -11,9 +11,9 @@ describe('MCP Server', () => {
     expect(server).toBeDefined();
   });
 
-  it('registers all 98 tools', () => {
+  it('registers all 101 tools', () => {
     const tools = getToolDefinitions();
-    expect(tools).toHaveLength(98);
+    expect(tools).toHaveLength(101);
   });
 
   it('registers all 9 resources', () => {

--- a/packages/cli/tests/mcp/tools/api-craft.test.ts
+++ b/packages/cli/tests/mcp/tools/api-craft.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  handleApiCraft,
+  handleApiCraftFinalize,
+  apiCraftDefinition,
+  apiCraftFinalizeDefinition,
+} from '../../../src/mcp/tools/api-craft';
+
+const ROUTE = "router.post('/widgets', async (req, res) => { res.json({}); });";
+
+function writeRoute(dir: string): void {
+  fs.mkdirSync(path.join(dir, 'src', 'routes'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'src', 'routes', 'widgets.ts'), ROUTE);
+}
+
+describe('api_craft MCP tool', () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-craft-mcp-'));
+    savedEnv = process.env.HARNESS_CRAFT_LLM;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedEnv;
+  });
+
+  it('definition exposes mode and promptBudget on input schema', () => {
+    expect(apiCraftDefinition.inputSchema.properties).toHaveProperty('mode');
+    expect(apiCraftDefinition.inputSchema.properties).toHaveProperty('promptBudget');
+  });
+
+  it('finalize definition declares path, runId, responses as required', () => {
+    expect(apiCraftFinalizeDefinition.inputSchema.required).toEqual(['path', 'runId', 'responses']);
+  });
+
+  it('rejects missing path', async () => {
+    // @ts-expect-error testing runtime validation
+    const r = await handleApiCraft({});
+    expect(r.isError).toBe(true);
+    expect(r.content[0]!.text).toContain('path');
+  });
+
+  it('returns pendingPrompts when mode=in-session (not a silent empty result)', async () => {
+    writeRoute(tmpDir);
+    const r = await handleApiCraft({ path: tmpDir, mode: 'in-session' });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(parsed.status).toBe('collected');
+    expect(parsed.pendingPrompts.length).toBeGreaterThan(0);
+    expect(parsed.runId).toBeTruthy();
+  });
+
+  it('default (in-session) mode collects prompts rather than returning findings:[]', async () => {
+    writeRoute(tmpDir);
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    const r = await handleApiCraft({ path: tmpDir });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('pendingPrompts');
+    expect(parsed).not.toHaveProperty('findings');
+  });
+
+  it('routes a round-trip through api_craft → api_craft_finalize', async () => {
+    writeRoute(tmpDir);
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    const collect = await handleApiCraft({ path: tmpDir });
+    const collected = JSON.parse(collect.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(collected.status).toBe('collected');
+
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"foundational","impact":"large","confidence":"high","message":"verb dishonest"}\n```'
+          : '```json\nnull\n```',
+    }));
+
+    const finalize = await handleApiCraftFinalize({
+      path: tmpDir,
+      runId: collected.runId,
+      responses,
+    });
+    expect(finalize.isError).toBeFalsy();
+    const out = JSON.parse(finalize.content[0]!.text) as {
+      findings: unknown[];
+      summary: { runId: string };
+    };
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.summary.runId).toBe(collected.runId);
+  });
+
+  it('finalize rejects when responses is not an array', async () => {
+    const r = await handleApiCraftFinalize({
+      path: tmpDir,
+      runId: 'abc',
+      // @ts-expect-error testing runtime validation
+      responses: 'oops',
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it('auto-routes to inline when HARNESS_CRAFT_LLM=mock and mode is unspecified', async () => {
+    writeRoute(tmpDir);
+    process.env.HARNESS_CRAFT_LLM = 'mock';
+    const r = await handleApiCraft({ path: tmpDir });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      findings: unknown[];
+      summary: { llmCalls: { provider: string } };
+    };
+    expect(parsed).toHaveProperty('findings');
+    expect(parsed.summary.llmCalls.provider).toBe('mock');
+  });
+});

--- a/packages/cli/tests/mcp/tools/cli-ergonomics-craft.test.ts
+++ b/packages/cli/tests/mcp/tools/cli-ergonomics-craft.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  handleCliErgonomicsCraft,
+  handleCliErgonomicsCraftFinalize,
+  cliErgonomicsCraftDefinition,
+  cliErgonomicsCraftFinalizeDefinition,
+} from '../../../src/mcp/tools/cli-ergonomics-craft';
+
+const LEAF = "new Command('build').option('--out <f>').action(async () => {});";
+
+function writeCommand(dir: string): void {
+  fs.mkdirSync(path.join(dir, 'src', 'commands'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'src', 'commands', 'build.ts'), LEAF);
+}
+
+describe('cli_ergonomics_craft MCP tool', () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-craft-mcp-'));
+    savedEnv = process.env.HARNESS_CRAFT_LLM;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedEnv;
+  });
+
+  it('definition exposes mode and promptBudget on input schema', () => {
+    expect(cliErgonomicsCraftDefinition.inputSchema.properties).toHaveProperty('mode');
+    expect(cliErgonomicsCraftDefinition.inputSchema.properties).toHaveProperty('promptBudget');
+  });
+
+  it('finalize definition declares path, runId, responses as required', () => {
+    expect(cliErgonomicsCraftFinalizeDefinition.inputSchema.required).toEqual([
+      'path',
+      'runId',
+      'responses',
+    ]);
+  });
+
+  it('rejects missing path', async () => {
+    // @ts-expect-error testing runtime validation
+    const r = await handleCliErgonomicsCraft({});
+    expect(r.isError).toBe(true);
+    expect(r.content[0]!.text).toContain('path');
+  });
+
+  it('returns pendingPrompts when mode=in-session (not a silent empty result)', async () => {
+    writeCommand(tmpDir);
+    const r = await handleCliErgonomicsCraft({ path: tmpDir, mode: 'in-session' });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(parsed.status).toBe('collected');
+    expect(parsed.pendingPrompts.length).toBeGreaterThan(0);
+    expect(parsed.runId).toBeTruthy();
+  });
+
+  it('default (in-session) mode collects prompts rather than returning findings:[]', async () => {
+    writeCommand(tmpDir);
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    const r = await handleCliErgonomicsCraft({ path: tmpDir });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('pendingPrompts');
+    expect(parsed).not.toHaveProperty('findings');
+  });
+
+  it('routes a round-trip through cli_ergonomics_craft → *_finalize', async () => {
+    writeCommand(tmpDir);
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    const collect = await handleCliErgonomicsCraft({ path: tmpDir });
+    const collected = JSON.parse(collect.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(collected.status).toBe('collected');
+
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"polish","impact":"small","confidence":"medium","message":"x"}\n```'
+          : '```json\nnull\n```',
+    }));
+
+    const finalize = await handleCliErgonomicsCraftFinalize({
+      path: tmpDir,
+      runId: collected.runId,
+      responses,
+    });
+    expect(finalize.isError).toBeFalsy();
+    const out = JSON.parse(finalize.content[0]!.text) as {
+      findings: unknown[];
+      summary: { runId: string };
+    };
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.summary.runId).toBe(collected.runId);
+  });
+
+  it('finalize rejects when responses is not an array', async () => {
+    const r = await handleCliErgonomicsCraftFinalize({
+      path: tmpDir,
+      runId: 'abc',
+      // @ts-expect-error testing runtime validation
+      responses: 'oops',
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it('auto-routes to inline when HARNESS_CRAFT_LLM=mock and mode is unspecified', async () => {
+    writeCommand(tmpDir);
+    process.env.HARNESS_CRAFT_LLM = 'mock';
+    const r = await handleCliErgonomicsCraft({ path: tmpDir });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      findings: unknown[];
+      summary: { llmCalls: { provider: string } };
+    };
+    expect(parsed).toHaveProperty('findings');
+    expect(parsed.summary.llmCalls.provider).toBe('mock');
+  });
+});

--- a/packages/cli/tests/mcp/tools/code-craft.test.ts
+++ b/packages/cli/tests/mcp/tools/code-craft.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  handleCodeCraft,
+  handleCodeCraftFinalize,
+  codeCraftDefinition,
+  codeCraftFinalizeDefinition,
+} from '../../../src/mcp/tools/code-craft';
+
+const SUBSTANTIVE_FN = `export function classify(x) {
+  if (x > 10) {
+    return 'big';
+  }
+  const doubled = x * 2;
+  return doubled > 5 ? 'medium' : 'small';
+}
+`;
+
+describe('code_craft MCP tool', () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-craft-mcp-'));
+    savedEnv = process.env.HARNESS_CRAFT_LLM;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedEnv;
+  });
+
+  it('definition exposes mode and promptBudget on input schema', () => {
+    expect(codeCraftDefinition.inputSchema.properties).toHaveProperty('mode');
+    expect(codeCraftDefinition.inputSchema.properties).toHaveProperty('promptBudget');
+  });
+
+  it('finalize definition declares path, runId, responses as required', () => {
+    expect(codeCraftFinalizeDefinition.inputSchema.required).toEqual([
+      'path',
+      'runId',
+      'responses',
+    ]);
+  });
+
+  it('rejects missing path', async () => {
+    // @ts-expect-error testing runtime validation
+    const r = await handleCodeCraft({});
+    expect(r.isError).toBe(true);
+    expect(r.content[0]!.text).toContain('path');
+  });
+
+  it('returns pendingPrompts when mode=in-session (not a silent empty result)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src.ts'), SUBSTANTIVE_FN);
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'src', 'classify.ts'), SUBSTANTIVE_FN);
+    const r = await handleCodeCraft({ path: tmpDir, mode: 'in-session' });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(parsed.status).toBe('collected');
+    expect(parsed.pendingPrompts.length).toBeGreaterThan(0);
+    expect(parsed.runId).toBeTruthy();
+  });
+
+  it('default (in-session) mode collects prompts rather than returning findings:[]', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'src', 'classify.ts'), SUBSTANTIVE_FN);
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    const r = await handleCodeCraft({ path: tmpDir });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('pendingPrompts');
+    expect(parsed).not.toHaveProperty('findings');
+  });
+
+  it('routes a round-trip through code_craft → code_craft_finalize', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'src', 'classify.ts'), SUBSTANTIVE_FN);
+    process.env.HARNESS_CRAFT_LLM = 'in-session';
+    const collect = await handleCodeCraft({ path: tmpDir });
+    const collected = JSON.parse(collect.content[0]!.text) as {
+      status: string;
+      runId: string;
+      pendingPrompts: Array<{ promptId: string }>;
+    };
+    expect(collected.status).toBe('collected');
+
+    const responses = collected.pendingPrompts.map((p, i) => ({
+      promptId: p.promptId,
+      raw:
+        i === 0
+          ? '```json\n{"tier":"polish","impact":"small","confidence":"medium","message":"x"}\n```'
+          : '```json\nnull\n```',
+    }));
+
+    const finalize = await handleCodeCraftFinalize({
+      path: tmpDir,
+      runId: collected.runId,
+      responses,
+    });
+    expect(finalize.isError).toBeFalsy();
+    const out = JSON.parse(finalize.content[0]!.text) as {
+      findings: unknown[];
+      summary: { runId: string };
+    };
+    expect(out.findings.length).toBeGreaterThanOrEqual(1);
+    expect(out.summary.runId).toBe(collected.runId);
+  });
+
+  it('finalize rejects when responses is not an array', async () => {
+    const r = await handleCodeCraftFinalize({
+      path: tmpDir,
+      runId: 'abc',
+      // @ts-expect-error testing runtime validation
+      responses: 'oops',
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it('auto-routes to inline when HARNESS_CRAFT_LLM=mock and mode is unspecified', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'src', 'classify.ts'), SUBSTANTIVE_FN);
+    process.env.HARNESS_CRAFT_LLM = 'mock';
+    const r = await handleCodeCraft({ path: tmpDir });
+    expect(r.isError).toBeFalsy();
+    const parsed = JSON.parse(r.content[0]!.text) as {
+      findings: unknown[];
+      summary: { llmCalls: { provider: string } };
+    };
+    expect(parsed).toHaveProperty('findings');
+    expect(parsed.summary.llmCalls.provider).toBe('mock');
+  });
+});


### PR DESCRIPTION
## The defect (BLOCKING, live on `main`)

The craft family defaults to the **in-session** LLM provider: instead of calling an LLM, it records each prompt and throws a deferral sentinel so the host chat session answers the prompts and feeds them back via a second `<skill>_finalize` step. `naming-craft` implemented that two-step flow correctly — but `code-craft`, `cli-ergonomics-craft`, and `api-craft` swallowed the deferral in a bare `catch {}` and never surfaced the collected prompts.

Result: a **default-mode call returned `{ findings: [] }` and exited SUCCESS** — a silent lie that looked like a clean pass.

## The fix — real two-step collect → finalize flow (mirrors naming-craft)

Per skill:

| Skill | New orchestrator entries | New finalize MCP tool |
|---|---|---|
| code-craft | `collectCodeCraftPrompts` / `finalizeCodeCraft` | `code_craft_finalize` |
| cli-ergonomics-craft | `collectCliErgonomicsCraftPrompts` / `finalizeCliErgonomicsCraft` | `cli_ergonomics_craft_finalize` |
| api-craft | `collectApiCraftPrompts` / `finalizeApiCraft` | `api_craft_finalize` |

- Each critique phase now exposes a pure `parseFindingFromRaw` + `buildPrompt` + system-prompt constant, so the collect/finalize path and the inline path share **one** parser (no drift).
- **Loud guard:** the inline entry points (`runCodeCraft` / `runCliErgonomicsCraft` / `runApiCraft`) now throw an actionable error when handed the in-session provider instead of returning `[]` — a direct CLI run in a non-agent context fails loudly with guidance.
- The three primary MCP tools route to the collect step in in-session mode (default), returning `{ status: "collected", runId, pendingPrompts }`.
- Finalize tools wired into `server.ts` (defs + handlers), `tool-capability-declarations.ts`, and `setup-mcp.ts`.

### MCP tool count: 98 → **101**

`server.test.ts` and `server-integration.test.ts` assertions updated (and verified against actual `getToolDefinitions().length`).

## code-craft discovery fixes (two MEDIUM gaps)

- **`src/` (then `app/`) fallback** when a project has no `packages/` directory — single-package repos are no longer scanned as silently empty.
- **`fixtures/` excluded** from the walk — its `cli-ergonomics-craft` and `api-craft` twins already exclude it.

## Default-path regression tests (the previously-missing coverage)

The existing tests injected `MockLlmProvider` and never exercised the default provider. Added, for all three skills:

- inline entry **throws the loud guard** under the in-session provider (never a silent `[]`);
- `collect*` returns **pendingPrompts**, not empty findings;
- **collect → finalize round-trip** produces real findings;
- MCP handler default (in-session) mode returns `pendingPrompts` (not `findings`), and the `code_craft`/`cli_ergonomics_craft`/`api_craft` → `*_finalize` round-trip;
- discovery-gap tests (src/app fallback, fixtures exclusion).

Plus: `@harness-engineering/cli` **minor** changeset, regenerated MCP-tools reference, SKILL.md "In-session flow" docs synced across all four platform copies, and an arch-baseline `--allow-regress` update (module-size growth + finalize functions crossing the function-length warning line).

## Verification

Full `packages/cli` suite green (5685 tests); the three MCP-tool test suites + both server suites pass at 101 tools; pre-commit (`harness ci check`: validate/arch/traceability) and the full pre-push gauntlet (changeset-check, prettier, typecheck, coverage-ratchet, `generate-docs --check`, skills platform-parity) all pass. A default-mode `code_craft` / `cli_ergonomics_craft` / `api_craft` call now returns `status: "collected"` with pending prompts (or the CLI path throws the loud guard) — it can no longer silently return `[]`.