### PR TITLE
fix(graph): skip plain-git worktree containers during source walking

### DIFF
--- a/.antigravity-extension/config/mcp_config.json
+++ b/.antigravity-extension/config/mcp_config.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.changeset/ci-protected-main-writes.md
+++ b/.changeset/ci-protected-main-writes.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix CI's two paths for landing housekeeping commits on a protected `main`.
+
+`roadmap-auto-done.yml` declared `permissions: pull-requests: read`, but its branch-protection fallback calls `gh pr create` with the built-in `GITHUB_TOKEN`. That call failed with `Resource not accessible by integration (createPullRequest)` _after_ the branch had already been pushed, so every merge into a protected branch stranded a `chore/auto-done-pr*` branch and silently dropped its roadmap flip. The fallback was added without widening the permission, so it had never once succeeded — 58 stranded branches had accumulated, spanning a long run of merges.
+
+`release.yml`'s "Promote golden build reference state" step pushed straight to `main` with no fallback at all, so it failed on every publish with `GH013: Changes must be made through a pull request`. The packages had already gone out by that point, so releases went red _after_ shipping and the golden reference manifest never advanced. It now uses the same retry-then-scope-guarded-self-approved-PR path as auto-done, with the diff guard pinned to `.harness/golden/manifest.json`.
+
+Branch protection is unchanged; both paths land through auditable, scope-checked PRs.

--- a/.changeset/skip-dirs-git-worktree-containers.md
+++ b/.changeset/skip-dirs-git-worktree-containers.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/graph': patch
+---
+
+Skip plain-git worktree containers (`.git-worktrees/`, `.worktrees/`) during source-file walking.
+
+`DEFAULT_SKIP_DIRS` already skipped agent sandbox dirs (`.claude`, `.cursor`, `.codex`, …) because each can hold a full checkout of the repo, but it missed the equivalent produced by `git worktree add .git-worktrees/<branch>`. Since `findFiles` sets `dot: true` deliberately so first-party source under dot-directories stays visible, that list is the only thing keeping nested checkouts out — so every scanner re-walked each worktree as first-party source.
+
+The visible symptom was a phantom complexity regression: three worktrees contributed 9,818 extra `.ts` files on top of 3,302 real ones, producing `[complexity] REGRESSION: 1327 > 333` with findings attributed to paths under `.git-worktrees/<branch>/`, which blocked commits that touched no source at all.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -34,7 +34,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -13,7 +13,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -17,7 +17,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.gemini-extension/gemini-extension.json
+++ b/.gemini-extension/gemini-extension.json
@@ -6,7 +6,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,15 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
+          # Must be `pnpm version`, not the action's default. The default runs
+          # `changeset version` directly, which bumps package.json but skips
+          # scripts/sync-plugin-pin.mjs — the only thing that re-pins the five
+          # plugin/extension manifests to the new CLI version. Every release
+          # therefore shipped manifests pinned to the PREVIOUS version and left
+          # main red on the plugin-pin-sync assertion in
+          # tests/scripts/plugin-pin-sync.test.mjs. package.json's `version`
+          # script pairs the two steps; this input is what actually invokes it.
+          version: pnpm version
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:
@@ -96,13 +105,65 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           HUSKY: '0'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOAPPROVE_PAT: ${{ secrets.BASELINE_AUTOAPPROVE_PAT }}
         run: |
           node packages/cli/dist/bin/harness.js golden-build promote
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .harness/golden/manifest.json
-          git diff --cached --quiet || git commit -m "chore: promote golden build reference state [skip ci]"
-          git push
+          MANIFEST=".harness/golden/manifest.json"
+          git add "$MANIFEST"
+          if git diff --cached --quiet; then
+            echo "Golden manifest unchanged; nothing to promote."
+            exit 0
+          fi
+          git commit -m "chore: promote golden build reference state [skip ci]"
+          OURS=$(git rev-parse HEAD)
+          BASE="${GITHUB_REF_NAME}"
+
+          # 1) Try a direct push, absorbing any concurrent merge. Reset hard to our
+          #    commit before each retry so a failed rebase can never leave the tree
+          #    dirty for the next attempt.
+          for attempt in 1 2 3; do
+            git rebase --abort 2>/dev/null || true
+            git reset --hard "$OURS" >/dev/null
+            git fetch origin "$BASE" -q || true
+            if git rebase "origin/$BASE" && git push origin "HEAD:$BASE" 2>/dev/null; then
+              echo "Pushed golden-manifest promotion directly to $BASE on attempt $attempt."
+              exit 0
+            fi
+            echo "Direct push attempt $attempt failed; retrying."
+            sleep 3
+          done
+
+          # 2) Direct push is blocked by branch protection ("changes must be made
+          #    through a pull request"). Open a scope-guarded self-approved PR, the
+          #    same fallback roadmap-auto-done.yml uses. Without this the step exited
+          #    1 on every publish, so the release ran red even though the packages
+          #    had already gone out, and the golden reference never advanced.
+          echo "Direct push unavailable; opening a self-approved PR."
+          git fetch origin "$BASE" -q
+          BRANCH="chore/golden-promote-$(git rev-parse --short "$OURS")-$(date +%s)"
+          git checkout -B "$BRANCH" "origin/$BASE"
+          git checkout "$OURS" -- "$MANIFEST"
+          git add "$MANIFEST"
+          if git diff --cached --quiet; then
+            echo "Base already carries this golden manifest; nothing to PR."
+            exit 0
+          fi
+          git commit -m "chore: promote golden build reference state [skip ci]"
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore: promote golden build reference state" \
+            --body "Automated golden-build reference promotion after a successful publish. Opened because direct pushes to $BASE are blocked by branch protection." \
+            --base "$BASE" \
+            --head "$BRANCH")
+          # Defensive scope check: the PAT may only ever approve a diff confined to
+          # the golden manifest (mirrors the roadmap auto-done guard).
+          gh pr diff "$PR_URL" --name-only | node scripts/assert-diff-scope.mjs "$MANIFEST"
+          GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
+            --body "Auto-approved: golden-build reference promotion from github-actions[bot]."
+          gh pr merge "$PR_URL" --auto --squash --delete-branch
 
   docker:
     needs: release

