### PR TITLE
fix(ci): omit optional cpu-features native build so windows-latest (VS 2026) can't red the required check

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
   },
   "packageManager": "pnpm@8.15.4",
   "pnpm": {
+    "neverBuiltDependencies": [
+      "cpu-features"
+    ],
     "overrides": {
       "hono": ">=4.12.34",
       "@grpc/grpc-js": "^1.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+neverBuiltDependencies:
+  - cpu-features
+
 overrides:
   hono: '>=4.12.34'
   '@grpc/grpc-js': ^1.14.4


### PR DESCRIPTION
## Item (cicd-fleet) — infra/config: windows build-and-test node-gyp / cpu-features break

**Fork chosen:** Fork A option **(b)** — OMIT/skip the optional `cpu-features` native dep on Windows CI so a runner-image bump can't red the required check. (Option **c**, pinning the runner backward to `windows-2022`, was explicitly rejected — we stay on the latest `windows-latest` image.)

### Root cause
`windows-latest` migrated to **Windows Server 2025 + Visual Studio 2026** (GA in GitHub Actions; default rollout June 8–15, 2026 per [actions/runner-images#14017](https://github.com/actions/runner-images/issues/14017) and the [GitHub Changelog](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/)). VS 2026 requires **node-gyp ≥ 12.1.0** (bundled in npm 11.6.3); the node-gyp bundled with the CI's Node 22 cannot build native modules against VS 2026. The optional transitive native dep **`cpu-features@0.0.10`** therefore fails its `node-gyp` build during `pnpm install --frozen-lockfile`, reddening the **windows `build-and-test`** required check.

`cpu-features` is an **optional** dependency of `ssh2`, pulled in only by the dev-only chain `testcontainers → dockerode → docker-modem → ssh2`. `ssh2` wraps the `cpu-features` require in try/catch — it is a CPU-feature-detection optimization, not a hard dependency.

### The fix
Add `cpu-features` to `pnpm.neverBuiltDependencies` (root `package.json` + the matching `neverBuiltDependencies` entry in `pnpm-lock.yaml`). Its `node-gyp` build script now never runs on any platform, so no VS/node-gyp version can red the required check via this build. This keeps `windows-latest` on the **latest** image (no backward pin) and is forward-compatible.

### Files touched
- `package.json` (+3: `pnpm.neverBuiltDependencies: ["cpu-features"]`)
- `pnpm-lock.yaml` (+3: matching `neverBuiltDependencies` block; no dependency-graph churn)

### Validation
- macOS / Node 22: `pnpm install --frozen-lockfile` **passes**; `cpu-features` is **not** built (`build/` absent); `ssh2`, `dockerode`, `testcontainers` still load.
- No changeset required — root-only change, `check-changesets` reports "No publishable package changes detected."
- **Validation limitation:** the Windows node-gyp/VS-2026 path cannot be exercised on macOS. The actual Windows behavior is validated by **this PR's CI** (the `windows-latest` `build-and-test` required check). Do not merge until that check is green.

🤖 Generated by cicd-fleet (WAVE 0). **Do not auto-merge** — hand back for human / pr-fleet review.
