### PR TITLE
test(burn): deflake budgets-models early-week forecast tests (date-dependent)

### DIFF
--- a/packages/burn/tests/budgets-models.test.ts
+++ b/packages/burn/tests/budgets-models.test.ts
@@ -40,10 +40,20 @@ function lateWeekConfig(now: Date, extra: Record<string, unknown> = {}): Record<
   };
 }
 
-/** A reset placed so that `now` sits `days` into the current week. */
+/**
+ * A reset placed so that `now` sits exactly `days` into the current week.
+ *
+ * Deflake: this previously forced `time: '00:00'`, dropping `start`'s time-of-day.
+ * That made the real days-into-week depend on `now`'s wall-clock time (and which
+ * side of midnight `now - days` fell on), so the early-week tests intermittently
+ * saw `frac >= 0.15` → 'medium' confidence instead of 'low' (summary.ts:162).
+ * Preserving `start`'s HH:MM makes days-into-week == `days` for ANY `now`.
+ */
 function weekStartingDaysAgo(now: Date, days: number): Record<string, unknown> {
   const start = daysAgo(now, days);
-  return { weekday: utcIsoWeekday(start), time: '00:00', tz: 'UTC' };
+  const hh = String(start.getUTCHours()).padStart(2, '0');
+  const mm = String(start.getUTCMinutes()).padStart(2, '0');
+  return { weekday: utcIsoWeekday(start), time: `${hh}:${mm}`, tz: 'UTC' };
 }
 
 /** `currentLines` plus enough prior-week volume to form a baseline. */


### PR DESCRIPTION
## Problem
`packages/burn/tests/budgets-models.test.ts`'s two early-week forecast tests use `new Date()` and fail **mid/late week** (`expected 'medium' to be 'low'`). Root cause: the `weekStartingDaysAgo()` helper forced the week reset to `time: '00:00'`, dropping `start`'s time-of-day — so the real days-into-week depended on the wall-clock run time, pushing `frac >= 0.15` → 'medium' confidence instead of 'low' (`summary.ts:162`).

This is on **main** and blocks every PR whose `--affected` set pulls in `@harness-engineering/burn` (any root-level file change does) — e.g. it's currently red-CI on #1150 (build-and-test, all 3 OS, on `budgets-models.test.ts:133/156`).

## Fix
Make the helper preserve `start`'s `HH:MM` so days-into-week equals the requested `days` for **any** `now` — deterministic. Test-only change; all 8 burn files / 87 tests pass.

## Verification
Full burn suite green after build (87 tests). No source/behavior change.