### PR TITLE
fix(ci): stop the release docker call deadlocking on its caller's concurrency group

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,8 +15,19 @@ on:
         required: true
         type: string
 
+# The group MUST start with a literal — never ${{ github.workflow }}.
+#
+# Under `workflow_call` the github context belongs to the CALLER, so
+# ${{ github.workflow }} evaluates to the caller's name ("Release"), making this
+# group "Release-refs/heads/main" — the very group the still-in-flight caller
+# already holds (release.yml uses the same expression with
+# cancel-in-progress: false). A called workflow that demands a concurrency group
+# its own caller holds can never start: GitHub detects the deadlock and kills the
+# run, so no `docker` job record is ever created and the Release run goes red even
+# though every job in it succeeded. That is why no container image was ever
+# published through the release path.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: docker-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/docs/changes/release-docker-workflow-call/plans/2026-08-09-release-docker-workflow-call-plan.md
+++ b/docs/changes/release-docker-workflow-call/plans/2026-08-09-release-docker-workflow-call-plan.md
@@ -1,0 +1,103 @@
+# Plan: fix the Release workflow's `docker` job never starting on a real publish
+
+**Date:** 2026-08-09 · **Spec:** `docs/changes/release-docker-workflow-call/proposal.md` · **Tasks:** 4 · **Time:** ~20 min · **Integration Tier:** small
+
+## Goal
+
+Make the `docker` job in `release.yml` actually dispatch on a real publish by removing the
+concurrency-group collision between the called `docker.yml` workflow and its caller. The
+container-publish path has never executed once in the repository's history; this change removes
+the single mechanical reason it cannot start.
+
+## Root Cause (established, not assumed)
+
+Under `workflow_call`, `${{ github.workflow }}` resolves to the **caller's** workflow name.
+`docker.yml` declares `group: ${{ github.workflow }}-${{ github.ref }}`, which therefore
+evaluates to `Release-refs/heads/main` — identical to the group the in-flight caller `Release`
+run already holds (`release.yml` declares the same expression with `cancel-in-progress: false`).
+A called workflow demanding a group its own caller holds is a deadlock; GitHub terminates the
+run instead of queueing it, so no `docker` job record is ever created.
+
+### Evidence that CONFIRMS the concurrency hypothesis
+
+1. **The failure is instantaneous, not a hang.** Run `31323256027` has `updated_at`
+   2026-08-09T16:19:07Z against a `release` job that completed at 16:19:05Z — the run concluded
+   two seconds after its dependency finished. A queued-forever concurrency wait would leave the
+   run `in_progress`; a deadlock that GitHub detects and terminates looks exactly like this.
+2. **The job record is absent, not skipped.** The run reports `total_count = 2`. Across the
+   eight most recent Release runs, every other run reports `total_count = 3` with `docker` present
+   as `skipped` — including runs where the `release` job **failed**. So job-record creation and
+   `if:` evaluation both work in the false case; only the true case (real dispatch) breaks.
+3. **Exclusivity.** `31323256027` is the only run in the window where `release` both succeeded
+   and actually published, and it is the only run missing the `docker` record.
+4. **Documented GitHub semantics.** GitHub's documentation states the `github` context in a
+   called workflow is associated with the caller, and that a called workflow uses its caller's
+   name in `${{ github.workflow }}`. Identical groups between a top-level workflow and a job
+   produce a documented deadlock termination.
+
+### Evidence that REFUTES the competing hypotheses
+
+- **Empty required input — REFUTED.** The run log for the `Extract CLI version for Docker` step
+  shows `publishedPackages` expanded to a full array and the CLI version resolving to `11.1.1`.
+  The job epilogue logs `Set output 'published'` and `Set output 'version'`. Both outputs were
+  populated, so `with: version:` did not receive an empty value.
+- **Missing `secrets: inherit` — REFUTED.** `docker.yml` consumes only `secrets.GITHUB_TOKEN`,
+  which GitHub provides to called workflows automatically. `secrets: inherit` governs
+  user-defined secrets, and a missing secret is a runtime failure, not a dispatch failure.
+- **Job-level `permissions:` on a `uses:` job — REFUTED.** Job-level `permissions` on a calling
+  job is the supported pattern, and the grant (`contents: read`, `packages: write`) is a subset
+  of the caller workflow's grant, matching `docker.yml`'s own top-level block.
+- **Zero `workflow_call` runs in history — NOT EVIDENCE.** A reusable workflow invoked via
+  `workflow_call` does not create its own workflow run; its jobs appear inside the caller's run.
+  Zero such runs is expected regardless of cause, so this observation is non-diagnostic and was
+  discarded rather than counted in favour of any hypothesis.
+
+## Observable Truths (Acceptance Criteria)
+
+1. The **value** of `concurrency.group` in `.github/workflows/docker.yml` no longer contains
+   `github.workflow`. The explanatory comment above it deliberately names the expression, so a
+   plain file-wide grep is not the right gate. **Gate:** parse the YAML and assert
+   `'github.workflow' not in doc['concurrency']['group']`.
+2. The concurrency group is a literal-prefixed expression that cannot collide with any caller.
+   **Gate:** the group reads `docker-${{ github.ref }}`.
+3. Both workflow files remain valid YAML with an unchanged job graph. **Gate:** YAML parse of
+   both files succeeds; `release.yml` still declares jobs `ci-gate`, `release`, `docker`.
+4. A comment at the changed line records why `${{ github.workflow }}` must not be reintroduced,
+   so the defect is not re-added by a future edit. **Gate:** comment present above the group.
+5. Repository formatting and CI gates pass. **Gate:** `pnpm format:check`, and all-OS CI green
+   on the branch.
+
+## Tasks
+
+1. **Replace the colliding concurrency group in `docker.yml`** with `docker-${{ github.ref }}`
+   and add the explanatory comment. Single-line semantic change.
+2. **Leave `release.yml` unmodified.** Its own concurrency group is correct for a top-level
+   workflow; the collision is entirely a property of the callee's expression.
+3. **Record the audit + plan artifacts** under `docs/changes/release-docker-workflow-call/`.
+4. **Run local gates** (`pnpm format:check`, YAML parse) and open the PR without merging.
+
+## Uncertainties
+
+- [ASSUMPTION] The literal prefix `docker-` is used rather than a hardcoded full name, matching
+  the pattern the GitHub community recommends for reusable workflows. Any literal distinct from
+  the caller's workflow name works; this one is descriptive and stable.
+- [ASSUMPTION] `cancel-in-progress: false` is retained. A container publish should not be
+  cancelled midway by a subsequent release, and changing it is not required by the root cause.
+- [ASSUMPTION] The `smoke-test` job and the 4-way build matrix are left untouched; the Dockerfile
+  targets `cli`, `mcp-server`, `orchestrator`, `dashboard` and `scripts/docker-smoke-test.sh` all
+  exist, so nothing downstream of dispatch is known to be broken.
+- [RESIDUAL RISK] The literal error string GitHub emitted for the failed dispatch could not be
+  retrieved. Run-level dispatch errors are not exposed through the REST API (the check suite
+  lists only the two real jobs, and no annotation is attached), and the run's HTML page is not
+  machine-readable from here. The diagnosis therefore rests on the timing signature, the
+  absent-versus-skipped job record, exclusivity to the publishing run, and documented GitHub
+  semantics — all four of which agree — rather than on a quoted error message.
+- [OUT OF SCOPE] Backfilling container images for already-published versions. `docker.yml` runs
+  `build-push-action` with `push: true` and a `latest` tag, so exercising it publishes real
+  images. That is a human decision and is not taken here.
+
+## Verification Caveat
+
+This defect reproduces only on a real publish, which a PR branch cannot trigger. All-OS CI green
+on this branch does **not** prove the container-release path works. The publish path remains
+unproven until the next real release.