--- a/.github/workflows/roadmap-auto-done.yml
+++ b/.github/workflows/roadmap-auto-done.yml
@@ -28,7 +28,13 @@ on:
 permissions:
   contents: write
   issues: read
-  pull-requests: read
+  # `write`, not `read`: the fallback below calls `gh pr create` with the built-in
+  # GITHUB_TOKEN. Under `read` that call fails with "Resource not accessible by
+  # integration (createPullRequest)" AFTER the branch has already been pushed, so
+  # every protected-branch merge stranded a chore/auto-done-pr* branch and silently
+  # dropped its roadmap flip. The fallback shipped without this widening, so it had
+  # never once succeeded.
+  pull-requests: write
 
 # Serialize commit-to-base across simultaneous PR merges into the same base
 # branch: a second auto-done waits for the first to finish its push rather than

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ temp/
 # Worktrees
 .worktrees/
 .claude/worktrees/
+.git-worktrees/
 
 # Harness runtime artifacts (see .harness/.gitignore)
 # Use **/ prefix so patterns match .harness dirs at any depth (e.g. packages/orchestrator/.harness/)

--- a/docs/roadmap.d/adr-fleet.md
+++ b/docs/roadmap.d/adr-fleet.md
@@ -6,11 +6,11 @@ order: 2
 
 ### adr-fleet — batch-drive pending architectural decisions to ADRs
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/adr-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. adr-fleet sweeps the backlog of pending architectural decisions and drives each to a batch ADR sign-off, fanning out drafting work and collecting the results for a single human review pass. It sits second in the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/adr-fleet/plans/2026-08-08-adr-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1197

