### PR TITLE
feat(design-craft): add CRAFT-P008 editorial-two-column-split polish pattern

### DIFF
--- a/.changeset/design-craft-editorial-split.md
+++ b/.changeset/design-craft-editorial-split.md
@@ -1,0 +1,10 @@
+---
+'@harness-engineering/cli': patch
+---
+
+feat(design-craft): add CRAFT-P008 editorial-two-column-split polish pattern
+
+Adds a `layout` POLISH pattern to the design-craft catalog, closing one of the
+documented P008–P015 gaps. `density-rhythm` already detects left-column
+monotony; this pattern prescribes the two-column heading-rail + body remedy.
+Additive-only (new catalog entry + `SEED_PATTERNS` registration).

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ tmp-plugin-*-agents/
 # Transient per-package vitest report written only under the pre-push gate
 # (HARNESS_PREPUSH=1). Never committed. See scripts/vitest-prepush-reporter.mjs.
 **/.vitest-report.json
+
+# Local orchestrator state backups (timestamped, disposable) — keep out of git + prettier
+**/.harness/state-backup-*/

--- a/.prettierignore
+++ b/.prettierignore
@@ -48,3 +48,6 @@ packages/core/tests/fixtures/code-nav/syntax-error.ts
 .changeset/workflow-audit-orchestrator-comment-no-release.md
 .changeset/stagedecision-jsdoc-comment-no-release.md
 .changeset/codex-test-windows-skip-no-release.md
+
+# Local orchestrator state backups (disposable)
+**/.harness/state-backup-*/

--- a/packages/cli/src/design-craft/catalog/patterns/editorial-two-column-split.ts
+++ b/packages/cli/src/design-craft/catalog/patterns/editorial-two-column-split.ts
@@ -1,0 +1,102 @@
+// packages/cli/src/design-craft/catalog/patterns/editorial-two-column-split.ts
+//
+// Catalog increment — layout polish pattern, closing one of the documented
+// P008-P015 gaps (a second `layout` sub-category pattern alongside P006
+// progressive-corner-rounding).
+//
+// CRAFT-P008 — Editorial two-column split. polish × large. Sourced from the
+// recurring "left-column monotony" finding a `density-rhythm` (C-tier)
+// critique surfaces on text-heavy marketing/docs pages: a run of sections
+// each rendered as one narrow `max-width` column pinned left (or centered),
+// leaving ~50% empty on the opposite side. The rubric *detects* the
+// monotony; this pattern *prescribes* the remedy — a heading rail + body
+// column — so POLISH can suggest a concrete move, not just a diagnosis.
+// Observed on real builds where every prose section hugged the left and the
+// right half read "unfinished" rather than "spacious".
+//
+// Honors ADR 0020 (living catalog H pattern): id/version/status/authoredAt/
+// contributors/source required so growth signal + provenance work.
+
+import type { PatternDefinition } from './spring-physics.js';
+
+/**
+ * Pattern: Editorial Two-Column Split.
+ *
+ * Turns a stack of left-hugged narrow-column text sections into a paired
+ * grid — eyebrow + heading in a left rail, body/content in the right
+ * column — that fills the width and establishes reading rhythm. polish ×
+ * large because it re-composes whole sections (not a finishing touch) yet
+ * is not a foundational defect (the content still reads without it).
+ */
+export const editorialTwoColumnSplitPattern: PatternDefinition = {
+  id: 'pattern-editorial-two-column-split',
+  name: 'Editorial Two-Column Split',
+  version: 1,
+  status: 'stable',
+  authoredAt: '2026-08-10',
+  contributors: ['@chadjw'],
+  source: {
+    ref: 'refactoring-ui#layout-and-spacing + stripe/linear docs shell',
+    url: 'https://www.refactoringui.com/',
+  },
+  applicableTo: [
+    { kind: 'css-property', match: 'max-width' },
+    { kind: 'css-property', match: 'margin-inline' },
+    { kind: 'jsx-pattern', match: 'prose' },
+  ],
+  when: [
+    'A run of text-heavy sections (intro, about, FAQ, scope, proposal',
+    'body) are each rendered as a single narrow `max-width` column pinned',
+    'to the left (or centered), leaving roughly half the section width',
+    'empty. Repeated down the page the composition reads monotonous and',
+    '"unfinished" — the empty side looks like a bug, not intentional',
+    'whitespace — because nothing anchors it and every section is the',
+    'same one-column shape.',
+  ].join('\n'),
+  suggest: [
+    'Re-compose the section as a two-column grid: eyebrow + heading in a',
+    'left rail, body/content in the right column. The rail may be',
+    '`position: sticky` (top offset clearing any fixed header) so the',
+    'heading holds while the body scrolls — an editorial/docs-shell move.',
+    'Give the rail a smaller fractional width than the body (e.g.',
+    '`minmax(220px, 0.8fr) 1.6fr`) so the content, not the label, leads.',
+    'Collapse to a single column below a tablet breakpoint (and drop the',
+    'sticky) so mobile stays a clean linear read. Reserve the plain',
+    'single-column measure for genuinely long-form narrative (archetype',
+    'C / editorial), not for every section by default.',
+  ].join('\n'),
+  before: [
+    '<section class="section">',
+    '  <div class="wrap measure">           /* max-width; margin-inline:auto */',
+    '    <p class="eyebrow">The idea</p>',
+    '    <h2>One ownable concept</h2>',
+    '    <p>Lorem ipsum body copy that sits in a narrow left column…</p>',
+    '  </div>                                /* right half sits empty */',
+    '</section>',
+  ].join('\n'),
+  after: [
+    '<section class="section">',
+    '  <div class="wrap split">             /* grid: rail + body */',
+    '    <div class="split__head">          /* optionally position:sticky */',
+    '      <p class="eyebrow">The idea</p>',
+    '      <h2 class="split__title">One ownable concept</h2>',
+    '    </div>',
+    '    <div class="split__body">',
+    '      <p>Lorem ipsum body copy in the wider right column…</p>',
+    '    </div>',
+    '  </div>',
+    '</section>',
+    '',
+    '/* .split { display:grid; grid-template-columns:minmax(220px,.8fr) 1.6fr;',
+    '           gap: 2rem 4rem; align-items:start; }',
+    '   .split__head { position: sticky; top: 96px; }',
+    '   @media (max-width:820px){ .split{grid-template-columns:1fr}',
+    '                             .split__head{position:static} }             */',
+  ].join('\n'),
+  findingTemplate: {
+    code: 'CRAFT-P008',
+    tier: 'polish',
+    impact: 'large',
+    phase: 'polish',
+  },
+};

