### PR TITLE
fix(cli): scanners self-exclude when the checkout path contains a skip-dir segment (e.g. .claude)

### DIFF
--- a/.changeset/fix-scanner-skip-dir-self-exclude.md
+++ b/.changeset/fix-scanner-skip-dir-self-exclude.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/cli': patch
+'@harness-engineering/core': patch
+---
+
+Fix documentation-coverage scanner self-excluding when the checkout's own
+absolute path contains a skip-dir segment (notably `.claude`).
+
+`checkDocCoverage` matched its exclude globs against each file's absolute path
+as well as its scan-root-relative path. When the default skip-dir globs include
+`**/.claude/**` and the checkout lives under `<repo>/.claude/worktrees/<agent>/`
+(where `isolation: worktree` agents run), every file's absolute path contained
+`/.claude/` and matched, dropping all files. The denominator collapsed to zero,
+which — since the zero-denominator became a loud failure — produced
+deterministic false "stale docs" failures on those checkouts (CI was unaffected
+because CI checkouts are not nested under a skip-dir).
+
+The exclude globs now match the scan-root-relative path only, so the checkout's
+own path prefix can no longer self-match. A skip directory that genuinely lives
+inside the scanned tree is still excluded.

--- a/docs/changes/fix-scanner-skip-dir-self-exclude/proposal.md
+++ b/docs/changes/fix-scanner-skip-dir-self-exclude/proposal.md
@@ -1,0 +1,78 @@
+# Fix: scanners self-exclude when the checkout path contains a skip-dir segment
+
+**Type:** bugfix
+**Keywords:** doc-coverage, skip-dirs, glob, minimatch, worktree, self-exclude, .claude
+
+## Symptom
+
+`harness check-docs` (and any caller of `checkDocCoverage`) reports a
+zero-file scan — `scanned: 0` — when it is run from a checkout whose own
+**absolute path** contains a directory segment that the default skip-dir list
+excludes (notably `.claude`). Since #1165 made a zero denominator a loud
+failure ("ABSTAINED: 0 source files scanned", exit code 3), this turns into a
+deterministic false failure for any `isolation: worktree` agent, whose
+checkout lives under `<repo>/.claude/worktrees/<agent>/`. CI is unaffected
+because CI checkouts are not nested under a skip-dir.
+
+## Root cause (verified)
+
+`packages/core/src/context/doc-coverage.ts` builds its source-file list with
+`findFiles(..., sourceDir)` (which returns **absolute** paths), then filters
+each file against the exclude patterns with:
+
+```ts
+minimatch(relativePath, pattern, { dot: true }) || minimatch(file, pattern, { dot: true });
+```
+
+The second clause matches the pattern against the **absolute** path. When the
+default patterns include `**/.claude/**` (from `skipDirGlobs()`) and the
+checkout is at `.../.claude/worktrees/agent-x/`, every file's absolute path
+contains `/.claude/`, so `minimatch(absolutePath, '**/.claude/**')` is `true`
+for every file → all files are dropped → `scanned: 0`.
+
+Empirically confirmed:
+
+- `glob(..., { absolute: true, ignore: skipDirGlobs() })` is **not** the
+  culprit — glob v13's `ignore` is anchored to the scan root (matches
+  cwd-relative paths), so it correctly returns the files and still excludes a
+  genuinely nested `.claude/`.
+- The redundant `minimatch(file /* absolute */, pattern)` clause is the sole
+  self-exclusion. `packages/core/src/entropy/snapshot.ts` already filters
+  relative-only and is not affected.
+
+## Fix
+
+Anchor the exclude match to the scan root: match the exclude patterns only
+against the **cwd-relative** path (`relativePath`), never the absolute path.
+This preserves the intended behavior — a `.claude/` (or any skip) directory
+that genuinely lives **inside** the scanned tree still matches
+`**/.claude/**` via its relative path and is excluded — while the checkout's
+own path prefix can no longer self-match.
+
+## Scope / sites audited
+
+Grepped every `skipDirGlobs()` and `absolute: true` glob site plus every
+`minimatch(<file-var>, ...)` call across `packages/**/src`:
+
+- **Fixed:** `packages/core/src/context/doc-coverage.ts` (absolute-path
+  minimatch clause removed).
+- **Not vulnerable (verified), left unchanged:**
+  - `packages/core/src/shared/fs-utils.ts` and every other
+    `glob({ absolute: true, ignore })` site — glob v13 anchors `ignore` to the
+    scan root.
+  - `packages/core/src/entropy/snapshot.ts` — filters relative-only.
+  - `packages/core/src/security/scanner.ts` — `minimatch` is rule **include**
+    matching (`fileGlob`), not skip-dir exclusion.
+  - `packages/cli/src/commands/operational-drift.ts` — matches git-relative
+    changed paths.
+  - `packages/core/src/constraints/layers.ts`,
+    `packages/graph/src/constraints/GraphConstraintAdapter.ts` — architecture
+    layer classification, not skip-dir exclusion.
+
+## Acceptance criteria
+
+1. `checkDocCoverage` run with default `skipDirGlobs()` exclude patterns from a
+   `sourceDir` whose absolute path contains a `.claude` segment discovers its
+   source files (`scanned > 0`).
+2. A `.claude/` directory nested **inside** the scanned tree is still excluded.
+3. Regression test fails on current `main` and passes with the fix.

