### PR TITLE
fix(test-craft): refuse to report zero findings for zero critiques (#1346, #1347)

### DIFF
--- a/.changeset/test-craft-abstention-and-esm-discovery.md
+++ b/.changeset/test-craft-abstention-and-esm-discovery.md
@@ -1,0 +1,37 @@
+---
+'@harness-engineering/cli': minor
+---
+
+fix(test-craft): refuse to report zero findings for zero critiques (#1346, #1347)
+
+`harness test-craft` could not produce a finding under its own default provider,
+and could not see ESM test suites at all. Both failures printed the same thing:
+`No test findings.` at exit 0.
+
+**The critique phase never ran (#1346).** `InSessionLlmProvider.callText` throws
+`PromptDeferredError` on every call — it queues the prompt for the calling agent
+rather than answering it — and `critiqueTest` caught every throw in a bare
+`catch {}`. Every `(test × rubric)` pair failed and was discarded. `test-craft`
+now refuses that provider up front, the way `naming-craft` already does, and
+per-rubric failures are counted into `summary.counts.critiqueErrors` instead of
+being dropped.
+
+**Discovery was blind to `.mjs` / `.cjs` / `.mts` / `.cts` (#1347).** The
+extension list lived in two places — the discovery walk and a second regex gate
+inside `extract/tests.ts` — so the bug had two halves: the walker skipped
+`*.test.mjs`, and passing one through `--files` cleared the walker only to be
+dropped by the extractor, reporting `filesScanned: 1` against
+`testsExtracted: 0`. Both now read from `extract/test-file-exts.ts`.
+
+Measured on a 53-file ESM repo: `0 findings / 60 tests / 9 files / 0 LLM calls`
+became `8936 findings / 1117 tests / 53 files / 8936 LLM calls`.
+
+**Behaviour change:** `runTestCraft` and `critiqueTestsInFile` now throw when
+handed the in-session provider rather than returning an empty result. Callers
+relying on the silent-empty return must configure a real backend via
+`agent.backends` + `HARNESS_CRAFT_LLM`, or set `HARNESS_CRAFT_LLM=mock`.
+
+`TestCraftSummary.counts` gains `critiqueErrors` and `testsTruncated`. Both are
+required fields, so code constructing that type (rather than only reading it)
+needs updating. The CLI now also warns when the per-file cap truncated a file
+and notes when nothing source-paired, which silently disables `TEST-R007`.

--- a/agents/skills/claude-code/test-craft/SKILL.md
+++ b/agents/skills/claude-code/test-craft/SKILL.md
@@ -25,7 +25,7 @@
    - `craft.test.frameworks` — restrict to subset (default: all five)
    - `craft.test.sourcePair` — toggle source-pairing (default true)
 
-2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs.
+2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,mts,cts}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs. The extension list is defined once in `extract/test-file-exts.ts` and shared by discovery and extraction — a private second copy is what made `*.test.mjs` suites invisible (#1347).
 
 3. **Detect framework per file** via import signatures (order matters; most-specific first):
    - `@playwright/test` → playwright
@@ -87,7 +87,10 @@ Emit `TestCraftOutput`:
     durationMs: number;
     llmCalls: { provider, model, count, costUsd };
     catalog: { rubricsApplied: string[] };
-    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired };
+    // critiqueErrors > 0 or testsTruncated > 0 means the run is partly
+    // unmeasured: findings are a floor, not a total.
+    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired,
+              critiqueErrors, testsTruncated };
     frameworksDetected: Record<TestFramework, number>;
     runId: string;
   }
@@ -208,6 +211,8 @@ TEST-R004 [polish/large/medium] vitest:142
 
 ## Escalation
 
+- **When the run refuses with "cannot run against the in-session provider":** test-craft has no two-step collect/finalize flow, so the in-session provider (which defers every prompt to the calling agent) cannot answer a single rubric. Configure a real backend via `agent.backends` + `HARNESS_CRAFT_LLM`, or set `HARNESS_CRAFT_LLM=mock` for tests. It refuses rather than critiquing nothing and reporting zero findings (#1346).
+- **When the summary reports `critiqueErrors` or `testsTruncated` above zero:** the run is partly unmeasured — findings are a floor, not a total.
 - **When LLM cost is too high:** drop `maxTestsPerFile` (default 20) or scope to specific frameworks with `--frameworks vitest`. Disable source-pairing with `--no-source-pair` to halve prompt size on every test.
 - **When intentionally narrative test names get flagged (e.g., learning tests, examples):** scope via `--files` to exclude. v1.x adds `// test-craft:skip` annotation.
 - **When source-pairing finds the wrong source for ambiguous names:** the LLM gets misleading context for `TEST-R007`. Use `--no-source-pair` to fall back to test-file-only rubrics, or v1.x's `harness.config.json` test→source mapping.

--- a/agents/skills/codex/test-craft/SKILL.md
+++ b/agents/skills/codex/test-craft/SKILL.md
@@ -25,7 +25,7 @@
    - `craft.test.frameworks` — restrict to subset (default: all five)
    - `craft.test.sourcePair` — toggle source-pairing (default true)
 
-2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs.
+2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,mts,cts}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs. The extension list is defined once in `extract/test-file-exts.ts` and shared by discovery and extraction — a private second copy is what made `*.test.mjs` suites invisible (#1347).
 
 3. **Detect framework per file** via import signatures (order matters; most-specific first):
    - `@playwright/test` → playwright
@@ -87,7 +87,10 @@ Emit `TestCraftOutput`:
     durationMs: number;
     llmCalls: { provider, model, count, costUsd };
     catalog: { rubricsApplied: string[] };
-    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired };
+    // critiqueErrors > 0 or testsTruncated > 0 means the run is partly
+    // unmeasured: findings are a floor, not a total.
+    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired,
+              critiqueErrors, testsTruncated };
     frameworksDetected: Record<TestFramework, number>;
     runId: string;
   }
