### PR TITLE
docs(roadmap): mark design.exclude (#742) done — stop reopen churn

### DIFF
--- a/docs/roadmap.d/feat-design-support-path-exclusions-for-the-design-token-drift-linter-design-exc.md
+++ b/docs/roadmap.d/feat-design-support-path-exclusions-for-the-design-token-drift-linter-design-exc.md
@@ -6,7 +6,7 @@ order: 7
 
 ### feat(design): support path exclusions for the design-token drift linter (design.exclude)
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/design-drift-exclude/proposal.md
 - **Summary:** Problem Since v4, `harness validate` runs the design-token drift linter (DRIFT-T001..T004) over every `.ts/.tsx/.js/.jsx/.css/.scss` file under the project root (skipping only `node_modules`/`dist`/`build`/`coverage`/dot-dirs). The only configuration surface is `design.strictness` and `design.audit.driftDetection.enabled`. In a real monorepo this produces thousands of unavoidable findings: - **The token palette sources themselves** (e.g. a `tokens-reference.ts` or generated `theme/tokens.ts`) by definition contain raw hex literals — ours account for 350+ DRIFT-T001 errors. - **Test files** asserting on rendered colors/fonts. - **Non-UI code** (backend service definitions, DSL/DAG files) where hex strings aren't design tokens at all. With no way to scope the linter, the practical options today are `strictness: permissive` (gate passes but output is still swamped) or disabling drift detection entirely — losing the signal where it *is* valuable (component source in the UI package). Proposal Support an exclusion/scoping config for drift detection, mirroring the existing `security.exclude` shape, e.g.: An `include` allowlist (or per-path severity, e.g. error in `packages/ui`, warn elsewhere) would be even better, but plain excludes would unblock most monorepos. Context harness-engineering CLI 4.1.0. Observed while re-greening `harness validate` after the 2.8 → 4.x upgrade: 1,614 findings, 1,545 errors, 100% from `driftDetection`.
 - **Blockers:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1321,7 +1321,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### feat(design): support path exclusions for the design-token drift linter (design.exclude)
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/design-drift-exclude/proposal.md
 - **Summary:** Problem Since v4, `harness validate` runs the design-token drift linter (DRIFT-T001..T004) over every `.ts/.tsx/.js/.jsx/.css/.scss` file under the project root (skipping only `node_modules`/`dist`/`build`/`coverage`/dot-dirs). The only configuration surface is `design.strictness` and `design.audit.driftDetection.enabled`. In a real monorepo this produces thousands of unavoidable findings: - **The token palette sources themselves** (e.g. a `tokens-reference.ts` or generated `theme/tokens.ts`) by definition contain raw hex literals — ours account for 350+ DRIFT-T001 errors. - **Test files** asserting on rendered colors/fonts. - **Non-UI code** (backend service definitions, DSL/DAG files) where hex strings aren't design tokens at all. With no way to scope the linter, the practical options today are `strictness: permissive` (gate passes but output is still swamped) or disabling drift detection entirely — losing the signal where it *is* valuable (component source in the UI package). Proposal Support an exclusion/scoping config for drift detection, mirroring the existing `security.exclude` shape, e.g.: An `include` allowlist (or per-path severity, e.g. error in `packages/ui`, warn elsewhere) would be even better, but plain excludes would unblock most monorepos. Context harness-engineering CLI 4.1.0. Observed while re-greening `harness validate` after the 2.8 → 4.x upgrade: 1,614 findings, 1,545 errors, 100% from `driftDetection`.
 - **Blockers:** —


### PR DESCRIPTION
## What

Flip the roadmap shard for **feat(design): support path exclusions for the design-token drift linter (design.exclude)** from `Status: planned` to `Status: done`, and regenerate the aggregate `docs/roadmap.md`.

## Why

GitHub issue #742 (design.exclude for the drift linter) was **resolved by merged PR #1045**, but its roadmap shard was still `Status: planned`. Because the shard was stale-planned, a roadmap sync kept **reopening the closed issue #742**. Flipping the shard to `done` makes the close stick.

## Change

- `docs/roadmap.d/feat-design-support-path-exclusions-for-the-design-token-drift-linter-design-exc.md`: `Status: planned` → `done` (all other fields, including `External-ID: github:Intense-Visions/harness-engineering#742`, unchanged).
- `docs/roadmap.md`: regenerated from the shards with the repo's own regenerator — the diff is the single status row `planned` → `done` (byte-parity verified against the committed aggregate before the change).

Docs-only; no changeset. `.harness/arch/baselines.json` untouched.