### PR TITLE
fix(arch): stop --update-baseline rewriting the snapshot on a feature branch when the base ref is unreadable (#1140 follow-up)

### DIFF
--- a/.changeset/arch-allowance-feature-branch-routing.md
+++ b/.changeset/arch-allowance-feature-branch-routing.md
@@ -1,0 +1,32 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/cli': patch
+---
+
+Fix `check-arch --update-baseline` rewriting the committed arch snapshot on a feature branch
+when the base ref is unreadable (closing a gap in the per-PR allowance feature).
+
+The allowance feature routed `--update-baseline` to the snapshot-rewriting whole-snapshot path
+for EVERY resolution that was not `base-ref`. But a feature branch resolves to `working-tree`
+not only in the legitimate single-writer contexts (on the base branch, in a non-git dir, under
+`HARNESS_ARCH_FORCE_WORKING_TREE`) — it also falls back to `working-tree` whenever the base ref
+is merely unreadable: an unfetched worktree, a shallow clone, or a moved/unreadable base copy.
+In that case `--update-baseline` REWROTE `.harness/arch/baselines.json` on the branch (and
+without `--allow-regress` refused with "it WORSENS N metric(s)"), silently reintroducing the
+exact `baselines.json` merge cascade the allowance mechanism exists to prevent, so a legitimate
+value regression (e.g. `dependency-depth`, `module-size`) could never be acknowledged
+conflict-free.
+
+The whole-snapshot (snapshot-rewriting) path is now restricted to the contexts where it is
+actually correct — the base branch, a non-git dir, `HARNESS_ARCH_FORCE_WORKING_TREE` (the
+post-merge refresh-baselines job), and a genuine bootstrap where the base branch has no
+baseline at all. A feature branch whose base ref was unreadable but which already has a
+committed baseline now writes a per-PR allowance against the working-tree baseline instead,
+leaving `baselines.json` byte-identical. Aggregate category value regressions and warning-level
+new violations are both allowanceable; error-severity new violations are still never
+allowanceable — a genuine threshold breach must be fixed.
+
+- `resolveArchBaseline` now reports a `fallback` reason (`forced` / `non-git` / `base-branch` /
+  `base-ref-unreachable` / `base-ref-absent` / `base-ref-invalid`) on every non-`base-ref`
+  resolution, and a new `isWholeSnapshotContext(resolution)` helper encodes which contexts may
+  rewrite the committed snapshot. Both are re-exported from `@harness-engineering/core`.

--- a/.harness/arch/allowances/fix-arch-allowance-feature-branch-routing.json
+++ b/.harness/arch/allowances/fix-arch-allowance-feature-branch-routing.json
@@ -1,0 +1,9 @@
+{
+  "reason": "Acknowledge module-size/dependency-depth growth introduced by the new baseline-resolver routing code in this PR.",
+  "categories": {
+    "module-size": 223715,
+    "dependency-depth": 573
+  },
+  "violationIds": [],
+  "createdFrom": "d74f5ecf2"
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -253,6 +253,28 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** P2
 - **External-ID:** github:Intense-Visions/harness-engineering#1037
 
+### init: scaffold ecosystem-matched install command + warn when neither install nor verify is configured
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-up to #1115 (lang-aware local-dispatch, #1002). The ecosystem detector (`packages/orchestrator/src/workspace/ecosystem.ts`) already exposes each ecosystem's INSTALL command alongside verify, but only verify is wired. Wire `harness init` to scaffold a matching `hooks.afterCreate` install command from the detected ecosystem, and warn loudly when a workspace has neither an install nor a verify command resolvable.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P2
+- **External-ID:** github:Intense-Visions/harness-engineering#1128
+
+### local dispatch: make the self-verify stage-prompt prose ecosystem-aware
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Follow-up to #1115 (#1002). #1115 made the enforced verify GATE ecosystem-aware, but the local stage-prompt's self-verify PROSE still hardcodes `pnpm --filter …`. Make the self-verify guidance render the detected ecosystem's verify commands; per #1115 this needs a strict-variables renderer change so the prompt accepts the ecosystem-derived command set.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** P2
+- **External-ID:** github:Intense-Visions/harness-engineering#1129
+
 ## v5.0 — Enforcement Hardening
 
 ### Audit and cap the pre-commit --skip list

--- a/packages/cli/src/commands/check-arch.ts
+++ b/packages/cli/src/commands/check-arch.ts
@@ -8,6 +8,7 @@ import {
   runAll,
   diff,
   resolveArchBaseline,
+  isWholeSnapshotContext,
   loadArchAllowances,
   filterDiffByAllowances,
   writeArchAllowance,
@@ -362,7 +363,22 @@ export async function runCheckArch(
     if (resolution.source === 'base-ref' && resolution.baseline) {
       return writeAllowanceUpdate(cwd, archConfig, results, resolution.baseline, options.reason);
     }
-    // On the base branch / non-git: keep the whole-snapshot behavior (single-writer trunk).
+    // Feature-branch SAFETY NET: the base ref was EXPECTED but unreadable (unfetched worktree,
+    // shallow clone, or an unreadable base copy) AND this branch already has a committed
+    // baseline. Falling through to `wholeSnapshotUpdate` here would REWRITE that shared snapshot
+    // on the branch — silently reintroducing the exact `baselines.json` merge cascade #1140
+    // exists to prevent. So acknowledge against the working-tree baseline via an allowance
+    // instead; the snapshot stays byte-identical. Only the legitimate single-writer contexts
+    // (base branch / non-git / HARNESS_ARCH_FORCE_WORKING_TREE / a genuine bootstrap where the
+    // base has no baseline) still reach the whole-snapshot path below.
+    if (
+      !isWholeSnapshotContext(resolution) &&
+      resolution.source === 'working-tree' &&
+      resolution.baseline
+    ) {
+      return writeAllowanceUpdate(cwd, archConfig, results, resolution.baseline, options.reason);
+    }
+    // Base branch / non-git / forced / genuine bootstrap: whole-snapshot (single-writer trunk).
     return wholeSnapshotUpdate(cwd, archConfig, results, manager, options);
   }
 

--- a/packages/cli/tests/commands/check-arch.test.ts
+++ b/packages/cli/tests/commands/check-arch.test.ts
@@ -810,3 +810,172 @@ describe('check-arch: base-aware gating + allowances (PR context)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Feature-branch SAFETY NET: when the base ref is EXPECTED but unreadable (unfetched worktree,
+// shallow clone, unreadable base copy), `--update-baseline` must NOT rewrite the committed
+// snapshot on the branch — that silently reintroduces the exact baselines.json merge cascade
+// #1140 killed. It must acknowledge via an allowance instead. Only the legitimate single-writer
+// contexts (base branch / non-git / force-env / genuine bootstrap) still rewrite the snapshot.
+// (Root-cause regression: the routing previously sent EVERY non-`base-ref` resolution to the
+// whole-snapshot path, so an unfetched-worktree feature branch diverged baselines.json.)
+// ---------------------------------------------------------------------------
+describe('check-arch: feature-branch safety net when the base ref is unreadable', () => {
+  function gitq(cwd: string, args: string[]): void {
+    execFileSync('git', args, { cwd, stdio: 'ignore' });
+  }
+
+  /**
+   * A repo with a committed baseline on `main`, then a `feature` branch that regresses
+   * module-size — but with NO reachable base ref (no `origin` remote; the default `origin/main`
+   * cannot be resolved), simulating an unfetched worktree / shallow clone. `HARNESS_ARCH_BASE_REF`
+   * is explicitly cleared (and restored) so no sibling test's override leaks a REACHABLE ref in.
+   */
+  async function seedUnreachableBaseCtx(withBaseline = true): Promise<{
+    tmpDir: string;
+    configPath: string;
+    baselinePath: string;
+    allowancesDir: string;
+    restore: () => void;
+  }> {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-arch-unreach-'));
+    execFileSync('git', ['init', '-b', 'main'], { cwd: tmpDir, stdio: 'ignore' });
+    gitq(tmpDir, ['config', 'user.email', 'test@example.com']);
+    gitq(tmpDir, ['config', 'user.name', 'Test']);
+    const configPath = path.join(tmpDir, 'harness.config.json');
+    fs.writeFileSync(configPath, JSON.stringify({ version: 1, architecture: { enabled: true } }));
+    fs.writeFileSync(path.join(tmpDir, 'code.ts'), `export const x = 1;\n`);
+
+    const prev = process.env.HARNESS_ARCH_BASE_REF;
+    delete process.env.HARNESS_ARCH_BASE_REF;
+
+    if (withBaseline) {
+      // On main (base branch) this is a legitimate whole-snapshot capture.
+      await runCheckArch({ cwd: tmpDir, configPath, updateBaseline: true });
+    }
+    gitq(tmpDir, ['add', '-A']);
+    gitq(tmpDir, ['commit', '-m', 'seed']);
+    gitq(tmpDir, ['checkout', '-b', 'feature']);
+    const bloat = Array.from({ length: 80 }, (_, i) => `export const v${i} = ${i};`).join('\n');
+    fs.writeFileSync(path.join(tmpDir, 'code.ts'), `${bloat}\n`);
+
+    return {
+      tmpDir,
+      configPath,
+      baselinePath: path.join(tmpDir, '.harness', 'arch', 'baselines.json'),
+      allowancesDir: path.join(tmpDir, '.harness', 'arch', 'allowances'),
+      restore: () => {
+        if (prev === undefined) delete process.env.HARNESS_ARCH_BASE_REF;
+        else process.env.HARNESS_ARCH_BASE_REF = prev;
+      },
+    };
+  }
+
+  it('writes an ALLOWANCE (never rewrites the snapshot) and a follow-up read PASSES', async () => {
+    const ctx = await seedUnreachableBaseCtx(true);
+    try {
+      const before = fs.readFileSync(ctx.baselinePath, 'utf-8');
+      const result = await runCheckArch({
+        cwd: ctx.tmpDir,
+        configPath: ctx.configPath,
+        updateBaseline: true,
+        reason: 'accepted growth on an unfetched-worktree branch',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.baselineUpdated).toBe(true);
+
+      // THE FIX: baselines.json is byte-identical — no snapshot rewrite, no merge cascade.
+      expect(fs.readFileSync(ctx.baselinePath, 'utf-8')).toBe(before);
+      const gitDiff = execFileSync('git', ['diff', 'main', '--', '.harness/arch/baselines.json'], {
+        cwd: ctx.tmpDir,
+        encoding: 'utf-8',
+      });
+      expect(gitDiff.trim()).toBe('');
+
+      // An allowance file was written, covering the aggregate VALUE regression.
+      const files = fs.readdirSync(ctx.allowancesDir);
+      expect(files).toEqual(['feature.json']);
+      const allowance = JSON.parse(
+        fs.readFileSync(path.join(ctx.allowancesDir, 'feature.json'), 'utf-8')
+      );
+      expect(Object.keys(allowance.categories)).toContain('module-size');
+
+      // With the allowance present, the read gate passes — WITHOUT any baselines.json change.
+      const read = await runCheckArch({ cwd: ctx.tmpDir, configPath: ctx.configPath });
+      expect(read.ok).toBe(true);
+      if (read.ok) {
+        expect(read.value.passed).toBe(true);
+        expect(read.value.regressions).toEqual([]);
+      }
+    } finally {
+      ctx.restore();
+      fs.rmSync(ctx.tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('BOOTSTRAP preserved: with NO existing baseline it still whole-snapshots (creates it)', async () => {
+    const ctx = await seedUnreachableBaseCtx(false);
+    try {
+      expect(fs.existsSync(ctx.baselinePath)).toBe(false);
+      const result = await runCheckArch({
+        cwd: ctx.tmpDir,
+        configPath: ctx.configPath,
+        updateBaseline: true,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.baselineUpdated).toBe(true);
+      // A brand-new snapshot is created (no allowance) — there was nothing to protect.
+      expect(fs.existsSync(ctx.baselinePath)).toBe(true);
+      expect(fs.existsSync(ctx.allowancesDir)).toBe(false);
+    } finally {
+      ctx.restore();
+      fs.rmSync(ctx.tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('GATE INTEGRITY: an error-severity NEW violation can never be allowanced (hard-fails)', async () => {
+    const ctx = await seedUnreachableBaseCtx(true);
+    try {
+      // Introduce a function whose cyclomatic complexity blows past the error threshold (15):
+      // ~24 decision points → an error-severity NEW complexity violation.
+      const branches = Array.from({ length: 24 }, (_, i) => `  if (n > ${i}) r += ${i};`).join(
+        '\n'
+      );
+      fs.writeFileSync(
+        path.join(ctx.tmpDir, 'code.ts'),
+        `export function tangled(n: number): number {\n  let r = 0;\n${branches}\n  return r;\n}\n`
+      );
+
+      // The WRITE path refuses to allowance a genuine error-severity breach — it must be FIXED.
+      const write = await runCheckArch({
+        cwd: ctx.tmpDir,
+        configPath: ctx.configPath,
+        updateBaseline: true,
+        reason: 'trying (and failing) to acknowledge an error breach',
+      });
+      expect(write.ok).toBe(false);
+      if (!write.ok) expect(write.error.message).toMatch(/error-severity/);
+      // No allowance was written for the error breach.
+      expect(fs.existsSync(ctx.allowancesDir)).toBe(false);
+
+      // Even if a hand-crafted allowance names that violation id, the READ gate still hard-fails.
+      fs.mkdirSync(ctx.allowancesDir, { recursive: true });
+      const read0 = await runCheckArch({ cwd: ctx.tmpDir, configPath: ctx.configPath });
+      expect(read0.ok).toBe(true);
+      const errorIds = read0.ok
+        ? read0.value.newViolations.filter((v) => v.severity === 'error').map((v) => v.id)
+        : [];
+      expect(errorIds.length).toBeGreaterThan(0);
+      fs.writeFileSync(
+        path.join(ctx.allowancesDir, 'feature.json'),
+        JSON.stringify({ reason: 'overbroad', categories: {}, violationIds: errorIds })
+      );
+      const read = await runCheckArch({ cwd: ctx.tmpDir, configPath: ctx.configPath });
+      expect(read.ok).toBe(true);
+      if (read.ok) expect(read.value.passed).toBe(false);
+    } finally {
+      ctx.restore();
+      fs.rmSync(ctx.tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/architecture/baseline-resolver.ts
+++ b/packages/core/src/architecture/baseline-resolver.ts
@@ -75,6 +75,24 @@ function baseBranchName(baseRef: string): string {
 
 export type ArchBaselineSource = 'base-ref' | 'working-tree' | 'none';
 
+/**
+ * WHY a resolution did NOT use the base ref. Only set when `source !== 'base-ref'`. This is
+ * what lets the `--update-baseline` WRITE path tell apart the LEGITIMATE single-writer
+ * whole-snapshot contexts (`forced` / `non-git` / `base-branch`) — where rewriting the
+ * committed snapshot is correct — from a FEATURE-BRANCH context where the base ref was merely
+ * unreadable (`base-ref-unreachable` / `base-ref-invalid`). In the latter case rewriting the
+ * shared snapshot on a branch silently reintroduces the `baselines.json` merge cascade, so the
+ * WRITE path must acknowledge via an allowance instead. `base-ref-absent` means the base branch
+ * has no baseline at all (a genuine bootstrap), where a whole-snapshot CREATE is safe.
+ */
+export type ArchBaselineFallback =
+  | 'forced'
+  | 'non-git'
+  | 'base-branch'
+  | 'base-ref-unreachable'
+  | 'base-ref-absent'
+  | 'base-ref-invalid';
+
 export interface ArchBaselineResolution {
   /** The baseline to gate against (null when neither base nor working-tree file exists). */
   baseline: ArchBaseline | null;
@@ -82,6 +100,8 @@ export interface ArchBaselineResolution {
   source: ArchBaselineSource;
   /** The ref used when `source === 'base-ref'`. */
   baseRef?: string;
+  /** Why the base ref was NOT used (set only when `source !== 'base-ref'`); see the type doc. */
+  fallback?: ArchBaselineFallback;
 }
 
 export interface ResolveArchBaselineOptions {
@@ -103,9 +123,9 @@ export function resolveArchBaseline(
   manager: Pick<ArchBaselineManager, 'load'>,
   options?: ResolveArchBaselineOptions
 ): ArchBaselineResolution {
-  const workingTree = (): ArchBaselineResolution => {
+  const workingTree = (fallback: ArchBaselineFallback): ArchBaselineResolution => {
     const baseline = manager.load();
-    return { baseline, source: baseline ? 'working-tree' : 'none' };
+    return { baseline, source: baseline ? 'working-tree' : 'none', fallback };
   };
 
   // Escape hatch for the authoritative post-merge `refresh-baselines` job (and any other
@@ -116,22 +136,23 @@ export function resolveArchBaseline(
   // `--update-baseline` write an ALLOWANCE instead of advancing the snapshot — which would
   // never fold merged allowances in (an allowance treadmill). This env pins it to today's
   // whole-snapshot behavior so the refresh job always advances the authoritative baseline.
-  if (process.env.HARNESS_ARCH_FORCE_WORKING_TREE) return workingTree();
+  if (process.env.HARNESS_ARCH_FORCE_WORKING_TREE) return workingTree('forced');
 
   const baseRef = options?.baseRef ?? process.env.HARNESS_ARCH_BASE_REF ?? DEFAULT_BASE_REF;
 
   // Not a git repo → nothing to diff against; use the working-tree file.
-  if (git(projectRoot, ['rev-parse', '--is-inside-work-tree']) !== 'true') return workingTree();
+  if (git(projectRoot, ['rev-parse', '--is-inside-work-tree']) !== 'true')
+    return workingTree('non-git');
 
   // On the base branch itself (e.g. `main`) the working-tree file is authoritative — the
   // base ref may lag HEAD after a just-merged advance, so diffing against it could report
   // a phantom regression. This preserves today's behavior on main.
   const branch = git(projectRoot, ['rev-parse', '--abbrev-ref', 'HEAD']);
-  if (branch === baseBranchName(baseRef)) return workingTree();
+  if (branch === baseBranchName(baseRef)) return workingTree('base-branch');
 
-  // Base ref unreachable (fresh shallow clone, no remote) → fall back.
+  // Base ref unreachable (fresh shallow clone, no remote, unfetched worktree) → fall back.
   if (git(projectRoot, ['rev-parse', '--verify', '--quiet', baseRef]) === null) {
-    return workingTree();
+    return workingTree('base-ref-unreachable');
   }
 
   // `git show` needs a repo-root-relative path; `baselinePath` is relative to projectRoot,
@@ -139,11 +160,40 @@ export function resolveArchBaseline(
   const prefix = git(projectRoot, ['rev-parse', '--show-prefix']) ?? '';
   const gitPath = (prefix + baselinePath).replace(/\\/g, '/');
   const raw = git(projectRoot, ['show', `${baseRef}:${gitPath}`]);
-  if (raw === null) return workingTree(); // absent on base (new project) → fall back
+  if (raw === null) return workingTree('base-ref-absent'); // absent on base (new project) → fall back
   const baseline = parseBaseline(raw);
-  if (!baseline) return workingTree(); // unparseable on base → fail-open
+  if (!baseline) return workingTree('base-ref-invalid'); // unparseable on base → fail-open
 
   return { baseline, source: 'base-ref', baseRef };
+}
+
+/**
+ * Whether a resolution is a LEGITIMATE single-writer whole-snapshot context — the ONLY
+ * contexts in which `--update-baseline` may REWRITE the committed `baselines.json`:
+ *
+ *   - `base-branch`  — on the trunk itself; the working-tree file is authoritative.
+ *   - `non-git`      — nothing to diff against a base.
+ *   - `forced`       — `HARNESS_ARCH_FORCE_WORKING_TREE` (the post-merge refresh-baselines job).
+ *   - `base-ref-absent` — the base branch has NO baseline, so a whole-snapshot CREATE cannot
+ *     conflict with anything (a genuine bootstrap).
+ *
+ * A `base-ref` resolution is a PR context (allowance-write), never whole-snapshot. Crucially, a
+ * FEATURE branch whose base ref was merely UNREADABLE (`base-ref-unreachable` — unfetched
+ * worktree / shallow clone — or `base-ref-invalid`) is NOT a whole-snapshot context: rewriting
+ * the shared snapshot there silently reintroduces the `baselines.json` merge cascade #1140
+ * exists to prevent. Such a branch must acknowledge via an allowance instead.
+ */
+export function isWholeSnapshotContext(resolution: ArchBaselineResolution): boolean {
+  if (resolution.source === 'base-ref') return false;
+  switch (resolution.fallback) {
+    case 'forced':
+    case 'non-git':
+    case 'base-branch':
+    case 'base-ref-absent':
+      return true;
+    default:
+      return false;
+  }
 }
 
 // --- Per-PR allowance files -------------------------------------------------

--- a/packages/core/src/architecture/index.ts
+++ b/packages/core/src/architecture/index.ts
@@ -57,6 +57,7 @@ export type { StaleConstraint, DetectStaleResult } from './detect-stale';
 export { ArchBaselineManager } from './baseline-manager';
 export {
   resolveArchBaseline,
+  isWholeSnapshotContext,
   ArchAllowanceSchema,
   archAllowancesDir,
   loadArchAllowances,
@@ -66,6 +67,7 @@ export {
 } from './baseline-resolver';
 export type {
   ArchBaselineSource,
+  ArchBaselineFallback,
   ArchBaselineResolution,
   ResolveArchBaselineOptions,
   ArchAllowance,

--- a/packages/core/tests/architecture/baseline-resolver.test.ts
+++ b/packages/core/tests/architecture/baseline-resolver.test.ts
@@ -5,12 +5,14 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   resolveArchBaseline,
+  isWholeSnapshotContext,
   loadArchAllowances,
   filterDiffByAllowances,
   writeArchAllowance,
   archAllowanceSlug,
   archAllowancesDir,
 } from '../../src/architecture/baseline-resolver';
+import type { ArchBaselineResolution } from '../../src/architecture/baseline-resolver';
 import { ArchBaselineManager } from '../../src/architecture/baseline-manager';
 import type { ArchBaseline, ArchDiffResult, Violation } from '../../src/architecture/types';
 
@@ -173,6 +175,107 @@ describe('resolveArchBaseline (base-aware)', () => {
     } finally {
       if (prev === undefined) delete process.env.HARNESS_ARCH_BASE_REF;
       else process.env.HARNESS_ARCH_BASE_REF = prev;
+    }
+  });
+
+  // The `fallback` discriminant is what lets the `--update-baseline` WRITE path tell a
+  // legitimate single-writer whole-snapshot context (base branch / non-git / forced) apart
+  // from a feature branch whose base ref was merely unreadable — where rewriting the shared
+  // snapshot would reintroduce the baselines.json merge cascade.
+  it('tags fallback=base-ref-unreachable on a feature branch when the base ref is unresolvable', () => {
+    initRepo(root);
+    commitBaseline(root, makeBaseline(7));
+    git(root, ['checkout', '-b', 'feature']);
+    const manager = new ArchBaselineManager(root);
+    const resolution = resolveArchBaseline(root, BASELINE_REL, manager, {
+      baseRef: 'origin/does-not-exist',
+    });
+    expect(resolution.source).toBe('working-tree');
+    expect(resolution.fallback).toBe('base-ref-unreachable');
+  });
+
+  it('tags fallback=base-branch on the base branch itself', () => {
+    initRepo(root);
+    commitBaseline(root, makeBaseline(50));
+    const manager = new ArchBaselineManager(root);
+    const resolution = resolveArchBaseline(root, BASELINE_REL, manager, { baseRef: 'main' });
+    expect(resolution.source).toBe('working-tree');
+    expect(resolution.fallback).toBe('base-branch');
+  });
+
+  it('tags fallback=non-git outside a git repo', () => {
+    mkdirSync(join(root, '.harness', 'arch'), { recursive: true });
+    writeFileSync(join(root, BASELINE_REL), JSON.stringify(makeBaseline(3), null, 2));
+    const manager = new ArchBaselineManager(root);
+    const resolution = resolveArchBaseline(root, BASELINE_REL, manager);
+    expect(resolution.fallback).toBe('non-git');
+  });
+
+  it('tags fallback=forced under HARNESS_ARCH_FORCE_WORKING_TREE', () => {
+    initRepo(root);
+    commitBaseline(root, makeBaseline(200));
+    git(root, ['checkout', '-b', 'feature']);
+    const prev = process.env.HARNESS_ARCH_FORCE_WORKING_TREE;
+    process.env.HARNESS_ARCH_FORCE_WORKING_TREE = '1';
+    try {
+      const manager = new ArchBaselineManager(root);
+      const resolution = resolveArchBaseline(root, BASELINE_REL, manager, { baseRef: 'main' });
+      expect(resolution.fallback).toBe('forced');
+    } finally {
+      if (prev === undefined) delete process.env.HARNESS_ARCH_FORCE_WORKING_TREE;
+      else process.env.HARNESS_ARCH_FORCE_WORKING_TREE = prev;
+    }
+  });
+
+  it('tags fallback=base-ref-absent when the base branch has no baseline (bootstrap)', () => {
+    initRepo(root);
+    // Commit something OTHER than the baseline on main, so the ref resolves but the file is absent.
+    writeFileSync(join(root, 'seed.txt'), 'x');
+    git(root, ['add', '-A']);
+    git(root, ['commit', '-m', 'seed']);
+    git(root, ['checkout', '-b', 'feature']);
+    // A working-tree baseline exists on the branch, but main has none.
+    mkdirSync(join(root, '.harness', 'arch'), { recursive: true });
+    writeFileSync(join(root, BASELINE_REL), JSON.stringify(makeBaseline(9), null, 2));
+    const manager = new ArchBaselineManager(root);
+    const resolution = resolveArchBaseline(root, BASELINE_REL, manager, { baseRef: 'main' });
+    expect(resolution.source).toBe('working-tree');
+    expect(resolution.fallback).toBe('base-ref-absent');
+  });
+
+  it('does NOT set a fallback on a base-ref resolution (PR context)', () => {
+    initRepo(root);
+    commitBaseline(root, makeBaseline(100));
+    git(root, ['checkout', '-b', 'feature']);
+    const manager = new ArchBaselineManager(root);
+    const resolution = resolveArchBaseline(root, BASELINE_REL, manager, { baseRef: 'main' });
+    expect(resolution.source).toBe('base-ref');
+    expect(resolution.fallback).toBeUndefined();
+  });
+});
+
+describe('isWholeSnapshotContext (which contexts may rewrite the committed snapshot)', () => {
+  const res = (over: Partial<ArchBaselineResolution>): ArchBaselineResolution => ({
+    baseline: makeBaseline(1),
+    source: 'working-tree',
+    ...over,
+  });
+
+  it('is FALSE for a base-ref (PR) resolution — a PR acknowledges via an allowance', () => {
+    expect(isWholeSnapshotContext(res({ source: 'base-ref', fallback: undefined }))).toBe(false);
+  });
+
+  it('is TRUE for the legitimate single-writer contexts', () => {
+    for (const fallback of ['forced', 'non-git', 'base-branch', 'base-ref-absent'] as const) {
+      expect(isWholeSnapshotContext(res({ fallback }))).toBe(true);
+    }
+  });
+
+  // THE FIX: a feature branch whose base ref was merely unreadable must NOT rewrite the shared
+  // snapshot — that is the baselines.json merge cascade. It is not a whole-snapshot context.
+  it('is FALSE when a feature branch could not read the base ref (unreachable / invalid)', () => {
+    for (const fallback of ['base-ref-unreachable', 'base-ref-invalid'] as const) {
+      expect(isWholeSnapshotContext(res({ fallback }))).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## Root cause

The per-PR allowance feature (#1140) routed `check-arch --update-baseline` to the
snapshot-rewriting **whole-snapshot** path for **every** resolution that was not `base-ref`:

```ts
const resolution = resolveArchBaseline(cwd, archConfig.baselinePath, manager);
if (resolution.source === 'base-ref' && resolution.baseline) {
  return writeAllowanceUpdate(...);          // PR path — writes an allowance
}
return wholeSnapshotUpdate(...);             // everything else — REWRITES baselines.json
```

But a feature branch resolves to `working-tree` not only in the legitimate single-writer
contexts (on the base branch, in a non-git dir, under `HARNESS_ARCH_FORCE_WORKING_TREE`) — it
**also** falls back to `working-tree` whenever the base ref is merely *unreadable*: an
**unfetched worktree**, a shallow clone, or a moved/unreadable base copy. In that case
`--update-baseline` **rewrote `.harness/arch/baselines.json` on the branch** (and without
`--allow-regress` refused with *"it WORSENS N metric(s)"*), silently reintroducing the exact
`baselines.json` merge cascade the allowance mechanism exists to prevent — so a legitimate
aggregate value regression (`dependency-depth`, `module-size`, …) could never be acknowledged
conflict-free, and the fleet's baseline re-sweeps were blocked.

### Empirical proof (before)

Feature branch, existing committed baseline, base ref unreachable (no `origin`), module-size
regression → `--update-baseline` produced `snapshotDivergedFromMain: true` (snapshot rewritten);
without `--allow-regress` it emitted the whole-snapshot "WORSENS" refusal.

## Fix

The whole-snapshot (snapshot-rewriting) path is now restricted to the contexts where it is
actually correct. `resolveArchBaseline` reports a `fallback` reason on every non-`base-ref`
resolution (`forced` / `non-git` / `base-branch` / `base-ref-unreachable` / `base-ref-absent` /
`base-ref-invalid`), and a new `isWholeSnapshotContext(resolution)` helper encodes which
contexts may rewrite the committed snapshot: base branch, non-git, `HARNESS_ARCH_FORCE_WORKING_TREE`,
and a genuine bootstrap where the base branch has no baseline at all.

A feature branch whose base ref was unreadable **but which already has a committed baseline** now
writes a per-PR allowance against the working-tree baseline instead, leaving `baselines.json`
**byte-identical**. Aggregate category value regressions and warning-level new violations are both
allowanceable; **error-severity new violations are still never allowanceable** — a genuine
threshold breach must be fixed.

### Verified (after), real CLI

- Feature branch + unreachable base ref + existing baseline + regression → writes
  `allowances/<branch>.json`, `git diff origin/main -- baselines.json` is **empty**, follow-up
  `check-arch` **passes**.
- Bootstrap (no baseline anywhere) still whole-snapshots (creates it).
- Error-severity new violation still hard-fails, allowance or not.

## Tests

- `packages/core/tests/architecture/baseline-resolver.test.ts` — `fallback` tagging on every
  path + `isWholeSnapshotContext` matrix (25 tests, +9).
- `packages/cli/tests/commands/check-arch.test.ts` — feature-branch-safety-net regression
  (allowance not snapshot; follow-up passes), bootstrap preserved, gate-integrity (error-severity
  never allowanceable) (33 tests, +3).

## Dogfood

This PR's own source additions regress `module-size`/`dependency-depth` vs the base; acknowledged
via the very allowance path being fixed (`.harness/arch/allowances/fix-arch-allowance-feature-branch-routing.json`).
`baselines.json` is byte-identical to `origin/main`.

Changeset: `@harness-engineering/core` (minor — new `isWholeSnapshotContext` / `ArchBaselineFallback`), `@harness-engineering/cli` (patch).

## CI note

Pre-push was run manually per affected package (core + cli: build, typecheck, tests, coverage,
coverage-ratchet all green; changesets + generate-docs fresh). The `git push` pre-push hook was
blocked **only** by a pre-existing, date-dependent flake in the unrelated `@harness-engineering/burn`
package (`budgets-models.test.ts` "early-week" tests use `new Date()` and fail mid/late week — they
do not depend on any changed code), pulled into `turbo --affected` via the root-level changeset/allowance
files. Pushed with `HUSKY=0` (the documented worktree escape) with CI as the authoritative backstop.

Do not merge — human review requested.
