### PR TITLE
test(core,orchestrator): deflake timing-sensitive tests under coverage

### DIFF
--- a/.changeset/deflake-core-timing-tests.md
+++ b/.changeset/deflake-core-timing-tests.md
@@ -1,0 +1,32 @@
+---
+'@harness-engineering/core': patch
+'@harness-engineering/orchestrator': patch
+---
+
+Deflake timing-sensitive tests that fail intermittently under `test:coverage`.
+
+Several suites spawn real git/node subprocesses (`baseline-resolver`,
+`derive-repo`, `git-scan`, `hotspot`, event-sourcing `concurrency` in core;
+`claim-coordination` and `orchestrator` integration in orchestrator) and one
+exercises a real HTTP receiver with a retry/backoff path (the core OTLP
+exporter). Under v8 coverage instrumentation plus parallel workers, those
+subprocess spawns are starved of CPU on loaded runners and intermittently blew
+tight timeouts — failing green code and blocking the pre-push gauntlet for every
+PR touching core (orchestrator is `--affected` by any core change).
+
+The fix is test-only and deterministic:
+
+- **core**: raise the global vitest `testTimeout` and the separately-budgeted
+  `hookTimeout` (git init/cleanup runs in `beforeEach`) to a generous 60s
+  ceiling, and widen the OTLP exporter's `vi.waitFor` budgets with a small poll
+  interval.
+- **orchestrator**: the package `vitest.config` already sets a generous 90s
+  `testTimeout`/`hookTimeout` for exactly this reason, but four
+  `claim-coordination` tests and two `orchestrator` integration tests carried
+  per-test `{ timeout: 15000 }` overrides that capped them _below_ that global,
+  defeating the protection. Those caps are removed so the tests inherit the 90s
+  ceiling.
+
+A larger ceiling only tolerates slow/loaded runners; a genuine hang still fails,
+so it cannot mask a real bug. No assertions were weakened, no tests skipped, and
+coverage is unchanged.

--- a/packages/core/src/solutions/scan-candidates/git-scan.test.ts
+++ b/packages/core/src/solutions/scan-candidates/git-scan.test.ts
@@ -32,7 +32,7 @@ describe('gitScan', () => {
       'fix(orchestrator): retry logic',
       'fix: handle null in parser',
     ]);
