### PR TITLE
fix(graph): method-level @RequestMapping no longer overwrites Java basePath

### DIFF
--- a/.changeset/apipath-java-basepath-scope.md
+++ b/.changeset/apipath-java-basepath-scope.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/graph': patch
+---
+
+fix(graph): method-level @RequestMapping no longer overwrites Java basePath
+
+ApiPathExtractor now derives the file-wide Spring basePath only from a
+class/interface/enum-level `@RequestMapping`, classified by its target declaration
+rather than the brittle "this line lacks `class`" heuristic. A method-level
+`@RequestMapping` now contributes the method path (e.g. class `/api` + method `/foo`
+resolves to `/api/foo`) instead of overwriting basePath, and the class-level
+annotation is no longer emitted as a spurious endpoint.

--- a/docs/changes/fix-apipath-java-basepath-scope/plans/plan.md
+++ b/docs/changes/fix-apipath-java-basepath-scope/plans/plan.md
@@ -1,0 +1,47 @@
+# Plan: method-level @RequestMapping no longer overwrites Java basePath
+
+**Issue:** #1367
+**Spec:** ../proposal.md
+**Owning package:** `@harness-engineering/graph`
+
+## Tasks
+
+### T1 — Regression test + fixture (TDD red)
+
+- Add fixture `packages/graph/__fixtures__/extractor-project/RoutesMethodMapping.java`
+  with a class-level `@RequestMapping("/api")` and a method-level
+  `@RequestMapping("/foo")`.
+- Add a test in `packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts`
+  asserting the resolved record name is `ANY /api/foo` (and that neither `ANY /foo`
+  nor `ANY /foo/foo` appears).
+- Run test → expect RED (current heuristic yields `/foo/foo`).
+
+### T2 — Implement target-declaration classification (green)
+
+- In `extractJava`, add a helper `targetIsTypeDeclaration(lines, annotationLineIndex)`:
+  scan forward from the annotation line, skip lines that are blank, line comments
+  (`//`), or annotations (`@...`), stop at the first real declaration line, return
+  whether it matches `/\b(class|interface|enum)\b/`.
+- basePath loop: set `basePath` only when the `@RequestMapping` target is a type.
+- endpoint loop: skip emitting a `@RequestMapping` whose target is a type
+  (it is the class basePath, not an endpoint).
+- Run test → expect GREEN. Confirm existing `Routes.java` Spring test still green.
+
+### T3 — Validate + gates
+
+- `pnpm turbo build --filter=@harness-engineering/graph`
+- `pnpm --filter @harness-engineering/graph exec tsc --noEmit` (typecheck)
+- Full `ApiPathExtractor.test.ts` suite green.
+- Lint changed files.
+- Add changeset (patch, `@harness-engineering/graph`), prettier --write changed files.
+
+## Checkpoints
+
+- After T1: reproducing test fails on current code (proves the bug).
+- After T2: new test + all prior extractor tests pass.
+- After T3: build/typecheck/lint clean, changeset present.
+
+## Risks
+
+- The class-level `@RequestMapping` re-matching the endpoint pattern (spurious record)
+  — mitigated by the endpoint-loop skip. Verified by asserting record count/absence.

