### PR TITLE
fix(entropy): classify entry points instead of suggesting deletion

### DIFF
--- a/.changeset/dead-code-entrypoint-classification.md
+++ b/.changeset/dead-code-entrypoint-classification.md
@@ -1,0 +1,21 @@
+---
+'@harness-engineering/core': minor
+---
+
+fix(entropy): classify unreferenced build entry points instead of suggesting deletion
+
+The dead-code detector treated every file unreachable from `entropy.entryPoints` as a
+generic dead file (`reason: 'NO_IMPORTERS'`), so the suggestion fixer emitted a
+high-priority `delete` recommendation and the auto-fix fixer emitted a `delete-file`
+fix for build entry points — `*.config.ts`, `src/main.ts(x)`, `app.module.ts` — that
+are reachable at build/runtime rather than through static imports. Deleting one breaks
+the build; the correct remediation is to declare it in `entryPoints`.
+
+`findDeadFiles` (and the graph-based path) now classify an unreachable file whose path
+matches a build entry-point convention with the new `DeadFile` reason
+`UNREFERENCED_ENTRY_POINT`. For those files the suggestion fixer emits a new,
+non-destructive `Suggestion` type `configure-entrypoint` at `low` (info) priority —
+"declare it in entryPoints" — and the auto-fix fixer never emits a `delete-file` fix.
+Genuinely orphaned files still get the `delete` suggestion and `delete-file` fix.
+
+Closes #1325.

--- a/docs/changes/fix-dead-code-entrypoint-classification/plans/2026-08-15-dead-code-entrypoint-plan.md
+++ b/docs/changes/fix-dead-code-entrypoint-classification/plans/2026-08-15-dead-code-entrypoint-plan.md
@@ -1,0 +1,39 @@
+# Plan: classify entry points instead of suggesting deletion
+
+**Date:** 2026-08-15 · **Spec:** `docs/changes/fix-dead-code-entrypoint-classification/proposal.md` · **Issue:** #1325 · **Tasks:** 7 · **Integration Tier:** small
+
+## Goal
+
+Stop the dead-code pipeline from recommending deletion of build entry points.
+Classify unreachable files that match entry-point conventions as a distinct finding
+(`reason: 'UNREFERENCED_ENTRY_POINT'`) in the detector, emit a non-delete
+`configure-entrypoint` suggestion for them, never auto-delete them, and seed the
+repo's real build entry points into `harness.config.json`. Genuine dead files are
+unaffected.
+
+## Observable Truths (Acceptance Criteria)
+
+1. Unreachable `*.config.ts` → `DeadFile.reason === 'UNREFERENCED_ENTRY_POINT'`. **Gate:** detector test.
+2. Unreachable `src/main.ts` → `DeadFile.reason === 'UNREFERENCED_ENTRY_POINT'`. **Gate:** detector test.
+3. `generateSuggestions` for an `UNREFERENCED_ENTRY_POINT` file → a suggestion with `type === 'configure-entrypoint'`, `priority === 'low'`, and no `delete` suggestion for that file. **Gate:** suggestions test.
+4. `createDeadFileFixes` for an `UNREFERENCED_ENTRY_POINT` file → no `delete-file` fix; a `NO_IMPORTERS` file still yields one. **Gate:** safe-fixes test.
+5. A `NO_IMPORTERS` file still yields a `delete` suggestion. **Gate:** existing suggestions test stays green.
+6. `pnpm turbo build --filter=@harness-engineering/core` + typecheck + entropy tests + lint all green. **Gate:** local run.
+7. `harness.config.json` `entropy.entryPoints` includes the repo's real build entry points; config still schema-valid. **Gate:** build/CI config validation.
+
+## Tasks (TDD order)
+
+1. **Type: add `UNREFERENCED_ENTRY_POINT`** to `DeadFile['reason']` union in `packages/core/src/entropy/types/dead-code.ts`.
+2. **Type: add `configure-entrypoint`** to `Suggestion['type']` union in `packages/core/src/entropy/types/fix.ts`.
+3. **Detector (RED→GREEN):** add `isEntryPointConvention(path)` helper + apply it in `findDeadFiles` and `classifyUnreachableNode` in `packages/core/src/entropy/detectors/dead-code.ts`. Add fixtures (`src/main.ts`, `something.config.ts`) + detector tests (AC 1,2).
+4. **Suggestions (RED→GREEN):** branch `deadFileSuggestion` on `reason` in `packages/core/src/entropy/fixers/suggestions.ts`; emit `configure-entrypoint` info suggestion for entry points. Add suggestions test (AC 3,5).
+5. **Safe-fixes (RED→GREEN):** filter `UNREFERENCED_ENTRY_POINT` out of `createDeadFileFixes` in `packages/core/src/entropy/fixers/safe-fixes.ts`. Add safe-fixes test (AC 4).
+6. **Config:** seed real build entry points into `harness.config.json` `entropy.entryPoints`.
+7. **Validate:** build core, typecheck, run entropy dead-code + fixer + safe-fixes tests, lint, prettier, changeset.
+
+## Uncertainties
+
+- [ASSUMPTION] "info severity" maps to the suggestion `priority: 'low'` — `DeadFile`/`Suggestion` have no `info` severity enum, and adding one would ripple through unrelated consumers (YAGNI). Recorded as an assumption per the issue's "record as assumptions" instruction.
+- [ASSUMPTION] Entry-point conventions cover config files (`*.config.{ts,mts,cts,js,mjs,cjs}`) and framework roots (`main.ts(x)`, `main.mts`, `app.module.ts`). Extensible constant; not exhaustive of every framework.
+- [ASSUMPTION] Seeding extra `entryPoints` is safe because `resolveEntryPoints` maps them as literal paths with no on-disk existence gate (verified in `packages/core/src/entropy/entry-points.ts`).
+- [ASSUMPTION] New finding type is a **minor** bump for `@harness-engineering/core` (new public reason/suggestion-type value), per the lane brief.

