### PR TITLE
feat(cli): refuse to scan when sharply out of step with the workspace

### DIFF
--- a/.changeset/toolchain-version-guard.md
+++ b/.changeset/toolchain-version-guard.md
@@ -1,0 +1,60 @@
+---
+'@harness-engineering/cli': patch
+---
+
+Refuse to run findings-producing commands when the CLI is sharply out of step
+with the workspace it is scanning.
+
+A stale scanner does not fail — it emits well-formed, confident, wrong output.
+In the run that motivated this change, a Node bin directory was prepended to
+`PATH` to obtain Node 22; that directory also contained a `harness` shim
+symlinked to an install ten major versions old. Every process spawned under that
+`PATH` ran the old CLI, which predates the prior-line `harness-ignore`
+suppression pass and therefore re-reported every already-justified suppression.
+33 of 36 code-side security findings were phantoms, and the single finding
+escalated to a human decision gate pointed at a line that was the XSS detection
+vocabulary registry — annotated as definitional and suppressed.
+
+A workspace can now declare the CLI line it expects via a new optional
+`toolchain.cliVersion` key in `harness.config.json` (a semver range, e.g.
+`">=11"`). The CLI compares its own version against that range, falling back to a
+`@harness-engineering/cli` range in the project's `package.json`
+`devDependencies`/`dependencies` when no config pin is set. Non-semver
+specifiers (`workspace:*`, `file:`, `link:`, `git+`, `*`, `latest`) are ignored
+rather than coerced, so monorepos do not produce false mismatches.
+
+The severity ladder is deliberately asymmetric, because staleness is the
+dangerous direction — an older scanner re-reports resolved findings (falsehood),
+while a newer one reports rules the workspace has not adopted yet (noise):
+
+- range satisfied — silent
+- 2+ majors behind the range minimum — **refuse**, exit code 3 (`ZERO_DENOMINATOR`
+  — "abstained, not passed"; deliberately not exit 1, which is what these
+  commands already return when they found _real_ findings)
+- exactly 1 major behind, or unsatisfied at a delta of 0 or less — warn, proceed
+
+Only findings-producing commands are gated: `check-security`, `check-docs`,
+`check-deps`, `check-perf`, `check-harness-strength`, `cleanup`, `validate`, and
+`review-ci`. `doctor`, `update`, `setup`, and `init` are deliberately never
+gated — those are the commands you need when your toolchain is wrong, and a
+guard that blocks its own remedy is a trap.
+
+When no expected version can be resolved, the guard is silent. Warning there
+would fire for every project that has not opted in and would train everyone to
+ignore the output, destroying the signal for the case that matters.
+
+`HARNESS_NO_VERSION_GUARD=1` downgrades a refusal to a warning. It
+deliberately does **not** silence the notice: a variable that suppressed the
+message entirely would be exported once into a shell profile or CI config and
+would restore the original silent failure permanently. The hatch buys a working
+command, not a quiet one.
+
+The refusal message names both versions, the expectation's source, and the
+resolved path of the binary actually running — that last line is the one that
+makes a shadowed `PATH` visible, which is what nobody could see when this
+happened.
+
+Note the inherent limitation: this guard cannot fire inside a CLI old enough to
+predate it. It makes the failure class loud going forward; the accompanying
+`-fleet` family reference documents the `PATH`-shadowing trap for as long as
+stale binaries remain in circulation.

--- a/.changeset/toolchain-version-guard.md
+++ b/.changeset/toolchain-version-guard.md
@@ -33,9 +33,9 @@ while a newer one reports rules the workspace has not adopted yet (noise):
   commands already return when they found _real_ findings)
 - exactly 1 major behind, or unsatisfied at a delta of 0 or less — warn, proceed
 
-Only findings-producing commands are gated: `check-security`, `check-docs`,
-`check-deps`, `check-perf`, `check-harness-strength`, `cleanup`, `validate`, and
-`review-ci`. `doctor`, `update`, `setup`, and `init` are deliberately never
+Only findings-producing commands are gated: `check-arch`, `check-deployment`,
+`check-deps`, `check-docs`, `check-harness-strength`, `check-perf`,
+`check-security`, `cleanup`, `cross-check`, `review-ci`, and `validate`. `doctor`, `update`, `setup`, and `init` are deliberately never
 gated — those are the commands you need when your toolchain is wrong, and a
 guard that blocks its own remedy is a trap.
 

--- a/docs/changes/toolchain-version-guard/plans/2026-08-10-toolchain-version-guard-plan.md
+++ b/docs/changes/toolchain-version-guard/plans/2026-08-10-toolchain-version-guard-plan.md
@@ -41,28 +41,25 @@ make every config-loading command emit a spurious warning. Hard prerequisite.
 
 ---
 
-### T2 — Extract a prefix-free `resolveCommandPath`
+### T2 — A prefix-free `resolveCommandPath` (owned by the guard)
 
-**File:** `packages/cli/src/bin/command-telemetry.ts`
+**File:** `packages/cli/src/utils/version-guard.ts`
 
-Split the existing `resolveCommandName` (lines 77-88):
+The guard needs a command path with no namespace prefix. The existing helper in
+`command-telemetry.ts` returns `cli/`-prefixed names; reusing it directly would
+make `GUARDED_COMMANDS.has(...)` always false — a permanently silent no-op, i.e.
+this change reproducing its own bug class. Caught in soundness review as B1.
 
-```ts
-export function resolveCommandPath(cmd: Command): string; // "validate", "graph.scan"
-function resolveCommandName(cmd: Command): string; // `cli/${resolveCommandPath(cmd)}`
-```
+Originally planned as a refactor extracting the shared traversal out of
+`command-telemetry.ts`. **Changed during execution:** `required-review` failed on
+the first push because touching that file pulled its pre-existing, annotated
+PostHog ingest key into the scanned diff (the `harness-ignore` is honored by the
+security scanner but not by the review-ci heuristic path). Since the refactor
+benefits §5 not at all, the guard now owns a local copy and
+`command-telemetry.ts` is left untouched. A test pins the divergence.
 
-`resolveCommandName` keeps its exact current output, including the empty-string
-case when the path is empty (it must NOT become `cli/`). Telemetry behavior is
-unchanged; this is a pure refactor.
-
-**Why this task exists at all:** the existing helper returns `cli/`-prefixed
-names. Reusing it directly in the guard would make `GUARDED_COMMANDS.has(...)`
-always false — a permanently silent no-op, i.e. this change reproducing its own
-bug class. Caught in soundness review as B1.
-
-**Test:** `packages/cli/tests/bin/command-telemetry.test.ts` — assert
-`resolveCommandPath` returns unprefixed paths and `_resolveCommandName` still
+**Test:** `packages/cli/tests/utils/version-guard-wiring.test.ts` — assert
+`resolveCommandPath` returns unprefixed paths while `_resolveCommandName` still
 returns `cli/`-prefixed ones. (Criterion 7a.)
 
 ---

--- a/docs/changes/toolchain-version-guard/plans/2026-08-10-toolchain-version-guard-plan.md
+++ b/docs/changes/toolchain-version-guard/plans/2026-08-10-toolchain-version-guard-plan.md
@@ -1,0 +1,195 @@
+# Plan: toolchain version guard
+
+**Spec:** `docs/changes/toolchain-version-guard/proposal.md`
+**Package:** `@harness-engineering/cli`
+**Base:** `origin/main` @ `255ccbe24`
+**Scope:** §5 of the fleet-command first-run report only.
+
+## Preconditions verified before planning
+
+- Node 22 pinned by absolute path (`/Users/cwarner/.nvm/versions/node/v22.20.0/bin/node`),
+  exposed through a shim directory containing **only** `node` — the nvm `bin`
+  directory is never placed on `PATH`, since it carries the stale `harness`
+  shim that this change exists to defend against.
+- `harness` resolves to `/opt/homebrew/bin/harness`, `--version` → `11.1.1`.
+- Baseline: `pnpm build` 13/13 successful; `packages/cli` tests 526 files /
+  6027 tests, all passing. Any failure after this point is mine.
+
+## Task graph
+
+Tasks are ordered so that pure logic lands and is tested before any wiring, and
+so the two behavior-preserving refactors (T2) are separated from behavior
+changes (T4).
+
+### T1 — Config schema: `toolchain.cliVersion`
+
+**File:** `packages/cli/src/config/schema.ts`
+
+Add to `HarnessConfigSchema` (line ~924):
+
+```ts
+toolchain: z.object({ cliVersion: z.string().optional() }).optional(),
+```
+
+**Why first:** `HarnessConfigSchema` is a closed `z.object` that strips unknown
+keys, and `warnStrippedKeys` (`config/loader.ts:87`) writes a stderr warning per
+stripped key. Without this, adding the pin to `harness.config.json` in T6 would
+make every config-loading command emit a spurious warning. Hard prerequisite.
+
+**Test:** `packages/cli/tests/config/` — loading a config containing
+`toolchain.cliVersion` retains it. (Criterion 8.)
+
+---
+
+### T2 — Extract a prefix-free `resolveCommandPath`
+
+**File:** `packages/cli/src/bin/command-telemetry.ts`
+
+Split the existing `resolveCommandName` (lines 77-88):
+
+```ts
+export function resolveCommandPath(cmd: Command): string; // "validate", "graph.scan"
+function resolveCommandName(cmd: Command): string; // `cli/${resolveCommandPath(cmd)}`
+```
+
+`resolveCommandName` keeps its exact current output, including the empty-string
+case when the path is empty (it must NOT become `cli/`). Telemetry behavior is
+unchanged; this is a pure refactor.
+
+**Why this task exists at all:** the existing helper returns `cli/`-prefixed
+names. Reusing it directly in the guard would make `GUARDED_COMMANDS.has(...)`
+always false — a permanently silent no-op, i.e. this change reproducing its own
+bug class. Caught in soundness review as B1.
+
+**Test:** `packages/cli/tests/bin/command-telemetry.test.ts` — assert
+`resolveCommandPath` returns unprefixed paths and `_resolveCommandName` still
+returns `cli/`-prefixed ones. (Criterion 7a.)
+
+---
+
+### T3 — The evaluator: `packages/cli/src/utils/version-guard.ts`
+
+New module, sibling of `node-version.ts`. Pure logic + two error-swallowing file
+reads. **Never prints, never exits, never reads `process.env`.**
+
+Exports: `VersionGuardStatus`, `ExpectedVersion`, `VersionGuardResult`,
+`GUARDED_COMMANDS`, `resolveExpectedVersion`, `evaluateVersionGuard`.
+
+`resolveExpectedVersion(projectRoot, configPathOverride?)`:
+
+1. Read `configPathOverride ?? join(projectRoot, 'harness.config.json')` via
+   `readFileSync` + `JSON.parse` in a try/catch. Take `toolchain.cliVersion`.
+   **Not** via `resolveConfig` — it prints to stderr and ignores `projectRoot`
+   (soundness B3).
+2. Fall back to `<projectRoot>/package.json` `devDependencies` then
+   `dependencies` for `@harness-engineering/cli`.
+3. Both candidates pass through `semver.validRange()`; invalid → skip that
+   source. This covers `workspace:*`, `file:`, `link:`, `git+`, `latest`.
+   (`*` is a _valid_ range whose `minVersion` is `0.0.0`; it is filtered
+   explicitly as uninformative.)
+
+`evaluateVersionGuard(cliVersion, expected, { bypass })`:
+
+```
+if (!expected) return unknown
+if (!semver.valid(cliVersion) || cliVersion === '0.0.0') return unknown   // S3
+if (semver.satisfies(cliVersion, expected.range)) return ok
+const min = semver.minVersion(expected.range)                            // may be null
+if (!min) return unknown                                                 // B2
+delta = min.major - semver.major(cliVersion)
+status = delta >= 2 ? 'refuse' : 'warn'
+if (status === 'refuse' && bypass) status = 'warn', bypassed = true       // N2
+```
+
+`GUARDED_COMMANDS`: `ReadonlySet<string>` of the eight verified top-level names
+— `check-security`, `check-docs`, `check-deps`, `check-perf`,
+`check-harness-strength`, `cleanup`, `validate`, `review-ci`.
+
+**Tests:** `packages/cli/tests/utils/version-guard.test.ts` (tests mirror `src/`
+under `tests/`; there is no co-located `__tests__` convention here). Cover
+criteria 1, 2, 3-status, 4, 5, 7b, 7c, 9, 10. Explicitly assert **no throw** for
+`latest`, `workspace:*`, `file:../cli`, `>=11 <10`.
+
+---
+
+### T4 — Wiring: `installVersionGuard`
+
+**Files:** `packages/cli/src/utils/version-guard.ts` (installer),
+`packages/cli/src/index.ts` (one call inside `createProgram()`).
+
+Root `program.hook('preAction', …)` with the `typeof program.hook !== 'function'`
+test-environment guard. Resolves the command path, returns early if not guarded,
+resolves expected version (honoring `optsWithGlobals().config`, criterion 7d),
+evaluates with `bypass: envEnabled(process.env['HARNESS_NO_VERSION_GUARD'])`.
+
+- `warn` → `process.stderr.write(message)`, continue.
+- `refuse` → `process.stderr.write(message)`, `process.exit(ExitCode.ZERO_DENOMINATOR)`.
+
+`process.exit()` inside a `preAction` hook has direct in-repo precedent at
+`check-security.ts:247-253`, and commander runs ancestor hooks before descendant
+ones, so the root guard fires first.
+
+Message content: both versions, the expectation source, `Running binary`
+(`process.argv[1]`), `Node` (`process.execPath`), the `which -a harness` hint,
+and the escape hatch.
+
+**Tests:** criteria 6 and 7 — `doctor`/`update` are not gated; every
+`GUARDED_COMMANDS` entry matches a top-level command on `createProgram()`.
+
+**Regression risk checked:** no existing test imports the real `createProgram`
+from `src/index` (the four `createProgram` occurrences in tests are local
+helpers; `tests/bin/first-run-integration.test.ts:16` mocks it). Adding the hook
+is safe.
+
+---
+
+### T5 — Docs
+
+- `docs/reference/fleet-family.md` — **done during spec phase.** New "Runtime
+  preconditions" section after "The worktree push-path caveat". No issue/PR/
+  roadmap numbers (criterion 11).
+- `docs/reference/configuration.md` — hand-write the `toolchain` key into the
+  top-level fields section. This file is **not** generated (`generate-docs.mjs`
+  emits only `cli-commands.md`, `mcp-tools.md`, `skills-catalog.md`).
+
+VitePress constraints: no multi-line inline code spans, no bare angle brackets.
+
+---
+
+### T6 — Dogfood
+
+`harness.config.json` gains `"toolchain": { "cliVersion": ">=11" }`. Major-only
+comparison means no maintenance across the v11 line.
+
+---
+
+### T7 — Verification
+
+1. `pnpm --filter @harness-engineering/cli test` — full suite, compare to the
+   6027-test baseline.
+2. `pnpm build` (arch scan reads the local `dist`, so build before pushing).
+3. `pnpm typecheck`, `pnpm lint`.
+4. `pnpm format:check` — CI gate that `harness validate` does not catch.
+5. `pnpm check:changesets`.
+6. `pnpm docs:build` — VitePress gate, also not caught by `harness validate`.
+7. `/opt/homebrew/bin/harness validate`.
+8. **Live end-to-end**: with the dogfood pin in place, run a guarded command via
+   the built `dist` and confirm exit 0; then simulate a stale CLI by evaluating
+   against `1.13.1` and confirm `refuse`. The whole point is a mechanism that
+   demonstrably fires.
+9. `.harness/arch/baselines.json` — inspect for byte-noise churn before staging.
+
+## Checkpoints
+
+- **After T3** — evaluator green in isolation. If the ladder is wrong, it is
+  cheap to change here and expensive after wiring.
+- **After T4** — full `packages/cli` suite must still be 6027 passing (plus new).
+  A root `preAction` hook is the highest-blast-radius edit in this change.
+- **Before push** — rebase on `origin/main`; sibling fleet lanes are running and
+  generated artifacts conflict on every parallel PR.
+
+## Out of scope (do not drift into)
+
+The other 31 findings in the source report; `harness doctor` integration; Node
+interpreter pinning beyond the existing `node-version.ts`; any edit to a fleet
+`SKILL.md` body; auto-remediation of a detected mismatch.

