### PR TITLE
fix(graph): correct mermaid compact-edge drop and plantuml arrow-direction inversion

### DIFF
--- a/.changeset/diagram-parser-edge-extraction.md
+++ b/.changeset/diagram-parser-edge-extraction.md
@@ -1,0 +1,22 @@
+---
+'@harness-engineering/graph': patch
+---
+
+fix(graph): correct two silent edge-extraction defects in the diagram parsers
+
+Two independent correctness bugs in `packages/graph/src/ingest/parsers/` silently
+put missing or inverted relationships into the knowledge graph:
+
+- **Mermaid compact unlabeled edges were dropped.** `extractUnlabeledEdges`
+  required whitespace after the arrow (`\s+`), so a valid compact edge like
+  `A-->B` matched nothing while the spaced form `A --> B` and labeled edges in
+  the same diagram survived. The arrow's trailing whitespace is now optional, so
+  compact and spaced unlabeled edges extract identically.
+
+- **PlantUML left-pointing arrows recorded an inverted edge.** `parseRelationshipMatch`
+  read endpoints by textual position and ignored arrow direction, so
+  `ClassA <-- ClassB` (which means ClassB points to ClassA) was recorded as
+  `ClassA -> ClassB`. The parser now captures the arrow token and emits the edge
+  in the direction the arrow points; right-pointing arrows are unchanged.
+
+Both are covered by new reproducing tests in `DiagramParser.test.ts`.

--- a/packages/graph/src/ingest/parsers/mermaid.ts
+++ b/packages/graph/src/ingest/parsers/mermaid.ts
@@ -127,7 +127,10 @@ function extractUnlabeledEdges(
   labeledEdges: readonly DiagramRelationship[]
 ): DiagramRelationship[] {
   const relationships: DiagramRelationship[] = [];
-  const unlabeledEdgeRegex = /([A-Za-z0-9_]+)\s*--+>?\s+([A-Za-z0-9_]+)/g;
+  // Whitespace around the arrow is optional in Mermaid: `A-->B` is as valid as
+  // `A --> B`. Requiring `\s+` after the arrow silently dropped every compact
+  // unlabeled edge while labeled edges (which don't) survived.
+  const unlabeledEdgeRegex = /([A-Za-z0-9_]+)\s*--+>?\s*([A-Za-z0-9_]+)/g;
 
   let match = unlabeledEdgeRegex.exec(stripped);
   while (match !== null) {

--- a/packages/graph/src/ingest/parsers/plantuml.ts
+++ b/packages/graph/src/ingest/parsers/plantuml.ts
@@ -68,11 +68,20 @@ function extractComponents(body: string, entities: Map<string, DiagramEntity>): 
 
 /** Parse a single relationship match into a DiagramRelationship. */
 function parseRelationshipMatch(match: RegExpExecArray): DiagramRelationship | null {
-  const from = match[1] ?? '';
-  const to = match[2] ?? '';
-  if (!from || !to) return null;
+  const left = match[1] ?? '';
+  const arrow = match[2] ?? '';
+  const right = match[3] ?? '';
+  if (!left || !right) return null;
 
-  const label = match[3]?.trim();
+  // Arrow direction, not textual order, decides the edge. A left-pointing arrow
+  // (`ClassA <-- ClassB`) means ClassB points to ClassA, so the edge is
+  // ClassB -> ClassA. Reading endpoints by position alone silently inverts
+  // every `<--` / `<-` relationship.
+  const pointsLeft = arrow.startsWith('<');
+  const from = pointsLeft ? right : left;
+  const to = pointsLeft ? left : right;
+
+  const label = match[4]?.trim();
   return { from, to, ...(label ? { label } : {}) };
 }
 
@@ -92,7 +101,7 @@ function collectRelationshipMatches(body: string, regex: RegExp): DiagramRelatio
 function extractRelationships(body: string): DiagramRelationship[] {
   return collectRelationshipMatches(
     body,
-    /(\w+)\s*(?:-->|->|<--|<-|\.\.>|--)\s*(\w+)(?:\s*:\s*(.+))?/g
+    /(\w+)\s*(-->|->|<--|<-|\.\.>|--)\s*(\w+)(?:\s*:\s*(.+))?/g
   );
 }
 

--- a/packages/graph/tests/ingest/DiagramParser.test.ts
+++ b/packages/graph/tests/ingest/DiagramParser.test.ts
@@ -174,6 +174,23 @@ describe('MermaidParser', () => {
         expect(result.entities).toHaveLength(0);
       });
     });
