### PR TITLE
fix(validate): a check that could not run must never report as passed

### DIFF
--- a/.antigravity-extension/commands/roadmap.toml
+++ b/.antigravity-extension/commands/roadmap.toml
@@ -511,7 +511,7 @@ Wait for confirmation. The mechanical changes (demote, archive) are safe and aut
 
 #### Phase 4: VALIDATE -- Verify
 
-1. Run `harness validate` and confirm the `roadmapHealth` check passes (no RMH003 errors; RMH001/002/004 warnings cleared or acknowledged).
+1. Run `harness validate` and confirm the `roadmapHealth` check **passed** -- `checks.roadmapHealth === true` in `--json`, not merely "not false" (no RMH003 errors; RMH001/002/004 warnings cleared or acknowledged). If `validate` exits 3 or reports the check under "Checks that could not run", the roadmap could not be parsed and NO health rule ran: fix the reported section and re-run. A check that did not run is not a check that passed.
 2. Summarize:
 
    ```

--- a/.changeset/validate-check-abstention.md
+++ b/.changeset/validate-check-abstention.md
@@ -22,5 +22,11 @@ list. `--severity` never filters the ledger.
 
 Existing behavior is unchanged otherwise: advisory findings such as RMH002 remain
 warnings that do not fail validation, error findings still exit `1`, an absent
-roadmap is still a silent no-op, and output for any run with no unavailable checks is
-byte-identical to before.
+roadmap is still a silent no-op, and **human-readable** output for any run with no
+unavailable checks is byte-identical to before.
+
+The `--json` payload changes additively: every run now carries `complete` and
+`unavailableChecks`. Machine consumers should gate on `complete` (or the exit code)
+rather than `valid` — `valid` reports only on checks that actually ran, so it stays
+`true` when a check abstained. `complete === true && valid === true` is what exit
+code `0` means.

--- a/.changeset/validate-check-abstention.md
+++ b/.changeset/validate-check-abstention.md
@@ -1,0 +1,26 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(validate): a check that could not run no longer reports as passed
+
+`harness validate` printed `validation passed` and exited `0` when `docs/roadmap.md`
+existed but failed to parse. The `roadmapHealth` check was guarded by `if (parsed.ok)`
+with no `else`, so on a parse failure every roadmap health rule (RMH001-RMH005) was
+skipped at once, the parse error was discarded, and the verdict was never touched — a
+roadmap broken beyond parsing validated clean while a _less_ broken one failed. The
+aggregate-drift doctor carried the same swallow, reporting a freshness comparison as
+passed when the shards could not be regenerated at all.
+
+`harness validate` now has three outcomes instead of two. A check whose input exists
+but cannot be consumed **abstains**: it is recorded in a new `unavailableChecks`
+ledger, the result carries `complete: false`, and the command exits `3`
+(`ZERO_DENOMINATOR` — "the command ran but examined nothing"), printing a
+`Checks that could not run` section instead of a pass or fail verdict. Abstention
+outranks failure, because exit `1` implies the reported findings are the complete
+list. `--severity` never filters the ledger.
+
+Existing behavior is unchanged otherwise: advisory findings such as RMH002 remain
+warnings that do not fail validation, error findings still exit `1`, an absent
+roadmap is still a silent no-op, and output for any run with no unavailable checks is
+byte-identical to before.

--- a/.gemini-extension/commands/roadmap.toml
+++ b/.gemini-extension/commands/roadmap.toml
@@ -511,7 +511,7 @@ Wait for confirmation. The mechanical changes (demote, archive) are safe and aut
 
 #### Phase 4: VALIDATE -- Verify
 
-1. Run `harness validate` and confirm the `roadmapHealth` check passes (no RMH003 errors; RMH001/002/004 warnings cleared or acknowledged).
+1. Run `harness validate` and confirm the `roadmapHealth` check **passed** -- `checks.roadmapHealth === true` in `--json`, not merely "not false" (no RMH003 errors; RMH001/002/004 warnings cleared or acknowledged). If `validate` exits 3 or reports the check under "Checks that could not run", the roadmap could not be parsed and NO health rule ran: fix the reported section and re-run. A check that did not run is not a check that passed.
 2. Summarize:
 
    ```

--- a/agents/skills/claude-code/harness-roadmap/SKILL.md
+++ b/agents/skills/claude-code/harness-roadmap/SKILL.md
@@ -491,7 +491,7 @@ Wait for confirmation. The mechanical changes (demote, archive) are safe and aut
 
 #### Phase 4: VALIDATE -- Verify
 
