### PR TITLE
fix(ci): invoke the version SCRIPT, not pnpm's built-in version command

### DIFF
--- a/.changeset/release-version-run-script.md
+++ b/.changeset/release-version-run-script.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Fix the release workflow invoking pnpm's built-in `version` command instead of the `version` script.
+
+`version` is a built-in pnpm command, so the `version: pnpm version` input passed to `changesets/action` resolved to the built-in — which only prints a version dictionary — and never ran package.json's `version` script. The release bumped nothing, so `changeset-release/main` came out byte-identical to `main` and the action failed creating its PR with `Validation Failed: No commits between main and changeset-release/main`.
+
+Corrected to `pnpm run version`, which invokes the script (`changeset version && node scripts/sync-plugin-pin.mjs`). The sibling `publish: pnpm release` input was never affected because `release` is not a built-in pnpm command and therefore falls through to `run`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,15 +70,25 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm release
-          # Must be `pnpm version`, not the action's default. The default runs
-          # `changeset version` directly, which bumps package.json but skips
-          # scripts/sync-plugin-pin.mjs — the only thing that re-pins the five
-          # plugin/extension manifests to the new CLI version. Every release
-          # therefore shipped manifests pinned to the PREVIOUS version and left
-          # main red on the plugin-pin-sync assertion in
+          # `pnpm run version` — the `run` is REQUIRED and not stylistic.
+          #
+          # `version` is a built-in pnpm command, so a bare `pnpm version`
+          # resolves to the built-in (which just PRINTS a version dictionary)
+          # and never executes package.json's `version` script. The release then
+          # bumps nothing, `changeset-release/main` comes out identical to main,
+          # and the action dies creating its PR:
+          #   Validation Failed: No commits between main and changeset-release/main
+          # `publish: pnpm release` above is safe from this only because
+          # `release` is NOT a built-in and falls through to `run`.
+          #
+          # We override the action's default (`changeset version`) at all because
+          # the default skips scripts/sync-plugin-pin.mjs — the only thing that
+          # re-pins the five plugin/extension manifests to the new CLI version.
+          # Without it every release shipped manifests pinned to the PREVIOUS
+          # version and left main red on the plugin-pin-sync assertion in
           # tests/scripts/plugin-pin-sync.test.mjs. package.json's `version`
-          # script pairs the two steps; this input is what actually invokes it.
-          version: pnpm version
+          # script pairs the bump and the sync; this input invokes that script.
+          version: pnpm run version
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:


### PR DESCRIPTION
**Regression I introduced in the release-workflow fix. This corrects it.**

## What broke

`version` is a **built-in pnpm command**. So the `version: pnpm version` input I passed to `changesets/action` resolved to the built-in — which only *prints* a version dictionary — and never executed `package.json`'s `version` script.

The release therefore bumped nothing, `changeset-release/main` came out byte-identical to `main`, and the action failed creating its PR:

```
HttpError: Validation Failed: {"resource":"PullRequest","code":"custom",
"message":"No commits between main and changeset-release/main"}
```

You can see the built-in's output in the failing job log — a Node/V8 version dump (`openssl`, `v8`, `zstd`, …) where a version bump should have been.

Two release runs failed this way: `a05b6de4d` and `4830b8faf`.

## The asymmetry that hid it

The sibling input `publish: pnpm release` was **never** affected — `release` is not a built-in pnpm command, so it falls through to `run`. Two inputs of identical shape, resolved differently. The comment now says so explicitly, so the next person doesn't "simplify" it back.

## Damage assessment

- **Nothing published incorrectly** — npm remains `@harness-engineering/cli@11.1.0`
- No spurious version bumps, tags, or GitHub releases
- **Three changesets are unconsumed** on `main` (`ci-protected-main-writes`, `orchestrator-bind-error-handling`, `skip-dirs-git-worktree-containers`); they will be picked up by the next successful release run

## Why the override exists at all

Unchanged from the original intent, and still needed: the action's default (`changeset version`) skips `scripts/sync-plugin-pin.mjs`, the only thing that re-pins the five plugin/extension manifests to the new CLI version. Without it, every release shipped manifests pinned to the *previous* version and left `main` red on the `plugin-pin-sync` assertion in `tests/scripts/plugin-pin-sync.test.mjs`. `package.json`'s `version` script pairs the bump with the sync; this input has to invoke that script.

## Verification

Proven empirically rather than by inference — which is exactly what I failed to do the first time. In an isolated temp package whose `version` script is `echo SCRIPT_WAS_INVOKED`:

| Command | Result |
| --- | --- |
| `pnpm version` | prints `{ probe: '1.0.0', npm: …, node: … }` — script never runs |
| `pnpm run version` | prints `SCRIPT_WAS_INVOKED` |

Workflow YAML parses; resolved inputs confirmed as `version: 'pnpm run version'`, `publish: 'pnpm release'`.