@@ -208,6 +211,8 @@ TEST-R004 [polish/large/medium] vitest:142
 
 ## Escalation
 
+- **When the run refuses with "cannot run against the in-session provider":** test-craft has no two-step collect/finalize flow, so the in-session provider (which defers every prompt to the calling agent) cannot answer a single rubric. Configure a real backend via `agent.backends` + `HARNESS_CRAFT_LLM`, or set `HARNESS_CRAFT_LLM=mock` for tests. It refuses rather than critiquing nothing and reporting zero findings (#1346).
+- **When the summary reports `critiqueErrors` or `testsTruncated` above zero:** the run is partly unmeasured — findings are a floor, not a total.
 - **When LLM cost is too high:** drop `maxTestsPerFile` (default 20) or scope to specific frameworks with `--frameworks vitest`. Disable source-pairing with `--no-source-pair` to halve prompt size on every test.
 - **When intentionally narrative test names get flagged (e.g., learning tests, examples):** scope via `--files` to exclude. v1.x adds `// test-craft:skip` annotation.
 - **When source-pairing finds the wrong source for ambiguous names:** the LLM gets misleading context for `TEST-R007`. Use `--no-source-pair` to fall back to test-file-only rubrics, or v1.x's `harness.config.json` test→source mapping.

--- a/agents/skills/cursor/test-craft/SKILL.md
+++ b/agents/skills/cursor/test-craft/SKILL.md
@@ -25,7 +25,7 @@
    - `craft.test.frameworks` — restrict to subset (default: all five)
    - `craft.test.sourcePair` — toggle source-pairing (default true)
 
-2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs.
+2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,mts,cts}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs. The extension list is defined once in `extract/test-file-exts.ts` and shared by discovery and extraction — a private second copy is what made `*.test.mjs` suites invisible (#1347).
 
 3. **Detect framework per file** via import signatures (order matters; most-specific first):
    - `@playwright/test` → playwright
@@ -87,7 +87,10 @@ Emit `TestCraftOutput`:
     durationMs: number;
     llmCalls: { provider, model, count, costUsd };
     catalog: { rubricsApplied: string[] };
-    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired };
+    // critiqueErrors > 0 or testsTruncated > 0 means the run is partly
+    // unmeasured: findings are a floor, not a total.
+    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired,
+              critiqueErrors, testsTruncated };
     frameworksDetected: Record<TestFramework, number>;
     runId: string;
   }
@@ -208,6 +211,8 @@ TEST-R004 [polish/large/medium] vitest:142
 
 ## Escalation
 
+- **When the run refuses with "cannot run against the in-session provider":** test-craft has no two-step collect/finalize flow, so the in-session provider (which defers every prompt to the calling agent) cannot answer a single rubric. Configure a real backend via `agent.backends` + `HARNESS_CRAFT_LLM`, or set `HARNESS_CRAFT_LLM=mock` for tests. It refuses rather than critiquing nothing and reporting zero findings (#1346).
+- **When the summary reports `critiqueErrors` or `testsTruncated` above zero:** the run is partly unmeasured — findings are a floor, not a total.
 - **When LLM cost is too high:** drop `maxTestsPerFile` (default 20) or scope to specific frameworks with `--frameworks vitest`. Disable source-pairing with `--no-source-pair` to halve prompt size on every test.
 - **When intentionally narrative test names get flagged (e.g., learning tests, examples):** scope via `--files` to exclude. v1.x adds `// test-craft:skip` annotation.
 - **When source-pairing finds the wrong source for ambiguous names:** the LLM gets misleading context for `TEST-R007`. Use `--no-source-pair` to fall back to test-file-only rubrics, or v1.x's `harness.config.json` test→source mapping.

--- a/agents/skills/gemini-cli/test-craft/SKILL.md
+++ b/agents/skills/gemini-cli/test-craft/SKILL.md
@@ -25,7 +25,7 @@
    - `craft.test.frameworks` — restrict to subset (default: all five)
    - `craft.test.sourcePair` — toggle source-pairing (default true)
 
-2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs.
+2. **Glob test files** under project root: `**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,mts,cts}` plus pytest naming (`test_*.py` / `*_test.py`). Skip `node_modules`, `dist`, `build`, `coverage`, `__pycache__`, `venv`, `vendor`, dotdirs. The extension list is defined once in `extract/test-file-exts.ts` and shared by discovery and extraction — a private second copy is what made `*.test.mjs` suites invisible (#1347).
 
 3. **Detect framework per file** via import signatures (order matters; most-specific first):
    - `@playwright/test` → playwright
@@ -87,7 +87,10 @@ Emit `TestCraftOutput`:
     durationMs: number;
     llmCalls: { provider, model, count, costUsd };
     catalog: { rubricsApplied: string[] };
-    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired };
+    // critiqueErrors > 0 or testsTruncated > 0 means the run is partly
+    // unmeasured: findings are a floor, not a total.
+    counts: { filesScanned, testsExtracted, testsSkippedOrTodo, sourcePaired,
+              critiqueErrors, testsTruncated };
     frameworksDetected: Record<TestFramework, number>;
     runId: string;
   }
