### PR TITLE
fix(roadmap): stop syncRoadmap corrupting planned features with named Blockers

### DIFF
--- a/.changeset/fix-roadmap-sync-planned-blocked-corruption.md
+++ b/.changeset/fix-roadmap-sync-planned-blocked-corruption.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/core': patch
+---
+
+Fix `syncRoadmap` corrupting `planned` features with named `Blockers:` into `blocked` status.
+
+The `Blockers` field is informational — it documents a dependency relationship. `Status: blocked` is semantic: "actively waiting on something we can't influence right now". Conflating the two meant every item carrying `Blockers: <sibling-planned-item>` was silently flipped to `blocked` on the next sync, even when the dependency was just a queued sibling in the same milestone. In one observed milestone, 13 of 46 newly added items had to be reverted by hand.
+
+The fix preserves the cascade-unblock behavior — a manually-set `blocked` feature returns to `planned` once all of its blockers reach `done` — but removes the bogus `→ blocked` proposal that conflated a documented dependency with execution state. The existing test that codified the bug (`proposes blocked when blocker is in-progress`) is replaced by three tests covering the reproduction case and the corrected semantics.

--- a/packages/core/src/roadmap/sync.ts
+++ b/packages/core/src/roadmap/sync.ts
@@ -83,16 +83,26 @@ async function inferStatus(
   projectPath: string,
   allFeatures: RoadmapFeature[]
 ): Promise<FeatureStatus | null> {
-  // 1. Blocker check takes precedence
-  if (feature.blockedBy.length > 0) {
-    const blockerNotDone = feature.blockedBy.some((blockerName) => {
+  // 1. Blocker check — cascade-unblock only.
+  //
+  // The `blockedBy` field is informational: it documents the dependency
+  // relationship. It is NOT a signal that the feature's status should be
+  // `blocked`. `Status: blocked` means "actively waiting on something we
+  // can't influence right now" — a planned feature waiting on another
+  // planned feature in the same milestone is normal queue position, not
+  // blocked. Conflating the two silently flipped every item added with
+  // `Blockers: <sibling-planned-item>` to `blocked` on the next sync.
+  //
+  // The only legitimate sync transition based on blocker state is the
+  // cascade-unblock: a feature that was manually marked `blocked` should
+  // return to `planned` once all its blockers complete, so downstream
+  // work is freed without a manual edit.
+  if (feature.status === 'blocked' && feature.blockedBy.length > 0) {
+    const allBlockersDone = feature.blockedBy.every((blockerName) => {
       const blocker = allFeatures.find((f) => f.name.toLowerCase() === blockerName.toLowerCase());
-      return !blocker || blocker.status !== 'done';
+      return blocker?.status === 'done';
     });
-    if (blockerNotDone) return 'blocked';
-    // All blockers are done. Unblock currently-blocked features so cascading
-    // completion frees downstream work without a manual edit.
-    if (feature.status === 'blocked') return 'planned';
+    if (allBlockersDone) return 'planned';
   }
 
   // 2. If no plans linked, cannot infer

--- a/packages/core/tests/roadmap/sync.test.ts
+++ b/packages/core/tests/roadmap/sync.test.ts
@@ -217,7 +217,10 @@ describe('syncRoadmap()', () => {
   });
 
   describe('blocker inference', () => {
-    it('proposes blocked when a blocker feature is not done', async () => {
+    it('leaves planned feature unchanged when blocker is done', async () => {
+      // Sanity: with a `done` blocker, the dependent stays as-is (no change).
+      // (Prior test name said "proposes blocked when blocker is not done"
+      // which contradicted the body — blocker IS done here, expected `[]`.)
       const roadmap = baseRoadmap();
       roadmap.milestones[0]!.features = [
         {
@@ -234,7 +237,7 @@ describe('syncRoadmap()', () => {
           spec: null,
           plans: [],
           blockedBy: ['Feature A'],
-          summary: 'Blocked feature',
+          summary: 'Blocker done; feature stays planned',
         },
       ];
       // Feature A is done, so Feature B should NOT be blocked
@@ -244,7 +247,12 @@ describe('syncRoadmap()', () => {
       expect(result.value).toEqual([]);
     });
 
-    it('proposes blocked when blocker is in-progress', async () => {
+    it('leaves planned feature unchanged when blocker is in-progress', async () => {
+      // `Blockers: <name>` on a planned feature is informational queue
+      // position, not a status signal. The dependency is already documented
+      // by the field. Flipping status to `blocked` adds no information and
+      // corrupts items whose blockers are sibling planned items in the same
+      // milestone.
       const roadmap = baseRoadmap();
       roadmap.milestones[0]!.features = [
         {
@@ -261,13 +269,74 @@ describe('syncRoadmap()', () => {
           spec: null,
           plans: [],
           blockedBy: ['Feature A'],
-          summary: 'Blocked feature',
+          summary: 'Has named dep but is in normal queue position',
         },
       ];
       const result = await syncRoadmap({ projectPath: tmpDir, roadmap });
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value).toEqual([{ feature: 'Feature B', from: 'planned', to: 'blocked' }]);
+      expect(result.value).toEqual([]);
+    });
+
+    it('leaves planned feature unchanged when blocker is also planned', async () => {
+      // Reproduction of the observed corruption: dependent and blocker are
+      // both `planned`. Neither has any active execution state. The sync
+      // must not invent a `blocked` transition based purely on the
+      // existence of a named dependency.
+      const roadmap = baseRoadmap();
+      roadmap.milestones[0]!.features = [
+        {
+          name: 'outcome-eval skill',
+          status: 'planned',
+          spec: null,
+          plans: [],
+          blockedBy: [],
+          summary: 'Dep, also planned',
+        },
+        {
+          name: 'rollback primitive',
+          status: 'planned',
+          spec: null,
+          plans: [],
+          blockedBy: ['outcome-eval skill'],
+          summary: 'Depends on outcome-eval skill, both planned',
+        },
+      ];
+      const result = await syncRoadmap({ projectPath: tmpDir, roadmap });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toEqual([]);
+    });
+
+    it('leaves in-progress feature unchanged when blocker is not done', async () => {
+      // `in-progress` → `blocked` is a status-rank regression (2 → 1) which
+      // the directional guard blocks anyway (see status-rank.ts).
+      // So the only observable buggy surface is `planned → blocked`.
+      // Confirming here that in-progress features also stay put: `Blockers`
+      // remains informational across all source statuses.
+      const roadmap = baseRoadmap();
+      roadmap.milestones[0]!.features = [
+        {
+          name: 'Feature A',
+          status: 'planned',
+          spec: null,
+          plans: [],
+          blockedBy: [],
+          summary: 'Dep',
+        },
+        {
+          name: 'Feature B',
+          status: 'in-progress',
+          spec: null,
+          plans: [],
+          blockedBy: ['Feature A'],
+          summary: 'Already in-progress despite un-done dep',
+        },
+      ];
+      const result = await syncRoadmap({ projectPath: tmpDir, roadmap });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

`syncRoadmap` treats a named `Blockers:` entry as a status signal: any feature whose blocker is not yet `done` gets proposed as `blocked`. But the two fields mean different things:

- **`Blockers:`** is *informational* — it documents a dependency relationship.
- **`Status: blocked`** is *semantic* — "actively waiting on something we can't influence right now".

Conflating them silently flips every item added with `Blockers: <sibling-planned-item>` to `blocked` on the next sync, even when the dependency is just normal queue position within the same milestone. In one observed milestone, 13 of 46 newly added items had to be reverted by hand.

Blocker inference is now **cascade-unblock only**: a feature already marked `blocked` returns to `planned` once all of its blockers reach `done`. The bogus `→ blocked` proposal is gone.

## The bug, still live on `main`

`packages/core/src/roadmap/sync.ts` before this change:

```ts
if (feature.blockedBy.length > 0) {
  const blockerNotDone = feature.blockedBy.some(...);
  if (blockerNotDone) return 'blocked';   // ← corrupts planned features
  if (feature.status === 'blocked') return 'planned';
}
```

## Tests

The existing test that *codified* the bug (`proposes blocked when blocker is in-progress`) is replaced by three tests covering the corrected semantics:

- dependent and blocker both `planned` (the reproduction case)
- blocker `in-progress`, dependent `planned`
- dependent already `in-progress` with an un-done blocker

Verified these are real regression tests — against the unfixed `sync.ts` **2 of 19 fail**; with the fix **19/19 pass**. Cascade-unblock coverage is retained.

## Verification

- `packages/core` roadmap suite: **525 passed**, 1 skipped
- `packages/cli` roadmap/MCP suites: **109 passed**
- `tsc --noEmit` on `packages/core`: clean
- prettier: clean
- No caller or test anywhere in the repo asserted a sync-produced `blocked` transition

## Provenance

The fix was authored on `fix/manage-roadmap-planned-blocked-corruption` (2026-06-04) but never had a PR opened, so the bug stayed live. Rebased onto current `main` here; the only conflict was signature drift — `inferStatus` became `async` upstream — resolved by keeping the async event-sourced signature and applying the corrected blocker logic on top.