+
+    describe('unlabeled edges', () => {
+      it('captures a compact unlabeled edge with no spaces around the arrow', () => {
+        // `A-->B` is valid Mermaid; whitespace around `-->` is optional. It must
+        // yield the same edge as the spaced form.
+        const result = parser.parse('flowchart TD\n  A[Auth]-->B[Home]\n', 'probe.mmd');
+        expect(result.relationships).toContainEqual(
+          expect.objectContaining({ from: 'A', to: 'B' })
+        );
+      });
+
+      it('captures compact and spaced unlabeled edges identically', () => {
+        const compact = parser.parse('flowchart TD\n  A-->B\n', 'c.mmd').relationships;
+        const spaced = parser.parse('flowchart TD\n  A --> B\n', 's.mmd').relationships;
+        expect(compact).toEqual(spaced);
+      });
+    });
   });
 });
 
@@ -279,6 +296,30 @@ describe('PlantUmlParser', () => {
     it('sets metadata.format to plantuml and diagramType to class', () => {
       expect(result.metadata.format).toBe('plantuml');
       expect(result.metadata.diagramType).toBe('class');
+    });
+  });
+
+  describe('arrow direction', () => {
+    it('records a left-pointing arrow (A <-- B) as the edge B -> A', () => {
+      // In PlantUML `ClassA <-- ClassB` means ClassB points to ClassA. Reading
+      // endpoints by textual position alone inverts the edge.
+      const result = parser.parse(
+        '@startuml\nclass ClassA\nclass ClassB\nClassA <-- ClassB\n@enduml',
+        'rev.puml'
+      );
+      expect(result.relationships).toHaveLength(1);
+      expect(result.relationships[0].from).toBe('ClassB');
+      expect(result.relationships[0].to).toBe('ClassA');
+    });
+
+    it('records a right-pointing arrow (A --> B) as the edge A -> B', () => {
+      const result = parser.parse(
+        '@startuml\nclass ClassA\nclass ClassB\nClassA --> ClassB\n@enduml',
+        'fwd.puml'
+      );
+      expect(result.relationships).toHaveLength(1);
+      expect(result.relationships[0].from).toBe('ClassA');
+      expect(result.relationships[0].to).toBe('ClassB');
     });
   });
 


### PR DESCRIPTION
## Summary

Two NEW, independently-verified correctness defects in the diagram parsers (`packages/graph/src/ingest/parsers/`), found during a proactive adversarial hunt of the ingest subsystem. Both silently corrupt the knowledge graph's relationship edges.

### Bug 1 — Mermaid: compact unlabeled edges silently dropped
`extractUnlabeledEdges` used `/([A-Za-z0-9_]+)\s*--+>?\s+([A-Za-z0-9_]+)/g` — the `\s+` **requires** whitespace after the arrow. A valid compact edge `A-->B` (after node-shape stripping) matched nothing, while `A --> B` and labeled edges (`A-->|x|B`) in the same file survived. Fixed by making trailing whitespace optional (`\s*`).

### Bug 2 — PlantUML: left-pointing arrows recorded inverted
`parseRelationshipMatch` read endpoints by textual position and ignored arrow direction, so `ClassA <-- ClassB` (ClassB points to ClassA) was stored as `ClassA -> ClassB` — every `<--` / `<-` edge inverted, corrupting direction-sensitive queries (blast radius, layering). Fixed by capturing the arrow token and emitting the edge in the direction it points. Right-pointing arrows are unchanged.

## Tests

Adds 4 reproducing tests to `DiagramParser.test.ts` (2 per bug), each RED against the base commit and green with the fix. Full ingest suite: 483 passing (was 479 + 4 new), no regressions.

Both defects are area-local pure-function fixes with no public API / schema change.