### PR TITLE
fix(knowledge-craft): harden discovery and critique-validation edge cases

### DIFF
--- a/.changeset/knowledge-craft-edge-cases.md
+++ b/.changeset/knowledge-craft-edge-cases.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(knowledge-craft): harden discovery and critique-validation edge cases
+
+Three latent bugs found by the bug-fleet hunt over `packages/cli/src/knowledge-craft/`:
+
+- Discovery gated `.md` case-sensitively (`endsWith('.md')`) while the README
+  exclusion right below it was case-insensitive, so a `NOTES.MD` entry was
+  silently skipped. The extension gate is now case-insensitive to match.
+- `maxFiles` guarded only `null`/`undefined`, so a negative value hit JS
+  negative-index `slice` semantics and silently dropped trailing entries
+  (`maxFiles: -1` scanned all but the last file). A negative / non-finite cap
+  now falls back to the default; `maxFiles: 0` still caps to zero.
+- The critique parser rejected only truly-empty messages, so a whitespace-only
+  `message` became a finding with an unusable body. It is now trimmed before the
+  non-empty check.

--- a/packages/cli/src/knowledge-craft/extract/discover.ts
+++ b/packages/cli/src/knowledge-craft/extract/discover.ts
@@ -50,7 +50,9 @@ function walk(dir: string, root: string, out: DiscoveredEntry[], exclude: Set<st
       continue;
     }
     if (!entry.isFile()) continue;
-    if (!entry.name.endsWith('.md')) continue;
+    // Case-insensitive extension gate — mirrors the case-insensitive README
+    // exclusion below so a `NOTES.MD` entry is not silently skipped.
+    if (!entry.name.toLowerCase().endsWith('.md')) continue;
     if (entry.name.toLowerCase() === 'readme.md') continue;
     const rel = path.relative(root, full).replaceAll('\\', '/');
     out.push({ file: full, relative: rel });

--- a/packages/cli/src/knowledge-craft/index.ts
+++ b/packages/cli/src/knowledge-craft/index.ts
@@ -34,7 +34,14 @@ const DEFAULT_MAX_FILES = 50;
 export async function runKnowledgeCraft(input: KnowledgeCraftInput): Promise<KnowledgeCraftOutput> {
   const startedAt = Date.now();
   const projectRoot = sanitizePath(input.path);
-  const maxFiles = input.maxFiles ?? DEFAULT_MAX_FILES;
+  // A cap must be a non-negative finite number. A negative value would hit
+  // JS negative-index `slice` semantics and silently drop trailing entries
+  // (e.g. maxFiles=-1 => scans all but the last file); NaN/Infinity are
+  // equally nonsensical. Fall back to the default for any invalid cap.
+  const maxFiles =
+    input.maxFiles !== undefined && Number.isFinite(input.maxFiles) && input.maxFiles >= 0
+      ? input.maxFiles
+      : DEFAULT_MAX_FILES;
   const provider = input.__testProvider ?? getProvider();
   const rubrics = SEED_RUBRICS;
 

--- a/packages/cli/src/knowledge-craft/phases/critique.ts
+++ b/packages/cli/src/knowledge-craft/phases/critique.ts
@@ -40,7 +40,7 @@ export async function critiqueOne(input: CritiqueInput): Promise<KnowledgeFindin
   const impact = parsed.impact as Impact;
   const confidence = parsed.confidence as Confidence;
   if (!isTier(tier) || !isImpact(impact) || !isConfidence(confidence)) return null;
-  if (typeof parsed.message !== 'string' || parsed.message.length === 0) return null;
+  if (typeof parsed.message !== 'string' || parsed.message.trim().length === 0) return null;
 
   return {
     code: rubric.id,

--- a/packages/cli/tests/knowledge-craft/edge-cases.test.ts
+++ b/packages/cli/tests/knowledge-craft/edge-cases.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { runKnowledgeCraft } from '../../src/knowledge-craft';
+import { critiqueOne } from '../../src/knowledge-craft/phases/critique';
+import { loadBearingFactRubric } from '../../src/knowledge-craft/catalog/rubrics/load-bearing-fact';
+import { MockLlmProvider } from '../../src/shared/craft/llm/provider';
+
+/**
+ * Regression tests for latent edge-case bugs in knowledge-craft discovery /
+ * validation (bug-fleet AREA 3). Each assertion fails at base 7a9a865ca.
+ */
+describe('knowledge-craft edge cases', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kc-edge-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+  function writeFile(rel: string, content = '# stub\n\nbody\n'): void {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  // F4: the .md extension gate must be case-insensitive, matching the
+  // case-insensitive README exclusion. A `NOTES.MD` file was silently skipped.
+  it('discovers an uppercase .MD entry (case-insensitive extension gate)', async () => {
+    writeFile('docs/knowledge/NOTES.MD');
+    const out = await runKnowledgeCraft({ path: tmpDir });
+    expect(out.summary.counts.filesScanned).toBe(1);
+  });
+
+  it('still excludes an uppercase README.MD', async () => {
+    writeFile('docs/knowledge/README.MD');
+    writeFile('docs/knowledge/real.md');
+    const out = await runKnowledgeCraft({ path: tmpDir });
+    expect(out.summary.counts.filesScanned).toBe(1);
+  });
+
+  // F2: a negative / non-finite maxFiles must not silently drop trailing
+  // entries via JS negative-index slice; it falls back to the default cap.
+  it('treats a negative maxFiles as invalid and scans all entries', async () => {
+    for (let i = 0; i < 3; i++) writeFile(`docs/knowledge/e${i}.md`);
+    const out = await runKnowledgeCraft({ path: tmpDir, maxFiles: -1 });
+    expect(out.summary.counts.filesScanned).toBe(3);
+  });
+
+  it('still honors a valid maxFiles cap of 0', async () => {
+    for (let i = 0; i < 3; i++) writeFile(`docs/knowledge/e${i}.md`);
+    const out = await runKnowledgeCraft({ path: tmpDir, maxFiles: 0 });
+    expect(out.summary.counts.filesScanned).toBe(0);
+  });
+
+  // F6: a whitespace-only message must be rejected like an empty one.
+  it('rejects a whitespace-only critique message', async () => {
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'KNOW-R001',
+        response:
+          '```json\n{"tier":"foundational","impact":"large","confidence":"high","message":"   "}\n```',
+      },
+    ]);
+    const finding = await critiqueOne({
+      file: '/x/a.md',
+      relative: 'a.md',
+      content: 'body',
+      rubric: loadBearingFactRubric,
+      provider,
+    });
+    expect(finding).toBeNull();
+  });
+
+  it('still accepts a non-empty critique message', async () => {
+    const provider = new MockLlmProvider([
+      {
+        promptIncludes: 'KNOW-R001',
+        response:
+          '```json\n{"tier":"foundational","impact":"large","confidence":"high","message":"real critique"}\n```',
+      },
+    ]);
+    const finding = await critiqueOne({
+      file: '/x/a.md',
+      relative: 'a.md',
+      content: 'body',
+      rubric: loadBearingFactRubric,
+      provider,
+    });
+    expect(finding).not.toBeNull();
+    expect(finding!.message).toBe('real critique');
+  });
+});