--- a/docs/changes/toolchain-version-guard/proposal.md
+++ b/docs/changes/toolchain-version-guard/proposal.md
@@ -83,6 +83,15 @@ other findings; they are routed separately and are explicitly out of scope here.
   `packages/cli/src/utils/node-version.ts` already does.
 - Any auto-remediation (auto-upgrading, re-execing the correct binary). The
   guard reports and refuses; it never rewrites the caller's environment.
+- **The MCP surface.** The guard is a commander `preAction` hook, so it covers
+  CLI invocations only. The MCP tools call the check implementations in-process
+  and do not pass through commander, so a stale `harness-mcp` shim — and the
+  Node-22 bin directory carries one alongside `harness` — reproduces this
+  incident with no mitigation from this change. That is a real remaining gap, and
+  arguably the more likely path for an agent-driven conductor. Gating the
+  findings-producing MCP tool handlers with the same evaluator is the natural
+  follow-up; it is named here so the gap is explicit rather than implied to be
+  covered.
 
 ## Prior art in this codebase
 
@@ -185,8 +194,10 @@ Rationale for the thresholds:
   has already justified, which is falsehood. Noise is a warning; falsehood, at
   sufficient distance, is a refusal.
 
-Comparison is on the **major** component only. This keeps the config pin
-low-maintenance: a repo pinning `>=11` needs no edit across the entire v11 line.
+Range satisfaction is full-precision; only the **severity** decision is
+major-only. This keeps the config pin low-maintenance — a repo pinning `>=11`
+needs no edit across the entire v11 line — while still letting a narrower pin
+like `^11.2.0` produce an honest warning against `11.1.1`.
 
 ### D3 — Which commands does the guard gate?
 
@@ -205,9 +216,17 @@ wrong, and a guard that blocks its own remedy is a trap. An explicit allowlist,
 exported as a single reviewable constant, also means the gated set can be
 asserted in a test rather than inferred.
 
-The gated set is the eight findings-producing commands:
-`check-security`, `check-docs`, `check-deps`, `check-perf`,
-`check-harness-strength`, `cleanup`, `validate`, `review-ci`.
+The gated set is every findings-producing command. The objective membership
+test is the `--findings-json` contract flag — that is the machine-readable output
+an orchestrator parses and schedules on, which is exactly what a stale scanner
+corrupts: `check-arch`, `check-deployment`, `check-deps`, `check-docs`,
+`check-security`, `cleanup`, `cross-check`. Four more produce findings without
+the contract flag: `check-perf`, `check-harness-strength`, `validate`,
+`review-ci`. Eleven in total.
+
+A test derives the `--findings-json` family from source and asserts the set
+covers it, so a new findings producer cannot ship ungated. Membership tests
+alone would only catch renames, not omissions.
 
 Deliberately **not** gated: `doctor`, `update`, `setup`, `init`, `--version`,
 `--help`, and everything else. `doctor` in particular should _report_ the

