### PR TITLE
fix(hooks): session-retrospect installer must never destroy an agent's existing config (retro-review of #1136)

### DIFF
--- a/.changeset/session-retrospect-config-preservation.md
+++ b/.changeset/session-retrospect-config-preservation.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix two config-preservation gaps in the multi-agent session-retrospect installer (follow-up to #1136).
+
+The installer that wires the opt-in `session-retrospect` trigger into Gemini CLI, Codex CLI, and Cursor documents that "unrelated user config is always preserved," but two paths violated that:
+
+- **Gemini / Cursor JSON clobber (data loss).** When an existing `.gemini/settings.json` or `.cursor/hooks.json` failed to parse (a hand-edited file, JSONC/comments, a trailing comma, a partial write), the reader treated it as absent and the writer then overwrote the whole file with only the harness hook — silently destroying the user's `theme`, `mcpServers`, and every other setting. The reader now distinguishes absent / valid-object / unparseable and the writers report a `conflict` (leaving the file untouched) instead of overwriting, mirroring how `hooks init` refuses to clobber a malformed `.claude/settings.json`.
+- **Codex TOML corruption.** The `notify` key was inserted before "the first line beginning with `[`". A top-level nested-array literal (e.g. `matrix = [\n  [1, 2],\n]`) has element lines that begin with `[`, so `notify` could be spliced _inside_ the array and corrupt the TOML. `notify` is now prepended as a top-level key at the very top of the file, which is always valid TOML — it precedes every table and is never placed inside a multi-line array.
+
+Both fixes are covered by new regression tests. Runtime behavior of the hooks themselves is unchanged; this only hardens the one-time install-time config writes.

--- a/docs/changes/session-retrospect-config-preservation/proposal.md
+++ b/docs/changes/session-retrospect-config-preservation/proposal.md
@@ -1,0 +1,87 @@
+# session-retrospect installer must never destroy an agent's existing config
+
+**Keywords:** hooks, session-retrospect, multi-agent, gemini, codex, cursor, config-preservation, data-loss, toml, json
+
+## Overview
+
+Retroactive-review follow-up to #1136 (multi-agent `session-retrospect` triggers
+for Claude Code, Gemini CLI, Codex CLI, and Cursor). #1136 shipped without a
+harness code-review pass; a retroactive review found two ways the install-time
+config writers in `packages/cli/src/hooks/agent-retrospect.ts` violate their own
+stated contract — "unrelated user config is always preserved."
+
+Both are install-time (`harness hooks init`) issues. The runtime hooks
+themselves are unaffected.
+
+### Problem 1 — Gemini/Cursor JSON clobber (silent data loss)
+
+`readJsonObject` returned `{}` for any file it could not `JSON.parse`, and the
+writers (`writeGeminiSessionEndHook`, `writeCursorRetrospectHooks`) then wrote
+that object back — replacing the user's entire `.gemini/settings.json` /
+`.cursor/hooks.json` with only the harness hook.
+
+Trigger: any existing-but-unparseable config — a trailing comma, JSONC-style
+comments, a hand edit in progress, or a partially written file. Result: the
+user's `theme`, `mcpServers`, and all other settings are silently destroyed.
+
+This is inconsistent with `hooks init`, which _throws_ rather than clobber a
+malformed `.claude/settings.json`.
+
+### Problem 2 — Codex TOML corruption on top-level nested arrays
+
+`writeCodexNotifyHook` inserted the top-level `notify` key before the first line
+matching `/^[ \t]*\[/` (assumed to be a table header). A top-level array literal
+whose element lines begin with `[` — e.g.
+
+```toml
+matrix = [
+  [1, 2],
+  [3, 4],
+]
+```
+
+makes the element line `  [1, 2],` match that pattern, so `notify` is spliced
+into the middle of the array, producing corrupt TOML.
+
+### Goals
+
+1. Never overwrite an existing, unparseable agent config — report a `conflict`
+   and leave the file byte-for-byte untouched (surfaced to the user as a warning
+   with a reason).
+2. Never corrupt a Codex `config.toml` regardless of top-level array shape.
+3. Preserve all existing behavior: fresh install, idempotent re-run, foreign
+   `notify` conflict, and preservation of valid unrelated config.
+
+### Out of scope
+
+- The at-most-once-per-session semantics and the "archive the most-recently
+  modified session" resolver (design as shipped in #1136).
+- Windows shell-command portability of `buildHookCommand` (pre-existing, shared
+  by all harness hooks — not introduced by #1136).
+
+## Approach
+
+- Replace `readJsonObject` with `readJsonConfig` returning a discriminated
+  `absent | parsed | unparseable` result. Empty files count as `absent` (safe to
+  create); valid non-object JSON (array/string) counts as `unparseable` (do not
+  merge). Gemini/Cursor writers return `conflict` on `unparseable`.
+- Attach a human-readable `reason` for Gemini/Cursor conflicts in
+  `installAgentRetrospectHooks` (parity with the existing Codex conflict reason);
+  `printInitResult` already warns on `conflict`.
+- Replace the Codex "insert before first table" logic with a prepend of the
+  top-level `notify` key at the very top of the file — always valid TOML,
+  independent of any array/table shape below.
+
+## Acceptance criteria
+
+- Given an existing `.gemini/settings.json` that fails `JSON.parse`, when the
+  Gemini writer runs, then it returns `conflict` and the file is unchanged.
+- Given an existing `.cursor/hooks.json` that fails `JSON.parse`, when the Cursor
+  writer runs, then it returns `conflict` and the file is unchanged.
+- Given an empty (whitespace-only) config file, when the writer runs, then it
+  installs cleanly (treated as absent).
+- Given a `config.toml` containing a top-level multi-line array whose element
+  lines begin with `[`, when the Codex writer runs, then `notify` is added as a
+  top-level key, the array survives intact, and no array line is split.
+- All pre-existing agent-retrospect tests continue to pass (fresh install,
+  idempotency, unrelated-config preservation, foreign-notify conflict).

--- a/packages/cli/src/hooks/agent-retrospect.ts
+++ b/packages/cli/src/hooks/agent-retrospect.ts
@@ -50,15 +50,46 @@ export interface AgentRetrospectResult {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic JSON config shapes
 type JsonObject = Record<string, any>;
 
-function readJsonObject(filePath: string): JsonObject {
-  if (!fs.existsSync(filePath)) return {};
+/**
+ * Read a JSON config file, distinguishing three outcomes so a caller never
+ * silently destroys a user's existing config:
+ *  - `absent`      — the file does not exist (or is empty); safe to create.
+ *  - `parsed`      — a valid JSON object; merge into it and preserve its keys.
+ *  - `unparseable` — the file exists with content that is not a JSON object
+ *                    (malformed JSON, JSONC/comments, a top-level array, …).
+ *
+ * A previous version returned `{}` for the `unparseable` case, which caused the
+ * caller's write to OVERWRITE the user's whole config with only the harness
+ * hook — silent data loss that violated this module's "unrelated user config is
+ * always preserved" contract. We now surface it so the writers report a
+ * `conflict` and leave the file untouched, mirroring how `hooks init` refuses to
+ * clobber a malformed `.claude/settings.json`.
+ */
+type JsonReadResult =
+  | { kind: 'absent' }
+  | { kind: 'parsed'; value: JsonObject }
+  | { kind: 'unparseable' };
+
+function readJsonConfig(filePath: string): JsonReadResult {
+  if (!fs.existsSync(filePath)) return { kind: 'absent' };
+  let raw: string;
   try {
-    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-    return parsed && typeof parsed === 'object' ? (parsed as JsonObject) : {};
+    raw = fs.readFileSync(filePath, 'utf-8');
   } catch {
-    // Malformed config — treat as absent rather than crash the installer. The
-    // caller's atomic write below replaces it with a valid document.
-    return {};
+    // Unreadable (permissions, race) — do not clobber.
+    return { kind: 'unparseable' };
+  }
+  if (raw.trim() === '') return { kind: 'absent' };
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { kind: 'parsed', value: parsed as JsonObject };
+    }
+    // Valid JSON but not an object (array / string / number) — not a config
+    // shape we can safely merge into, so preserve it rather than overwrite.
+    return { kind: 'unparseable' };
+  } catch {
+    return { kind: 'unparseable' };
   }
 }
 
@@ -85,13 +116,17 @@ function hasRetrospectEntry(entries: JsonObject[], command: string): boolean {
 
 /**
  * Wire the SessionEnd trigger into `.gemini/settings.json`. Preserves all other
- * settings and all other hook events; idempotent by name/command.
+ * settings and all other hook events; idempotent by name/command. An existing
+ * file that is not a JSON object is reported as a `conflict` and left untouched
+ * rather than overwritten.
  */
 export function writeGeminiSessionEndHook(
   settingsPath: string,
   command: string
 ): AgentRetrospectStatus {
-  const settings = readJsonObject(settingsPath);
+  const read = readJsonConfig(settingsPath);
+  if (read.kind === 'unparseable') return 'conflict';
+  const settings: JsonObject = read.kind === 'parsed' ? read.value : {};
   if (!settings.hooks || typeof settings.hooks !== 'object') settings.hooks = {};
   if (!Array.isArray(settings.hooks.SessionEnd)) settings.hooks.SessionEnd = [];
 
@@ -111,13 +146,17 @@ export function writeGeminiSessionEndHook(
 
 /**
  * Wire the `stop` + `sessionEnd` triggers into `.cursor/hooks.json`. Preserves
- * the existing version and any other events/entries; idempotent by command.
+ * the existing version and any other events/entries; idempotent by command. An
+ * existing file that is not a JSON object is reported as a `conflict` and left
+ * untouched rather than overwritten.
  */
 export function writeCursorRetrospectHooks(
   hooksPath: string,
   command: string
 ): AgentRetrospectStatus {
-  const config = readJsonObject(hooksPath);
+  const read = readJsonConfig(hooksPath);
+  if (read.kind === 'unparseable') return 'conflict';
+  const config: JsonObject = read.kind === 'parsed' ? read.value : {};
   if (typeof config.version !== 'number') config.version = 1;
   if (!config.hooks || typeof config.hooks !== 'object') config.hooks = {};
 
@@ -143,8 +182,13 @@ export function writeCursorRetrospectHooks(
  *  - already ours      → 'skipped' (idempotent)
  *  - a different notify → 'conflict' (left untouched; caller warns)
  *
- * The notify entry is a top-level TOML key, so it must be inserted BEFORE the
- * first table header (otherwise it would be parsed into that table).
+ * The notify entry is a top-level TOML key, so it must precede the first table
+ * header (otherwise it would be parsed into that table). We prepend it at the
+ * very top of the file: a top-level key on line 1 is always valid TOML — it
+ * comes before every table AND is never spliced inside a multi-line array. The
+ * previous "find the first line starting with `[` and insert before it"
+ * heuristic could mistake an array-element line (e.g. `  [1, 2],` inside a
+ * top-level array literal) for a table header and corrupt the file.
  */
 export function writeCodexNotifyHook(
   configPath: string,
@@ -165,17 +209,9 @@ export function writeCodexNotifyHook(
   if (existing.trim() === '') {
     updated = notifyLine + '\n';
   } else {
-    const lines = existing.split('\n');
-    const firstTableIdx = lines.findIndex((l) => /^[ \t]*\[/.test(l));
-    if (firstTableIdx === -1) {
-      // No tables: append as another top-level key.
-      const sep = existing.endsWith('\n') ? '' : '\n';
-      updated = existing + sep + notifyLine + '\n';
-    } else {
-      // Insert before the first table, with a blank-line separator.
-      lines.splice(firstTableIdx, 0, notifyLine, '');
-      updated = lines.join('\n');
-    }
+    // Prepend as a top-level key. A blank line keeps it visually separate from
+    // whatever the user already had at the top of the file.
+    updated = notifyLine + '\n\n' + existing;
   }
 
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
@@ -202,7 +238,11 @@ export function installAgentRetrospectHooks(options: {
   if (fs.existsSync(path.join(projectDir, '.gemini'))) {
     const configPath = path.join(projectDir, '.gemini', 'settings.json');
     const status = writeGeminiSessionEndHook(configPath, buildCommand('session-retrospect-gemini'));
-    results.push({ agent: 'Gemini CLI', status, configPath });
+    const geminiResult: AgentRetrospectResult = { agent: 'Gemini CLI', status, configPath };
+    if (status === 'conflict') {
+      geminiResult.reason = 'unparseable .gemini/settings.json left untouched';
+    }
+    results.push(geminiResult);
   }
 
   // Codex CLI — .codex present.
@@ -226,7 +266,11 @@ export function installAgentRetrospectHooks(options: {
       configPath,
       buildCommand('session-retrospect-cursor')
     );
-    results.push({ agent: 'Cursor', status, configPath });
+    const cursorResult: AgentRetrospectResult = { agent: 'Cursor', status, configPath };
+    if (status === 'conflict') {
+      cursorResult.reason = 'unparseable .cursor/hooks.json left untouched';
+    }
+    results.push(cursorResult);
   }
 
   return results;

--- a/packages/cli/tests/hooks/agent-retrospect.test.ts
+++ b/packages/cli/tests/hooks/agent-retrospect.test.ts
@@ -68,6 +68,26 @@ describe('agent-retrospect writers', () => {
       const cfg = JSON.parse(fs.readFileSync(p, 'utf-8'));
       expect(cfg.hooks.SessionEnd).toHaveLength(1);
     });
+
+    it('never clobbers an unparseable settings.json — reports a conflict', () => {
+      const p = path.join(dir, '.gemini', 'settings.json');
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      // Valid-looking but malformed (trailing comma) — a hand-edited config.
+      const original = '{\n  "theme": "dark",\n  "mcpServers": { "harness": {} },\n}\n';
+      fs.writeFileSync(p, original);
+      expect(writeGeminiSessionEndHook(p, CMD)).toBe('conflict');
+      // The user's config is left exactly as it was — nothing overwritten.
+      expect(fs.readFileSync(p, 'utf-8')).toBe(original);
+    });
+
+    it('treats an empty file as absent and installs cleanly', () => {
+      const p = path.join(dir, '.gemini', 'settings.json');
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, '   \n');
+      expect(writeGeminiSessionEndHook(p, CMD)).toBe('installed');
+      const cfg = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      expect(cfg.hooks.SessionEnd).toHaveLength(1);
+    });
   });
 
   describe('Cursor (.cursor/hooks.json)', () => {
@@ -106,6 +126,15 @@ describe('agent-retrospect writers', () => {
       const cfg = JSON.parse(fs.readFileSync(p, 'utf-8'));
       expect(cfg.hooks.stop).toHaveLength(1);
       expect(cfg.hooks.sessionEnd).toHaveLength(1);
+    });
+
+    it('never clobbers an unparseable hooks.json — reports a conflict', () => {
+      const p = path.join(dir, '.cursor', 'hooks.json');
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      const original = '{ this is not valid json }';
+      fs.writeFileSync(p, original);
+      expect(writeCursorRetrospectHooks(p, CMD)).toBe('conflict');
+      expect(fs.readFileSync(p, 'utf-8')).toBe(original);
     });
   });
 
@@ -149,6 +178,27 @@ describe('agent-retrospect writers', () => {
       expect(writeCodexNotifyHook(p, SCRIPT)).toBe('conflict');
       // The user's notify is untouched.
       expect(fs.readFileSync(p, 'utf-8')).toBe('notify = ["python3", "/home/me/my-notify.py"]\n');
+    });
+
+    it('does not corrupt a top-level nested-array literal (array element line begins with `[`)', () => {
+      const p = path.join(dir, '.codex', 'config.toml');
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      // `matrix` is a multi-line array whose element lines start with `[`. The
+      // old "insert before the first line starting with `[`" heuristic would
+      // splice `notify` INTO this array and corrupt the TOML.
+      const arrayBlock = 'matrix = [\n  [1, 2],\n  [3, 4],\n]';
+      fs.writeFileSync(p, `model = "gpt-5"\n${arrayBlock}\n\n[mcp_servers.foo]\ncommand = "x"\n`);
+      expect(writeCodexNotifyHook(p, SCRIPT)).toBe('installed');
+
+      const toml = fs.readFileSync(p, 'utf-8');
+      // notify lands as a top-level key, before both the array and the table.
+      const notifyIdx = toml.indexOf('notify =');
+      expect(notifyIdx).toBeGreaterThanOrEqual(0);
+      expect(notifyIdx).toBeLessThan(toml.indexOf('matrix'));
+      expect(notifyIdx).toBeLessThan(toml.indexOf('[mcp_servers.foo]'));
+      // The array block survives intact — not split by the insertion.
+      expect(toml).toContain(arrayBlock);
+      expect(toml).toContain('command = "x"');
     });
   });
 


### PR DESCRIPTION
## Why

Retroactive harness code-review of #1136 (multi-agent `session-retrospect` triggers for Claude Code / Gemini / Codex / Cursor), which merged without going through the pipeline's code-review phase. The review found two ways the **install-time** config writers in `packages/cli/src/hooks/agent-retrospect.ts` violate their own documented contract — _"unrelated user config is always preserved."_ Both are triggered by `harness hooks init`; the runtime hooks themselves are unaffected.

## Findings fixed

### 1. Gemini / Cursor JSON clobber — silent data loss

`readJsonObject` returned `{}` for any file it could not `JSON.parse`, and the writers then wrote that object back — **replacing the user's entire `.gemini/settings.json` / `.cursor/hooks.json` with only the harness hook.**

Trigger: any existing-but-unparseable config — a trailing comma, JSONC comments, a hand edit in progress, a partial write. Result: `theme`, `mcpServers`, and every other setting silently destroyed. This is inconsistent with `hooks init`, which _throws_ rather than clobber a malformed `.claude/settings.json`.

**Fix:** `readJsonConfig` now returns `absent | parsed | unparseable`. Empty files are `absent` (safe to create); an existing file that is not a JSON object is `unparseable`, and the writers return `conflict` (file left byte-for-byte untouched, surfaced as a warning with a reason).

### 2. Codex TOML corruption on top-level nested arrays

`writeCodexNotifyHook` inserted the top-level `notify` key before the first line matching `/^[ \t]*\[/` (assumed a table header). A top-level array literal whose element lines begin with `[`:

```toml
matrix = [
  [1, 2],
  [3, 4],
]
```

makes `  [1, 2],` match, so `notify` is spliced **inside** the array → corrupt TOML.

**Fix:** `notify` is now prepended as a top-level key at the very top of the file — always valid TOML (precedes every table, never inside a multi-line array), eliminating the whole "find the first table" class of bugs.

## Hand-audit of the other risk areas (no change needed)

- **Codex single-slot `notify` conflict handling:** correctly never clobbers a foreign `notify` (reports `conflict`). Confirmed.
- **Idempotency / sentinel dedupe:** correct per-agent; sentinel + sessions dir share the resolved cwd. (Noted: when a session id is missing, the shared `unknown.archived` sentinel degrades to at-most-once-ever — low severity, ids are normally present.)
- **Cross-platform:** Codex uses an argv array (`["node", <abs path>]`), portable; Windows shell portability of `buildHookCommand` is pre-existing and shared by all harness hooks, not introduced by #1136.
- **Fail-soft:** every entry point wraps in try/catch and always `exit 0`. Confirmed.

## Tests

New regression tests in `agent-retrospect.test.ts`:

- Gemini/Cursor: unparseable config → `conflict`, file unchanged.
- Gemini: empty file → treated as absent, installs cleanly.
- Codex: top-level nested-array literal → `notify` prepended, array survives intact.

All pre-existing agent-retrospect tests still pass. Local gauntlet under Node 22: build, typecheck (22/22), lint, prettier, and `agent-retrospect` + `support-files` + `roadmap-regen` e2e (42/42) all green; committed through the pre-commit hook (arch + traceability pass) with no `--no-verify`. Arch baseline untouched.

Spec: `docs/changes/session-retrospect-config-preservation/proposal.md`.
