### PR TITLE
fix(orchestrator): resolve webhook target hosts and refuse redirects (SSRF)

### DIFF
--- a/.changeset/webhook-ssrf-resolve-guard.md
+++ b/.changeset/webhook-ssrf-resolve-guard.md
@@ -1,0 +1,39 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Harden outbound webhook delivery against SSRF (CWE-918).
+
+The private-address guard matched the subscription hostname as a string and
+never resolved it, so a public hostname whose DNS record pointed at loopback,
+an RFC-1918 range, or the link-local metadata address passed unchallenged. The
+delivery `fetch` also followed redirects, letting a receiver that passed the
+guard walk the request onto a private address on the next hop.
+
+`guardOutboundHost` now resolves the hostname and refuses the request if any
+resolved address is private; the existing string check is kept as a cheap
+pre-filter, and both a resolver error and an empty address list fail closed.
+Delivery sets `redirect: 'manual'` and records a 3xx as a delivery failure
+instead of following it.
+
+The refused-address set is also wider than the old regex: it now covers
+RFC-6598 CGNAT (`100.64.0.0/10`, which doubles as a Kubernetes pod CIDR and as
+Alibaba Cloud's metadata endpoint), the RFC-6890 protocol-assignments `/24`
+(Oracle Cloud's legacy metadata address), the benchmarking block, multicast and
+reserved space, IPv6 unique-local and link-local, and every IPv6 form that
+embeds an IPv4 address — v4-mapped in both dotted and hex spelling,
+v4-compatible, v4-translated, NAT64 `64:ff9b::/96` and 6to4.
+
+Two behavior changes worth noting:
+
+- IPv6-literal webhook URLs are now classified directly instead of being sent
+  through DNS. This fixes a pre-existing hole where `https://[::1]/` was
+  _accepted_ — `URL.hostname` returns IPv6 hosts bracketed, and the old regex
+  had no bracket handling. Legitimate bracketed public IPv6 targets keep working.
+- A rejected registration returns a generic 422. The specific reason is logged
+  server-side rather than returned, so the response cannot be used to probe
+  which internal hostnames exist.
+
+Residual: the guard resolves the name, and the connection resolves it again, so
+a record that changes between the two (DNS rebinding) is not covered. Closing
+that requires pinning the resolved address at connect time.

--- a/docs/changes/webhook-ssrf-resolve-guard/autopilot-state.json
+++ b/docs/changes/webhook-ssrf-resolve-guard/autopilot-state.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": 5,
+  "sessionSlug": "changes--webhook-ssrf-resolve-guard--proposal",
+  "specPath": "docs/changes/webhook-ssrf-resolve-guard/proposal.md",
+  "planPath": "docs/changes/webhook-ssrf-resolve-guard/plans/2026-08-09-webhook-ssrf-resolve-guard-plan.md",
+  "startingCommit": "143b27628d983ac768abdb02f0f05e1a64ce7f17",
+  "currentState": "DONE",
+  "currentPhase": 1,
+  "rigorLevel": "thorough",
+  "runtimeNote": "The harness MCP runtime was unavailable in this environment (run_skill / manage_state fail). Per the documented fallback, harness-brainstorming and harness-autopilot were executed by reading each SKILL.md and running its phases directly. This file is the committed copy of the autopilot state, because .harness/sessions/ is gitignored and would not survive onto the branch.",
+  "phases": [
+    {
+      "n": 1,
+      "name": "Resolve-then-check + refuse redirects",
+      "complexity": "medium",
+      "status": "complete"
+    }
+  ],
+  "history": [
+    {
+      "state": "EXPLORE",
+      "skill": "harness-brainstorming",
+      "outcome": "Finding re-confirmed from first principles in this worktree at the pinned base SHA before any edit: (a) localtest.me / lvh.me resolve to 127.0.0.1 and isPrivateHost returns false for both; (b) the delivery fetch call shape follows a 302 to a second host, and a 307 preserves method, body and the X-Harness-Signature header."
+    },
+    {
+      "state": "EVALUATE",
+      "skill": "harness-brainstorming",
+      "outcome": "Design forks resolved and recorded as spec Decisions 1-7. Key fork: rewrite isPrivateHost as async vs. add a resolving guard alongside it. Chose the latter to keep literal rejection independent of DNS availability and to leave the existing unit tests intact."
+    },
+    {
+      "state": "PRIORITIZE",
+      "skill": "harness-brainstorming",
+      "outcome": "Two approaches weighed: (A) resolve-then-check + refuse redirects (chosen, bounded); (B) pin the resolved IP at connect time via a custom undici dispatcher (rejected as disproportionate; recorded as residual risk instead of being silently implied away)."
+    },
+    {
+      "state": "VALIDATE",
+      "skill": "harness-brainstorming",
+      "outcome": "Spec written to docs/changes/webhook-ssrf-resolve-guard/proposal.md with an explicit honest-impact section: blind SSRF with a write side effect, NOT response-body exfiltration."
+    },
+    {
+      "state": "PLAN",
+      "skill": "harness-autopilot",
+      "outcome": "Plan written with 10 observable acceptance criteria and 9 tasks."
+    },
+    {
+      "state": "EXECUTE",
+      "skill": "harness-autopilot",
+      "outcome": "TDD. Regression tests written first and confirmed RED at the base behavior (3 route tests returned 200 instead of 422; the delivery redirect test recorded the redirect target actually receiving GET /latest/meta-data/). Then the guard, both call sites, and redirect:'manual' landed; all GREEN."
+    },
+    {
+      "state": "VERIFY",
+      "skill": "harness-autopilot",
+      "outcome": "131 tests green across the 7 webhook-touching suites; full orchestrator suite green; typecheck and lint clean."
+    },
+    {
+      "state": "FINAL_REVIEW",
+      "skill": "harness-security-reviewer",
+      "outcome": "Verdict: request changes. 1 blocking fail-open (empty address list), 1 blocking range gap (RFC-6598 CGNAT), plus IPv6 embedded-v4 spelling gaps, an IPv6-literal functional regression, and a response-body reason oracle. All five fixed in-scope and re-verified. Two availability findings (DNS outside the timeout/abort path; per-attempt uncached lookup on the libuv threadpool) parked as follow-up and disclosed."
+    }
+  ],
+  "humanGates": {
+    "note": "harness-brainstorming Phase 2/Phase 4 and harness-autopilot APPROVE_PLAN are human-interactive gates. This ran as an autonomous fix-tier agent whose scope, remedy shape, and hard limits were fixed in advance by the dispatching run, so no new design authority was exercised: every fork was resolved inside the pre-authorized bounds and recorded in the spec rather than decided ad hoc. No human sign-off was obtained. The PR is opened UNMERGED and carries the sign-off.",
+    "specApproved": false,
+    "planApproved": false
+  }
+}

--- a/docs/changes/webhook-ssrf-resolve-guard/plans/2026-08-09-webhook-ssrf-resolve-guard-plan.md
+++ b/docs/changes/webhook-ssrf-resolve-guard/plans/2026-08-09-webhook-ssrf-resolve-guard-plan.md
@@ -1,0 +1,143 @@
+# Plan: resolve-then-check the outbound webhook host and stop following redirects
+
+**Date:** 2026-08-09 · **Spec:** `docs/changes/webhook-ssrf-resolve-guard/proposal.md` · **Tasks:** 9 · **Time:** ~50 min · **Integration Tier:** small
+
+## Goal
+
+Close two independent SSRF bypasses on the orchestrator's outbound webhook path
+(CWE-918): the private-address guard matches the hostname as a string and never
+resolves it, and the delivery `fetch` follows redirects. Add a resolving guard
+alongside the existing literal pre-filter, wire it into both call sites
+(registration + fire-time recheck), and refuse redirects at delivery.
+
+## Observable Truths (Acceptance Criteria)
+
+1. `guardOutboundHost('evil.test', { lookup })` where the injected lookup returns
+   `169.254.169.254` yields `{ blocked: true, reason: 'private-address' }`.
+   **Gate:** unit test in `webhooks-url-guard.test.ts`.
+2. `guardOutboundHost('localhost', { lookup })` yields `reason:
+'private-literal'` and the injected lookup is **never invoked** (spy call
+   count 0) — the literal pre-filter short-circuits without DNS.
+   **Gate:** unit test asserting the spy count.
+3. `guardOutboundHost('hooks.example.com', { lookup })` with a public resolved
+   address yields `{ blocked: false }`. **Gate:** unit test.
+4. A rejecting lookup yields `{ blocked: true, reason: 'dns-failure' }`.
+   **Gate:** unit test.
+5. `isPrivateAddress` returns true for each of `127.0.0.1`, `10.0.0.1`,
+   `172.16.0.1`, `192.168.1.1`, `169.254.169.254`, `0.0.0.0`, `::1`,
+   `fd00::1` (unique-local), `fe80::1` (link-local), `::ffff:127.0.0.1`
+   (IPv4-mapped), and false for `8.8.8.8`, `172.15.0.1`, `2606:4700::1111`.
+   **Gate:** unit test table.
+6. `POST /api/v1/webhooks` with a URL whose hostname resolves to a private
+   address returns 422; the same route still returns 200 for a hostname
+   resolving publicly. **Gate:** route test with `vi.mock('node:dns/promises')`.
+7. `WebhookDelivery` dead-letters a subscription whose hostname resolves private
+   (injected `lookupImpl`) with **zero** HTTP requests issued.
+   **Gate:** delivery test asserting the receiver got nothing and the dead row's
+   `lastError` names the resolved-address reason.
+8. `WebhookDelivery` does not follow a redirect: given a 302 to a second local
+   server, that second server receives **zero** requests and the delivery is
+   recorded failed with a `redirect not followed` error.
+   **Gate:** delivery test with two `http.createServer` instances.
+9. Every pre-existing test in `delivery.test.ts`, `webhooks-url-guard.test.ts`
+   and `webhooks-integration.test.ts` passes **unmodified**. **Gate:** targeted
+   vitest run; the diff must not touch their existing assertions.
+10. `pnpm typecheck`, `pnpm lint`, and the orchestrator unit suite are green, and
+    a patch changeset for `@harness-engineering/orchestrator` exists.
+    **Gate:** local gate run.
+
+## Uncertainties
+
+- [ASSUMPTION] Node's `fetch` with `redirect: 'manual'` surfaces the real 3xx
+  status rather than an opaque response. **Verified** on the pinned base commit
+  under Node 22.20.0: `manual status=302 ok=false`. Not assumed.
+- [ASSUMPTION] `dns.promises.lookup` on an IP literal short-circuits without a
+  network call. Irrelevant in practice here because the literal pre-filter
+  catches every private literal before the lookup runs.
+- [ASSUMPTION] The route's create handler already runs inside an async IIFE, so
+  making the guard awaitable needs no signature change on
+  `handleV1WebhooksRoute` (which stays sync-returning `boolean`). Confirmed at
+  `webhooks.ts:121-170`.
+- [DEFERRABLE] Whether a 3xx should dead-letter immediately instead of consuming
+  the retry budget. Left on the ordinary retry path deliberately (spec Decision 6) — it is a behavior change, not a security fix.
+- [OUT OF SCOPE] Pinning the resolved IP at connect time (custom undici
+  dispatcher) to close the TOCTOU/DNS-rebinding window. Documented as residual
+  risk; not attempted.
+
+## File Map
+
+- MODIFY `packages/orchestrator/src/server/utils/url-guard.ts` — add
+  `isPrivateAddress`, `guardOutboundHost`, `HostGuardVerdict`, `HostLookup`;
+  leave `isPrivateHost` and its regexes untouched.
+- MODIFY `packages/orchestrator/src/server/routes/v1/webhooks.ts` — await the
+  resolving guard at registration.
+- MODIFY `packages/orchestrator/src/gateway/webhooks/delivery.ts` — `lookupImpl`
+  option, resolving fire-time recheck, `redirect: 'manual'`, 3xx handling.
+- MODIFY `packages/orchestrator/src/server/routes/v1/webhooks-url-guard.test.ts`
+  — append new describe blocks (existing blocks untouched).
+- MODIFY `packages/orchestrator/src/gateway/webhooks/delivery.test.ts` — append
+  two regression tests (existing tests untouched).
+- CREATE `.changeset/<name>.md` — patch bump for the orchestrator.
+
+## Skeleton
+
+1. **Guard core (TDD)** — write the failing `guardOutboundHost` /
+   `isPrivateAddress` unit tests, then implement (~3 tasks, ~20 min)
+2. **Registration call site** — route swap + route regression test (~2 tasks, ~10 min)
+3. **Delivery call site** — recheck swap, redirect refusal, two regression tests
+   (~3 tasks, ~15 min)
+4. **Gates** — changeset, typecheck/lint/test, security self-review of the diff
+   (~1 task, ~5 min)
+
+## Tasks
+
+### Task 1 — Failing tests for `isPrivateAddress`
+
+Append a `describe('isPrivateAddress')` table to `webhooks-url-guard.test.ts`
+covering AC 5. Fails at import (symbol does not exist).
+
+### Task 2 — Failing tests for `guardOutboundHost`
+
+Append a `describe('guardOutboundHost')` block covering AC 1–4, using a
+hand-rolled injected `lookup` (no vitest module mocking) plus a call-count spy
+for the short-circuit assertion.
+
+### Task 3 — Implement the guard
+
+Add `isPrivateAddress` (IPv4 ranges incl. `0.0.0.0/8`, IPv6 `::`, `::1`,
+`fc00::/7`, `fe80::/10`, IPv4-mapped delegation) and `guardOutboundHost`
+(pre-filter → `dns.promises.lookup(host, { all: true })` → block if any address
+is private; reject → `dns-failure`). Tasks 1–2 go green.
+
+### Task 4 — Failing route test
+
+New `describe` in `webhooks-url-guard.test.ts` (or a sibling file) using
+`vi.mock('node:dns/promises')` to make a public-looking hostname resolve to
+`169.254.169.254`; assert 422. Add the public-resolution 200 counterpart.
+
+### Task 5 — Switch the registration guard
+
+`await guardOutboundHost(targetHostname)` in the create handler; include the
+verdict reason in the 422 body. Task 4 goes green. `[checkpoint:verify]`
+
+### Task 6 — Failing delivery tests
+
+Append to `delivery.test.ts`: (a) resolved-private dead-letter via injected
+`lookupImpl`, zero HTTP requests; (b) redirect-not-followed with two servers.
+
+### Task 7 — Switch the delivery guard + refuse redirects
+
+Add `lookupImpl` to `DeliveryWorkerOptions`, await the resolving guard, keep the
+`private/loopback` substring in the dead-letter message, add `redirect:
+'manual'` and the 3xx branch. Task 6 goes green.
+
+### Task 8 — Full targeted suite
+
+Run the orchestrator webhook suites and confirm AC 9 (no pre-existing test was
+edited to pass). `[checkpoint:verify]`
+
+### Task 9 — Changeset + gates + security self-review
+
+Patch changeset for `@harness-engineering/orchestrator`; `pnpm typecheck`,
+`pnpm lint`, unit suite; dispatch the OWASP/CWE security reviewer over the diff
+and address blocking findings.

--- a/docs/changes/webhook-ssrf-resolve-guard/proposal.md
+++ b/docs/changes/webhook-ssrf-resolve-guard/proposal.md
@@ -1,0 +1,274 @@
+# Resolve-then-check the outbound webhook host and stop following redirects
+
+**Keywords:** ssrf, webhooks, dns-resolution, url-guard, redirect, link-local, outbound-delivery
+
+## Overview
+
+The orchestrator's outbound webhook path decides whether a subscription URL is
+safe to POST to by matching the **hostname string** against a set of regexes.
+`isPrivateHost` (`packages/orchestrator/src/server/utils/url-guard.ts:6`) tests
+the hostname against `PRIVATE_HOSTNAME_RE` (`localhost` / `*.local`),
+`PRIVATE_IPV4_RE` (127./10./172.16-31./192.168./169.254./0.0.0.0) and
+`LOOPBACK_IPV6_RE` — and nothing else. It never resolves the name.
+
+Consequently an ordinary-looking public hostname whose DNS A record points at a
+private address passes the guard. This is not hypothetical: measured in this
+worktree on the pinned base commit,
+
+```
+host=localtest.me isPrivateHost=false resolves-to=127.0.0.1
+host=lvh.me       isPrivateHost=false resolves-to=127.0.0.1
+```
+
+Both are registrable public names that resolve to loopback. The same shape
+covers a name resolving to `169.254.169.254` (cloud instance metadata) or any
+RFC-1918 address. The guard runs at two places — subscription registration
+(`packages/orchestrator/src/server/routes/v1/webhooks.ts:148`) and again at
+fire time in the delivery worker
+(`packages/orchestrator/src/gateway/webhooks/delivery.ts:127`) — and both
+inherit the same string-only weakness.
+
+Second, independent hole: the delivery POST at
+`packages/orchestrator/src/gateway/webhooks/delivery.ts:144-153` passes no
+`redirect` option, so `fetch` follows redirects by default. A subscription URL
+that legitimately passes the guard can answer with a redirect to a private
+address, and the guard is bypassed entirely because it only ever inspected the
+first URL. Measured on the pinned base commit:
+
+```
+final status=200 ok=true url=http://127.0.0.1:<port>/metadata redirected=true
+(target server logged: RECEIVED GET /metadata)
+```
+
+and with a `307` instead of a `302` the redirected request retains the method,
+the body, **and** the `X-Harness-Signature` header:
+
+```
+307-TARGET method=POST url=/latest/meta-data/ body="{\"secret\":\"payload\"}" sig=sha256=deadbeef
+```
+
+CWE-918 (Server-Side Request Forgery). Evidence class: exploitable-path.
+
+## Honest impact
+
+This is a **blind** SSRF with a write side effect. Being precise about what an
+attacker gains matters more than the label:
+
+- **The response body never reaches the subscriber.** `executeDelivery` reads
+  only `res.ok` and `res.status`; the body is discarded
+  (`delivery.ts:154-155`). There is no data-exfiltration channel here.
+- **The observable oracle is coarse.** The only delivery telemetry exposed over
+  the API is `GET /api/v1/webhooks/queue/stats`, which returns aggregate counts
+  (`pending`/`inFlight`/`failed`/`dead`/`delivered`) and no per-delivery status
+  or error string (`webhooks.ts:98`, `queue.ts:218-230`). So an attacker who can
+  read stats learns roughly one bit per delivery — "the internal endpoint
+  answered 2xx" vs "it did not" — plus timing inferred from their own
+  redirector. That is enough to sweep for live internal hosts and ports, not
+  enough to read their contents.
+- **The real teeth are the side effect, not the read.** Because a `307` preserves
+  method, body and headers, the orchestrator can be made to issue an
+  authenticated-looking signed POST at an arbitrary internal endpoint from
+  inside the trust boundary. The body is a harness-generated gateway event, not
+  attacker-chosen, which bounds this — but "an internal service receives a POST
+  it would otherwise never receive" is the concrete harm.
+- **Who can trigger it.** Anyone who can create a webhook subscription. The
+  registration guard is the only thing standing between a caller and an outbound
+  request, and it is the guard being bypassed.
+
+Deliberately _not_ claimed: full internal-response exfiltration, credential
+theft, or metadata-service credential capture. None of those follow from this
+code path, because the response body is dropped.
+
+## Decisions made
+
+1. **Resolve-then-check, keep the string check as a pre-filter.** The regexes
+   stay exactly as they are and keep their existing name and tests; they become
+   a cheap fast path that avoids a DNS round trip for the common literal case. A
+   new async guard adds resolution on top.
+   _Rationale:_ the existing `isPrivateHost` unit tests
+   (`webhooks-url-guard.test.ts:14-54`) encode real intent — literal private
+   addresses must be refused without any network dependency. Rewriting the
+   function to be async would have forced every one of those to change and would
+   have made a purely-literal rejection depend on DNS being up.
+
+2. **The resolving guard returns a verdict, not a bare boolean.** Callers need
+   to distinguish "rejected because the literal is private", "rejected because
+   it resolves private", and "could not resolve" in order to write a useful
+   error string into the DLQ or the 422 body.
+
+3. **DNS failure fails closed.** An unresolvable host is refused rather than
+   allowed through.
+   _Rationale:_ a host that does not resolve cannot be delivered to anyway, so
+   failing closed costs no legitimate delivery. It does mean a transient
+   resolver outage produces a 422 at registration; the verdict's distinct
+   `dns-failure` reason makes that diagnosable rather than mysterious.
+
+4. **Address coverage is widened past the current regexes.** The resolved-address
+   check covers IPv4 `0.0.0.0/8`, `10/8`, `127/8`, `169.254/16`, `172.16/12`,
+   `192.168/16`, and IPv6 `::`, `::1`, `fc00::/7` (unique-local), `fe80::/10`
+   (link-local), plus IPv4-mapped IPv6 (`::ffff:a.b.c.d`) delegated to the IPv4
+   check. The pre-existing `PRIVATE_IPV4_RE` only matched `0.0.0.0` exactly and
+   had no unique-local IPv6 case.
+
+5. **Redirects are refused, not followed.** `redirect: 'manual'` on the delivery
+   fetch, and a 3xx response is recorded as a delivery failure with an explicit
+   `redirect not followed` error rather than being chased.
+   _Rationale:_ following a redirect re-opens the whole hole no matter how good
+   the first-hop guard is. Re-running the guard on each hop was considered and
+   rejected as more machinery for the same outcome — a webhook receiver has no
+   legitimate need to redirect a signed event POST.
+
+6. **Redirects keep the ordinary retry/backoff path rather than dead-lettering
+   immediately.** A 3xx is treated like any other non-2xx.
+   _Rationale:_ smaller change. Immediate dead-lettering is arguably better
+   operationally (a redirect will never start succeeding on retry), but that is a
+   behavior expansion beyond the security defect and is left out.
+
+7. **Injectable seams mirror the existing `fetchImpl` convention.** The guard
+   takes an optional `lookup`, and `WebhookDelivery` gains an optional
+   `lookupImpl`, so the regression tests are deterministic and never touch the
+   network.
+
+8. **Decisions added after the security self-review.** The OWASP/CWE reviewer ran
+   over the diff before push and found five items worth acting on; all are inside
+   the guard already being changed, so none grew the scope:
+   - An empty resolved-address list returned `{ blocked: false }` — `[].find()`
+     is `undefined`. Fail-open inside a fail-closed function. Now blocked as
+     `dns-failure`.
+   - The refused-address set omitted RFC-6598 CGNAT (`100.64.0.0/10`, which is
+     both a common Kubernetes pod/service CIDR and Alibaba Cloud's metadata
+     endpoint at `100.100.100.200`) and the RFC-6890 protocol-assignments `/24`
+     (Oracle Cloud's legacy metadata address at `192.0.0.192`). Both added,
+     along with the benchmarking, multicast and reserved ranges.
+   - IPv6 forms that embed an IPv4 address were only recognised in their dotted
+     spelling. `::ffff:7f00:1` is the same address as `::ffff:127.0.0.1` and was
+     classified public. The IPv6 branch now fully expands the address and
+     unwraps v4-mapped (both spellings), v4-compatible, v4-translated, NAT64
+     `64:ff9b::/96` and 6to4 before classifying.
+   - Sending every hostname through DNS meant bracketed IPv6 literals — the form
+     `URL.hostname` actually returns — were rejected as `dns-failure`, breaking
+     legitimate `https://[2606:4700:4700::1111]/` targets. An IP-literal fast
+     path now classifies them directly. This also closes a pre-existing hole:
+     `https://[::1]/` was _accepted_ before, because `LOOPBACK_IPV6_RE` has no
+     bracket handling.
+   - Returning `verdict.reason` in the 422 body let a caller distinguish "name
+     resolves to something internal" from "name does not exist", enumerating the
+     internal namespace one registration at a time. The reason is now logged
+     server-side and the response body is generic.
+
+   Parked as follow-up, deliberately not fixed here: the DNS lookup runs outside
+   the per-delivery timeout and outside the abort path (`dns.lookup` is not
+   abortable), and it is uncached, so it consumes a libuv threadpool slot per
+   delivery attempt. Both are availability concerns, not SSRF, and fixing them
+   properly means either a resolver swap with its own trade-offs (`dns.resolve*`
+   bypasses `/etc/hosts`, which would _lose_ coverage) or a verdict cache.
+
+## Technical design
+
+### `packages/orchestrator/src/server/utils/url-guard.ts`
+
+Unchanged export:
+
+```ts
+export function isPrivateHost(hostname: string): boolean; // literal pre-filter, as today
+```
+
+New exports:
+
+```ts
+export type HostGuardReason = 'private-literal' | 'private-address' | 'dns-failure';
+
+export interface HostGuardVerdict {
+  blocked: boolean;
+  reason?: HostGuardReason;
+  detail?: string;
+}
+
+export type HostLookup = (hostname: string) => Promise<Array<{ address: string; family: number }>>;
+
+export function isPrivateAddress(ip: string): boolean;
+
+export async function guardOutboundHost(
+  hostname: string,
+  opts?: { lookup?: HostLookup }
+): Promise<HostGuardVerdict>;
+```
+
+`guardOutboundHost` runs the literal pre-filter, short-circuits on a hit, then
+resolves with `dns.promises.lookup(hostname, { all: true })` and blocks if **any**
+returned address satisfies `isPrivateAddress`. A lookup rejection yields
+`{ blocked: true, reason: 'dns-failure' }`.
+
+### `packages/orchestrator/src/server/routes/v1/webhooks.ts`
+
+The create handler already runs inside `void (async () => { ... })()`, so the
+call site becomes an `await guardOutboundHost(targetHostname)` and the 422 body
+gains the verdict's reason.
+
+### `packages/orchestrator/src/gateway/webhooks/delivery.ts`
+
+- `DeliveryWorkerOptions` gains `lookupImpl?: HostLookup`.
+- The fire-time recheck becomes `await guardOutboundHost(hostname, { lookup })`,
+  writing the verdict reason into the dead-letter `lastError`. The existing
+  `'private/loopback'` substring is preserved in the message so the existing
+  dead-letter assertion keeps its meaning.
+- The delivery `fetch` gains `redirect: 'manual'`; a `res.status >= 300 &&
+res.status < 400` sets an explicit `redirect not followed (HTTP <status>)`
+  error.
+
+## Integration Points
+
+- **Entry Points** — no new entry point. Two existing call sites change
+  (`POST /api/v1/webhooks` registration guard, `WebhookDelivery.executeDelivery`
+  fire-time guard + fetch). Three new exports from the existing
+  `server/utils/url-guard.ts` module.
+- **Registrations Required** — none. `url-guard.ts` is imported directly by both
+  consumers; no barrel regeneration and no route registration.
+- **Documentation Updates** — none required; no user-visible API contract
+  changes beyond a more specific 422 error string. A changeset (patch,
+  `@harness-engineering/orchestrator`) is required by the repo.
+- **Architectural Decisions** — none rise to a standalone ADR. This is a small
+  bounded hardening of an existing guard, not a new architectural seam.
+- **Knowledge Impact** — the durable lesson is "a hostname allowlist/denylist
+  that never resolves is not a network guard, and a guard that does not also
+  refuse redirects only guards the first hop." Captured in this proposal.
+
+## Success Criteria
+
+1. `guardOutboundHost` blocks a hostname whose resolved addresses include a
+   loopback, RFC-1918, link-local, or unique-local address, with reason
+   `private-address`.
+2. `guardOutboundHost` blocks a literal private host without performing any
+   lookup (injected lookup is never called), with reason `private-literal`.
+3. `guardOutboundHost` allows a hostname resolving only to public addresses.
+4. `guardOutboundHost` blocks with reason `dns-failure` when resolution rejects.
+5. `POST /api/v1/webhooks` returns 422 for a URL whose hostname resolves to a
+   private address, and still returns 200 for one that resolves publicly.
+6. `WebhookDelivery` dead-letters a subscription whose hostname resolves private,
+   without issuing any HTTP request.
+7. `WebhookDelivery` does **not** follow a redirect: the redirect target server
+   receives zero requests and the delivery is recorded as failed.
+8. Delivery to a normal public-shaped endpoint that answers 200 directly still
+   succeeds — every pre-existing delivery test still passes unmodified.
+
+## Implementation Order
+
+1. Extend `url-guard.ts` with `isPrivateAddress` + `guardOutboundHost` and its
+   unit tests (tests first — they fail on the base commit because the symbols do
+   not exist).
+2. Switch the registration route to the resolving guard; add the route-level
+   regression test.
+3. Switch the delivery worker's fire-time recheck to the resolving guard and add
+   `redirect: 'manual'` + 3xx handling; add the two delivery regression tests.
+4. Changeset, full local gates, security self-review of the diff.
+
+## Residual risk (explicit)
+
+The fix closes resolve-time and redirect-time bypasses. It does **not** close
+the TOCTOU window between the guard's `lookup` and the connection the subsequent
+`fetch` opens — `fetch` resolves the name a second time, so a DNS record that
+flips between the two resolutions (classic DNS rebinding with a short TTL) can
+still land on a private address. Fully closing that requires pinning the
+resolved IP at connect time via a custom `undici` dispatcher or a `lookup`-hooked
+agent, which is a materially larger change than this defect warrants. It is
+stated here and in the PR body rather than papered over.

--- a/packages/orchestrator/src/gateway/webhooks/delivery.test.ts
+++ b/packages/orchestrator/src/gateway/webhooks/delivery.test.ts
@@ -194,6 +194,84 @@ describe('WebhookDelivery (queue-backed)', () => {
     expect(queue.list({ status: 'dead' })[0]?.lastError).toContain('private/loopback');
   });
 
+  it('dead-letters when the hostname RESOLVES to a private address (no HTTP attempt)', async () => {
+    // The literal `hooks.attacker.example` is an ordinary public name — the
+    // string-matching pre-filter has nothing to catch. Only resolution reveals
+    // that it points at the link-local metadata address.
+    const sub = await store.create({
+      tokenId: 't',
+      url: 'https://hooks.attacker.example/hook',
+      events: ['*.*'],
+    });
+    const lookedUp: string[] = [];
+    const worker = new WebhookDelivery({
+      queue,
+      store,
+      tickIntervalMs: 20,
+      lookupImpl: async (hostname) => {
+        lookedUp.push(hostname);
+        return [{ address: '169.254.169.254', family: 4 }];
+      },
+      fetchImpl: () => {
+        throw new Error('delivery must not issue an HTTP request for a private-resolving host');
+      },
+    });
+    worker.enqueue(sub, makeGatewayEvent());
+    worker.start();
+    await new Promise((r) => setTimeout(r, 150));
+    await worker.stop();
+    expect(lookedUp).toEqual(['hooks.attacker.example']);
+    expect(received).toHaveLength(0);
+    expect(queue.list({ status: 'dead' })).toHaveLength(1);
+    expect(queue.list({ status: 'dead' })[0]?.lastError).toContain('private/loopback');
+  });
+
+  it('does NOT follow a redirect — the redirect target receives nothing', async () => {
+    // A subscription URL can pass every host check and still answer 302 to a
+    // private address. Following it would bypass the guard entirely, so the
+    // worker must refuse the hop and record a failure.
+    const redirectTargetHits: string[] = [];
+    const redirectTarget = http.createServer((req, res) => {
+      redirectTargetHits.push(`${req.method} ${req.url}`);
+      res.writeHead(200);
+      res.end('{}');
+    });
+    await new Promise<void>((r) => redirectTarget.listen(0, '127.0.0.1', () => r()));
+    const targetPort = (redirectTarget.address() as AddressInfo).port;
+
+    const redirector = http.createServer((_req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${targetPort}/latest/meta-data/` });
+      res.end();
+    });
+    await new Promise<void>((r) => redirector.listen(0, '127.0.0.1', () => r()));
+    const redirectorPort = (redirector.address() as AddressInfo).port;
+
+    const sub = await store.create({
+      tokenId: 't',
+      url: `http://127.0.0.1:${redirectorPort}/hook`,
+      events: ['*.*'],
+    });
+    const worker = new WebhookDelivery({
+      queue,
+      store,
+      tickIntervalMs: 20,
+      allowPrivateHosts: true,
+    });
+    worker.enqueue(sub, makeGatewayEvent());
+    worker.start();
+    await new Promise((r) => setTimeout(r, 250));
+    await worker.stop();
+
+    expect(redirectTargetHits).toEqual([]);
+    expect(queue.stats().delivered).toBe(0);
+    const failed = queue.list({ status: 'failed' });
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.lastError).toContain('redirect not followed');
+
+    await new Promise<void>((r) => redirectTarget.close(() => r()));
+    await new Promise<void>((r) => redirector.close(() => r()));
+  });
+
   it('deleted subscription dead-letters the queued delivery', async () => {
     const sub = await store.create({ tokenId: 't', url: receiverUrl, events: ['*.*'] });
     const worker = new WebhookDelivery({

--- a/packages/orchestrator/src/gateway/webhooks/delivery.ts
+++ b/packages/orchestrator/src/gateway/webhooks/delivery.ts
@@ -3,7 +3,7 @@ import type { WebhookSubscription, GatewayEvent } from '@harness-engineering/typ
 import { sign } from './signer.js';
 import { type WebhookQueue, type QueueRow, RETRY_DELAYS_MS, MAX_ATTEMPTS } from './queue.js';
 import type { WebhookStore } from './store.js';
-import { isPrivateHost } from '../../server/utils/url-guard.js';
+import { guardOutboundHost, type HostLookup } from '../../server/utils/url-guard.js';
 
 interface DeliveryWorkerOptions {
   queue: WebhookQueue;
@@ -19,6 +19,12 @@ interface DeliveryWorkerOptions {
    * bound to 127.0.0.1. Production callers MUST leave this false (default).
    */
   allowPrivateHosts?: boolean;
+  /**
+   * Hostname resolver used by the delivery-time SSRF recheck. Defaults to
+   * `dns.promises.lookup`; injected in tests so the recheck is deterministic
+   * and offline (mirrors the `fetchImpl` seam).
+   */
+  lookupImpl?: HostLookup;
 }
 
 export class WebhookDelivery {
@@ -30,6 +36,7 @@ export class WebhookDelivery {
   private readonly maxConcurrentPerSub: number;
   private readonly drainTimeoutMs: number;
   private readonly allowPrivateHosts: boolean;
+  private readonly lookupImpl: HostLookup | undefined;
   private readonly inFlight = new Map<string, number>();
   /**
    * AbortControllers for currently executing HTTP POSTs, keyed by delivery id.
@@ -49,6 +56,7 @@ export class WebhookDelivery {
     this.maxConcurrentPerSub = opts.maxConcurrentPerSub ?? 4;
     this.drainTimeoutMs = opts.drainTimeoutMs ?? 30_000;
     this.allowPrivateHosts = opts.allowPrivateHosts ?? false;
+    this.lookupImpl = opts.lookupImpl;
   }
 
   enqueue(sub: WebhookSubscription, event: GatewayEvent): void {
@@ -124,14 +132,17 @@ export class WebhookDelivery {
         this.queue.markFailed(row.id, MAX_ATTEMPTS, Date.now(), 'invalid URL');
         return;
       }
-      if (!this.allowPrivateHosts && isPrivateHost(hostname)) {
-        this.queue.markFailed(
-          row.id,
-          MAX_ATTEMPTS,
-          Date.now(),
-          'URL resolves to private/loopback host'
-        );
-        return;
+      if (!this.allowPrivateHosts) {
+        const verdict = await guardOutboundHost(hostname, { lookup: this.lookupImpl });
+        if (verdict.blocked) {
+          this.queue.markFailed(
+            row.id,
+            MAX_ATTEMPTS,
+            Date.now(),
+            `URL resolves to private/loopback host (${verdict.reason}: ${verdict.detail ?? hostname})`
+          );
+          return;
+        }
       }
 
       const signature = sign(sub.secret, row.payload);
@@ -151,9 +162,19 @@ export class WebhookDelivery {
           },
           body: row.payload,
           signal: ctrl.signal,
+          // Do not chase redirects. The host guard above only ever inspected
+          // the subscription's own hostname, so a receiver that answers 3xx
+          // could otherwise walk the delivery onto a private address the guard
+          // never saw. A 307/308 would carry the method, body and signature
+          // headers along with it.
+          redirect: 'manual',
         });
         ok = res.ok;
-        if (!ok) lastError = `HTTP ${res.status}`;
+        if (res.status >= 300 && res.status < 400) {
+          lastError = `redirect not followed (HTTP ${res.status})`;
+        } else if (!ok) {
+          lastError = `HTTP ${res.status}`;
+        }
       } catch (err) {
         aborted = ctrl.signal.aborted;
         lastError = err instanceof Error ? err.message : String(err);

--- a/packages/orchestrator/src/server/routes/v1/webhooks-url-guard.test.ts
+++ b/packages/orchestrator/src/server/routes/v1/webhooks-url-guard.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { isPrivateHost } from '../../utils/url-guard.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isPrivateHost,
+  isPrivateAddress,
+  guardOutboundHost,
+  type HostLookup,
+} from '../../utils/url-guard.js';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -8,6 +13,25 @@ import { WebhookStore } from '../../../gateway/webhooks/store.js';
 import { EventEmitter } from 'node:events';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { Socket } from 'node:net';
+
+/**
+ * The route-level guard now RESOLVES the hostname, so the route tests below
+ * would otherwise depend on live DNS. Stub `node:dns/promises` with an
+ * in-memory table so every route case (including the pre-existing
+ * "accepts https://example.com/hook") is deterministic and offline.
+ * The `isPrivateHost` / `isPrivateAddress` / `guardOutboundHost` unit tests
+ * below never reach this stub — they are pure, or inject their own lookup.
+ */
+const dnsStub = vi.hoisted(() => ({ table: new Map<string, string[]>() }));
+vi.mock('node:dns/promises', () => ({
+  lookup: async (hostname: string) => {
+    const addresses = dnsStub.table.get(hostname);
+    if (!addresses) {
+      throw Object.assign(new Error(`getaddrinfo ENOTFOUND ${hostname}`), { code: 'ENOTFOUND' });
+    }
+    return addresses.map((address) => ({ address, family: address.includes(':') ? 6 : 4 }));
+  },
+}));
 
 // --- Unit tests for isPrivateHost ---
 
@@ -53,6 +77,196 @@ describe('isPrivateHost', () => {
   });
 });
 
+// --- Unit tests for isPrivateAddress (resolved-address classification) ---
+
+describe('isPrivateAddress', () => {
+  const blocked = [
+    ['127.0.0.1', 'IPv4 loopback'],
+    ['127.255.255.254', 'IPv4 loopback, upper /8'],
+    ['10.0.0.1', 'RFC-1918 10/8'],
+    ['172.16.0.1', 'RFC-1918 172.16/12 lower'],
+    ['172.31.255.255', 'RFC-1918 172.16/12 upper'],
+    ['192.168.1.1', 'RFC-1918 192.168/16'],
+    ['169.254.169.254', 'link-local / cloud instance metadata'],
+    ['0.0.0.0', 'unspecified'],
+    ['0.1.2.3', '0.0.0.0/8 "this network"'],
+    ['::1', 'IPv6 loopback'],
+    ['::', 'IPv6 unspecified'],
+    ['fd00::1', 'IPv6 unique-local fd'],
+    ['fc00::1', 'IPv6 unique-local fc'],
+    ['fe80::1', 'IPv6 link-local'],
+    ['febf::1', 'IPv6 link-local, upper /10'],
+    ['::ffff:127.0.0.1', 'IPv4-mapped loopback'],
+    ['::ffff:169.254.169.254', 'IPv4-mapped link-local'],
+    ['100.64.0.1', 'RFC-6598 CGNAT lower'],
+    ['100.100.100.200', 'RFC-6598 CGNAT — Alibaba Cloud metadata'],
+    ['100.127.255.255', 'RFC-6598 CGNAT upper'],
+    ['192.0.0.192', 'RFC-6890 protocol assignments — Oracle Cloud legacy metadata'],
+    ['198.18.0.1', 'RFC-2544 benchmarking'],
+    ['224.0.0.1', 'multicast'],
+    ['255.255.255.255', 'broadcast'],
+    ['240.0.0.1', 'reserved 240/4'],
+    ['::ffff:7f00:1', 'IPv4-mapped loopback in hex spelling'],
+    ['::ffff:a9fe:a9fe', 'IPv4-mapped link-local in hex spelling'],
+    ['::ffff:0:127.0.0.1', 'RFC-2765 IPv4-translated loopback'],
+    ['::7f00:1', 'deprecated IPv4-compatible loopback'],
+    ['64:ff9b::a9fe:a9fe', 'NAT64-embedded link-local metadata address'],
+    ['64:ff9b::7f00:1', 'NAT64-embedded loopback'],
+    ['2002:7f00:1::', '6to4-embedded loopback'],
+    ['ff02::1', 'IPv6 link-local all-nodes multicast'],
+    ['[::1]', 'bracketed IPv6 loopback, as URL.hostname yields it'],
+    ['FE80::1', 'uppercase IPv6 link-local'],
+    ['fe80::1%en0', 'IPv6 link-local with a zone id'],
+  ] as const;
+
+  for (const [ip, why] of blocked) {
+    it(`returns true for ${ip} (${why})`, () => {
+      expect(isPrivateAddress(ip)).toBe(true);
+    });
+  }
+
+  const allowed = [
+    ['8.8.8.8', 'public IPv4'],
+    ['172.15.0.1', 'below RFC-1918 172.16/12'],
+    ['172.32.0.1', 'above RFC-1918 172.16/12'],
+    ['169.253.0.1', 'adjacent to link-local but public'],
+    ['192.167.1.1', 'adjacent to RFC-1918 but public'],
+    ['2606:4700::1111', 'public IPv6'],
+    ['fec0::1', 'above fe80::/10 (deprecated site-local, not link-local)'],
+    ['fc0::1', 'leading hextet 0x0fc0 — outside fc00::/7 despite the prefix'],
+    ['::ffff:8.8.8.8', 'IPv4-mapped public'],
+    ['100.63.255.255', 'just below RFC-6598 CGNAT'],
+    ['100.128.0.1', 'just above RFC-6598 CGNAT'],
+    ['192.0.1.1', 'just above the RFC-6890 protocol-assignments /24'],
+    ['198.20.0.1', 'just above the benchmarking block'],
+    ['223.255.255.255', 'just below multicast'],
+    ['[2606:4700:4700::1111]', 'bracketed public IPv6'],
+    ['64:ff9b::8.8.8.8', 'NAT64-embedded public address'],
+  ] as const;
+
+  for (const [ip, why] of allowed) {
+    it(`returns false for ${ip} (${why})`, () => {
+      expect(isPrivateAddress(ip)).toBe(false);
+    });
+  }
+});
+
+// --- Unit tests for guardOutboundHost (resolve-then-check) ---
+
+function stubLookup(map: Record<string, string[]>): HostLookup & { calls: string[] } {
+  const calls: string[] = [];
+  const fn = (async (hostname: string) => {
+    calls.push(hostname);
+    const addresses = map[hostname];
+    if (!addresses) throw new Error(`getaddrinfo ENOTFOUND ${hostname}`);
+    return addresses.map((address) => ({ address, family: address.includes(':') ? 6 : 4 }));
+  }) as HostLookup & { calls: string[] };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('guardOutboundHost', () => {
+  it('blocks a public hostname that resolves to the cloud metadata address', async () => {
+    const lookup = stubLookup({ 'hooks.attacker.example': ['169.254.169.254'] });
+    const verdict = await guardOutboundHost('hooks.attacker.example', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-address');
+    expect(verdict.detail).toBe('169.254.169.254');
+  });
+
+  it('blocks a public hostname that resolves to loopback', async () => {
+    const lookup = stubLookup({ 'localtest.example': ['127.0.0.1'] });
+    const verdict = await guardOutboundHost('localtest.example', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-address');
+  });
+
+  it('blocks when ANY resolved address is private, even if others are public', async () => {
+    const lookup = stubLookup({ 'split.example': ['93.184.216.34', '10.1.2.3'] });
+    const verdict = await guardOutboundHost('split.example', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-address');
+    expect(verdict.detail).toBe('10.1.2.3');
+  });
+
+  it('blocks a hostname resolving to an IPv6 unique-local address', async () => {
+    const lookup = stubLookup({ 'ula.example': ['fd12:3456::1'] });
+    const verdict = await guardOutboundHost('ula.example', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-address');
+  });
+
+  it('blocks a literal private host WITHOUT performing a lookup', async () => {
+    const lookup = stubLookup({});
+    const verdict = await guardOutboundHost('127.0.0.1', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-literal');
+    expect(lookup.calls).toHaveLength(0);
+  });
+
+  it('blocks localhost via the literal pre-filter WITHOUT performing a lookup', async () => {
+    const lookup = stubLookup({});
+    const verdict = await guardOutboundHost('localhost', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-literal');
+    expect(lookup.calls).toHaveLength(0);
+  });
+
+  it('allows a hostname that resolves only to public addresses', async () => {
+    const lookup = stubLookup({ 'hooks.example.com': ['93.184.216.34', '2606:4700::1111'] });
+    const verdict = await guardOutboundHost('hooks.example.com', { lookup });
+    expect(verdict.blocked).toBe(false);
+    expect(verdict.reason).toBeUndefined();
+    expect(lookup.calls).toEqual(['hooks.example.com']);
+  });
+
+  it('fails closed when resolution rejects', async () => {
+    const lookup = stubLookup({});
+    const verdict = await guardOutboundHost('nxdomain.example', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('dns-failure');
+  });
+
+  it('fails closed when resolution returns an empty address list', async () => {
+    const lookup = (async () => []) as HostLookup;
+    const verdict = await guardOutboundHost('empty.example', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('dns-failure');
+  });
+
+  it('blocks a bracketed IPv6 loopback literal WITHOUT a lookup', async () => {
+    // `new URL('https://[::1]/').hostname` is '[::1]'. The bracketed form
+    // slipped past the old string-only guard entirely.
+    const lookup = stubLookup({});
+    const verdict = await guardOutboundHost('[::1]', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-literal');
+    expect(lookup.calls).toHaveLength(0);
+  });
+
+  it('allows a bracketed public IPv6 literal WITHOUT a lookup', async () => {
+    const lookup = stubLookup({});
+    const verdict = await guardOutboundHost('[2606:4700:4700::1111]', { lookup });
+    expect(verdict.blocked).toBe(false);
+    expect(lookup.calls).toHaveLength(0);
+  });
+
+  it('allows a public IPv4 literal WITHOUT a lookup', async () => {
+    const lookup = stubLookup({});
+    const verdict = await guardOutboundHost('93.184.216.34', { lookup });
+    expect(verdict.blocked).toBe(false);
+    expect(lookup.calls).toHaveLength(0);
+  });
+
+  it('blocks a CGNAT IPv4 literal that the string pre-filter does not know', async () => {
+    const lookup = stubLookup({});
+    expect(isPrivateHost('100.100.100.200')).toBe(false); // pre-filter misses it
+    const verdict = await guardOutboundHost('100.100.100.200', { lookup });
+    expect(verdict.blocked).toBe(true);
+    expect(verdict.reason).toBe('private-literal');
+  });
+});
+
 // --- Integration-style test: route handler rejects private URLs with 422 ---
 
 function makeReq(method: string, url: string, body?: unknown): IncomingMessage {
@@ -95,6 +309,13 @@ describe('handleV1WebhooksRoute — SSRF guard', () => {
     dir = mkdtempSync(join(tmpdir(), 'harness-wh-urlguard-'));
     store = new WebhookStore(join(dir, 'webhooks.json'));
     bus = new EventEmitter();
+    dnsStub.table.clear();
+    // A legitimate, publicly-resolving receiver.
+    dnsStub.table.set('example.com', ['93.184.216.34']);
+    // A public hostname whose A record points at the cloud metadata service.
+    dnsStub.table.set('hooks.attacker.example', ['169.254.169.254']);
+    // A public hostname whose A record points at loopback.
+    dnsStub.table.set('localtest.example', ['127.0.0.1']);
   });
 
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
@@ -132,5 +353,43 @@ describe('handleV1WebhooksRoute — SSRF guard', () => {
     handleV1WebhooksRoute(req, res, { store, bus });
     await new Promise((r) => setTimeout(r, 20));
     expect(statusCode()).toBe(200);
+  });
+
+  // --- Regression: the guard must resolve, not just pattern-match ---
+
+  it('POST rejects a public hostname whose DNS points at the metadata address', async () => {
+    const req = makeReq('POST', '/api/v1/webhooks', {
+      url: 'https://hooks.attacker.example/hook',
+      events: ['*.*'],
+    });
+    const { res, chunks, statusCode } = makeRes();
+    handleV1WebhooksRoute(req, res, { store, bus });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(statusCode()).toBe(422);
+    expect(chunks.join('')).toContain('private or loopback');
+    expect(await store.list()).toHaveLength(0);
+  });
+
+  it('POST rejects a public hostname whose DNS points at loopback', async () => {
+    const req = makeReq('POST', '/api/v1/webhooks', {
+      url: 'https://localtest.example/hook',
+      events: ['*.*'],
+    });
+    const { res, statusCode } = makeRes();
+    handleV1WebhooksRoute(req, res, { store, bus });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(statusCode()).toBe(422);
+    expect(await store.list()).toHaveLength(0);
+  });
+
+  it('POST rejects a hostname that does not resolve (fails closed)', async () => {
+    const req = makeReq('POST', '/api/v1/webhooks', {
+      url: 'https://nxdomain.example/hook',
+      events: ['*.*'],
+    });
+    const { res, statusCode } = makeRes();
+    handleV1WebhooksRoute(req, res, { store, bus });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(statusCode()).toBe(422);
   });
 });

--- a/packages/orchestrator/src/server/routes/v1/webhooks.ts
+++ b/packages/orchestrator/src/server/routes/v1/webhooks.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { EventEmitter } from 'node:events';
 import { z } from 'zod';
 import { readBody } from '../../utils.js';
-import { isPrivateHost } from '../../utils/url-guard.js';
+import { guardOutboundHost } from '../../utils/url-guard.js';
 import { WebhookSubscriptionPublicSchema, type TokenScope } from '@harness-engineering/types';
 import type { WebhookStore } from '../../../gateway/webhooks/store';
 import type { WebhookQueue } from '../../../gateway/webhooks/queue';
@@ -144,8 +144,19 @@ export function handleV1WebhooksRoute(
         sendJSON(res, 422, { error: 'URL must use https' });
         return;
       }
+      // Resolve the hostname before accepting it. A string match alone is not
+      // a network decision: an ordinary public name can carry an A record
+      // pointing at loopback or at the link-local metadata address.
       const targetHostname = new URL(parsed.data.url).hostname;
-      if (isPrivateHost(targetHostname)) {
+      const verdict = await guardOutboundHost(targetHostname);
+      if (verdict.blocked) {
+        // Deliberately generic. The verdict distinguishes "spelled privately"
+        // from "resolves to something internal" from "does not resolve at
+        // all"; returning that discriminator would let a caller enumerate the
+        // internal namespace one registration at a time. It stays in the log.
+        console.warn(
+          `[webhook] refused subscription URL host=${targetHostname} reason=${verdict.reason}`
+        );
         sendJSON(res, 422, { error: 'URL must not target private or loopback addresses' });
         return;
       }

--- a/packages/orchestrator/src/server/utils/url-guard.ts
+++ b/packages/orchestrator/src/server/utils/url-guard.ts
@@ -1,12 +1,250 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
 const PRIVATE_HOSTNAME_RE = /^(localhost|.*\.local)$/i;
 const PRIVATE_IPV4_RE =
   /^(127\.\d+\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+|169\.254\.\d+\.\d+|0\.0\.0\.0)$/;
 const LOOPBACK_IPV6_RE = /^(::1|::ffff:127\.\d+\.\d+\.\d+|::ffff:0:127\.\d+\.\d+\.\d+)$/i;
 
+/**
+ * Literal-only check: does this hostname *spell* a private/loopback target?
+ *
+ * This is a string match, not a network decision. It cannot see through a
+ * public name that resolves to a private address, so it is only ever safe as
+ * a cheap pre-filter in front of `guardOutboundHost`. Callers deciding whether
+ * to open an outbound connection MUST use `guardOutboundHost`.
+ */
 export function isPrivateHost(hostname: string): boolean {
   return (
     PRIVATE_HOSTNAME_RE.test(hostname) ||
     PRIVATE_IPV4_RE.test(hostname) ||
     LOOPBACK_IPV6_RE.test(hostname)
   );
+}
+
+/**
+ * IPv4 ranges we refuse to open a connection to, as CIDR strings.
+ *
+ * Beyond the loopback/RFC-1918/link-local set the old regex covered, this also
+ * refuses RFC-6598 CGNAT (which doubles as a Kubernetes pod/service CIDR and as
+ * Alibaba Cloud's metadata endpoint at 100.100.100.200), the IETF protocol
+ * assignments block (Oracle Cloud's legacy metadata address lives at
+ * 192.0.0.192), the benchmarking block, multicast, and the reserved 240/4 range
+ * that ends in the broadcast address. None is a legitimate webhook receiver,
+ * and each has been used as an SSRF target.
+ */
+const PRIVATE_IPV4_CIDRS = [
+  '0.0.0.0/8', // "this network"
+  '10.0.0.0/8', // RFC-1918
+  '100.64.0.0/10', // RFC-6598 CGNAT
+  '127.0.0.0/8', // loopback
+  '169.254.0.0/16', // link-local, incl. cloud metadata
+  '172.16.0.0/12', // RFC-1918
+  '192.0.0.0/24', // RFC-6890 protocol assignments
+  '192.168.0.0/16', // RFC-1918
+  '198.18.0.0/15', // RFC-2544 benchmarking
+  '224.0.0.0/4', // multicast
+  '240.0.0.0/4', // reserved, incl. 255.255.255.255 broadcast
+] as const;
+
+function toUint32(a: number, b: number, c: number, d: number): number {
+  return (((a << 24) >>> 0) + (b << 16) + (c << 8) + d) >>> 0;
+}
+
+const PRIVATE_IPV4_RANGES: ReadonlyArray<readonly [number, number]> = PRIVATE_IPV4_CIDRS.map(
+  (cidr) => {
+    const [network = '', bits = '0'] = cidr.split('/');
+    const [a = 0, b = 0, c = 0, d = 0] = network.split('.').map(Number);
+    const mask = (0xffffffff << (32 - Number(bits))) >>> 0;
+    return [(toUint32(a, b, c, d) & mask) >>> 0, mask] as const;
+  }
+);
+
+function isPrivateIpv4Octets(a: number, b: number, c: number, d: number): boolean {
+  const value = toUint32(a, b, c, d);
+  return PRIVATE_IPV4_RANGES.some(([base, mask]) => (value & mask) >>> 0 === base);
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const octets = ip.split('.');
+  if (octets.length !== 4) return false;
+  const parts = octets.map((o) => Number(o));
+  if (parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b, c, d] = parts as [number, number, number, number];
+  return isPrivateIpv4Octets(a, b, c, d);
+}
+
+/** The v4 address embedded in two IPv6 hextets, e.g. 0x7f00,0x0001 -> 127.0.0.1. */
+function isPrivateEmbeddedIpv4(hi: number, lo: number): boolean {
+  return isPrivateIpv4Octets((hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff);
+}
+
+/** One `:`-separated group: a hex hextet, or a trailing dotted quad worth two. */
+function parseIpv6Group(group: string): number[] | null {
+  if (group.includes('.')) {
+    const octets = group.split('.').map(Number);
+    if (octets.length !== 4) return null;
+    if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+    const [a, b, c, d] = octets as [number, number, number, number];
+    return [(a << 8) | b, (c << 8) | d];
+  }
+  if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+  return [Number.parseInt(group, 16)];
+}
+
+function parseIpv6Segment(segment: string): number[] | null {
+  if (segment === '') return [];
+  const out: number[] = [];
+  for (const group of segment.split(':')) {
+    const parsed = parseIpv6Group(group);
+    if (parsed === null) return null;
+    out.push(...parsed);
+  }
+  return out;
+}
+
+/**
+ * Expand an IPv6 address to its eight 16-bit groups, or null if unparseable.
+ *
+ * Full expansion rather than prefix matching, because neither an abbreviated
+ * group nor an embedded-IPv4 form is the prefix it looks like: `fc0::1` has a
+ * leading group of 0x0fc0 (outside fc00::/7, so a `startsWith('fc')` would
+ * wrongly block it), while `::ffff:7f00:1` and `::ffff:127.0.0.1` are the same
+ * address written two ways and must classify identically.
+ */
+function expandIpv6(ip: string): number[] | null {
+  const halves = ip.split('::');
+  if (halves.length > 2) return null;
+  const head = parseIpv6Segment(halves[0] ?? '');
+  if (head === null) return null;
+  if (halves.length === 1) return head.length === 8 ? head : null;
+  const tail = parseIpv6Segment(halves[1] ?? '');
+  if (tail === null) return null;
+  const gap = 8 - head.length - tail.length;
+  if (gap < 0) return null;
+  return [...head, ...(Array(gap).fill(0) as number[]), ...tail];
+}
+
+/**
+ * The two hextets holding an embedded IPv4 address, or null if this address
+ * does not embed one.
+ *
+ * Covers v4-mapped (`::ffff:a.b.c.d`, and equivalently `::ffff:7f00:1`),
+ * v4-compatible (`::a.b.c.d`, which also subsumes `::` and `::1`),
+ * v4-translated (`::ffff:0:a.b.c.d`), NAT64 (`64:ff9b::/96`) and 6to4
+ * (`2002::/16`). NAT64 matters wherever the host sits behind a NAT64 gateway —
+ * IPv6-only cloud subnets — where `64:ff9b::a9fe:a9fe` translates to the
+ * 169.254.169.254 metadata address.
+ */
+function embeddedIpv4Hextets(h: readonly number[]): readonly [number, number] | null {
+  const [h0 = 0, h1 = 0, h2 = 0, h3 = 0, h4 = 0, h5 = 0, h6 = 0, h7 = 0] = h;
+  const topFourZero = h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0;
+  if (topFourZero && h4 === 0 && (h5 === 0xffff || h5 === 0)) return [h6, h7];
+  if (topFourZero && h4 === 0xffff && h5 === 0) return [h6, h7];
+  if (h0 === 0x0064 && h1 === 0xff9b) return [h6, h7];
+  if (h0 === 0x2002) return [h1, h2];
+  return null;
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const normalized = (ip.replace(/^\[|\]$/g, '').split('%')[0] ?? '').toLowerCase();
+  const h = expandIpv6(normalized);
+  if (h === null) return false;
+  const embedded = embeddedIpv4Hextets(h);
+  if (embedded !== null) return isPrivateEmbeddedIpv4(embedded[0], embedded[1]);
+  const h0 = h[0] ?? 0;
+  if ((h0 & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  if ((h0 & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((h0 & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  return false;
+}
+
+/**
+ * Is this *resolved address* one we refuse to open a connection to?
+ *
+ * Covers the IPv4 loopback/private/CGNAT/link-local/multicast/reserved ranges
+ * and the IPv6 unspecified, loopback, unique-local, link-local and multicast
+ * ranges. Every IPv6 form that embeds an IPv4 address — v4-mapped (in either
+ * dotted or hex spelling), v4-compatible, v4-translated, NAT64 and 6to4 — is
+ * unwrapped and classified as IPv4, so a mapped spelling cannot smuggle a
+ * private v4 address past the v6 branch.
+ */
+export function isPrivateAddress(ip: string): boolean {
+  const bare = ip.replace(/^\[|\]$/g, '');
+  if (bare.includes(':')) return isPrivateIpv6(bare);
+  return isPrivateIpv4(bare);
+}
+
+export type HostGuardReason = 'private-literal' | 'private-address' | 'dns-failure';
+
+export interface HostGuardVerdict {
+  blocked: boolean;
+  reason?: HostGuardReason;
+  detail?: string;
+}
+
+export type HostLookup = (hostname: string) => Promise<Array<{ address: string; family: number }>>;
+
+const defaultLookup: HostLookup = (hostname) => lookup(hostname, { all: true });
+
+/**
+ * Decide whether an outbound request to `hostname` is allowed to leave.
+ *
+ * Three stages: the literal pre-filter (`isPrivateHost`, no network), an
+ * IP-literal fast path, then DNS resolution — because a perfectly ordinary
+ * public hostname can carry an A record pointing at loopback or at
+ * 169.254.169.254, and a string match will never see it. Every resolved address
+ * must be public; one private address in the set blocks the whole host, which
+ * also closes the A/AAAA mismatch where the guard checks one family and the
+ * connector picks the other.
+ *
+ * Resolution failure blocks, and so does an empty address list. A host that
+ * will not resolve cannot be delivered to anyway, so failing closed costs no
+ * legitimate traffic, and the distinct `dns-failure` reason keeps a resolver
+ * outage diagnosable rather than indistinguishable from an attack.
+ *
+ * `detail` may carry a resolved internal address or a raw resolver error. It is
+ * for server-side logs and the dead-letter record — do not put it in an HTTP
+ * response body, where it would become an internal-network oracle.
+ *
+ * KNOWN RESIDUAL RISK: this resolves the name, but the connection that follows
+ * resolves it a second time. A record that changes between the two (DNS
+ * rebinding with a short TTL) can still land on a private address. Closing that
+ * requires pinning the resolved IP at connect time via a custom dispatcher.
+ */
+export async function guardOutboundHost(
+  hostname: string,
+  opts?: { lookup?: HostLookup | undefined }
+): Promise<HostGuardVerdict> {
+  if (isPrivateHost(hostname)) {
+    return { blocked: true, reason: 'private-literal', detail: hostname };
+  }
+  // An IP literal needs no resolution. `URL.hostname` hands back IPv6 literals
+  // bracketed, which `dns.lookup` rejects — without this branch every
+  // IPv6-literal target would be refused as a DNS failure.
+  const bareLiteral = hostname.replace(/^\[|\]$/g, '');
+  if (isIP(bareLiteral) !== 0) {
+    return isPrivateAddress(bareLiteral)
+      ? { blocked: true, reason: 'private-literal', detail: bareLiteral }
+      : { blocked: false };
+  }
+  const resolve = opts?.lookup ?? defaultLookup;
+  let addresses: Array<{ address: string; family: number }>;
+  try {
+    addresses = await resolve(hostname);
+  } catch (err) {
+    return {
+      blocked: true,
+      reason: 'dns-failure',
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (addresses.length === 0) {
+    return { blocked: true, reason: 'dns-failure', detail: 'no addresses resolved' };
+  }
+  const offending = addresses.find((a) => isPrivateAddress(a.address));
+  if (offending) {
+    return { blocked: true, reason: 'private-address', detail: offending.address };
+  }
+  return { blocked: false };
 }


### PR DESCRIPTION
## What

The orchestrator's outbound webhook path decided whether a subscription URL was safe to POST to by matching the **hostname string** against a set of regexes. It never resolved the name. A perfectly ordinary public hostname whose DNS record points at a private address therefore passed the guard unchallenged.

Separately, the delivery `fetch` passed no `redirect` option, so it followed redirects by default — meaning a URL that legitimately passed the guard could answer `302`/`307` and walk the request onto a private address the guard never inspected.

CWE-918 (SSRF).

## Evidence

Both reproduce on the base commit. Measured, not inferred:

```
host=localtest.me isPrivateHost=false resolves-to=127.0.0.1
host=lvh.me       isPrivateHost=false resolves-to=127.0.0.1
```

Both are registrable public names that resolve to loopback. The same shape covers any name pointed at `169.254.169.254` or an RFC-1918 address.

For the redirect, using the exact call shape from `delivery.ts`:

```
final status=200 ok=true url=http://127.0.0.1:<port>/metadata redirected=true
(target server logged: RECEIVED GET /metadata)
```

and with a `307` the redirected request keeps the method, the body **and** the signature header:

```
307-TARGET method=POST url=/latest/meta-data/ body="{\"secret\":\"payload\"}" sig=sha256=deadbeef
```

The new delivery regression test reproduced this against the unfixed worker: the redirect target recorded `GET /latest/meta-data/`.

## Honest impact

This is a **blind** SSRF with a write side effect. Being precise matters more than the label:

- **No data exfiltration.** `executeDelivery` reads only `res.ok` and `res.status`; the response body is discarded. There is no channel back to the subscriber.
- **The oracle is coarse.** The only delivery telemetry on the API is `GET /api/v1/webhooks/queue/stats`, which returns aggregate counts and no per-delivery status or error string. An attacker who can read stats learns roughly one bit per delivery — "the internal endpoint answered 2xx" or not — plus timing from their own redirector. Enough to sweep for live internal hosts and ports; not enough to read them.
- **The real teeth are the side effect.** Because a `307` preserves method, body and headers, the orchestrator can be made to issue a signed POST at an arbitrary internal endpoint from inside the trust boundary. The body is a harness-generated gateway event, not attacker-chosen, which bounds it.
- **Trigger:** anyone who can create a webhook subscription.

Deliberately **not** claimed: internal-response exfiltration, credential theft, or metadata-service credential capture. None follow from this code path.

## The fix

Two bounded changes.

**1. Resolve, then check.** `guardOutboundHost` keeps the existing string check as a cheap pre-filter, adds an IP-literal fast path, then resolves via `dns.promises.lookup(host, { all: true })` and blocks if **any** resolved address is private. Blocking on any address also closes the A/AAAA mismatch where a guard checks one family and the connector picks the other. Both call sites — registration and the fire-time recheck — now use it.

The refused-address set is wider than the old regex. It now covers RFC-6598 CGNAT (`100.64.0.0/10` — both a common Kubernetes pod CIDR and Alibaba Cloud's metadata endpoint at `100.100.100.200`), the RFC-6890 protocol-assignments `/24` (Oracle Cloud's legacy metadata address at `192.0.0.192`), the benchmarking block, multicast and reserved space, IPv6 unique-local and link-local, and every IPv6 form that embeds an IPv4 address — v4-mapped in **both** dotted and hex spelling, v4-compatible, v4-translated, NAT64 `64:ff9b::/96` and 6to4.

**2. Refuse redirects.** Delivery sets `redirect: 'manual'` and records a 3xx as a delivery failure with an explicit `redirect not followed` message rather than chasing it. A webhook receiver has no legitimate reason to redirect a signed event POST.

## Behavior changes worth review

- **IPv6-literal targets are now classified directly instead of going through DNS.** This fixes a pre-existing hole in passing: `https://[::1]/` was previously *accepted*, because `URL.hostname` returns IPv6 hosts bracketed and the old `LOOPBACK_IPV6_RE` had no bracket handling. Legitimate bracketed public IPv6 targets keep working (covered by test).
- **A rejected registration returns a generic 422.** The specific reason is logged server-side instead of returned. Returning it would let a caller distinguish "this internal name exists and resolves" from "it does not", enumerating the internal namespace one registration at a time.
- **DNS failure and an empty address list both fail closed.** A host that will not resolve cannot be delivered to anyway, so this costs no legitimate delivery.

## Tests

Regression tests fail before the fix and pass after — verified in both directions, not assumed.

| Test | Before | After |
| --- | --- | --- |
| `webhooks-url-guard.test.ts` › route rejects a public hostname whose DNS points at the metadata address | FAIL (200) | PASS (422) |
| `webhooks-url-guard.test.ts` › route rejects a public hostname whose DNS points at loopback | FAIL (200) | PASS (422) |
| `webhooks-url-guard.test.ts` › route rejects a hostname that does not resolve | FAIL (200) | PASS (422) |
| `delivery.test.ts` › dead-letters when the hostname RESOLVES to a private address | FAIL (no lookup performed) | PASS |
| `delivery.test.ts` › does NOT follow a redirect | FAIL (target got `GET /latest/meta-data/`) | PASS (target got nothing) |

Plus new unit coverage for `isPrivateAddress` (26 blocked spellings, 15 allowed) and `guardOutboundHost` (resolution, short-circuit-without-DNS, IP-literal fast path, fail-closed paths).

Every pre-existing test in `delivery.test.ts`, `webhooks-url-guard.test.ts` and `webhooks-integration.test.ts` passes **unmodified** — no existing assertion was edited to accommodate the fix. The one non-assertion change to an existing test file is a `node:dns/promises` stub, added because the route tests would otherwise depend on live DNS; it makes the pre-existing "accepts `https://example.com/hook`" case deterministic and offline rather than changing what it asserts.

## Assumptions made

- **Residual TOCTOU / DNS rebinding — the fix is not total.** The guard resolves the name, and the `fetch` that follows resolves it *again*. A record that changes between the two (short-TTL rebinding) can still land on a private address. Fully closing this means pinning the validated IP at connect time via a custom undici dispatcher with a `connect.lookup` hook — materially larger than this defect warrants. Stated here rather than implied away.
- **Failing closed on DNS error is the right trade.** It means a transient resolver outage returns 422 at registration. Judged acceptable because an unresolvable host cannot be delivered to regardless.
- **A 3xx consumes the ordinary retry budget rather than dead-lettering immediately.** Arguably a redirect should dead-letter, since it will never start succeeding — but that is a behavior expansion beyond the security defect, so it is left alone.
- **`redirect: 'manual'` was verified, not assumed.** Node 22 / undici returns the real 3xx status with `ok === false` rather than a spec-shaped opaque `status: 0` response. The code is safe under both: `ok` is false either way, so `markDelivered` is never reached.
- **Registration and delivery are the only attacker-reachable outbound fetches touched here.** Two other `fetch` calls exist in the package (the Slack notification sink and an Ollama peer-unload), both taking operator config rather than API-settable input. Out of scope.

## Parked follow-ups (not fixed here)

Both are availability, not SSRF, and neither should hold this fix:

- The DNS lookup runs **outside** the per-delivery timeout and outside the abort path (`dns.lookup` is not abortable), so a slow authoritative nameserver can hold a concurrency slot past `timeoutMs` and stretch `drainTimeoutMs` on shutdown.
- The lookup is uncached and runs per delivery attempt, consuming a libuv threadpool slot each time; under fan-out this can pressure the shared pool. A short-TTL verdict cache is the natural fix (and would shrink the rebinding window as a side benefit). Note that swapping to `dns.resolve*` to get a timeout would **lose** coverage — it bypasses `/etc/hosts`, where a public name mapped to `127.0.0.1` is caught today.

## Verification

- `pnpm --filter @harness-engineering/orchestrator typecheck` — clean
- `pnpm --filter @harness-engineering/orchestrator lint` — clean
- Full orchestrator suite — 2589 passed, 1 skipped (238 files)
- Webhook-touching suites — 131 passed (7 files)
- OWASP/CWE security reviewer run over this diff before push; it returned "request changes" with a fail-open on empty DNS results, a CGNAT range gap, IPv6 embedded-v4 spelling gaps, an IPv6-literal functional regression, and the response-body reason oracle. All five are fixed in this PR and re-verified; the two availability findings are the parked items above.
- Changeset included (patch, `@harness-engineering/orchestrator`).
