### PR TITLE
fix(roadmap-fleet): satisfiable VERIFY provenance + closing-keyword contract

### DIFF
--- a/.antigravity-extension/commands/roadmap-fleet.toml
+++ b/.antigravity-extension/commands/roadmap-fleet.toml
@@ -12,8 +12,8 @@ Autonomous batch-build orchestrator — score and confirm a batch of backlog can
 Phases:
 - select: Enumerate candidates (open issues + unblocked roadmap shards), cross-check against merged/open PRs, score and order via roadmap-pilot impact scoring
 - confirm: Present the ranked batch in one round — resolved items flagged for closure, decision forks as questions, proposed concurrency — for a single up-front human approval
-- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item, capped at the concurrency governor
-- verify: Independently confirm each returned branch has a plan artifact plus autopilot-state and is CI-green across all OS plus enforce and harness — never by subagent self-report
+- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item (writing a committed provenance file and using the scope-correct closing keyword — Closes for full resolution, Refs for a slice), capped at the concurrency governor
+- verify: Independently confirm each returned branch has a plan artifact plus a committed provenance file, a scope-correct closing keyword in the PR body, and is CI-green across all OS plus enforce and harness — never by subagent self-report
 - report: Emit a one-row-per-item batch summary with assumptions notes for bulk human review, close already-resolved issues citing the resolving PR, never merge
 </objective>
 
@@ -50,7 +50,7 @@ Building a backlog through the harness pipeline one item at a time is an attenti
 
 **A PR is "merge-ready" only after independent artifact + all-OS-CI verification. The fleet never auto-merges, and never accepts a subagent's self-report as proof its pipeline ran.**
 
-A subagent that reports "done — pipeline ran, CI green" has told you what it believes, not what is true. The only evidence that the real per-item pipeline ran is the artifact it necessarily leaves behind (a plan directory plus an autopilot-state) and the CI signal on the pushed branch. If either is missing, the item did not run the pipeline as required and is rejected or retried — regardless of how confident the report reads. And landing the batch is the human's call: the fleet stops at a set of verified, reviewable PRs.
+A subagent that reports "done — pipeline ran, CI green" has told you what it believes, not what is true. The only evidence that the real per-item pipeline ran is the artifact it necessarily leaves behind (a plan directory plus a committed pipeline-provenance file) and the CI signal on the pushed branch. If either is missing, the item did not run the pipeline as required and is rejected or retried — regardless of how confident the report reads. And landing the batch is the human's call: the fleet stops at a set of verified, reviewable PRs.
 
 ```
 Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
@@ -114,21 +114,31 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 4. **Record an "assumptions made" note per item.** Each subagent records the recommended-option defaults it took so the eventual PR carries an assumptions note — batch review is only trustworthy when the reviewer can see what was assumed.
 
-5. **Push-path caveat.** A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
+5. **Write a committed pipeline-provenance file.** Each lane **MUST** write `docs/changes/<slug>/provenance.json` and commit it onto its branch. This is the verifiable proof the real pipeline ran — it replaces the session state that `.harness/.gitignore` excludes from every branch by construction (and so never survives into a PR). The file records at minimum: the item's **issue number(s)**, the **pipeline stages run** (e.g. `brainstorming`, `autopilot`/`planning`, `execution`, `review`), the **plan-artifact path** under `docs/changes/<slug>/plans/`, and the **assumptions** taken (the recommended-option defaults from item 4). VERIFY checks for this committed file; a branch without it did not run the pipeline.
+
+6. **Reference the issue with the correct closing keyword.** Each lane decides — and states in its PR body — how its PR references the issue it was dispatched for. This is a real decision with a default, not an incidental phrasing:
+   - A PR that **fully resolves** its issue uses `Closes #<N>`, so the merge-triggered reconciler closes the issue and marks the roadmap row done.
+   - A PR that lands only **one slice** of a multi-finding issue uses `Refs #<N>` (which triggers no auto-close) and **flags the issue for manual reconciliation** in REPORT, naming the row that still needs attention.
+
+   Defaulting to `Refs` on a fully-resolving PR silently strands the roadmap row `planned`/`in-progress` forever, because `Refs` fires no closing behavior; defaulting to `Closes` on a partial slice closes an issue that still has open findings. The lane picks deliberately and records which keyword it used (and why, if partial) in its assumptions note and provenance file.
+
+7. **Push-path caveat.** A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
 
 ### Phase 4: VERIFY — Independent Confirmation, Never Self-Report
 
 1. **Never accept a subagent's self-report as verification.** "The pipeline ran and CI is green" is a claim to be checked, not a result. For each returned branch, the orchestrator independently confirms the evidence itself.
 
-2. **Require the pipeline artifact.** Confirm that both exist on the branch:
+2. **Require the pipeline artifact.** Confirm that both exist **committed on the branch** (so they survive into the PR):
    - A plan artifact under `docs/changes/<slug>/plans/` — the necessary trace of a real brainstorming→autopilot run.
-   - An autopilot-state (session state) for the item.
+   - A committed pipeline-provenance file under `docs/changes/<slug>/` (e.g. `provenance.json`) recording the item's issue number(s), the pipeline stages run, the plan-artifact path, and the assumptions taken. This replaces the old session-state check: session state lives under `.harness/sessions/`, which `.harness/.gitignore` excludes from every branch by construction, so it is absent from every PR and can never be verified — the committed provenance file is the artifact that actually survives to where the orchestrator can check it.
 
-   An item with **no plan artifact did not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry once); it is never marked merge-ready.
+   An item with **no plan artifact or no committed provenance file did not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry once); it is never marked merge-ready.
 
-3. **Require all-OS CI green.** Confirm the pushed branch's CI is green on **all three operating systems** plus the enforce and harness checks (`gh pr checks` / `gh run list`). Green on one OS is not green. A subset-red branch is not merge-ready — it is reported as failed, and the batch continues.
+3. **Check the PR body's issue reference.** Confirm the PR body carries the closing keyword that matches the item's scope (the DISPATCH contract): a fully-resolving item uses `Closes #<N>`; a partial-slice item uses `Refs #<N>` and is flagged for manual reconciliation. A **fully-resolving item whose PR body carries no closing keyword** will strand its roadmap row on merge — flag it for correction before the batch is handed over. This is cheaply detectable from the PR body at verify time.
 