--- a/docs/roadmap.d/cicd-fleet.md
+++ b/docs/roadmap.d/cicd-fleet.md
@@ -6,11 +6,11 @@ order: 5
 
 ### cicd-fleet — autonomous CI/CD-red / flaky-test backlog sweep
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/cicd-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cicd-fleet sweeps the CI/CD-red and flaky-test backlog, fanning out diagnosis and fixes across failing pipelines and batching remediation PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/cicd-fleet/plans/2026-08-08-cicd-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1196

--- a/docs/roadmap.d/cleanup-fleet.md
+++ b/docs/roadmap.d/cleanup-fleet.md
@@ -6,11 +6,11 @@ order: 7
 
 ### cleanup-fleet — autonomous entropy/hotspot remediation sweep
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/cleanup-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cleanup-fleet sweeps the entropy/hotspot backlog, fanning out remediation across high-churn and high-risk areas and batching the resulting cleanup PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/cleanup-fleet/plans/2026-08-08-cleanup-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1200

--- a/docs/roadmap.d/craft-fleet.md
+++ b/docs/roadmap.d/craft-fleet.md
@@ -6,7 +6,7 @@ order: 9
 
 ### craft-fleet — ceiling-raising code-quality elevation sweep
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/craft-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. craft-fleet is the ceiling twin of cleanup-fleet: where cleanup-fleet works the rule-based entropy floor, craft-fleet sweeps the craft skills' LLM-judgment critique and hands back a tiered batch — elevation PRs for bounded, high-confidence, cited polish and filed roadmap items for structural quality debt. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —

--- a/docs/roadmap.d/design-fleet.md
+++ b/docs/roadmap.d/design-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "design-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 13
+---
+
+### design-fleet — fan out design-system drift remediation
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. design-fleet fleet-ifies design-pipeline / detect-design-drift: it fans out design-token and component drift detection, emitting a batch of fixes. Most valuable in design-heavy repos. Composes design-pipeline as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps cleanup-fleet (drift floor) and craft-fleet (design-craft ceiling); may be folded rather than shipped standalone.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1231

--- a/docs/roadmap.d/docs-fleet.md
+++ b/docs/roadmap.d/docs-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "docs-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 14
+---
+
+### docs-fleet — fan out doc-drift remediation across the codebase
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. docs-fleet fleet-ifies docs-pipeline / detect-doc-drift: it fans out doc-drift detection over the codebase, emitting a batch of doc-fix PRs. Composes docs-pipeline as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps cleanup-fleet (drift floor) and craft-fleet (docs-craft ceiling); likely fold is drift to cleanup-fleet and quality to craft-fleet.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1230

--- a/docs/roadmap.d/fleet-command.md
+++ b/docs/roadmap.d/fleet-command.md
@@ -6,7 +6,7 @@ order: 15
 
 ### fleet-command — the conductor coordinating the `-fleet` family across the SDLC
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/fleet-command/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the capstone, one tier above the members and deliberately not named `-fleet`: it coordinates the fleets themselves rather than fanning out over an item-queue. Plans a run as a hybrid dependency DAG (a cicd-fleet CI prerequisite, the conveyor spine sequential, the quality sweeps parallel, pr-fleet terminal), enforces one **global** concurrency budget across every fleet in flight instead of additive per-fleet governors, owns cross-fleet deconfliction (merge-order planning, regeneration sequencing, lane serialization, cross-fleet filing dedup), batches the members' human gates by wave without ever answering them, verifies each lane from its emitted artifacts rather than re-running it, and emits one consolidated report. Never auto-merges.
 - **Blockers:** —