--- a/docs/changes/fix-dead-code-entrypoint-classification/proposal.md
+++ b/docs/changes/fix-dead-code-entrypoint-classification/proposal.md
@@ -1,0 +1,96 @@
+# fix-dead-code-entrypoint-classification — classify entry points instead of suggesting deletion
+
+**Status:** Draft · **Tier:** Small · **Type:** bugfix (entropy dead-code detector + fixer)
+**Issue:** #1325
+**Keywords:** entropy, dead-code, reachability, entry-points, false-positive, suggestions, safe-fixes, config
+
+## Overview
+
+The dead-code detector treats every file that is unreachable from the configured
+`entropy.entryPoints` as generic dead code. In
+`packages/core/src/entropy/detectors/dead-code.ts` (`findDeadFiles`) each such file
+is emitted as a `DeadFile` with `reason: 'NO_IMPORTERS'` and no entry-point
+classification. Two downstream fixers then turn that finding into a **delete**
+recommendation:
+
+- `packages/core/src/entropy/fixers/suggestions.ts` (`deadFileSuggestion`) emits a
+  high-priority `type: 'delete'` suggestion — "This file is not imported by any
+  other file and can be safely removed."
+- `packages/core/src/entropy/fixers/safe-fixes.ts` (`createDeadFileFixes`) emits an
+  auto-applicable `action: 'delete-file'` fix for **every** dead file.
+
+Build entry points are reachable at build/runtime, not through static
+`import` edges: `vite.config.ts`, `vitest.config.ts`, `tsup.config.ts`,
+`src/main.ts(x)` (Vue/Angular/React roots), `app.module.ts` (NestJS). When such a
+file is not listed in `entropy.entryPoints` it is unreachable in the import graph and
+gets a **delete** recommendation — the correct remediation is to declare it in
+`entryPoints`, not to delete it. `harness.config.json` currently seeds only package
+`index.ts` roots, so the repo's own build configs and framework roots are exposed to
+this false positive.
+
+## Goals
+
+- Teach the detector to classify an unreachable file that matches an **entry-point
+  convention** as a distinct finding (`reason: 'UNREFERENCED_ENTRY_POINT'`) instead
+  of generic `NO_IMPORTERS` dead code.
+- Make the suggestion fixer emit a **non-delete**, informational suggestion
+  (`type: 'configure-entrypoint'`, low/info priority) for those files — "declare in
+  entryPoints" — and never a delete suggestion.
+- Make the auto-fix fixer **never** auto-delete an entry-point-convention file.
+- Preserve existing behavior for genuinely orphaned files: they still get the delete
+  suggestion and the delete-file fix.
+- Seed the repo's obvious real build entry points into `harness.config.json`
+  `entropy.entryPoints`.
+
+## Non-goals (YAGNI)
+
+- Detecting entry points by parsing build-tool configs or `package.json` scripts —
+  v1 uses filename/path conventions only.
+- Changing reachability traversal or the graph-based dead-code path's semantics
+  beyond applying the same classification.
+- A new severity enum on `DeadFile` — the `reason` field is the classification
+  signal; "info severity" maps to the suggestion's existing `priority: 'low'`.
+
+## Decisions made
+
+1. **The classification lives in the detector; fixers key off `reason`.** A single
+   source of truth: `findDeadFiles` (snapshot path) and `classifyUnreachableNode`
+   (graph path) set `reason: 'UNREFERENCED_ENTRY_POINT'` when the path matches an
+   entry-point convention. `suggestions.ts` and `safe-fixes.ts` branch on that
+   `reason` — they do not re-implement path matching.
+
+2. **Entry-point conventions (v1).** A file matches when its basename/path matches:
+   - config files: basename matching `/\.config\.(m|c)?[jt]s$/` (vite/vitest/tsup/
+     rollup/etc. `*.config.ts|mts|cts|js|mjs|cjs`);
+   - framework module roots: basename in `{ main.ts, main.tsx, main.mts,
+app.module.ts }` (Vue/Angular/React `src/main.*`, NestJS `app.module.ts`).
+     The set is a documented constant, easy to extend.
+
+3. **New non-delete suggestion type `configure-entrypoint`.** Added to the
+   `Suggestion['type']` union. The suggestion has `priority: 'low'` (info),
+   `title: "Unreferenced entry point: <file>"`, and steps that tell the user to add
+   the file to `entropy.entryPoints` — never delete steps.
+
+4. **Auto-fix skips entry points.** `createDeadFileFixes` filters out
+   `UNREFERENCED_ENTRY_POINT` files so the more dangerous auto-delete path can never
+   remove a build entry point.
+
+5. **Seed real entry points.** Add the repo's genuine build entry points
+   (dashboard `main.tsx` + `vite.config.ts`, `tsup.config.ts` build configs) to
+   `harness.config.json` `entropy.entryPoints`. `resolveEntryPoints` treats
+   `entryPoints` as literal paths (no existence gate), so seeding is safe.
+
+## Acceptance criteria
+
+1. A `*.config.ts` file that is unreachable is emitted with
+   `reason: 'UNREFERENCED_ENTRY_POINT'` (not `NO_IMPORTERS`).
+2. A `src/main.ts` file that is unreachable is emitted with
+   `reason: 'UNREFERENCED_ENTRY_POINT'`.
+3. The suggestion fixer emits a `configure-entrypoint` (non-`delete`) suggestion for
+   an `UNREFERENCED_ENTRY_POINT` file, and never a `delete` suggestion for it.
+4. `createDeadFileFixes` emits no `delete-file` fix for an `UNREFERENCED_ENTRY_POINT`
+   file.
+5. A genuinely orphaned util (`reason: 'NO_IMPORTERS'`) still gets a `delete`
+   suggestion and a `delete-file` fix.
+6. `@harness-engineering/core` builds, typechecks, and the entropy dead-code +
+   fixer test suites pass; lint clean.

