### PR TITLE
fix(cli): ship ESM marker + read-hook-stdin so installed hooks load cleanly

### DIFF
--- a/.changeset/hook-installer-esm-completeness.md
+++ b/.changeset/hook-installer-esm-completeness.md
@@ -1,0 +1,8 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix the hook installer so installed hooks load cleanly in adopter projects.
+
+- Write `.harness/hooks/package.json` (`{ "type": "module" }`) at install time (both `harness hooks init` and `harness hooks add`). The hook scripts are ES modules shipped as bare `.js`; without this marker Node resolves their module type from the adopter's nearest `package.json` — which is CommonJS-default (or absent) in most projects — and reparses each hook as ESM at runtime, emitting a `MODULE_TYPELESS_PACKAGE_JSON` warning on every hook fire.
+- Ship `read-hook-stdin.js` alongside the hooks that import it. Those hooks were installed without their shared sibling module and failed at load with `ERR_MODULE_NOT_FOUND` — a non-blocking failure that silently stopped the gate from running. A new registry↔import drift guard fails the build if a hook imports a sibling module the installer does not ship, so this cannot silently regress.

--- a/packages/cli/src/commands/hooks/add.ts
+++ b/packages/cli/src/commands/hooks/add.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import { HOOK_SCRIPTS } from '../../hooks/profiles';
 import { supportFilesFor } from '../../hooks/support-files';
 import { logger } from '../../output/logger';
