### PR TITLE
fix(graph): isolate per-connector failures in SyncManager.syncAll

### DIFF
--- a/.changeset/syncmanager-connector-isolation.md
+++ b/.changeset/syncmanager-connector-isolation.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/graph': patch
+---
+
+fix(graph): isolate per-connector failures in `SyncManager.syncAll`
+
+A connector whose `ingest()` (or its per-connector metadata write) threw an
+uncaught exception previously rejected the entire `syncAll()` run, silently
+starving every connector registered after it and skipping the post-sync
+KnowledgeLinker pass. `syncAll` now wraps each connector in a try/catch,
+records the failure into the combined result's `errors` array, and continues
+with the remaining connectors. Public return contract is unchanged.

--- a/packages/graph/src/ingest/connectors/SyncManager.ts
+++ b/packages/graph/src/ingest/connectors/SyncManager.ts
@@ -70,7 +70,19 @@ export class SyncManager {
     };
 
     for (const [name] of this.registrations) {
-      const result = await this.sync(name);
+      // Isolate each connector: a connector whose ingest() (or the per-connector
+      // metadata write) throws an *uncaught* exception must not abort the rest of
+      // the sync. Capture the failure into combined.errors and carry on, so one
+      // broken connector can't silently starve every connector after it.
+      let result: IngestResult;
+      try {
+        result = await this.sync(name);
+      } catch (err) {
+        combined.errors.push(
+          `Connector "${name}" error: ${err instanceof Error ? err.message : String(err)}`
+        );
+        continue;
+      }
       combined.nodesAdded += result.nodesAdded;
       combined.nodesUpdated += result.nodesUpdated;
       combined.edgesAdded += result.edgesAdded;

--- a/packages/graph/tests/ingest/connectors/SyncManager.test.ts
+++ b/packages/graph/tests/ingest/connectors/SyncManager.test.ts
@@ -140,6 +140,47 @@ describe('SyncManager', () => {
     expect(parsed.connectors['disk']).toBeDefined();
   });
 
+  it('syncAll isolates a connector whose ingest throws so remaining connectors still run', async () => {
+    // A connector whose ingest() throws (an *uncaught* exception, e.g. a
+    // network fault or a metadata-write failure) rather than returning an
+    // IngestResult with errors. syncAll must isolate this: the failure is
+    // captured into combined.errors and every remaining connector still runs.
+    const throwing: GraphConnector = {
+      name: 'throwing',
+      source: 'throwing',
+      ingest: async () => {
+        throw new Error('connector boom');
+      },
+    };
+    const good: IngestResult = {
+      nodesAdded: 4,
+      nodesUpdated: 0,
+      edgesAdded: 2,
+      edgesUpdated: 0,
+      errors: [],
+      durationMs: 3,
+    };
+
+    // Register the throwing connector FIRST (Map iteration is insertion order)
+    // so its failure would abort the loop before the good connector runs.
+    manager.registerConnector(throwing, {});
+    manager.registerConnector(makeMockConnector('good', good), {});
+
+    // syncAll must not reject when a connector throws — it isolates the failure.
+    const outcome = await manager.syncAll().then(
+      (result) => ({ ok: true as const, result }),
+      (err: unknown) => ({ ok: false as const, err })
+    );
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    // The second connector still ran despite the first throwing.
+    expect(outcome.result.nodesAdded).toBeGreaterThanOrEqual(4);
+    expect(outcome.result.edgesAdded).toBe(2);
+    // The throwing connector's failure is captured, not fatal.
+    expect(outcome.result.errors.some((e) => e.includes('throwing'))).toBe(true);
+  });
+
   it('invokes KnowledgeLinker after syncAll completes', async () => {
     const result: IngestResult = {
       nodesAdded: 1,


### PR DESCRIPTION
## Summary
Bug-fleet Area-1 follow-up. `SyncManager.syncAll` looped over connectors with **no per-connector isolation**: if any connector's `ingest()` (or its per-connector metadata write in `sync()`) threw an *uncaught* exception, the rejection propagated out of the loop, aborting **every remaining connector** and rejecting the whole `syncAll()` — the post-sync KnowledgeLinker pass never ran and the failure was captured nowhere.

## Why it's real (not refuted)
The `GraphConnector` interface only types `ingest(): Promise<IngestResult>` — it does **not** guarantee no-throw. Bundled connectors happen to catch internally and return `errors`, but (a) adopters ship their own connectors (harness is adopter-portable), and (b) `sync()` itself throws on disk-IO failures in `saveMetadata` (EACCES/ENOSPC/read-only FS) *after* a successful ingest — a throw path never captured in `result.errors`. Either aborts all remaining connectors.

## Fix (bounded-safe)
Per-iteration try/catch in the `syncAll` loop: a connector that throws has its failure recorded into the existing combined `errors` array and the loop continues. **Public return contract unchanged** (`IngestResult`; errors collected in `errors`).

## Test (TDD)
`syncAll isolates a connector whose ingest throws so remaining connectors still run` — throwing connector registered first, asserts the second still runs, errors captured, and `syncAll` does not reject. Verified **deterministically RED 3× at base 7a9a865ca** (`AssertionError: expected false to be true`), GREEN on this branch (8/8 in file).

## Provenance
- Base SHA: 7a9a865ca
- Class: bounded-safe (per-iteration try/catch, no contract change)
- Changeset: `@harness-engineering/graph: patch`
- Cross-check: no existing issue/PR (PR #238 is the unrelated original Phase-3 integration)