### PR TITLE
fix(craft): nesting-aware fenced-JSON parse stops dropping findings

### DIFF
--- a/.changeset/craft-nested-fence-json-parse.md
+++ b/.changeset/craft-nested-fence-json-parse.md
@@ -1,0 +1,20 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(craft): nesting-aware fenced-JSON parse stops dropping findings
+
+Every craft family's CRITIQUE phase used a lazy fence regex
+(`/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/`) to extract the JSON finding from the
+LLM response. When a finding's `message` value itself contained a ```fence
+(critiques routinely quote code blocks), the lazy match truncated at that inner
+fence,`JSON.parse` threw, and the finding was silently dropped.
+
+Extraction is now nesting-aware via a single shared util,
+`extractFencedJsonPayload` (`shared/craft/fenced-json.ts`): it anchors on the
+opening fence, then runs a string/escape-aware, brace-balanced scan that returns
+the first complete JSON value. Inner fences inside string values no longer
+truncate the object, and two separate fenced blocks are never merged. All ten
+craft families (code / docs / spec / copy / naming / test / security / api /
+cli-ergonomics / knowledge) now share this util; the duplicated regexes,
+`FENCED_JSON` consts, and `stripJsonFence` helper are gone.

--- a/docs/changes/fix-craft-nested-fence-json-parse/plans/plan.md
+++ b/docs/changes/fix-craft-nested-fence-json-parse/plans/plan.md
@@ -1,0 +1,46 @@
+# Plan: nesting-aware fenced-JSON parse (issue #1369)
+
+Slug: `fix-craft-nested-fence-json-parse`
+Spec: `../proposal.md`
+
+## Task 1 — Author the shared extractor (TDD)
+
+- Write `packages/cli/src/shared/craft/fenced-json.test.ts` covering: plain
+  single fence, bare ` ``` ` fence, unfenced JSON, `null` sentinel, message
+  containing an inner ` ``` ` fence (issue #1369 regression), inner fence
+  with a `json` info-string, two separate blocks not merged, braces inside
+  strings, escaped quotes, top-level array.
+- Implement `packages/cli/src/shared/craft/fenced-json.ts` exporting
+  `extractFencedJsonPayload(raw)`: anchor on opening fence, then a
+  string/escape-aware brace-balanced scan returning the first complete JSON
+  value; fall back to fence-strip for the `null` literal.
+- Gate: `vitest run src/shared/craft/fenced-json.test.ts` green.
+
+## Task 2 — Rewire all ten craft families
+
+For each of `code / docs / spec / copy / naming / test / security / api /
+cli-ergonomics / knowledge` `phases/critique.ts`:
+
+- Add `import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';`
+  (naming-craft imports the util from the same shared path even though its
+  other imports are local).
+- Replace the inline lazy-regex extraction (or the hoisted `FENCED_JSON` const /
+  docs-craft's `stripJsonFence` helper) with
+  `const body = extractFencedJsonPayload(raw);`.
+- Delete the now-dead `FENCED_JSON` consts (api, code) and `stripJsonFence`
+  helper (docs) so no duplicate extractor remains.
+- Preserve each caller's existing `null` check and shape validation.
+
+## Task 3 — Validate
+
+- `pnpm turbo build --filter=@harness-engineering/cli` (bundles + DTS typecheck).
+- Full `@harness-engineering/cli` vitest suite green (no regressions).
+- ESLint clean on all changed files.
+- Confirm: 10 imports of the shared util, zero remaining lazy regex /
+  `FENCED_JSON` / `stripJsonFence`.
+
+## Task 4 — Ship
+
+- Changeset (patch bump, `@harness-engineering/cli`).
+- `prettier --write` changed files.
+- Commit, push (non-`.claude` worktree), open PR `Closes #1369`.

--- a/docs/changes/fix-craft-nested-fence-json-parse/proposal.md
+++ b/docs/changes/fix-craft-nested-fence-json-parse/proposal.md
@@ -1,0 +1,81 @@
+# Fix: nesting-aware fenced-JSON parse stops dropping craft findings
+
+Issue: #1369
+Slug: `fix-craft-nested-fence-json-parse`
+
+## Problem
+
+Every craft family's CRITIQUE phase asks an LLM for a fenced JSON finding, then
+extracts the JSON body before `JSON.parse`. Ten families
+(`code / docs / spec / copy / naming / test / security / api / cli-ergonomics /
+knowledge`) each carried a byte-identical **lazy** fence extractor:
+
+````
+/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/
+````
+
+The `*?` (lazy) capture stops at the FIRST closing ` ``` `. When a
+finding's `message` value itself contains a ` ``` ` fence — which happens
+constantly, because critiques quote code blocks in their suggested revision —
+the match truncates at that INNER fence. The captured body is an unterminated
+JSON object, `JSON.parse` throws, `parseFencedJson` returns `null`, and the
+finding is **silently dropped**. The reviewer sees a clean run and never learns
+a real finding was lost.
+
+## Goal
+
+A finding whose `message` contains a ` ``` ` fence must be parsed, not
+dropped — without merging two genuinely-separate fenced blocks (the failure
+mode of a naive greedy "match to the last fence" fix).
+
+## Design
+
+Introduce ONE shared extractor and reuse it across all ten copies (all live in
+`packages/cli`, so this is an internal module, not a new
+`@harness-engineering/core` export — the core barrel allowlist is untouched):
+
+- `packages/cli/src/shared/craft/fenced-json.ts` →
+  `extractFencedJsonPayload(raw: string): string`
+
+It is **nesting-aware** rather than regex-based:
+
+1. Anchor on the opening fence (` ```json ` / ` ``` `) when present, so
+   leading prose can't derail the scan; otherwise scan from the top so bare
+   (unfenced) JSON still parses.
+2. From there, perform a **string-and-escape-aware, brace-balanced scan** and
+   return the FIRST complete JSON value (object or array).
+   - Inner ` ``` ` fences live inside a JSON string (`"..."`), so they
+     never affect brace balance → the full object is recovered (bug fixed).
+   - The scan stops at the first balanced value, so two separate blocks are
+     never merged — the second stays independently recoverable.
+3. If the fenced region has no brace/bracket structure (e.g. the literal
+   `null` sentinel), strip a trailing fence and return the trimmed remainder,
+   preserving the existing `body === 'null'` / `body.trim() === 'null'` checks
+   in every caller.
+
+The function returns a string; each caller keeps ownership of `JSON.parse` +
+`try/catch` and its own shape validation, matching the pre-existing contract.
+
+## Acceptance criteria
+
+- A fenced finding whose `message` contains a ` ``` ` fence parses to the
+  full object (not dropped). _(covered)_
+- Two separate fenced JSON blocks are not merged; the first parses and the
+  second remains independently recoverable. _(covered)_
+- A plain single fence still parses; bare JSON still parses; the `null`
+  sentinel still returns `null`. _(covered)_
+- Braces inside string values and escaped quotes do not confuse the scan.
+  _(covered)_
+- All ten craft families import the shared util; no duplicate lazy regex,
+  `FENCED_JSON` const, or `stripJsonFence` helper remains.
+- Full `@harness-engineering/cli` suite, typecheck, and lint stay green.
+
+## Assumptions (defaults taken, per lane brief)
+
+- Shared util placed in the cli package (`shared/craft/`), NOT added as a new
+  core export — all consumers are in `packages/cli`, so no barrel-allowlist
+  edit is required.
+- Chose a brace-balanced scan over a greedy "last-fence" regex because greedy
+  merges separate blocks (the failure the issue warns about).
+- Scope limited to the ten families that carried the lazy regex; `design-craft`
+  uses a different mechanism and was left untouched.

--- a/docs/changes/fix-craft-nested-fence-json-parse/provenance.json
+++ b/docs/changes/fix-craft-nested-fence-json-parse/provenance.json
@@ -1,0 +1,38 @@
+{
+  "issue": 1369,
+  "slug": "fix-craft-nested-fence-json-parse",
+  "title": "nesting-aware fenced-JSON parse stops dropping craft findings",
+  "branch": "fix/craft-nested-fence-json",
+  "pipelineStages": [
+    "brainstorming: authored docs/changes/fix-craft-nested-fence-json-parse/proposal.md",
+    "planning: authored docs/changes/fix-craft-nested-fence-json-parse/plans/plan.md",
+    "tdd: authored fenced-json.test.ts (10 cases) then extractFencedJsonPayload",
+    "execution: rewired all 10 craft families to the shared util",
+    "validation: turbo build (bundle+DTS typecheck), full cli vitest suite, eslint"
+  ],
+  "planArtifact": "docs/changes/fix-craft-nested-fence-json-parse/plans/plan.md",
+  "sharedUtil": "packages/cli/src/shared/craft/fenced-json.ts",
+  "consumers": [
+    "packages/cli/src/code-craft/phases/critique.ts",
+    "packages/cli/src/docs-craft/phases/critique.ts",
+    "packages/cli/src/spec-craft/phases/critique.ts",
+    "packages/cli/src/copy-craft/phases/critique.ts",
+    "packages/cli/src/naming-craft/phases/critique.ts",
+    "packages/cli/src/test-craft/phases/critique.ts",
+    "packages/cli/src/security-craft/phases/critique.ts",
+    "packages/cli/src/api-craft/phases/critique.ts",
+    "packages/cli/src/cli-ergonomics-craft/phases/critique.ts",
+    "packages/cli/src/knowledge-craft/phases/critique.ts"
+  ],
+  "assumptions": [
+    "Shared util placed in packages/cli/src/shared/craft (internal module), NOT a new @harness-engineering/core export, since all 10 consumers live in packages/cli; core-barrel allowlist untouched.",
+    "Chose a string/escape-aware brace-balanced scan over a greedy last-fence regex because greedy would merge two separate fenced blocks (the failure mode the issue warns about).",
+    "Scoped to the 10 families carrying the lazy regex; design-craft uses a different parse mechanism and was left untouched.",
+    "Ran a faithful brainstorming -> planning -> TDD -> execution -> validation pipeline with committed artifacts; did not invoke the interactive run_skill orchestration to keep this isolated build lane deterministic and non-blocking."
+  ],
+  "localChecks": {
+    "build": "pass (turbo build @harness-engineering/cli, bundle + DTS typecheck)",
+    "test": "pass (full cli vitest suite 6224 tests + 10 new util tests)",
+    "lint": "pass (eslint clean on all changed files)"
+  }
+}

--- a/packages/cli/src/api-craft/phases/critique.ts
+++ b/packages/cli/src/api-craft/phases/critique.ts
@@ -14,11 +14,9 @@ import type { LlmProvider } from '../../shared/craft/llm/provider.js';
 import type { ApiRubric, ApiSurfaceKind } from '../catalog/rubrics/index.js';
 import type { ApiFinding, Tier, Impact, Confidence } from '../findings/schema.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 const MAX_CONTENT_CHARS = 8000;
-
-/** Fenced-JSON block extractor, hoisted so its quantifiers don't inflate the parser's complexity. */
-const FENCED_JSON = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/;
 
 export const CRITIQUE_SYSTEM_PROMPT =
   'You are a senior API designer critiquing a single API surface (an OpenAPI/Swagger document ' +
@@ -126,8 +124,7 @@ export function buildPrompt(input: BuildPromptInput): string {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = FENCED_JSON.exec(raw);
-  const body = (match?.[1] ?? raw).trim();
+  const body = extractFencedJsonPayload(raw);
   if (body === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check below gates shape, downstream callers re-validate fields

--- a/packages/cli/src/cli-ergonomics-craft/phases/critique.ts
+++ b/packages/cli/src/cli-ergonomics-craft/phases/critique.ts
@@ -8,6 +8,7 @@ import type { LlmProvider } from '../../shared/craft/llm/provider.js';
 import type { CliRubric, CommandKind } from '../catalog/rubrics/index.js';
 import type { CliErgonomicsFinding, Tier, Impact, Confidence } from '../findings/schema.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 const MAX_CONTENT_CHARS = 6000;
 
@@ -105,8 +106,7 @@ export function buildPrompt(input: BuildPromptInput): string {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = (match?.[1] ?? raw).trim();
+  const body = extractFencedJsonPayload(raw);
   if (body === 'null') return null;
   return parseJsonObject(body);
 }

--- a/packages/cli/src/code-craft/phases/critique.ts
+++ b/packages/cli/src/code-craft/phases/critique.ts
@@ -16,12 +16,10 @@ import type { LlmProvider } from '../../shared/craft/llm/provider.js';
 import type { CodeRubric } from '../catalog/rubrics/index.js';
 import type { CodeUnit, CodeFinding, Tier, Impact, Confidence } from '../findings/schema.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 import { unitSource } from '../extract/units.js';
 
 const MAX_UNIT_CHARS = 2500;
-
-/** Fenced-JSON block extractor, hoisted so its quantifiers don't inflate the parser's complexity. */
-const FENCED_JSON = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/;
 
 /**
  * Conservative-confidence system prompt. Readability judgments are inherently
@@ -124,8 +122,7 @@ export function buildPrompt(input: BuildPromptInput): string {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = FENCED_JSON.exec(raw);
-  const body = (match?.[1] ?? raw).trim();
+  const body = extractFencedJsonPayload(raw);
   if (body === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check below gates shape, downstream callers re-validate fields

--- a/packages/cli/src/copy-craft/phases/critique.ts
+++ b/packages/cli/src/copy-craft/phases/critique.ts
@@ -12,6 +12,7 @@ import type { CopyRubric } from '../catalog/rubrics/index.js';
 import type { ExtractedCopyItem, CopyFinding } from '../findings/schema.js';
 import type { Tier, Impact, Confidence } from '../../shared/craft/findings/axes.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 const MAX_SNIPPET_CHARS = 1500;
 
@@ -93,8 +94,7 @@ function buildPrompt(input: CritiqueInput): string {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = match !== null ? match[1]! : raw;
+  const body = extractFencedJsonPayload(raw);
   if (body.trim() === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check on next line gates shape, downstream callers re-validate fields

--- a/packages/cli/src/docs-craft/phases/critique.ts
+++ b/packages/cli/src/docs-craft/phases/critique.ts
@@ -8,6 +8,7 @@ import type { LlmProvider } from '../../shared/craft/llm/provider.js';
 import type { DocsRubric, DocKind } from '../catalog/rubrics/index.js';
 import type { DocsFinding, Tier, Impact, Confidence } from '../findings/schema.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 const MAX_CONTENT_CHARS = 6000;
 
@@ -82,12 +83,6 @@ function buildPrompt(input: CritiqueInput): string {
   ].join('\n');
 }
 
-/** Strip an optional ```json fence, returning the trimmed payload. */
-function stripJsonFence(raw: string): string {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  return (match?.[1] ?? raw).trim();
-}
-
 /** Narrow parsed JSON to a plain object, rejecting null/arrays/primitives. */
 function asJsonObject(parsed: unknown): Record<string, unknown> | null {
   if (parsed === null || typeof parsed !== 'object') return null;
@@ -95,7 +90,7 @@ function asJsonObject(parsed: unknown): Record<string, unknown> | null {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const body = stripJsonFence(raw);
+  const body = extractFencedJsonPayload(raw);
   if (body === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; asJsonObject gates shape, downstream callers re-validate fields

--- a/packages/cli/src/knowledge-craft/phases/critique.ts
+++ b/packages/cli/src/knowledge-craft/phases/critique.ts
@@ -11,6 +11,7 @@ import type { LlmProvider } from '../../shared/craft/llm/provider.js';
 import type { KnowledgeRubric } from '../catalog/rubrics/index.js';
 import type { KnowledgeFinding, Tier, Impact, Confidence } from '../findings/schema.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 const MAX_CONTENT_CHARS = 4000;
 
@@ -81,8 +82,7 @@ function buildPrompt(input: CritiqueInput): string {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = match !== null ? match[1]! : raw;
+  const body = extractFencedJsonPayload(raw);
   if (body.trim() === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check on next line gates shape, downstream callers re-validate fields

--- a/packages/cli/src/naming-craft/phases/critique.ts
+++ b/packages/cli/src/naming-craft/phases/critique.ts
@@ -18,6 +18,7 @@ import type {
 } from '../findings/schema.js';
 import type { ExtractedIdentifier } from '../extract/identifiers.js';
 import { derivePriority } from '../findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 export interface CritiqueInput {
   identifier: ExtractedIdentifier;
@@ -124,8 +125,7 @@ function kindToConventionKey(
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = match !== null ? match[1]! : raw;
+  const body = extractFencedJsonPayload(raw);
   if (body.trim() === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check on next line gates shape, downstream callers re-validate fields

--- a/packages/cli/src/security-craft/phases/critique.ts
+++ b/packages/cli/src/security-craft/phases/critique.ts
@@ -19,6 +19,7 @@ import type {
   Confidence,
 } from '../findings/schema.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 const CONTEXT_WINDOW_CHARS = 1500;
 
@@ -147,8 +148,7 @@ function expandWindow(
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = match !== null ? match[1]! : raw;
+  const body = extractFencedJsonPayload(raw);
   if (body.trim() === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check on next line gates shape, downstream callers re-validate fields

--- a/packages/cli/src/shared/craft/fenced-json.test.ts
+++ b/packages/cli/src/shared/craft/fenced-json.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { extractFencedJsonPayload } from './fenced-json.js';
+
+describe('extractFencedJsonPayload', () => {
+  it('extracts the body of a plain single ```json fence', () => {
+    const raw = '```json\n{ "tier": "polish", "message": "tighten this" }\n```';
+    const payload = extractFencedJsonPayload(raw);
+    expect(JSON.parse(payload)).toEqual({ tier: 'polish', message: 'tighten this' });
+  });
+
+  it('extracts a bare ``` fence without the json info-string', () => {
+    const raw = '```\n{ "message": "hi" }\n```';
+    expect(JSON.parse(extractFencedJsonPayload(raw))).toEqual({ message: 'hi' });
+  });
+
+  it('parses bare (unfenced) JSON', () => {
+    const raw = '{ "message": "no fence here" }';
+    expect(JSON.parse(extractFencedJsonPayload(raw))).toEqual({ message: 'no fence here' });
+  });
+
+  it('returns the literal null sentinel unwrapped', () => {
+    expect(extractFencedJsonPayload('```json\nnull\n```')).toBe('null');
+    expect(extractFencedJsonPayload('null')).toBe('null');
+  });
+
+  // Regression for issue #1369: a finding whose `message` contains a ``` fence
+  // must be parsed, not silently dropped by a lazy match truncating at the
+  // INNER fence.
+  it('parses a finding whose message value itself contains a ``` fence', () => {
+    const message =
+      'Prefer a guard clause. Replace:\n```ts\nif (x) { ... }\n```\nwith an early return.';
+    const raw = '```json\n' + JSON.stringify({ tier: 'polish', message }, null, 2) + '\n```';
+    const parsed = JSON.parse(extractFencedJsonPayload(raw)) as Record<string, unknown>;
+    expect(parsed.tier).toBe('polish');
+    expect(parsed.message).toBe(message);
+  });
+
+  it('handles an inner fence with a json info-string inside the message', () => {
+    const message = 'Bad config:\n```json\n{ "a": 1 }\n```\nUse an array instead.';
+    const raw = '```json\n' + JSON.stringify({ message }) + '\n```';
+    const parsed = JSON.parse(extractFencedJsonPayload(raw)) as Record<string, unknown>;
+    expect(parsed.message).toBe(message);
+  });
+
+  // The greedy "match to the last closing fence" fix would merge these two
+  // blocks into one invalid blob and lose BOTH. The extractor must return the
+  // FIRST complete value, leaving the second recoverable — two remain two.
+  it('does not merge two separate fenced JSON blocks', () => {
+    const raw = '```json\n{ "message": "first" }\n```\n\n```json\n{ "message": "second" }\n```';
+    const first = extractFencedJsonPayload(raw);
+    expect(JSON.parse(first)).toEqual({ message: 'first' });
+
+    // The second block is not fused into the first, and is independently
+    // recoverable from the remainder of the response.
+    const afterFirst = raw.slice(raw.indexOf(first) + first.length);
+    expect(JSON.parse(extractFencedJsonPayload(afterFirst))).toEqual({ message: 'second' });
+  });
+
+  it('ignores braces that appear inside string values', () => {
+    const raw = '```json\n{ "message": "a } close brace and { open in text" }\n```';
+    expect(JSON.parse(extractFencedJsonPayload(raw))).toEqual({
+      message: 'a } close brace and { open in text',
+    });
+  });
+
+  it('ignores escaped quotes when tracking string boundaries', () => {
+    const raw = '```json\n{ "message": "he said \\"hi\\" then }" }\n```';
+    expect(JSON.parse(extractFencedJsonPayload(raw))).toEqual({
+      message: 'he said "hi" then }',
+    });
+  });
+
+  it('extracts a top-level JSON array', () => {
+    const raw = '```json\n[ { "a": 1 }, { "b": 2 } ]\n```';
+    expect(JSON.parse(extractFencedJsonPayload(raw))).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+});

--- a/packages/cli/src/shared/craft/fenced-json.ts
+++ b/packages/cli/src/shared/craft/fenced-json.ts
@@ -1,0 +1,96 @@
+// packages/cli/src/shared/craft/fenced-json.ts
+//
+// Shared fenced-JSON payload extractor for the craft families' CRITIQUE
+// phases. Every craft family (code / docs / spec / copy / naming / test /
+// security / api / cli-ergonomics / knowledge) asks an LLM for a fenced JSON
+// finding and then extracts the JSON body before `JSON.parse`.
+//
+// The previous per-family extractor used a LAZY fence regex
+// (/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/). When a finding's `message` value
+// itself contained a ``` fence (e.g. the model quotes a code block in its
+// critique), the lazy match truncated at that INNER fence, producing an
+// unterminated JSON body → `JSON.parse` threw → the finding was SILENTLY
+// DROPPED (see issue #1369).
+//
+// A naive greedy fix (match to the LAST closing fence) is wrong the other
+// way: given TWO separate fenced blocks it would merge everything between the
+// first opener and the last closer into one invalid blob, losing both.
+//
+// This extractor is nesting-aware. It anchors on the opening fence when
+// present, then performs a string-and-escape-aware, brace-balanced scan to
+// return the FIRST complete JSON value. Because inner ``` fences live inside a
+// JSON string (`"..."`), they never affect brace balance, so the full object
+// is recovered; and because the scan stops at the first balanced value, two
+// separate blocks are never merged.
+
+/**
+ * Extract the JSON payload string from a raw LLM response that MAY wrap it in
+ * a ```json fence.
+ *
+ * Behaviour:
+ * - Fenced JSON whose `message` contains an inner ``` fence → full object
+ *   recovered (no truncation at the inner fence).
+ * - Two separate fenced JSON blocks → only the FIRST complete value is
+ *   returned; the blocks are never merged.
+ * - Plain single fence (`` ```json\n{...}\n``` ``) → the `{...}` body.
+ * - Bare (unfenced) JSON → returned as-is.
+ * - Non-object literals such as the bare `null` sentinel → the trimmed
+ *   literal (callers compare against `'null'`).
+ *
+ * Always returns a string (the caller owns `JSON.parse` + try/catch), matching
+ * the pre-existing per-family contract of "return the body, let the caller
+ * parse".
+ */
+export function extractFencedJsonPayload(raw: string): string {
+  // Anchor at the opening fence when present so leading prose can't derail the
+  // scan; otherwise scan from the top so bare JSON still parses.
+  const opener = /```(?:json)?[ \t]*\r?\n?/.exec(raw);
+  const searchFrom = opener !== null ? opener.index + opener[0].length : 0;
+  const region = raw.slice(searchFrom);
+
+  const balanced = firstBalancedJson(region);
+  if (balanced !== null) return balanced;
+
+  // No brace/bracket structure in the fenced region (e.g. the literal `null`).
+  // Strip a trailing closing fence if present and return the trimmed remainder.
+  const closer = region.indexOf('```');
+  const tail = closer === -1 ? region : region.slice(0, closer);
+  return tail.trim();
+}
+
+/**
+ * Scan `s` for the first complete, brace-balanced JSON value (object or
+ * array), tracking string and escape state so that braces/backticks inside
+ * string literals are ignored. Returns the exact substring of that value, or
+ * `null` when no balanced value is found (unterminated or none present).
+ */
+function firstBalancedJson(s: string): string | null {
+  const start = s.search(/[{[]/);
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i]!;
+
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{' || ch === '[') {
+      depth++;
+    } else if (ch === '}' || ch === ']') {
+      depth--;
+      if (depth === 0) return s.slice(start, i + 1);
+    }
+  }
+
+  return null;
+}

--- a/packages/cli/src/spec-craft/phases/critique.ts
+++ b/packages/cli/src/spec-craft/phases/critique.ts
@@ -13,6 +13,7 @@ import type { ParsedSection } from '../extract/sections.js';
 import type { SpecFinding } from '../findings/schema.js';
 import type { Tier, Impact, Confidence } from '../../shared/craft/findings/axes.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 const MAX_BODY_CHARS = 2000;
 
@@ -85,8 +86,7 @@ function buildPrompt(input: CritiqueInput): string {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = match !== null ? match[1]! : raw;
+  const body = extractFencedJsonPayload(raw);
   if (body.trim() === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check on next line gates shape, downstream callers re-validate fields

--- a/packages/cli/src/test-craft/phases/critique.ts
+++ b/packages/cli/src/test-craft/phases/critique.ts
@@ -12,6 +12,7 @@ import type { ExtractedTest, TestFinding } from '../findings/schema.js';
 import type { Tier, Impact, Confidence } from '../../shared/craft/findings/axes.js';
 import type { SourcePairResult } from '../extract/source-pair.js';
 import { derivePriority } from '../../shared/craft/findings/derived.js';
+import { extractFencedJsonPayload } from '../../shared/craft/fenced-json.js';
 
 export interface CritiqueInput {
   test: ExtractedTest;
@@ -96,8 +97,7 @@ function buildPrompt(input: CritiqueInput): string {
 }
 
 function parseFencedJson(raw: string): Record<string, unknown> | null {
-  const match = /```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/.exec(raw);
-  const body = match !== null ? match[1]! : raw;
+  const body = extractFencedJsonPayload(raw);
   if (body.trim() === 'null') return null;
   try {
     // harness-ignore SEC-DES-001: parses LLM model output; typeof check on next line gates shape, downstream callers re-validate fields


### PR DESCRIPTION
Closes #1369

## Problem
Every craft family's CRITIQUE phase used a lazy fence regex
(`/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/`) to extract the JSON finding from the
LLM response. When a finding's `message` value itself contained a ``` fence
(critiques routinely quote code blocks in their suggested revision), the lazy
match truncated at that INNER fence → `JSON.parse` threw → `parseFencedJson`
returned `null` → the finding was **silently dropped**.

## Fix
One shared, nesting-aware extractor — `extractFencedJsonPayload`
(`packages/cli/src/shared/craft/fenced-json.ts`). It anchors on the opening
fence, then runs a string/escape-aware, brace-balanced scan returning the FIRST
complete JSON value:
- Inner ``` fences live inside a JSON string, so they no longer truncate the
  object (bug fixed).
- The scan stops at the first balanced value, so two SEPARATE fenced blocks are
  never merged (the failure mode a naive greedy fix would cause).

All ten families that carried the duplicated regex now import the shared util
(code / docs / spec / copy / naming / test / security / api / cli-ergonomics /
knowledge); the duplicate regexes, `FENCED_JSON` consts, and `stripJsonFence`
helper are removed. Internal to `packages/cli`, so no new `@harness-engineering/core`
export and no barrel-allowlist change.

## Tests
New `fenced-json.test.ts` (10 cases): message-contains-fence regression,
two-separate-blocks-not-merged, plain single fence, bare fence, unfenced JSON,
`null` sentinel, inner fence with json info-string, braces-in-strings,
escaped-quotes, top-level array. Full `@harness-engineering/cli` suite (6224
tests) + typecheck + lint green.

## Assumptions
- Shared util is an internal cli module, not a new core export (all consumers in
  `packages/cli`).
- Brace-balanced scan chosen over greedy last-fence regex (greedy merges
  separate blocks).
- Scoped to the 10 families with the lazy regex; design-craft uses a different
  parse mechanism and was untouched.

Artifacts: `docs/changes/fix-craft-nested-fence-json-parse/` (proposal, plans/plan.md, provenance.json).