--- a/packages/cli/src/design-craft/catalog/patterns/index.ts
+++ b/packages/cli/src/design-craft/catalog/patterns/index.ts
@@ -14,6 +14,7 @@ import { pageTransitionCrossfadePattern } from './page-transition-crossfade.js';
 import { fluidTypeScalePattern } from './fluid-type-scale.js';
 import { progressiveCornerRoundingPattern } from './progressive-corner-rounding.js';
 import { focusRingCraftPattern } from './focus-ring-craft.js';
+import { editorialTwoColumnSplitPattern } from './editorial-two-column-split.js';
 
 export { springPhysicsPattern } from './spring-physics.js';
 export { skeletonContentMatchedPattern } from './skeleton-content-matched.js';
@@ -22,6 +23,7 @@ export { pageTransitionCrossfadePattern } from './page-transition-crossfade.js';
 export { fluidTypeScalePattern } from './fluid-type-scale.js';
 export { progressiveCornerRoundingPattern } from './progressive-corner-rounding.js';
 export { focusRingCraftPattern } from './focus-ring-craft.js';
+export { editorialTwoColumnSplitPattern } from './editorial-two-column-split.js';
 
 /**
  * Phase 2 seed polish patterns. The earlier Phase 2 increment anchored
@@ -59,4 +61,5 @@ export const SEED_PATTERNS: readonly PatternDefinition[] = [
   fluidTypeScalePattern,
   progressiveCornerRoundingPattern,
   focusRingCraftPattern,
+  editorialTwoColumnSplitPattern,
 ];

--- a/packages/cli/tests/design-craft/integration/catalog-seed.test.ts
+++ b/packages/cli/tests/design-craft/integration/catalog-seed.test.ts
@@ -51,7 +51,7 @@ import { MockLlmProvider } from '../../../src/design-craft/llm/provider.js';
 import { handleDesignCraft } from '../../../src/mcp/tools/design-craft.js';
 
 describe('design-craft Phase 2 catalog seed — patterns', () => {
-  it('SEED_PATTERNS contains the seven Phase 2 patterns in stable order', () => {
+  it('SEED_PATTERNS contains the eight Phase 2 patterns in stable order', () => {
     const ids = SEED_PATTERNS.map((p) => p.id);
     expect(ids).toEqual([
       'pattern-spring-physics',
@@ -61,6 +61,7 @@ describe('design-craft Phase 2 catalog seed — patterns', () => {
       'pattern-fluid-type-scale',
       'pattern-progressive-corner-rounding',
       'pattern-focus-ring-craft',
+      'pattern-editorial-two-column-split',
     ]);
   });
 
@@ -105,6 +106,12 @@ describe('design-craft Phase 2 catalog seed — patterns', () => {
     expect(byId.get('pattern-focus-ring-craft')?.findingTemplate).toMatchObject({
       code: 'CRAFT-P007',
       tier: 'foundational',
+      impact: 'large',
+      phase: 'polish',
+    });
+    expect(byId.get('pattern-editorial-two-column-split')?.findingTemplate).toMatchObject({
+      code: 'CRAFT-P008',
+      tier: 'polish',
       impact: 'large',
       phase: 'polish',
     });

--- a/packages/cli/tests/design-craft/integration/polish-phase.test.ts
+++ b/packages/cli/tests/design-craft/integration/polish-phase.test.ts
@@ -189,10 +189,10 @@ describe('design-craft MCP handler — POLISH phase wiring', () => {
     // into runPolish), not the ones that emitted findings. Widened across
     // Phase 2 catalog increments to include skeleton-content-matched
     // (P002), stagger-timing (P003), page-transition-crossfade (P004),
-    // fluid-type-scale (P005), progressive-corner-rounding (P006), and
-    // focus-ring-craft (P007); only spring-physics (P001) actually fires
-    // for the cubic-bezier fixture because the prefilter rules out the
-    // others.
+    // fluid-type-scale (P005), progressive-corner-rounding (P006),
+    // focus-ring-craft (P007), and editorial-two-column-split (P008);
+    // only spring-physics (P001) actually fires for the cubic-bezier
+    // fixture because the prefilter rules out the others.
     expect(payload.summary.catalog.patternsApplied).toEqual([
       'pattern-spring-physics',
       'pattern-skeleton-content-matched',
@@ -201,6 +201,7 @@ describe('design-craft MCP handler — POLISH phase wiring', () => {
       'pattern-fluid-type-scale',
       'pattern-progressive-corner-rounding',
       'pattern-focus-ring-craft',
+      'pattern-editorial-two-column-split',
     ]);
 
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Adds **CRAFT-P008 `editorial-two-column-split`**, a POLISH-phase pattern that closes one of the documented P008–P015 layout gaps in the design-craft catalog.

The density-rhythm critique already *detects* "left-column monotony" (text sections each pinned to a narrow left column, ~half the width empty, reading unfinished). This pattern *prescribes* the remedy: a heading-rail + body-column grid, sticky rail optional, collapsing to a single column on mobile. Distilled from real marketing/docs builds. Schema mirrors `stagger-timing` (P003); registered in `SEED_PATTERNS` as the 8th pattern (`polish` tier × `large` impact).

## Changes
- `catalog/patterns/editorial-two-column-split.ts` — the new pattern (finding template `CRAFT-P008`, HTML/CSS remedy, prefilter).
- `catalog/patterns/index.ts` — register in `SEED_PATTERNS`.
- Tests: extend `catalog-seed` and `polish-phase` integration assertions for the 8th pattern.
- Changeset: patch `@harness-engineering/cli`.

## Testing
- `npx vitest run tests/design-craft/integration/catalog-seed.test.ts tests/design-craft/integration/polish-phase.test.ts` → 23 passed.
- Pre-push gate (test:coverage, format:check, reference-docs) green.