--- a/docs/changes/fix-apipath-java-basepath-scope/proposal.md
+++ b/docs/changes/fix-apipath-java-basepath-scope/proposal.md
@@ -1,0 +1,74 @@
+# Fix: method-level @RequestMapping no longer overwrites Java basePath
+
+**Issue:** #1367
+**Keywords:** api-path-extractor, java, spring, RequestMapping, basePath, code-graph, ingest
+
+> Autonomous fleet lane. No human sign-off is available in this context; the recommended defaults from the issue are taken and recorded as assumptions below.
+
+## Overview and Goals
+
+`ApiPathExtractor.extractJava` derives a file-wide `basePath` from the class-level
+`@RequestMapping(...)` annotation and prefixes it onto every method endpoint. The
+current heuristic sets `basePath` for **any** `@RequestMapping(...)` line where the
+same line lacks the `class` keyword. In idiomatic Spring code the annotation always
+sits on its own line above the declaration, so a **method-level** `@RequestMapping`
+(which also lacks `class` on its line) wrongly overwrites the class-level basePath.
+
+Goal: `basePath` must come only from a **class/interface/enum-level**
+`@RequestMapping`. A method-level `@RequestMapping` must contribute the **method**
+path (prefixed by the class basePath), not replace basePath.
+
+## Problem Boundary
+
+- **In scope:** the `basePath` selection loop in `extractJava` (single file,
+  `packages/graph/src/ingest/extractors/ApiPathExtractor.ts`), plus a regression test
+  and a fixture.
+- **Out of scope:** other languages/frameworks, multi-`@RequestMapping` merge
+  semantics, method-name-array path forms, non-string annotation attributes.
+
+## Decisions Made
+
+| Decision                                                                                                                                                                                        | Rationale                                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Classify each `@RequestMapping` by its **target declaration** (the next non-annotation, non-blank, non-comment line): only set `basePath` when that target contains `class`/`interface`/`enum`. | Directly matches Java semantics — a class-level annotation annotates a type declaration; a method-level one annotates a method. Replaces the brittle "this line lacks `class`" heuristic. (Recommended default from issue #1367.) |
+| A class-level `@RequestMapping` used as basePath is **not** additionally emitted as an endpoint.                                                                                                | Prevents a spurious `ANY /api/api` record (the class annotation would otherwise re-match the endpoint pattern and be prefixed by its own basePath). Preserves the existing fixture's record set.                                  |
+| Preserve existing `Routes.java` fixture behavior; add a new fixture for the method-level case.                                                                                                  | Keeps the current Spring test green while adding the regression coverage the issue requires.                                                                                                                                      |
+
+## Technical Design
+
+Add a small helper that, from a `@RequestMapping` line index, finds the target
+declaration line by scanning forward past annotation lines (`@...`), blank lines, and
+line comments, then reports whether that declaration is a **type** (matches
+`\b(class|interface|enum)\b`).
+
+- **basePath loop:** set `basePath` only when the `@RequestMapping` target is a type.
+- **endpoint loop:** when a matched annotation is a class-level `@RequestMapping`
+  (target is a type), skip emitting it as an endpoint; otherwise emit as today with
+  the resolved `basePath + path`.
+
+Resolved path for a class `@RequestMapping("/api")` + method `@RequestMapping("/foo")`
+becomes `/api/foo` (method `ANY`).
+
+## Integration Points
+
+- **Entry Points:** none new — internal behavior of the existing `api-paths`
+  extractor consumed by graph ingest.
+- **Registrations Required:** none — no new exports, tools, or routes.
+- **Documentation Updates:** None (small internal bug fix).
+- **Architectural Decisions:** None.
+- **Knowledge Impact:** None.
+
+## Success Criteria
+
+1. Class-level `@RequestMapping("/api")` + method-level `@RequestMapping("/foo")`
+   resolves to `/api/foo` (not `/foo` and not `/foo/foo`). (New regression test.)
+2. Existing `Routes.java` Spring test stays green (endpoints resolve under `/api`).
+3. No spurious endpoint record is emitted for the class-level `@RequestMapping`.
+4. `@harness-engineering/graph` builds, typechecks, lints, and all
+   `ApiPathExtractor` tests pass.
+
+## Implementation Order
+
+1. TDD: add regression test + fixture for the method-level `@RequestMapping` case (red).
+2. Implement target-declaration classification in `extractJava` (green).
+3. Build, typecheck, lint, run full extractor suite.

--- a/docs/changes/fix-apipath-java-basepath-scope/provenance.json
+++ b/docs/changes/fix-apipath-java-basepath-scope/provenance.json
@@ -1,0 +1,38 @@
+{
+  "issue": 1367,
+  "slug": "fix-apipath-java-basepath-scope",
+  "branch": "fix/apipath-java-basepath",
+  "owningPackage": "@harness-engineering/graph",
+  "pipelineStages": [
+    {
+      "stage": "brainstorming",
+      "artifact": "docs/changes/fix-apipath-java-basepath-scope/proposal.md"
+    },
+    {
+      "stage": "planning",
+      "artifact": "docs/changes/fix-apipath-java-basepath-scope/plans/plan.md"
+    },
+    {
+      "stage": "tdd-execution",
+      "artifacts": [
+        "packages/graph/__fixtures__/extractor-project/RoutesMethodMapping.java",
+        "packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts",
+        "packages/graph/src/ingest/extractors/ApiPathExtractor.ts"
+      ]
+    }
+  ],
+  "planArtifact": "docs/changes/fix-apipath-java-basepath-scope/plans/plan.md",
+  "assumptions": [
+    "Autonomous fleet lane: no human sign-off available; took the issue's recommended fix as default (classify @RequestMapping by its target declaration; only class/interface/enum targets set basePath).",
+    "A class-level @RequestMapping used as basePath is not additionally emitted as an endpoint, preventing a spurious ANY /api/api record.",
+    "Target-declaration detection scans forward past annotations, blank lines, and // line comments to the first real declaration line.",
+    "Preserved the existing Routes.java Spring fixture unchanged; added a new RoutesMethodMapping.java fixture for the method-level regression case.",
+    "Ran brainstorming/plan/TDD stages directly (fast mode) rather than via interactive human gates, since no human is reachable in this lane."
+  ],
+  "localChecks": {
+    "build": "pass",
+    "typecheck": "pass",
+    "test": "pass (968 graph tests, incl. new regression)",
+    "lint": "pass"
+  }
+}

--- a/packages/graph/__fixtures__/extractor-project/RoutesMethodMapping.java
+++ b/packages/graph/__fixtures__/extractor-project/RoutesMethodMapping.java
@@ -1,0 +1,18 @@
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class LegacyController {
+
+    // Method-level @RequestMapping must contribute the method path,
+    // not overwrite the class-level basePath.
+    @RequestMapping("/foo")
+    public String foo() {
+        return null;
+    }
+
+    @GetMapping("/bar")
+    public String bar() {
+        return null;
+    }
+}

--- a/packages/graph/src/ingest/extractors/ApiPathExtractor.ts
+++ b/packages/graph/src/ingest/extractors/ApiPathExtractor.ts
@@ -236,11 +236,29 @@ export class ApiPathExtractor implements SignalExtractor {
     const springPattern =
       /@(GetMapping|PostMapping|PutMapping|PatchMapping|DeleteMapping|RequestMapping)\s*\(\s*(?:value\s*=\s*)?["']([^"']+)["']/;
 
-    // Base path from @RequestMapping on class
+    // Whether the @RequestMapping at `lineIndex` annotates a type declaration
+    // (class/interface/enum) rather than a method. The annotation sits on its own
+    // line above its target, so scan forward past further annotations, blank lines,
+    // and line comments to the first real declaration line.
+    const targetIsTypeDeclaration = (lineIndex: number): boolean => {
+      for (let j = lineIndex + 1; j < lines.length; j++) {
+        const next = lines[j]!.trim();
+        if (next === '' || next.startsWith('//') || next.startsWith('@')) {
+          continue;
+        }
+        return /\b(class|interface|enum)\b/.test(next);
+      }
+      return false;
+    };
+
+    // Base path comes only from a CLASS/interface/enum-level @RequestMapping.
+    // A method-level @RequestMapping must NOT overwrite the file-wide basePath.
     let basePath = '';
-    for (const line of lines) {
-      const baseMatch = line.match(/@RequestMapping\s*\(\s*(?:value\s*=\s*)?["']([^"']+)["']\s*\)/);
-      if (baseMatch && line.match(/class\s/) === null) {
+    for (let i = 0; i < lines.length; i++) {
+      const baseMatch = lines[i]!.match(
+        /@RequestMapping\s*\(\s*(?:value\s*=\s*)?["']([^"']+)["']\s*\)/
+      );
+      if (baseMatch && targetIsTypeDeclaration(i)) {
         basePath = baseMatch[1]!;
       }
     }
@@ -251,6 +269,11 @@ export class ApiPathExtractor implements SignalExtractor {
       const match = line.match(springPattern);
       if (match) {
         const annotation = match[1]!;
+        // A class-level @RequestMapping is the base path, not an endpoint — skip it
+        // so it is not emitted as a spurious `ANY <basePath><basePath>` record.
+        if (annotation === 'RequestMapping' && targetIsTypeDeclaration(i)) {
+          continue;
+        }
         const routePath = basePath + match[2]!;
         const methodMap: Record<string, string> = {
           GetMapping: 'GET',

--- a/packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts
+++ b/packages/graph/tests/ingest/extractors/ApiPathExtractor.test.ts
@@ -87,6 +87,30 @@ describe('ApiPathExtractor', () => {
     expect(getUsers!.metadata.framework).toBe('spring');
   });
 
+  it('does not let a method-level @RequestMapping overwrite the class basePath', () => {
+    const content = readFixture('RoutesMethodMapping.java');
+    const records = extractor.extract(content, 'RoutesMethodMapping.java', 'java');
+
+    const names = records.map((r) => r.name);
+
+    // Method-level @RequestMapping("/foo") under class @RequestMapping("/api")
+    // must resolve to /api/foo — not /foo (basePath lost) or /foo/foo (basePath polluted).
+    expect(names).toContain('ANY /api/foo');
+    expect(names).not.toContain('ANY /foo');
+    expect(names).not.toContain('ANY /foo/foo');
+
+    // The sibling @GetMapping must also resolve under the class basePath.
+    expect(names).toContain('GET /api/bar');
+
+    // The class-level @RequestMapping must not be emitted as its own endpoint.
+    expect(names).not.toContain('ANY /api/api');
+
+    const foo = records.find((r) => r.name === 'ANY /api/foo');
+    expect(foo!.metadata.method).toBe('ANY');
+    expect(foo!.metadata.path).toBe('/api/foo');
+    expect(foo!.metadata.framework).toBe('spring');
+  });
+
   it('generates stable IDs', () => {
     const content = readFixture('routes.ts');
     const records1 = extractor.extract(content, 'routes.ts', 'typescript');


### PR DESCRIPTION
Closes #1367

## Problem
`ApiPathExtractor.extractJava` derived the file-wide Spring `basePath` from **any** `@RequestMapping(...)` line where that same line lacked the `class` keyword. Because the annotation sits on its own line *above* its target declaration, a **method-level** `@RequestMapping` (which also lacks `class` on its line) wrongly **overwrote** the class-level basePath — yielding wrong resolved API paths in the Java code graph.

## Fix
Each `@RequestMapping` is now classified by its **target declaration** — the next non-annotation, non-blank, non-comment line. Only a **class/interface/enum** target sets `basePath`. A method-level `@RequestMapping` contributes the **method** path prefixed by the class basePath (class `/api` + method `/foo` → `/api/foo`). The class-level `@RequestMapping` is no longer emitted as a spurious `ANY /api/api` endpoint.

## Tests
- New regression test + `RoutesMethodMapping.java` fixture: class `@RequestMapping("/api")` + method `@RequestMapping("/foo")` resolves to `/api/foo` (asserts NOT `/foo`, NOT `/foo/foo`, NOT `/api/api`).
- Existing `Routes.java` Spring fixture + test preserved and green.
- Full graph suite: 968 tests pass. Build, typecheck, lint clean.

## Assumptions (autonomous fleet lane — no human sign-off available)
- Took the issue's recommended fix (classify by target declaration; only class/interface/enum set basePath).
- A class-level `@RequestMapping` used as basePath is not additionally emitted as an endpoint.
- Target detection scans forward past annotations, blank lines, and `//` line comments.

Artifacts: spec + plan + provenance under `docs/changes/fix-apipath-java-basepath-scope/`.