### PR TITLE
feat(burn): port the usage-burn HUD to TypeScript as `harness burn`

### DIFF
--- a/.changeset/burn-hud-ts-port.md
+++ b/.changeset/burn-hud-ts-port.md
@@ -1,0 +1,38 @@
+---
+'@harness-engineering/burn': minor
+'@harness-engineering/cli': minor
+---
+
+Ship the usage-burn HUD as `@harness-engineering/burn` + `harness burn`, replacing the
+standalone `claude-burn-hud` Python/shell tool.
+
+The HUD reports Claude Code usage pace from local transcripts: week-anchored spend,
+a baseline-shrunk forecast, per-model family limits, and a `/clear` nudge once the
+checked-out branch has merged. It is a local proxy, never Anthropic's real quota —
+`/usage` remains the authority, and no percentage is trustworthy until reconciled
+against it.
+
+Two surfaces, split on latency rather than taste:
+
+- `harness burn` (report, `weeks`, `calibrate`, `budget`, `reset-day`, `scan`,
+  `install`) — human-invoked, so the CLI's module graph is affordable.
+- `harness-burn-hud` (`line`, `session-start`, `stop`, `scan`) — a standalone binary
+  for the statusline repaint and the Stop hook. `harness --version` costs ~0.85s to
+  load against a ~0.11s repaint budget, so this binary imports nothing from
+  `@harness-engineering/*`; a test asserts that import graph, because the regression
+  would show up only as a terminal that feels slow.
+
+Every regression test from the Python suite came across, each still tied to a defect
+that actually shipped: the Monday-UTC week assumption that understated a 97% week by
+~81×, the write race that silently dropped 85% of the record store, transcript usage
+blocks inflating totals ~3.5×, and a 3-hour extrapolation firing CRITICAL. Parity was
+verified against 33,305 real records — every shared record byte-identical, and with
+`now` pinned the summaries differ only in float rendering.
+
+The port also fixed two hot-path defects of its own: the binary is emitted as `.mjs`
+so Node does not detect-and-reparse it on every launch, and `line` no longer blocks
+forever when run from a terminal.
+
+`harness burn install` performs the cutover into `~/.claude/settings.json` additively —
+it backs the file up, leaves unrelated hooks alone, and leaves the previous
+`~/.claude/hud` install on disk so there is a way back.

--- a/.gemini-extension/commands/burn-hud.toml
+++ b/.gemini-extension/commands/burn-hud.toml
@@ -36,16 +36,21 @@ Install, calibrate, verify and diagnose a local Claude Code usage-pace HUD that 
 
 ## Implementation
 
-This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line Python and shell tool does not belong inside a skill directory.
+This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line tool does not belong inside a skill directory.
 
-A reference implementation providing `scan.py`, `statusline.sh`, `burn.py` (the `claude-burn` CLI), `install.sh`, `uninstall.sh` and a stdlib test suite is expected at the path the user supplies. Its contract, which this skill assumes throughout:
+For Claude Code the reference implementation ships with the harness itself, as `@harness-engineering/burn`:
+
+- `harness burn` — the interactive surface (report, `weeks`, `calibrate`, `reset-day`, `budget`, `scan`, `install`).
+- `harness-burn-hud` — a standalone binary for the two hot paths (`line` for the statusline, `session-start`/`stop` for the hooks). It deliberately imports nothing from the CLI: loading that module graph costs ~0.85s against a ~0.11s repaint budget, and a laggy statusline is a regression nobody bisects.
+
+For any other agent CLI, an equivalent implementation is expected at the path the user supplies. Either way the contract this skill assumes throughout is:
 
 | Artifact             | Contract                                                                                                                                                       |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `state/summary.json` | Written atomically. Carries `status`, `week.reset_spec`, `wtd.units`, `budget.pct_used`, `projection.confidence`, `models_exhausted`, `calibration`, `scan.*`. |
 | `state/usage.tsv`    | Deduped record store, one row per request id.                                                                                                                  |
 | `state/files.tsv`    | Scan fingerprints, first line `#count\t<n>` — the record count, written in the same atomic write.                                                              |
-| `claude-burn`        | `status`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan`.                                                           |
+| CLI                  | `report`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan` (for Claude Code: `harness burn <subcommand>`).            |
 | statusline           | Reads the cached summary only. Never scans.                                                                                                                    |
 
 If the user has no implementation, that is the blocker to resolve first — do not hand-roll a partial scanner mid-session, because an under-counting scanner is precisely the failure this skill exists to prevent.
@@ -98,7 +103,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Ask the user to run `/usage`** and report: the weekly percentage, the reset day _and_ time _and_ timezone, whether any per-model bar is shown separately, and whether a promo or temporary limit is active.
 
-2. **Set the window first.** `claude-burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
+2. **Set the window first.** `harness burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
 
 3. **Re-scan.** The window change recuts every historical bucket, so the baseline moves too.
 
@@ -110,7 +115,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Calibrate late in the week, not early.** `/usage` reports whole percents, so the error is `±0.5/pct`: ~17% at 3%, ~1.5% at 34%. Calibrating just after a reset produces a near-useless ceiling.
 
-2. **Record the validity date if a promo is active.** `claude-burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
+2. **Record the validity date if a promo is active.** `harness burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
 
 3. **Add per-model budgets** if `/usage` shows a separate family bar. A family limit can be fully spent while the pooled bar looks survivable — observed in practice at 100% of one model family's own limit while that family was only 29% of the pooled week.
 
@@ -243,7 +248,7 @@ That combination is diagnostic: the record store lost rows while the fingerprint
 
 ```bash
 rm ~/.claude/hud/state/files.tsv     # distrust the fingerprints
-claude-burn                          # rebuild from source
+harness burn                         # rebuild from source
 ```
 
 Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause named: record loss. Then fixed structurally — atomic writes, an `flock`, and a count header so fingerprints and records can never again disagree.
@@ -253,8 +258,8 @@ Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause nam
 `/usage` showed `97% used`, reset `Wed 08:59 America/Chicago`, a separate model-family bar at `100%`, and a `+50% weekly limits` promo with an end date.
 
 ```bash
-claude-burn reset-day wed 08:59 America/Chicago   # window FIRST
-claude-burn calibrate 97 2026-08-19               # expiry recorded
+harness burn reset-day wed 08:59 America/Chicago   # window FIRST
+harness burn calibrate 97 2026-08-19               # expiry recorded
 ```
 
 Then a per-family budget for the separate bar. Reconciled: HUD `97.2%` against `/usage` `97%` — inside G4.

--- a/.harness/arch/allowances/feat-burn-ts-port.json
+++ b/.harness/arch/allowances/feat-burn-ts-port.json
@@ -1,0 +1,26 @@
+{
+  "reason": "New packages/burn: the ~1.4k-line claude-burn-hud (Python + shell) ported to TypeScript, plus the harness burn CLI surface. The complexity/module-size/dependency-depth deltas are the cost of the package existing rather than of any one function: every error-severity threshold finding the gate raised was FIXED, not acknowledged — renderStatusline, renderReport, calibrate, parseTranscript and setResetDay were each decomposed into named helpers (see PR). Only warning-severity findings and the three aggregate totals remain.",
+  "categories": {
+    "complexity": 324,
+    "module-size": 222886,
+    "dependency-depth": 569
+  },
+  "violationIds": [
+    "033cfda904cfc4120fafcdea99ad22b420d9060460b1e26786ce652da5df7172",
+    "08341d540aa07e8a0dd1589bf0c3fdefd9030e73ae855fe0bd22c6642753ea31",
+    "3f9d226333c50b6b2b4f2eee59b1b1bbe429f426fb8648a6b0c9062caf989a5a",
+    "42f9a499a6e4a3d75790dff4c9a1a491d4ff51edcdd3251a20b536a399f625f2",
+    "4342852fc18c2b36c6753fb647bcc03612c4ce4b89c230813924ce76f056a761",
+    "47be0d9ae7ccff3462f865985e91fdc83d415ab44d4c86031df781cfb7a3e11c",
+    "4a246440339627b3afcb89bbaf03bcd5bc8e7684c4a939f287bad214bb2ded36",
+    "4bf6860ff1cb7b3e559a2539bcbe8b88b6db82a2590c05cc502cd2f0d2824ac4",
+    "5bd28ae7a9f7e3a365f433e6a7d30596b4ae3054dc8301aada6fbc5efcf06ead",
+    "7caf2390b170086fcef54a50ef4296fe15ee2ce803b8487fee999d8a0024f843",
+    "b9fdf936f6b47dd57c065733ad30050483a592532e76e2dc1abb2b9a84c42ba6",
+    "d0180f42fb8cc60b38094213f5e16e902c543ecdc6fd2ba17ce8299361444389",
+    "dc7e1e7169573a27c213096e681db2c7eabdbc8a2b31ae0412b06dc4648a4406",
+    "efcc34b7f563efe5e2f32ad4af518350674a54f89da96b7f0fb268718558ddf4",
+    "f6cff03a752ef859e63f4f3efd6f0e11dba73dfc5e8c979b01548481ba315646"
+  ],
+  "createdFrom": "59590da6c"
+}

--- a/agents/skills/claude-code/burn-hud/SKILL.md
+++ b/agents/skills/claude-code/burn-hud/SKILL.md
@@ -22,16 +22,21 @@
 
 ## Implementation
 
-This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line Python and shell tool does not belong inside a skill directory.
+This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line tool does not belong inside a skill directory.
 
-A reference implementation providing `scan.py`, `statusline.sh`, `burn.py` (the `claude-burn` CLI), `install.sh`, `uninstall.sh` and a stdlib test suite is expected at the path the user supplies. Its contract, which this skill assumes throughout:
+For Claude Code the reference implementation ships with the harness itself, as `@harness-engineering/burn`:
+
+- `harness burn` — the interactive surface (report, `weeks`, `calibrate`, `reset-day`, `budget`, `scan`, `install`).
+- `harness-burn-hud` — a standalone binary for the two hot paths (`line` for the statusline, `session-start`/`stop` for the hooks). It deliberately imports nothing from the CLI: loading that module graph costs ~0.85s against a ~0.11s repaint budget, and a laggy statusline is a regression nobody bisects.
+
+For any other agent CLI, an equivalent implementation is expected at the path the user supplies. Either way the contract this skill assumes throughout is:
 
 | Artifact             | Contract                                                                                                                                                       |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `state/summary.json` | Written atomically. Carries `status`, `week.reset_spec`, `wtd.units`, `budget.pct_used`, `projection.confidence`, `models_exhausted`, `calibration`, `scan.*`. |
 | `state/usage.tsv`    | Deduped record store, one row per request id.                                                                                                                  |
 | `state/files.tsv`    | Scan fingerprints, first line `#count\t<n>` — the record count, written in the same atomic write.                                                              |
-| `claude-burn`        | `status`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan`.                                                           |
+| CLI                  | `report`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan` (for Claude Code: `harness burn <subcommand>`).            |
 | statusline           | Reads the cached summary only. Never scans.                                                                                                                    |
 
 If the user has no implementation, that is the blocker to resolve first — do not hand-roll a partial scanner mid-session, because an under-counting scanner is precisely the failure this skill exists to prevent.
@@ -84,7 +89,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Ask the user to run `/usage`** and report: the weekly percentage, the reset day _and_ time _and_ timezone, whether any per-model bar is shown separately, and whether a promo or temporary limit is active.
 
-2. **Set the window first.** `claude-burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
+2. **Set the window first.** `harness burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
 
 3. **Re-scan.** The window change recuts every historical bucket, so the baseline moves too.
 
@@ -96,7 +101,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Calibrate late in the week, not early.** `/usage` reports whole percents, so the error is `±0.5/pct`: ~17% at 3%, ~1.5% at 34%. Calibrating just after a reset produces a near-useless ceiling.
 
-2. **Record the validity date if a promo is active.** `claude-burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
+2. **Record the validity date if a promo is active.** `harness burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
 
 3. **Add per-model budgets** if `/usage` shows a separate family bar. A family limit can be fully spent while the pooled bar looks survivable — observed in practice at 100% of one model family's own limit while that family was only 29% of the pooled week.
 
@@ -229,7 +234,7 @@ That combination is diagnostic: the record store lost rows while the fingerprint
 
 ```bash
 rm ~/.claude/hud/state/files.tsv     # distrust the fingerprints
-claude-burn                          # rebuild from source
+harness burn                         # rebuild from source
 ```
 
 Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause named: record loss. Then fixed structurally — atomic writes, an `flock`, and a count header so fingerprints and records can never again disagree.
@@ -239,8 +244,8 @@ Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause nam
 `/usage` showed `97% used`, reset `Wed 08:59 America/Chicago`, a separate model-family bar at `100%`, and a `+50% weekly limits` promo with an end date.
 
 ```bash
-claude-burn reset-day wed 08:59 America/Chicago   # window FIRST
-claude-burn calibrate 97 2026-08-19               # expiry recorded
+harness burn reset-day wed 08:59 America/Chicago   # window FIRST
+harness burn calibrate 97 2026-08-19               # expiry recorded
 ```
 
 Then a per-family budget for the separate bar. Reconciled: HUD `97.2%` against `/usage` `97%` — inside G4.

--- a/agents/skills/codex/burn-hud/SKILL.md
+++ b/agents/skills/codex/burn-hud/SKILL.md
@@ -22,16 +22,21 @@
 
 ## Implementation
 
-This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line Python and shell tool does not belong inside a skill directory.
+This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line tool does not belong inside a skill directory.
 
-A reference implementation providing `scan.py`, `statusline.sh`, `burn.py` (the `claude-burn` CLI), `install.sh`, `uninstall.sh` and a stdlib test suite is expected at the path the user supplies. Its contract, which this skill assumes throughout:
+For Claude Code the reference implementation ships with the harness itself, as `@harness-engineering/burn`:
+
+- `harness burn` — the interactive surface (report, `weeks`, `calibrate`, `reset-day`, `budget`, `scan`, `install`).
+- `harness-burn-hud` — a standalone binary for the two hot paths (`line` for the statusline, `session-start`/`stop` for the hooks). It deliberately imports nothing from the CLI: loading that module graph costs ~0.85s against a ~0.11s repaint budget, and a laggy statusline is a regression nobody bisects.
+
+For any other agent CLI, an equivalent implementation is expected at the path the user supplies. Either way the contract this skill assumes throughout is:
 
 | Artifact             | Contract                                                                                                                                                       |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `state/summary.json` | Written atomically. Carries `status`, `week.reset_spec`, `wtd.units`, `budget.pct_used`, `projection.confidence`, `models_exhausted`, `calibration`, `scan.*`. |
 | `state/usage.tsv`    | Deduped record store, one row per request id.                                                                                                                  |
 | `state/files.tsv`    | Scan fingerprints, first line `#count\t<n>` — the record count, written in the same atomic write.                                                              |
-| `claude-burn`        | `status`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan`.                                                           |
+| CLI                  | `report`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan` (for Claude Code: `harness burn <subcommand>`).            |
 | statusline           | Reads the cached summary only. Never scans.                                                                                                                    |
 
 If the user has no implementation, that is the blocker to resolve first — do not hand-roll a partial scanner mid-session, because an under-counting scanner is precisely the failure this skill exists to prevent.
@@ -84,7 +89,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Ask the user to run `/usage`** and report: the weekly percentage, the reset day _and_ time _and_ timezone, whether any per-model bar is shown separately, and whether a promo or temporary limit is active.
 
-2. **Set the window first.** `claude-burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
+2. **Set the window first.** `harness burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
 
 3. **Re-scan.** The window change recuts every historical bucket, so the baseline moves too.
 
@@ -96,7 +101,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Calibrate late in the week, not early.** `/usage` reports whole percents, so the error is `±0.5/pct`: ~17% at 3%, ~1.5% at 34%. Calibrating just after a reset produces a near-useless ceiling.
 
-2. **Record the validity date if a promo is active.** `claude-burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
+2. **Record the validity date if a promo is active.** `harness burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
 
 3. **Add per-model budgets** if `/usage` shows a separate family bar. A family limit can be fully spent while the pooled bar looks survivable — observed in practice at 100% of one model family's own limit while that family was only 29% of the pooled week.
 
@@ -229,7 +234,7 @@ That combination is diagnostic: the record store lost rows while the fingerprint
 
 ```bash
 rm ~/.claude/hud/state/files.tsv     # distrust the fingerprints
-claude-burn                          # rebuild from source
+harness burn                         # rebuild from source
 ```
 
 Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause named: record loss. Then fixed structurally — atomic writes, an `flock`, and a count header so fingerprints and records can never again disagree.
@@ -239,8 +244,8 @@ Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause nam
 `/usage` showed `97% used`, reset `Wed 08:59 America/Chicago`, a separate model-family bar at `100%`, and a `+50% weekly limits` promo with an end date.
 
 ```bash
-claude-burn reset-day wed 08:59 America/Chicago   # window FIRST
-claude-burn calibrate 97 2026-08-19               # expiry recorded
+harness burn reset-day wed 08:59 America/Chicago   # window FIRST
+harness burn calibrate 97 2026-08-19               # expiry recorded
 ```
 
 Then a per-family budget for the separate bar. Reconciled: HUD `97.2%` against `/usage` `97%` — inside G4.

--- a/agents/skills/cursor/burn-hud/SKILL.md
+++ b/agents/skills/cursor/burn-hud/SKILL.md
@@ -22,16 +22,21 @@
 
 ## Implementation
 
-This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line Python and shell tool does not belong inside a skill directory.
+This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line tool does not belong inside a skill directory.
 
-A reference implementation providing `scan.py`, `statusline.sh`, `burn.py` (the `claude-burn` CLI), `install.sh`, `uninstall.sh` and a stdlib test suite is expected at the path the user supplies. Its contract, which this skill assumes throughout:
+For Claude Code the reference implementation ships with the harness itself, as `@harness-engineering/burn`:
+
+- `harness burn` — the interactive surface (report, `weeks`, `calibrate`, `reset-day`, `budget`, `scan`, `install`).
+- `harness-burn-hud` — a standalone binary for the two hot paths (`line` for the statusline, `session-start`/`stop` for the hooks). It deliberately imports nothing from the CLI: loading that module graph costs ~0.85s against a ~0.11s repaint budget, and a laggy statusline is a regression nobody bisects.
+
+For any other agent CLI, an equivalent implementation is expected at the path the user supplies. Either way the contract this skill assumes throughout is:
 
 | Artifact             | Contract                                                                                                                                                       |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `state/summary.json` | Written atomically. Carries `status`, `week.reset_spec`, `wtd.units`, `budget.pct_used`, `projection.confidence`, `models_exhausted`, `calibration`, `scan.*`. |
 | `state/usage.tsv`    | Deduped record store, one row per request id.                                                                                                                  |
 | `state/files.tsv`    | Scan fingerprints, first line `#count\t<n>` — the record count, written in the same atomic write.                                                              |
-| `claude-burn`        | `status`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan`.                                                           |
+| CLI                  | `report`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan` (for Claude Code: `harness burn <subcommand>`).            |
 | statusline           | Reads the cached summary only. Never scans.                                                                                                                    |
 
 If the user has no implementation, that is the blocker to resolve first — do not hand-roll a partial scanner mid-session, because an under-counting scanner is precisely the failure this skill exists to prevent.
@@ -84,7 +89,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Ask the user to run `/usage`** and report: the weekly percentage, the reset day _and_ time _and_ timezone, whether any per-model bar is shown separately, and whether a promo or temporary limit is active.
 
-2. **Set the window first.** `claude-burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
+2. **Set the window first.** `harness burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
 
 3. **Re-scan.** The window change recuts every historical bucket, so the baseline moves too.
 
@@ -96,7 +101,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Calibrate late in the week, not early.** `/usage` reports whole percents, so the error is `±0.5/pct`: ~17% at 3%, ~1.5% at 34%. Calibrating just after a reset produces a near-useless ceiling.
 
-2. **Record the validity date if a promo is active.** `claude-burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
+2. **Record the validity date if a promo is active.** `harness burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
 
 3. **Add per-model budgets** if `/usage` shows a separate family bar. A family limit can be fully spent while the pooled bar looks survivable — observed in practice at 100% of one model family's own limit while that family was only 29% of the pooled week.
 
@@ -229,7 +234,7 @@ That combination is diagnostic: the record store lost rows while the fingerprint
 
 ```bash
 rm ~/.claude/hud/state/files.tsv     # distrust the fingerprints
-claude-burn                          # rebuild from source
+harness burn                         # rebuild from source
 ```
 
 Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause named: record loss. Then fixed structurally — atomic writes, an `flock`, and a count header so fingerprints and records can never again disagree.
@@ -239,8 +244,8 @@ Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause nam
 `/usage` showed `97% used`, reset `Wed 08:59 America/Chicago`, a separate model-family bar at `100%`, and a `+50% weekly limits` promo with an end date.
 
 ```bash
-claude-burn reset-day wed 08:59 America/Chicago   # window FIRST
-claude-burn calibrate 97 2026-08-19               # expiry recorded
+harness burn reset-day wed 08:59 America/Chicago   # window FIRST
+harness burn calibrate 97 2026-08-19               # expiry recorded
 ```
 
 Then a per-family budget for the separate bar. Reconciled: HUD `97.2%` against `/usage` `97%` — inside G4.

--- a/agents/skills/gemini-cli/burn-hud/SKILL.md
+++ b/agents/skills/gemini-cli/burn-hud/SKILL.md
@@ -22,16 +22,21 @@
 
 ## Implementation
 
-This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line Python and shell tool does not belong inside a skill directory.
+This skill governs _how_ to install, calibrate and trust a usage HUD. The scanner, statusline, hooks and CLI are a separate deliverable, because a ~1.4k-line tool does not belong inside a skill directory.
 
-A reference implementation providing `scan.py`, `statusline.sh`, `burn.py` (the `claude-burn` CLI), `install.sh`, `uninstall.sh` and a stdlib test suite is expected at the path the user supplies. Its contract, which this skill assumes throughout:
+For Claude Code the reference implementation ships with the harness itself, as `@harness-engineering/burn`:
+
+- `harness burn` — the interactive surface (report, `weeks`, `calibrate`, `reset-day`, `budget`, `scan`, `install`).
+- `harness-burn-hud` — a standalone binary for the two hot paths (`line` for the statusline, `session-start`/`stop` for the hooks). It deliberately imports nothing from the CLI: loading that module graph costs ~0.85s against a ~0.11s repaint budget, and a laggy statusline is a regression nobody bisects.
+
+For any other agent CLI, an equivalent implementation is expected at the path the user supplies. Either way the contract this skill assumes throughout is:
 
 | Artifact             | Contract                                                                                                                                                       |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `state/summary.json` | Written atomically. Carries `status`, `week.reset_spec`, `wtd.units`, `budget.pct_used`, `projection.confidence`, `models_exhausted`, `calibration`, `scan.*`. |
 | `state/usage.tsv`    | Deduped record store, one row per request id.                                                                                                                  |
 | `state/files.tsv`    | Scan fingerprints, first line `#count\t<n>` — the record count, written in the same atomic write.                                                              |
-| `claude-burn`        | `status`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan`.                                                           |
+| CLI                  | `report`, `weeks`, `calibrate <pct> [valid_until]`, `reset-day <day> [time] [tz]`, `budget`, `scan` (for Claude Code: `harness burn <subcommand>`).            |
 | statusline           | Reads the cached summary only. Never scans.                                                                                                                    |
 
 If the user has no implementation, that is the blocker to resolve first — do not hand-roll a partial scanner mid-session, because an under-counting scanner is precisely the failure this skill exists to prevent.
@@ -84,7 +89,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Ask the user to run `/usage`** and report: the weekly percentage, the reset day _and_ time _and_ timezone, whether any per-model bar is shown separately, and whether a promo or temporary limit is active.
 
-2. **Set the window first.** `claude-burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
+2. **Set the window first.** `harness burn reset-day <mon..sun> <HH:MM> <tz>`. Weekday alone is not enough — a time-of-day error is a multi-hour window shift, and the two together caused the 81× understatement.
 
 3. **Re-scan.** The window change recuts every historical bucket, so the baseline moves too.
 
@@ -96,7 +101,7 @@ Note the asymmetry is deliberate and runs one way only: withhold a _reassuring_ 
 
 1. **Calibrate late in the week, not early.** `/usage` reports whole percents, so the error is `±0.5/pct`: ~17% at 3%, ~1.5% at 34%. Calibrating just after a reset produces a near-useless ceiling.
 
-2. **Record the validity date if a promo is active.** `claude-burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
+2. **Record the validity date if a promo is active.** `harness burn calibrate <pct> <YYYY-MM-DD>`. A promo inflates the ceiling; a calibration taken during one **under-warns** once it lapses. With a date recorded the HUD flags itself instead of quietly trusting a stale budget.
 
 3. **Add per-model budgets** if `/usage` shows a separate family bar. A family limit can be fully spent while the pooled bar looks survivable — observed in practice at 100% of one model family's own limit while that family was only 29% of the pooled week.
 
@@ -229,7 +234,7 @@ That combination is diagnostic: the record store lost rows while the fingerprint
 
 ```bash
 rm ~/.claude/hud/state/files.tsv     # distrust the fingerprints
-claude-burn                          # rebuild from source
+harness burn                         # rebuild from source
 ```
 
 Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause named: record loss. Then fixed structurally — atomic writes, an `flock`, and a count header so fingerprints and records can never again disagree.
@@ -239,8 +244,8 @@ Recovered 29,475 records; status moved `OK (3%)` → `CRITICAL (98%)`. Cause nam
 `/usage` showed `97% used`, reset `Wed 08:59 America/Chicago`, a separate model-family bar at `100%`, and a `+50% weekly limits` promo with an end date.
 
 ```bash
