### PR TITLE
fix(review): treat command-substitution values as reference-only in the CWE-798 secret detector

### DIFF
--- a/.changeset/secret-reference-command-substitution.md
+++ b/.changeset/secret-reference-command-substitution.md
@@ -1,0 +1,21 @@
+---
+'@harness-engineering/core': patch
+---
+
+Stop the CWE-798 secret detector flagging command-substitution values as
+hardcoded secrets.
+
+The reference-vs-literal guard already suppressed variable references
+(`$NAME`, `${NAME}`, `${NAME:-default}`) and CI expressions
+(`${{ secrets.X }}`). It still flagged a quoted **command substitution**, whose
+value is produced by running a command at runtime rather than embedded in
+source, e.g. `GH_TOKEN="$(gh auth token)"` or the backtick form. That fired a
+blocking `critical` on the ordinary, shellcheck-clean way to pass a token to a
+subcommand in a CI workflow.
+
+`isReferenceOnlySecretValue` now strips single-level `$( ... )` and backtick
+`` ` ... ` `` substitutions before its literal-residue check, so both the
+heuristic review-tier detector and the deterministic `SEC-SEC-*` rules stop
+mis-firing. Genuine literals — including a command substitution mixed with a
+literal suffix (`"$(id)-sk-live-..."`) and nested substitutions — are still
+detected.