--- a/docs/changes/release-docker-workflow-call/proposal.md
+++ b/docs/changes/release-docker-workflow-call/proposal.md
@@ -55,7 +55,7 @@ registry is empty.
 
 ## Phase 4 — Findings
 
-### [ERROR] concurrency-deadlock — `.github/workflows/docker.yml:17`
+### [ERROR] concurrency-deadlock — `.github/workflows/docker.yml:19` (at base `143b27628`)
 
 Under `workflow_call`, `${{ github.workflow }}` resolves to the **caller's** workflow name, so
 the called workflow's concurrency group evaluates to `Release-refs/heads/main` — the exact group
@@ -88,7 +88,7 @@ container publishing works.
 Requires human decision: whether to backfill images for already-published versions. Explicitly
 out of scope for this change.
 
-### [WARNING] shell-interpolation — `.github/workflows/docker.yml:57`
+### [WARNING] shell-interpolation — `.github/workflows/docker.yml:60` (at base `143b27628`)
 
 `VERSION="${{ inputs.version }}"` interpolates a workflow input straight into a shell script.
 Routing it through `env:` would make it data rather than code.

--- a/docs/changes/release-docker-workflow-call/proposal.md
+++ b/docs/changes/release-docker-workflow-call/proposal.md
@@ -1,0 +1,111 @@
+# Workflow Audit: the Release `docker` job never starts on a real publish
+
+**Date:** 2026-08-09 · **Skill:** `harness-workflow-audit` · **Scope:** `.github/workflows/release.yml`, `.github/workflows/docker.yml`
+**Failing evidence:** Release run `31323256027` (head `7536404cf72bdee394a1f338886b0c303809977f`, 2026-08-09T16:14:16Z)
+
+## Summary
+
+```text
+WORKFLOW AUDIT: harness-engineering (scoped to release.yml + docker.yml)
+Workflows audited: 2   Findings: 1 error, 2 warning, 1 info
+Gates that never fire: docker.yml container publish (never executed once in repo history)
+Documented-but-unwired gates: none
+```
+
+The container-publish gate is the Iron Law case this skill exists for: a gate that looks
+correct, is wired up, and has never enforced anything. `docker.yml` has produced zero
+container images since it was chained from `release.yml`, and the organisation's container
+registry is empty.
+
+## Phase 1 — Inventory
+
+`release.yml`
+
+- Trigger: `push` on `main`. No path filters.
+- Concurrency: group `${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: false`.
+- Jobs: `ci-gate`, `release`, `docker` (the last calls `./.github/workflows/docker.yml`).
+
+`docker.yml`
+
+- Triggers: `push` on tags `@harness-engineering/*`, `workflow_dispatch`, `workflow_call`.
+- Concurrency: group `${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: false`.
+- Jobs: `build-and-push` (4-way matrix), `smoke-test`.
+
+## Phase 2 — Mechanical checks
+
+| Check                         | Result                                                                                                                                                                                              |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1 path filters               | No `paths:` / `paths-ignore:` in either file. The tag glob `@harness-engineering/*` matches 352 tracked tags — live, not stale.                                                                     |
+| M2 permission scoping         | The `docker` job carries a correctly narrowed job-level grant (`contents: read`, `packages: write`). No over-grant found.                                                                           |
+| M3 action pinning             | Third-party actions are on mutable major tags (`docker/build-push-action@v6`, `changesets/action@v1`, `pnpm/action-setup@v5`). Consistent with repo-wide convention. Informational only.            |
+| M4 self-trigger + concurrency | **ERROR — see finding below.** The `release` job's push-back to `main` is correctly guarded with `[skip ci]`.                                                                                       |
+| M5 secret handling            | No secret is echoed. `GITHUB_TOKEN` is consumed via `with:`, not on a command line.                                                                                                                 |
+| M6 dead references            | All resolve: `./.github/workflows/docker.yml`, `scripts/docker-smoke-test.sh`, `scripts/assert-diff-scope.mjs`, and all four Dockerfile targets (`cli`, `mcp-server`, `orchestrator`, `dashboard`). |
+
+## Phase 3 — Judgment checks
+
+- **J1 injection** — `docker.yml` interpolates `${{ inputs.version }}` directly into a `run:`
+  script. Under `workflow_call` the value is repo-internal; under `workflow_dispatch` it is
+  operator-supplied. Low severity, reported below, deliberately **not** fixed here to keep this
+  change single-purpose.
+- **J2 gate completeness** — the container-publish gate is wired but has never fired. See the
+  escalation note.
+- **J3 ratchet calibration** — not applicable to these two workflows.
+- **J4 fork-PR degradation** — not applicable; `release.yml` runs only on push to `main`.
+
+## Phase 4 — Findings
+
+### [ERROR] concurrency-deadlock — `.github/workflows/docker.yml:17`
+
+Under `workflow_call`, `${{ github.workflow }}` resolves to the **caller's** workflow name, so
+the called workflow's concurrency group evaluates to `Release-refs/heads/main` — the exact group
+the still-in-flight caller `Release` run already holds, with `cancel-in-progress: false`. A
+called workflow that demands a concurrency group held by its own caller can never start, and
+GitHub's deadlock detection terminates the run rather than queueing it forever.
+
+Effect: on every real publish the `docker` job is never created, the run is marked `failure`
+even though every job in it succeeded, and no container image is ever built or pushed.
+
+Patch:
+
+```diff
+ concurrency:
+-  group: ${{ github.workflow }}-${{ github.ref }}
++  # NOTE: do NOT use ${{ github.workflow }} here. Under `workflow_call` it resolves to the
++  # CALLER's workflow name (Release), which collides with the caller's own in-flight
++  # concurrency group and deadlocks the call so the job is never created.
++  group: docker-${{ github.ref }}
+   cancel-in-progress: false
+```
+
+### [WARNING] gate-never-fired — `.github/workflows/docker.yml`
+
+The container-publish gate has produced zero images across the repository's entire history. The
+organisation container registry (`orgs/Intense-Visions/packages?package_type=container`) returns
+empty. Until a real publish exercises the fixed path, "green CI" says nothing about whether
+container publishing works.
+
+Requires human decision: whether to backfill images for already-published versions. Explicitly
+out of scope for this change.
+
+### [WARNING] shell-interpolation — `.github/workflows/docker.yml:57`
+
+`VERSION="${{ inputs.version }}"` interpolates a workflow input straight into a shell script.
+Routing it through `env:` would make it data rather than code.
+
+Requires human decision: fold into a follow-up change; deliberately excluded here so this fix
+stays reviewable as a single-cause remediation.
+
+### [INFO] action-pinning — both files
+
+Third-party actions ride mutable major tags. SHA pinning is the stronger form. Repo-wide
+convention, not specific to this defect.
+
+## Escalation (per skill: long-dead gate)
+
+This gate has been dead since it was introduced — not merely stale. Per the skill's escalation
+rule, re-arming a long-dead gate usually surfaces a backlog of real findings, so the fix should
+not be assumed sufficient on merge alone. The recommended follow-up is one controlled,
+human-authorised exercise of the publish path. **That exercise is not performed as part of this
+change**, because `docker.yml` builds with `push: true` and a `latest` tag, so any dispatch
+publishes real images to the org registry. That decision belongs to a human.