--- a/docs/roadmap.d/ideate-fleet.md
+++ b/docs/roadmap.d/ideate-fleet.md
@@ -6,7 +6,7 @@ order: 9
 
 ### ideate-fleet — fan out strategy-grounded ideation as the head of the fleet spine
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/ideate-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. ideate-fleet is the head of the core conveyor (ideate → issue → adr → roadmap → pr): it derives a queue of disjoint themes from STRATEGY.md tracks and supplied opportunity areas, fans out worktree-isolated subagents that each run the real `harness-ideate` pipeline to a ranked artifact, re-derives every ranking independently, and returns one curated ranked shortlist for a human to pick from. It files nothing — no issue, roadmap row, spec, or PR.
 - **Blockers:** —

--- a/docs/roadmap.d/issue-fleet.md
+++ b/docs/roadmap.d/issue-fleet.md
@@ -6,11 +6,11 @@ order: 1
 
 ### issue-fleet — autonomous intake/triage of the open-issue backlog
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/issue-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. issue-fleet is the intake stage: it autonomously triages the open-issue backlog (labeling, deduping, routing, and prioritizing) so downstream fleets receive a clean, ordered queue. It is the entry point of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/issue-fleet/plans/2026-08-08-issue-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1195

--- a/docs/roadmap.d/knowledge-fleet.md
+++ b/docs/roadmap.d/knowledge-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "knowledge-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 12
+---
+
+### knowledge-fleet — fan out knowledge extraction/reconciliation
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. knowledge-fleet fleet-ifies knowledge-pipeline: it fans out extraction of undocumented knowledge and decisions across the codebase, emitting a batch of knowledge entries. Composes knowledge-pipeline as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps adr-fleet (decisions) and knowledge-craft (quality ceiling); may be folded rather than shipped standalone.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1232

--- a/docs/roadmap.d/perf-fleet.md
+++ b/docs/roadmap.d/perf-fleet.md
@@ -1,0 +1,16 @@
+---
+slug: "perf-fleet"
+milestone: "Fleet Family — Batch Orchestration"
+order: 11
+---
+
+### perf-fleet — fan out performance-budget/regression remediation
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. perf-fleet fans out perf-budget and regression analysis over hotspots and critical paths, emitting a batch of optimization PRs. Benchmark-gated: a regression needs a measured before/after, mirroring bug-fleet's reproduction bar. Composes the perf skills / check-perf as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps cleanup-fleet (hotspots) and bug-fleet (perf-as-defect); may be folded rather than shipped standalone.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1233

--- a/docs/roadmap.d/pr-fleet.md
+++ b/docs/roadmap.d/pr-fleet.md
@@ -6,11 +6,11 @@ order: 4
 
 ### pr-fleet — PR-queue triage, review-assist & land
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/pr-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. pr-fleet works the open-PR queue: triaging, assisting review, and landing PRs across the queue while keeping the final merge decision with a human. It is the terminal stage of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/pr-fleet/plans/2026-08-08-pr-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1186

--- a/docs/roadmap.d/roadmap-fleet.md
+++ b/docs/roadmap.d/roadmap-fleet.md
@@ -6,11 +6,11 @@ order: 3
 
 ### roadmap-fleet — backlog → verified merge-ready PRs
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/roadmap-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. roadmap-fleet turns the backlog (external issues + roadmap shards) into verified, merge-ready PRs, fanning out implementation across the queue and gating on verification before batching the results for human review. It is the delivery hub of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/roadmap-fleet/plans/2026-08-07-roadmap-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1198