--- a/docs/changes/fix-dead-code-entrypoint-classification/provenance.json
+++ b/docs/changes/fix-dead-code-entrypoint-classification/provenance.json
@@ -1,0 +1,43 @@
+{
+  "issue": 1325,
+  "slug": "fix-dead-code-entrypoint-classification",
+  "branch": "fix/dead-code-entrypoints",
+  "title": "classify entry points instead of suggesting deletion",
+  "pipelineStages": [
+    {
+      "stage": "brainstorming",
+      "artifact": "docs/changes/fix-dead-code-entrypoint-classification/proposal.md"
+    },
+    {
+      "stage": "planning",
+      "artifact": "docs/changes/fix-dead-code-entrypoint-classification/plans/2026-08-15-dead-code-entrypoint-plan.md"
+    },
+    {
+      "stage": "execution",
+      "detail": "TDD: type widening, detector classification (isEntryPointConvention), suggestion + safe-fix branching, config seeding; tests-first per fixer",
+      "tests": [
+        "packages/core/tests/entropy/detectors/dead-code.test.ts",
+        "packages/core/tests/entropy/fixers/suggestions.test.ts",
+        "packages/core/tests/entropy/fixers/safe-fixes.test.ts"
+      ]
+    }
+  ],
+  "planArtifact": "docs/changes/fix-dead-code-entrypoint-classification/plans/2026-08-15-dead-code-entrypoint-plan.md",
+  "sourceChanges": [
+    "packages/core/src/entropy/types/dead-code.ts",
+    "packages/core/src/entropy/types/fix.ts",
+    "packages/core/src/entropy/detectors/dead-code.ts",
+    "packages/core/src/entropy/fixers/suggestions.ts",
+    "packages/core/src/entropy/fixers/safe-fixes.ts",
+    "harness.config.json"
+  ],
+  "assumptions": [
+    "'info severity' maps to Suggestion priority 'low' — no info severity enum exists on DeadFile/Suggestion, and adding one would ripple through unrelated consumers (YAGNI).",
+    "Entry-point conventions (v1) = config files matching /\\.config\\.(m|c)?[jt]s$/ plus framework roots basename in {main.ts, main.tsx, main.mts, app.module.ts}. Extensible constant, not exhaustive of every framework.",
+    "Seeding extra entryPoints into harness.config.json is safe: resolveEntryPoints maps explicit entries as literal paths with no on-disk existence gate.",
+    "New DeadFile reason + Suggestion type value is a minor bump for @harness-engineering/core.",
+    "Classification lives in the detector (single source of truth); fixers key off DeadFile.reason and never re-implement path matching. Applied to both the snapshot path (findDeadFiles) and the graph path (classifyUnreachableNode).",
+    "Auto-fix (safe-fixes createDeadFileFixes) is the most dangerous path and must also skip entry points — not only the advisory suggestion fixer."
+  ],
+  "notes": "Lane agent authored the spec/plan artifacts and implemented the recommended fix directly via TDD (dedicated lane agent), rather than delegating to a subagent. All local gates green."
+}

