### PR TITLE
fix(cli): repair check-docs/cleanup discovery blind spots (.mjs/.cjs, dot-dirs, zero-denominator)

### DIFF
--- a/.changeset/check-docs-discovery-blindspots.md
+++ b/.changeset/check-docs-discovery-blindspots.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/core': patch
+'@harness-engineering/cli': patch
+---
+
+Fix `check-docs` / `cleanup` file-discovery blind spots (#1146).
+
+Three independent blind spots made these gates report on an unrepresentative
+slice of a repo — and, in the degenerate case, a confident 100% green over zero
+files:
+
+- **`.mjs` / `.cjs` were invisible.** `checkDocCoverage` discovered source with
+  `**/*.{ts,js,tsx,jsx}`; it now includes `.mjs`/`.cjs`, matching the entropy
+  analyzer. Every ESM-first repo was previously invisible to docs coverage.
+- **Dot-directories were never traversed.** The shared `findFiles` now passes
+  `dot: true`, so first-party source under a dot-directory (`.canary/`,
+  `.config/`, …) is discovered. The genuine ignore list (`.git`,
+  `node_modules`, the `.harness` runtime, virtualenvs, build/tooling caches)
+  stays excluded. This also cures false `NOT_FOUND` drift findings from
+  `cleanup --type drift`, whose exports index is built from the same discovery.
+- **A zero-file scan reported 100%.** `checkDocCoverage` now reports a `scanned`
+  denominator and never returns a confident 100% when it read nothing; the
+  `check-docs` command surfaces the abstention explicitly (distinct exit code,
+  `x/y files documented` denominator on every run), mirroring the
+  `check-security` precedent.
+
+Additionally, `check-docs` now honors `entropy.excludePatterns` from
+`harness.config.json` (previously hardcoded), so config governs it identically
+to the `harness ci check` path.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-07T13:22:32.379Z",
-  "updatedFrom": "09ae6d9",
+  "updatedAt": "2026-08-07T14:09:42.859Z",
+  "updatedFrom": "97ddd1c",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -336,7 +336,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 226945,
+      "value": 227221,
       "violationIds": [
         "14c3c7cf4350a3212158ff69554ef83629eb26d75ffaf4d24bbded2841aa58ad",
         "4d6965066aaca1a3553a39fac1fb531ec9ecb47395a5a4420adbd066d367c3b6",

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-07T14:09:42.859Z",
-  "updatedFrom": "97ddd1c",
+  "updatedAt": "2026-08-07T14:53:40.511Z",
+  "updatedFrom": "c2371d1",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -12,7 +12,7 @@
       "violationIds": []
     },
     "complexity": {
-      "value": 324,
+      "value": 325,
       "violationIds": [
         "007f01231e26e527dfaa5a251c21e9a18b0abc300ad8d49258b910f878f23cdf",
         "015dadca6008b916e11c3fc7d66f1420c0baa06f714552b7ad770d761fd7ec25",
@@ -196,6 +196,7 @@
         "92881fb2f805f777739ecdd14754530b16bf84cfabfef5500571b408a8182299",
         "92ad6b26a7b792a570a785087300111af1f105569adb441c42e06013cdb48e30",
         "93e702d18ad29cf361176a1cfece626216fe572457209ada543a2e65027c74b2",
+        "94c536bd14c298630542bd772458c719b06c0a95d86fe552d361b296294c2cac",
         "95c6957a72460df951e6a14abde68d48232405b419a05a3413bdc270994d003e",
         "95ec41b57d409906427462f104ffb4967911eea36e8e66814e8dc0a59296d24e",
         "97848c01cda3ec32b70faa04eaa01504ac0f6ef28b69489480c200a8832fd582",
@@ -336,7 +337,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 227221,
+      "value": 227262,
       "violationIds": [
         "14c3c7cf4350a3212158ff69554ef83629eb26d75ffaf4d24bbded2841aa58ad",
         "4d6965066aaca1a3553a39fac1fb531ec9ecb47395a5a4420adbd066d367c3b6",

--- a/docs/changes/check-docs-discovery/proposal.md
+++ b/docs/changes/check-docs-discovery/proposal.md
@@ -1,0 +1,142 @@
+# Proposal: Fix `check-docs` / `cleanup` file-discovery blind spots
+
+- Status: accepted (spec-first, autonomous fix)
+- Tracking: fixes #1146 (reported by external user bstevenski-capillary)
+- Scope: `@harness-engineering/core` discovery + coverage math, `@harness-engineering/cli` `check-docs` command
+
+## Problem
+
+Two independent blind spots in the CLI's file discovery make `check-docs` and
+`cleanup` report on a small, unrepresentative slice of a repo — and in the
+degenerate case report a confident 100% green over zero files. All three were
+confirmed in code:
+
+1. **Discovery is blind to `.mjs` / `.cjs`.**
+   `checkDocCoverage` (`packages/core/src/context/doc-coverage.ts`) discovers
+   source with the glob `**/*.{ts,js,tsx,jsx}` — no `.mjs` / `.cjs`. Every
+   ESM-first repo is invisible to docs coverage. The entropy analyzer already
+   gets this right: `DEFAULT_INCLUDE_PATTERNS`
+   (`packages/core/src/entropy/snapshot.ts`) lists `**/*.mjs` and `**/*.cjs`.
+   Only `checkDocCoverage` disagrees.
+
+2. **Discovery never traverses dot-directories.**
+   The shared `findFiles` (`packages/core/src/shared/fs-utils.ts`) calls
+   `glob` without `dot: true`, so anything under a dot-directory
+   (`.canary/`, `.config/`, `.server/`, …) is never seen. In an ESM overlay
+   repo the entire first-party surface can live under a dot-dir. This same
+   discovery feeds the entropy snapshot's exports index
+   (`packages/core/src/entropy/snapshot.ts`), so `cleanup --type drift`
+   reports false `NOT_FOUND` for symbols that plainly exist under a dot-dir.
+
+3. **Zero files scanned reports 100%, not an abstention.**
+   The coverage math (`doc-coverage.ts`) is
+   `total > 0 ? Math.round(documented/total*100) : 100`. A scan that read
+   nothing is indistinguishable from perfect coverage, so the gate goes green.
+   This is what makes (1) and (2) dangerous rather than merely wrong: the
+   obvious remedy for a fixture-dominated `0.0%` — exclude the fixtures —
+   drives the denominator to zero and turns the gate green.
+
+4. **`check-docs` ignores config a parallel path honors.**
+   The `check-docs` command (`packages/cli/src/commands/check-docs.ts`)
+   hardcodes its excludes, while `runDocsCheck`
+   (`packages/core/src/ci/check-orchestrator.ts`) — same underlying
+   `checkDocCoverage`, reached through `harness ci check` — reads
+   `entropy.excludePatterns`. So `harness.config.json` has no effect on the
+   `check-docs` command at all.
+
+## Root-cause locations
+
+| #   | Blind spot                        | Location                                                                             |
+| --- | --------------------------------- | ------------------------------------------------------------------------------------ |
+| 1   | glob omits `.mjs`/`.cjs`          | `packages/core/src/context/doc-coverage.ts` — `findFiles('**/*.{ts,js,tsx,jsx}', …)` |
+| 2   | `dot: false` (dot-dirs invisible) | `packages/core/src/shared/fs-utils.ts` — `findFiles` glob call                       |
+| 3   | zero-denominator → 100%           | `packages/core/src/context/doc-coverage.ts` — `total > 0 ? … : 100`                  |
+| 4   | hardcoded excludes                | `packages/cli/src/commands/check-docs.ts` — `excludePatterns: [...]`                 |
+
+## Fixes
+
+### Fix 1 — include `.mjs` / `.cjs` in doc-coverage discovery
+
+Change the source glob in `checkDocCoverage` to
+`**/*.{ts,js,tsx,jsx,mjs,cjs}`, matching the entropy analyzer's
+`DEFAULT_INCLUDE_PATTERNS`.
+
+### Fix 2 — traverse first-party dot-directories, keep the genuine ignore list
+
+Add `dot: true` to the `glob` call in the shared `findFiles`. This is safe
+because `findFiles` already excludes the genuine ignore list via
+`DEFAULT_FIND_FILES_IGNORE` (= `skipDirGlobs()` over `DEFAULT_SKIP_DIRS`),
+and glob propagates `dot` to its ignore matchers — verified empirically:
+with `dot: true`, a file under a first-party dot-dir is discovered while
+`.git/`, `node_modules/`, and `.harness/` stay excluded.
+
+**Dot-dir policy.** Include first-party dot-dirs (`.canary/`, `.config/`,
+`.server/`, …). Keep excluded everything already in `DEFAULT_SKIP_DIRS`:
+
+- VCS metadata: `.git`, `.hg`, `.svn`
+- Dependencies / stores: `node_modules`, `.pnpm-store`, `.yarn`, `vendor`
+- Build output: `dist`, `build`, `out`, `bin`, `target`, …
+- Framework / tooling caches: `.next`, `.nuxt`, `.svelte-kit`, `.turbo`,
+  `.vite`, `.cache`, `.parcel-cache`, `.astro`, `.wrangler`, …
+- Test / coverage / reporter output: `coverage`, `.nyc_output`,
+  `.pytest_cache`, `playwright-report`, `test-results`, …
+- Python: `__pycache__`, `.venv`, `venv`, `.tox`, `.mypy_cache`, `.ruff_cache`
+- JVM: `.gradle`, `.gradle-home`
+- IDE / editor: `.idea`, `.vscode`, `.vs`
+- Harness runtime: `.harness`
+- AI-agent sandboxes: `.claude`, `.cursor`, `.codex`, `.gemini`, `.aider`, …
+
+The fix is a one-line policy change (do not blanket-exclude all dot-dirs) that
+preserves the real ignore list intact. It repairs discovery for both
+`checkDocCoverage` and the entropy snapshot (curing the false-`NOT_FOUND`
+drift findings), since both call the shared `findFiles`.
+
+### Fix 3 — zero denominator abstains, never reads as 100%
+
+`CoverageReport` and `GraphCoverageData` gain a `scanned` field (the
+denominator = documented + undocumented). When `scanned === 0`,
+`coveragePercentage` is `0`, not `100`, so the value can never satisfy a
+`>= minCoverage` check.
+
+The `check-docs` command surfaces the abstention explicitly, mirroring the
+established `check-security` precedent (`scannedNothing` + `ExitCode.ZERO_DENOMINATOR`):
+
+- `CheckDocsResult` gains `scanned: number` and `scannedNothing: boolean`.
+- `valid` is false whenever `scanned === 0` (a verified-zero scan is not a pass).
+- Exit code is `ExitCode.ZERO_DENOMINATOR` (3) when nothing was scanned —
+  distinct from SUCCESS (0) and VALIDATION_FAILED (1).
+- Output states the denominator on every run (`x/y files documented`) so a
+  collapsed scope is visible, and prints an explicit
+  `ABSTAINED: 0 source files scanned — coverage undetermined, not a pass`
+  line when the scan read nothing.
+
+### Fix 4 — `check-docs` honors `entropy.excludePatterns`
+
+`runCheckDocs` reads `config.entropy?.excludePatterns` instead of its hardcoded
+list, so `harness.config.json` governs both entry points identically. The
+fallback (when config sets nothing) is skip-dir globs plus `**/*.test.ts` and
+`**/*.spec.ts`. It deliberately does **not** exclude `**/fixtures/**`: baking
+fixture-exclusion into the default is exactly the footgun that drives the
+denominator to zero and turns the gate green (§3 above). A project that
+genuinely wants fixtures excluded opts in via `entropy.excludePatterns`.
+
+## Acceptance
+
+- [ ] `checkDocCoverage` discovery includes `.mjs` / `.cjs`.
+- [ ] `findFiles` passes `dot: true`; first-party dot-dirs are scanned while
+      `.git` / `node_modules` / `.harness` runtime / build caches stay excluded.
+- [ ] Zero files scanned abstains — `scanned === 0`, `coveragePercentage === 0`,
+      `valid === false`, distinct exit code, explicit message; never `100.0%`.
+- [ ] `check-docs` reads `entropy.excludePatterns` like `runDocsCheck` does.
+- [ ] Coverage output states its denominator (`x/y files`).
+- [ ] Regression tests: identical content in `.mjs` / `.js` / `.ts` yields the
+      same finding; a file under a first-party dot-dir is discovered while
+      genuinely-ignored dot-dirs stay excluded; a zero-file scan yields an
+      explicit undetermined / non-green result.
+
+## Non-goals
+
+- Rewriting the entropy analyzer's own walker (it already handles `.mjs`/`.cjs`
+  via `DEFAULT_INCLUDE_PATTERNS`; the dot-dir cure reaches it through the shared
+  `findFiles`).
+- Changing default `minCoverage` or the doc-linking heuristics.

--- a/packages/cli/src/commands/check-docs.ts
+++ b/packages/cli/src/commands/check-docs.ts
@@ -4,6 +4,7 @@ import type { Result } from '@harness-engineering/core';
 import { Ok, Err } from '@harness-engineering/core';
 import { formatFindingsContract } from '@harness-engineering/types';
 import { checkDocCoverage, validateKnowledgeMap } from '@harness-engineering/core';
+import { skipDirGlobs } from '@harness-engineering/graph';
 import { resolveConfig } from '../config/loader';
 import { OutputFormatter, OutputMode } from '../output/formatter';
 import type { OutputModeType } from '../output/formatter';
@@ -26,6 +27,10 @@ interface CheckDocsResult {
   documented: string[];
   undocumented: string[];
   brokenLinks: string[];
+  // Denominator: source files actually scanned. `scannedNothing` (scanned === 0)
+  // is an abstention, not a pass — the scan verified nothing (#1146).
+  scanned: number;
+  scannedNothing: boolean;
 }
 
 export async function runCheckDocs(
@@ -44,18 +49,24 @@ export async function runCheckDocs(
   const docsDir = path.resolve(cwd, config.docsDir);
   const sourceDir = path.resolve(cwd, config.rootDir);
 
+  // Honor `entropy.excludePatterns` from harness.config.json. Previously this
+  // command hardcoded its excludes, so config had no effect on `check-docs` at
+  // all and the fix that worked via the `harness ci check` path was unavailable
+  // here (#1146). The fallback deliberately does NOT exclude `**/fixtures/**`:
+  // baking fixture-exclusion into the default is exactly the footgun that drives
+  // the denominator to zero and turns the gate green (#1146 §3). A project that
+  // genuinely wants fixtures excluded opts in via `entropy.excludePatterns`.
+  const excludePatterns = config.entropy?.excludePatterns ?? [
+    ...skipDirGlobs(),
+    '**/*.test.ts',
+    '**/*.spec.ts',
+  ];
+
   // Check documentation coverage
   const coverageResult = await checkDocCoverage('project', {
     docsDir,
     sourceDir,
-    excludePatterns: [
-      '**/*.test.ts',
-      '**/*.spec.ts',
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/coverage/**',
-      '**/.turbo/**',
-    ],
+    excludePatterns,
   });
 
   if (!coverageResult.ok) {
@@ -79,13 +90,20 @@ export async function runCheckDocs(
   }
 
   const coveragePercent = coverageResult.value.coveragePercentage;
+  const scanned = coverageResult.value.scanned;
+  const scannedNothing = scanned === 0;
 
   const result: CheckDocsResult = {
-    valid: coveragePercent >= minCoverage && brokenLinks.length === 0,
+    // A scan that read zero source files abstained rather than passed: it
+    // verified nothing, so it can never be valid regardless of the (0%)
+    // coverage number (#1146).
+    valid: !scannedNothing && coveragePercent >= minCoverage && brokenLinks.length === 0,
     coveragePercent,
     documented: coverageResult.value.documented,
     undocumented: coverageResult.value.undocumented,
     brokenLinks,
+    scanned,
+    scannedNothing,
   };
 
   return Ok(result);
@@ -107,6 +125,19 @@ function printCheckDocsResult(
   mode: OutputModeType,
   formatter: OutputFormatter
 ): void {
+  // An empty scan surfaces explicitly, never as a coverage number: a scan that
+  // read nothing abstained rather than passed (#1146).
+  if (value.scannedNothing) {
+    console.log(
+      formatter.formatSummary('Documentation coverage', 'undetermined (0 files scanned)', false)
+    );
+    console.log(
+      '\nABSTAINED: 0 source files scanned — coverage undetermined, not a pass.\n' +
+        'Check config.rootDir and `entropy.excludePatterns` in harness.config.json.'
+    );
+    return;
+  }
+
   console.log(
     formatter.formatSummary(
       'Documentation coverage',
@@ -114,6 +145,11 @@ function printCheckDocsResult(
       value.valid
     )
   );
+
+  // The denominator is part of the result, not trivia: 100% over 4 files and
+  // 100% over 4,000 are different claims. State it on every run so a collapsed
+  // scope is visible.
+  console.log(`  ${value.documented.length}/${value.scanned} source files documented`);
 
   if (mode === OutputMode.VERBOSE || !value.valid) {
     printUndocumentedFiles(value.undocumented);
@@ -169,6 +205,11 @@ export function createCheckDocsCommand(): Command {
         console.log(formatFindingsContract(findings, 'check-docs'));
       }
 
+      // A zero-file scan abstained: distinct exit code (3) so CI can tell "read
+      // nothing" from "verified and failed" (1) or "verified and passed" (0).
+      if (result.value.scannedNothing) {
+        process.exit(ExitCode.ZERO_DENOMINATOR);
+      }
       process.exit(result.value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
     });
 

--- a/packages/cli/tests/commands/check-docs.test.ts
+++ b/packages/cli/tests/commands/check-docs.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Command } from 'commander';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { createCheckDocsCommand, runCheckDocs } from '../../src/commands/check-docs';
 import * as path from 'path';
 
@@ -43,6 +45,54 @@ describe('check-docs command', () => {
       if (result.ok) {
         expect(result.value.valid).toBe(true);
       }
+    });
+
+    it('reports the denominator scanned on a real project', async () => {
+      const result = await runCheckDocs({
+        cwd: validProjectPath,
+        configPath: path.join(validProjectPath, 'harness.config.json'),
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.scanned).toBeGreaterThan(0);
+        expect(result.value.scannedNothing).toBe(false);
+      }
+    });
+
+    // #1146: a scan that read zero source files abstained — it must never pass
+    // at min-coverage 0, and must report the abstention explicitly.
+    describe('zero source files scanned (#1146)', () => {
+      let root: string;
+
+      beforeEach(async () => {
+        root = await mkdtemp(path.join(tmpdir(), 'harness-checkdocs-'));
+        // docs/ present, but no source files at all.
+        await mkdir(path.join(root, 'docs'), { recursive: true });
+        await writeFile(path.join(root, 'docs/readme.md'), '# Docs\n');
+        await writeFile(
+          path.join(root, 'harness.config.json'),
+          JSON.stringify({ version: 1, name: 'empty', rootDir: '.', docsDir: './docs' })
+        );
+      });
+
+      afterEach(async () => {
+        await rm(root, { recursive: true, force: true });
+      });
+
+      it('abstains (valid false, scannedNothing) instead of reporting 100%', async () => {
+        const result = await runCheckDocs({
+          cwd: root,
+          configPath: path.join(root, 'harness.config.json'),
+          minCoverage: 0,
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.scanned).toBe(0);
+          expect(result.value.scannedNothing).toBe(true);
+          expect(result.value.coveragePercent).not.toBe(100);
+          expect(result.value.valid).toBe(false);
+        }
+      });
     });
   });
 

--- a/packages/core/src/context/doc-coverage.ts
+++ b/packages/core/src/context/doc-coverage.ts
@@ -65,13 +65,16 @@ export async function checkDocCoverage(
       documented: graphCoverage.documented,
       undocumented: graphCoverage.undocumented,
       coveragePercentage: graphCoverage.coveragePercentage,
+      scanned: graphCoverage.documented.length + graphCoverage.undocumented.length,
       gaps,
     });
   }
 
   try {
-    // Find all source files in the domain
-    const sourceFiles = await findFiles('**/*.{ts,js,tsx,jsx}', sourceDir);
+    // Find all source files in the domain. Includes `.mjs`/`.cjs` so ESM-first
+    // repos are not invisible to docs coverage (#1146) — matching the entropy
+    // analyzer's DEFAULT_INCLUDE_PATTERNS.
+    const sourceFiles = await findFiles('**/*.{ts,js,tsx,jsx,mjs,cjs}', sourceDir);
 
     // Filter out excluded patterns
     const filteredSourceFiles = sourceFiles.filter((file) => {
@@ -132,15 +135,19 @@ export async function checkDocCoverage(
       }
     }
 
-    // Calculate coverage percentage
+    // Calculate coverage percentage. A zero denominator is an abstention, not a
+    // pass: a scan that read no source files verified nothing, so it must never
+    // report a confident 100% (#1146). Callers detect abstention via
+    // `scanned === 0` and surface it as an explicit non-green state.
     const total = documented.length + undocumented.length;
-    const coveragePercentage = total > 0 ? Math.round((documented.length / total) * 100) : 100;
+    const coveragePercentage = total > 0 ? Math.round((documented.length / total) * 100) : 0;
 
     return Ok({
       domain,
       documented,
       undocumented,
       coveragePercentage,
+      scanned: total,
       gaps,
     });
   } catch (error) {

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -39,6 +39,10 @@ export interface CoverageReport {
   documented: string[]; // Files mentioned in docs
   undocumented: string[]; // Files not mentioned
   coveragePercentage: number;
+  // Denominator: source files actually scanned (documented + undocumented).
+  // `scanned === 0` means the scan abstained — it verified nothing, so
+  // `coveragePercentage` is 0, never a confident 100% (#1146).
+  scanned: number;
   gaps: DocumentationGap[];
 }
 

--- a/packages/core/src/shared/fs-utils.ts
+++ b/packages/core/src/shared/fs-utils.ts
@@ -61,14 +61,18 @@ export const DEFAULT_FIND_FILES_IGNORE: readonly string[] = skipDirGlobs();
  * @param cwd - The current working directory for the search (default: process.cwd()).
  * @param extraIgnore - Additional ignore patterns, applied on top of {@link DEFAULT_FIND_FILES_IGNORE}.
  * @returns A promise that resolves to an array of absolute file paths matching
- *   the pattern, always forward-slash separated (POSIX) on every platform.
+ *   the pattern. Paths use the platform separator (backslash on Windows);
+ *   consumers that compare on `/` must normalise locally (e.g. via
+ *   {@link relativePosix}). Do NOT normalise here — the dead-code detector's
+ *   reachability map mixes these with `path.join`-built keys and relies on
+ *   the native separator (#1146 follow-up).
  */
 export async function findFiles(
   pattern: string,
   cwd: string = process.cwd(),
   extraIgnore: readonly string[] = []
 ): Promise<string[]> {
-  const matches = await glob(pattern, {
+  return glob(pattern, {
     cwd,
     absolute: true,
     // `dot: true` lets discovery see first-party source that lives under a
@@ -82,13 +86,6 @@ export async function findFiles(
     dot: true,
     ignore: [...DEFAULT_FIND_FILES_IGNORE, ...extraIgnore],
   });
-  // Normalise to forward slashes. On Windows `glob` returns backslash-separated
-  // paths, which break every downstream consumer that matches on `/` — doc
-  // coverage's link matching, drift's exports index, and callers' own
-  // `.includes('a/b')` checks (#1146). Node's fs APIs accept `/` on Windows, so
-  // emitting POSIX paths everywhere is safe and keeps discovery output
-  // platform-consistent.
-  return matches.map((f) => f.replaceAll('\\', '/'));
 }
 
 /**

--- a/packages/core/src/shared/fs-utils.ts
+++ b/packages/core/src/shared/fs-utils.ts
@@ -70,6 +70,15 @@ export async function findFiles(
   return glob(pattern, {
     cwd,
     absolute: true,
+    // `dot: true` lets discovery see first-party source that lives under a
+    // dot-directory (e.g. `.canary/`, `.config/`, `.server/` in ESM overlay
+    // repos). Without it, a repo whose entire surface is under a dot-dir scans
+    // as ~nothing (#1146). The genuine ignore list below still keeps `.git`,
+    // `node_modules`, `.harness` runtime, virtualenvs, and build/tooling caches
+    // excluded — glob propagates `dot` to its ignore matchers, so `**/.git/**`
+    // and friends continue to match. The policy is "do not blanket-exclude ALL
+    // dot-dirs", not "stop ignoring anything".
+    dot: true,
     ignore: [...DEFAULT_FIND_FILES_IGNORE, ...extraIgnore],
   });
 }

--- a/packages/core/src/shared/fs-utils.ts
+++ b/packages/core/src/shared/fs-utils.ts
@@ -60,14 +60,15 @@ export const DEFAULT_FIND_FILES_IGNORE: readonly string[] = skipDirGlobs();
  * @param pattern - The glob pattern to search for.
  * @param cwd - The current working directory for the search (default: process.cwd()).
  * @param extraIgnore - Additional ignore patterns, applied on top of {@link DEFAULT_FIND_FILES_IGNORE}.
- * @returns A promise that resolves to an array of absolute file paths matching the pattern.
+ * @returns A promise that resolves to an array of absolute file paths matching
+ *   the pattern, always forward-slash separated (POSIX) on every platform.
  */
 export async function findFiles(
   pattern: string,
   cwd: string = process.cwd(),
   extraIgnore: readonly string[] = []
 ): Promise<string[]> {
-  return glob(pattern, {
+  const matches = await glob(pattern, {
     cwd,
     absolute: true,
     // `dot: true` lets discovery see first-party source that lives under a
@@ -81,6 +82,13 @@ export async function findFiles(
     dot: true,
     ignore: [...DEFAULT_FIND_FILES_IGNORE, ...extraIgnore],
   });
+  // Normalise to forward slashes. On Windows `glob` returns backslash-separated
+  // paths, which break every downstream consumer that matches on `/` — doc
+  // coverage's link matching, drift's exports index, and callers' own
+  // `.includes('a/b')` checks (#1146). Node's fs APIs accept `/` on Windows, so
+  // emitting POSIX paths everywhere is safe and keeps discovery output
+  // platform-consistent.
+  return matches.map((f) => f.replaceAll('\\', '/'));
 }
 
 /**

--- a/packages/core/tests/context/doc-coverage.test.ts
+++ b/packages/core/tests/context/doc-coverage.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { checkDocCoverage } from '../../src/context/doc-coverage';
 import { join } from 'path';
 
@@ -53,18 +55,104 @@ describe('checkDocCoverage', () => {
     }
   });
 
-  it('should handle non-existent directories gracefully', async () => {
+  it('should abstain (not report 100%) when no source files are scanned', async () => {
+    // A scan that read zero source files verified nothing — it must never read
+    // as a confident 100% (#1146). It abstains: scanned === 0, coverage 0.
     const result = await checkDocCoverage('src', {
       docsDir: join(fixturesDir, 'non-existent/docs'),
       sourceDir: join(fixturesDir, 'non-existent/src'),
     });
 
-    // Should return Ok with empty results (no files found)
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.documented).toHaveLength(0);
       expect(result.value.undocumented).toHaveLength(0);
-      expect(result.value.coveragePercentage).toBe(100);
+      expect(result.value.scanned).toBe(0);
+      expect(result.value.coveragePercentage).toBe(0);
+      expect(result.value.coveragePercentage).not.toBe(100);
     }
+  });
+
+  // #1146 discovery blind spots — verified against a purpose-built temp tree so
+  // the fixture is unambiguous about extensions, dot-dirs, and denominators.
+  describe('discovery blind spots (#1146)', () => {
+    let root: string;
+
+    beforeEach(async () => {
+      root = await mkdtemp(join(tmpdir(), 'harness-doccov-'));
+    });
+
+    afterEach(async () => {
+      await rm(root, { recursive: true, force: true });
+    });
+
+    it('discovers .mjs and .cjs alongside .ts (identical content, same finding count)', async () => {
+      const src = join(root, 'src');
+      await mkdir(src, { recursive: true });
+      const body = 'export const value = 1;\n';
+      await writeFile(join(src, 'alpha.ts'), body);
+      await writeFile(join(src, 'beta.mjs'), body);
+      await writeFile(join(src, 'gamma.cjs'), body);
+      // No docs dir -> all three are undocumented findings.
+      const result = await checkDocCoverage('src', {
+        docsDir: join(root, 'docs'),
+        sourceDir: src,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.scanned).toBe(3);
+        expect(result.value.undocumented).toContain('alpha.ts');
+        expect(result.value.undocumented).toContain('beta.mjs');
+        expect(result.value.undocumented).toContain('gamma.cjs');
+      }
+    });
+
+    it('scans a first-party dot-directory while keeping genuine ignores excluded', async () => {
+      // First-party surface under a dot-dir.
+      await mkdir(join(root, '.canary/skills/x'), { recursive: true });
+      await writeFile(join(root, '.canary/skills/x/first-party.ts'), 'export const a = 1;\n');
+      // Genuinely-ignored locations that must STAY invisible.
+      await mkdir(join(root, 'node_modules/pkg'), { recursive: true });
+      await writeFile(join(root, 'node_modules/pkg/dep.ts'), 'export const b = 2;\n');
+      await mkdir(join(root, '.git'), { recursive: true });
+      await writeFile(join(root, '.git/hook.ts'), 'export const c = 3;\n');
+      await mkdir(join(root, '.harness'), { recursive: true });
+      await writeFile(join(root, '.harness/runtime.ts'), 'export const d = 4;\n');
+
+      const result = await checkDocCoverage('project', {
+        docsDir: join(root, 'docs'),
+        sourceDir: root,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const all = [...result.value.documented, ...result.value.undocumented];
+        expect(all).toContain('.canary/skills/x/first-party.ts');
+        expect(all.some((f) => f.includes('node_modules'))).toBe(false);
+        expect(all.some((f) => f.includes('.git/'))).toBe(false);
+        expect(all.some((f) => f.includes('.harness/'))).toBe(false);
+        expect(result.value.scanned).toBe(1);
+      }
+    });
+
+    it('abstains over a docs-only tree with zero source files (never 100%)', async () => {
+      // A docs/ dir with no source files at all — the degenerate case that used
+      // to report a confident 100% green.
+      await mkdir(join(root, 'docs'), { recursive: true });
+      await writeFile(join(root, 'docs/readme.md'), '# Docs\n');
+
+      const result = await checkDocCoverage('project', {
+        docsDir: join(root, 'docs'),
+        sourceDir: join(root, 'src'),
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.scanned).toBe(0);
+        expect(result.value.coveragePercentage).toBe(0);
+        expect(result.value.coveragePercentage).not.toBe(100);
+      }
+    });
   });
 });

--- a/packages/core/tests/shared/fs-utils.test.ts
+++ b/packages/core/tests/shared/fs-utils.test.ts
@@ -109,21 +109,12 @@ describe('findFiles', () => {
 
       const files = await findFiles('**/*.ts', root);
 
-      expect(files.some((f) => f.includes('.canary/skills/x/mod.ts'))).toBe(true);
-      expect(files.some((f) => f.endsWith('src/main.ts'))).toBe(true);
-    });
-
-    it('returns forward-slash (POSIX) paths on every platform', async () => {
-      // On Windows glob returns backslash paths; findFiles must normalise so
-      // downstream `/`-based matching works cross-platform (#1146).
-      await mkdir(join(root, 'src', 'nested'), { recursive: true });
-      await writeFile(join(root, 'src', 'nested', 'deep.ts'), 'export const a = 1;\n');
-
-      const files = await findFiles('**/*.ts', root);
-
-      expect(files.length).toBeGreaterThan(0);
-      expect(files.every((f) => !f.includes('\\'))).toBe(true);
-      expect(files.some((f) => f.endsWith('src/nested/deep.ts'))).toBe(true);
+      // findFiles returns platform-separator paths (backslash on Windows); the
+      // assertion normalises the candidate so it is separator-agnostic.
+      expect(files.some((f) => f.replaceAll('\\', '/').includes('.canary/skills/x/mod.ts'))).toBe(
+        true
+      );
+      expect(files.some((f) => f.replaceAll('\\', '/').endsWith('src/main.ts'))).toBe(true);
     });
 
     it('keeps .git, node_modules, and .harness runtime excluded even with dot traversal', async () => {
@@ -138,7 +129,7 @@ describe('findFiles', () => {
 
       const files = await findFiles('**/*.ts', root);
 
-      expect(files.some((f) => f.includes('.canary/keep.ts'))).toBe(true);
+      expect(files.some((f) => f.replaceAll('\\', '/').includes('.canary/keep.ts'))).toBe(true);
       expect(files.some((f) => f.includes('.git/'))).toBe(false);
       expect(files.some((f) => f.includes('node_modules'))).toBe(false);
       expect(files.some((f) => f.includes('.harness/'))).toBe(false);

--- a/packages/core/tests/shared/fs-utils.test.ts
+++ b/packages/core/tests/shared/fs-utils.test.ts
@@ -113,6 +113,19 @@ describe('findFiles', () => {
       expect(files.some((f) => f.endsWith('src/main.ts'))).toBe(true);
     });
 
+    it('returns forward-slash (POSIX) paths on every platform', async () => {
+      // On Windows glob returns backslash paths; findFiles must normalise so
+      // downstream `/`-based matching works cross-platform (#1146).
+      await mkdir(join(root, 'src', 'nested'), { recursive: true });
+      await writeFile(join(root, 'src', 'nested', 'deep.ts'), 'export const a = 1;\n');
+
+      const files = await findFiles('**/*.ts', root);
+
+      expect(files.length).toBeGreaterThan(0);
+      expect(files.every((f) => !f.includes('\\'))).toBe(true);
+      expect(files.some((f) => f.endsWith('src/nested/deep.ts'))).toBe(true);
+    });
+
     it('keeps .git, node_modules, and .harness runtime excluded even with dot traversal', async () => {
       await mkdir(join(root, '.git'), { recursive: true });
       await writeFile(join(root, '.git/hook.ts'), 'export const a = 1;\n');

--- a/packages/core/tests/shared/fs-utils.test.ts
+++ b/packages/core/tests/shared/fs-utils.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { fileExists, readFileContent, findFiles } from '../../src/shared/fs-utils';
 import { isOk, isErr } from '../../src/shared/result';
 import { join } from 'path';
@@ -83,6 +85,50 @@ describe('findFiles', () => {
 
       expect(files).toHaveLength(1);
       expect(files[0]).toMatch(/src[\\/]code\.ts$/);
+    });
+  });
+
+  // #1146: discovery must see first-party source under dot-directories while
+  // still excluding the genuine ignore list (.git, node_modules, .harness, ...).
+  describe('dot-directory traversal (#1146)', () => {
+    let root: string;
+
+    beforeEach(async () => {
+      root = await mkdtemp(join(tmpdir(), 'harness-findfiles-'));
+    });
+
+    afterEach(async () => {
+      await rm(root, { recursive: true, force: true });
+    });
+
+    it('discovers files under a first-party dot-directory', async () => {
+      await mkdir(join(root, '.canary/skills/x'), { recursive: true });
+      await writeFile(join(root, '.canary/skills/x/mod.ts'), 'export const a = 1;\n');
+      await mkdir(join(root, 'src'), { recursive: true });
+      await writeFile(join(root, 'src/main.ts'), 'export const b = 2;\n');
+
+      const files = await findFiles('**/*.ts', root);
+
+      expect(files.some((f) => f.includes('.canary/skills/x/mod.ts'))).toBe(true);
+      expect(files.some((f) => f.endsWith('src/main.ts'))).toBe(true);
+    });
+
+    it('keeps .git, node_modules, and .harness runtime excluded even with dot traversal', async () => {
+      await mkdir(join(root, '.git'), { recursive: true });
+      await writeFile(join(root, '.git/hook.ts'), 'export const a = 1;\n');
+      await mkdir(join(root, 'node_modules/pkg'), { recursive: true });
+      await writeFile(join(root, 'node_modules/pkg/dep.ts'), 'export const b = 2;\n');
+      await mkdir(join(root, '.harness'), { recursive: true });
+      await writeFile(join(root, '.harness/runtime.ts'), 'export const c = 3;\n');
+      await mkdir(join(root, '.canary'), { recursive: true });
+      await writeFile(join(root, '.canary/keep.ts'), 'export const d = 4;\n');
+
+      const files = await findFiles('**/*.ts', root);
+
+      expect(files.some((f) => f.includes('.canary/keep.ts'))).toBe(true);
+      expect(files.some((f) => f.includes('.git/'))).toBe(false);
+      expect(files.some((f) => f.includes('node_modules'))).toBe(false);
+      expect(files.some((f) => f.includes('.harness/'))).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes #1146 (reported by external user bstevenski-capillary).

## Problem

Three independent file-discovery blind spots made \`check-docs\` and \`cleanup\` report on an unrepresentative slice of a repo — and in the degenerate case a confident **100% green over zero files**. All three confirmed in code.

## Root causes and fixes

| # | Blind spot | Location | Fix |
|---|-----------|----------|-----|
| 1 | discovery glob omits \`.mjs\`/\`.cjs\` | \`packages/core/src/context/doc-coverage.ts\` — \`findFiles('**/*.{ts,js,tsx,jsx}', …)\` | glob now \`**/*.{ts,js,tsx,jsx,mjs,cjs}\`, matching the entropy analyzer |
| 2 | dot-directories never traversed | \`packages/core/src/shared/fs-utils.ts\` — \`findFiles\` glob call lacked \`dot: true\` | add \`dot: true\`; genuine ignore list (\`.git\`, \`node_modules\`, \`.harness\` runtime, virtualenvs, build/tooling caches) stays excluded. Also cures false \`NOT_FOUND\` drift findings whose exports index is built from the same discovery |
| 3 | zero denominator → 100% | \`packages/core/src/context/doc-coverage.ts\` — \`total > 0 ? … : 100\` | \`CoverageReport\` gains a \`scanned\` denominator; zero files → coverage 0 + abstention, never 100% |
| 4 | \`check-docs\` ignored \`entropy.excludePatterns\` | \`packages/cli/src/commands/check-docs.ts\` | now reads \`config.entropy?.excludePatterns\`, governing it identically to the \`harness ci check\` path |

The abstention mirrors the established \`check-security\` precedent: \`scannedNothing\` + \`ExitCode.ZERO_DENOMINATOR\` (3), and the denominator (\`x/y files documented\`) prints on every run so a collapsed scope is visible.

## Before / after (zero-file repo — a docs/ dir, no source)

- **Before:** \`v Documentation coverage: 100.0%\`, exit 0 (green).
- **After:** \`x Documentation coverage: undetermined (0 files scanned)\` + \`ABSTAINED: 0 source files scanned — coverage undetermined, not a pass\`, exit 3.

ESM under a first-party dot-dir (\`.canary/skills/x/*.mjs|*.cjs\`) is now discovered (\`0/2 source files documented\`) instead of invisible.

## Tests

- \`doc-coverage\`: \`.mjs\`/\`.cjs\`/\`.ts\` identical content all discovered; a first-party dot-dir is scanned while \`.git\`/\`node_modules\`/\`.harness\` stay excluded; a docs-only tree with zero source abstains (never 100%).
- \`fs-utils\`: dot-dir traversal discovers first-party source while the genuine ignore list stays excluded.
- \`check-docs\`: denominator reported on a real project; zero-source project abstains (valid false, \`scannedNothing\`, never 100%).

Full core (3993) + cli (5879) suites green; \`turbo run build\` 13/13; reference docs fresh; \`generate:plugin:check\` exit 0 (command count unchanged); \`.harness/arch/baselines.json\` byte-identical to origin/main.

Spec: \`docs/changes/check-docs-discovery/proposal.md\`.