### PR TITLE
fix(entropy): drift FPs on fenced-code links & '&'-headings (#1342/#1332) + findFunctionEnd EOF overrun (#1329)

### DIFF
--- a/.changeset/entropy-detector-fp-fixes.md
+++ b/.changeset/entropy-detector-fp-fixes.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(entropy): correct detector false positives and a corrupt complexity metric
+
+- `findFunctionEnd` (complexity detector) no longer runs its brace scan into the
+  next function or to end-of-file for an expression-bodied arrow or a bodyless
+  declaration; the statement now closes on its own line, so function length,
+  cyclomatic complexity, and nesting are attributed correctly (#1329).
+- The drift detector's structure-link extractor now tracks fenced code blocks
+  (``` and ~~~) and ignores links written inside them, so documentation examples
+  are not reported as broken references (#1342, #1332).
+- `slugifyHeading` now emits one hyphen per whitespace character (matching
+  GitHub) instead of collapsing runs, so anchors for headings such as
+  "Tips & Tricks" (`tips--tricks`) are validated correctly and no longer flagged.

--- a/packages/core/src/entropy/detectors/complexity.ts
+++ b/packages/core/src/entropy/detectors/complexity.ts
@@ -101,6 +101,12 @@ function findFunctionEnd(lines: string[], startIdx: number): number {
         if (foundOpen && depth === 0) {
           return i;
         }
+      } else if (ch === ';' && !foundOpen && depth === 0) {
+        // Expression-bodied arrow / bodyless declaration: the statement ends
+        // before any block opens, so the function ends on this line rather
+        // than running the brace scan into the next function or to EOF
+        // (issue #1329).
+        return i;
       }
     }
   }

--- a/packages/core/src/entropy/detectors/drift.ts
+++ b/packages/core/src/entropy/detectors/drift.ts
@@ -340,10 +340,20 @@ interface MarkdownLink {
 function extractFileLinks(content: string): MarkdownLink[] {
   const links: MarkdownLink[] = [];
   const lines = content.split('\n');
+  let inFencedCodeBlock = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!line) continue;
+
+    // Fenced code blocks (``` or ~~~) hold illustrative markdown, not real
+    // references — toggle on the fence line and skip everything inside so a
+    // sample link is never reported as broken drift (issue #1342).
+    if (/^\s*(?:```|~~~)/.test(line)) {
+      inFencedCodeBlock = !inFencedCodeBlock;
+      continue;
+    }
+    if (inFencedCodeBlock) continue;
 
     // Markdown links: [text](path)
     const linkRegex = /\[([^\]]*)\]\(([^)]+)\)/g;
@@ -384,7 +394,7 @@ function slugifyHeading(text: string): string {
     .toLowerCase()
     .replace(/[^\w\s-]/g, '')
     .trim()
-    .replace(/\s+/g, '-');
+    .replace(/\s/g, '-');
 }
 
 async function extractHeadingSlugs(filePath: string): Promise<Set<string>> {

--- a/packages/core/tests/entropy/detectors/complexity.test.ts
+++ b/packages/core/tests/entropy/detectors/complexity.test.ts
@@ -305,3 +305,40 @@ export function fn2(a: number) { return a; }
     expect(result.value.stats.functionsAnalyzed).toBe(2);
   });
 });
+
+// Regression: github issue #1329. findFunctionEnd() only stops when brace
+// depth returns to zero, so an expression-bodied arrow (no `{` block) never
+// "closes" — the scan runs forward into the *next* function's braces (or to
+// EOF when it is the last construct), inflating the measured length and
+// corrupting every downstream complexity metric attributed to that function.
+describe('detectComplexityViolations — issue #1329 (findFunctionEnd runs to EOF)', () => {
+  it('measures an expression-bodied arrow at its true length, not into the next function', async () => {
+    const content = [
+      'export const inc = (n: number): number => n + 1;',
+      '',
+      'export function big(a: number): number {',
+      '  const x1 = a + 1;',
+      '  const x2 = x1 + 1;',
+      '  const x3 = x2 + 1;',
+      '  const x4 = x3 + 1;',
+      '  const x5 = x4 + 1;',
+      '  return x5;',
+      '}',
+      '',
+    ].join('\n');
+    await writeFixture('arrow-eof.ts', content);
+    const snapshot = makeSnapshot([{ name: 'arrow-eof.ts', content }]);
+
+    const config: ComplexityConfig = { thresholds: { functionLength: { warn: 5 } } };
+    const result = await detectComplexityViolations(snapshot, config);
+    expect(isOk(result)).toBe(true);
+    if (!isOk(result)) return;
+
+    // `inc` is a genuine one-line function; it must NOT be reported as a
+    // length violation. At base it spans the whole `big` body (~10 lines).
+    const incLengthViolations = result.value.violations.filter(
+      (v) => v.function === 'inc' && v.metric === 'functionLength'
+    );
+    expect(incLengthViolations).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/entropy/detectors/drift.test.ts
+++ b/packages/core/tests/entropy/detectors/drift.test.ts
@@ -433,3 +433,86 @@ describe('drift detector — issue #816 regressions', () => {
     expect(apiDrifts.some((d) => d.reference === 'real_export')).toBe(false);
   });
 });
+
+// Regression: github issue #1342 / #1332. The structure-drift link extractor
+// has no fenced-code-block tracking, so links written *inside* ```fences``` as
+// documentation examples are checked for existence and reported as broken.
+// Separately, slugifyHeading() collapses whitespace runs with /\s+/ where
+// GitHub emits one hyphen per space, so a heading like "Tips & Tricks" (whose
+// real GitHub anchor is `tips--tricks`) is reconstructed as `tips-tricks` and a
+// working anchor is flagged. 27/27 false positives were reported on canary.
+describe('drift detector — issue #1342/#1332 regressions', () => {
+  const parser2 = new TypeScriptParser();
+  let projectDir1342: string;
+
+  beforeEach(async () => {
+    projectDir1342 = await mkdtemp(join(tmpdir(), 'drift-1342-'));
+    await mkdir(join(projectDir1342, 'src'), { recursive: true });
+    await mkdir(join(projectDir1342, 'docs'), { recursive: true });
+    await writeFile(
+      join(projectDir1342, 'src', 'index.ts'),
+      'export function realFunction() { return 1; }\n'
+    );
+  });
+
+  afterEach(async () => {
+    await rm(projectDir1342, { recursive: true, force: true });
+  });
+
+  async function structureDriftFor() {
+    const snapshotResult = await buildSnapshot({
+      rootDir: projectDir1342,
+      parser: parser2,
+      analyze: { drift: true },
+      include: ['src/**/*.ts'],
+      docPaths: ['docs/**/*.md'],
+    });
+    expect(snapshotResult.ok).toBe(true);
+    if (!snapshotResult.ok) return [];
+    const result = await detectDocDrift(snapshotResult.value, {
+      checkApiSignatures: false,
+      checkExamples: false,
+      checkStructure: true,
+      docPaths: [],
+      ignorePatterns: [],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return [];
+    return result.value.drifts.filter((d) => d.type === 'structure');
+  }
+
+  it('does not flag a link written inside a fenced code block', async () => {
+    await writeFile(
+      join(projectDir1342, 'docs', 'guide.md'),
+      [
+        '# Guide',
+        '',
+        'To wire it up, add a link like this:',
+        '',
+        '```markdown',
+        'See [the config](./this-file-does-not-exist.md) for details.',
+        '```',
+        '',
+        'That is only an illustration.',
+      ].join('\n')
+    );
+
+    const structureDrifts = await structureDriftFor();
+    // The link lives inside a ```fence``` — documentation, not a real
+    // reference, and must not be reported as a broken link.
+    expect(structureDrifts).toHaveLength(0);
+  });
+
+  it('reconstructs a "Foo & Bar" heading anchor the way GitHub does', async () => {
+    await writeFile(join(projectDir1342, 'docs', 'index.md'), '[tricks](./page.md#tips--tricks)\n');
+    await writeFile(
+      join(projectDir1342, 'docs', 'page.md'),
+      ['# Page', '', '## Tips & Tricks', '', 'Body.'].join('\n')
+    );
+
+    const structureDrifts = await structureDriftFor();
+    // GitHub renders "## Tips & Tricks" as the anchor `tips--tricks` (one hyphen
+    // per space). The link targets exactly that, so nothing is broken.
+    expect(structureDrifts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Bug-fleet HUNT over `packages/core/src/entropy/detectors/` (base `7a9a865ca`). Reproduces and fixes three already-filed false-positive / corrupt-metric bugs in the gate-critical drift + complexity detectors. Each fix ships with a TDD repro that is assertion-red at the base SHA and green on this branch.

### Fixes

- **#1329 — `findFunctionEnd` runs to EOF.** The brace scanner only stopped when depth returned to zero, so an expression-bodied arrow (`const inc = n => n + 1`) or a bodyless declaration never "closed" — the scan ran forward into the *next* function's braces (or to end-of-file), inflating the measured length and corrupting cyclomatic/nesting/length metrics attributed to that function. Now a `;` at depth 0 before any block opens terminates the function on its own line.
- **#1342 / #1332 — drift false positives on working links.**
  - `extractFileLinks` had no fenced-code-block tracking, so links written inside ` ``` ` / `~~~` fences as documentation examples were existence-checked and reported as broken. Now fenced blocks are skipped.
  - `slugifyHeading` collapsed whitespace runs with `/\s+/` where GitHub emits one hyphen per space. A heading like `## Tips & Tricks` (real anchor `tips--tricks`) was reconstructed as `tips-tricks`, flagging a working anchor. Now one hyphen per whitespace char, matching GitHub.

### Tests

- `packages/core/tests/entropy/detectors/complexity.test.ts` — issue #1329 repro.
- `packages/core/tests/entropy/detectors/drift.test.ts` — issue #1342/#1332 repros (fenced-code link + `&`-heading anchor).
- Full `tests/entropy` + `tests/architecture/collectors/complexity` suites green (169 tests), repros verified 3× red-at-base / green-on-branch.

Closes #1329. Addresses #1342, #1332.

Provenance: bug-fleet HUNT subagent, area 2 (`entropy/detectors`), pinned base `7a9a865ca`.