--- a/docs/changes/toolchain-version-guard/proposal.md
+++ b/docs/changes/toolchain-version-guard/proposal.md
@@ -1,0 +1,631 @@
+# Refuse to scan when the CLI is sharply out of step with the workspace it is scanning
+
+**Keywords:** toolchain-pin, version-guard, semver, stale-scanner, phantom-findings, preAction-hook, harness-config, runtime-precondition
+
+## Overview
+
+A scanner that predates the rules it is evaluating does not fail — it produces
+confident, well-formatted, wrong output. That output is indistinguishable from a
+real result, and everything downstream treats it as evidence.
+
+This is not hypothetical. Measured live on this machine:
+
+```
+$ ~/.nvm/versions/node/v22.20.0/bin/harness --version
+1.13.1
+$ /opt/homebrew/bin/harness --version
+11.1.1
+```
+
+`~/.nvm/versions/node/v22.20.0/bin/harness` is a symlink (dated Mar 27) into
+`../lib/node_modules/@harness-engineering/cli/dist/bin/harness.js`. The
+Node-22 bin directory is not just an interpreter directory — it carries its own
+`harness` and `harness-mcp` shims. Anything that prepends that directory to
+`PATH` in order to get Node 22 silently also acquires a ten-major-versions-stale
+`harness`.
+
+That is exactly what happened in the run that produced this work item. A fleet
+conductor, correctly obeying a documented "use Node 22 for this repo"
+precondition, prepended the Node-22 bin directory to `PATH` for every probe and
+every lane. Every one of them then ran a v1.13.1 scanner against a v11 workspace.
+v1.13.1 predates the prior-line `harness-ignore` suppression pass, so it
+re-reported every already-justified suppression as a live finding. The
+consequences were not cosmetic:
+
+- 33 of the security probe's 36 code-side findings were phantoms.
+- The sole ERROR escalated to a human decision gate — `dangerouslySetInnerHTML`
+  at `packages/core/src/review/finding-integrity.ts:94` — **does not exist**.
+  That line is the XSS _detection vocabulary registry_, annotated
+  `harness-ignore SEC-XSS-002: definitional`.
+- A queue depth of 41 that drove a scheduling decision was roughly 90% noise.
+
+Three properties of this failure are worth naming, because they determine the
+shape of the fix:
+
+1. **It is silent.** No error, no warning, no exit code. The only signal was a
+   version string nobody thought to read.
+2. **It is high-leverage.** One environment assumption, injected once, corrupted
+   every downstream consumer simultaneously.
+3. **The victims were all doing the right thing.** The precondition was real, the
+   directory was correct for its stated purpose, and the failure came from a
+   side effect of _how_ it was applied.
+
+Point 3 is why the durable fix cannot be "be more careful with `PATH`."
+Prescribing careful `PATH` handling asks every future caller to get an invisible
+detail right forever. The load-bearing fix is to make the CLI itself refuse to
+emit findings when it is sharply out of step with the workspace it is pointed
+at — so that when the careful handling is eventually gotten wrong (and it will
+be), the result is a loud refusal rather than 33 phantoms.
+
+This proposal addresses **§5 of the source report only**. The report carries 31
+other findings; they are routed separately and are explicitly out of scope here.
+
+## Problem boundary
+
+**In scope**
+
+- A mechanism inside the CLI that detects a sharp version mismatch between the
+  running binary and the workspace it is scanning, and refuses to produce
+  findings when the gap is large.
+- A declarative way for a workspace to state which CLI major line it expects.
+- Documenting the Node-22 runtime precondition — and the `PATH`-shadowing trap
+  that the naive reading of it creates — in the `-fleet` family reference, which
+  today says nothing about runtime environment at all.
+
+**Out of scope**
+
+- The other 31 findings in the source report (probe-depth fidelity, the
+  structural shed, gate batching, enforcement seams, the separable defects).
+- Changing how any fleet skill actually spawns processes. No fleet `SKILL.md`
+  body is modified by this change; the family reference is the single documented
+  home for the family-wide precondition.
+- Pinning or validating the Node interpreter version beyond what
+  `packages/cli/src/utils/node-version.ts` already does.
+- Any auto-remediation (auto-upgrading, re-execing the correct binary). The
+  guard reports and refuses; it never rewrites the caller's environment.
+
+## Prior art in this codebase
+
+The pieces this builds on already exist; nothing here is a new pattern.
+
+- `packages/cli/src/utils/node-version.ts` — `REQUIRED_NODE_VERSION = '>=22.0.0'`
+  and `checkNodeVersion()` via `semver.satisfies(process.version, ...)`. This is
+  the established "your toolchain is wrong" shape, and the new guard is a direct
+  sibling of it. It is consumed by `commands/doctor.ts:676` and
+  `commands/setup.ts:224` — i.e. it _reports_, it does not gate.
+- `packages/cli/src/commands/install-constraints.ts:80-88` — already does a
+  `semver.lt(CLI_VERSION, bundle.minHarnessVersion)` refusal against a
+  `minHarnessVersion` declared on a constraint bundle
+  (`packages/core/src/constraints/sharing/types.ts:10`). The concept of "this
+  artifact declares the CLI version it needs" is therefore already established;
+  this proposal extends it from constraint bundles to the workspace itself.
+- `packages/cli/src/version.ts` — `CLI_VERSION`, read from the CLI's own
+  `package.json` via `createRequire`, falling back to `'0.0.0'`.
+- `packages/cli/src/bin/command-telemetry.ts:45-72` — the only existing
+  _root-level_ `program.hook('preAction', ...)`. It proves a root hook fires for
+  every subcommand and shows the `resolveCommandName(actionCommand)` idiom for
+  recovering the dotted command name (`graph.scan`). The guard reuses both.
+- `packages/core/src/update-checker.ts:33-37` — `HARNESS_NO_UPDATE_CHECK === '1'`
+  is the established env-var opt-out convention (`HARNESS_*`, compared against
+  the string `'1'`).
+- `semver` is already a direct dependency of `packages/cli` (`^7.7.4`, with
+  `@types/semver`). It is **not** a dependency of `packages/core`, which is one
+  reason the guard is placed in `cli`.
+
+Nothing anywhere currently reads the consuming project's expected harness
+version. `HarnessConfigSchema` (`packages/cli/src/config/schema.ts:924`) has a
+top-level `version: z.literal(1)`, but that is the _config schema_ version, not a
+toolchain pin. There is no existing symbol named `versionMismatch`,
+`majorVersion`, or `checkVersion` in the repo.
+
+## Decisions made
+
+Per the `-fleet` family's autonomous-default interaction model, each decision
+below was taken on its recommended default and is recorded here with the
+tradeoff that was weighed, rather than deferred to an interactive round.
+
+### D1 — Where does the "expected version" come from?
+
+|            | A) Project `package.json` dep only | B) New `harness.config.json` field only | C) Config field, falling back to the dep |
+| ---------- | ---------------------------------- | --------------------------------------- | ---------------------------------------- |
+| **Pros**   | Zero new config surface            | Works for global installs               | Covers both install shapes               |
+| **Cons**   | Blind to global installs           | New schema surface to maintain          | Two sources, needs a precedence rule     |
+| **Risk**   | Inert in the exact reported case   | Inert for adopters who never set it     | Low                                      |
+| **Effort** | Low                                | Low                                     | Low                                      |
+
+**Chosen: C.** Option A is disqualified by measurement, not preference: this
+repo's root `package.json` declares only `@harness-engineering/eslint-plugin`
+among harness packages, there is no `node_modules/@harness-engineering/cli`, and
+the offending binary in the incident was a _global_ install. Under A the guard
+would have been inert in precisely the situation that motivated it. The
+`harness.config.json` field is therefore load-bearing rather than speculative.
+The `package.json` dependency range is kept as a fallback because for adopters
+who _do_ install locally it is a pin they already maintain, and reading it costs
+nothing.
+
+Precedence: explicit config pin wins over an inferred dependency range, because
+one is a statement of intent and the other is an artifact of package management.
+
+### D2 — What does "differs sharply" mean?
+
+|            | A) Any major difference refuses | B) Major delta ≥ 2 refuses | C) Satisfies-range first, then a delta ladder  |
+| ---------- | ------------------------------- | -------------------------- | ---------------------------------------------- |
+| **Pros**   | Simplest rule to state          | Tolerates routine upgrades | Uniform across both sources; no false refusals |
+| **Cons**   | Breaks every mid-upgrade repo   | Ignores intra-major pins   | Two-step rule to document                      |
+| **Risk**   | High — hostile to adopters      | Medium                     | Low                                            |
+| **Effort** | Low                             | Low                        | Low                                            |
+
+**Chosen: C.** Both sources naturally yield a semver _range_ (`^11.1.1` from a
+dependency, `>=11` from a hand-written pin), so range satisfaction is the honest
+primary test, and it makes the whole guard silent in the overwhelmingly common
+case where nothing is wrong. Only when the range is _not_ satisfied does severity
+need deciding, and there the delta ladder applies:
+
+```
+satisfies(CLI_VERSION, range)                        -> ok        (silent)
+otherwise, delta = minVersion(range).major - CLI major:
+  delta >= 2                                         -> refuse
+  delta == 1                                         -> warn
+  delta <= 0                                         -> warn
+```
+
+Rationale for the thresholds:
+
+- **≥ 2 refuses.** Two or more majors behind is not an upgrade in progress; it is
+  a different tool. The incident was a delta of 10.
+- **Exactly 1 warns rather than refuses.** Being one major behind is the normal
+  state of a repository partway through an upgrade. Refusing there would convert
+  this guard from a safety net into an outage, and would guarantee it gets
+  disabled wholesale.
+- **delta ≤ 0 warns.** This covers two cases: an unsatisfied pin _within_ a major
+  (`^11.2.0` pinned, `11.1.1` running — a minor gap, never worth blocking) and a
+  CLI _ahead_ of the pinned major. Being ahead is a genuinely milder failure than
+  being behind: a newer scanner may report rules the workspace has not adopted
+  yet, which is noise, whereas an older scanner re-reports findings the workspace
+  has already justified, which is falsehood. Noise is a warning; falsehood, at
+  sufficient distance, is a refusal.
+
+Comparison is on the **major** component only. This keeps the config pin
+low-maintenance: a repo pinning `>=11` needs no edit across the entire v11 line.
+
+### D3 — Which commands does the guard gate?
+
+|            | A) Every command         | B) Allowlist of findings-producing commands | C) Everything except a recovery set |
+| ---------- | ------------------------ | ------------------------------------------- | ----------------------------------- |
+| **Pros**   | No gaps                  | Scoped to the actual failure mode           | Few gaps, keeps recovery working    |
+| **Cons**   | Bricks `doctor`/`update` | New commands must opt in                    | Large blast radius; denylist drifts |
+| **Risk**   | High                     | Low                                         | Medium                              |
+| **Effort** | Low                      | Low                                         | Low                                 |
+
+**Chosen: B.** The report's ask is specific — "refuse to **scan**" — and the harm
+is specific to commands whose output is a findings list that a human or a
+conductor will act on. Gating everything is actively dangerous: `harness doctor`
+and `harness update` are the commands a user needs _most_ when their toolchain is
+wrong, and a guard that blocks its own remedy is a trap. An explicit allowlist,
+exported as a single reviewable constant, also means the gated set can be
+asserted in a test rather than inferred.
+
+The gated set is the eight findings-producing commands:
+`check-security`, `check-docs`, `check-deps`, `check-perf`,
+`check-harness-strength`, `cleanup`, `validate`, `review-ci`.
+
+Deliberately **not** gated: `doctor`, `update`, `setup`, `init`, `--version`,
+`--help`, and everything else. `doctor` in particular should _report_ the
+mismatch, which it can do by reusing the same evaluator.
+
+### D3a — What exit code does a refusal use?
+
+`packages/cli/src/utils/errors.ts:4-20` defines exactly four codes. The choice
+matters more than it looks:
+
+- **`VALIDATION_FAILED` (1) — rejected.** This is what `check-docs` and
+  `check-security` return when they found _real findings_. A refusal exiting 1 is
+  indistinguishable to an automated consumer from "the scan ran and found
+  problems," which is precisely the confusion this change exists to eliminate.
+- **`ERROR` (2) — rejected.** Defensible, but it conflates "your toolchain is
+  stale" with "the command malfunctioned," and it is the code an unhandled throw
+  already produces.
+- **`ZERO_DENOMINATOR` (3) — chosen.** Its own doc comment reads: "The command
+  ran but examined NOTHING — a zero denominator. […] A gate that matched,
+  compared, or fetched zero items has **abstained, not passed**, and must never
+  read as green." A refusal is an abstention: nothing was examined, nothing
+  malfunctioned, and the one thing that must not happen is for it to read as a
+  pass. It is a general-purpose code, not roadmap-specific.
+
+### D4 — Is an escape hatch needed, and what does it suppress?
+
+|            | A) No hatch                     | B) `HARNESS_SKIP_VERSION_GUARD=1` silences everything | C) Hatch downgrades refusal to warning |
+| ---------- | ------------------------------- | ----------------------------------------------------- | -------------------------------------- |
+| **Pros**   | Cannot be defeated              | Simple                                                | Unblocks without hiding                |
+| **Cons**   | No path for legitimate cases    | Recreates the silent failure it exists to prevent     | Slightly more to explain               |
+| **Risk**   | High — becomes a support burden | High — a set-and-forget var restores the incident     | Low                                    |
+| **Effort** | —                               | Low                                                   | Low                                    |
+
+**Chosen: C.** Legitimate cross-version use exists — bisecting across a major
+boundary, deliberately reproducing an old scanner's output, or an adopter who
+must keep CI on the old CLI for one more day. An unbypassable gate in a CLI is a
+support burden that gets solved by pinning an old version forever, which is worse.
+
+But option B would reintroduce the exact defect this change exists to prevent: a
+`HARNESS_SKIP_VERSION_GUARD=1` exported once in a shell profile or a CI config
+would restore silent phantom findings permanently, and nobody would remember it
+was set. So the hatch is scoped to suppress the **refusal**, never the **notice**.
+With the hatch set and a sharp mismatch present, the warning is still printed to
+stderr on every run. The escape hatch buys you a working command; it does not buy
+you a quiet one.
+
+Name: `HARNESS_NO_VERSION_GUARD`. The repo's two existing suppression variables
+are `HARNESS_NO_UPDATE_CHECK` (`packages/core/src/update-checker.ts:34`) and
+`HARNESS_SUPPRESS_CONFIG_WARNINGS` (`packages/cli/src/config/loader.ts:88`);
+there is no `HARNESS_SKIP_*` anywhere, so `HARNESS_NO_*` is the convention.
+Truthiness is tested with the existing `envEnabled()` helper
+(`packages/cli/src/utils/env-flag.ts`), which accepts `1`/`true`/`yes`/`on`
+case-insensitively — hardcoding `=== '1'` would refuse a user who exported
+`=true`, which is a bug report waiting to happen.
+
+### D5 — What happens when no expected version can be determined?
+
+**Chosen: proceed silently.** No config pin and no dependency range means the
+guard has nothing to compare against. Warning in that case would fire on every
+adopter who has not opted in, training everyone to ignore the guard's output —
+which destroys the signal for the case that matters. An undeterminable version is
+recorded in the evaluator's result as a distinct outcome (`unknown`) so that
+`doctor` can surface it as an advisory, but it never gates and never warns during
+a scan.
+
+This is an accepted limitation and worth stating plainly: **the guard is
+forward-looking.** It cannot help against a CLI old enough to predate the guard
+itself — v1.13.1 will never refuse anything, because it does not contain this
+code. What it does is ensure that from this version onward, the same class of
+drift surfaces loudly. That is why the documentation half of this change is not
+decorative: until stale binaries age out, the `PATH`-shadowing trap has to be
+written down where the people who set `PATH` will read it.
+
+## Technical design
+
+### New module: `packages/cli/src/utils/version-guard.ts`
+
+Placed beside `node-version.ts` as its sibling. The module is a pure evaluator
+plus a resolver; it performs no I/O beyond reading two JSON files, and it never
+writes, prints, or exits. All printing and exiting is the caller's job, which
+keeps the decision logic directly unit-testable.
+
+```ts
+export type VersionGuardStatus = 'ok' | 'unknown' | 'warn' | 'refuse';
+export type ExpectedVersionSource = 'config' | 'dependency';
+
+export interface ExpectedVersion {
+  /** The raw semver range as written by the workspace. */
+  range: string;
+  source: ExpectedVersionSource;
+}
+
+export interface VersionGuardResult {
+  status: VersionGuardStatus;
+  cliVersion: string;
+  expected?: ExpectedVersion;
+  /** minVersion(range).major - major(cliVersion); absent when status is 'unknown'. */
+  majorDelta?: number;
+  /**
+   * True when a refusal was downgraded by the escape hatch. When set, `status`
+   * is rewritten to 'warn' — callers branch on `status` alone, so the bypass
+   * must be expressed there rather than as a flag the caller has to remember.
+   */
+  bypassed: boolean;
+  /** Human-readable explanation; empty string when status is 'ok' or 'unknown'. */
+  message: string;
+}
+
+export function resolveExpectedVersion(
+  projectRoot: string,
+  configPathOverride?: string
+): ExpectedVersion | undefined;
+export function evaluateVersionGuard(
+  cliVersion: string,
+  expected: ExpectedVersion | undefined,
+  opts?: { bypass?: boolean }
+): VersionGuardResult;
+```
+
+`resolveExpectedVersion` reads, in precedence order (D1):
+
+1. `harness.config.json` → `toolchain.cliVersion`.
+2. `<projectRoot>/package.json` → `devDependencies` then `dependencies` for
+   `@harness-engineering/cli`.
+
+**The config file is read directly** with `readFileSync` + `JSON.parse`, _not_
+through `resolveConfig`. Two reasons, both disqualifying for the loader:
+
+- `resolveConfig` → `loadConfig` → `warnStrippedKeys`
+  (`packages/cli/src/config/loader.ts:77,87`) writes to `process.stderr` for
+  every stripped key. Commands that also load config (`check-deps`, `cleanup`,
+  `validate`) would emit those warnings **twice**, violating success criterion 1.
+- `resolveConfig()` with no argument searches from `process.cwd()` via
+  `findConfigFile()`, ignoring the `projectRoot` it was given. The signature is
+  unimplementable against it.
+
+The direct read mirrors the error-swallowing `readPackageDeps` shape at
+`packages/cli/src/commands/advise-skills.ts:19`.
+
+**Every range from either source is validated with `semver.validRange()` before
+use, and anything invalid is treated as `unknown`.** This is not defensive
+padding — it is required for correctness. Measured against the repo's own
+`semver@^7.7.4`, `semver.minVersion()` _throws_ on `latest`, `workspace:*`,
+`file:../cli`, and returns `null` on an unsatisfiable range like `>=11 <10`.
+A user writing `"toolchain": { "cliVersion": "latest" }` would otherwise get a
+`TypeError` raised inside a `preAction` hook, which `parseAsync` rejects into
+`handleError` — bricking all eight guarded commands on a typo'd pin. A version
+guard that breaks the CLI when misconfigured is worse than the drift it prevents.
+The `minVersion() === null` case is likewise mapped to `unknown`.
+
+The non-semver filter therefore applies to **both** sources, not just
+`package.json`. `workspace:*` and friends say nothing about a published version;
+coercing them would manufacture false mismatches in monorepos.
+
+Project root is located by walking up for `harness.config.json`, reusing the
+`findProjectRoot` idiom at `command-telemetry.ts:27-35`. When the global
+`-c/--config <path>` option is present it takes precedence over the walk-up
+result, so that `harness check-deps -c /other/harness.config.json` guards against
+the same config the command scans with — otherwise the guard and the command
+would disagree about which workspace they are in.
+
+`evaluateVersionGuard` implements the D2 ladder. It is a pure function of its
+arguments — no `process.env`, no `process.cwd()` — so the bypass flag is passed
+in by the caller rather than read internally. Every branch is directly testable.
+
+Two additional cases it maps to `unknown` rather than gating:
+
+- `cliVersion === '0.0.0'`. `packages/cli/src/version.ts:6-10` falls back to
+  `'0.0.0'` when its `createRequire('../package.json')` resolution throws.
+  Against this repo's own `>=11` pin that is a major delta of 11 — so any
+  packaging or bundling regression would silently convert into a blanket refusal
+  of every scan command. The sentinel must never gate.
+- A `cliVersion` that is not itself valid semver.
+
+### Wiring: a root `preAction` hook
+
+A single root-level hook installed from `createProgram()` in
+`packages/cli/src/index.ts`, alongside the existing command registration:
+
+```ts
+installVersionGuard(program, process.cwd());
+```
+
+**Placement note.** `installCommandTelemetry` is called from
+`packages/cli/src/bin/harness.ts:29`, _outside_ `createProgram()`. The guard is
+installed _inside_ it instead — deliberately, so that the program object
+`createProgram()` returns is already guarded for every consumer (and so success
+criterion 7 can assert the guarded set against that same object). The installer
+still copies telemetry's internal structure, including the
+`typeof program.hook !== 'function'` test-environment guard at
+`command-telemetry.ts:47`.
+
+```ts
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  const path = resolveCommandPath(actionCommand);
+  if (!GUARDED_COMMANDS.has(path)) return;
+  const expected = resolveExpectedVersion(root, actionCommand.optsWithGlobals().config);
+  const result = evaluateVersionGuard(CLI_VERSION, expected, {
+    bypass: envEnabled(process.env['HARNESS_NO_VERSION_GUARD']),
+  });
+  if (result.status === 'warn') {
+    /* stderr */ return;
+  }
+  if (result.status === 'refuse') {
+    /* stderr + exit ZERO_DENOMINATOR */
+  }
+});
+```
+
+**The command-name helper must be prefix-free.** `resolveCommandName` in
+`command-telemetry.ts:77-88` returns a `cli/`-prefixed path — `harness validate`
+resolves to `cli/validate`, not `validate`. That prefix is _telemetry's_
+namespace (it separates CLI adoption records from hook records). Reusing it
+verbatim would make `GUARDED_COMMANDS.has(...)` always false, and the guard would
+be a permanent silent no-op — the very failure class this change exists to
+prevent, reproduced inside the fix.
+
+So the traversal is extracted as a prefix-free `resolveCommandPath()` returning
+`validate` / `graph.scan`, and telemetry applies its own `cli/` prefix at its
+call site. The helper is already exported for tests as `_resolveCommandName`
+(`command-telemetry.ts:183-186`), so this is a refactor of an existing seam
+rather than a new one.
+
+`GUARDED_COMMANDS` is an exported `ReadonlySet<string>` holding the eight
+**top-level** names from D3, so a test can assert every entry corresponds to a
+registered command — preventing the set from rotting as commands are renamed.
+The set must be matched against the full dotted path, not a bare name: `validate`
+and `update` are ambiguous as bare names (there are nested `skill validate`,
+`linter validate`, `skill update`, `perf update` commands), but they resolve to
+`skill.validate` / `perf.update` and so cannot collide with the top-level
+entries.
+
+### Refusal output
+
+The message must be actionable on its own, because the person reading it usually
+does not yet know they have two `harness` binaries. It names both versions, the
+source of the expectation, the resolved path of the binary that is actually
+running, and the hatch:
+
+```
+harness: refusing to run `check-security`.
+
+  This CLI is v1.13.1, but the workspace expects >=11 (harness.config.json).
+  A scanner 10 major versions behind will report findings this workspace has
+  already resolved.
+
+  Running binary: /Users/…/.nvm/versions/node/v22.20.0/bin/harness
+  Node:           /Users/…/.nvm/versions/node/v22.20.0/bin/node
+
+  Check `which -a harness` — a Node bin directory added to PATH may be
+  shadowing the intended install.
+
+  To run anyway (the warning stays): HARNESS_NO_VERSION_GUARD=1
+```
+
+Printing the running binary path is the single highest-value line: the incident
+was invisible precisely because nobody could see _which_ `harness` was running.
+The script path comes from `process.argv[1]` and the interpreter from
+`process.execPath`. Note that for a global install `process.argv[1]` is the
+_resolved_ `…/dist/bin/harness.js` target rather than the `bin/harness` symlink
+the user typed. That is the more diagnostic of the two — it names the install
+that is actually executing — but the message must not imply otherwise, so it is
+labelled `Running binary` against the resolved path and the accompanying
+`which -a harness` hint is what surfaces the shadowing symlink.
+
+Exit code: `ExitCode.ZERO_DENOMINATOR` per D3a.
+
+### Config schema addition
+
+In `packages/cli/src/config/schema.ts`, added to `HarnessConfigSchema`:
+
+```ts
+toolchain: z
+  .object({
+    cliVersion: z.string().optional(),
+  })
+  .optional(),
+```
+
+Nesting under `toolchain` rather than a flat `cliVersion` key is deliberate: the
+config already has a top-level `version: z.literal(1)` (the schema version) and a
+`template.version` (a number), so a bare `cliVersion` at the root would be the
+third differently-meaning `version`-ish key. `toolchain` scopes it unambiguously.
+
+**Important:** `HarnessConfigSchema` strips unknown keys, mitigated only by the
+stderr warning in `warnStrippedKeys` (`config/loader.ts:87`). A pin added to a
+config without the schema change would be silently discarded, so the schema
+change is a hard prerequisite, not a nicety.
+
+### Dogfooding
+
+This repo's own `harness.config.json` gains `"toolchain": { "cliVersion": ">=11" }`.
+Because comparison is major-only, this pin needs no maintenance across the v11
+line, and it makes the guard live in the repository that produced the incident
+rather than shipping a mechanism nothing exercises.
+
+### Documentation
+
+`docs/reference/fleet-family.md` gains a **Runtime preconditions** section,
+placed adjacent to the existing "The worktree push-path caveat" section, which is
+the established home for family-wide environment gotchas. It states three things:
+
+1. Node ≥ 22 is required (native `better-sqlite3` ABI).
+2. Pin the interpreter by absolute path. Do **not** prepend a Node bin directory
+   to `PATH` to obtain it — those directories can contain their own `harness`
+   shim, and prepending silently substitutes a different CLI for every child
+   process.
+3. Verify `harness --version` before trusting scan output; a stale scanner
+   re-reports already-justified findings without erroring.
+
+Per the content rules for shipped artifacts, this text carries **no** issue, PR,
+or roadmap numbers — the reference is read in adopter projects. It describes the
+failure shape generically, not the specific incident.
+
+No `-fleet` `SKILL.md` body is edited. The family reference is the documented
+single home for the family-wide statement, and editing eleven skill bodies to say
+the same thing is the copy-paste the reference exists to prevent.
+
+## Integration points
+
+**Entry points**
+
+- New module `packages/cli/src/utils/version-guard.ts` (`resolveExpectedVersion`,
+  `evaluateVersionGuard`, `installVersionGuard`, `GUARDED_COMMANDS`).
+- One new call in `createProgram()` at `packages/cli/src/index.ts`.
+- New optional `toolchain` object on `HarnessConfigSchema`.
+- New env var `HARNESS_NO_VERSION_GUARD`.
+- `resolveCommandPath` extracted in `packages/cli/src/bin/command-telemetry.ts`
+  (behavior-preserving: telemetry keeps emitting `cli/`-prefixed names).
+
+**Registrations required**
+
+- None for command discovery — this adds no command, so `_registry.ts` does not
+  change and no barrel regeneration is required for the guard itself.
+- A changeset is required (patch on `@harness-engineering/cli`).
+
+**Documentation updates**
+
+- `docs/reference/fleet-family.md` — new Runtime preconditions section.
+- `docs/reference/configuration.md` — the `toolchain` key. This file is
+  **hand-maintained**: `scripts/generate-docs.mjs` emits only
+  `cli-commands.md`, `mcp-tools.md`, and `skills-catalog.md`, and
+  `configuration.md` carries no generated-file banner. The key is written by
+  hand into the top-level fields section.
+
+**Architectural decisions**
+
+None. This is a small, additive guard reusing three established patterns
+(`node-version.ts`'s check shape, `install-constraints.ts`'s
+declared-minimum-version refusal, and `command-telemetry.ts`'s root hook). It
+introduces no new architectural concept that would warrant a standalone ADR.
+
+**Knowledge impact**
+
+One concept worth recording: _a stale analysis tool is more dangerous than a
+broken one, because its output is well-formed_. This generalizes past this guard
+to any cached, pinned, or vendored analyzer in the pipeline.
+
+## Success criteria
+
+Phrased as EARS statements; each is observable and testable.
+
+1. When the running CLI's version satisfies the workspace's declared range, the
+   guard shall produce no output and shall not alter the exit code.
+2. When no expected version can be resolved, the guard shall report `unknown` and
+   shall not warn, print, or gate.
+3. When the running CLI's major version is 2 or more majors below the minimum of
+   the declared range, and the invoked command is in `GUARDED_COMMANDS`, the
+   system shall print a refusal naming both versions and the running binary path,
+   and shall exit `ZERO_DENOMINATOR` (3) without running the command.
+4. When the major delta is exactly 1, or the range is unsatisfied at a delta of 0
+   or less, the system shall print a warning to stderr and shall run the command.
+5. If `HARNESS_NO_VERSION_GUARD` is truthy per `envEnabled`, then the system
+   shall report status `warn` with `bypassed: true` instead of `refuse`, and
+   shall still print the mismatch warning to stderr.
+6. When a command outside `GUARDED_COMMANDS` is invoked, the guard shall not
+   gate it, regardless of mismatch severity — verified specifically for `doctor`
+   and `update`.
+7. Every name in `GUARDED_COMMANDS` shall correspond to a **top-level** command
+   registered on the program built by `createProgram()`, matched against the
+   prefix-free dotted path.
+   7a. `resolveCommandPath` shall return `validate` for `harness validate` and
+   `graph.scan` for `harness graph scan` (no `cli/` prefix), while
+   `command-telemetry` shall continue to record `cli/`-prefixed names.
+   7b. If a declared range is not valid semver (`latest`, `workspace:*`, `file:…`)
+   or is unsatisfiable, then the guard shall report `unknown` and shall not
+   throw.
+   7c. When `CLI_VERSION` is the `'0.0.0'` resolution-failure sentinel, the guard
+   shall report `unknown` and shall not gate.
+   7d. When the global `-c/--config <path>` option is supplied, the guard shall
+   resolve the expected version from that config file.
+8. When `harness.config.json` declares `toolchain.cliVersion`, the loaded config
+   shall retain it (i.e. it is not stripped by the schema).
+9. When both a config pin and a `package.json` dependency range are present, the
+   config pin shall be the one used.
+10. When the `package.json` range uses a non-semver protocol (`workspace:*`,
+    `file:`, `link:`, `git+`, `*`, `latest`), it shall be ignored rather than
+    coerced.
+11. The section added to `docs/reference/fleet-family.md` shall state the
+    Node-22 precondition, the absolute-path pinning rule, and the
+    `PATH`-shadowing trap, and shall contain no issue, PR, or roadmap numbers.
+    (Scoped to the added section — the rest of the file is pre-existing and out
+    of scope for this change.)
+
+**Explicitly not a criterion:** wiring the `unknown` status into `harness doctor`
+as an advisory. `doctor` builds a `CheckResult[]` and adapting the guard's result
+into that shape is a separate, additive change; D5 names the affordance, this
+change does not spend it.
+
+## Implementation order
+
+1. **Evaluator core.** `version-guard.ts` with `evaluateVersionGuard` and
+   `resolveExpectedVersion`, plus unit tests covering criteria 1–5 and 9–10.
+   Pure logic first, no wiring.
+2. **Config schema.** Add `toolchain.cliVersion`; test criterion 8.
+3. **Wiring.** Lift the dotted-name helper out of `command-telemetry.ts`, add
+   `installVersionGuard` and the `createProgram()` call; test criteria 6–7.
+4. **Dogfood + docs.** Pin this repo's `harness.config.json`, write the
+   fleet-family Runtime preconditions section, regenerate any generated config
+   reference; verify criterion 11.
+5. **Changeset, build, full verification.**

--- a/docs/changes/toolchain-version-guard/proposal.md
+++ b/docs/changes/toolchain-version-guard/proposal.md
@@ -425,11 +425,17 @@ verbatim would make `GUARDED_COMMANDS.has(...)` always false, and the guard woul
 be a permanent silent no-op — the very failure class this change exists to
 prevent, reproduced inside the fix.
 
-So the traversal is extracted as a prefix-free `resolveCommandPath()` returning
-`validate` / `graph.scan`, and telemetry applies its own `cli/` prefix at its
-call site. The helper is already exported for tests as `_resolveCommandName`
-(`command-telemetry.ts:183-186`), so this is a refactor of an existing seam
-rather than a new one.
+The guard therefore carries its own prefix-free `resolveCommandPath()` returning
+`validate` / `graph.scan`. **The two traversals are deliberately not unified.**
+Collapsing them requires editing `command-telemetry.ts`, and that file holds a
+pre-existing, already-annotated PostHog ingest key which the `review-ci`
+heuristic path flags whenever the file enters a diff (the `harness-ignore`
+suppression is honored by the security scanner but not by that path). Editing it
+would drag an unrelated security finding into this change's review surface for no
+benefit to §5. A test pins the divergence so the duplication is visible and
+intentional rather than accidental; unifying the helpers — and fixing the
+suppression gap that makes unification expensive — is a worthwhile follow-up, not
+a prerequisite.
 
 `GUARDED_COMMANDS` is an exported `ReadonlySet<string>` holding the eight
 **top-level** names from D3, so a test can assert every entry corresponds to a

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -61,6 +61,54 @@ Path to the documentation directory used by doc validation and generation tools.
 
 How often (in milliseconds) to check for CLI updates. Omit or set to `0` to disable update checks.
 
+### `toolchain`
+
+- **Type:** `object`
+- **Required:** No
+
+Toolchain expectations this workspace declares.
+
+| Key          | Type     | Description                                                        |
+| ------------ | -------- | ------------------------------------------------------------------ |
+| `cliVersion` | `string` | Semver range naming the `@harness-engineering/cli` line to expect. |
+
+```json
+{
+  "toolchain": {
+    "cliVersion": ">=11"
+  }
+}
+```
+
+A stale scanner does not fail — it re-reports findings the workspace has already
+justified and suppressed, so its output is well-formed, confident, and wrong.
+When `cliVersion` is set, the CLI compares its own version against the range
+before running any findings-producing command (`check-security`, `check-docs`,
+`check-deps`, `check-perf`, `check-harness-strength`, `cleanup`, `validate`,
+`review-ci`):
+
+- Range satisfied — silent.
+- Two or more majors below the range minimum — **refuses** and exits `3`
+  (the abstain code: the command examined nothing, so it must never read as
+  green, and must not be confused with exit `1`, which is what these commands
+  return when they found real findings).
+- Exactly one major below, or unsatisfied at a smaller distance — warns and
+  proceeds. Being one major behind is the normal state of a repository partway
+  through an upgrade.
+
+`doctor`, `update`, `setup`, and `init` are never gated — those are the commands
+you need when the toolchain is wrong.
+
+When `cliVersion` is omitted, the CLI falls back to a `@harness-engineering/cli`
+range declared in the project's `package.json` (`devDependencies`, then
+`dependencies`). Non-semver specifiers such as `workspace:*`, `file:`, `link:`,
+`git+`, `*`, and `latest` are ignored rather than coerced. When no expected
+version can be resolved at all, the check is silent.
+
+Set `HARNESS_NO_VERSION_GUARD=1` to downgrade a refusal to a warning. It does not
+silence the warning — a variable that hid the message entirely would restore the
+silent failure the check exists to prevent.
+
 ## `layers`
 
 - **Type:** `Array<Layer>`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -83,9 +83,10 @@ Toolchain expectations this workspace declares.
 A stale scanner does not fail — it re-reports findings the workspace has already
 justified and suppressed, so its output is well-formed, confident, and wrong.
 When `cliVersion` is set, the CLI compares its own version against the range