-claude-burn reset-day wed 08:59 America/Chicago   # window FIRST
-claude-burn calibrate 97 2026-08-19               # expiry recorded
+harness burn reset-day wed 08:59 America/Chicago   # window FIRST
+harness burn calibrate 97 2026-08-19               # expiry recorded
 ```
 
 Then a per-family budget for the separate bar. Reconciled: HUD `97.2%` against `/usage` `97%` — inside G4.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -780,6 +780,57 @@ Show provenance, verdicts, convergence, and tool-use for a run
 
 - `--dir` — Black-box directory (default: ".harness/black-box")
 
+## Burn Commands
+
+Claude Code usage burn: pace, budget, calibration
+
+### `harness burn budget [value]`
+
+Set or clear the self-imposed weekly ceiling (250M, 1.2x, or off)
+
+**Arguments:**
+
+- `value` (optional) — budget value; omit to show the current setting
+
+### `harness burn calibrate <percent> [valid-until]`
+
+Anchor the budget to a real /usage reading
+
+**Arguments:**
+
+- `percent` (required) — the percentage /usage reports right now
+- `valid-until` (optional) — YYYY-MM-DD after which this calibration is distrusted
+
+### `harness burn install`
+
+Wire the burn HUD statusline and hooks into ~/.claude/settings.json
+
+**Options:**
+
+- `--dry-run` — show what would change without writing
+
+### `harness burn report`
+
+Rescan and print the full burn report (default)
+
+### `harness burn reset-day [day] [time] [tz]`
+
+Align the week window with the reset /usage reports
+
+**Arguments:**
+
+- `day` (optional) — mon..sun or 0..6 (0=Mon); omit to show the current setting
+- `time` (optional) — local time of the reset, e.g. 08:59
+- `tz` (optional) — IANA timezone, e.g. America/Chicago
+
+### `harness burn scan`
+
+Force a cache refresh
+
+### `harness burn weeks`
+
+Weekly usage history, anchored to the configured reset
+
 ## Ci Commands
 
 CI/CD integration commands

--- a/packages/burn/README.md
+++ b/packages/burn/README.md
@@ -1,0 +1,140 @@
+# @harness-engineering/burn
+
+Usage-burn HUD for Claude Code: a transcript scanner, a week-anchored rollup, and a
+dependency-free statusline renderer.
+
+TypeScript port of the standalone `claude-burn-hud` (Python + shell). The behaviour,
+the on-disk formats and the failure-mode discipline are carried over unchanged; see
+[Porting notes](#porting-notes) for the three places the runtime forced a real change.
+
+## The one thing to know
+
+**This does not know your real weekly limit.** Anthropic enforces that server-side, and
+nothing on this machine caches remaining quota. So this package never prints a
+"% of your weekly limit" on its own authority — that number would be fabricated
+precision, and a confident-but-invented gauge is worse than no gauge.
+
+What it reports is measured:
+
+- **actual consumption**, parsed from `~/.claude/projects/**/*.jsonl` and deduped by
+  `requestId` (transcripts repeat each usage block ~3×, so naive counting inflates
+  totals ~3.5×)
+- **pace vs your own trailing baseline** (median of the last 4 complete weeks)
+- **pace vs a budget you set**, once calibrated against a real `/usage` reading
+
+For real quota status, run `/usage`. That is the authority; this is a proxy.
+
+## Surfaces
+
+| Surface                                                  | Where it lives       | Why                                                                |
+| -------------------------------------------------------- | -------------------- | ------------------------------------------------------------------ |
+| `harness burn …`                                         | `packages/cli`       | Interactive: report, weeks, calibrate, budget, reset-day, install. |
+| `harness-burn-hud line \| session-start \| stop \| scan` | this package's `bin` | Hot paths. Standalone, zero `@harness-engineering/*` imports.      |
+| `buildSummary`, `scan`, `renderStatusline`, …            | this package's `src` | The library both of the above call.                                |
+
+### Why two binaries
+
+`harness --version` costs **~0.85s** to load the CLI's module graph. The statusline
+repaints on every prompt against a **~0.11s** budget, and the Stop hook fires after every
+assistant turn. So the hot paths ship as a separate bundled binary that imports only Node
+builtins. `tests/bin-startup.test.ts` asserts that import graph — a single stray
+`@harness-engineering/*` import would make the statusline ~8× more expensive with no
+symptom beyond a terminal that feels sluggish.
+
+## Units
+
+A weighted proxy for cost/limit pressure, using Opus-like price ratios:
+
+```
+units = output×5 + input×1 + cache_write×1.25 + cache_read×0.1
+```
+
+Cache reads dominate raw token counts but are nearly free, which is why raw tokens are a
+misleading headline and this weighting exists.
+
+## Design rules
+
+These come from the "check the denominator" habit: a green readout must never be
+reachable by a path that did not actually measure anything.
+
+- **A zero denominator is an abstention, not a pass.** No usage records → `NO_DATA`
+  ("blind, not clear"), never `0% — you're fine`.
+- **A thin sample cannot produce a confident all-clear.** Under ~1 day elapsed, a
+  full-week forecast is noise, so a would-be `OK` is downgraded to `EARLY`. Elevated
+  statuses are _not_ suppressed — spend already incurred is real regardless of forecast
+  confidence, and that asymmetry is deliberate.
+- **Actual spend leads; a forecast is always marked as one.** `N% of budget` is banned
+  outright — it names the budget without saying whether that is spent or predicted.
+- **A forecast may only escalate on the evidence behind it.** Otherwise 2% of budget spent
+  in three hours extrapolates to 118% and cries `CRITICAL`, which teaches you to ignore
+  the alarm that matters.
+- **Silently-degraded tooling is a headline alert.** A stale or unreadable cache is
+  reported in the statusline, the session brief and the CLI — never swallowed.
+
+## The week window is load-bearing
+
+The first version assumed a Monday-midnight-UTC week. The real reset was **Wednesday
+08:59 America/Chicago**. That mismatch reported **3.4M units and a calm `EARLY` while the
+account was at 97% of its actual weekly limit** — an ~81× understatement.
+
+The denominator was fine and the data was real; the tool was measuring _the wrong seven
+days_. No amount of zero-denominator checking catches a correct computation over a wrong
+window — only reconciling against `/usage` does. After changing `week_reset`, always
+re-run `harness burn calibrate`.
+
+## Tests
+
+```bash
+pnpm --filter @harness-engineering/burn test
+```
+
+Every test in `scan.test.ts`, `statusline.test.ts`, `budgets-models.test.ts` and
+`concurrency.test.ts` corresponds to a defect that actually shipped:
+
+| Group            | Guards against                                                  |
+| ---------------- | --------------------------------------------------------------- |
+| week anchor      | the Monday-UTC assumption that understated a 97% week by ~81×   |
+| data loss        | the write race that silently dropped 85% of the record store    |
+| dedupe           | repeated usage blocks inflating every figure ~3.5×              |
+| abstention       | a zero or thin denominator reading as a pass                    |
+| concurrency      | partial rows and header/store disagreement under parallel scans |
+| budgets & models | a spent per-family limit hiding behind a healthy pooled bar     |
+| bin startup      | the CLI module graph creeping onto the statusline hot path      |
+
+Locking and atomic writes are exercised in real subprocesses, since neither means
+anything within a single process.
+
+## Porting notes
+
+Three places where the runtime, not the design, forced a change:
+
+1. **Locking.** Python used `fcntl.flock`, which the kernel releases when the holder
+   dies. Node has no `flock`, so `store.ts` uses an atomic `mkdir` plus a staleness
+   reclaim (dead pid, or older than a scan could plausibly take). Two tests cover what
+   the kernel used to do for free.
+2. **Timezones.** `zoneinfo` → `Intl.DateTimeFormat`, with a two-pass offset resolution
+   so a reset near a DST boundary lands on the right side of the shift. Asserted across
+   the 2026-11-01 US transition.
+3. **Timestamps.** Summaries are written as `…+00:00` rather than Node's default `…Z`,
+   because `datetime.fromisoformat` rejected `Z` before Python 3.11 and the old HUD may
+   still be reading these files during cutover.
+
+Parity was verified by running both implementations over the same 33,305 real records:
+every shared record was byte-identical, and with `now` pinned the summaries differed only
+in Python's microsecond vs JS millisecond precision and `100.0` vs `100` JSON rendering.
+
+## Known blind spots
+
+State these rather than let a confident number imply otherwise:
+
+- **This machine only.** `/usage` notes its own breakdown excludes other devices and
+  claude.ai, so local units undercount account usage if you work across two machines.
+  Calibration absorbs the other device's share while the device mix holds, and drifts
+  when it changes.
+- **Units are a fixed weighting**, not a live price feed. A large shift in workload mix
+  drifts the mapping — observed 1.9× in two days. Treat a calibration as good for days,
+  not weeks.
+- **The 5-hour session window is a trailing approximation** of an anchored server-side
+  window, so treat it as directional.
+- **Weekly limits can be per-model.** The pooled bar and a family bar are different
+  limits; `model_budgets` is how the HUD knows about the latter.

--- a/packages/burn/package.json
+++ b/packages/burn/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@harness-engineering/burn",
+  "version": "0.0.0",
+  "license": "MIT",
+  "description": "Claude Code usage-burn HUD: transcript scanner, week-anchored rollup, and a dependency-free statusline renderer",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "harness-burn-hud": "./dist/bin/burn-hud.mjs"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
+    "clean": "node ../../scripts/clean.mjs dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Intense-Visions/harness-engineering.git",
+    "directory": "packages/burn"
+  },
+  "bugs": {
+    "url": "https://github.com/Intense-Visions/harness-engineering/issues"
+  },
+  "homepage": "https://github.com/Intense-Visions/harness-engineering/tree/main/packages/burn#readme",
+  "devDependencies": {
+    "@types/node": "^22.19.15",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/burn/src/bin/burn-hud.ts
+++ b/packages/burn/src/bin/burn-hud.ts
@@ -1,0 +1,151 @@
+/**
+ * harness-burn-hud — the hot-path binary.
+ *
+ * Three of these four subcommands run on a latency budget the main `harness`
+ * CLI cannot meet: `line` renders on every statusline repaint and `stop` fires
+ * after every assistant turn. Measured on this machine, `harness --version`
+ * costs ~0.85s to load its module graph against the statusline's ~0.11s budget,
+ * so this entry point is built standalone and imports nothing from
+ * `@harness-engineering/*`. `tests/bin-startup.test.ts` fails the build if that
+ * ever stops being true.
+ *
+ * The rich, interactive surface (report, weeks, calibrate, budget) lives in
+ * `harness burn`, where latency does not matter.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { loadConfig, resolvePaths } from '../config';
+import { gitSegment } from '../git';
+import { escalation, sessionBrief, type NotifyState } from '../hooks';
+import { readSummary } from '../read-summary';
+import { refresh, refreshIfStale } from '../refresh';
+import { renderStatusline } from '../statusline';
+
+/**
+ * Read the JSON payload Claude Code pipes in.
+ *
+ * Blocking on fd 0 is what the shell version did (`$(cat)`), and it is correct
+ * when the caller writes and closes. The TTY guard is for the other case: a
+ * human running `harness-burn-hud line` by hand would otherwise sit at a dead
+ * prompt with no clue why.
+ */
+function readStdin(): Record<string, unknown> {
+  if (process.stdin.isTTY) return {};
+  try {
+    const raw = readFileSync(0, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    return parsed !== null && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function cwdFrom(payload: Record<string, unknown>): string {
+  const direct = typeof payload.cwd === 'string' ? payload.cwd : '';
+  const workspace = payload.workspace as { current_dir?: string } | undefined;
+  return process.env.CLAUDE_HUD_CWD || direct || workspace?.current_dir || process.cwd();
+}
+
+function cmdLine(): void {
+  const payload = readStdin();
+  const paths = resolvePaths();
+  const model = payload.model as { display_name?: string } | undefined;
+  process.stdout.write(
+    renderStatusline({
+      summary: readSummary(paths),
+      config: loadConfig(paths),
+      git: gitSegment(cwdFrom(payload)),
+      modelName: model?.display_name ?? null,
+    })
+  );
+}
+
+function cmdSessionStart(): void {
+  const payload = readStdin();
+  const paths = resolvePaths();
+  const cwd = cwdFrom(payload);
+
+  // Keep the cache warm; this is the one hook where a full scan is affordable.
+  try {
+    refresh(paths);
+  } catch {
+    // A failed scan still gets a brief — built from whatever is cached, and
+    // saying "blind" if that is nothing.
+  }
+
+  const git = gitSegment(cwd);
+  const mergedBranch = git?.kind === 'merged' ? git.label : null;
+  process.stdout.write(JSON.stringify(sessionBrief(readSummary(paths), mergedBranch)));
+}
+
+function cmdStop(): void {
+  readStdin(); // drain; this hook needs no session fields
+  const paths = resolvePaths();
+  try {
+    refreshIfStale(paths);
+  } catch {
+    // Fall through to whatever is cached.
+  }
+
+  const summary = readSummary(paths);
+  if (!summary) return; // a broken cache is the session-brief hook's problem
+
+  let previous: NotifyState | null;
+  try {
+    previous = JSON.parse(readFileSync(paths.lastNotify, 'utf8')) as NotifyState;
+  } catch {
+    previous = null;
+  }
+
+  const { message, nextNotify } = escalation(summary, previous);
+  if (nextNotify) {
+    try {
+      writeFileSync(paths.lastNotify, JSON.stringify(nextNotify));
+    } catch {
+      // Losing the ladder state only costs one duplicate notification.
+    }
+  }
+  if (message) process.stdout.write(JSON.stringify({ systemMessage: message }));
+}
+
+function cmdScan(): void {
+  const summary = refresh(resolvePaths());
+  if (process.argv.includes('--json')) {
+    process.stdout.write(JSON.stringify(summary, null, 2));
+  }
+}
+
+const USAGE = `harness-burn-hud <line|session-start|stop|scan>
+
+  line           render the statusline from the cached summary (never scans)
+  session-start  SessionStart hook: warm the cache, brief the session
+  stop           Stop hook: refresh if cold, speak only on escalation
+  scan           force a refresh (--json to print the summary)
+`;
+
+function main(): number {
+  switch (process.argv[2]) {
+    case 'line':
+      cmdLine();
+      return 0;
+    case 'session-start':
+      cmdSessionStart();
+      return 0;
+    case 'stop':
+      cmdStop();
+      return 0;
+    case 'scan':
+      cmdScan();
+      return 0;
+    default:
+      process.stdout.write(USAGE);
+      return 0;
+  }
+}
+
+try {
+  process.exitCode = main();
+} catch {
+  // A HUD that crashes must not take the statusline or a hook down with it.
+  process.exitCode = 0;
+}

--- a/packages/burn/src/config.ts
+++ b/packages/burn/src/config.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import type { BurnConfig } from './types';
+
+/**
+ * Where the HUD keeps its state.
+ *
+ * The `CLAUDE_HUD_*` env names are inherited from the Python HUD rather than
+ * renamed: an existing install already sets them, and the test suite drives the
+ * real code against a throwaway tree through the same three variables.
+ */
+export interface BurnPaths {
+  hud: string;
+  state: string;
+  projects: string;
+  config: string;
+  summary: string;
+  usageTsv: string;
+  filesTsv: string;
+  lock: string;
+  lastNotify: string;
+}
+
+export function resolvePaths(env: NodeJS.ProcessEnv = process.env): BurnPaths {
+  const home = env.HOME || homedir();
+  const hud = env.CLAUDE_HUD_HOME || path.join(home, '.claude', 'hud');
+  const state = env.CLAUDE_HUD_STATE || path.join(hud, 'state');
+  const projects = env.CLAUDE_HUD_PROJECTS || path.join(home, '.claude', 'projects');
+  return {
+    hud,
+    state,
+    projects,
+    config: path.join(hud, 'config.json'),
+    summary: path.join(state, 'summary.json'),
+    usageTsv: path.join(state, 'usage.tsv'),
+    filesTsv: path.join(state, 'files.tsv'),
+    lock: path.join(state, 'scan.lock'),
+    lastNotify: path.join(state, 'last-notify.json'),
+  };
+}
+
+export const DEFAULT_CONFIG: BurnConfig = {
+  // Must mirror /usage. weekday: 0=Mon .. 6=Sun.
+  week_reset: { weekday: 0, time: '00:00', tz: 'UTC' },
+  weekly_budget_units: null,
+  model_budgets: {},
+  session_window_hours: 5,
+  session_budget_units: null,
+  warm_ratio: 1.25,
+  hot_ratio: 1.6,
+  baseline_weeks: 4,
+  stale_after_minutes: 90,
+};
+
+function clone(cfg: BurnConfig): BurnConfig {
+  return JSON.parse(JSON.stringify(cfg)) as BurnConfig;
+}
+
+/**
+ * Read the user's config over the defaults.
+ *
+ * A broken config must not take the HUD down — an unreadable file falls back to
+ * defaults, because a HUD that fails to start is indistinguishable from a HUD
+ * reporting nothing to worry about.
+ */
+export function loadConfig(paths: BurnPaths): BurnConfig {
+  const cfg = clone(DEFAULT_CONFIG);
+  if (!existsSync(paths.config)) return cfg;
+
+  let user: Record<string, unknown>;
+  try {
+    user = JSON.parse(readFileSync(paths.config, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return cfg;
+  }
+  if (user === null || typeof user !== 'object') return cfg;
+
+  // Legacy flat key, kept working so an old config cannot silently revert the
+  // week window to Monday-UTC — the mismatch that understated a 97% week by ~81x.
+  if ('week_reset_weekday' in user && !('week_reset' in user)) {
+    const wd = Number(user.week_reset_weekday);
+    if (Number.isFinite(wd)) cfg.week_reset.weekday = ((wd % 7) + 7) % 7;
+  }
+
+  for (const [k, v] of Object.entries(user)) {
+    if (k === 'week_reset_weekday') continue;
+    if (k === 'week_reset' && v !== null && typeof v === 'object') {
+      Object.assign(cfg.week_reset, v);
+    } else {
+      (cfg as unknown as Record<string, unknown>)[k] = v;
+    }
+  }
+  return cfg;
+}
+
+/** Read the raw on-disk config (no defaults merged) — what `harness burn` edits. */
+export function readRawConfig(paths: BurnPaths): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(paths.config, 'utf8'));
+    return parsed !== null && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveRawConfig(paths: BurnPaths, cfg: Record<string, unknown>): void {
+  mkdirSync(path.dirname(paths.config), { recursive: true });
+  writeFileSync(paths.config, JSON.stringify(cfg, null, 2) + '\n');
+}

--- a/packages/burn/src/git.ts
+++ b/packages/burn/src/git.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from 'node:child_process';
+
+import type { GitSegment } from './statusline';
+
+function git(cwd: string, args: string[]): string | null {
+  try {
+    return execFileSync('git', ['-C', cwd, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Branch state for the statusline, in at most two git invocations.
+ *
+ * `ahead == 0` against the base means the branch is fully contained in it — the
+ * work merged, so the session's context has stopped paying for itself. That is
+ * the moment the /clear nudge fires.
+ */
+export function gitSegment(cwd: string): GitSegment | null {
+  const branch = git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  if (!branch || branch === 'HEAD') return null;
+  if (branch === 'main' || branch === 'master' || branch === 'develop') {
+    return { kind: 'plain', label: branch };
+  }
+
+  const ahead =
+    git(cwd, ['rev-list', '--count', `origin/main..${branch}`]) ??
+    git(cwd, ['rev-list', '--count', `origin/master..${branch}`]);
+
+  if (ahead === '0') return { kind: 'merged', label: branch };
+  if (ahead) return { kind: 'plain', label: `${branch} +${ahead}` };
+  return { kind: 'plain', label: branch };
+}

--- a/packages/burn/src/hooks.ts
+++ b/packages/burn/src/hooks.ts
@@ -1,0 +1,231 @@
+import type { Summary } from './types';
+import { human } from './units';
+
+/**
+ * Hook payload builders.
+ *
+ * Both hooks split their audience deliberately:
+ *   additionalContext -> ALWAYS injected (model-only, costs the user nothing)
+ *                        so the assistant knows the pace without being asked.
+ *   systemMessage     -> ONLY when there is something to act on.
+ * Noise is why the previous always-on reminder stopped being read, so the
+ * visible channel stays quiet unless it has earned the interruption.
+ */
+
+export interface SessionBriefOutput {
+  hookSpecificOutput: { hookEventName: 'SessionStart'; additionalContext: string };
+  systemMessage?: string;
+}
+
+function formatPace(s: Summary): string {
+  const budget = s.budget ?? { set: false };
+  if (budget.set && budget.pct_projected != null) {
+    return `${Math.round(budget.pct_projected)}% of the weekly budget`;
+  }
+  const ratio = s.projection?.ratio_vs_baseline;
+  return ratio ? `${ratio}x your 4-week median` : 'no baseline yet';
+}
+
+function staleMinutes(s: Summary, now: Date, threshold = 90): number | null {
+  const generated = Date.parse(s.generated_at ?? '');
+  if (!Number.isFinite(generated)) return null;
+  const age = (now.getTime() - generated) / 60_000;
+  return age > threshold ? Math.floor(age) : null;
+}
+
+export function sessionBrief(
+  summary: Summary | null,
+  mergedBranch: string | null,
+  now: Date = new Date()
+): SessionBriefOutput {
+  if (!summary) {
+    // A cache that cannot be read is a finding, not an all-clear.
+    return {
+      systemMessage:
+        'BURN HUD: no usage cache could be read — the HUD is blind, not clear. Run: harness burn scan',
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext:
+          'BURN HUD UNAVAILABLE: the usage cache is missing or unreadable, so pace is UNKNOWN. ' +
+          'Treat this as a finding, not an all-clear — say so if the user asks about usage.',
+      },
+    };
+  }
+
+  const status = summary.status ?? '?';
+  const pace = formatPace(summary);
+  const stale = staleMinutes(summary, now);
+  const budget = summary.budget ?? { set: false };
+  const base = summary.baseline?.median_units;
+
+  const context: string[] = [
+    `BURN HUD (local usage proxy, not Anthropic's real quota): status=${status}.`,
+    `Week to date ${human(summary.wtd.units)} units ` +
+      `(${summary.wtd.requests.toLocaleString('en-US')} requests); ` +
+      `projected ${human(summary.projection.units_at_reset)} by reset in ` +
+      `${summary.week.days_left.toFixed(1)}d; pace = ${pace} ` +
+      `(forecast confidence: ${summary.projection.confidence}).`,
+  ];
+  if (base) context.push(`4-week median baseline: ${human(base)} units/week.`);
+  if (!budget.set) {
+    context.push(
+      'No weekly budget is set, so there is no percentage-of-limit to report. ' +
+        'Never invent one — the real limit is server-side; /usage is the authority.'
+    );
+  }
+  if (stale) context.push(`WARNING: cache is ${stale} minutes stale.`);
+  if (mergedBranch) {
+    context.push(
+      `The checked-out branch '${mergedBranch}' is ALREADY MERGED into its base. ` +
+        "The task it belongs to is done, so this session's context is now pure cost. " +
+        'Recommend /clear in your first message.'
+    );
+  }
+
+  const visible: string[] = [];
+  const labels: Record<string, string> = {
+    WARM: 'above your usual pace',
+    HOT: 'running hot',
+    CRITICAL: 'over budget at this pace',
+  };
+  if (labels[status]) {
+    visible.push(
+      `🔥 Burn ${status} — ${labels[status]}: ${human(summary.wtd.units)} units used, ` +
+        `${human(summary.projection.units_at_reset)} projected by reset (${pace}).`
+    );
+  } else if (status === 'NO_DATA') {
+    visible.push('⚠ Burn HUD has NO usage data — blind, not clear.');
+  }
+  if (stale) visible.push(`⚠ Burn cache ${stale}m stale.`);
+  if (mergedBranch) {
+    visible.push(
+      `✅ '${mergedBranch}' is already merged — good moment to /clear before starting the next task.`
+    );
+  }
+
+  const out: SessionBriefOutput = {
+    hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: context.join(' ') },
+  };
+  if (visible.length) out.systemMessage = visible.join('\n');
+  return out;
+}
+
+/** Status -> escalation level. Everything below WARM is silence. */
+const LEVEL: Record<string, number> = {
+  NO_DATA: 0,
+  EARLY: 0,
+  NO_BASELINE: 0,
+  OK: 0,
+  WARM: 1,
+  HOT: 2,
+  CRITICAL: 3,
+};
+
+export interface NotifyState {
+  level: number;
+  status: string;
+  ts: string;
+}
+
+export interface EscalationOutput {
+  /** null when this turn has not earned an interruption. */
+  message: string | null;
+  /** Ladder state to persist, or null to leave the previous state untouched. */
+  nextNotify: NotifyState | null;
+}
+
+function formatInZone(iso: string, tz: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: tz,
+      weekday: 'short',
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+      timeZoneName: 'short',
+    }).format(d);
+  } catch {
+    return d.toISOString();
+  }
+}
+
+/**
+ * Decide whether the Stop hook speaks.
+ *
+ * It runs after EVERY assistant turn, so the bar is high: it notifies when the
+ * status LEVEL RISES, or when an already-elevated level persists past the
+ * cooldown. A warning repeated every turn becomes wallpaper, and wallpaper is
+ * how a real limit gets hit anyway.
+ */
+export function escalation(
+  summary: Summary,
+  previous: NotifyState | null,
+  now: Date = new Date(),
+  cooldownMinutes = 45
+): EscalationOutput {
+  const status = summary.status ?? 'OK';
+  const level = LEVEL[status] ?? 0;
+
+  if (level === 0) {
+    // Reset the ladder so a later re-entry into WARM notifies again.
+    return { message: null, nextNotify: { level: 0, status, ts: now.toISOString() } };
+  }
+
+  const prevLevel = previous?.level ?? 0;
+  const prevTs = previous?.ts ? Date.parse(previous.ts) : NaN;
+  const escalated = level > prevLevel;
+  const cooled = !Number.isFinite(prevTs) || (now.getTime() - prevTs) / 60_000 >= cooldownMinutes;
+  if (!escalated && !cooled) return { message: null, nextNotify: null };
+
+  const wtd = human(summary.wtd.units);
+  const proj = human(summary.projection.units_at_reset);
+  const budget = summary.budget ?? { set: false };
+  const ratio = summary.projection?.ratio_vs_baseline;
+  const headline = { 1: '🟠 Burn WARM', 2: '🔥 Burn HOT', 3: '🔴 Burn CRITICAL' }[level] ?? '';
+
+  // Lead with what is actually spent. Quoting a projected percentage next to a
+  // small absolute figure once produced "5.8M used ... 108% of your weekly
+  // budget", which reads as self-contradictory and taught the reader to
+  // discount the alarm.
+  let spent: string;
+  let forecast: string;
+  if (budget.set && budget.pct_used != null) {
+    spent = `${wtd} used — ${Math.round(budget.pct_used)}% of your weekly budget`;
+    forecast =
+      budget.pct_projected != null
+        ? `; on current pace ~${Math.round(budget.pct_projected)}% by reset`
+        : '';
+  } else {
+    spent = `${wtd} used this week`;
+    forecast = `; projected ${proj} by reset${ratio ? ` (${ratio}x your 4-week median)` : ''}`;
+  }
+
+  let msg = `${headline} — ${spent}${forecast}. Reset in ${summary.week.days_left.toFixed(1)}d.`;
+  if (summary.projection?.confidence === 'low') {
+    msg += '\n   (Early in the week, so the forecast is weakly supported.)';
+  }
+  for (const m of summary.models_exhausted ?? []) {
+    msg += `\n   ${m} is at 100% of its own separate limit — already spent.`;
+  }
+  if (level >= 2) {
+    msg +=
+      '\n   Worth slowing down: batch prompts, /clear finished work, and check /usage for real quota.';
+  }
+  if (budget.exhausts_before_reset && budget.exhausts_at) {
+    // Report in the account's reset timezone; /usage speaks that timezone, and
+    // a UTC time here would not line up with what the user reads there.
+    const tz = summary.week?.tz || 'UTC';
+    msg += `\n   At this rate the budget runs out ${formatInZone(budget.exhausts_at, tz)}, before reset.`;
+  }
+  if (summary.calibration?.expired) {
+    msg +=
+      `\n   NOTE: the budget calibration expired (${summary.calibration.valid_until}) — ` +
+      "re-run 'harness burn calibrate <pct>'; until then this percentage may under-warn.";
+  }
+
+  return { message: msg, nextNotify: { level, status, ts: now.toISOString() } };
+}

--- a/packages/burn/src/index.ts
+++ b/packages/burn/src/index.ts
@@ -1,0 +1,32 @@
+export type {
+  BudgetBlock,
+  BurnConfig,
+  BurnStatus,
+  Calibration,
+  Confidence,
+  ModelBlock,
+  ScanInfo,
+  SessionBlock,
+  Summary,
+  UsageRecord,
+  WeekReset,
+} from './types';
+
+export { DEFAULT_CONFIG, loadConfig, readRawConfig, resolvePaths, saveRawConfig } from './config';
+export type { BurnPaths } from './config';
+
+export { human, units, W_CACHE_READ, W_CACHE_WRITE, W_IN, W_OUT } from './units';
+export { safeZone, WEEK_MS, wallToInstant, weekBounds } from './window';
+
+export { atomicWrite, readFingerprints, readRecords, withScanLock } from './store';
+export { parseTranscript, scan, scanInfoFromStore } from './scan';
+export { buildSummary, writeSummary } from './summary';
+export { readSummary } from './read-summary';
+export { recompute, refresh, refreshIfStale } from './refresh';
+
+export { compactUnits, renderStatusline } from './statusline';
+export type { GitSegment, StatuslineInput } from './statusline';
+export { gitSegment } from './git';
+
+export { escalation, sessionBrief } from './hooks';
+export type { EscalationOutput, NotifyState, SessionBriefOutput } from './hooks';

--- a/packages/burn/src/read-summary.ts
+++ b/packages/burn/src/read-summary.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+
+import type { BurnPaths } from './config';
+import type { Summary } from './types';
+
+/**
+ * Read the cached summary, or null.
+ *
+ * Missing and corrupt collapse to the same answer on purpose: both mean the HUD
+ * cannot say anything about usage, and every consumer must render that as
+ * stated ignorance rather than as a comfortable green.
+ */
+export function readSummary(paths: BurnPaths): Summary | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(paths.summary, 'utf8'));
+    if (parsed === null || typeof parsed !== 'object') return null;
+    return parsed as Summary;
+  } catch {
+    return null;
+  }
+}