--- a/docs/roadmap.d/test-fleet.md
+++ b/docs/roadmap.d/test-fleet.md
@@ -6,11 +6,11 @@ order: 6
 
 ### test-fleet — autonomous test-coverage backlog sweep
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/test-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. test-fleet works the test-coverage backlog, fanning out test authoring across under-covered areas and producing a batch of test PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/test-fleet/plans/2026-08-08-test-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1199

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -345,77 +345,77 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### issue-fleet — autonomous intake/triage of the open-issue backlog
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/issue-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. issue-fleet is the intake stage: it autonomously triages the open-issue backlog (labeling, deduping, routing, and prioritizing) so downstream fleets receive a clean, ordered queue. It is the entry point of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/issue-fleet/plans/2026-08-08-issue-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1195
 
 ### adr-fleet — batch-drive pending architectural decisions to ADRs
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/adr-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. adr-fleet sweeps the backlog of pending architectural decisions and drives each to a batch ADR sign-off, fanning out drafting work and collecting the results for a single human review pass. It sits second in the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/adr-fleet/plans/2026-08-08-adr-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1197
 
 ### roadmap-fleet — backlog → verified merge-ready PRs
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/roadmap-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. roadmap-fleet turns the backlog (external issues + roadmap shards) into verified, merge-ready PRs, fanning out implementation across the queue and gating on verification before batching the results for human review. It is the delivery hub of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/roadmap-fleet/plans/2026-08-07-roadmap-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1198
 
 ### pr-fleet — PR-queue triage, review-assist & land
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/pr-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. pr-fleet works the open-PR queue: triaging, assisting review, and landing PRs across the queue while keeping the final merge decision with a human. It is the terminal stage of the fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet, with cicd-fleet / test-fleet / cleanup-fleet running alongside.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/pr-fleet/plans/2026-08-08-pr-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1186
 
 ### cicd-fleet — autonomous CI/CD-red / flaky-test backlog sweep
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/cicd-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cicd-fleet sweeps the CI/CD-red and flaky-test backlog, fanning out diagnosis and fixes across failing pipelines and batching remediation PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/cicd-fleet/plans/2026-08-08-cicd-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1196
 
 ### test-fleet — autonomous test-coverage backlog sweep
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/test-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. test-fleet works the test-coverage backlog, fanning out test authoring across under-covered areas and producing a batch of test PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/test-fleet/plans/2026-08-08-test-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1199
 
 ### cleanup-fleet — autonomous entropy/hotspot remediation sweep
 
-- **Status:** planned
-- **Spec:** —
+- **Status:** done
+- **Spec:** docs/changes/cleanup-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. cleanup-fleet sweeps the entropy/hotspot backlog, fanning out remediation across high-churn and high-risk areas and batching the resulting cleanup PRs for human review. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/cleanup-fleet/plans/2026-08-08-cleanup-fleet-plan.md
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1200
@@ -433,7 +433,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### craft-fleet — ceiling-raising code-quality elevation sweep
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/craft-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. craft-fleet is the ceiling twin of cleanup-fleet: where cleanup-fleet works the rule-based entropy floor, craft-fleet sweeps the craft skills' LLM-judgment critique and hands back a tiered batch — elevation PRs for bounded, high-confidence, cited polish and filed roadmap items for structural quality debt. It runs alongside the core fleet spine issue-fleet → adr-fleet → roadmap-fleet → pr-fleet.
 - **Blockers:** —
@@ -444,7 +444,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### ideate-fleet — fan out strategy-grounded ideation as the head of the fleet spine
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/ideate-fleet/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. ideate-fleet is the head of the core conveyor (ideate → issue → adr → roadmap → pr): it derives a queue of disjoint themes from STRATEGY.md tracks and supplied opportunity areas, fans out worktree-isolated subagents that each run the real `harness-ideate` pipeline to a ranked artifact, re-derives every ranking independently, and returns one curated ranked shortlist for a human to pick from. It files nothing — no issue, roadmap row, spec, or PR.
 - **Blockers:** —
@@ -453,9 +453,53 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1228
 
