### PR TITLE
test(orchestrator,cli): deflake test:coverage gauntlet under v8 coverage load

### DIFF
--- a/.changeset/deflake-cli-coverage-gauntlet-blockers.md
+++ b/.changeset/deflake-cli-coverage-gauntlet-blockers.md
@@ -1,0 +1,27 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Deflake the two CLI tests that block the full-suite `test:coverage` pre-push
+gauntlet.
+
+The pre-push gate runs `turbo run test:coverage` for the whole workspace, so a
+flaky CLI test gates every PR — including orchestrator-only changes, since CLI
+depends on orchestrator. Two CLI tests fail under v8 coverage + parallel-worker
+CPU starvation:
+
+- `slash-commands/integration.ts > detects orphaned codex skill directories`
+  carried a per-test `{ timeout: 15000 }` cap that overrode the package's 90s
+  ceiling. The test runs `generateSlashCommands` twice (heavy synchronous
+  filesystem writes) and reliably blew 15s under full-suite coverage load,
+  failing effectively every `test:coverage` run. The cap is removed so it
+  inherits the generous global ceiling (same fix as #1153 for orchestrator).
+
+- `commands/scan-config.ts > scans large config files within 100ms` asserted a
+  hard 100ms perf budget that v8 instrumentation inflates past. The budget is
+  now coverage-aware (relaxed via HARNESS_COVERAGE, forwarded from vitest.config
+  when `--coverage` is passed) while still catching an order-of-magnitude
+  regression.
+
+Test-only and deterministic: no source or behavior changes, no assertions
+weakened, no tests skipped, coverage unchanged.

--- a/.changeset/deflake-orchestrator-coverage-tests.md
+++ b/.changeset/deflake-orchestrator-coverage-tests.md
@@ -1,0 +1,30 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Deflake orchestrator tests that fail intermittently under `test:coverage`.
+
+The telemetry-latency p99 budget carried a coverage-relaxation branch keyed on
+`NODE_V8_COVERAGE` / `VITEST_COVERAGE`, but vitest sets neither in the worker
+environment under `--coverage`, so the branch was dead and the strict 5 ms
+budget applied under coverage — where v8 instrumentation plus parallel-worker
+CPU starvation routinely pushes the measured delta past it. The vitest config
+now detects `--coverage` in the CLI argv and forwards it to the worker as
+`HARNESS_COVERAGE`, which the test reads to apply the intended relaxed budget.
+The assertion (exporter overhead is bounded) is preserved, just made
+deterministic under coverage.
+
+The package's global test/hook timeout ceiling is raised 90s → 120s. Several
+integration/tracker suites run `git init` + commits inside `beforeEach` via
+`execSync`; under full-suite coverage load those subprocess cold-starts
+occasionally blew the 90s hook ceiling on green code. A higher ceiling only
+tolerates a slow/loaded runner — a genuine hang still fails — so it cannot mask
+a real bug.
+
+The server integration `SC8` test replaced a fixed 1 s sleep (racing the
+asynchronous plan-watcher auto-resolve under load) with a polling `vi.waitFor`,
+so it resolves as soon as the watcher fires and only fails if resolution never
+happens.
+
+Test-only and deterministic: no source or behavior changes, no assertions
+weakened, no tests skipped, coverage unchanged.

--- a/packages/cli/tests/commands/scan-config.test.ts
+++ b/packages/cli/tests/commands/scan-config.test.ts
@@ -256,7 +256,14 @@ describe('runScanConfig', () => {
       const start = Date.now();
       await runScanConfig(tempDir, {});
       const elapsed = Date.now() - start;
-      expect(elapsed).toBeLessThan(100);
+      // 100ms is the uninstrumented budget. Under v8 coverage the scan is
+      // instrumented and parallel-worker CPU starvation adds another order of
+      // magnitude, so the strict budget flakes on the pre-push gate. Relax it
+      // under coverage (HARNESS_COVERAGE is forwarded by vitest.config) while
+      // still catching an order-of-magnitude regression. The intent — the scan
+      // is fast, not accidentally quadratic — is preserved.
+      const budgetMs = process.env['HARNESS_COVERAGE'] === '1' ? 2000 : 100;
+      expect(elapsed).toBeLessThan(budgetMs);
     });
 
     it('does not scan files outside the CONFIG_FILES list', async () => {

--- a/packages/cli/tests/slash-commands/integration.test.ts
+++ b/packages/cli/tests/slash-commands/integration.test.ts
@@ -243,7 +243,14 @@ describe('codex sync', () => {
     expect(results[0].unchanged.length).toBeGreaterThan(0);
   });
 
-  it('detects orphaned codex skill directories for removal', { timeout: 15000 }, () => {
+  // No per-test timeout: inherit the package-wide 90s ceiling (vitest.config).
+  // This test runs `generateSlashCommands` twice (heavy synchronous filesystem
+  // writes over the whole skill fixture set); under the full-suite coverage gate
+  // (v8 instrumentation + parallel workers self-contending) that work reliably
+  // blew the tight 15s cap, deterministically failing every `test:coverage` run
+  // and blocking the pre-push gauntlet. The 90s ceiling only tolerates a
+  // slow/loaded runner — a genuine hang still fails — so it cannot mask a bug.
+  it('detects orphaned codex skill directories for removal', () => {
     // First generate to create the skill directories
     generateSlashCommands({
       platforms: ['codex'],

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -1,11 +1,22 @@
 import { defineConfig } from 'vitest/config';
 
+// v8 coverage is only active when the run passed `--coverage` (i.e.
+// `test:coverage`). Vitest does not propagate a coverage flag into the worker
+// `process.env`, so a test that needs to relax a timing-sensitive budget under
+// coverage cannot detect it on its own. Detect it here — where the CLI argv is
+// visible — and forward it via `test.env` as HARNESS_COVERAGE. Consumed by
+// scan-config's coverage-aware perf budget.
+const COVERAGE = process.argv.includes('--coverage');
+
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
     setupFiles: ['tests/setup.ts'],
+    // Forward the coverage signal into the worker environment (see COVERAGE note
+    // above). Empty string when not running under coverage.
+    env: { HARNESS_COVERAGE: COVERAGE ? '1' : '' },
     // 37 test files in this package spawn `node`/`git` subprocesses. On the
     // pre-push gate the package runs under v8 coverage with files in parallel,
     // and `turbo --concurrency=2` may run a second package's suite alongside it.

--- a/packages/orchestrator/tests/integration/telemetry-latency.test.ts
+++ b/packages/orchestrator/tests/integration/telemetry-latency.test.ts
@@ -42,10 +42,13 @@ const ITERATIONS = 200;
 // and noisy neighbors that push single-run microbenchmarks well above the
 // production target. 25 ms is loose enough to absorb CI variance while
 // still catching a real exporter regression (orders-of-magnitude slowdown).
-// Coverage instrumentation (v8/istanbul) adds another order of magnitude
-// of overhead — skip the assertion's tight budget in that case, while still
-// running the body so coverage stays accurate.
-const COVERAGE = process.env['NODE_V8_COVERAGE'] || process.env['VITEST_COVERAGE'];
+// Coverage instrumentation (v8) adds another order of magnitude of overhead —
+// relax the budget in that case, while still running the body so coverage stays
+// accurate. Vitest does NOT expose a coverage flag in the worker env, so
+// vitest.config.mts detects `--coverage` in the CLI argv and forwards it as
+// HARNESS_COVERAGE (see the note there). NODE_V8_COVERAGE is kept as a fallback
+// for a raw `node --experimental-test-coverage`-style invocation.
+const COVERAGE = process.env['HARNESS_COVERAGE'] === '1' || !!process.env['NODE_V8_COVERAGE'];
 const P99_BUDGET_MS = COVERAGE ? 250 : process.env['CI'] === 'true' ? 25 : 5;
 const UNREACHABLE_ENDPOINT = 'http://127.0.0.1:1/v1/traces';
 

--- a/packages/orchestrator/tests/server/integration.test.ts
+++ b/packages/orchestrator/tests/server/integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as http from 'node:http';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -154,12 +154,20 @@ describe('OrchestratorServer integration', () => {
     const content = await fs.readFile(planFile, 'utf-8');
     expect(content).toBe('# Plan for ISSUE-SC8');
 
-    // Wait for plan watcher to auto-resolve
-    await new Promise((r) => setTimeout(r, 1000));
-
-    const interactions = await queue.list();
-    const resolved = interactions.find((i) => i.id === 'int-sc8');
-    expect(resolved?.status).toBe('resolved');
+    // Wait for the plan watcher to auto-resolve the interaction. The watcher is
+    // fully asynchronous (fs event → debounce → resolve), so a fixed sleep races
+    // under coverage load (v8 instrumentation + parallel workers) and the read
+    // lands while the status is still 'pending'. Poll instead: this returns as
+    // soon as the watcher fires and only fails if resolution never happens —
+    // preserving the intent while being deterministic under load.
+    await vi.waitFor(
+      async () => {
+        const interactions = await queue.list();
+        const resolved = interactions.find((i) => i.id === 'int-sc8');
+        expect(resolved?.status).toBe('resolved');
+      },
+      { timeout: 15_000, interval: 50 }
+    );
   });
 
   it('state snapshot endpoint still works', async () => {

--- a/packages/orchestrator/vitest.config.mts
+++ b/packages/orchestrator/vitest.config.mts
@@ -1,10 +1,23 @@
 import { defineConfig } from 'vitest/config';
 
+// Coverage instrumentation (v8) is only active when the run passed `--coverage`
+// (i.e. `test:coverage`). Vitest does NOT propagate a coverage flag into the
+// worker `process.env` (neither NODE_V8_COVERAGE nor VITEST_COVERAGE is set
+// there), so a test that needs to relax a timing-sensitive budget under
+// coverage cannot detect it on its own. Detect it here in the config process —
+// where the CLI argv is visible — and forward it via `test.env` so the worker
+// can read `process.env.HARNESS_COVERAGE`. Consumed by telemetry-latency's
+// coverage-aware p99 budget.
+const COVERAGE = process.argv.includes('--coverage');
+
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
     setupFiles: ['./tests/setup.ts'],
     environment: 'node',
+    // Forward the coverage signal into the worker environment (see COVERAGE note
+    // above). Empty string when not running under coverage.
+    env: { HARNESS_COVERAGE: COVERAGE ? '1' : '' },
     // 37 test files here spawn subprocesses. Like the cli package, on the
     // pre-push gate (v8 coverage, files in parallel, `turbo --concurrency=2`
     // running a second package alongside) subprocess cold-start starves for CPU
@@ -12,8 +25,16 @@ export default defineConfig({
     // package was observed flaking in the pre-push gate right after cli (#620).
     // A timeout is a latency ceiling, not a correctness gate; raising it removes
     // the false failures without touching parallelism. CI runs the full suite.
-    testTimeout: 90_000,
-    hookTimeout: 90_000,
+    //
+    // Bumped 90s → 120s: several integration/tracker suites do `git init` +
+    // commits inside `beforeEach` via execSync. Under full-suite coverage load
+    // (234 files, parallel workers all cold-starting git subprocesses at once)
+    // that hook still occasionally blew the 90s ceiling on otherwise-green code
+    // (orchestrator-model-pool, orchestrator, file-less-stub). A higher ceiling
+    // only tolerates a slow/loaded runner — a genuine hang still fails — so it
+    // cannot mask a real bug.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],


### PR DESCRIPTION
## What

Deflake the `test:coverage` gauntlet for the orchestrator suite (the assigned task) plus the two CLI tests that deterministically block the shared full-suite pre-push gate. Sibling to the just-merged core deflake (#1153) — same class of fix (coverage-load CPU starvation flaking green code).

**Test-only and deterministic**: no source/behavior changes, no assertions weakened, no tests skipped, coverage unchanged, no baseline changes.

## Why the CLI changes are here

The pre-push gate's final step runs `turbo run test:coverage --concurrency=2` for the **whole workspace** (not `--affected`), so a flaky CLI test gates *every* PR — including an orchestrator-only change, since `cli` depends on `orchestrator`. The CLI `codex` test failed on **3/3** full-suite coverage runs (a per-test `{ timeout: 15000 }` cap that coverage-load blows deterministically), making it impossible to warm the cache or push any orchestrator change without also fixing it. Both CLI flakes are the identical classes fixed here for orchestrator, so they are addressed in the same PR with their own changeset.

## Orchestrator (`@harness-engineering/orchestrator`)

| Test | Before | After |
|------|--------|-------|
| `telemetry-latency` — p99 exporter overhead budget | Coverage-relaxation branch keyed on `NODE_V8_COVERAGE`/`VITEST_COVERAGE` — **neither is set in the vitest worker under `--coverage`**, so the branch was dead and the strict 5 ms budget applied under coverage (reproduced failing at ~6.7 ms). | `vitest.config.mts` detects `--coverage` in argv and forwards `HARNESS_COVERAGE` into the worker env; the test reads it and applies the intended relaxed 250 ms budget. Intent (bounded exporter overhead) preserved. |
| `orchestrator-model-pool`, `orchestrator`, `file-less-stub` — git-subprocess `beforeEach` hook timeouts | Inherited the package-global 90 s hook ceiling, which still occasionally blew under full-suite coverage load (parallel workers all cold-starting `git init`+commit at once). | Global `testTimeout`/`hookTimeout` raised 90 s → 120 s. A higher ceiling only tolerates a slow/loaded runner — a genuine hang still fails. |
| `server/integration` SC8 — plan-watcher auto-resolve | Fixed `setTimeout(1000)` raced the async watcher under load → `expected 'pending' to be 'resolved'`. | Polling `vi.waitFor` (15 s ceiling, 50 ms interval): returns as soon as the watcher fires, only fails if resolution never happens. |

## CLI (`@harness-engineering/cli`)

| Test | Before | After |
|------|--------|-------|
| `slash-commands/integration` — detects orphaned codex skill dirs | Per-test `{ timeout: 15000 }` cap overriding the package 90 s ceiling; runs `generateSlashCommands` twice (heavy fs writes) and blew 15 s on effectively every coverage run. | Cap removed → inherits the 90 s ceiling (same fix as #1153 for orchestrator). |
| `commands/scan-config` — scans large config within 100 ms | Hard 100 ms perf budget that v8 instrumentation inflates past. | Coverage-aware via `HARNESS_COVERAGE` (forwarded from `vitest.config.mts`): 2000 ms under coverage, 100 ms otherwise — still catches an order-of-magnitude regression. |

## Verification

- Orchestrator full `test:coverage`: **3× green** (2484 passed each), plus targeted stress under 12 CPU hogs — telemetry **6/6 green** at the relaxed budget (previously failed ~1/4 at 5 ms), SC8 **4/4 green**.
- CLI full `test:coverage` via turbo: **2× green (`--force`)** — 503 files / 5772 tests each (previously failed on 1–2 tests every run).
- Constraints: `.harness/arch/baselines.json` unchanged (0-diff vs main), `.claude-plugin/commands/*.md` count unchanged (69), strictly test-only + vitest config + changesets.

## Follow-up note for reviewer

The pre-push gate running the **full** `test:coverage` (not `--affected`) means any package's coverage flake blocks the whole fleet. CLI has additional latent same-class perf budgets (e.g. `graph-loader` 5 ms, `dispatcher.perf` 500/1000 ms) that did not fail in this round but are the same risk; a dedicated CLI-wide deflake (mirroring core → orchestrator → cli) would be worth a follow-up.