--- a/packages/burn/src/refresh.ts
+++ b/packages/burn/src/refresh.ts
@@ -1,0 +1,41 @@
+import { statSync } from 'node:fs';
+
+import { loadConfig, type BurnPaths } from './config';
+import { scan, scanInfoFromStore } from './scan';
+import { buildSummary, writeSummary } from './summary';
+import type { Summary } from './types';
+
+/** Rescan transcripts and publish a fresh summary. */
+export function refresh(paths: BurnPaths, now: Date = new Date()): Summary {
+  const cfg = loadConfig(paths);
+  const summary = buildSummary(paths, scan(paths), cfg, now);
+  writeSummary(paths, summary);
+  return summary;
+}
+
+/** Recompute the summary from stored records, without re-reading transcripts. */
+export function recompute(paths: BurnPaths, now: Date = new Date()): Summary {
+  const cfg = loadConfig(paths);
+  const summary = buildSummary(paths, scanInfoFromStore(paths), cfg, now);
+  writeSummary(paths, summary);
+  return summary;
+}
+
+/**
+ * Rescan only if the cache has gone cold.
+ *
+ * The Stop hook fires after every assistant turn, and with several concurrent
+ * Claude sessions that meant many overlapping scans competing to rewrite the
+ * same store — the pressure that lost 85% of the records on 2026-08-04. Scans
+ * are locked now, but not stampeding in the first place is the cheaper fix, and
+ * usage cannot move meaningfully inside a minute.
+ */
+export function refreshIfStale(paths: BurnPaths, maxAgeSeconds = 60, now: Date = new Date()): void {
+  try {
+    const age = (now.getTime() - statSync(paths.summary).mtimeMs) / 1000;
+    if (age < maxAgeSeconds) return;
+  } catch {
+    // No summary yet — that is exactly when a scan is worth doing.
+  }
+  refresh(paths, now);
+}

