### PR TITLE
feat(ci): enforce auditExceptions with expiry + reconcile gate

### DIFF
--- a/.github/workflows/audit-exceptions.yml
+++ b/.github/workflows/audit-exceptions.yml
@@ -1,0 +1,43 @@
+name: Audit Exceptions
+
+# Issue #1324 — Enforce the `auditExceptions` register so time-boxed deferrals
+# cannot silently become permanent exemptions.
+#
+# Runs the dependency audit and reconciles every active advisory against the
+# `auditExceptions` register in package.json. FAILS (blocking — no
+# continue-on-error) when an active advisory has no register entry, or when a
+# covering entry has lapsed (past its `expires` date, or missing one). This is
+# the enforcement the register previously lacked: before this job nothing ran
+# `pnpm audit` and nothing read the register.
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit-exceptions:
+    name: Reconcile audit exceptions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      # Blocking: an uncovered or lapsed advisory fails the PR. The script runs
+      # `pnpm audit --json` itself and exits non-zero on any failure.
+      - name: Reconcile auditExceptions
+        run: node scripts/audit-exceptions.mjs

--- a/docs/changes/audit-exceptions-enforcement/plans/plan.md
+++ b/docs/changes/audit-exceptions-enforcement/plans/plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan — Enforce `auditExceptions` with expiry + reconcile gate
+
+Spec: `docs/changes/audit-exceptions-enforcement/proposal.md`
+Issue: #1324
+
+## Task graph
+
+### T1 — Migrate `auditExceptions` entry shape (package.json)
+
+- Convert each of the 5 GHSA entries from `"<GHSA>": "<reason>"` to
+  `"<GHSA>": { "reason": "<reason>", "expires": "2026-11-15" }`.
+- Preserve the existing justification text verbatim as `reason`.
+- Depends on: none.
+- Verify: `node -e` parse of `package.json` shows every `auditExceptions` value
+  is an object with `reason` + `expires`.
+
+### T2 — Reconcile script (`scripts/audit-exceptions.mjs`)
+
+- Pure exports: `extractAdvisories`, `lapseReason`, `reconcile`.
+- `main()`: spawn `pnpm audit --json` (capture stdout even on non-zero exit),
+  parse, read register from `package.json`, reconcile vs `new Date()`, print,
+  exit 1 on failure / unparseable output.
+- `isMain` guard so importing the module has no side effects (mirrors
+  `check-changesets.mjs`).
+- Depends on: T1 (shape it reads).
+- Verify: run against current tree → exit 0, report "5 covered".
+
+### T3 — Package script
+
+- Add `"check:audit-exceptions": "node scripts/audit-exceptions.mjs"` to root
+  `package.json` scripts.
+- Depends on: T2.
+
+### T4 — Unit test (`tests/scripts/audit-exceptions.test.mjs`)
+
+- `node:test` cases: uncovered → fail; expired → fail; missing-expiry → fail;
+  covered+unexpired → pass; stale (no active advisory) → warn+ok.
+- Depends on: T2.
+- Verify: `node --test tests/scripts/audit-exceptions.test.mjs` all pass.
+
+### T5 — CI workflow (`.github/workflows/audit-exceptions.yml`)
+
+- `pull_request` on `main`; checkout → pnpm/action-setup → setup-node 22 (pnpm
+  cache) → `pnpm install --frozen-lockfile` → `node
+scripts/audit-exceptions.mjs` (blocking).
+- Depends on: T2.
+- Verify: `actionlint` clean (or manual YAML review).
+
+### T6 — Local validation + gauntlet
+
+- Run script (green), `pnpm prettier --write` changed files, add changeset if
+  the gate asks (root-only change → empty changeset if needed), commit, push.
+- Depends on: T1–T5.
+
+## Checkpoints
+
+- After T2: script green against current tree (the critical "don't leave PR red"
+  gate).
+- After T4: unit tests green.
+- After T6: pre-push gauntlet green.

