### PR TITLE
chore: sync harness update — fail-closed guard hooks, session retrospect

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/block-no-verify.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/block-no-verify.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/protect-config.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/protect-config.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       },
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/sentinel-pre.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/sentinel-pre.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       }
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/quality-warner.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/quality-warner.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       },
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/sentinel-post.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/sentinel-post.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       }
@@ -55,7 +55,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/pre-compact-state.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/pre-compact-state.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       }
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/adoption-tracker.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/adoption-tracker.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       },
@@ -75,7 +75,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$(git rev-parse --show-toplevel)/.harness/hooks/telemetry-reporter.js\""
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/telemetry-reporter.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/session-retrospect.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
           }
         ]
       }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,5 @@
+notify = ["node", "/Users/cwarner/Projects/harness-engineering/.harness/hooks/session-retrospect-codex.js"]
+
 [mcp_servers.context7]
 args = [
     "-y",

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "hooks": {
+    "stop": [
+      {
+        "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/session-retrospect-cursor.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/session-retrospect-cursor.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\""
+      }
+    ]
+  }
+}

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -16,5 +16,18 @@
       "command": "npx",
       "args": ["-y", "@playwright/mcp"]
     }
+  },
+  "hooks": {
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "g=\"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)\" || exit 0; f=\"$(dirname \"$g\")/.harness/hooks/session-retrospect-gemini.js\"; [ -f \"$f\" ] || exit 0; exec node \"$f\"",
+            "name": "harness-session-retrospect"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.harness/hooks/adoption-tracker.js
+++ b/.harness/hooks/adoption-tracker.js
@@ -8,6 +8,7 @@
 import { readFileSync, writeFileSync, mkdirSync, appendFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import process from 'node:process';
+import { readHookStdin } from './read-hook-stdin.js';
 
 const ADOPTION_CURSOR_FILE = '.adoption-cursor';
 
@@ -31,7 +32,9 @@ function isAdoptionEnabled(cwd) {
 /** Read the cursor offset for events.jsonl processing. */
 function readEventsCursor(cwd) {
   try {
-    const data = JSON.parse(readFileSync(join(cwd, '.harness', 'metrics', ADOPTION_CURSOR_FILE), 'utf-8'));
+    const data = JSON.parse(
+      readFileSync(join(cwd, '.harness', 'metrics', ADOPTION_CURSOR_FILE), 'utf-8')
+    );
     return typeof data.offset === 'number' ? data.offset : 0;
   } catch {
     return 0;
@@ -86,6 +89,57 @@ function deriveOutcome(events) {
   return 'abandoned';
 }
 
+/**
+ * Failure-reason taxonomy (keep in sync with FAILURE_CATEGORIES in
+ * @harness-engineering/types). Each rule maps a keyword pattern found in an
+ * error event's `failureType` to a category; the first match wins.
+ */
+const FAILURE_CATEGORY_RULES = [
+  [/timeout|timed[-_ ]?out|deadline/i, 'timeout'],
+  [/cancel|abort|interrupt|user[-_ ]?stop|declin/i, 'user-cancelled'],
+  [/prereq|prerequisite|precondition|not[-_ ]?found|missing/i, 'prerequisite-missing'],
+  [/depend|upstream|blocked|blocker/i, 'dependency-failure'],
+  [/gate|reject|verify|unsatisf|not[-_ ]?satisf|outcome/i, 'gate-rejected'],
+  [/inconclusive|unknown|indeterminate/i, 'inconclusive'],
+];
+
+/** Map a free-form failureType string to a closed FailureCategory. */
+function classifyFailureType(failureType) {
+  if (typeof failureType === 'string' && failureType) {
+    for (const [pattern, category] of FAILURE_CATEGORY_RULES) {
+      if (pattern.test(failureType)) return category;
+    }
+  }
+  // A recorded error with no more specific signal is a generic agent error.
+  return 'agent-error';
+}
+
+/**
+ * Derive the failure category for a run, or undefined when it does not apply.
+ *
+ * - Completed runs never carry a category.
+ * - An explicit `error` event is the most specific signal: its `failureType`
+ *   is mapped through the keyword table (defaulting to `agent-error`).
+ * - Otherwise a failed `gate_result` (passed === false) is a `gate-rejected`.
+ * - A run that merely stopped (abandoned) with no error and no failed gate has
+ *   no determinable reason, so the field is omitted rather than guessed.
+ */
+function deriveFailureCategory(events, outcome) {
+  if (outcome === 'completed') return undefined;
+
+  const errorEvent = events.find((e) => e.type === 'error');
+  if (errorEvent) {
+    return classifyFailureType(errorEvent.data && errorEvent.data.failureType);
+  }
+
+  const gateRejected = events.some(
+    (e) => e.type === 'gate_result' && e.data && e.data.passed === false
+  );
+  if (gateRejected) return 'gate-rejected';
+
+  return undefined;
+}
+
 /** Derive phases reached from phase_transition events. */
 function derivePhasesReached(events) {
   const phases = [];
@@ -114,19 +168,18 @@ function deriveDuration(events) {
 
 /** Read stdin (fd 0) and parse it as JSON. Returns null when it should exit-0. */
 function readStdinJson() {
-  let raw;
-  try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
+  // readHookStdin retries the EAGAIN that fd 0 throws under compound load (v8
+  // coverage on the pre-push gate): the writer races ahead of the read, and a
+  // raw readFileSync(0) would mistake that backpressure for empty stdin and
+  // skip the adoption write, flaking the suite (#620). A genuine read failure
+  // or empty stdin still returns null (fail-open — this is a log-only hook).
+  const stdin = readHookStdin();
+  if (!stdin.ok || !stdin.data.trim()) {
     return null;
   }
 
-  if (!raw.trim()) {
-    return null;
-  }
-
   try {
-    return JSON.parse(raw);
+    return JSON.parse(stdin.data);
   } catch {
     process.stderr.write('[adoption-tracker] Could not parse stdin — skipping\n');
     return null;
@@ -149,14 +202,19 @@ function groupBySkill(events) {
 function buildRecord(skill, events, allEvents, sessionId) {
   // Use all events for this skill (including non-relevant) for timing
   const allSkillEvents = allEvents.filter((e) => e.skill === skill);
-  return {
+  const outcome = deriveOutcome(events);
+  const record = {
     skill,
     session: sessionId,
     startedAt: allSkillEvents[0]?.timestamp ?? events[0].timestamp,
     duration: deriveDuration(allSkillEvents.length > 0 ? allSkillEvents : events),
-    outcome: deriveOutcome(events),
+    outcome,
     phasesReached: derivePhasesReached(events),
   };
+  // Additive, optional: only present when a reason is determinable.
+  const failureCategory = deriveFailureCategory(events, outcome);
+  if (failureCategory) record.failureCategory = failureCategory;
+  return record;
 }
 
 function main() {

--- a/.harness/hooks/block-no-verify.js
+++ b/.harness/hooks/block-no-verify.js
@@ -1,20 +1,30 @@
 #!/usr/bin/env node
 // block-no-verify.js — PreToolUse:Bash hook
+// harness-ignore SEC-AGT-006: definitional — this hook exists to BLOCK the bypass flag it names
 // Blocks git commands that use --no-verify to skip hooks.
 // Exit codes: 0 = allow, 2 = block
 
-import { readFileSync } from 'node:fs';
 import process from 'node:process';
 
+import { readHookStdin } from './read-hook-stdin.js';
+
 function main() {
-  let raw = '';
-  try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
-    // No stdin or read error — fail open
-    process.exit(0);
+  const stdin = readHookStdin();
+  if (!stdin.ok) {
+    // Fail CLOSED. A guard that cannot read the command it is guarding must not
+    // vouch for it — exiting 0 here is what let --no-verify through whenever the
+    // stdin pipe hiccuped, while CI still went green.
+    process.stderr.write(
+      `BLOCKED: could not read hook input (${stdin.error.code ?? stdin.error.message}); ` +
+        'refusing to allow the command unverified.\n'
+    );
+    process.exit(2);
   }
 
+  const raw = stdin.data;
+
+  // A successful read of nothing is a real "no payload" invocation, not a
+  // blind hook — that stays fail-open.
   if (!raw.trim()) {
     process.exit(0);
   }
@@ -35,6 +45,7 @@ function main() {
 
     if (containsHookBypass(command)) {
       process.stderr.write(
+        // harness-ignore SEC-AGT-006: definitional — user-facing message names the flag this hook blocks
         'BLOCKED: --no-verify flag detected. Hooks must not be bypassed.\n'
       );
       process.exit(2);
@@ -60,6 +71,7 @@ function stripStringsAndComments(cmd) {
 
 function containsHookBypass(command) {
   const stripped = stripStringsAndComments(command);
+  // harness-ignore SEC-AGT-006: definitional — this IS the detection regex for the bypass flag
   if (/(?:^|\s)--no-verify(?=\s|$)/.test(stripped)) return true;
   if (/\bgit\s+(?:[\w-]+\s+)*?commit\b[^\n]*?(?:^|\s)-n(?=\s|$)/.test(stripped)) return true;
   return false;

--- a/.harness/hooks/package.json
+++ b/.harness/hooks/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/.harness/hooks/pre-compact-state.js
+++ b/.harness/hooks/pre-compact-state.js
@@ -9,6 +9,7 @@
 import { readFileSync, mkdirSync, writeFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import process from 'node:process';
+import { readHookStdin } from './read-hook-stdin.js';
 
 function readJsonSafe(filePath) {
   try {
@@ -48,13 +49,16 @@ function findActiveSession(sessionsDir) {
  * fail-open stderr message and exits 0. Returns the raw string on success.
  */
 function readValidStdin() {
-  let raw = '';
-  try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
+  // readHookStdin retries the EAGAIN that fd 0 throws under compound load (v8
+  // coverage on the pre-push gate): the writer races ahead of the read, and a
+  // raw readFileSync(0) would mistake that backpressure for empty stdin and
+  // fail-open, silently skipping the summary write and flaking the suite (#620).
+  const stdin = readHookStdin();
+  if (!stdin.ok) {
     process.stderr.write('[pre-compact-state] Could not read stdin — allowing (fail-open)\n');
     process.exit(0);
   }
+  const raw = stdin.data;
 
   if (!raw.trim()) {
     process.stderr.write('[pre-compact-state] Empty stdin — allowing (fail-open)\n');

--- a/.harness/hooks/profile.json
+++ b/.harness/hooks/profile.json
@@ -1,3 +1,20 @@
 {
-  "profile": "standard"
+  "profile": "standard",
+  "fileHashes": {
+    "block-no-verify.js": "9d224eb5dbdfea4f6ae9ae8b82a431a61a983c4589b1bf9230b70f71efafa9e8",
+    "protect-config.js": "91a2b8af5a3f15ca82efaf9f465ebcf936ad9c772fde4fe717f5ac2d8b877c87",
+    "quality-warner.js": "acf787c9904277d18679a5fef98e1bea381ea0938dfe0c150c940f835613f3a8",
+    "pre-compact-state.js": "4b562a64b69c293d73c7a9f902164a59865145a46393be09f3cea430542fb206",
+    "adoption-tracker.js": "211e336a8b63b41e0d7aec020cd6d383bbf2eec7aa2194fb37ae7d1d26c51666",
+    "telemetry-reporter.js": "396f40066d9cbcebd582692d2647cef64de2d540170d1f95ae52755cc3310081",
+    "session-retrospect.js": "54936d2bb4d54ebb18c4fe3df25a517d501c1bf9c83b79f071df6ee062ddc3c2",
+    "sentinel-pre.js": "79e6218ef603d81aaca752db8289cd369bba963135024f486f2ec305253db07f",
+    "sentinel-post.js": "8f892b15d70ee2da155d508ede59e22c1c8f160edc975534546b695253dd03da",
+    "read-hook-stdin.js": "54e8e2606868070d8fbc4b8bbdb277eadea769dfb3483e7c5cdef106c47cfc06",
+    "format-check.js": "8bb8f5e4c97711f8ba633137d7cac99ed2c29bc444a2684cc7d295c10485a4d5",
+    "session-retrospect-core.js": "d6b734cd0fbeb19b1c23ccec0b753965393edfad32da784bc3c5ed172208d909",
+    "session-retrospect-gemini.js": "9e614ea2c6ff0dcee0170113850991f580c7f6760d015f3fb9119944bf5eaab0",
+    "session-retrospect-codex.js": "a748fcf8860c7a3cd4ea4ffcd9736c58cb6c20fb65ee1805109192394173f498",
+    "session-retrospect-cursor.js": "655281322a654cc0b436445340df6ab9aeedfc185c81d87642d7977ffb824c79"
+  }
 }

--- a/.harness/hooks/protect-config.js
+++ b/.harness/hooks/protect-config.js
@@ -10,9 +10,10 @@
 //     potentially unprotected config edit.
 // Exit codes: 0 = allow, 2 = block
 
-import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 import process from 'node:process';
+
+import { readHookStdin } from './read-hook-stdin.js';
 
 // Protected config file patterns
 const PROTECTED_PATTERNS = [
@@ -35,13 +36,21 @@ function isProtected(filePath) {
 }
 
 function main() {
-  let raw;
-  try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
-    process.stderr.write('[protect-config] Could not read stdin — allowing (fail-open)\n');
-    process.exit(0);
+  const stdin = readHookStdin();
+  if (!stdin.ok) {
+    // Fail CLOSED. On a pipe, fd 0 is non-blocking and a read issued before the
+    // writer has filled it throws EAGAIN; treating that as "no input" and
+    // exiting 0 let a config edit through unverified while the check still
+    // reported success (#993, same seam as block-no-verify). A guard that
+    // cannot read the edit it is guarding must not vouch for it.
+    process.stderr.write(
+      `BLOCKED: protect-config could not read hook input (${stdin.error.code ?? stdin.error.message}); ` +
+        'refusing to allow a potentially unprotected config edit unverified.\n'
+    );
+    process.exit(2);
   }
+
+  const raw = stdin.data;
 
   if (!raw.trim()) {
     process.stderr.write('[protect-config] Empty stdin — allowing (fail-open)\n');

--- a/.harness/hooks/read-hook-stdin.js
+++ b/.harness/hooks/read-hook-stdin.js
@@ -1,0 +1,60 @@
+// read-hook-stdin.js — resilient stdin reader shared by PreToolUse hooks.
+//
+// Why this exists: `readFileSync(0)` on a pipe can throw EAGAIN when the writer
+// hasn't filled the pipe yet — the fd is non-blocking and the read simply isn't
+// ready. Hooks that treated that throw as "no input" failed OPEN, so a guard
+// like block-no-verify silently stopped enforcing under CI load while still
+// reporting success (issue #619 patched the test, not this seam).
+//
+// The distinction that matters to a caller: a read that FAILED is not the same
+// as a read that succeeded and returned nothing. The former means the hook is
+// blind and must not vouch for the command; the latter is a legitimate
+// "hook invoked with no payload" and stays fail-open.
+
+import { Buffer } from 'node:buffer';
+import { readSync } from 'node:fs';
+
+const CHUNK_BYTES = 64 * 1024;
+const EAGAIN_DEADLINE_MS = 5000;
+const EAGAIN_BACKOFF_MS = 5;
+
+/** Synchronously sleep without spinning the CPU. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Read all of stdin, retrying while the pipe reports EAGAIN.
+ *
+ * @returns {{ ok: true, data: string } | { ok: false, error: Error }}
+ *   `ok: false` means the read genuinely failed and the caller is blind.
+ *   `ok: true` with `data: ''` means stdin was legitimately empty.
+ */
+export function readHookStdin() {
+  const chunks = [];
+  const buf = Buffer.alloc(CHUNK_BYTES);
+  const deadline = Date.now() + EAGAIN_DEADLINE_MS;
+
+  for (;;) {
+    let bytesRead;
+    try {
+      bytesRead = readSync(0, buf, 0, CHUNK_BYTES, null);
+    } catch (err) {
+      // Pipe not ready yet — the writer is still catching up. Retry until the
+      // deadline rather than mistaking backpressure for end-of-input.
+      if (err.code === 'EAGAIN') {
+        if (Date.now() >= deadline) return { ok: false, error: err };
+        sleepSync(EAGAIN_BACKOFF_MS);
+        continue;
+      }
+      // EOF is how some platforms signal a closed tty rather than a 0-byte read.
+      if (err.code === 'EOF') break;
+      return { ok: false, error: err };
+    }
+
+    if (bytesRead === 0) break;
+    chunks.push(Buffer.from(buf.subarray(0, bytesRead)));
+  }
+
+  return { ok: true, data: Buffer.concat(chunks).toString('utf-8') };
+}

--- a/.harness/hooks/sentinel-post.js
+++ b/.harness/hooks/sentinel-post.js
@@ -7,6 +7,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import process from 'node:process';
+import { readHookStdin } from './read-hook-stdin.js';
 
 // Minimal inline patterns for when @harness-engineering/core isn't available.
 // Keep in sync with @harness-engineering/core injection-patterns.ts ALL_PATTERNS.
@@ -32,6 +33,7 @@ const INLINE_RULES = [
   // HIGH: INJ-PERM-002 — Disable safety/security
   { severity: 'high', ruleId: 'INJ-PERM-002', pattern: /(?:disable|turn\s+off|remove|bypass)\s+(?:all\s+)?(?:safety|security|restrictions?|guardrails?|protections?|checks?)/i },
   // HIGH: INJ-PERM-003 — Auto-approve directive
+  // harness-ignore SEC-AGT-006: definitional — this IS the detection pattern for the bypass flags
   { severity: 'high', ruleId: 'INJ-PERM-003', pattern: /(?:auto[- ]?approve|--no-verify|--dangerously-skip-permissions)/i },
   // HIGH: INJ-ENC-001 — Suspicious base64
   { severity: 'high', ruleId: 'INJ-ENC-001', pattern: /(?<!Bearer\s)(?<![:])(?<![A-Za-z0-9/])(?!eyJ)(?:[A-Za-z0-9+/]{4}){7,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?(?![A-Za-z0-9/])/ },
@@ -65,15 +67,15 @@ function inlineScan(text) {
 
 /** Read stdin (fd 0) and parse it as JSON. Returns null when it should exit-0. */
 function readStdinJson() {
-  let raw;
+  // readHookStdin retries the EAGAIN that fd 0 throws under compound load (v8
+  // coverage on the pre-push gate): the writer races ahead of the read, and a
+  // raw readFileSync(0) would mistake that backpressure for empty stdin and
+  // fail-open, flaking the suite (#620). A genuine read failure or empty stdin
+  // still returns null (fail-open — PostToolUse cannot block anyway).
+  const stdin = readHookStdin();
+  if (!stdin.ok || !stdin.data.trim()) return null;
   try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
-    return null;
-  }
-  if (!raw.trim()) return null;
-  try {
-    return JSON.parse(raw);
+    return JSON.parse(stdin.data);
   } catch {
     return null;
   }

--- a/.harness/hooks/sentinel-pre.js
+++ b/.harness/hooks/sentinel-pre.js
@@ -5,6 +5,7 @@
 // (the actual prompt-injection vector). This hook performs NO injection detection
 // on tool INPUTS — an agent's own tool inputs are its intent, not untrusted content,
 // and scanning them here falsely tainted legitimate work (e.g. an agent running
+// harness-ignore SEC-AGT-006: this hook's design doc references the bypass flag it guards against
 // `git commit --no-verify`, or inputs containing base64/git-SHA tokens), then blocked
 // the agent's own `git push`. Detection lives in sentinel-post; pre only enforces.
 // Exit codes: 0 = allow, 2 = block
@@ -16,6 +17,8 @@
 import { readFileSync, unlinkSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import process from 'node:process';
+
+import { readHookStdin } from './read-hook-stdin.js';
 
 // Destructive tool patterns blocked during taint.
 // Keep in sync with DESTRUCTIVE_BASH exported from @harness-engineering/core injection-patterns.ts.
@@ -39,19 +42,25 @@ function isOutsideWorkspace(filePath, workspaceRoot) {
   return !realResolved.startsWith(workspaceRoot);
 }
 
-/** Read stdin (fd 0) and parse it as JSON. Returns null when it should exit-0. */
+/**
+ * Read stdin (fd 0) and parse it as JSON.
+ *
+ * Returns `{ blind: true }` when the read genuinely FAILED (the guard is blind
+ * and must fail closed), `{ input: null }` for a legitimately empty or malformed
+ * payload (benign — fail open), or `{ input }` on success. Distinguishing a
+ * failed read from an empty one is the whole point: conflating them let a tool
+ * call through unverified during a tainted session whenever the stdin pipe
+ * hiccuped, while the check still reported success (#993, same seam as
+ * block-no-verify).
+ */
 function readStdinJson() {
-  let raw;
+  const stdin = readHookStdin();
+  if (!stdin.ok) return { blind: true, error: stdin.error };
+  if (!stdin.data.trim()) return { input: null };
   try {
-    raw = readFileSync(0, 'utf-8');
+    return { input: JSON.parse(stdin.data) };
   } catch {
-    return null;
-  }
-  if (!raw.trim()) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
+    return { input: null };
   }
 }
 
@@ -113,7 +122,18 @@ function enforceTaint(toolName, toolInput, workspaceRoot) {
 }
 
 async function main() {
-  const input = readStdinJson();
+  const result = readStdinJson();
+  if (result.blind) {
+    // Fail CLOSED: a taint guard that cannot read the tool call it is guarding
+    // must not wave it through. Exiting 0 here would silently disable Sentinel
+    // during a tainted session on the exact EAGAIN pipe race #993 describes.
+    process.stderr.write(
+      `BLOCKED by Sentinel: could not read hook input (${result.error.code ?? result.error.message}); ` +
+        'refusing to allow the tool call unverified during a possibly-tainted session.\n'
+    );
+    process.exit(2);
+  }
+  const input = result.input;
   if (input === null) {
     process.exit(0);
   }

--- a/.harness/hooks/session-retrospect-codex.js
+++ b/.harness/hooks/session-retrospect-codex.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// session-retrospect-codex.js — Codex CLI notify hook (opt-in).
+//
+// Thin entry point for Codex CLI. Codex has no session-end lifecycle hook; its
+// `[hooks]`/hooks.json engine only exposes tool-use events. The only end-of-turn
+// seam is the `notify` key in `.codex/config.toml`, which fires on
+// `agent-turn-complete` and passes its event as a SINGLE JSON ARGV ARGUMENT (not
+// stdin) (per https://learn.chatgpt.com/docs/config-file/config-advanced and
+// https://github.com/openai/codex, verified 2026-08). The payload fields are
+// `type`, `thread-id` (the session/conversation identifier), `turn-id`, `cwd`,
+// `input-messages`, and `last-assistant-message`.
+//
+// The generated notify line no longer references this file by absolute path.
+// notify is now fired via the PATH-resolvable `harness hooks run
+// session-retrospect-codex` command (machine-independent, committable). This
+// file remains shipped as a copied support script for backward compatibility
+// with configs that still reference it; both paths share the same payload
+// parser (`parseCodexNotifyPayload`) and archive core so they cannot drift.
+//
+// notify fires once per AGENT TURN, not once per session, so this would fire
+// many times in an interactive session. The shared core dedupes per session id
+// (`thread-id`) via the same sentinel every other agent uses, so per-turn firing
+// archives the session AT MOST ONCE. `thread-id` is stable across the turns of
+// one Codex conversation, which is exactly the dedupe key we want.
+//
+// Because notify runs as a detached subprocess whose cwd is not guaranteed to be
+// the project, the archive targets the payload's `cwd` field (falling back to
+// the process cwd).
+//
+// Fail-soft: any error is swallowed and the hook exits 0. Codex does not act on
+// notify exit codes, so this never blocks or delays anything.
+//
+// Exit codes: 0 = allow (always, log-only hook)
+
+import process from 'node:process';
+import {
+  parseCodexNotifyPayload,
+  retrospectLogLine,
+  retrospectSession,
+} from './session-retrospect-core.js';
+
+async function main() {
+  // Codex delivers the notification as a single JSON string in argv, not stdin.
+  const parsed = parseCodexNotifyPayload(process.argv[2]);
+  if (!parsed) {
+    process.exit(0);
+  }
+
+  try {
+    const result = await retrospectSession(parsed);
+    const line = retrospectLogLine('session-retrospect-codex', result);
+    if (line) process.stderr.write(line);
+    process.exit(0);
+  } catch (err) {
+    process.stderr.write(
+      `[session-retrospect-codex] Failed: ${err && err.message ? err.message : String(err)}\n`
+    );
+    process.exit(0);
+  }
+}
+
+main();

--- a/.harness/hooks/session-retrospect-core.js
+++ b/.harness/hooks/session-retrospect-core.js
@@ -1,0 +1,240 @@
+// session-retrospect-core.js — shared, agent-agnostic core for the opt-in
+// end-of-session retrospection trigger.
+//
+// Why this exists: the session-archive lifecycle runs its `onArchived` step
+// (session summary, index, and — when enabled — retrospection) only when a
+// session is archived. The only caller that archives a session is the
+// `archive_session` state action, which autonomous flows invoke at teardown.
+// A manual, interactive session is never archived, so its end-of-session
+// analysis never runs. The per-agent session-end hooks close that gap: at
+// session end each agent's hook archives the active session through the same
+// public archive seam, so `onArchived` fires for manually driven sessions too.
+//
+// This module holds the agent-agnostic middle: the opt-in gate, the
+// once-per-session dedupe, the active-session resolver, and the archive call.
+// Each agent's entry point (session-retrospect.js for Claude Code,
+// session-retrospect-gemini.js, -codex.js, -cursor.js) is a thin wrapper that
+// parses its own session-end event, extracts a session id, and delegates to
+// `retrospectSession` here. Extracting the core keeps every agent on the exact
+// same archive engine (#1124's archiveSession / buildArchiveHooks) instead of a
+// parallel retrospection path, and keeps the fail-soft, at-most-once-per-session
+// guarantees in one place.
+//
+// Opt-in: the whole flow is a no-op unless HARNESS_SESSION_RETROSPECTION is
+// enabled (default off), matching the same flag that gates the retrospection
+// step inside the archive lifecycle. Callers who have not opted in pay nothing
+// beyond a single env-var check — no archive package is even resolved.
+//
+// Once per session: a session-end hook can fire more than once per real session
+// (Claude's Stop fires on every turn-stop; Codex's notify fires on every
+// agent-turn-complete). Archiving on every fire would tear down a live session,
+// so this archives AT MOST ONCE per session, keyed on the agent's session id via
+// a sentinel file under `.harness/state/retrospection/<sessionId>.archived`. The
+// first fire that finds an active session archives it and writes the sentinel;
+// every later fire for the same session is a no-op. A fire that finds no session
+// to archive writes no sentinel, so a session created later in the same run can
+// still be caught.
+//
+// Fail-soft: any error — unreadable stdin, missing packages, a failed archive —
+// is swallowed by the entry point and the hook exits 0. It never blocks or
+// delays session exit.
+
+import { Buffer } from 'node:buffer';
+import { existsSync, mkdirSync, readdirSync, readSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+
+const CHUNK_BYTES = 64 * 1024;
+const EAGAIN_DEADLINE_MS = 5000;
+const EAGAIN_BACKOFF_MS = 5;
+
+/** Synchronously sleep without spinning the CPU. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Read all of stdin, retrying while the pipe reports EAGAIN. Mirrors the shared
+ * read-hook-stdin helper so a writer that races ahead of the read is not
+ * mistaken for empty stdin. Used by the agents that deliver their session-end
+ * event on stdin (Claude Code, Gemini CLI, Cursor); Codex delivers its event as
+ * an argv argument and does not use this.
+ * @returns {{ ok: true, data: string } | { ok: false }}
+ */
+export function readHookStdin() {
+  const chunks = [];
+  const buf = Buffer.alloc(CHUNK_BYTES);
+  const deadline = Date.now() + EAGAIN_DEADLINE_MS;
+
+  for (;;) {
+    let bytesRead;
+    try {
+      bytesRead = readSync(0, buf, 0, CHUNK_BYTES, null);
+    } catch (err) {
+      if (err.code === 'EAGAIN') {
+        if (Date.now() >= deadline) return { ok: false };
+        sleepSync(EAGAIN_BACKOFF_MS);
+        continue;
+      }
+      if (err.code === 'EOF') break;
+      return { ok: false };
+    }
+    if (bytesRead === 0) break;
+    chunks.push(Buffer.from(buf.subarray(0, bytesRead)));
+  }
+
+  return { ok: true, data: Buffer.concat(chunks).toString('utf-8') };
+}
+
+/**
+ * Parse Codex's notify JSON payload (delivered as a single argv string) into
+ * the retrospect inputs. Returns null when the payload is absent or unparseable
+ * so callers can fail-soft (exit 0). `thread-id` (hyphenated) is Codex's stable
+ * per-conversation session id; cwd falls back to the process cwd because the
+ * notify subprocess cwd is not guaranteed to be the project.
+ * @param {unknown} raw
+ * @returns {{ sessionId: string, cwd: string } | null}
+ */
+export function parseCodexNotifyPayload(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  let input;
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!input || typeof input !== 'object') return null;
+  const sessionId = typeof input['thread-id'] === 'string' ? input['thread-id'] : 'unknown';
+  const cwd = typeof input.cwd === 'string' && input.cwd ? input.cwd : process.cwd();
+  return { sessionId, cwd };
+}
+
+/** Whether end-of-session retrospection is opted in via env flag (default off). */
+export function isRetrospectionEnabled() {
+  const value = (process.env.HARNESS_SESSION_RETROSPECTION ?? '').trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
+/** Make a session id safe to use as a single path segment. */
+function sanitizeSessionId(sessionId) {
+  return String(sessionId).replace(/[^A-Za-z0-9._-]/g, '_') || 'unknown';
+}
+
+/** Absolute path of the once-per-session sentinel for this session id. */
+function sentinelPath(cwd, sessionId) {
+  return join(
+    cwd,
+    '.harness',
+    'state',
+    'retrospection',
+    `${sanitizeSessionId(sessionId)}.archived`
+  );
+}
+
+/**
+ * Resolve the slug of the session to archive: the most-recently-modified
+ * directory under `.harness/sessions/`. Returns null when there is none.
+ */
+function findActiveSessionSlug(cwd) {
+  const sessionsDir = join(cwd, '.harness', 'sessions');
+  let latestSlug = null;
+  let latestMtime = -1;
+  let entries;
+  try {
+    entries = readdirSync(sessionsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const stat = statSync(join(sessionsDir, entry.name));
+      if (stat.mtimeMs > latestMtime) {
+        latestMtime = stat.mtimeMs;
+        latestSlug = entry.name;
+      }
+    } catch {
+      // Unreadable entry — skip it.
+    }
+  }
+  return latestSlug;
+}
+
+/**
+ * Archive the given session through the public archive seam, wiring the same
+ * `onArchived` hook bundle the archive_session action uses so the summary,
+ * index, and (when enabled) retrospection steps run. Returns true on success.
+ */
+async function archiveActiveSession(cwd, slug) {
+  const { archiveSession } = await import('@harness-engineering/core');
+  const { buildArchiveHooks } = await import('@harness-engineering/orchestrator');
+  const hooks = buildArchiveHooks({ projectPath: cwd });
+  const result = await archiveSession(cwd, slug, { hooks });
+  return Boolean(result && result.ok);
+}
+
+/** Persist the once-per-session sentinel so later fires are no-ops. */
+function writeSentinel(cwd, sessionId) {
+  const file = sentinelPath(cwd, sessionId);
+  mkdirSync(join(cwd, '.harness', 'state', 'retrospection'), { recursive: true });
+  writeFileSync(file, new Date().toISOString() + '\n', { encoding: 'utf-8' });
+}
+
+/**
+ * Agent-agnostic end-of-session retrospection: gate on the opt-in flag, dedupe
+ * once per session, resolve the active session, and archive it through the
+ * shared archive seam. Never throws for the "nothing to do" cases; a genuine
+ * archive failure is allowed to propagate so the caller can log it and still
+ * exit 0. The opt-in gate is checked FIRST so a caller who has not opted in
+ * never triggers the dynamic import of the archive packages.
+ *
+ * @param {{ cwd: string, sessionId: string }} params
+ * @returns {Promise<{ status: 'disabled' | 'already-archived' | 'no-session' | 'archived' | 'archive-failed', slug?: string }>}
+ */
+export async function retrospectSession({ cwd, sessionId }) {
+  if (!isRetrospectionEnabled()) {
+    return { status: 'disabled' };
+  }
+
+  const id = typeof sessionId === 'string' && sessionId ? sessionId : 'unknown';
+
+  // Once-per-session dedupe: a session-end hook can fire more than once, so bail
+  // if this session was already archived.
+  if (existsSync(sentinelPath(cwd, id))) {
+    return { status: 'already-archived' };
+  }
+
+  const slug = findActiveSessionSlug(cwd);
+  if (!slug) {
+    // Nothing to archive yet. Do not write the sentinel — a session created
+    // later in this same run should still be caught by a subsequent fire.
+    return { status: 'no-session' };
+  }
+
+  const archived = await archiveActiveSession(cwd, slug);
+  if (archived) {
+    // Only mark the session done once the archive actually succeeded, so a
+    // transient failure can be retried on the next fire.
+    writeSentinel(cwd, id);
+    return { status: 'archived', slug };
+  }
+  return { status: 'archive-failed', slug };
+}
+
+/**
+ * Render the stderr line for a retrospection result, or null when the result
+ * warrants no output (disabled, already-archived, no-session). `label` is the
+ * per-agent hook name so log lines identify which agent's hook fired.
+ * @param {string} label
+ * @param {{ status: string, slug?: string }} result
+ * @returns {string | null}
+ */
+export function retrospectLogLine(label, result) {
+  if (result.status === 'archived') {
+    return `[${label}] Archived session '${result.slug}' at session end\n`;
+  }
+  if (result.status === 'archive-failed') {
+    return `[${label}] Archive of '${result.slug}' did not succeed — will retry\n`;
+  }
+  return null;
+}

--- a/.harness/hooks/session-retrospect-cursor.js
+++ b/.harness/hooks/session-retrospect-cursor.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// session-retrospect-cursor.js — Cursor stop / sessionEnd hook (opt-in).
+//
+// Thin entry point for Cursor. Registered under BOTH the `stop` and `sessionEnd`
+// events in `.cursor/hooks.json` (see agent-retrospect.ts). Cursor delivers its
+// hook event as JSON on stdin. Per https://cursor.com/docs/agent/hooks (verified
+// 2026-08):
+//   - the `stop` payload carries `conversation_id` (and generation_id, status…);
+//   - the `sessionEnd` payload carries both `session_id` and `conversation_id`.
+// So this prefers `session_id` and falls back to `conversation_id`, giving one
+// stable dedupe key whichever event fired. The shared core dedupes once per
+// session id, so wiring both events archives the session AT MOST ONCE.
+//
+// KNOWN LIMITATION — Cursor CLI: `sessionEnd` is documented as IDE-only ("tied
+// to the IDE session, not a cloud agent chat"), and the local `cursor-agent` CLI
+// has historically emitted only beforeShellExecution / afterShellExecution. The
+// `stop` event is documented for cloud/agent chats. This hook is wired for both
+// events so it works today in the Cursor IDE agent (and in cloud agents that
+// emit `stop`), and starts working in the local CLI the moment it emits these
+// events — but full local-CLI coverage cannot be guaranteed yet. See the hooks
+// guide for the current coverage matrix.
+//
+// Cursor's `stop` payload has no `cwd` field but does carry `workspace_roots`;
+// the archive targets the first workspace root when present, else the process
+// cwd.
+//
+// Fail-soft: any error is swallowed and the hook exits 0. It never blocks or
+// delays session exit.
+//
+// Exit codes: 0 = allow (always, log-only hook)
+
+import process from 'node:process';
+import { readHookStdin, retrospectLogLine, retrospectSession } from './session-retrospect-core.js';
+
+async function main() {
+  const stdin = readHookStdin();
+  if (!stdin.ok || !stdin.data.trim()) {
+    process.exit(0);
+  }
+
+  let input;
+  try {
+    input = JSON.parse(stdin.data);
+  } catch {
+    process.exit(0);
+  }
+
+  try {
+    // sessionEnd carries session_id; stop carries only conversation_id.
+    const sessionId =
+      typeof input.session_id === 'string' && input.session_id
+        ? input.session_id
+        : typeof input.conversation_id === 'string' && input.conversation_id
+          ? input.conversation_id
+          : 'unknown';
+    const workspaceRoot =
+      Array.isArray(input.workspace_roots) && typeof input.workspace_roots[0] === 'string'
+        ? input.workspace_roots[0]
+        : null;
+    const cwd = workspaceRoot ?? process.cwd();
+    const result = await retrospectSession({ cwd, sessionId });
+    const line = retrospectLogLine('session-retrospect-cursor', result);
+    if (line) process.stderr.write(line);
+    process.exit(0);
+  } catch (err) {
+    process.stderr.write(
+      `[session-retrospect-cursor] Failed: ${err && err.message ? err.message : String(err)}\n`
+    );
+    process.exit(0);
+  }
+}
+
+main();

--- a/.harness/hooks/session-retrospect-gemini.js
+++ b/.harness/hooks/session-retrospect-gemini.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// session-retrospect-gemini.js — Gemini CLI SessionEnd hook (opt-in).
+//
+// Thin entry point for Gemini CLI. Registered under the `SessionEnd` event in
+// `.gemini/settings.json` (see agent-retrospect.ts). Gemini delivers its hook
+// event as JSON on stdin; the SessionEnd payload's base fields include
+// `session_id` and `cwd` (per https://geminicli.com/docs/hooks/reference/,
+// verified 2026-08). It extracts the session id and delegates to the shared
+// agent-agnostic core, which gates on HARNESS_SESSION_RETROSPECTION, dedupes
+// once per session, and archives the active session through the same archive
+// seam every other agent uses.
+//
+// Gemini "does not wait for SessionEnd and ignores flow-control fields", which
+// is fine: this is a best-effort, log-only, fail-soft hook that never blocks or
+// delays session exit. Any error is swallowed and the hook exits 0.
+//
+// Exit codes: 0 = allow (always, log-only hook)
+
+import process from 'node:process';
+import { readHookStdin, retrospectLogLine, retrospectSession } from './session-retrospect-core.js';
+
+async function main() {
+  const stdin = readHookStdin();
+  if (!stdin.ok || !stdin.data.trim()) {
+    process.exit(0);
+  }
+
+  let input;
+  try {
+    input = JSON.parse(stdin.data);
+  } catch {
+    process.exit(0);
+  }
+
+  try {
+    // Gemini's SessionEnd payload carries `cwd`; prefer it so the archive
+    // targets the project the session ran in, falling back to the process cwd.
+    const cwd = typeof input.cwd === 'string' && input.cwd ? input.cwd : process.cwd();
+    const sessionId = typeof input.session_id === 'string' ? input.session_id : 'unknown';
+    const result = await retrospectSession({ cwd, sessionId });
+    const line = retrospectLogLine('session-retrospect-gemini', result);
+    if (line) process.stderr.write(line);
+    process.exit(0);
+  } catch (err) {
+    process.stderr.write(
+      `[session-retrospect-gemini] Failed: ${err && err.message ? err.message : String(err)}\n`
+    );
+    process.exit(0);
+  }
+}
+
+main();

--- a/.harness/hooks/session-retrospect.js
+++ b/.harness/hooks/session-retrospect.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// session-retrospect.js — Claude Code Stop:* hook (opt-in).
+//
+// Thin entry point: reads Claude Code's Stop hook JSON from stdin, extracts the
+// `session_id`, and delegates to the shared, agent-agnostic core
+// (session-retrospect-core.js) that gates on HARNESS_SESSION_RETROSPECTION,
+// dedupes once per session, and archives the active session through the same
+// public archive seam the archive_session action uses (so summary + index +
+// retrospection run for manually driven sessions too).
+//
+// The core is shared with the Gemini CLI, Codex CLI, and Cursor entry points so
+// every agent runs the exact same archive engine and the same at-most-once,
+// fail-soft guarantees. See session-retrospect-core.js for the full rationale.
+//
+// Once per session: a Stop hook fires on every turn-stop, not only at genuine
+// session end, and Claude Code's Stop payload carries no reliable "this is the
+// last turn" signal. The core archives AT MOST ONCE per Claude session, keyed on
+// `session_id` via a sentinel file.
+//
+// Fail-soft: any error is swallowed and the hook exits 0. It never blocks the
+// session.
+//
+// Exit codes: 0 = allow (always, log-only hook)
+
+import process from 'node:process';
+import { readHookStdin, retrospectLogLine, retrospectSession } from './session-retrospect-core.js';
+
+async function main() {
+  const stdin = readHookStdin();
+  if (!stdin.ok || !stdin.data.trim()) {
+    process.exit(0);
+  }
+
+  let input;
+  try {
+    input = JSON.parse(stdin.data);
+  } catch {
+    process.exit(0);
+  }
+
+  try {
+    const cwd = process.cwd();
+    const sessionId = typeof input.session_id === 'string' ? input.session_id : 'unknown';
+    const result = await retrospectSession({ cwd, sessionId });
+    const line = retrospectLogLine('session-retrospect', result);
+    if (line) process.stderr.write(line);
+    process.exit(0);
+  } catch (err) {
+    process.stderr.write(
+      `[session-retrospect] Failed: ${err && err.message ? err.message : String(err)}\n`
+    );
+    process.exit(0);
+  }
+}
+
+main();

--- a/.harness/hooks/telemetry-reporter.js
+++ b/.harness/hooks/telemetry-reporter.js
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import process from 'node:process';
+import { readHookStdin } from './read-hook-stdin.js';
 
 // PostHog project API key — public, write-only (cannot read data)
 const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY ?? 'phc_wNTdCMcfJXZPgdNeDociZW6vwoGGo4nb7vqEfWThFfsG'; // harness-ignore SEC-SEC-002: public PostHog write-only ingest key
@@ -261,12 +262,16 @@ function showFirstRunNotice(cwd) {
 // --- Main ---
 
 async function main() {
-  let raw = '';
-  try {
-    raw = readFileSync(0, 'utf-8');
-  } catch {
+  // readHookStdin retries the EAGAIN that fd 0 throws under compound load (v8
+  // coverage on the pre-push gate): the writer races ahead of the read, and a
+  // raw readFileSync(0) would mistake that backpressure for empty stdin and
+  // fail-open, flaking the suite (#620). Log-only hook, so a genuine read
+  // failure or empty stdin still exits 0.
+  const stdin = readHookStdin();
+  if (!stdin.ok) {
     process.exit(0);
   }
+  const raw = stdin.data;
 
   if (!raw.trim()) {
     process.exit(0);


### PR DESCRIPTION
Adopts the current `harness update` output for this repo's own harness config. Mostly config, but **one part is a security fix**, so it's worth more than a rubber stamp.

## The guard hooks were bypassable

`block-no-verify` and `protect-config` now fail **CLOSED** via a new shared `read-hook-stdin.js`.

Each previously did:

```js
try { raw = readFileSync(0, 'utf-8'); }
catch { process.exit(0); }   // "no stdin — fail open"
```

But **fd 0 on a pipe is non-blocking**: a read issued before the writer has filled it throws `EAGAIN`. That was treated as "no input" and the operation was allowed **unverified, while the check still reported success**. So `--no-verify` could slip past the hook whose entire job is blocking it, and a protected-config edit past its guard — with CI green either way.

A guard that cannot read what it is guarding must not vouch for it. Both now exit 2 with the underlying error code.

## Also included

- **session-retrospect hooks** — `core` plus `claude` / `codex` / `cursor` / `gemini` adapters
- **`.cursor/hooks.json`** — wires the Cursor platform
- **`.codex/config.toml`**
- refreshed `adoption-tracker`, `pre-compact-state`, `sentinel-pre` / `sentinel-post`, `telemetry-reporter`, and the hook `profile.json`

## Relationship to the older local sync commit

This supersedes an unpushed local `f8a07c2df`. Of its 18 still-relevant files, **14 are byte-identical** here and **4 are newer** (`.gemini/settings.json`, `hooks/profile.json`, `session-retrospect-codex.js`, `session-retrospect-core.js`). Its other 3 files (`.harness/.gitignore`, `.mcp.json`, `harness.config.json`) already match `main` via other PRs, so nothing from it is lost by dropping it.

## Verification

- all **15** hooks pass `node --check`
- every touched JSON parses, and `.codex/config.toml` parses as TOML
- branch cut from current `origin/main`; no overlap with the concurrently-active `feat/roadmap-thematic-grouping` branch

## Reviewer note

The fail-closed flip is a behavior change by design: a hook that can't read its input now **blocks** instead of allowing. If a transient pipe hiccup occurs during a legitimate commit, the correct outcome is a retry, not a silent bypass — that silent bypass is exactly the defect being fixed.