-  }, 30_000);
+  });
 
   it('reports filesChanged count per commit', async () => {
     mkdirSync(join(tmp, 'src'));

--- a/packages/core/src/solutions/scan-candidates/hotspot.test.ts
+++ b/packages/core/src/solutions/scan-candidates/hotspot.test.ts
@@ -27,7 +27,7 @@ describe('computeHotspots', () => {
     expect(result[0]?.path).toBe('hot.ts');
     expect(result[0]?.churn).toBe(5);
     expect(result.find((r) => r.path === 'cold.ts')).toBeUndefined();
-  }, 60_000);
+  });
 
   it('returns empty list on empty repo', async () => {
     const result = await computeHotspots({ since: '30d', cwd: tmp, threshold: 1 });

--- a/packages/core/src/telemetry/exporter/otlp-http.test.ts
+++ b/packages/core/src/telemetry/exporter/otlp-http.test.ts
@@ -100,7 +100,10 @@ describe('OTLPExporter', () => {
     exporter.start();
     exporter.push(makeSpan());
 
-    await vi.waitFor(() => expect(receiver.received).toHaveLength(1), { timeout: 1000 });
+    await vi.waitFor(() => expect(receiver.received).toHaveLength(1), {
+      timeout: 10_000,
+      interval: 20,
+    });
     const envelope = receiver.received[0] as {
       resourceSpans: [{ scopeSpans: [{ spans: unknown[] }] }];
     };
@@ -119,7 +122,10 @@ describe('OTLPExporter', () => {
     exporter.push(makeSpan({ name: 'span-c' }));
     exporter.push(makeSpan({ name: 'span-d' }));
 
-    await vi.waitFor(() => expect(receiver.received).toHaveLength(2), { timeout: 2000 });
+    await vi.waitFor(() => expect(receiver.received).toHaveLength(2), {
+      timeout: 10_000,
+      interval: 20,
+    });
   });
 
   it('drops the batch after 3 failed attempts and warns once', async () => {
@@ -145,7 +151,14 @@ describe('OTLPExporter', () => {
     await advanceAll();
     vi.useRealTimers();
 
-    await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1), { timeout: 2000 });
+    // The terminal warn fires only after 3 real HTTP round-trips to the 503
+    // receiver complete; under v8 coverage overhead + loaded runners those
+    // round-trips are slow, so give vi.waitFor a generous budget. A genuine
+    // never-warn bug still fails (it just fails later), so this cannot mask one.
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1), {
+      timeout: 15_000,
+      interval: 20,
+    });
     expect(receiver.received).toHaveLength(0);
   });
 
@@ -200,7 +213,10 @@ describe('OTLPExporter', () => {
     });
     exporter.push(span);
 
-    await vi.waitFor(() => expect(receiver.received).toHaveLength(1), { timeout: 1000 });
+    await vi.waitFor(() => expect(receiver.received).toHaveLength(1), {
+      timeout: 10_000,
+      interval: 20,
+    });
     const env = receiver.received[0] as {
       resourceSpans: [
         {

--- a/packages/core/tests/state/event-sourcing/concurrency.test.ts
+++ b/packages/core/tests/state/event-sourcing/concurrency.test.ts
@@ -61,7 +61,7 @@ describe('SC3 concurrency (INV-1/INV-2)', () => {
     for (const w of writerIds) {
       expect(loaded.value.filter((e) => e.writerId === w).length).toBe(K);
     }
-  }, 30_000);
+  });
 
   it('N processes spilling oversized payloads lose zero events and all blobs rehydrate (I5)', async () => {
     // Stresses the real edge the design hinges on: blob spill firing UNDER concurrent
@@ -106,5 +106,5 @@ describe('SC3 concurrency (INV-1/INV-2)', () => {
     // shared blob for it, so total distinct blobs is (unique payloads) + 1, well under N*K.
     const blobCount = fs.readdirSync(blobsDir).length;
     expect(blobCount).toBe(N * (K - 1) + 1);
-  }, 30_000);
+  });
 });

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -4,7 +4,18 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    testTimeout: 15_000,
+    // Generous global ceiling. Many core suites spawn real git/node subprocesses
+    // (baseline-resolver, derive-repo, git-scan, hotspot, event-sourcing
+    // concurrency). Under `test:coverage` the v8 instrumentation plus parallel
+    // workers starve those subprocess spawns of CPU, so a 15s default timed out
+    // intermittently even on green code. A larger ceiling only tolerates slow /
+    // loaded runners — a genuine hang still fails — so it cannot mask a real bug.
+    testTimeout: 60_000,
+    // Same rationale for setup/teardown hooks, which have their own separate
+    // budget (vitest default 10s). Several suites do `git init` + commits inside
+    // `beforeEach` via execSync; under coverage-load CPU starvation those hooks
+    // blew the 10s default and failed green suites. Raise the hook ceiling too.
+    hookTimeout: 60_000,
     setupFiles: ['./tests/setup.ts'],
     // Restrict discovery to source/test trees. Without this, vitest 4's
     // default include picks up compiled `dist/**/*.test.js` artifacts whose

--- a/packages/orchestrator/tests/integration/claim-coordination.test.ts
+++ b/packages/orchestrator/tests/integration/claim-coordination.test.ts
@@ -138,148 +138,145 @@ describe('Multi-Orchestrator Claim Coordination', () => {
   // tick that claims an issue takes ~2s. Tests involving claims need a
   // generous timeout to avoid flaking.
   describe('no duplicate dispatch', () => {
-    it(
-      'only one orchestrator dispatches when two race for the same issue',
-      { timeout: 15000 },
-      async () => {
-        const issue = makeIssue();
-        const { makeTracker } = createRacingTracker([issue]);
+    // No per-test timeout: inherit the package-wide 90s ceiling (vitest.config).
+    // A tight 15s cap here overrode that generous global and flaked under the
+    // pre-push coverage gate (v8 + parallel workers starve subprocess spawns).
+    it('only one orchestrator dispatches when two race for the same issue', async () => {
+      const issue = makeIssue();
+      const { makeTracker } = createRacingTracker([issue]);
 
-        // Two orchestrators sharing the same tracker (shared claimedBy state)
-        const trackerA = makeTracker();
-        const trackerB = makeTracker();
+      // Two orchestrators sharing the same tracker (shared claimedBy state)
+      const trackerA = makeTracker();
+      const trackerB = makeTracker();
 
-        const orchA = new Orchestrator(
-          createMockConfig({ orchestratorId: 'orch-alpha' }),
-          'Prompt',
-          { tracker: trackerA, backend: new MockBackend(), execFileFn: noopExecFile }
-        );
-        const orchB = new Orchestrator(
-          createMockConfig({ orchestratorId: 'orch-beta' }),
-          'Prompt',
-          { tracker: trackerB, backend: new MockBackend(), execFileFn: noopExecFile }
-        );
+      const orchA = new Orchestrator(createMockConfig({ orchestratorId: 'orch-alpha' }), 'Prompt', {
+        tracker: trackerA,
+        backend: new MockBackend(),
+        execFileFn: noopExecFile,
+      });
+      const orchB = new Orchestrator(createMockConfig({ orchestratorId: 'orch-beta' }), 'Prompt', {
+        tracker: trackerB,
+        backend: new MockBackend(),
+        execFileFn: noopExecFile,
+      });
 
-        try {
-          // Both tick -- the first claimIssue call wins the shared tracker
-          await orchA.tick();
-          await orchB.tick();
+      try {
+        // Both tick -- the first claimIssue call wins the shared tracker
+        await orchA.tick();
+        await orchB.tick();
 
-          // Wait for async dispatch to settle
-          await new Promise((resolve) => setTimeout(resolve, 500));
+        // Wait for async dispatch to settle
+        await new Promise((resolve) => setTimeout(resolve, 500));
 
-          const snapA = orchA.getSnapshot();
-          const snapB = orchB.getSnapshot();
+        const snapA = orchA.getSnapshot();
+        const snapB = orchB.getSnapshot();
 
-          // Exactly one should have dispatched (claimed or completed)
-          const aDispatched =
-            (snapA.claimed as string[]).includes(issue.id) ||
-            (snapA.completed as string[]).includes(issue.id);
-          const bDispatched =
-            (snapB.claimed as string[]).includes(issue.id) ||
-            (snapB.completed as string[]).includes(issue.id);
+        // Exactly one should have dispatched (claimed or completed)
+        const aDispatched =
+          (snapA.claimed as string[]).includes(issue.id) ||
+          (snapA.completed as string[]).includes(issue.id);
+        const bDispatched =
+          (snapB.claimed as string[]).includes(issue.id) ||
+          (snapB.completed as string[]).includes(issue.id);
 
-          // One dispatched, not both
-          expect(aDispatched || bDispatched).toBe(true);
-          expect(aDispatched && bDispatched).toBe(false);
-        } finally {
-          await orchA.stop();
-          await orchB.stop();
-        }
+        // One dispatched, not both
+        expect(aDispatched || bDispatched).toBe(true);
+        expect(aDispatched && bDispatched).toBe(false);
+      } finally {
+        await orchA.stop();
+        await orchB.stop();
       }
-    );
+    });
   });
 
   describe('stale claim recovery', () => {
-    it(
-      'releases stale claim from dead orchestrator and dispatches the issue',
-      { timeout: 15000 },
-      async () => {
-        // Simulate a crashed orchestrator: issue is in-progress, assigned to
-        // 'dead-orch', with updatedAt 20 minutes ago (well past any TTL).
-        const staleIssue = makeIssue({
-          id: 'issue-stale-1',
-          identifier: 'H-STALE-1',
-          state: 'in-progress',
-          assignee: 'dead-orch',
-          updatedAt: new Date(Date.now() - 1_200_000).toISOString(), // 20 min ago
-        });
+    // Inherit the package-wide 90s ceiling (see vitest.config); the tight 15s
+    // cap here defeated that global and flaked under the pre-push coverage gate.
+    it('releases stale claim from dead orchestrator and dispatches the issue', async () => {
+      // Simulate a crashed orchestrator: issue is in-progress, assigned to
+      // 'dead-orch', with updatedAt 20 minutes ago (well past any TTL).
+      const staleIssue = makeIssue({
+        id: 'issue-stale-1',
+        identifier: 'H-STALE-1',
+        state: 'in-progress',
+        assignee: 'dead-orch',
+        updatedAt: new Date(Date.now() - 1_200_000).toISOString(), // 20 min ago
+      });
 
-        // The tracker starts with the stale issue as the only candidate.
-        // After releaseIssue is called, the issue reverts to 'planned' state
-        // and becomes a normal candidate on the same tick.
-        let issueState = { ...staleIssue };
-        const tracker: IssueTrackerClient = {
-          fetchCandidateIssues: vi.fn().mockImplementation(() => {
-            // Return the issue in its current state
-            return Promise.resolve(Ok([{ ...issueState }]));
-          }),
-          fetchIssuesByStates: vi.fn().mockResolvedValue(Ok([])),
-          fetchIssueStatesByIds: vi.fn().mockImplementation((ids: string[]) => {
-            const map = new Map<string, Issue>();
-            for (const id of ids) {
-              if (id === issueState.id) {
-                map.set(id, { ...issueState });
-              }
+      // The tracker starts with the stale issue as the only candidate.
+      // After releaseIssue is called, the issue reverts to 'planned' state
+      // and becomes a normal candidate on the same tick.
+      let issueState = { ...staleIssue };
+      const tracker: IssueTrackerClient = {
+        fetchCandidateIssues: vi.fn().mockImplementation(() => {
+          // Return the issue in its current state
+          return Promise.resolve(Ok([{ ...issueState }]));
+        }),
+        fetchIssuesByStates: vi.fn().mockResolvedValue(Ok([])),
+        fetchIssueStatesByIds: vi.fn().mockImplementation((ids: string[]) => {
+          const map = new Map<string, Issue>();
+          for (const id of ids) {
+            if (id === issueState.id) {
+              map.set(id, { ...issueState });
             }
-            return Promise.resolve(Ok(map));
-          }),
-          markIssueComplete: vi.fn().mockResolvedValue(Ok(undefined)),
-          claimIssue: vi.fn().mockImplementation((_id: string, orchestratorId: string) => {
-            issueState = {
-              ...issueState,
-              assignee: orchestratorId,
-              state: 'in-progress',
-              updatedAt: new Date().toISOString(),
-            };
-            return Promise.resolve(Ok(undefined));
-          }),
-          releaseIssue: vi.fn().mockImplementation((_id: string) => {
-            issueState = {
-              ...issueState,
-              assignee: null,
-              state: 'planned',
-              updatedAt: new Date().toISOString(),
-            };
-            return Promise.resolve(Ok(undefined));
-          }),
-        };
+          }
+          return Promise.resolve(Ok(map));
+        }),
+        markIssueComplete: vi.fn().mockResolvedValue(Ok(undefined)),
+        claimIssue: vi.fn().mockImplementation((_id: string, orchestratorId: string) => {
+          issueState = {
+            ...issueState,
+            assignee: orchestratorId,
+            state: 'in-progress',
+            updatedAt: new Date().toISOString(),
+          };
+          return Promise.resolve(Ok(undefined));
+        }),
+        releaseIssue: vi.fn().mockImplementation((_id: string) => {
+          issueState = {
+            ...issueState,
+            assignee: null,
+            state: 'planned',
+            updatedAt: new Date().toISOString(),
+          };
+          return Promise.resolve(Ok(undefined));
+        }),
+      };
 
-        const orch = new Orchestrator(createMockConfig({ orchestratorId: 'orch-live' }), 'Prompt', {
-          tracker,
-          backend: new MockBackend(),
-          execFileFn: noopExecFile,
-        });
+      const orch = new Orchestrator(createMockConfig({ orchestratorId: 'orch-live' }), 'Prompt', {
+        tracker,
+        backend: new MockBackend(),
+        execFileFn: noopExecFile,
+      });
 
-        try {
-          // First tick: detects stale claim, releases it.
-          // The issue becomes available but won't be dispatched on this tick
-          // because releaseIssue resets the state after candidates are fetched.
-          await orch.tick();
+      try {
+        // First tick: detects stale claim, releases it.
+        // The issue becomes available but won't be dispatched on this tick
+        // because releaseIssue resets the state after candidates are fetched.
+        await orch.tick();
 
-          // releaseIssue should have been called for the stale claim
-          expect(tracker.releaseIssue).toHaveBeenCalledWith('issue-stale-1');
+        // releaseIssue should have been called for the stale claim
+        expect(tracker.releaseIssue).toHaveBeenCalledWith('issue-stale-1');
 
-          // Second tick: issue is now in 'planned' state, normal candidate flow
-          await orch.tick();
+        // Second tick: issue is now in 'planned' state, normal candidate flow
+        await orch.tick();
 
-          // Wait for async dispatch to settle
-          await new Promise((resolve) => setTimeout(resolve, 500));
+        // Wait for async dispatch to settle
+        await new Promise((resolve) => setTimeout(resolve, 500));
 
-          const snapshot = orch.getSnapshot();
-          const dispatched =
-            (snapshot.claimed as string[]).includes('issue-stale-1') ||
-            (snapshot.completed as string[]).includes('issue-stale-1');
-          expect(dispatched).toBe(true);
-        } finally {
-          await orch.stop();
-        }
+        const snapshot = orch.getSnapshot();
+        const dispatched =
+          (snapshot.claimed as string[]).includes('issue-stale-1') ||
+          (snapshot.completed as string[]).includes('issue-stale-1');
+        expect(dispatched).toBe(true);
+      } finally {
+        await orch.stop();
       }
-    );
+    });
   });
 
   describe('claim rejection graceful skip', () => {
-    it('skips the issue without error when claim is rejected', { timeout: 15000 }, async () => {
+    it('skips the issue without error when claim is rejected', async () => {
       const issue = makeIssue({
         id: 'issue-race-1',
         identifier: 'H-RACE-1',
@@ -332,7 +329,7 @@ describe('Multi-Orchestrator Claim Coordination', () => {
       }
     });
 
-    it('does not crash when claimIssue itself returns an error', { timeout: 15000 }, async () => {
+    it('does not crash when claimIssue itself returns an error', async () => {
       const issue = makeIssue({
         id: 'issue-err-1',
         identifier: 'H-ERR-1',

--- a/packages/orchestrator/tests/integration/orchestrator.test.ts
+++ b/packages/orchestrator/tests/integration/orchestrator.test.ts
@@ -130,7 +130,7 @@ describe('Orchestrator Integration', () => {
     }
   });
 
-  it('should poll, dispatch, and run an agent session', { timeout: 15000 }, async () => {
+  it('should poll, dispatch, and run an agent session', async () => {
     // 1. Initial tick
     await orchestrator.tick();
 
@@ -153,7 +153,7 @@ describe('Orchestrator Integration', () => {
     expect((finalSnapshot.completed as string[]).includes(mockIssue.id)).toBe(true);
   });
 
-  it('should stop active runs when orchestrator stops', { timeout: 15000 }, async () => {
+  it('should stop active runs when orchestrator stops', async () => {
     await orchestrator.tick();
     const snapshot = orchestrator.getSnapshot();
     expect(snapshot.running.length).toBe(1);


### PR DESCRIPTION
## Problem

Timing-sensitive tests in `@harness-engineering/core` (and, via `--affected`, `@harness-engineering/orchestrator`) fail intermittently under `test:coverage`. The v8 coverage instrumentation plus parallel vitest workers starve real git/node subprocess spawns of CPU on loaded runners, so correct, green code blows tight timeouts and fails. This blocks the pre-push gauntlet for **every** PR that touches core (directly or via `--affected`).

## Root causes found

1. **core** — the OTLP exporter's `vi.waitFor` budgets were as tight as 1-2s while the terminal state depends on 3 real HTTP round-trips; and the global `testTimeout` was 15s with **no** `hookTimeout` override, so git-subprocess suites (`baseline-resolver`, `derive-repo`, `git-scan`, `hotspot`, event-sourcing `concurrency`) blew both the 15s test timeout **and** the separately-budgeted 10s `hookTimeout` (git init runs in `beforeEach`) under load.
2. **orchestrator** — its `vitest.config` already sets a generous 90s `testTimeout`/`hookTimeout` for exactly this reason, but six integration tests (four in `claim-coordination`, two in `orchestrator`) carried per-test `{ timeout: 15000 }` overrides that **capped them below** that global, defeating the protection.

## Fix (test-only, deterministic)

- **core `vitest.config.mts`**: `testTimeout` 15s → 60s; add `hookTimeout: 60_000`.
- **core `otlp-http.test.ts`**: widen the four `vi.waitFor` budgets (to 10-15s) with a small `interval: 20`.
- **core git/subprocess tests**: removed ad-hoc per-test timeouts so they inherit the generous 60s global (nothing caps below it).
- **orchestrator `claim-coordination.test.ts` / `orchestrator.test.ts`**: removed the six `{ timeout: 15000 }` caps so those tests inherit the package's 90s global.

A larger ceiling only tolerates slow/loaded runners — a genuine hang still fails, it just fails later — so it **cannot mask a real bug**. No assertions weakened, no tests skipped, coverage unchanged, no source/behavior/baseline changes.

## Verification

- Reproduced the original OTLP flake in isolation (~2/5 failures at the 2s `vi.waitFor`), and the git-subprocess `hookTimeout`/`testTimeout` timeouts under full-suite coverage load.
- Post-fix: `turbo run test:coverage --filter=@harness-engineering/core` green 3x under sustained heavy load (3937 passed each time); `--filter=@harness-engineering/orchestrator` green (2484 passed) where it previously flaked a different `claim-coordination` test each run.
- Full pre-push gauntlet green.