### PR TITLE
fix(graph): don't stamp fresh last-synced timestamp on hard-failed connector sync (#1336)

### DIFF
--- a/.changeset/syncmanager-no-fresh-timestamp-on-failure.md
+++ b/.changeset/syncmanager-no-fresh-timestamp-on-failure.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/graph': patch
+---
+
+fix(graph): a hard-failed connector sync no longer stamps a fresh "last synced" timestamp (#1336)
+
+`SyncManager.sync()` wrote `lastSyncTimestamp: new Date().toISOString()` on every
+run, including runs where `connector.ingest()` returned errors and ingested
+nothing. `sync-metadata.json` is the one surface a human (and the
+`harness graph integrity` GI-C001 check) reads for freshness, so a failed sync
+read as freshly synced.
+
+Now only a run with no errors advances the timestamp. A hard failure still records
+its `lastResult` — so the errors stay visible — but preserves the previous
+successful timestamp, or an empty string if the connector has never succeeded.
+The failed run is no longer misrepresented as a successful one.

--- a/packages/graph/src/ingest/connectors/SyncManager.ts
+++ b/packages/graph/src/ingest/connectors/SyncManager.ts
@@ -39,10 +39,17 @@ export class SyncManager {
     const { connector, config } = registration;
     const result = await connector.ingest(this.store, config);
 
-    // Update metadata
+    // Update metadata. Only a run that ingested successfully (no errors)
+    // advances the "last synced" clock. A hard failure records its result — so
+    // the errors stay visible — but preserves the previous success timestamp
+    // (empty if the connector never succeeded), because sync-metadata.json is
+    // the one surface a human checks and a fresh timestamp on a failed run reads
+    // as a successful sync (see GraphIntegrityChecker GI-C001).
     const metadata = await this.loadMetadata();
+    const previous = metadata.connectors[connectorName];
+    const succeeded = result.errors.length === 0;
     metadata.connectors[connectorName] = {
-      lastSyncTimestamp: new Date().toISOString(),
+      lastSyncTimestamp: succeeded ? new Date().toISOString() : (previous?.lastSyncTimestamp ?? ''),
       lastResult: result,
     };
     await this.saveMetadata(metadata);

--- a/packages/graph/tests/ingest/connectors/SyncManager.test.ts
+++ b/packages/graph/tests/ingest/connectors/SyncManager.test.ts
@@ -123,6 +123,29 @@ describe('SyncManager', () => {
     expect(ts <= after).toBe(true);
   });
 
+  it('does not stamp a fresh success timestamp when the sync hard-fails (#1336)', async () => {
+    const failed: IngestResult = {
+      nodesAdded: 0,
+      nodesUpdated: 0,
+      edgesAdded: 0,
+      edgesUpdated: 0,
+      errors: ['GitHub Actions API error: status 500'],
+      durationMs: 3,
+    };
+    manager.registerConnector(makeMockConnector('broken', failed), {});
+
+    await manager.sync('broken');
+
+    const metadata = await manager.getMetadata();
+    const entry = metadata.connectors['broken']!;
+    // The failed run is still recorded so its errors remain visible...
+    expect(entry.lastResult.errors).toHaveLength(1);
+    // ...but the "last synced" clock must NOT advance for a run that errored and
+    // ingested nothing. A never-succeeded connector reads as empty rather than
+    // as freshly synced — otherwise the one surface a human checks lies.
+    expect(entry.lastSyncTimestamp).toBe('');
+  });
+
   it('metadata persists to disk as sync-metadata.json', async () => {
     const result: IngestResult = {
       nodesAdded: 1,


### PR DESCRIPTION
## Summary

Fixes the root cause of #1336. `SyncManager.sync()` wrote `lastSyncTimestamp: new Date().toISOString()` on **every** run — including runs where `connector.ingest()` returned errors and ingested nothing. Since `sync-metadata.json` is the one surface a human (and the `harness graph integrity` GI-C001 check) reads for freshness, a hard-failed connector read as *freshly synced*.

## Fix

Only a run with no errors advances the timestamp. A hard failure still records its `lastResult` (so the errors stay visible) but preserves the previous successful timestamp, or an empty string if the connector has never succeeded. Area-local change in `packages/graph/src/ingest/connectors/SyncManager.ts`; no public API / schema change (`SyncMetadata` unchanged).

## Test

Adds a reproducing test in `SyncManager.test.ts` that fails at base (`lastSyncTimestamp` was a fresh ISO string on a hard-failed sync) and passes with the fix. Full ingest suite (479 tests) and the `GraphIntegrityChecker` suite remain green.

Relates to the detection layer added in the `harness graph integrity` work (GI-C001), which flagged this condition but did not prevent it.

Closes #1336