--- a/packages/core/src/context/doc-coverage.ts
+++ b/packages/core/src/context/doc-coverage.ts
@@ -76,14 +76,24 @@ export async function checkDocCoverage(
     // analyzer's DEFAULT_INCLUDE_PATTERNS.
     const sourceFiles = await findFiles('**/*.{ts,js,tsx,jsx,mjs,cjs}', sourceDir);
 
-    // Filter out excluded patterns
+    // Filter out excluded patterns.
+    //
+    // Match the skip-dir/exclude globs ONLY against the scan-root-relative
+    // path — never the absolute path. `findFiles` returns absolute paths, and
+    // matching an exclude glob like `**/.claude/**` against an absolute path
+    // self-excludes every file whenever the checkout's own path prefix
+    // contains that segment (e.g. an `isolation: worktree` agent whose
+    // checkout lives under `<repo>/.claude/worktrees/<agent>/`). That drove
+    // the denominator to zero and, since #1165 made a zero denominator a loud
+    // failure, produced deterministic false "stale docs" failures for those
+    // checkouts. Anchoring to the relative path keeps the intended behavior —
+    // a `.claude/` (or any skip) dir that genuinely lives INSIDE the scanned
+    // tree still matches via its relative path and is excluded — while the
+    // checkout's path prefix can no longer self-match. (`snapshot.ts` already
+    // filters relative-only for the same reason.)
     const filteredSourceFiles = sourceFiles.filter((file) => {
       const relativePath = relativePosix(sourceDir, file);
-      return !excludePatterns.some((pattern) => {
-        return (
-          minimatch(relativePath, pattern, { dot: true }) || minimatch(file, pattern, { dot: true })
-        );
-      });
+      return !excludePatterns.some((pattern) => minimatch(relativePath, pattern, { dot: true }));
     });
 
     // Find all documentation files

--- a/packages/core/tests/context/doc-coverage.test.ts
+++ b/packages/core/tests/context/doc-coverage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { checkDocCoverage } from '../../src/context/doc-coverage';
+import { skipDirGlobs } from '@harness-engineering/graph';
 import { join } from 'path';
 
 describe('checkDocCoverage', () => {
@@ -133,6 +134,45 @@ describe('checkDocCoverage', () => {
         expect(all.some((f) => f.includes('.git/'))).toBe(false);
         expect(all.some((f) => f.includes('.harness/'))).toBe(false);
         expect(result.value.scanned).toBe(1);
+      }
+    });
+
+    // Regression: a scanner must not self-exclude when the CHECKOUT's own
+    // absolute path contains a skip-dir segment (e.g. an `isolation: worktree`
+    // agent checked out under `<repo>/.claude/worktrees/<agent>/`). The
+    // default `skipDirGlobs()` list includes `**/.claude/**`; when that glob
+    // was matched against the absolute file path, the checkout's `.claude`
+    // prefix matched every file and drove the denominator to zero — a loud
+    // false failure since #1165. See docs/changes/fix-scanner-skip-dir-self-exclude.
+    it('does not self-exclude when the scan-root path contains a skip-dir segment (.claude)', async () => {
+      // Build a source tree whose ABSOLUTE path literally contains `/.claude/`,
+      // mirroring a worktree checkout under `<repo>/.claude/worktrees/<agent>/`.
+      const proj = join(root, '.claude', 'worktrees', 'agent-x', 'proj');
+      const src = join(proj, 'src');
+      await mkdir(src, { recursive: true });
+      await writeFile(join(src, 'alpha.ts'), 'export const a = 1;\n');
+      await writeFile(join(src, 'beta.ts'), 'export const b = 2;\n');
+      // A genuinely-nested `.claude/` INSIDE the scanned tree must STILL be
+      // excluded — anchoring must not become "never skip .claude".
+      await mkdir(join(src, '.claude', 'nested'), { recursive: true });
+      await writeFile(join(src, '.claude', 'nested', 'inside.ts'), 'export const c = 3;\n');
+
+      const result = await checkDocCoverage('project', {
+        docsDir: join(proj, 'docs'),
+        sourceDir: src,
+        // The default exclude set — the vulnerable configuration.
+        excludePatterns: [...skipDirGlobs(), '**/*.test.ts', '**/*.spec.ts'],
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const all = [...result.value.documented, ...result.value.undocumented];
+        // Files ARE discovered despite the `.claude` checkout-path prefix.
+        expect(result.value.scanned).toBe(2);
+        expect(all).toContain('alpha.ts');
+        expect(all).toContain('beta.ts');
+        // The genuinely-nested `.claude/` inside the tree stays excluded.
+        expect(all.some((f) => f.includes('.claude/'))).toBe(false);
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes documentation-coverage scanning self-excluding **every** file when the repository checkout's own absolute path contains a skip-dir segment — notably `.claude`, which is exactly where `isolation: worktree` agents check out (`<repo>/.claude/worktrees/<agent>/`).

## Root cause (verified)

`packages/core/src/context/doc-coverage.ts` built its file list via `findFiles(..., sourceDir)` (returns **absolute** paths), then filtered each file against the exclude globs with:

```ts
minimatch(relativePath, pattern, { dot: true }) || minimatch(file, pattern, { dot: true })
```

The second clause matched the pattern against the **absolute** path. The default skip-dir globs (`skipDirGlobs()`) include `**/.claude/**`; when the checkout lives under `.../.claude/worktrees/<agent>/`, every file's absolute path contains `/.claude/`, so `minimatch(absolutePath, '**/.claude/**')` is `true` for **every** file → all files dropped → `scanned: 0`.

Since #1165 made a zero denominator a loud failure ("ABSTAINED: 0 source files scanned", exit 3), this became a **deterministic false failure** for worktree agents' local pre-push gate. CI stayed green only because CI checkouts are not nested under a skip-dir.

I verified empirically that glob's own `ignore` option (used at the `absolute: true` glob sites) is already anchored to the scan root in **glob v13** — it matches cwd-relative paths and is **not** the culprit. The redundant absolute-path `minimatch` in doc-coverage was the sole self-exclusion site. `entropy/snapshot.ts` already filters relative-only.

## Fix

Anchor the exclude match to the scan root: match the exclude globs against the **cwd-relative** path only. The checkout's own path prefix can no longer self-match, while a `.claude/` (or any skip) directory that genuinely lives **inside** the scanned tree is still excluded via its relative path.

## Sites audited

Grepped every `skipDirGlobs()`, `absolute: true` glob, and `minimatch(<file-var>, ...)` call across `packages/**/src`:

- **Fixed:** `packages/core/src/context/doc-coverage.ts`.
- **Not vulnerable, unchanged:** every `glob({ absolute: true, ignore })` site (glob v13 anchors `ignore`); `entropy/snapshot.ts` (relative-only); `security/scanner.ts` (rule *include* matching, not skip-dir exclusion); `operational-drift.ts` (git-relative paths); architecture layer matchers.

## Regression test

`packages/core/tests/context/doc-coverage.test.ts` adds a test that runs `checkDocCoverage` with the default `skipDirGlobs()` excludes from a scan root whose absolute path contains `/.claude/`. It asserts files ARE discovered (`scanned: 2`) and that a genuinely nested `.claude/` is STILL excluded. **Fails on main (`scanned: 0`), passes with this fix.**

## Verification

- Regression test fails before / passes after; full core context + orchestrator + mechanical-checks suites green (93 tests).
- Built the CLI and ran `harness check-docs` from a `.claude/`-nested checkout with default config: reports a non-zero denominator (`0/2`) instead of the false abstention — the real-world manifestation is gone.
- `harness-code-review` over the diff: **approve**.
- Pre-push gate (check-docs, generate-docs --check, coverage ratchet, arch, traceability) cleared from a `.claude/worktrees/` checkout.

## Merge note

This is a test/infra reliability fix that unblocks the local pre-push gate for every `isolation: worktree` agent running under `.claude/`. Low-risk, well-scoped, with a locking regression test — a good candidate to merge quickly.