### PR TITLE
fix(scan-config): apply fileGlob so path-scoped rules stop matching the wrong files

### DIFF
--- a/.changeset/scan-config-fileglob-filtering.md
+++ b/.changeset/scan-config-fileglob-filtering.md
@@ -1,0 +1,27 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(scan-config): apply `fileGlob` so path-scoped rules stop matching the wrong files
+
+`scan-config` called `SecurityScanner.scanContent`, which documents that it
+evaluates every active rule "regardless of filePath". Path-scoped rules were
+therefore matched against files their `fileGlob` excludes.
+
+The visible cost was SEC-AGT-007 ("Shell metacharacters in hook commands"),
+scoped to `**/settings*.json,**/hooks.json`, whose pattern ``/`[^`]+`/``
+matches ordinary Markdown inline code. Measured on a real repository, the scan
+reported **787** findings and exited 2; **758** of them were SEC-AGT-007 (378),
+SEC-MCP-002 (377) and SEC-MCP-004 (3) firing on `CLAUDE.md` and `AGENTS.md`
+prose such as ``If on `main`:``. After the fix the same repository reports 29
+findings — the genuine `INJ-SUS-*` matches — and exits 0.
+
+The scan now calls `scanFileContent`, which applies the same `fileGlob`
+filtering as `scanFile` while reusing the content already read from disk.
+`packages/orchestrator/src/workspace/config-scanner.ts` had already routed
+around this for its copy of the workflow, naming SEC-AGT-007 and SEC-MCP-002 in
+a comment; the CLI command was never brought across.
+
+Rules whose `fileGlob` does match are unaffected — a regression test asserts
+SEC-AGT-006 still fires on `CLAUDE.md`, so the fix narrows by path rather than
+switching the security engine off.

--- a/packages/cli/src/commands/scan-config.ts
+++ b/packages/cli/src/commands/scan-config.ts
@@ -95,7 +95,16 @@ function scanSingleFile(
   const injectionFindings = scanForInjection(content);
   const findings = mapInjectionFindings(injectionFindings);
 
-  const secFindings = scanner.scanContent(content, filePath);
+  // `scanFileContent`, not `scanContent`: only the former applies a rule's
+  // `fileGlob`. `scanContent` documents that it fires every active rule
+  // "regardless of filePath", so path-scoped rules matched the wrong files —
+  // SEC-AGT-007 (`**/settings*.json,**/hooks.json`) carries the pattern
+  // /`[^`]+`/ and matched ordinary Markdown inline code, reporting a real
+  // CLAUDE.md's prose as 26 HIGH "shell metacharacters in hook commands".
+  // `packages/orchestrator/src/workspace/config-scanner.ts` already routes
+  // around this for its copy of the workflow; this is the same fix for the CLI.
+  // It takes the content already in hand rather than re-reading from disk.
+  const secFindings = scanner.scanFileContent(content, filePath);
   findings.push(...mapSecurityFindings(secFindings, findings));
 
   if (options.fix) {

--- a/packages/cli/tests/commands/scan-config.test.ts
+++ b/packages/cli/tests/commands/scan-config.test.ts
@@ -274,4 +274,67 @@ describe('runScanConfig', () => {
       expect(result.results.length).toBe(0);
     });
   });