--- a/harness.config.json
+++ b/harness.config.json
@@ -251,7 +251,11 @@
       "packages/cli/src/bin/harness.ts",
       "packages/eslint-plugin/src/index.ts",
       "packages/linter-gen/src/index.ts",
-      "packages/orchestrator/src/index.ts"
+      "packages/orchestrator/src/index.ts",
+      "packages/dashboard/src/client/main.tsx",
+      "packages/dashboard/vite.config.ts",
+      "packages/burn/tsup.config.ts",
+      "packages/cli/tsup.config.ts"
     ],
     "autoFix": false
   },

--- a/packages/core/src/entropy/detectors/dead-code.ts
+++ b/packages/core/src/entropy/detectors/dead-code.ts
@@ -11,7 +11,48 @@ import type {
 } from '../types';
 import type { ProtectedRegionMap } from '../../annotations';
 import type { AST } from '../../shared/parsers';
-import { dirname, extname, resolve } from 'path';
+import { basename, dirname, extname, resolve } from 'path';
+
+/**
+ * Build entry points are reachable at build/runtime, not through static `import`
+ * edges, so they appear "unreachable" in the import graph when they are not listed
+ * in `entropy.entryPoints`. Deleting one breaks the build; the correct remediation
+ * is to declare it in `entryPoints` (issue #1325). These conventions let the
+ * detector classify such a file as `UNREFERENCED_ENTRY_POINT` instead of a generic
+ * dead file, so the fixers offer "configure entry point" rather than "delete".
+ *
+ * The set is intentionally convention-based (filename/path) and easy to extend; it
+ * is not derived from build-tool configs.
+ */
+
+/** Build-config files: `*.config.ts|mts|cts|js|mjs|cjs` (vite/vitest/tsup/rollup/…). */
+const CONFIG_FILE_RE = /\.config\.(m|c)?[jt]s$/;
+
+/** Framework module roots addressed by tooling, not by a static import. */
+const ENTRY_POINT_BASENAMES = new Set([
+  'main.ts', // Vue / Angular / NestJS root
+  'main.tsx', // React (Vite) root
+  'main.mts',
+  'app.module.ts', // NestJS root module
+]);
+
+/**
+ * True when an unreachable file's path matches a build entry-point convention and
+ * should be declared in `entryPoints` rather than deleted.
+ */
+export function isEntryPointConvention(filePath: string): boolean {
+  const base = basename(filePath);
+  return CONFIG_FILE_RE.test(base) || ENTRY_POINT_BASENAMES.has(base);
+}
+
+/**
+ * Classify an unreachable file's `DeadFile.reason`: an entry-point-convention file
+ * is `UNREFERENCED_ENTRY_POINT` (declare in entryPoints), everything else is a
+ * genuine `NO_IMPORTERS` dead file.
+ */
+function unreachableFileReason(filePath: string): 'NO_IMPORTERS' | 'UNREFERENCED_ENTRY_POINT' {
+  return isEntryPointConvention(filePath) ? 'UNREFERENCED_ENTRY_POINT' : 'NO_IMPORTERS';
+}
 
 /**
  * Module-resolution conventions where the import specifier writes a runtime
@@ -314,7 +355,7 @@ function findDeadFiles(snapshot: CodebaseSnapshot, reachability: Map<string, boo
     if (!isReachable) {
       deadFiles.push({
         path: file.path,
-        reason: 'NO_IMPORTERS',
+        reason: unreachableFileReason(file.path),
         exportCount: file.exports.filter((e) => !e.isReExport).length,
         lineCount: countLinesFromAST(file.ast),
       });
@@ -438,9 +479,10 @@ function classifyUnreachableNode(
   deadExports: DeadExport[]
 ): void {
   if (FILE_TYPES.has(node.type)) {
+    const filePath = node.path || node.id;
     deadFiles.push({
-      path: node.path || node.id,
-      reason: 'NO_IMPORTERS',
+      path: filePath,
+      reason: unreachableFileReason(filePath),
       exportCount: 0,
       lineCount: 0,
     });

--- a/packages/core/src/entropy/fixers/safe-fixes.ts
+++ b/packages/core/src/entropy/fixers/safe-fixes.ts
@@ -23,14 +23,21 @@ const DEFAULT_FIX_CONFIG: FixConfig = {
  * Create fixes for dead files
  */
 function createDeadFileFixes(deadCodeReport: DeadCodeReport): Fix[] {
-  return deadCodeReport.deadFiles.map((file) => ({
-    type: 'dead-files' as FixType,
-    file: file.path,
-    description: `Delete dead file (${file.reason}): ${basename(file.path)}`,
-    action: 'delete-file' as const,
-    safe: true,
-    reversible: true,
-  }));
+  return (
+    deadCodeReport.deadFiles
+      // Never auto-delete a build entry point: it is reachable at build/runtime, not
+      // through static imports, so it only looks dead. Remediation is to declare it in
+      // entryPoints, surfaced as an advisory suggestion instead (issue #1325).
+      .filter((file) => file.reason !== 'UNREFERENCED_ENTRY_POINT')
+      .map((file) => ({
+        type: 'dead-files' as FixType,
+        file: file.path,
+        description: `Delete dead file (${file.reason}): ${basename(file.path)}`,
+        action: 'delete-file' as const,
+        safe: true,
+        reversible: true,
+      }))
+  );
 }
 
 /**

--- a/packages/core/src/entropy/fixers/suggestions.ts
+++ b/packages/core/src/entropy/fixers/suggestions.ts
@@ -6,8 +6,41 @@ import type {
   SuggestionReport,
 } from '../types';
 
+/**
+ * Build an informational suggestion for an unreferenced build entry point.
+ *
+ * Entry points (config files, framework module roots) are reachable at build/runtime
+ * rather than through static imports, so they look "dead" when absent from
+ * `entropy.entryPoints`. The remediation is to declare them, never to delete them
+ * (issue #1325).
+ */
+function entryPointSuggestion(file: DeadCodeReport['deadFiles'][number]): Suggestion {
+  const name = file.path.split('/').pop();
+  return {
+    type: 'configure-entrypoint',
+    priority: 'low', // info: advisory, never a destructive default
+    source: 'dead-code',
+    relatedIssues: [`unreferenced-entry-point:${file.path}`],
+    title: `Unreferenced entry point: ${name}`,
+    description:
+      `"${name}" looks like a build entry point (config file or framework module root) ` +
+      `but is unreachable from the configured entryPoints. Declare it in ` +
+      `entropy.entryPoints — do not delete it.`,
+    files: [file.path],
+    steps: [
+      `Add "${file.path}" to entropy.entryPoints in harness.config.json`,
+      'Re-run dead-code detection to confirm it is no longer flagged',
+    ],
+    whyManual:
+      'Entry points are reachable at build/runtime, not via static imports; deleting one breaks the build',
+  };
+}
+
 /** Build a suggestion for a single dead file. */
 function deadFileSuggestion(file: DeadCodeReport['deadFiles'][number]): Suggestion {
+  if (file.reason === 'UNREFERENCED_ENTRY_POINT') {
+    return entryPointSuggestion(file);
+  }
   return {
     type: 'delete',
     priority: 'high',

--- a/packages/core/src/entropy/types/dead-code.ts
+++ b/packages/core/src/entropy/types/dead-code.ts
@@ -11,7 +11,13 @@ export interface DeadExport {
 
 export interface DeadFile {
   path: string;
-  reason: 'NO_IMPORTERS' | 'NOT_ENTRY_POINT' | 'ALL_EXPORTS_DEAD';
+  /**
+   * - `NO_IMPORTERS` — unreachable from entry points; a genuine dead file.
+   * - `UNREFERENCED_ENTRY_POINT` — unreachable, but the path matches a build
+   *   entry-point convention (config file, framework module root). Remediation is
+   *   to declare it in `entropy.entryPoints`, NOT to delete it (issue #1325).
+   */
+  reason: 'NO_IMPORTERS' | 'UNREFERENCED_ENTRY_POINT' | 'NOT_ENTRY_POINT' | 'ALL_EXPORTS_DEAD';
   exportCount: number;
   lineCount: number;
 }

--- a/packages/core/src/entropy/types/fix.ts
+++ b/packages/core/src/entropy/types/fix.ts
@@ -83,7 +83,10 @@ export interface Suggestion {
     | 'delete'
     | 'update-docs'
     | 'add-export'
-    | 'refactor';
+    | 'refactor'
+    // Non-destructive remediation for an unreferenced build entry point: declare
+    // it in `entropy.entryPoints` rather than delete it (issue #1325).
+    | 'configure-entrypoint';
   priority: 'high' | 'medium' | 'low';
   source: 'drift' | 'dead-code' | 'pattern';
   relatedIssues: string[];

--- a/packages/core/tests/entropy/detectors/dead-code.test.ts
+++ b/packages/core/tests/entropy/detectors/dead-code.test.ts
@@ -249,6 +249,49 @@ describe('detectDeadCode with protectedRegions', () => {
   });
 });
 
+describe('detectDeadCode entry-point classification (issue #1325)', () => {
+  const parser = new TypeScriptParser();
+  const fixturesDir = join(__dirname, '../../fixtures/entropy/dead-code-entrypoints');
+  const toPosix = (p: string) => p.replace(/\\/g, '/');
+
+  async function report() {
+    const snapshotResult = await buildSnapshot({
+      rootDir: fixturesDir,
+      parser,
+      analyze: { deadCode: true },
+      include: ['src/**/*.ts'],
+      entryPoints: ['src/index.ts'],
+    });
+    expect(snapshotResult.ok).toBe(true);
+    if (!snapshotResult.ok) throw new Error('snapshot failed');
+    const result = await detectDeadCode(snapshotResult.value);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('detect failed');
+    return result.value;
+  }
+
+  it('classifies an unreachable *.config.ts as UNREFERENCED_ENTRY_POINT (not deletable)', async () => {
+    const value = await report();
+    const config = value.deadFiles.find((f) => toPosix(f.path).endsWith('/src/app.config.ts'));
+    expect(config, 'app.config.ts must be flagged as unreachable').toBeDefined();
+    expect(config!.reason).toBe('UNREFERENCED_ENTRY_POINT');
+  });
+
+  it('classifies an unreachable src/main.ts as UNREFERENCED_ENTRY_POINT', async () => {
+    const value = await report();
+    const main = value.deadFiles.find((f) => toPosix(f.path).endsWith('/src/main.ts'));
+    expect(main, 'main.ts must be flagged as unreachable').toBeDefined();
+    expect(main!.reason).toBe('UNREFERENCED_ENTRY_POINT');
+  });
+
+  it('still classifies a genuinely orphaned util as a deletable NO_IMPORTERS dead file', async () => {
+    const value = await report();
+    const orphan = value.deadFiles.find((f) => toPosix(f.path).endsWith('/src/orphan.ts'));
+    expect(orphan, 'orphan.ts must be flagged as unreachable').toBeDefined();
+    expect(orphan!.reason).toBe('NO_IMPORTERS');
+  });
+});
+
 describe('buildReachabilityMap with NodeNext .js import extensions (issue #279)', () => {
   const parser = new TypeScriptParser();
   const fixturesDir = join(__dirname, '../../fixtures/entropy/dead-code-nodenext');

--- a/packages/core/tests/entropy/fixers/safe-fixes.test.ts
+++ b/packages/core/tests/entropy/fixers/safe-fixes.test.ts
@@ -51,6 +51,42 @@ describe('createFixes', () => {
     expect(fixes[0].reversible).toBe(true);
   });
 
+  it('never emits a delete-file fix for an unreferenced entry point, but still deletes genuine dead files (issue #1325)', () => {
+    const deadCodeReport: DeadCodeReport = {
+      deadExports: [],
+      deadFiles: [
+        {
+          path: '/project/vite.config.ts',
+          reason: 'UNREFERENCED_ENTRY_POINT',
+          exportCount: 1,
+          lineCount: 12,
+        },
+        { path: '/project/src/orphan.ts', reason: 'NO_IMPORTERS', exportCount: 1, lineCount: 8 },
+      ],
+      deadInternals: [],
+      unusedImports: [],
+      stats: {
+        filesAnalyzed: 10,
+        entryPointsUsed: [],
+        totalExports: 20,
+        deadExportCount: 0,
+        totalFiles: 10,
+        deadFileCount: 2,
+        estimatedDeadLines: 20,
+      },
+    };
+
+    const fixes = createFixes(deadCodeReport, {
+      fixTypes: ['dead-files'],
+      dryRun: false,
+      createBackup: true,
+    });
+
+    expect(fixes.length).toBe(1);
+    expect(fixes[0].file).toBe('/project/src/orphan.ts');
+    expect(fixes.some((f) => f.file === '/project/vite.config.ts')).toBe(false);
+  });
+
   it('should create fix for unused imports', () => {
     const deadCodeReport: DeadCodeReport = {
       deadExports: [],

--- a/packages/core/tests/entropy/fixers/suggestions.test.ts
+++ b/packages/core/tests/entropy/fixers/suggestions.test.ts
@@ -74,6 +74,56 @@ describe('generateSuggestions', () => {
     expect(unusedImportSuggestion?.type).toBe('delete');
   });
 
+  it('emits a non-delete configure-entrypoint suggestion for an unreferenced entry point (issue #1325)', () => {
+    const deadCodeReport: DeadCodeReport = {
+      deadFiles: [
+        {
+          path: '/project/vite.config.ts',
+          reason: 'UNREFERENCED_ENTRY_POINT',
+          exportCount: 1,
+          lineCount: 12,
+        },
+        {
+          path: '/project/src/orphan.ts',
+          reason: 'NO_IMPORTERS',
+          exportCount: 1,
+          lineCount: 8,
+        },
+      ],
+      deadExports: [],
+      unusedImports: [],
+      deadInternals: [],
+      stats: {
+        filesAnalyzed: 10,
+        entryPointsUsed: [],
+        totalExports: 20,
+        deadExportCount: 0,
+        totalFiles: 10,
+        deadFileCount: 2,
+        estimatedDeadLines: 20,
+      },
+    };
+
+    const result = generateSuggestions(deadCodeReport);
+
+    const entryPointSuggestion = result.suggestions.find((s) =>
+      s.files.includes('/project/vite.config.ts')
+    );
+    expect(entryPointSuggestion).toBeDefined();
+    expect(entryPointSuggestion?.type).toBe('configure-entrypoint');
+    expect(entryPointSuggestion?.type).not.toBe('delete');
+    expect(entryPointSuggestion?.priority).toBe('low');
+    expect(entryPointSuggestion?.steps.some((s) => /entryPoints/.test(s))).toBe(true);
+    expect(entryPointSuggestion?.steps.some((s) => /^Delete /.test(s))).toBe(false);
+
+    // A genuinely orphaned file still gets a delete suggestion.
+    const orphanSuggestion = result.suggestions.find((s) =>
+      s.files.includes('/project/src/orphan.ts')
+    );
+    expect(orphanSuggestion?.type).toBe('delete');
+    expect(orphanSuggestion?.priority).toBe('high');
+  });
+
   it('should generate suggestions from drift report', () => {
     const driftReport: DriftReport = {
       drifts: [

--- a/packages/core/tests/fixtures/entropy/dead-code-entrypoints/package.json
+++ b/packages/core/tests/fixtures/entropy/dead-code-entrypoints/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dead-code-entrypoints-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts"
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/app.config.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/app.config.ts
@@ -1,0 +1,6 @@
+// A build-config file (`*.config.ts`). Loaded by tooling, not via static import,
+// so it is unreachable in the import graph but must be declared in entryPoints,
+// not deleted.
+export default {
+  build: true,
+};

--- a/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/index.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/index.ts
@@ -1,0 +1,5 @@
+import { used } from './used';
+
+export function run(): string {
+  return used();
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/main.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/main.ts
@@ -1,0 +1,6 @@
+// A framework module root (e.g. Vue/Angular/NestJS). Reachable at build/runtime,
+// not through a static import, so it is unreachable in the import graph but must
+// NOT be classified as a deletable dead file.
+export function bootstrap(): void {
+  // side-effecting entry point
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/orphan.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/orphan.ts
@@ -1,0 +1,5 @@
+// A genuinely orphaned utility: not imported anywhere and not an entry point.
+// It must still be classified as a deletable dead file (NO_IMPORTERS).
+export function orphanUtil(): number {
+  return 42;
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/used.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-entrypoints/src/used.ts
@@ -1,0 +1,3 @@
+export function used(): string {
+  return 'used';
+}


### PR DESCRIPTION
Closes #1325

## Problem
The dead-code detector treated every file unreachable from `entropy.entryPoints` as generic dead code (`reason: 'NO_IMPORTERS'`). Two fixers then turned that into a **delete** recommendation:
- `suggestions.ts` → high-priority `type: 'delete'` ("can be safely removed")
- `safe-fixes.ts` → auto-applicable `action: 'delete-file'` for **every** dead file

Build entry points (`*.config.ts`, `src/main.ts(x)`, `app.module.ts`) are reachable at build/runtime, not through static imports, so when they're absent from `entryPoints` they look dead and get a delete suggestion. The correct remediation is to declare them in `entryPoints`, not delete them.

## Fix
- **Detector** (`dead-code.ts`): new `isEntryPointConvention()` helper; `findDeadFiles` and the graph path (`classifyUnreachableNode`) now emit the new `DeadFile` reason `UNREFERENCED_ENTRY_POINT` for entry-point-convention files.
- **Suggestion fixer**: emits a new non-destructive `Suggestion` type `configure-entrypoint` at `low` (info) priority — "declare it in entryPoints" — never a delete suggestion.
- **Auto-fix fixer**: filters `UNREFERENCED_ENTRY_POINT` out of `createDeadFileFixes`, so a build entry point can never be auto-deleted.
- **Config**: seed the repo's real build entry points (dashboard main.tsx/vite.config, tsup configs) into `harness.config.json`.
- Genuinely orphaned files (`NO_IMPORTERS`) still get the delete suggestion + delete-file fix.

Classification lives only in the detector (single source of truth); fixers branch on `DeadFile.reason`.

## Conventions (v1)
Config files matching `/\.config\.(m|c)?[jt]s$/` + framework roots basename `{main.ts, main.tsx, main.mts, app.module.ts}`. Documented, extensible constant.

## Tests
Detector (config + main.ts classified as entry points; orphan stays NO_IMPORTERS), suggestions (configure-entrypoint non-delete for entry point; delete for orphan), safe-fixes (no delete-file for entry point; still deletes orphan). Full entropy suite green (168 tests).

## Assumptions (recommended defaults, per issue)
- "info severity" maps to Suggestion `priority: 'low'` — no info enum exists; adding one would ripple through unrelated consumers (YAGNI).
- Entry-point conventions cover config files + `main.*`/`app.module.ts`; extensible, not exhaustive.
- Seeding extra `entryPoints` is safe: `resolveEntryPoints` maps explicit entries as literal paths (no existence gate).
- New reason/suggestion-type value → **minor** bump for `@harness-engineering/core`.

Artifacts: `docs/changes/fix-dead-code-entrypoint-classification/` (proposal, plan, provenance).