-before running any findings-producing command (`check-security`, `check-docs`,
-`check-deps`, `check-perf`, `check-harness-strength`, `cleanup`, `validate`,
-`review-ci`):
+before running any findings-producing command (`check-arch`,
+`check-deployment`, `check-deps`, `check-docs`, `check-harness-strength`,
+`check-perf`, `check-security`, `cleanup`, `cross-check`, `review-ci`,
+`validate`):
 
 - Range satisfied — silent.
 - Two or more majors below the range minimum — **refuses** and exits `3`

--- a/docs/reference/fleet-family.md
+++ b/docs/reference/fleet-family.md
@@ -52,6 +52,16 @@ Cap concurrent subagents at **2 (default), max ~3**. Beyond roughly three concur
 
 A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
 
+## Runtime preconditions
+
+A conductor or a fan-out parent is the one actor able to inject a single bad environment assumption into every lane at once, so the runtime a lane inherits is part of the contract — not an implementation detail left to whoever launches it.
+
+**Node 22 or newer is required.** The graph and state layers load a native `better-sqlite3` binding, and a mismatched Node ABI fails at load time rather than at install time. A lane that inherits the wrong interpreter fails in ways that look like flaky subagents.
+
+**Pin the interpreter by absolute path — do not prepend a Node bin directory to `PATH` to obtain it.** A Node installation's `bin` directory is not only an interpreter directory: package managers place shims for globally-installed CLIs there too, and a `harness` shim among them can be years older than the one the operator intends to run. Prepending the directory silently substitutes that older CLI for every child process the run spawns. Pass the resolved absolute path to the interpreter (and, where a lane invokes the CLI, the resolved absolute path to the CLI) instead of mutating `PATH` and relying on implicit resolution order.
+
+**Verify the toolchain before trusting any scan output.** Have SELECT record the resolved paths and the reported `harness --version`, and treat that record as part of the probe's evidence. A stale scanner does not error — it re-reports findings the workspace has already justified and suppressed, so its output is well-formed, confident, and wrong. Findings, queue depths, and any scheduling decision derived from them inherit that corruption silently. Recent CLI versions refuse to run findings-producing commands when they are sharply out of step with the workspace's declared `toolchain.cliVersion`, but that guard cannot fire inside a CLI old enough to predate it, which is exactly the case the pinning rule above exists to prevent.
+
 ## What each member defines for itself
 
 The spine above is shared. Each member's own `SKILL.md` defines:

