### PR TITLE
fix(orchestrator): reject on bind failure instead of hanging; ephemeral test ports

### DIFF
--- a/.changeset/orchestrator-bind-error-handling.md
+++ b/.changeset/orchestrator-bind-error-handling.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+`OrchestratorServer.start()` now rejects when the port cannot be bound, and adopts the OS-assigned port when constructed with `0`.
+
+`listen()` was called with no `'error'` listener, so a bind failure did two bad things at once: the error surfaced as an unhandled `'error'` event (under a test runner, an "Uncaught Exception" attributed to nothing in particular), and the returned promise never settled. An `EADDRINUSE` collision therefore presented as a multi-minute hang until the caller's timeout, rather than as a bind failure — a real hazard for any embedder that starts the server on a port something else already holds.
+
+`start()` now attaches one-shot `'error'`/`'listening'` handlers, rejects with the host, port, and underlying cause on failure, and on success adopts the actual bound port so passing `0` yields a usable ephemeral port. The new `boundPort` getter exposes it.

--- a/packages/orchestrator/src/server/http.ts
+++ b/packages/orchestrator/src/server/http.ts
@@ -814,13 +814,51 @@ export class OrchestratorServer {
       this.planWatcher.start();
     }
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const host = getBindHost();
-      this.httpServer.listen(this.port, host, () => {
+
+      // A bind failure MUST reject. Without an 'error' listener, `listen()`
+      // emits an unhandled 'error' (crashing the process or, under a test
+      // runner, surfacing as an unrelated "Uncaught Exception") AND this
+      // promise never settles — so an EADDRINUSE collision presented as a
+      // hang until the caller's timeout rather than as a bind failure. Rejecting
+      // turns a multi-minute stall into an immediate, attributable error.
+      const onError = (err: Error): void => {
+        this.httpServer.removeListener('listening', onListening);
+        reject(
+          new Error(`Orchestrator API failed to bind ${host}:${this.port}: ${err.message}`, {
+            cause: err,
+          })
+        );
+      };
+
+      const onListening = (): void => {
+        this.httpServer.removeListener('error', onError);
+        // When port 0 was requested the OS assigns an ephemeral port; adopt it
+        // so callers reading `this.port` (and the log line below) report where
+        // the server is actually listening rather than the sentinel 0.
+        const address = this.httpServer.address();
+        if (typeof address === 'object' && address !== null) {
+          this.port = address.port;
+        }
         console.log(`Orchestrator API listening on ${host}:${this.port}`);
         resolve();
-      });
+      };
+
+      this.httpServer.once('error', onError);
+      this.httpServer.once('listening', onListening);
+      this.httpServer.listen(this.port, host);
     });