--- a/packages/burn/src/scan.ts
+++ b/packages/burn/src/scan.ts
@@ -1,0 +1,189 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import type { BurnPaths } from './config';
+import {
+  readFingerprints,
+  readRecords,
+  withScanLock,
+  writeFingerprints,
+  writeRecords,
+} from './store';
+import type { ScanInfo, UsageRecord } from './types';
+
+/** Below this ratio of the asserted count, the store is treated as having lost rows. */
+const INTEGRITY_FLOOR = 0.98;
+
+function listTranscripts(root: string): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable directory is not a reason to abandon the scan
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.jsonl')) found.push(full);
+    }
+  };
+  if (existsSync(root)) walk(root);
+  return found;
+}
+
+interface TranscriptLine {
+  requestId?: string;
+  timestamp?: string;
+  message?: {
+    model?: string;
+    usage?: {
+      output_tokens?: number;
+      input_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+}
+
+/**
+ * Fold one transcript into `records`, keyed by requestId.
+ *
+ * Transcripts repeat the same usage block ~3x per request, so counting rows
+ * instead of request ids inflates every figure by roughly 3.5x. First write
+ * wins: a requestId already present is skipped, which also makes the scan
+ * idempotent across overlapping files.
+ */
+/** One transcript line -> a record, or null when the line is not a usage turn. */
+function toRecord(line: string): { id: string; record: UsageRecord } | null {
+  // Cheap prefilter: most lines are not assistant turns.
+  if (!line.includes('"usage"')) return null;
+
+  let obj: TranscriptLine;
+  try {
+    obj = JSON.parse(line) as TranscriptLine;
+  } catch {
+    return null;
+  }
+
+  const id = obj.requestId;
+  const usage = obj.message?.usage;
+  if (!id || !usage || typeof usage !== 'object') return null;
+
+  return {
+    id,
+    record: {
+      ts: obj.timestamp ?? '',
+      model: obj.message?.model ?? 'unknown',
+      out: Number(usage.output_tokens) || 0,
+      in: Number(usage.input_tokens) || 0,
+      cacheWrite: Number(usage.cache_creation_input_tokens) || 0,
+      cacheRead: Number(usage.cache_read_input_tokens) || 0,
+    },
+  };
+}
+
+export function parseTranscript(file: string, records: Map<string, UsageRecord>): number {
+  let text: string;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch {
+    return 0;
+  }
+
+  let added = 0;
+  for (const line of text.split('\n')) {
+    const parsed = toRecord(line);
+    if (!parsed || records.has(parsed.id)) continue;
+    records.set(parsed.id, parsed.record);
+    added += 1;
+  }
+  return added;
+}
+
+/**
+ * Incrementally rescan changed transcripts and rewrite the record store.
+ *
+ * Scans fire from the SessionStart hook, the Stop hook and the CLI, and several
+ * Claude sessions run at once, so the whole body is serialised. A scan that
+ * cannot take the lock returns what is already on disk rather than joining in.
+ */
+export function scan(paths: BurnPaths): ScanInfo {
+  return withScanLock(paths, (acquired): ScanInfo => {
+    if (!acquired) {
+      // Another scan is mid-flight and will publish a fresher summary.
+      const records = readRecords(paths);
+      const { fingerprints } = readFingerprints(paths);
+      return {
+        files_total: fingerprints.size,
+        files_rescanned: 0,
+        records_added: 0,
+        records_total: records.size,
+        skipped_locked: true,
+      };
+    }
+
+    let { fingerprints, expected } = readFingerprints(paths);
+    const records = readRecords(paths);
+
+    // Integrity gate. If the store holds materially fewer records than the
+    // fingerprints claim were scanned, the store lost rows — so every
+    // fingerprint is now a lie that would suppress the rebuild. Distrust them
+    // all and re-read from source.
+    let lost = 0;
+    if (expected !== null && records.size < expected * INTEGRITY_FLOOR) {
+      lost = expected - records.size;
+      fingerprints = new Map();
+    }
+
+    const seen = new Map<string, string>();
+    let rescanned = 0;
+    let added = 0;
+
+    for (const file of listTranscripts(paths.projects)) {
+      let st;
+      try {
+        st = statSync(file);
+      } catch {
+        continue;
+      }
+      const sig = `${Math.floor(st.mtimeMs / 1000)}\t${st.size}`;
+      seen.set(file, sig);
+      if (fingerprints.get(file) === sig) continue;
+      rescanned += 1;
+      added += parseTranscript(file, records);
+    }
+
+    // Fingerprints first, so the count and the fingerprints it describes land
+    // in one atomic write and can never disagree.
+    writeFingerprints(paths, seen, records.size);
+    writeRecords(paths, records);
+
+    const info: ScanInfo = {
+      files_total: seen.size,
+      files_rescanned: rescanned,
+      records_added: added,
+      records_total: records.size,
+    };
+    if (lost > 0) {
+      // Degraded tooling is a headline, not a footnote.
+      info.data_loss_detected = true;
+      info.records_lost = lost;
+      info.records_recovered = added;
+      info.unrecovered = Math.max(lost - added, 0);
+    }
+    return info;
+  });
+}
+
+/** Recompute from the stored records without touching transcripts. */
+export function scanInfoFromStore(paths: BurnPaths): ScanInfo {
+  const { fingerprints } = readFingerprints(paths);
+  return {
+    files_total: fingerprints.size,
+    files_rescanned: 0,
+    records_added: 0,
+    records_total: readRecords(paths).size,
+  };
+}

--- a/packages/burn/src/statusline.ts
+++ b/packages/burn/src/statusline.ts
@@ -1,0 +1,155 @@
+import type { BurnConfig, Summary } from './types';
+
+/**
+ * Statusline rendering.
+ *
+ * Ordering here is not cosmetic. The projected percentage once occupied the
+ * headline slot, so a line reading `🔴 277.5M wtd → 381.1M proj · 133% of budget`
+ * was taken to mean 133% consumed when actual spend was 7%. A forecast sitting
+ * where a reader takes it for a measurement is a false reading even when every
+ * number in it is correct — so what leads, and how the forecast is labelled, is
+ * asserted in tests the same way the scanner's arithmetic is.
+ *
+ * Two invariants, both learned by breaking them:
+ *   1. Actual spend leads; a forecast is always marked as one. `N% of budget`
+ *      is banned outright — it names the budget without saying whether that is
+ *      spent or predicted.
+ *   2. A missing or stale cache is stated out loud. A silent HUD reads as "all
+ *      clear" when it is really just blind.
+ */
+
+const RESET = '\u001b[0m';
+
+function dim(s: string): string {
+  return `\u001b[2m${s}${RESET}`;
+}
+
+function col(code: string, s: string): string {
+  return `\u001b[${code}m${s}${RESET}`;
+}
+
+/**
+ * Truncating unit format, deliberately distinct from `human()`.
+ *
+ * The statusline never rounds up: showing 250.0M when 249.96M was measured
+ * reads as crossing a threshold that was not crossed.
+ */
+export function compactUnits(u: number): string {
+  const v = Number(u) || 0;
+  if (v >= 1e6) return `${Math.floor((v / 1e6) * 10) / 10}M`;
+  if (v >= 1e3) return `${Math.floor(v / 1e3)}k`;
+  return `${Math.floor(v)}`;
+}
+
+const STATUS_STYLE: Record<string, [string, string]> = {
+  CRITICAL: ['31', '🔴'],
+  HOT: ['31', '🔥'],
+  WARM: ['33', '🟠'],
+  OK: ['32', '🟢'],
+  EARLY: ['36', '🌱'],
+  UNDERCOUNT: ['31', '⁉️'],
+  NO_DATA: ['33', '⚠'],
+};
+
+export interface GitSegment {
+  /** `merged` means the branch is fully contained in its base — the /clear signal. */
+  kind: 'merged' | 'plain';
+  label: string;
+}
+
+export interface StatuslineInput {
+  /** `null` when the cache is missing OR unparseable — both are "blind". */
+  summary: Summary | null;
+  config?: Partial<BurnConfig>;
+  git?: GitSegment | null;
+  modelName?: string | null;
+  now?: Date;
+}
+
+/**
+ * The pace phrase. ACTUAL SPEND LEADS; the forecast is marked with "proj".
+ *
+ * Order and labelling are the whole point — see the invariant above.
+ */
+function paceText(summary: Summary): string {
+  const budget = summary.budget ?? { set: false };
+  if (budget.set === true && budget.pct_used != null) {
+    const used = `${Math.floor(budget.pct_used)}% used`;
+    return budget.pct_projected != null
+      ? `${used} · ~${Math.floor(budget.pct_projected)}% proj`
+      : used;
+  }
+  if (summary.projection?.ratio_vs_baseline != null) {
+    return `${summary.projection.ratio_vs_baseline}× 4wk median proj`;
+  }
+  return 'no baseline yet';
+}
+
+/** Minutes since the cache was written, or -1 when that cannot be determined. */
+function cacheAgeMinutes(summary: Summary, now: Date): number {
+  const generated = Date.parse(summary.generated_at ?? '');
+  return Number.isFinite(generated) ? Math.floor((now.getTime() - generated) / 60_000) : -1;
+}
+
+function burnSegment(summary: Summary, staleAfter: number, now: Date): string {
+  const [colour, icon] = STATUS_STYLE[summary.status] ?? ['33', '❔'];
+  let out = col(colour, `${icon} ${compactUnits(summary.wtd?.units ?? 0)}`);
+  if (summary.status === 'UNDERCOUNT') {
+    out += col('31', '+ lost rows — UNDERCOUNT, run harness burn');
+  }
+  out += dim(
+    ` wtd → ${compactUnits(summary.projection?.units_at_reset ?? 0)} proj · ${paceText(summary)}`
+  );
+  if (summary.projection?.confidence === 'low') out += dim(' (early)');
+
+  const age = cacheAgeMinutes(summary, now);
+  if (age > staleAfter) out += col('33', ` [stale ${age}m]`);
+  return out;
+}
+
+/**
+ * Reset countdown. Hours once inside two days: "2d" reads as plenty of runway
+ * when it is really one working afternoon.
+ */
+function countdownSegment(summary: Summary): string {
+  const hoursLeft = summary.week?.hours_left ?? (summary.week?.days_left ?? 0) * 24;
+  if (hoursLeft > 48) return dim(`${Math.round(summary.week?.days_left ?? 0)}d to reset`);
+  const label = `${Math.round(hoursLeft)}h to reset`;
+  return hoursLeft <= 12 ? col('33', label) : dim(label);
+}
+
+/** A per-model limit can be exhausted while the pooled one still looks fine. */
+function exhaustedSegment(summary: Summary): string | null {
+  const exhausted = summary.models_exhausted ?? [];
+  if (exhausted.length === 0) return null;
+  return col('31', `⛔ ${exhausted.map((m) => m.replace(/^claude-/, '')).join(',')} spent`);
+}
+
+/** The 5h session window, only once it is worth knowing about. */
+function sessionSegment(summary: Summary): string | null {
+  const pct = summary.session?.pct_used ?? 0;
+  return pct >= 70 ? col('33', `⏳ session ~${Math.round(pct)}%`) : null;
+}
+
+function gitText(git: GitSegment): string {
+  return git.kind === 'merged' ? col('35', `✅ ${git.label} merged → /clear`) : dim(git.label);
+}
+
+export function renderStatusline(input: StatuslineInput): string {
+  const { summary, config, git, modelName } = input;
+  const now = input.now ?? new Date();
+
+  const burnSegments: (string | null)[] = summary
+    ? [
+        burnSegment(summary, config?.stale_after_minutes ?? 90, now),
+        countdownSegment(summary),
+        exhaustedSegment(summary),
+        sessionSegment(summary),
+        // A calibration that outlived its basis must not be trusted silently.
+        summary.calibration?.expired ? col('33', '⚠ recalibrate') : null,
+      ]
+    : [col('33', 'burn: no cache — run: harness burn scan')];
+
+  const segments = [...burnSegments, git ? gitText(git) : null, modelName ? dim(modelName) : null];
+  return segments.filter((s): s is string => s !== null).join(dim(' │ '));
+}

--- a/packages/burn/src/store.ts
+++ b/packages/burn/src/store.ts
@@ -1,0 +1,202 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
+import path from 'node:path';
+
+import type { BurnPaths } from './config';
+import type { UsageRecord } from './types';
+
+/**
+ * Write via temp + rename.
+ *
+ * A plain truncating write leaves a short file if the process is killed or a
+ * racing writer lands mid-write, and a short file still parses — which is how
+ * 85% of the record store was lost on 2026-08-04 while the HUD went on
+ * reporting a comfortable green.
+ */
+export function atomicWrite(target: string, contents: string): void {
+  mkdirSync(path.dirname(target), { recursive: true });
+  const tmp = `${target}.tmp`;
+  const fd = openSync(tmp, 'w');
+  try {
+    writeSync(fd, contents);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmp, target);
+}
+
+/**
+ * Cross-process scan lock.
+ *
+ * PORTING NOTE: the Python HUD used `fcntl.flock`, which the kernel releases
+ * when the holder dies. Node has no `flock` in its standard library, so this
+ * uses an atomic `mkdir` instead — equally exclusive, but NOT auto-released,
+ * so a crashed holder would otherwise wedge every future scan. The staleness
+ * reclaim below is what replaces the kernel's cleanup: a lock whose owner is
+ * gone, or which is older than a scan could plausibly take, is broken.
+ */
+const LOCK_STALE_MS = 60_000;
+const LOCK_POLL_MS = 150;
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function holderIsGone(lockDir: string): boolean {
+  let meta: { pid?: number; at?: number };
+  try {
+    meta = JSON.parse(readFileSync(path.join(lockDir, 'owner.json'), 'utf8')) as {
+      pid?: number;
+      at?: number;
+    };
+  } catch {
+    // No readable owner record: either mid-acquisition or debris. Treat as
+    // stale only once it is old enough that it cannot be mid-acquisition.
+    return false;
+  }
+  if (typeof meta.at === 'number' && Date.now() - meta.at > LOCK_STALE_MS) return true;
+  if (typeof meta.pid === 'number') {
+    try {
+      process.kill(meta.pid, 0);
+      return false;
+    } catch (err) {
+      // EPERM means the process exists but belongs to another user — alive.
+      return (err as NodeJS.ErrnoException).code !== 'EPERM';
+    }
+  }
+  return false;
+}
+
+/**
+ * Run `fn` under the scan lock. `fn` receives whether the lock was actually
+ * acquired; a caller that did not get it must NOT write the store — joining in
+ * is the very race the lock exists to prevent.
+ */
+export function withScanLock<T>(
+  paths: BurnPaths,
+  fn: (acquired: boolean) => T,
+  timeoutMs = 6000
+): T {
+  mkdirSync(paths.state, { recursive: true });
+  const lockDir = paths.lock;
+  const deadline = Date.now() + timeoutMs;
+  let acquired = false;
+
+  while (Date.now() < deadline) {
+    try {
+      mkdirSync(lockDir);
+      writeFileSync(
+        path.join(lockDir, 'owner.json'),
+        JSON.stringify({ pid: process.pid, at: Date.now() })
+      );
+      acquired = true;
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      if (holderIsGone(lockDir)) {
+        try {
+          rmSync(lockDir, { recursive: true, force: true });
+        } catch {
+          // Another process won the reclaim; fall through and retry normally.
+        }
+        continue;
+      }
+      sleepSync(LOCK_POLL_MS);
+    }
+  }
+
+  try {
+    return fn(acquired);
+  } finally {
+    if (acquired) {
+      try {
+        rmSync(lockDir, { recursive: true, force: true });
+      } catch {
+        // Losing the release only costs the next scan a staleness reclaim.
+      }
+    }
+  }
+}
+
+export interface Fingerprints {
+  /** absolute transcript path -> [mtime seconds, size bytes] */
+  fingerprints: Map<string, string>;
+  /** Record count asserted by the header, or null when absent. */
+  expected: number | null;
+}
+
+/**
+ * Read scan fingerprints plus the record count they claim to describe.
+ *
+ * The count lives in this file's header so it lands in the SAME atomic write as
+ * the fingerprints. That pairing is what lets a later scan notice the record
+ * store lost rows: fingerprints alone would go on asserting "already scanned"
+ * over a gutted store forever.
+ */
+export function readFingerprints(paths: BurnPaths): Fingerprints {
+  const fingerprints = new Map<string, string>();
+  let expected: number | null = null;
+  if (!existsSync(paths.filesTsv)) return { fingerprints, expected };
+
+  for (const line of readFileSync(paths.filesTsv, 'utf8').split('\n')) {
+    if (!line) continue;
+    if (line.startsWith('#count\t')) {
+      const n = Number(line.split('\t')[1]);
+      if (Number.isFinite(n)) expected = n;
+      continue;
+    }
+    const parts = line.split('\t');
+    if (parts.length === 3) fingerprints.set(parts[0]!, `${parts[1]}\t${parts[2]}`);
+  }
+  return { fingerprints, expected };
+}
+
+export function writeFingerprints(
+  paths: BurnPaths,
+  seen: Map<string, string>,
+  recordCount: number
+): void {
+  const lines = [`#count\t${recordCount}\n`];
+  for (const [file, sig] of seen) lines.push(`${file}\t${sig}\n`);
+  atomicWrite(paths.filesTsv, lines.join(''));
+}
+
+/** requestId -> record. Rows that do not have all seven fields are discarded. */
+export function readRecords(paths: BurnPaths): Map<string, UsageRecord> {
+  const records = new Map<string, UsageRecord>();
+  if (!existsSync(paths.usageTsv)) return records;
+
+  for (const line of readFileSync(paths.usageTsv, 'utf8').split('\n')) {
+    if (!line) continue;
+    const p = line.split('\t');
+    if (p.length !== 7) continue;
+    records.set(p[0]!, {
+      ts: p[1]!,
+      model: p[2]!,
+      out: Number(p[3]) || 0,
+      in: Number(p[4]) || 0,
+      cacheWrite: Number(p[5]) || 0,
+      cacheRead: Number(p[6]) || 0,
+    });
+  }
+  return records;
+}
+
+export function writeRecords(paths: BurnPaths, records: Map<string, UsageRecord>): void {
+  const lines: string[] = [];
+  for (const [id, r] of records) {
+    lines.push(`${id}\t${r.ts}\t${r.model}\t${r.out}\t${r.in}\t${r.cacheWrite}\t${r.cacheRead}\n`);
+  }
+  atomicWrite(paths.usageTsv, lines.join(''));
+}

--- a/packages/burn/src/summary.ts
+++ b/packages/burn/src/summary.ts
@@ -1,0 +1,312 @@
+import { mkdirSync } from 'node:fs';
+
+import type { BurnPaths } from './config';
+import { atomicWrite } from './store';
+import { readRecords } from './store';
+import type {
+  BudgetBlock,
+  BurnConfig,
+  BurnStatus,
+  Calibration,
+  Confidence,
+  ModelBlock,
+  ScanInfo,
+  SessionBlock,
+  Summary,
+} from './types';
+import { units } from './units';
+import { weekBounds } from './window';
+
+const WEEK_SECONDS = 7 * 86_400;
+
+function roundTo(value: number, places: number): number {
+  const f = 10 ** places;
+  return Math.round(value * f) / f;
+}
+
+function median(sorted: number[]): number | null {
+  const n = sorted.length;
+  if (n === 0) return null;
+  if (n % 2 === 1) return sorted[Math.floor(n / 2)]!;
+  return (sorted[n / 2 - 1]! + sorted[n / 2]!) / 2;
+}
+
+/** Rank used to compare status severities. */
+const RANK: Record<string, number> = { OK: 0, WARM: 1, HOT: 2, CRITICAL: 3 };
+
+function band(pct: number): 'OK' | 'WARM' | 'HOT' | 'CRITICAL' {
+  if (pct >= 100) return 'CRITICAL';
+  if (pct >= 85) return 'HOT';
+  if (pct >= 65) return 'WARM';
+  return 'OK';
+}
+
+/**
+ * How far a FORECAST may escalate, by how much of the week it rests on.
+ *
+ * Incurred spend is a fact and always escalates; a projection is evidence whose
+ * weight grows with the week, so it earns severity gradually. Without this
+ * split, 2% of budget spent in one morning extrapolated to 118% and fired
+ * CRITICAL — and noise is what stops alarms being read at all.
+ */
+const PROJECTION_CEILING: Record<Confidence, 'OK' | 'HOT' | 'CRITICAL'> = {
+  low: 'OK',
+  medium: 'HOT',
+  high: 'CRITICAL',
+};
+
+/**
+ * `2026-08-05T14:00:00.000+00:00` rather than Node's default `...Z`.
+ *
+ * Both are valid ISO 8601, but Python's `datetime.fromisoformat` did not accept
+ * the `Z` suffix before 3.11, and during cutover an older consumer may still be
+ * reading a summary this code wrote. Matching the Python HUD's own output keeps
+ * the rollback path open for the cost of one string replacement.
+ */
+function isoUtc(d: Date): string {
+  return d.toISOString().replace('Z', '+00:00');
+}
+
+function utcDateOnly(d: Date): number {
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+function withCalibrationValidity(cal: Calibration | undefined, now: Date): Calibration {
+  const out: Calibration = cal ? { ...cal } : {};
+  if (!cal?.valid_until) return out;
+  const parsed = Date.parse(`${cal.valid_until}T00:00:00Z`);
+  if (!Number.isFinite(parsed)) return out;
+  out.expired = utcDateOnly(now) > parsed;
+  out.days_left = Math.round((parsed - utcDateOnly(now)) / 86_400_000);
+  return out;
+}
+
+/**
+ * Roll the stored records up into the summary every consumer reads.
+ *
+ * `now` is injectable so the suite can place itself anywhere in a week without
+ * waiting for one.
+ */
+export function buildSummary(
+  paths: BurnPaths,
+  scanInfo: ScanInfo,
+  cfg: BurnConfig,
+  now: Date = new Date()
+): Summary {
+  const records = readRecords(paths);
+  const { start: curStart, end: curEnd } = weekBounds(now, cfg);
+
+  const sessionHours = Number(cfg.session_window_hours ?? 5) || 5;
+  const sessionCut = now.getTime() - sessionHours * 3_600_000;
+
+  // Bucketed in whole weeks back from the current window, so history stays
+  // aligned to the same anchor as the live week.
+  const buckets = new Map<number, { requests: number; out: number; units: number }>();
+  const perModel = new Map<string, { requests: number; units: number }>();
+  let sessionUnits = 0;
+  let sessionRequests = 0;
+
+  for (const rec of records.values()) {
+    if (!rec.ts) continue;
+    const t = Date.parse(rec.ts);
+    if (!Number.isFinite(t)) continue;
+
+    const u = units(rec.out, rec.in, rec.cacheWrite, rec.cacheRead);
+    const deltaSeconds = (curStart.getTime() - t) / 1000;
+    const idx = deltaSeconds <= 0 ? 0 : Math.floor(deltaSeconds / WEEK_SECONDS) + 1;
+
+    const bucket = buckets.get(idx) ?? { requests: 0, out: 0, units: 0 };
+    bucket.requests += 1;
+    bucket.out += rec.out;
+    bucket.units += u;
+    buckets.set(idx, bucket);
+
+    if (idx === 0) {
+      const m = perModel.get(rec.model) ?? { requests: 0, units: 0 };
+      m.requests += 1;
+      m.units += u;
+      perModel.set(rec.model, m);
+    }
+    if (t >= sessionCut) {
+      sessionUnits += u;
+      sessionRequests += 1;
+    }
+  }
+
+  const cur = buckets.get(0) ?? { requests: 0, out: 0, units: 0 };
+
+  // Trailing COMPLETE weeks only; the partial current week must never dilute
+  // its own baseline.
+  const baselineWeeks = Number(cfg.baseline_weeks ?? 4) || 4;
+  const tail: number[] = [];
+  for (let i = 1; i <= baselineWeeks; i += 1) {
+    const b = buckets.get(i);
+    if (b) tail.push(b.units);
+  }
+  const tailSorted = [...tail].sort((a, b) => a - b);
+  const baseMedian = median(tailSorted);
+  const baseMax = tailSorted.length ? tailSorted[tailSorted.length - 1]! : null;
+
+  const elapsedSeconds = (now.getTime() - curStart.getTime()) / 1000;
+  const frac = Math.max(Math.min(elapsedSeconds / WEEK_SECONDS, 1.0), 1e-6);
+  const linear = cur.units / frac;
+
+  // Shrink the forecast toward the trailing baseline in proportion to how much
+  // of the week has NOT yet happened. A linear extrapolation from three hours
+  // carries almost no information about where the week lands — the best
+  // available estimate that early is "a normal week".
+  const projected = baseMedian ? frac * linear + (1 - frac) * baseMedian : linear;
+  const projectionMethod = baseMedian ? 'shrunk-to-baseline' : 'linear';
+
+  const ratio = baseMedian ? projected / baseMedian : null;
+  const confidence: Confidence = frac >= 0.3 ? 'high' : frac >= 0.15 ? 'medium' : 'low';
+
+  // ---- budget
+  const budgetUnits = cfg.weekly_budget_units;
+  const budget: BudgetBlock = { set: budgetUnits !== null && budgetUnits !== undefined };
+  if (budgetUnits) {
+    budget.units = budgetUnits;
+    budget.pct_used = (100 * cur.units) / budgetUnits;
+    budget.pct_projected = (100 * projected) / budgetUnits;
+    budget.remaining_units = Math.max(budgetUnits - cur.units, 0);
+
+    const rate = cur.units / Math.max(elapsedSeconds, 1);
+    if (cur.units >= budgetUnits) {
+      budget.exhausts_at = isoUtc(now);
+      budget.exhausts_before_reset = true;
+    } else if (confidence === 'low') {
+      // "You run dry Tuesday" derived from one morning is the same noise as the
+      // projection itself. Withhold the date rather than dress a guess up with
+      // a timestamp, which reads far more certain than it is.
+      budget.exhausts_before_reset = false;
+      budget.exhaust_estimate_withheld = 'too early in the week to forecast';
+    } else if (rate > 0) {
+      // Only materialise a date when it actually lands before the reset. A tiny
+      // rate against a large budget yields a runway of millions of days, which
+      // overflowed Python's timedelta and killed the whole scan.
+      const seconds = (budgetUnits - cur.units) / rate;
+      const horizon = Math.max((curEnd.getTime() - now.getTime()) / 1000, 0);
+      if (seconds <= horizon) {
+        budget.exhausts_at = isoUtc(new Date(now.getTime() + seconds * 1000));
+        budget.exhausts_before_reset = true;
+      } else {
+        budget.exhausts_before_reset = false;
+        budget.runway_days = roundTo(Math.min(seconds / 86_400, 99_999), 1);
+      }
+    }
+  }
+
+  // A budget that outlived its basis is a false-green risk, so expiry is
+  // surfaced rather than silently trusted.
+  const calibration = withCalibrationValidity(cfg.calibration, now);
+
+  // ---- per-model, with optional per-family budgets (Fable has its own limit)
+  const modelBudgets = cfg.model_budgets ?? {};
+  const models: Record<string, ModelBlock> = {};
+  const sortedModels = [...perModel.entries()].sort((a, b) => b[1].units - a[1].units);
+  for (const [name, m] of sortedModels) {
+    const entry: ModelBlock = {
+      requests: m.requests,
+      units: Math.round(m.units),
+      pct_of_week: cur.units ? roundTo((100 * m.units) / cur.units, 1) : 0,
+    };
+    const familyBudget = modelBudgets[name];
+    if (familyBudget) {
+      entry.budget_units = familyBudget;
+      entry.pct_of_budget = roundTo((100 * m.units) / familyBudget, 1);
+    }
+    models[name] = entry;
+  }
+
+  // ---- session window
+  const session: SessionBlock = {
+    window_hours: sessionHours,
+    requests: sessionRequests,
+    units: Math.round(sessionUnits),
+  };
+  if (cfg.session_budget_units) {
+    session.budget_units = cfg.session_budget_units;
+    session.pct_used = roundTo((100 * sessionUnits) / cfg.session_budget_units, 1);
+  }
+
+  // ---- status. A zero denominator is an abstention, never a pass.
+  let status: BurnStatus;
+  if ((scanInfo.records_total ?? 0) === 0) {
+    status = 'NO_DATA';
+  } else if (budgetUnits) {
+    const used = band(budget.pct_used!);
+    let proj = band(budget.pct_projected!);
+    const ceiling = PROJECTION_CEILING[confidence];
+    if (RANK[proj]! > RANK[ceiling]!) proj = ceiling;
+    status = RANK[used]! >= RANK[proj]! ? used : proj;
+  } else if (ratio === null) {
+    status = 'NO_BASELINE';
+  } else {
+    status = ratio >= cfg.hot_ratio ? 'HOT' : ratio >= cfg.warm_ratio ? 'WARM' : 'OK';
+  }
+
+  // Incurred spend is real whatever the forecast confidence, so an elevated
+  // status always stands. Only a reassuring verdict is held back on a thin
+  // sample — that is the direction in which a wrong read does harm.
+  if (confidence === 'low' && status === 'OK') status = 'EARLY';
+
+  // A per-model limit can be exhausted while the pooled limit still looks fine.
+  const exhausted = Object.entries(models)
+    .filter(([, e]) => (e.pct_of_budget ?? 0) >= 100)
+    .map(([m]) => m);
+  if (exhausted.length && (status === 'OK' || status === 'EARLY' || status === 'WARM')) {
+    status = 'HOT';
+  }
+
+  // If rows were lost and could not all be re-read from source, every number
+  // above is an UNDERCOUNT. Say so rather than let a rebuilt-but-incomplete
+  // store report a confident figure.
+  if ((scanInfo.unrecovered ?? 0) > 0) status = 'UNDERCOUNT';
+
+  const wr = cfg.week_reset;
+  const perWeekBack: Record<string, number> = {};
+  for (let i = 1; i <= baselineWeeks; i += 1) {
+    const b = buckets.get(i);
+    if (b) perWeekBack[String(i)] = Math.round(b.units);
+  }
+
+  return {
+    generated_at: isoUtc(now),
+    scan: scanInfo,
+    week: {
+      start: isoUtc(curStart),
+      reset_at: isoUtc(curEnd),
+      reset_spec: `${wr.weekday}@${wr.time} ${wr.tz}`,
+      tz: wr.tz || 'UTC',
+      elapsed_frac: roundTo(frac, 4),
+      days_left: roundTo(7 * (1 - frac), 2),
+      hours_left: roundTo((curEnd.getTime() - now.getTime()) / 3_600_000, 1),
+    },
+    wtd: { requests: cur.requests, output_tokens: cur.out, units: Math.round(cur.units) },
+    baseline: {
+      complete_weeks_used: tail.length,
+      median_units: baseMedian ? Math.round(baseMedian) : null,
+      max_units: baseMax ? Math.round(baseMax) : null,
+      per_week_back: perWeekBack,
+    },
+    projection: {
+      units_at_reset: Math.round(projected),
+      units_at_reset_linear: Math.round(linear),
+      method: projectionMethod,
+      ratio_vs_baseline: ratio ? roundTo(ratio, 2) : null,
+      confidence,
+    },
+    budget,
+    calibration,
+    models,
+    models_exhausted: exhausted,
+    session,
+    status,
+  };
+}
+
+/** Publish the summary atomically — the statusline must never read a half file. */
+export function writeSummary(paths: BurnPaths, summary: Summary): void {
+  mkdirSync(paths.state, { recursive: true });
+  atomicWrite(paths.summary, JSON.stringify(summary, null, 2));
+}

--- a/packages/burn/src/types.ts
+++ b/packages/burn/src/types.ts
@@ -1,0 +1,144 @@
+/**
+ * Wire shapes for the burn HUD.
+ *
+ * The snake_case keys are deliberate: `state/summary.json` is read by the
+ * statusline binary, both hooks and the CLI report, and the Python HUD this
+ * package replaces wrote exactly these keys. Keeping the shape identical is
+ * what makes the cutover reversible — an older consumer can still read a
+ * summary written by this code, and vice versa.
+ */
+
+/** Anchored weekly reset. `weekday` is 0=Mon..6=Sun, matching Python's `date.weekday()`. */
+export interface WeekReset {
+  weekday: number;
+  time: string;
+  tz: string;
+}
+
+export interface Calibration {
+  /** ISO instant the calibration was taken. */
+  at?: string;
+  /** The whole percentage `/usage` reported at that instant. */
+  reported_pct?: number;
+  wtd_units_then?: number;
+  implied_units_per_pct?: number;
+  /** Date past which the calibration is no longer trusted (e.g. a promo end). */
+  valid_until?: string;
+  note?: string;
+  /** Derived at summary time, never stored in config. */
+  expired?: boolean;
+  days_left?: number;
+}
+
+export interface BurnConfig {
+  week_reset: WeekReset;
+  weekly_budget_units: number | null;
+  /** Per-family ceilings; a family can be spent while the pooled bar looks fine. */
+  model_budgets: Record<string, number>;
+  session_window_hours: number;
+  session_budget_units: number | null;
+  warm_ratio: number;
+  hot_ratio: number;
+  baseline_weeks: number;
+  stale_after_minutes: number;
+  calibration?: Calibration;
+}
+
+/** One deduped assistant turn, keyed by `requestId` in the store. */
+export interface UsageRecord {
+  ts: string;
+  model: string;
+  out: number;
+  in: number;
+  cacheWrite: number;
+  cacheRead: number;
+}
+
+export interface ScanInfo {
+  files_total: number;
+  files_rescanned: number;
+  records_added: number;
+  records_total: number;
+  /** Set when another scan held the lock; this one deferred rather than raced it. */
+  skipped_locked?: boolean;
+  data_loss_detected?: boolean;
+  records_lost?: number;
+  records_recovered?: number;
+  /** Rows the rebuild could not recover — every figure is then a floor. */
+  unrecovered?: number;
+}
+
+export type BurnStatus =
+  | 'NO_DATA'
+  | 'NO_BASELINE'
+  | 'EARLY'
+  | 'OK'
+  | 'WARM'
+  | 'HOT'
+  | 'CRITICAL'
+  | 'UNDERCOUNT';
+
+export type Confidence = 'low' | 'medium' | 'high';
+
+export interface BudgetBlock {
+  set: boolean;
+  units?: number;
+  pct_used?: number;
+  pct_projected?: number;
+  remaining_units?: number;
+  exhausts_at?: string;
+  exhausts_before_reset?: boolean;
+  exhaust_estimate_withheld?: string;
+  runway_days?: number;
+}
+
+export interface ModelBlock {
+  requests: number;
+  units: number;
+  pct_of_week: number;
+  budget_units?: number;
+  pct_of_budget?: number;
+}
+
+export interface SessionBlock {
+  window_hours: number;
+  requests: number;
+  units: number;
+  budget_units?: number;
+  pct_used?: number;
+}
+
+export interface Summary {
+  generated_at: string;
+  scan: ScanInfo;
+  week: {
+    start: string;
+    reset_at: string;
+    reset_spec: string;
+    tz: string;
+    elapsed_frac: number;
+    days_left: number;
+    hours_left: number;
+  };
+  wtd: { requests: number; output_tokens: number; units: number };
+  baseline: {
+    complete_weeks_used: number;
+    median_units: number | null;
+    max_units: number | null;
+    per_week_back: Record<string, number>;
+  };
+  projection: {
+    units_at_reset: number;
+    /** Kept visible so a shrunk forecast never silently replaces the raw one. */
+    units_at_reset_linear: number;
+    method: 'linear' | 'shrunk-to-baseline';
+    ratio_vs_baseline: number | null;
+    confidence: Confidence;
+  };
+  budget: BudgetBlock;
+  calibration: Calibration;
+  models: Record<string, ModelBlock>;
+  models_exhausted: string[];
+  session: SessionBlock;
+  status: BurnStatus;
+}

--- a/packages/burn/src/units.ts
+++ b/packages/burn/src/units.ts
@@ -1,0 +1,24 @@
+/**
+ * Opus-like price ratios, normalised to input=1.
+ *
+ * Cache reads dominate raw token counts but are nearly free, which is why raw
+ * tokens make a misleading headline and this weighting exists at all.
+ */
+export const W_OUT = 5.0;
+export const W_IN = 1.0;
+export const W_CACHE_WRITE = 1.25;
+export const W_CACHE_READ = 0.1;
+
+export function units(out: number, inp: number, cacheWrite: number, cacheRead: number): number {
+  return out * W_OUT + inp * W_IN + cacheWrite * W_CACHE_WRITE + cacheRead * W_CACHE_READ;
+}
+
+/** Compact unit rendering shared by the report, the hooks and the statusline. */
+export function human(u: number | null | undefined): string {
+  const v = Number(u ?? 0);
+  if (!Number.isFinite(v)) return '0';
+  if (v >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `${Math.round(v / 1e3)}k`;
+  return `${Math.round(v)}`;
+}

--- a/packages/burn/src/window.ts
+++ b/packages/burn/src/window.ts
@@ -1,0 +1,157 @@
+import type { BurnConfig } from './types';
+
+/**
+ * The week window is load-bearing.
+ *
+ * An earlier version assumed a Monday-midnight-UTC week. For an account whose
+ * real reset is Wednesday 08:59 America/Chicago that understated week-to-date
+ * burn by ~81x and reported a calm green at 97% of the actual limit. No amount
+ * of zero-denominator checking catches a correct computation over the wrong
+ * seven days — only matching /usage exactly does.
+ *
+ * Ported from Python's `zoneinfo` to `Intl.DateTimeFormat`, which is the only
+ * IANA-zone facility in the Node standard library. The arithmetic below is
+ * wall-clock arithmetic (subtract calendar days, then resolve to an instant),
+ * matching what `aware_datetime - timedelta` does under `zoneinfo`.
+ */
+
+interface WallClock {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+const formatters = new Map<string, Intl.DateTimeFormat>();
+
+function formatterFor(tz: string): Intl.DateTimeFormat {
+  const cached = formatters.get(tz);
+  if (cached) return cached;
+  const f = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  formatters.set(tz, f);
+  return f;
+}
+
+/** Resolve a timezone name, falling back to UTC rather than throwing. */
+export function safeZone(tz: string | undefined | null): string {
+  const name = tz || 'UTC';
+  try {
+    formatterFor(name);
+    return name;
+  } catch {
+    return 'UTC';
+  }
+}
+
+function partsIn(instant: Date, tz: string): WallClock & { second: number } {
+  const parts = formatterFor(tz).formatToParts(instant);
+  const get = (type: string): number => {
+    const p = parts.find((x) => x.type === type);
+    return p ? Number(p.value) : 0;
+  };
+  // `hourCycle: 'h23'` still renders midnight as 24 in some ICU builds.
+  const hour = get('hour') % 24;
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour,
+    minute: get('minute'),
+    second: get('second'),
+  };
+}
+
+/** Offset of `tz` at `instant`, in ms (local wall clock minus UTC). */
+function offsetAt(instant: Date, tz: string): number {
+  const p = partsIn(instant, tz);
+  const asUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  return asUtc - instant.getTime();
+}
+
+/**
+ * Resolve a wall-clock reading in `tz` to an absolute instant.
+ *
+ * Two passes: the first offset is looked up at the naive guess, the second at
+ * the corrected instant, which is what gets a boundary near a DST transition
+ * onto the right side of the shift.
+ */
+export function wallToInstant(wall: WallClock, tz: string): Date {
+  const guess = Date.UTC(wall.year, wall.month - 1, wall.day, wall.hour, wall.minute, 0);
+  const firstPass = guess - offsetAt(new Date(guess), tz);
+  const secondPass = guess - offsetAt(new Date(firstPass), tz);
+  return new Date(secondPass);
+}
+
+/** 0=Mon..6=Sun, matching Python's `date.weekday()` (JS `getUTCDay` is 0=Sun). */
+function isoWeekday(wall: WallClock): number {
+  return (new Date(Date.UTC(wall.year, wall.month - 1, wall.day)).getUTCDay() + 6) % 7;
+}
+
+function shiftDays(wall: WallClock, days: number): WallClock {
+  const d = new Date(Date.UTC(wall.year, wall.month - 1, wall.day));
+  d.setUTCDate(d.getUTCDate() + days);
+  return {
+    year: d.getUTCFullYear(),
+    month: d.getUTCMonth() + 1,
+    day: d.getUTCDate(),
+    hour: wall.hour,
+    minute: wall.minute,
+  };
+}
+
+function parseTimeOfDay(value: unknown): { hour: number; minute: number } {
+  // A config is user-edited JSON, so `time` may be anything at all; only a
+  // string can be a time, and everything else falls back to midnight.
+  const raw = typeof value === 'string' ? value : '00:00';
+  const [h, m] = raw.split(':');
+  const hour = Number(h);
+  const minute = Number(m);
+  return {
+    hour: Number.isFinite(hour) ? hour : 0,
+    minute: Number.isFinite(minute) ? minute : 0,
+  };
+}
+
+export const WEEK_MS = 7 * 86_400_000;
+
+/**
+ * The most recent reset instant at or before `now`, and the next one.
+ *
+ * Anchored on (weekday, local time, timezone) so it matches /usage exactly.
+ * At the reset instant itself the NEW week has begun — the boundary is
+ * inclusive on the left, which is what stops a reset-time reading being filed
+ * under the week that just ended.
+ */
+export function weekBounds(now: Date, cfg: Partial<BurnConfig>): { start: Date; end: Date } {
+  const wr = cfg.week_reset ?? {};
+  const wd = (((Number((wr as { weekday?: number }).weekday) || 0) % 7) + 7) % 7;
+  const tz = safeZone((wr as { tz?: string }).tz);
+  const { hour, minute } = parseTimeOfDay((wr as { time?: string }).time);
+
+  const local = partsIn(now, tz);
+  let candidate: WallClock = {
+    year: local.year,
+    month: local.month,
+    day: local.day,
+    hour,
+    minute,
+  };
+  const daysSinceReset = (((isoWeekday(candidate) - wd) % 7) + 7) % 7;
+  candidate = shiftDays(candidate, -daysSinceReset);
+
+  let start = wallToInstant(candidate, tz);
+  if (start.getTime() > now.getTime()) {
+    start = wallToInstant(shiftDays(candidate, -7), tz);
+  }
+  return { start, end: new Date(start.getTime() + WEEK_MS) };
+}

--- a/packages/burn/tests/bin-startup.test.ts
+++ b/packages/burn/tests/bin-startup.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The hot-path budget guard.
+ *
+ * `harness-burn-hud line` renders on every statusline repaint and `stop` fires
+ * after every assistant turn. Measured while porting: `harness --version` costs
+ * ~0.85s to load the CLI's module graph, against the shell statusline's ~0.11s.
+ * A single stray `import` from `@harness-engineering/*` into this binary would
+ * therefore make the statusline ~8x more expensive with no visible symptom
+ * beyond a laggy terminal — exactly the kind of silent regression nobody
+ * bisects. So the import graph is asserted, not just the timing.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { isBuiltin } from 'node:module';
+
+import { afterEach, beforeAll, expect, it } from 'vitest';
+
+import { BIN, makeHud, runBin, type Hud } from './helpers';
+
+let hud: Hud | null = null;
+
+beforeAll(() => {
+  if (!existsSync(BIN)) {
+    throw new Error(`built binary missing at ${BIN} — run \`pnpm build\` first`);
+  }
+});
+
+afterEach(() => {
+  hud?.cleanup();
+  hud = null;
+});
+
+it('bundles no @harness-engineering imports', () => {
+  // The deterministic half of the guard: this is what actually fails a PR.
+  const bundle = readFileSync(BIN, 'utf8');
+  expect(bundle).not.toContain('@harness-engineering/');
+  // Nothing may be resolved from node_modules at runtime either: a workspace
+  // package left external would slip past the string check above. The only
+  // legitimate unbundled specifiers are Node builtins.
+  // esbuild rewrites `node:fs` to a bare `fs`, so ask Node what is actually a
+  // builtin rather than pattern-matching the prefix.
+  const specifiers = [...bundle.matchAll(/(?:from|require\()\s*['"]([^'"]+)['"]/g)].map(
+    (m) => m[1]!
+  );
+  const external = [...new Set(specifiers)].filter((s) => !s.startsWith('.') && !isBuiltin(s));
+  expect(external).toEqual([]);
+});
+
+/** Median of `n` runs, so one scheduler hiccup cannot decide the result. */
+async function medianMs(run: () => Promise<unknown>, n = 5): Promise<number> {
+  const timings: number[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const started = performance.now();
+    await run();
+    timings.push(performance.now() - started);
+  }
+  timings.sort((a, b) => a - b);
+  return timings[Math.floor(n / 2)]!;
+}
+
+it('starts in the same order of magnitude as bare node', async () => {
+  // Measured as a RATIO against `node -e ''` in the same process environment,
+  // not as a wall-clock ceiling. An absolute ceiling fails for the wrong
+  // reason: this test first ran at 821ms against a 700ms limit purely because
+  // the rest of the monorepo's suites were saturating the CPU alongside it.
+  // Under load both sides of a ratio inflate together, so it keeps measuring
+  // the thing that actually matters — how much this binary adds over merely
+  // starting node.
+  //
+  // Observed on the porting machine: bare node 47ms, this binary 118ms (2.5x),
+  // the full harness CLI 902ms (19.2x). A 8x ceiling sits far above the former
+  // and far below the latter.
+  hud = makeHud();
+  writeFileSync(
+    hud.paths.summary,
+    JSON.stringify({
+      generated_at: new Date().toISOString(),
+      status: 'OK',
+      week: { days_left: 3, hours_left: 72, tz: 'UTC' },
+      wtd: { units: 1_000_000 },
+      projection: { units_at_reset: 2_000_000, confidence: 'high', ratio_vs_baseline: 1 },
+      budget: { set: false },
+      models_exhausted: [],
+      session: {},
+      calibration: {},
+    })
+  );
+
+  const baseline = await medianMs(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const child = spawn(process.execPath, ['-e', '']);
+        child.on('error', reject);
+        child.on('close', () => resolve());
+      })
+  );
+  const rendered = await medianMs(() => runBin(['line'], hud!.env));
+
+  expect(rendered / baseline).toBeLessThan(8);
+});

--- a/packages/burn/tests/budgets-models.test.ts
+++ b/packages/burn/tests/budgets-models.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Budget, per-model-limit and forecast-escalation regressions, ported from the
+ * Python HUD's `TestBudgetsAndModels`.
+ *
+ * The through-line: incurred spend is a fact and always escalates; a projection
+ * is evidence whose weight grows with the week. Collapsing that distinction is
+ * what made a 3-hour extrapolation shout CRITICAL, and an alarm that cries wolf
+ * at 2% spent is an alarm nobody reads at 98%.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { refresh } from '../src/refresh';
+import {
+  daysAgo,
+  hoursAgo,
+  makeHud,
+  minutesAgo,
+  transcriptLine,
+  utcIsoWeekday,
+  type Hud,
+} from './helpers';
+
+let hud: Hud | null = null;
+
+function newHud(): Hud {
+  hud = makeHud();
+  return hud;
+}
+
+afterEach(() => {
+  hud?.cleanup();
+  hud = null;
+});
+
+/** A week that began ~6 days ago, i.e. late enough for a confident forecast. */
+function lateWeekConfig(now: Date, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    week_reset: { weekday: (utcIsoWeekday(now) + 1) % 7, time: '00:00', tz: 'UTC' },
+    ...extra,
+  };
+}
+
+/** A reset placed so that `now` sits `days` into the current week. */
+function weekStartingDaysAgo(now: Date, days: number): Record<string, unknown> {
+  const start = daysAgo(now, days);
+  return { weekday: utcIsoWeekday(start), time: '00:00', tz: 'UTC' };
+}
+
+/** `currentLines` plus enough prior-week volume to form a baseline. */
+function withBaseline(now: Date, currentLines: string[], weeks = 3, perWeekOut = 4000): string[] {
+  const lines = [...currentLines];
+  for (let wk = 1; wk <= weeks; wk += 1) {
+    for (let i = 0; i < 6; i += 1) {
+      lines.push(
+        transcriptLine(`w${wk}n${i}`, hoursAgo(daysAgo(now, 7 * wk), 2 + i), {
+          out: Math.floor(perWeekOut / 6),
+        })
+      );
+    }
+  }
+  return lines;
+}
+
+it('escalates when a per-model budget is exhausted', () => {
+  // A family limit can be spent while the pooled bar looks survivable — Fable
+  // hit 100% at 29% of the pooled week.
+  const h = newHud();
+  const now = new Date();
+  h.writeConfig(
+    lateWeekConfig(now, {
+      weekly_budget_units: 10 ** 12,
+      model_budgets: { 'claude-fable-5': 100 },
+    })
+  );
+  h.writeTranscript('a.jsonl', [
+    transcriptLine('r1', hoursAgo(now, 2), { model: 'claude-fable-5', out: 1000 }),
+  ]);
+
+  const s = refresh(h.paths);
+  expect(s.models_exhausted).toContain('claude-fable-5');
+  expect(['HOT', 'CRITICAL']).toContain(s.status);
+});
+
+describe('calibration validity', () => {
+  it('flags a calibration that has expired', () => {
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig(
+      lateWeekConfig(now, {
+        weekly_budget_units: 10 ** 6,
+        calibration: { reported_pct: 97, valid_until: '2000-01-01' },
+      })
+    );
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', hoursAgo(now, 2))]);
+    expect(refresh(h.paths).calibration.expired).toBe(true);
+  });
+
+  it('reports days remaining on a live calibration', () => {
+    const h = newHud();
+    const now = new Date();
+    const future = new Date(now.getTime() + 10 * 86_400_000).toISOString().slice(0, 10);
+    h.writeConfig(
+      lateWeekConfig(now, {
+        weekly_budget_units: 10 ** 6,
+        calibration: { reported_pct: 50, valid_until: future },
+      })
+    );
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', hoursAgo(now, 2))]);
+
+    const cal = refresh(h.paths).calibration;
+    expect(cal.expired).toBe(false);
+    expect(cal.days_left ?? 0).toBeGreaterThan(0);
+  });
+});
+
+describe('forecast escalation', () => {
+  it('does not escalate on early-week noise', () => {
+    // Regression: 2% of budget spent in the first hours extrapolated to 118%
+    // and fired CRITICAL. A forecast resting on 2% of a week must not raise the
+    // alarm at all — noise is what stops alarms being read.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: weekStartingDaysAgo(now, 0.15),
+      weekly_budget_units: 10 ** 7,
+    });
+    h.writeTranscript(
+      'a.jsonl',
+      withBaseline(now, [transcriptLine('cur', minutesAgo(now, 30), { out: 400 })])
+    );
+
+    const s = refresh(h.paths);
+    expect(s.projection.confidence).toBe('low');
+    expect(s.budget.pct_used!).toBeLessThan(20);
+    expect(['HOT', 'CRITICAL']).not.toContain(s.status);
+    expect(s.budget.exhausts_before_reset).toBeFalsy();
+    expect(s.budget.exhaust_estimate_withheld).toBeDefined();
+  });
+
+  it('still escalates on real overspend early in the week', () => {
+    // The other side of the same coin: incurred spend is a fact, so it
+    // escalates whatever the forecast confidence. Muting noise must not mute an
+    // actual blowout.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: weekStartingDaysAgo(now, 0.15),
+      weekly_budget_units: 10 ** 6,
+    });
+    h.writeTranscript(
+      'a.jsonl',
+      withBaseline(now, [transcriptLine('cur', minutesAgo(now, 30), { out: 10 ** 6 })])
+    );
+
+    const s = refresh(h.paths);
+    expect(s.projection.confidence).toBe('low');
+    expect(s.budget.pct_used!).toBeGreaterThanOrEqual(100);
+    expect(s.status).toBe('CRITICAL');
+  });
+
+  it('allows a late-week projection full severity', () => {
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: weekStartingDaysAgo(now, 6.0),
+      weekly_budget_units: 10 ** 6,
+    });
+    const lines = Array.from({ length: 5 }, (_, i) =>
+      transcriptLine(`c${i}`, hoursAgo(now, i + 1), { out: 40_000 })
+    );
+    h.writeTranscript('a.jsonl', withBaseline(now, lines));
+
+    const s = refresh(h.paths);
+    expect(s.projection.confidence).toBe('high');
+    expect(['WARM', 'HOT', 'CRITICAL']).toContain(s.status);
+  });
+
+  it('shrinks the early forecast toward the baseline, keeping both visible', () => {
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: weekStartingDaysAgo(now, 0.15),
+      weekly_budget_units: 10 ** 7,
+    });
+    h.writeTranscript(
+      'a.jsonl',
+      withBaseline(now, [transcriptLine('cur', minutesAgo(now, 30), { out: 400 })])
+    );
+
+    const s = refresh(h.paths);
+    const p = s.projection;
+    const base = s.baseline.median_units!;
+    expect(p.method).toBe('shrunk-to-baseline');
+    // Shrinkage pulls TOWARD the baseline, which may be up or down — the
+    // property is proximity to a normal week, not a smaller number.
+    expect(Math.abs(p.units_at_reset - base)).toBeLessThan(
+      Math.abs(p.units_at_reset_linear - base)
+    );
+    // And it must land between the two, never outside them.
+    const [lo, hi] = [p.units_at_reset_linear, base].sort((a, b) => a - b) as [number, number];
+    expect(p.units_at_reset).toBeGreaterThanOrEqual(lo);
+    expect(p.units_at_reset).toBeLessThanOrEqual(hi);
+  });
+
+  it('falls back to a linear forecast with no baseline, still without escalating', () => {
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: weekStartingDaysAgo(now, 0.15),
+      weekly_budget_units: 10 ** 7,
+    });
+    h.writeTranscript('a.jsonl', [transcriptLine('cur', minutesAgo(now, 30), { out: 400 })]);
+
+    const s = refresh(h.paths);
+    expect(s.projection.method).toBe('linear');
+    expect(['HOT', 'CRITICAL']).not.toContain(s.status);
+  });
+});

