### PR TITLE
[DRAFT SPEC] Role-shaped dashboard front doors — PM/BA author-intent lane (#711)

### DIFF
--- a/.changeset/author-intent-form.md
+++ b/.changeset/author-intent-form.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/dashboard': minor
+---
+
+feat(dashboard): author-intent form on PM/BA roadmap lane (#711)
+
+Adds a first-class, plain-language "Author intent" panel to the Roadmap page
+(`/s/roadmap`, the pm-ba lane's landing route), rendered only in the `pm-ba` and
+`dev` lanes and hidden from the read/progress-oriented `client` lane. It writes a
+backlog item through the existing `appendToRoadmap` → `POST /api/roadmap/append`
+path — no chat thread, no slash command, no terminal — reusing the shipped
+conflict/toast plumbing: on success it clears, confirms with a toast, and the new
+row surfaces in the existing FeatureTable after the roadmap re-fetch; on a
+409 conflict it surfaces the existing conflict toast and preserves the entered
+content for retry. Lanes remain presentation-only (the server AUTHORIZATION SEAM
+is untouched).

--- a/docs/changes/role-shaped-dashboard-front-doors/plans/author-intent-form.md
+++ b/docs/changes/role-shaped-dashboard-front-doors/plans/author-intent-form.md
@@ -1,0 +1,49 @@
+# Plan — Author-intent form on the PM/BA roadmap lane (#711)
+
+Spec: [`../proposal.md`](../proposal.md) · Roadmap item #711 · Track: Full-lifecycle reach
+
+Implements the spec's **Buildable slice** verbatim: a first-class, plain-language
+intent-capture form on the Roadmap page (`/s/roadmap`, the pm-ba lane's landing
+route), rendered only in the `pm-ba` and `dev` lanes, writing through the shipped
+`appendToRoadmap` → `POST /api/roadmap/append`. No new endpoint, role, or store;
+lanes stay presentation-only (the `AUTHORIZATION SEAM` is untouched).
+
+## Task order (maps the spec's 3 phases to files + ACs)
+
+### Phase 1 — Author-intent form component → AC2, AC4, AC5 (+ success half of AC3)
+
+1. `src/client/stores/toastStore.ts` — additive `success` slot + `pushSuccess` /
+   `clearSuccess`. The shipped store was conflict-only; this adds a success
+   channel without changing the existing `current` conflict slot or its type, so
+   `ConflictToastRegion` and every existing toast test are untouched.
+2. `src/client/components/roadmap/AuthorIntentForm.tsx` — new controlled Title
+   input + Description textarea; submit disabled until the trimmed Title is
+   non-empty (**AC4**); on submit calls `appendToRoadmap({ title, summary })` with
+   `summary` omitted when Description is blank (**AC2**); on success clears both
+   fields and pushes a success toast (**AC3** success half); on conflict/error the
+   helper's toast surfaces and the entered content is preserved for retry
+   (**AC5**).
+3. Tests: `tests/client/components/roadmap/AuthorIntentForm.test.tsx` → AC2, AC4,
+   AC5, and the clears-fields+toast half of AC3.
+
+### Phase 2 — Lane-gated placement → AC1, AC3, AC6
+
+4. `src/client/pages/Roadmap.tsx` — import `AuthorIntentForm` + `useRole`; render
+   it at the top of the page gated by `role === 'pm-ba' || role === 'dev'`
+   (**AC6**); wire `onCreated` to the page's existing `handleConflictRefresh` so a
+   successful append re-fetches `GET /api/roadmap` and the new backlog row lands
+   in the existing `FeatureTable` (**AC3**).
+5. Tests: `tests/client/pages/Roadmap.authorIntent.test.tsx` → AC1 (fields render,
+   no chat thread created on mount), AC3 (success re-fetch surfaces the new row),
+   AC6 (pm-ba/dev render, client hidden). `useSSE` mocked, `fetch` stubbed.
+
+### Phase 3 — Invariant guard → AC7
+
+6. No change to `orchestrator-proxy.ts` (`AUTHORIZATION SEAM`), `shared/roles.ts`,
+   or `types/roles.ts` presentation wording. The existing `roles.test.ts` and
+   `identity-role.test.ts` suites pass unmodified.
+
+## Acceptance evidence
+
+`pnpm --filter @harness-engineering/dashboard test` — full suite green, including
+the two new files and the untouched roles/identity suites (AC7).

--- a/docs/changes/role-shaped-dashboard-front-doors/proposal.md
+++ b/docs/changes/role-shaped-dashboard-front-doors/proposal.md
@@ -1,0 +1,96 @@
+# Role-shaped dashboard front doors — the PM/BA author-intent lane
+
+**Status:** DRAFT (autonomously drafted; awaiting human review — do NOT merge as-is) · **Tier:** Small · **Domain:** dashboard (client + orchestrator API)
+**Roadmap item:** #711 · **Track:** Full-lifecycle reach (`STRATEGY.md` v2)
+**Keywords:** role-scoped-lanes, pm-ba, author-intent, non-technical-access, dashboard, roadmap-append, presentation-only
+
+## Overview
+
+Roadmap item #711 asks for **role-scoped front doors** — PM/BA and client lanes through the _existing_ dashboard + router + chat so non-technical users can **author intent, watch agents, and adjudicate at decision points** without a terminal. This spec scopes **one lane (PM/BA), one edge (author intent), end to end** as the buildable slice, because a grounding pass against the real code found that the other two verbs and the lane-scoping machinery itself have **already shipped** — and author-intent-without-a-terminal is the one promise of #711 with a genuine gap.
+
+## What already shipped (honest grounding)
+
+The premise in the shard — _"the surfaces exist; they need role-scoped paths"_ — is now understated: the **role-scoped paths themselves already exist**, landed in PR #1132 (`feat(dashboard): role-shaped front doors (presentation-only lanes)`) and refined by #1137. Verified against the tree:
+
+- **Role taxonomy** `dev | pm-ba | client` — `packages/dashboard/src/shared/roles.ts` (`DashboardRole`, `DASHBOARD_ROLES`, `DEFAULT_ROLE = 'dev'`, `coerceRole`).
+- **Per-role navigation lanes** — `packages/dashboard/src/client/types/roles.ts` (`ROLE_LANES`): `pm-ba` → `['roadmap','kanban','orchestrator','streams','proposals']` landing on `/s/roadmap`, described verbatim as _"Author intent, watch agents, and adjudicate at decision points."_; `client` → `['roadmap','traceability']`.
+- **Lane switcher + scoped sidebar** — `packages/dashboard/src/client/components/layout/ThreadSidebar.tsx` renders `pagesForRole(role)` and a `<select>` lane switcher calling `setRole`.
+- **Role resolution** — `packages/dashboard/src/client/hooks/useRole.tsx` (localStorage → `GET /api/identity` → `dev`) and the server seed `packages/dashboard/src/server/identity.ts` (`resolveRole()` reads `HARNESS_DASHBOARD_ROLE`).
+- **Role-aware landing** — `packages/dashboard/src/client/main.tsx` (`RoleHome` → `defaultRouteForRole`).
+- **Tests already present** — `tests/client/types/roles.test.ts`, `tests/server/identity-role.test.ts`.
+
+The two other #711 verbs are also already reachable through shipped surfaces:
+
+- **Watch agents** — `pages/Orchestrator.tsx`, `pages/Kanban.tsx` (`/s/kanban`, "Work in Flight"), `pages/Streams.tsx`, live over `/ws` via `hooks/useOrchestratorSocket.ts`. All in the `pm-ba` lane.
+- **Adjudicate at decision points** — two surfaces already work and are reachable from the `pm-ba` lane: (a) live agent decision points surface as **Attention threads in the sidebar for every role** (`hooks/useAttentionSync.ts` → `pages/Attention.tsx` / `components/threads/AttentionThreadView.tsx`, Claim/Dismiss/Resolve via `GET /api/interactions` + `PATCH /api/interactions/:id`); (b) the skill-proposal review queue `pages/Proposals.tsx` (approve/reject via `POST /api/v1/proposals/:id/{approve,reject}`), which is in the `pm-ba` lane allowlist.
+
+**Conclusion:** re-building lanes, watch, or adjudication would be redundant. The honest remaining gap is the **author-intent edge**.
+
+## The remaining gap (what this spec builds)
+
+Today a non-technical user cannot cleanly **author intent from the dashboard without a terminal**:
+
+- The only first-class write into the roadmap is `POST /api/roadmap/append` (server `packages/orchestrator/src/server/routes/roadmap-actions.ts`; client `packages/dashboard/src/client/utils/appendToRoadmap.ts`), and its **only caller today is the Analyze flow** (`components/analyze/useAnalyze.ts`) — authoring is a byproduct of running an analysis, not a first-class action.
+- The Roadmap page's `AddToRoadmapButton` (`pages/Roadmap.tsx`) launches a **chat thread running the `harness:roadmap-add` slash command** — a terminal-flavored, developer-shaped path, exactly what #711 says to avoid.
+- The `pm-ba` lane lands on `/s/roadmap`, but that landing surface has **no plain-language "state what you want built" form**.
+
+So the buildable slice is a **first-class, plain-language intent-capture form on the PM/BA lane's landing surface** that writes through the _existing, proven_ `POST /api/roadmap/append` endpoint — no chat, no slash command, no terminal.
+
+## Buildable slice (this spec's scope)
+
+Add an **"Author intent"** panel to the Roadmap page (`/s/roadmap`, the `pm-ba` lane's landing route), rendered only in the `pm-ba` and `dev` lanes:
+
+1. A plain-language form: a **Title** field ("What do you want built?") and a multi-line **Description** field ("Any detail — plain language, no jargon"). No harness vocabulary, no command syntax.
+2. On submit it calls the **existing** `appendToRoadmap({ title, summary })` helper → `POST /api/roadmap/append`, reusing the shipped `fetchWithConflict` + `toastStore` + `ConflictToastRegion` plumbing for success/error/409-conflict.
+3. On success the form clears, a success toast fires, and the new item appears in the existing `FeatureTable` on the same page after the roadmap re-fetch.
+4. The panel is **absent in the `client` lane** (which is read/progress-oriented) and unchanged in `dev`.
+
+This touches one page, one new component, and one line of lane config. It invents no endpoint, no store, and no role.
+
+## Surfaces reused (all real, all shipped)
+
+| Concern             | Reused surface (verified path)                                                                                                                             |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Role / lane gating  | `packages/dashboard/src/client/hooks/useRole.tsx`, `packages/dashboard/src/client/types/roles.ts` (`ROLE_LANES`)                                           |
+| Landing page host   | `packages/dashboard/src/client/pages/Roadmap.tsx` (already the `pm-ba` default route `/s/roadmap`)                                                         |
+| Write path (client) | `packages/dashboard/src/client/utils/appendToRoadmap.ts` (`appendToRoadmap`)                                                                               |
+| Write path (server) | `packages/orchestrator/src/server/routes/roadmap-actions.ts` (`POST /api/roadmap/append`; zod `title.min(1)` + optional `summary`; rejects newlines/`###`) |
+| Conflict / feedback | `packages/dashboard/src/client/utils/fetchWithConflict.ts`, `stores/toastStore.ts`, `components/ConflictToastRegion.tsx`                                   |
+| Result list         | `packages/dashboard/src/client/components/roadmap/FeatureTable.tsx`, `GET /api/roadmap`                                                                    |
+
+## Non-goals / out of scope
+
+- **Server-side authorization.** Lanes remain **presentation-only** by design. The single documented place for real per-role enforcement is the `AUTHORIZATION SEAM` comment block in `packages/dashboard/src/server/orchestrator-proxy.ts`, which is deliberately deferred until authenticated multi-user sessions exist. This spec must not touch that seam and must not imply the form is access-controlled — a hand-typed request can still reach the endpoint regardless of lane.
+- **The `client` lane.** Out of scope beyond hiding the panel from it.
+- **Re-building lane scoping, watch, or adjudication** — all shipped (#1132/#1137); see grounding above.
+- **A new roadmap-authoring endpoint or a spec/PRD authoring form.** The slice writes a backlog _item_ via the existing append endpoint; turning that item into a spec is downstream (`harness-brainstorming`) and unchanged.
+- **Rich intent capture** (attachments, structured requirements, EARS criteria). The `product-requirements` skill owns that; here the field is free-text `summary`.
+
+## Success Criteria (measurable / observable)
+
+Each is verifiable with a component/integration test using a mocked `fetch`; the server contract (`title.min(1)`, newline/heading rejection) is already covered by existing roadmap-actions tests.
+
+- **AC1** — In the `pm-ba` lane, `/s/roadmap` renders an "Author intent" form exposing a Title input and a Description textarea, **without** creating any chat thread or issuing any slash command (assert the two fields render and `useThreadStore.createThread` is not called on mount).
+- **AC2** — Submitting with a non-empty title issues exactly one `POST /api/roadmap/append` whose JSON body is `{ title: <title>, summary: <description> }` matching the entered values (assert via mocked fetch; when Description is empty, `summary` is omitted or equals the title, matching the server default).
+- **AC3** — On a `200 { ok: true, featureName }` response, the form fields clear, a success toast is pushed to `toastStore`, and a subsequent `GET /api/roadmap` re-fetch renders the new item in `FeatureTable` (assert cleared inputs + toast entry + row present).
+- **AC4** — Submitting with an empty/whitespace title is blocked client-side (submit disabled or inline validation) and issues **no** `fetch` (assert zero network calls).
+- **AC5** — A `409` conflict response routes through `fetchWithConflict` and surfaces the existing `ConflictToastRegion` toast, and the form's Title/Description content is **preserved** for retry (assert toast + inputs unchanged).
+- **AC6** — The panel is gated by lane: it renders for `role === 'pm-ba'` and `role === 'dev'`, and does **not** render for `role === 'client'` (assert by driving `useRole` with each role).
+- **AC7** (invariant / regression) — No server-side authorization is added: the `AUTHORIZATION SEAM` block in `orchestrator-proxy.ts` is unchanged, the presentation-only wording in `shared/roles.ts` / `types/roles.ts` stands, and the existing `roles.test.ts` + `identity-role.test.ts` suites pass unmodified.
+
+## Phasing
+
+- **Phase 1 — Author-intent form component (~0.5d).** New `components/roadmap/AuthorIntentForm.tsx`: controlled Title + Description, submit-disabled-until-valid, calls `appendToRoadmap`, clears + toasts on success, preserves on error. Unit tests → AC2, AC4, AC5.
+- **Phase 2 — Lane-gated placement (~0.5d).** Mount the form at the top of `pages/Roadmap.tsx` guarded by `useRole()` (`pm-ba`/`dev` only); confirm re-fetch surfaces the new row in `FeatureTable`. Tests → AC1, AC3, AC6.
+- **Phase 3 — Invariant guard (~0.25d).** Assert the presentation-only posture is untouched and existing role/identity suites are green. Test → AC7.
+
+## Strategy grounding
+
+Extends the **Full-lifecycle reach** track (`STRATEGY.md#tracks`): _"reach those edges through role-shaped front doors … rather than the CLI … completing the two human edges is what lets non-technical people drive real lifecycle work."_ Per `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md` (§"Non-technical access" and recommendation #3), the intent edge is exactly where harness is thinnest for non-engineers; this slice puts **authoring intent** (not code) as the input for the PM/BA persona, through an existing surface, with no terminal — directly on the track's thesis. It contradicts no strategy section.
+
+## Open questions for the human reviewer
+
+1. **Scope check:** is the author-intent edge the right slice, given watch + adjudicate + lane scoping already shipped (#1132/#1137)? Or should #711 instead be re-scoped to server-side lane _enforcement_ (the deferred `AUTHORIZATION SEAM`) — a larger, hosting-dependent effort?
+2. **Backlog target:** the append endpoint writes to the Backlog milestone. Should PM/BA-authored items land somewhere more visible (a "Proposed by PM/BA" bucket) so a human triages them before they enter the pilot's pickup set?
+3. **Client lane:** should the `client` lane get a strictly read-only progress view later, or is hiding the authoring panel sufficient for now?
+4. **Guardrails:** the server already rejects newlines/`###`; do we want additional length/rate limits on a non-technical write surface before it's exposed in a hosted context?

--- a/docs/roadmap.d/role-shaped-dashboard-front-doors-non-technical-lanes.md
+++ b/docs/roadmap.d/role-shaped-dashboard-front-doors-non-technical-lanes.md
@@ -10,7 +10,7 @@ order: 2
 - **Spec:** docs/changes/role-shaped-dashboard-front-doors/proposal.md
 - **Summary:** **Priority: NEXT.** PM/BA and client lanes through the existing dashboard + router + chat: author intent, watch agents, adjudicate at decision points — no terminal. The surfaces exist; they need role-scoped paths. Lever for non-technical access per the Full-lifecycle reach track. --- _Part of the **Full-lifecycle reach** track (STRATEGY.md v2). Rationale: `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md`._
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/role-shaped-dashboard-front-doors/plans/author-intent-form.md
 - **Assignee:** —
 - **Priority:** P1
 - **External-ID:** github:Intense-Visions/harness-engineering#711

--- a/docs/roadmap.d/role-shaped-dashboard-front-doors-non-technical-lanes.md
+++ b/docs/roadmap.d/role-shaped-dashboard-front-doors-non-technical-lanes.md
@@ -7,7 +7,7 @@ order: 2
 ### Role-shaped dashboard front doors (non-technical lanes)
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/role-shaped-dashboard-front-doors/proposal.md
 - **Summary:** **Priority: NEXT.** PM/BA and client lanes through the existing dashboard + router + chat: author intent, watch agents, adjudicate at decision points — no terminal. The surfaces exist; they need role-scoped paths. Lever for non-technical access per the Full-lifecycle reach track. --- _Part of the **Full-lifecycle reach** track (STRATEGY.md v2). Rationale: `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md`._
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1227,7 +1227,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Role-shaped dashboard front doors (non-technical lanes)
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/role-shaped-dashboard-front-doors/proposal.md
 - **Summary:** **Priority: NEXT.** PM/BA and client lanes through the existing dashboard + router + chat: author intent, watch agents, adjudicate at decision points — no terminal. The surfaces exist; they need role-scoped paths. Lever for non-technical access per the Full-lifecycle reach track. --- _Part of the **Full-lifecycle reach** track (STRATEGY.md v2). Rationale: `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md`._
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1230,7 +1230,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Spec:** docs/changes/role-shaped-dashboard-front-doors/proposal.md
 - **Summary:** **Priority: NEXT.** PM/BA and client lanes through the existing dashboard + router + chat: author intent, watch agents, adjudicate at decision points — no terminal. The surfaces exist; they need role-scoped paths. Lever for non-technical access per the Full-lifecycle reach track. --- _Part of the **Full-lifecycle reach** track (STRATEGY.md v2). Rationale: `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md`._
 - **Blockers:** —
-- **Plan:** —
+- **Plan:** docs/changes/role-shaped-dashboard-front-doors/plans/author-intent-form.md
 - **Assignee:** —
 - **Priority:** P1
 - **External-ID:** github:Intense-Visions/harness-engineering#711

--- a/packages/dashboard/src/client/components/roadmap/AuthorIntentForm.tsx
+++ b/packages/dashboard/src/client/components/roadmap/AuthorIntentForm.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { appendToRoadmap } from '../../utils/appendToRoadmap';
+import { useToastStore } from '../../stores/toastStore';
+
+interface Props {
+  /**
+   * Called after a successful append with the new item's tracker externalId
+   * (may be undefined in monolith roadmap mode, which returns only
+   * `{ ok, featureName }`). The Roadmap page wires this to its existing
+   * roadmap re-fetch so the new backlog item surfaces in the FeatureTable.
+   */
+  onCreated?: (externalId: string | undefined) => void;
+}
+
+/**
+ * Author-intent panel for the PM/BA (and dev) roadmap lane.
+ *
+ * A plain-language, first-class intent-capture form — no chat thread, no slash
+ * command, no terminal. It writes through the shipped `appendToRoadmap`
+ * (`POST /api/roadmap/append`) and reuses the shipped toast/conflict plumbing:
+ * on a TRACKER_CONFLICT the helper pushes the conflict toast surfaced by the
+ * page's `ConflictToastRegion`, and this form preserves the entered content for
+ * a retry. On success it clears, pushes a success toast, and asks the page to
+ * re-fetch the roadmap.
+ *
+ * This is presentation-only, like the lanes themselves: it invents no endpoint,
+ * store, or role, and is not an access-control boundary (a hand-typed request
+ * still reaches the endpoint regardless of lane).
+ */
+export function AuthorIntentForm({ onCreated }: Props) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const success = useToastStore((s) => s.success);
+  const clearSuccess = useToastStore((s) => s.clearSuccess);
+  const pushSuccess = useToastStore((s) => s.pushSuccess);
+
+  const canSubmit = title.trim().length > 0 && !submitting;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const t = title.trim();
+    if (!t) return; // AC4: whitespace-only title never submits
+    setSubmitting(true);
+    // AC2: summary omitted when Description is empty (server defaults it to the
+    // title), otherwise the trimmed free-text description.
+    const summary = description.trim();
+    const result = await appendToRoadmap({
+      title: t,
+      summary: summary.length > 0 ? summary : undefined,
+    });
+    setSubmitting(false);
+    if (result.ok) {
+      // AC3: clear the fields, confirm with a success toast, and let the page
+      // re-fetch so the new row lands in the FeatureTable.
+      setTitle('');
+      setDescription('');
+      pushSuccess({ message: `Added “${result.featureName ?? t}” to the roadmap.` });
+      onCreated?.(result.externalId);
+    }
+    // AC5: on conflict/error appendToRoadmap has already surfaced the toast;
+    // leave Title/Description untouched so the user can retry.
+  };
+
+  return (
+    <section
+      aria-labelledby="author-intent-heading"
+      className="rounded-lg border border-gray-800 bg-gray-900 p-4"
+    >
+      <h2
+        id="author-intent-heading"
+        className="mb-1 text-xs font-semibold uppercase tracking-widest text-gray-500"
+      >
+        Author intent
+      </h2>
+      <p className="mb-3 text-xs text-gray-500">
+        State what you want built — plain language, no jargon. It joins the backlog for a human to
+        pick up.
+      </p>
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-2">
+        <div>
+          <label
+            htmlFor="author-intent-title"
+            className="mb-1 block text-[10px] font-semibold uppercase tracking-widest text-gray-400"
+          >
+            What do you want built?
+          </label>
+          <input
+            id="author-intent-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. A weekly progress digest for stakeholders"
+            className="w-full rounded border border-gray-700 bg-gray-800 px-2 py-1.5 text-sm text-gray-200 placeholder-gray-600 focus:border-primary-500 focus:outline-none"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="author-intent-description"
+            className="mb-1 block text-[10px] font-semibold uppercase tracking-widest text-gray-400"
+          >
+            Any detail (optional)
+          </label>
+          <textarea
+            id="author-intent-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            placeholder="Any detail — plain language, no jargon."
+            className="w-full rounded border border-gray-700 bg-gray-800 px-2 py-1.5 text-sm text-gray-200 placeholder-gray-600 focus:border-primary-500 focus:outline-none"
+          />
+        </div>
+        <div className="flex items-center justify-end gap-3">
+          {success && success.kind === 'success' && (
+            <div
+              role="status"
+              aria-live="polite"
+              className="flex items-center gap-2 text-xs text-emerald-400"
+            >
+              <span data-testid="author-intent-success">{success.message}</span>
+              <button
+                type="button"
+                aria-label="Dismiss confirmation"
+                onClick={clearSuccess}
+                className="rounded px-1 text-[10px] font-bold uppercase tracking-widest text-emerald-300 hover:text-emerald-100"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="rounded bg-primary-500 px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-white transition-colors hover:bg-primary-400 disabled:opacity-40"
+          >
+            {submitting ? 'Adding…' : 'Add to roadmap'}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/packages/dashboard/src/client/pages/Roadmap.tsx
+++ b/packages/dashboard/src/client/pages/Roadmap.tsx
@@ -7,11 +7,13 @@ import { ProgressChart } from '../components/ProgressChart';
 import { DependencyGraph } from '../components/DependencyGraph';
 import { StatsBar } from '../components/roadmap/StatsBar';
 import { FeatureTable } from '../components/roadmap/FeatureTable';
+import { AuthorIntentForm } from '../components/roadmap/AuthorIntentForm';
 import { ClaimConfirmation } from '../components/roadmap/ClaimConfirmation';
 import { AssignmentHistory } from '../components/roadmap/AssignmentHistory';
 import { ConflictToastRegion } from '../components/ConflictToastRegion';
 import { scrollToFeatureRow } from '../utils/scrollToFeatureRow';
 import { fetchWithConflict } from '../utils/fetchWithConflict';
+import { useRole } from '../hooks/useRole';
 import { SSE_ENDPOINT } from '@shared/constants';
 import { isRoadmapData } from '../utils/typeGuards';
 import type {
@@ -310,6 +312,13 @@ const CONFLICT_REFRESH_DEBOUNCE_MS = 500;
 export function Roadmap() {
   const { data, lastUpdated, stale, error } = useSSE(SSE_ENDPOINT, 'overview');
 
+  // Presentation-only lane gating: the author-intent panel is the PM/BA lane's
+  // first-class "state what you want built" surface, also shown to developers.
+  // It is hidden from the read/progress-oriented `client` lane. This is not an
+  // access-control boundary — see the AUTHORIZATION SEAM note in the server.
+  const { role } = useRole();
+  const showAuthorIntent = role === 'pm-ba' || role === 'dev';
+
   // Phase 7 D-P7-E: manual refresh override applied on TRACKER_CONFLICT.
   // Cleared on next SSE lastUpdated tick so live updates resume.
   const [refreshedData, setRefreshedData] = useState<RoadmapData | null>(null);
@@ -369,6 +378,14 @@ export function Roadmap() {
           <StaleIndicator lastUpdated={lastUpdated} stale={stale} error={error} />
         </div>
       </div>
+
+      {showAuthorIntent && (
+        <div className="mb-6">
+          <AuthorIntentForm
+            onCreated={(externalId) => void handleConflictRefresh(externalId ?? '')}
+          />
+        </div>
+      )}
 
       {!data && !error && <p className="text-sm text-gray-500">Connecting to data stream…</p>}
 

--- a/packages/dashboard/src/client/stores/toastStore.ts
+++ b/packages/dashboard/src/client/stores/toastStore.ts
@@ -8,8 +8,24 @@ export interface ConflictToast {
   seq: number;
 }
 
+/**
+ * A transient success confirmation (e.g. an item was authored into the
+ * roadmap). Kept in a slot separate from {@link ConflictToast.current} so
+ * success feedback never supersedes — and is never superseded by — a
+ * TRACKER_CONFLICT toast: the two are independent, mutually-exclusive moments
+ * and the `current` conflict slot keeps its original type/contract intact.
+ */
+export interface SuccessToast {
+  kind: 'success';
+  message: string;
+  /** Monotonic counter so repeat successes re-trigger consumer effects. */
+  seq: number;
+}
+
 interface ToastStore {
   current: ConflictToast | null;
+  /** Latest success confirmation, or null. Independent of {@link current}. */
+  success: SuccessToast | null;
   /**
    * Push a new conflict toast, superseding any existing toast.
    *
@@ -23,11 +39,19 @@ interface ToastStore {
    *   single-toast model.
    */
   pushConflict: (input: { externalId: string; conflictedWith: string | null }) => void;
+  /**
+   * Push a success confirmation into the independent `success` slot. Same
+   * monotonic-`seq` supersession contract as {@link pushConflict}.
+   */
+  pushSuccess: (input: { message: string }) => void;
   clear: () => void;
+  /** Dismiss the current success confirmation without touching `current`. */
+  clearSuccess: () => void;
 }
 
 export const useToastStore = create<ToastStore>((set, get) => ({
   current: null,
+  success: null,
   pushConflict: ({ externalId, conflictedWith }) => {
     const prevSeq = get().current?.seq ?? 0;
     set({
@@ -39,5 +63,16 @@ export const useToastStore = create<ToastStore>((set, get) => ({
       },
     });
   },
+  pushSuccess: ({ message }) => {
+    const prevSeq = get().success?.seq ?? 0;
+    set({
+      success: {
+        kind: 'success',
+        message,
+        seq: prevSeq + 1,
+      },
+    });
+  },
   clear: () => set({ current: null }),
+  clearSuccess: () => set({ success: null }),
 }));

--- a/packages/dashboard/tests/client/components/roadmap/AuthorIntentForm.test.tsx
+++ b/packages/dashboard/tests/client/components/roadmap/AuthorIntentForm.test.tsx
@@ -1,0 +1,164 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { AuthorIntentForm } from '../../../../src/client/components/roadmap/AuthorIntentForm';
+import { useToastStore } from '../../../../src/client/stores/toastStore';
+
+/**
+ * Component-level acceptance coverage for the author-intent form.
+ * Phase 1 of the spec → AC2 (append body), AC4 (empty-title guard),
+ * AC5 (409 conflict preserves inputs), plus the success-clears half of AC3.
+ * The form is exercised in isolation with a mocked `fetch`; no real
+ * `POST /api/roadmap/append` is issued.
+ */
+
+function successResponse(body: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 201,
+    json: async () => ({ ok: true, featureName: 'X', externalId: 'github:o/r#7', ...body }),
+  };
+}
+
+function conflictResponse() {
+  return {
+    ok: false,
+    status: 409,
+    json: async () => ({
+      error: 'conflict',
+      code: 'TRACKER_CONFLICT',
+      externalId: 'github:o/r#42',
+      conflictedWith: '@alice',
+      refreshHint: 'reload-roadmap',
+    }),
+  };
+}
+
+beforeEach(() => {
+  useToastStore.getState().clear();
+  useToastStore.getState().clearSuccess();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('AuthorIntentForm', () => {
+  it('renders a Title input and a Description textarea (AC1 fields)', () => {
+    render(<AuthorIntentForm />);
+    expect(screen.getByLabelText(/what do you want built/i)).toBeDefined();
+    expect(screen.getByLabelText(/any detail/i)).toBeDefined();
+  });
+
+  it('AC2: submitting posts exactly one /api/roadmap/append with {title, summary}', async () => {
+    const fetchSpy = vi.fn(async () => successResponse());
+    vi.stubGlobal('fetch', fetchSpy);
+    const onCreated = vi.fn();
+    render(<AuthorIntentForm onCreated={onCreated} />);
+
+    fireEvent.change(screen.getByLabelText(/what do you want built/i), {
+      target: { value: '  A weekly digest  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/any detail/i), {
+      target: { value: '  send it every friday  ' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add to roadmap/i }));
+    });
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/roadmap/append');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      title: 'A weekly digest',
+      summary: 'send it every friday',
+    });
+    expect(onCreated).toHaveBeenCalledWith('github:o/r#7');
+  });
+
+  it('AC2: omits summary when the Description is empty', async () => {
+    const fetchSpy = vi.fn(async () => successResponse());
+    vi.stubGlobal('fetch', fetchSpy);
+    render(<AuthorIntentForm />);
+
+    fireEvent.change(screen.getByLabelText(/what do you want built/i), {
+      target: { value: 'Just a title' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add to roadmap/i }));
+    });
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ title: 'Just a title' });
+  });
+
+  it('AC3 (success half): clears fields and pushes a success toast on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => successResponse({ featureName: 'A weekly digest' }))
+    );
+    render(<AuthorIntentForm />);
+
+    const title = screen.getByLabelText(/what do you want built/i) as HTMLInputElement;
+    const desc = screen.getByLabelText(/any detail/i) as HTMLTextAreaElement;
+    fireEvent.change(title, { target: { value: 'A weekly digest' } });
+    fireEvent.change(desc, { target: { value: 'detail' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add to roadmap/i }));
+    });
+
+    await waitFor(() => expect(title.value).toBe(''));
+    expect(desc.value).toBe('');
+    expect(useToastStore.getState().success?.kind).toBe('success');
+    expect(useToastStore.getState().success?.message).toContain('A weekly digest');
+    expect(screen.getByTestId('author-intent-success')).toBeDefined();
+  });
+
+  it('AC4: an empty/whitespace title disables submit and issues no fetch', async () => {
+    const fetchSpy = vi.fn(async () => successResponse());
+    vi.stubGlobal('fetch', fetchSpy);
+    render(<AuthorIntentForm />);
+
+    const button = screen.getByRole('button', { name: /add to roadmap/i }) as HTMLButtonElement;
+    // Empty by default.
+    expect(button.disabled).toBe(true);
+    // Whitespace-only stays disabled.
+    fireEvent.change(screen.getByLabelText(/what do you want built/i), {
+      target: { value: '   ' },
+    });
+    expect(button.disabled).toBe(true);
+    // Even a forced form submit is guarded → no network call.
+    await act(async () => {
+      fireEvent.submit(button.closest('form') as HTMLFormElement);
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC5: a 409 conflict surfaces the conflict toast and preserves inputs', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => conflictResponse())
+    );
+    const onCreated = vi.fn();
+    render(<AuthorIntentForm onCreated={onCreated} />);
+
+    const title = screen.getByLabelText(/what do you want built/i) as HTMLInputElement;
+    const desc = screen.getByLabelText(/any detail/i) as HTMLTextAreaElement;
+    fireEvent.change(title, { target: { value: 'Contested item' } });
+    fireEvent.change(desc, { target: { value: 'keep me' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add to roadmap/i }));
+    });
+
+    await waitFor(() => expect(useToastStore.getState().current?.externalId).toBe('github:o/r#42'));
+    expect(useToastStore.getState().current?.conflictedWith).toBe('@alice');
+    // Inputs preserved for retry; no success, no onCreated.
+    expect(title.value).toBe('Contested item');
+    expect(desc.value).toBe('keep me');
+    expect(useToastStore.getState().success).toBeNull();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/tests/client/pages/Roadmap.authorIntent.test.tsx
+++ b/packages/dashboard/tests/client/pages/Roadmap.authorIntent.test.tsx
@@ -1,0 +1,173 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import type { RoadmapData, DashboardFeature } from '../../../src/shared/types';
+
+/**
+ * Page-level acceptance coverage for the author-intent panel on the Roadmap
+ * page. Phase 2/3 of the spec → AC1 (fields render, no chat thread on mount),
+ * AC3 (success re-fetch surfaces the new row in FeatureTable), AC6 (lane
+ * gating: pm-ba/dev render, client hidden).
+ *
+ * `useSSE` is mocked (no EventSource in jsdom) and `fetch` is stubbed.
+ */
+
+function feature(name: string): DashboardFeature {
+  return {
+    name,
+    status: 'planned',
+    summary: '',
+    milestone: 'Backlog',
+    blockedBy: [],
+    assignee: null,
+    priority: null,
+    spec: null,
+    plans: [],
+    externalId: null,
+    updatedAt: null,
+  };
+}
+
+function makeRoadmap(names: string[]): RoadmapData {
+  return {
+    milestones: [
+      {
+        name: 'Backlog',
+        isBacklog: true,
+        total: names.length,
+        done: 0,
+        inProgress: 0,
+        planned: names.length,
+        blocked: 0,
+        backlog: names.length,
+        needsHuman: 0,
+      },
+    ],
+    features: names.map(feature),
+    assignmentHistory: [],
+    totalFeatures: names.length,
+    totalDone: 0,
+    totalInProgress: 0,
+    totalPlanned: names.length,
+    totalBlocked: 0,
+    totalBacklog: names.length,
+    totalNeedsHuman: 0,
+  };
+}
+
+// Mock SSE to seed the page with one existing backlog item.
+vi.mock('../../../src/client/hooks/useSSE', () => ({
+  useSSE: () => ({
+    data: { roadmap: makeRoadmap(['Existing item']) },
+    lastUpdated: '2026-08-15T00:00:00Z',
+    stale: false,
+    error: null,
+  }),
+}));
+
+// Import AFTER the mock is registered.
+const { Roadmap } = await import('../../../src/client/pages/Roadmap');
+const { RoleProvider } = await import('../../../src/client/hooks/useRole');
+const { useToastStore } = await import('../../../src/client/stores/toastStore');
+const { useThreadStore } = await import('../../../src/client/stores/threadStore');
+
+const STORAGE_KEY = 'harness.dashboard.role';
+
+function stubFetch(roadmapAfterAppend: RoadmapData) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string, init?: RequestInit) => {
+      // Order matters: /api/roadmap/append is a prefix-match of /api/roadmap.
+      if (input.startsWith('/api/roadmap/append')) {
+        expect(init?.method).toBe('POST');
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ ok: true, featureName: 'New digest', externalId: 'github:o/r#711' }),
+        };
+      }
+      if (input.startsWith('/api/roadmap')) {
+        return { ok: true, status: 200, json: async () => roadmapAfterAppend };
+      }
+      if (input.startsWith('/api/identity')) {
+        return { ok: true, json: async () => ({ username: 'chadjw', source: 'gh-cli' }) };
+      }
+      return { ok: false, status: 404, json: async () => ({ error: 'unknown' }) };
+    })
+  );
+}
+
+function renderRoadmap() {
+  return render(
+    <MemoryRouter>
+      <RoleProvider>
+        <Roadmap />
+      </RoleProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useToastStore.getState().clear();
+  useToastStore.getState().clearSuccess();
+  Element.prototype.scrollIntoView = vi.fn();
+  stubFetch(makeRoadmap(['Existing item', 'New digest']));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe('Roadmap author-intent panel', () => {
+  it('AC1: renders the form fields in the pm-ba lane without creating a chat thread on mount', async () => {
+    localStorage.setItem(STORAGE_KEY, 'pm-ba');
+    const createSpy = vi.spyOn(useThreadStore.getState(), 'createThread');
+    renderRoadmap();
+
+    expect(screen.getByLabelText(/what do you want built/i)).toBeDefined();
+    expect(screen.getByLabelText(/any detail/i)).toBeDefined();
+    // No slash command / chat thread is spun up just by landing on the page.
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('AC3: a successful submit clears the field, toasts, and surfaces the new row', async () => {
+    localStorage.setItem(STORAGE_KEY, 'pm-ba');
+    renderRoadmap();
+
+    const title = screen.getByLabelText(/what do you want built/i) as HTMLInputElement;
+    fireEvent.change(title, { target: { value: 'New digest' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add to roadmap/i }));
+    });
+
+    await waitFor(() => expect(title.value).toBe(''));
+    expect(useToastStore.getState().success?.message).toContain('New digest');
+    // The page re-fetched /api/roadmap and the new backlog row is now rendered.
+    await waitFor(() => expect(screen.getByText('New digest')).toBeDefined());
+  });
+
+  it('AC6: the panel renders for dev and pm-ba but is hidden for client', () => {
+    // dev
+    localStorage.setItem(STORAGE_KEY, 'dev');
+    const dev = renderRoadmap();
+    expect(dev.queryByText(/author intent/i)).not.toBeNull();
+    dev.unmount();
+
+    // pm-ba
+    localStorage.setItem(STORAGE_KEY, 'pm-ba');
+    const pmba = renderRoadmap();
+    expect(pmba.queryByText(/author intent/i)).not.toBeNull();
+    pmba.unmount();
+
+    // client — hidden
+    localStorage.setItem(STORAGE_KEY, 'client');
+    const client = renderRoadmap();
+    expect(client.queryByText(/author intent/i)).toBeNull();
+    expect(client.queryByLabelText(/what do you want built/i)).toBeNull();
+    client.unmount();
+  });
+});


### PR DESCRIPTION
## Role-shaped dashboard front doors — the PM/BA author-intent lane (#711)

**Status: DRAFT — autonomously drafted spec, now with the buildable slice implemented. Awaiting human review; do not merge as-is.**

This PR began as the DRAFT spec (`docs/changes/role-shaped-dashboard-front-doors/proposal.md`) and now also carries the implementation of that spec's **Buildable slice**: a first-class, plain-language **"Author intent"** panel on the Roadmap page (`/s/roadmap`, the pm-ba lane's landing route), rendered only in the `pm-ba` and `dev` lanes and hidden from `client`.

An honest grounding pass found that #711's other two verbs (watch agents, adjudicate) and the lane-scoping machinery itself already shipped (#1132/#1137); the remaining genuine gap was **authoring intent without a terminal**. This slice writes a backlog item through the already-shipped `appendToRoadmap` → `POST /api/roadmap/append`, reusing the shipped `fetchWithConflict` / toast / `ConflictToastRegion` plumbing. It invents no new endpoint or role, and lanes stay **presentation-only** (the server `AUTHORIZATION SEAM` is untouched — a hand-typed request still reaches the endpoint regardless of lane).

### What changed
- `packages/dashboard/src/client/components/roadmap/AuthorIntentForm.tsx` — new controlled Title + Description form; no chat thread, no slash command.
- `packages/dashboard/src/client/pages/Roadmap.tsx` — mounts the form at the top of the page, gated by `useRole()` (`pm-ba`/`dev` only); wires success to the page's existing roadmap re-fetch.
- `packages/dashboard/src/client/stores/toastStore.ts` — **additive** `success` slot + `pushSuccess`/`clearSuccess` (the shipped store was conflict-only; the existing `current` conflict slot and its type are unchanged, so `ConflictToastRegion` and every existing toast test are untouched).
- Plan artifact + roadmap shard/aggregate `Plan:` link.
- Tests: `AuthorIntentForm.test.tsx`, `Roadmap.authorIntent.test.tsx`.

### Acceptance-criteria coverage
- **AC1** — pm-ba `/s/roadmap` renders Title + Description with no chat thread created on mount → `Roadmap.authorIntent.test.tsx` (createThread not called) + `AuthorIntentForm.test.tsx`.
- **AC2** — exactly one `POST /api/roadmap/append` with body `{ title, summary }`; `summary` omitted when Description is blank → `AuthorIntentForm.test.tsx`.
- **AC3** — success clears fields, pushes a success toast, and the new row appears in `FeatureTable` after the `GET /api/roadmap` re-fetch → `AuthorIntentForm.test.tsx` (clears + toast) + `Roadmap.authorIntent.test.tsx` (new row via re-fetch).
- **AC4** — empty/whitespace title disables submit and issues zero fetch → `AuthorIntentForm.test.tsx`.
- **AC5** — a 409 conflict surfaces the existing conflict toast and preserves Title/Description for retry → `AuthorIntentForm.test.tsx`.
- **AC6** — lane gating: renders for `pm-ba`/`dev`, hidden for `client` → `Roadmap.authorIntent.test.tsx`.
- **AC7** (invariant) — no server-side authorization added; `AUTHORIZATION SEAM`, `shared/roles.ts`, `types/roles.ts` presentation wording untouched; `roles.test.ts` + `identity-role.test.ts` pass unmodified.

Full dashboard suite: **927 passing** (baseline 918 + 9 new).

### Deviation note for the reviewer
The spec named `toastStore` as the surface that carries the **success** toast, but the shipped store was **conflict-only**. Rather than invent a new store, I added an **additive** success channel (`success` slot + `pushSuccess`) alongside the untouched `current` conflict slot. Also: the append endpoint responds **201** (not 200 as the spec's AC3 illustration says); `fetchWithConflict` treats any 2xx as success, so behavior is unchanged.

### Open questions for the human reviewer (carried forward from the spec)
1. **Scope check:** is the author-intent edge the right slice, given watch + adjudicate + lane scoping already shipped (#1132/#1137)? Or should #711 instead be re-scoped to server-side lane _enforcement_ (the deferred `AUTHORIZATION SEAM`) — a larger, hosting-dependent effort?
2. **Backlog target:** the append endpoint writes to the Backlog milestone. Should PM/BA-authored items land somewhere more visible (a "Proposed by PM/BA" bucket) so a human triages them before they enter the pilot's pickup set?
3. **Client lane:** should the `client` lane get a strictly read-only progress view later, or is hiding the authoring panel sufficient for now?
4. **Guardrails:** the server already rejects newlines/`###`; do we want additional length/rate limits on a non-technical write surface before it's exposed in a hosted context?
