### PR TITLE
test(core): deflake mechanical-gate by removing subprocess-spawn nondeterminism on win32

### DIFF
--- a/packages/core/tests/state/gate.test.ts
+++ b/packages/core/tests/state/gate.test.ts
@@ -12,7 +12,13 @@ describe('runMechanicalGate', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true });
+    // Windows: a just-exited `npm` subprocess (spawned by runMechanicalGate via
+    // execSync) can briefly retain handles on files under tmpDir, so a plain
+    // recursive rmSync intermittently throws EBUSY / ENOTEMPTY / EPERM. `force`
+    // + `maxRetries`/`retryDelay` makes Node retry until the OS releases the
+    // handles ("await the settle"), removing the teardown-race nondeterminism.
+    // A no-op on POSIX, where handles are released synchronously on exit.
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   });
 
   it('should return passed=true with no checks when project type is undetectable', async () => {

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -13,6 +13,17 @@ export default defineConfig({
     // workers starve those subprocess spawns of CPU, so a 15s default timed out
     // intermittently even on green code. A larger ceiling only tolerates slow /
     // loaded runners — a genuine hang still fails — so it cannot mask a real bug.
+    // Isolate the subprocess-spawning suites' process pool on Windows. Several
+    // core suites (mechanical-gate, baseline-resolver, git-scan, ...) spawn real
+    // `npm`/`git` children via execSync. On win32 those spawns are slow AND, run
+    // concurrently across parallel worker processes under v8 coverage, they
+    // storm Windows process creation and starve each other of CPU — the exact
+    // nondeterminism behind the intermittent gate.test.ts timeouts. Serializing
+    // test FILES on win32 removes the concurrent-spawn storm (each file still
+    // gets its own isolated process) without touching mac/linux parallelism.
+    // This removes the nondeterminism at its source rather than merely widening
+    // a timeout, which the raised ceiling below already showed does not fix it.
+    fileParallelism: process.platform === 'win32' ? false : true,
     testTimeout: 60_000,
     // Same rationale for setup/teardown hooks, which have their own separate
     // budget (vitest default 10s). Several suites do `git init` + commits inside


### PR DESCRIPTION
## Item (cicd-fleet) — flake: `packages/core/tests/state/gate.test.ts` timeout on windows

**Fork chosen:** Fork B option **(a)** — REMOVE the subprocess-spawn nondeterminism (await settle + isolate the test's process pool on win32). Merely raising the timeout (rejected) was already tried: the core config's `testTimeout` is documented as raised to 60s for exactly this flake class, and it still flapped.

### Root cause
`runMechanicalGate` spawns **real `npm` subprocesses** via `execSync` (`npm test` / `npm run lint` against `echo` scripts). Two Windows-specific nondeterminism sources:

1. **Teardown race** — `afterEach` removed the temp dir with a bare `fs.rmSync(tmpDir, { recursive: true })`. On Windows a just-exited `npm` child can briefly retain file handles under `tmpDir`, so recursive removal intermittently throws `EBUSY` / `ENOTEMPTY` / `EPERM`.
2. **Process-pool storm** — under v8 coverage, vitest's parallel worker processes each spawn `npm` children concurrently; on Windows this storms process creation and starves the spawns of CPU, so `npm` cold-start blows the per-test budget nondeterministically. (`packages/core/vitest.config.mts` already documents raising `testTimeout` to 60s for this class — proving a wider timeout does not fix it.)

### The fix (removes the nondeterminism — no skip, no retry, no timeout bump)
- **await the settle:** `afterEach` now uses `{ recursive: true, force: true, maxRetries: 10, retryDelay: 100 }`, so Node retries the removal until the OS releases the handles. No-op on POSIX.
- **isolate the process pool on win32:** `packages/core/vitest.config.mts` sets `fileParallelism: false` on `win32` only, serializing test **files** so the concurrent-`npm`-spawn storm is removed at its source (each file still runs in its own isolated process). mac/linux parallelism is unchanged.

### Files touched
- `packages/core/tests/state/gate.test.ts` (hardened teardown)
- `packages/core/vitest.config.mts` (win32 `fileParallelism: false`)

### Validation
- macOS / Node 22: `gate.test.ts` passes **3/3** runs; the config change is **inert** on non-win32 (`fileParallelism` stays `true`).
- No changeset required — `check-changesets` reports "No publishable package changes detected" (test + config only).
- **Validation limitation:** deterministic **Windows** green cannot be exercised on macOS. It is validated by **this PR's CI** — the `windows-latest` `build-and-test` required check, re-run across the CI matrix. Per the cicd-fleet Iron Law a deflake is merge-ready only on **deterministic** green (repeated-run stability), so confirm the Windows leg is green across a re-run before landing.

### Pre-authorized fallback (do NOT skip the test)
Per the authorized decision: **if** this traces to an uncontrollable Windows `npm`-spawn limit that the above does not tame, the fallback is a **tracked quarantine proposal**, never a silent skip. Draft proposal, to be filed only if the Windows leg still flaps after this fix:

> **QUARANTINE PROPOSAL (draft, not yet applied):** Move the three `npm`-spawning cases in `gate.test.ts` behind a documented `it.skipIf(process.platform === 'win32' && process.env.CI)` guard **with a linked tracking issue**, and cover `runMechanicalGate`'s discovery/gating/aggregation logic on win32 via an injected in-process command executor (no real `npm` spawn). This keeps the logic under test on Windows while removing the uncontrollable external-spawn dependency. Requires human sign-off before applying.

🤖 Generated by cicd-fleet (WAVE 0). **Do not auto-merge** — hand back for human / pr-fleet review.