--- a/packages/burn/tests/concurrency.test.ts
+++ b/packages/burn/tests/concurrency.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Locking and atomic writes only mean something across processes, so these
+ * drive the built binary in real subprocesses rather than calling the library.
+ *
+ * The failure being guarded: scans fire from the SessionStart hook, the Stop
+ * hook and the CLI while several Claude sessions run at once. Two overlapping
+ * scans both read the record store and then both rewrite it, so the loser's
+ * write lands a partial file — which is how 85% of the store was lost on
+ * 2026-08-04 while the HUD kept reporting a comfortable green.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+
+import { afterEach, beforeAll, expect, it } from 'vitest';
+
+import { BIN, DEFAULT_WEEK, hoursAgo, makeHud, runBin, transcriptLine, type Hud } from './helpers';
+
+let hud: Hud | null = null;
+
+beforeAll(() => {
+  if (!existsSync(BIN)) {
+    throw new Error(`built binary missing at ${BIN} — run \`pnpm build\` first`);
+  }
+});
+
+afterEach(() => {
+  hud?.cleanup();
+  hud = null;
+});
+
+it('leaves a consistent store after six concurrent scans', async () => {
+  hud = makeHud();
+  const now = new Date();
+  hud.writeConfig({ week_reset: DEFAULT_WEEK });
+  hud.writeTranscript(
+    'a.jsonl',
+    Array.from({ length: 200 }, (_, i) => transcriptLine(`r${i}`, hoursAgo(now, 1)))
+  );
+
+  const results = await Promise.all(Array.from({ length: 6 }, () => runBin(['scan'], hud!.env)));
+  for (const r of results) {
+    expect(r.stderr).toBe('');
+    expect(r.code).toBe(0);
+  }
+
+  const rows = readFileSync(hud.paths.usageTsv, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim());
+  expect(rows).toHaveLength(200);
+  for (const row of rows) {
+    expect(row.split('\t')).toHaveLength(7); // no partial rows
+  }
+
+  const header = readFileSync(hud.paths.filesTsv, 'utf8').split('\n')[0];
+  expect(header).toBe(`#count\t${rows.length}`);
+});

--- a/packages/burn/tests/config-units.test.ts
+++ b/packages/burn/tests/config-units.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Config resolution and unit formatting.
+ *
+ * Both are small, but both sit under every number the HUD prints: a config that
+ * silently reverts to defaults measures the wrong seven days, and a formatter
+ * that rounds up shows a threshold being crossed that was not.
+ */
+import { writeFileSync } from 'node:fs';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_CONFIG,
+  loadConfig,
+  readRawConfig,
+  resolvePaths,
+  saveRawConfig,
+} from '../src/config';
+import { readSummary } from '../src/read-summary';
+import { refresh, refreshIfStale } from '../src/refresh';
+import { human, units } from '../src/units';
+import { safeZone } from '../src/window';
+import { DEFAULT_WEEK, makeHud, transcriptLine, type Hud } from './helpers';
+
+let hud: Hud | null = null;
+
+function newHud(): Hud {
+  hud = makeHud();
+  return hud;
+}
+
+afterEach(() => {
+  hud?.cleanup();
+  hud = null;
+});
+
+describe('config', () => {
+  it('returns defaults when no config file exists', () => {
+    const h = newHud();
+    expect(loadConfig(h.paths)).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('merges week_reset field-by-field rather than replacing it', () => {
+    // A config that sets only the timezone must not lose the weekday, or the
+    // window silently slides back to Monday.
+    const h = newHud();
+    h.writeConfig({ week_reset: { tz: 'America/Chicago' } });
+    const cfg = loadConfig(h.paths);
+    expect(cfg.week_reset.tz).toBe('America/Chicago');
+    expect(cfg.week_reset.weekday).toBe(0);
+    expect(cfg.week_reset.time).toBe('00:00');
+  });
+
+  it('prefers an explicit week_reset over the legacy flat key', () => {
+    const h = newHud();
+    h.writeConfig({ week_reset_weekday: 5, week_reset: { weekday: 2, time: '08:59', tz: 'UTC' } });
+    expect(loadConfig(h.paths).week_reset.weekday).toBe(2);
+  });
+
+  it('round-trips a raw config without inventing defaults', () => {
+    const h = newHud();
+    saveRawConfig(h.paths, { weekly_budget_units: 123 });
+    expect(readRawConfig(h.paths)).toEqual({ weekly_budget_units: 123 });
+    // The raw read must not synthesise keys the user never wrote.
+    expect(readRawConfig(h.paths).week_reset).toBeUndefined();
+  });
+
+  it('treats a corrupt raw config as empty rather than throwing', () => {
+    const h = newHud();
+    writeFileSync(h.paths.config, '}{');
+    expect(readRawConfig(h.paths)).toEqual({});
+  });
+
+  it('resolves paths from the CLAUDE_HUD_* overrides', () => {
+    const paths = resolvePaths({ CLAUDE_HUD_HOME: '/tmp/x', HOME: '/home/nobody' });
+    expect(paths.hud).toBe('/tmp/x');
+    expect(paths.summary).toContain('/tmp/x');
+  });
+
+  it('falls back to UTC for an unknown timezone instead of throwing', () => {
+    expect(safeZone('Mars/Olympus_Mons')).toBe('UTC');
+    expect(safeZone('America/Chicago')).toBe('America/Chicago');
+  });
+});
+
+describe('units', () => {
+  it('weights output far above cache reads', () => {
+    expect(units(1, 0, 0, 0)).toBe(5);
+    expect(units(0, 1, 0, 0)).toBe(1);
+    expect(units(0, 0, 1, 0)).toBe(1.25);
+    expect(units(0, 0, 0, 1)).toBe(0.1);
+  });
+
+  it('formats across every magnitude', () => {
+    expect(human(2_400_000_000)).toBe('2.40B');
+    expect(human(21_400_000)).toBe('21.4M');
+    expect(human(21_400)).toBe('21k');
+    expect(human(42)).toBe('42');
+    expect(human(null)).toBe('0');
+  });
+});
+
+describe('refresh throttling', () => {
+  it('skips the rescan while the cache is warm', () => {
+    // The Stop hook fires after every turn; not stampeding is cheaper than
+    // relying on the lock to sort out six concurrent scans.
+    const h = newHud();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', new Date())]);
+    refresh(h.paths);
+
+    h.writeTranscript('b.jsonl', [transcriptLine('r2', new Date())]);
+    refreshIfStale(h.paths, 60);
+    // The new transcript is deliberately NOT picked up yet: the published
+    // summary still describes one record.
+    expect(readSummary(h.paths)!.scan.records_total).toBe(1);
+  });
+
+  it('rescans once the cache has gone cold', () => {
+    const h = newHud();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', new Date())]);
+    refresh(h.paths);
+
+    h.writeTranscript('b.jsonl', [transcriptLine('r2', new Date())]);
+    // Pretend two minutes have passed rather than sleeping.
+    refreshIfStale(h.paths, 60, new Date(Date.now() + 120_000));
+    expect(readSummary(h.paths)!.scan.records_total).toBe(2);
+  });
+});

--- a/packages/burn/tests/config-units.test.ts
+++ b/packages/burn/tests/config-units.test.ts
@@ -6,6 +6,7 @@
  * that rounds up shows a threshold being crossed that was not.
  */
 import { writeFileSync } from 'node:fs';
+import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -72,9 +73,12 @@ describe('config', () => {
   });
 
   it('resolves paths from the CLAUDE_HUD_* overrides', () => {
-    const paths = resolvePaths({ CLAUDE_HUD_HOME: '/tmp/x', HOME: '/home/nobody' });
-    expect(paths.hud).toBe('/tmp/x');
-    expect(paths.summary).toContain('/tmp/x');
+    const home = path.join(path.sep, 'tmp', 'x');
+    const paths = resolvePaths({ CLAUDE_HUD_HOME: home, HOME: path.join(path.sep, 'nobody') });
+    expect(paths.hud).toBe(home);
+    // Built with path.join, so the separator is the platform's — asserting a
+    // literal '/' here is what failed the Windows leg of CI.
+    expect(paths.summary).toBe(path.join(home, 'state', 'summary.json'));
   });
 
   it('falls back to UTC for an unknown timezone instead of throwing', () => {

--- a/packages/burn/tests/helpers.ts
+++ b/packages/burn/tests/helpers.ts
@@ -1,0 +1,118 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { resolvePaths, type BurnPaths } from '../src/config';
+
+export const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const BIN = path.join(PACKAGE_ROOT, 'dist', 'bin', 'burn-hud.mjs');
+
+/**
+ * Run the built binary with stdin closed immediately.
+ *
+ * The binary reads stdin to completion (Claude Code pipes a JSON payload in),
+ * so a caller that leaves the pipe open hangs it — `execFile` does exactly
+ * that, which is how a 30s test timeout surfaced the footgun.
+ */
+export function runBin(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  stdin = '{}'
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [BIN, ...args], { env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d: Buffer) => (stdout += d.toString()));
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, stderr, code }));
+    child.stdin.end(stdin);
+  });
+}
+
+/** An isolated HUD tree, driven through the same env vars a real install uses. */
+export interface Hud {
+  root: string;
+  paths: BurnPaths;
+  env: NodeJS.ProcessEnv;
+  writeConfig(cfg: Record<string, unknown>): void;
+  writeTranscript(name: string, lines: string[]): void;
+  cleanup(): void;
+}
+
+export function makeHud(): Hud {
+  const root = mkdtempSync(path.join(tmpdir(), 'burn-hud-'));
+  const home = path.join(root, 'hud');
+  const state = path.join(home, 'state');
+  const projects = path.join(root, 'projects');
+  const projectDir = path.join(projects, '-proj');
+  mkdirSync(state, { recursive: true });
+  mkdirSync(projectDir, { recursive: true });
+
+  const env = {
+    ...process.env,
+    CLAUDE_HUD_HOME: home,
+    CLAUDE_HUD_STATE: state,
+    CLAUDE_HUD_PROJECTS: projects,
+  };
+
+  return {
+    root,
+    paths: resolvePaths(env),
+    env,
+    writeConfig(cfg) {
+      writeFileSync(path.join(home, 'config.json'), JSON.stringify(cfg));
+    },
+    writeTranscript(name, lines) {
+      writeFileSync(path.join(projectDir, name), lines.join('\n') + '\n');
+    },
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+/** A Monday-UTC week, matching the Python suite's default fixture config. */
+export const DEFAULT_WEEK = { weekday: 0, time: '00:00', tz: 'UTC' };
+
+export function transcriptLine(
+  requestId: string,
+  when: Date,
+  opts: { model?: string; out?: number; in?: number; cw?: number; cr?: number } = {}
+): string {
+  return JSON.stringify({
+    requestId,
+    timestamp: when.toISOString(),
+    type: 'assistant',
+    message: {
+      id: `msg_${requestId}`,
+      model: opts.model ?? 'claude-opus-5',
+      usage: {
+        output_tokens: opts.out ?? 100,
+        input_tokens: opts.in ?? 10,
+        cache_creation_input_tokens: opts.cw ?? 0,
+        cache_read_input_tokens: opts.cr ?? 0,
+      },
+    },
+  });
+}
+
+export function hoursAgo(now: Date, hours: number): Date {
+  return new Date(now.getTime() - hours * 3_600_000);
+}
+
+export function minutesAgo(now: Date, minutes: number): Date {
+  return new Date(now.getTime() - minutes * 60_000);
+}
+
+export function daysAgo(now: Date, days: number): Date {
+  return new Date(now.getTime() - days * 86_400_000);
+}
+
+/** 0=Mon..6=Sun for a Date, in UTC — the weekday convention the config uses. */
+export function utcIsoWeekday(d: Date): number {
+  return (d.getUTCDay() + 6) % 7;
+}

--- a/packages/burn/tests/hooks.test.ts
+++ b/packages/burn/tests/hooks.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Hook behaviour: what gets said, to whom, and how often.
+ *
+ * The Stop hook fires after EVERY assistant turn, so the bar for speaking is
+ * high. A warning repeated every turn becomes wallpaper, and wallpaper is how a
+ * real limit gets hit anyway — so the ladder and the cooldown are asserted, not
+ * just the wording.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { escalation, sessionBrief, type NotifyState } from '../src/hooks';
+import type { Summary } from '../src/types';
+
+function summary(over: Record<string, unknown> = {}): Summary {
+  const base = {
+    generated_at: '2026-08-06T12:00:00+00:00',
+    scan: { files_total: 1, files_rescanned: 0, records_added: 0, records_total: 10 },
+    status: 'OK',
+    week: { days_left: 3.2, hours_left: 76.8, tz: 'America/Chicago' },
+    wtd: { units: 12_400_000, requests: 400, output_tokens: 100_000 },
+    baseline: { median_units: 200_000_000 },
+    projection: { units_at_reset: 180_000_000, confidence: 'high', ratio_vs_baseline: 0.9 },
+    budget: { set: false },
+    models_exhausted: [],
+    session: {},
+    calibration: {},
+  } as unknown as Record<string, unknown>;
+  for (const [k, v] of Object.entries(over)) {
+    const existing = base[k];
+    base[k] =
+      v !== null &&
+      typeof v === 'object' &&
+      !Array.isArray(v) &&
+      existing !== null &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing)
+        ? { ...(existing as object), ...(v as object) }
+        : v;
+  }
+  return base as unknown as Summary;
+}
+
+/** The fixture's `generated_at`, so staleness only fires when a test asks for it. */
+const FRESH = new Date('2026-08-06T12:00:00Z');
+
+describe('session brief', () => {
+  it('states ignorance loudly when there is no cache', () => {
+    // A cache that cannot be read is a finding, not an all-clear.
+    const out = sessionBrief(null, null);
+    expect(out.systemMessage).toContain('blind, not clear');
+    expect(out.hookSpecificOutput.additionalContext).toContain('UNKNOWN');
+  });
+
+  it('always briefs the model but stays silent to the user when on pace', () => {
+    const out = sessionBrief(summary(), null, FRESH);
+    expect(out.hookSpecificOutput.additionalContext).toContain('status=OK');
+    expect(out.systemMessage).toBeUndefined();
+  });
+
+  it('tells the model never to invent a percentage with no budget set', () => {
+    expect(sessionBrief(summary(), null, FRESH).hookSpecificOutput.additionalContext).toContain(
+      'Never invent one'
+    );
+  });
+
+  it('interrupts the user once the pace is elevated', () => {
+    const out = sessionBrief(summary({ status: 'HOT' }), null, FRESH);
+    expect(out.systemMessage).toContain('Burn HOT');
+  });
+
+  it('surfaces a merged branch as the /clear signal in both channels', () => {
+    const out = sessionBrief(summary(), 'feat/x', FRESH);
+    expect(out.hookSpecificOutput.additionalContext).toContain('ALREADY MERGED');
+    expect(out.systemMessage).toContain('/clear');
+  });
+
+  it('reports a stale cache rather than swallowing it', () => {
+    const out = sessionBrief(summary(), null, new Date('2026-08-06T15:00:00Z'));
+    expect(out.systemMessage).toContain('180m stale');
+  });
+});
+
+describe('escalation ladder', () => {
+  const hot = summary({ status: 'HOT' });
+  const now = new Date('2026-08-06T12:00:00Z');
+
+  it('says nothing below WARM, and resets the ladder', () => {
+    const out = escalation(summary({ status: 'OK' }), { level: 2, status: 'HOT', ts: '' }, now);
+    expect(out.message).toBeNull();
+    // Reset so a later re-entry into WARM notifies again.
+    expect(out.nextNotify?.level).toBe(0);
+  });
+
+  it('speaks when the level rises', () => {
+    const prev: NotifyState = { level: 1, status: 'WARM', ts: now.toISOString() };
+    expect(escalation(hot, prev, now).message).toContain('Burn HOT');
+  });
+
+  it('stays quiet at the same level inside the cooldown', () => {
+    const prev: NotifyState = { level: 2, status: 'HOT', ts: now.toISOString() };
+    const out = escalation(hot, prev, new Date(now.getTime() + 10 * 60_000));
+    expect(out.message).toBeNull();
+    // And leaves the ladder untouched, so the cooldown keeps running.
+    expect(out.nextNotify).toBeNull();
+  });
+
+  it('speaks again once the cooldown has passed', () => {
+    const prev: NotifyState = { level: 2, status: 'HOT', ts: now.toISOString() };
+    const out = escalation(hot, prev, new Date(now.getTime() + 46 * 60_000));
+    expect(out.message).toContain('Burn HOT');
+  });
+
+  it('leads with spend, not the forecast, when a budget is set', () => {
+    // "5.8M used ... 108% of your weekly budget" read as self-contradictory and
+    // taught the reader to discount the alarm.
+    const s = summary({
+      status: 'CRITICAL',
+      budget: { set: true, pct_used: 104, pct_projected: 130 },
+    });
+    const msg = escalation(s, null, now).message!;
+    expect(msg.indexOf('104% of your weekly budget')).toBeLessThan(msg.indexOf('130%'));
+    expect(msg).toContain('on current pace');
+  });
+
+  it('marks a weakly-supported forecast as one', () => {
+    const s = summary({ status: 'WARM', projection: { confidence: 'low' } });
+    expect(escalation(s, null, now).message).toContain('weakly supported');
+  });
+
+  it('names an exhausted model family and an expired calibration', () => {
+    const s = summary({
+      status: 'HOT',
+      models_exhausted: ['claude-fable-5'],
+      calibration: { expired: true, valid_until: '2026-08-01' },
+    });
+    const msg = escalation(s, null, now).message!;
+    expect(msg).toContain('claude-fable-5 is at 100%');
+    expect(msg).toContain('may under-warn');
+  });
+
+  it('reports the run-dry time in the account reset timezone, not UTC', () => {
+    // /usage speaks that timezone; a UTC time would not line up with what the
+    // user reads there.
+    const s = summary({
+      status: 'CRITICAL',
+      budget: {
+        set: true,
+        pct_used: 101,
+        pct_projected: 140,
+        exhausts_before_reset: true,
+        exhausts_at: '2026-08-07T18:30:00+00:00',
+      },
+    });
+    // 18:30 UTC is 13:30 in America/Chicago (CDT).
+    expect(escalation(s, null, now).message).toContain('13:30');
+  });
+});

--- a/packages/burn/tests/robustness.test.ts
+++ b/packages/burn/tests/robustness.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Malformed-input behaviour.
+ *
+ * The HUD's whole premise is that a green readout must never be reachable by a
+ * path that did not actually measure anything. Every case here feeds it
+ * something broken — a half-written store, a config with the wrong types, a
+ * summary from another version — and asserts it degrades to stated ignorance
+ * rather than to a confident number.
+ */
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { readSummary } from '../src/read-summary';
+import { refresh } from '../src/refresh';
+import { parseTranscript } from '../src/scan';
+import { renderStatusline, type GitSegment } from '../src/statusline';
+import { readFingerprints, readRecords } from '../src/store';
+import type { Summary, UsageRecord } from '../src/types';
+import { weekBounds } from '../src/window';
+import { DEFAULT_WEEK, makeHud, transcriptLine, type Hud } from './helpers';
+
+const ANSI = /\u001b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI, '');
+}
+
+/** The smallest summary the statusline should still be able to render. */
+function minimalSummary(over: Record<string, unknown> = {}): Summary {
+  return {
+    status: 'OK',
+    generated_at: new Date().toISOString(),
+    week: { hours_left: 72, days_left: 3 },
+    wtd: { units: 1000 },
+    projection: { units_at_reset: 2000, confidence: 'high', ratio_vs_baseline: 1 },
+    budget: { set: false },
+    ...over,
+  } as unknown as Summary;
+}
+
+let hud: Hud | null = null;
+
+function newHud(): Hud {
+  hud = makeHud();
+  return hud;
+}
+
+afterEach(() => {
+  hud?.cleanup();
+  hud = null;
+});
+
+describe('store', () => {
+  it('discards malformed rows instead of importing partial records', () => {
+    // A partial row is exactly what a torn write leaves behind; importing it
+    // would put a bogus record into the totals.
+    const h = newHud();
+    writeFileSync(
+      h.paths.usageTsv,
+      ['good\t2026-08-06T00:00:00Z\tclaude-opus-5\t1\t2\t3\t4', 'short\trow', '', 'a\tb'].join('\n')
+    );
+    expect([...readRecords(h.paths).keys()]).toEqual(['good']);
+  });
+
+  it('ignores a fingerprint header that is not a number', () => {
+    const h = newHud();
+    writeFileSync(h.paths.filesTsv, ['#count\tnonsense', '/a.jsonl\t123\t456'].join('\n'));
+    const { fingerprints, expected } = readFingerprints(h.paths);
+    expect(expected).toBeNull();
+    expect(fingerprints.size).toBe(1);
+  });
+
+  it('returns empty structures when nothing has been written yet', () => {
+    const h = newHud();
+    expect(readRecords(h.paths).size).toBe(0);
+    expect(readFingerprints(h.paths).expected).toBeNull();
+  });
+});
+
+describe('transcript parsing', () => {
+  it('skips unparseable lines, lines without usage, and missing files', () => {
+    const h = newHud();
+    const file = path.join(h.paths.projects, '-proj', 'mixed.jsonl');
+    writeFileSync(
+      file,
+      [
+        '{ this is not json but mentions "usage"',
+        JSON.stringify({ type: 'user', message: { content: 'hi' } }),
+        JSON.stringify({ requestId: 'no-usage-block', message: { model: 'x' } }),
+        JSON.stringify({ timestamp: 'x', message: { usage: { output_tokens: 5 } } }), // no id
+        transcriptLine('good', new Date()),
+      ].join('\n')
+    );
+
+    const records = new Map<string, UsageRecord>();
+    expect(parseTranscript(file, records)).toBe(1);
+    expect([...records.keys()]).toEqual(['good']);
+    expect(parseTranscript(path.join(h.paths.projects, 'missing.jsonl'), records)).toBe(0);
+  });
+
+  it('defaults an absent model and absent token counts rather than failing', () => {
+    const h = newHud();
+    const file = path.join(h.paths.projects, '-proj', 'sparse.jsonl');
+    writeFileSync(
+      file,
+      JSON.stringify({ requestId: 'r', timestamp: '2026-08-06T00:00:00Z', message: { usage: {} } })
+    );
+    const records = new Map<string, UsageRecord>();
+    parseTranscript(file, records);
+    expect(records.get('r')).toEqual({
+      ts: '2026-08-06T00:00:00Z',
+      model: 'unknown',
+      out: 0,
+      in: 0,
+      cacheWrite: 0,
+      cacheRead: 0,
+    });
+  });
+
+  it('stores but does not count a record whose timestamp will not parse', () => {
+    // An unparseable timestamp cannot be filed into any week, and guessing one
+    // would move real spend into the wrong window.
+    const h = newHud();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    writeFileSync(
+      path.join(h.paths.projects, '-proj', 'bad-ts.jsonl'),
+      JSON.stringify({
+        requestId: 'r',
+        timestamp: 'not-a-date',
+        message: { model: 'claude-opus-5', usage: { output_tokens: 10_000 } },
+      })
+    );
+    const s = refresh(h.paths);
+    expect(s.scan.records_total).toBe(1);
+    expect(s.wtd.requests).toBe(0);
+  });
+
+  it('walks past a directory it cannot read', () => {
+    const h = newHud();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    const locked = path.join(h.paths.projects, 'locked');
+    mkdirSync(locked, { recursive: true });
+    chmodSync(locked, 0o000);
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', new Date())]);
+    try {
+      expect(refresh(h.paths).scan.records_total).toBe(1);
+    } finally {
+      chmodSync(locked, 0o755); // so the temp dir can be cleaned up
+    }
+  });
+});
+
+describe('week window with a hostile config', () => {
+  const at = new Date('2026-08-06T12:00:00Z'); // a Thursday
+  const mondayBefore = '2026-08-03T00:00:00.000Z';
+
+  it('falls back to midnight when time is not a string', () => {
+    const cfg = { week_reset: { weekday: 0, time: { hour: 9 } as unknown as string, tz: 'UTC' } };
+    expect(weekBounds(at, cfg).start.toISOString()).toBe(mondayBefore);
+  });
+
+  it('falls back to midnight when time is unparseable', () => {
+    const cfg = { week_reset: { weekday: 0, time: 'lunchtime', tz: 'UTC' } };
+    expect(weekBounds(at, cfg).start.toISOString()).toBe(mondayBefore);
+  });
+
+  it('normalises an out-of-range weekday', () => {
+    const nine = weekBounds(at, { week_reset: { weekday: 9, time: '00:00', tz: 'UTC' } }).start;
+    const two = weekBounds(at, { week_reset: { weekday: 2, time: '00:00', tz: 'UTC' } }).start;
+    expect(nine.toISOString()).toBe(two.toISOString());
+  });
+
+  it('defaults to Monday UTC when week_reset is missing entirely', () => {
+    expect(weekBounds(at, {}).start.toISOString()).toBe(mondayBefore);
+  });
+
+  it('falls back to UTC for an unknown timezone', () => {
+    const cfg = { week_reset: { weekday: 0, time: '00:00', tz: 'Nowhere/Special' } };
+    expect(weekBounds(at, cfg).start.toISOString()).toBe(mondayBefore);
+  });
+});
+
+describe('statusline with a summary from another version', () => {
+  it('renders an unrecognised status without pretending it is fine', () => {
+    const out = stripAnsi(
+      renderStatusline({ summary: minimalSummary({ status: 'SOMETHING_NEW' }) })
+    );
+    expect(out).toContain('❔'); // no green tick for a status we cannot interpret
+    expect(out).toContain('1k'); // measured spend is still shown
+  });
+
+  it('survives a summary missing every optional block', () => {
+    const out = stripAnsi(
+      renderStatusline({
+        summary: { status: 'OK', generated_at: new Date().toISOString() } as unknown as Summary,
+      })
+    );
+    expect(out).toContain('no baseline yet');
+    // A missing week block degrades to "0h", i.e. toward urgency rather than
+    // toward reassurance — the safe direction for a wrong read.
+    expect(out).toContain('0h to reset');
+  });
+
+  it('colours the countdown urgently inside twelve hours', () => {
+    const near = renderStatusline({
+      summary: minimalSummary({ week: { hours_left: 6, days_left: 0.25 } }),
+    });
+    expect(stripAnsi(near)).toContain('6h to reset');
+    expect(near).toContain('\u001b[33m'); // yellow, not dim
+  });
+
+  it('renders an unmerged branch and the model name without a /clear nudge', () => {
+    const git: GitSegment = { kind: 'plain', label: 'feat/x +3' };
+    const out = stripAnsi(
+      renderStatusline({ summary: minimalSummary(), git, modelName: 'Opus 5' })
+    );
+    expect(out).toContain('feat/x +3');
+    expect(out).toContain('Opus 5');
+    expect(out).not.toContain('/clear');
+  });
+});
+
+describe('summary reading', () => {
+  it('treats a non-object summary as no summary at all', () => {
+    const h = newHud();
+    writeFileSync(h.paths.summary, '"just a string"');
+    expect(readSummary(h.paths)).toBeNull();
+    writeFileSync(h.paths.summary, 'null');
+    expect(readSummary(h.paths)).toBeNull();
+  });
+});