+### perf-fleet — fan out performance-budget/regression remediation
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. perf-fleet fans out perf-budget and regression analysis over hotspots and critical paths, emitting a batch of optimization PRs. Benchmark-gated: a regression needs a measured before/after, mirroring bug-fleet's reproduction bar. Composes the perf skills / check-perf as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps cleanup-fleet (hotspots) and bug-fleet (perf-as-defect); may be folded rather than shipped standalone.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1233
+
+### knowledge-fleet — fan out knowledge extraction/reconciliation
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. knowledge-fleet fleet-ifies knowledge-pipeline: it fans out extraction of undocumented knowledge and decisions across the codebase, emitting a batch of knowledge entries. Composes knowledge-pipeline as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps adr-fleet (decisions) and knowledge-craft (quality ceiling); may be folded rather than shipped standalone.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1232
+
+### design-fleet — fan out design-system drift remediation
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. design-fleet fleet-ifies design-pipeline / detect-design-drift: it fans out design-token and component drift detection, emitting a batch of fixes. Most valuable in design-heavy repos. Composes design-pipeline as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps cleanup-fleet (drift floor) and craft-fleet (design-craft ceiling); may be folded rather than shipped standalone.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1231
+
+### docs-fleet — fan out doc-drift remediation across the codebase
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Candidate member of the `-fleet` skill family (epic #1194) — the family technique is autonomous fan-out orchestration over an SDLC work-queue, with batch human review and never auto-merge. docs-fleet fleet-ifies docs-pipeline / detect-doc-drift: it fans out doc-drift detection over the codebase, emitting a batch of doc-fix PRs. Composes docs-pipeline as its DISPATCH engine.
+- **Blockers:** Fold-vs-standalone decision deferred — overlaps cleanup-fleet (drift floor) and craft-fleet (docs-craft ceiling); likely fold is drift to cleanup-fleet and quality to craft-fleet.
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1230
+
 ### fleet-command — the conductor coordinating the `-fleet` family across the SDLC
 
-- **Status:** in-progress
+- **Status:** done
 - **Spec:** docs/changes/fleet-command/proposal.md
 - **Summary:** Part of the `-fleet` skill family (epic #1194) — the capstone, one tier above the members and deliberately not named `-fleet`: it coordinates the fleets themselves rather than fanning out over an item-queue. Plans a run as a hybrid dependency DAG (a cicd-fleet CI prerequisite, the conveyor spine sequential, the quality sweeps parallel, pr-fleet terminal), enforces one **global** concurrency budget across every fleet in flight instead of additive per-fleet governors, owns cross-fleet deconfliction (merge-order planning, regeneration sequencing, lane serialization, cross-fleet filing dedup), batches the members' human gates by wave without ever answering them, verifies each lane from its emitted artifacts rather than re-running it, and emits one consolidated report. Never auto-merges.
 - **Blockers:** —

--- a/packages/graph/src/ingest/skip-dirs.ts
+++ b/packages/graph/src/ingest/skip-dirs.ts
@@ -15,6 +15,7 @@
  *   - JVM build outputs
  *   - IDE / editor metadata
  *   - AI agent sandbox directories (Claude Code worktrees, Cursor, Codex, etc.)
+ *   - Plain-git worktree containers (`.git-worktrees/`, `.worktrees/`)
  *
  * Consumers may extend or replace this set via {@link CodeIngestorOptions}
  * or the project-level `ingest.skipDirs` / `ingest.additionalSkipDirs` config.
@@ -93,6 +94,19 @@ export const DEFAULT_SKIP_DIRS: ReadonlySet<string> = new Set([
   '.agents',
   '.agentastic',
   '.playwright-mcp',
+
+  // Plain-git worktree containers. Same hazard as the agent sandboxes above —
+  // each holds a full checkout of this repo — but reached via `git worktree
+  // add` rather than an agent. Without these, every scanner re-walks each
+  // nested checkout as if it were first-party source: three worktrees here
+  // added 9,818 .ts files on top of 3,302 real ones, which surfaced as a
+  // phantom `[complexity] REGRESSION: 1327 > 333` blocking a docs-only commit,
+  // with findings attributed to paths under `.git-worktrees/<branch>/`.
+  // `findFiles` sets `dot: true` deliberately (#1146) so first-party source
+  // under dot-dirs stays visible, which makes this list the only thing keeping
+  // nested checkouts out.
+  '.git-worktrees',
+  '.worktrees',
 ]);
 
 /**

--- a/packages/graph/tests/ingest/CodeIngestor-skip-dirs.test.ts
+++ b/packages/graph/tests/ingest/CodeIngestor-skip-dirs.test.ts
@@ -71,6 +71,38 @@ describe('CodeIngestor — skip-dirs and exclude config', () => {
     expect(paths.some((p) => p.includes('.claude/worktrees'))).toBe(false);
   });
 
+  it('default skip list covers plain-git worktree containers', async () => {
+    // `.claude` covers agent-created worktrees, but a `git worktree add` into
+    // `.git-worktrees/<branch>/` is the same hazard — a full checkout of this
+    // repo — reached without an agent. Omitting these let every scanner count
+    // nested checkouts as first-party source.
+    for (const dir of ['.git-worktrees', '.worktrees']) {
+      expect(DEFAULT_SKIP_DIRS.has(dir)).toBe(true);
+    }
+  });
+
+  it('does not descend into .git-worktrees checkouts', async () => {
+    const root = await buildProject(async (r) => {
+      // Simulate `git worktree add .git-worktrees/feature-x`: a full second
+      // checkout, including a nested package tree that looks like real source.
+      await mkdir(join(r, '.git-worktrees', 'feature-x', 'packages', 'cli', 'src'), {
+        recursive: true,
+      });
+      await writeFile(
+        join(r, '.git-worktrees', 'feature-x', 'packages', 'cli', 'src', 'nested.ts'),
+        'export const nested = 1;\n'
+      );
+      await mkdir(join(r, '.worktrees', 'feature-y', 'src'), { recursive: true });
+      await writeFile(join(r, '.worktrees', 'feature-y', 'src', 'other.ts'), 'x;\n');
+    });
+    const store = new GraphStore();
+    await new CodeIngestor(store).ingest(root);
+    const paths = ingestedPaths(root, store);
+    expect(paths).toContain('src/main.ts');
+    expect(paths.some((p) => p.includes('.git-worktrees'))).toBe(false);
+    expect(paths.some((p) => p.includes('.worktrees'))).toBe(false);
+  });
+
   it('does not descend into .turbo, .vite, or .next caches', async () => {
     const root = await buildProject(async (r) => {
       await mkdir(join(r, '.turbo', 'cache'), { recursive: true });


### PR DESCRIPTION
## Problem

`DEFAULT_SKIP_DIRS` skips agent sandbox dirs (`.claude`, `.cursor`, `.codex`, `.gemini`, …) because each can hold a full checkout of the repo. It missed the identical hazard created by `git worktree add .git-worktrees/<branch>` — reached without an agent.

`findFiles` sets `dot: true` deliberately (#1146) so first-party source under dot-directories stays visible, which makes this list **the only thing** keeping nested checkouts out. So every scanner re-walked each worktree as first-party source.

## Symptom

Three worktrees contributed **9,818** extra `.ts` files on top of the **3,302** real ones, surfacing as a phantom

```
[complexity] REGRESSION: 1327 > 333 (delta: 994)
```

with findings attributed to paths under `.git-worktrees/<branch>/packages/...`. This blocked commits that touched **no source at all** — it was hit while committing a docs-only roadmap change.

## Fix

Add `.git-worktrees` and `.worktrees` alongside the agent sandboxes, with a comment explaining why the list is load-bearing given `dot: true`.

## Verification

- 2 new regression tests mirroring the existing `.claude/worktrees` pair (assert membership + assert the walker does not descend). **13/13 pass** in `CodeIngestor-skip-dirs.test.ts`.
- With the fix built, `harness check-arch` exits **0** on a tree that previously failed; the blocked docs-only commit then went through.

## Assumptions made

- Included `.worktrees` as well as `.git-worktrees` — `.gitignore` already treated both as worktree containers, so leaving one out would have left the same bug reachable under the other name.
- Scoped to the shared skip-dirs set rather than per-scanner config, since the collectors that *did* behave correctly (`dep-depth`, `module-size`) do so via their own dot-dir guard; fixing the shared list repairs every consumer at once.