### PR TITLE
docs(roadmap): add PR Queue Triage & Merge Assistant Skill to Intake

### DIFF
--- a/docs/roadmap.d/pr-queue-triage-merge-assistant-skill.md
+++ b/docs/roadmap.d/pr-queue-triage-merge-assistant-skill.md
@@ -1,0 +1,16 @@
+---
+slug: "pr-queue-triage-merge-assistant-skill"
+milestone: "Intake"
+order: 26
+---
+
+### PR Queue Triage & Merge Assistant Skill
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** A skill to help teams stay on top of a large PR backlog in busy projects — triage/sort the open-PR list by risk & readiness, surface what needs review vs. what is mergeable, and assist with review and merge to cut the manual sorting effort.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1186

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -220,6 +220,17 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** P1
 - **External-ID:** github:Intense-Visions/harness-engineering#849
 
+### PR Queue Triage & Merge Assistant Skill
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** A skill to help teams stay on top of a large PR backlog in busy projects — triage/sort the open-PR list by risk & readiness, surface what needs review vs. what is mergeable, and assist with review and merge to cut the manual sorting effort.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1186
+
 ### Curate which MCP-server tools the local agent sees (per-server tool allowlist)
 
 - **Status:** in-progress


### PR DESCRIPTION
## Summary

Adds an `Intake` roadmap item for a proposed skill to help teams stay on top of a large PR backlog in busy projects — triage/sort the open-PR queue by risk & readiness, surface what needs review vs. what is mergeable, and assist with review and merge to cut manual sorting effort.

Added via the `/harness:roadmap` skill (`manage_roadmap add` → single shard + regenerated aggregate).

## Scope
- New shard: `docs/roadmap.d/pr-queue-triage-merge-assistant-skill.md`
- Regenerated aggregate: `docs/roadmap.md`
- Status `planned` in the `Intake` lane (the tool's normalized default for freshly-added intake items; consistent with the existing intake rows). No spec/plan yet, so it carries the same advisory RMH002 as its lane-mates — no new validation failure class introduced.

## Notes
- Docs-only change → no changeset required (per `scripts/check-changesets.mjs`, only `packages/*/src` & `package.json` are publishable).
- **Refs #1186** — this PR only registers the roadmap item; the tracking issue stays open until the skill itself is designed and built. Deliberately *not* `Closes`, so the auto-done reconciler doesn't flip the row to `done` prematurely.