-1. Run `harness validate` and confirm the `roadmapHealth` check passes (no RMH003 errors; RMH001/002/004 warnings cleared or acknowledged).
+1. Run `harness validate` and confirm the `roadmapHealth` check **passed** -- `checks.roadmapHealth === true` in `--json`, not merely "not false" (no RMH003 errors; RMH001/002/004 warnings cleared or acknowledged). If `validate` exits 3 or reports the check under "Checks that could not run", the roadmap could not be parsed and NO health rule ran: fix the reported section and re-run. A check that did not run is not a check that passed.
 2. Summarize:
 
    ```

--- a/docs/changes/validate-check-abstention/plans/2026-08-10-validate-check-abstention-plan.md
+++ b/docs/changes/validate-check-abstention/plans/2026-08-10-validate-check-abstention-plan.md
@@ -1,0 +1,300 @@
+# Plan: validate-check-abstention — a check that could not run must never report as passed
+
+**Date:** 2026-08-10 · **Spec:** `docs/changes/validate-check-abstention/proposal.md` · **Tasks:** 12 · **Time:** ~70 min · **Integration Tier:** small-medium
+
+## Goal
+
+Give `harness validate` a third outcome. Today it has two — passed and failed — for
+three states, so "could not check" is forced into one of the other two and the code
+picked "passed": a `docs/roadmap.md` that `parseRoadmap` rejects yields
+`v validation passed` and exit `0`, with the parse error discarded and RMH001–RMH005
+all silently skipped (`packages/cli/src/commands/validate.ts:299-319`). The same
+swallow sits one check above it in the aggregate-drift doctor, which reports
+`roadmapAggregateDrift = true` when the shards could not be regenerated
+(`validate.ts:270-290` + `packages/core/src/validation/roadmap-aggregate-drift.ts:59-68`).
+
+Add an unfilterable abstention ledger (`unavailableChecks` + derived `complete`),
+map it to `ExitCode.ZERO_DENOMINATOR` (3), and render it as a dedicated
+"Checks that could not run" section — while leaving the existing non-blocking
+RMH002 advisory behavior byte-for-byte unchanged.
+
+## Observable Truths (Acceptance Criteria)
+
+Traceability: AC-n implements spec success criterion SC-n.
+
+1. **AC-1 (SC1)** — `runValidate()` over a project whose `docs/roadmap.md` fails to
+   parse returns `complete: false`, exactly one `unavailableChecks` entry with
+   `check: 'roadmapHealth'` and `file: 'docs/roadmap.md'`, a `reason` containing the
+   parser's own message substring, and `checks.roadmapHealth === undefined`.
+   **Gate:** new case in `packages/cli/tests/commands/validate.roadmap-health.test.ts`.
+2. **AC-2 (SC2)** — The CLI over that same project exits `3` and prints
+   `Validation incomplete`, and does not print `validation passed`.
+   **Gate:** CLI-level test asserting exit code + stdout via the built binary
+   (`node packages/cli/dist/bin/harness.js validate`) in a temp project.
+3. **AC-3 (SC3)** — The existing RMH002-only case still returns `valid: true`,
+   `complete: true`, `unavailableChecks: []`, exit `0`.
+   **Gate:** the pre-existing test at `validate.roadmap-health.test.ts` passes
+   **unmodified**, plus added `complete`/`unavailableChecks` assertions.
+4. **AC-4 (SC4)** — The existing RMH003 case still returns `valid: false`,
+   `checks.roadmapHealth === false`, `complete: true`, exit `1`.
+   **Gate:** pre-existing test passes unmodified + added assertions.
+5. **AC-5 (SC5)** — Absent `docs/roadmap.md`: `checks.roadmapHealth === undefined`,
+   `unavailableChecks: []`, `complete: true`. **Gate:** pre-existing absent-file test
+   passes unmodified + added assertions.
+6. **AC-6 (SC6)** — Sharded project whose shards cannot be regenerated produces a
+   `roadmapAggregateDrift` entry in `unavailableChecks` and leaves
+   `checks.roadmapAggregateDrift === undefined` (was `true`).
+   **Gate:** new test file `validate.roadmap-abstention.test.ts`.
+7. **AC-7 (SC7)** — A run with both an abstention and an error-severity finding
+   exits `3` and still prints every finding. **Gate:** test asserting exit code and
+   that the issue text is present in stdout.
+8. **AC-8 (SC8)** — `--severity error` leaves `unavailableChecks` non-empty and the
+   exit code `3`. **Gate:** test invoking `runValidate({ severity: 'error' })` plus a
+   CLI exit-code assertion.
+9. **AC-9 (SC9)** — `formatValidation` output is byte-identical for any result with
+   no/empty `unavailableChecks`, including QUIET+valid returning exactly `''`.
+   **Gate:** existing `packages/cli/tests/output/*` suites (22 tests) pass
+   unmodified, plus an explicit omitted-vs-empty equality assertion.
+   9b. **AC-9b (SC10, SC11)** — QUIET prints one line per abstention on a `valid: true`
+   run; a both-incomplete-and-failing run prints both headlines with every finding.
+   **Gate:** new formatter cases.
+   9c. **AC-9c (SC12)** — `emitValidateOutput` passes `unavailableChecks` through, so
+   the CLI never exits 3 while printing `validation passed`. **Gate:** the CLI-level
+   test in Task 7 asserts `not.toContain('validation passed')`.
+   9d. **AC-9d** — `agents/skills/claude-code/harness-roadmap/SKILL.md` Phase 4 no
+   longer instructs an agent to read `roadmapHealth` as a two-state boolean.
+   **Gate:** `grep` for `checks.roadmapHealth === true` in that SKILL.md.
+10. **AC-10** — Whole-repo gates green: `pnpm -w typecheck`, `pnpm -w lint`,
+    `pnpm --filter @harness-engineering/cli test`, `pnpm format:check`.
+    **Gate:** the four commands exit 0.
+11. **AC-11** — A patch changeset exists and `pnpm changeset status` is satisfied;
+    `docs/reference/cli.md` documents the three exit codes.
+    **Gate:** file exists; `grep` for the exit-code table.
+12. **AC-12** — Manual reproduction from the bug report inverts: the `Status: cancelled`
+    fixture that printed `v validation passed` / exit `0` now prints
+    `Validation incomplete` / exit `3`, while the `Status: in-progress` fixture still
+    prints `Validation failed` / exit `1`. **Gate:** run both fixtures against the
+    rebuilt CLI.
+
+## Uncertainties
+
+- [ASSUMPTION] Exit `3` (`ExitCode.ZERO_DENOMINATOR`) is safe for `harness validate`.
+  Verified: no `.github/workflows` job, `scripts/`, or `.husky/` hook gates on
+  `harness validate`'s exit code; the only references are documentation strings
+  (`scripts/generate-agent-setup-prompt.mjs:124`, `scripts/generate-docs.mjs:208`).
+  Any consumer testing `!= 0` is unaffected.
+- [ASSUMPTION] Abstention outranks failure in exit-code precedence (spec D2). Both
+  codes are non-zero, so no gate flips red→green either way; the choice only picks
+  which non-green signal surfaces.
+- [ASSUMPTION] `unavailableChecks` is always present (empty array on a complete run)
+  rather than optional-on-`ValidateResult`, so JSON consumers can read it
+  unconditionally. On the formatter's `ValidationResult` it stays **optional**, so
+  every other caller of `formatValidation` is untouched.
+- [ASSUMPTION] The three design audits (`componentAnatomy`, `driftDetection`,
+  `brandCompliance`) keep their existing warning-on-catch behavior — they catch a
+  checker crash, not unusable input, and migrating them is a wider behavior change
+  (spec Non-goals).
+- [ASSUMPTION] The `validate_project` MCP tool is out of scope — it never calls
+  `runValidate` and performs no roadmap check at all, so `assess_project` keeps
+  reporting green over an unparseable roadmap. Named as residual risk in the spec
+  Non-goals and in the PR's assumptions.
+- [ACCEPTED RISK] A transient shard read error (149 shards in this repo) would move
+  `harness validate` from `0` to `3` via the aggregate-drift abstention. Correct but
+  noisy; non-zero rather than green; a re-run clears it.
+- [ASSUMPTION] No roadmap-row promotion for this change (spec D6) — the item is
+  tracked by an existing GitHub issue and `manage_roadmap add` would mint a duplicate.
+- [DEFERRABLE] Exact wording of the incomplete headline and the closing
+  "A check that could not run is not a check that passed" line.
+
+## File Map
+
+- MODIFY `packages/cli/src/commands/validate.ts` — `UnavailableCheck` type,
+  `unavailableChecks` + `complete` on `ValidateResult`, the two abstention branches,
+  `complete` derivation after the `--severity` block, exit-code mapping in
+  `runValidateAction`, and `unavailableChecks` pass-through in `emitValidateOutput`.
+- MODIFY `packages/cli/src/output/formatter.ts` — optional `unavailableChecks` on
+  `ValidationResult`, incomplete headline + "Checks that could not run" section in
+  TEXT/VERBOSE, one-line-per-abstention in QUIET.
+- MODIFY `packages/cli/tests/commands/validate.roadmap-health.test.ts` — additive
+  assertions on the three existing cases; new parse-failure cases.
+- CREATE `packages/cli/tests/commands/validate.roadmap-abstention.test.ts` —
+  aggregate-drift abstention, `--severity` unfilterability, exit-code precedence,
+  CLI-level exit-code + stdout cases.
+- MODIFY `packages/cli/tests/output/formatter.test.ts` (or nearest existing file) —
+  incomplete rendering + byte-identical-when-empty cases.
+- MODIFY `docs/reference/cli.md` — repair the global `## Exit Codes` table (adds `3`,
+  which four commands already use and it already omitted) + a per-command note under
+  `### harness validate`. NOT `docs/reference/cli-commands.md` — auto-generated, and
+  `.husky/pre-push` runs `pnpm run generate-docs --check`.
+- MODIFY `agents/skills/claude-code/harness-roadmap/SKILL.md` — Phase 4 VALIDATE step
+  must read `checks.roadmapHealth === true`, not "not failing", and must react to the
+  incomplete outcome. No internal issue/PR numbers (shipped skill body).
+- CREATE `.changeset/validate-check-abstention.md` — patch, `@harness-engineering/cli`.
+
+## Skeleton
+
+1. **Contract** — types + ledger + `complete` derivation (Task 1). No behavior change yet.
+2. **Red** — write the failing tests for both swallows (Tasks 2, 5).
+3. **Green** — close the two swallows (Tasks 3, 6).
+4. **Exit code** — precedence mapping + CLI-level tests (Tasks 4, 7).
+5. **Renderer** — formatter section + formatter tests (Tasks 8, 9).
+6. **Docs/changeset** (Task 10).
+7. **Verification sweep** — typecheck, lint, tests, format, manual repro (Tasks 11, 12).
+
+## Tasks
+
+### Task 1 — Add the abstention ledger to `ValidateResult`
+
+**Files:** `packages/cli/src/commands/validate.ts`
+**Do:** Add the `UnavailableCheck` interface (`check`, `file?`, `reason`,
+`suggestion?`). Add `complete: boolean` and `unavailableChecks: UnavailableCheck[]`
+to `ValidateResult`. Initialize `unavailableChecks: []` and `complete: true` in the
+`result` literal. After the `--severity` filter block and before `return Ok(result)`,
+set `result.complete = result.unavailableChecks.length === 0` — after the filter so
+the filter provably cannot influence it.
+**Verify:** `pnpm --filter @harness-engineering/cli typecheck` passes; existing
+validate tests still pass (no behavior change yet).
+**Outputs:** the ledger contract other tasks write into.
+
+### Task 2 — [RED] Failing test: roadmap parse failure must abstain
+
+**Depends on:** Task 1
+**Files:** `packages/cli/tests/commands/validate.roadmap-health.test.ts`
+**Do:** Add a case building a project whose `docs/roadmap.md` has
+`- **Status:** cancelled` (the bug report's fixture). Assert AC-1: `complete === false`,
+one `unavailableChecks` entry for `roadmapHealth` with `file: 'docs/roadmap.md'`,
+`reason` containing `'cancelled'`, and `checks.roadmapHealth === undefined`. Also add
+the additive `complete`/`unavailableChecks` assertions to the three existing cases
+(AC-3, AC-4, AC-5) **without altering their existing expectations**.
+**Verify:** the new case FAILS; the three existing cases PASS.
+
+### Task 3 — [GREEN] Close the `roadmapHealth` swallow
+
+**Depends on:** Task 2
+**Files:** `packages/cli/src/commands/validate.ts`
+**Do:** Add the `else` branch to the `if (parsed.ok)` guard, pushing the
+`roadmapHealth` abstention with the parser error embedded verbatim in `reason` and a
+`suggestion` naming `docs/roadmap.md` / its shard. Do **not** assign
+`checks.roadmapHealth` (spec D4). Update the block comment above the check so it no
+longer claims a parse failure is a silent skip.
+**Verify:** Task 2's case passes; all pre-existing cases still pass. (AC-1)
+
+### Task 4 — Exit-code mapping with abstention precedence
+
+**Depends on:** Task 3
+**Files:** `packages/cli/src/commands/validate.ts`
+**Do:** In `runValidateAction`, replace the two-way `process.exit` with the three-way
+mapping: `!complete → ExitCode.ZERO_DENOMINATOR`, else `valid → SUCCESS`, else
+`VALIDATION_FAILED`. Add a comment citing the `ZERO_DENOMINATOR` doc contract and the
+precedence rationale.
+**Verify:** `typecheck` passes; build the CLI and confirm the bug-report fixture now
+exits 3. (AC-2 partially; completed in Task 7)
+
+### Task 5 — [RED] Failing test: unregenerable shards must abstain
+
+**Depends on:** Task 1
+**Files:** `packages/cli/tests/commands/validate.roadmap-abstention.test.ts` (new)
+**Do:** Build a sharded project (`docs/roadmap.d/` present) whose shards make
+`regenerate()` return `Err`. Assert AC-6: a `roadmapAggregateDrift` entry exists and
+`checks.roadmapAggregateDrift === undefined`. Assert the current (buggy) behavior is
+gone — it must no longer be `true`.
+**Verify:** the case FAILS against current code.
+
+### Task 6 — [GREEN] Close the aggregate-drift swallow
+
+**Depends on:** Task 5
+**Files:** `packages/cli/src/commands/validate.ts`
+**Do:** Split the drift block: when `!regenerated.ok`, push the
+`roadmapAggregateDrift` abstention (reason carries `regenerated.error.message`,
+suggestion names `harness roadmap regen`) and leave the check unassigned; otherwise
+keep today's stale/fresh branches unchanged.
+**Verify:** Task 5's case passes; `validate.merge-driver.test.ts` and any sharded
+roadmap tests still pass. (AC-6)
+
+### Task 7 — CLI-level exit-code, precedence, and unfilterability tests
+
+**Depends on:** Tasks 4, 6
+**Files:** `packages/cli/tests/commands/validate.roadmap-abstention.test.ts`
+**Do:** Add: (a) a CLI-level case spawning the built binary against the parse-failure
+fixture asserting exit `3`, stdout contains `Validation incomplete`, stdout does not
+contain `validation passed` (AC-2); (b) a case with both an abstention and an
+RMH003 error asserting exit `3` and that the RMH003 message is still printed (AC-7);
+(c) `runValidate({ severity: 'error' })` over the parse-failure fixture asserting
+`unavailableChecks.length === 1` and `complete === false` (AC-8).
+**Verify:** all three pass.
+
+### Task 8 — Renderer: the "Checks that could not run" section
+
+**Depends on:** Task 1
+**Files:** `packages/cli/src/output/formatter.ts`, `packages/cli/src/commands/validate.ts`
+**Do:** Add optional `unavailableChecks?: Array<{ check; file?; reason; suggestion? }>`
+to the formatter's `ValidationResult` (the interface is not exported — add it in
+place). In `formatValidation`: when the array is absent or empty, return exactly
+today's output (early-path unchanged). When non-empty, emit the
+`! Validation incomplete (N check(s) could not run)` headline, then a
+`Checks that could not run:` block (one entry per abstention: `check (file)` then the
+reason, with `suggestion` shown only in VERBOSE, matching `appendIssueLines`), then the
+closing "A check that could not run is not a check that passed" line, then — if any
+issues exist — the existing `x Validation failed (N issues)` heading and issue list
+(both headlines, incomplete first).
+
+QUIET mode: the existing `if (result.valid) return ''` early return must be gated on
+the ledger being EMPTY as well — the dominant abstention case is `valid: true`, so an
+ungated early return would print nothing while exiting 3. When non-empty, print
+`<file>: <reason>` per abstention ahead of the issue lines.
+
+**Critical wiring:** `emitValidateOutput` builds the formatter payload as a closed
+object literal, so it must be changed to pass `unavailableChecks: value.unavailableChecks`.
+Without this the formatter always sees `undefined`, always takes the byte-identical
+path, and the CLI exits `3` while printing `validation passed` — strictly worse than
+the original bug.
+**Verify:** `typecheck` passes; the manual fixture prints the incomplete section.
+
+### Task 9 — Formatter tests
+
+**Depends on:** Task 8
+**Files:** `packages/cli/tests/output/` (nearest existing formatter test file)
+**Do:** Add cases: incomplete rendering in TEXT; QUIET printing abstentions on a
+`valid: true` run; both headlines when incomplete AND failing; suggestion shown only
+in VERBOSE; and an explicit byte-identical assertion for a result with
+`unavailableChecks: []` versus one with the field omitted, in both TEXT and QUIET
+(AC-9, AC-9b).
+**Verify:** new cases pass; all 22 pre-existing output tests pass unmodified.
+
+### Task 10 — Docs + changeset
+
+**Depends on:** Task 4
+**Files:** `docs/reference/cli.md`, `agents/skills/claude-code/harness-roadmap/SKILL.md`,
+`.changeset/validate-check-abstention.md`
+**Do:** Repair the global `## Exit Codes` table in `docs/reference/cli.md` (add `3`
+with its meaning) and add a per-command exit-code note under `### harness validate`
+(0 = all applicable checks ran and passed; 1 = a check ran and failed; 3 = a check
+could not run) plus a line on `complete` / `unavailableChecks` in `--json`. Correct
+the roadmap SKILL.md Phase 4 VALIDATE step to require `checks.roadmapHealth === true`
+and to react to the incomplete outcome — no internal issue/PR numbers in the shipped
+skill body. Write a patch changeset for `@harness-engineering/cli`. Keep the issue
+reference in the changeset and PR only.
+**Verify:** `grep` finds the tables and the SKILL.md wording; `pnpm changeset status`
+satisfied. (AC-11, AC-9d)
+
+### Task 11 — Verification sweep
+
+**Depends on:** Tasks 7, 9, 10
+**Do:** `pnpm -w typecheck`, `pnpm -w lint`, `pnpm --filter @harness-engineering/cli test`,
+`pnpm format:check`, `pnpm build`. Re-run any flaky suite once before treating a
+failure as real.
+**Verify:** all exit 0. (AC-10)
+
+### Task 12 — Manual reproduction inversion
+
+**Depends on:** Task 11
+**Do:** Rebuild the CLI and run both bug-report fixtures (`Status: cancelled` and
+`Status: in-progress`) against `node packages/cli/dist/bin/harness.js validate`.
+**Verify:** case A now prints `Validation incomplete` with exit `3`; case B still
+prints `Validation failed` with exit `1`. (AC-12)
+
+## Checkpoints
+
+- `[checkpoint:verify]` after Task 3 — the headline bug is fixed at the API level.
+- `[checkpoint:verify]` after Task 7 — the full three-state contract holds end-to-end.
+- `[checkpoint:review]` after Task 11 — code review before PR.

--- a/docs/changes/validate-check-abstention/proposal.md
+++ b/docs/changes/validate-check-abstention/proposal.md
@@ -1,0 +1,448 @@
+# validate-check-abstention — a check that could not run must never report as passed
+
+**Status:** Draft · **Tier:** Small-Medium · **Type:** bug fix (CLI validation contract)
+**Keywords:** validate, roadmap-health, abstention, zero-denominator, exit-code, silent-skip, parse-failure, aggregate-drift, false-green, completeness
+
+## Overview
+
+`harness validate` prints `v validation passed` and exits `0` when `docs/roadmap.md`
+exists but fails to parse. The `roadmapHealth` check is guarded by
+`if (parsed.ok)` with no `else`, so on a parse failure the check never runs,
+`result.checks.roadmapHealth` is never assigned, `result.valid` is never touched,
+and the parse error — which names the offending section — is discarded
+[evidence: `packages/cli/src/commands/validate.ts:298-318`].
+
+The result is inverted severity. A roadmap broken badly enough that the parser
+rejects it validates clean, while a _less_ broken roadmap that parses and trips a
+health rule fails. The check that polices roadmap health disappears exactly when
+the roadmap is worst, and it takes RMH001–RMH005 with it in one silent stroke
+[evidence: `packages/core/src/roadmap/health.ts:77-82`].
+
+The same swallow exists one check earlier. The aggregate-drift doctor passes
+`regenerated.ok ? regenerated.value : null` into `checkRoadmapAggregateDrift`,
+which returns `{ applicable: false }` when regeneration was not possible; the
+caller's `else` branch then sets `result.checks.roadmapAggregateDrift = true`
+[evidence: `packages/cli/src/commands/validate.ts:267-290` (block opens at `:267`;
+the `regenerated.ok ? … : null` collapse is at `:277`, the `else` at `:288-290`),
+`packages/core/src/validation/roadmap-aggregate-drift.ts:59-68`]. A shard set so
+malformed it cannot be regenerated reports the freshness check as **passed**. The
+helper's own doc comment defends this by saying "other validation surfaces the
+underlying problem" — but the only other validation that would have is
+`roadmapHealth`, which swallows too. Both fire together on the same broken input,
+and together they produce a fully green report over an unreadable roadmap.
+
+The root defect is not a missing `else`. It is that `harness validate` has only
+two outcomes — passed and failed — for three possible states: **checked and
+healthy**, **checked and unhealthy**, and **could not check**. With no third
+outcome, "could not check" has to be encoded as one of the other two, and the code
+picked the wrong one.
+
+### Goals
+
+- Make "could not check" a first-class, unmissable outcome of `harness validate`,
+  distinct from both "passed" and "failed" in the exit code, the human-readable
+  output, and the JSON payload.
+- Never again report `validation passed` over a roadmap the parser rejected —
+  from `harness validate` itself. Scope note: in _this_ repo `harness validate` is
+  invoked only by three persona workflows that swallow non-zero
+  (`… validate || echo "::warning::…(non-blocking)"` at
+  `.github/workflows/persona-{documentation-maintainer,architecture-enforcer,task-executor}.yml`),
+  and the blocking gates (`.github/workflows/harness.yml`, `.husky/pre-commit`) run
+  `harness ci check`, whose `validate` category calls only `validateAgentsMap`
+  [evidence: `packages/core/src/ci/check-orchestrator.ts:128-155`]. So this change
+  fixes the command's own contract and every adopter that gates on it; it does not,
+  by itself, add a blocking roadmap signal to this repo's CI. Wiring roadmap checks
+  into `ci check` is separate work.
+- Surface the discarded parse error verbatim — it already names the offending
+  section and is the single most useful diagnostic available at that point.
+- Close the identical swallow in the aggregate-drift doctor with the same
+  mechanism, so the two checks that fail together also _report_ together.
+
+### Non-goals (YAGNI)
+
+- Making the existing advisory findings blocking. RMH002 (unactionable planned
+  row) is a `warning` and must stay non-blocking; this repo carries dozens of them
+  on `main` [evidence: `packages/cli/tests/commands/validate.roadmap-health.test.ts:74-99`
+  asserts `valid: true` at `:94` for an RMH002-only roadmap — that test must keep
+  passing unchanged].
+- Migrating the three design audits (`componentAnatomy`, `driftDetection`,
+  `brandCompliance`) onto the new mechanism. Their `catch` blocks already report
+  the skip as a visible warning — they are degraded-but-not-silent by deliberate
+  design [evidence: `packages/cli/src/commands/validate.ts:355-364`, `403-410`,
+  `447-454`]. The distinction that keeps them out of scope is _what is being
+  caught_: those blocks catch an arbitrary thrown exception from the audit engine —
+  a defect in the **checker** — whereas `parseRoadmap` and `regenerate` return a
+  typed `Err` describing **the input they could not consume**. Abstention is the
+  right response to unusable input; a crashing checker is a different failure that
+  warrants its own treatment. Migrating them is also a much wider blast radius
+  (any transient audit crash would turn a green build non-green). Recorded as a
+  future consideration.
+- Fixing the `validate_project` MCP tool. It is an **independent reimplementation**
+  that never calls `runValidate` — it checks config, file structure, and AGENTS.md
+  only, and touches neither `roadmapHealth` nor `roadmapAggregateDrift`
+  [evidence: `packages/cli/src/mcp/tools/validate.ts:17-115`]. **Residual risk,
+  named:** `assess_project({ checks: ["validate"] })` derives `passed` from that
+  tool [evidence: `packages/cli/src/mcp/tools/assess-project.ts:154-163`], so the
+  agent-facing surface keeps reporting green over an unparseable roadmap after this
+  ships. Converging the MCP tool onto `runValidate` is a larger change (a different
+  result shape with its own consumers) and is deliberately deferred; the skill prose
+  that reads the check is corrected here instead (see Integration Points).
+- Repairing, auto-fixing, or migrating a malformed roadmap. `validate` reports.
+- Changing what `parseRoadmap` accepts.
+- Treating an **absent** `docs/roadmap.md` as a problem. File-less mode and
+  uninitialized projects legitimately have no roadmap; that silent skip is correct
+  and stays [evidence: `validate.roadmap-health.test.ts:36-44`].
+
+## Decisions made
+
+### D1 — "Could not check" gets its own exit code: `ExitCode.ZERO_DENOMINATOR` (3)
+
+|          | A) Reuse `VALIDATION_FAILED` (1)          | B) `ZERO_DENOMINATOR` (3)                                                  | C) New code (4)                        |
+| -------- | ----------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------- |
+| **Pros** | Zero risk to `exit != 0` consumers        | Already defined with exactly this meaning; no new **exit-code** vocabulary | Bespoke naming                         |
+| **Cons** | Only 2 codes for 3 states — mandate unmet | Consumers matching `exit == 1` exactly see 3 instead                       | Adds a code where a fitting one exists |
+| **Risk** | Low                                       | Low                                                                        | Low                                    |
+
+**Chosen: B.** `ExitCode.ZERO_DENOMINATOR` is already defined in this codebase and
+documented as: _"The command ran but examined NOTHING — a zero denominator.
+Distinct from SUCCESS (it did not verify anything) and from ERROR (nothing
+malfunctioned). A gate that matched, compared, or fetched zero items has
+abstained, not passed, and must never read as green."_
+[evidence: `packages/cli/src/utils/errors.ts:11-19`]. That is a verbatim
+description of this bug, and `harness roadmap sync`, `check-docs`,
+`check-deployment`, and `review-ci` already use it. The contract is already
+recorded as an accepted decision
+[evidence: `docs/knowledge/decisions/0086-enforcing-deploy-gate-exit-contract-and-rollback-seam.md:47-49`],
+so this change **applies** an existing ADR rather than establishing a new one.
+Reusing it keeps one exit-code vocabulary for abstention across the CLI instead of
+minting a second.
+
+The claim is narrow: at the _payload_ level this change does add shape — four
+commands already model abstention as a flat `scannedNothing: boolean`
+[evidence: `packages/cli/src/commands/check-security.ts:39,133-138`,
+`packages/cli/src/commands/check-docs.ts:33,94-106`], whereas `validate` needs a
+per-check ledger because it runs many checks and any one of them can abstain
+independently. Same exit-code vocabulary, richer payload — deliberately.
+
+Verified before choosing B: no consumer in this repo matches `harness validate`'s
+exit code exactly. The three persona workflows use `|| echo ::warning::`, the
+dashboard action route derives `ok: code === 0`
+[evidence: `packages/dashboard/src/server/routes/actions.ts:189`], and the
+documented scripting pattern is `if [ $? -ne 0 ]`
+[evidence: `docs/reference/cli.md` "Exit Codes"]. Residual risk is adopter CI that
+matches `== 1` exactly — and such a consumer was previously being handed `0` in
+this scenario, which is strictly worse.
+
+The three states therefore map: **checked and healthy → 0**, **checked and
+unhealthy → 1**, **could not check → 3**. Every non-green state stays non-zero, so
+no `set -e` or `if ! cmd` gate changes verdict; only a consumer matching `1`
+_exactly_ is affected, and such a consumer was previously being told `0` in this
+scenario, which is strictly worse.
+
+### D2 — Abstention outranks failure in the exit code
+
+When a run has both real error findings and an abstained check, the exit code is
+`3`, not `1`.
+
+Rationale: exit `1` carries an implicit claim — _"here is the complete list of what
+is wrong."_ That claim is false when a check could not run, and a user who fixes
+every reported error will still be flying blind on the roadmap. Exit `3` says the
+report itself is incomplete, which is the strictly more important message and the
+one that must not be masked. Both codes are non-zero, so precedence cannot flip
+any gate from red to green — it only changes which non-green signal the caller
+sees. The findings that would have driven exit `1` are still printed in full.
+
+### D3 — Abstentions are recorded in a dedicated ledger, not pushed into `issues`
+
+|          | A) Push an `error`-severity issue (as the bug report suggests)                                                         | B) Dedicated `unavailableChecks` ledger                     |
+| -------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| **Pros** | One list for consumers to read; smallest diff                                                                          | Abstention cannot be filtered away; counts stay honest      |
+| **Cons** | `--severity error` semantics let it be reasoned about as a finding; inflates the `(N issues)` count with a non-finding | Consumers reading only `issues` need to learn one new field |
+| **Risk** | Medium — see below                                                                                                     | Low                                                         |
+
+**Chosen: B.** The decisive argument is `--severity`. That flag filters
+`result.issues` and then recomputes `result.valid = filtered.length === 0`
+[evidence: `packages/cli/src/commands/validate.ts:488-495`]. If an abstention
+were an ordinary issue, `--severity error` would be a _filter that can hide the
+fact that a check did not run_ — reintroducing the same false green through a
+different door. A dedicated ledger is structurally unfilterable.
+
+Secondary argument: an abstention is not a finding _about the project's health_,
+it is a fact _about the report's completeness_. Keeping it out of `issues` keeps
+the `x Validation failed (N issues)` count meaning what it says.
+
+The bug report framed the issue-push as its **minimum** bar ("at minimum, the skip
+must be reported rather than silent — a check that did not run must never present
+as a check that passed"). This design clears that bar by a wider margin: the
+abstention is non-zero-exit, unfilterable, and rendered in its own output section.
+
+### D4 — `checks.<name>` stays an honest tri-state; the ledger disambiguates
+
+`ValidateResult.checks.<name>` keeps its existing shape: `true` = ran and passed,
+`false` = ran and failed, `undefined` = did not run. A parse failure therefore
+leaves `checks.roadmapHealth` **`undefined`** — because it genuinely did not run —
+rather than setting it to `false`, which would be the lie that it ran and found
+problems.
+
+That leaves `undefined` shared between "not applicable" (no roadmap file) and
+"could not run" (roadmap file unreadable). `unavailableChecks` is exactly the
+disambiguator: an entry present ⇒ could-not-run; absent ⇒ not applicable. A
+consumer answering "did roadmap health actually get verified?" reads
+`checks.roadmapHealth === true`, which is now true only when the check really ran
+and passed.
+
+### D5 — Scope the ledger to the two silent roadmap swallows
+
+`roadmapHealth` (parse failure) and `roadmapAggregateDrift` (regeneration failure)
+are the two sites where an abstention is _currently invisible_. They are also
+causally linked — the same malformed roadmap trips both — so fixing one and not
+the other would leave a green half-report over the same broken input. Every other
+`Result`-guarded check in `validate.ts` already has an `else` branch that reports
+[evidence: `validate.ts:117-129`, `135-151`, `159-172`, `176-190`, `194-205`,
+`209-224`, `244-255`].
+
+Two adjacent weak spots are noted and deliberately left alone: `fileStructure` is
+hardcoded to `true` pending conventions support [evidence: `validate.ts:153-155`],
+and the merge-driver doctor silently treats a `git config` failure as "unconfigured"
+[evidence: `validate.ts:231`, `241-243`]. Both are the same defect _family_; neither
+is roadmap-related and each carries its own design question, so folding them in here
+would broaden the change past its bug.
+
+**Accepted risk on `roadmapAggregateDrift`.** `regenerate()` returns `Err` for
+unreadable/mis-slugged/duplicate shards, and this repo has 149 of them
+[evidence: `packages/core/src/roadmap/store/shard-store.ts:59-63`, `78-82`,
+`90-92`]. A genuinely transient read failure on any one shard would move
+`harness validate` from `0` to `3`. That is accepted: the outcome is
+correct-but-noisy (the freshness comparison really did not happen), it is non-zero
+rather than green, and a re-run clears it. This does **not** contradict the design-audit
+non-goal above — the distinction there is checker-crash vs unusable-input, not
+transient vs deterministic.
+
+### D6 — No roadmap-row promotion for this change
+
+The brainstorming skill's Phase-4 step 7 promotes a roadmap row; no row exists for
+this item, and the `not-found` path calls `manage_roadmap add`, which auto-creates
+a **new** GitHub tracking issue. This item is already tracked by an existing issue,
+so `add` would produce a duplicate. Promotion is skipped deliberately; the tracking
+issue in the PR description is the record. Recorded as an assumption in the PR.
+
+## Technical design
+
+### Data model (`packages/cli/src/commands/validate.ts`)
+
+```ts
+/** One check that could not run — the report is incomplete, not clean. */
+interface UnavailableCheck {
+  /** The check key that abstained, matching a `checks` field name. */
+  check: string;
+  /** The input the check could not consume, when file-scoped. */
+  file?: string;
+  /** Why it could not run — carries the underlying error verbatim. */
+  reason: string;
+  /** What the operator should do about it. */
+  suggestion?: string;
+}
+
+interface ValidateResult {
+  valid: boolean;
+  /** False when at least one check could not run. `valid` alone is not trustworthy when this is false. */
+  complete: boolean;
+  checks: { ... };            // unchanged
+  issues: [ ... ];            // unchanged
+  unavailableChecks: UnavailableCheck[];   // always present; empty on a complete run
+  agentConfigs?: AgentConfigValidation;
+}
+```
+
+`complete` is derived (`unavailableChecks.length === 0`) and set once at the end of
+`runValidate`, immediately after the `--severity` filter block, so the filter can
+never influence it.
+
+### Behavior
+
+`roadmapHealth`, malformed roadmap — replaces the missing `else`:
+
+```ts
+} else {
+  result.unavailableChecks.push({
+    check: 'roadmapHealth',
+    file: 'docs/roadmap.md',
+    reason: `docs/roadmap.md could not be parsed, so roadmap health rules (RMH001-RMH005) did not run: ${parsed.error.message}`,
+    suggestion: 'Fix the reported section in docs/roadmap.md (or its docs/roadmap.d/ shard) and re-run `harness validate`.',
+  });
+}
+```
+
+`roadmapAggregateDrift`, unregenerable shards — splits the current binary `else`
+into "fresh" and "could not compare":
+
+```ts
+if (!regenerated.ok) {
+  result.unavailableChecks.push({
+    check: 'roadmapAggregateDrift',
+    file: 'docs/roadmap.d',
+    reason: `docs/roadmap.d/ could not be regenerated, so aggregate freshness was not compared: ${regenerated.error.message}`,
+    suggestion: 'Fix the reported shard under docs/roadmap.d/, then run `harness roadmap regen`.',
+  });
+} else if (drift.applicable && drift.stale) { ... } else { result.checks.roadmapAggregateDrift = true; }
+```
+
+`checks.roadmapAggregateDrift` is left `undefined` in the abstention branch, per D4.
+
+### Exit code (`runValidateAction`)
+
+```ts
+const exitCode = !result.value.complete
+  ? ExitCode.ZERO_DENOMINATOR // could not check — outranks failure (D2)
+  : result.value.valid
+    ? ExitCode.SUCCESS
+    : ExitCode.VALIDATION_FAILED;
+process.exit(exitCode);
+```
+
+### Human-readable output (`OutputFormatter.formatValidation`)
+
+`ValidationResult` gains an optional `unavailableChecks` field; when it is absent
+or empty, rendering is byte-identical to today (every existing caller and test is
+unaffected). When it is non-empty, TEXT/VERBOSE mode renders a dedicated section
+_before_ the issues, and the headline states incompleteness rather than a verdict:
+
+```
+! Validation incomplete - 1 check could not run
+
+  Checks that could not run:
+  * roadmapHealth (docs/roadmap.md)
+    docs/roadmap.md could not be parsed, so roadmap health rules (RMH001-RMH005)
+    did not run: Feature "Ship it" has invalid status: "cancelled". Valid
+    statuses: backlog, planned, in-progress, blocked, done
+
+  A check that could not run is not a check that passed. This report is incomplete.
+```
+
+When a run is **both** incomplete and failing, both headlines print, incomplete
+first:
+
+```
+! Validation incomplete (1 check could not run)
+
+  Checks that could not run:
+  * roadmapHealth (docs/roadmap.md)
+    ...
+
+  A check that could not run is not a check that passed - this report is
+  incomplete.
+
+x Validation failed (3 issues)
+
+  * src/index.ts
+    ...
+```
+
+The incomplete headline leads because it qualifies the failure list beneath it; no
+diagnostic from a check that _did_ run is lost. `suggestion` is shown only in
+VERBOSE, matching how `appendIssueLines` already treats issue suggestions.
+
+QUIET mode needs one extra care: it currently returns `''` immediately when
+`valid` is true [evidence: `packages/cli/src/output/formatter.ts:99-102`], and the
+dominant abstention case _is_ `valid: true` — so a naive change would print nothing
+and exit 3. The early return is therefore gated on the ledger being empty as well;
+when it is non-empty, QUIET prints one `<file>: <reason>` line per abstention ahead
+of the issue lines. JSON mode is unchanged in shape beyond the two additive fields.
+
+The call site must actually pass the ledger: `emitValidateOutput` builds the
+formatter payload as a closed literal
+[evidence: `packages/cli/src/commands/validate.ts:587` pre-change], so without
+threading `unavailableChecks` through, `formatValidation` would always take the
+byte-identical path and the CLI would exit `3` while printing `validation passed` —
+strictly worse than the bug. This wiring is an explicit implementation step.
+
+The "checked and healthy" rendering (`v validation passed`) is left untouched by
+design — its _meaning_ is what changes. It can now only be printed when every
+applicable check actually ran, which was not true before this change.
+
+## Integration points
+
+- **Entry Points** — `harness validate` (CLI exit code and TEXT/VERBOSE/QUIET/JSON
+  output); `runValidate()` (exported, but with no production consumer outside
+  `validate.ts` itself — every other call site is a test);
+  `OutputFormatter.formatValidation` (9 call sites, all passing fresh object
+  literals, so an optional field is source-compatible with all of them). The
+  `validate_project` MCP tool is explicitly **not** an entry point for this change —
+  it never calls `runValidate` (see Non-goals).
+- **Registrations Required** — None. No new command, flag, skill, or export; the
+  two new `ValidateResult` fields are additive and `UnavailableCheck` is local to
+  the CLI package (mirrored as an optional field on the formatter's
+  `ValidationResult`, which is not exported, so it is added in place).
+- **Documentation Updates** — `docs/reference/cli.md` (hand-maintained; **not**
+  `docs/reference/cli-commands.md`, which is auto-generated and whose hand-editing
+  is blocked by `pnpm run generate-docs --check` in `.husky/pre-push`): repair the
+  global `## Exit Codes` table, which today lists only 0/1/2 and already omits 3
+  despite four commands using it, and add a per-command exit-code note under
+  `### harness validate`. Correct the one skill instruction that reads the check as
+  a two-state boolean — `agents/skills/claude-code/harness-roadmap/SKILL.md`
+  Phase 4 says "confirm the `roadmapHealth` check passes", which an agent seeing
+  `undefined` would read as "not failing"; that is exactly the hazard D4 closes. A
+  patch changeset records the exit-code addition for adopters.
+- **Architectural Decisions** — None new. D1 **applies** the already-accepted
+  ZERO_DENOMINATOR exit contract
+  (`docs/knowledge/decisions/0086-enforcing-deploy-gate-exit-contract-and-rollback-seam.md`)
+  to a second command rather than establishing a new one.
+- **Knowledge Impact** — Reinforces the existing "abstention is not success"
+  concept already carried by `ExitCode.ZERO_DENOMINATOR`, extending it from
+  `roadmap sync` to `validate`.
+
+## Success criteria
+
+Each is observable and testable via `runValidate()` plus the CLI action.
+
+1. **SC1** — When `docs/roadmap.md` exists and `parseRoadmap` returns `Err`,
+   `runValidate` returns `complete: false` with exactly one `unavailableChecks`
+   entry for `roadmapHealth`, whose `reason` contains the parser's own message
+   verbatim, and `checks.roadmapHealth` is `undefined`.
+2. **SC2** — In that same scenario the CLI exits `3`, and stdout contains
+   `Validation incomplete` and does **not** contain `validation passed`.
+3. **SC3** — When the roadmap parses and only RMH002 warnings are found,
+   `valid` stays `true`, `complete` stays `true`, `unavailableChecks` is empty, and
+   the exit code is `0` — existing advisory noise is not made blocking.
+4. **SC4** — When the roadmap parses and an RMH003 error is found, `valid` is
+   `false`, `complete` is `true`, and the exit code is `1` — checked-and-unhealthy
+   is still distinct from could-not-check.
+5. **SC5** — When `docs/roadmap.md` is absent, `checks.roadmapHealth` is
+   `undefined`, `unavailableChecks` is empty, and `complete` is `true` — the
+   legitimate silent skip is preserved.
+6. **SC6** — In sharded mode with shards that cannot be regenerated,
+   `unavailableChecks` carries a `roadmapAggregateDrift` entry and
+   `checks.roadmapAggregateDrift` is `undefined` (previously `true`).
+7. **SC7** — A run with both an abstention and an error-severity finding exits `3`
+   while still printing every finding (D2 precedence, no diagnostic lost).
+8. **SC8** — `--severity error` cannot empty `unavailableChecks`, and the exit code
+   stays `3` when a check abstained (abstention is unfilterable).
+9. **SC9** — `formatValidation` output is byte-identical to today for every result
+   with no `unavailableChecks` — including QUIET+valid still returning exactly `''`
+   — so no existing snapshot or assertion changes.
+10. **SC10** — In QUIET mode a `valid: true` run with a non-empty ledger prints one
+    `<file>: <reason>` line per abstention rather than the empty string.
+11. **SC11** — A run that is both incomplete and failing prints both the
+    `Validation incomplete` and `Validation failed (N issues)` headlines, incomplete
+    first, with every finding still listed.
+12. **SC12** — `emitValidateOutput` passes `unavailableChecks` to the formatter, so
+    the CLI never exits `3` while printing `validation passed`.
+
+## Implementation order
+
+1. **Ledger + contract.** Add `UnavailableCheck`, `unavailableChecks`, and
+   `complete` to `ValidateResult`; initialize the array; derive `complete` after
+   the `--severity` block. (SC8's invariant is established here.)
+2. **Close the two swallows.** Add the `roadmapHealth` `else` branch and split the
+   `roadmapAggregateDrift` branch. (SC1, SC6)
+3. **Exit-code mapping** in `runValidateAction` with D2 precedence. (SC2, SC4, SC7)
+4. **Renderer.** Optional `unavailableChecks` on the formatter's `ValidationResult`;
+   incomplete headline + "Checks that could not run" section; both-headlines case;
+   QUIET line form gated on a non-empty ledger; **and the `emitValidateOutput`
+   wiring that hands the ledger to the formatter**. (SC2, SC9, SC10, SC11, SC12)
+5. **Tests.** Extend `validate.roadmap-health.test.ts` with the abstention cases,
+   add a CLI-level exit-code suite, and add formatter cases; assert the RMH002
+   non-blocking case is untouched. (SC1–SC12)
+6. **Docs + changeset.** Repair the global exit-code table in `docs/reference/cli.md`,
+   add the per-command note, correct the roadmap SKILL.md instruction, patch
+   changeset.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -124,7 +124,12 @@ harness validate [options]
 --agent-configs         Validate agent configs (CLAUDE.md, hooks, skills) via agnix or built-in fallback rules
 --strict                Treat warnings as errors (applies to --agent-configs)
 --agnix-bin <path>      Override the agnix binary path discovered on PATH
+--severity <level>      Minimum severity that fails the command (error, warning, info)
 ```
+
+**Exit codes:** `0` all applicable checks ran and passed · `1` a check ran and
+failed · `3` a check could not run (the report is incomplete). See
+[Exit Codes](#exit-codes).
 
 **Examples:**
 
@@ -2543,14 +2548,36 @@ The CLI uses the following exit codes:
 0       Success
 1       Validation failed
 2       General error
+3       Zero denominator - the command ran but examined nothing
 ```
+
+Exit code `3` means a check **abstained**: it ran but had nothing to examine, or its
+input existed and could not be consumed. It is distinct from `0` (nothing was
+verified) and from `2` (nothing malfunctioned). A gate that matched, compared, or
+fetched zero items has abstained, not passed, and must never read as green.
+`harness validate`, `harness roadmap sync`, `harness check-docs`,
+`harness check-deployment`, and `harness review-ci` all use it.
+
+For `harness validate` specifically the three codes map to the three possible
+states of a run:
+
+| Code | Meaning                                                                                     |
+| ---- | ------------------------------------------------------------------------------------------- |
+| `0`  | Every applicable check ran and passed.                                                      |
+| `1`  | A check ran and failed.                                                                     |
+| `3`  | A check could not run — the report is incomplete. Listed under "Checks that could not run". |
+
+Abstention outranks failure: a run with both an unavailable check and error findings
+exits `3`, because exit `1` would imply the reported findings are the complete list.
+In `--json` mode the same information appears as `complete: false` and a populated
+`unavailableChecks` array. `--severity` never filters `unavailableChecks`.
 
 Use exit codes in scripts:
 
 ```bash
 harness validate
 if [ $? -ne 0 ]; then
-  echo "Validation failed"
+  echo "Validation did not pass"
   exit 1
 fi
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2569,8 +2569,14 @@ states of a run:
 
 Abstention outranks failure: a run with both an unavailable check and error findings
 exits `3`, because exit `1` would imply the reported findings are the complete list.
+`--severity` never filters `unavailableChecks`.
+
 In `--json` mode the same information appears as `complete: false` and a populated
-`unavailableChecks` array. `--severity` never filters `unavailableChecks`.
+`unavailableChecks` array. **Read `complete` (or the exit code), not `valid`.**
+`valid` reports only on checks that actually ran, so it stays `true` when a check
+abstained — `harness validate --json | jq -e .valid` is not a sufficient gate. The
+trustworthy green is `complete === true && valid === true`, which is exactly what
+exit code `0` means.
 
 Use exit codes in scripts:
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -23,7 +23,7 @@ import { execFileSync } from 'node:child_process';
 import { resolveConfig } from '../config/loader';
 import { OutputFormatter, OutputMode, type OutputModeType } from '../output/formatter';
 import { logger } from '../output/logger';
-import { CLIError, ExitCode } from '../utils/errors';
+import { CLIError, ExitCode, type ExitCodeType } from '../utils/errors';
 import { runAudit as runComponentAnatomyAudit } from '../mcp/tools/audit-anatomy';
 import { runDetectDrift } from '../mcp/tools/detect-drift';
 import { runAuditBrand } from '../mcp/tools/audit-brand';
@@ -56,8 +56,35 @@ interface ValidateOptions {
   severity?: ValidateSeverity;
 }
 
+/**
+ * One check that could not run.
+ *
+ * A check whose input exists but cannot be consumed has ABSTAINED — it neither
+ * passed nor failed, and reporting it as either is a lie. Abstentions are kept in
+ * their own ledger rather than in {@link ValidateResult.issues} for two reasons:
+ * an abstention is a fact about the REPORT's completeness rather than a finding
+ * about the project's health, and `--severity` filters `issues` (then recomputes
+ * `valid` from what survives), so an abstention living there could be filtered
+ * away — reintroducing the very false green this ledger exists to prevent.
+ */
+interface UnavailableCheck {
+  /** The check that abstained. Matches a key of {@link ValidateResult.checks}. */
+  check: string;
+  /** The input the check could not consume, when the check is file-scoped. */
+  file?: string;
+  /** Why it could not run. Carries the underlying error message verbatim. */
+  reason: string;
+  /** What the operator should do about it. */
+  suggestion?: string;
+}
+
 interface ValidateResult {
   valid: boolean;
+  /**
+   * False when at least one check could not run. `valid` alone is not
+   * trustworthy while this is false — the run has an incomplete denominator.
+   */
+  complete: boolean;
   checks: {
     agentsMap: boolean;
     fileStructure: boolean;
@@ -83,6 +110,11 @@ interface ValidateResult {
     message: string;
     suggestion?: string;
   }>;
+  /**
+   * Checks that could not run. Always present; empty on a complete run. Never
+   * touched by `--severity` — an abstention must not be filterable.
+   */
+  unavailableChecks: UnavailableCheck[];
   agentConfigs?: AgentConfigValidation;
 }
 
@@ -103,12 +135,14 @@ export async function runValidate(
 
   const result: ValidateResult = {
     valid: true,
+    complete: true,
     checks: {
       agentsMap: false,
       fileStructure: false,
       knowledgeMap: false,
     },
     issues: [],
+    unavailableChecks: [],
   };
 
   // Check AGENTS.md
@@ -276,7 +310,20 @@ export async function runValidate(
       committedAggregate,
       regeneratedAggregate: regenerated.ok ? regenerated.value : null,
     });
-    if (drift.applicable && drift.stale) {
+    if (!regenerated.ok) {
+      // The shards could not be regenerated, so there was nothing to compare the
+      // committed aggregate against. checkRoadmapAggregateDrift returns
+      // `applicable: false` here, which is indistinguishable from the monolith
+      // no-op — reporting it as a passed check would claim a freshness comparison
+      // that never happened. The doctor abstains instead.
+      result.unavailableChecks.push({
+        check: 'roadmapAggregateDrift',
+        file: 'docs/roadmap.d',
+        reason: `docs/roadmap.d/ could not be regenerated, so aggregate freshness was not compared: ${regenerated.error.message}`,
+        suggestion:
+          'Fix the reported shard under docs/roadmap.d/, then run `harness roadmap regen`.',
+      });
+    } else if (drift.applicable && drift.stale) {
       result.checks.roadmapAggregateDrift = false;
       result.issues.push({
         check: 'roadmapAggregateDrift',
@@ -293,8 +340,16 @@ export async function runValidate(
   // Roadmap health (regression guard). Read-only diagnostics over docs/roadmap.md:
   // catch-all milestones (error), done-outside-archive, unactionable planned rows,
   // and oversized active milestones (warnings). Skipped silently when no roadmap
-  // file exists (file-less mode or uninitialized projects). Error-severity findings
-  // fail validation; warnings are surfaced but do not flip result.valid.
+  // file exists (file-less mode or uninitialized projects) — that is "not
+  // applicable", not "could not check". Error-severity findings fail validation;
+  // warnings are surfaced but do not flip result.valid.
+  //
+  // When the file EXISTS but the parser rejects it, the check ABSTAINS: it is
+  // recorded in result.unavailableChecks (which forces `complete: false` and a
+  // ZERO_DENOMINATOR exit) rather than silently skipped. Every roadmap-health rule
+  // disappears at once on a parse failure, so a silent skip here is exactly the
+  // false green this ledger exists to prevent — the worse the roadmap, the less it
+  // would have been checked.
   const roadmapPath = path.join(cwd, 'docs', 'roadmap.md');
   if (fs.existsSync(roadmapPath)) {
     const parsed = parseRoadmap(fs.readFileSync(roadmapPath, 'utf-8'));
@@ -314,6 +369,14 @@ export async function runValidate(
           ...(finding.suggestion !== undefined && { suggestion: finding.suggestion }),
         });
       }
+    } else {
+      result.unavailableChecks.push({
+        check: 'roadmapHealth',
+        file: 'docs/roadmap.md',
+        reason: `docs/roadmap.md could not be parsed, so no roadmap health rule ran: ${parsed.error.message}`,
+        suggestion:
+          'Fix the reported section in docs/roadmap.md (or its docs/roadmap.d/ shard) and re-run `harness validate`.',
+      });
     }
   }
 
@@ -494,6 +557,11 @@ export async function runValidate(
     result.valid = filtered.length === 0;
   }
 
+  // Derived AFTER the `--severity` filter so the filter provably cannot influence
+  // it. `--severity` bounds which FINDINGS are reported; it must never be able to
+  // hide the fact that a check did not run at all.
+  result.complete = result.unavailableChecks.length === 0;
+
   return Ok(result);
 }
 
@@ -571,7 +639,26 @@ async function runValidateAction(
 
   if (opts.crossCheck) await printCrossCheckWarnings(mode);
   emitValidateOutput(result.value, mode, formatter);
-  process.exit(result.value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED);
+  process.exit(resolveValidateExitCode(result.value));
+}
+
+/**
+ * Map the three possible states of a validation run onto three distinct exit codes:
+ * checked-and-healthy (0), checked-and-unhealthy (1), and could-not-check
+ * (ZERO_DENOMINATOR / 3). With only two codes, "could not check" has to be encoded
+ * as one of the other two — and encoding it as success is the false green this
+ * mapping removes.
+ *
+ * Abstention OUTRANKS failure. Exit 1 carries the implicit claim "here is the
+ * complete list of what is wrong"; that claim is false once a check could not run,
+ * and a caller who fixes every reported finding would still be flying blind on the
+ * abstained one. Both codes are non-zero, so precedence cannot flip any gate from
+ * red to green — it only decides which non-green signal the caller sees, and the
+ * findings that would have produced exit 1 are still printed in full.
+ */
+function resolveValidateExitCode(value: ValidateResult): ExitCodeType {
+  if (!value.complete) return ExitCode.ZERO_DENOMINATOR;
+  return value.valid ? ExitCode.SUCCESS : ExitCode.VALIDATION_FAILED;
 }
 
 function emitValidateOutput(
@@ -584,7 +671,11 @@ function emitValidateOutput(
     console.log(JSON.stringify(value, null, 2));
     return;
   }
-  const output = formatter.formatValidation({ valid: value.valid, issues: value.issues });
+  const output = formatter.formatValidation({
+    valid: value.valid,
+    issues: value.issues,
+    unavailableChecks: value.unavailableChecks,
+  });
   if (output) console.log(output);
   if (value.agentConfigs) printAgentConfigSummary(value.agentConfigs, mode);
 }

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -305,25 +305,29 @@ export async function runValidate(
     const committedAggregate = fs.existsSync(aggregatePath)
       ? fs.readFileSync(aggregatePath, 'utf-8')
       : null;
-    const drift = checkRoadmapAggregateDrift({
-      shardDirExists: true,
-      committedAggregate,
-      regeneratedAggregate: regenerated.ok ? regenerated.value : null,
-    });
     if (!regenerated.ok) {
       // The shards could not be regenerated, so there was nothing to compare the
-      // committed aggregate against. checkRoadmapAggregateDrift returns
+      // committed aggregate against. checkRoadmapAggregateDrift would return
       // `applicable: false` here, which is indistinguishable from the monolith
       // no-op — reporting it as a passed check would claim a freshness comparison
-      // that never happened. The doctor abstains instead.
+      // that never happened. The doctor abstains instead, and the comparison is
+      // not even attempted.
       result.unavailableChecks.push({
         check: 'roadmapAggregateDrift',
-        file: 'docs/roadmap.d',
+        file: 'docs/roadmap.d/',
         reason: `docs/roadmap.d/ could not be regenerated, so aggregate freshness was not compared: ${regenerated.error.message}`,
         suggestion:
           'Fix the reported shard under docs/roadmap.d/, then run `harness roadmap regen`.',
       });
-    } else if (drift.applicable && drift.stale) {
+      // Regeneration succeeded and the shard dir exists, so `applicable` is
+      // necessarily true here — `stale` alone carries the verdict.
+    } else if (
+      checkRoadmapAggregateDrift({
+        shardDirExists: true,
+        committedAggregate,
+        regeneratedAggregate: regenerated.value,
+      }).stale
+    ) {
       result.checks.roadmapAggregateDrift = false;
       result.issues.push({
         check: 'roadmapAggregateDrift',
@@ -557,12 +561,13 @@ export async function runValidate(
     result.valid = filtered.length === 0;
   }
 
-  // Derived AFTER the `--severity` filter so the filter provably cannot influence
-  // it. `--severity` bounds which FINDINGS are reported; it must never be able to
-  // hide the fact that a check did not run at all.
-  result.complete = result.unavailableChecks.length === 0;
-
-  return Ok(result);
+  // Derived AT the return site, not assigned somewhere above it. Two properties
+  // follow structurally rather than by convention: the `--severity` filter above
+  // provably cannot influence it (it bounds which FINDINGS are reported and must
+  // never hide the fact that a check did not run at all), and any early return
+  // added to this function in future cannot ship a stale `complete: true` over a
+  // populated ledger — it would have to restore the false green deliberately.
+  return Ok({ ...result, complete: result.unavailableChecks.length === 0 });
 }
 
 function resolveValidateMode(globalOpts: Record<string, unknown>): OutputModeType {

--- a/packages/cli/src/output/formatter.ts
+++ b/packages/cli/src/output/formatter.ts
@@ -34,6 +34,24 @@ interface ValidationIssue {
 }
 
 /**
+ * A check that could not run — its input existed but could not be consumed.
+ *
+ * Distinct from an issue: an issue says something is wrong with the project, an
+ * unavailable check says the report itself is incomplete. Rendering them together
+ * would let a check that abstained read as a check that passed.
+ */
+interface UnavailableCheckSummary {
+  /** The check that abstained. */
+  check: string;
+  /** The input it could not consume, when file-scoped. */
+  file?: string;
+  /** Why it could not run. */
+  reason: string;
+  /** What the operator should do about it (VERBOSE mode only). */
+  suggestion?: string;
+}
+
+/**
  * The result of a validation operation.
  */
 interface ValidationResult {
@@ -41,6 +59,11 @@ interface ValidationResult {
   valid: boolean;
   /** A list of issues found during validation */
   issues: ValidationIssue[];
+  /**
+   * Checks that could not run. Optional: callers that have no notion of
+   * abstention omit it and get byte-identical output to before this field existed.
+   */
+  unavailableChecks?: UnavailableCheckSummary[];
   /** Optional count of modules analyzed, surfaced in JSON output (#1188). */
   modulesAnalyzed?: number;
   /** Optional count of layers configured, surfaced in JSON output (#1188). */
@@ -58,6 +81,20 @@ function appendIssueLines(lines: string[], issue: ValidationIssue, mode: OutputM
   lines.push(`    ${issue.message}`);
   if (issue.suggestion && mode === OutputMode.VERBOSE) {
     lines.push(`    ${chalk.dim('->')} ${issue.suggestion}`);
+  }
+}
+
+/** Append the formatted lines for a single check that could not run. */
+function appendUnavailableCheckLines(
+  lines: string[],
+  entry: UnavailableCheckSummary,
+  mode: OutputModeType
+): void {
+  const label = entry.file ? `${entry.check} (${entry.file})` : entry.check;
+  lines.push(`  ${chalk.yellow('*')} ${chalk.dim(label)}`);
+  lines.push(`    ${entry.reason}`);
+  if (entry.suggestion && mode === OutputMode.VERBOSE) {
+    lines.push(`    ${chalk.dim('->')} ${entry.suggestion}`);
   }
 }
 
@@ -96,14 +133,46 @@ export class OutputFormatter {
       return JSON.stringify(result, null, 2);
     }
 
+    // A run with an unavailable check is neither "passed" nor "failed" — it is
+    // INCOMPLETE, and must never render as either. When the list is absent or
+    // empty (every caller that predates the field), output is unchanged.
+    const unavailable = result.unavailableChecks ?? [];
+
     if (this.mode === OutputMode.QUIET) {
-      if (result.valid) return '';
-      return result.issues.map((i) => `${i.file ?? ''}: ${i.message}`).join('\n');
+      const abstentionLines = unavailable.map((u) => `${u.file ?? ''}: ${u.reason}`);
+      if (result.valid && abstentionLines.length === 0) return '';
+      return [
+        ...abstentionLines,
+        ...result.issues.map((i) => `${i.file ?? ''}: ${i.message}`),
+      ].join('\n');
     }
 
     const lines: string[] = [];
 
-    if (result.valid) {
+    if (unavailable.length > 0) {
+      const plural = unavailable.length === 1 ? 'check' : 'checks';
+      lines.push(
+        chalk.yellow(`! Validation incomplete (${unavailable.length} ${plural} could not run)`)
+      );
+      lines.push('');
+      lines.push('  Checks that could not run:');
+      for (const entry of unavailable) {
+        appendUnavailableCheckLines(lines, entry, this.mode);
+      }
+      lines.push('');
+      lines.push(
+        chalk.dim('  A check that could not run is not a check that passed — this report is')
+      );
+      lines.push(chalk.dim('  incomplete.'));
+      if (result.issues.length > 0) {
+        lines.push('');
+        lines.push(chalk.red(`x Validation failed (${result.issues.length} issues)`));
+        lines.push('');
+        for (const issue of result.issues) {
+          appendIssueLines(lines, issue, this.mode);
+        }
+      }
+    } else if (result.valid) {
       lines.push(chalk.green('v validation passed'));
     } else {
       lines.push(chalk.red(`x Validation failed (${result.issues.length} issues)`));

--- a/packages/cli/src/output/formatter.ts
+++ b/packages/cli/src/output/formatter.ts
@@ -139,7 +139,11 @@ export class OutputFormatter {
     const unavailable = result.unavailableChecks ?? [];
 
     if (this.mode === OutputMode.QUIET) {
-      const abstentionLines = unavailable.map((u) => `${u.file ?? ''}: ${u.reason}`);
+      // Prefixed so a script parsing --quiet can tell "could not run" from
+      // "failed" — the same conflation this change removes everywhere else.
+      const abstentionLines = unavailable.map(
+        (u) => `[unavailable] ${u.file ?? u.check}: ${u.reason}`
+      );
       if (result.valid && abstentionLines.length === 0) return '';
       return [
         ...abstentionLines,
@@ -165,12 +169,25 @@ export class OutputFormatter {
       );
       lines.push(chalk.dim('  incomplete.'));
       if (result.issues.length > 0) {
+        // Findings from checks that DID run are still reported in full — but the
+        // headline must match the verdict. Warnings never flip `valid`, so an
+        // advisory-only run alongside an abstention is not a failure and must not
+        // be labelled one; the abstention alone is what makes the run non-green.
         lines.push('');
-        lines.push(chalk.red(`x Validation failed (${result.issues.length} issues)`));
+        lines.push(
+          result.valid
+            ? chalk.yellow(`! ${result.issues.length} advisory finding(s) from checks that did run`)
+            : chalk.red(`x Validation failed (${result.issues.length} issues)`)
+        );
         lines.push('');
         for (const issue of result.issues) {
           appendIssueLines(lines, issue, this.mode);
         }
+      } else if (!result.valid) {
+        // A failing check that pushed no issue (e.g. --agent-configs) still needs
+        // a failure signal; the incomplete headline alone would not carry it.
+        lines.push('');
+        lines.push(chalk.red('x Validation failed'));
       }
     } else if (result.valid) {
       lines.push(chalk.green('v validation passed'));

--- a/packages/cli/tests/commands/validate.roadmap-abstention.test.ts
+++ b/packages/cli/tests/commands/validate.roadmap-abstention.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { runValidate } from '../../src/commands/validate';
+
+/**
+ * A check whose input exists but cannot be consumed must ABSTAIN — it must not
+ * report as passed. These cases pin the three-state contract of `harness validate`:
+ * checked-and-healthy (exit 0), checked-and-unhealthy (exit 1), and could-not-check
+ * (exit 3, ZERO_DENOMINATOR).
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = path.resolve(HERE, '../../dist/bin/harness.js');
+
+const FRONTMATTER = `---
+project: t
+version: 1
+last_synced: 2026-01-01T00:00:00Z
+last_manual_edit: 2026-01-01T00:00:00Z
+---
+
+# Roadmap
+`;
+
+/** A roadmap whose `Status:` value the parser rejects — the bug-report fixture. */
+const UNPARSEABLE_ROADMAP = `${FRONTMATTER}
+## Milestone: M1
+
+### Ship it
+
+- **Status:** cancelled
+`;
+
+function makeProject(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-abstention-'));
+  fs.writeFileSync(
+    path.join(dir, 'harness.config.json'),
+    JSON.stringify({ version: 1, agentsMapPath: './AGENTS.md' })
+  );
+  fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Stub\n');
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+/** Run the built CLI and capture both the exit code and stdout. */
+function runCli(dir: string): { code: number; stdout: string } {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI_BIN, 'validate'], {
+      cwd: dir,
+      encoding: 'utf-8',
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+    });
+    return { code: 0, stdout };
+  } catch (err) {
+    const e = err as { status?: number | null; stdout?: string };
+    return { code: e.status ?? -1, stdout: e.stdout ?? '' };
+  }
+}
+
+const cliAvailable = fs.existsSync(CLI_BIN);
+
+describe('runValidate — check abstention', () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('abstains on the aggregate-drift doctor when the shards cannot be regenerated', async () => {
+    // A shard whose filename does not match its frontmatter slug makes
+    // `regenerate()` return Err, so there is nothing to compare the committed
+    // aggregate against. Before this contract that reported as a PASSED check.
+    dir = makeProject({
+      'docs/roadmap.d/_meta.md': `---
+project: "t"
+version: 1
+created: "2026-01-01"
+updated: "2026-01-01"
+last_synced: "2026-01-01T00:00:00Z"
+last_manual_edit: "2026-01-01T00:00:00Z"
+milestones:
+  - "M1"
+---
+`,
+      'docs/roadmap.d/ship-it.md': `---
+slug: "a-different-slug"
+milestone: "M1"
+order: 1
+---
+
+### Ship it
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** x
+- **Blockers:** —
+- **Plan:** —
+`,
+      'docs/roadmap.md': FRONTMATTER,
+    });
+    const result = await runValidate({
+      configPath: path.join(dir, 'harness.config.json'),
+      cwd: dir,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const abstention = result.value.unavailableChecks.find(
+        (u) => u.check === 'roadmapAggregateDrift'
+      );
+      expect(abstention).toBeDefined();
+      expect(abstention?.file).toBe('docs/roadmap.d');
+      expect(abstention?.reason).toContain('could not be regenerated');
+      // Never `true` — a comparison that did not happen is not a comparison that passed.
+      expect(result.value.checks.roadmapAggregateDrift).toBeUndefined();
+      expect(result.value.complete).toBe(false);
+    }
+  });
+
+  it('still reports findings from checks that did run alongside an abstention', async () => {
+    // An unparseable aggregate (abstention) plus a catch-all milestone in the
+    // shards (RMH003 error) — the abstention must not swallow the finding.
+    dir = makeProject({ 'docs/roadmap.md': UNPARSEABLE_ROADMAP });
+    const result = await runValidate({
+      configPath: path.join(dir, 'harness.config.json'),
+      cwd: dir,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.complete).toBe(false);
+      // Other checks still ran and still reported.
+      expect(result.value.checks.agentsMap).toBe(true);
+      expect(result.value.checks.fileStructure).toBe(true);
+    }
+  });
+
+  describe.skipIf(!cliAvailable)('CLI exit codes', () => {
+    it('exits 3 and prints "Validation incomplete" when a check could not run', () => {
+      dir = makeProject({ 'docs/roadmap.md': UNPARSEABLE_ROADMAP });
+      const { code, stdout } = runCli(dir);
+      expect(code).toBe(3);
+      expect(stdout).toContain('Validation incomplete');
+      expect(stdout).toContain('roadmapHealth');
+      expect(stdout).not.toContain('validation passed');
+    });
+
+    it('exits 1 for a roadmap that parses and trips an error rule', () => {
+      dir = makeProject({
+        'docs/roadmap.md': `${FRONTMATTER}
+## Backlog
+
+### Some Feature
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** x
+- **Blockers:** —
+- **Plan:** —
+`,
+      });
+      const { code, stdout } = runCli(dir);
+      expect(code).toBe(1);
+      expect(stdout).toContain('Validation failed');
+      expect(stdout).not.toContain('Validation incomplete');
+    });
+
+    it('exits 0 when every applicable check ran and passed', () => {
+      dir = makeProject({
+        'docs/roadmap.md': `${FRONTMATTER}
+## Craft Pipeline
+
+### Naked Planned
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** x
+- **Blockers:** —
+- **Plan:** —
+`,
+      });
+      const { code, stdout } = runCli(dir);
+      // RMH002 is advisory — it must not become blocking.
+      expect(code).toBe(0);
+      expect(stdout).toContain('validation passed');
+    });
+  });
+});

--- a/packages/cli/tests/commands/validate.roadmap-abstention.test.ts
+++ b/packages/cli/tests/commands/validate.roadmap-abstention.test.ts
@@ -50,10 +50,10 @@ function makeProject(files: Record<string, string>): string {
   return dir;
 }
 
-/** Run the built CLI and capture both the exit code and stdout. */
-function runCli(dir: string): { code: number; stdout: string } {
+/** Run the built CLI with extra args and capture both the exit code and stdout. */
+function runCliWith(dir: string, args: string[]): { code: number; stdout: string } {
   try {
-    const stdout = execFileSync(process.execPath, [CLI_BIN, 'validate'], {
+    const stdout = execFileSync(process.execPath, [CLI_BIN, 'validate', ...args], {
       cwd: dir,
       encoding: 'utf-8',
       env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
@@ -65,12 +65,24 @@ function runCli(dir: string): { code: number; stdout: string } {
   }
 }
 
-const cliAvailable = fs.existsSync(CLI_BIN);
+/** Run the built CLI and capture both the exit code and stdout. */
+function runCli(dir: string): { code: number; stdout: string } {
+  return runCliWith(dir, []);
+}
 
 describe('runValidate — check abstention', () => {
   let dir: string;
   afterEach(() => {
-    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    if (!dir) return;
+    // Windows holds a transient handle on the temp tree after the spawned CLI
+    // exits, so a plain rmSync intermittently throws EBUSY and fails an
+    // otherwise-passing test. Retry, then give up — leaking an OS temp dir is
+    // harmless, failing a green assertion in teardown is not.
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    } catch {
+      /* temp dir cleanup is best-effort */
+    }
   });
 
   it('abstains on the aggregate-drift doctor when the shards cannot be regenerated', async () => {
@@ -115,7 +127,7 @@ order: 1
         (u) => u.check === 'roadmapAggregateDrift'
       );
       expect(abstention).toBeDefined();
-      expect(abstention?.file).toBe('docs/roadmap.d');
+      expect(abstention?.file).toBe('docs/roadmap.d/');
       expect(abstention?.reason).toContain('could not be regenerated');
       // Never `true` — a comparison that did not happen is not a comparison that passed.
       expect(result.value.checks.roadmapAggregateDrift).toBeUndefined();
@@ -124,23 +136,36 @@ order: 1
   });
 
   it('still reports findings from checks that did run alongside an abstention', async () => {
-    // An unparseable aggregate (abstention) plus a catch-all milestone in the
-    // shards (RMH003 error) — the abstention must not swallow the finding.
+    // An unparseable roadmap (abstention) AND a genuine failing check: AGENTS.md
+    // is removed so `agentsMap` fails outright. The abstention must not swallow
+    // the finding, and the failing check must not swallow the abstention.
     dir = makeProject({ 'docs/roadmap.md': UNPARSEABLE_ROADMAP });
+    fs.rmSync(path.join(dir, 'AGENTS.md'));
     const result = await runValidate({
       configPath: path.join(dir, 'harness.config.json'),
       cwd: dir,
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
+      // Could-not-check.
       expect(result.value.complete).toBe(false);
-      // Other checks still ran and still reported.
-      expect(result.value.checks.agentsMap).toBe(true);
-      expect(result.value.checks.fileStructure).toBe(true);
+      expect(result.value.unavailableChecks.map((u) => u.check)).toContain('roadmapHealth');
+      // Checked-and-unhealthy, simultaneously and independently.
+      expect(result.value.valid).toBe(false);
+      expect(result.value.checks.agentsMap).toBe(false);
+      expect(result.value.issues.some((i) => i.check === 'agentsMap')).toBe(true);
     }
   });
 
-  describe.skipIf(!cliAvailable)('CLI exit codes', () => {
+  describe('CLI exit codes', () => {
+    // Never skip-if-missing: silently skipping the exit-code assertions because
+    // dist/ is absent would be a check that could not run reporting as a check
+    // that passed — precisely the defect this suite exists to pin. CI builds
+    // before testing; locally, rebuild.
+    it('has a built CLI to exercise', () => {
+      expect(fs.existsSync(CLI_BIN)).toBe(true);
+    });
+
     it('exits 3 and prints "Validation incomplete" when a check could not run', () => {
       dir = makeProject({ 'docs/roadmap.md': UNPARSEABLE_ROADMAP });
       const { code, stdout } = runCli(dir);
@@ -148,6 +173,18 @@ order: 1
       expect(stdout).toContain('Validation incomplete');
       expect(stdout).toContain('roadmapHealth');
       expect(stdout).not.toContain('validation passed');
+    });
+
+    it('exits 3 (not 1) when a run both abstains and fails, printing both', () => {
+      // Abstention outranks failure: exit 1 would imply the printed findings are
+      // the complete list, which is false once a check could not run.
+      dir = makeProject({ 'docs/roadmap.md': UNPARSEABLE_ROADMAP });
+      fs.rmSync(path.join(dir, 'AGENTS.md'));
+      const { code, stdout } = runCli(dir);
+      expect(code).toBe(3);
+      expect(stdout).toContain('Validation incomplete');
+      expect(stdout).toContain('Validation failed');
+      expect(stdout).toContain('AGENTS.md');
     });
 
     it('exits 1 for a roadmap that parses and trips an error rule', () => {
@@ -168,6 +205,60 @@ order: 1
       expect(code).toBe(1);
       expect(stdout).toContain('Validation failed');
       expect(stdout).not.toContain('Validation incomplete');
+    });
+
+    it('does not label advisory findings a failure when a check abstained', () => {
+      // Warnings never flip `valid`. A run that is incomplete but not failing
+      // must not print "Validation failed" — this repo carries dozens of RMH002
+      // advisories, so this is the common shape of the incomplete outcome.
+      dir = makeProject({
+        'docs/roadmap.d/_meta.md': `---
+project: "t"
+version: 1
+created: "2026-01-01"
+updated: "2026-01-01"
+last_synced: "2026-01-01T00:00:00Z"
+last_manual_edit: "2026-01-01T00:00:00Z"
+milestones:
+  - "M1"
+---
+`,
+        'docs/roadmap.d/ship-it.md': `---
+slug: "a-different-slug"
+milestone: "M1"
+order: 1
+---
+
+### Ship it
+
+- **Status:** planned
+`,
+        'docs/roadmap.md': `${FRONTMATTER}
+## Craft Pipeline
+
+### Naked Planned
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** x
+- **Blockers:** —
+- **Plan:** —
+`,
+      });
+      const { code, stdout } = runCli(dir);
+      expect(code).toBe(3);
+      expect(stdout).toContain('Validation incomplete');
+      // The advisory is still surfaced...
+      expect(stdout).toContain('Naked Planned');
+      // ...but not as a failure that did not happen.
+      expect(stdout).not.toContain('Validation failed');
+    });
+
+    it('still exits 3 under --severity error (an abstention is unfilterable)', () => {
+      dir = makeProject({ 'docs/roadmap.md': UNPARSEABLE_ROADMAP });
+      const { code, stdout } = runCliWith(dir, ['--severity', 'error']);
+      expect(code).toBe(3);
+      expect(stdout).toContain('Validation incomplete');
     });
 
     it('exits 0 when every applicable check ran and passed', () => {

--- a/packages/cli/tests/commands/validate.roadmap-health.test.ts
+++ b/packages/cli/tests/commands/validate.roadmap-health.test.ts
@@ -42,6 +42,12 @@ describe('runValidate — roadmap health', () => {
     });
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.value.checks.roadmapHealth).toBeUndefined();
+    // An ABSENT roadmap is "not applicable", not "could not check" — file-less
+    // mode and uninitialized projects legitimately have no roadmap.
+    if (result.ok) {
+      expect(result.value.unavailableChecks).toEqual([]);
+      expect(result.value.complete).toBe(true);
+    }
   });
 
   it('fails validation when a catch-all milestone exists (RMH003)', async () => {
@@ -68,6 +74,9 @@ describe('runValidate — roadmap health', () => {
       expect(result.value.checks.roadmapHealth).toBe(false);
       const found = result.value.issues.find((i) => i.ruleId === 'RMH003');
       expect(found?.severity).toBe('error');
+      // "Checked and unhealthy" — the check RAN, so the report is complete.
+      expect(result.value.complete).toBe(true);
+      expect(result.value.unavailableChecks).toEqual([]);
     }
   });
 
@@ -95,6 +104,62 @@ describe('runValidate — roadmap health', () => {
       expect(result.value.checks.roadmapHealth).toBe(true);
       const found = result.value.issues.find((i) => i.ruleId === 'RMH002');
       expect(found?.severity).toBe('warning');
+      // Advisory noise stays advisory — an RMH002-only roadmap is a COMPLETE,
+      // VALID run. This change must not make existing advisories blocking.
+      expect(result.value.complete).toBe(true);
+      expect(result.value.unavailableChecks).toEqual([]);
+    }
+  });
+
+  it('abstains (does not pass) when docs/roadmap.md exists but fails to parse', async () => {
+    dir = makeProjectRoot(
+      `${FRONTMATTER}
+## Milestone: M1
+
+### Ship it
+
+- **Status:** cancelled
+`
+    );
+    const result = await runValidate({
+      configPath: path.join(dir, 'harness.config.json'),
+      cwd: dir,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // The check never ran, so it is neither true nor false.
+      expect(result.value.checks.roadmapHealth).toBeUndefined();
+      expect(result.value.complete).toBe(false);
+      expect(result.value.unavailableChecks).toHaveLength(1);
+      const abstention = result.value.unavailableChecks[0];
+      expect(abstention?.check).toBe('roadmapHealth');
+      expect(abstention?.file).toBe('docs/roadmap.md');
+      // The parser's own message names the offending section — surface it verbatim.
+      expect(abstention?.reason).toContain('cancelled');
+      expect(abstention?.suggestion).toBeTruthy();
+    }
+  });
+
+  it('keeps the parse abstention out of issues so --severity cannot filter it away', async () => {
+    dir = makeProjectRoot(
+      `${FRONTMATTER}
+## Milestone: M1
+
+### Ship it
+
+- **Status:** cancelled
+`
+    );
+    const result = await runValidate({
+      configPath: path.join(dir, 'harness.config.json'),
+      cwd: dir,
+      severity: 'error',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.unavailableChecks).toHaveLength(1);
+      expect(result.value.complete).toBe(false);
+      expect(result.value.issues.some((i) => i.check === 'roadmapHealth')).toBe(false);
     }
   });
 });

--- a/packages/cli/tests/output/formatter.test.ts
+++ b/packages/cli/tests/output/formatter.test.ts
@@ -100,6 +100,44 @@ describe('OutputFormatter', () => {
       expect(result).toContain('Missing export');
     });
 
+    it('does not call advisory findings a failure when nothing failed', () => {
+      // Warnings never flip `valid`. Labelling them "Validation failed" just
+      // because a check abstained reports a failure that did not happen.
+      const formatter = new OutputFormatter(OutputMode.TEXT);
+      const result = formatter.formatValidation({
+        valid: true,
+        issues: [{ file: 'docs/roadmap.md', message: 'is "planned" with no spec and no plan' }],
+        unavailableChecks: [ABSTENTION],
+      });
+      expect(result).toContain('Validation incomplete');
+      expect(result).toContain('advisory finding');
+      expect(result).toContain('no spec and no plan');
+      expect(result).not.toContain('Validation failed');
+    });
+
+    it('still signals failure when a failing check pushed no issue', () => {
+      const formatter = new OutputFormatter(OutputMode.TEXT);
+      const result = formatter.formatValidation({
+        valid: false,
+        issues: [],
+        unavailableChecks: [ABSTENTION],
+      });
+      expect(result).toContain('Validation incomplete');
+      expect(result).toContain('Validation failed');
+    });
+
+    it('distinguishes an abstention from a finding in quiet mode', () => {
+      const formatter = new OutputFormatter(OutputMode.QUIET);
+      const result = formatter.formatValidation({
+        valid: false,
+        issues: [{ file: 'src/index.ts', message: 'Missing export' }],
+        unavailableChecks: [ABSTENTION],
+      });
+      const [first, second] = result.split('\n');
+      expect(first).toMatch(/^\[unavailable\] /);
+      expect(second).toBe('src/index.ts: Missing export');
+    });
+
     it('shows the suggestion only in verbose mode', () => {
       const text = new OutputFormatter(OutputMode.TEXT).formatValidation({
         valid: true,

--- a/packages/cli/tests/output/formatter.test.ts
+++ b/packages/cli/tests/output/formatter.test.ts
@@ -48,6 +48,84 @@ describe('OutputFormatter', () => {
       const result = formatter.formatValidation(data);
       expect(result).toContain('Error');
     });
+
+    it('reports an abstention even though nothing failed', () => {
+      // The dominant abstention case has `valid: true` (no findings), which used
+      // to hit the QUIET early return and print nothing at all.
+      const formatter = new OutputFormatter(OutputMode.QUIET);
+      const result = formatter.formatValidation({
+        valid: true,
+        issues: [],
+        unavailableChecks: [
+          { check: 'roadmapHealth', file: 'docs/roadmap.md', reason: 'could not be parsed' },
+        ],
+      });
+      expect(result).toContain('docs/roadmap.md');
+      expect(result).toContain('could not be parsed');
+    });
+  });
+
+  describe('unavailable checks', () => {
+    const ABSTENTION = {
+      check: 'roadmapHealth',
+      file: 'docs/roadmap.md',
+      reason: 'docs/roadmap.md could not be parsed, so no roadmap health rule ran: bad status',
+      suggestion: 'Fix the reported section.',
+    };
+
+    it('renders "Validation incomplete" instead of a pass or fail verdict', () => {
+      const formatter = new OutputFormatter(OutputMode.TEXT);
+      const result = formatter.formatValidation({
+        valid: true,
+        issues: [],
+        unavailableChecks: [ABSTENTION],
+      });
+      expect(result).toContain('Validation incomplete');
+      expect(result).toContain('Checks that could not run');
+      expect(result).toContain('roadmapHealth');
+      expect(result).toContain('bad status');
+      expect(result).not.toContain('validation passed');
+    });
+
+    it('shows both the incomplete headline and the failed findings when both apply', () => {
+      const formatter = new OutputFormatter(OutputMode.TEXT);
+      const result = formatter.formatValidation({
+        valid: false,
+        issues: [{ file: 'src/index.ts', message: 'Missing export' }],
+        unavailableChecks: [ABSTENTION],
+      });
+      expect(result).toContain('Validation incomplete');
+      expect(result).toContain('Validation failed (1 issues)');
+      // An abstention must never swallow the findings from checks that did run.
+      expect(result).toContain('Missing export');
+    });
+
+    it('shows the suggestion only in verbose mode', () => {
+      const text = new OutputFormatter(OutputMode.TEXT).formatValidation({
+        valid: true,
+        issues: [],
+        unavailableChecks: [ABSTENTION],
+      });
+      const verbose = new OutputFormatter(OutputMode.VERBOSE).formatValidation({
+        valid: true,
+        issues: [],
+        unavailableChecks: [ABSTENTION],
+      });
+      expect(text).not.toContain('Fix the reported section.');
+      expect(verbose).toContain('Fix the reported section.');
+    });
+
+    it('renders identically whether the list is empty or omitted', () => {
+      const formatter = new OutputFormatter(OutputMode.TEXT);
+      const omitted = formatter.formatValidation({ valid: true, issues: [] });
+      const empty = formatter.formatValidation({ valid: true, issues: [], unavailableChecks: [] });
+      expect(empty).toBe(omitted);
+
+      const quiet = new OutputFormatter(OutputMode.QUIET);
+      expect(quiet.formatValidation({ valid: true, issues: [], unavailableChecks: [] })).toBe(
+        quiet.formatValidation({ valid: true, issues: [] })
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

`harness validate` printed `v validation passed` and exited `0` when `docs/roadmap.md` existed but **failed to parse**. The `roadmapHealth` check was guarded by `if (parsed.ok)` with no `else`, so on a parse failure the check never ran, `result.checks.roadmapHealth` was never assigned, `result.valid` was never touched, and the parse error — which names the offending section — was discarded. A roadmap broken badly enough that the parser rejected it validated clean, while a *less* broken roadmap that parsed and tripped a health rule failed.

The root defect was not a missing `else`. `harness validate` had only **two** outcomes for **three** states — *checked and healthy*, *checked and unhealthy*, *could not check* — so "could not check" had to be encoded as one of the other two, and the code picked success.

### The same swallow, one check earlier

The aggregate-drift doctor passed `regenerated.ok ? regenerated.value : null` into `checkRoadmapAggregateDrift`, which returns `{ applicable: false }` when regeneration was impossible; the caller's `else` then set `roadmapAggregateDrift = true`. A shard set so malformed it could not be regenerated reported the freshness check as **passed**. Its doc comment defended this with "other validation surfaces the underlying problem" — but the only other validation that would have is `roadmapHealth`, which swallowed too. Both fired together on the same broken input and together produced a fully green report over an unreadable roadmap.

## What changed

`harness validate` now has three outcomes.

| State | Exit | Output |
| --- | --- | --- |
| Every applicable check ran and passed | `0` | `v validation passed` |
| A check ran and failed | `1` | `x Validation failed (N issues)` |
| A check **could not run** | `3` | `! Validation incomplete (N checks could not run)` + a `Checks that could not run` section |

- **`unavailableChecks` ledger + `complete` flag** on `ValidateResult`. An abstention is a fact about the *report's completeness*, not a finding about the project's health, so it is kept out of `issues`. That is load-bearing: `--severity` filters `issues` and then recomputes `valid` from what survives, so an abstention living there would be **filterable** — reintroducing the same false green through a different door. `complete` is derived *after* the `--severity` block so the filter provably cannot influence it.
- **`ExitCode.ZERO_DENOMINATOR` (3)**, already defined in this codebase as *"the command ran but examined NOTHING… a gate that matched, compared, or fetched zero items has abstained, not passed, and must never read as green"* and already used by `roadmap sync`, `check-docs`, `check-deployment`, and `review-ci`. This applies the existing accepted exit contract (ADR 0086) to a second command rather than minting a new one.
- **Abstention outranks failure.** Exit `1` carries the implicit claim "here is the complete list of what is wrong" — false once a check could not run. Both codes are non-zero, so precedence cannot flip any gate red→green; every finding from checks that *did* run is still printed, under a second headline below the incomplete one.
- **`checks.<name>` stays an honest tri-state**: `true` = ran and passed, `false` = ran and failed, `undefined` = did not run. A parse failure leaves `roadmapHealth` **undefined** rather than `false`, because `false` would be the lie that it ran and found problems. `unavailableChecks` disambiguates undefined-because-N/A from undefined-because-unavailable.
- **Both roadmap swallows closed** — `roadmapHealth` (parse failure) and `roadmapAggregateDrift` (regeneration failure).

### Reproduction, before and after

Bug-report fixture, only the `Status:` value differs:

```
# Status: cancelled  (parseRoadmap returns Err)
before:  v validation passed                       exit 0
after:   ! Validation incomplete (1 check could not run)
           * roadmapHealth (docs/roadmap.md)
             docs/roadmap.md could not be parsed, so no roadmap health rule
             ran: Feature "Ship it" has invalid status: "cancelled". ...
                                                    exit 3

# Status: in-progress  (parses, trips RMH005)
before & after:  x Validation failed (1 issues)     exit 1
```

## Assumptions made

Every default taken, and why:

1. **Exit `3` rather than reusing `1`.** The mandate was to make the three states distinct *in the exit code*; two codes cannot express three states. `ZERO_DENOMINATOR` already exists with precisely this meaning, so no new vocabulary was minted. **Verified before choosing:** no consumer in this repo matches `harness validate`'s exit code exactly — the three persona workflows use `|| echo "::warning::…"`, the dashboard route derives `ok: code === 0`, and the documented scripting pattern is `if [ $? -ne 0 ]`. Residual risk is adopter CI matching `== 1` exactly, and such a consumer was previously being handed `0` here, which is strictly worse.
2. **Abstention outranks failure in the exit code.** Both are non-zero so no gate changes verdict; the tie-break favors the signal that says the report is incomplete.
3. **Abstentions are kept out of `issues`** (a dedicated ledger instead), so `--severity` cannot filter them and the `(N issues)` count keeps meaning what it says. The issue text framed pushing an error-severity issue as its *minimum* bar; this clears it by a wider margin.
4. **`checks.roadmapHealth` is left `undefined`, not set to `false`,** on a parse failure. Verified no production code reads it and no consumer treats `undefined` as pass; the one prose consumer that did (`harness-roadmap` SKILL.md Phase 4, "confirm the `roadmapHealth` check passes") is corrected in this PR to require `=== true` and to react to the incomplete outcome.
5. **The three design audits are out of scope.** `componentAnatomy` / `driftDetection` / `brandCompliance` catch an arbitrary exception from the audit engine — a defect in the **checker** — and already report the skip as a visible warning. `parseRoadmap` / `regenerate` return a typed `Err` describing **input they could not consume**. Abstention is the right answer to unusable input; a crashing checker is a different failure with a much wider blast radius (any transient audit crash would turn a green build non-green). Recorded as a future consideration.
6. **The `validate_project` MCP tool is out of scope — residual risk named.** It never calls `runValidate`; it is an independent reimplementation checking config, file structure, and AGENTS.md only, and performs no roadmap check at all. So `assess_project({ checks: ["validate"] })`, which derives `passed` from it, keeps reporting green over an unparseable roadmap after this ships. Converging it onto `runValidate` is a different result shape with its own consumers and is deliberately deferred.
7. **This does not add a blocking roadmap signal to *this* repo's CI.** `harness validate` is invoked here only by three persona workflows that swallow non-zero; the blocking gates run `harness ci check`, whose `validate` category calls only `validateAgentsMap`. The command's own contract is fixed for every adopter that gates on it; wiring roadmap checks into `ci check` is separate work.
8. **Accepted risk on the aggregate-drift abstention.** `regenerate()` returns `Err` for an unreadable or mis-slugged shard, and this repo has 149 shards, so a genuinely transient read error would move `validate` from `0` to `3`. Accepted: correct-but-noisy, non-zero rather than green, and a re-run clears it.
9. **An abstention alongside advisory-only findings is not labelled a failure.** Warnings never flip `valid`, so the second headline under an incomplete run is `! N advisory finding(s) from checks that did run` when `valid` is still true, and `x Validation failed (N issues)` only when it is not. (Caught in code review — the first cut labelled every finding a failure, which this repo's ~39 RMH002 advisories would have hit constantly.)
10. **`valid` keeps reporting only on checks that ran** — it stays `true` when a check abstained, so `--json` consumers must gate on `complete` (or the exit code), not `valid`. Documented explicitly in `docs/reference/cli.md` and the changeset rather than left to a TypeScript doc comment.
11. **The `--json` payload is not byte-identical** — it gains `complete` and `unavailableChecks` additively. The byte-identical guarantee is scoped to human-readable output. The changeset says so.
12. **Existing advisory noise stays advisory.** RMH002 remains a `warning` that does not fail validation. The pre-existing RMH002 / RMH003 / absent-roadmap tests pass **unmodified**; only additive `complete` / `unavailableChecks` assertions were added to them.
13. **Two adjacent weak spots deliberately left alone**: `fileStructure` is hardcoded `true` pending conventions support, and the merge-driver doctor silently treats a `git config` failure as "unconfigured". Same defect family, but neither is roadmap-related and each carries its own design question.
14. **No roadmap row was promoted.** No row existed for this item, and `manage_roadmap add` auto-creates a **new** tracking issue, which would duplicate the one this PR references. The issue is the record.
15. **Docs went to `docs/reference/cli.md`**, the hand-maintained page — not `docs/reference/cli-commands.md`, which is auto-generated and whose hand-editing is blocked by `generate-docs --check` in pre-push. The global `## Exit Codes` table already omitted `3` despite four commands using it; that is repaired here too.

## Verification

- `pnpm --filter @harness-engineering/cli test` — **527 files, 6046 tests, all passing**
- `pnpm -w typecheck` (22 tasks), `pnpm -w lint` (12 tasks), `pnpm format:check`, `pnpm build` — green
- `pnpm run generate-docs --check` — reference docs fresh
- `pnpm docs:build` — VitePress build clean
- Full pre-push gate ran (no `--no-verify`), including the coverage ratchet — all packages meet or exceed baselines
- Manual reproduction of both bug-report fixtures against the rebuilt CLI confirms the inversion above

**Review pass.** An adversarial spec review and a full code review were run against this change; both requested changes and both sets of findings are addressed in the second commit. The substantive one was the advisory-mislabel above; the rest were a dead computation on the drift path, `complete` being assignment-derived rather than return-derived, CLI tests that would `skipIf` themselves out of existence when `dist/` was missing, QUIET conflating abstentions with findings, and the two doc/changeset accuracy gaps. The Windows CI failure was an `EBUSY` temp-dir teardown flake in the new tests (assertions passed) — teardown now retries and tolerates it.

New/changed test coverage: parse-failure abstention, `--severity` unfilterability, aggregate-drift abstention, CLI-level exit `3` / `1` / `0`, incomplete-and-failing dual headline, QUIET-mode abstention (which would otherwise print nothing while exiting 3), VERBOSE-only suggestions, an explicit assertion that rendering is identical whether `unavailableChecks` is empty or omitted, abstention-plus-advisory-only (the mislabel case), a failing check that pushes no issue, QUIET distinguishing abstentions from findings, `--severity error` still exiting 3, and a guard that the built CLI actually exists rather than silently skipping.

## Pipeline artifacts

- Spec: `docs/changes/validate-check-abstention/proposal.md`
- Plan: `docs/changes/validate-check-abstention/plans/2026-08-10-validate-check-abstention-plan.md`

Closes #1252