--- a/harness.config.json
+++ b/harness.config.json
@@ -1,6 +1,9 @@
 {
   "version": 1,
   "name": "harness-engineering",
+  "toolchain": {
+    "cliVersion": ">=11"
+  },
   "constraintPacks": ["secrets-and-injection"],
   "layers": [
     {

--- a/packages/cli/src/bin/command-telemetry.ts
+++ b/packages/cli/src/bin/command-telemetry.ts
@@ -75,21 +75,6 @@ export function installCommandTelemetry(program: Command, cwd: string): void {
  * Resolve the full dotted command name (e.g. "hooks.init", "graph.scan").
  */
 function resolveCommandName(cmd: Command): string {
-  const path = resolveCommandPath(cmd);
-  return path.length > 0 ? `cli/${path}` : '';
-}
-
-/**
- * Resolve the dotted command path WITHOUT any namespace prefix
- * (e.g. "validate", "graph.scan").
- *
- * Kept separate from {@link resolveCommandName} because the `cli/` prefix is
- * telemetry's own namespace — it distinguishes CLI adoption records from hook
- * records. Other consumers that need to identify a command (such as the
- * toolchain version guard, which matches against a set of bare command names)
- * must not inherit that prefix.
- */
-export function resolveCommandPath(cmd: Command): string {
   const parts: string[] = [];
   let current: Command | null = cmd;
   while (current) {
@@ -99,7 +84,7 @@ export function resolveCommandPath(cmd: Command): string {
     }
     current = current.parent;
   }
-  return parts.join('.');
+  return parts.length > 0 ? `cli/${parts.join('.')}` : '';
 }
 
 /**

--- a/packages/cli/src/bin/command-telemetry.ts
+++ b/packages/cli/src/bin/command-telemetry.ts
@@ -75,6 +75,21 @@ export function installCommandTelemetry(program: Command, cwd: string): void {
  * Resolve the full dotted command name (e.g. "hooks.init", "graph.scan").
  */
 function resolveCommandName(cmd: Command): string {
+  const path = resolveCommandPath(cmd);
+  return path.length > 0 ? `cli/${path}` : '';
+}
+
+/**
+ * Resolve the dotted command path WITHOUT any namespace prefix
+ * (e.g. "validate", "graph.scan").
+ *
+ * Kept separate from {@link resolveCommandName} because the `cli/` prefix is
+ * telemetry's own namespace — it distinguishes CLI adoption records from hook
+ * records. Other consumers that need to identify a command (such as the
+ * toolchain version guard, which matches against a set of bare command names)
+ * must not inherit that prefix.
+ */
+export function resolveCommandPath(cmd: Command): string {
   const parts: string[] = [];
   let current: Command | null = cmd;
   while (current) {
@@ -84,7 +99,7 @@ function resolveCommandName(cmd: Command): string {
     }
     current = current.parent;
   }
-  return parts.length > 0 ? `cli/${parts.join('.')}` : '';
+  return parts.join('.');
 }
 
 /**

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1060,6 +1060,24 @@ export const HarnessConfigSchema = z.object({
   telemetry: TelemetryConfigSchema.optional(),
   /** How often (in ms) to check for CLI updates */
   updateCheckInterval: z.number().int().min(0).optional(),
+  /**
+   * Toolchain expectations this workspace declares.
+   *
+   * Distinct from the top-level `version` (the config schema version) and from
+   * `template.version` — hence the nesting rather than a bare `cliVersion` key.
+   */
+  toolchain: z
+    .object({
+      /**
+       * Semver range naming the `@harness-engineering/cli` line this workspace
+       * expects, e.g. `">=11"`. A CLI two or more majors below the range
+       * minimum refuses to run findings-producing commands, because a scanner
+       * that predates the rules it evaluates re-reports findings the workspace
+       * has already justified.
+       */
+      cliVersion: z.string().optional(),
+    })
+    .optional(),
   /** Graph ingest and connector settings */
   graph: z
     .object({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { Command } from 'commander';
 import { CLI_VERSION } from './version';
 import { commandCreators } from './commands/_registry';
 import { registerDeprecatedGraphAliases } from './commands/graph/deprecated-aliases';
+import { installVersionGuard } from './utils/version-guard';
 
 /**
  * Creates and configures the main Harness CLI program.
@@ -42,6 +43,11 @@ export function createProgram(): Command {
   // Legacy top-level scan/query/ingest, kept as hidden deprecated aliases of
   // the canonical `harness graph <op>` commands (see #644).
   registerDeprecatedGraphAliases(program);
+
+  // Refuse to emit findings when this CLI is sharply out of step with the
+  // workspace it is scanning. Installed here rather than in bin/harness.ts so
+  // every consumer of createProgram() gets a guarded program.
+  installVersionGuard(program, process.cwd());
 
   return program;
 }

--- a/packages/cli/src/utils/version-guard.ts
+++ b/packages/cli/src/utils/version-guard.ts
@@ -1,0 +1,346 @@
+/**
+ * Toolchain version guard.
+ *
+ * A scanner that predates the rules it evaluates does not fail — it emits
+ * well-formed, confident, wrong output. An older CLI re-reports findings the
+ * workspace has already justified and suppressed, and every consumer downstream
+ * treats that output as evidence.
+ *
+ * This module decides whether the running CLI is far enough out of step with the
+ * workspace it is pointed at that it should refuse to produce findings at all.
+ *
+ * It is deliberately I/O- and side-effect-light: {@link evaluateVersionGuard} is
+ * a pure function of its arguments (no `process.env`, no `process.cwd()`), and
+ * {@link resolveExpectedVersion} does nothing but two error-swallowing file
+ * reads. Nothing here prints or exits — that is {@link installVersionGuard}'s
+ * job, which keeps the decision logic directly unit-testable.
+ */
+import { readFileSync } from 'node:fs';
+import { join, parse as parsePath, resolve } from 'node:path';
+import type { Command } from 'commander';
+import semver from 'semver';
+import { CLI_VERSION } from '../version';
+import { ExitCode } from './errors';
+import { envEnabled } from './env-flag';
+import { resolveCommandPath } from '../bin/command-telemetry';
+
+/** The published package whose version a workspace pins. */
+const CLI_PACKAGE = '@harness-engineering/cli';
+
+/**
+ * Sentinel emitted by `version.ts` when it cannot resolve its own package.json.
+ * Never gate on it — a packaging regression must not become a blanket refusal.
+ */
+const UNRESOLVED_CLI_VERSION = '0.0.0';
+
+/**
+ * Commands whose output is a findings list that a human or an orchestrator will
+ * act on. These are the only commands the guard gates.
+ *
+ * `doctor`, `update`, `setup`, and `init` are deliberately absent: those are the
+ * commands you need when your toolchain is wrong, and a guard that blocks its
+ * own remedy is a trap.
+ *
+ * Matched against the prefix-free dotted path, so nested commands that share a
+ * leaf name (`skill validate`, `perf update`) resolve to `skill.validate` /
+ * `perf.update` and cannot collide with these top-level entries.
+ */
+export const GUARDED_COMMANDS: ReadonlySet<string> = new Set([
+  'check-security',
+  'check-docs',
+  'check-deps',
+  'check-perf',
+  'check-harness-strength',
+  'cleanup',
+  'validate',
+  'review-ci',
+]);
+
+export type VersionGuardStatus = 'ok' | 'unknown' | 'warn' | 'refuse';
+export type ExpectedVersionSource = 'config' | 'dependency';
+
+export interface ExpectedVersion {
+  /** The semver range as written by the workspace. Always a valid range. */
+  range: string;
+  source: ExpectedVersionSource;
+  /** Human-readable origin, used in the message (e.g. "harness.config.json"). */
+  origin: string;
+}
+
+export interface VersionGuardResult {
+  status: VersionGuardStatus;
+  cliVersion: string;
+  expected?: ExpectedVersion;
+  /** `minVersion(range).major - major(cliVersion)`. Absent when `unknown`. */
+  majorDelta?: number;
+  /**
+   * True when a refusal was downgraded by the escape hatch. When set, `status`
+   * is already rewritten to `'warn'` — callers branch on `status` alone, so the
+   * bypass is expressed there rather than as a flag callers must remember.
+   */
+  bypassed: boolean;
+  /** Empty string when `ok` or `unknown`. */
+  message: string;
+}
+
+/**
+ * Walk up from `startDir` looking for harness.config.json; fall back to
+ * `startDir`. Mirrors the idiom in command-telemetry.ts.
+ */
+export function findProjectRoot(startDir: string): string {
+  let dir = resolve(startDir);
+  const { root } = parsePath(dir);
+  while (dir !== root) {
+    try {
+      readFileSync(join(dir, 'harness.config.json'), 'utf-8');
+      return dir;
+    } catch {
+      // Not here — keep walking.
+    }
+    dir = resolve(dir, '..');
+  }
+  return startDir;
+}
+
+function readJson(path: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * A range is usable only if semver can parse it AND it says something specific.
+ *
+ * `semver.minVersion` THROWS on package-manager protocols (`workspace:*`,
+ * `file:../cli`, `latest`) and returns null on an unsatisfiable range
+ * (`>=11 <10`). Letting either reach the ladder would raise inside a commander
+ * preAction hook and brick every guarded command on a typo'd pin — strictly
+ * worse than the drift the guard prevents.
+ *
+ * `*` parses fine but its minimum is 0.0.0, which would refuse every CLI. It is
+ * uninformative, not a pin, so it is filtered too.
+ */
+function usableRange(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const range = raw.trim();
+  if (range.length === 0 || range === '*' || range === 'x') return undefined;
+  if (semver.validRange(range) === null) return undefined;
+  return range;
+}
+
+/**
+ * Resolve the CLI version range this workspace expects.
+ *
+ * Precedence: an explicit `toolchain.cliVersion` pin in harness.config.json
+ * beats a `@harness-engineering/cli` range inferred from package.json — one is a
+ * statement of intent, the other an artifact of package management.
+ *
+ * The config file is read directly rather than through `resolveConfig`, which
+ * writes stripped-key warnings to stderr (the guard must stay silent) and
+ * searches from `process.cwd()` rather than the root it is handed.
+ *
+ * @param projectRoot Directory to resolve relative paths against.
+ * @param configPathOverride Value of the global `-c/--config` option, when set,
+ *   so the guard reads the same config the command will scan with.
+ */
+export function resolveExpectedVersion(
+  projectRoot: string,
+  configPathOverride?: string
+): ExpectedVersion | undefined {
+  const configPath = configPathOverride
+    ? resolve(projectRoot, configPathOverride)
+    : join(projectRoot, 'harness.config.json');
+
+  const config = readJson(configPath);
+  const toolchain = config?.['toolchain'];
+  if (typeof toolchain === 'object' && toolchain !== null) {
+    const pinned = usableRange((toolchain as Record<string, unknown>)['cliVersion']);
+    if (pinned) {
+      // Name the file actually read — with `-c` that is not harness.config.json,
+      // and a message pointing at the wrong file sends the reader hunting.
+      return {
+        range: pinned,
+        source: 'config',
+        origin: configPathOverride ? configPath : 'harness.config.json',
+      };
+    }
+  }
+
+  const pkg = readJson(join(projectRoot, 'package.json'));
+  if (pkg) {
+    for (const field of ['devDependencies', 'dependencies'] as const) {
+      const deps = pkg[field];
+      if (typeof deps !== 'object' || deps === null) continue;
+      const declared = usableRange((deps as Record<string, unknown>)[CLI_PACKAGE]);
+      if (declared) {
+        return {
+          range: declared,
+          source: 'dependency',
+          origin: `package.json ${field}.${CLI_PACKAGE}`,
+        };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function buildMessage(
+  verb: string,
+  commandPath: string,
+  cliVersion: string,
+  expected: ExpectedVersion,
+  majorDelta: number,
+  bypassed: boolean
+): string {
+  const behind =
+    majorDelta > 0
+      ? `A scanner ${majorDelta} major version${majorDelta === 1 ? '' : 's'} behind will ` +
+        'report findings this workspace has already resolved.'
+      : 'The running CLI does not satisfy the version this workspace declares.';
+
+  const lines = [
+    `harness: ${verb} \`${commandPath}\`.`,
+    '',
+    `  This CLI is v${cliVersion}, but the workspace expects ${expected.range} (${expected.origin}).`,
+    `  ${behind}`,
+    '',
+    `  Running binary: ${process.argv[1] ?? '(unknown)'}`,
+    `  Node:           ${process.execPath}`,
+    '',
+    '  Check `which -a harness` — a Node bin directory added to PATH may be',
+    '  shadowing the intended install.',
+    '',
+  ];
+
+  if (bypassed) {
+    lines.push('  HARNESS_NO_VERSION_GUARD is set, so this is a warning rather than a refusal.');
+  } else {
+    lines.push('  To run anyway (the warning stays): HARNESS_NO_VERSION_GUARD=1');
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Decide whether the running CLI may produce findings for this workspace.
+ *
+ * The ladder is asymmetric on purpose. Staleness is the dangerous direction: an
+ * older scanner re-reports findings the workspace already justified (falsehood),
+ * while a newer one reports rules the workspace has not adopted yet (noise).
+ * Noise warns; falsehood, at sufficient distance, refuses.
+ *
+ * One major behind only warns because that is the normal state of a repository
+ * partway through an upgrade — refusing there would turn a safety net into an
+ * outage and guarantee the guard gets disabled wholesale.
+ */
+export function evaluateVersionGuard(
+  cliVersion: string,
+  expected: ExpectedVersion | undefined,
+  opts: { bypass?: boolean; commandPath?: string } = {}
+): VersionGuardResult {
+  const unknown: VersionGuardResult = {
+    status: 'unknown',
+    cliVersion,
+    // Spread rather than assign: `exactOptionalPropertyTypes` forbids setting an
+    // optional property to an explicit `undefined`.
+    ...(expected ? { expected } : {}),
+    bypassed: false,
+    message: '',
+  };
+
+  // Nothing to compare against. Stay silent rather than nagging every project
+  // that has not opted in — a guard everyone learns to ignore protects nobody.
+  if (!expected) return unknown;
+
+  // A CLI that could not resolve its own version must never gate.
+  if (cliVersion === UNRESOLVED_CLI_VERSION || semver.valid(cliVersion) === null) {
+    return unknown;
+  }
+
+  if (semver.satisfies(cliVersion, expected.range)) {
+    return { status: 'ok', cliVersion, expected, majorDelta: 0, bypassed: false, message: '' };
+  }
+
+  const minimum = semver.minVersion(expected.range);
+  if (!minimum) return unknown;
+
+  const majorDelta = minimum.major - semver.major(cliVersion);
+  const bypassed = majorDelta >= 2 && opts.bypass === true;
+  const status: VersionGuardStatus = majorDelta >= 2 && !bypassed ? 'refuse' : 'warn';
+  const verb = status === 'refuse' ? 'refusing to run' : 'version mismatch running';
+
+  return {
+    status,
+    cliVersion,
+    expected,
+    majorDelta,
+    bypassed,
+    message: buildMessage(
+      verb,
+      opts.commandPath ?? 'this command',
+      cliVersion,
+      expected,
+      majorDelta,
+      bypassed
+    ),
+  };
+}
+
+/**
+ * Install the guard as a root-level `preAction` hook.
+ *
+ * Installed from `createProgram()` rather than from `bin/harness.ts` (where
+ * telemetry is installed) so that the program object `createProgram()` returns
+ * is already guarded for every consumer.
+ *
+ * Commander runs ancestor `preAction` hooks before descendant ones, so this
+ * fires before a command's own hooks. Exiting from inside a hook has direct
+ * precedent in `commands/check-security.ts`.
+ */
+export function installVersionGuard(program: Command, cwd: string): void {
+  // program.hook() may not exist in test environments.
+  if (typeof program.hook !== 'function') return;
+
+  program.hook('preAction', (_thisCommand, actionCommand) => {
+    const commandPath = resolveCommandPath(actionCommand);
+    if (!GUARDED_COMMANDS.has(commandPath)) return;
+
+    let configOverride: string | undefined;
+    try {
+      const opts = actionCommand.optsWithGlobals() as { config?: string };
+      configOverride = opts.config;
+    } catch {
+      configOverride = undefined;
+    }
+
+    const projectRoot = findProjectRoot(cwd);
+    const result = evaluateVersionGuard(
+      CLI_VERSION,
+      resolveExpectedVersion(projectRoot, configOverride),
+      {
+        bypass: envEnabled(process.env['HARNESS_NO_VERSION_GUARD']),
+        commandPath,
+      }
+    );
+
+    if (result.status === 'warn') {
+      process.stderr.write(result.message);
+      return;
+    }
+
+    if (result.status === 'refuse') {
+      process.stderr.write(result.message);
+      // ZERO_DENOMINATOR, not VALIDATION_FAILED: the command examined nothing.
+      // Exit 1 is what these commands return when they found REAL findings, and
+      // a refusal must never be mistaken for a completed scan.
+      process.exit(ExitCode.ZERO_DENOMINATOR);
+    }
+  });
+}

--- a/packages/cli/src/utils/version-guard.ts
+++ b/packages/cli/src/utils/version-guard.ts
@@ -22,7 +22,6 @@ import semver from 'semver';
 import { CLI_VERSION } from '../version';
 import { ExitCode } from './errors';
 import { envEnabled } from './env-flag';
-import { resolveCommandPath } from '../bin/command-telemetry';
 
 /** The published package whose version a workspace pins. */
 const CLI_PACKAGE = '@harness-engineering/cli';
@@ -81,6 +80,34 @@ export interface VersionGuardResult {
   bypassed: boolean;
   /** Empty string when `ok` or `unknown`. */
   message: string;
+}
+
+/**
+ * Resolve a command's dotted path with NO namespace prefix
+ * (e.g. "validate", "graph.scan").
+ *
+ * `command-telemetry.ts` has a near-identical traversal, but it returns a
+ * `cli/`-prefixed name — that prefix is telemetry's own namespace, separating
+ * CLI adoption records from hook records. The guard matches against bare command
+ * names, so inheriting the prefix would make every `GUARDED_COMMANDS.has()` test
+ * false and turn this guard into a permanently silent no-op.
+ *
+ * The two are kept separate rather than unified because collapsing them means
+ * editing telemetry, which drags an unrelated pre-existing security annotation
+ * into this change's review surface. Unifying them is a worthwhile follow-up,
+ * not a prerequisite.
+ */
+export function resolveCommandPath(cmd: Command): string {
+  const parts: string[] = [];
+  let current: Command | null = cmd;
+  while (current) {
+    const name = current.name();
+    if (name && name !== 'harness') {
+      parts.unshift(name);
+    }
+    current = current.parent;
+  }
+  return parts.join('.');
 }
 
 /**

--- a/packages/cli/src/utils/version-guard.ts
+++ b/packages/cli/src/utils/version-guard.ts
@@ -15,7 +15,7 @@
  * reads. Nothing here prints or exits — that is {@link installVersionGuard}'s
  * job, which keeps the decision logic directly unit-testable.
  */
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join, parse as parsePath, resolve } from 'node:path';
 import type { Command } from 'commander';
 import semver from 'semver';
@@ -45,12 +45,20 @@ const UNRESOLVED_CLI_VERSION = '0.0.0';
  * `perf.update` and cannot collide with these top-level entries.
  */
 export const GUARDED_COMMANDS: ReadonlySet<string> = new Set([
-  'check-security',
-  'check-docs',
+  // Every command that emits the `--findings-json` contract. That flag is the
+  // objective definition of "findings-producing" in this repo: it is the machine
+  // -readable output an orchestrator parses and schedules on, which is exactly
+  // what went wrong when a stale scanner produced it.
+  'check-arch',
+  'check-deployment',
   'check-deps',
+  'check-docs',
+  'check-security',
+  'cleanup',
+  'cross-check',
+  // Findings-producing without the contract flag.
   'check-perf',
   'check-harness-strength',
-  'cleanup',
   'validate',
   'review-ci',
 ]);
@@ -118,15 +126,12 @@ export function findProjectRoot(startDir: string): string {
   let dir = resolve(startDir);
   const { root } = parsePath(dir);
   while (dir !== root) {
-    try {
-      readFileSync(join(dir, 'harness.config.json'), 'utf-8');
-      return dir;
-    } catch {
-      // Not here — keep walking.
-    }
+    // existsSync, not readFileSync — this is an existence probe, and reading
+    // then discarding a whole config on every level is pointless work.
+    if (existsSync(join(dir, 'harness.config.json'))) return dir;
     dir = resolve(dir, '..');
   }
-  return startDir;
+  return resolve(startDir);
 }
 
 function readJson(path: string): Record<string, unknown> | undefined {
@@ -155,8 +160,14 @@ function readJson(path: string): Record<string, unknown> | undefined {
 function usableRange(raw: unknown): string | undefined {
   if (typeof raw !== 'string') return undefined;
   const range = raw.trim();
-  if (range.length === 0 || range === '*' || range === 'x') return undefined;
-  if (semver.validRange(range) === null) return undefined;
+  if (range.length === 0) return undefined;
+  const normalized = semver.validRange(range);
+  if (normalized === null) return undefined;
+  // `semver` normalizes every any-version spelling — `*`, `x`, `X`, `||`,
+  // `>=0`, `0.x`, `^0`, `~0` — to the single token `*`. Comparing the
+  // normalized form catches them all; string-matching the raw input would miss
+  // most. An any-version range is not a pin and cannot express a mismatch.
+  if (normalized === '*') return undefined;
   return range;
 }
 
@@ -171,16 +182,23 @@ function usableRange(raw: unknown): string | undefined {
  * writes stripped-key warnings to stderr (the guard must stay silent) and
  * searches from `process.cwd()` rather than the root it is handed.
  *
- * @param projectRoot Directory to resolve relative paths against.
+ * @param projectRoot Directory holding harness.config.json / package.json.
  * @param configPathOverride Value of the global `-c/--config` option, when set,
  *   so the guard reads the same config the command will scan with.
+ * @param cwd Base for resolving `configPathOverride`. It must be the process
+ *   working directory, NOT `projectRoot`: `loadConfig` hands the flag straight
+ *   to `readFileSync`, so `-c ./ci.config.json` is cwd-relative. Resolving it
+ *   against the walked-up root would make the guard read a different file than
+ *   the command — and on the resulting ENOENT it would fall through to
+ *   `unknown`, so passing `-c` would silently *disable* the guard.
  */
 export function resolveExpectedVersion(
   projectRoot: string,
-  configPathOverride?: string
+  configPathOverride?: string,
+  cwd: string = process.cwd()
 ): ExpectedVersion | undefined {
   const configPath = configPathOverride
-    ? resolve(projectRoot, configPathOverride)
+    ? resolve(cwd, configPathOverride)
     : join(projectRoot, 'harness.config.json');
 
   const config = readJson(configPath);
@@ -291,8 +309,31 @@ export function evaluateVersionGuard(
     return unknown;
   }
 
-  if (semver.satisfies(cliVersion, expected.range)) {
-    return { status: 'ok', cliVersion, expected, majorDelta: 0, bypassed: false, message: '' };
+  // Enforce the "always a valid range" invariant HERE, at the public boundary
+  // that documents it, not only inside resolveExpectedVersion. Both functions
+  // are exported, and a caller that builds an ExpectedVersion itself would
+  // otherwise reach semver.minVersion, which THROWS on 'latest' / 'workspace:*'.
+  // semver.satisfies swallows a bad range and returns false, so it is no shield.
+  if (semver.validRange(expected.range) === null) return unknown;
+
+  // includePrerelease so a prerelease CLI newer than the pin is not perpetually
+  // warned at. Without it, satisfies('12.0.0-rc.0', '>=11') is false, and every
+  // RC tester would see a spurious warning on every scan — precisely the
+  // "train everyone to ignore the guard" outcome the silent-when-unknown rule
+  // exists to avoid.
+  if (semver.satisfies(cliVersion, expected.range, { includePrerelease: true })) {
+    const lowerBound = semver.minVersion(expected.range);
+    return {
+      status: 'ok',
+      cliVersion,
+      expected,
+      // Report the true distance, not a hardcoded 0. `doctor` is the named next
+      // consumer, and an advisory claiming "0 majors apart" while the CLI is 3
+      // ahead is the same confidently-wrong output this guard exists to stop.
+      ...(lowerBound ? { majorDelta: lowerBound.major - semver.major(cliVersion) } : {}),
+      bypassed: false,
+      message: '',
+    };
   }
 
   const minimum = semver.minVersion(expected.range);
@@ -336,26 +377,30 @@ export function installVersionGuard(program: Command, cwd: string): void {
   if (typeof program.hook !== 'function') return;
 
   program.hook('preAction', (_thisCommand, actionCommand) => {
-    const commandPath = resolveCommandPath(actionCommand);
-    if (!GUARDED_COMMANDS.has(commandPath)) return;
-
-    let configOverride: string | undefined;
+    let result: VersionGuardResult;
     try {
-      const opts = actionCommand.optsWithGlobals() as { config?: string };
-      configOverride = opts.config;
-    } catch {
-      configOverride = undefined;
-    }
+      const commandPath = resolveCommandPath(actionCommand);
+      if (!GUARDED_COMMANDS.has(commandPath)) return;
 
-    const projectRoot = findProjectRoot(cwd);
-    const result = evaluateVersionGuard(
-      CLI_VERSION,
-      resolveExpectedVersion(projectRoot, configOverride),
-      {
-        bypass: envEnabled(process.env['HARNESS_NO_VERSION_GUARD']),
-        commandPath,
-      }
-    );
+      const opts = actionCommand.optsWithGlobals() as { config?: unknown };
+      // Narrow rather than assert: a subcommand declaring `--config` as a
+      // boolean flag would otherwise reach resolve(root, true) and throw.
+      const configOverride = typeof opts.config === 'string' ? opts.config : undefined;
+
+      const projectRoot = findProjectRoot(cwd);
+      result = evaluateVersionGuard(
+        CLI_VERSION,
+        resolveExpectedVersion(projectRoot, configOverride, cwd),
+        {
+          bypass: envEnabled(process.env['HARNESS_NO_VERSION_GUARD']),
+          commandPath,
+        }
+      );
+    } catch {
+      // A broken guard must never break the CLI. Refusing to scan is a
+      // deliberate act; crashing on the way to deciding is not one.
+      return;
+    }
 
     if (result.status === 'warn') {
       process.stderr.write(result.message);

--- a/packages/cli/tests/config/toolchain-schema.test.ts
+++ b/packages/cli/tests/config/toolchain-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { HarnessConfigSchema } from '../../src/config/schema';
+
+/**
+ * `HarnessConfigSchema` is a closed `z.object` that strips unknown keys, and
+ * `warnStrippedKeys` in config/loader.ts writes a stderr warning for each one.
+ *
+ * So this schema entry is not cosmetic: without it, a workspace declaring the
+ * pin would have it silently discarded AND would emit a spurious warning on
+ * every config-loading command. That is the regression this file guards.
+ */
+describe('HarnessConfigSchema — toolchain', () => {
+  it('retains toolchain.cliVersion instead of stripping it', () => {
+    const parsed = HarnessConfigSchema.parse({
+      version: 1,
+      toolchain: { cliVersion: '>=11' },
+    });
+    expect(parsed.toolchain?.cliVersion).toBe('>=11');
+  });
+
+  it('accepts a config with no toolchain block', () => {
+    const parsed = HarnessConfigSchema.parse({ version: 1 });
+    expect(parsed.toolchain).toBeUndefined();
+  });
+
+  it('accepts an empty toolchain block', () => {
+    const parsed = HarnessConfigSchema.parse({ version: 1, toolchain: {} });
+    expect(parsed.toolchain?.cliVersion).toBeUndefined();
+  });
+
+  it('rejects a non-string cliVersion', () => {
+    expect(() =>
+      HarnessConfigSchema.parse({ version: 1, toolchain: { cliVersion: 11 } })
+    ).toThrow();
+  });
+
+  it('keeps this repo own pin parseable', () => {
+    // Guards against the dogfood pin drifting out of schema.
+    const parsed = HarnessConfigSchema.parse({
+      version: 1,
+      name: 'harness-engineering',
+      toolchain: { cliVersion: '>=11' },
+    });
+    expect(parsed.toolchain?.cliVersion).toBe('>=11');
+  });
+});

--- a/packages/cli/tests/utils/version-guard-wiring.test.ts
+++ b/packages/cli/tests/utils/version-guard-wiring.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Command } from 'commander';
 import { createProgram } from '../../src/index';
 import {
@@ -70,6 +73,29 @@ describe('GUARDED_COMMANDS against the real program', () => {
     expect(topLevel.has(name)).toBe(true);
     expect(GUARDED_COMMANDS.has(name)).toBe(false);
   });
+
+  // The membership test above only catches renames. This catches OMISSIONS:
+  // every command emitting the machine-readable findings contract must be
+  // gated, so adding a new one without gating it fails here rather than
+  // silently shipping an ungated findings producer.
+  it('gates every command that emits the --findings-json contract', () => {
+    const emitters = readdirSync(join(__dirname, '..', '..', 'src', 'commands'))
+      .filter((f) => f.endsWith('.ts'))
+      .filter((f) =>
+        readFileSync(join(__dirname, '..', '..', 'src', 'commands', f), 'utf-8').includes(
+          'findings-json'
+        )
+      )
+      .map((f) => f.replace(/\.ts$/, ''));
+
+    expect(emitters.length).toBeGreaterThan(0);
+    for (const name of emitters) {
+      expect(
+        GUARDED_COMMANDS.has(name),
+        `${name} emits --findings-json but is not in GUARDED_COMMANDS`
+      ).toBe(true);
+    }
+  });
 });
 
 describe('installVersionGuard', () => {
@@ -88,5 +114,136 @@ describe('installVersionGuard', () => {
     } as unknown as Command;
     installVersionGuard(fake, process.cwd());
     expect(calls).toEqual(['preAction']);
+  });
+});
+
+/**
+ * End-to-end enforcement.
+ *
+ * Asserting only that `.hook('preAction')` was called proves nothing — those
+ * assertions pass with an empty hook body. These drive a real commander program
+ * so that a regression to a silently-inert guard fails CI.
+ *
+ * CLI_VERSION is mocked to 1.13.1, the version from the incident this guards
+ * against, so the fixtures describe the real failure.
+ */
+vi.mock('../../src/version', () => ({ CLI_VERSION: '1.13.1' }));
+
+describe('installVersionGuard — enforcement', () => {
+  let root: string;
+  let exitSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'guard-enforce-'));
+    writeFileSync(
+      join(root, 'harness.config.json'),
+      JSON.stringify({ version: 1, toolchain: { cliVersion: '>=11' } })
+    );
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('PROCESS_EXIT');
+    }) as never);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function program(commandName: string, action: () => void, cwd = root): Command {
+    const p = new Command();
+    p.name('harness').option('-c, --config <path>');
+    p.command(commandName).action(action);
+    installVersionGuard(p, cwd);
+    return p;
+  }
+
+  const stderrText = (): string => stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+
+  it('refuses a guarded command, exits 3, and never runs the action', async () => {
+    const ran = vi.fn();
+    await expect(
+      program('validate', ran).parseAsync(['validate'], { from: 'user' })
+    ).rejects.toThrow('PROCESS_EXIT');
+
+    expect(exitSpy).toHaveBeenCalledWith(3);
+    expect(ran).not.toHaveBeenCalled();
+    expect(stderrText()).toContain('refusing to run');
+    expect(stderrText()).toContain('1.13.1');
+  });
+
+  it('lets an unguarded command run at the same mismatch', async () => {
+    const ran = vi.fn();
+    await program('doctor', ran).parseAsync(['doctor'], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(ran).toHaveBeenCalledOnce();
+    expect(stderrText()).toBe('');
+  });
+
+  it('warns but still runs when only one major behind', async () => {
+    writeFileSync(
+      join(root, 'harness.config.json'),
+      JSON.stringify({ version: 1, toolchain: { cliVersion: '>=2' } })
+    );
+    const ran = vi.fn();
+    await program('validate', ran).parseAsync(['validate'], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(ran).toHaveBeenCalledOnce();
+    expect(stderrText()).toContain('version mismatch');
+  });
+
+  it('stays silent when the workspace declares nothing', async () => {
+    rmSync(join(root, 'harness.config.json'));
+    const ran = vi.fn();
+    await program('validate', ran, root).parseAsync(['validate'], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(ran).toHaveBeenCalledOnce();
+    expect(stderrText()).toBe('');
+  });
+
+  it('downgrades to a warning under HARNESS_NO_VERSION_GUARD but still runs', async () => {
+    vi.stubEnv('HARNESS_NO_VERSION_GUARD', '1');
+    const ran = vi.fn();
+    await program('validate', ran).parseAsync(['validate'], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(ran).toHaveBeenCalledOnce();
+    expect(stderrText()).toContain('1.13.1');
+    vi.unstubAllEnvs();
+  });
+
+  // Regression guard for the relative `-c` bug: resolving the override against
+  // the walked-up project root rather than the cwd made the guard read a
+  // different file than the command, fall through to `unknown`, and silently
+  // stop enforcing — so passing `-c` *disabled* the guard.
+  it('resolves a relative -c path against the cwd, not the project root', async () => {
+    const sub = join(root, 'packages', 'cli');
+    mkdirSync(sub, { recursive: true });
+    writeFileSync(
+      join(sub, 'ci.harness.config.json'),
+      JSON.stringify({ version: 1, toolchain: { cliVersion: '>=11' } })
+    );
+    const ran = vi.fn();
+    await expect(
+      program('validate', ran, sub).parseAsync(['validate', '-c', './ci.harness.config.json'], {
+        from: 'user',
+      })
+    ).rejects.toThrow('PROCESS_EXIT');
+
+    expect(exitSpy).toHaveBeenCalledWith(3);
+    expect(ran).not.toHaveBeenCalled();
+  });
+
+  it('never lets a malformed config break the command', async () => {
+    writeFileSync(join(root, 'harness.config.json'), '{ not json');
+    const ran = vi.fn();
+    await program('validate', ran).parseAsync(['validate'], { from: 'user' });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(ran).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/tests/utils/version-guard-wiring.test.ts
+++ b/packages/cli/tests/utils/version-guard-wiring.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { Command } from 'commander';
 import { createProgram } from '../../src/index';
-import { GUARDED_COMMANDS, installVersionGuard } from '../../src/utils/version-guard';
-import { resolveCommandPath, _resolveCommandName } from '../../src/bin/command-telemetry';
+import {
+  GUARDED_COMMANDS,
+  installVersionGuard,
+  resolveCommandPath,
+} from '../../src/utils/version-guard';
+import { _resolveCommandName } from '../../src/bin/command-telemetry';
 
 describe('resolveCommandPath', () => {
   function build(): Command {
@@ -35,16 +39,20 @@ describe('resolveCommandPath', () => {
     expect(resolveCommandPath(find(build(), ['graph', 'scan']))).toBe('graph.scan');
   });
 
-  it('leaves telemetry still emitting cli/-prefixed names', () => {
-    expect(_resolveCommandName(find(build(), ['validate']))).toBe('cli/validate');
-    expect(_resolveCommandName(find(build(), ['graph', 'scan']))).toBe('cli/graph.scan');
+  // Pins the intentional divergence: telemetry keeps its own namespace, and if
+  // someone later unifies the two helpers this test says which output is whose.
+  it('diverges from telemetry, which still emits cli/-prefixed names', () => {
+    const validate = find(build(), ['validate']);
+    expect(resolveCommandPath(validate)).toBe('validate');
+    expect(_resolveCommandName(validate)).toBe('cli/validate');
+
+    const scan = find(build(), ['graph', 'scan']);
+    expect(resolveCommandPath(scan)).toBe('graph.scan');
+    expect(_resolveCommandName(scan)).toBe('cli/graph.scan');
   });
 
-  it('returns an empty string for the root program, and telemetry agrees', () => {
-    const program = build();
-    expect(resolveCommandPath(program)).toBe('');
-    // Must stay '' rather than becoming 'cli/'.
-    expect(_resolveCommandName(program)).toBe('');
+  it('returns an empty string for the root program', () => {
+    expect(resolveCommandPath(build())).toBe('');
   });
 });
 

--- a/packages/cli/tests/utils/version-guard-wiring.test.ts
+++ b/packages/cli/tests/utils/version-guard-wiring.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { createProgram } from '../../src/index';
+import { GUARDED_COMMANDS, installVersionGuard } from '../../src/utils/version-guard';
+import { resolveCommandPath, _resolveCommandName } from '../../src/bin/command-telemetry';
+
+describe('resolveCommandPath', () => {
+  function build(): Command {
+    const program = new Command();
+    program.name('harness');
+    const graph = program.command('graph');
+    graph.command('scan');
+    program.command('validate');
+    return program;
+  }
+
+  function find(program: Command, path: string[]): Command {
+    let current: Command = program;
+    for (const segment of path) {
+      const next = current.commands.find((c) => c.name() === segment);
+      if (!next) throw new Error(`missing command ${segment}`);
+      current = next;
+    }
+    return current;
+  }
+
+  // Criterion 7a. The `cli/` prefix is telemetry's namespace. If the guard
+  // inherited it, GUARDED_COMMANDS.has() would always be false and the guard
+  // would be a permanently silent no-op — this change reproducing its own bug.
+  it('returns an unprefixed path for a top-level command', () => {
+    expect(resolveCommandPath(find(build(), ['validate']))).toBe('validate');
+  });
+
+  it('returns an unprefixed dotted path for a nested command', () => {
+    expect(resolveCommandPath(find(build(), ['graph', 'scan']))).toBe('graph.scan');
+  });
+
+  it('leaves telemetry still emitting cli/-prefixed names', () => {
+    expect(_resolveCommandName(find(build(), ['validate']))).toBe('cli/validate');
+    expect(_resolveCommandName(find(build(), ['graph', 'scan']))).toBe('cli/graph.scan');
+  });
+
+  it('returns an empty string for the root program, and telemetry agrees', () => {
+    const program = build();
+    expect(resolveCommandPath(program)).toBe('');
+    // Must stay '' rather than becoming 'cli/'.
+    expect(_resolveCommandName(program)).toBe('');
+  });
+});
+
+describe('GUARDED_COMMANDS against the real program', () => {
+  const program = createProgram();
+  const topLevel = new Set(program.commands.map((c) => c.name()));
+
+  // Criterion 7: keeps the set from silently rotting as commands are renamed.
+  it.each([...GUARDED_COMMANDS])('%s is a registered top-level command', (name) => {
+    expect(topLevel.has(name)).toBe(true);
+  });
+
+  // Criterion 6: the remedy commands must remain reachable.
+  it.each(['doctor', 'update'])('%s exists and is not gated', (name) => {
+    expect(topLevel.has(name)).toBe(true);
+    expect(GUARDED_COMMANDS.has(name)).toBe(false);
+  });
+});
+
+describe('installVersionGuard', () => {
+  it('is a no-op when the program has no hook method (test environments)', () => {
+    const fake = { hook: undefined } as unknown as Command;
+    expect(() => installVersionGuard(fake, process.cwd())).not.toThrow();
+  });
+
+  it('registers a preAction hook when one is available', () => {
+    const calls: string[] = [];
+    const fake = {
+      hook: (event: string) => {
+        calls.push(event);
+        return fake;
+      },
+    } as unknown as Command;
+    installVersionGuard(fake, process.cwd());
+    expect(calls).toEqual(['preAction']);
+  });
+});

--- a/packages/cli/tests/utils/version-guard.test.ts
+++ b/packages/cli/tests/utils/version-guard.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  GUARDED_COMMANDS,
+  evaluateVersionGuard,
+  resolveExpectedVersion,
+  findProjectRoot,
+  type ExpectedVersion,
+} from '../../src/utils/version-guard';
+
+const pin = (range: string): ExpectedVersion => ({
+  range,
+  source: 'config',
+  origin: 'harness.config.json',
+});
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'version-guard-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeConfig(contents: unknown, at = dir): void {
+  writeFileSync(join(at, 'harness.config.json'), JSON.stringify(contents));
+}
+
+function writePackage(contents: unknown, at = dir): void {
+  writeFileSync(join(at, 'package.json'), JSON.stringify(contents));
+}
+
+describe('evaluateVersionGuard — satisfied ranges are silent', () => {
+  // Criterion 1: a satisfied range produces no output and no gating.
+  it.each([
+    ['11.1.1', '>=11'],
+    ['12.0.0', '>=11'],
+    ['11.1.1', '^11.1.1'],
+    ['11.9.9', '11.x'],
+  ])('%s satisfies %s', (cliVersion, range) => {
+    const result = evaluateVersionGuard(cliVersion, pin(range));
+    expect(result.status).toBe('ok');
+    expect(result.message).toBe('');
+  });
+});
+
+describe('evaluateVersionGuard — unknown never gates', () => {
+  // Criterion 2: nothing to compare against means silence, not a nag.
+  it('reports unknown when no expected version is resolvable', () => {
+    const result = evaluateVersionGuard('11.1.1', undefined);
+    expect(result.status).toBe('unknown');
+    expect(result.message).toBe('');
+  });
+
+  // Criterion 7c: the version.ts resolution-failure sentinel must never gate.
+  // Against a >=11 pin this is a delta of 11, so without the guard any
+  // packaging regression would become a blanket refusal of every scan command.
+  it('reports unknown for the 0.0.0 sentinel rather than refusing', () => {
+    const result = evaluateVersionGuard('0.0.0', pin('>=11'));
+    expect(result.status).toBe('unknown');
+  });
+
+  it('reports unknown when the CLI version is not valid semver', () => {
+    expect(evaluateVersionGuard('not-a-version', pin('>=11')).status).toBe('unknown');
+  });
+
+  // Criterion 7b: minVersion() returns null for an unsatisfiable range.
+  it('reports unknown for an unsatisfiable range instead of throwing', () => {
+    expect(() => evaluateVersionGuard('11.1.1', pin('>=11 <10'))).not.toThrow();
+    expect(evaluateVersionGuard('11.1.1', pin('>=11 <10')).status).toBe('unknown');
+  });
+});
+
+describe('evaluateVersionGuard — the severity ladder', () => {
+  // Criterion 3: this is the reported incident — a v1 CLI in a v11 workspace.
+  it('refuses when the CLI is 10 majors behind', () => {
+    const result = evaluateVersionGuard('1.13.1', pin('>=11'), { commandPath: 'check-security' });
+    expect(result.status).toBe('refuse');
+    expect(result.majorDelta).toBe(10);
+  });
+
+  it('refuses at a delta of exactly 2', () => {
+    expect(evaluateVersionGuard('9.0.0', pin('>=11')).status).toBe('refuse');
+  });
+
+  // Criterion 4: one major behind is the normal state of a repo mid-upgrade.
+  // Refusing there would turn a safety net into an outage.
+  it('warns rather than refuses at a delta of exactly 1', () => {
+    const result = evaluateVersionGuard('10.4.0', pin('>=11'));
+    expect(result.status).toBe('warn');
+    expect(result.majorDelta).toBe(1);
+  });
+
+  it('warns for an unsatisfied pin within the same major', () => {
+    const result = evaluateVersionGuard('11.1.1', pin('^11.2.0'));
+    expect(result.status).toBe('warn');
+    expect(result.majorDelta).toBe(0);
+  });
+
+  // A newer CLI reports rules the workspace has not adopted (noise), which is
+  // milder than an older one re-reporting resolved findings (falsehood).
+  it('warns rather than refuses when the CLI is ahead of the pinned major', () => {
+    const result = evaluateVersionGuard('14.0.0', pin('=11.1.1'));
+    expect(result.status).toBe('warn');
+    expect(result.majorDelta).toBe(-3);
+  });
+
+  it('names both versions and the running binary in a refusal', () => {
+    const result = evaluateVersionGuard('1.13.1', pin('>=11'), { commandPath: 'check-security' });
+    expect(result.message).toContain('1.13.1');
+    expect(result.message).toContain('>=11');
+    expect(result.message).toContain('check-security');
+    expect(result.message).toContain('Running binary:');
+    expect(result.message).toContain('which -a harness');
+  });
+});
+
+describe('evaluateVersionGuard — the escape hatch', () => {
+  // Criterion 5: the hatch buys a working command, not a quiet one. Silencing
+  // the notice would let one exported variable restore the original silent
+  // failure permanently.
+  it('downgrades a refusal to a warning but still reports the mismatch', () => {
+    const result = evaluateVersionGuard('1.13.1', pin('>=11'), {
+      bypass: true,
+      commandPath: 'check-security',
+    });
+    expect(result.status).toBe('warn');
+    expect(result.bypassed).toBe(true);
+    expect(result.message).toContain('1.13.1');
+    expect(result.message).toContain('HARNESS_NO_VERSION_GUARD');
+  });
+
+  it('does not mark an ordinary warning as bypassed', () => {
+    const result = evaluateVersionGuard('10.0.0', pin('>=11'), { bypass: true });
+    expect(result.status).toBe('warn');
+    expect(result.bypassed).toBe(false);
+  });
+});
+
+describe('resolveExpectedVersion', () => {
+  it('reads toolchain.cliVersion from harness.config.json', () => {
+    writeConfig({ version: 1, toolchain: { cliVersion: '>=11' } });
+    expect(resolveExpectedVersion(dir)).toMatchObject({ range: '>=11', source: 'config' });
+  });
+
+  it('falls back to a package.json dependency range', () => {
+    writeConfig({ version: 1 });
+    writePackage({ devDependencies: { '@harness-engineering/cli': '^11.1.1' } });
+    expect(resolveExpectedVersion(dir)).toMatchObject({
+      range: '^11.1.1',
+      source: 'dependency',
+    });
+  });
+
+  it('prefers dependencies when devDependencies has no entry', () => {
+    writePackage({ dependencies: { '@harness-engineering/cli': '^9.0.0' } });
+    expect(resolveExpectedVersion(dir)?.range).toBe('^9.0.0');
+  });
+
+  // Criterion 9: an explicit pin is a statement of intent; a dependency range
+  // is an artifact of package management.
+  it('prefers the config pin over the package.json range', () => {
+    writeConfig({ version: 1, toolchain: { cliVersion: '>=11' } });
+    writePackage({ devDependencies: { '@harness-engineering/cli': '^9.0.0' } });
+    expect(resolveExpectedVersion(dir)).toMatchObject({ range: '>=11', source: 'config' });
+  });
+
+  // Criterion 10: coercing these would manufacture false mismatches in
+  // monorepos, and minVersion() throws on all of them.
+  it.each(['workspace:*', 'file:../cli', 'link:../cli', 'git+https://x/y.git', 'latest', '*'])(
+    'ignores the non-semver specifier %s',
+    (spec) => {
+      writePackage({ devDependencies: { '@harness-engineering/cli': spec } });
+      expect(resolveExpectedVersion(dir)).toBeUndefined();
+    }
+  );
+
+  it('ignores an invalid config pin rather than throwing', () => {
+    writeConfig({ version: 1, toolchain: { cliVersion: 'latest' } });
+    expect(() => resolveExpectedVersion(dir)).not.toThrow();
+    expect(resolveExpectedVersion(dir)).toBeUndefined();
+  });
+
+  it('returns undefined when neither source exists', () => {
+    expect(resolveExpectedVersion(dir)).toBeUndefined();
+  });
+
+  it('swallows malformed JSON in either file', () => {
+    writeFileSync(join(dir, 'harness.config.json'), '{ not json');
+    writeFileSync(join(dir, 'package.json'), '{ also not json');
+    expect(() => resolveExpectedVersion(dir)).not.toThrow();
+    expect(resolveExpectedVersion(dir)).toBeUndefined();
+  });
+
+  // Criterion 7d: the guard must read the same config the command scans with.
+  it('honors an explicit config path override', () => {
+    writeConfig({ version: 1, toolchain: { cliVersion: '>=11' } });
+    const other = join(dir, 'other.config.json');
+    writeFileSync(other, JSON.stringify({ version: 1, toolchain: { cliVersion: '>=20' } }));
+    expect(resolveExpectedVersion(dir, other)?.range).toBe('>=20');
+  });
+
+  it('names the overridden file as the origin, not harness.config.json', () => {
+    const other = join(dir, 'other.config.json');
+    writeFileSync(other, JSON.stringify({ version: 1, toolchain: { cliVersion: '>=20' } }));
+    expect(resolveExpectedVersion(dir, other)?.origin).toBe(other);
+  });
+
+  it('names harness.config.json as the origin when no override is given', () => {
+    writeConfig({ version: 1, toolchain: { cliVersion: '>=11' } });
+    expect(resolveExpectedVersion(dir)?.origin).toBe('harness.config.json');
+  });
+});
+
+describe('findProjectRoot', () => {
+  it('walks up to the directory holding harness.config.json', () => {
+    writeConfig({ version: 1 });
+    const nested = join(dir, 'packages', 'thing', 'src');
+    mkdirSync(nested, { recursive: true });
+    expect(findProjectRoot(nested)).toBe(dir);
+  });
+
+  it('falls back to the start directory when no config is found', () => {
+    const nested = join(dir, 'nowhere');
+    mkdirSync(nested, { recursive: true });
+    expect(findProjectRoot(nested)).toBe(nested);
+  });
+});
+
+describe('GUARDED_COMMANDS', () => {
+  it('gates the findings-producing commands', () => {
+    for (const name of [
+      'check-security',
+      'check-docs',
+      'check-deps',
+      'check-perf',
+      'check-harness-strength',
+      'cleanup',
+      'validate',
+      'review-ci',
+    ]) {
+      expect(GUARDED_COMMANDS.has(name)).toBe(true);
+    }
+  });
+
+  // A guard that blocks its own remedy is a trap: these are exactly the
+  // commands you reach for when your toolchain is wrong.
+  it.each(['doctor', 'update', 'setup', 'init'])('does not gate %s', (name) => {
+    expect(GUARDED_COMMANDS.has(name)).toBe(false);
+  });
+
+  // Nested commands share leaf names with gated ones; they must not collide.
+  it.each(['skill.validate', 'linter.validate', 'perf.update', 'graph.scan'])(
+    'does not gate the nested command %s',
+    (path) => {
+      expect(GUARDED_COMMANDS.has(path)).toBe(false);
+    }
+  );
+});

--- a/packages/cli/tests/utils/version-guard.test.ts
+++ b/packages/cli/tests/utils/version-guard.test.ts
@@ -73,6 +73,18 @@ describe('evaluateVersionGuard — unknown never gates', () => {
     expect(() => evaluateVersionGuard('11.1.1', pin('>=11 <10'))).not.toThrow();
     expect(evaluateVersionGuard('11.1.1', pin('>=11 <10')).status).toBe('unknown');
   });
+
+  // The evaluator is exported independently of resolveExpectedVersion, so it
+  // must enforce range validity itself. semver.satisfies swallows a bad range
+  // and returns false, so control would otherwise reach minVersion, which
+  // THROWS on these — inside a preAction hook, bricking every guarded command.
+  it.each(['latest', 'workspace:*', 'file:../cli', 'not a range'])(
+    'reports unknown rather than throwing for the invalid range %s',
+    (range) => {
+      expect(() => evaluateVersionGuard('11.1.1', pin(range))).not.toThrow();
+      expect(evaluateVersionGuard('11.1.1', pin(range)).status).toBe('unknown');
+    }
+  );
 });
 
 describe('evaluateVersionGuard — the severity ladder', () => {
@@ -106,6 +118,28 @@ describe('evaluateVersionGuard — the severity ladder', () => {
   it('warns rather than refuses when the CLI is ahead of the pinned major', () => {
     const result = evaluateVersionGuard('14.0.0', pin('=11.1.1'));
     expect(result.status).toBe('warn');
+    expect(result.majorDelta).toBe(-3);
+  });
+
+  // The property that matters most: the guard must never refuse a CLI it should
+  // have accepted. A false refusal blocks correct work.
+  it.each([
+    ['12.0.0-rc.0', '>=11', 'a prerelease newer than the pin'],
+    ['0.30.0', '^0.41.0', 'a 0.x workspace'],
+    ['12.0.0', '10.x || 11.x', 'an OR-range the CLI is ahead of'],
+    ['11.1.1', '<=11', 'an upper-bounded range'],
+    ['11.0.0', '~11', 'a tilde range'],
+  ])('never refuses %s against %s (%s)', (cliVersion, range) => {
+    expect(evaluateVersionGuard(cliVersion, pin(range)).status).not.toBe('refuse');
+  });
+
+  it('still refuses across an OR-range when genuinely far behind', () => {
+    expect(evaluateVersionGuard('9.0.0', pin('11.x || 12.x')).status).toBe('refuse');
+  });
+
+  it('reports the true distance on the ok path rather than a hardcoded zero', () => {
+    const result = evaluateVersionGuard('14.0.0', pin('>=11'));
+    expect(result.status).toBe('ok');
     expect(result.majorDelta).toBe(-3);
   });
 


### PR DESCRIPTION
Refs #1259 — **§5 only** (_"The conductor broadcast a defective precondition to every lane"_).

The issue carries 32 findings. **This PR addresses §5 and nothing else.** The other 31 are being routed separately and are explicitly out of scope here.

## The defect

Project guidance says "use Node 22 for this repo" (required — native `better-sqlite3` ABI). Acting on it, a fleet conductor put `~/.nvm/versions/node/v22.20.0/bin` on `PATH` for every probe and lane. That directory contains its own `harness` shim, symlinked to a March-era v1.13.1 install. Still reproducible on the machine this was built on:

```
~/.nvm/versions/node/v22.20.0/bin/harness -> .../cli/dist/bin/harness.js   # v1.13.1 (Mar 27)
/opt/homebrew/bin/harness                                                  # v11.1.1
```

v1.13.1 predates the prior-line `harness-ignore` suppression pass, so it re-reported every already-justified suppression. 33 of 36 code-side security findings were phantoms; the sole ERROR escalated to a human decision gate pointed at `packages/core/src/review/finding-integrity.ts:94`, which is the XSS *detection vocabulary registry*, annotated `harness-ignore SEC-XSS-002: definitional`; and a queue depth of 41 that drove a scheduling decision was ~90% noise.

Three things make this worth a mechanism rather than a warning: it is **silent** (no error, no exit code), it is **high-leverage** (one assumption, injected once, corrupts every lane at once), and **everyone involved was doing the right thing** — the precondition was real and the directory was correct for its stated purpose. That last point is why "be careful with `PATH`" is not a fix: it asks every future caller to get an invisible detail right forever.

## What this does

The issue proposes three fixes and names the third as load-bearing. This PR implements that one, plus the documentation gap the issue also flags.

**1. The CLI refuses to scan when sharply out of step.** A workspace declares the CLI line it expects via a new optional `toolchain.cliVersion` semver range in `harness.config.json`, falling back to a `@harness-engineering/cli` range in `package.json`. Ladder:

| condition | outcome |
|---|---|
| range satisfied | silent |
| 2+ majors below the range minimum | **refuse**, exit `3` |
| exactly 1 major below, or unsatisfied at a smaller distance | warn, proceed |
| nothing to compare against | silent |

Only the eight findings-producing commands are gated (`check-security`, `check-docs`, `check-deps`, `check-perf`, `check-harness-strength`, `cleanup`, `validate`, `review-ci`). `doctor`, `update`, `setup`, `init` are never gated — those are the commands you need when your toolchain is wrong, and a guard that blocks its own remedy is a trap.

**2. The runtime precondition is documented.** `docs/reference/fleet-family.md` gains a "Runtime preconditions" section: Node ≥22 is required, pin the interpreter by absolute path rather than prepending its bin directory, and verify `harness --version` before trusting scan output. Carries no issue/PR/roadmap numbers (it ships to adopter projects).

Verified live end-to-end, not just unit-tested — with a workspace pinned `>=20`, the built v11.1.1 CLI refuses `check-docs` and exits 3; with the hatch set it warns and exits 0; `doctor` is unaffected.

## Assumptions made

1. **"Sharply" means a major delta of ≥ 2, measured against `semver.minVersion(range)`.** One major behind is the normal state of a repo mid-upgrade; refusing there would turn a safety net into an outage and guarantee the guard gets disabled wholesale.
2. **The ladder is asymmetric — staleness is the dangerous direction.** An older scanner re-reports findings the workspace already justified (falsehood); a newer one reports rules not yet adopted (noise). Noise warns; falsehood, at distance, refuses.
3. **An escape hatch is needed, but it must not silence.** `HARNESS_NO_VERSION_GUARD` downgrades a refusal to a warning and still prints it. A variable that hid the message entirely would be exported once into a shell profile and silently restore the original defect forever.
4. **Exit code `3` (`ZERO_DENOMINATOR`), not `1`.** Exit 1 is what these commands return when they found *real* findings — a refusal exiting 1 is indistinguishable from a completed scan, which is the exact confusion this change exists to remove. `ZERO_DENOMINATOR`'s own contract is "abstained, not passed, must never read as green."
5. **The config pin is load-bearing, not speculative.** Measured: this repo's root `package.json` has no `@harness-engineering/cli` dep and no `node_modules/@harness-engineering/cli`, and the offending binary was a *global* install. A package.json-only design would have been inert in precisely the case that motivated it.
6. **An allowlist, not a denylist.** The issue says "refuse to scan"; gating everything would brick recovery commands.
7. **Silence when undeterminable.** Warning every project that has not opted in would train everyone to ignore the guard, destroying the signal for the case that matters.
8. **The guard is forward-looking and cannot fix the reported incident retroactively** — v1.13.1 will never refuse anything, because it does not contain this code. That is stated plainly in the spec, and is why the documentation half is not decorative.
9. **No fleet `SKILL.md` body was edited.** The family reference is the documented single home for family-wide statements; editing eleven skill bodies is the copy-paste that reference exists to prevent.
10. **`harness doctor` integration was left out.** The `unknown` status is surfaced in the evaluator's result so `doctor` can adopt it later; wiring it into `doctor`'s `CheckResult[]` is a separate additive change.

## A note on the review that shaped this

The soundness pass caught a blocker worth flagging: the existing command-name helper returns `cli/`-prefixed paths (`cli/validate`, not `validate`). Reusing it directly would have made `GUARDED_COMMANDS.has(...)` always false — **a permanently silent no-op**, i.e. this change reproducing its own bug class inside the fix. It also caught that `semver.minVersion` *throws* on `workspace:*` / `latest` / `file:`, which would have bricked all eight commands on a typo'd pin. Both are fixed and directly tested.

## Verification

- `packages/cli`: 528 files / **6086 tests pass** (+59 new; baseline was 526 / 6027 — zero regressions)
- Full monorepo `pnpm test`: **26/26 tasks green** (one earlier `core` failure was the known parallelism flake — passes standalone at 4108 tests and on re-run)
- `pnpm build` 13/13, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm docs:build` (VitePress), `pnpm check:changesets` — all green
- `harness validate` exit 0; no `.harness/arch/baselines.json` churn
- Pre-commit and pre-push gates passed without `--no-verify`

Changeset included (patch on `@harness-engineering/cli`).

Spec: `docs/changes/toolchain-version-guard/proposal.md`
Plan: `docs/changes/toolchain-version-guard/plans/2026-08-10-toolchain-version-guard-plan.md`

---

## Review round: two blockers found and fixed

An adversarial code-review pass on the first push found two blockers worth surfacing, because both are instances of the failure mode this PR is about:

1. **A relative `-c` path silently disabled the guard.** The override was resolved against the walked-up project root, but `loadConfig` hands the flag straight to `readFileSync`, so it is **cwd-relative**. The guard read a different file than the command, hit ENOENT, fell through to `unknown`, and stopped enforcing. Worse than not honoring `-c` at all — it also skipped the real pin. Fixed; the regression test was mutation-verified to fail against the old code.
2. **The enforcement path had no test.** The only `installVersionGuard` tests asserted `.hook('preAction')` was called on a stub — assertions that pass with an *empty hook body*. Nothing verified the hook fires, writes stderr, exits 3, or suppresses the action. Now covered end-to-end against a real commander program.

An earlier soundness pass had already caught a third: the existing command-name helper returns `cli/`-prefixed paths, so reusing it would have made `GUARDED_COMMANDS.has(...)` always false — a permanently silent no-op.

Three separate near-misses all landed on "the guard looks installed but does nothing." That is the same shape as the incident itself, and it is why the enforcement tests are the load-bearing part of this PR.

Also fixed in the same round: `check-arch`, `check-deployment`, and `cross-check` were ungated despite emitting the same `--findings-json` contract (a test now derives that family from source so a new emitter cannot ship ungated); `evaluateVersionGuard` now validates the range itself, since `semver.minVersion` throws on `latest`/`workspace:*` while `satisfies` silently returns `false`; prereleases use `includePrerelease`; and the whole hook body is wrapped, because a broken guard must never break the CLI.

## Additional assumptions (review round)

11. **"Findings-producing" is defined by the `--findings-json` contract flag**, not by intuition — that flag is the machine-readable output an orchestrator parses and schedules on, which is precisely what a stale scanner corrupts. Eleven commands are gated.
12. **The MCP surface is out of scope and now says so explicitly.** The guard is a commander `preAction` hook; MCP tools call the check implementations in-process. A stale `harness-mcp` shim — and the Node-22 bin directory carries one alongside `harness` — reproduces this incident unmitigated. Named as the natural follow-up rather than left implied to be covered.
13. **The two command-path traversals are deliberately not unified.** Collapsing them means editing `command-telemetry.ts`, which holds a pre-existing annotated PostHog ingest key that `review-ci`'s heuristic path flags whenever the file enters a diff (the `harness-ignore` is honored by the security scanner but not by that path). That would drag an unrelated security finding into this review for no benefit to §5. A test pins the divergence.
