### PR TITLE
chore(dogfood): opt this repo into the secrets-and-injection constraint pack

### DIFF
--- a/harness.config.json
+++ b/harness.config.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "name": "harness-engineering",
+  "constraintPacks": ["secrets-and-injection"],
   "layers": [
     {
       "name": "types",


### PR DESCRIPTION
## What

Dogfoods the opt-in constraint packs (#1126, now merged) by opting **this** repo into the `secrets-and-injection` pack in `harness.config.json`:

```json
"constraintPacks": ["secrets-and-injection"]
```

Elevates `SEC-SEC-*` (hardcoded secrets) and `SEC-INJ-*` (injection) to **blocking (error)** at pre-merge and pre-release via the named pack, instead of hand-maintaining equivalent `security.rules` overrides.

## Verification
- `harness ci check --stage pre-merge` passes on current main with the pack active: **exit 0**, no blocking secrets/injection findings, pack recognized (no unknown-pack warning).
- One-line config change; no code.

## Scope
`secrets-and-injection` is the first dogfood pack (universally valuable, zero current violations). `ai-agent-safety` and `web-hardening` can follow once their rule surfaces are confirmed clean here.