### PR TITLE
fix(ci): let auto-done and golden-promote land on protected main

### DIFF
--- a/.antigravity-extension/config/mcp_config.json
+++ b/.antigravity-extension/config/mcp_config.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.changeset/ci-protected-main-writes.md
+++ b/.changeset/ci-protected-main-writes.md
@@ -1,0 +1,11 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix CI's two paths for landing housekeeping commits on a protected `main`.
+
+`roadmap-auto-done.yml` declared `permissions: pull-requests: read`, but its branch-protection fallback calls `gh pr create` with the built-in `GITHUB_TOKEN`. That call failed with `Resource not accessible by integration (createPullRequest)` _after_ the branch had already been pushed, so every merge into a protected branch stranded a `chore/auto-done-pr*` branch and silently dropped its roadmap flip. The fallback was added without widening the permission, so it had never once succeeded — 58 stranded branches had accumulated, spanning a long run of merges.
+
+`release.yml`'s "Promote golden build reference state" step pushed straight to `main` with no fallback at all, so it failed on every publish with `GH013: Changes must be made through a pull request`. The packages had already gone out by that point, so releases went red _after_ shipping and the golden reference manifest never advanced. It now uses the same retry-then-scope-guarded-self-approved-PR path as auto-done, with the diff guard pinned to `.harness/golden/manifest.json`.
+
+Branch protection is unchanged; both paths land through auditable, scope-checked PRs.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -34,7 +34,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -13,7 +13,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -17,7 +17,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.gemini-extension/gemini-extension.json
+++ b/.gemini-extension/gemini-extension.json
@@ -6,7 +6,7 @@
   "mcpServers": {
     "harness": {
       "command": "npx",
-      "args": ["-y", "-p", "@harness-engineering/cli@11.0.0", "harness-mcp"]
+      "args": ["-y", "-p", "@harness-engineering/cli@11.1.0", "harness-mcp"]
     }
   }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,13 +96,65 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           HUSKY: '0'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTOAPPROVE_PAT: ${{ secrets.BASELINE_AUTOAPPROVE_PAT }}
         run: |
           node packages/cli/dist/bin/harness.js golden-build promote
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .harness/golden/manifest.json
-          git diff --cached --quiet || git commit -m "chore: promote golden build reference state [skip ci]"
-          git push
+          MANIFEST=".harness/golden/manifest.json"
+          git add "$MANIFEST"
+          if git diff --cached --quiet; then
+            echo "Golden manifest unchanged; nothing to promote."
+            exit 0
+          fi
+          git commit -m "chore: promote golden build reference state [skip ci]"
+          OURS=$(git rev-parse HEAD)
+          BASE="${GITHUB_REF_NAME}"
+
+          # 1) Try a direct push, absorbing any concurrent merge. Reset hard to our
+          #    commit before each retry so a failed rebase can never leave the tree
+          #    dirty for the next attempt.
+          for attempt in 1 2 3; do
+            git rebase --abort 2>/dev/null || true
+            git reset --hard "$OURS" >/dev/null
+            git fetch origin "$BASE" -q || true
+            if git rebase "origin/$BASE" && git push origin "HEAD:$BASE" 2>/dev/null; then
+              echo "Pushed golden-manifest promotion directly to $BASE on attempt $attempt."
+              exit 0
+            fi
+            echo "Direct push attempt $attempt failed; retrying."
+            sleep 3
+          done
+
+          # 2) Direct push is blocked by branch protection ("changes must be made
+          #    through a pull request"). Open a scope-guarded self-approved PR, the
+          #    same fallback roadmap-auto-done.yml uses. Without this the step exited
+          #    1 on every publish, so the release ran red even though the packages
+          #    had already gone out, and the golden reference never advanced.
+          echo "Direct push unavailable; opening a self-approved PR."
+          git fetch origin "$BASE" -q
+          BRANCH="chore/golden-promote-$(git rev-parse --short "$OURS")-$(date +%s)"
+          git checkout -B "$BRANCH" "origin/$BASE"
+          git checkout "$OURS" -- "$MANIFEST"
+          git add "$MANIFEST"
+          if git diff --cached --quiet; then
+            echo "Base already carries this golden manifest; nothing to PR."
+            exit 0
+          fi
+          git commit -m "chore: promote golden build reference state [skip ci]"
+          git push -u origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "chore: promote golden build reference state" \
+            --body "Automated golden-build reference promotion after a successful publish. Opened because direct pushes to $BASE are blocked by branch protection." \
+            --base "$BASE" \
+            --head "$BRANCH")
+          # Defensive scope check: the PAT may only ever approve a diff confined to
+          # the golden manifest (mirrors the roadmap auto-done guard).
+          gh pr diff "$PR_URL" --name-only | node scripts/assert-diff-scope.mjs "$MANIFEST"
+          GH_TOKEN="$AUTOAPPROVE_PAT" gh pr review "$PR_URL" --approve \
+            --body "Auto-approved: golden-build reference promotion from github-actions[bot]."
+          gh pr merge "$PR_URL" --auto --squash --delete-branch
 
   docker:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,15 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