--- a/packages/burn/tests/scan.test.ts
+++ b/packages/burn/tests/scan.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Regression suite for the burn scanner, ported 1:1 from the Python HUD's
+ * `tests/test_scan.py`.
+ *
+ * Every test here corresponds to a defect that ACTUALLY SHIPPED and that a
+ * human caught before the tool did. They are regression tests in the strict
+ * sense, not coverage decoration:
+ *
+ *   week anchor    the Monday-UTC assumption that understated a 97% week by
+ *                  ~81x and displayed a calm green
+ *   data loss      the write race that silently dropped 85% of the record store
+ *                  while reporting OK at 3% of budget
+ *   dedupe         transcripts repeat each usage block ~3x; naive counting
+ *                  inflates totals ~3.5x
+ *   abstention     a zero or short denominator must never read as a pass
+ */
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../src/config';
+import { refresh } from '../src/refresh';
+import { withScanLock } from '../src/store';
+import { units } from '../src/units';
+import { weekBounds } from '../src/window';
+import {
+  DEFAULT_WEEK,
+  daysAgo,
+  hoursAgo,
+  makeHud,
+  minutesAgo,
+  transcriptLine,
+  utcIsoWeekday,
+  type Hud,
+} from './helpers';
+
+let hud: Hud | null = null;
+
+function newHud(): Hud {
+  hud = makeHud();
+  return hud;
+}
+
+afterEach(() => {
+  hud?.cleanup();
+  hud = null;
+});
+
+describe('dedupe', () => {
+  it('collapses repeated usage blocks within a transcript', () => {
+    // Transcripts repeat the same usage block ~3x per request. Counting rows
+    // instead of requestIds inflates every figure ~3.5x.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    const line = transcriptLine('req_A', hoursAgo(now, 1), { out: 1000 });
+    h.writeTranscript('a.jsonl', [line, line, line]);
+
+    const s = refresh(h.paths);
+    expect(s.scan.records_total).toBe(1);
+    expect(s.wtd.output_tokens).toBe(1000);
+  });
+
+  it('collapses the same requestId across two transcripts', () => {
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    const line = transcriptLine('req_dup', hoursAgo(now, 1), { out: 500 });
+    h.writeTranscript('a.jsonl', [line]);
+    h.writeTranscript('b.jsonl', [line]);
+
+    expect(refresh(h.paths).scan.records_total).toBe(1);
+  });
+});
+
+describe('week anchor', () => {
+  // The 81x regression. weekBounds is pure, so assert it exactly.
+  it('anchors a Wednesday 08:59 America/Chicago window', () => {
+    const cfg = { week_reset: { weekday: 2, time: '08:59', tz: 'America/Chicago' } };
+    const now = new Date('2026-08-04T18:00:00Z'); // a Tuesday
+    const { start, end } = weekBounds(now, cfg);
+    expect(start.toISOString()).toBe('2026-07-29T13:59:00.000Z');
+    expect(end.toISOString()).toBe('2026-08-05T13:59:00.000Z');
+  });
+
+  it('documents how far the Monday-UTC assumption missed', () => {
+    // The same instant bucketed under a Monday-UTC week starts 4.5 days later,
+    // so days of spend fall outside "week to date" and the HUD under-reports.
+    const now = new Date('2026-08-04T18:00:00Z');
+    const wed = weekBounds(now, {
+      week_reset: { weekday: 2, time: '08:59', tz: 'America/Chicago' },
+    }).start;
+    const mon = weekBounds(now, { week_reset: DEFAULT_WEEK }).start;
+    expect((mon.getTime() - wed.getTime()) / 1000).toBeGreaterThan(4 * 86_400);
+  });
+
+  it('places the reset instant itself in the new week', () => {
+    const cfg = { week_reset: { weekday: 2, time: '08:59', tz: 'America/Chicago' } };
+    const at = new Date('2026-08-05T13:59:00Z');
+    expect(weekBounds(at, cfg).start.getTime()).toBe(at.getTime());
+  });
+
+  it('honours the legacy flat weekday key', () => {
+    // An old config must not silently revert to Monday-UTC — that is how the
+    // 81x understatement would come back.
+    const h = newHud();
+    h.writeConfig({ week_reset_weekday: 2 });
+    expect(loadConfig(h.paths).week_reset.weekday).toBe(2);
+  });
+
+  it('survives a DST boundary without moving the weekday', () => {
+    // Not in the Python suite: the port swapped zoneinfo for Intl, so the
+    // two-pass offset resolution needs its own guard. US DST ended
+    // 2026-11-01; the Wednesday reset either side must stay 08:59 local.
+    const cfg = { week_reset: { weekday: 2, time: '08:59', tz: 'America/Chicago' } };
+    const before = weekBounds(new Date('2026-10-30T12:00:00Z'), cfg).start;
+    const after = weekBounds(new Date('2026-11-06T12:00:00Z'), cfg).start;
+    // Compare parts rather than a formatted string: the separators between
+    // weekday and time are locale data, and asserting them makes the test fail
+    // on an ICU update rather than on a real regression.
+    const localParts = (d: Date): Record<string, string> =>
+      Object.fromEntries(
+        new Intl.DateTimeFormat('en-GB', {
+          timeZone: 'America/Chicago',
+          weekday: 'short',
+          hour: '2-digit',
+          minute: '2-digit',
+          hourCycle: 'h23',
+        })
+          .formatToParts(d)
+          .map((p) => [p.type, p.value])
+      );
+    for (const d of [before, after]) {
+      expect(localParts(d).weekday).toBe('Wed');
+      expect(`${localParts(d).hour}:${localParts(d).minute}`).toBe('08:59');
+    }
+    // ...and the offset really did change across the boundary.
+    expect(before.toISOString().slice(11, 16)).toBe('13:59');
+    expect(after.toISOString().slice(11, 16)).toBe('14:59');
+  });
+});
+
+describe('abstention', () => {
+  // A zero or short denominator is an abstention, never a pass.
+  it('reports NO_DATA rather than OK when there are no records', () => {
+    const h = newHud();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    expect(refresh(h.paths).status).toBe('NO_DATA');
+  });
+
+  it('downgrades a would-be OK to EARLY on a thin sample', () => {
+    // Early in the week a full-week forecast is noise, so a reassuring verdict
+    // is withheld. Needs prior weeks present, since without a baseline the
+    // status is the (also correct) NO_BASELINE abstention instead.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: { weekday: utcIsoWeekday(now), time: '00:00', tz: 'UTC' },
+    });
+    const lines = [transcriptLine('cur1', minutesAgo(now, 5), { out: 10 })];
+    for (let wk = 1; wk <= 3; wk += 1) {
+      for (let i = 0; i < 5; i += 1) {
+        lines.push(
+          transcriptLine(`w${wk}n${i}`, hoursAgo(daysAgo(now, 7 * wk), 3 + i), { out: 200 })
+        );
+      }
+    }
+    h.writeTranscript('a.jsonl', lines);
+
+    const s = refresh(h.paths);
+    expect(s.projection.confidence).toBe('low');
+    expect(s.baseline.median_units).not.toBeNull();
+    expect(s.status).toBe('EARLY');
+  });
+
+  it('does not crash on a huge budget against a low burn rate', () => {
+    // Regression: a low rate against a large budget produced a multi-million-day
+    // runway, overflowed Python's timedelta, and killed the scan outright —
+    // leaving no summary and a blank HUD.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: { weekday: (utcIsoWeekday(now) + 1) % 7, time: '00:00', tz: 'UTC' },
+      weekly_budget_units: 10 ** 15,
+    });
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', hoursAgo(now, 2), { out: 1 })]);
+
+    const s = refresh(h.paths);
+    expect(s.budget.exhausts_before_reset).toBeFalsy();
+    expect(s.budget.runway_days).toBeDefined();
+  });
+
+  it('does not suppress an elevated status on a thin sample', () => {
+    // Incurred spend is real whatever the forecast confidence. Only a
+    // reassuring verdict is held back — the asymmetry is deliberate.
+    const h = newHud();
+    const now = new Date();
+    h.writeConfig({
+      week_reset: { weekday: utcIsoWeekday(now), time: '00:00', tz: 'UTC' },
+      weekly_budget_units: 1000,
+    });
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', minutesAgo(now, 5), { out: 100_000 })]);
+
+    const s = refresh(h.paths);
+    expect(s.projection.confidence).toBe('low');
+    expect(s.status).toBe('CRITICAL');
+  });
+
+  it('falls back to defaults on a corrupt config instead of failing', () => {
+    const h = newHud();
+    writeFileSync(h.paths.config, 'NOT JSON {{{');
+    const now = new Date();
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', hoursAgo(now, 1))]);
+    expect(refresh(h.paths).status).toBeDefined();
+  });
+
+  it('weights cache reads far below output tokens', () => {
+    // Raw token counts are a misleading headline: cache reads dominate volume
+    // but are nearly free.
+    expect(units(1000, 0, 0, 0)).toBeGreaterThan(units(0, 0, 0, 1000));
+  });
+});
+
+describe('data loss', () => {
+  // The 85% silent loss. Fingerprints must not outlive their records.
+  function seed(h: Hud, n = 40): number {
+    const now = new Date();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    h.writeTranscript(
+      'a.jsonl',
+      Array.from({ length: n }, (_, i) => transcriptLine(`r${i}`, hoursAgo(now, 1), { out: 100 }))
+    );
+    refresh(h.paths);
+    return n;
+  }
+
+  it('writes the count header alongside the fingerprints', () => {
+    const h = newHud();
+    const n = seed(h);
+    expect(readFileSync(h.paths.filesTsv, 'utf8').split('\n')[0]).toBe(`#count\t${n}`);
+  });
+
+  it('self-heals a truncated store whose fingerprints survived', () => {
+    // The exact production failure: the store loses rows, the fingerprints
+    // survive claiming everything was scanned, so nothing is ever re-read.
+    const h = newHud();
+    const n = seed(h);
+    const rows = readFileSync(h.paths.usageTsv, 'utf8').split('\n').filter(Boolean);
+    writeFileSync(h.paths.usageTsv, rows.slice(0, 5).join('\n') + '\n'); // lose 35 of 40
+
+    const s = refresh(h.paths);
+    expect(s.scan.data_loss_detected).toBe(true);
+    expect(s.scan.records_total).toBe(n); // fully rebuilt
+    expect(s.scan.unrecovered).toBe(0);
+    expect(s.status).not.toBe('UNDERCOUNT');
+  });
+
+  it('reports UNDERCOUNT when the loss cannot be recovered', () => {
+    // When the source transcripts are gone the rows cannot come back, so the
+    // figures are a floor and must be labelled as such.
+    const h = newHud();
+    seed(h);
+    const lines = readFileSync(h.paths.filesTsv, 'utf8').split('\n').filter(Boolean);
+    lines[0] = '#count\t9999'; // claim far more were scanned
+    writeFileSync(h.paths.filesTsv, lines.join('\n') + '\n');
+
+    const s = refresh(h.paths);
+    expect(s.scan.data_loss_detected).toBe(true);
+    expect(s.scan.unrecovered ?? 0).toBeGreaterThan(0);
+    expect(s.status).toBe('UNDERCOUNT');
+  });
+
+  it('rebuilds cleanly when the fingerprints are missing entirely', () => {
+    const h = newHud();
+    const n = seed(h);
+    rmSync(h.paths.filesTsv);
+    expect(refresh(h.paths).scan.records_total).toBe(n);
+  });
+
+  it('leaves no .tmp files behind', () => {
+    const h = newHud();
+    h.writeConfig({ week_reset: DEFAULT_WEEK });
+    h.writeTranscript('a.jsonl', [transcriptLine('r1', new Date())]);
+    refresh(h.paths);
+    expect(readdirSync(h.paths.state).filter((f) => f.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('releases the scan lock when the body throws', () => {
+    // Not in the Python suite, and required by the port: flock was released by
+    // the kernel when the holder died, but this port holds a mkdir lock that
+    // only its own `finally` clears. A leaked lock wedges every later scan
+    // until the staleness window expires.
+    const h = newHud();
+    expect(() =>
+      withScanLock(h.paths, () => {
+        throw new Error('boom');
+      })
+    ).toThrow('boom');
+    expect(existsSync(h.paths.lock)).toBe(false);
+  });
+
+  it('reclaims a lock whose owner process is gone', () => {
+    // The other half of losing flock's kernel cleanup: a lock left behind by a
+    // crashed scan must not lock the HUD out permanently.
+    const h = newHud();
+    mkdirSync(h.paths.lock, { recursive: true });
+    writeFileSync(
+      path.join(h.paths.lock, 'owner.json'),
+      // A pid that cannot be running, with a fresh timestamp so only the
+      // liveness check (not the age check) can break the lock.
+      JSON.stringify({ pid: 0x7ffffff0, at: Date.now() })
+    );
+
+    let acquired = false;
+    withScanLock(h.paths, (got) => {
+      acquired = got;
+    });
+    expect(acquired).toBe(true);
+  });
+});

--- a/packages/burn/tests/statusline.test.ts
+++ b/packages/burn/tests/statusline.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression suite for the statusline's *presentation*, ported from the Python
+ * HUD's `tests/test_statusline.py`.
+ *
+ * Ordering here is not cosmetic. The projected percentage once occupied the
+ * headline slot, so a statusline reading
+ *
+ *     🔴 277.5M wtd → 381.1M proj · 133% of budget
+ *
+ * was taken to mean 133% consumed when actual spend was 7%. A forecast that
+ * sits where a reader will take it for a measurement is a false reading even
+ * when every number in it is correct — so what leads, and how the forecast is
+ * labelled, is asserted the same way the scanner's arithmetic is.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { renderStatusline } from '../src/statusline';
+import type { Summary } from '../src/types';
+
+// eslint-disable-next-line no-control-regex
+const ANSI = /\u001b\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI, '');
+}
+
+function summary(over: Record<string, unknown> = {}): Summary {
+  const base = {
+    generated_at: '2099-01-01T00:00:00+00:00',
+    status: 'EARLY',
+    week: { days_left: 6.5, hours_left: 156.0, tz: 'UTC' },
+    wtd: { units: 21_400_000 },
+    projection: {
+      units_at_reset: 249_000_000,
+      confidence: 'low',
+      ratio_vs_baseline: 1.01,
+      method: 'shrunk-to-baseline',
+    },
+    budget: { set: true, pct_used: 4.0, pct_projected: 46.0 },
+    models_exhausted: [],
+    session: {},
+    calibration: {},
+  } as unknown as Record<string, unknown>;
+
+  for (const [k, v] of Object.entries(over)) {
+    const existing = base[k];
+    base[k] =
+      v !== null &&
+      typeof v === 'object' &&
+      !Array.isArray(v) &&
+      existing !== null &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing)
+        ? { ...(existing as object), ...(v as object) }
+        : v;
+  }
+  return base as unknown as Summary;
+}
+
+/** The fixture's `generated_at` is in 2099, so staleness never fires here. */
+function render(over: Record<string, unknown> = {}): string {
+  return stripAnsi(
+    renderStatusline({ summary: summary(over), config: { stale_after_minutes: 90 } })
+  );
+}
+
+describe('used leads the projection', () => {
+  it('puts actual spend before the forecast', () => {
+    // The regression: a reader takes the first percentage as spend.
+    const out = render();
+    expect(out).toContain('4% used');
+    expect(out).toContain('proj');
+    expect(out.indexOf('4% used')).toBeLessThan(out.indexOf('46% proj'));
+  });
+
+  it('marks the forecast explicitly as a forecast', () => {
+    // A bare percentage is indistinguishable from a measurement.
+    expect(render()).toMatch(/~\s*46%\s*proj/);
+  });
+
+  it('never uses the bare "% of budget" phrasing', () => {
+    // '133% of budget' was the exact wording that misled, because it names the
+    // budget without saying whether it is spent or predicted.
+    expect(render()).not.toMatch(/\d+%\s+of\s+budget/);
+  });
+
+  it('shows used and projected as distinct figures', () => {
+    const out = render({ budget: { set: true, pct_used: 4.0, pct_projected: 46.0 } });
+    expect(out).toContain('4% used');
+    expect(out).toContain('46% proj');
+  });
+});
+
+describe('abstention surfaces', () => {
+  it('states ignorance when the cache is missing', () => {
+    // No summary must read as unknown, never as a green figure.
+    const out = stripAnsi(renderStatusline({ summary: null }));
+    expect(out).toContain('no cache');
+    expect(out).not.toContain('% used');
+  });
+
+  it('shouts an UNDERCOUNT status', () => {
+    // A rebuilt-but-incomplete store must not present a confident number.
+    expect(render({ status: 'UNDERCOUNT' })).toContain('UNDERCOUNT');
+  });
+
+  it('surfaces an exhausted model family', () => {
+    const out = render({ models_exhausted: ['claude-fable-5'] });
+    expect(out).toContain('fable-5');
+    expect(out).toContain('spent');
+  });
+
+  it('surfaces an expired calibration', () => {
+    expect(render({ calibration: { expired: true } })).toContain('recalibrate');
+  });
+
+  it('labels the baseline ratio as a projection when no budget is set', () => {
+    // Without a budget the only figure is baseline-relative — and it is still a
+    // forecast, so it must say so rather than imply consumption.
+    const out = render({ budget: { set: false } });
+    expect(out).toContain('4wk median');
+    expect(out).toContain('proj');
+  });
+
+  it('announces a stale cache rather than swallowing it', () => {
+    // Silently-degraded tooling is a headline, not a footnote.
+    const out = stripAnsi(
+      renderStatusline({
+        summary: summary({ generated_at: '2026-01-01T00:00:00+00:00' }),
+        config: { stale_after_minutes: 90 },
+        now: new Date('2026-01-01T04:00:00Z'),
+      })
+    );
+    expect(out).toMatch(/\[stale 240m\]/);
+  });
+});
+
+describe('segments', () => {
+  it('counts down in hours once inside two days', () => {
+    // "2d" reads as plenty of runway when it is really one working afternoon.
+    expect(render({ week: { days_left: 1.5, hours_left: 36.0 } })).toContain('36h to reset');
+    expect(render({ week: { days_left: 6.5, hours_left: 156.0 } })).toContain('7d to reset');
+  });
+
+  it('renders the merged-branch /clear nudge', () => {
+    const out = stripAnsi(
+      renderStatusline({
+        summary: summary(),
+        git: { kind: 'merged', label: 'feat/x' },
+      })
+    );
+    expect(out).toContain('feat/x merged → /clear');
+  });
+
+  it('shows the session window only once it is worth knowing about', () => {
+    expect(render({ session: { pct_used: 40 } })).not.toContain('session');
+    expect(render({ session: { pct_used: 82 } })).toContain('session ~82%');
+  });
+
+  it('truncates units rather than rounding up', () => {
+    // Showing 250.0M when 249.96M was measured reads as crossing a threshold
+    // that was not crossed.
+    expect(render({ wtd: { units: 249_960_000 } })).toContain('249.9M');
+  });
+});

--- a/packages/burn/tsconfig.build.json
+++ b/packages/burn/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": false,
+    "incremental": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/burn/tsconfig.json
+++ b/packages/burn/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/burn/tsup.config.ts
+++ b/packages/burn/tsup.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  // Library entry — consumed by the CLI's `harness burn` command.
+  {
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    outDir: 'dist',
+    tsconfig: 'tsconfig.build.json',
+  },
+  // Hot-path binary. Rendered on every statusline repaint and after every
+  // assistant turn, so it is built as a single self-contained file with NO
+  // dependency on @harness-engineering/* — importing the CLI's module graph
+  // costs ~0.85s per invocation against a ~0.11s budget. Guarded by
+  // tests/bin-startup.test.ts, which fails if a harness import creeps in.
+  {
+    entry: ['src/bin/burn-hud.ts'],
+    format: ['esm'],
+    dts: false,
+    outDir: 'dist/bin',
+    // `.mjs`, not `.js`: this package ships CJS too, so it cannot set
+    // `"type": "module"`, and Node would then have to detect-and-reparse the
+    // binary on every launch — it says so itself via MODULE_TYPELESS_PACKAGE_JSON
+    // ("This incurs a performance overhead"). Paying a reparse on the statusline
+    // hot path is exactly what this binary exists to avoid.
+    outExtension: () => ({ js: '.mjs' }),
+    tsconfig: 'tsconfig.build.json',
+    banner: { js: '#!/usr/bin/env node' },
+  },
+]);

--- a/packages/burn/vitest.config.mts
+++ b/packages/burn/vitest.config.mts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    testTimeout: 30_000,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html'],
+      exclude: ['node_modules/', 'tests/', '**/*.test.ts', 'src/index.ts', 'src/bin/**'],
+      thresholds: { lines: 80, functions: 80, branches: 80, statements: 80 },
+    },
+  },
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",
+    "@harness-engineering/burn": "workspace:*",
     "@harness-engineering/core": "workspace:*",
     "@harness-engineering/dashboard": "workspace:*",
     "@harness-engineering/graph": "workspace:*",

--- a/packages/cli/src/commands/_registry.ts
+++ b/packages/cli/src/commands/_registry.ts
@@ -12,6 +12,7 @@ import { createAuditProtectedCommand } from './audit-protected';
 import { createBackfillSkillProvenanceCommand } from './backfill-skill-provenance';
 import { createBlackBoxCommand } from './orchestrator-black-box';
 import { createBlueprintCommand } from './blueprint';
+import { createBurnCommand } from './burn';
 import { createCheckArchCommand } from './check-arch';
 import { createCheckDepsCommand } from './check-deps';
 import { createCheckDesignCommand } from './check-design';
