### PR TITLE
docs(roadmap): register the -fleet skill family (7 members)

### DIFF
--- a/docs/roadmap.d/_meta.md
+++ b/docs/roadmap.d/_meta.md
@@ -7,6 +7,7 @@ last_synced: "2026-08-04T19:50:51.000Z"
 last_manual_edit: "2026-06-27T12:51:51.967Z"
 milestones:
   - "Intake"
+  - "Fleet Family — Batch Orchestration"
   - "v5.0 — Enforcement Hardening"
   - "v5.0 — Catalog Rationalization"
   - "v5.0 — Telemetry & Effectiveness"

--- a/docs/roadmap.d/adr-fleet.md
+++ b/docs/roadmap.d/adr-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "adr-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 2
+---
+
+### adr-fleet — batch-drive pending architectural decisions to ADRs
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. adr-fleet sweeps the backlog of pending architectural decisions and drives each to a batch ADR sign-off, fanning out drafting work and collecting the results for a single human review pass. It sits second in the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1197

--- a/docs/roadmap.d/cicd-fleet.md
+++ b/docs/roadmap.d/cicd-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "cicd-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 5
+---
+
+### cicd-fleet — autonomous CI/CD-red / flaky-test backlog sweep
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cicd-fleet sweeps the CI/CD-red and flaky-test backlog, fanning out diagnosis and fixes across failing pipelines and batching remediation PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1196

--- a/docs/roadmap.d/cleanup-fleet.md
+++ b/docs/roadmap.d/cleanup-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "cleanup-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 7
+---
+
+### cleanup-fleet — autonomous entropy/hotspot remediation sweep
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cleanup-fleet sweeps the entropy/hotspot backlog, fanning out remediation across high-churn and high-risk areas and batching the resulting cleanup PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1200

--- a/docs/roadmap.d/issue-fleet.md
+++ b/docs/roadmap.d/issue-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "issue-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 1
+---
+
+### issue-fleet — autonomous intake/triage of the open-issue backlog
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. issue-fleet is the intake stage: it autonomously triages the open-issue backlog (labeling, deduping, routing, and prioritizing) so downstream fleets receive a clean, ordered queue. It is the entry point of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1195

--- a/docs/roadmap.d/pr-fleet.md
+++ b/docs/roadmap.d/pr-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "pr-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 4
+---
+
+### pr-fleet — PR-queue triage, review-assist & land
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. pr-fleet works the open-PR queue: triaging, assisting review, and landing PRs across the queue while keeping the final merge decision with a human. It is the terminal stage of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1186

--- a/docs/roadmap.d/roadmap-fleet.md
+++ b/docs/roadmap.d/roadmap-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "roadmap-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 3
+---
+
+### roadmap-fleet — backlog → verified merge-ready PRs
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. roadmap-fleet turns the backlog (external issues + roadmap shards) into verified, merge-ready PRs, fanning out implementation across the queue and gating on verification before batching the results for human review. It is the delivery hub of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1198

--- a/docs/roadmap.d/test-fleet.md
+++ b/docs/roadmap.d/test-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "test-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 6
+---
+
+### test-fleet — autonomous test-coverage backlog sweep
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. test-fleet works the test-coverage backlog, fanning out test authoring across under-covered areas and producing a batch of test PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1199

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -319,6 +319,85 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** P2
 - **External-ID:** github:Intense-Visions/harness-engineering#1129
 
+## Fleet Family — Batch Orchestration
+
+### issue-fleet — autonomous intake/triage of the open-issue backlog
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. issue-fleet is the intake stage: it autonomously triages the open-issue backlog (labeling, deduping, routing, and prioritizing) so downstream fleets receive a clean, ordered queue. It is the entry point of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1195
+
+### adr-fleet — batch-drive pending architectural decisions to ADRs
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. adr-fleet sweeps the backlog of pending architectural decisions and drives each to a batch ADR sign-off, fanning out drafting work and collecting the results for a single human review pass. It sits second in the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1197
+
+### roadmap-fleet — backlog → verified merge-ready PRs
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. roadmap-fleet turns the backlog (external issues + roadmap shards) into verified, merge-ready PRs, fanning out implementation across the queue and gating on verification before batching the results for human review. It is the delivery hub of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1198
+
+### pr-fleet — PR-queue triage, review-assist & land
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. pr-fleet works the open-PR queue: triaging, assisting review, and landing PRs across the queue while keeping the final merge decision with a human. It is the terminal stage of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1186
+
+### cicd-fleet — autonomous CI/CD-red / flaky-test backlog sweep
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cicd-fleet sweeps the CI/CD-red and flaky-test backlog, fanning out diagnosis and fixes across failing pipelines and batching remediation PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1196
+
+### test-fleet — autonomous test-coverage backlog sweep
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. test-fleet works the test-coverage backlog, fanning out test authoring across under-covered areas and producing a batch of test PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1199
+
+### cleanup-fleet — autonomous entropy/hotspot remediation sweep
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cleanup-fleet sweeps the entropy/hotspot backlog, fanning out remediation across high-churn and high-risk areas and batching the resulting cleanup PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1200
+
 ## v5.0 — Enforcement Hardening
 
 ### Audit and cap the pre-commit --skip list


### PR DESCRIPTION
Registers the `-fleet` skill family on the project roadmap as seven dedicated shards, each linked to its **already-existing** GitHub issue via `External-ID`. No new issues were created (the open-issue count is unchanged).

## Family epic
Epic #1194 — the `-fleet` skill family: autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. Each shard references this epic in its summary.

## Members (new milestone: "Fleet Family — Batch Orchestration")
Ordered along the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd/test/cleanup running alongside:

| order | Member | Issue |
|---|---|---|
| 1 | issue-fleet — intake/triage of the open-issue backlog | #1195 |
| 2 | adr-fleet — batch-drive pending architectural decisions to ADRs | #1197 |
| 3 | roadmap-fleet — backlog → verified merge-ready PRs | #1198 |
| 4 | pr-fleet — PR-queue triage, review-assist & land | #1186 |
| 5 | cicd-fleet — CI/CD-red / flaky-test backlog sweep | #1196 |
| 6 | test-fleet — test-coverage backlog sweep | #1199 |
| 7 | cleanup-fleet — entropy/hotspot remediation sweep | #1200 |

## Changes
- 7 new shards under `docs/roadmap.d/<slug>.md`
- New milestone added to `docs/roadmap.d/_meta.md` (after "Intake")
- `docs/roadmap.md` aggregate regenerated deterministically from the shards (`harness roadmap regen` equivalent)

Mechanical roadmap-docs registration only — no code changes, no changeset required (docs-only). Please do not merge without review.