+          # Must be `pnpm version`, not the action's default. The default runs
+          # `changeset version` directly, which bumps package.json but skips
+          # scripts/sync-plugin-pin.mjs — the only thing that re-pins the five
+          # plugin/extension manifests to the new CLI version. Every release
+          # therefore shipped manifests pinned to the PREVIOUS version and left
+          # main red on the plugin-pin-sync assertion in
+          # tests/scripts/plugin-pin-sync.test.mjs. package.json's `version`
+          # script pairs the two steps; this input is what actually invokes it.
+          version: pnpm version
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:

--- a/.github/workflows/roadmap-auto-done.yml
+++ b/.github/workflows/roadmap-auto-done.yml
@@ -28,7 +28,13 @@ on:
 permissions:
   contents: write
   issues: read
-  pull-requests: read
+  # `write`, not `read`: the fallback below calls `gh pr create` with the built-in
+  # GITHUB_TOKEN. Under `read` that call fails with "Resource not accessible by
+  # integration (createPullRequest)" AFTER the branch has already been pushed, so
+  # every protected-branch merge stranded a chore/auto-done-pr* branch and silently
+  # dropped its roadmap flip. The fallback shipped without this widening, so it had
+  # never once succeeded.
+  pull-requests: write
 
 # Serialize commit-to-base across simultaneous PR merges into the same base
 # branch: a second auto-done waits for the first to finish its push rather than


### PR DESCRIPTION
Two workflows commit housekeeping back to `main`. Both were broken by the branch-protection ruleset, in different ways, and both failed **silently enough that nobody noticed for 58 merges**.

## 1. `roadmap-auto-done.yml` — a permission that never matched its own fallback

It declared `permissions: pull-requests: read`, while its fallback calls `gh pr create` with the built-in `GITHUB_TOKEN`. That call fails with

```
Resource not accessible by integration (createPullRequest)
```

**after** the branch has already been pushed — so every merge into a protected branch pushed a `chore/auto-done-pr*` branch, failed to open its PR, and dropped the roadmap flip on the floor.

The fallback logic itself is correct and shipped in #749, but the permission was never widened to match, so **this path had never succeeded once**. `git log -L` on the permissions block confirms the line has read `read` since the workflow was created. Evidence: **58** stranded `chore/auto-done-pr*` branches on origin, spanning PR #793 → #1243.

Repo settings already allow Actions to create PRs (`can_approve_pull_request_reviews: true`), and the ruleset requires 1 approving review with **no** required status checks — so once the permission is right, the existing self-approve + `--auto --squash` path completes on its own.

## 2. `release.yml` — a bare push with no fallback at all

"Promote golden build reference state" pushed straight to `main`:

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through a pull request.
```

Publishing happens **earlier in the same job**, so the release went red *after* the packages shipped (`@harness-engineering/cli@11.1.0` published fine; the run still failed), and the golden reference manifest never advanced — quietly degrading golden-build drift detection.

It now uses the same retry-then-self-approved-PR path, with the scope guard pinned to `.harness/golden/manifest.json`.

## Verification

- Both workflows parse (`yaml.safe_load`); resolved `permissions` confirmed.
- Scope guard exercised both ways: accepts a manifest-only diff, and **fails closed** (exit 1) when an extra path is present, so the PAT can never approve beyond the manifest.
- `release.yml` triggers only on `push` to `main`, so `GITHUB_REF_NAME` is the correct base.
- `BASELINE_AUTOAPPROVE_PAT` confirmed present as a repo secret.

## Assumptions made

- **Kept branch protection unchanged** rather than adding `github-actions[bot]` as a ruleset bypass actor. A bypass would have fixed both with no new YAML, but would let any workflow holding `contents: write` push straight to `main`. Both paths now land as auditable, scope-checked PRs instead.
- Mirrored auto-done's retry-then-PR structure in `release.yml` rather than extracting a shared composite action — duplication is ~30 lines, and factoring it out would put a refactor of the release path inside a fix PR.
- Left the direct-push attempt first in both paths, so if a bypass is ever granted the PR fallback quietly stops being exercised.

## Not included

The **58 stranded branches** are handled separately: 44 carry only flips already satisfied and are safe to prune, but **14 carry a `done` flip for a row whose tracking issue is currently OPEN** (e.g. ULID identity #603, whose plan had 3 phases). Replaying those wholesale could mark incomplete work as shipped, so they need a human call rather than a scripted replay.