### PR DESCRIPTION
## Summary

Bug-fleet hunt over \`packages/cli/src/knowledge-craft/\` (AREA 3). Three latent, deterministically-reproducible edge-case bugs, each with a regression test that fails at base \`7a9a865ca\` and passes here.

1. **Case-sensitive \`.md\` gate skipped uppercase entries.** \`discover.ts\` gated inclusion with \`endsWith('.md')\` (case-sensitive) while the README exclusion immediately below used \`toLowerCase()\`. A \`NOTES.MD\` entry was silently dropped from discovery (matters on case-sensitive filesystems / Linux CI). Gate is now case-insensitive, mirroring the README check.
2. **Negative \`maxFiles\` silently dropped trailing entries.** The cap guarded only \`null\`/\`undefined\`, so a negative value hit JS negative-index \`slice\` semantics — \`maxFiles: -1\` scanned all but the *last* file, under-counting \`filesScanned\` with no \`filesSkipped\` signal. A negative / non-finite cap now falls back to the default; \`maxFiles: 0\` still caps to zero.
3. **Whitespace-only critique message passed the non-empty guard.** \`critique.ts\` rejected only \`length === 0\`, so a \`"   "\` message became a finding with an unusable body. Now trimmed before the check.

## Test

New \`tests/knowledge-craft/edge-cases.test.ts\` (6 cases, incl. "still-works" guards). Full knowledge-craft suite: 28 passed. \`tsc --noEmit\` clean.

## Scope note

Two higher-severity findings surfaced in the same hunt are **cross-cutting across the older-generation craft family** (docs/spec/copy/knowledge-craft share the code verbatim) and are intentionally left out of this bounded PR — reported separately for a coordinated fix:
- In-session provider (the default mode) throws \`PromptDeferredError\`, which \`runKnowledgeCraft\`'s bare \`catch\` swallows → hollow \`findings: []\` success. Newer-gen naming-craft throws a loud two-step-flow guard instead.
- The shared lazy fenced-JSON regex truncates any LLM response whose \`message\` contains a code fence.

Seeded candidate #1330 (\`decisionsDir\` hardcoded) is **out of this area** — it lives in \`packages/graph/src/ingest/KnowledgePipelineRunner.ts:340\`.