### PR TITLE
fix(graph): EnumConstantExtractor drops siblings after a multi-line nested object value

### DIFF
--- a/.changeset/enum-nested-object-members.md
+++ b/.changeset/enum-nested-object-members.md
@@ -1,0 +1,23 @@
+---
+'@harness-engineering/graph': patch
+---
+
+fix(graph): EnumConstantExtractor no longer mis-reads `as const` / `Object.freeze` objects with nested values
+
+`collectObjectKeys` matched `^(\w+)\s*:` on every line and broke on the first
+line starting with `}`, with no brace-depth tracking. A const object whose value
+spanned multiple lines with a nested object or array — e.g.
+
+```ts
+export const CONFIG = {
+  server: {
+    port: 3000,
+  },
+  debug: false,
+} as const;
+```
+
+was recorded with members `["server", "port"]`: the nested key `port` leaked in
+as a false member and the nested closing brace ended collection early, dropping
+`debug`. The extractor now tracks nesting depth and collects only the object's
+top-level keys (`["server", "debug"]`). Covered by a new reproducing test.

--- a/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
+++ b/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
@@ -462,12 +462,25 @@ export class EnumConstantExtractor implements SignalExtractor {
 
   private collectObjectKeys(lines: string[], startLine: number): string[] {
     const keys: string[] = [];
+    // Only keys at the object's top level are real members. Without tracking
+    // nesting depth, keys inside a nested object/array value (e.g. `A: { b: 1 }`
+    // spread across lines) were collected as false members, and the nested
+    // closing brace ended collection early, dropping every sibling after it.
+    let depth = 0;
     for (let i = startLine; i < lines.length; i++) {
       const line = lines[i]!.trim();
-      if (line.startsWith('}')) break;
       if (line === '' || line.startsWith('//')) continue;
-      const match = line.match(/^(\w+)\s*:/);
-      if (match) keys.push(match[1]!);
+      if (depth === 0) {
+        if (line.startsWith('}')) break;
+        const match = line.match(/^(\w+)\s*:/);
+        if (match) keys.push(match[1]!);
+      }
+      // Update depth after the key check so `A: {` records A, then descends.
+      for (const ch of line) {
+        if (ch === '{' || ch === '[') depth++;
+        else if (ch === '}' || ch === ']') depth--;
+      }
+      if (depth < 0) break;
     }
     return keys;
   }

--- a/packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts
+++ b/packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts
@@ -82,4 +82,22 @@ describe('EnumConstantExtractor', () => {
 
     expect(records1.map((r) => r.id)).toEqual(records2.map((r) => r.id));
   });
+
+  it('collects only top-level keys of an as-const object with a multi-line nested value', () => {
+    // A nested object value must not leak its keys into the parent member list,
+    // and its closing brace must not end collection early (dropping siblings).
+    const content = [
+      'export const CONFIG = {',
+      '  server: {',
+      '    port: 3000,',
+      '  },',
+      '  debug: false,',
+      '} as const;',
+    ].join('\n');
+    const records = extractor.extract(content, 'config.ts', 'typescript');
+
+    const config = records.find((r) => r.name === 'CONFIG');
+    expect(config).toBeDefined();
+    expect(config!.metadata.members).toEqual(['server', 'debug']);
+  });
 });


### PR DESCRIPTION
## Summary

NEW bounded-safe correctness bug found during a proactive adversarial hunt of the ingest subsystem.

`EnumConstantExtractor.collectObjectKeys` matched `^(\w+)\s*:` on every line and broke on the first line starting with `}`, with **no brace-depth tracking**. A const object (`as const` / `Object.freeze`) whose value spans multiple lines with a nested object/array is mis-parsed:

```ts
export const CONFIG = {
  server: {
    port: 3000,
  },
  debug: false,
} as const;
```

- Recorded members (base): `["server", "port"]` — nested key `port` leaks in, and the nested `}` ends collection early, **dropping `debug`**.
- With fix: `["server", "debug"]`.

`business_term` nodes for any such object carried wrong/incomplete `members` metadata. (Inline single-line nested values, e.g. `A: { b: 1 },`, were already handled correctly — this is specifically the multi-line form.)

## Fix

Track nesting depth (`{`/`[` increment, `}`/`]` decrement) and collect only top-level keys. Area-local pure-function change; no public API / schema change.

## Test

Adds a reproducing test to `EnumConstantExtractor.test.ts` (RED at base, green with fix). Full ingest suite green, no regressions.