-4. **Classify each returned item** as `verified` (artifact present + all-OS CI green), `rejected` (missing artifact or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
+4. **Require all-OS CI green.** Confirm the pushed branch's CI is green on **all three operating systems** plus the enforce and harness checks (`gh pr checks` / `gh run list`). Green on one OS is not green. A subset-red branch is not merge-ready — it is reported as failed, and the batch continues.
+
+5. **Classify each returned item** as `verified` (plan artifact + committed provenance file present, correct closing keyword, and all-OS CI green), `rejected` (missing artifact/provenance or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
 
 ### Phase 5: REPORT — Batch Summary, Resolved-Issue Closure, Never Merge
 
@@ -158,7 +168,7 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Success Criteria
 
-- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with a verified plan artifact and green CI across all three OS plus enforce and harness.
+- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with a verified plan artifact, a committed provenance file, a scope-correct closing keyword, and green CI across all three OS plus enforce and harness.
 - There is **exactly one** up-front human decision round; no per-item interactive pauses except a genuinely-new fork parked to its own item.
 - **Every emitted PR carries an "assumptions made" note.**
 - Already-resolved candidates are **closed with resolving-PR citations, not rebuilt**.
@@ -169,7 +179,8 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Gates
 
-- **No "merge-ready" without a verified plan artifact.** An item lacking `docs/changes/<slug>/plans/` did not run the real pipeline. It is rejected or retried — never reported as merge-ready, no matter what the subagent claimed.
+- **No "merge-ready" without a verified plan artifact and committed provenance file.** An item lacking either `docs/changes/<slug>/plans/` or a committed `docs/changes/<slug>/provenance.json` did not run the real pipeline (the provenance file — not the gitignored session state, which never reaches a branch — is the artifact that survives into the PR). It is rejected or retried — never reported as merge-ready, no matter what the subagent claimed.
+- **No fully-resolving PR without a closing keyword.** A PR that fully resolves its issue but whose body carries no `Closes #<N>` will strand its roadmap row on merge; a partial-slice PR must use `Refs #<N>` and be flagged for manual reconciliation. A mismatch between scope and keyword is a gate finding — correct it before handover.
 - **No "merge-ready" without all-OS CI green.** Green on a subset of operating systems (or with enforce/harness checks red) is not merge-ready. Report it failed; do not ship it.
 - **Never auto-merge.** The fleet stops at reviewable PRs. Merging a feature PR from inside the fleet = gate violation; the human lands the batch.
 - **Never exceed the concurrency governor.** More than ~3 concurrent build agents is the machine-storm zone; do not raise the cap to "go faster."
@@ -187,16 +198,16 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Rationalizations to Reject
 
-| Rationalization                                                                   | Reality                                                                                                                                                                            |
-| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The subagent reported its pipeline ran and CI is green, so it did"               | A self-report is a claim, not evidence. Independently confirm the `docs/changes/<slug>/plans/` artifact and autopilot-state exist and CI is green — or the item did not run.       |
-| "CI is green on Linux, ship it"                                                   | Green on one OS is not green. Merge-ready requires all three operating systems plus the enforce and harness checks. A subset-red branch is reported failed, not shipped.           |
-| "This item's fork is small — I'll just guess and keep the batch moving"           | Unforeseen forks **park and report**; they are never silently guessed mid-flight. Guessing buries an unstated assumption in a PR the reviewer cannot see.                          |
-| "I'll hand-implement this one item — it's faster than driving the whole pipeline" | Dogfood the real per-item skills. A hand-built item leaves no plan artifact, fails VERIFY, and breaks the guarantee that every PR ran the audited pipeline.                        |
-| "The batch is verified and ready — I'll merge them to save the human a step"      | Never auto-merge. The fleet stops at reviewable PRs; the human (or `pr-fleet`) lands the batch. Auto-merging removes the one review the whole model is built around.               |
-| "One item's pipeline failed, so the run is a bust — abort the batch"              | Degrade gracefully. Report the failed item and keep the verified ones; one bad item never sinks the batch.                                                                         |
-| "This candidate looks new to me, no need to check merged PRs"                     | Cross-check every candidate against merged/open PRs. An already-resolved item rebuilt from scratch is duplicate work and a conflicting PR; resolved items get closed, not rebuilt. |
-| "Bumping concurrency to six will finish the batch sooner"                         | Beyond ~3 concurrent build agents is the machine-storm zone — compound load produces flaky failures that cost more in re-runs than the extra parallelism saves.                    |
+| Rationalization                                                                   | Reality                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The subagent reported its pipeline ran and CI is green, so it did"               | A self-report is a claim, not evidence. Independently confirm the `docs/changes/<slug>/plans/` artifact and the committed `docs/changes/<slug>/provenance.json` exist and CI is green — or the item did not run. |
+| "CI is green on Linux, ship it"                                                   | Green on one OS is not green. Merge-ready requires all three operating systems plus the enforce and harness checks. A subset-red branch is reported failed, not shipped.                                         |
+| "This item's fork is small — I'll just guess and keep the batch moving"           | Unforeseen forks **park and report**; they are never silently guessed mid-flight. Guessing buries an unstated assumption in a PR the reviewer cannot see.                                                        |
+| "I'll hand-implement this one item — it's faster than driving the whole pipeline" | Dogfood the real per-item skills. A hand-built item leaves no plan artifact, fails VERIFY, and breaks the guarantee that every PR ran the audited pipeline.                                                      |
+| "The batch is verified and ready — I'll merge them to save the human a step"      | Never auto-merge. The fleet stops at reviewable PRs; the human (or `pr-fleet`) lands the batch. Auto-merging removes the one review the whole model is built around.                                             |
+| "One item's pipeline failed, so the run is a bust — abort the batch"              | Degrade gracefully. Report the failed item and keep the verified ones; one bad item never sinks the batch.                                                                                                       |
+| "This candidate looks new to me, no need to check merged PRs"                     | Cross-check every candidate against merged/open PRs. An already-resolved item rebuilt from scratch is duplicate work and a conflicting PR; resolved items get closed, not rebuilt.                               |
+| "Bumping concurrency to six will finish the batch sooner"                         | Beyond ~3 concurrent build agents is the machine-storm zone — compound load produces flaky failures that cost more in re-runs than the extra parallelism saves.                                                  |
 
 ## Red Flags
 
@@ -237,9 +248,9 @@ Phase 3: DISPATCH (governor = 2)
     -> parks and reports; the other 3 continue.
 
 Phase 4: VERIFY (independent — no self-report)
-  item A: plan artifact + autopilot-state present, CI green all 3 OS + enforce + harness -> verified
-  item B: plan artifact + autopilot-state present, CI green all 3 OS -> verified
-  item C: NO plan artifact on the branch (self-reported "done") -> REJECTED (hand-built, not piped)
+  item A: plan artifact + provenance.json present, Closes #N in body, CI green all 3 OS + enforce + harness -> verified
+  item B: plan artifact + provenance.json present, Closes #N in body, CI green all 3 OS -> verified
+  item C: NO plan artifact / no provenance.json on the branch (self-reported "done") -> REJECTED (hand-built, not piped)
   item D: parked in DISPATCH -> not verified (fork awaits human)
 
 Phase 5: REPORT
@@ -255,13 +266,17 @@ Phase 5: REPORT
 
 ### Example: Rejecting a hand-built item
 
-A subagent returns a branch and reports "done — implemented the fix, tests pass, CI green." VERIFY looks for `docs/changes/<slug>/plans/` and finds nothing: there is no plan artifact and no autopilot-state. The item was hand-implemented, short-cutting the real pipeline. Per the Iron Law it is **rejected** (retried once, still no artifact → reported as "did not run the pipeline"), never marked merge-ready. The batch's other verified items proceed to REPORT unaffected.
+A subagent returns a branch and reports "done — implemented the fix, tests pass, CI green." VERIFY looks for `docs/changes/<slug>/plans/` and finds nothing: there is no plan artifact and no committed `provenance.json`. The item was hand-implemented, short-cutting the real pipeline. Per the Iron Law it is **rejected** (retried once, still no artifact → reported as "did not run the pipeline"), never marked merge-ready. The batch's other verified items proceed to REPORT unaffected.
 
 ## Test Scenarios
 
 ### Scenario 1: Gate — a self-report accepted as verification
 
-VERIFY receives a subagent claiming "pipeline ran, CI green" but the branch has no `docs/changes/<slug>/plans/` artifact. Expected: the "no merge-ready without a verified plan artifact" Gate halts marking it merge-ready; the item is rejected/retried, not reported as a PR. Accepting the self-report is the failure this scenario guards against.
+VERIFY receives a subagent claiming "pipeline ran, CI green" but the branch has no `docs/changes/<slug>/plans/` artifact and no committed `provenance.json`. Expected: the "no merge-ready without a verified plan artifact and committed provenance file" Gate halts marking it merge-ready; the item is rejected/retried, not reported as a PR. Accepting the self-report is the failure this scenario guards against.
+
+### Scenario 4: Closing-keyword contract — a fully-resolving PR briefed with `Refs`
+
+A lane fully resolves its single-finding issue but its PR body reads `Refs #N`. Expected: VERIFY's PR-body check flags the scope/keyword mismatch — a fully-resolving PR must use `Closes #N` or the merge-triggered reconciler leaves the roadmap row `planned`/`in-progress` forever. The lane corrects the body to `Closes #N` before handover. A partial-slice PR of a multi-finding issue is the mirror case: it correctly keeps `Refs #N` and is flagged for manual reconciliation. Defaulting the keyword by accident — the failure that stranded rows #1208/#1128/#1129/#603 — is what this scenario guards against.
 
 ### Scenario 2: Rationalization — hand-implementing one item
 
@@ -320,10 +335,10 @@ phases:
     description: Present the ranked batch in one round — resolved items flagged for closure, decision forks as questions, proposed concurrency — for a single up-front human approval
     required: true
   - name: dispatch
-    description: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item, capped at the concurrency governor
+    description: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item (writing a committed provenance file and using the scope-correct closing keyword — Closes for full resolution, Refs for a slice), capped at the concurrency governor
     required: true
   - name: verify
-    description: Independently confirm each returned branch has a plan artifact plus autopilot-state and is CI-green across all OS plus enforce and harness — never by subagent self-report
+    description: Independently confirm each returned branch has a plan artifact plus a committed provenance file, a scope-correct closing keyword in the PR body, and is CI-green across all OS plus enforce and harness — never by subagent self-report
     required: true
   - name: report
     description: Emit a one-row-per-item batch summary with assumptions notes for bulk human review, close already-resolved issues citing the resolving PR, never merge

--- a/.claude-plugin/commands/roadmap-fleet.md
+++ b/.claude-plugin/commands/roadmap-fleet.md
@@ -23,8 +23,8 @@ Phases:
 
 - select: Enumerate candidates (open issues + unblocked roadmap shards), cross-check against merged/open PRs, score and order via roadmap-pilot impact scoring
 - confirm: Present the ranked batch in one round — resolved items flagged for closure, decision forks as questions, proposed concurrency — for a single up-front human approval
-- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item, capped at the concurrency governor
-- verify: Independently confirm each returned branch has a plan artifact plus autopilot-state and is CI-green across all OS plus enforce and harness — never by subagent self-report
+- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item (writing a committed provenance file and using the scope-correct closing keyword — Closes for full resolution, Refs for a slice), capped at the concurrency governor
+- verify: Independently confirm each returned branch has a plan artifact plus a committed provenance file, a scope-correct closing keyword in the PR body, and is CI-green across all OS plus enforce and harness — never by subagent self-report
 - report: Emit a one-row-per-item batch summary with assumptions notes for bulk human review, close already-resolved issues citing the resolving PR, never merge
   </objective>
 

--- a/.cursor-plugin/commands/roadmap-fleet.md
+++ b/.cursor-plugin/commands/roadmap-fleet.md
@@ -17,8 +17,8 @@ Phases:
 
 - select: Enumerate candidates (open issues + unblocked roadmap shards), cross-check against merged/open PRs, score and order via roadmap-pilot impact scoring
 - confirm: Present the ranked batch in one round — resolved items flagged for closure, decision forks as questions, proposed concurrency — for a single up-front human approval
-- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item, capped at the concurrency governor
-- verify: Independently confirm each returned branch has a plan artifact plus autopilot-state and is CI-green across all OS plus enforce and harness — never by subagent self-report
+- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item (writing a committed provenance file and using the scope-correct closing keyword — Closes for full resolution, Refs for a slice), capped at the concurrency governor
+- verify: Independently confirm each returned branch has a plan artifact plus a committed provenance file, a scope-correct closing keyword in the PR body, and is CI-green across all OS plus enforce and harness — never by subagent self-report
 - report: Emit a one-row-per-item batch summary with assumptions notes for bulk human review, close already-resolved issues citing the resolving PR, never merge
   </objective>
 

--- a/.gemini-extension/commands/roadmap-fleet.toml
+++ b/.gemini-extension/commands/roadmap-fleet.toml
@@ -12,8 +12,8 @@ Autonomous batch-build orchestrator — score and confirm a batch of backlog can
 Phases:
 - select: Enumerate candidates (open issues + unblocked roadmap shards), cross-check against merged/open PRs, score and order via roadmap-pilot impact scoring
 - confirm: Present the ranked batch in one round — resolved items flagged for closure, decision forks as questions, proposed concurrency — for a single up-front human approval
-- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item, capped at the concurrency governor
-- verify: Independently confirm each returned branch has a plan artifact plus autopilot-state and is CI-green across all OS plus enforce and harness — never by subagent self-report
+- dispatch: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item (writing a committed provenance file and using the scope-correct closing keyword — Closes for full resolution, Refs for a slice), capped at the concurrency governor
+- verify: Independently confirm each returned branch has a plan artifact plus a committed provenance file, a scope-correct closing keyword in the PR body, and is CI-green across all OS plus enforce and harness — never by subagent self-report
 - report: Emit a one-row-per-item batch summary with assumptions notes for bulk human review, close already-resolved issues citing the resolving PR, never merge
 </objective>
 
@@ -50,7 +50,7 @@ Building a backlog through the harness pipeline one item at a time is an attenti
 
 **A PR is "merge-ready" only after independent artifact + all-OS-CI verification. The fleet never auto-merges, and never accepts a subagent's self-report as proof its pipeline ran.**
 
-A subagent that reports "done — pipeline ran, CI green" has told you what it believes, not what is true. The only evidence that the real per-item pipeline ran is the artifact it necessarily leaves behind (a plan directory plus an autopilot-state) and the CI signal on the pushed branch. If either is missing, the item did not run the pipeline as required and is rejected or retried — regardless of how confident the report reads. And landing the batch is the human's call: the fleet stops at a set of verified, reviewable PRs.
+A subagent that reports "done — pipeline ran, CI green" has told you what it believes, not what is true. The only evidence that the real per-item pipeline ran is the artifact it necessarily leaves behind (a plan directory plus a committed pipeline-provenance file) and the CI signal on the pushed branch. If either is missing, the item did not run the pipeline as required and is rejected or retried — regardless of how confident the report reads. And landing the batch is the human's call: the fleet stops at a set of verified, reviewable PRs.
 
 ```
 Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
@@ -114,21 +114,31 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 4. **Record an "assumptions made" note per item.** Each subagent records the recommended-option defaults it took so the eventual PR carries an assumptions note — batch review is only trustworthy when the reviewer can see what was assumed.
 
-5. **Push-path caveat.** A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
+5. **Write a committed pipeline-provenance file.** Each lane **MUST** write `docs/changes/<slug>/provenance.json` and commit it onto its branch. This is the verifiable proof the real pipeline ran — it replaces the session state that `.harness/.gitignore` excludes from every branch by construction (and so never survives into a PR). The file records at minimum: the item's **issue number(s)**, the **pipeline stages run** (e.g. `brainstorming`, `autopilot`/`planning`, `execution`, `review`), the **plan-artifact path** under `docs/changes/<slug>/plans/`, and the **assumptions** taken (the recommended-option defaults from item 4). VERIFY checks for this committed file; a branch without it did not run the pipeline.
+
+6. **Reference the issue with the correct closing keyword.** Each lane decides — and states in its PR body — how its PR references the issue it was dispatched for. This is a real decision with a default, not an incidental phrasing:
+   - A PR that **fully resolves** its issue uses `Closes #<N>`, so the merge-triggered reconciler closes the issue and marks the roadmap row done.
+   - A PR that lands only **one slice** of a multi-finding issue uses `Refs #<N>` (which triggers no auto-close) and **flags the issue for manual reconciliation** in REPORT, naming the row that still needs attention.
+
+   Defaulting to `Refs` on a fully-resolving PR silently strands the roadmap row `planned`/`in-progress` forever, because `Refs` fires no closing behavior; defaulting to `Closes` on a partial slice closes an issue that still has open findings. The lane picks deliberately and records which keyword it used (and why, if partial) in its assumptions note and provenance file.
+
+7. **Push-path caveat.** A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
 
 ### Phase 4: VERIFY — Independent Confirmation, Never Self-Report
 
 1. **Never accept a subagent's self-report as verification.** "The pipeline ran and CI is green" is a claim to be checked, not a result. For each returned branch, the orchestrator independently confirms the evidence itself.
 
-2. **Require the pipeline artifact.** Confirm that both exist on the branch:
+2. **Require the pipeline artifact.** Confirm that both exist **committed on the branch** (so they survive into the PR):
    - A plan artifact under `docs/changes/<slug>/plans/` — the necessary trace of a real brainstorming→autopilot run.
-   - An autopilot-state (session state) for the item.
+   - A committed pipeline-provenance file under `docs/changes/<slug>/` (e.g. `provenance.json`) recording the item's issue number(s), the pipeline stages run, the plan-artifact path, and the assumptions taken. This replaces the old session-state check: session state lives under `.harness/sessions/`, which `.harness/.gitignore` excludes from every branch by construction, so it is absent from every PR and can never be verified — the committed provenance file is the artifact that actually survives to where the orchestrator can check it.
 
-   An item with **no plan artifact did not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry once); it is never marked merge-ready.
+   An item with **no plan artifact or no committed provenance file did not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry once); it is never marked merge-ready.
 