+
+  /**
+   * `fileGlob` rule filtering.
+   *
+   * `SecurityScanner` exposes two content-scanning entry points, and only one
+   * of them honours a rule's `fileGlob`: `scanContent` documents that it fires
+   * every active rule "regardless of filePath", while `scanFileContent` filters
+   * first. `scan-config` walks a fixed CONFIG_FILES list of Markdown and JSON,
+   * so a rule scoped to `**\/settings*.json,**\/hooks.json` must not be given
+   * `CLAUDE.md` to match against.
+   *
+   * The concrete report: SEC-AGT-007 ("Shell metacharacters in hook commands")
+   * carries the pattern /`[^`]+`/, which matches ordinary Markdown inline code.
+   * On a real CLAUDE.md that is 26 HIGH findings on prose such as
+   * "If on `main`:" — enough to make the check unusable on any repo that
+   * documents a shell command in its agent instructions.
+   *
+   * `packages/orchestrator/src/workspace/config-scanner.ts` already fixed this
+   * for its own copy of the workflow, naming SEC-AGT-007 and SEC-MCP-002 in a
+   * comment. The CLI command was never brought across.
+   */
+  describe('fileGlob filtering', () => {
+    it('does not fire a hooks-only rule on Markdown inline code (SEC-AGT-007)', async () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'CLAUDE.md'),
+        ['# Project', '', 'If on `main`:', '', '- Run `npm test` before pushing.', ''].join('\n')
+      );
+
+      const result = await runScanConfig(tempDir, {});
+      const ruleIds = (result.results[0]?.findings ?? []).map((f) => f.ruleId);
+
+      expect(ruleIds).not.toContain('SEC-AGT-007');
+    });
+
+    it('does not fire an .mcp.json-only rule on Markdown (SEC-MCP-002)', async () => {
+      fs.writeFileSync(
+        path.join(tempDir, 'AGENTS.md'),
+        '# Agents\n\nConfigure the server with `command: npx -y some-server`.\n'
+      );
+
+      const result = await runScanConfig(tempDir, {});
+      const ruleIds = (result.results[0]?.findings ?? []).map((f) => f.ruleId);
+
+      expect(ruleIds).not.toContain('SEC-MCP-002');
+    });
+
+    it('still fires a rule whose fileGlob DOES match the scanned file', async () => {
+      // The denominator check: filtering must narrow by path, not switch the
+      // SEC-AGT engine off. SEC-AGT-006's fileGlob covers CLAUDE.md, and
+      // `--dangerously-skip-permissions` is one of its patterns, so this is a
+      // true positive that must survive the fix. Without it, a change that
+      // dropped every SEC rule would pass the two assertions above.
+      fs.writeFileSync(
+        path.join(tempDir, 'CLAUDE.md'),
+        '# Project\n\nRun claude --dangerously-skip-permissions to skip prompts.\n'
+      );
+
+      const result = await runScanConfig(tempDir, {});
+      const ruleIds = (result.results[0]?.findings ?? []).map((f) => f.ruleId);
+
+      expect(ruleIds).toContain('SEC-AGT-006');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`scan-config` matched path-scoped security rules against files their `fileGlob`
excludes, because it called `SecurityScanner.scanContent` — the entry point
whose own docstring states it evaluates every active rule "regardless of
filePath".

The visible cost is **SEC-AGT-007** ("Shell metacharacters in hook commands"),
scoped to `**/settings*.json,**/hooks.json`, whose pattern ``/`[^`]+`/`` matches
ordinary Markdown inline code. Since `CONFIG_FILES` includes `CLAUDE.md` and
`AGENTS.md`, every backtick-quoted phrase in an agent-instruction file was
reported as a HIGH-severity shell-injection finding.

This is already known in-tree: `packages/orchestrator/src/workspace/config-scanner.ts:72-75`
carries the fix for its copy of the same workflow, naming SEC-AGT-007 and
SEC-MCP-002 by ID in a comment. The CLI command was never brought across, so the
orchestrator path is clean while `harness scan-config` is not.

## Changes

- `packages/cli/src/commands/scan-config.ts` — call `scanFileContent(content, filePath)`
  instead of `scanContent(content, filePath)`. Same `fileGlob` filtering as
  `scanFile`, reusing the content already read from disk rather than re-reading it.
- `packages/cli/tests/commands/scan-config.test.ts` — a `fileGlob filtering`
  describe block with three cases.
- `.changeset/scan-config-fileglob-filtering.md` — patch for `@harness-engineering/cli`.

## Measured effect

On a real repository (`bop-clocktower/canary`), same tree, CLI built from this
branch vs published 11.1.1:

| | findings | exit | breakdown |
|---|---|---|---|
| before | **787** | 2 | SEC-AGT-007 378, SEC-MCP-002 377, SEC-MCP-004 3, INJ-SUS-001 23, INJ-SUS-002 6 |
| after | **29** | 0 | INJ-SUS-001 23, INJ-SUS-002 6 |

758 false positives removed; the genuine `INJ-SUS-*` findings are untouched.
Representative removed match, ordinary prose from a `CLAUDE.md`:

```json
{ "ruleId": "SEC-AGT-007", "severity": "high",
  "match": "If on `main`:", "line": 11 }
```

## Testing

Three regression tests, **written red first** — the two false-positive cases
failed with `expected [ 'SEC-AGT-007', 'SEC-AGT-007', …(2) ] to not include
'SEC-AGT-007'` before the one-line change, and pass after.

The third is the denominator guard, and it is the one worth reviewing: it
asserts **SEC-AGT-006 still fires on `CLAUDE.md`** — a rule whose `fileGlob`
legitimately covers Markdown. Without it, a change that narrowed by switching
the SEC engine off entirely rather than by path would satisfy the first two
assertions and look correct.

There is also an existing hedge this removes the need for, at
`tests/commands/scan-config.test.ts:197`:

```ts
// SEC-AGT rules may or may not match depending on fileGlob filtering in scanContent
```

- [x] `pnpm build` passes
- [x] `pnpm test` passes — `@harness-engineering/cli` 6163 passed (532 files),
      `@harness-engineering/core` 4132 passed / 1 skipped
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes

## Related Issues

Closes #1343