@@ -114,6 +115,7 @@ export const commandCreators: Array<() => Command> = [
   createBackfillSkillProvenanceCommand,
   createBlackBoxCommand,
   createBlueprintCommand,
+  createBurnCommand,
   createCheckArchCommand,
   createCheckDepsCommand,
   createCheckDesignCommand,

--- a/packages/cli/src/commands/burn/budget.ts
+++ b/packages/cli/src/commands/burn/budget.ts
@@ -1,0 +1,74 @@
+import {
+  human,
+  readRawConfig,
+  readSummary,
+  refresh,
+  resolvePaths,
+  saveRawConfig,
+} from '@harness-engineering/burn';
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+import { printReport } from './report';
+
+/** Parse `250M`, `1.2B`, `800k`, `1.5x` (multiple of the 4wk median), or a raw number. */
+export function parseBudget(arg: string, baselineMedian: number | null): number | null {
+  const a = arg.trim().toLowerCase();
+  const value = Number.parseFloat(a);
+  if (!Number.isFinite(value)) return null;
+  if (a.endsWith('x')) return baselineMedian ? value * baselineMedian : null;
+  if (a.endsWith('b')) return value * 1e9;
+  if (a.endsWith('m')) return value * 1e6;
+  if (a.endsWith('k')) return value * 1e3;
+  return value;
+}
+
+export function setBudget(arg: string | undefined): number {
+  const paths = resolvePaths();
+
+  if (arg === undefined) {
+    const current = readRawConfig(paths).weekly_budget_units;
+    console.log(`budget: ${current ? `${human(Number(current))} units` : 'not set'}`);
+    return 0;
+  }
+
+  const cfg = readRawConfig(paths);
+  if (['off', 'none', 'clear'].includes(arg.trim().toLowerCase())) {
+    cfg.weekly_budget_units = null;
+    saveRawConfig(paths, cfg);
+    // Must rescan: the cached summary still holds a budget-derived status, so
+    // skipping this leaves a stale CRITICAL on the statusline indefinitely.
+    refresh(paths);
+    console.log(`${chalk.green('Budget cleared')} — back to pace-vs-baseline only.`);
+    return 0;
+  }
+
+  refresh(paths);
+  const median = readSummary(paths)?.baseline.median_units ?? null;
+  const value = parseBudget(arg, median);
+  if (value === null) {
+    console.log(
+      chalk.yellow(
+        arg.trim().toLowerCase().endsWith('x')
+          ? 'No baseline yet — set an absolute number instead.'
+          : `Could not read '${arg}'. Try: 250M, 1.2x, or off`
+      )
+    );
+    return 1;
+  }
+
+  cfg.weekly_budget_units = Math.round(value);
+  saveRawConfig(paths, cfg);
+  refresh(paths);
+  console.log(chalk.green(`Weekly budget set to ${human(value)} units.`));
+  return printReport();
+}
+
+export function createBudgetCommand(): Command {
+  return new Command('budget')
+    .description('Set or clear the self-imposed weekly ceiling (250M, 1.2x, or off)')
+    .argument('[value]', 'budget value; omit to show the current setting')
+    .action((value?: string) => {
+      process.exitCode = setBudget(value);
+    });
+}

--- a/packages/cli/src/commands/burn/calibrate.ts
+++ b/packages/cli/src/commands/burn/calibrate.ts
@@ -1,0 +1,123 @@
+import {
+  human,
+  readRawConfig,
+  readSummary,
+  refresh,
+  resolvePaths,
+  saveRawConfig,
+  type Calibration,
+} from '@harness-engineering/burn';
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+import { printReport } from './report';
+
+/**
+ * Turn the local proxy into a calibrated gauge.
+ *
+ * Given the percentage /usage reports right now, derive units-per-percent from
+ * this week's measured burn and set the budget to the implied 100%. Only valid
+ * if the reset day already matches, and only precise once enough of the week
+ * has elapsed — /usage reports whole percents, so calibrating at 3% carries
+ * ~17% error. Both caveats are printed rather than silently absorbed.
+ */
+export function calibrate(pctArg: string, validUntil?: string): number {
+  const pct = Number.parseFloat(pctArg.trim().replace(/%$/, ''));
+  if (!Number.isFinite(pct)) {
+    console.log(chalk.yellow('Give the percentage /usage shows, e.g. harness burn calibrate 34'));
+    return 1;
+  }
+  if (!(pct > 0 && pct <= 100)) {
+    console.log(chalk.yellow('Percentage must be between 0 and 100.'));
+    return 1;
+  }
+
+  const paths = resolvePaths();
+  refresh(paths);
+  const summary = readSummary(paths);
+  if (!summary) {
+    console.log(chalk.yellow('No usage cache — run harness burn scan first.'));
+    return 1;
+  }
+
+  const wtd = summary.wtd.units;
+  if (wtd <= 0) {
+    console.log(chalk.yellow('Zero units measured this week — nothing to calibrate against.'));
+    console.log(chalk.dim('A zero denominator is an abstention, not a calibration.'));
+    return 1;
+  }
+
+  const budget = (wtd * 100) / pct;
+  const err = (0.5 / pct) * 100; // /usage rounds to whole percents
+
+  const cfg = readRawConfig(paths);
+  const previous = (cfg.calibration ?? {}) as Calibration;
+  cfg.weekly_budget_units = Math.round(budget);
+
+  const cal: Calibration = {
+    at: new Date().toISOString(),
+    reported_pct: pct,
+    wtd_units_then: wtd,
+    implied_units_per_pct: Math.round(wtd / pct),
+  };
+  // Carry forward an expiry/note so a promo caveat is not silently dropped by a
+  // routine re-calibration.
+  if (validUntil) cal.valid_until = validUntil;
+  else if (previous.valid_until) cal.valid_until = previous.valid_until;
+  if (previous.note) cal.note = previous.note;
+
+  cfg.calibration = cal;
+  saveRawConfig(paths, cfg);
+  refresh(paths);
+
+  printCalibration({ pct, wtd, budget, err, mondayAssumed: assumesMonday(cfg) });
+  return printReport();
+}
+
+function assumesMonday(cfg: Record<string, unknown>): boolean {
+  const weekReset = cfg.week_reset as { weekday?: number } | undefined;
+  return !weekReset || (weekReset.weekday ?? 0) === 0;
+}
+
+/**
+ * Report what was derived, and the two caveats that decide whether to believe
+ * it. Both are printed rather than silently absorbed: a calibration taken at a
+ * low percentage, or against the wrong week window, produces a confident wrong
+ * ceiling — which is worse than no ceiling.
+ */
+function printCalibration(v: {
+  pct: number;
+  wtd: number;
+  budget: number;
+  err: number;
+  mondayAssumed: boolean;
+}): void {
+  console.log('');
+  console.log(
+    `  ${chalk.green('Calibrated.')} /usage said ${v.pct}% at ${human(v.wtd)} units week-to-date.`
+  );
+  console.log(`  ${'1% ≈'.padEnd(22)}${human(v.wtd / v.pct)} units`);
+  console.log(
+    `  ${'implied weekly limit'.padEnd(22)}${chalk.bold(human(v.budget))} units  ${chalk.dim('(= your 100%)')}`
+  );
+  console.log(chalk.dim(`  ±${Math.round(v.err)}% precision — /usage reports whole percents.`));
+  if (v.pct < 10) {
+    console.log(chalk.yellow(`  ⚠ Calibrated at only ${v.pct}%, so this is rough.`));
+    console.log(chalk.yellow('    Re-run mid-week at a higher percentage to tighten it.'));
+  }
+  if (v.mondayAssumed) {
+    console.log(chalk.dim('  Assumes a Monday reset. If /usage shows otherwise:'));
+    console.log(chalk.dim('    harness burn reset-day <mon..sun>   then re-calibrate.'));
+  }
+  console.log('');
+}
+
+export function createCalibrateCommand(): Command {
+  return new Command('calibrate')
+    .description('Anchor the budget to a real /usage reading')
+    .argument('<percent>', 'the percentage /usage reports right now')
+    .argument('[valid-until]', 'YYYY-MM-DD after which this calibration is distrusted')
+    .action((percent: string, validUntil?: string) => {
+      process.exitCode = calibrate(percent, validUntil);
+    });
+}

--- a/packages/cli/src/commands/burn/commands.test.ts
+++ b/packages/cli/src/commands/burn/commands.test.ts
@@ -1,0 +1,231 @@
+/**
+ * End-to-end behaviour of the config-mutating burn commands.
+ *
+ * These drive the real functions against a throwaway HUD tree via the same
+ * `CLAUDE_HUD_*` variables a real install uses, so the config round-trip and
+ * the "rescan after every mutation" rule are exercised rather than mocked.
+ * The rescan matters: skipping it leaves a stale budget-derived status on the
+ * statusline indefinitely.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setBudget } from './budget';
+import { calibrate } from './calibrate';
+import { setResetDay } from './reset-day';
+import { printWeeks } from './weeks';
+
+let root: string;
+let configPath: string;
+let logged: string[];
+const originalEnv = { ...process.env };
+
+/** `{}` when no config exists — a command that refuses must not write one. */
+function config(): Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'burn-cmd-'));
+  const hud = path.join(root, 'hud');
+  mkdirSync(hud, { recursive: true });
+  configPath = path.join(hud, 'config.json');
+  process.env.CLAUDE_HUD_HOME = hud;
+  process.env.CLAUDE_HUD_STATE = path.join(hud, 'state');
+  process.env.CLAUDE_HUD_PROJECTS = path.join(root, 'projects');
+
+  logged = [];
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logged.push(args.map(String).join(' '));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env.CLAUDE_HUD_HOME = originalEnv.CLAUDE_HUD_HOME;
+  process.env.CLAUDE_HUD_STATE = originalEnv.CLAUDE_HUD_STATE;
+  process.env.CLAUDE_HUD_PROJECTS = originalEnv.CLAUDE_HUD_PROJECTS;
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Seed a transcript so the week has measurable spend to calibrate against. */
+function seedUsage(outTokens = 100_000): void {
+  const dir = path.join(root, 'projects', '-proj');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, 'a.jsonl'),
+    JSON.stringify({
+      requestId: 'r1',
+      timestamp: new Date().toISOString(),
+      message: {
+        model: 'claude-opus-5',
+        usage: {
+          output_tokens: outTokens,
+          input_tokens: 10,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    }) + '\n'
+  );
+}
+
+describe('calibrate', () => {
+  it('derives a ceiling from a real /usage reading', () => {
+    seedUsage();
+    expect(calibrate('25')).toBe(0);
+    const cal = config().calibration as { reported_pct: number; implied_units_per_pct: number };
+    expect(cal.reported_pct).toBe(25);
+    // 500,010 units at 25% implies ~2.0M for 100%.
+    expect(config().weekly_budget_units).toBe(2_000_040);
+    expect(cal.implied_units_per_pct).toBe(20_000);
+  });
+
+  it('records an expiry so a promo-inflated ceiling flags itself', () => {
+    // A calibration taken during a temporary limit increase under-warns once
+    // the promo lapses; the date is what makes the HUD nag instead of trust it.
+    seedUsage();
+    calibrate('25', '2026-08-19');
+    expect((config().calibration as { valid_until: string }).valid_until).toBe('2026-08-19');
+  });
+
+  it('carries a previous expiry through a routine re-calibration', () => {
+    seedUsage();
+    calibrate('25', '2026-08-19');
+    calibrate('30');
+    expect((config().calibration as { valid_until: string }).valid_until).toBe('2026-08-19');
+  });
+
+  it('refuses to calibrate against a zero denominator', () => {
+    // A zero denominator is an abstention, not a calibration.
+    expect(calibrate('25')).toBe(1);
+    expect(logged.join('\n')).toContain('abstention');
+  });
+
+  it('rejects a percentage it cannot read or that is out of range', () => {
+    seedUsage();
+    expect(calibrate('lots')).toBe(1);
+    expect(calibrate('0')).toBe(1);
+    expect(calibrate('101')).toBe(1);
+    expect(config().calibration).toBeUndefined();
+  });
+
+  it('warns that a low-percentage calibration is rough', () => {
+    seedUsage();
+    calibrate('3');
+    expect(logged.join('\n')).toContain('so this is rough');
+  });
+});
+
+describe('weeks', () => {
+  it('states ignorance rather than printing an empty table', () => {
+    expect(printWeeks()).toBe(1);
+    expect(logged.join('\n')).toContain('Blind, not clear');
+  });
+
+  it('prints a history row anchored to the configured reset', () => {
+    seedUsage();
+    setResetDay('wed', '08:59', 'America/Chicago');
+    logged = [];
+    expect(printWeeks()).toBe(0);
+    const out = logged.join('\n');
+    expect(out).toContain('weeks anchored to reset');
+    expect(out).toContain('current (partial)');
+  });
+});
+
+describe('budget', () => {
+  it('writes an absolute ceiling and reports it', () => {
+    expect(setBudget('250M')).toBe(0);
+    expect(config().weekly_budget_units).toBe(250_000_000);
+    expect(logged.join('\n')).toContain('250.0M');
+  });
+
+  it('clears the ceiling back to baseline-relative', () => {
+    setBudget('250M');
+    expect(setBudget('off')).toBe(0);
+    expect(config().weekly_budget_units).toBeNull();
+    expect(logged.join('\n')).toContain('pace-vs-baseline only');
+  });
+
+  it('reports the current setting when given no value', () => {
+    setBudget('1B');
+    logged = [];
+    expect(setBudget(undefined)).toBe(0);
+    expect(logged.join('\n')).toContain('1.00B');
+  });
+
+  it('says "not set" rather than inventing a number', () => {
+    expect(setBudget(undefined)).toBe(0);
+    expect(logged.join('\n')).toContain('not set');
+  });
+
+  it('refuses a multiplier when there is no baseline to multiply', () => {
+    // Deriving a ceiling from no baseline is the fabricated precision the HUD
+    // exists to refuse.
+    expect(setBudget('1.5x')).toBe(1);
+    expect(logged.join('\n')).toContain('No baseline yet');
+  });
+
+  it('refuses input it cannot read, without writing a config', () => {
+    expect(setBudget('some')).toBe(1);
+    expect(config().weekly_budget_units).toBeUndefined();
+  });
+});
+
+describe('reset-day', () => {
+  it('records weekday, time and timezone together', () => {
+    // Weekday alone is not enough: a time-of-day error is a multi-hour window
+    // shift, and the two together caused the ~81x understatement.
+    setResetDay('wed', '08:59', 'America/Chicago');
+    expect(config().week_reset).toEqual({
+      weekday: 2,
+      time: '08:59',
+      tz: 'America/Chicago',
+    });
+  });
+
+  it('drops the legacy flat key when the anchor is set', () => {
+    writeFileSync(configPath, JSON.stringify({ week_reset_weekday: 5 }));
+    setResetDay('tue');
+    expect(config().week_reset_weekday).toBeUndefined();
+    expect((config().week_reset as { weekday: number }).weekday).toBe(1);
+  });
+
+  it('keeps the existing time and zone when only the day is given', () => {
+    setResetDay('wed', '08:59', 'America/Chicago');
+    setResetDay('thu');
+    expect(config().week_reset).toEqual({
+      weekday: 3,
+      time: '08:59',
+      tz: 'America/Chicago',
+    });
+  });
+
+  it('warns that an existing budget no longer matches the moved window', () => {
+    setBudget('250M');
+    logged = [];
+    setResetDay('fri');
+    expect(logged.join('\n')).toContain('re-run harness burn calibrate');
+  });
+
+  it('reports the current anchor when given no day', () => {
+    setResetDay('wed', '08:59', 'America/Chicago');
+    logged = [];
+    expect(setResetDay(undefined)).toBe(0);
+    expect(logged.join('\n')).toContain('Wed');
+    expect(logged.join('\n')).toContain('America/Chicago');
+  });
+
+  it('rejects a day it cannot parse without touching the config', () => {
+    expect(setResetDay('someday')).toBe(1);
+    expect(config().week_reset).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/burn/format.ts
+++ b/packages/cli/src/commands/burn/format.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk';
+
+/**
+ * Render a UTC ISO stamp in the account's reset timezone.
+ *
+ * /usage speaks that timezone, so a UTC time here would not line up with what
+ * the user reads there — and the whole point of the week window is matching
+ * /usage exactly.
+ */
+export function localTime(iso: string, tz: string, withZone = true): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: tz,
+      weekday: 'short',
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+      ...(withZone ? { timeZoneName: 'short' as const } : {}),
+    }).format(d);
+  } catch {
+    return d.toISOString();
+  }
+}
+
+/** Progress bar that goes red past 100% rather than silently clamping. */
+export function bar(fraction: number, width = 28): string {
+  const f = Math.max(0, Math.min(fraction, 1.5));
+  const filled = Math.round(Math.min(f, 1) * width);
+  const s = '█'.repeat(filled) + '░'.repeat(width - filled);
+  if (f > 1) return chalk.red(s);
+  return f < 0.65 ? chalk.green(s) : chalk.yellow(s);
+}
+
+export function pad(label: string, width = 18): string {
+  return label.padEnd(width);
+}

--- a/packages/cli/src/commands/burn/index.ts
+++ b/packages/cli/src/commands/burn/index.ts
@@ -1,0 +1,48 @@
+import { refresh, resolvePaths } from '@harness-engineering/burn';
+import { Command } from 'commander';
+
+import { createBudgetCommand } from './budget';
+import { createCalibrateCommand } from './calibrate';
+import { createInstallCommand } from './install';
+import { createReportCommand, printReport } from './report';
+import { createResetDayCommand } from './reset-day';
+import { createWeeksCommand } from './weeks';
+
+/**
+ * `harness burn` — the interactive surface of the usage HUD.
+ *
+ * The hot paths (statusline render, Stop hook) deliberately do NOT live here:
+ * they ship as the standalone `harness-burn-hud` binary, because loading this
+ * CLI's module graph costs ~0.85s against a ~0.11s repaint budget. Everything
+ * under this command is human-invoked, where that cost does not matter.
+ *
+ * The gauge it drives is a local proxy, never Anthropic's real quota — /usage
+ * is the authority, and no reading here is trustworthy until reconciled
+ * against it.
+ */
+export function createBurnCommand(): Command {
+  const command = new Command('burn')
+    .description('Claude Code usage burn: pace, budget, calibration')
+    .action(() => {
+      // Bare `harness burn` is the report, matching the old `claude-burn`.
+      process.exitCode = printReport();
+    });
+
+  command.addCommand(createReportCommand());
+  command.addCommand(createWeeksCommand());
+  command.addCommand(createBudgetCommand());
+  command.addCommand(createCalibrateCommand());
+  command.addCommand(createResetDayCommand());
+  command.addCommand(createInstallCommand());
+  command.addCommand(
+    new Command('scan').description('Force a cache refresh').action(() => {
+      const summary = refresh(resolvePaths());
+      console.log(
+        `scanned ${summary.scan.files_total} transcripts · ` +
+          `${summary.scan.records_total.toLocaleString('en-US')} deduped requests · status ${summary.status}`
+      );
+    })
+  );
+
+  return command;
+}

