### PR TITLE
test(signals): deflake command-runner subprocess flake (#1143) + investigate Windows orchestrator test ENOENT flake

### DIFF
--- a/.changeset/deflake-subprocess-command-runner.md
+++ b/.changeset/deflake-subprocess-command-runner.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/signals': patch
+---
+
+Deflake the `command-runner` subprocess test under full-suite parallelism.
+
+`defaultCommandRunner` spawned its `execFile` child under a fixed 5s timeout.
+Under a full-suite parallel test run — many workers each launching a fresh
+`node` subprocess — even a bare launch can exceed 5s purely from host load, so
+the fixed budget killed an otherwise-healthy child and surfaced a spurious
+failure. The timeout is now an optional third argument (default unchanged at 5s,
+exposed as `DEFAULT_COMMAND_TIMEOUT_MS`); callers on a loaded host can widen it,
+and the runner's own test does so. A larger budget only tolerates a slow runner
+— a genuine hang still fails — so it cannot mask a real defect. Production
+behavior for real git/gh callers (the 5s default) is unchanged.

--- a/docs/changes/deflake-subprocess-windows/proposal.md
+++ b/docs/changes/deflake-subprocess-windows/proposal.md
@@ -1,0 +1,100 @@
+# Proposal: deflake remaining subprocess tests + investigate Windows stream-write flake
+
+Status: proposed
+Type: test-reliability / cross-platform robustness hardening
+Related: issue #1143 (subprocess-spawning tests flaky under full-suite parallelism); siblings #1153 / #1155 (same class of deflake).
+
+Spec-first is optional for pure test/robustness hardening; this proposal mirrors
+how #1153 / #1155 were scoped and records the investigation and the honest
+outcome of both parts.
+
+## Part A — issue #1143 remainder (subprocess tests flaky under full-suite parallelism)
+
+#1153 already deflaked `core/src/solutions/scan-candidates/git-scan.test.ts` and
+`core/tests/state/event-sourcing/concurrency.test.ts` by removing their
+sub-global per-test `30_000` caps so they inherit core's generous 60s
+`testTimeout`/`hookTimeout`. Two files from the issue remained:
+
+### `packages/signals/tests/command-runner.test.ts` — FIXED
+
+Root cause is a fixed subprocess timeout in **source**, not the vitest ceiling:
+`defaultCommandRunner` (`packages/signals/src/command-runner.ts`) ran its
+`execFile` child under a hard `timeout: 5_000`. Under a full-suite parallel run
+(many vitest workers each spawning a fresh `node`), a bare `node -e` launch can
+exceed 5s purely from host load; the fixed budget then kills the healthy child
+and rejects, failing green code. Raising the vitest `testTimeout` alone cannot
+fix this — the child is killed at 5s regardless of the outer ceiling.
+
+Fix (minimal, production-behavior-preserving):
+
+- `command-runner.ts`: the timeout is now an optional third argument defaulting
+  to the exported `DEFAULT_COMMAND_TIMEOUT_MS` (5s). Real git/gh callers keep the
+  5s default; direct callers on a loaded host (and the runner's own test) can
+  widen it. The `CommandRunner` type is unchanged (2-arg), so injected-seam
+  consumers are unaffected.
+- `command-runner.test.ts`: the two subprocess-spawning cases pass a generous
+  30s budget.
+- `packages/signals/vitest.config.mts`: `testTimeout` 30s → 60s and add
+  `hookTimeout: 60_000`, kept above the per-subprocess budget so the child's own
+  budget (not the vitest ceiling) guards a true hang.
+
+A larger budget only tolerates a slow/loaded runner — a genuine hang still fails
+— so it cannot mask a real bug. No assertions weakened, no tests skipped.
+
+### `packages/core/tests/review/ci/default-exec-file.test.ts` — ALREADY COVERED
+
+This file spawns real `node -e` children through the production `defaultExecFile`
+seam (default subprocess timeout 120s). It carries **no** sub-global per-test
+timeout caps and **no** wall-clock assertions — every rejection assertion matches
+a load-invariant message (`exited with code …`, `output exceeded N bytes`). It
+therefore already inherits core's generous 60s global from #1153 (the same state
+into which #1153 moved the sibling files by removing their `30_000` caps). No
+change is warranted; verified 3× green under load.
+
+### Verification
+
+Reproduction of the original load flake was best-effort: on the dev host a bare
+`node -e` launch stays ~60ms even at load average 65 (fast SSD, warm binary
+cache), so the 5s ceiling could not be tripped synthetically. The mechanism is
+well-documented in the issue (`command-runner.ts:14`) and the fix is
+deterministic. Both target files are 3× green consecutively under CPU
+saturation.
+
+## Part B — Windows orchestrator `test` (non-coverage) ENOENT flake — INVESTIGATED, NO SOURCE FIX
+
+Reported: on Windows CI, `@harness-engineering/orchestrator#test` intermittently
+fails with ENOENT temp-path writes under `.harness/streams/<id>/N.jsonl`,
+`.harness/interactions/interaction-*.json`, and `audit.log`.
+
+Investigation of every production writer to those three path families:
+
+- **streams** — `StreamRecorder.startRecording` (`core/stream-recorder.ts`)
+  calls `fs.mkdirSync(issueDir, { recursive: true })` before its first write;
+  `recordEvent` / `finishRecording` wrap their `appendFileSync` in try/catch and
+  swallow (best-effort). `core` stream index (`state/stream-resolver.ts`) and
+  `flight-recorder.ts` both `mkdirSync(..., { recursive: true })` before writing.
+- **interactions** — `InteractionQueue.push` (`core/interaction-queue.ts`) calls
+  `fs.mkdir(this.dir, { recursive: true })` before writing; `updateStatus` reads
+  the file first and only writes if it exists.
+- **audit** — `AuditLogger.writeLine` (`auth/audit.ts`) `mkdir(dirname(path),
+{ recursive: true })` before the append and swallows failures (best-effort,
+  `console.warn`, never throws); the queue chain is `.catch()`-guarded.
+
+Every production write to the three named families already creates its parent
+directory recursively before writing (or reads-first, or swallows). There is no
+deterministic missing-mkdir write path, and no unguarded test-setup write to
+those paths (the only direct test write, `stream-recorder.test.ts`, follows
+`startRecording`).
+
+Decisive diagnostic: a missing-parent-dir ENOENT fails **deterministically on
+every platform**, not intermittently on Windows only. The Windows-only,
+intermittent signature is consistent with a filesystem teardown-timing race
+(fire-and-forget async writes interleaving with `afterEach` `rmSync`, under
+Windows' stricter file-handle / unlink semantics), not an
+ENOENT-from-a-missing-parent-dir in production code.
+
+Per the task's explicit guidance ("if you genuinely cannot locate a missing-mkdir
+write path … STOP Part B and report that honestly rather than guessing"), no
+source or test change is made for Part B. Adding redundant `mkdir` calls in front
+of writes that already `mkdir` (or already recreate the tree recursively) would
+be gold-plating and would not address a timing race. Part A ships on its own.

--- a/packages/signals/src/command-runner.ts
+++ b/packages/signals/src/command-runner.ts
@@ -8,10 +8,29 @@ import { execFile } from 'node:child_process';
  */
 export type CommandRunner = (cmd: string, args: string[]) => Promise<string>;
 
-/** Default `execFile`-based runner with a 5s timeout. */
-export const defaultCommandRunner: CommandRunner = (cmd, args) =>
+/** Default per-command timeout (ms) for {@link defaultCommandRunner}. */
+export const DEFAULT_COMMAND_TIMEOUT_MS = 5_000;
+
+/**
+ * Default `execFile`-based runner.
+ *
+ * `timeoutMs` defaults to {@link DEFAULT_COMMAND_TIMEOUT_MS} (5s) — the budget
+ * real git/gh calls run under in production. It is an optional escape hatch so a
+ * caller on a heavily-loaded host (e.g. a full-suite parallel test run where many
+ * workers each spawn a fresh subprocess) can widen it: under saturation even a
+ * bare `node -e` launch can exceed 5s, so the fixed budget would kill an
+ * otherwise-healthy child and surface a spurious failure. A larger budget only
+ * tolerates a slow/loaded host — a genuine hang still hits the ceiling — so it
+ * cannot mask a real defect. Direct callers may pass a wider value; callers that
+ * consume the `CommandRunner` type keep the 5s default.
+ */
+export const defaultCommandRunner: CommandRunner = (
+  cmd,
+  args,
+  timeoutMs: number = DEFAULT_COMMAND_TIMEOUT_MS
+) =>
   new Promise<string>((resolve, reject) => {
-    execFile(cmd, args, { timeout: 5_000, maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
+    execFile(cmd, args, { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
       if (err) {
         reject(err as Error);
         return;

--- a/packages/signals/tests/command-runner.test.ts
+++ b/packages/signals/tests/command-runner.test.ts
@@ -1,15 +1,27 @@
 import { describe, it, expect } from 'vitest';
 import { defaultCommandRunner, type CommandRunner } from '../src/command-runner';
 
+// Widen the per-subprocess budget well past the 5s production default. These
+// tests spawn a real `node -e` child; under a full-suite parallel run (many
+// vitest workers each launching node) that launch can exceed 5s purely from
+// host load and get killed, failing green code. A generous budget only tolerates
+// a slow/loaded host — a genuine hang still fails at the vitest ceiling — so it
+// cannot mask a real bug.
+const SUBPROCESS_BUDGET_MS = 30_000;
+
 describe('defaultCommandRunner', () => {
   it('runs a command and returns trimmed stdout', async () => {
-    const out = await defaultCommandRunner('node', ['-e', 'process.stdout.write("hi\\n")']);
+    const out = await defaultCommandRunner(
+      'node',
+      ['-e', 'process.stdout.write("hi\\n")'],
+      SUBPROCESS_BUDGET_MS
+    );
     expect(out).toBe('hi');
   });
   it('rejects when the command exits non-zero', async () => {
-    await expect(defaultCommandRunner('node', ['-e', 'process.exit(3)'])).rejects.toBeInstanceOf(
-      Error
-    );
+    await expect(
+      defaultCommandRunner('node', ['-e', 'process.exit(3)'], SUBPROCESS_BUDGET_MS)
+    ).rejects.toBeInstanceOf(Error);
   });
   it('satisfies the CommandRunner type', () => {
     const r: CommandRunner = defaultCommandRunner;

--- a/packages/signals/vitest.config.mts
+++ b/packages/signals/vitest.config.mts
@@ -4,7 +4,15 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    testTimeout: 30_000,
+    // Generous ceilings. The command-runner suite spawns a real node subprocess;
+    // under a full-suite parallel run (many workers each launching node) that
+    // launch can be starved of CPU, so a tighter budget timed out intermittently
+    // on green code. A larger ceiling only tolerates a slow/loaded runner — a
+    // genuine hang still fails — so it cannot mask a real bug. Kept above the
+    // per-subprocess budget the runner tests widen to, so the child's own budget
+    // (not the vitest ceiling) is what guards a true hang.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],


### PR DESCRIPTION
## What

Two related test-reliability fixes for external flaky-test reports, shipped as one PR. Same class as the merged #1153 / #1155 deflakes.

## Part A — remainder of #1143 (subprocess tests flaky under full-suite parallelism)

#1153 already deflaked `git-scan.test.ts` and event-sourcing `concurrency.test.ts` by removing their sub-global per-test `30_000` caps so they inherit core's 60s global. Two files from #1143 remained:

**`packages/signals/tests/command-runner.test.ts` — FIXED (source + test + config).**
Root cause is a fixed subprocess timeout in *source*, not the vitest ceiling: `defaultCommandRunner` ran its `execFile` child under a hard `timeout: 5_000`. Under a full-suite parallel run (many workers each spawning a fresh `node`), a bare `node -e` launch can exceed 5s purely from host load, so the fixed budget kills a healthy child and rejects — failing green code. Raising the vitest `testTimeout` alone can't fix it; the child is killed at 5s regardless.

- `command-runner.ts`: timeout is now an optional third arg defaulting to the exported `DEFAULT_COMMAND_TIMEOUT_MS` (5s). Real git/gh callers keep 5s; direct callers on a loaded host (and the runner's own test) can widen it. The `CommandRunner` type is unchanged (2-arg), so injected-seam consumers are unaffected. Production behavior is preserved.
- `command-runner.test.ts`: the two subprocess cases pass a generous 30s budget.
- `signals/vitest.config.mts`: `testTimeout` 30s → 60s + `hookTimeout: 60_000`, kept above the per-subprocess budget so the child's own budget (not the vitest ceiling) guards a true hang.

**`packages/core/tests/review/ci/default-exec-file.test.ts` — ALREADY COVERED (no change).**
It spawns real `node -e` children via the production `defaultExecFile` seam (120s default subprocess timeout), has **no** sub-global per-test caps and **no** wall-clock assertions (every rejection matches a load-invariant message like `exited with code …` / `output exceeded N bytes`). It therefore already inherits core's 60s global from #1153 — the same state into which #1153 moved the sibling files by removing their caps. Verified 3× green under load.

## Part B — Windows orchestrator `test` (non-coverage) ENOENT flake — INVESTIGATED, NO SOURCE FIX

Reported: on Windows CI, `@harness-engineering/orchestrator#test` intermittently ENOENTs on temp writes under `.harness/streams/<id>/N.jsonl`, `.harness/interactions/interaction-*.json`, and `audit.log`. #1155 hardened only `test:coverage`.

Every production writer to those three path families **already** recursively creates its parent before writing:
- **streams** — `StreamRecorder.startRecording` `mkdirSync(issueDir, { recursive: true })` before its first write; `recordEvent`/`finishRecording` swallow (best-effort try/catch). Core `stream-resolver.ts` and `flight-recorder.ts` both `mkdirSync(recursive)` first.
- **interactions** — `InteractionQueue.push` `mkdir(dir, { recursive: true })` first; `updateStatus` reads-first.
- **audit** — `AuditLogger.writeLine` `mkdir(dirname, { recursive: true })` first and swallows failures (best-effort, never throws); the queue chain is `.catch()`-guarded.

No deterministic missing-mkdir write path exists, and no unguarded test-setup write to those paths (the only direct test write, `stream-recorder.test.ts`, follows `startRecording`).

**Decisive diagnostic:** a missing-parent-dir ENOENT fails deterministically on *every* platform, not intermittently on Windows only. The Windows-only intermittent signature is consistent with a filesystem teardown-timing race (fire-and-forget async writes interleaving with `afterEach` `rmSync`, under Windows' stricter file-handle/unlink semantics), not an ENOENT-from-a-missing-parent-dir in production code.

Per the task's own guardrail — "if you genuinely cannot locate a missing-mkdir write path, STOP and report honestly rather than guessing" — no source/test change is made for Part B. Adding redundant `mkdir`s in front of writes that already `mkdir` would be gold-plating and wouldn't address a timing race. Part A ships on its own. Full write-up in `docs/changes/deflake-subprocess-windows/proposal.md`.

## Verification

- Both #1143 target files 3× green consecutively under CPU saturation (signals command-runner 3/3, core default-exec-file 3/3). Original load flake could not be reproduced synthetically on the dev host (a bare `node -e` launch stays ~60ms even at load avg 65 — fast SSD, warm cache), so the deterministic fix follows the well-documented mechanism.
- Full `turbo run build` 13/13. Full `turbo run test` green (two unrelated packages — `burn` concurrency, `intelligence` — flaked once under machine saturation with the same #1143 timeout signature; both 87/87 and 573/573 green in isolation).
- `.harness/arch/baselines.json` byte-identical to origin/main. `generate:plugin:check` EXIT 0, plugin command count unchanged (70). Test-only + one production-behavior-preserving signals change; changeset is a `signals` patch.

Closes part of #1143 (signals remainder); also documents the honest outcome of the Windows orchestrator `test` ENOENT investigation.
