### PR TITLE
fix(roadmap): round-trip the roadmap preamble through shard and regen

### DIFF
--- a/.changeset/roadmap-preserve-preamble.md
+++ b/.changeset/roadmap-preserve-preamble.md
@@ -1,0 +1,42 @@
+---
+'@harness-engineering/types': minor
+'@harness-engineering/core': minor
+---
+
+Preserve the roadmap's preamble — the block between `# Roadmap` and the first
+milestone heading — through `shard` → `regen`.
+
+That block is where a roadmap carries instructions to the tooling and humans
+downstream of it: a `<!-- markdownlint-disable-file MD013 -->` directive that
+keeps a required docs-lint check green against a schema that mandates one
+physical line per field, and the note recording why the file is formatter-exempt
+and must not be reflowed. It entered neither `_meta.md` nor any shard, so `regen`
+faithfully rebuilt an aggregate the block had never been part of and it was gone
+— at exit code 0, with nothing warning. The tooling erased the note documenting
+its own contract, and erased it silently (#1328).
+
+`Roadmap` gains an optional `preamble`, captured verbatim by `parseRoadmap` and
+re-emitted by `serializeRoadmap` under the title — the same
+never-silently-drop-it contract the narrative `### Group:` sections already have.
+`RoadmapMeta` carries it in the `_meta.md` body ahead of any
+`## Assignment History` section, because it is roadmap-level and not derivable
+from shards, exactly like the assignment history. It therefore also survives the
+`_meta.md` rewrites of `stampLastSynced` and `patchAssignmentHistory`, and the
+`shard` command's pre-write round-trip assertion now covers it: dropping it is a
+detected failure that aborts the migration rather than a silent strip.
+
+The field is attached only when a roadmap actually has a preamble, so a
+preamble-free roadmap parses to the same shape and serializes to the same bytes
+as before, and `_meta.md` is byte-identical for every existing shard directory.
+The H1 title line is not part of the preamble (the serializer still canonicalizes
+it to `# Roadmap`); content authored above the title is kept and re-emitted below
+it, so a second parse of the serialized form returns the same string and regen
+stays byte-stable.
+
+Scope is deliberately the preamble only. Everything after the first `##` heading
+— continuation lines of a wrapped field, unmodeled `- **Key:**` bullets,
+section-intro blockquotes — is still unmodeled and still lost on a rewrite; the
+`findUnpreservedLines` guard continues to report it and `MonolithStore` continues
+to refuse those writes. What changes there is that the guard no longer reports
+preamble lines, which the serializer now keeps: it was blocking single-file
+roadmap writes over content that is no longer at risk.

--- a/docs/guides/roadmap-sharding.md
+++ b/docs/guides/roadmap-sharding.md
@@ -13,9 +13,16 @@ knowledge entries under [`docs/knowledge/roadmap/`](../knowledge/roadmap/).
 A monolith roadmap is a single `docs/roadmap.md` file that every session edits in
 place — a permanent multi-writer conflict surface (the file had grown past 100 KB).
 Sharding splits it into **one file per row**, `docs/roadmap.d/<slug>.md`, plus a
-`_meta.md` (project frontmatter + the ordered milestone list + an optional
-`## Assignment History`). Two PRs that touch two different rows now touch two
-different files and never conflict.
+`_meta.md` (project frontmatter + the ordered milestone list + the aggregate's
+preamble + an optional `## Assignment History`). Two PRs that touch two different
+rows now touch two different files and never conflict.
+
+The **preamble** is the block between `# Roadmap` and the first `##` heading —
+where a roadmap carries directives such as `<!-- markdownlint-disable-file
+MD013 -->` and notes to the humans downstream. Like the assignment history it is
+roadmap-level and not derivable from a shard, so it lives in `_meta.md` and is
+re-emitted under the title on every regen. Content _after_ the first `##` heading
+is not modeled and is still dropped by a rewrite (see (e) and (f)).
 
 `docs/roadmap.md` does not go away — it becomes a **generated** `merge=ours`
 aggregate, a convenient read-only view regenerated from the shards. The crucial

--- a/packages/cli/tests/commands/roadmap/shard-roundtrip.e2e.test.ts
+++ b/packages/cli/tests/commands/roadmap/shard-roundtrip.e2e.test.ts
@@ -7,9 +7,14 @@ import { runRoadmapShard } from '../../../src/commands/roadmap/shard';
 import { runRoadmapRegen } from '../../../src/commands/roadmap/regen';
 import { runRoadmapUnshard } from '../../../src/commands/roadmap/unshard';
 
-// Realistic monolith: multiple milestones incl. an EMPTY milestone, a slug
-// collision (`Fix login` / `Fix: login!`), mixed statuses, a populated
-// `## Assignment History`, and 1-2 digit issue refs only.
+// The directive block a real roadmap carries under its title (#1328).
+const PREAMBLE = `<!-- markdownlint-disable-file MD013 -->
+<!-- Machine-managed by harness roadmap tooling: each feature field is a single
+     line by schema contract, so the 80-column rule does not apply. -->`;
+
+// Realistic monolith: a preamble under the title, multiple milestones incl. an
+// EMPTY milestone, a slug collision (`Fix login` / `Fix: login!`), mixed statuses,
+// a populated `## Assignment History`, and 1-2 digit issue refs only.
 const ROADMAP_MD = `---
 project: harness-engineering
 version: 1
@@ -20,6 +25,8 @@ last_manual_edit: 2026-06-27T11:00:00.000Z
 ---
 
 # Roadmap
+
+${PREAMBLE}
 
 ## MVP Release
 
@@ -104,6 +111,16 @@ describe('roadmap shard/regen/unshard end-to-end round-trip', () => {
       // Assignment history survives.
       expect(after.value.assignmentHistory).toHaveLength(2);
     }
+  });
+
+  it('shard then regen keeps the preamble instead of silently deleting it (#1328)', async () => {
+    await runRoadmapShard({ cwd });
+    // It must live in `_meta.md` — the only roadmap-level home a shard dir has.
+    expect(fs.readFileSync(path.join(shardDir, '_meta.md'), 'utf-8')).toContain(PREAMBLE);
+
+    await runRoadmapRegen({ cwd });
+    const regenerated = fs.readFileSync(roadmapPath, 'utf-8');
+    expect(regenerated).toContain(`# Roadmap\n\n${PREAMBLE}\n\n## MVP Release`);
   });
 
   it('regen is deterministic: two consecutive runs are byte-identical', async () => {

--- a/packages/core/src/roadmap/parse.ts
+++ b/packages/core/src/roadmap/parse.ts
@@ -71,11 +71,35 @@ export function parseRoadmap(markdown: string): Result<Roadmap> {
   const historyResult = parseAssignmentHistory(body);
   if (!historyResult.ok) return historyResult;
 
-  return Ok({
+  const roadmap: Roadmap = {
     frontmatter: fmResult.value,
     milestones: milestonesResult.value,
     assignmentHistory: historyResult.value,
-  });
+  };
+  const preamble = parsePreamble(body);
+  if (preamble !== '') roadmap.preamble = preamble;
+  return Ok(roadmap);
+}
+
+/**
+ * The verbatim block between the document title and the first `##` heading.
+ *
+ * This is where a roadmap carries instructions to the tooling and humans
+ * downstream of it — `<!-- markdownlint-disable-file MD013 -->`, a note on why the
+ * file must not be reflowed. It is the only prose region the serializer models, so
+ * `serializeRoadmap` re-emits it under `# Roadmap` and the shard store persists it
+ * in `_meta.md` (#1328). Everything AFTER the first milestone heading remains
+ * unmodeled and lossy by design — {@link findUnpreservedLines} reports it.
+ *
+ * The H1 title line is dropped here because the serializer canonicalizes the
+ * title to `# Roadmap`; content on either side of it is kept, and re-emitted
+ * below the title, so a second parse of the serialized form returns this same
+ * string (idempotence, which the byte-stable regen depends on).
+ */
+function parsePreamble(body: string): string {
+  const firstH2 = body.match(/^## /m);
+  const head = firstH2 ? body.slice(0, firstH2.index) : body;
+  return head.replace(/^# .*$/m, '').trim();
 }
 
 function parseFrontmatter(raw: string): Result<RoadmapFrontmatter> {

--- a/packages/core/src/roadmap/preservation.ts
+++ b/packages/core/src/roadmap/preservation.ts
@@ -43,8 +43,10 @@ export interface UnpreservedLine {
 /**
  * Return the lines of `markdown` that a `serializeRoadmap` rewrite would silently
  * drop. A line is preservable iff it is frontmatter (regenerated from the model),
- * blank, an H1 title, an H2/H3 heading, an assignment-history table row, or a
- * single-line modeled `- **Key:** …` field. Everything else — multi-line field
+ * part of the preamble (everything before the first `## ` heading, which the model
+ * now carries verbatim — #1328), blank, an H1 title, an H2/H3 heading, an
+ * assignment-history table row, or a single-line modeled `- **Key:** …` field.
+ * Everything else — multi-line field
  * continuations, unmodeled bullets, blockquotes, comments, arbitrary prose — is
  * reported. An empty result means the document round-trips without content loss.
  *
@@ -65,6 +67,8 @@ export function findUnpreservedLines(markdown: string): UnpreservedLine[] {
 
   let inFrontmatter = false;
   let frontmatterDone = false;
+  /** Past the first `## ` heading — before it the lines are the modeled preamble. */
+  let inBody = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
@@ -89,21 +93,33 @@ export function findUnpreservedLines(markdown: string): UnpreservedLine[] {
       frontmatterDone = true;
     }
 
-    if (trimmed === '') continue; // blank lines carry no content
-    if (/^# /.test(text)) continue; // H1 title (serializer canonicalizes it to `# Roadmap`)
-    if (/^## /.test(text)) continue; // milestone / Backlog / Assignment History heading
-    if (/^### /.test(text)) continue; // feature heading (`### x` or `### Feature: x`)
-    if (/^\s*\|.*\|\s*$/.test(text)) continue; // assignment-history table row/header/separator
+    // Preamble region: everything up to the first `## ` heading is captured as
+    // `Roadmap.preamble` and re-emitted verbatim under the title (#1328), so it is
+    // preservable — reporting it would block a write that loses nothing. Past the
+    // first milestone heading the body is unmodeled again and the guard applies.
+    if (!inBody) {
+      if (!/^## /.test(text)) continue;
+      inBody = true;
+    }
 
-    // Single-line modeled field. The value is optional: the serializer emits
-    // `- **Status:** …` etc. unconditionally, so the line survives whether or not
-    // it carries a value. A modeled key with a MULTI-line body still surfaces its
-    // continuation lines here — they fail every pattern above and are reported.
-    const field = text.match(/^- \*\*(.+?):\*\*/);
-    if (field && MODELED_FIELD_KEYS.has(field[1]!)) continue;
-
-    lost.push({ line: i + 1, text });
+    if (!isPreservableBodyLine(text)) lost.push({ line: i + 1, text });
   }
 
   return lost;
+}
+
+/** Does a post-preamble body line survive a `serializeRoadmap` rewrite? */
+function isPreservableBodyLine(text: string): boolean {
+  if (text.trim() === '') return true; // blank lines carry no content
+  if (/^# /.test(text)) return true; // H1 title (serializer canonicalizes it to `# Roadmap`)
+  if (/^## /.test(text)) return true; // milestone / Backlog / Assignment History heading
+  if (/^### /.test(text)) return true; // feature heading (`### x` or `### Feature: x`)
+  if (/^\s*\|.*\|\s*$/.test(text)) return true; // assignment-history table row/header/separator
+
+  // Single-line modeled field. The value is optional: the serializer emits
+  // `- **Status:** …` etc. unconditionally, so the line survives whether or not
+  // it carries a value. A modeled key with a MULTI-line body still surfaces its
+  // continuation lines here — they fail every pattern above and are reported.
+  const field = text.match(/^- \*\*(.+?):\*\*/);
+  return Boolean(field && MODELED_FIELD_KEYS.has(field[1]!));
 }

--- a/packages/core/src/roadmap/serialize.ts
+++ b/packages/core/src/roadmap/serialize.ts
@@ -33,25 +33,16 @@ export function serializeRoadmap(roadmap: Roadmap): string {
   lines.push('');
   lines.push('# Roadmap');
 
-  for (const milestone of roadmap.milestones) {
+  // The directive/notes block under the title is re-emitted verbatim so a
+  // parse → mutate → serialize cycle never silently drops it (#1328) — same
+  // contract as the narrative `### Group:` sections below.
+  if (roadmap.preamble) {
     lines.push('');
-    lines.push(serializeMilestoneHeading(milestone));
-    for (const feature of milestone.features) {
-      lines.push('');
-      lines.push(...serializeFeature(feature));
-    }
-    // Narrative `### Group:` sections are re-emitted verbatim AFTER the strict
-    // features so a parse → mutate → serialize cycle never silently drops them.
-    for (const group of milestone.groups ?? []) {
-      lines.push('');
-      lines.push(`### Group: ${group.name}`);
-      // An empty body emits the heading alone — pushing a blank line plus an empty
-      // string would leave a stray trailing blank line in the file.
-      if (group.body !== '') {
-        lines.push('');
-        lines.push(group.body);
-      }
-    }
+    lines.push(roadmap.preamble);
+  }
+
+  for (const milestone of roadmap.milestones) {
+    lines.push(...serializeMilestoneSection(milestone));
   }
 
   // Assignment history section (omit if empty)
@@ -62,6 +53,28 @@ export function serializeRoadmap(roadmap: Roadmap): string {
 
   lines.push('');
   return lines.join('\n');
+}
+
+/** One milestone: its heading, its strict feature rows, then its narrative groups. */
+function serializeMilestoneSection(milestone: RoadmapMilestone): string[] {
+  const lines: string[] = ['', serializeMilestoneHeading(milestone)];
+  for (const feature of milestone.features) {
+    lines.push('');
+    lines.push(...serializeFeature(feature));
+  }
+  // Narrative `### Group:` sections are re-emitted verbatim AFTER the strict
+  // features so a parse → mutate → serialize cycle never silently drops them.
+  for (const group of milestone.groups ?? []) {
+    lines.push('');
+    lines.push(`### Group: ${group.name}`);
+    // An empty body emits the heading alone — pushing a blank line plus an empty
+    // string would leave a stray trailing blank line in the file.
+    if (group.body !== '') {
+      lines.push('');
+      lines.push(group.body);
+    }
+  }
+  return lines;
 }
 
 function serializeMilestoneHeading(milestone: RoadmapMilestone): string {

--- a/packages/core/src/roadmap/store/assembler.ts
+++ b/packages/core/src/roadmap/store/assembler.ts
@@ -23,11 +23,15 @@ export function assembleRoadmap(shards: Shard[], meta: RoadmapMeta): Roadmap {
   const ordered = orderMilestoneNames(meta, byMilestone);
   const milestones: RoadmapMilestone[] = ordered.map((name) => buildMilestone(name, byMilestone));
 
-  return {
+  const roadmap: Roadmap = {
     frontmatter: meta.frontmatter,
     milestones,
     assignmentHistory: meta.assignmentHistory ?? [],
   };
+  // Roadmap-level and shard-independent, like the assignment history: carried by
+  // `_meta` so regen re-emits it instead of deleting it (#1328).
+  if (meta.preamble) roadmap.preamble = meta.preamble;
+  return roadmap;
 }
 
 /** Group shards by their milestone, preserving first-seen insertion order. */

--- a/packages/core/src/roadmap/store/meta.ts
+++ b/packages/core/src/roadmap/store/meta.ts
@@ -31,6 +31,8 @@ export function parseMeta(md: string): Result<RoadmapMeta> {
   if (!milestones.ok) return Err(milestones.error);
 
   const meta: RoadmapMeta = { frontmatter: frontmatter.value, milestones: milestones.value };
+  const preamble = parsePreamble(body);
+  if (preamble !== '') meta.preamble = preamble;
   return attachAssignmentHistory(meta, body);
 }
 
@@ -95,6 +97,17 @@ function parseMilestones(data: Record<string, unknown>): Result<string[]> {
 }
 
 /**
+ * The aggregate's preamble, carried verbatim in the `_meta.md` body ahead of any
+ * `## Assignment History` section (the only other thing the body ever holds).
+ * A body with no preamble yields '' and no field is attached, so history-free and
+ * preamble-free `_meta.md` files stay byte-identical to Phase 1.
+ */
+function parsePreamble(body: string): string {
+  const history = body.indexOf('## Assignment History');
+  return (history === -1 ? body : body.slice(0, history)).trim();
+}
+
+/**
  * Optional trailing `## Assignment History` body. Reuse the exported roadmap
  * parser; absence yields []. Only attach when records exist so history-free
  * `_meta.md` stays structurally identical (and byte-stable) to Phase 1.
@@ -137,6 +150,12 @@ export function serializeMeta(meta: RoadmapMeta): string {
     }
   }
   lines.push('---');
+  // Optional preamble: a blank line then the verbatim block, emitted BEFORE any
+  // assignment history so `parsePreamble`'s split at the history heading recovers
+  // exactly these bytes.
+  if (meta.preamble) {
+    lines.push('', meta.preamble);
+  }
   // Optional `## Assignment History` body: a blank line then the verbatim
   // serializer output. Empty/absent history emits nothing (byte-stable with
   // history-free `_meta.md`); preserves the single-trailing-newline contract.

--- a/packages/core/src/roadmap/store/migration.ts
+++ b/packages/core/src/roadmap/store/migration.ts
@@ -20,9 +20,9 @@ import type { Shard, RoadmapMeta } from './roadmap-store';
  * `order` is the feature's index WITHIN its milestone (0,1,2,…). Because the
  * assembler sorts by `order` ascending first and these orders are unique per
  * milestone, the round-trip reproduces document order exactly (status/slug
- * tiebreakers never engage). Frontmatter, milestone order, and assignment
- * history are copied verbatim — no timestamps are bumped — so a strict semantic
- * round-trip holds.
+ * tiebreakers never engage). Frontmatter, milestone order, the preamble, and
+ * assignment history are copied verbatim — no timestamps are bumped — so a strict
+ * semantic round-trip holds.
  */
 export function roadmapToShards(roadmap: Roadmap): { shards: Shard[]; meta: RoadmapMeta } {
   const shards: Shard[] = [];
@@ -44,6 +44,7 @@ export function roadmapToShards(roadmap: Roadmap): { shards: Shard[]; meta: Road
     milestones: roadmap.milestones.map((m) => m.name),
     assignmentHistory: roadmap.assignmentHistory ?? [],
   };
+  if (roadmap.preamble) meta.preamble = roadmap.preamble;
   return { shards, meta };
 }
 

--- a/packages/core/src/roadmap/store/roadmap-store.ts
+++ b/packages/core/src/roadmap/store/roadmap-store.ts
@@ -20,6 +20,14 @@ export interface RoadmapMeta {
   /** Milestone names in canonical document order (includes 'Backlog'). */
   milestones: string[];
   /**
+   * The aggregate's preamble (the directive block under `# Roadmap`), carried in
+   * the `_meta.md` body ahead of any `## Assignment History` section. Roadmap-level
+   * and NOT derivable from shards, so — like the assignment history — `_meta.md` is
+   * its only home; without it `shard` → `regen` silently deleted the block (#1328).
+   * Absent means no preamble, and `_meta.md` stays byte-stable with Phase 1.
+   */
+  preamble?: string;
+  /**
    * Roadmap-level assignment audit log, carried in the `_meta.md` body as an
    * optional trailing `## Assignment History` section. Empty or absent means no
    * section is emitted (byte-stable with history-free `_meta.md`). This is the

--- a/packages/core/tests/roadmap/preservation.test.ts
+++ b/packages/core/tests/roadmap/preservation.test.ts
@@ -19,14 +19,17 @@ describe('findUnpreservedLines (#839 monolith write-preservation guard)', () => 
   });
 
   describe('detects hand-authored content the serializer would drop', () => {
-    it('flags an unmodeled `- **Issue:**` bullet', () => {
-      const lost = findUnpreservedLines(OLD_ROADMAP_MD);
-      // OLD_ROADMAP_MD carries an HTML comment + a narrative prose line.
-      expect(lost.map((l) => l.text)).toContain(
-        '<!-- Hand-authored monolith with extra prose, to prove SEMANTIC (not byte) equivalence. -->'
+    it('flags a milestone-section blockquote but not the preamble above it', () => {
+      const lost = findUnpreservedLines(OLD_ROADMAP_MD).map((l) => l.text);
+      // Prose inside a milestone section is still unmodeled and still lost.
+      expect(lost.filter((t) => t.startsWith('> Section intro prose'))).toHaveLength(1);
+      // The block under the title is the preamble: modeled and re-emitted (#1328),
+      // so flagging it would block a monolith write that loses nothing.
+      expect(lost).not.toContain(
+        '<!-- Hand-authored preamble: directives and notes to the tooling downstream. -->'
       );
-      expect(lost.map((l) => l.text)).toContain(
-        'This narrative line and the comment above are dropped by the lossy serializer.'
+      expect(lost).not.toContain(
+        'This line and the comment above round-trip verbatim through shard -> regen.'
       );
     });
 

--- a/packages/core/tests/roadmap/store/fixtures.ts
+++ b/packages/core/tests/roadmap/store/fixtures.ts
@@ -278,9 +278,16 @@ const MIG_FUTURE: RoadmapFeature = feat('Future idea', 'backlog', {
   summary: 'Something for later.',
 });
 
+/** The preamble block `OLD_ROADMAP_MD` carries under its title (#1328). */
+export const MIGRATION_PREAMBLE = [
+  '<!-- Hand-authored preamble: directives and notes to the tooling downstream. -->',
+  'This line and the comment above round-trip verbatim through shard -> regen.',
+].join('\n');
+
 export const MIGRATION_META: RoadmapMeta = {
   frontmatter: META.frontmatter,
   milestones: ['MVP Release', 'v5.0 Hardening', 'Backlog'],
+  preamble: MIGRATION_PREAMBLE,
 };
 
 export const MIGRATION_SHARDS: Shard[] = [
@@ -354,10 +361,13 @@ last_manual_edit: 2026-06-27T11:00:00.000Z
 
 # Roadmap
 
-<!-- Hand-authored monolith with extra prose, to prove SEMANTIC (not byte) equivalence. -->
-This narrative line and the comment above are dropped by the lossy serializer.
+<!-- Hand-authored preamble: directives and notes to the tooling downstream. -->
+This line and the comment above round-trip verbatim through shard -> regen.
 
 ## MVP Release
+
+> Section intro prose, dropped by the lossy serializer — this fixture proves
+> SEMANTIC (not byte) equivalence.
 
 ### Core foundation
 

--- a/packages/core/tests/roadmap/store/preamble-round-trip.test.ts
+++ b/packages/core/tests/roadmap/store/preamble-round-trip.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { parseRoadmap } from '../../../src/roadmap/parse';
+import { serializeRoadmap } from '../../../src/roadmap/serialize';
+import { findUnpreservedLines } from '../../../src/roadmap/preservation';
+import { parseMeta, serializeMeta } from '../../../src/roadmap/store/meta';
+import { roadmapToShards, assertSemanticRoundTrip } from '../../../src/roadmap/store/migration';
+import { serializeShard } from '../../../src/roadmap/store/shard';
+import { regenerate } from '../../../src/roadmap/store/regenerator';
+import type { ShardIO } from '../../../src/roadmap/store/shard-store';
+
+/**
+ * #1328: the block between `# Roadmap` and the first `##` heading — in practice a
+ * roadmap's machine-readable directives (`markdownlint-disable-file`) and the note
+ * explaining why the file is formatter-exempt — entered neither `_meta.md` nor any
+ * shard, so `shard` → `regen` deleted it at exit code 0.
+ */
+const PREAMBLE = [
+  '<!-- markdownlint-disable-file MD013 -->',
+  '<!-- Machine-managed by harness roadmap tooling: each feature field is a single',
+  '     line by schema contract, so the 80-column rule does not apply. -->',
+].join('\n');
+
+const ROADMAP_WITH_PREAMBLE = [
+  '---',
+  'project: demo',
+  'version: 1',
+  'last_synced: 2026-08-10T00:00:00.000Z',
+  'last_manual_edit: 2026-08-10T00:00:00.000Z',
+  '---',
+  '',
+  '# Roadmap',
+  '',
+  PREAMBLE,
+  '',
+  '## MVP Release',
+  '',
+  '### Core foundation',
+  '',
+  '- **Status:** in-progress',
+  '- **Spec:** —',
+  '- **Summary:** Ship it.',
+  '- **Blockers:** —',
+  '- **Plan:** —',
+  '',
+].join('\n');
+
+const SHARD_DIR = '/repo/docs/roadmap.d';
+
+function basename(p: string): string {
+  return p.slice(p.lastIndexOf('/') + 1);
+}
+
+/** In-memory shard dir written exactly as `harness roadmap shard` writes it. */
+function shardToDisk(markdown: string): ShardIO {
+  const parsed = parseRoadmap(markdown);
+  if (!parsed.ok) throw parsed.error;
+  const { shards, meta } = roadmapToShards(parsed.value);
+
+  const files = new Map<string, string>();
+  for (const shard of shards) {
+    files.set(`${SHARD_DIR}/${shard.slug}.md`, serializeShard(shard));
+  }
+  files.set(`${SHARD_DIR}/_meta.md`, serializeMeta(meta));
+
+  return {
+    listDir: async (dir) => [...files.keys()].filter((p) => p.startsWith(`${dir}/`)).map(basename),
+    readFile: async (p) => {
+      const v = files.get(p);
+      if (v === undefined) throw new Error(`ENOENT: ${p}`);
+      return v;
+    },
+    writeFile: async (p, d) => void files.set(p, d),
+  };
+}
+
+describe('roadmap preamble round-trip (#1328)', () => {
+  it('parses the block under the title as the preamble', () => {
+    const parsed = parseRoadmap(ROADMAP_WITH_PREAMBLE);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.value.preamble).toBe(PREAMBLE);
+  });
+
+  it('omits `preamble` entirely when the roadmap has none', () => {
+    const parsed = parseRoadmap(ROADMAP_WITH_PREAMBLE.replace(`${PREAMBLE}\n\n`, ''));
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect('preamble' in parsed.value).toBe(false);
+  });
+
+  it('re-emits the preamble under `# Roadmap`, and re-parsing is idempotent', () => {
+    const parsed = parseRoadmap(ROADMAP_WITH_PREAMBLE);
+    if (!parsed.ok) throw parsed.error;
+
+    const serialized = serializeRoadmap(parsed.value);
+    expect(serialized).toContain(`# Roadmap\n\n${PREAMBLE}\n\n## MVP Release`);
+
+    const reparsed = parseRoadmap(serialized);
+    expect(reparsed.ok).toBe(true);
+    if (reparsed.ok) {
+      expect(reparsed.value.preamble).toBe(PREAMBLE);
+      expect(serializeRoadmap(reparsed.value)).toBe(serialized);
+    }
+  });
+
+  it('carries the preamble through `_meta.md`', () => {
+    const parsed = parseRoadmap(ROADMAP_WITH_PREAMBLE);
+    if (!parsed.ok) throw parsed.error;
+    const { meta } = roadmapToShards(parsed.value);
+    expect(meta.preamble).toBe(PREAMBLE);
+
+    const reparsed = parseMeta(serializeMeta(meta));
+    expect(reparsed.ok).toBe(true);
+    if (reparsed.ok) expect(reparsed.value.preamble).toBe(PREAMBLE);
+  });
+
+  it('survives shard -> regen (the reported repro)', async () => {
+    const io = shardToDisk(ROADMAP_WITH_PREAMBLE);
+    const regen = await regenerate(SHARD_DIR, io);
+    expect(regen.ok).toBe(true);
+    if (regen.ok) expect(regen.value).toContain(PREAMBLE);
+  });
+
+  it('regenerates byte-identically on rerun', async () => {
+    const io = shardToDisk(ROADMAP_WITH_PREAMBLE);
+    const first = await regenerate(SHARD_DIR, io);
+    const second = await regenerate(SHARD_DIR, io);
+    expect(first.ok && second.ok).toBe(true);
+    if (first.ok && second.ok) expect(second.value).toBe(first.value);
+  });
+
+  it("the shard command's pre-write round-trip assertion covers the preamble", () => {
+    const parsed = parseRoadmap(ROADMAP_WITH_PREAMBLE);
+    if (!parsed.ok) throw parsed.error;
+    const { shards, meta } = roadmapToShards(parsed.value);
+
+    expect(assertSemanticRoundTrip(parsed.value, shards, meta).ok).toBe(true);
+    // Dropping it is now a detected round-trip failure rather than a silent strip.
+    const { preamble: _dropped, ...stripped } = meta;
+    expect(assertSemanticRoundTrip(parsed.value, shards, stripped).ok).toBe(false);
+  });
+
+  it('no longer reports the preamble as content a monolith rewrite would drop', () => {
+    // The #839 guard must not block a write the serializer now preserves.
+    expect(findUnpreservedLines(ROADMAP_WITH_PREAMBLE)).toEqual([]);
+  });
+});

--- a/packages/types/src/roadmap.ts
+++ b/packages/types/src/roadmap.ts
@@ -107,6 +107,13 @@ export interface RoadmapFrontmatter {
 export interface Roadmap {
   /** Parsed frontmatter */
   frontmatter: RoadmapFrontmatter;
+  /**
+   * Verbatim content between the document title and the first milestone heading —
+   * in practice the roadmap's directive block (`markdownlint-disable-file`, a note
+   * on why the file is formatter-exempt). Absent when there is none, so a
+   * preamble-free roadmap stays byte-identical through parse → serialize (#1328).
+   */
+  preamble?: string;
   /** Milestones in document order (including Backlog) */
   milestones: RoadmapMilestone[];
   /** Assignment history records, in document order */


### PR DESCRIPTION
Fixes #1328. Persists the block between `# Roadmap` and the first milestone heading in `_meta.md` — alongside the frontmatter and assignment history it already round-trips — and re-emits it under the title on regen, as suggested in the issue.

## Root cause

The loss happens at `shard`, not `regen`. `serializeMeta()` round-trips only `project`/`version`/`created`/`updated`/`last_synced`/`last_manual_edit`/`milestones` plus assignment history, so a leading block enters neither `_meta.md` nor any shard. `regen` then faithfully rebuilds a document the content was already absent from — exit 0 at every step, no warning.

## Approach

`Roadmap.preamble` / `RoadmapMeta.preamble` are **optional and attached only when present**, so preamble-free roadmaps and every existing `_meta.md` stay byte-identical. Because the value flows through `assembleRoadmap`, `shard`, `regen`, `unshard`, `stampLastSynced` and `patchAssignmentHistory` all preserve it with no CLI change.

Stored as body markdown rather than a YAML block scalar, to avoid escaping/quoting round-trip risk.

The `shard` command's existing pre-write round-trip assertion now covers the preamble, so dropping it aborts the migration instead of passing silently.

## One deliberate consequence

`findUnpreservedLines` (the #839 monolith write guard) was reporting preamble lines as unpreservable. After this fix that is a false positive blocking `MonolithStore` writes over content no longer at risk, and it violates the guard's own stated invariant (`findUnpreservedLines(serializeRoadmap(x)) === []`). Lines before the first `##` are now preservable; **everything after the first `##` — wrapped-field continuations, unmodeled bullets, blockquotes — is still unmodeled, still reported, still refused.**

That forced two fixtures to change (`OLD_ROADMAP_MD` carried its lossy prose in exactly that region). I kept their intent by moving the lossy prose into a milestone section, so the "SEMANTIC not byte equivalence" fixture still proves what it was written to prove.

## Verification

New `packages/core/tests/roadmap/store/preamble-round-trip.test.ts` — 8 cases, written before any src change, 6 red beforehand. Plus a case added to the existing `shard-roundtrip.e2e.test.ts` (real disk, real commands), which ran red against the pre-fix `dist`.

Reproduced the issue's exact scenario against a downstream 51-row roadmap with the freshly built CLI: `shard` → 51 shards, `regen` → all eight comment lines back under the title.

Full `pnpm test` (26/26 turbo tasks, 4140 core tests), `pnpm lint` (12/12), `pnpm typecheck` (22/22), `pnpm build` (13/13) all green. Changeset included (`types` + `core`, minor), matching the `roadmap-narrative-group-sections` precedent.

## Unrelated flake, flagged not ignored

The first full-suite run failed `@harness-engineering/core#test` with `Error: write EPIPE` in `tests/review/ci/default-exec-file.test.ts`, while all 4140 tests passed — an unhandled error from a child process's stdin. It does not reproduce (green standalone and on two later full runs) and nothing here spawns a process, so it is pre-existing, but it looks like a real flake under turbo's parallel load.

## Alternative considered

The issue's fallback — warn on `shard` that content is being dropped — is a much smaller change, but leaves consumers hand-repairing the file indefinitely. Happy to switch if you would rather not widen the model.