--- a/packages/cli/src/commands/burn/install.test.ts
+++ b/packages/cli/src/commands/burn/install.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseBudget } from './budget';
+import { applySettings, buildPlan } from './install';
+
+const BIN = '/opt/harness/burn/dist/bin/burn-hud.mjs';
+
+describe('install plan', () => {
+  it('treats a fresh settings file as pure additions', () => {
+    const plan = buildPlan({}, BIN);
+    expect(plan.added).toEqual(['statusLine', 'SessionStart', 'Stop']);
+    expect(plan.replaced).toEqual([]);
+    expect(plan.clobbered).toBeNull();
+  });
+
+  it('reports the old Python HUD as a replacement, not an addition', () => {
+    // The cutover case: these entries point at the predecessor and are the ones
+    // that must be removed, or both HUDs scan and both hooks speak.
+    const plan = buildPlan(
+      {
+        statusLine: { command: '/Users/x/.claude/hud/statusline.sh' },
+        hooks: {
+          SessionStart: [
+            { hooks: [{ command: '/Users/x/.claude/hud/hooks/burn-session-brief.sh' }] },
+          ],
+          Stop: [{ hooks: [{ command: '/Users/x/.claude/hud/hooks/burn-escalation.sh' }] }],
+        },
+      },
+      BIN
+    );
+    expect(plan.added).toEqual([]);
+    expect(plan.replaced).toHaveLength(3);
+    expect(plan.clobbered).toBeNull();
+  });
+
+  it('flags an unrelated statusline as a take-over rather than claiming to leave it', () => {
+    // A statusline is single-valued, so installing one necessarily takes it.
+    // Saying otherwise would make the printed plan disagree with the write.
+    const plan = buildPlan({ statusLine: { command: 'starship prompt' } }, BIN);
+    expect(plan.clobbered).toBe('starship prompt');
+    expect(plan.replaced).toEqual([]);
+  });
+
+  it('leaves unrelated hooks out of the plan entirely', () => {
+    const plan = buildPlan(
+      { hooks: { Stop: [{ hooks: [{ command: 'my-own-linter.sh' }] }] } },
+      BIN
+    );
+    expect(plan.replaced).toEqual([]);
+    expect(plan.added).toContain('Stop'); // ours is added alongside, not instead
+  });
+
+  it('recognises an already-installed HUD as a replacement', () => {
+    const plan = buildPlan({ statusLine: { command: `${BIN} line` } }, BIN);
+    expect(plan.replaced[0]).toContain('burn-hud.mjs line');
+  });
+});
+
+describe('settings rewrite', () => {
+  interface Hooked {
+    hooks?: Record<string, { hooks?: { command?: string }[] }[]>;
+  }
+
+  function stopCommands(settings: Record<string, unknown>): string[] {
+    return ((settings as Hooked).hooks?.Stop ?? []).flatMap((e) =>
+      (e.hooks ?? []).map((h) => h.command ?? '')
+    );
+  }
+
+  it('is idempotent — installing twice leaves one hook, not two', () => {
+    // Two Stop hooks means the escalation fires twice per assistant turn, and
+    // a warning that double-prints is the noise this HUD exists to avoid.
+    const once = applySettings({}, BIN);
+    const twice = applySettings(once, BIN);
+    expect(stopCommands(twice)).toEqual([`${BIN} stop`]);
+  });
+
+  it('drops the predecessor rather than running both HUDs', () => {
+    const migrated = applySettings(
+      {
+        hooks: {
+          Stop: [{ hooks: [{ command: '/Users/x/.claude/hud/hooks/burn-escalation.sh' }] }],
+        },
+      },
+      BIN
+    );
+    expect(stopCommands(migrated)).toEqual([`${BIN} stop`]);
+  });
+
+  it('preserves unrelated hooks and unrelated settings keys', () => {
+    const migrated = applySettings(
+      {
+        permissions: { allow: ['Bash(npm run:*)'] },
+        hooks: { Stop: [{ hooks: [{ command: 'my-own-linter.sh' }] }] },
+      },
+      BIN
+    );
+    expect(stopCommands(migrated)).toEqual(['my-own-linter.sh', `${BIN} stop`]);
+    expect(migrated.permissions).toEqual({ allow: ['Bash(npm run:*)'] });
+  });
+});
+
+describe('budget parsing', () => {
+  it('reads suffixed magnitudes', () => {
+    expect(parseBudget('250M', null)).toBe(250_000_000);
+    expect(parseBudget('1.2B', null)).toBe(1_200_000_000);
+    expect(parseBudget('800k', null)).toBe(800_000);
+    expect(parseBudget('12000', null)).toBe(12_000);
+  });
+
+  it('reads a multiplier against the trailing baseline', () => {
+    expect(parseBudget('1.5x', 200_000_000)).toBe(300_000_000);
+  });
+
+  it('refuses a multiplier with no baseline to multiply', () => {
+    // Inventing a ceiling out of no baseline is exactly the fabricated
+    // precision the HUD refuses to print.
+    expect(parseBudget('1.5x', null)).toBeNull();
+  });
+
+  it('refuses input it cannot read', () => {
+    expect(parseBudget('lots', null)).toBeNull();
+    expect(parseBudget('', null)).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/burn/install.ts
+++ b/packages/cli/src/commands/burn/install.ts
@@ -1,0 +1,189 @@
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+/**
+ * Wire the HUD into `~/.claude/settings.json`, replacing the standalone
+ * `claude-burn-hud` install.
+ *
+ * Deliberately additive and reversible: the file is backed up first, unrelated
+ * hooks survive, and only entries that point at this HUD (old or new) are
+ * touched. The old Python install stays on disk afterwards — a HUD that
+ * silently deletes its own predecessor leaves no way back if the replacement
+ * misreports.
+ */
+
+/** Absolute path to the hot-path binary shipped by @harness-engineering/burn. */
+export function resolveHudBinary(): string {
+  const require = createRequire(import.meta.url);
+  const entry = require.resolve('@harness-engineering/burn');
+  return path.join(path.dirname(entry), 'bin', 'burn-hud.mjs');
+}
+
+interface HookEntry {
+  hooks?: { type?: string; command?: string }[];
+}
+
+/**
+ * True for a hook/statusline command belonging to either HUD generation.
+ *
+ * These are substrings of a shell command already written into settings.json,
+ * not paths being constructed — the separator is whatever the user's shell
+ * recorded, so `path.join` has nothing to contribute here.
+ */
+function isBurnHudCommand(command: string | undefined): boolean {
+  if (!command) return false;
+  return (
+    // Matches both the bin name (`harness-burn-hud`) and the path it resolves
+    // to (`.../bin/burn-hud.mjs`). Matching only the bin name meant a repeat
+    // install did not recognise its own entry and stacked a second Stop hook
+    // on every run.
+    command.includes('burn-hud') ||
+    // eslint-disable-next-line @harness-engineering/no-hardcoded-path-separator -- matching a recorded command string, not building a path
+    command.includes('.claude/hud/') ||
+    command.includes('claude-burn')
+  );
+}
+
+export interface InstallPlan {
+  statusLine: string;
+  replaced: string[];
+  added: string[];
+  /** A statusline belonging to something else, which installing will take over. */
+  clobbered: string | null;
+}
+
+/**
+ * Describe exactly what `install` will do, so the printed plan and the write
+ * cannot disagree. A statusline is single-valued: installing one necessarily
+ * takes it over, so an unrelated existing command is reported as a clobber
+ * rather than quietly overwritten.
+ */
+export function buildPlan(settings: Record<string, unknown>, binary: string): InstallPlan {
+  const replaced: string[] = [];
+  const added: string[] = [];
+  let clobbered: string | null = null;
+
+  const existingStatus = (settings.statusLine ?? {}) as { command?: string };
+  if (isBurnHudCommand(existingStatus.command)) {
+    replaced.push(`statusLine: ${existingStatus.command}`);
+  } else if (existingStatus.command) {
+    clobbered = existingStatus.command;
+  } else {
+    added.push('statusLine');
+  }
+
+  const hooks = (settings.hooks ?? {}) as Record<string, HookEntry[]>;
+  for (const event of ['SessionStart', 'Stop']) {
+    const entries = hooks[event] ?? [];
+    const mine = entries.flatMap((e) => (e.hooks ?? []).filter((h) => isBurnHudCommand(h.command)));
+    if (mine.length) replaced.push(`${event}: ${mine.map((h) => h.command).join(', ')}`);
+    else added.push(event);
+  }
+
+  return { statusLine: `${binary} line`, replaced, added, clobbered };
+}
+
+/**
+ * Return `settings` with this HUD wired in.
+ *
+ * Pure and idempotent: every burn-HUD entry (this generation or the previous
+ * one) is dropped first and exactly one fresh entry appended, so running the
+ * install twice leaves one hook rather than two firing on every turn.
+ */
+export function applySettings(
+  settings: Record<string, unknown>,
+  binary: string
+): Record<string, unknown> {
+  const updated: Record<string, unknown> = { ...settings };
+  updated.statusLine = { type: 'command', command: `${binary} line` };
+
+  const existing = (settings.hooks ?? {}) as Record<string, HookEntry[]>;
+  const hooks: Record<string, HookEntry[]> = { ...existing };
+  for (const [event, sub] of [
+    ['SessionStart', 'session-start'],
+    ['Stop', 'stop'],
+  ] as const) {
+    const kept = (existing[event] ?? [])
+      .map((entry) => ({
+        ...entry,
+        hooks: (entry.hooks ?? []).filter((h) => !isBurnHudCommand(h.command)),
+      }))
+      .filter((entry) => (entry.hooks ?? []).length > 0);
+    kept.push({ hooks: [{ type: 'command', command: `${binary} ${sub}` }] });
+    hooks[event] = kept;
+  }
+  updated.hooks = hooks;
+  return updated;
+}
+
+export function install(dryRun: boolean): number {
+  const binary = resolveHudBinary();
+  if (!existsSync(binary)) {
+    console.log(chalk.red(`HUD binary not found at ${binary}`));
+    console.log(chalk.dim('Run `pnpm build` (from a source checkout) or reinstall the CLI.'));
+    return 1;
+  }
+
+  const settingsPath = path.join(homedir(), '.claude', 'settings.json');
+  let settings: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      // Refuse rather than overwrite: this file holds the user's whole Claude
+      // Code configuration, and a parse failure here means we cannot merge
+      // safely, not that there is nothing to preserve.
+      console.log(chalk.red(`${settingsPath} is not valid JSON — fix it before installing.`));
+      return 1;
+    }
+  }
+
+  const plan = buildPlan(settings, binary);
+  console.log('');
+  console.log(`  ${chalk.bold('burn HUD install')} ${chalk.dim(`→ ${settingsPath}`)}`);
+  console.log(`  ${chalk.dim('binary:')} ${binary}`);
+  for (const r of plan.replaced) console.log(`  ${chalk.yellow('replace')} ${r}`);
+  for (const a of plan.added) console.log(`  ${chalk.green('add')}     ${a}`);
+  if (plan.clobbered) {
+    console.log(
+      `  ${chalk.red('TAKE OVER')} statusLine currently runs something else: ${plan.clobbered}`
+    );
+    console.log(
+      chalk.dim('            a statusline is single-valued; the old command is kept in the backup.')
+    );
+  }
+  if (dryRun) {
+    console.log('');
+    console.log(chalk.dim('  --dry-run: nothing written.'));
+    return 0;
+  }
+
+  const updated = applySettings(settings, binary);
+
+  const backupPath = `${settingsPath}.bak`;
+  if (existsSync(settingsPath)) copyFileSync(settingsPath, backupPath);
+  writeFileSync(settingsPath, JSON.stringify(updated, null, 2) + '\n');
+
+  console.log('');
+  console.log(chalk.green('  Installed.') + chalk.dim(` Backup: ${backupPath}`));
+  console.log(chalk.dim('  Restart Claude Code to pick up the statusline.'));
+  console.log(
+    chalk.dim('  The previous ~/.claude/hud install is untouched — remove it once satisfied.')
+  );
+  console.log('');
+  return 0;
+}
+
+export function createInstallCommand(): Command {
+  return new Command('install')
+    .description('Wire the burn HUD statusline and hooks into ~/.claude/settings.json')
+    .option('--dry-run', 'show what would change without writing')
+    .action((opts: { dryRun?: boolean }) => {
+      process.exitCode = install(opts.dryRun === true);
+    });
+}

--- a/packages/cli/src/commands/burn/report.test.ts
+++ b/packages/cli/src/commands/burn/report.test.ts
@@ -1,0 +1,246 @@
+import type { Summary } from '@harness-engineering/burn';
+import { describe, expect, it } from 'vitest';
+
+import { bar, localTime, pad } from './format';
+import { renderReport } from './report';
+import { parseWeekday } from './reset-day';
+
+function summary(over: Record<string, unknown> = {}): Summary {
+  const base = {
+    generated_at: '2026-08-06T20:00:00+00:00',
+    scan: { files_total: 588, files_rescanned: 0, records_added: 0, records_total: 33_359 },
+    status: 'OK',
+    week: {
+      start: '2026-08-05T14:00:00+00:00',
+      reset_at: '2026-08-12T14:00:00+00:00',
+      reset_spec: '2@09:00 America/Chicago',
+      tz: 'America/Chicago',
+      elapsed_frac: 0.18,
+      days_left: 5.7,
+      hours_left: 138,
+    },
+    wtd: { requests: 3713, output_tokens: 2_400_000, units: 114_400_000 },
+    baseline: {
+      complete_weeks_used: 4,
+      median_units: 233_400_000,
+      max_units: 300_000_000,
+      per_week_back: {},
+    },
+    projection: {
+      units_at_reset: 305_800_000,
+      units_at_reset_linear: 635_900_000,
+      method: 'shrunk-to-baseline',
+      ratio_vs_baseline: 1.31,
+      confidence: 'medium',
+    },
+    budget: { set: false },
+    calibration: {},
+    models: {},
+    models_exhausted: [],
+    session: { window_hours: 5, requests: 100, units: 20_100_000 },
+  } as unknown as Record<string, unknown>;
+
+  for (const [k, v] of Object.entries(over)) {
+    const existing = base[k];
+    base[k] =
+      v !== null &&
+      typeof v === 'object' &&
+      !Array.isArray(v) &&
+      existing !== null &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing)
+        ? { ...(existing as object), ...(v as object) }
+        : v;
+  }
+  return base as unknown as Summary;
+}
+
+function render(over: Record<string, unknown> = {}): string {
+  return renderReport(summary(over)).join('\n');
+}
+
+describe('report — what it must always say', () => {
+  it('never omits what the numbers are and are not', () => {
+    // The footer is the standing disclaimer: a local proxy, this machine only,
+    // /usage is the authority. A healthy-looking report is exactly when a
+    // reader is most likely to mistake it for the real quota.
+    const out = render();
+    expect(out).toContain('THIS MACHINE ONLY');
+    expect(out).toContain('For actual limit status run /usage');
+    expect(out).toContain('weighted proxy');
+  });
+
+  it('reports spend before the forecast', () => {
+    const out = render();
+    expect(out.indexOf('week to date')).toBeLessThan(out.indexOf('projected at reset'));
+  });
+
+  it('shows the raw extrapolation alongside a shrunk forecast', () => {
+    // Quietly adjusting a number the user reads daily is its own kind of
+    // untrustworthiness, even when the adjustment is the sound one.
+    const out = render();
+    expect(out).toContain('blended toward your baseline');
+    expect(out).toContain('635.9M'); // the un-shrunk figure stays visible
+  });
+
+  it('hides the blending note once the forecast is well supported', () => {
+    expect(render({ projection: { confidence: 'high' } })).not.toContain('blended toward');
+  });
+
+  it('states the status blurb, not just the label', () => {
+    expect(render({ status: 'NO_DATA' })).toContain('the HUD is blind, not clear');
+    expect(render({ status: 'UNDERCOUNT' })).toContain('FLOOR, not a total');
+  });
+
+  it('falls back to a readable line for a status it does not know', () => {
+    expect(render({ status: 'FUTURE_STATUS' })).toContain('FUTURE_STATUS');
+  });
+});
+
+describe('report — budget section', () => {
+  it('offers to set a budget when none is configured', () => {
+    const out = render();
+    expect(out).toContain('No weekly budget set');
+    expect(out).toContain('harness burn budget 1.2x');
+  });
+
+  it('shows used and projected bars once a budget exists', () => {
+    const out = render({
+      budget: {
+        set: true,
+        units: 535_000_000,
+        pct_used: 21,
+        pct_projected: 57,
+        remaining_units: 420_600_000,
+      },
+    });
+    expect(out).toContain('used');
+    expect(out).toContain('21%');
+    expect(out).toContain('57%');
+    expect(out).toContain('remaining');
+  });
+
+  it('warns, in the reset timezone, when the budget runs dry first', () => {
+    const out = render({
+      budget: {
+        set: true,
+        units: 100,
+        pct_used: 90,
+        pct_projected: 140,
+        exhausts_before_reset: true,
+        exhausts_at: '2026-08-11T11:20:00+00:00',
+      },
+    });
+    expect(out).toContain('you run dry');
+    // 11:20 UTC is 06:20 in America/Chicago (CDT), which is what /usage shows.
+    expect(out).toContain('06:20');
+  });
+});
+
+describe('report — per-model and degraded states', () => {
+  it('flags a family limit that is spent even when the pooled bar looks fine', () => {
+    // Fable ran out at 29% of the pooled week; this is not decoration.
+    const out = render({
+      models: {
+        'claude-fable-5': {
+          requests: 10,
+          units: 5_000_000,
+          pct_of_week: 29,
+          budget_units: 5_000_000,
+          pct_of_budget: 100,
+        },
+      },
+      models_exhausted: ['claude-fable-5'],
+    });
+    expect(out).toContain('fable-5');
+    expect(out).toContain('100% of its own limit');
+    expect(out).toContain('is spent');
+  });
+
+  it('omits models below the noise floor', () => {
+    const out = render({
+      models: { 'claude-tiny': { requests: 1, units: 12, pct_of_week: 0 } },
+    });
+    expect(out).not.toContain('tiny');
+  });
+
+  it('shouts unrecoverable record loss rather than printing a confident total', () => {
+    const out = render({
+      status: 'UNDERCOUNT',
+      scan: {
+        data_loss_detected: true,
+        records_lost: 9999,
+        records_recovered: 40,
+        unrecovered: 9959,
+      },
+    });
+    expect(out).toContain('UNRECOVERABLE');
+    expect(out).toContain('treat the figures above as a floor');
+  });
+
+  it('reports a recovered loss without calling the figures a floor', () => {
+    const out = render({
+      scan: { data_loss_detected: true, records_lost: 35, records_recovered: 35, unrecovered: 0 },
+    });
+    expect(out).toContain('recovered');
+    expect(out).not.toContain('UNRECOVERABLE');
+  });
+
+  it('surfaces an expired calibration as a warning to re-run', () => {
+    const out = render({ calibration: { expired: true, valid_until: '2026-08-01' } });
+    expect(out).toContain('Calibration expired');
+    expect(out).toContain('may under-warn');
+  });
+
+  it('reports remaining validity on a live calibration', () => {
+    const out = render({
+      calibration: {
+        at: '2026-08-05T00:00:00+00:00',
+        reported_pct: 4,
+        days_left: 2,
+        valid_until: '2026-08-08',
+      },
+    });
+    expect(out).toContain('valid 2d more');
+  });
+
+  it('shows the session window only when a budget makes it meaningful', () => {
+    expect(render()).not.toContain('session (5h)');
+    expect(render({ session: { pct_used: 29 } })).toContain('session (5h)');
+  });
+});
+
+describe('format helpers', () => {
+  it('renders a bar that goes over-full rather than clamping silently', () => {
+    // Clamping at 100% would hide exactly the case worth seeing.
+    expect(bar(0.5, 10)).toContain('█');
+    expect(bar(0.5, 10)).toContain('░');
+    expect(bar(1.4, 10)).not.toContain('░');
+  });
+
+  it('renders a timestamp in the requested zone and survives a bad one', () => {
+    expect(localTime('2026-08-11T11:20:00+00:00', 'America/Chicago')).toContain('06:20');
+    expect(localTime('not-a-date', 'UTC')).toBe('not-a-date');
+    expect(localTime('2026-08-11T11:20:00+00:00', 'Nowhere/Special')).toContain('2026');
+  });
+
+  it('pads labels to a stable column', () => {
+    expect(pad('x')).toHaveLength(18);
+    expect(pad('a-very-long-label-indeed')).toBe('a-very-long-label-indeed');
+  });
+});
+
+describe('weekday parsing', () => {
+  it('accepts names, prefixes and numbers', () => {
+    expect(parseWeekday('mon')).toBe(0);
+    expect(parseWeekday('Wednesday')).toBe(2);
+    expect(parseWeekday('SUN')).toBe(6);
+    expect(parseWeekday('2')).toBe(2);
+  });
+
+  it('normalises out-of-range numbers and rejects nonsense', () => {
+    expect(parseWeekday('9')).toBe(2);
+    expect(parseWeekday('-1')).toBe(6);
+    expect(parseWeekday('someday')).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/burn/report.ts
+++ b/packages/cli/src/commands/burn/report.ts
@@ -1,0 +1,250 @@
+import { human, readSummary, refresh, resolvePaths, type Summary } from '@harness-engineering/burn';
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+import { bar, localTime, pad } from './format';
+
+/**
+ * The full burn report.
+ *
+ * Latency does not matter here (unlike the statusline), so this favours a
+ * readable report over subprocess frugality — it always rescans first.
+ *
+ * Composed from one function per section. Each returns its own lines (empty
+ * when the section has nothing to say), so a section can be read, changed or
+ * tested without holding the whole page in your head.
+ */
+const STYLE: Record<string, { colour: (s: string) => string; icon: string; blurb: string }> = {
+  CRITICAL: { colour: chalk.red, icon: '🔴', blurb: 'over budget at this pace' },
+  HOT: { colour: chalk.red, icon: '🔥', blurb: 'running hot — ease off' },
+  WARM: { colour: chalk.yellow, icon: '🟠', blurb: 'above your usual pace' },
+  OK: { colour: chalk.green, icon: '🟢', blurb: 'on pace' },
+  EARLY: { colour: chalk.cyan, icon: '🌱', blurb: 'too early to forecast' },
+  NO_BASELINE: {
+    colour: chalk.yellow,
+    icon: '❔',
+    blurb: 'no complete weeks to compare against',
+  },
+  NO_DATA: {
+    colour: chalk.yellow,
+    icon: '⚠',
+    blurb: 'NO USAGE DATA — the HUD is blind, not clear',
+  },
+  UNDERCOUNT: {
+    colour: chalk.red,
+    icon: '⁉️',
+    blurb: 'records were lost and NOT fully recovered — every figure below is a FLOOR, not a total',
+  },
+};
+
+function headerSection(s: Summary, tz: string): string[] {
+  const hoursLeft = s.week.hours_left;
+  const left =
+    hoursLeft != null && hoursLeft <= 48
+      ? `${Math.round(hoursLeft)}h left`
+      : `${s.week.days_left.toFixed(1)}d left`;
+  const style = STYLE[s.status] ?? { colour: chalk.dim, icon: '·', blurb: s.status };
+
+  return [
+    '',
+    `  ${chalk.bold('Claude burn')} ${chalk.dim(
+      `· week began ${localTime(s.week.start, tz, false)} · resets ${localTime(s.week.reset_at, tz)} (${left})`
+    )}`,
+    '',
+    `  ${style.colour(`${style.icon}  ${s.status}`)} ${chalk.dim(`— ${style.blurb}`)}`,
+    '',
+  ];
+}
+
+function spendSection(s: Summary): string[] {
+  const out = [
+    `  ${pad('week to date')} ${chalk.bold(human(s.wtd.units))} units ` +
+      chalk.dim(
+        `(${s.wtd.requests.toLocaleString('en-US')} requests, ${human(s.wtd.output_tokens)} output tokens)`
+      ),
+    `  ${pad('projected at reset')} ${chalk.bold(human(s.projection.units_at_reset))} units ` +
+      chalk.dim(`(forecast confidence: ${s.projection.confidence})`),
+  ];
+
+  // Be explicit that the forecast is shrunk, and show the raw extrapolation.
+  // Quietly adjusting a number the user reads daily would be its own way of
+  // being untrustworthy, even when the adjustment is the sound one.
+  if (s.projection.method === 'shrunk-to-baseline' && s.projection.confidence !== 'high') {
+    out.push(
+      `  ${pad('')} ` +
+        chalk.dim(
+          `↳ blended toward your baseline; raw extrapolation from ` +
+            `${Math.round(s.week.elapsed_frac * 100)}% of the week was ${human(s.projection.units_at_reset_linear)}`
+        )
+    );
+  }
+  if (s.baseline.median_units) {
+    out.push(
+      `  ${pad('your 4wk median')} ${human(s.baseline.median_units)} units` +
+        (s.projection.ratio_vs_baseline
+          ? chalk.dim(`  → projected ${s.projection.ratio_vs_baseline}× that`)
+          : '')
+    );
+  }
+  return out;
+}
+
+function budgetSection(s: Summary, tz: string): string[] {
+  if (!s.budget.set || s.budget.pct_used == null || s.budget.pct_projected == null) {
+    return [
+      '',
+      chalk.dim('  No weekly budget set — showing pace vs your own baseline only.'),
+      chalk.dim('  Set one with: harness burn budget 1.2x   (or e.g. 250M)'),
+    ];
+  }
+
+  const out = [
+    '',
+    `  ${pad('budget')} ${human(s.budget.units)} units`,
+    `  ${pad('used')} ${bar(s.budget.pct_used / 100)} ${Math.round(s.budget.pct_used)}%`,
+    `  ${pad('projected')} ${bar(s.budget.pct_projected / 100)} ${Math.round(s.budget.pct_projected)}%`,
+  ];
+  if (s.budget.remaining_units != null) {
+    out.push(`  ${pad('remaining')} ${human(s.budget.remaining_units)} units`);
+  }
+  if (s.budget.exhausts_before_reset && s.budget.exhausts_at) {
+    out.push(
+      '',
+      chalk.red(
+        `  ⚠ At this pace you run dry ${localTime(s.budget.exhausts_at, tz)} — before the ${localTime(s.week.reset_at, tz)} reset.`
+      )
+    );
+  }
+  return out;
+}
+
+/**
+ * Per-model. A family limit can be exhausted while the pooled bar looks OK, so
+ * this is not decoration — Fable ran out at 29% of the pooled week.
+ */
+function modelsSection(s: Summary): string[] {
+  const models = Object.entries(s.models ?? {});
+  if (models.length === 0) return [];
+
+  const out = ['', `  ${chalk.bold('by model')}`];
+  for (const [name, e] of models.slice(0, 6)) {
+    if (e.units < 1000) continue;
+    let line = `  ${pad(name.replace(/^claude-/, ''))}${human(e.units).padStart(8)} ${chalk.dim(
+      `(${Math.round(e.pct_of_week)}% of week)`
+    )}`;
+    if (e.pct_of_budget != null) {
+      const p = e.pct_of_budget;
+      const colour = p >= 100 ? chalk.red : p >= 85 ? chalk.yellow : chalk.green;
+      line += `  ${colour(`${Math.round(p)}% of its own limit`)}`;
+    }
+    out.push(line);
+  }
+  for (const m of s.models_exhausted ?? []) {
+    out.push(chalk.red(`  ⛔ ${m} is spent — its separate limit is at 100%.`));
+  }
+  return out;
+}
+
+function sessionSection(s: Summary): string[] {
+  if (s.session?.pct_used == null) return [];
+  return [
+    '',
+    `  ${pad(`session (${Math.round(s.session.window_hours)}h)`)}${bar(s.session.pct_used / 100)} ` +
+      `${Math.round(s.session.pct_used)}%  ${chalk.dim(`${human(s.session.units)} units`)}`,
+  ];
+}
+
+function calibrationSection(s: Summary): string[] {
+  const cal = s.calibration ?? {};
+  if (Object.keys(cal).length === 0) return [];
+
+  const out = [''];
+  if (cal.expired) {
+    out.push(
+      chalk.red(
+        `  ⚠ Calibration expired ${cal.valid_until} — re-run: harness burn calibrate <pct>`
+      ),
+      chalk.dim('    Until then these percentages may under-warn.')
+    );
+  } else if (cal.days_left != null) {
+    out.push(
+      chalk.dim(
+        `  calibrated ${(cal.at ?? '').slice(0, 10)} at ${cal.reported_pct}% · valid ${cal.days_left}d more (until ${cal.valid_until})`
+      )
+    );
+  }
+  if (cal.note) {
+    out.push(chalk.dim(`    ${cal.note.slice(0, 96)}${cal.note.length > 96 ? '...' : ''}`));
+  }
+  return out;
+}
+
+/** Degraded tooling is a headline, not a footnote. */
+function dataLossSection(s: Summary): string[] {
+  if (!s.scan.data_loss_detected) return [];
+
+  const out = [
+    '',
+    chalk.yellow(
+      `  ⚠ record store had lost ${(s.scan.records_lost ?? 0).toLocaleString('en-US')} rows; ` +
+        `recovered ${(s.scan.records_recovered ?? 0).toLocaleString('en-US')} by re-reading transcripts.`
+    ),
+  ];
+  if ((s.scan.unrecovered ?? 0) > 0) {
+    out.push(
+      chalk.red(
+        `    ${s.scan.unrecovered!.toLocaleString('en-US')} rows are UNRECOVERABLE (their transcripts are gone) — treat the figures above as a floor.`
+      )
+    );
+  }
+  return out;
+}
+
+/** What the numbers are and are not. Never omitted, however healthy the report. */
+function footerSection(s: Summary): string[] {
+  return [
+    '',
+    chalk.dim(
+      `  window: ${s.week.reset_spec} · ${s.scan.records_total.toLocaleString('en-US')} deduped requests across ${s.scan.files_total} transcripts`
+    ),
+    chalk.dim('  THIS MACHINE ONLY — excludes your other devices and claude.ai.'),
+    chalk.dim('  Units are a weighted proxy (out×5 + in×1 + cache_wr×1.25 + cache_rd×0.1),'),
+    chalk.dim("  not Anthropic's real quota. For actual limit status run /usage."),
+    '',
+  ];
+}
+
+export function renderReport(s: Summary): string[] {
+  const tz = s.week.tz || 'UTC';
+  return [
+    ...headerSection(s, tz),
+    ...spendSection(s),
+    ...budgetSection(s, tz),
+    ...modelsSection(s),
+    ...sessionSection(s),
+    ...calibrationSection(s),
+    ...dataLossSection(s),
+    ...footerSection(s),
+  ];
+}
+
+/** Rescan, then print. Returns a process exit code. */
+export function printReport(): number {
+  const paths = resolvePaths();
+  refresh(paths);
+  const summary = readSummary(paths);
+  if (!summary) {
+    console.log(chalk.yellow('No summary — run: harness burn scan'));
+    return 1;
+  }
+  for (const line of renderReport(summary)) console.log(line);
+  return 0;
+}
+
+export function createReportCommand(): Command {
+  return new Command('report')
+    .description('Rescan and print the full burn report (default)')
+    .action(() => {
+      process.exitCode = printReport();
+    });
+}

--- a/packages/cli/src/commands/burn/reset-day.ts
+++ b/packages/cli/src/commands/burn/reset-day.ts
@@ -1,0 +1,108 @@
+import { readRawConfig, refresh, resolvePaths, saveRawConfig } from '@harness-engineering/burn';
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+import { printReport } from './report';
+
+const WEEKDAYS: Record<string, number> = {
+  mon: 0,
+  tue: 1,
+  wed: 2,
+  thu: 3,
+  fri: 4,
+  sat: 5,
+  sun: 6,
+};
+
+/**
+ * Align the HUD's week window with the account's real reset.
+ *
+ * Time-of-day matters more than it looks: a Monday-midnight-UTC assumption
+ * against a real Wednesday-08:59-Chicago reset understated week-to-date burn by
+ * ~81x and showed a calm green at 97% of the actual limit.
+ */
+/** `mon`..`sun` or `0`..`6` (0=Mon), or null when it is neither. */
+export function parseWeekday(day: string): number | null {
+  const key = day.trim().toLowerCase().slice(0, 3);
+  if (key in WEEKDAYS) return WEEKDAYS[key]!;
+  const n = Number.parseInt(day, 10);
+  return Number.isFinite(n) ? ((n % 7) + 7) % 7 : null;
+}
+
+function weekdayName(weekday: number): string {
+  const name = Object.keys(WEEKDAYS).find((k) => WEEKDAYS[k] === weekday) ?? String(weekday);
+  return `${name[0]!.toUpperCase()}${name.slice(1)}`;
+}
+
+interface WeekResetConfig {
+  weekday?: number;
+  time?: string;
+  tz?: string;
+}
+
+function showCurrentReset(existing: WeekResetConfig): number {
+  const wd = existing.weekday ?? 0;
+  console.log(
+    `week resets on ${weekdayName(wd)} (${wd}) at ${existing.time ?? '00:00'} ${existing.tz ?? 'UTC'}`
+  );
+  return 0;
+}
+
+/** Persist the new anchor, rescan against it, and say what moved. */
+function applyReset(
+  cfg: Record<string, unknown>,
+  existing: WeekResetConfig,
+  weekday: number,
+  time?: string,
+  tz?: string
+): number {
+  const weekReset = {
+    weekday,
+    time: time ?? existing.time ?? '00:00',
+    tz: tz ?? existing.tz ?? 'UTC',
+  };
+  cfg.week_reset = weekReset;
+  delete cfg.week_reset_weekday; // drop the legacy flat key
+
+  const paths = resolvePaths();
+  saveRawConfig(paths, cfg);
+  refresh(paths);
+
+  console.log(
+    chalk.green(`Week now resets ${weekdayName(weekday)} ${weekReset.time} ${weekReset.tz}.`)
+  );
+  console.log(chalk.dim('Baseline weeks recut against the new anchor.'));
+  if (cfg.weekly_budget_units) {
+    console.log(
+      chalk.yellow(
+        'The window moved, so the existing budget no longer matches what it was calibrated against — re-run harness burn calibrate.'
+      )
+    );
+  }
+  return printReport();
+}
+
+export function setResetDay(day: string | undefined, time?: string, tz?: string): number {
+  const cfg = readRawConfig(resolvePaths());
+  const existing = (cfg.week_reset ?? {}) as WeekResetConfig;
+
+  if (day === undefined) return showCurrentReset(existing);
+
+  const weekday = parseWeekday(day);
+  if (weekday === null) {
+    console.log(chalk.yellow('Use mon..sun or 0..6 (0=Mon).'));
+    return 1;
+  }
+  return applyReset(cfg, existing, weekday, time, tz);
+}
+
+export function createResetDayCommand(): Command {
+  return new Command('reset-day')
+    .description('Align the week window with the reset /usage reports')
+    .argument('[day]', 'mon..sun or 0..6 (0=Mon); omit to show the current setting')
+    .argument('[time]', 'local time of the reset, e.g. 08:59')
+    .argument('[tz]', 'IANA timezone, e.g. America/Chicago')
+    .action((day?: string, time?: string, tz?: string) => {
+      process.exitCode = setResetDay(day, time, tz);
+    });
+}

--- a/packages/cli/src/commands/burn/weeks.ts
+++ b/packages/cli/src/commands/burn/weeks.ts
@@ -1,0 +1,84 @@
+import {
+  human,
+  loadConfig,
+  readRecords,
+  refresh,
+  resolvePaths,
+  units,
+  weekBounds,
+} from '@harness-engineering/burn';
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+const WEEK_SECONDS = 7 * 86_400;
+
+/**
+ * Weekly history, bucketed against the SAME anchored reset the live report
+ * uses.
+ *
+ * It previously used the legacy flat weekday key, which left this table
+ * Monday-anchored while the main report was Wednesday-anchored — two views of
+ * the same data disagreeing about the same week.
+ */
+export function printWeeks(): number {
+  const paths = resolvePaths();
+  refresh(paths);
+  const cfg = loadConfig(paths);
+  const { start: curStart } = weekBounds(new Date(), cfg);
+
+  const rows = new Map<number, { requests: number; out: number; units: number }>();
+  for (const rec of readRecords(paths).values()) {
+    const t = Date.parse(rec.ts);
+    if (!Number.isFinite(t)) continue;
+    const delta = (curStart.getTime() - t) / 1000;
+    const idx = delta <= 0 ? 0 : Math.floor(delta / WEEK_SECONDS) + 1;
+    const row = rows.get(idx) ?? { requests: 0, out: 0, units: 0 };
+    row.requests += 1;
+    row.out += rec.out;
+    row.units += units(rec.out, rec.in, rec.cacheWrite, rec.cacheRead);
+    rows.set(idx, row);
+  }
+
+  if (rows.size === 0) {
+    console.log(chalk.yellow('⚠ No usage records. Blind, not clear.'));
+    return 1;
+  }
+
+  const budget = cfg.weekly_budget_units;
+  const indexes = [...rows.keys()].filter((i) => i <= 11).sort((a, b) => a - b);
+  const peak = Math.max(...indexes.map((i) => rows.get(i)!.units));
+  const wr = cfg.week_reset;
+
+  console.log('');
+  console.log(chalk.dim(`  weeks anchored to reset: weekday ${wr.weekday} ${wr.time} ${wr.tz}`));
+  console.log(
+    chalk.bold(
+      `  ${'week of'.padEnd(12)}${'requests'.padStart(10)}${'output'.padStart(10)}${'units'.padStart(10)}`
+    )
+  );
+  for (const i of [...indexes].reverse()) {
+    const v = rows.get(i)!;
+    const start = new Date(curStart.getTime() - i * WEEK_SECONDS * 1000).toISOString().slice(0, 10);
+    const blocks = Math.round((v.units / peak) * 20);
+    const tag = i === 0 ? chalk.dim('  ← current (partial)') : '';
+    const over =
+      budget && i > 0 && v.units > budget
+        ? `  ${chalk.red(`${Math.round((100 * v.units) / budget)}% of today's budget`)}`
+        : '';
+    console.log(
+      `  ${start.padEnd(12)}${v.requests.toLocaleString('en-US').padStart(10)}` +
+        `${human(v.out).padStart(10)}${human(v.units).padStart(10)}  ` +
+        `${chalk.dim('▂'.repeat(blocks))}${tag}${over}`
+    );
+  }
+  console.log('');
+  return 0;
+}
+
+export function createWeeksCommand(): Command {
+  return new Command('weeks')
+    .description('Weekly usage history, anchored to the configured reset')
+    .action(() => {
+      process.exitCode = printWeeks();
+    });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,11 +116,32 @@ importers:
         specifier: ^3.5.0
         version: 3.5.31(typescript@5.9.3)
 
+  packages/burn:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.1)(vite@6.4.3)
+
   packages/cli:
     dependencies:
       '@clack/prompts':
         specifier: ^0.9.1
         version: 0.9.1
+      '@harness-engineering/burn':
+        specifier: workspace:*
+        version: link:../burn
       '@harness-engineering/core':
         specifier: workspace:*
         version: link:../core
@@ -6956,8 +6977,8 @@ packages:
   /magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
     dev: true
 
@@ -8835,7 +8856,7 @@ packages:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
     dev: true
 
@@ -9179,7 +9200,7 @@ packages:
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9717,7 +9738,7 @@ packages:
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 6.4.3(@types/node@22.19.15)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,41 @@
   "extends": "./tsconfig.base.json",
   "files": [],
   "references": [
-    { "path": "./packages/types" },
-    { "path": "./packages/graph" },
-    { "path": "./packages/signals" },
-    { "path": "./packages/core" },
-    { "path": "./packages/cli" },
-    { "path": "./packages/eslint-plugin" },
-    { "path": "./packages/linter-gen" },
-    { "path": "./packages/intelligence" },
-    { "path": "./packages/orchestrator" },
-    { "path": "./packages/dashboard" },
-    { "path": "./packages/local-models" }
+    {
+      "path": "./packages/types"
+    },
+    {
+      "path": "./packages/graph"
+    },
+    {
+      "path": "./packages/signals"
+    },
+    {
+      "path": "./packages/burn"
+    },
+    {
+      "path": "./packages/core"
+    },
+    {
+      "path": "./packages/cli"
+    },
+    {
+      "path": "./packages/eslint-plugin"
+    },
+    {
+      "path": "./packages/linter-gen"
+    },
+    {
+      "path": "./packages/intelligence"
+    },
+    {
+      "path": "./packages/orchestrator"
+    },
+    {
+      "path": "./packages/dashboard"
+    },
+    {
+      "path": "./packages/local-models"
+    }
   ]
 }


### PR DESCRIPTION
Replaces the standalone [`claude-burn-hud`](https://github.com/bstevenski-capillary/claude-burn-hud) (Python + shell, ~1.4k lines) with an in-repo package, so the gauge and the harness stop drifting apart.

## Two surfaces, split on latency rather than taste

| Surface | What | Why |
|---|---|---|
| `harness burn` | report, `weeks`, `calibrate`, `budget`, `reset-day`, `scan`, `install` | Human-invoked, so the CLI's module graph is affordable. |
| `harness-burn-hud` | `line`, `session-start`, `stop`, `scan` | The statusline repaint and the Stop hook. |

The split is measured, not stylistic. On this machine:

```
statusline.sh (the thing being replaced)   0.11s
node -e     (bare interpreter startup)   0.05s
harness --version (full CLI module graph)  0.85s   ← 8x the repaint budget
```

So `harness-burn-hud` is bundled standalone and imports **nothing** from `@harness-engineering/*`. A test asserts that import graph, because the regression has no symptom other than a terminal that feels slow — nobody bisects that.

## Parity

Both implementations were run over the same **33,305 real transcript records**:

- every shared record **byte-identical**
- with `now` pinned, the summaries differ only in Python's microsecond vs JS millisecond precision and `100.0` vs `100` JSON rendering

## Tests

87 in `packages/burn`, 33 in the CLI command. Every regression test came across from the Python suite, each still tied to a defect that actually shipped:

| Guards against | |
|---|---|
| the Monday-UTC week assumption | understated a 97% week by **~81x** behind a calm green |
| the write race | silently dropped **85%** of the record store while reporting OK |
| repeated usage blocks | inflated every figure **~3.5x** |
| a 3-hour extrapolation | fired CRITICAL at 2% of budget spent |
| a zero/thin denominator | must read as abstention, never as a pass |

## Three runtime-forced changes

Documented at each site:

1. **Locking** — `fcntl.flock` (kernel-released on death) → atomic `mkdir` plus a staleness reclaim, since Node has no `flock` and a crashed holder would otherwise wedge every later scan. Two tests cover what the kernel used to do for free.
2. **Timezones** — `zoneinfo` → `Intl` with two-pass offset resolution, asserted across the 2026-11-01 DST boundary.
3. **Timestamps** — summaries keep Python's `+00:00` form (not Node's `Z`), because `fromisoformat` rejected `Z` before 3.11 and the old HUD may still read these files during cutover.

## Four defects the port introduced and the tests caught

- The binary is emitted as `.mjs` — as `.js` Node was detect-and-reparsing it on **every launch**, which it warns "incurs a performance overhead", on the one path where that matters.
- `line` no longer blocks forever when stdin never closes (surfaced as a 30s test timeout).
- `install` recognises its own previous entry instead of stacking a **duplicate Stop hook on every run** — the bin path is `burn-hud.mjs`, which does not contain the string `harness-burn-hud`.
- The startup guard asserts a **ratio** against bare `node` rather than a wall-clock ceiling. The absolute version failed at 821ms against a 700ms limit purely from parallel test load; under load both sides of a ratio inflate together. Observed: this binary 2.5x bare node, the full CLI 19.2x.

## Cutover

`harness burn install` is additive and reversible: backs up `settings.json`, leaves unrelated hooks alone, reports a statusline take-over rather than silently clobbering, and leaves `~/.claude/hud` on disk so there is a way back. Archiving the standalone repo waits until the TS version has real mileage.

## Gates

Build, typecheck, lint, test, format, coverage ratchet, plugin/barrel checks all green.

- **Arch gate:** every *error-severity* threshold finding was **fixed**, not acknowledged — `renderStatusline`, `renderReport`, `calibrate`, `parseTranscript` and `setResetDay` were each decomposed into named helpers. The gate explicitly refuses to allowance an error-severity breach, which is the right call. The remaining aggregate deltas (the cost of the package existing) are in a per-PR allowance, leaving `baselines.json` byte-identical to the base.
- **Unrelated finding:** the full local suite has a pre-existing flake, reproduced 2/2 on a clean `origin/main` worktree with a different subprocess-timing test failing each run. Filed as #1143 rather than left as folklore.
