### PR TITLE
fix(entropy): drift no longer flags working links (slug + nested-fence)

### DIFF
--- a/.changeset/fix-drift-working-links.md
+++ b/.changeset/fix-drift-working-links.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(entropy): drift no longer flags working links (slug + nested-fence)
+
+`checkStructureDrift` no longer reports working documentation links as drift.
+`slugifyHeading` now matches GitHub's GFM slugger: it keeps the leading hyphen
+an emoji leaves behind (`## 📖 Usage` → `#-usage`) and preserves Unicode letters
+(`## Café` → `#café`) instead of dropping them as ASCII `\w` did. A new
+nesting-aware fence stripper closes a fence only on a same-character run at least
+as long as the opener, so a 4-tick fence wrapping a 3-tick block no longer
+exposes the inner half; it is shared by both link and heading extraction, so a
+`# Title` quoted inside a fence is no longer treated as a real anchor. Duplicate
+headings now disambiguate GitHub-style (a second `## Setup` anchors at
+`#setup-1`). Preserves the earlier fence-awareness and `&`-heading fixes.

--- a/docs/changes/fix-drift-working-links-false-positive/plans/plan.md
+++ b/docs/changes/fix-drift-working-links-false-positive/plans/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Fix drift working-link false positives (#1342)
+
+Spec: `docs/changes/fix-drift-working-links-false-positive/proposal.md`
+Target file: `packages/core/src/entropy/detectors/drift.ts`
+Tests: `packages/core/tests/entropy/detectors/drift.test.ts`
+
+## Task 1 — TDD: add failing unit tests (RED)
+
+Extend the existing `drift detector — issue #1342/#1332 regressions` describe
+block with cases:
+
+- `## 📖 Usage` heading + link `#-usage` → 0 structure drifts.
+- `## Café` heading + link `#café` → 0 structure drifts.
+- Nested 4-tick fence wrapping a 3-tick fence, with a broken-looking link in the
+  second half of the quoted region → 0 structure drifts (inner half not exposed).
+- `# Title` heading inside a fenced block → an anchor link `#title` to the OUTER
+  file is flagged (in-fence heading is NOT a real anchor).
+- Duplicate `## Setup` headings; link to `#setup-1` → 0 structure drifts.
+
+Verify these FAIL against current code before implementing.
+
+## Task 2 — Fix `slugifyHeading` (GREEN part 1)
+
+Replace body with:
+
+```ts
+return text
+  .toLowerCase()
+  .replace(/[^\p{L}\p{N}\s_-]/gu, '')
+  .replace(/\s/g, '-');
+```
+
+Update the JSDoc to note Unicode-aware, no-trim semantics.
+
+## Task 3 — Add nesting-aware `blankFencedRegions` and route both call sites
+
+- Add module-private `blankFencedRegions(content: string): string`:
+  - Split into lines; track `fence: { char, len } | null`.
+  - Open on `^\s*(`{3,}|~{3,})` when closed; record char + run length; blank line.
+  - When open, close only on same-char run `>= len` with whitespace-only trailer;
+    otherwise blank the line. Blank the closer too.
+  - Join with `\n` (line count preserved).
+- `extractFileLinks`: strip via `blankFencedRegions` up front; remove
+  `inFencedCodeBlock` toggle and the fence-line `continue`.
+- `extractHeadingSlugs`: strip via `blankFencedRegions` before the heading regex.
+
+## Task 4 — Duplicate-heading dedup in `extractHeadingSlugs` (GREEN part 2)
+
+Track `const seen = new Map<string, number>()`; for each heading compute
+`base = slugifyHeading(...)`, `count = seen.get(base) ?? 0`, `seen.set(base, count+1)`,
+add `count === 0 ? base : \`${base}-${count}\``.
+
+## Task 5 — Verify
+
+- `pnpm vitest run tests/entropy/detectors/drift.test.ts` (all green: new + #1363
+  - #492 + #816 regressions).
+- `pnpm turbo build --filter=@harness-engineering/core`, typecheck, lint.
+- Add changeset (patch, `@harness-engineering/core`), prettier --write changed files.
+
+## Checkpoints
+
+- After Task 1: tests RED (confirm reproduction).
+- After Task 4: tests GREEN.
+- After Task 5: build/typecheck/lint green; ready to commit.

--- a/docs/changes/fix-drift-working-links-false-positive/proposal.md
+++ b/docs/changes/fix-drift-working-links-false-positive/proposal.md
@@ -1,0 +1,103 @@
+# Fix: checkStructureDrift reports working links as drift (slug + nested-fence)
+
+**Keywords:** entropy, drift, structure-drift, slugify, gfm-anchor, fenced-code, unicode-slug, heading-dedup
+
+**Issue:** #1342
+
+## Overview and Goals
+
+`checkStructureDrift` in `packages/core/src/entropy/detectors/drift.ts` reports
+working documentation links as drift. On one consumer repo (canary) these
+account for 27 of 27 structural drift findings — a 100% false-positive rate that
+makes the check unable to surface a genuinely dead link.
+
+A prior partial fix (PR #1363) added fence-awareness to `extractFileLinks` and
+`&`-heading handling to `slugifyHeading`. **Those gains must not regress.** Two
+defects remain live:
+
+1. **`slugifyHeading` slugs incorrectly.** It calls `.trim()` _before_ converting
+   whitespace to hyphens, so `## 📖 Usage` slugs to `usage` where GitHub emits
+   `-usage` (GitHub keeps the space the emoji left behind). It also uses `\w`
+   (ASCII-only), so `## Café` slugs to `caf` where GitHub keeps `café`.
+2. **Fence handling is not nesting-aware.** `extractFileLinks` uses a naive
+   open/close backtick toggle, so a 4-tick ` ` ``region wrapping a
+3-tick` ` ` region re-toggles on the inner fence and exposes the second
+   half of the quoted document. Separately, `extractHeadingSlugs` reads headings
+   that live _inside_ fenced blocks (a `# Title` in a quoted example registers as
+   a real anchor) and does not disambiguate duplicate headings the way GitHub
+   does (`## Setup` twice → `#setup`, `#setup-1`).
+
+Goal: `checkStructureDrift` matches GitHub's anchor semantics for emoji/accented/
+duplicate headings and treats nested fences correctly, while preserving the
+#1363 fence-awareness and `&`-heading behavior.
+
+## Decisions Made
+
+- **Fix `slugifyHeading` per the issue's recommended default.** Drop the
+  `.trim()`; map each whitespace character to one hyphen (`/\s/g`, already the
+  case post-#1363); replace the ASCII `\w` class with Unicode `\p{L}\p{N}` plus
+  an explicit `_` and `-` (the `u` flag). Rationale: mirrors GitHub's GFM slugger
+  for the common hand-written-anchor case, which is what the check validates
+  against. (Assumption A1)
+- **Introduce a single nesting-aware fence-stripping helper.** A shared
+  `blankFencedRegions(content)` blanks every line inside a fenced region
+  (preserving line numbers so link line reporting stays correct) and requires a
+  fence CLOSE to be the _same_ fence character with a run length `>=` the
+  opener's, with no info string — matching CommonMark/GFM. Both `extractFileLinks`
+  and `extractHeadingSlugs` route content through it, replacing the ad-hoc toggle.
+  Rationale: one correct implementation shared by both call sites avoids the two
+  detectors drifting apart. (Assumption A2)
+- **Dedup duplicate headings GitHub-style.** In `extractHeadingSlugs`, track base
+  slug counts; the Nth (N>1) occurrence of a base slug anchors at `base-{N-1}`.
+  (Assumption A3)
+
+## Technical Design
+
+`packages/core/src/entropy/detectors/drift.ts`:
+
+- `slugifyHeading(text)`:
+  ```ts
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s_-]/gu, '')
+    .replace(/\s/g, '-');
+  ```
+- New `blankFencedRegions(content: string): string` — line-by-line; tracks an
+  open fence `{ char, len }`; opens on `^\s*(`{3,}|~{3,})`; closes only on a bare
+same-char run `>= len` with whitespace-only trailer; blanks opener, body, and
+  closer lines (line count preserved).
+- `extractFileLinks(content)` — pre-pass `content` through `blankFencedRegions`,
+  drop the local `inFencedCodeBlock` toggle; iterate the blanked lines.
+- `extractHeadingSlugs(filePath)` — pre-pass file content through
+  `blankFencedRegions`; run the existing heading regex over the blanked content;
+  dedup via a `Map<string, number>` of base-slug counts.
+
+## Integration Points
+
+- **Entry Points:** None new — internal helpers of the existing structure-drift
+  detector reached via `detectDocDrift` / `checkStructureDrift`.
+- **Registrations Required:** None (no new exports; `blankFencedRegions` is
+  module-private).
+- **Documentation Updates:** None (no CLI/command surface change).
+- **Architectural Decisions:** None (small change, < 3 files).
+- **Knowledge Impact:** None.
+
+## Success Criteria
+
+1. `## 📖 Usage` slugs to `-usage`; a link to `#-usage` is not flagged.
+2. `## Café` slugs to `café`; a link to `#café` is not flagged.
+3. A 3-tick fence wrapped in a 4-tick fence does not expose the inner half — a
+   link in the second half of the quoted region is not flagged.
+4. A heading inside a fenced block does not register as a real anchor.
+5. Duplicate headings dedup: second `## Setup` anchors at `#setup-1`.
+6. All pre-existing #1363 behavior (fence-awareness, `## Tips & Tricks` →
+   `tips--tricks`) still passes.
+7. Build, typecheck, lint, and the drift detector's vitest suite are green.
+
+## Implementation Order
+
+1. TDD: add failing unit tests for criteria 1–5 (emoji, accented, nested fence,
+   in-fence heading, duplicate headings).
+2. Implement `slugifyHeading` fix, `blankFencedRegions`, and route both call
+   sites through it; add dedup.
+3. Verify all drift tests (new + #1363 + #492 + #816) green; build/typecheck/lint.

--- a/docs/changes/fix-drift-working-links-false-positive/provenance.json
+++ b/docs/changes/fix-drift-working-links-false-positive/provenance.json
@@ -1,0 +1,30 @@
+{
+  "issue": 1342,
+  "title": "checkStructureDrift reports working links as drift (slug + nested-fence)",
+  "branch": "fix/drift-working-links",
+  "pipelineStages": [
+    "harness-brainstorming (spec authored non-interactively; autonomous fleet lane, no human interview)",
+    "planning (plan artifact authored)",
+    "tdd (5 failing unit tests authored RED, then implementation to GREEN)",
+    "execution (implementation of slugifyHeading + blankFencedRegions + heading dedup)",
+    "verification (build, typecheck, lint, vitest all green)"
+  ],
+  "specArtifact": "docs/changes/fix-drift-working-links-false-positive/proposal.md",
+  "planArtifact": "docs/changes/fix-drift-working-links-false-positive/plans/plan.md",
+  "targetFile": "packages/core/src/entropy/detectors/drift.ts",
+  "testFile": "packages/core/tests/entropy/detectors/drift.test.ts",
+  "priorArt": "PR #1363 added fence-awareness + '&'-heading handling; preserved (not regressed).",
+  "assumptions": [
+    "A1: Applied the issue's recommended slugifyHeading fix verbatim — drop .trim(), map each whitespace char to one hyphen, replace ASCII \\w with Unicode \\p{L}\\p{N} plus explicit _ and - under the u flag.",
+    "A2: Introduced a single module-private blankFencedRegions(content) helper shared by extractFileLinks and extractHeadingSlugs; a fence CLOSE requires the same fence char with run length >= the opener's and no info string (CommonMark/GFM). Line count is preserved so link/heading line numbers stay accurate.",
+    "A3: Duplicate-heading dedup follows GitHub: the Nth (N>1) occurrence of a base slug anchors at base-{N-1} (second '## Setup' -> '#setup-1').",
+    "A4: Ran the harness-brainstorming/planning stages non-interactively because this lane is an autonomous fleet build with no human available to answer EVALUATE questions; recommended defaults from the issue were taken as the approved design.",
+    "A5: Scoped the change to drift.ts only; Defect 3 in the issue (generate-agent-definitions dead links) is explicitly out of scope per the issue's own suggestion to split it into a separate issue."
+  ],
+  "localChecks": {
+    "build": "pass",
+    "typecheck": "pass",
+    "lint": "pass (0 errors; 1 pre-existing warning in untouched entry-points.test.ts)",
+    "test": "pass (25/25 in drift.test.ts, incl. #492/#816/#1342/#1363 regressions)"
+  }
+}

--- a/packages/core/src/entropy/detectors/drift.ts
+++ b/packages/core/src/entropy/detectors/drift.ts
@@ -337,23 +337,55 @@ interface MarkdownLink {
  * Splits `file.md#anchor` into `path = file.md` and `anchor = anchor` so the
  * existence check operates on the file path alone (see github issue #492).
  */
+/**
+ * Blank every line inside a fenced code block, preserving line count so link
+ * and heading line numbers stay accurate. A fence opens on a bare run of 3+
+ * backticks or tildes and closes ONLY on a same-character run at least as long
+ * as the opener with no info string — mirroring CommonMark/GFM. This makes a
+ * 4-tick fence legitimately wrap 3-tick blocks: a naive open/close toggle
+ * re-opens on the inner fence and exposes the second half of a quoted document
+ * (issue #1342). Shared by link extraction and heading-slug extraction so the
+ * two structure-drift passes agree on what is quoted illustration.
+ */
+function blankFencedRegions(content: string): string {
+  const lines = content.split('\n');
+  let fence: { char: string; len: number } | null = null;
+
+  return lines
+    .map((line) => {
+      const match = /^\s*(`{3,}|~{3,})(.*)$/.exec(line);
+      if (fence === null) {
+        if (match) {
+          const run = match[1] as string;
+          fence = { char: run[0] as string, len: run.length };
+          return '';
+        }
+        return line;
+      }
+      // Inside a fence: close only on a bare same-char run >= opener length.
+      if (
+        match &&
+        (match[1] as string)[0] === fence.char &&
+        (match[1] as string).length >= fence.len &&
+        (match[2] as string).trim() === ''
+      ) {
+        fence = null;
+      }
+      return '';
+    })
+    .join('\n');
+}
+
 function extractFileLinks(content: string): MarkdownLink[] {
   const links: MarkdownLink[] = [];
-  const lines = content.split('\n');
-  let inFencedCodeBlock = false;
+  // Fenced code blocks (``` / ~~~, including nested runs) hold illustrative
+  // markdown, not real references — blank them first so a sample link is never
+  // reported as broken drift, while keeping line numbers intact (issue #1342).
+  const lines = blankFencedRegions(content).split('\n');
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!line) continue;
-
-    // Fenced code blocks (``` or ~~~) hold illustrative markdown, not real
-    // references — toggle on the fence line and skip everything inside so a
-    // sample link is never reported as broken drift (issue #1342).
-    if (/^\s*(?:```|~~~)/.test(line)) {
-      inFencedCodeBlock = !inFencedCodeBlock;
-      continue;
-    }
-    if (inFencedCodeBlock) continue;
 
     // Markdown links: [text](path)
     const linkRegex = /\[([^\]]*)\]\(([^)]+)\)/g;
@@ -384,16 +416,19 @@ function extractFileLinks(content: string): MarkdownLink[] {
 }
 
 /**
- * GFM-style heading slug: lowercase, spaces → hyphens, drop characters that
- * aren't alphanumeric / hyphens. Mirrors GitHub's behavior well enough for
- * the common case (no full Unicode normalization, but matches typical
- * hand-written anchors).
+ * GFM-style heading slug: lowercase, drop characters that aren't Unicode
+ * letters/numbers, `_`, `-`, or whitespace, then map each whitespace character
+ * to one hyphen. Mirrors GitHub's slugger for typical hand-written anchors:
+ * - No `.trim()` before hyphenating — GitHub keeps the space a stripped emoji
+ *   leaves behind, so `## 📖 Usage` anchors at `#-usage`.
+ * - Unicode `\p{L}\p{N}` instead of ASCII `\w`, so `## Café` keeps `café`.
+ * - One hyphen per whitespace character (not per run), so `## Tips & Tricks`
+ *   (the `&` dropped, two spaces kept) anchors at `#tips--tricks`.
  */
 function slugifyHeading(text: string): string {
   return text
     .toLowerCase()
-    .replace(/[^\w\s-]/g, '')
-    .trim()
+    .replace(/[^\p{L}\p{N}\s_-]/gu, '')
     .replace(/\s/g, '-');
 }
 
@@ -406,11 +441,21 @@ async function extractHeadingSlugs(filePath: string): Promise<Set<string>> {
   } catch {
     return slugs;
   }
+  // Blank fenced regions first so a `# Title` quoted inside a code fence does
+  // not register as a real anchor (issue #1342).
+  const scanned = blankFencedRegions(content);
   const headingRe = /^#{1,6}[ \t]+(.+?)[ \t]*#*\s*$/gm;
+  // GitHub disambiguates repeated headings: the Nth (N>1) occurrence of a base
+  // slug anchors at `base-{N-1}` (second `## Setup` -> `#setup-1`).
+  const seen = new Map<string, number>();
   let m: RegExpExecArray | null;
-  while ((m = headingRe.exec(content)) !== null) {
+  while ((m = headingRe.exec(scanned)) !== null) {
     const heading = m[1];
-    if (heading) slugs.add(slugifyHeading(heading));
+    if (!heading) continue;
+    const base = slugifyHeading(heading);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    slugs.add(count === 0 ? base : `${base}-${count}`);
   }
   return slugs;
 }

--- a/packages/core/tests/entropy/detectors/drift.test.ts
+++ b/packages/core/tests/entropy/detectors/drift.test.ts
@@ -515,4 +515,85 @@ describe('drift detector — issue #1342/#1332 regressions', () => {
     // per space). The link targets exactly that, so nothing is broken.
     expect(structureDrifts).toHaveLength(0);
   });
+
+  it('slugs an emoji heading the way GitHub does (keeps the leading hyphen)', async () => {
+    await writeFile(join(projectDir1342, 'docs', 'index.md'), '[usage](./page.md#-usage)\n');
+    await writeFile(
+      join(projectDir1342, 'docs', 'page.md'),
+      ['# Page', '', '## 📖 Usage', '', 'Body.'].join('\n')
+    );
+
+    const structureDrifts = await structureDriftFor();
+    // GitHub keeps the space the emoji left behind: "## 📖 Usage" -> `#-usage`.
+    // Trimming before hyphenating (the old bug) produced `usage` and flagged the
+    // working anchor.
+    expect(structureDrifts).toHaveLength(0);
+  });
+
+  it('slugs an accented heading with full Unicode letters (not ASCII \\w)', async () => {
+    await writeFile(join(projectDir1342, 'docs', 'index.md'), '[cafe](./page.md#café)\n');
+    await writeFile(
+      join(projectDir1342, 'docs', 'page.md'),
+      ['# Page', '', '## Café', '', 'Body.'].join('\n')
+    );
+
+    const structureDrifts = await structureDriftFor();
+    // GitHub keeps "café"; the old ASCII-only `\w` class dropped the é to `caf`.
+    expect(structureDrifts).toHaveLength(0);
+  });
+
+  it('does not expose the inner half of a 4-tick fence wrapping a 3-tick fence', async () => {
+    await writeFile(
+      join(projectDir1342, 'docs', 'guide.md'),
+      [
+        '# Guide',
+        '',
+        'Quoting a whole markdown file, code blocks and all:',
+        '',
+        '````markdown',
+        '# Quoted',
+        '',
+        '```',
+        'See [broken](./nope-does-not-exist.md) inside the quote.',
+        '```',
+        '',
+        'Still inside the quoted file.',
+        '````',
+        '',
+        'Back to real prose.',
+      ].join('\n')
+    );
+
+    const structureDrifts = await structureDriftFor();
+    // The 3-tick fence lives INSIDE a 4-tick fence. A naive open/close toggle
+    // re-opens on the inner fence and exposes the link in the second half.
+    expect(structureDrifts).toHaveLength(0);
+  });
+
+  it('does not treat a heading inside a fenced block as a real anchor', async () => {
+    await writeFile(join(projectDir1342, 'docs', 'index.md'), '[fake](./page.md#fake-heading)\n');
+    await writeFile(
+      join(projectDir1342, 'docs', 'page.md'),
+      ['# Page', '', '```markdown', '# Fake Heading', '```', ''].join('\n')
+    );
+
+    const structureDrifts = await structureDriftFor();
+    // "# Fake Heading" is quoted inside a fence, so it is NOT a real anchor —
+    // the link to `#fake-heading` must be reported broken.
+    expect(structureDrifts).toHaveLength(1);
+    expect(structureDrifts[0]?.context).toBe('link-anchor');
+  });
+
+  it('disambiguates duplicate headings the way GitHub does (setup, setup-1)', async () => {
+    await writeFile(join(projectDir1342, 'docs', 'index.md'), '[second](./page.md#setup-1)\n');
+    await writeFile(
+      join(projectDir1342, 'docs', 'page.md'),
+      ['# Page', '', '## Setup', 'First.', '', '## Setup', 'Second.'].join('\n')
+    );
+
+    const structureDrifts = await structureDriftFor();
+    // GitHub anchors the second "## Setup" at `#setup-1`; today the link is
+    // reported missing because slugs are not disambiguated.
+    expect(structureDrifts).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Closes #1342

## Summary
Two remaining defects in `packages/core/src/entropy/detectors/drift.ts` made `checkStructureDrift` report working documentation links as drift (27/27 false positives on the canary consumer repo). This preserves the prior fence-awareness + `&`-heading fixes from PR #1363.

- **slugifyHeading now mirrors GitHub GFM.** Dropped the `.trim()` that ran before hyphenation, so `## 📖 Usage` anchors at `#-usage` (GitHub keeps the space the emoji leaves behind). Replaced ASCII `\w` with Unicode `\p{L}\p{N}` (plus `_`/`-`, `u` flag), so `## Café` keeps `café` instead of mangling to `caf`.
- **Nesting-aware fence stripping.** New module-private `blankFencedRegions()` closes a fence only on a same-character run at least as long as the opener with no info string (CommonMark/GFM), so a 4-tick fence wrapping a 3-tick block no longer re-toggles and exposes the inner half. It is shared by `extractFileLinks` and `extractHeadingSlugs`, so a `# Title` quoted inside a fence no longer registers as a real anchor. Line count is preserved so link/heading line numbers stay accurate.
- **Duplicate-heading dedup.** `extractHeadingSlugs` now disambiguates repeated headings GitHub-style — a second `## Setup` anchors at `#setup-1`.

## Tests
Added 5 unit tests (emoji heading, accented heading, nested 4-tick/3-tick fence, in-fence heading, duplicate headings) to the existing #1342 regression block. All 25 drift tests pass, including the #492/#816/#1363 regressions. Build, typecheck, and lint green.

## Assumptions
- Applied the issue's recommended fix verbatim (slug regex, fence-close rule, dedup scheme).
- Scoped to `drift.ts` only; Defect 3 (generate-agent-definitions dead links) is out of scope per the issue's own suggestion to split it into a separate issue.
- Ran the brainstorming/planning stages non-interactively (autonomous fleet lane); spec, plan, and provenance are committed under `docs/changes/fix-drift-working-links-false-positive/`.