--- a/docs/changes/release-docker-workflow-call/session-state.md
+++ b/docs/changes/release-docker-workflow-call/session-state.md
@@ -1,0 +1,69 @@
+# Session State: release-docker-workflow-call
+
+**Item:** Release workflow's `docker` job never starts on a real publish
+**Branch:** `fix/release-docker-workflow-call` · **Base SHA:** `143b27628d983ac768abdb02f0f05e1a64ce7f17`
+**Skill:** `harness-workflow-audit` (phases: inventory, mechanical, judgment, report)
+**Date:** 2026-08-09
+
+## Phase Ledger
+
+| Phase      | Status   | Outcome                                                                                                                             |
+| ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| inventory  | complete | 2 workflows in scope; triggers, jobs, permissions, concurrency groups and `uses:` refs recorded.                                    |
+| mechanical | complete | M1/M2/M3/M5/M6 clean. M4 produced the error-severity concurrency-deadlock finding.                                                  |
+| judgment   | complete | J2 confirms a wired-but-never-fired gate. J1 raised a low-severity interpolation warning (not fixed — scope). J3/J4 not applicable. |
+| report     | complete | Findings ranked; one error carrying a concrete patch, applied as the remediation.                                                   |
+
+## Decisions
+
+1. **Audit scoped to `release.yml` + `docker.yml`** rather than all 21 workflow files. The skill
+   explicitly supports single-workflow scoping with all phases still running, and the remediation
+   mandate for this item is single-defect.
+2. **Fixed the callee, not the caller.** `release.yml`'s concurrency group is correct for a
+   top-level workflow. The collision is a property of the callee evaluating
+   `${{ github.workflow }}` in the caller's context, so the change belongs in `docker.yml`.
+3. **Literal prefix `docker-`** chosen over any expression-derived name, so the group cannot
+   collide with a caller under any trigger.
+4. **`cancel-in-progress: false` retained** — a container publish should not be cancelled midway,
+   and changing it is not implicated by the root cause.
+5. **No `secrets: inherit` added.** `GITHUB_TOKEN` reaches called workflows automatically; adding
+   inherit would broaden secret exposure for no benefit.
+6. **J1 interpolation warning left unfixed**, to keep the change a single-cause remediation.
+
+## Constraints Honoured
+
+- The `Docker` workflow was **not** triggered. `build-push-action` runs with `push: true` and a
+  `latest` tag, so any dispatch would publish real images to the org registry. No
+  `gh workflow run` was issued.
+- No image backfill performed.
+- Nothing merged; no issues closed.
+- No unrelated already-green failures touched.
+
+## Evidence Register
+
+- Run `31323256027`: `conclusion=failure`, `total_count=2`, jobs `ci-gate:success`,
+  `release:success`, `updated_at` 16:19:07Z vs `release` completion 16:19:05Z.
+- Eight-run comparison: every other Release run reports `total_count=3` with `docker:skipped`,
+  including runs where `release` itself failed.
+- Release job log: `publishedPackages` array expanded, CLI version `11.1.1`; epilogue logs
+  `Set output 'published'` and `Set output 'version'`.
+- Repo assets verified present: all four Dockerfile targets, `scripts/docker-smoke-test.sh`,
+  `scripts/assert-diff-scope.mjs`; tag glob matches 352 tracked tags.
+
+## Open Questions / Residual Risk
+
+- The literal GitHub dispatch-error string could not be retrieved — run-level dispatch errors are
+  not exposed via the REST API and no annotation is attached to the check suite. Diagnosis rests
+  on four converging lines of evidence rather than a quoted error.
+- The publish path stays unproven until the next real release; a PR branch cannot trigger it.
+
+## Environment Notes
+
+- `mcp__harness__run_skill` and `mcp__harness__manage_state` are both broken in this environment:
+  the MCP bundle imports `dist/state-events-N3XCOJK3.js` while the installed package ships
+  `dist/state-events-TV76F42L.js`. The `harness` CLI itself works. The skill's documented
+  fallback (read SKILL.md and follow its workflow directly) was used.
+- `harness skill run harness-workflow-audit` reports `Skill not found` — the skill ships as a
+  Claude Code skill under `dist/agents/skills/` but is not in the CLI's runnable registry.
+- Gitignored `.harness/` runtime state (`sessions/`, `state.json`) is absent in a fresh worktree
+  and cannot land on a branch, so this session state is committed as a durable document instead.


