### PR TITLE
fix(security): extract secret values to the matching close quote

### DIFF
--- a/.changeset/secret-value-matching-close-quote.md
+++ b/.changeset/secret-value-matching-close-quote.md
@@ -1,0 +1,32 @@
+---
+'@harness-engineering/core': patch
+---
+
+Extract secret values to the matching close quote, so shell env plumbing stops
+reporting as a hardcoded secret.
+
+The reference-vs-literal guard added for the `${{ secrets.X }}` false positive
+works, but the value handed to it was truncated. Both extractors used a
+character class excluding _both_ quote types — `["']([^"']{8,})` in the
+review-tier detector and `['"]([^'"]*)['"]` in `extractQuotedSecretValue` — and
+neither understood backslash escapes, so any value containing an inner quote
+came back as a fragment:
+
+```sh
+GITHUB_TOKEN="$(sed -n 's/^GITHUB_TOKEN=//p' .env)"   # -> $(sed -n
+GITHUB_TOKEN="${GITHUB_TOKEN#\"}"                     # -> ${GITHUB_TOKEN#\
+```
+
+Neither fragment parses as a command substitution or a brace expansion, so
+`isReferenceOnlySecretValue` saw literal residue and reported `critical`. Only
+values with no inner quote (`"${TOKEN:-}"`) were suppressed correctly — which is
+why the workflow-YAML class looked fixed while the shell class was not.
+
+Extraction is now quote-type aware and escape aware, so the value runs to the
+matching close quote. The closing quote stays optional in the review-tier
+pattern, so an unterminated string is still scanned rather than skipped.
+
+Verified against a real `.husky/pre-push`: 5 findings → 0. Literal secrets still
+fire, including a literal containing an escaped quote.
+
+Refs Capillary/capwell#1372, Capillary/capwell#1216.

--- a/packages/core/src/review/agents/security-agent.ts
+++ b/packages/core/src/review/agents/security-agent.ts
@@ -26,7 +26,7 @@ const EVAL_PATTERN = /\beval\s*\(|new\s+Function\s*\(/;
  * `isReferenceOnlySecretValue`.
  */
 const SECRET_PATTERNS = [
-  /(?:api[_-]?key|secret|password|token|private[_-]?key)\s*=\s*["']([^"']{8,})/i,
+  /(?:api[_-]?key|secret|password|token|private[_-]?key)\s*=\s*(?:"((?:\\.|[^"\\]){8,})|'((?:\\.|[^'\\]){8,}))/i,
   /["']((?:sk|pk|api|key|secret|token|password)[-_][a-zA-Z0-9]{10,})["']/i,
 ];
 