-3. **Require all-OS CI green.** Confirm the pushed branch's CI is green on **all three operating systems** plus the enforce and harness checks (`gh pr checks` / `gh run list`). Green on one OS is not green. A subset-red branch is not merge-ready — it is reported as failed, and the batch continues.
+3. **Check the PR body's issue reference.** Confirm the PR body carries the closing keyword that matches the item's scope (the DISPATCH contract): a fully-resolving item uses `Closes #<N>`; a partial-slice item uses `Refs #<N>` and is flagged for manual reconciliation. A **fully-resolving item whose PR body carries no closing keyword** will strand its roadmap row on merge — flag it for correction before the batch is handed over. This is cheaply detectable from the PR body at verify time.
 
-4. **Classify each returned item** as `verified` (artifact present + all-OS CI green), `rejected` (missing artifact or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
+4. **Require all-OS CI green.** Confirm the pushed branch's CI is green on **all three operating systems** plus the enforce and harness checks (`gh pr checks` / `gh run list`). Green on one OS is not green. A subset-red branch is not merge-ready — it is reported as failed, and the batch continues.
+
+5. **Classify each returned item** as `verified` (plan artifact + committed provenance file present, correct closing keyword, and all-OS CI green), `rejected` (missing artifact/provenance or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
 
 ### Phase 5: REPORT — Batch Summary, Resolved-Issue Closure, Never Merge
 
@@ -158,7 +168,7 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Success Criteria
 
-- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with a verified plan artifact and green CI across all three OS plus enforce and harness.
+- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with a verified plan artifact, a committed provenance file, a scope-correct closing keyword, and green CI across all three OS plus enforce and harness.
 - There is **exactly one** up-front human decision round; no per-item interactive pauses except a genuinely-new fork parked to its own item.
 - **Every emitted PR carries an "assumptions made" note.**
 - Already-resolved candidates are **closed with resolving-PR citations, not rebuilt**.
@@ -169,7 +179,8 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Gates
 
-- **No "merge-ready" without a verified plan artifact.** An item lacking `docs/changes/<slug>/plans/` did not run the real pipeline. It is rejected or retried — never reported as merge-ready, no matter what the subagent claimed.
+- **No "merge-ready" without a verified plan artifact and committed provenance file.** An item lacking either `docs/changes/<slug>/plans/` or a committed `docs/changes/<slug>/provenance.json` did not run the real pipeline (the provenance file — not the gitignored session state, which never reaches a branch — is the artifact that survives into the PR). It is rejected or retried — never reported as merge-ready, no matter what the subagent claimed.
+- **No fully-resolving PR without a closing keyword.** A PR that fully resolves its issue but whose body carries no `Closes #<N>` will strand its roadmap row on merge; a partial-slice PR must use `Refs #<N>` and be flagged for manual reconciliation. A mismatch between scope and keyword is a gate finding — correct it before handover.
 - **No "merge-ready" without all-OS CI green.** Green on a subset of operating systems (or with enforce/harness checks red) is not merge-ready. Report it failed; do not ship it.
 - **Never auto-merge.** The fleet stops at reviewable PRs. Merging a feature PR from inside the fleet = gate violation; the human lands the batch.
 - **Never exceed the concurrency governor.** More than ~3 concurrent build agents is the machine-storm zone; do not raise the cap to "go faster."
@@ -187,16 +198,16 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Rationalizations to Reject
 
-| Rationalization                                                                   | Reality                                                                                                                                                                            |
-| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The subagent reported its pipeline ran and CI is green, so it did"               | A self-report is a claim, not evidence. Independently confirm the `docs/changes/<slug>/plans/` artifact and autopilot-state exist and CI is green — or the item did not run.       |
-| "CI is green on Linux, ship it"                                                   | Green on one OS is not green. Merge-ready requires all three operating systems plus the enforce and harness checks. A subset-red branch is reported failed, not shipped.           |
-| "This item's fork is small — I'll just guess and keep the batch moving"           | Unforeseen forks **park and report**; they are never silently guessed mid-flight. Guessing buries an unstated assumption in a PR the reviewer cannot see.                          |
-| "I'll hand-implement this one item — it's faster than driving the whole pipeline" | Dogfood the real per-item skills. A hand-built item leaves no plan artifact, fails VERIFY, and breaks the guarantee that every PR ran the audited pipeline.                        |
-| "The batch is verified and ready — I'll merge them to save the human a step"      | Never auto-merge. The fleet stops at reviewable PRs; the human (or `pr-fleet`) lands the batch. Auto-merging removes the one review the whole model is built around.               |
-| "One item's pipeline failed, so the run is a bust — abort the batch"              | Degrade gracefully. Report the failed item and keep the verified ones; one bad item never sinks the batch.                                                                         |
-| "This candidate looks new to me, no need to check merged PRs"                     | Cross-check every candidate against merged/open PRs. An already-resolved item rebuilt from scratch is duplicate work and a conflicting PR; resolved items get closed, not rebuilt. |
-| "Bumping concurrency to six will finish the batch sooner"                         | Beyond ~3 concurrent build agents is the machine-storm zone — compound load produces flaky failures that cost more in re-runs than the extra parallelism saves.                    |
+| Rationalization                                                                   | Reality                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The subagent reported its pipeline ran and CI is green, so it did"               | A self-report is a claim, not evidence. Independently confirm the `docs/changes/<slug>/plans/` artifact and the committed `docs/changes/<slug>/provenance.json` exist and CI is green — or the item did not run. |
+| "CI is green on Linux, ship it"                                                   | Green on one OS is not green. Merge-ready requires all three operating systems plus the enforce and harness checks. A subset-red branch is reported failed, not shipped.                                         |
+| "This item's fork is small — I'll just guess and keep the batch moving"           | Unforeseen forks **park and report**; they are never silently guessed mid-flight. Guessing buries an unstated assumption in a PR the reviewer cannot see.                                                        |
+| "I'll hand-implement this one item — it's faster than driving the whole pipeline" | Dogfood the real per-item skills. A hand-built item leaves no plan artifact, fails VERIFY, and breaks the guarantee that every PR ran the audited pipeline.                                                      |
+| "The batch is verified and ready — I'll merge them to save the human a step"      | Never auto-merge. The fleet stops at reviewable PRs; the human (or `pr-fleet`) lands the batch. Auto-merging removes the one review the whole model is built around.                                             |
+| "One item's pipeline failed, so the run is a bust — abort the batch"              | Degrade gracefully. Report the failed item and keep the verified ones; one bad item never sinks the batch.                                                                                                       |
+| "This candidate looks new to me, no need to check merged PRs"                     | Cross-check every candidate against merged/open PRs. An already-resolved item rebuilt from scratch is duplicate work and a conflicting PR; resolved items get closed, not rebuilt.                               |
+| "Bumping concurrency to six will finish the batch sooner"                         | Beyond ~3 concurrent build agents is the machine-storm zone — compound load produces flaky failures that cost more in re-runs than the extra parallelism saves.                                                  |
 
 ## Red Flags
 
@@ -237,9 +248,9 @@ Phase 3: DISPATCH (governor = 2)
     -> parks and reports; the other 3 continue.
 
 Phase 4: VERIFY (independent — no self-report)
-  item A: plan artifact + autopilot-state present, CI green all 3 OS + enforce + harness -> verified
-  item B: plan artifact + autopilot-state present, CI green all 3 OS -> verified
-  item C: NO plan artifact on the branch (self-reported "done") -> REJECTED (hand-built, not piped)
+  item A: plan artifact + provenance.json present, Closes #N in body, CI green all 3 OS + enforce + harness -> verified
+  item B: plan artifact + provenance.json present, Closes #N in body, CI green all 3 OS -> verified
+  item C: NO plan artifact / no provenance.json on the branch (self-reported "done") -> REJECTED (hand-built, not piped)
   item D: parked in DISPATCH -> not verified (fork awaits human)
 
 Phase 5: REPORT
@@ -255,13 +266,17 @@ Phase 5: REPORT
 
 ### Example: Rejecting a hand-built item
 
-A subagent returns a branch and reports "done — implemented the fix, tests pass, CI green." VERIFY looks for `docs/changes/<slug>/plans/` and finds nothing: there is no plan artifact and no autopilot-state. The item was hand-implemented, short-cutting the real pipeline. Per the Iron Law it is **rejected** (retried once, still no artifact → reported as "did not run the pipeline"), never marked merge-ready. The batch's other verified items proceed to REPORT unaffected.
+A subagent returns a branch and reports "done — implemented the fix, tests pass, CI green." VERIFY looks for `docs/changes/<slug>/plans/` and finds nothing: there is no plan artifact and no committed `provenance.json`. The item was hand-implemented, short-cutting the real pipeline. Per the Iron Law it is **rejected** (retried once, still no artifact → reported as "did not run the pipeline"), never marked merge-ready. The batch's other verified items proceed to REPORT unaffected.
 
 ## Test Scenarios
 
 ### Scenario 1: Gate — a self-report accepted as verification
 
-VERIFY receives a subagent claiming "pipeline ran, CI green" but the branch has no `docs/changes/<slug>/plans/` artifact. Expected: the "no merge-ready without a verified plan artifact" Gate halts marking it merge-ready; the item is rejected/retried, not reported as a PR. Accepting the self-report is the failure this scenario guards against.
+VERIFY receives a subagent claiming "pipeline ran, CI green" but the branch has no `docs/changes/<slug>/plans/` artifact and no committed `provenance.json`. Expected: the "no merge-ready without a verified plan artifact and committed provenance file" Gate halts marking it merge-ready; the item is rejected/retried, not reported as a PR. Accepting the self-report is the failure this scenario guards against.
+
+### Scenario 4: Closing-keyword contract — a fully-resolving PR briefed with `Refs`
+
+A lane fully resolves its single-finding issue but its PR body reads `Refs #N`. Expected: VERIFY's PR-body check flags the scope/keyword mismatch — a fully-resolving PR must use `Closes #N` or the merge-triggered reconciler leaves the roadmap row `planned`/`in-progress` forever. The lane corrects the body to `Closes #N` before handover. A partial-slice PR of a multi-finding issue is the mirror case: it correctly keeps `Refs #N` and is flagged for manual reconciliation. Defaulting the keyword by accident — the failure that stranded rows #1208/#1128/#1129/#603 — is what this scenario guards against.
 
 ### Scenario 2: Rationalization — hand-implementing one item
 
@@ -320,10 +335,10 @@ phases:
     description: Present the ranked batch in one round — resolved items flagged for closure, decision forks as questions, proposed concurrency — for a single up-front human approval
     required: true
   - name: dispatch
-    description: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item, capped at the concurrency governor
+    description: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item (writing a committed provenance file and using the scope-correct closing keyword — Closes for full resolution, Refs for a slice), capped at the concurrency governor
     required: true
   - name: verify
-    description: Independently confirm each returned branch has a plan artifact plus autopilot-state and is CI-green across all OS plus enforce and harness — never by subagent self-report
+    description: Independently confirm each returned branch has a plan artifact plus a committed provenance file, a scope-correct closing keyword in the PR body, and is CI-green across all OS plus enforce and harness — never by subagent self-report
     required: true
   - name: report
     description: Emit a one-row-per-item batch summary with assumptions notes for bulk human review, close already-resolved issues citing the resolving PR, never merge

--- a/agents/skills/claude-code/roadmap-fleet/SKILL.md
+++ b/agents/skills/claude-code/roadmap-fleet/SKILL.md
@@ -29,7 +29,7 @@ Building a backlog through the harness pipeline one item at a time is an attenti
 
 **A PR is "merge-ready" only after independent artifact + all-OS-CI verification. The fleet never auto-merges, and never accepts a subagent's self-report as proof its pipeline ran.**
 
-A subagent that reports "done — pipeline ran, CI green" has told you what it believes, not what is true. The only evidence that the real per-item pipeline ran is the artifact it necessarily leaves behind (a plan directory plus an autopilot-state) and the CI signal on the pushed branch. If either is missing, the item did not run the pipeline as required and is rejected or retried — regardless of how confident the report reads. And landing the batch is the human's call: the fleet stops at a set of verified, reviewable PRs.
+A subagent that reports "done — pipeline ran, CI green" has told you what it believes, not what is true. The only evidence that the real per-item pipeline ran is the artifact it necessarily leaves behind (a plan directory plus a committed pipeline-provenance file) and the CI signal on the pushed branch. If either is missing, the item did not run the pipeline as required and is rejected or retried — regardless of how confident the report reads. And landing the batch is the human's call: the fleet stops at a set of verified, reviewable PRs.
 
 ```
 Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
@@ -93,21 +93,31 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 4. **Record an "assumptions made" note per item.** Each subagent records the recommended-option defaults it took so the eventual PR carries an assumptions note — batch review is only trustworthy when the reviewer can see what was assumed.
 
-5. **Push-path caveat.** A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
+5. **Write a committed pipeline-provenance file.** Each lane **MUST** write `docs/changes/<slug>/provenance.json` and commit it onto its branch. This is the verifiable proof the real pipeline ran — it replaces the session state that `.harness/.gitignore` excludes from every branch by construction (and so never survives into a PR). The file records at minimum: the item's **issue number(s)**, the **pipeline stages run** (e.g. `brainstorming`, `autopilot`/`planning`, `execution`, `review`), the **plan-artifact path** under `docs/changes/<slug>/plans/`, and the **assumptions** taken (the recommended-option defaults from item 4). VERIFY checks for this committed file; a branch without it did not run the pipeline.
+
+6. **Reference the issue with the correct closing keyword.** Each lane decides — and states in its PR body — how its PR references the issue it was dispatched for. This is a real decision with a default, not an incidental phrasing:
+   - A PR that **fully resolves** its issue uses `Closes #<N>`, so the merge-triggered reconciler closes the issue and marks the roadmap row done.
+   - A PR that lands only **one slice** of a multi-finding issue uses `Refs #<N>` (which triggers no auto-close) and **flags the issue for manual reconciliation** in REPORT, naming the row that still needs attention.
+
+   Defaulting to `Refs` on a fully-resolving PR silently strands the roadmap row `planned`/`in-progress` forever, because `Refs` fires no closing behavior; defaulting to `Closes` on a partial slice closes an issue that still has open findings. The lane picks deliberately and records which keyword it used (and why, if partial) in its assumptions note and provenance file.
+
+7. **Push-path caveat.** A worktree created under a `.claude/`-nested path breaks the local pre-push `check-docs` gate (it self-excludes and scans zero files). Subagents push via the GitHub API or from a non-`.claude` throwaway worktree. **Never `--no-verify`** — bypassing the gate defeats the verification the fleet depends on.
 
 ### Phase 4: VERIFY — Independent Confirmation, Never Self-Report
 
 1. **Never accept a subagent's self-report as verification.** "The pipeline ran and CI is green" is a claim to be checked, not a result. For each returned branch, the orchestrator independently confirms the evidence itself.
 
-2. **Require the pipeline artifact.** Confirm that both exist on the branch:
+2. **Require the pipeline artifact.** Confirm that both exist **committed on the branch** (so they survive into the PR):
    - A plan artifact under `docs/changes/<slug>/plans/` — the necessary trace of a real brainstorming→autopilot run.
-   - An autopilot-state (session state) for the item.
+   - A committed pipeline-provenance file under `docs/changes/<slug>/` (e.g. `provenance.json`) recording the item's issue number(s), the pipeline stages run, the plan-artifact path, and the assumptions taken. This replaces the old session-state check: session state lives under `.harness/sessions/`, which `.harness/.gitignore` excludes from every branch by construction, so it is absent from every PR and can never be verified — the committed provenance file is the artifact that actually survives to where the orchestrator can check it.
 
-   An item with **no plan artifact did not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry once); it is never marked merge-ready.
+   An item with **no plan artifact or no committed provenance file did not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry once); it is never marked merge-ready.
 
