### PR TITLE
fix(knowledge-pipeline): abstain on empty coverage denominator; exclude test files and fixtures from extraction

### DIFF
--- a/.changeset/knowledge-pipeline-correctness.md
+++ b/.changeset/knowledge-pipeline-correctness.md
@@ -1,0 +1,28 @@
+---
+'@harness-engineering/graph': patch
+'@harness-engineering/cli': patch
+---
+
+Fix two `harness knowledge-pipeline` correctness bugs where the command produced
+confident, unactionable verdicts (#1110, #1111).
+
+**Coverage abstains on a zero denominator (#1110).** `CoverageScorer` graded a
+domain `F` whenever it had no linkable code (`0/0`), so "no graph / no data" and
+"genuinely bad coverage" were indistinguishable — a fresh checkout with no graph
+scored worse than a real assessment. Domains with no linkable-code denominator
+are now reported as `measured: false` / grade `N/A` and excluded from the
+aggregate; an entirely empty graph yields `graphPresent: false` and an `N/A`
+overall grade. The `--coverage` output prints an explicit "no graph — run
+`harness graph scan`" escalation instead of a grade, and per-domain `0/0` lines
+render `N/A` rather than `F (0/100)`. A first-run drift score (all findings
+`new`) is now labelled so `1.00` is not misread as "everything drifted".
+
+**Test files and fixtures are excluded from extraction (#1111).** The code-signal
+extractors walked `tests/`, `fixtures/`, `expected/`, and snapshot trees, staging
+test titles and golden-file data as `business_rule`/`business_term` gaps — so the
+gap report's "undocumented" count was dominated by test artifacts. `ExtractionRunner`
+now applies a default exclude set (test files and fixture/golden/snapshot trees,
+mirroring the existing `security.exclude` / `entropy.excludePatterns` conventions),
+extendable via a new `knowledge.extractionExclude` config field. Staged entries
+now carry their source `path` so a finding is attributable without grepping the
+repo. First-party source is untouched.

--- a/.harness/arch/baselines.json
+++ b/.harness/arch/baselines.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-07T13:22:32.379Z",
-  "updatedFrom": "09ae6d9",
+  "updatedAt": "2026-08-07T14:09:42.859Z",
+  "updatedFrom": "97ddd1c",
   "metrics": {
     "circular-deps": {
       "value": 0,
@@ -336,7 +336,7 @@
       "violationIds": []
     },
     "module-size": {
-      "value": 226945,
+      "value": 227221,
       "violationIds": [
         "14c3c7cf4350a3212158ff69554ef83629eb26d75ffaf4d24bbded2841aa58ad",
         "4d6965066aaca1a3553a39fac1fb531ec9ecb47395a5a4420adbd066d367c3b6",

--- a/docs/changes/knowledge-pipeline-correctness/proposal.md
+++ b/docs/changes/knowledge-pipeline-correctness/proposal.md
@@ -1,0 +1,163 @@
+# Knowledge Pipeline Correctness — coverage abstention + extractor test/fixture excludes
+
+Status: Proposed
+Track: bug-fix
+Related: #1110 (coverage grades F on a zero denominator), #1111 (test fixtures extracted as business knowledge)
+
+## Problem
+
+Two external user reports (from the same pipeline run against an overlay repo)
+describe the `harness knowledge-pipeline` command producing confident,
+unactionable verdicts:
+
+### #1110 — coverage grades F on 0/0 linked code
+
+`harness knowledge-pipeline --coverage` grades a domain **F** when the graph
+contains nothing to link. "No graph / no data" and "genuinely bad coverage"
+render identically:
+
+- Before `graph scan` (empty graph): `Coverage: F (19/100)` with every domain
+  showing `0/0 code linked` — a zero denominator.
+- After `graph scan`: `Coverage: D (24/100)` with real `31/93`, `35/234` ratios.
+
+The empty run produces a numeric score and letter grade indistinguishable from
+a measured one — and a _worse_ grade than the measured result, so the honest
+answer looks like a regression. The pipeline's own escalation rule
+(`SKILL.md`) already states the missing-graph case must be handled explicitly:
+"When no graph is available: run extractors and diagram parsers only … report
+extraction results as gap analysis." The coverage grader does not implement it.
+
+Root cause is in `packages/graph/src/ingest/CoverageScorer.ts`:
+
+- `computeDomainScore` returns `0` for the code-coverage component whenever
+  `codeEntities === 0` (there is no denominator to divide by).
+- `scoreDomain` then passes that `0` through `toGrade`, which maps `< 20` to
+  `F`. A domain with nothing to link is indistinguishable from a domain that
+  was measured and scored terribly.
+- `score()` averages every domain's number — including these
+  no-denominator zeros — into the aggregate, and an entirely empty graph yields
+  `overallGrade: 'F'`.
+
+### #1111 — extracts test files/fixtures as business knowledge
+
+`harness knowledge-pipeline` extracts "business knowledge" from test files and
+test **fixtures** (golden files), then reports them as documentation gaps. In
+the repro, all 37 "undocumented knowledge" signals traced to `tests/`:
+test titles from `*.test.ts` (via `test-descriptions`) and generator
+golden-file fixtures under `.../fixtures/.../expected/**` (via
+`validation-rules` and `enum-constants`), each staged as
+`nodeType: business_rule/business_term, confidence: 0.7`.
+
+Root cause is in `packages/graph/src/ingest/extractors/ExtractionRunner.ts`:
+`findSourceFiles` skips only directory _names_ in `DEFAULT_SKIP_DIRS`. It has
+no test-file or fixture-tree exclusion, so `tests/`, `fixtures/`, `expected/`,
+and snapshot trees are all walked and fed to the extractors. Every other
+harness gate already excludes these — `harness.config.json` carries
+`**/*.test.ts`, `**/tests/fixtures/**`, `**/rehearsal-fixtures/**` in both the
+`security.exclude` and `entropy.excludePatterns` sets — but the knowledge
+extractors do not mirror that intent.
+
+A secondary provenance gap: a staged entry
+(`KnowledgeStagingAggregator.StagedEntry`) carries no source path, so a
+reviewer cannot tell a fixture-derived finding from a real one without grepping
+the repo for the name string.
+
+## Goals
+
+1. Coverage abstains rather than grading when there is no denominator:
+   distinguish "no data" from "bad ratio".
+2. Test files and fixture trees are excluded from knowledge extraction, so the
+   gap report's undocumented count reflects real first-party knowledge — while
+   legitimate first-party source is untouched.
+3. Staged entries carry their source path so provenance is attributable.
+
+## Non-goals
+
+- Rewriting the scoring weights, the drift classifier, or the gap-report
+  format beyond what the two behaviours above require.
+- Auto-running `graph scan` from inside the pipeline (the report points the
+  operator at it; running it implicitly is out of scope).
+
+## Design
+
+### Fix #1110 — coverage abstention (`CoverageScorer.ts` + command output)
+
+Introduce an explicit _unmeasured_ state keyed off the denominator, never a
+confident grade:
+
+- Add `'N/A'` to the grade union (new exported `Grade` type).
+- `DomainCoverageScore` gains `readonly measured: boolean`. A domain is
+  `measured` when `codeEntities > 0` (there is a linkable-code denominator).
+  When `!measured`, its `grade` is `'N/A'`. Its score is still computed (for the
+  knowledge-depth / source-diversity components) but never surfaced as a letter.
+- `CoverageReport` gains `readonly graphPresent: boolean` (any code _or_
+  knowledge node exists) and `readonly measuredDomainCount: number`.
+  `overallScore` is the rounded average of **measured** domains only —
+  unmeasured domains are excluded from the aggregate rather than averaging a
+  zero into it. When no domain is measured, `overallGrade` is `'N/A'`.
+- Unmeasured domains still appear in `domains[]` (visible as `N/A`), so a domain
+  with nothing to link reads as "not scanned", not "not applicable".
+
+Command output (`knowledge-pipeline.ts`):
+
+- When `!graphPresent`, print one loud line pointing at the escalation the
+  SKILL already specifies (run the graph scan command) instead of a grade.
+- The overall line renders `N/A` (not a `/100` score) when `overallGrade` is
+  `'N/A'`.
+- Per-domain unmeasured lines render `N/A — <k> knowledge, no code to link`
+  instead of `F (0/100) — … 0/0 code linked`.
+- Drift-score label: on a first run where every finding is `new` (no
+  `stale`/`drifted`/`contradicting`), annotate the drift score as a first-run
+  value so `1.00` is not misread as "everything drifted". This matches the
+  verdict beneath it (correctly `WARN`).
+
+### Fix #1111 — extractor test/fixture excludes + staged provenance
+
+- Add `DEFAULT_EXTRACTION_EXCLUDE` (minimatch globs, POSIX-relative) mirroring
+  the repo's existing security/entropy exclusion intent. The set:
+  - Test files: `**/*.test.*`, `**/*.spec.*`, `**/*_test.go`, `**/test_*.py`,
+    `**/*_test.py`
+  - Test directories: `**/tests/**`, `**/__tests__/**`, `**/test/**`
+  - Fixture / golden-file / snapshot trees: `**/fixtures/**`,
+    `**/__fixtures__/**`, `**/expected/**`, `**/__snapshots__/**`,
+    `**/rehearsal-fixtures/**`
+
+- `ExtractionRunner` accepts an `{ excludeGlobs }` option (defaulting to
+  `DEFAULT_EXTRACTION_EXCLUDE`). `findSourceFiles` matches each candidate file's
+  project-relative POSIX path against the globs (using the same `minimatch`
+  matcher already used by `CodeIngestor`), and prunes excluded directories
+  during the walk. First-party source that is not a test/fixture is untouched.
+- The exclude list is configurable and additive via a new
+  `knowledge.extractionExclude` config field, threaded
+  CLI → `KnowledgePipelineOptions` → `createExtractionRunner`. Caller globs
+  extend (not replace) the built-in defaults, matching the existing
+  `knowledge.domainPatterns` / `knowledge.domainBlocklist` convention.
+- `StagedEntry` gains `readonly path?: string`; `stageNewFindings` populates it
+  from the graph node's `path`, so a staged finding is attributable to its
+  source file without grepping.
+
+## Acceptance criteria
+
+- A domain with `0` linkable code entities (0/0) is reported `measured: false` /
+  grade `N/A` and is excluded from the aggregate — NOT graded `F`.
+- A domain with real linkage (code entities > 0) still grades normally
+  (A–F unchanged).
+- An entirely empty graph yields `graphPresent: false` and `overallGrade: 'N/A'`,
+  and the command prints the run-the-graph-scan escalation.
+- Files under `tests/` and fixture trees are not extracted as
+  business-knowledge signals; a genuine first-party source signal still is.
+- `knowledge.extractionExclude` extends the default exclude set.
+- Staged entries carry a `path` for extractor-sourced findings.
+
+## Test plan
+
+- `CoverageScorer`: 0/0 domain → `measured:false`, grade `N/A`, excluded from
+  aggregate; measured domain grades normally; empty graph → `graphPresent:false`,
+  `overallGrade:'N/A'`; mixed measured + unmeasured → aggregate over measured
+  only.
+- `ExtractionRunner`: a temp project tree with a first-party source file, a
+  `*.test.ts` file, and a `fixtures/expected/**` golden file → only the
+  first-party signal is extracted; caller-supplied `excludeGlobs` also honored.
+- `KnowledgePipelineRunner`: staged entries carry `path`.
+- Existing `CoverageScorer` empty-graph test updated from `F` to `N/A`
+  (intentional behaviour change — the crux of #1110).

--- a/packages/cli/src/commands/knowledge-pipeline.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.ts
@@ -44,7 +44,8 @@ function buildPipelineOptions(
   opts: KnowledgePipelineCommandOptions,
   projectDir: string,
   graphDir: string,
-  inferenceOptions: Record<string, unknown> | undefined
+  inferenceOptions: Record<string, unknown> | undefined,
+  extractionExclude: readonly string[]
 ): Record<string, unknown> {
   const pipelineOpts: Record<string, unknown> = {
     projectDir,
@@ -54,6 +55,7 @@ function buildPipelineOptions(
     graphDir,
     analyzeImages: Boolean(opts.analyzeImages),
     ...(inferenceOptions ? { inferenceOptions } : {}),
+    ...(extractionExclude.length > 0 ? { extractionExclude } : {}),
   };
 
   // Parse image paths if provided
@@ -118,6 +120,8 @@ function printJsonResult(result: KnowledgePipelineResult): void {
         coverage: {
           overallScore: result.coverage.overallScore,
           overallGrade: result.coverage.overallGrade,
+          graphPresent: result.coverage.graphPresent,
+          measuredDomainCount: result.coverage.measuredDomainCount,
           domains: result.coverage.domains.length,
         },
         ...(result.materialization
@@ -148,7 +152,13 @@ function printSummary(result: KnowledgePipelineResult): void {
   console.log('');
   console.log(`KNOWLEDGE PIPELINE -- Verdict: ${verdictColor}`);
   console.log('');
-  console.log(`  Drift Score: ${result.driftScore.toFixed(2)}`);
+  // On a first run every finding is `new` (no prior graph state), which drives
+  // the drift score toward 1.00. Label it so the headline is not misread as
+  // "everything drifted" when the verdict beneath it is correctly WARN (#1110).
+  const f = result.findings;
+  const firstRun = f.new > 0 && f.stale === 0 && f.drifted === 0 && f.contradicting === 0;
+  const driftLabel = firstRun ? ' (first run — no prior graph state)' : '';
+  console.log(`  Drift Score: ${result.driftScore.toFixed(2)}${driftLabel}`);
   console.log(
     `  Findings: ${result.findings.new} new, ${result.findings.stale} stale, ${result.findings.drifted} drifted, ${result.findings.contradicting} contradicting`
   );
@@ -222,8 +232,32 @@ function printCoverage(
     return;
   }
   console.log('');
-  console.log(`  Coverage: ${result.coverage.overallGrade} (${result.coverage.overallScore}/100)`);
-  for (const d of result.coverage.domains) {
+
+  const cov = result.coverage;
+
+  // No graph (or an empty one): abstain loudly and point at the escalation the
+  // SKILL already specifies, rather than emitting a confident failing grade on
+  // no data (#1110).
+  if (!cov.graphPresent) {
+    console.log(`  Coverage: ${chalk.yellow('N/A')} — no graph found (gap-analysis mode)`);
+    console.log(`    Run ${chalk.cyan('harness graph scan')} to enable coverage grading.`);
+    return;
+  }
+
+  const overall =
+    cov.overallGrade === 'N/A'
+      ? `${chalk.yellow('N/A')} — no measurable domains (run ${chalk.cyan('harness graph scan')})`
+      : `${cov.overallGrade} (${cov.overallScore}/100)`;
+  console.log(`  Coverage: ${overall}`);
+
+  for (const d of cov.domains) {
+    if (!d.measured) {
+      // No linkable-code denominator (0/0): report undetermined, not F.
+      console.log(
+        `    ${d.domain}: ${chalk.yellow('N/A')} — ${d.knowledgeEntries} knowledge, no code to link (run graph scan)`
+      );
+      continue;
+    }
     console.log(
       `    ${d.domain}: ${d.grade} (${d.score}/100) — ${d.knowledgeEntries} knowledge, ${d.linkedEntities}/${d.codeEntities} code linked`
     );
@@ -276,9 +310,16 @@ export function createKnowledgePipelineCommand(): Command {
         const cfgResult = resolveConfig();
         const cfgKnowledge = cfgResult.ok ? cfgResult.value.knowledge : undefined;
         const inferenceOptions = resolveInferenceOptions(cfgKnowledge);
+        const extractionExclude = cfgKnowledge?.extractionExclude ?? [];
 
         // Build pipeline options
-        const pipelineOpts = buildPipelineOptions(opts, projectDir, graphDir, inferenceOptions);
+        const pipelineOpts = buildPipelineOptions(
+          opts,
+          projectDir,
+          graphDir,
+          inferenceOptions,
+          extractionExclude
+        );
 
         // Set up analysis provider for image analysis if requested
         if (opts.analyzeImages) {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -662,6 +662,13 @@ export const KnowledgeConfigSchema = z.object({
     .default([]),
   /** Caller-supplied blocklisted path segments (e.g. `["scratch", "fixtures"]`). Extends defaults. */
   domainBlocklist: z.array(z.string().min(1)).optional().default([]),
+  /**
+   * Caller-supplied glob patterns (minimatch) excluded from code-signal
+   * extraction, e.g. `["**\/golden/**"]`. Extends the built-in defaults
+   * (test files and fixture/golden trees), which are always excluded so the
+   * gap report is not inflated with test titles and fixture data (#1111).
+   */
+  extractionExclude: z.array(z.string().min(1)).optional().default([]),
 });
 
 /**

--- a/packages/cli/tests/config/knowledge-schema.test.ts
+++ b/packages/cli/tests/config/knowledge-schema.test.ts
@@ -178,6 +178,7 @@ describe('HarnessConfigSchema with knowledge block', () => {
     expect(result.knowledge).toEqual({
       domainPatterns: [],
       domainBlocklist: [],
+      extractionExclude: [],
     });
   });
 });

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -90,7 +90,7 @@ export type {
   ContradictionResult,
 } from './ingest/ContradictionDetector.js';
 export { CoverageScorer } from './ingest/CoverageScorer.js';
-export type { DomainCoverageScore, CoverageReport } from './ingest/CoverageScorer.js';
+export type { DomainCoverageScore, CoverageReport, Grade } from './ingest/CoverageScorer.js';
 export { KnowledgeStagingAggregator } from './ingest/KnowledgeStagingAggregator.js';
 export type {
   StagedEntry,

--- a/packages/graph/src/ingest/CoverageScorer.ts
+++ b/packages/graph/src/ingest/CoverageScorer.ts
@@ -5,6 +5,13 @@ import { inferDomain, type DomainInferenceOptions } from './domain-inference.js'
 
 // --- Exported result types ---
 
+/**
+ * Coverage grade. `'N/A'` is the *unmeasured* state: it is emitted when there
+ * is no linkable-code denominator to score against (0/0), so that "no graph /
+ * no data" is never rendered as the confident failing grade `'F'` (#1110).
+ */
+export type Grade = 'A' | 'B' | 'C' | 'D' | 'F' | 'N/A';
+
 export interface DomainCoverageScore {
   readonly domain: string;
   readonly score: number;
@@ -13,13 +20,25 @@ export interface DomainCoverageScore {
   readonly linkedEntities: number;
   readonly unlinkedEntities: number;
   readonly sourceBreakdown: Record<string, number>;
-  readonly grade: 'A' | 'B' | 'C' | 'D' | 'F';
+  /**
+   * Whether this domain had a linkable-code denominator (`codeEntities > 0`).
+   * When `false` the domain is *unmeasured*: its `grade` is `'N/A'` and it is
+   * excluded from the report aggregate rather than averaging a zero into it.
+   */
+  readonly measured: boolean;
+  readonly grade: Grade;
 }
 
 export interface CoverageReport {
   readonly domains: readonly DomainCoverageScore[];
+  /** Rounded average of *measured* domains only (0 when none are measured). */
   readonly overallScore: number;
-  readonly overallGrade: 'A' | 'B' | 'C' | 'D' | 'F';
+  /** `'N/A'` when no domain was measurable (no linkable code anywhere). */
+  readonly overallGrade: Grade;
+  /** Whether the graph contained any code or knowledge nodes at all. */
+  readonly graphPresent: boolean;
+  /** Count of domains with a linkable-code denominator. */
+  readonly measuredDomainCount: number;
   readonly generatedAt: string;
 }
 
@@ -146,6 +165,11 @@ function scoreDomain(
 
   const score = computeDomainScore(knowledgeEntries, codeEntities, linkedEntities, uniqueSources);
 
+  // A domain is *measured* only when it has a linkable-code denominator. With
+  // `codeEntities === 0` there is nothing to link (0/0), so we abstain from a
+  // letter grade rather than emit a confident `F` on no data (#1110).
+  const measured = codeEntities > 0;
+
   return {
     domain,
     score,
@@ -154,7 +178,8 @@ function scoreDomain(
     linkedEntities,
     unlinkedEntities: codeEntities - linkedEntities,
     sourceBreakdown,
-    grade: toGrade(score),
+    measured,
+    grade: measured ? toGrade(score) : 'N/A',
   };
 }
 
@@ -179,15 +204,22 @@ export class CoverageScorer {
       );
     }
 
+    // Aggregate over *measured* domains only. Averaging no-denominator zeros
+    // into the overall would let an unscanned repo read as a failing grade
+    // (#1110). When nothing is measurable the overall grade abstains to 'N/A'.
+    const measuredDomains = domains.filter((d) => d.measured);
     const overallScore =
-      domains.length > 0
-        ? Math.round(domains.reduce((sum, d) => sum + d.score, 0) / domains.length)
+      measuredDomains.length > 0
+        ? Math.round(measuredDomains.reduce((sum, d) => sum + d.score, 0) / measuredDomains.length)
         : 0;
+    const graphPresent = knowledgeNodes.length > 0 || codeNodes.length > 0;
 
     return {
       domains,
       overallScore,
-      overallGrade: toGrade(overallScore),
+      overallGrade: measuredDomains.length > 0 ? toGrade(overallScore) : 'N/A',
+      graphPresent,
+      measuredDomainCount: measuredDomains.length,
       generatedAt: new Date().toISOString(),
     };
   }

--- a/packages/graph/src/ingest/KnowledgePipelineRunner.ts
+++ b/packages/graph/src/ingest/KnowledgePipelineRunner.ts
@@ -74,6 +74,13 @@ export interface KnowledgePipelineOptions {
    * `knowledge.domainBlocklist` (→ extraBlocklist). Defaults to {} when absent.
    */
   readonly inferenceOptions?: DomainInferenceOptions;
+  /**
+   * Caller-supplied glob patterns that *extend* the built-in
+   * `DEFAULT_EXTRACTION_EXCLUDE` set for code-signal extraction. Sourced by the
+   * CLI from `harness.config.json#knowledge.extractionExclude`. Test files and
+   * fixture trees are always excluded regardless of this list (#1111).
+   */
+  readonly extractionExclude?: readonly string[];
 }
 
 export interface ExtractionCounts {
@@ -267,8 +274,9 @@ export class KnowledgePipelineRunner {
     const extractedDir = path.join(options.projectDir, '.harness', 'knowledge', 'extracted');
     await fs.mkdir(extractedDir, { recursive: true });
 
-    // Code signal extractors
-    const runner = createExtractionRunner();
+    // Code signal extractors (test files + fixture trees excluded by default;
+    // config-supplied globs extend that set)
+    const runner = createExtractionRunner(options.extractionExclude ?? []);
     const extractionResult = await runner.run(options.projectDir, this.store, extractedDir);
 
     // Diagram parsers
@@ -462,15 +470,21 @@ export class KnowledgePipelineRunner {
 
     const stagedEntries: StagedEntry[] = newFindings
       .filter((f): f is DriftFinding & { fresh: KnowledgeSnapshotEntry } => f.fresh != null)
-      .map((f) => ({
-        id: f.fresh.id,
-        source: this.classifySource(f.fresh.source),
-        nodeType: f.fresh.type,
-        name: f.fresh.name,
-        confidence: 0.7,
-        contentHash: f.fresh.contentHash,
-        timestamp: new Date().toISOString(),
-      }));
+      .map((f) => {
+        // Carry the source file path from the materialized graph node so a
+        // staged finding is attributable without grepping the repo (#1111).
+        const nodePath = this.store.getNode(f.fresh.id)?.path;
+        return {
+          id: f.fresh.id,
+          source: this.classifySource(f.fresh.source),
+          nodeType: f.fresh.type,
+          name: f.fresh.name,
+          confidence: 0.7,
+          contentHash: f.fresh.contentHash,
+          timestamp: new Date().toISOString(),
+          ...(nodePath ? { path: nodePath } : {}),
+        };
+      });
 
     if (stagedEntries.length > 0) {
       const aggregator = new KnowledgeStagingAggregator(options.projectDir, this.inferenceOptions);

--- a/packages/graph/src/ingest/KnowledgeStagingAggregator.ts
+++ b/packages/graph/src/ingest/KnowledgeStagingAggregator.ts
@@ -22,6 +22,13 @@ export interface StagedEntry {
   readonly confidence: number;
   readonly contentHash: string;
   readonly timestamp: string;
+  /**
+   * Source file path (repo-relative) the entry was derived from, when known.
+   * Carried so a reviewer can attribute a staged finding to its origin without
+   * grepping the repo for the name string — the step that surfaced the
+   * fixture-derived provenance in #1111.
+   */
+  readonly path?: string;
 }
 
 export interface GapEntry {

--- a/packages/graph/src/ingest/extractors/ExtractionRunner.ts
+++ b/packages/graph/src/ingest/extractors/ExtractionRunner.ts
@@ -1,9 +1,39 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { minimatch } from 'minimatch';
 import type { GraphStore } from '../../store/GraphStore.js';
 import type { IngestResult, GraphNode, GraphEdge, EdgeType } from '../../types.js';
 import { DEFAULT_SKIP_DIRS } from '../skip-dirs.js';
 import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
+
+/**
+ * Default glob patterns (minimatch, POSIX-relative) excluded from knowledge
+ * extraction. Test files and fixture/golden-file trees exist to be executed or
+ * compared, not to state business knowledge — extracting them inflates the gap
+ * report with unactionable "undocumented" signals (#1111). This mirrors the
+ * intent of the `security.exclude` / `entropy.excludePatterns` sets already in
+ * `harness.config.json`.
+ *
+ * Callers extend (not replace) this set via `knowledge.extractionExclude`.
+ */
+export const DEFAULT_EXTRACTION_EXCLUDE: readonly string[] = [
+  // Test files (naming conventions across languages)
+  '**/*.test.*',
+  '**/*.spec.*',
+  '**/*_test.go',
+  '**/test_*.py',
+  '**/*_test.py',
+  // Test directories
+  '**/tests/**',
+  '**/__tests__/**',
+  '**/test/**',
+  // Fixture / golden-file / snapshot trees
+  '**/fixtures/**',
+  '**/__fixtures__/**',
+  '**/expected/**',
+  '**/__snapshots__/**',
+  '**/rehearsal-fixtures/**',
+];
 
 /** Map file extensions to Language. */
 const EXT_TO_LANGUAGE: Record<string, Language> = {
@@ -45,7 +75,15 @@ const EXTRACTOR_EDGE_TYPE: Record<string, EdgeType> = {
  * persists to graph, and handles stale detection.
  */
 export class ExtractionRunner {
-  constructor(private readonly extractors: readonly SignalExtractor[]) {}
+  /** Effective exclude globs (POSIX-relative, minimatch). */
+  private readonly excludeGlobs: readonly string[];
+
+  constructor(
+    private readonly extractors: readonly SignalExtractor[],
+    options: { excludeGlobs?: readonly string[] } = {}
+  ) {
+    this.excludeGlobs = options.excludeGlobs ?? DEFAULT_EXTRACTION_EXCLUDE;
+  }
 
   /**
    * Run all extractors against a project directory.
@@ -231,8 +269,18 @@ export class ExtractionRunner {
     return count;
   }
 
-  /** Recursively find source files, skipping common non-source directories. */
+  /**
+   * Recursively find source files, skipping common non-source directories and
+   * any path matching {@link excludeGlobs} (test files, fixture/golden trees).
+   * Exclude globs are matched against each path's POSIX form relative to `dir`
+   * (the walk root), so they behave the same whether the runner is pointed at a
+   * project root or a subtree.
+   */
   async findSourceFiles(dir: string): Promise<string[]> {
+    return this.walkSourceFiles(dir, dir);
+  }
+
+  private async walkSourceFiles(dir: string, root: string): Promise<string[]> {
     const results: string[] = [];
     let entries: import('node:fs').Dirent[];
     try {
@@ -242,12 +290,38 @@ export class ExtractionRunner {
     }
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory() && !DEFAULT_SKIP_DIRS.has(entry.name)) {
-        results.push(...(await this.findSourceFiles(fullPath)));
+      const relPath = path.relative(root, fullPath).replaceAll('\\', '/');
+      if (entry.isDirectory()) {
+        if (DEFAULT_SKIP_DIRS.has(entry.name)) continue;
+        if (this.isDirExcluded(relPath)) continue;
+        results.push(...(await this.walkSourceFiles(fullPath, root)));
       } else if (entry.isFile() && detectLanguage(fullPath) !== undefined) {
+        if (this.isFileExcluded(relPath)) continue;
         results.push(fullPath);
       }
     }
     return results;
+  }
+
+  /** Match a project-relative POSIX file path against the exclude globs. */
+  private isFileExcluded(relPath: string): boolean {
+    for (const pattern of this.excludeGlobs) {
+      if (minimatch(relPath, pattern, { dot: true })) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Prune a directory whose entire subtree is excluded. Applies only to
+   * directory-scoped patterns (those ending in `/**`); file-name patterns like
+   * `**\/*.test.*` are handled per-file in {@link isFileExcluded}.
+   */
+  private isDirExcluded(relPath: string): boolean {
+    for (const pattern of this.excludeGlobs) {
+      if (!pattern.endsWith('/**')) continue;
+      const base = pattern.slice(0, -3);
+      if (minimatch(relPath, base, { dot: true })) return true;
+    }
+    return false;
   }
 }

--- a/packages/graph/src/ingest/extractors/index.ts
+++ b/packages/graph/src/ingest/extractors/index.ts
@@ -1,5 +1,9 @@
 export type { ExtractionRecord, SignalExtractor, Language } from './types.js';
-export { ExtractionRunner, detectLanguage } from './ExtractionRunner.js';
+export {
+  ExtractionRunner,
+  detectLanguage,
+  DEFAULT_EXTRACTION_EXCLUDE,
+} from './ExtractionRunner.js';
 export { TestDescriptionExtractor } from './TestDescriptionExtractor.js';
 export { EnumConstantExtractor } from './EnumConstantExtractor.js';
 export { ValidationRuleExtractor } from './ValidationRuleExtractor.js';
@@ -9,7 +13,7 @@ import { TestDescriptionExtractor } from './TestDescriptionExtractor.js';
 import { EnumConstantExtractor } from './EnumConstantExtractor.js';
 import { ValidationRuleExtractor } from './ValidationRuleExtractor.js';
 import { ApiPathExtractor } from './ApiPathExtractor.js';
-import { ExtractionRunner } from './ExtractionRunner.js';
+import { ExtractionRunner, DEFAULT_EXTRACTION_EXCLUDE } from './ExtractionRunner.js';
 import type { SignalExtractor } from './types.js';
 
 /** All built-in code signal extractors. */
@@ -20,7 +24,18 @@ export const ALL_EXTRACTORS: readonly SignalExtractor[] = [
   new ApiPathExtractor(),
 ];
 
-/** Create an ExtractionRunner with all built-in extractors. */
-export function createExtractionRunner(): ExtractionRunner {
-  return new ExtractionRunner(ALL_EXTRACTORS);
+/**
+ * Create an ExtractionRunner with all built-in extractors.
+ *
+ * @param additionalExcludes - Caller-supplied exclude globs that *extend* the
+ *   built-in {@link DEFAULT_EXTRACTION_EXCLUDE} set (sourced by the CLI from
+ *   `knowledge.extractionExclude`). Test files and fixture trees are always
+ *   excluded regardless.
+ */
+export function createExtractionRunner(
+  additionalExcludes: readonly string[] = []
+): ExtractionRunner {
+  return new ExtractionRunner(ALL_EXTRACTORS, {
+    excludeGlobs: [...DEFAULT_EXTRACTION_EXCLUDE, ...additionalExcludes],
+  });
 }

--- a/packages/graph/tests/ingest/CoverageScorer.test.ts
+++ b/packages/graph/tests/ingest/CoverageScorer.test.ts
@@ -117,7 +117,7 @@ describe('CoverageScorer', () => {
     expect(report.overallScore).toBe(expectedOverall);
   });
 
-  it('returns empty report for empty graph', () => {
+  it('abstains (N/A) for an empty graph rather than grading F (#1110)', () => {
     const store = new GraphStore();
     const scorer = new CoverageScorer();
 
@@ -125,7 +125,10 @@ describe('CoverageScorer', () => {
 
     expect(report.domains).toHaveLength(0);
     expect(report.overallScore).toBe(0);
-    expect(report.overallGrade).toBe('F');
+    // An empty graph is "no data", not "bad coverage" — it must not read as F.
+    expect(report.overallGrade).toBe('N/A');
+    expect(report.graphPresent).toBe(false);
+    expect(report.measuredDomainCount).toBe(0);
     expect(report.generatedAt).toBeDefined();
     // Validate ISO timestamp format
     expect(() => new Date(report.generatedAt)).not.toThrow();
@@ -345,6 +348,80 @@ describe('CoverageScorer', () => {
     const report = scorer.score(store);
     expect(report.overallScore).toBe(report.domains[0]!.score);
     expect(report.overallGrade).toBe(report.domains[0]!.grade);
+  });
+
+  describe('unmeasured domains abstain instead of grading F (#1110)', () => {
+    it('a domain with a zero linkable-code denominator is N/A, not F', () => {
+      const store = new GraphStore();
+      const scorer = new CoverageScorer();
+
+      // Knowledge only, no code entities in this domain → 0/0, nothing to link.
+      store.addNode(makeKnowledgeNode('kn-1', 'docsdomain', 'confluence'));
+      store.addNode(makeKnowledgeNode('kn-2', 'docsdomain', 'jira'));
+
+      const report = scorer.score(store);
+      const domain = findDomain(report, 'docsdomain');
+
+      expect(domain).toBeDefined();
+      expect(domain!.codeEntities).toBe(0);
+      expect(domain!.measured).toBe(false);
+      expect(domain!.grade).toBe('N/A');
+    });
+
+    it('a domain WITH real linkage still grades normally', () => {
+      const store = new GraphStore();
+      const scorer = new CoverageScorer();
+
+      // 3 code, all linked, 10 knowledge from 3 sources → grade A, measured.
+      for (let i = 0; i < 3; i++) store.addNode(makeCodeNode(`c-${i}`, 'measured'));
+      for (let i = 0; i < 10; i++) {
+        store.addNode(makeKnowledgeNode(`k-${i}`, 'measured', ['a', 'b', 'c'][i % 3]!));
+      }
+      for (let i = 0; i < 3; i++) store.addEdge(makeEdge(`k-${i}`, `c-${i}`, 'governs'));
+
+      const report = scorer.score(store);
+      const domain = findDomain(report, 'measured');
+
+      expect(domain!.measured).toBe(true);
+      expect(domain!.grade).toBe('A');
+    });
+
+    it('excludes unmeasured domains from the aggregate (not averaged as zero)', () => {
+      const store = new GraphStore();
+      const scorer = new CoverageScorer();
+
+      // Measured domain: full coverage → grade A.
+      for (let i = 0; i < 3; i++) store.addNode(makeCodeNode(`m-${i}`, 'graded'));
+      for (let i = 0; i < 10; i++) {
+        store.addNode(makeKnowledgeNode(`gk-${i}`, 'graded', ['a', 'b', 'c'][i % 3]!));
+      }
+      for (let i = 0; i < 3; i++) store.addEdge(makeEdge(`gk-${i}`, `m-${i}`, 'governs'));
+
+      // Unmeasured domain: knowledge only, 0/0.
+      store.addNode(makeKnowledgeNode('u-1', 'ungraded', 'confluence'));
+
+      const report = scorer.score(store);
+      const graded = findDomain(report, 'graded');
+
+      // Overall reflects the measured domain only — the 0/0 domain must not
+      // drag the aggregate down toward F.
+      expect(report.measuredDomainCount).toBe(1);
+      expect(report.overallScore).toBe(graded!.score);
+      expect(report.overallGrade).toBe(graded!.grade);
+      expect(report.graphPresent).toBe(true);
+    });
+
+    it('graphPresent is false only when there are no nodes at all', () => {
+      const store = new GraphStore();
+      const scorer = new CoverageScorer();
+      store.addNode(makeKnowledgeNode('kn-only', 'x', 'docs'));
+
+      const report = scorer.score(store);
+      // Knowledge exists → graph is present, but no measurable domain → N/A.
+      expect(report.graphPresent).toBe(true);
+      expect(report.overallGrade).toBe('N/A');
+      expect(report.measuredDomainCount).toBe(0);
+    });
   });
 
   describe('inferenceOptions plumbing (Phase 4)', () => {

--- a/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
+++ b/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
@@ -343,6 +343,36 @@ Route all auth through AuthService.
         // File may not exist if no new findings
       }
     });
+    it('carries the source file path on staged extractor findings (#1111)', async () => {
+      // A genuine first-party source signal: a Zod schema in src/ (not a test
+      // file or fixture) → validation-rules extractor → business_rule node.
+      const srcDir = path.join(tmpDir, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+      await fs.writeFile(
+        path.join(srcDir, 'orders.ts'),
+        'import { z } from "zod";\nexport const OrderSchema = z.object({\n  id: z.string().min(1),\n});\n'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      await runner.run(makeOptions());
+
+      const stagedPath = path.join(
+        tmpDir,
+        '.harness',
+        'knowledge',
+        'staged',
+        'pipeline-staged.jsonl'
+      );
+      const content = await fs.readFile(stagedPath, 'utf-8');
+      const entries = content
+        .trim()
+        .split('\n')
+        .map((l) => JSON.parse(l) as { source: string; path?: string; name: string });
+
+      const extractorEntry = entries.find((e) => e.source === 'extractor' && e.path);
+      expect(extractorEntry).toBeDefined();
+      expect(extractorEntry!.path).toBe('src/orders.ts');
+    });
   });
 
   describe('CI mode', () => {

--- a/packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts
+++ b/packages/graph/tests/ingest/extractors/ExtractionRunner.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import {
   ExtractionRunner,
   detectLanguage,
+  DEFAULT_EXTRACTION_EXCLUDE,
 } from '../../../src/ingest/extractors/ExtractionRunner.js';
 import { GraphStore } from '../../../src/store/GraphStore.js';
 import type {
@@ -159,6 +160,78 @@ describe('ExtractionRunner', () => {
     // No new nodes on second run
     expect(nodesAfter).toBe(nodesBefore);
     expect(result2.nodesAdded).toBe(0);
+  });
+
+  describe('test / fixture exclusion (#1111)', () => {
+    /** Write a small polyglot-free TS project tree under a temp root. */
+    async function buildProjectTree(root: string): Promise<void> {
+      const write = async (rel: string, body = 'export const x = 1;\n') => {
+        const full = path.join(root, rel);
+        await fs.mkdir(path.dirname(full), { recursive: true });
+        await fs.writeFile(full, body, 'utf-8');
+      };
+      await write('src/orders.ts'); // genuine first-party source
+      await write('src/orders.test.ts'); // co-located test file
+      await write('tests/sync-runtime.test.ts'); // test directory
+      await write('tests/skills/fixtures/optum/expected/schema.ts'); // golden fixture
+      await write('src/__snapshots__/thing.ts'); // snapshot tree
+    }
+
+    it('findSourceFiles walks first-party source but skips test files and fixtures', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'excl-test-'));
+      await buildProjectTree(root);
+
+      const runner = new ExtractionRunner([]);
+      const files = (await runner.findSourceFiles(root)).map((f) =>
+        path.relative(root, f).replaceAll('\\', '/')
+      );
+
+      expect(files).toContain('src/orders.ts');
+      expect(files).not.toContain('src/orders.test.ts');
+      expect(files).not.toContain('tests/sync-runtime.test.ts');
+      expect(files).not.toContain('tests/skills/fixtures/optum/expected/schema.ts');
+      expect(files).not.toContain('src/__snapshots__/thing.ts');
+    });
+
+    it('extracts a genuine first-party signal but not test/fixture-derived ones', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'excl-test-'));
+      await buildProjectTree(root);
+      const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'excl-out-'));
+
+      // Stub emits one record per file it is given — so the produced records'
+      // filePaths reveal exactly which files the runner fed to the extractors.
+      const stub = createStubExtractor('probe');
+      const runner = new ExtractionRunner([stub]);
+      const store = new GraphStore();
+      await runner.run(root, store, outDir);
+
+      const paths = store
+        .findNodes({ type: 'business_rule' })
+        .filter((n) => n.metadata.source === 'code-extractor')
+        .map((n) => n.path);
+
+      expect(paths).toContain('src/orders.ts');
+      expect(paths).not.toContain('src/orders.test.ts');
+      expect(paths).not.toContain('tests/sync-runtime.test.ts');
+      expect(paths).not.toContain('tests/skills/fixtures/optum/expected/schema.ts');
+    });
+
+    it('honors caller-supplied excludeGlobs that extend the defaults', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'excl-test-'));
+      await fs.mkdir(path.join(root, 'src'), { recursive: true });
+      await fs.writeFile(path.join(root, 'src/orders.ts'), 'export const x = 1;\n');
+      await fs.writeFile(path.join(root, 'src/generated.ts'), 'export const y = 2;\n');
+
+      const runner = new ExtractionRunner([], {
+        excludeGlobs: [...DEFAULT_EXTRACTION_EXCLUDE, '**/generated.ts'],
+      });
+      const files = (await runner.findSourceFiles(root)).map((f) =>
+        path.relative(root, f).replaceAll('\\', '/')
+      );
+
+      expect(files).toContain('src/orders.ts');
+      expect(files).not.toContain('src/generated.ts');
+    });
   });
 
   it('marks stale nodes when signals disappear', async () => {


### PR DESCRIPTION
Fixes #1110
Fixes #1111

Two related correctness bugs in `harness knowledge-pipeline`, reported from the same run against an overlay repo, where the command produced confident but unactionable verdicts. Spec: `docs/changes/knowledge-pipeline-correctness/proposal.md`.

## #1110 — coverage graded F on a zero denominator

`CoverageScorer` mapped a domain with no linkable code (`0/0`) to grade `F` via `toGrade(0)`, so "no graph / no data" and "genuinely bad coverage" rendered identically — a fresh checkout with no graph scored *worse* (F, 19/100) than a real assessment (D, 24/100).

- `DomainCoverageScore` gains `measured: boolean`; a domain with `codeEntities === 0` is now `measured: false` / grade `N/A`, never `F`.
- `CoverageReport` gains `graphPresent` and `measuredDomainCount`; `overallScore` averages **measured** domains only (no more averaging no-denominator zeros in), and `overallGrade` is `N/A` when nothing is measurable.
- `--coverage` output prints an explicit "no graph — run `harness graph scan`" escalation (the one the SKILL already specifies) and renders per-domain `0/0` as `N/A` instead of `F (0/100)`.
- A first-run drift score (all findings `new`) is labelled `(first run — no prior graph state)` so `1.00` is not misread as "everything drifted".

## #1111 — test files/fixtures extracted as business knowledge

`ExtractionRunner.findSourceFiles` skipped only directory *names*, so `tests/`, `fixtures/`, `expected/`, and snapshot trees were walked and staged as `business_rule`/`business_term` gaps — the repro's 37 "undocumented" signals were all test artifacts.

- New `DEFAULT_EXTRACTION_EXCLUDE` (test files + fixture/golden/snapshot trees, mirroring the existing `security.exclude` / `entropy.excludePatterns` conventions), matched with `minimatch` against project-relative paths, with directory pruning.
- Extendable via a new additive `knowledge.extractionExclude` config field, threaded CLI → `KnowledgePipelineOptions` → `createExtractionRunner`.
- `StagedEntry` gains `path` so a finding is attributable without grepping. First-party source is untouched.

## Before / after

No-graph run (smoke):

- Before: `Coverage: F (19/100)` with `0/0 code linked`.
- After: `Coverage: N/A — no measurable domains (run harness graph scan)`; per-domain `orders: N/A — 1 knowledge, no code to link`; `Drift Score: 1.00 (first run — no prior graph state)`. A genuine first-party `OrderSchema` signal is still extracted; the co-located `tests/orders.test.ts` title is not.

## Tests

- `CoverageScorer`: 0/0 domain → `measured:false` / `N/A` and excluded from the aggregate; measured domain still grades A–F; empty graph → `graphPresent:false` / `N/A`; knowledge-only graph → present but `N/A`.
- `ExtractionRunner`: first-party source extracted while `*.test.ts`, `tests/**`, `fixtures/**/expected/**`, and snapshot trees are skipped; caller `excludeGlobs` honored.
- `KnowledgePipelineRunner`: staged extractor entries carry `path`.
- Updated the config-schema default-shape test and the empty-graph grade expectation (F → N/A, the crux of #1110).

Full `turbo run build` 13/13, graph + cli suites green through the pre-push gauntlet; `.harness/arch/baselines.json` byte-identical to `origin/main`; `generate:plugin:check` exit 0 with unchanged command count; generated reference docs fresh.