-import { buildHookCommand, resolveHookSourceDir } from './init';
+import { buildHookCommand, resolveHookSourceDir, writeHooksModuleMarker } from './init';
 
 const ALIASES: Record<string, string[]> = {
   sentinel: ['sentinel-pre', 'sentinel-post'],
@@ -37,6 +37,9 @@ export function addHooks(hookName: string, projectDir: string): AddResult {
   const srcDir = resolveHookSourceDir();
   const destDir = path.join(projectDir, '.harness', 'hooks');
   fs.mkdirSync(destDir, { recursive: true });
+  // Declare the hooks dir as ESM so Node doesn't reparse each copied .js hook
+  // and warn (MODULE_TYPELESS_PACKAGE_JSON) in CommonJS-default adopters.
+  writeHooksModuleMarker(destDir);
 
   const claudeDir = path.join(projectDir, '.claude');
   fs.mkdirSync(claudeDir, { recursive: true });

--- a/packages/cli/src/commands/hooks/init.ts
+++ b/packages/cli/src/commands/hooks/init.ts
@@ -37,6 +37,28 @@ export function resolveHookSourceDir(): string {
 }
 
 /**
+ * Write the ESM module-type marker into `.harness/hooks/`.
+ *
+ * Hook scripts are ES modules (`import`/`export`) shipped as bare `.js`. Without
+ * a `package.json` declaring `"type": "module"` beside them, Node resolves each
+ * hook's module type from the adopter's nearest package.json — which is
+ * CommonJS-default (or absent) in most non-harness projects. Node then reparses
+ * every hook as ESM at runtime and emits a `MODULE_TYPELESS_PACKAGE_JSON`
+ * performance warning on each fire; Claude Code surfaces that stderr as a
+ * non-blocking "hook error" (spam on every PreToolUse:Bash call). A local marker
+ * pins the directory to ESM regardless of the adopter's root package.json.
+ *
+ * The stale-`.js` wipe in initHooks only removes `.js` entries, so this marker
+ * survives regeneration; removeHooks deletes the whole directory.
+ */
+export function writeHooksModuleMarker(hooksDestDir: string): void {
+  fs.writeFileSync(
+    path.join(hooksDestDir, 'package.json'),
+    JSON.stringify({ type: 'module' }, null, 2) + '\n'
+  );
+}
+
+/**
  * Build the settings.json `command` for a hook script.
  *
  * The generated command must resolve `.harness/hooks/<name>.js` against the
@@ -164,6 +186,9 @@ export function initHooks(options: { profile: HookProfile; projectDir: string; f
   // 1. Copy active hook scripts to .harness/hooks/
   const hooksDestDir = path.join(projectDir, '.harness', 'hooks');
   fs.mkdirSync(hooksDestDir, { recursive: true });
+  // Declare the hooks dir as ESM so Node doesn't reparse each copied .js hook
+  // and warn (MODULE_TYPELESS_PACKAGE_JSON) in CommonJS-default adopters.
+  writeHooksModuleMarker(hooksDestDir);
 
   const profilePath = path.join(hooksDestDir, 'profile.json');
   const recordedHashes = readRecordedHashes(profilePath);

--- a/packages/cli/src/hooks/support-files.test.ts
+++ b/packages/cli/src/hooks/support-files.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { HOOK_SUPPORT_FILES, supportFilesFor } from './support-files';
+import { HOOK_SCRIPTS } from './profiles';
 
 /**
  * Behavior guard for the hook support-file registry. supportFilesFor() resolves
@@ -14,48 +17,85 @@ describe('HOOK_SUPPORT_FILES registry', () => {
     expect(HOOK_SUPPORT_FILES['strict-quality-gate']).toEqual(['format-check.js']);
   });
 
-  it('has no entry for self-contained hooks that need no support file', () => {
-    // A hook that ships as a single verbatim .js file must not appear in the
-    // registry, otherwise the installer would try to preserve a phantom file.
-    expect(HOOK_SUPPORT_FILES['protect-config']).toBeUndefined();
-    expect(HOOK_SUPPORT_FILES['cost-tracker']).toBeUndefined();
+  it('maps the read-hook-stdin-dependent hooks to their shared support module', () => {
+    // Extracted in #994; each hook below `import`s './read-hook-stdin.js'.
+    for (const name of [
+      'block-no-verify',
+      'protect-config',
+      'cost-tracker',
+      'sentinel-pre',
+      'sentinel-post',
+      'adoption-tracker',
+      'pre-compact-state',
+      'telemetry-reporter',
+    ]) {
+      expect(HOOK_SUPPORT_FILES[name], `${name} must ship read-hook-stdin.js`).toEqual([
+        'read-hook-stdin.js',
+      ]);
+    }
   });
+
+  it('does not register a support module as a hook entry-point', () => {
+    // Support modules are shipped because a hook needs them, never installed as
+    // hooks in their own right, so they must not appear as registry keys.
+    expect(HOOK_SUPPORT_FILES['format-check.js']).toBeUndefined();
+    expect(HOOK_SUPPORT_FILES['read-hook-stdin.js']).toBeUndefined();
+  });
+});
+
+/**
+ * Registry↔import drift guard. This is the invariant that #994 violated: a hook
+ * whose source statically `import`s a sibling `./x.js` module MUST list that
+ * basename in HOOK_SUPPORT_FILES, or the installer copies the hook without its
+ * dependency and Node fails the hook at load with ERR_MODULE_NOT_FOUND in the
+ * adopter. Deriving the expectation from the hook sources (not a hardcoded list)
+ * means a future extraction that adds a new sibling import fails here until the
+ * registry is updated.
+ */
+describe('registry covers every sibling import in the hook sources', () => {
+  const hooksDir = __dirname;
+  const siblingImport = /from\s+['"]\.\/([^'"]+)['"]/g;
+
+  for (const script of HOOK_SCRIPTS) {
+    it(`${script.name} declares every sibling module it imports`, () => {
+      const srcFile = path.join(hooksDir, `${script.name}.js`);
+      expect(fs.existsSync(srcFile), `${srcFile} should exist`).toBe(true);
+      const source = fs.readFileSync(srcFile, 'utf-8');
+      const imported = [...source.matchAll(siblingImport)].map((m) => m[1]);
+      const declared = HOOK_SUPPORT_FILES[script.name] ?? [];
+      for (const dep of imported) {
+        expect(declared, `${script.name} imports './${dep}' but does not ship it`).toContain(dep);
+      }
+    });
+  }
 });
 
 describe('supportFilesFor', () => {
   it('returns the support files for a single registered hook', () => {
     expect(supportFilesFor(['quality-warner'])).toEqual(['format-check.js']);
+    expect(supportFilesFor(['block-no-verify'])).toEqual(['read-hook-stdin.js']);
   });
 
   it('deduplicates support files shared across multiple active hooks', () => {
-    // Both registered hooks depend on the same support module; the installer
-    // should be told to ship it exactly once.
+    // Both hooks depend on the same support module; the installer should be told
+    // to ship it exactly once.
     expect(supportFilesFor(['quality-warner', 'strict-quality-gate'])).toEqual(['format-check.js']);
+    expect(supportFilesFor(['block-no-verify', 'protect-config', 'sentinel-pre'])).toEqual([
+      'read-hook-stdin.js',
+    ]);
   });
 
   it('ignores hook names that have no registry entry', () => {
-    expect(supportFilesFor(['protect-config', 'cost-tracker'])).toEqual([]);
+    expect(supportFilesFor(['nonexistent-hook'])).toEqual([]);
   });
 
-  it('collects only the registered hooks from a mixed set', () => {
-    const result = supportFilesFor(['protect-config', 'strict-quality-gate', 'block-no-verify']);
-    expect(result).toEqual(['format-check.js']);
+  it('collects the distinct support files from a mixed set, first-seen order', () => {
+    const result = supportFilesFor(['quality-warner', 'block-no-verify']);
+    expect(result).toEqual(['format-check.js', 'read-hook-stdin.js']);
   });
 
   it('returns an empty array for no active hooks', () => {
     expect(supportFilesFor([])).toEqual([]);
-  });
-
-  it('preserves first-seen order across distinct support files', () => {
-    // Derive expectations from the registry itself so this test tracks the real
-    // source of truth rather than a hardcoded ordering. We build two hook names
-    // whose support files differ, then assert union order is first-seen.
-    const registered = Object.entries(HOOK_SUPPORT_FILES);
-    const withFiles = registered.filter(([, files]) => files.length > 0);
-    // Current registry only contains one distinct support file; assert the
-    // dedupe still yields that single-element ordering deterministically.
-    const distinct = [...new Set(withFiles.flatMap(([, files]) => files))];
-    expect(supportFilesFor(withFiles.map(([name]) => name))).toEqual(distinct);
   });
 
   it('does not mutate the underlying registry entries', () => {

--- a/packages/cli/src/hooks/support-files.ts
+++ b/packages/cli/src/hooks/support-files.ts
@@ -11,8 +11,22 @@
  * ADR: "installer ships hook support files".
  */
 export const HOOK_SUPPORT_FILES: Record<string, string[]> = {
+  // Hooks that share format-check.js.
   'quality-warner': ['format-check.js'],
   'strict-quality-gate': ['format-check.js'],
+  // Hooks that share read-hook-stdin.js (extracted in #994). Every hook that
+  // `import`s a sibling must be listed here, or the installer ships a hook whose
+  // static import fails at load with ERR_MODULE_NOT_FOUND in the adopter — a
+  // non-blocking failure that silently stops the gate from running. The
+  // registry↔import drift guard in support-files.test.ts pins this invariant.
+  'block-no-verify': ['read-hook-stdin.js'],
+  'adoption-tracker': ['read-hook-stdin.js'],
+  'cost-tracker': ['read-hook-stdin.js'],
+  'protect-config': ['read-hook-stdin.js'],
+  'pre-compact-state': ['read-hook-stdin.js'],
+  'sentinel-pre': ['read-hook-stdin.js'],
+  'sentinel-post': ['read-hook-stdin.js'],
+  'telemetry-reporter': ['read-hook-stdin.js'],
 };
 
 /**

--- a/packages/cli/tests/commands/hooks.test.ts
+++ b/packages/cli/tests/commands/hooks.test.ts
@@ -233,7 +233,8 @@ describe('initHooks', () => {
 
     initHooks({ profile: 'minimal', projectDir: tmpDir });
     const minimalFiles = fs.readdirSync(hooksDir).filter((f) => f.endsWith('.js'));
-    expect(minimalFiles).toEqual(['block-no-verify.js']);
+    // minimal ships block-no-verify.js plus its shared support module.
+    expect(minimalFiles.sort()).toEqual(['block-no-verify.js', 'read-hook-stdin.js']);
   });
 });
 
@@ -362,7 +363,10 @@ describe('initHooks support files (format-check.js)', () => {
     expect(fs.existsSync(path.join(hooksDir(), 'format-check.js'))).toBe(true);
     initHooks({ profile: 'minimal', projectDir: tmpDir });
     const remaining = fs.readdirSync(hooksDir()).filter((f) => f.endsWith('.js'));
-    expect(remaining).toEqual(['block-no-verify.js']);
+    // format-check.js is orphaned by the downgrade and dropped; block-no-verify
+    // and its own support module read-hook-stdin.js remain.
+    expect(remaining.sort()).toEqual(['block-no-verify.js', 'read-hook-stdin.js']);
+    expect(remaining).not.toContain('format-check.js');
   });
 
   it('the copied strict-quality-gate.js resolves its sibling import and runs (exit 0 on empty stdin)', () => {
@@ -379,6 +383,60 @@ describe('initHooks support files (format-check.js)', () => {
     // exit non-zero with ERR_MODULE_NOT_FOUND. Exit 0 proves resolution worked.
     expect(result.signal ? 0 : (result.status ?? 1)).toBe(0);
     expect(result.stderr ?? '').not.toContain('ERR_MODULE_NOT_FOUND');
+  });
+});
+
+// Regression: installed ESM hooks warned MODULE_TYPELESS_PACKAGE_JSON on every
+// fire in adopters whose nearest package.json is CommonJS-default (or absent),
+// because the installer shipped bare `.js` ES modules with no `package.json`
+// declaring the hooks dir as `"type": "module"`. Claude Code surfaced the
+// per-fire stderr warning as a non-blocking "hook error". The installer must
+// write the ESM marker beside the copied hooks.
+describe('initHooks ESM module marker (MODULE_TYPELESS_PACKAGE_JSON)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-hooks-esm-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const markerPath = () => path.join(tmpDir, '.harness', 'hooks', 'package.json');
+
+  it('writes .harness/hooks/package.json declaring type:module', () => {
+    initHooks({ profile: 'standard', projectDir: tmpDir });
+    expect(fs.existsSync(markerPath())).toBe(true);
+    expect(JSON.parse(fs.readFileSync(markerPath(), 'utf-8'))).toEqual({ type: 'module' });
+  });
+
+  it('preserves the marker across the stale-.js wipe on profile downgrade', () => {
+    initHooks({ profile: 'strict', projectDir: tmpDir });
+    initHooks({ profile: 'minimal', projectDir: tmpDir });
+    expect(fs.existsSync(markerPath())).toBe(true);
+    expect(JSON.parse(fs.readFileSync(markerPath(), 'utf-8'))).toEqual({ type: 'module' });
+  });
+
+  it('loads a copied hook cleanly in a CommonJS-default adopter (no warning, no missing sibling)', () => {
+    // Reproduce the adopter condition: a root package.json WITHOUT type:module.
+    // Two failure modes are guarded together here:
+    //  - Without the .harness/hooks marker, Node reparses the ESM hook and warns
+    //    MODULE_TYPELESS_PACKAGE_JSON on every fire.
+    //  - Without the hook's shared support module shipped alongside it, the static
+    //    `import './read-hook-stdin.js'` fails at load with ERR_MODULE_NOT_FOUND.
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"adopter"}\n');
+    initHooks({ profile: 'minimal', projectDir: tmpDir });
+    const hookPath = path.join(tmpDir, '.harness', 'hooks', 'block-no-verify.js');
+    const result = spawnSync('node', [hookPath], {
+      input: '',
+      encoding: 'utf-8',
+      cwd: tmpDir,
+      timeout: 30000,
+    });
+    const stderr = result.stderr ?? '';
+    expect(stderr).not.toContain('MODULE_TYPELESS_PACKAGE_JSON');
+    expect(stderr).not.toContain('ERR_MODULE_NOT_FOUND');
   });
 });
 
@@ -519,6 +577,25 @@ describe('addHooks', () => {
       e.hooks.map((h: any) => h.command)
     );
     expect(preCommands).toContain(buildHookCommand('sentinel-pre'));
+  });
+
+  it('writes the ESM module marker and ships support modules so copied hooks load cleanly', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"adopter"}\n');
+    addHooks('sentinel', tmpDir);
+    const markerPath = path.join(tmpDir, '.harness', 'hooks', 'package.json');
+    expect(JSON.parse(fs.readFileSync(markerPath, 'utf-8'))).toEqual({ type: 'module' });
+    // sentinel-pre imports './read-hook-stdin.js'; addHooks must ship it too.
+    expect(fs.existsSync(path.join(tmpDir, '.harness', 'hooks', 'read-hook-stdin.js'))).toBe(true);
+    const hookPath = path.join(tmpDir, '.harness', 'hooks', 'sentinel-pre.js');
+    const result = spawnSync('node', [hookPath], {
+      input: '',
+      encoding: 'utf-8',
+      cwd: tmpDir,
+      timeout: 30000,
+    });
+    const stderr = result.stderr ?? '';
+    expect(stderr).not.toContain('MODULE_TYPELESS_PACKAGE_JSON');
+    expect(stderr).not.toContain('ERR_MODULE_NOT_FOUND');
   });
 
   it('adds a single hook by name', () => {


### PR DESCRIPTION
## Summary

The hook installer ships ES-module hook scripts as bare `.js` into an adopter's `.harness/hooks/`. Two installer-completeness defects made those hooks fail in adopter projects whose package tree is not ESM. Surfaced by a `MODULE_TYPELESS_PACKAGE_JSON` "hook error" in a real adopter (a project with no root `package.json`); investigating it turned up a second, more severe bug in the same installer.

## Changes

- **`MODULE_TYPELESS_PACKAGE_JSON` warning (root cause A).** No `package.json` marked `.harness/hooks/` as `"type": "module"`, so Node resolved each hook's module type from the adopter's nearest `package.json` (CommonJS-default, or absent) and reparsed every hook as ESM at runtime, warning on each fire. Fix: new shared `writeHooksModuleMarker()` writes `.harness/hooks/package.json = {"type":"module"}` at install time from both `hooks init` and `hooks add`. The stale-`.js` wipe only removes `.js`, so the marker survives regeneration; `removeHooks` deletes the whole dir.
- **`ERR_MODULE_NOT_FOUND` at hook load (root cause B, more severe).** `read-hook-stdin.js` (extracted in #994) is statically `import`ed by 8 hooks but was never added to `HOOK_SUPPORT_FILES`, so the installer shipped those hooks without it. In an adopter each such hook failed at load with `ERR_MODULE_NOT_FOUND` — non-blocking, so the gate (e.g. block-no-verify) silently stopped running. Fix: register `read-hook-stdin.js` for all 8 importing hooks, plus a data-driven registry↔import **drift guard** that parses every hook's sibling imports and fails the build if the installer would not ship one.

## Testing

- [x] `pnpm test` — hook + support-file suites pass, incl. new regression tests; revert-and-fail verified for both fixes (removing the marker calls fails the marker tests; restoring the old registry fails 16 tests incl. the runtime `ERR_MODULE_NOT_FOUND` case).
- [x] `pnpm lint` — clean on changed source files.
- [x] `pnpm typecheck` — no errors in changed files.
- [ ] `pnpm build` — not run in the worktree; deferred to CI.

Regression tests: `packages/cli/tests/commands/hooks.test.ts` (marker presence/content, preserve-across-wipe, clean-load spawn asserting no `MODULE_TYPELESS` and no `ERR_MODULE_NOT_FOUND`, for both `initHooks` and `addHooks`) and `packages/cli/src/hooks/support-files.test.ts` (registry contract + drift guard).

## Related Issues

Follow-up to #994 (which extracted `read-hook-stdin.js` without registering it as a support file).