--- a/docs/changes/audit-exceptions-enforcement/proposal.md
+++ b/docs/changes/audit-exceptions-enforcement/proposal.md
@@ -1,0 +1,129 @@
+# Enforce `auditExceptions` with expiry + reconcile gate
+
+**Keywords:** audit-exceptions, dependency-audit, GHSA, expiry, CI-gate, reconcile, supply-chain
+
+**Issue:** #1324
+
+## Overview and goals
+
+`auditExceptions` in the root `package.json` is a register of dependency
+advisories the project has consciously deferred (each keyed by GHSA ID with a
+free-text justification). The register is read by **nothing**: no source
+consumes it, and no workflow in `.github/workflows/` runs `pnpm audit`. So a
+time-boxed deferral silently becomes a permanent exemption — advisories are
+neither enforced (a new, unlisted advisory never fails CI) nor expired (a
+listed advisory is exempt forever).
+
+Goal: make the register load-bearing.
+
+1. A **reconcile script** runs the dependency audit and fails when either
+   (a) an active advisory has no register entry, or (b) a covering entry has
+   lapsed (past its expiry, or missing an expiry).
+2. Every register entry gains a required **`expires`** (ISO date). A missing
+   expiry is treated as **already lapsed → fail**, so silence cannot re-enter
+   through an entry that never expires.
+3. A **CI workflow** runs the reconcile script on PRs so the gate is enforced.
+
+## Decisions made
+
+- **Entry shape migrates from `string` to `{ reason, expires }`.** The current
+  value is the justification string; the new shape keeps that as `reason` and
+  adds a required ISO-date `expires`. Rationale: expiry must be first-class and
+  machine-checkable, and keeping `reason` preserves the existing justifications.
+- **Missing/invalid/lapsed expiry all fail.** Treating a missing `expires` as
+  lapsed (rather than "no expiry = forever") is the whole point of the issue —
+  it makes the safe default _fail closed_.
+- **Match on `github_advisory_id` (GHSA).** `pnpm audit --json` keys advisories
+  by an internal numeric id but carries `github_advisory_id`; the register is
+  GHSA-keyed, so reconcile matches on GHSA.
+- **Unused entries warn, don't fail.** An entry that no longer matches any
+  active advisory is stale hygiene, not a security regression — report it as a
+  warning so the gate stays focused on real exposure and isn't brittle when a
+  dependency upgrade drops an advisory.
+- **Expiry is inclusive of its whole day.** An entry `expires` on date D stays
+  valid through the end of D (UTC); it lapses at the first instant of D+1. Avoids
+  a same-day off-by-one where an entry dated today reads as already expired.
+- **Reconcile logic is a pure, exported function** (`reconcile`) so it is unit
+  testable without the network; the script's `main()` does the `pnpm audit` IO.
+- **Pipeline: standalone root script, not the harness CLI.** This is a
+  repo-governance gate (like `check-changesets.mjs`), so it lives in
+  `scripts/*.mjs` with a `node --test` unit test — matching the existing
+  convention — rather than a new CLI command.
+
+## Technical design
+
+### `scripts/audit-exceptions.mjs`
+
+Exports (pure, no side effects on import):
+
+- `extractAdvisories(auditJson)` → `Array<{ id, severity, module }>` — pulls
+  `github_advisory_id` from each entry of `pnpm audit --json`'s `advisories`
+  map.
+- `lapseReason(entry, now)` → `string | null` — returns a human reason when an
+  entry is lapsed (missing/invalid/past `expires`), else `null`. Expiry is
+  inclusive of its whole UTC day.
+- `reconcile({ activeAdvisoryIds, register, now })` →
+  `{ ok, failures, warnings, covered }` — for each active advisory requires a
+  non-lapsed covering entry; entries with no active advisory become warnings.
+
+`main()` runs `pnpm audit --json` (tolerating its non-zero exit when vulns are
+found), parses it, reads `auditExceptions` from `package.json`, reconciles
+against `new Date()`, prints a report, and exits `1` on any failure or if the
+audit output cannot be parsed (fail closed — never silently pass).
+
+### `package.json`
+
+- Migrate each `auditExceptions` entry to `{ "reason": <old string>,
+"expires": "<ISO date>" }`.
+- Add script `"check:audit-exceptions": "node scripts/audit-exceptions.mjs"`.
+
+### `.github/workflows/audit-exceptions.yml`
+
+PR-triggered job: checkout → pnpm/setup-node (22) → `pnpm install
+--frozen-lockfile` → `node scripts/audit-exceptions.mjs`. **Blocking** (no
+`continue-on-error`) — an uncovered or lapsed advisory fails the PR.
+
+### `tests/scripts/audit-exceptions.test.mjs`
+
+`node:test` unit tests over the pure functions: uncovered advisory → fail;
+expired entry → fail; missing-expiry entry → fail; covered + unexpired → pass;
+stale entry (no active advisory) → warning, still ok.
+
+## Integration Points
+
+- **Entry Points:** new root script `scripts/audit-exceptions.mjs`; new
+  `check:audit-exceptions` package script; new `audit-exceptions.yml` workflow.
+- **Registrations Required:** the workflow is auto-discovered by GitHub Actions;
+  the `node --test 'tests/scripts/*.test.mjs'` CI step already globs the new
+  test. None else.
+- **Documentation Updates:** None (self-documenting script + workflow; the
+  `auditExceptions` block remains self-describing via `reason`).
+- **Architectural Decisions:** None rise to a standalone ADR (small governance
+  change).
+- **Knowledge Impact:** None.
+
+## Success criteria
+
+1. `node scripts/audit-exceptions.mjs` exits `0` against the current tree
+   (all 5 active advisories covered and unexpired).
+2. Introducing an uncovered advisory (or removing/expiring an entry) makes it
+   exit `1`.
+3. The new workflow runs the script on PRs as a blocking check.
+4. Unit tests cover uncovered / expired / missing-expiry / covered-pass / stale.
+
+## Implementation order
+
+1. Migrate `auditExceptions` entries to `{ reason, expires }` in `package.json`.
+2. Write `scripts/audit-exceptions.mjs`.
+3. Add the `check:audit-exceptions` package script.
+4. Write the unit test.
+5. Add the CI workflow.
+6. Validate: run the script (green), typecheck/lint, run the test.
+
+## Assumptions (autonomous lane — recommended defaults taken)
+
+- Entry shape `{ reason, expires }` (not a parallel `auditExpiries` map).
+- Expiry date assigned to all 5 existing entries: **2026-11-15** (~3 months from
+  the 2026-08-15 authoring date) — a reasonable near-future re-evaluation box.
+- Unused entries warn rather than fail.
+- Gate is blocking on PRs (the issue's intent: advisories must be _enforced_).

--- a/docs/changes/audit-exceptions-enforcement/provenance.json
+++ b/docs/changes/audit-exceptions-enforcement/provenance.json
@@ -1,0 +1,42 @@
+{
+  "issue": 1324,
+  "slug": "audit-exceptions-enforcement",
+  "title": "Enforce auditExceptions with expiry + reconcile gate",
+  "pipeline": {
+    "stages": [
+      {
+        "stage": "brainstorming",
+        "skill": "harness-brainstorming",
+        "artifact": "docs/changes/audit-exceptions-enforcement/proposal.md"
+      },
+      {
+        "stage": "planning",
+        "artifact": "docs/changes/audit-exceptions-enforcement/plans/plan.md"
+      },
+      {
+        "stage": "execution",
+        "artifacts": [
+          "scripts/audit-exceptions.mjs",
+          "tests/scripts/audit-exceptions.test.mjs",
+          ".github/workflows/audit-exceptions.yml",
+          "package.json"
+        ]
+      }
+    ]
+  },
+  "planArtifact": "docs/changes/audit-exceptions-enforcement/plans/plan.md",
+  "localChecks": {
+    "reconcileScript": "node scripts/audit-exceptions.mjs -> exit 0 (5 active advisories, all covered + unexpired)",
+    "unitTests": "node --test tests/scripts/audit-exceptions.test.mjs -> 12/12 pass"
+  },
+  "assumptions": [
+    "auditExceptions entry shape migrated from string to { reason, expires } (reason preserves the prior justification verbatim).",
+    "expires date assigned to all 5 existing entries: 2026-11-15 (~3 months from the 2026-08-15 authoring date) as a reasonable near-future re-evaluation box.",
+    "Missing/invalid/past expires is treated as already-lapsed -> fail closed.",
+    "Reconcile matches advisories on github_advisory_id (GHSA), the register's key.",
+    "Register entries with no matching active advisory warn (stale hygiene) but do not fail.",
+    "expires is inclusive of its whole UTC day (lapses at start of the next day).",
+    "Gate is a standalone root script (scripts/audit-exceptions.mjs) + blocking PR workflow, mirroring check-changesets.mjs convention, not a new CLI command.",
+    "The 5 currently-active advisories map exactly to the 5 pre-existing register entries, so the new gate is green on this PR without adding any new exemptions."
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "generate:persona-workflows:check": "node scripts/generate-persona-workflows.mjs --check",
     "changeset": "changeset",
     "check:changesets": "BASE_REF=origin/main node scripts/check-changesets.mjs",
+    "check:audit-exceptions": "node scripts/audit-exceptions.mjs",
     "version": "changeset version && node scripts/sync-plugin-pin.mjs",
     "release": "pnpm build && changeset publish",
     "prepare": "husky"
@@ -109,11 +110,26 @@
     }
   },
   "auditExceptions": {
-    "GHSA-67mh-4wv8-2f99": "esbuild dev-server CORS — dev-only, no network exposure. Blocked by vitepress ^5 pin.",
-    "GHSA-4w7w-66w2-5vf9": "vite .map path traversal — dev-only, no --host usage. Blocked by vitepress ^5 pin.",
-    "GHSA-fx2h-pf6j-xcff": "vite server.fs.deny bypass (HIGH) — app/test copies bumped to >=6.4.3; residual is the vite 5.4.x copy pulled only by vitepress ^5 (no 5.x patch exists). Dev/docs-only, no --host. Real fix is upgrading vitepress off vite 5.",
-    "GHSA-v6wh-96g9-6wx3": "launch-editor NTLM disclosure via vite (HIGH) — same residual as GHSA-fx2h: only the vitepress ^5 vite 5.4.x copy. Dev/docs-only, Windows-only. Real fix is upgrading vitepress off vite 5.",
-    "GHSA-g7r4-m6w7-qqqr": "esbuild dev-server arbitrary file read — tsx moved to 4.23.11, which resolves the patched esbuild 0.28.2; the residual vulnerable 0.27.7 copy is now pulled only by tsup 8.5.1 (and its bundle-require dep), which caps esbuild at ^0.27.0 with no newer tsup published. Still dev-only, Windows-only, low severity. Forcing esbuild >=0.28.1 under tsup would be an out-of-range override of the bundler's own compiler; real fix is a tsup release on esbuild >=0.28.1."
+    "GHSA-67mh-4wv8-2f99": {
+      "reason": "esbuild dev-server CORS — dev-only, no network exposure. Blocked by vitepress ^5 pin.",
+      "expires": "2026-11-15"
+    },
+    "GHSA-4w7w-66w2-5vf9": {
+      "reason": "vite .map path traversal — dev-only, no --host usage. Blocked by vitepress ^5 pin.",
+      "expires": "2026-11-15"
+    },
+    "GHSA-fx2h-pf6j-xcff": {
+      "reason": "vite server.fs.deny bypass (HIGH) — app/test copies bumped to >=6.4.3; residual is the vite 5.4.x copy pulled only by vitepress ^5 (no 5.x patch exists). Dev/docs-only, no --host. Real fix is upgrading vitepress off vite 5.",
+      "expires": "2026-11-15"
+    },
+    "GHSA-v6wh-96g9-6wx3": {
+      "reason": "launch-editor NTLM disclosure via vite (HIGH) — same residual as GHSA-fx2h: only the vitepress ^5 vite 5.4.x copy. Dev/docs-only, Windows-only. Real fix is upgrading vitepress off vite 5.",
+      "expires": "2026-11-15"
+    },
+    "GHSA-g7r4-m6w7-qqqr": {
+      "reason": "esbuild dev-server arbitrary file read — tsx moved to 4.23.11, which resolves the patched esbuild 0.28.2; the residual vulnerable 0.27.7 copy is now pulled only by tsup 8.5.1 (and its bundle-require dep), which caps esbuild at ^0.27.0 with no newer tsup published. Still dev-only, Windows-only, low severity. Forcing esbuild >=0.28.1 under tsup would be an out-of-range override of the bundler's own compiler; real fix is a tsup release on esbuild >=0.28.1.",
+      "expires": "2026-11-15"
+    }
   },
   "engines": {
     "node": ">=22.0.0",

--- a/scripts/audit-exceptions.mjs
+++ b/scripts/audit-exceptions.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * Enforce the `auditExceptions` register in the root package.json so a
+ * time-boxed deferral cannot silently become a permanent exemption (issue
+ * #1324).
+ *
+ * Before this gate the register was decorative: no source read it and no
+ * workflow ran `pnpm audit`, so a NEW advisory never failed CI and a listed
+ * advisory was exempt forever. This script closes both holes.
+ *
+ * It runs `pnpm audit --json`, matches each active advisory (by its
+ * `github_advisory_id`, i.e. GHSA id) against the register, and FAILS when:
+ *   (a) an active advisory has no register entry, or
+ *   (b) a covering entry has lapsed — past its `expires` date, or missing one.
+ *
+ * A MISSING `expires` is treated as ALREADY LAPSED (fail closed): silence must
+ * not re-enter through an entry that never expires. Register entries that no
+ * longer match any active advisory are reported as warnings (stale hygiene),
+ * not failures.
+ *
+ * The reconcile logic (`extractAdvisories`, `lapseReason`, `reconcile`) is
+ * exported as pure functions for unit testing; only `main()` touches the
+ * network. Importing this module has no side effects.
+ *
+ * Usage: node scripts/audit-exceptions.mjs
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Extract the active advisories from `pnpm audit --json` output.
+ *
+ * pnpm keys its `advisories` map by an internal numeric id but carries the
+ * canonical `github_advisory_id` (GHSA) on each entry — the register is
+ * GHSA-keyed, so that is the id we reconcile on. Entries without a GHSA fall
+ * back to a `numeric:<key>` sentinel so they still surface as uncovered rather
+ * than vanishing.
+ *
+ * @param {unknown} auditJson Parsed `pnpm audit --json` object.
+ * @returns {Array<{ id: string, severity: string, module: string }>}
+ */
+export function extractAdvisories(auditJson) {
+  const advisories =
+    auditJson && typeof auditJson === 'object' ? auditJson.advisories : undefined;
+  if (!advisories || typeof advisories !== 'object') return [];
+  const out = [];
+  for (const [numericKey, a] of Object.entries(advisories)) {
+    if (!a || typeof a !== 'object') continue;
+    const id = a.github_advisory_id || `numeric:${numericKey}`;
+    out.push({
+      id,
+      severity: a.severity || 'unknown',
+      module: a.module_name || 'unknown',
+    });
+  }
+  return out;
+}
+
+/**
+ * Return a human-readable reason when a register entry is lapsed, or `null`
+ * when it is still valid.
+ *
+ * The entry must be an object carrying an ISO-date `expires`. A missing or
+ * malformed `expires` is lapsed (fail closed). `expires` is inclusive of its
+ * whole UTC day: an entry dated D stays valid through the end of D and lapses
+ * at the first instant of D+1 — this avoids a same-day off-by-one where an
+ * entry dated today would read as already expired.
+ *
+ * @param {unknown} entry
+ * @param {Date} now
+ * @returns {string | null}
+ */
+export function lapseReason(entry, now) {
+  if (!entry || typeof entry !== 'object') {
+    return 'entry is not an object with a `reason` and `expires` — treated as already lapsed.';
+  }
+  const expires = entry.expires;
+  if (!expires || typeof expires !== 'string') {
+    return 'missing `expires` — treated as already lapsed.';
+  }
+  const parsed = Date.parse(expires);
+  if (Number.isNaN(parsed)) {
+    return `invalid \`expires\` date: ${JSON.stringify(expires)} — treated as already lapsed.`;
+  }
+  // Inclusive of the whole expiry day: valid until the start of the next day.
+  const deadline = parsed + MS_PER_DAY;
+  if (now.getTime() >= deadline) {
+    return `exception expired on ${expires}.`;
+  }
+  return null;
+}
+
+/**
+ * Reconcile active advisories against the `auditExceptions` register.
+ *
+ * For every active advisory there must be a register entry that is not lapsed.
+ * Register entries that match no active advisory become warnings (stale, safe
+ * to remove) — never failures.
+ *
+ * @param {object} args
+ * @param {string[]} args.activeAdvisoryIds GHSA ids of currently active advisories.
+ * @param {Record<string, unknown>} args.register The `auditExceptions` map.
+ * @param {Date} [args.now]
+ * @returns {{
+ *   ok: boolean,
+ *   failures: Array<{ type: 'uncovered' | 'expired', id: string, detail: string }>,
+ *   warnings: Array<{ type: 'stale', id: string, detail: string }>,
+ *   covered: string[],
+ * }}
+ */
+export function reconcile({ activeAdvisoryIds, register, now = new Date() }) {
+  const reg = register && typeof register === 'object' ? register : {};
+  const active = new Set(activeAdvisoryIds || []);
+  const failures = [];
+  const warnings = [];
+  const covered = [];
+
+  for (const id of active) {
+    if (!Object.prototype.hasOwnProperty.call(reg, id)) {
+      failures.push({
+        type: 'uncovered',
+        id,
+        detail: `Active advisory ${id} has no auditExceptions entry. Fix the dependency, or add an entry with a justification and an \`expires\` date.`,
+      });
+      continue;
+    }
+    const reason = lapseReason(reg[id], now);
+    if (reason) {
+      failures.push({
+        type: 'expired',
+        id,
+        detail: `auditExceptions entry ${id}: ${reason} Re-evaluate the advisory and either resolve it or renew the deferral with a new \`expires\` date.`,
+      });
+      continue;
+    }
+    covered.push(id);
+  }
+
+  for (const id of Object.keys(reg)) {
+    if (!active.has(id)) {
+      warnings.push({
+        type: 'stale',
+        id,
+        detail: `auditExceptions entry ${id} no longer matches any active advisory — safe to remove.`,
+      });
+    }
+  }
+
+  return { ok: failures.length === 0, failures, warnings, covered };
+}
+
+/**
+ * Run `pnpm audit --json` and return its parsed output.
+ *
+ * `pnpm audit` exits non-zero when it finds vulnerabilities, so we capture
+ * stdout from the thrown error too. Throws only when the output cannot be
+ * parsed as JSON (so the caller fails closed rather than passing silently).
+ *
+ * @returns {unknown}
+ */
+function runAudit() {
+  let stdout;
+  try {
+    stdout = execSync('pnpm audit --json', { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 });
+  } catch (err) {
+    // Non-zero exit (vulnerabilities present) still delivers JSON on stdout.
+    stdout = err && typeof err.stdout === 'string' ? err.stdout : '';
+  }
+  const trimmed = (stdout || '').trim();
+  if (!trimmed) {
+    throw new Error('`pnpm audit --json` produced no output — cannot reconcile audit exceptions.');
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (err) {
+    throw new Error(
+      `Could not parse \`pnpm audit --json\` output as JSON: ${err.message}\n` +
+        `First 300 chars:\n${trimmed.slice(0, 300)}`,
+      { cause: err }
+    );
+  }
+}
+
+function loadRegister(repoRoot) {
+  const pkgPath = resolve(repoRoot, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  return pkg.auditExceptions || {};
+}
+
+function main() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = resolve(here, '..');
+
+  let auditJson;
+  try {
+    auditJson = runAudit();
+  } catch (err) {
+    console.error(`\naudit-exceptions: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  const register = loadRegister(repoRoot);
+  const advisories = extractAdvisories(auditJson);
+  const activeAdvisoryIds = advisories.map((a) => a.id);
+  const { ok, failures, warnings, covered } = reconcile({
+    activeAdvisoryIds,
+    register,
+    now: new Date(),
+  });
+
+  console.log(
+    `audit-exceptions: ${advisories.length} active ${advisories.length === 1 ? 'advisory' : 'advisories'}, ` +
+      `${Object.keys(register).length} register ${Object.keys(register).length === 1 ? 'entry' : 'entries'}.`
+  );
+  if (advisories.length > 0) {
+    console.log('Active advisories:');
+    for (const a of advisories) {
+      console.log(`  - ${a.id} (${a.severity}, ${a.module})`);
+    }
+  }
+
+  for (const w of warnings) {
+    console.log(`  [warn] ${w.detail}`);
+  }
+
+  if (ok) {
+    console.log(
+      covered.length > 0
+        ? `\nOK — all ${covered.length} active ${covered.length === 1 ? 'advisory is' : 'advisories are'} covered by an unexpired exception.`
+        : '\nOK — no active advisories.'
+    );
+    process.exit(0);
+  }
+
+  console.error('\naudit-exceptions FAILED:');
+  for (const f of failures) {
+    console.error(`  [${f.type}] ${f.detail}`);
+  }
+  console.error(
+    '\nThe auditExceptions register in package.json converts time-boxed deferrals into\n' +
+      'enforced, expiring exemptions. Every active dependency advisory must be covered by\n' +
+      'an entry with a justification and a future `expires` date. See issue #1324.'
+  );
+  process.exit(1);
+}
+
+// Only run the audit-driven gate when invoked as a script; importing the module
+// (e.g. from tests) exposes the pure functions without side effects.
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/tests/scripts/audit-exceptions.test.mjs
+++ b/tests/scripts/audit-exceptions.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the auditExceptions reconcile gate (issue #1324).
+ *
+ * The register was decorative — nothing read it — so a NEW advisory never
+ * failed CI and a listed advisory was exempt forever. The reconcile logic makes
+ * it load-bearing: every active advisory needs a covering entry that has not
+ * lapsed, and a missing `expires` counts as already lapsed (fail closed).
+ *
+ * These tests pin the pure logic (no network). Run with:
+ *   node --test tests/scripts/audit-exceptions.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  extractAdvisories,
+  lapseReason,
+  reconcile,
+} from '../../scripts/audit-exceptions.mjs';
+
+const NOW = new Date('2026-08-15T12:00:00Z');
+const FUTURE = '2026-11-15';
+const PAST = '2026-07-01';
+
+test('reconcile: uncovered active advisory fails', () => {
+  const { ok, failures } = reconcile({
+    activeAdvisoryIds: ['GHSA-aaaa-bbbb-cccc'],
+    register: {},
+    now: NOW,
+  });
+  assert.equal(ok, false);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].type, 'uncovered');
+  assert.equal(failures[0].id, 'GHSA-aaaa-bbbb-cccc');
+});
+
+test('reconcile: expired covering entry fails', () => {
+  const { ok, failures } = reconcile({
+    activeAdvisoryIds: ['GHSA-aaaa-bbbb-cccc'],
+    register: { 'GHSA-aaaa-bbbb-cccc': { reason: 'deferred', expires: PAST } },
+    now: NOW,
+  });
+  assert.equal(ok, false);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].type, 'expired');
+});
+
+test('reconcile: missing `expires` is treated as already lapsed → fail', () => {
+  const { ok, failures } = reconcile({
+    activeAdvisoryIds: ['GHSA-aaaa-bbbb-cccc'],
+    register: { 'GHSA-aaaa-bbbb-cccc': { reason: 'no expiry given' } },
+    now: NOW,
+  });
+  assert.equal(ok, false);
+  assert.equal(failures[0].type, 'expired');
+});
+
+test('reconcile: legacy string entry (pre-migration shape) fails', () => {
+  // The old register value was a bare justification string with no expiry.
+  const { ok, failures } = reconcile({
+    activeAdvisoryIds: ['GHSA-aaaa-bbbb-cccc'],
+    register: { 'GHSA-aaaa-bbbb-cccc': 'just a justification, no expiry' },
+    now: NOW,
+  });
+  assert.equal(ok, false);
+  assert.equal(failures[0].type, 'expired');
+});
+
+test('reconcile: covered + unexpired entry passes', () => {
+  const { ok, failures, covered } = reconcile({
+    activeAdvisoryIds: ['GHSA-aaaa-bbbb-cccc'],
+    register: { 'GHSA-aaaa-bbbb-cccc': { reason: 'deferred', expires: FUTURE } },
+    now: NOW,
+  });
+  assert.equal(ok, true);
+  assert.deepEqual(failures, []);
+  assert.deepEqual(covered, ['GHSA-aaaa-bbbb-cccc']);
+});
+
+test('reconcile: stale entry (no active advisory) warns but stays ok', () => {
+  const { ok, warnings } = reconcile({
+    activeAdvisoryIds: [],
+    register: { 'GHSA-old-old-old': { reason: 'resolved upstream', expires: FUTURE } },
+    now: NOW,
+  });
+  assert.equal(ok, true);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].type, 'stale');
+});
+
+test('reconcile: mixed batch reports each failure independently', () => {
+  const { ok, failures, covered } = reconcile({
+    activeAdvisoryIds: ['GHSA-cov-ered-ok', 'GHSA-unc-over-ed', 'GHSA-exp-ired-x'],
+    register: {
+      'GHSA-cov-ered-ok': { reason: 'ok', expires: FUTURE },
+      'GHSA-exp-ired-x': { reason: 'lapsed', expires: PAST },
+    },
+    now: NOW,
+  });
+  assert.equal(ok, false);
+  assert.deepEqual(covered, ['GHSA-cov-ered-ok']);
+  const types = failures.map((f) => `${f.type}:${f.id}`).sort();
+  assert.deepEqual(types, ['expired:GHSA-exp-ired-x', 'uncovered:GHSA-unc-over-ed']);
+});
+
+test('lapseReason: expiry is inclusive of its whole UTC day', () => {
+  // An entry expiring today is still valid at any time today...
+  assert.equal(lapseReason({ expires: '2026-08-15' }, new Date('2026-08-15T23:59:59Z')), null);
+  // ...and lapses at the first instant of the next day.
+  assert.match(
+    lapseReason({ expires: '2026-08-15' }, new Date('2026-08-16T00:00:00Z')) || '',
+    /expired/
+  );
+});
+
+test('lapseReason: invalid date string is lapsed', () => {
+  assert.match(lapseReason({ expires: 'not-a-date' }, NOW) || '', /invalid/);
+});
+
+test('extractAdvisories: pulls github_advisory_id from the advisories map', () => {
+  const auditJson = {
+    advisories: {
+      1102341: {
+        github_advisory_id: 'GHSA-67mh-4wv8-2f99',
+        severity: 'moderate',
+        module_name: 'esbuild',
+      },
+      1123525: {
+        github_advisory_id: 'GHSA-fx2h-pf6j-xcff',
+        severity: 'high',
+        module_name: 'vite',
+      },
+    },
+  };
+  const advisories = extractAdvisories(auditJson);
+  assert.deepEqual(
+    advisories.map((a) => a.id).sort(),
+    ['GHSA-67mh-4wv8-2f99', 'GHSA-fx2h-pf6j-xcff']
+  );
+});
+
+test('extractAdvisories: entry without a GHSA falls back to a numeric sentinel', () => {
+  const advisories = extractAdvisories({
+    advisories: { 999999: { severity: 'low', module_name: 'foo' } },
+  });
+  assert.deepEqual(advisories, [{ id: 'numeric:999999', severity: 'low', module: 'foo' }]);
+});
+
+test('extractAdvisories: empty / malformed audit output yields no advisories', () => {
+  assert.deepEqual(extractAdvisories({}), []);
+  assert.deepEqual(extractAdvisories(null), []);
+  assert.deepEqual(extractAdvisories({ advisories: null }), []);
+});


### PR DESCRIPTION
Closes #1324

## Problem

`auditExceptions` in `package.json` was read by nothing — ZERO source consumers, and no workflow ran `pnpm audit`. So the register was decorative: a **new** advisory never failed CI, and a **listed** advisory was exempt forever. Time-boxed deferrals silently became permanent exemptions.

## Fix

- **`scripts/audit-exceptions.mjs`** — runs `pnpm audit --json`, reconciles each active advisory (matched by `github_advisory_id` / GHSA) against the register, and exits non-zero when (a) an active advisory has no register entry, or (b) a covering entry has lapsed. A **missing `expires` is treated as already-lapsed → fail closed**, so silence cannot re-enter. Pure `extractAdvisories`/`lapseReason`/`reconcile` exports; only `main()` touches the network.
- **`package.json`** — migrated each `auditExceptions` entry from a bare string to `{ reason, expires }` (reason preserves the prior justification verbatim). Added `check:audit-exceptions` script.
- **`.github/workflows/audit-exceptions.yml`** — blocking PR gate running the reconcile script.
- **`tests/scripts/audit-exceptions.test.mjs`** — 12 `node:test` cases: uncovered / expired / missing-expiry / legacy-string → fail; covered+unexpired → pass; stale entry → warn+ok; plus `extractAdvisories`/`lapseReason` edge cases.

## Green on this PR

The 5 currently-active advisories map **exactly** to the 5 pre-existing register entries, so the gate is green here without adding any new exemptions:

```
audit-exceptions: 5 active advisories, 5 register entries.
OK — all 5 active advisories are covered by an unexpired exception.  (exit 0)
```

## Local checks

- `node scripts/audit-exceptions.mjs` → exit 0 (green)
- `node --test 'tests/scripts/*.test.mjs'` → 74/74 pass (12 new)
- `pnpm format:check` → clean; changeset gate → no publishable change; pre-commit + pre-push gauntlets → pass

## Assumptions (autonomous lane — recommended defaults)

- Entry shape `{ reason, expires }`.
- `expires: 2026-11-15` assigned to all 5 existing entries (~3 months from the 2026-08-15 authoring date) as a near-future re-evaluation box.
- Missing/invalid/past `expires` → fail closed; `expires` inclusive of its whole UTC day.
- Stale entries (no matching active advisory) warn, don't fail.
- Standalone root script + blocking workflow (mirrors `check-changesets.mjs`), not a new CLI command.

Pipeline artifacts: `docs/changes/audit-exceptions-enforcement/{proposal.md,plans/plan.md,provenance.json}`.