+  }
+
+  /**
+   * The port this server is listening on. Equals the constructor argument
+   * except when 0 was passed, in which case it is the OS-assigned ephemeral
+   * port and is only meaningful after `start()` resolves. Tests should bind 0
+   * and read this instead of guessing a random port, which collides.
+   */
+  public get boundPort(): number {
+    return this.port;
   }
 
   public stop(): void {

--- a/packages/orchestrator/tests/server/http.test.ts
+++ b/packages/orchestrator/tests/server/http.test.ts
@@ -16,14 +16,12 @@ import type { Proposal } from '@harness-engineering/types';
 describe('OrchestratorServer', () => {
   let server: OrchestratorServer;
   let mockOrchestrator: EventEmitter & { getSnapshot: ReturnType<typeof vi.fn> };
-  let port: number;
 
   beforeEach(() => {
-    port = Math.floor(Math.random() * 10000) + 10000;
     mockOrchestrator = Object.assign(new EventEmitter(), {
       getSnapshot: vi.fn().mockReturnValue({ running: [], retryAttempts: [], claimed: [] }),
     });
-    server = new OrchestratorServer(mockOrchestrator, port);
+    server = new OrchestratorServer(mockOrchestrator, 0);
   });
 
   afterEach(async () => {
@@ -36,7 +34,7 @@ describe('OrchestratorServer', () => {
     await server.start();
 
     const response = await new Promise((resolve) => {
-      http.get(`http://localhost:${port}/api/v1/state`, (res) => {
+      http.get(`http://localhost:${server.boundPort}/api/v1/state`, (res) => {
         let data = '';
         res.on('data', (chunk) => (data += chunk));
         res.on('end', () => {
@@ -54,7 +52,7 @@ describe('OrchestratorServer', () => {
     await server.start();
 
     const response = await new Promise((resolve) => {
-      http.get(`http://localhost:${port}/unknown`, (res) => {
+      http.get(`http://localhost:${server.boundPort}/unknown`, (res) => {
         let data = '';
         res.on('data', (chunk) => (data += chunk));
         res.on('end', () => {
@@ -69,7 +67,7 @@ describe('OrchestratorServer', () => {
   it('broadcasts state_change events to WebSocket clients', RETRY, async () => {
     await server.start();
 
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const ws = new WebSocket(`ws://127.0.0.1:${server.boundPort}/ws`);
     await new Promise<void>((r) => ws.on('open', r));
 
     const messages: string[] = [];
@@ -91,7 +89,7 @@ describe('OrchestratorServer', () => {
   it('broadcasts agent_event events to WebSocket clients', RETRY, async () => {
     await server.start();
 
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const ws = new WebSocket(`ws://127.0.0.1:${server.boundPort}/ws`);
     await new Promise<void>((r) => ws.on('open', r));
 
     const messages: string[] = [];
@@ -112,7 +110,7 @@ describe('OrchestratorServer', () => {
   it('broadcasts interaction_new via broadcastInteraction', RETRY, async () => {
     await server.start();
 
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const ws = new WebSocket(`ws://127.0.0.1:${server.boundPort}/ws`);
     await new Promise<void>((r) => ws.on('open', r));
 
     const messages: string[] = [];
@@ -251,11 +249,10 @@ describe('OrchestratorServer LMLM Phase 6 wiring', () => {
 
   it('getModelPool wired → model approve reaches the live pool (no 501)', async () => {
     writeModelProposal(tmpDir, 'proposal_model_live');
-    const port = Math.floor(Math.random() * 10000) + 20000;
-    const server = makeServer(port, { projectPath: tmpDir, getModelPool: () => fakePool() });
+    const server = makeServer(0, { projectPath: tmpDir, getModelPool: () => fakePool() });
     await server.start();
 
-    const res = await post(port, '/api/v1/proposals/proposal_model_live/approve');
+    const res = await post(server.boundPort, '/api/v1/proposals/proposal_model_live/approve');
     // The 501 stub is retired: the request reaches the pool handler. A swap/add
     // approval installs the target asynchronously (the pull would otherwise block
     // past the proxy headersTimeout), so it returns 202 { disposition:'installing' }
@@ -267,16 +264,14 @@ describe('OrchestratorServer LMLM Phase 6 wiring', () => {
 
   it('getModelPool absent → model approve still returns 501 (LMLM disabled)', async () => {
     writeModelProposal(tmpDir, 'proposal_model_off');
-    const port = Math.floor(Math.random() * 10000) + 30000;
-    const server = makeServer(port, { projectPath: tmpDir, getModelPool: () => null });
+    const server = makeServer(0, { projectPath: tmpDir, getModelPool: () => null });
     await server.start();
 
-    const res = await post(port, '/api/v1/proposals/proposal_model_off/approve');
+    const res = await post(server.boundPort, '/api/v1/proposals/proposal_model_off/approve');
     expect(res.statusCode).toBe(501);
   });
 
   it('registers POST /api/v1/local-models/refresh → 200 with emitted count', async () => {
-    const port = Math.floor(Math.random() * 10000) + 40000;
     const tick: TickResult = {
       candidatesEvaluated: 4,
       proposalsEmitted: 2,
@@ -286,23 +281,22 @@ describe('OrchestratorServer LMLM Phase 6 wiring', () => {
       warnings: [],
       errors: [],
     };
-    const server = makeServer(port, {
+    const server = makeServer(0, {
       projectPath: tmpDir,
       getRefreshScheduler: () => ({ forceRefresh: async () => tick }),
     });
     await server.start();
 
-    const res = await post(port, '/api/v1/local-models/refresh');
+    const res = await post(server.boundPort, '/api/v1/local-models/refresh');
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).emitted).toBe(2);
   });
 
   it('refresh route returns 503 when the scheduler is absent (LMLM disabled)', async () => {
-    const port = Math.floor(Math.random() * 10000) + 50000;
-    const server = makeServer(port, { projectPath: tmpDir });
+    const server = makeServer(0, { projectPath: tmpDir });
     await server.start();
 
-    const res = await post(port, '/api/v1/local-models/refresh');
+    const res = await post(server.boundPort, '/api/v1/local-models/refresh');
     expect(res.statusCode).toBe(503);
     expect(JSON.parse(res.body).error).toContain('LMLM disabled');
   });
@@ -350,24 +344,22 @@ describe('OrchestratorServer LMLM Phase 7 GET route bridging', () => {
   }
 
   it('GET /hardware routes to the new handler (200 HardwareProfile, not the status route)', async () => {
-    const port = Math.floor(Math.random() * 1000) + 60000;
-    const server = makeServer(port, {
+    const server = makeServer(0, {
       projectPath: tmpDir,
       getHardwareProfile: () => Promise.resolve(HW_PROFILE),
     });
     await server.start();
 
-    const res = await get(port, '/api/v1/local-models/hardware');
+    const res = await get(server.boundPort, '/api/v1/local-models/hardware');
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toMatchObject({ vramGb: 24, platform: 'macos' });
   });
 
   it('GET /pool routes to the new handler (200 PoolState, not the status route)', async () => {
-    const port = Math.floor(Math.random() * 1000) + 64000;
-    const server = makeServer(port, { projectPath: tmpDir, getModelPool: () => fakePool() });
+    const server = makeServer(0, { projectPath: tmpDir, getModelPool: () => fakePool() });
     await server.start();
 
-    const res = await get(port, '/api/v1/local-models/pool');
+    const res = await get(server.boundPort, '/api/v1/local-models/pool');
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     // PoolState shape — the legacy status handler returns a statuses array, not this.
@@ -375,54 +367,53 @@ describe('OrchestratorServer LMLM Phase 7 GET route bridging', () => {
   });
 
   it('GET /recommendations validates params → 400 (only the new handler does this)', async () => {
-    const port = Math.floor(Math.random() * 1000) + 62000;
-    const server = makeServer(port, {
+    const server = makeServer(0, {
       projectPath: tmpDir,
       getRecommendations: async () => [],
     });
     await server.start();
 
-    const bad = await get(port, '/api/v1/local-models/recommendations?top=-1');
+    const bad = await get(server.boundPort, '/api/v1/local-models/recommendations?top=-1');
     expect(bad.statusCode).toBe(400);
     expect(JSON.parse(bad.body).error).toContain('invalid top');
 
-    const ok = await get(port, '/api/v1/local-models/recommendations?top=5&profile=coding');
+    const ok = await get(
+      server.boundPort,
+      '/api/v1/local-models/recommendations?top=5&profile=coding'
+    );
     expect(ok.statusCode).toBe(200);
     expect(JSON.parse(ok.body)).toEqual([]);
   });
 
   it('GET /proposals routes to the new handler (200 list)', async () => {
-    const port = Math.floor(Math.random() * 1000) + 63000;
-    const server = makeServer(port, {
+    const server = makeServer(0, {
       projectPath: tmpDir,
       listModelProposals: async () =>
         [{ id: 'p1', kind: 'model', status: 'open' }] as unknown as Proposal[],
     });
     await server.start();
 
-    const res = await get(port, '/api/v1/local-models/proposals');
+    const res = await get(server.boundPort, '/api/v1/local-models/proposals');
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toHaveLength(1);
   });
 
   it('all four GETs return 503 LMLM-disabled when accessors are absent (reached the new handler, not the status route)', async () => {
-    const port = Math.floor(Math.random() * 1000) + 61000;
-    const server = makeServer(port, { projectPath: tmpDir });
+    const server = makeServer(0, { projectPath: tmpDir });
     await server.start();
 
     for (const name of ['hardware', 'pool', 'recommendations', 'proposals']) {
-      const res = await get(port, `/api/v1/local-models/${name}`);
+      const res = await get(server.boundPort, `/api/v1/local-models/${name}`);
       expect(res.statusCode).toBe(503);
       expect(JSON.parse(res.body).error).toContain('LMLM disabled');
     }
   });
 
   it('fans out local-models:pool bus events to connected /ws clients', RETRY, async () => {
-    const port = Math.floor(Math.random() * 1000) + 59000;
-    const server = makeServer(port, { projectPath: tmpDir });
+    const server = makeServer(0, { projectPath: tmpDir });
     await server.start();
 
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const ws = new WebSocket(`ws://127.0.0.1:${server.boundPort}/ws`);
     await new Promise<void>((r) => ws.on('open', r));
     const messages: string[] = [];
     ws.on('message', (d) => messages.push(d.toString()));
@@ -447,8 +438,7 @@ describe('OrchestratorServer LMLM Phase 7 GET route bridging', () => {
   });
 
   it('detaches the bus→WS model listeners on stop()', async () => {
-    const port = Math.floor(Math.random() * 1000) + 58000;
-    const server = makeServer(port, { projectPath: tmpDir });
+    const server = makeServer(0, { projectPath: tmpDir });
     await server.start();
     // Two topics were subscribed in wireEvents().
     expect(mockOrchestrator.listenerCount('local-models:pool')).toBe(1);
@@ -459,5 +449,49 @@ describe('OrchestratorServer LMLM Phase 7 GET route bridging', () => {
 
     expect(mockOrchestrator.listenerCount('local-models:pool')).toBe(0);
     expect(mockOrchestrator.listenerCount('local-models:proposal')).toBe(0);
+  });
+});
+
+describe('OrchestratorServer — bind failures and ephemeral ports', () => {
+  let mockOrchestrator: EventEmitter & { getSnapshot: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockOrchestrator = Object.assign(new EventEmitter(), {
+      getSnapshot: vi.fn().mockReturnValue({ running: [], retryAttempts: [], claimed: [] }),
+    });
+  });
+
+  it('binds an OS-assigned port when constructed with 0 and exposes it as boundPort', async () => {
+    const server = new OrchestratorServer(mockOrchestrator, 0);
+    try {
+      await server.start();
+      expect(server.boundPort).toBeGreaterThan(0);
+
+      // The adopted port must be the one actually serving traffic.
+      const status = await new Promise<number | undefined>((resolve) => {
+        http.get(`http://localhost:${server.boundPort}/api/v1/state`, (res) =>
+          resolve(res.statusCode)
+        );
+      });
+      expect(status).toBe(200);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('rejects instead of hanging when the port is already in use', async () => {
+    const first = new OrchestratorServer(mockOrchestrator, 0);
+    await first.start();
+    const taken = first.boundPort;
+
+    const second = new OrchestratorServer(mockOrchestrator, taken);
+    try {
+      // Before the 'error' listener existed this neither resolved nor rejected:
+      // the bind error went unhandled and the caller stalled until its timeout.
+      await expect(second.start()).rejects.toThrow(/failed to bind/i);
+    } finally {
+      second.stop();
+      first.stop();
+    }
   });
 });


### PR DESCRIPTION
## The production bug

`OrchestratorServer.start()` called `listen()` with **no `'error'` listener**, so a bind failure did two bad things at once:

1. the error surfaced as an unhandled `'error'` event — under a test runner, an "Uncaught Exception" attributed to nothing in particular, and
2. **the returned promise never settled**.

An `EADDRINUSE` collision therefore presented as a multi-minute *hang* until the caller's timeout, rather than as a bind failure. That's a real hazard for any embedder starting the server on a port something else already holds: the failure is silent, unattributable, and looks like a stall rather than a refusal.

## How it surfaced

It reddened `build-and-test (macos-latest, 22)` on an unrelated PR:

```
FAIL tests/server/http.test.ts > refresh route returns 503 when the scheduler is absent
Error: Test timed out in 120000ms.
  301|  const port = Math.floor(Math.random() * 10000) + 50000;

Uncaught Exception:
Error: listen EADDRINUSE: address already in use 127.0.0.1:55555
```

The test gambled on a random port, something already held `55555`, and the run burned 120 seconds before dying — on a branch that had touched nothing related.

## The fix

`start()` now attaches one-shot `'error'`/`'listening'` handlers and rejects with the host, port, and underlying `cause`. On success it adopts the **actual** bound port, so constructing with `0` yields a working ephemeral port; the new `boundPort` getter exposes it.

All 12 random-port allocations in `tests/server/http.test.ts` now bind `0` and read `boundPort` — eliminating the collision rather than mitigating it. Worth noting the file already declared `{ retry: 2 }`, but retry can't help while the failure mode is a 120s hang, and the test that actually failed didn't carry it anyway.

## Verification

- **2 new regression tests**: port `0` binds and serves traffic on `boundPort`; a second bind to an already-taken port **rejects** instead of hanging. The first could not even compile before this change — `boundPort` did not exist.
- `packages/orchestrator`: **237 files / 2519 tests pass**.
- Observed directly: with the fix, a mis-wired test fails in ~51ms instead of 120s.

## Scope deliberately left out

Nine other orchestrator test files still hold ~10 random-port allocations of the same shape (`integration/spec-b-phase-5-http-ws`, `server/websocket`, `server/static`, `server/integration`, `server/lmlm-phase7-e2e`, `server/local-model-broadcast`, `server/routes/chat-proxy`, `server/routes/plans`, `integration/amr-routing-endpoints-e2e`).

They are now far less dangerous — a collision fails fast and is retryable rather than hanging — but they remain collisions. Converting them is mechanical follow-up; this PR stays scoped to the production fix plus the one file with a demonstrated failure.