-3. **Require all-OS CI green.** Confirm the pushed branch's CI is green on **all three operating systems** plus the enforce and harness checks (`gh pr checks` / `gh run list`). Green on one OS is not green. A subset-red branch is not merge-ready — it is reported as failed, and the batch continues.
+3. **Check the PR body's issue reference.** Confirm the PR body carries the closing keyword that matches the item's scope (the DISPATCH contract): a fully-resolving item uses `Closes #<N>`; a partial-slice item uses `Refs #<N>` and is flagged for manual reconciliation. A **fully-resolving item whose PR body carries no closing keyword** will strand its roadmap row on merge — flag it for correction before the batch is handed over. This is cheaply detectable from the PR body at verify time.
 
-4. **Classify each returned item** as `verified` (artifact present + all-OS CI green), `rejected` (missing artifact or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
+4. **Require all-OS CI green.** Confirm the pushed branch's CI is green on **all three operating systems** plus the enforce and harness checks (`gh pr checks` / `gh run list`). Green on one OS is not green. A subset-red branch is not merge-ready — it is reported as failed, and the batch continues.
+
+5. **Classify each returned item** as `verified` (plan artifact + committed provenance file present, correct closing keyword, and all-OS CI green), `rejected` (missing artifact/provenance or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
 
 ### Phase 5: REPORT — Batch Summary, Resolved-Issue Closure, Never Merge
 
@@ -137,7 +147,7 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Success Criteria
 
-- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with a verified plan artifact and green CI across all three OS plus enforce and harness.
+- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with a verified plan artifact, a committed provenance file, a scope-correct closing keyword, and green CI across all three OS plus enforce and harness.
 - There is **exactly one** up-front human decision round; no per-item interactive pauses except a genuinely-new fork parked to its own item.
 - **Every emitted PR carries an "assumptions made" note.**
 - Already-resolved candidates are **closed with resolving-PR citations, not rebuilt**.
@@ -148,7 +158,8 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Gates
 
-- **No "merge-ready" without a verified plan artifact.** An item lacking `docs/changes/<slug>/plans/` did not run the real pipeline. It is rejected or retried — never reported as merge-ready, no matter what the subagent claimed.
+- **No "merge-ready" without a verified plan artifact and committed provenance file.** An item lacking either `docs/changes/<slug>/plans/` or a committed `docs/changes/<slug>/provenance.json` did not run the real pipeline (the provenance file — not the gitignored session state, which never reaches a branch — is the artifact that survives into the PR). It is rejected or retried — never reported as merge-ready, no matter what the subagent claimed.
+- **No fully-resolving PR without a closing keyword.** A PR that fully resolves its issue but whose body carries no `Closes #<N>` will strand its roadmap row on merge; a partial-slice PR must use `Refs #<N>` and be flagged for manual reconciliation. A mismatch between scope and keyword is a gate finding — correct it before handover.
 - **No "merge-ready" without all-OS CI green.** Green on a subset of operating systems (or with enforce/harness checks red) is not merge-ready. Report it failed; do not ship it.
 - **Never auto-merge.** The fleet stops at reviewable PRs. Merging a feature PR from inside the fleet = gate violation; the human lands the batch.
 - **Never exceed the concurrency governor.** More than ~3 concurrent build agents is the machine-storm zone; do not raise the cap to "go faster."
@@ -166,16 +177,16 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ## Rationalizations to Reject
 
-| Rationalization                                                                   | Reality                                                                                                                                                                            |
-| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "The subagent reported its pipeline ran and CI is green, so it did"               | A self-report is a claim, not evidence. Independently confirm the `docs/changes/<slug>/plans/` artifact and autopilot-state exist and CI is green — or the item did not run.       |
-| "CI is green on Linux, ship it"                                                   | Green on one OS is not green. Merge-ready requires all three operating systems plus the enforce and harness checks. A subset-red branch is reported failed, not shipped.           |
-| "This item's fork is small — I'll just guess and keep the batch moving"           | Unforeseen forks **park and report**; they are never silently guessed mid-flight. Guessing buries an unstated assumption in a PR the reviewer cannot see.                          |
-| "I'll hand-implement this one item — it's faster than driving the whole pipeline" | Dogfood the real per-item skills. A hand-built item leaves no plan artifact, fails VERIFY, and breaks the guarantee that every PR ran the audited pipeline.                        |
-| "The batch is verified and ready — I'll merge them to save the human a step"      | Never auto-merge. The fleet stops at reviewable PRs; the human (or `pr-fleet`) lands the batch. Auto-merging removes the one review the whole model is built around.               |
-| "One item's pipeline failed, so the run is a bust — abort the batch"              | Degrade gracefully. Report the failed item and keep the verified ones; one bad item never sinks the batch.                                                                         |
-| "This candidate looks new to me, no need to check merged PRs"                     | Cross-check every candidate against merged/open PRs. An already-resolved item rebuilt from scratch is duplicate work and a conflicting PR; resolved items get closed, not rebuilt. |
-| "Bumping concurrency to six will finish the batch sooner"                         | Beyond ~3 concurrent build agents is the machine-storm zone — compound load produces flaky failures that cost more in re-runs than the extra parallelism saves.                    |
+| Rationalization                                                                   | Reality                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "The subagent reported its pipeline ran and CI is green, so it did"               | A self-report is a claim, not evidence. Independently confirm the `docs/changes/<slug>/plans/` artifact and the committed `docs/changes/<slug>/provenance.json` exist and CI is green — or the item did not run. |
+| "CI is green on Linux, ship it"                                                   | Green on one OS is not green. Merge-ready requires all three operating systems plus the enforce and harness checks. A subset-red branch is reported failed, not shipped.                                         |
+| "This item's fork is small — I'll just guess and keep the batch moving"           | Unforeseen forks **park and report**; they are never silently guessed mid-flight. Guessing buries an unstated assumption in a PR the reviewer cannot see.                                                        |
+| "I'll hand-implement this one item — it's faster than driving the whole pipeline" | Dogfood the real per-item skills. A hand-built item leaves no plan artifact, fails VERIFY, and breaks the guarantee that every PR ran the audited pipeline.                                                      |
+| "The batch is verified and ready — I'll merge them to save the human a step"      | Never auto-merge. The fleet stops at reviewable PRs; the human (or `pr-fleet`) lands the batch. Auto-merging removes the one review the whole model is built around.                                             |
+| "One item's pipeline failed, so the run is a bust — abort the batch"              | Degrade gracefully. Report the failed item and keep the verified ones; one bad item never sinks the batch.                                                                                                       |
+| "This candidate looks new to me, no need to check merged PRs"                     | Cross-check every candidate against merged/open PRs. An already-resolved item rebuilt from scratch is duplicate work and a conflicting PR; resolved items get closed, not rebuilt.                               |
+| "Bumping concurrency to six will finish the batch sooner"                         | Beyond ~3 concurrent build agents is the machine-storm zone — compound load produces flaky failures that cost more in re-runs than the extra parallelism saves.                                                  |
 
 ## Red Flags
 
@@ -216,9 +227,9 @@ Phase 3: DISPATCH (governor = 2)
     -> parks and reports; the other 3 continue.
 
 Phase 4: VERIFY (independent — no self-report)
-  item A: plan artifact + autopilot-state present, CI green all 3 OS + enforce + harness -> verified
-  item B: plan artifact + autopilot-state present, CI green all 3 OS -> verified
-  item C: NO plan artifact on the branch (self-reported "done") -> REJECTED (hand-built, not piped)
+  item A: plan artifact + provenance.json present, Closes #N in body, CI green all 3 OS + enforce + harness -> verified
+  item B: plan artifact + provenance.json present, Closes #N in body, CI green all 3 OS -> verified
+  item C: NO plan artifact / no provenance.json on the branch (self-reported "done") -> REJECTED (hand-built, not piped)
   item D: parked in DISPATCH -> not verified (fork awaits human)
 
 Phase 5: REPORT
@@ -234,13 +245,17 @@ Phase 5: REPORT
 
 ### Example: Rejecting a hand-built item
 
-A subagent returns a branch and reports "done — implemented the fix, tests pass, CI green." VERIFY looks for `docs/changes/<slug>/plans/` and finds nothing: there is no plan artifact and no autopilot-state. The item was hand-implemented, short-cutting the real pipeline. Per the Iron Law it is **rejected** (retried once, still no artifact → reported as "did not run the pipeline"), never marked merge-ready. The batch's other verified items proceed to REPORT unaffected.
+A subagent returns a branch and reports "done — implemented the fix, tests pass, CI green." VERIFY looks for `docs/changes/<slug>/plans/` and finds nothing: there is no plan artifact and no committed `provenance.json`. The item was hand-implemented, short-cutting the real pipeline. Per the Iron Law it is **rejected** (retried once, still no artifact → reported as "did not run the pipeline"), never marked merge-ready. The batch's other verified items proceed to REPORT unaffected.
 
 ## Test Scenarios
 
 ### Scenario 1: Gate — a self-report accepted as verification
 
-VERIFY receives a subagent claiming "pipeline ran, CI green" but the branch has no `docs/changes/<slug>/plans/` artifact. Expected: the "no merge-ready without a verified plan artifact" Gate halts marking it merge-ready; the item is rejected/retried, not reported as a PR. Accepting the self-report is the failure this scenario guards against.
+VERIFY receives a subagent claiming "pipeline ran, CI green" but the branch has no `docs/changes/<slug>/plans/` artifact and no committed `provenance.json`. Expected: the "no merge-ready without a verified plan artifact and committed provenance file" Gate halts marking it merge-ready; the item is rejected/retried, not reported as a PR. Accepting the self-report is the failure this scenario guards against.
+
+### Scenario 4: Closing-keyword contract — a fully-resolving PR briefed with `Refs`
+
+A lane fully resolves its single-finding issue but its PR body reads `Refs #N`. Expected: VERIFY's PR-body check flags the scope/keyword mismatch — a fully-resolving PR must use `Closes #N` or the merge-triggered reconciler leaves the roadmap row `planned`/`in-progress` forever. The lane corrects the body to `Closes #N` before handover. A partial-slice PR of a multi-finding issue is the mirror case: it correctly keeps `Refs #N` and is flagged for manual reconciliation. Defaulting the keyword by accident — the failure that stranded rows #1208/#1128/#1129/#603 — is what this scenario guards against.
 
 ### Scenario 2: Rationalization — hand-implementing one item
 

--- a/agents/skills/claude-code/roadmap-fleet/skill.yaml
+++ b/agents/skills/claude-code/roadmap-fleet/skill.yaml
@@ -45,10 +45,10 @@ phases:
     description: Present the ranked batch in one round — resolved items flagged for closure, decision forks as questions, proposed concurrency — for a single up-front human approval
     required: true
   - name: dispatch
-    description: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item, capped at the concurrency governor
+    description: Fan out worktree-isolated subagents, each running the real brainstorming then autopilot pipeline for one item (writing a committed provenance file and using the scope-correct closing keyword — Closes for full resolution, Refs for a slice), capped at the concurrency governor
     required: true
   - name: verify
-    description: Independently confirm each returned branch has a plan artifact plus autopilot-state and is CI-green across all OS plus enforce and harness — never by subagent self-report
+    description: Independently confirm each returned branch has a plan artifact plus a committed provenance file, a scope-correct closing keyword in the PR body, and is CI-green across all OS plus enforce and harness — never by subagent self-report
     required: true
   - name: report
     description: Emit a one-row-per-item batch summary with assumptions notes for bulk human review, close already-resolved issues citing the resolving PR, never merge

--- a/docs/changes/fix-roadmap-fleet-verify-contract/plans/2026-08-15-fix-roadmap-fleet-verify-contract-plan.md
+++ b/docs/changes/fix-roadmap-fleet-verify-contract/plans/2026-08-15-fix-roadmap-fleet-verify-contract-plan.md
@@ -1,0 +1,67 @@
+# Plan: satisfiable roadmap-fleet VERIFY provenance + closing-keyword contract
+
+- **Slug:** `fix-roadmap-fleet-verify-contract`
+- **Issues:** #1298, #1297
+- **Proposal:** `docs/changes/fix-roadmap-fleet-verify-contract/proposal.md`
+- **Primary surface:** `agents/skills/claude-code/roadmap-fleet/SKILL.md`
+
+## Approach
+
+Single-surface skill-contract edit plus generated-mirror regeneration. Both issues touch the same SKILL.md (VERIFY, DISPATCH, Gates, Rationalizations, Examples, Success Criteria, Test Scenarios), so they are one lane. Session state stays gitignored; we route the verifiable proof to a committed provenance file instead.
+
+## Tasks
+
+### T1 — Iron Law: swap the leave-behind evidence (#1298)
+
+- In the Iron Law prose, change "a plan directory plus an autopilot-state" to "a plan directory plus a committed pipeline-provenance file".
+- Checkpoint: Iron Law no longer names session/autopilot state as the evidence.
+
+### T2 — DISPATCH: mandate the provenance file (#1298)
+
+- Add a numbered DISPATCH step: each lane MUST write and commit `docs/changes/<slug>/provenance.json` with fields — issue number(s), pipeline stages run, plan-artifact path, assumptions.
+- Explain it replaces gitignored session state and survives into the PR.
+- Checkpoint: DISPATCH carries an explicit MUST-write-provenance instruction with all four fields.
+
+### T3 — DISPATCH: closing-keyword contract (#1297)
+
+- Add a numbered DISPATCH step: full resolution → `Closes #<N>`; slice of a multi-finding issue → `Refs #<N>` + flag for manual reconciliation.
+- State the failure modes of each wrong default (stranded row vs prematurely-closed issue).
+- Checkpoint: DISPATCH states both keyword cases and the default reasoning.
+
+### T4 — VERIFY: require plan + provenance; check PR-body keyword (#1298, #1297)
+
+- Replace the autopilot-state bullet with the committed provenance-file bullet (both committed on the branch).
+- Add a VERIFY step checking the PR body carries the scope-correct closing keyword.
+- Renumber subsequent VERIFY steps; update the classify step to name provenance + keyword.
+- Checkpoint: VERIFY requires plan + provenance, and checks the PR-body keyword; numbering is consistent.
+
+### T5 — Gates + Rationalizations + Examples + Success Criteria + Test Scenarios (#1298, #1297)
+
+- Gates: the "no merge-ready without a verified artifact" gate references plan + committed provenance (not session state); add a closing-keyword gate.
+- Rationalizations table: replace "autopilot-state" with the provenance file.
+- Examples (Phase 4 lines + hand-built rejection): swap autopilot-state → provenance.json; show `Closes #N` in bodies.
+- Success Criteria: add provenance + scope-correct closing keyword.
+- Test Scenarios: update Scenario 1 to mention provenance; add Scenario 4 for the closing-keyword contract.
+- Checkpoint: no `autopilot-state`/`session state` remains as a _required_ artifact; provenance + keyword are consistent throughout.
+
+### T6 — Regenerate generated mirrors
+
+- Run `pnpm generate:plugin:all` to regenerate `.claude-plugin`, `.cursor-plugin`, `.gemini-extension`, `.antigravity-extension`, and codex command copies from the edited source. Never hand-edit them.
+- Checkpoint: `pnpm generate:plugin:check` passes (no drift).
+
+### T7 — Dogfood + validate
+
+- Write this branch's own `provenance.json` under `docs/changes/<slug>/` — dogfooding the contract being added.
+- `pnpm prettier --write` changed markdown/json; run any SKILL.md lint/validation; add a changeset if the pre-push gate asks.
+- Checkpoint: prettier clean, validation passes, provenance file present and committed.
+
+## Verification
+
+- Independent check: `grep` confirms no required autopilot-state remains; provenance + closing-keyword contract present in DISPATCH, VERIFY, Gates.
+- `pnpm generate:plugin:check` green (mirrors match source).
+- Pre-push gauntlet green without `--no-verify`.
+
+## Risks / rollback
+
+- **Mirror drift** if regeneration is skipped — mitigated by T6 + the `:check` gate.
+- Pure-docs change: rollback is reverting the branch; no runtime/behavioral risk.

--- a/docs/changes/fix-roadmap-fleet-verify-contract/proposal.md
+++ b/docs/changes/fix-roadmap-fleet-verify-contract/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: satisfiable roadmap-fleet VERIFY provenance + closing-keyword contract
+
+- **Slug:** `fix-roadmap-fleet-verify-contract`
+- **Issues:** #1298 (VERIFY requires a gitignored autopilot-state artifact), #1297 (DISPATCH does not specify the closing-keyword contract)
+- **Surface:** `agents/skills/claude-code/roadmap-fleet/SKILL.md` (canonical source; cursor/codex/gemini-cli dirs are symlinks; `.claude-plugin` / `.cursor-plugin` / `.gemini-extension` / `.antigravity-extension` command copies are generated).
+
+## Problem
+
+`roadmap-fleet` is the batch-build stage of the `-fleet` conveyor. Two clauses of its own contract are broken:
+
+1. **#1298 — the VERIFY two-artifact check is unsatisfiable.** VERIFY demanded (a) a plan artifact under `docs/changes/<slug>/plans/` **and** (b) an "autopilot-state (session state)" on the branch. But `.harness/.gitignore` ignores `sessions/`, so session state is absent from every branch by construction — and gitignored `.harness` runtime artifacts are additionally absent in the fresh worktrees where every lane runs. The skill's own Gates section says a gate that cannot be evaluated counts as **failed, never passed**; applied literally, no item in this repo could ever be merge-ready. In practice the check was silently waived every run — theatre.
+
+2. **#1297 — DISPATCH never states the closing-keyword contract.** Nothing told a lane whether its PR should say `Closes #N` or `Refs #N`. Whichever the brief happened to carry silently decided whether the roadmap row ever reconciled. On the 2026-08-10 run every lane was briefed with `Refs`, which fires no auto-close, so the merge-triggered reconciler had nothing to match and rows stayed `planned`/`in-progress`. The irony: that same run had just landed #1290, which cleaned up five rows (#1208, #1128, #1129, #603) stranded by this exact failure mode.
+
+## Decisions (human-approved)
+
+- **#1298 → provenance file.** Replace the autopilot-state requirement with a **committed pipeline-provenance file** under `docs/changes/<slug>/` (e.g. `provenance.json`). VERIFY's two required artifacts become: (1) the plan artifact under `.../plans/`, and (2) the committed provenance file — both of which survive into the PR where the orchestrator can check them. DISPATCH states each lane MUST write it, with fields: issue number(s), pipeline stages run, plan-artifact path, assumptions. Gates reference the provenance file, not session state. This is issue #1298's Option 2 — the only option that restores the guarantee the Iron Law depends on, because it survives into the PR.
+- **#1297 → closing-keyword contract.** DISPATCH gains the contract: a PR that FULLY resolves its issue uses `Closes #<N>`; a PR that lands only a SLICE of a multi-finding issue uses `Refs #<N>` and flags the issue for manual reconciliation (no auto-close). VERIFY notes that the PR body is checked for the scope-correct keyword.
+
+## Non-goals
+
+- No change to any TypeScript, orchestrator code, or CI. This is a skill-contract (documentation) change.
+- No change to `.harness/.gitignore` — session state stays gitignored; the fix routes provenance to a committed path instead of fighting the ignore rule.
+- Not touching sibling fleet skills (e.g. `cicd-fleet`) even though they carry a similar phrase — out of scope for these two issues.
+
+## Acceptance criteria
+
+- VERIFY no longer requires any gitignored/session-state artifact; both required artifacts (plan + provenance file) are committed and survive into the PR.
+- DISPATCH instructs each lane to write a committed `docs/changes/<slug>/provenance.json` with issue number(s), pipeline stages run, plan-artifact path, and assumptions.
+- DISPATCH states the closing-keyword contract (`Closes` for full resolution, `Refs` + manual-reconciliation flag for a slice).
+- Gates and Rationalizations reference the provenance file rather than autopilot-state; a fully-resolving PR with no closing keyword is a gate finding.
+- No `autopilot-state`/`session state` remains as a _required_ VERIFY artifact anywhere in the skill (only as explanatory rationale for why it was replaced).
+- Generated command mirrors (`.claude-plugin`, `.cursor-plugin`, `.gemini-extension`, `.antigravity-extension`, codex) are regenerated to match the source, not hand-edited.
+- This change dogfoods its own contract: the branch carries this proposal, a plan under `plans/`, and a committed `provenance.json`.

--- a/docs/changes/fix-roadmap-fleet-verify-contract/provenance.json
+++ b/docs/changes/fix-roadmap-fleet-verify-contract/provenance.json
@@ -1,0 +1,19 @@
+{
+  "slug": "fix-roadmap-fleet-verify-contract",
+  "issues": [1297, 1298],
+  "pipelineStages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/fix-roadmap-fleet-verify-contract/plans/2026-08-15-fix-roadmap-fleet-verify-contract-plan.md",
+  "proposalArtifact": "docs/changes/fix-roadmap-fleet-verify-contract/proposal.md",
+  "primarySurface": "agents/skills/claude-code/roadmap-fleet/SKILL.md",
+  "closingKeyword": "Closes",
+  "closingKeywordRationale": "Both #1297 and #1298 are fully resolved by this single-surface skill-contract change, so the PR uses Closes #1297 and Closes #1298.",
+  "assumptions": [
+    "#1298 resolved via committed provenance file (issue Option 2, human-approved) rather than strengthening the plan-artifact check or verifying session state out-of-band.",
+    "Provenance filename is provenance.json under docs/changes/<slug>/, matching the example the issue and decision cite.",
+    "Scope limited to roadmap-fleet SKILL.md; the similar phrase in cicd-fleet SKILL.md is intentionally left untouched (out of scope for #1297/#1298).",
+    ".harness/.gitignore is left unchanged; session state stays gitignored and the fix routes proof to a committed path instead.",
+    "Generated command mirrors regenerated via `pnpm generate:plugin:all`, never hand-edited."
+  ],
+  "generatedBy": "roadmap-fleet lane (dogfooding the provenance contract added in this change)",
+  "date": "2026-08-15"
+}


### PR DESCRIPTION
Closes #1297
Closes #1298

## What

Fixes two broken clauses of `roadmap-fleet`'s own contract, both in `agents/skills/claude-code/roadmap-fleet/SKILL.md`.

### #1298 — VERIFY required a gitignored artifact (unsatisfiable)
VERIFY demanded a plan artifact **and** an "autopilot-state (session state)". Session state lives under `.harness/sessions/`, which `.harness/.gitignore` excludes from every branch by construction — so the two-artifact check could never pass and was silently waived every run (theatre). Replaced the autopilot-state requirement with a **committed `docs/changes/<slug>/provenance.json`** (issue #1298 Option 2 — the only option that survives into the PR where the orchestrator can check it). DISPATCH now mandates each lane write it with: issue number(s), pipeline stages run, plan-artifact path, and assumptions. Iron Law, Gates, Rationalizations, and Examples all reference the provenance file instead of session state.

### #1297 — DISPATCH never stated the closing-keyword contract
Nothing told a lane whether its PR should say `Closes #N` or `Refs #N`, so lanes manufactured stale roadmap rows (the 2026-08-10 run briefed every lane with `Refs`, which fires no auto-close). Added the contract to DISPATCH: a PR that **fully resolves** its issue uses `Closes #<N>`; a PR landing only a **slice** of a multi-finding issue uses `Refs #<N>` and flags the issue for manual reconciliation. VERIFY now checks the PR body for the scope-correct keyword; a fully-resolving PR with no closing keyword is a gate finding. New Test Scenario 4 covers it.

## Scope
- Source: `SKILL.md` + `skill.yaml` phase descriptions.
- Regenerated plugin command mirrors (claude/cursor/gemini/antigravity/codex) via `pnpm generate:plugin:all` — never hand-edited.
- Dogfoods the new contract: branch carries `docs/changes/fix-roadmap-fleet-verify-contract/` proposal.md, plans/, and provenance.json.

## Validation
- `harness skill validate roadmap-fleet` ✓
- `pnpm generate:plugin:check` ✓ (no mirror drift)
- `check-changesets` ✓ (no publishable package changed → no changeset required)
- prettier ✓; pre-commit + full pre-push gauntlet green (coverage ratchet, reference-docs freshness) without `--no-verify`.

## Assumptions
- #1298 resolved via committed provenance file (human-approved Option 2), not by strengthening the plan-artifact check or out-of-band session verification.
- Filename `provenance.json` under `docs/changes/<slug>/`.
- Scope limited to roadmap-fleet; the similar phrase in `cicd-fleet` SKILL.md is intentionally left untouched (out of scope for #1297/#1298).
- `.harness/.gitignore` unchanged — session state stays gitignored; proof is routed to a committed path instead.

Both issues fully resolved → Closes both.