@@ -208,6 +211,8 @@ TEST-R004 [polish/large/medium] vitest:142
 
 ## Escalation
 
+- **When the run refuses with "cannot run against the in-session provider":** test-craft has no two-step collect/finalize flow, so the in-session provider (which defers every prompt to the calling agent) cannot answer a single rubric. Configure a real backend via `agent.backends` + `HARNESS_CRAFT_LLM`, or set `HARNESS_CRAFT_LLM=mock` for tests. It refuses rather than critiquing nothing and reporting zero findings (#1346).
+- **When the summary reports `critiqueErrors` or `testsTruncated` above zero:** the run is partly unmeasured — findings are a floor, not a total.
 - **When LLM cost is too high:** drop `maxTestsPerFile` (default 20) or scope to specific frameworks with `--frameworks vitest`. Disable source-pairing with `--no-source-pair` to halve prompt size on every test.
 - **When intentionally narrative test names get flagged (e.g., learning tests, examples):** scope via `--files` to exclude. v1.x adds `// test-craft:skip` annotation.
 - **When source-pairing finds the wrong source for ambiguous names:** the LLM gets misleading context for `TEST-R007`. Use `--no-source-pair` to fall back to test-file-only rubrics, or v1.x's `harness.config.json` test→source mapping.

--- a/packages/cli/src/commands/test-craft.ts
+++ b/packages/cli/src/commands/test-craft.ts
@@ -97,7 +97,18 @@ function printResult(
   const { findings, summary } = result;
 
   if (findings.length === 0) {
-    console.log('No test findings.');
+    // An empty result is only a pass when critiques actually ran. Say which
+    // one this is rather than letting an unmeasured run read as a clean one.
+    if (summary.counts.testsExtracted === 0) {
+      console.log('No tests found to critique.');
+    } else if (summary.llmCalls.count === 0) {
+      console.log(
+        `ABSTAINED: ${summary.counts.testsExtracted} test(s) extracted but 0 critiques ran — ` +
+          'this is not a pass. Check the LLM backend configuration.'
+      );
+    } else {
+      console.log('No test findings.');
+    }
   } else {
     const byFile = new Map<string, typeof findings>();
     for (const f of findings) {
@@ -130,4 +141,25 @@ function printResult(
       `paired: ${summary.counts.sourcePaired}, ` +
       `${summary.llmCalls.count} LLM calls, $${summary.llmCalls.costUsd.toFixed(4)}, ${summary.durationMs}ms)`
   );
+
+  // Anything that narrowed coverage gets said out loud — a silently truncated
+  // or partly-failed run otherwise presents as a full one.
+  if (summary.counts.critiqueErrors > 0) {
+    console.log(
+      `WARNING: ${summary.counts.critiqueErrors} critique(s) failed and were discarded; ` +
+        'those (test, rubric) pairs are unmeasured.'
+    );
+  }
+  if (summary.counts.testsTruncated > 0) {
+    console.log(
+      `WARNING: ${summary.counts.testsTruncated} test(s) dropped by --max-tests-per-file; ` +
+        `"${summary.counts.testsExtracted} tests" is a cap, not the population.`
+    );
+  }
+  if (summary.counts.filesScanned > 0 && summary.counts.sourcePaired === 0) {
+    console.log(
+      'NOTE: no test file resolved to a source file, so TEST-R007 ' +
+        '(contract-not-implementation) had no contract to compare against.'
+    );
+  }
 }

--- a/packages/cli/src/test-craft/extract/test-file-exts.ts
+++ b/packages/cli/src/test-craft/extract/test-file-exts.ts
@@ -1,0 +1,44 @@
+/**
+ * Single source of truth for "what filename is a test file".
+ *
+ * This list existed in two places — the discovery walk in `test-craft/index.ts`
+ * and a second regex gate inside `extract/tests.ts` — and both omitted the
+ * ESM/CJS-explicit extensions. The two copies are why the bug had two halves:
+ * the walker skipped `*.test.mjs`, and passing one explicitly via `--files`
+ * got past the walker only to be dropped by the extractor, reporting
+ * `filesScanned: 1` against `testsExtracted: 0` (issue #1347).
+ *
+ * Adding an extension here must be enough. If you find yourself writing a
+ * second list, that is the defect recurring.
+ */
+
+/** `.test` / `.spec` — the two supported test-file infixes. */
+export const TEST_SUFFIXES = ['.test', '.spec'] as const;
+
+/**
+ * Language extensions. `.mjs` / `.cjs` / `.mts` / `.cts` are included
+ * deliberately: an ESM-first repo names its tests `*.test.mjs`, and omitting
+ * them made entire suites invisible while the summary still reported a
+ * confident zero.
+ */
+export const TEST_LANG_EXTS = [
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.mts',
+  '.cts',
+] as const;
+
+/** Every supported `<suffix><ext>` combination, e.g. `.test.mjs`. */
+export const TEST_FILE_EXTS: readonly string[] = TEST_SUFFIXES.flatMap((suffix) =>
+  TEST_LANG_EXTS.map((ext) => `${suffix}${ext}`)
+);
+
+/** True when the file name matches a supported TS/JS test-file convention. */
+export function isTsJsTestFileName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return TEST_FILE_EXTS.some((ext) => lower.endsWith(ext));
+}

--- a/packages/cli/src/test-craft/extract/tests.ts
+++ b/packages/cli/src/test-craft/extract/tests.ts
@@ -9,6 +9,7 @@
 
 import ts from 'typescript';
 import type { ExtractedTest, TestFramework } from '../findings/schema.js';
+import { isTsJsTestFileName } from './test-file-exts.js';
 
 const MAX_BODY_CHARS = 1500;
 
@@ -26,7 +27,10 @@ interface CalleeChain {
 }
 
 export function extractTests(input: ExtractTestsInput): ExtractedTest[] {
-  if (!/\.(?:test|spec)\.(?:tsx?|jsx?)$/i.test(input.file)) return [];
+  // Shared with the discovery walk — see extract/test-file-exts.ts. This gate
+  // used to carry its own regex that omitted .mjs/.cjs, so a file the walker
+  // found (or --files supplied) could still yield zero tests (#1347).
+  if (!isTsJsTestFileName(input.file)) return [];
 
   let sourceFile: ts.SourceFile;
   try {

--- a/packages/cli/src/test-craft/findings/schema.ts
+++ b/packages/cli/src/test-craft/findings/schema.ts
@@ -45,6 +45,17 @@ export interface TestCraftSummary {
     testsExtracted: number;
     testsSkippedOrTodo: number;
     sourcePaired: number;
+    /**
+     * (test, rubric) pairs whose critique threw and was discarded. Non-zero
+     * means the run is partly unmeasured: `findings: []` alongside a non-zero
+     * value here is an abstention, not a clean bill of health (issue #1346).
+     */
+    critiqueErrors: number;
+    /**
+     * Tests dropped because a file exceeded `maxTestsPerFile`. Non-zero means
+     * `testsExtracted` is a cap, not the population (issue #1347).
+     */
+    testsTruncated: number;
   };
   frameworksDetected: Record<TestFramework, number>;
   runId: string;

--- a/packages/cli/src/test-craft/index.ts
+++ b/packages/cli/src/test-craft/index.ts
@@ -10,10 +10,15 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { sanitizePath } from '../mcp/utils/sanitize-path.js';
-import { getProvider, type LlmProvider } from '../shared/craft/llm/provider.js';
+import {
+  getProvider,
+  InSessionLlmProvider,
+  type LlmProvider,
+} from '../shared/craft/llm/provider.js';
 import { detectFramework } from './extract/framework.js';
 import { extractTests } from './extract/tests.js';
 import { extractPythonTests, isPythonTestFile } from './extract/python-tests.js';
+import { isTsJsTestFileName } from './extract/test-file-exts.js';
 import { resolveSourceFile } from './extract/source-pair.js';
 import { SEED_RUBRICS, type TestRubric } from './catalog/rubrics/index.js';
 import { critiqueOne } from './phases/critique.js';
@@ -44,20 +49,32 @@ export interface TestCraftInput {
 
 const DEFAULT_MAX_FILES = 100;
 const DEFAULT_MAX_TESTS_PER_FILE = 20;
-const TEST_FILE_EXTS = [
-  '.test.ts',
-  '.test.tsx',
-  '.test.js',
-  '.test.jsx',
-  '.spec.ts',
-  '.spec.tsx',
-  '.spec.js',
-  '.spec.jsx',
-];
+
+/**
+ * `InSessionLlmProvider.callText` throws `PromptDeferredError` unconditionally
+ * — it queues the prompt for the calling agent rather than answering it. There
+ * is no two-step collect/finalize flow for test-craft yet, so with that
+ * provider every (test, rubric) critique throws and the command reports a
+ * confident `No test findings.` Refuse up front instead, the way naming-craft
+ * already does (issue #1346).
+ */
+function assertProviderCanAnswer(provider: LlmProvider, entryPoint: string): void {
+  if (!(provider instanceof InSessionLlmProvider)) return;
+  throw new Error(
+    `${entryPoint} cannot run against the in-session provider: it defers every ` +
+      'prompt to the calling agent, so no rubric would actually be evaluated ' +
+      'and the run would report zero findings for zero critiques. Configure a ' +
+      'real backend via agent.backends + HARNESS_CRAFT_LLM, or set ' +
+      'HARNESS_CRAFT_LLM=mock for tests.'
+  );
+}
+// Extension list lives in extract/test-file-exts.ts, shared with the extractor.
+// Keeping a private copy here is what let the two drift and produce a
+// `filesScanned: 1 / testsExtracted: 0` run (issue #1347).
 
 /** True when the file name matches a supported test-file naming convention. */
 function isTestFileName(name: string): boolean {
-  return TEST_FILE_EXTS.some((ext) => name.endsWith(ext)) || isPythonTestFile(name);
+  return isTsJsTestFileName(name) || isPythonTestFile(name);
 }
 
 /** Dispatch extraction by language: Python → light-parse, TS/JS → AST. */
@@ -76,6 +93,7 @@ export async function runTestCraft(input: TestCraftInput): Promise<TestCraftOutp
   const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
   const maxTestsPerFile = input.maxTestsPerFile ?? DEFAULT_MAX_TESTS_PER_FILE;
   const provider = input.__testProvider ?? getProvider();
+  assertProviderCanAnswer(provider, 'runTestCraft');
   const rubrics = SEED_RUBRICS;
   const sourcePairEnabled = input.sourcePair !== false;
   const frameworksFilter = input.frameworks !== undefined ? new Set(input.frameworks) : null;
@@ -90,14 +108,17 @@ export async function runTestCraft(input: TestCraftInput): Promise<TestCraftOutp
 
   // Critique loop
   const findings: TestFinding[] = [];
+  let critiqueErrors = 0;
   for (const test of extraction.allTests) {
     const pair = sourcePairEnabled ? (extraction.sourcePairCache.get(test.file) ?? null) : null;
-    findings.push(...(await critiqueTest(test, rubrics, provider, pair)));
+    const result = await critiqueTest(test, rubrics, provider, pair);
+    findings.push(...result.findings);
+    critiqueErrors += result.errors;
   }
 
   const output: TestCraftOutput = {
     findings,
-    summary: buildSummary({ provider, rubrics, files, extraction, startedAt }),
+    summary: buildSummary({ provider, rubrics, files, extraction, startedAt, critiqueErrors }),
   };
 
   await maybeEmitReport(output, input.emitTo, projectRoot);
@@ -111,8 +132,9 @@ function buildSummary(args: {
   files: readonly string[];
   extraction: ExtractionResult;
   startedAt: number;
+  critiqueErrors: number;
 }): TestCraftOutput['summary'] {
-  const { provider, rubrics, files, extraction, startedAt } = args;
+  const { provider, rubrics, files, extraction, startedAt, critiqueErrors } = args;
   const totalCost = sumCosts(provider);
   return {
     phaseRun: ['critique'],
@@ -130,6 +152,8 @@ function buildSummary(args: {
       testsExtracted: extraction.allTests.length,
       testsSkippedOrTodo: extraction.testsSkippedOrTodo,
       sourcePaired: extraction.sourcePairedCount,
+      critiqueErrors,
+      testsTruncated: extraction.testsTruncated,
     },
     frameworksDetected: extraction.frameworksDetected,
     runId: randomUUID(),
@@ -152,6 +176,7 @@ interface ExtractionResult {
   frameworksDetected: Record<TestFramework, number>;
   testsSkippedOrTodo: number;
   sourcePairedCount: number;
+  testsTruncated: number;
   sourcePairCache: Map<string, ReturnType<typeof resolveSourceFile>>;
 }
 
@@ -194,6 +219,7 @@ function extractTestsFromFiles(
   };
   let testsSkippedOrTodo = 0;
   let sourcePairedCount = 0;
+  let testsTruncated = 0;
   const sourcePairCache = new Map<string, ReturnType<typeof resolveSourceFile>>();
 
   for (const file of files) {
@@ -203,8 +229,11 @@ function extractTestsFromFiles(
     if (opts.frameworksFilter !== null && !opts.frameworksFilter.has(framework)) continue;
     frameworksDetected[framework]++;
 
-    // Cap per-file at maxTestsPerFile
-    const capped = extractTestsForFile(file, source, framework).slice(0, opts.maxTestsPerFile);
+    // Cap per-file at maxTestsPerFile, recording what the cap discarded so the
+    // summary cannot present a truncated count as the population (issue #1347).
+    const extracted = extractTestsForFile(file, source, framework);
+    const capped = extracted.slice(0, opts.maxTestsPerFile);
+    testsTruncated += extracted.length - capped.length;
     testsSkippedOrTodo += collectNonTodoTests(capped, allTests);
 
     if (opts.sourcePairEnabled && !sourcePairCache.has(file)) {
@@ -219,18 +248,31 @@ function extractTestsFromFiles(
     frameworksDetected,
     testsSkippedOrTodo,
     sourcePairedCount,
+    testsTruncated,
     sourcePairCache,
   };
 }
 
-/** Critique a single test against every rubric, swallowing per-rubric errors. */
+interface CritiqueTally {
+  findings: TestFinding[];
+  /** Rubrics whose critique threw. Counted, never silently discarded (#1346). */
+  errors: number;
+}
+
+/**
+ * Critique a single test against every rubric. One bad LLM call shouldn't sink
+ * the run, so per-rubric errors are still tolerated — but they are COUNTED and
+ * surfaced in the summary. Discarding them outright made a total failure and a
+ * clean result indistinguishable.
+ */
 async function critiqueTest(
   test: ExtractedTest,
   rubrics: ReadonlyArray<TestRubric>,
   provider: LlmProvider,
   pair: ReturnType<typeof resolveSourceFile> | null
-): Promise<TestFinding[]> {
+): Promise<CritiqueTally> {
   const findings: TestFinding[] = [];
+  let errors = 0;
   for (const rubric of rubrics) {
     try {
       const finding = await critiqueOne({
@@ -241,10 +283,10 @@ async function critiqueTest(
       });
       if (finding !== null) findings.push(finding);
     } catch {
-      /* swallow per-(test, rubric) errors */
+      errors++;
     }
   }
-  return findings;
+  return { findings, errors };
 }
 
 /**
@@ -266,6 +308,7 @@ export async function critiqueTestsInFile(
   if (opts.frameworks !== undefined && !opts.frameworks.includes(framework)) return [];
   const rubrics = opts.rubrics ?? SEED_RUBRICS;
   const provider = opts.provider ?? getProvider();
+  assertProviderCanAnswer(provider, 'critiqueTestsInFile');
   const tests = extractTestsForFile(file, source, framework)
     .filter((t) => !t.todo)
     .slice(0, opts.maxTests ?? DEFAULT_MAX_TESTS_PER_FILE);
@@ -274,7 +317,7 @@ export async function critiqueTestsInFile(
 
   const findings: TestFinding[] = [];
   for (const test of tests) {
-    findings.push(...(await critiqueTest(test, rubrics, provider, pair)));
+    findings.push(...(await critiqueTest(test, rubrics, provider, pair)).findings);
   }
   return findings;
 }

--- a/packages/cli/tests/test-craft/abstention.test.ts
+++ b/packages/cli/tests/test-craft/abstention.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression tests for the two ways test-craft reported a confident green over
+ * work it never did:
+ *
+ *   #1346 — the DEFAULT (in-session) provider throws PromptDeferredError on
+ *           every callText. `critiqueTest` caught every throw in a bare
+ *           `catch {}`, so all (test x rubric) pairs failed and the command
+ *           printed "No test findings." at exit 0. It was structurally
+ *           incapable of producing a finding in any repo.
+ *
+ *   #1347 — discovery listed only .ts/.tsx/.js/.jsx, so an ESM-first repo's
+ *           `*.test.mjs` suite was invisible; and maxTestsPerFile truncated
+ *           silently, presenting a capped count as the population.
+ *
+ * The shape these guard against is the same one #1146 fixed for
+ * check-docs/cleanup: a gate that examined nothing reads identically to a gate
+ * that examined everything and found nothing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runTestCraft, critiqueTestsInFile } from '../../src/test-craft';
+import {
+  MockLlmProvider,
+  InSessionLlmProvider,
+  type LlmProvider,
+} from '../../src/shared/craft/llm/provider';
+
+/** A provider that fails every call the way a broken backend would. */
+class AlwaysFailingProvider implements LlmProvider {
+  providerId = 'always-failing';
+  model = 'none';
+  async callText(): Promise<string> {
+    throw new Error('backend unavailable');
+  }
+  async callVision(): Promise<string> {
+    throw new Error('backend unavailable');
+  }
+  recordCost(): void {}
+  getCosts(): readonly { costUsd: number }[] {
+    return [];
+  }
+}
+
+describe('test-craft abstention guards', () => {
+  let tmpDir: string;
+  let savedMode: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-craft-abstain-'));
+    savedMode = process.env.HARNESS_CRAFT_LLM;
+    process.env.HARNESS_CRAFT_LLM = 'mock';
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (savedMode === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedMode;
+  });
+
+  function writeFile(rel: string, content: string): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  // --- #1346: the in-session provider cannot answer -----------------------
+
+  it('refuses the in-session provider instead of returning an empty result', async () => {
+    writeFile('src/foo.test.ts', `it('returns null when empty', () => {});`);
+    await expect(
+      runTestCraft({ path: tmpDir, __testProvider: new InSessionLlmProvider() })
+    ).rejects.toThrow(/in-session provider/);
+  });
+
+  it('names the fix in the refusal, so the message is actionable', async () => {
+    await expect(
+      runTestCraft({ path: tmpDir, __testProvider: new InSessionLlmProvider() })
+    ).rejects.toThrow(/HARNESS_CRAFT_LLM/);
+  });
+
+  it('refuses the in-session provider on the single-file entry point too', async () => {
+    writeFile('src/foo.test.ts', `it('returns null when empty', () => {});`);
+    await expect(
+      critiqueTestsInFile(path.join(tmpDir, 'src', 'foo.test.ts'), {
+        provider: new InSessionLlmProvider(),
+      })
+    ).rejects.toThrow(/in-session provider/);
+  });
+
+  // --- #1346: a failed critique is counted, not silently discarded --------
+
+  it('counts critique failures rather than reporting them as zero findings', async () => {
+    writeFile('src/foo.test.ts', `it('returns null when empty', () => {});`);
+    const out = await runTestCraft({
+      path: tmpDir,
+      __testProvider: new AlwaysFailingProvider(),
+    });
+
+    // Still no findings — but the summary now distinguishes "nothing wrong"
+    // from "nothing was checked". Before this, both read as `findings: []`.
+    expect(out.findings).toEqual([]);
+    expect(out.summary.counts.testsExtracted).toBe(1);
+    expect(out.summary.counts.critiqueErrors).toBeGreaterThan(0);
+    expect(out.summary.llmCalls.count).toBe(0);
+  });
+
+  it('reports zero critique errors on a healthy run, so the counter can fall', async () => {
+    // The negative control: a counter that is always non-zero proves nothing.
+    writeFile('src/foo.test.ts', `it('returns null when empty', () => {});`);
+    const out = await runTestCraft({
+      path: tmpDir,
+      __testProvider: new MockLlmProvider(),
+    });
+    expect(out.summary.counts.testsExtracted).toBe(1);
+    expect(out.summary.counts.critiqueErrors).toBe(0);
+  });
+
+  // --- #1347: ESM discovery ----------------------------------------------
+
+  it.each(['mjs', 'cjs', 'mts', 'cts'])('discovers *.test.%s files', async (ext) => {
+    writeFile(`src/foo.test.${ext}`, `it('returns null when empty', () => {});`);
+    const out = await runTestCraft({ path: tmpDir });
+    expect(out.summary.counts.filesScanned).toBe(1);
+    expect(out.summary.counts.testsExtracted).toBe(1);
+  });
+
+  it('discovers *.spec.mjs as well as *.test.mjs', async () => {
+    writeFile('src/a.spec.mjs', `it('one', () => {});`);
+    writeFile('src/b.test.mjs', `it('two', () => {});`);
+    const out = await runTestCraft({ path: tmpDir });
+    expect(out.summary.counts.filesScanned).toBe(2);
+    // Assert the tests too, not just the file count: discovery and extraction
+    // gate the extension separately, and a file-count-only assertion passes
+    // while extraction still returns nothing — which is the exact half of
+    // #1347 that survived the first fix attempt.
+    expect(out.summary.counts.testsExtracted).toBe(2);
+  });
+
+  it('extracts from an .mjs file passed explicitly via --files', async () => {
+    // The worse shape of the old bug: an explicit --files bypassed the walker
+    // but not the extractor, so filesScanned was 2 while testsExtracted was 0
+    // — a healthy file count over an empty denominator.
+    writeFile('src/foo.test.mjs', `it('returns null when empty', () => {});`);
+    const out = await runTestCraft({ path: tmpDir, files: ['src/foo.test.mjs'] });
+    expect(out.summary.counts.filesScanned).toBe(1);
+    expect(out.summary.counts.testsExtracted).toBe(1);
+  });
+
+  // --- #1347: the per-file cap is visible --------------------------------
+
+  it('reports how many tests the per-file cap discarded', async () => {
+    const body = Array.from({ length: 5 }, (_, i) => `it('case ${i}', () => {});`).join('\n');
+    writeFile('src/many.test.ts', body);
+
+    const out = await runTestCraft({ path: tmpDir, maxTestsPerFile: 2 });
+    expect(out.summary.counts.testsExtracted).toBe(2);
+    expect(out.summary.counts.testsTruncated).toBe(3);
+  });
+
+  it('reports zero truncation when the cap does not bind', async () => {
+    writeFile('src/few.test.ts', `it('only one', () => {});`);
+    const out = await runTestCraft({ path: tmpDir, maxTestsPerFile: 20 });
+    expect(out.summary.counts.testsTruncated).toBe(0);
+  });
+});

--- a/packages/cli/tests/test-craft/emit.test.ts
+++ b/packages/cli/tests/test-craft/emit.test.ts
@@ -187,7 +187,7 @@ describe('runTestCraft emitTo (issue #914)', () => {
     fs.mkdirSync(path.dirname(testFile), { recursive: true });
     fs.writeFileSync(testFile, `it('works', () => {});`);
 
-    await runTestCraft({ path: tmpDir });
+    await runTestCraft({ path: tmpDir, __testProvider: new MockLlmProvider() });
     expect(fs.readdirSync(tmpDir)).not.toContain('report.json');
   });
 });

--- a/packages/cli/tests/test-craft/integration.test.ts
+++ b/packages/cli/tests/test-craft/integration.test.ts
@@ -7,13 +7,21 @@ import { MockLlmProvider } from '../../src/shared/craft/llm/provider';
 
 describe('runTestCraft (integration)', () => {
   let tmpDir: string;
+  let savedMode: string | undefined;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-craft-int-'));
+    // Without this these cases silently resolved the in-session provider, whose
+    // callText always throws — so every critique failed and the suite asserted
+    // `findings: []` against a run in which no rubric was ever evaluated (#1346).
+    savedMode = process.env.HARNESS_CRAFT_LLM;
+    process.env.HARNESS_CRAFT_LLM = 'mock';
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (savedMode === undefined) delete process.env.HARNESS_CRAFT_LLM;
+    else process.env.HARNESS_CRAFT_LLM = savedMode;
   });
 
   function writeFile(rel: string, content: string): void {


### PR DESCRIPTION
Closes #1346. Closes #1347.

## Summary

`harness test-craft` could not produce a finding under its own default provider,
and could not see ESM test suites at all. Both failures printed the same thing:

```
No test findings.
```

Found while auditing a 53-file overlay repo: `test-craft` reported 9 files and
60 tests, made **0 LLM calls**, and exited 0. It had critiqued nothing.

## 1. The critique phase never ran (#1346)

`InSessionLlmProvider.callText` throws `PromptDeferredError` on every call by
design — it queues the prompt for the calling agent rather than answering it.
`critiqueTest` caught every throw in a bare `catch {}`:

```ts
try {
  const finding = await critiqueOne({ test, rubric, provider, ... });
  if (finding !== null) findings.push(finding);
} catch {
  /* swallow per-(test, rubric) errors */
}
```

So all 60 × 8 = 480 pairs failed and were discarded. `in-session` is the
**default** mode, so this was not repo-specific — no repo could get a real
result from `harness test-craft`.

`naming-craft` already guards this exact case and fails loudly. `test-craft`
now does the same, and per-rubric errors are **counted** into
`summary.counts.critiqueErrors` rather than dropped, so a partly-failed run
can no longer present as a clean one.

## 2. Discovery was blind to ESM — in two places (#1347)

The extension list omitted `.mjs` / `.cjs` / `.mts` / `.cts`, and it existed
**twice**: the discovery walk in `test-craft/index.ts`, and a second regex gate
inside `extract/tests.ts`.

That duplication is why the bug had two halves. The walker skipped
`*.test.mjs`; and passing one explicitly via `--files` cleared the walker only
to be dropped by the extractor — reporting `filesScanned: 1` against
`testsExtracted: 0`, which reads worse than being skipped outright.

Both now read from `extract/test-file-exts.ts`. This is the same class as
#1146 (check-docs/cleanup), which was fixed per-command and so never reached
here — hence one shared list rather than a third copy.

## 3. Silent narrowing, now stated

- `maxTestsPerFile` truncation is recorded (`summary.counts.testsTruncated`)
  and warned about — the default 20 silently dropped 39% of the reachable
  tests in the repo above while printing the capped number as the population.
- A zero source-pair rate is noted, because it silently disables `TEST-R007`
  (contract-not-implementation).
- An empty result now distinguishes "no tests found", "extracted N but ran 0
  critiques" (labelled `ABSTAINED`), and a genuine "No test findings."

## Verification

End-to-end against the repo that exposed it, same invocation:

| | before | after |
| --- | ---: | ---: |
| files scanned | 9 | **53** |
| tests critiqued | 0 | **1,117** |
| LLM calls | 0 | **8,936** |
| default provider | `No test findings.` | refuses, names the fix |

`8936 = 1117 × 8` rubrics — every pair now actually evaluated.

`packages/cli` test-craft suite: **79 passed**. Typecheck clean, `eslint src`
clean.

**The existing tests were passing for the wrong reason.** `integration.test.ts`
and `emit.test.ts` called `runTestCraft` with the default provider and asserted
`findings: []` — true only because nothing was ever evaluated. They now pin
`HARNESS_CRAFT_LLM=mock`. New `tests/test-craft/abstention.test.ts` covers both
regressions, including a negative control (`reports zero critique errors on a
healthy run`) so the new counter can actually fall rather than being trivially
non-zero.

Pre-existing failures in `deliveries`, `hermes-tools`, and `search` tests are
unrelated and reproduce identically on a clean `main` (verified by stashing).

## Behaviour change (why `minor`, not `patch`)

- `runTestCraft` / `critiqueTestsInFile` now **throw** on the in-session
  provider instead of returning an empty result.
- `TestCraftSummary.counts` gains two required fields, so code *constructing*
  that type needs updating (readers are unaffected).

## Deliberately not in scope

Source pairing still resolves 0/53 in that repo because the runtime sources
live under a dot-directory, which the walker skips. Loosening that skip has a
wide blast radius (`.git`, `.venv`, …) and wants its own design, so this PR
only makes the resulting `TEST-R007` blind spot visible rather than silent.
Happy to split that out if you'd like it tracked separately.