@@ -34,11 +34,22 @@ const SECRET_PATTERNS = [
  * Return the captured secret VALUE for the first matching pattern, or `null`
  * when no pattern matches. An empty string is a valid (matched-but-empty) value
  * distinct from `null` (no match).
+ *
+ * Pattern 1 branches per quote character so the value runs to the *matching*
+ * close quote: a single `["']([^"']{8,})` class stops at the first quote of
+ * either type, truncating `"$(sed -n 's/^TOKEN=//p' .env)"` to `$(sed -n ` and
+ * `"${TOKEN#\"}"` to `${TOKEN#\`. Neither fragment parses as a reference, so
+ * the value read as a literal and every env-plumbing line in a shell script
+ * was reported as a hardcoded secret (capwell#1372). Two branches means two
+ * groups, hence the `m[1] ?? m[2]` — only one can be defined per match.
+ *
+ * The closing quote stays optional, as before, so an unterminated string is
+ * still scanned rather than silently skipped.
  */
 function matchSecretValue(text: string): string | null {
   for (const pattern of SECRET_PATTERNS) {
     const m = pattern.exec(text);
-    if (m) return m[1] ?? '';
+    if (m) return m[1] ?? m[2] ?? '';
   }
   return null;
 }

--- a/packages/core/src/security/secret-reference.ts
+++ b/packages/core/src/security/secret-reference.ts
@@ -73,12 +73,32 @@ export function isReferenceOnlySecretValue(value: string): boolean {
 }
 
 /**
+ * Body of a quoted string: characters up to the *matching* close quote.
+ *
+ * Two properties matter, and getting either wrong truncates the value:
+ *
+ *  - **Quote-type aware.** `(?!\1)` lets the opposite quote appear inside, so
+ *    `"$(sed -n 's/^TOKEN=//p' .env)"` yields the whole command substitution
+ *    rather than stopping at the inner `'`. A class like `[^'"]` stops at the
+ *    first quote of *either* type.
+ *  - **Escape aware.** `\\.` consumes `\"` as one unit, so
+ *    `"${TOKEN#\"}"` yields the whole brace expansion rather than stopping at
+ *    the escaped quote.
+ *
+ * Truncation is what makes this a correctness bug rather than cosmetics: a
+ * half-captured `$(sed -n ` or `${TOKEN#\` is no longer recognizable as a
+ * reference, so `isReferenceOnlySecretValue` sees literal residue and the line
+ * is reported as a hardcoded secret (capwell#1372).
+ */
+const QUOTED_BODY = /(['"])((?:\\.|(?!\1)[^\\])*)\1/;
+
+/**
  * Extract the quoted value from a matched secret assignment, e.g.
  * `TOKEN="$AUTOAPPROVE_PAT"` → `$AUTOAPPROVE_PAT`. Returns `null` when the match
  * carries no quoted value, so callers treat unquoted/bare-token matches (which
  * the reference forms never produce) as literals rather than suppressing them.
  */
 export function extractQuotedSecretValue(matchText: string): string | null {
-  const m = /['"]([^'"]*)['"]/.exec(matchText);
-  return m ? (m[1] ?? '') : null;
+  const m = QUOTED_BODY.exec(matchText);
+  return m ? (m[2] ?? '') : null;
 }

--- a/packages/core/tests/review/agents/security-agent.test.ts
+++ b/packages/core/tests/review/agents/security-agent.test.ts
@@ -598,6 +598,82 @@ describe('runSecurityAgent()', () => {
     expect(runSecurityAgent(bundle).length).toBe(0);
   });
 
+  // ---- capwell#1372: shell env plumbing. The reference forms above were
+  // already understood; what broke was EXTRACTION. `["']([^"']{8,})` stops at
+  // the first quote of either type, so a value containing an inner quote came
+  // back truncated (`$(sed -n `, `${GITHUB_TOKEN#\`), no longer parsed as a
+  // reference, and was reported as a literal secret. This is the verbatim
+  // `.husky/pre-push` block that made every PR touching that file inherit a
+  // `critical` finding. ----
+
+  it('does NOT flag the .husky/pre-push env-plumbing block (capwell#1372)', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: '.husky/pre-push',
+          content: [
+            '#!/usr/bin/env sh',
+            'if [ -z "${GITHUB_TOKEN:-}" ] && [ -f .env ]; then',
+            `  GITHUB_TOKEN="$(sed -n 's/^GITHUB_TOKEN=//p' .env | tail -n 1)"`,
+            '  GITHUB_TOKEN="${GITHUB_TOKEN#\\"}"',
+            '  GITHUB_TOKEN="${GITHUB_TOKEN%\\"}"',
+            '  GITHUB_TOKEN="${GITHUB_TOKEN#\\\'}"',
+            '  GITHUB_TOKEN="${GITHUB_TOKEN%\\\'}"',
+            'fi',
+            'export GITHUB_TOKEN="${GITHUB_TOKEN:-}"',
+          ].join('\n'),
+          reason: 'changed',
+          lines: 9,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle)).toEqual([]);
+  });
+
+  it('does NOT flag a command substitution whose argument is single-quoted', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'scripts/env.sh',
+          content: `TOKEN="$(sed -n 's/^TOKEN=//p' .env)"`,
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(0);
+  });
+
+  // The other direction: widening extraction must not create a blind spot.
+
+  it('STILL flags a literal secret in a shell file', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'deploy/run.sh',
+          content: 'export API_KEY="sk-live-0123456789abcdef"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(1);
+  });
+
+  it('STILL flags a literal secret that itself contains an escaped quote', () => {
+    const bundle = makeBundle({
+      changedFiles: [
+        {
+          path: 'deploy/run.sh',
+          content: 'export TOKEN="abc\\"def-sk-live-0123456789"',
+          reason: 'changed',
+          lines: 1,
+        },
+      ],
+    });
+    expect(runSecurityAgent(bundle).length).toBe(1);
+  });
+
   it('STILL flags a command substitution mixed with a literal suffix (guard must not over-suppress)', () => {
     const bundle = makeBundle({
       changedFiles: [

--- a/packages/core/tests/security/secret-reference.test.ts
+++ b/packages/core/tests/security/secret-reference.test.ts
@@ -49,4 +49,31 @@ describe('extractQuotedSecretValue', () => {
   it('returns null when the match carries no quoted value', () => {
     expect(extractQuotedSecretValue('postgres://user:pass@host')).toBeNull();
   });
+
+  // capwell#1372: the value must run to the *matching* close quote. A class
+  // excluding both quote types truncates at the first inner quote, and the
+  // fragment left behind (`$(sed -n `, `${TOKEN#\`) no longer parses as a
+  // reference — so `isReferenceOnlySecretValue` reads it as a literal and the
+  // line is reported as a hardcoded secret.
+  it('keeps the opposite quote type inside the value', () => {
+    expect(extractQuotedSecretValue(`TOKEN="$(sed -n 's/^TOKEN=//p' .env)"`)).toBe(
+      `$(sed -n 's/^TOKEN=//p' .env)`
+    );
+  });
+
+  it('keeps an escaped quote inside the value', () => {
+    expect(extractQuotedSecretValue('TOKEN="${TOKEN#\\"}"')).toBe('${TOKEN#\\"}');
+  });
+
+  it('extracts values that survive as reference-only end to end', () => {
+    const value = extractQuotedSecretValue(`TOKEN="$(sed -n 's/^TOKEN=//p' .env)"`);
+    expect(value).not.toBeNull();
+    expect(isReferenceOnlySecretValue(value as string)).toBe(true);
+  });
+
+  it('still treats a literal containing an escaped quote as a literal', () => {
+    const value = extractQuotedSecretValue('TOKEN="abc\\"def-sk-live-9999"');
+    expect(value).toBe('abc\\"def-sk-live-9999');
+    expect(isReferenceOnlySecretValue(value as string)).toBe(false);
+  });
 });


### PR DESCRIPTION
Shell env plumbing is still reported as a hardcoded secret. The
reference-vs-literal guard added for the `${{ secrets.X }}` false positive is
correct — the bug is one step earlier, in the **value extraction** that feeds it.

## The bug

Both extractors matched the value with a character class excluding **both**
quote types, and neither understood backslash escapes:

| Site | Pattern |
|---|---|
| `review/agents/security-agent.ts` | `["']([^"']{8,})` |
| `security/secret-reference.ts` (`extractQuotedSecretValue`) | `['"]([^'"]*)['"]` |

So any value containing an inner quote came back as a fragment:

```sh
GITHUB_TOKEN="$(sed -n 's/^GITHUB_TOKEN=//p' .env)"   # extracted: $(sed -n
GITHUB_TOKEN="${GITHUB_TOKEN#\"}"                     # extracted: ${GITHUB_TOKEN#\
```

`$(sed -n ` is not a command substitution and `${GITHUB_TOKEN#\` is not a brace
expansion, so `isReferenceOnlySecretValue` saw literal residue and raised a
`critical` CWE-798.

This also explains why the earlier fix looked complete. `"${TOKEN:-}"` has no
inner quote, survives extraction whole, and is suppressed correctly — so the
GitHub-Actions class passed while the shell class kept failing. Same rule, same
FP shape, different input class. Fixing extraction collapses both rather than
special-casing shell.

## The fix

One shared idea applied at both sites: run the value to the **matching** close
quote.

- quote-type aware via `(?!\1)`, so the opposite quote may appear inside
- escape aware via `\\.`, so `\"` is consumed as one unit

The closing quote stays **optional** in the review-tier pattern, exactly as
before, so an unterminated string is still scanned rather than silently skipped.
The two-branch pattern means two capture groups, hence `m[1] ?? m[2]`.

## Verification

**Against the real file that reported it** — `capwell`'s `.husky/pre-push`, read
from disk and run through the built agent:

```
before: 5 finding(s) at lines 6, 7, 8, 9, 10
after:  0 finding(s)
```

**The tests fail without the fix.** Reverting only the two source files with the
new tests in place:

```
Tests  7 failed | 84 passed (91)
```

The 8th new test (`STILL flags a literal secret in a shell file`) passes either
way by design — it is a no-regression guard, not a fix-prover.

**No blind spot introduced.** Still flagged: literal API keys, literal
passwords, single-quoted literals, `${PREFIX}sk-live-…` (reference + literal
residue), `$(id)-sk-ant-…`, and a literal that itself contains an escaped quote.

**Suite:** `packages/core` 366 files / 3996 tests pass; `pnpm typecheck` and
`pnpm lint` clean across the workspace.

## Deliberately unchanged

`TOKEN="$(echo sk-ant-x)"` remains reference-only. Widening extraction makes
this reachable in more places, but it is not new policy — `secret-reference.ts`
already documents and accepts it, on the grounds that a command substitution
assigns runtime output and the entropy/gitleaks tiers backstop the adversarial
`echo`-a-secret shape. Kept consistent rather than carved out here.

## Downstream

`capwell` pins `@harness-engineering/cli@10.2.0` in `required-review.yml`, which
is currently the latest published, so that repo cannot pick this up until a
release goes out.

Refs Capillary/capwell#1372, Capillary/capwell#1216