--- a/docs/changes/cwe798-quoted-varref/proposal.md
+++ b/docs/changes/cwe798-quoted-varref/proposal.md
@@ -1,0 +1,161 @@
+---
+feature: cwe798-quoted-varref
+status: planned
+tier: small
+keywords:
+  - security-review
+  - CWE-798
+  - hardcoded-secret
+  - secret-reference
+  - command-substitution
+  - false-positive
+tracks:
+  - review-quality
+issue: '#1095'
+---
+
+# CWE-798 secret detector: treat command-substitution values as reference-only
+
+## Overview
+
+The review floor's hardcoded-secret detector (CWE-798) fires `critical` on quoted
+shell assignments whose value is not a literal. External issue #1095 reports that
+`GH_TOKEN="$VAR"`-style lines flip the `review-ci` verdict to `request-changes`
+(`exitCode: 1`) on essentially every PR that touches a GitHub Actions workflow,
+even though the secret never appears in source.
+
+A prior fix (`security/secret-reference.ts`, shipped as the reference-only guard)
+already suppresses the two literal repro forms from the issue — shell/env variable
+references (`$VAR`, `${VAR}`, `${VAR:-$OTHER}`) and CI expressions
+(`${{ secrets.X }}`). Verified against `origin/main`: those exact repro lines are
+now clean.
+
+One form the issue explicitly calls out remains a live false positive: a **command
+substitution** — `TOKEN="$(gh auth token)"` or the backtick form
+``TOKEN="`gh auth token`"``. The value is produced at runtime by running a
+command; no secret literal is assigned in source, yet the detector still emits a
+blocking `critical`. This change extends the same shared guard to recognize
+command-substitution values as reference-only.
+
+## Problem boundary
+
+**In scope:** Extend `isReferenceOnlySecretValue` in
+`packages/core/src/security/secret-reference.ts` so a value composed solely of
+command-substitution and/or variable/expression references is treated as
+reference-only. Both detection tiers that already consume this predicate benefit
+without further change:
+
+- the heuristic review-tier detector (`packages/core/src/review/agents/security-agent.ts`, `detectHardcodedSecrets`)
+- the deterministic secret rules (`packages/core/src/security/scanner.ts`, `SEC-SEC-*`)
+
+**Out of scope (deliberate YAGNI):** the issue's other two suggestions — a
+confidence floor for verdict-affecting findings, and making `security.exclude`
+apply to `review-ci`. Both are larger, independent changes; this proposal is the
+narrow, highest-leverage fix (issue suggestion #1) and stays in the family of the
+existing reference-only guard.
+
+## Decisions made
+
+- **D1 — Extend the existing shared guard, not the two call sites.** The
+  reference-vs-literal decision already lives once in `secret-reference.ts` and is
+  consumed by both detection tiers (`security-agent.ts:374`,
+  `scanner.ts:170`). Adding the command-substitution forms there means one edit
+  fixes both tiers, exactly as the prior fix intended. _Evidence:_
+  `packages/core/src/security/secret-reference.ts` (shared predicate);
+  `packages/core/src/review/agents/security-agent.ts:374`;
+  `packages/core/src/security/scanner.ts:170`.
+
+- **D2 — Strip command-substitution forms `$(…)` and `` `…` `` before the residue
+  check.** `isReferenceOnlySecretValue` works by removing every reference form and
+  then asking whether any alphanumeric residue remains (a literal leaves residue;
+  a pure reference leaves none). Command substitution is added to that strip list:
+  `$( … )` (single level) and backtick `` ` … ` ``. _Evidence:_ the existing
+  strip-then-residue algorithm in `secret-reference.ts` (`CI_EXPRESSION`,
+  `SHELL_BRACE_VAR`, `SHELL_BARE_VAR`).
+
+- **D3 — Conservative boundaries, documented, favoring the false positive over
+  the false negative.** For a security control a false positive is safer than a
+  false negative, so where the value cannot be cleanly proven reference-only it
+  stays flagged:
+  - **Mixed values stay flagged.** A command substitution followed by a literal
+    suffix — the value `$(id)-literalsuffix` — keeps its `literalsuffix` residue
+    and is still detected; only pure reference/command-substitution values are
+    suppressed.
+  - **Nested command substitution stays flagged.** The single-level
+    `$([^()]*)` pattern does not fully consume `$(a $(b))`, leaving residue, so
+    the value is conservatively still flagged. Nested command substitution in a
+    `TOKEN=` assignment is not a shape real code uses.
+  - **Known boundary — a literal wholly inside a command substitution**
+    (`TOKEN="$(echo sk-ant-literal)"`) is treated as reference-only and therefore
+    suppressed. This is accepted and documented: a command substitution assigns
+    the command's runtime output, not a static literal, and hiding a secret inside
+    `echo` is an adversarial evasion, not the CWE-798 "hardcoded literal" shape
+    (which — written directly — is still caught). The entropy/gitleaks tiers
+    remain the backstop for that pathological case. This mirrors the existing
+    documented partial-literal boundary in the module.
+
+## Technical design
+
+`packages/core/src/security/secret-reference.ts`:
+
+```ts
+// Command substitution: `$( … )` (single level) and backtick `` ` … ` ``.
+// The value is the command's runtime output — no literal is assigned in source.
+const COMMAND_SUBSTITUTION = /\$\([^()]*\)/g;
+const BACKTICK_SUBSTITUTION = /`[^`]*`/g;
+```
+
+These two `.replace(…, '')` calls are added to the existing strip chain in
+`isReferenceOnlySecretValue`, before the final alphanumeric-residue test. The
+`extractQuotedSecretValue` helper is unchanged — command-substitution values
+already arrive quoted (`TOKEN="$(…)"`), and pattern 1 of `SECRET_PATTERNS`
+captures the quoted value up to the closing quote.
+
+No signature changes, no new exports, no call-site changes.
+
+## Integration points
+
+- **Entry Points:** None new. The two existing consumers of
+  `isReferenceOnlySecretValue` (review-tier detector, deterministic `SEC-SEC-*`
+  rules) inherit the behavior.
+- **Registrations Required:** None. No barrel/export/registry changes.
+- **Documentation Updates:** None beyond the changeset. Detector body carries no
+  internal issue/PR references (it runs in adopter repos).
+- **Architectural Decisions:** None rise to a standalone ADR — this is a small,
+  in-family extension of an existing guard.
+- **Knowledge Impact:** Reinforces the existing "reference-vs-literal" concept for
+  secret detection; no new graph concepts.
+
+## Success criteria
+
+1. **False positive clears (review tier):** a changed file containing
+   `TOKEN="$(gh auth token)"` produces zero hardcoded-secret findings from
+   `runSecurityAgent`.
+2. **False positive clears (backtick):** ``TOKEN="`gh auth token`"`` produces
+   zero findings.
+3. **Predicate unit truth:** `isReferenceOnlySecretValue("$(gh auth token)")` and
+   `isReferenceOnlySecretValue("`gh auth token`")` both return `true`.
+4. **Genuine secret still fires (control):** a changed line that assigns a
+   literal API key directly (an `sk-ant-…` value, per the fixture in
+   `security-agent.test.ts`) still produces exactly one `critical` CWE-798
+   finding.
+5. **Mixed value still fires (conservative boundary):**
+   `isReferenceOnlySecretValue("$(id)-sk-ant-literalsuffix")` returns `false`.
+6. **Nested command substitution still fires:**
+   `isReferenceOnlySecretValue("$(a $(b))")` returns `false`.
+7. **Issue repro remains clean (regression lock-in for the prior fix):**
+   `GH_TOKEN="${AUTO_MERGE_TOKEN:-$GH_TOKEN}"` and `GH_TOKEN="$PR_CRED"` produce
+   zero findings.
+8. `review-ci --diff origin/main...HEAD` on this branch reports
+   `blockingFindings: []` and `exitCode: 0`.
+
+## Implementation order
+
+1. Extend `isReferenceOnlySecretValue` with the two command-substitution strip
+   forms and document the boundaries (D3).
+2. Add regression tests:
+   - `secret-reference.test.ts` — predicate cases (criteria 3, 5, 6, and the
+     literal-inside-command-substitution boundary).
+   - `security-agent.test.ts` — review-tier detector cases (criteria 1, 2, 4).
+3. Verify: full build, targeted tests, `review-ci` self-scan, then the full
+   pre-push gauntlet. Add a `patch` changeset for `@harness-engineering/core`.

--- a/packages/core/src/security/secret-reference.ts
+++ b/packages/core/src/security/secret-reference.ts
@@ -7,6 +7,9 @@
  *  - a shell/env variable: `$NAME`, `${NAME}`, `${NAME:-default}`
  *  - a CI expression: `${{ secrets.X }}`, `${{ env.X }}`, `${{ vars.X }}`, or
  *    any `${{ ... }}`
+ *  - a command substitution: `$( ... )` or a backtick `` ` ... ` `` — the value
+ *    is the command's runtime output, so no secret literal is assigned in source
+ *    (`GH_TOKEN="$(gh auth token)"`)
  *
  * These reference forms appear on essentially every CI workflow line that wires
  * a secret into an env var (`GH_TOKEN="$AUTOAPPROVE_PAT"`,
@@ -24,6 +27,14 @@ const CI_EXPRESSION = /\$\{\{[^{}]*\}\}/g;
 const SHELL_BRACE_VAR = /\$\{[^{}]*\}/g;
 // Shell/env bare form: `$NAME`.
 const SHELL_BARE_VAR = /\$[A-Za-z_][A-Za-z0-9_]*/g;
+// Command substitution, single level: `$( ... )`. The value is produced by
+// running the command at runtime — nothing is embedded in source. The inner
+// class excludes parens so a single level is consumed whole; a nested
+// substitution (`$(a $(b))`) is deliberately NOT fully consumed, leaving
+// residue so the conservative branch keeps it flagged.
+const COMMAND_SUBSTITUTION = /\$\([^()]*\)/g;
+// Backtick command substitution: `` ` ... ` ``. Same runtime-output rationale.
+const BACKTICK_SUBSTITUTION = /`[^`]*`/g;
 
 /**
  * True when `value` (the extracted right-hand side of a secret-shaped
@@ -37,12 +48,25 @@ const SHELL_BARE_VAR = /\$[A-Za-z_][A-Za-z0-9_]*/g;
  * literal such as `prefix-${VAR}` deliberately keeps its `prefix` residue and is
  * therefore NOT treated as reference-only — the conservative choice keeps real
  * secret detection intact.
+ *
+ * Command substitution is stripped whole, so `"$(gh auth token)"` is
+ * reference-only. Two conservative boundaries follow from that, both favoring a
+ * false positive over a false negative:
+ *  - a mixed value keeps its literal residue and stays flagged
+ *    (`"$(id)-sk-ant-live"` → `-skantlive`);
+ *  - a literal placed *inside* a command substitution (`"$(echo sk-ant-x)"`) is
+ *    treated as reference-only. This is accepted: a command substitution assigns
+ *    the command's runtime output, not a static literal, and a directly written
+ *    literal is still caught — the entropy/gitleaks tiers backstop the
+ *    adversarial `echo`-a-secret shape.
  */
 export function isReferenceOnlySecretValue(value: string): boolean {
   const trimmed = value.trim();
   if (trimmed === '') return false;
   const withoutRefs = trimmed
     .replace(CI_EXPRESSION, '')
+    .replace(COMMAND_SUBSTITUTION, '')
+    .replace(BACKTICK_SUBSTITUTION, '')
     .replace(SHELL_BRACE_VAR, '')
     .replace(SHELL_BARE_VAR, '');
   return !/[A-Za-z0-9]/.test(withoutRefs);

--- a/packages/core/tests/review/agents/security-agent.test.ts
+++ b/packages/core/tests/review/agents/security-agent.test.ts
@@ -566,6 +566,52 @@ describe('runSecurityAgent()', () => {
     expect(runSecurityAgent(bundle).length).toBe(1);
   });
 
+  // ---- command substitution: `$( ... )` / backticks produce the value at
+  // runtime, so no secret literal is assigned in source and the finding must
+  // not fire (issue-reported false positive: `GH_TOKEN="$(gh auth token)"`). ----
+
+  it('does NOT flag a $() command-substitution value assigned to a token', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: '.github/workflows/ci.yml',
+          content: 'GH_TOKEN="$(gh auth token)" gh pr create --title x',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('does NOT flag a backtick command-substitution value assigned to a token', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'deploy/run.sh',
+          content: 'API_KEY="`vault read -field=token secret/ci`"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  it('STILL flags a command substitution mixed with a literal suffix (guard must not over-suppress)', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'deploy/run.sh',
+          content: 'export API_KEY="$(id -u)-sk-live-0123456789abcdef"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(1);
+  });
+
   // ---- guards are code-scoped: test-markers and comment syntax are JS/TS
   // conventions, so they must not suppress findings in non-code files ----
 

--- a/packages/core/tests/security/secret-reference.test.ts
+++ b/packages/core/tests/security/secret-reference.test.ts
@@ -14,6 +14,11 @@ describe('isReferenceOnlySecretValue', () => {
     ['${{ vars.MY_VAR }}', 'CI vars expression'],
     ['${{ secrets.A }}-${{ secrets.B }}', 'two CI expressions joined by punctuation'],
     ['  $TOKEN  ', 'reference with surrounding whitespace'],
+    ['$(gh auth token)', 'command substitution'],
+    ['$( aws secretsmanager get-secret-value )', 'command substitution with spaces'],
+    ['`gh auth token`', 'backtick command substitution'],
+    ['$(gh auth token) ${FALLBACK}', 'command substitution + brace ref'],
+    ['$(echo sk-ant-live-hidden)', 'literal inside command substitution (documented boundary)'],
   ])('treats %s (%s) as reference-only', (value) => {
     expect(isReferenceOnlySecretValue(value)).toBe(true);
   });
@@ -23,6 +28,8 @@ describe('isReferenceOnlySecretValue', () => {
     ['hunter2hunter2', 'literal password'],
     ['${PREFIX}sk-live-abc123', 'partial: reference + literal residue'],
     ['prefix-${VAR}', 'partial: literal prefix + reference'],
+    ['$(id)-sk-ant-literalsuffix', 'partial: command substitution + literal residue'],
+    ['$(a $(b))', 'nested command substitution stays flagged (conservative)'],
     ['', 'empty string'],
     ['   ', 'whitespace only'],
   ])('treats %s (%s) as NOT reference-only', (value) => {


### PR DESCRIPTION
Fixes #1095

## Problem

The review floor's CWE-798 hardcoded-secret detector fires a blocking `critical`
on a quoted shell assignment whose value is a **command substitution** —
`GH_TOKEN="$(gh auth token)"` or the backtick form. The value is produced at
runtime by running a command; no secret literal appears in source, yet the
finding flips `review-ci` to `request-changes` / `exitCode: 1` on ordinary,
shellcheck-clean CI workflow lines.

The reference-vs-literal guard (`security/secret-reference.ts`) already suppressed
the issue's other repro forms — shell/env variables (`$VAR`, `${VAR}`,
`${VAR:-$OTHER}`) and CI expressions (`${{ secrets.X }}`). Command substitution
was the remaining live false positive (issue suggestion #1).

## Root cause

`isReferenceOnlySecretValue` strips known reference forms and then flags the value
if any alphanumeric residue remains. `$( ... )` and `` ` ... ` `` were not in the
strip list, so a command-substitution value left residue (`$(gh auth token)` →
`ghauthtoken`) and was treated as a literal.

## Fix

Add single-level `$( ... )` and backtick `` ` ... ` `` to the strip chain, before
the residue check. One edit in the shared guard fixes both detection tiers (the
heuristic review-tier detector and the deterministic `SEC-SEC-*` rules).

## Conservatism (security control — no weakened detection)

- Mixed values stay flagged: `$(id)-sk-live-...` keeps its literal residue.
- Nested `$(a $(b))` is not fully consumed → stays flagged.
- Genuine literals still fire `critical` (covered by control tests).
- Documented boundary: a literal placed wholly inside `$(echo ...)` is treated as
  reference-only (a command substitution assigns runtime output, not a static
  literal; directly written literals are still caught; entropy/gitleaks backstop
  the adversarial case).

## Verification

- `review-ci --diff origin/main...HEAD` on this branch: `approve | exitCode: 0`.
- New regression tests in `secret-reference.test.ts` (predicate) and
  `security-agent.test.ts` (review-tier detector) cover both directions:
  command-substitution false positives clear AND genuine secrets / mixed / nested
  values still fire.
- Full build (13/13), lint, typecheck green; baselines byte-identical; plugin
  check EXIT 0 with unchanged command count.

Spec: `docs/changes/cwe798-quoted-varref/proposal.md`.