### PR DESCRIPTION
> **Verification caveat:** this defect reproduces only on a real publish, which a PR branch cannot trigger. All-OS CI green on this branch does **NOT** prove the container-release path works. The publish path remains unproven until the next real release.

## What was broken

The `docker` job at the end of `.github/workflows/release.yml` has **never once started on a real publish**, and no container image has ever been published through the release path. The org container registry (`orgs/Intense-Visions/packages?package_type=container`) is empty.

Failing evidence: **Release run [`31323256027`](https://github.com/Intense-Visions/harness-engineering/actions/runs/31323256027)** (head `7536404c`, 2026-08-09T16:14:16Z) — run-level `failure` while **both** of its jobs (`ci-gate`, `release`) report `success`. The run reports `total_count = 2`; the `docker` job record is entirely absent.

## Root cause — leading hypothesis CONFIRMED

`docker.yml` declared:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
```

Under `workflow_call` the `github` context belongs to the **caller**, so `${{ github.workflow }}` evaluates to the caller's name — `Release`. The called workflow therefore demanded the group `Release-refs/heads/main`, which is the *exact* group the still-in-flight caller `Release` run already held (`release.yml` declares the identical expression with `cancel-in-progress: false`). A called workflow that demands a concurrency group its own caller holds can never start; GitHub terminates the run rather than queueing it forever, so no `docker` job record is ever created and the Release run goes red even though every job in it succeeded.

### Evidence that confirmed it

1. **The failure is instantaneous, not a hang.** The run's `updated_at` is 16:19:07Z against a `release` job that completed at 16:19:05Z — it concluded **two seconds** after its dependency finished. A queued-forever concurrency wait would leave the run `in_progress`; a detected-and-terminated deadlock looks exactly like this.
2. **The job record is absent, not skipped.** Across the eight most recent Release runs, every other run reports `total_count = 3` with `docker` present as `skipped` — *including runs where the `release` job itself failed*. So `if:` evaluation and job-record creation both work correctly in the false case. The breakage appears only when the condition is TRUE and the call is really dispatched.
3. **Exclusivity.** `31323256027` is the only run in the window where `release` both succeeded *and* actually published, and it is the only run missing the `docker` record.
4. **Documented GitHub semantics.** GitHub documents that the `github` context in a called workflow is associated with the caller, and that a called workflow uses its caller's name in `${{ github.workflow }}`. Identical concurrency groups between a top-level workflow and a job produce a documented deadlock termination.

### Competing hypotheses actively tested and REFUTED

- **Empty `workflow_call` input (`version`) — REFUTED.** The run log for `Extract CLI version for Docker` shows `publishedPackages` expanded to a full array with the CLI version resolving to **`11.1.1`**, and the job epilogue logs `Set output 'published'` and `Set output 'version'`. Both outputs were populated; `with: version:` did not receive an empty value.
- **Missing `secrets: inherit` — REFUTED.** `docker.yml` consumes only `secrets.GITHUB_TOKEN`, which GitHub provides to called workflows automatically. `secrets: inherit` governs user-defined secrets, and a missing secret is a runtime failure, not a dispatch failure.
- **Job-level `permissions:` on a `uses:` job — REFUTED.** That is the supported pattern, and the grant (`contents: read`, `packages: write`) is a subset of the caller workflow's grant and matches `docker.yml`'s own top-level block.
- **"Zero `workflow_call` runs in history" — DISCARDED as non-evidence.** A reusable workflow invoked via `workflow_call` does not create its own workflow run; its jobs appear inside the caller's run. Zero such runs is expected regardless of cause, so this observation does not discriminate between hypotheses and was not counted in favour of any.

## Remediation actions / assumptions made

**Changed — `.github/workflows/docker.yml` (one semantic line + explanatory comment):** concurrency group is now `docker-${{ github.ref }}`, a literal-prefixed group that cannot collide with any caller. A comment at the line records the hazard so it is not reintroduced by a future edit.

Recommended-option defaults taken:

- **Fixed the callee, not the caller.** `release.yml` is **unmodified** — its own group is correct for a top-level workflow; the collision is purely a property of the callee evaluating `${{ github.workflow }}` in the caller's context.
- **Literal prefix `docker-`** chosen over any expression-derived name, matching the pattern recommended for reusable workflows.
- **`cancel-in-progress: false` retained** — a container publish should not be cancelled midway, and it is not implicated by the root cause.
- **No `secrets: inherit` added** — unnecessary, and it would broaden secret exposure for no benefit.
- **Audit scoped to `release.yml` + `docker.yml`** rather than all 21 workflow files, to keep this a single-cause remediation.
- **A low-severity finding was deliberately left unfixed:** `docker.yml` interpolates `${{ inputs.version }}` straight into a `run:` script; routing it through `env:` would make it data rather than code. Recorded as a follow-up rather than folded in here.
- **`.harness/learnings.md` was deliberately reverted.** The pipeline appended a one-line learning at EOF — precisely the shape that conflicts across parallel PRs. The same content is preserved in the committed change docs instead.

## Explicitly NOT done

- **No container images were backfilled**, and the `Docker` workflow was **not triggered**. `docker.yml` runs `build-push-action` with `push: true` and a `latest` tag, so any dispatch would publish real images to the org registry. That decision belongs to a human.
- Nothing merged; no issues closed; no unrelated failures touched.

## Residual risk

The literal error string GitHub emitted for the failed dispatch **could not be retrieved** — run-level dispatch errors are not exposed through the REST API (the check suite lists only the two real jobs, and no annotation is attached). The diagnosis therefore rests on four converging lines of evidence — timing signature, absent-versus-skipped job record, exclusivity to the publishing run, and documented GitHub semantics — rather than on a quoted error message. All four agree, and every competing hypothesis was refuted on independent evidence.

Because this gate has been dead since it was introduced rather than merely stale, re-arming it may surface a backlog of real findings in the container build itself. All four Dockerfile targets (`cli`, `mcp-server`, `orchestrator`, `dashboard`) and `scripts/docker-smoke-test.sh` were verified to exist, so nothing downstream of dispatch is *known* to be broken — but that is a static check, not an execution.

## Pipeline artifacts

- Audit report: `docs/changes/release-docker-workflow-call/proposal.md`
- Plan: `docs/changes/release-docker-workflow-call/plans/2026-08-09-release-docker-workflow-call-plan.md`
- Session state: `docs/changes/release-docker-workflow-call/session-state.md`

Local gates run clean with no bypass: `check:changesets`, `prettier --check`, `turbo run typecheck --affected` (21/21), coverage ratchet, and `generate-docs --check`.
