### PR TITLE
feat(telemetry): ship aggregate-telemetry synthesis surface (#563)

### DIFF
--- a/.changeset/telemetry-synthesize-563.md
+++ b/.changeset/telemetry-synthesize-563.md
@@ -1,0 +1,30 @@
+---
+'@harness-engineering/types': minor
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+---
+
+feat(telemetry): add `harness telemetry synthesize` — a unified local telemetry report
+
+Ships the in-repo slice of #563: a read-only, local, single-project command that
+COMPOSES the five telemetry surfaces that already accrue — skill adoption
+(`readAdoptionRecords`/`aggregateBySkill`), Bayesian skill effectiveness
+(`computeSkillEffectiveness`/`detectFailingSkills`/`detectAbandonedSkills`), usage/cost
+(the usage aggregator), composite code-health insights (`composeInsights`), and
+`execution_outcome` graph verdicts — into one report. Markdown by default; `--json`
+emits a machine-readable `TelemetrySynthesis` object designed so a future dashboard can
+consume it unchanged.
+
+It collects nothing new — no hooks, event types, or storage — and is pure composition
+over existing readers, mirroring the `harness adoption retrospective` precedent.
+`--skip <section>` omits a source, `--window <days>` bounds the adoption/usage/outcome
+sources, and `--out <path>` writes to a file (default: stdout). A missing source
+contributes an explicit "no data" note in a "Sources with no data" footer — never a
+fabricated zero and never a crash.
+
+The cross-adopter public dashboard from the shard stays out of scope (it needs a
+PostHog aggregate + privacy review + hosting decision that do not exist in-repo); this
+is the buildable, testable per-project data layer that dashboard would render.
+
+`core` gains a `telemetry-synthesis` module (pure composer + Markdown renderer); the CLI
+is the composition root, keeping `core` free of any `intelligence`/`graph` dependency.

--- a/docs/changes/aggregate-telemetry-synthesis/autopilot-state.json
+++ b/docs/changes/aggregate-telemetry-synthesis/autopilot-state.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 5,
+  "specPath": "docs/changes/aggregate-telemetry-synthesis/proposal.md",
+  "sessionSlug": "changes--aggregate-telemetry-synthesis--proposal",
+  "startingCommit": "de75401e872271af2ade39fa795320e9b709a9fc",
+  "rigorLevel": "thorough",
+  "reviewPlans": false,
+  "currentState": "DONE",
+  "currentPhase": 0,
+  "phases": [
+    {
+      "name": "Aggregate-telemetry synthesis surface (harness telemetry synthesize)",
+      "complexity": "medium",
+      "complexityOverride": null,
+      "planPath": "docs/changes/aggregate-telemetry-synthesis/plans/plan.md",
+      "status": "PHASE_COMPLETE"
+    }
+  ],
+  "decisions": [
+    {
+      "state": "BRAINSTORM",
+      "what": "Validated the draft spec against the five existing readers by source inspection; flipped status DRAFT->PLANNED.",
+      "why": "Every source (readAdoptionRecords/aggregateBySkill, the intelligence skill scorers, the usage aggregator, composeInsights, execution_outcome graph nodes) exists with the signatures the spec assumes. The scope is buildable and testable in-repo; the cross-adopter dashboard is correctly deferred (needs a PostHog aggregate + privacy review + hosting that do not exist here)."
+    },
+    {
+      "state": "BRAINSTORM",
+      "what": "Refined the headline field `healthScore: number` to `healthPassed: boolean | null`.",
+      "why": "composeInsights yields InsightsHealthBlock { passed, signals, summary } — a pass/fail signal, not a numeric score. Decision 6 of the spec forbids fabricating a value; a boolean is the honest projection. No acceptance criterion asserts a numeric health score."
+    },
+    {
+      "state": "PLAN",
+      "what": "Resolved the spec's open layering question: core hosts a PURE composer; the CLI is the composition root.",
+      "why": "Effectiveness lives in @harness-engineering/intelligence and outcomes in @harness-engineering/graph; core must depend on neither. The CLI reads adoption/usage records, builds the effectiveness projection from the intelligence scorers, reads execution_outcome nodes via the graph loader, runs composeInsights, and hands them all to composeSynthesis. This mirrors how adoption.ts imports the scorers at the CLI layer, keeping the existing dependency direction intact."
+    },
+    {
+      "state": "EXECUTE",
+      "what": "Made composeSynthesis pure (all inputs injected, fixed `now` supported) rather than reading files itself.",
+      "why": "Determinism and unit-testability for the present/absent/mixed/windowed cases without touching disk; the CLI owns all IO. Windowing is applied consistently to adoption/usage/outcomes inside the composer, and effectiveness is built from the SAME windowed records so the two never diverge."
+    },
+    {
+      "state": "EXECUTE",
+      "what": "Outcome verdicts are counted from metadata.verdict (SATISFIED/NOT_SATISFIED/INCONCLUSIVE), falling back to metadata.result (success->SATISFIED, failure->NOT_SATISFIED) for nodes without an outcome-eval verdict.",
+      "why": "execution_outcome nodes from outcome-eval carry the 3-valued verdict; connector-only nodes carry just result. Reading both avoids undercounting while staying honest (an empty/absent set yields present:false, never a zero-rate section)."
+    },
+    {
+      "state": "EXECUTE",
+      "what": "Cost is priced through the same loadPricingData + calculateCost path `harness usage` uses; any unknown-pricing record makes the total null.",
+      "why": "AC6 requires no divergence from the usage surface. costMicroUSD is never stored in costs.jsonl — it is derived from model pricing — so the synthesize command must price identically. A null (not zero) total preserves the never-fabricate-a-value rule."
+    },
+    {
+      "state": "VERIFY",
+      "what": "14 core unit tests (compose present/absent/mixed/windowed/skip + render) and 10 CLI integration tests (AC1-AC11 against on-disk fixtures) pass; typecheck clean across types/core/cli.",
+      "why": "Each acceptance criterion has a covering test; the CLI tests exercise the real readers end-to-end rather than mocks. AC10 snapshots .harness/metrics before/after to prove read-only."
+    },
+    {
+      "state": "INTEGRATE",
+      "what": "Regenerated the core barrel (telemetry-synthesis auto-discovered via export *), regenerated reference docs (new CLI surface), and added a minor changeset for types/core/cli.",
+      "why": "Pre-push gates: stale docs/reference/* and a missing changeset both block the push; the barrel picks the new module up through auto-discovery plus a DIR_COMMENTS entry for a clean generated comment."
+    }
+  ],
+  "gates": {
+    "coreUnitTests": "14 passed (tests/telemetry-synthesis/synthesize.test.ts)",
+    "cliIntegrationTests": "10 passed (tests/commands/telemetry-synthesize.test.ts) — AC1-AC11",
+    "typecheck": "PASS — @harness-engineering/types, core, cli (tsc --noEmit, exactOptionalPropertyTypes)",
+    "readOnly": "verified — .harness/metrics snapshot unchanged across a run (AC10)",
+    "costParity": "verified — headline totalCost equals the usage aggregator total over the same fixture (AC6)"
+  }
+}

--- a/docs/changes/aggregate-telemetry-synthesis/plans/plan.md
+++ b/docs/changes/aggregate-telemetry-synthesis/plans/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan — Aggregate-Telemetry Synthesis Surface (#563)
+
+**Spec:** `docs/changes/aggregate-telemetry-synthesis/proposal.md` (status: PLANNED)
+**Produced by:** harness-autopilot (planning phase), 2026-08-16
+**Branch:** `build/telemetry-synthesize-563` (base `main`)
+
+## Objective
+
+Ship `harness telemetry synthesize` — a read-only, local, single-project CLI command that
+composes the five telemetry surfaces that already accrue in-repo into one unified report
+(Markdown default, `--json` for machines). Pure composition over existing readers; collects
+nothing new. Mirrors the `harness adoption retrospective` precedent.
+
+## Grounding — verified reader APIs (from source inspection)
+
+| #   | Source        | Reader (verified signature)                                                                                                                                            | Package                                           |
+| --- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| 1   | Adoption      | `readAdoptionRecords(projectRoot): SkillInvocationRecord[]`, `aggregateBySkill(records): SkillAdoptionSummary[]`                                                       | `@harness-engineering/core`                       |
+| 2   | Effectiveness | `computeSkillEffectiveness(records)`, `detectFailingSkills(records)`, `detectAbandonedSkills(records)`                                                                 | `@harness-engineering/intelligence`               |
+| 3   | Usage/cost    | `readCostRecords(projectRoot): UsageRecord[]`, `aggregateByDay(records): DailyUsage[]` (costMicroUSD)                                                                  | `@harness-engineering/core`                       |
+| 4   | Insights      | `composeInsights(projectPath, opts): Promise<InsightsReport>` (health block is pass/fail, not numeric)                                                                 | `@harness-engineering/core`                       |
+| 5   | Outcomes      | `store.findNodes({ type: 'execution_outcome' })`; verdict on `metadata.verdict` (SATISFIED/NOT_SATISFIED/INCONCLUSIVE), fallback `metadata.result` (success→SATISFIED) | `@harness-engineering/graph` via `loadGraphStore` |
+
+## Soundness refinement (planning-time)
+
+The spec's headline `healthScore: number | null` cannot be sourced honestly: `composeInsights`
+returns `InsightsHealthBlock { passed, signals, summary }` — a pass/fail signal, no numeric
+score. Per Decision 6 (never fabricate a value), the headline carries `healthPassed: boolean | null`.
+All other headline fields (`totalSkillInvocations`, `skillSuccessRate`, `outcomeSatisfiedRate`,
+`totalCostUsd`) are sourced directly. Recorded as an assumption in the PR.
+
+## Layering decision (spec §Core module — "to be confirmed in planning")
+
+Effectiveness (source 2) lives in `@harness-engineering/intelligence`; `core` must not depend on
+`intelligence`. Resolution: `composeSynthesis` lives in **core** and accepts the effectiveness
+section as an injected input (the same pattern `adoption.ts` uses — it imports the intelligence
+scorers at the CLI layer, not in core). The CLI command builds the effectiveness section (dynamic
+import of intelligence) and the graph outcome section (dynamic import of graph loader), then passes
+both into `composeSynthesis`. This keeps the existing dependency direction intact: core stays free
+of intelligence/graph, the CLI is the composition root. Adoption/usage/insights are read directly
+inside `composeSynthesis` (all in core).
+
+## Tasks (ordered, TDD)
+
+1. **Types** — `packages/types/src/telemetry-synthesis.ts`: `TelemetrySynthesis`, `TelemetrySynthesisHeadline`,
+   `AdoptionSection`, `EffectivenessSection`, `UsageSection`, `InsightsSection`, `OutcomeSection`,
+   `SourceAbsent = { present: false }`, `SynthesisSection<T> = T | SourceAbsent`. Export from `packages/types/src/index.ts`.
+2. **Core compose** — `packages/core/src/telemetry-synthesis/synthesize.ts`:
+   `composeSynthesis(projectRoot, opts)` where opts carries `windowDays`, `skip[]`, and the two
+   injected sections (`effectiveness`, `outcomes`). Per-source try/empty → `{ present: false }`.
+   Window filtering applied to adoption/usage/outcome record sets before aggregation.
+   Unit tests: all-present, all-absent, mixed, windowed.
+3. **Core render** — `packages/core/src/telemetry-synthesis/render.ts`:
+   `renderSynthesisMarkdown(synthesis)` — headline block, one section per present source, and a
+   "Sources with no data" footer listing every absent source. Unit tests: present rendered,
+   absent footered.
+4. **Barrel** — `packages/core/src/telemetry-synthesis/index.ts` (auto-discovered `export *`); add a
+   `DIR_COMMENTS` entry in `scripts/generate-core-barrel.mjs`; run `pnpm run generate:barrels`.
+5. **CLI** — `packages/cli/src/commands/telemetry/synthesize.ts`: `createSynthesizeCommand()` with
+   `--json`, `--out <path>`, `--skip <section...>`, `--window <days>`. Builds effectiveness + outcome
+   sections, calls `composeSynthesis` + `renderSynthesisMarkdown`. Register in
+   `packages/cli/src/commands/telemetry/index.ts`. Integration test: exit 0, headline, sections,
+   `--json` parity vs `adoption skills --json` and usage total, `--skip usage`, `--out`, read-only
+   snapshot, `--window`.
+6. **Docs** — `pnpm run generate-docs` (new CLI surface → reference freshness).
+7. **Changeset** — `.changeset/*.md`.
+8. **Gates** — build CLI, `pnpm format`, tests green, then push through the pre-push gauntlet.
+
+## Acceptance criteria → covering test map
+
+- AC1 exit0+markdown → cli integration `synthesize prints markdown`
+- AC2 headline + per-present section → cli integration + render unit
+- AC3 `--json` parseable TelemetrySynthesis, all 5 source keys + headline → cli integration `--json`
+- AC4 K skills / N invocations parity vs adoption skills → cli integration parity test
+- AC5 no adoption file → present:false + footer + null headline → compose unit (absent) + cli
+- AC6 cost total parity vs usage aggregator → cli integration cost parity
+- AC7 outcomes verdict counts + satisfiedRate; absent graph → present:false → compose unit + cli
+- AC8 `--skip usage` omits usage + null cost → cli integration skip test
+- AC9 `--out` writes + confirmation; no `--out` writes nothing → cli integration out test
+- AC10 zero writes to `.harness/metrics/*` → cli integration read-only snapshot test
+- AC11 `--window 30` bounds sections → compose unit windowed + cli
+- AC12 unit coverage compose+render; `harness validate` → this plan's unit suites + build gate
+
+## Verification
+
+- Build CLI (`node packages/cli/dist/bin/harness.js telemetry synthesize`) against a temp fixture project.
+- Run unit + integration suites green.
+- Confirm read-only: snapshot `.harness/metrics/` mtimes before/after.

--- a/docs/changes/aggregate-telemetry-synthesis/proposal.md
+++ b/docs/changes/aggregate-telemetry-synthesis/proposal.md
@@ -1,0 +1,167 @@
+# Aggregate-Telemetry Synthesis Surface
+
+**Status:** DRAFT — autonomously drafted for human review. Do not implement or merge until a maintainer has scoped and accepted it.
+
+**Roadmap item:** #563 · shard `docs/roadmap.d/ship-aggregate-telemetry-synthesis-surface.md` (P1, v5.0 — Telemetry & Effectiveness)
+
+**Keywords:** telemetry, synthesis, aggregation, adoption, effectiveness, usage, insights, cli, local-first, read-only
+
+## Overview
+
+The harness already accrues rich telemetry across at least six independent surfaces, but **no single surface synthesizes them back into one answer**. A maintainer or adopter asking "is the harness working here — are skills landing, are outcomes passing, what is it costing, is drift rising?" today has to run four unrelated commands and cross-reference a graph query by hand. Each existing surface answers exactly one dimension; none composes them.
+
+This proposal ships the minimal, honest, in-repo slice of #563: a **read-only, local, single-project telemetry synthesis command** — `harness telemetry synthesize` — that composes the telemetry that _already exists_ into one unified report (Markdown by default, `--json` for machines). It collects nothing new: no new hooks, no new event types, no new storage. It is pure composition over existing readers, following the exact precedent already set by `harness adoption retrospective` (which composes adoption records + the Bayesian effectiveness scorer into one report).
+
+The shard's broader vision — a **public, cross-adopter dashboard at a known URL, anonymized across the adopter base** — is deliberately **out of scope for this slice** and is scoped separately below, because it depends on server-side aggregation of the PostHog stream (a hosted backend), not on data available in-repo. See "Honest scoping" before building.
+
+## Honest scoping (read first)
+
+The shard describes three deliverables: (a) a public cross-adopter dashboard, (b) `docs/case-studies/`, (c) a README "Adopters" wall driven by `harness telemetry publish`. All three depend on **aggregating telemetry across the adopter base**, which lives in PostHog (streamed by `packages/cli/src/hooks/telemetry-reporter.js`), not in this repository. Building (a)/(b)/(c) requires:
+
+- a queryable PostHog aggregate (API key, hosted query layer, or export pipeline) — infrastructure that does not exist in-repo and cannot be built or tested here;
+- an anonymization / privacy review for publishing adopter-base statistics (DO_NOT_TRACK is respected at collection, but publishing aggregates is a new privacy surface);
+- a hosting decision for the public URL.
+
+Rather than draft a spec against infrastructure that isn't present (spec quality compounds — a spec that can't be verified is worse than none), this proposal ships the **loop-closing core that _is_ buildable and testable today**: the synthesis surface over the telemetry a single project already holds locally. This is genuinely valuable on its own (it answers "is this working _here_?" for one adopter, which the shard names as the core unmet need) and it is the exact data layer the future public dashboard would render. The cross-adopter public surface is filed as an explicit follow-on with its prerequisites listed, so a human can decide whether/how to fund the backend.
+
+## The real telemetry sources this synthesizes
+
+Every source below already accrues today; this command reads them, it does not create them.
+
+| #   | Source                                                                                                                                                      | Where it accrues                                                                | Existing reader / surface                                                                                                                                                                                             |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Skill-adoption telemetry** — per-invocation `SkillInvocationRecord` (skill, outcome, phasesReached, duration, tier, trigger)                              | `.harness/metrics/adoption.jsonl` (written by the `adoption-tracker` Stop hook) | `readAdoptionRecords` / `aggregateBySkill` in `@harness-engineering/core` (`packages/core/src/adoption/`); surfaced by `harness adoption skills\|recent\|skill`                                                       |
+| 2   | **Bayesian skill effectiveness** — Laplace-smoothed success / failing / abandoned-mid-workflow rankings derived from source 1                               | computed on read                                                                | `computeSkillEffectiveness`, `detectFailingSkills`, `detectAbandonedSkills` in `@harness-engineering/intelligence` (`packages/intelligence/src/effectiveness/`); already composed by `harness adoption retrospective` |
+| 3   | **Usage / cost telemetry** — per-day and per-session token usage and cost                                                                                   | `.harness/metrics/costs.jsonl`                                                  | `@harness-engineering/core` usage aggregator (`packages/core/src/usage/aggregator.ts`); surfaced by `harness usage`                                                                                                   |
+| 4   | **Composite code-health insights** — health, entropy, decay, attention, impact                                                                              | computed from graph + detectors on read                                         | `composeInsights` in `@harness-engineering/core` (`packages/core/src/insights/aggregator.ts`); surfaced by `harness insights` and the `insights_summary` MCP tool                                                     |
+| 5   | **`execution_outcome` graph nodes** — post-execution outcome-eval verdicts (SATISFIED / NOT_SATISFIED / INCONCLUSIVE) that feed the effectiveness baselines | knowledge graph                                                                 | `@harness-engineering/intelligence` outcome-eval (`packages/intelligence/src/outcome-eval/`, `packages/intelligence/src/outcome/`)                                                                                    |
+
+Sources 1–4 are read via already-exported, already-tested public APIs. Source 5 is included only if a graph is present; when absent the section is omitted honestly (mirroring how `discoverCatalogSkills` returns `undefined` rather than a false zero in `adoption.ts`).
+
+Explicitly **not** aggregated by this slice: the raw PostHog stream (source 6, `telemetry-reporter.js`) and the KPI timelines in `.harness/architecture/timeline.json` / `.harness/security/timeline.json` — the former is the cross-adopter follow-on's domain, the latter is already synthesized by `harness insights` (source 4) and would double-count.
+
+## Goals
+
+1. One command, `harness telemetry synthesize`, that produces a single unified report over sources 1–5 above.
+2. Read-only and local-first — collects nothing, writes nothing except the optional output file the user asks for.
+3. Markdown by default; `--json` emits a machine-readable `TelemetrySynthesis` object.
+4. Degrade gracefully and honestly — a missing source contributes an explicit "no data" note, never a fabricated zero and never a crash.
+5. Reuse existing readers/scorers verbatim; add composition + rendering only.
+
+## Non-Goals (this slice)
+
+- The public cross-adopter dashboard, `docs/case-studies/`, the README "Adopters" wall, and `harness telemetry publish` (the whole cross-adopter surface — see "Honest scoping"; filed as a follow-on).
+- Any new telemetry collection, hook, event type, or storage file.
+- Anonymization / publishing of adopter-base aggregates.
+- A dashboard (web) rendering — CLI only for this slice; the `--json` contract is designed so a later dashboard collector can consume it unchanged.
+- Cross-project or team-level aggregation.
+
+## Decisions
+
+| #   | Decision                          | Choice                                                                | Rationale                                                                                                                                      |
+| --- | --------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Surface                           | New subcommand `harness telemetry synthesize`                         | Keeps synthesis in the existing `telemetry` command family; no new top-level namespace                                                         |
+| 2   | Scope of this slice               | Single-project, local sources only                                    | The only telemetry buildable/testable in-repo; cross-adopter needs a PostHog backend (out of scope)                                            |
+| 3   | Sources                           | Adoption + effectiveness + usage + insights + execution_outcome (1–5) | Every one has an existing exported reader; zero new collection                                                                                 |
+| 4   | Output                            | Markdown default, `--json` flag                                       | Mirrors `harness adoption retrospective` and every other read surface; `--json` is the dashboard-ready contract                                |
+| 5   | Composition, not reimplementation | Call existing readers/scorers unchanged                               | The retrospective precedent; avoids drift between surfaces                                                                                     |
+| 6   | Missing-source posture            | Explicit per-section "no data" note, never a false zero               | The catalog-retrospective Iron Law: never collapse "no telemetry" into "abandoned/zero"                                                        |
+| 7   | Write behavior                    | `--out <path>` writes; default prints to stdout                       | Read-only by default; matches `harness adoption retrospective --no-write` posture inverted (synthesis is a lookup, not an artifact by default) |
+
+## Technical Design
+
+### Command
+
+`harness telemetry synthesize [--json] [--out <path>] [--skip <section>...] [--window <days>]`
+
+- `--json` — emit the `TelemetrySynthesis` object instead of Markdown.
+- `--out <path>` — write the Markdown (or JSON) to a file; default prints to stdout.
+- `--skip <section>` — omit a section (`adoption` | `effectiveness` | `usage` | `insights` | `outcomes`), repeatable.
+- `--window <days>` — bound the adoption/usage/outcome windows (default: all-time), passed through to the underlying readers where they accept it.
+
+Wired into `packages/cli/src/commands/telemetry/index.ts` via a new `createSynthesizeCommand()`, added alongside the existing `identify` / `status` / `test` subcommands.
+
+### Data model (`packages/types/src/telemetry-synthesis.ts`)
+
+```typescript
+interface TelemetrySynthesis {
+  generatedAt: string; // ISO 8601
+  windowDays: number | null; // null = all-time
+  sources: {
+    adoption: AdoptionSection | { present: false };
+    effectiveness: EffectivenessSection | { present: false };
+    usage: UsageSection | { present: false };
+    insights: InsightsSection | { present: false };
+    outcomes: OutcomeSection | { present: false };
+  };
+  // A small headline block computed from the present sections for the top of the report.
+  headline: {
+    totalSkillInvocations: number | null;
+    skillSuccessRate: number | null; // from adoption/effectiveness
+    outcomeSatisfiedRate: number | null; // from execution_outcome nodes
+    totalCostUsd: number | null; // from usage
+    healthScore: number | null; // from insights
+  };
+}
+```
+
+Each `*Section` is a thin projection of the corresponding existing reader's output (not a re-model): `AdoptionSection` from `aggregateBySkill`, `EffectivenessSection` from `computeSkillEffectiveness` / `detectFailingSkills` / `detectAbandonedSkills`, `UsageSection` from the usage aggregator, `InsightsSection` from `composeInsights`, `OutcomeSection` from a graph count of `execution_outcome` verdicts.
+
+### Core module (`packages/core/src/telemetry-synthesis/`)
+
+```
+telemetry-synthesis/
+  synthesize.ts   — composeSynthesis(projectRoot, opts): builds TelemetrySynthesis by calling existing readers
+  render.ts       — renderSynthesisMarkdown(synthesis): the Markdown report
+  index.ts        — public API (added to the curated core barrel allowlist in scripts/generate-core-barrel.mjs)
+```
+
+`composeSynthesis` calls `readAdoptionRecords` + `aggregateBySkill` (source 1), the intelligence effectiveness scorers (source 2), the usage aggregator (source 3), `composeInsights` (source 4), and a graph outcome-count (source 5). Each call is wrapped so a missing/empty source yields `{ present: false }` rather than throwing — the same defensive posture as `discoverCatalogSkills`.
+
+Effectiveness (source 2) lives in `@harness-engineering/intelligence`; to keep `core` free of an intelligence dependency, the CLI command composes the effectiveness section (exactly as `adoption.ts` already imports the scorers directly in `buildSkillEffectiveness`) and passes it into the renderer, OR the renderer accepts the pre-built section. Final layering to be confirmed in planning; both keep the existing dependency direction intact.
+
+### Rendering
+
+`renderSynthesisMarkdown` emits: a headline block, then one section per present source (reusing the existing per-surface table shapes so output is familiar), then an explicit "Sources with no data" footer listing every `{ present: false }` source. No section is silently dropped.
+
+### New / touched files
+
+```
+packages/types/src/telemetry-synthesis.ts          (new)
+packages/core/src/telemetry-synthesis/synthesize.ts (new)
+packages/core/src/telemetry-synthesis/render.ts     (new)
+packages/core/src/telemetry-synthesis/index.ts      (new)
+packages/core/src/index.ts                          (barrel export)
+scripts/generate-core-barrel.mjs                    (allowlist entry)
+packages/cli/src/commands/telemetry/synthesize.ts   (new)
+packages/cli/src/commands/telemetry/index.ts        (register subcommand)
+```
+
+## Acceptance criteria (measurable)
+
+Each criterion is observable by running a command and inspecting its output or exit code — verifiable per the acceptance-eval standard (a user-visible behavior with a covering test).
+
+1. `harness telemetry synthesize` exits 0 and prints a Markdown report to stdout in a project that has telemetry.
+2. The report contains a headline block and one clearly-labeled section per **present** source among {adoption, effectiveness, usage, insights, outcomes}.
+3. `harness telemetry synthesize --json` emits valid JSON parseable as `TelemetrySynthesis`, with a `sources` key carrying all five source keys and a `headline` block.
+4. Given a fixture `.harness/metrics/adoption.jsonl` with N records across K skills, the JSON `sources.adoption` reports exactly K skills and the headline `totalSkillInvocations === N` (matches what `harness adoption skills --json` reports over the same fixture — no divergence between surfaces).
+5. In a project with **no** `.harness/metrics/adoption.jsonl`, the command still exits 0, `sources.adoption` is `{ present: false }`, and the Markdown lists adoption under "Sources with no data" — no crash, no fabricated zero in the headline (`totalSkillInvocations === null`).
+6. Given a fixture `.harness/metrics/costs.jsonl`, headline `totalCostUsd` equals the total the existing usage aggregator reports over the same fixture.
+7. When a knowledge graph with `execution_outcome` nodes is present, `sources.outcomes` reports the SATISFIED/NOT_SATISFIED/INCONCLUSIVE counts and headline `outcomeSatisfiedRate` equals satisfied ÷ total; when no graph is present, `sources.outcomes` is `{ present: false }` and the rate is `null`.
+8. `--skip usage` produces a report whose `sources.usage` is absent/omitted and whose headline `totalCostUsd` is `null`, while other present sections are unaffected.
+9. `--out <path>` writes the report to `<path>` and prints a one-line confirmation; without `--out`, nothing is written to disk (verified: no new files after a run).
+10. The command performs **zero writes** to any `.harness/metrics/*` or telemetry source (read-only) — asserted by a test that snapshots those paths before/after.
+11. `--window 30` bounds adoption/usage/outcome sections to the trailing 30 days; a fixture record older than 30 days is excluded from the windowed counts and included with no `--window`.
+12. Unit tests cover `composeSynthesis` (all-present, all-absent, mixed) and `renderSynthesisMarkdown` (present sections rendered, absent sections footered); `harness validate` passes after all changes.
+
+## Implementation order
+
+1. **Types** — `TelemetrySynthesis` + section interfaces in `packages/types/src/telemetry-synthesis.ts`.
+2. **Core compose** — `composeSynthesis` calling existing readers with per-source `{ present: false }` fallback; unit tests for present/absent/mixed.
+3. **Core render** — `renderSynthesisMarkdown` incl. the "no data" footer; barrel + allowlist entry.
+4. **CLI** — `harness telemetry synthesize` subcommand (`--json`, `--out`, `--skip`, `--window`); wire into the telemetry command; cross-surface parity test against `harness adoption skills --json` / `harness usage`.
+5. **Docs** — one line in the telemetry command reference; regenerate reference docs (`pnpm run generate-docs`).
+
+## Follow-on (out of scope — filed for human decision)
+
+**Public cross-adopter synthesis dashboard** (the shard's deliverables a/b/c). Prerequisites before it can be specced: (1) a queryable PostHog aggregate or export pipeline; (2) a privacy/anonymization review for publishing adopter-base statistics; (3) a hosting decision for the public URL; (4) `harness telemetry publish` to push headline stats into the README wall. This slice's `--json` `TelemetrySynthesis` contract is intentionally the per-project shape such a dashboard would aggregate, so the follow-on renders rather than re-collects.

--- a/docs/changes/aggregate-telemetry-synthesis/proposal.md
+++ b/docs/changes/aggregate-telemetry-synthesis/proposal.md
@@ -1,6 +1,6 @@
 # Aggregate-Telemetry Synthesis Surface
 
-**Status:** DRAFT — autonomously drafted for human review. Do not implement or merge until a maintainer has scoped and accepted it.
+**Status:** PLANNED — soundness-reviewed via harness-brainstorming (2026-08-16). Scope validated against the five existing readers; one honest-composition refinement applied (headline `healthPassed: boolean | null` replaces `healthScore: number`, because `composeInsights` yields a pass/fail health signal, not a numeric score). Ready for implementation.
 
 **Roadmap item:** #563 · shard `docs/roadmap.d/ship-aggregate-telemetry-synthesis-surface.md` (P1, v5.0 — Telemetry & Effectiveness)
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1805,6 +1805,17 @@ Show current telemetry consent state, install ID, and identity
 
 - `--json` — Output as JSON
 
+### `harness telemetry synthesize`
+
+Compose adoption, effectiveness, usage, insights, and outcome telemetry into one local report
+
+**Options:**
+
+- `--json` — Emit the machine-readable TelemetrySynthesis object instead of Markdown
+- `--out` — Write the report to a file instead of stdout
+- `--skip` — Omit a section (adoption|effectiveness|usage|insights|outcomes); repeatable (default: [])
+- `--window` — Bound adoption/usage/outcome sources to the trailing N days
+
 ### `harness telemetry test`
 
 Send a test event to PostHog and verify connectivity

--- a/docs/roadmap.d/ship-aggregate-telemetry-synthesis-surface.md
+++ b/docs/roadmap.d/ship-aggregate-telemetry-synthesis-surface.md
@@ -7,7 +7,7 @@ order: 4
 ### Ship aggregate-telemetry synthesis surface
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/aggregate-telemetry-synthesis/proposal.md
 - **Summary:** `packages/cli/src/hooks/telemetry-reporter.js` collects rich payload (skillName, duration, outcome, phasesReached, project, team, os, harnessVersion, installId) and streams to PostHog. **No public surface synthesizes this data back.** `core-library-design/proposal.md:1338` planned "Case studies and testimonials" but never delivered. Adopters cannot validate "is this working for teams like mine?" Ship: (a) public adoption dashboard at a known URL aggregating skillName/outcome/phasesReached across the adopter base (anonymized), (b) `docs/case-studies/` directory with quarterly updates derived from telemetry + opt-in interviews, (c) README "Adopters" section with logo wall and headline stats updated by a `harness telemetry publish` script. For a tool that markets compounding-via-learning, the synthesis loop must close. Source: Pass 7-C.
 - **Blockers:** —
 - **Plan:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -935,7 +935,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 ### Ship aggregate-telemetry synthesis surface
 
 - **Status:** planned
-- **Spec:** —
+- **Spec:** docs/changes/aggregate-telemetry-synthesis/proposal.md
 - **Summary:** `packages/cli/src/hooks/telemetry-reporter.js` collects rich payload (skillName, duration, outcome, phasesReached, project, team, os, harnessVersion, installId) and streams to PostHog. **No public surface synthesizes this data back.** `core-library-design/proposal.md:1338` planned "Case studies and testimonials" but never delivered. Adopters cannot validate "is this working for teams like mine?" Ship: (a) public adoption dashboard at a known URL aggregating skillName/outcome/phasesReached across the adopter base (anonymized), (b) `docs/case-studies/` directory with quarterly updates derived from telemetry + opt-in interviews, (c) README "Adopters" section with logo wall and headline stats updated by a `harness telemetry publish` script. For a tool that markets compounding-via-learning, the synthesis loop must close. Source: Pass 7-C.
 - **Blockers:** —
 - **Plan:** —

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -2,11 +2,13 @@ import { Command } from 'commander';
 import { createIdentifyCommand } from './identify';
 import { createStatusCommand } from './status';
 import { createTestCommand } from './test';
+import { createSynthesizeCommand } from './synthesize';
 
 export function createTelemetryCommand(): Command {
   const command = new Command('telemetry').description('Telemetry identity and status management');
   command.addCommand(createIdentifyCommand());
   command.addCommand(createStatusCommand());
   command.addCommand(createTestCommand());
+  command.addCommand(createSynthesizeCommand());
   return command;
 }

--- a/packages/cli/src/commands/telemetry/synthesize.ts
+++ b/packages/cli/src/commands/telemetry/synthesize.ts
@@ -116,6 +116,51 @@ function parseWindow(raw: string | undefined): number | null {
   return Number.isFinite(n) && n > 0 ? n : null;
 }
 
+interface SynthesizeOptions {
+  json?: boolean;
+  out?: string;
+  skip: string[];
+  window?: string;
+}
+
+/** Writes the report to `outPath` (creating parent dirs) and logs a one-line confirmation. */
+function writeReport(cwd: string, outPath: string, output: string): void {
+  const resolved = path.resolve(cwd, outPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, output.endsWith('\n') ? output : output + '\n', 'utf-8');
+  logger.info(
+    `Telemetry synthesis written to ${path.relative(cwd, resolved).replaceAll('\\', '/')}`
+  );
+}
+
+/** Reads every source, composes the synthesis, and emits it (stdout or `--out`). */
+async function runSynthesize(opts: SynthesizeOptions): Promise<void> {
+  const cwd = process.cwd();
+  const skip = opts.skip.filter((s) => SKIPPABLE.has(s)) as TelemetrySynthesisSection[];
+  const skipSet = new Set<string>(skip);
+
+  const core = await import('@harness-engineering/core');
+  const intelligence = await import('@harness-engineering/intelligence');
+
+  const synthesis = core.composeSynthesis(
+    {
+      adoptionRecords: core.readAdoptionRecords(cwd),
+      usageRecords: skipSet.has('usage') ? [] : await loadUsageRecords(cwd),
+      insights: await loadInsights(cwd, skipSet.has('insights')),
+      buildEffectiveness: makeEffectivenessBuilder(intelligence),
+      outcomeNodes: skipSet.has('outcomes') ? null : await loadOutcomeNodes(cwd),
+    },
+    { windowDays: parseWindow(opts.window), skip }
+  );
+
+  const output = opts.json
+    ? JSON.stringify(synthesis, null, 2)
+    : core.renderSynthesisMarkdown(synthesis);
+
+  if (opts.out) writeReport(cwd, opts.out, output);
+  else console.log(output);
+}
+
 export function createSynthesizeCommand(): Command {
   return new Command('synthesize')
     .description(
@@ -130,48 +175,5 @@ export function createSynthesizeCommand(): Command {
       [] as string[]
     )
     .option('--window <days>', 'Bound adoption/usage/outcome sources to the trailing N days')
-    .action(async (opts) => {
-      const cwd = process.cwd();
-
-      const skip = (opts.skip as string[]).filter((s) =>
-        SKIPPABLE.has(s)
-      ) as TelemetrySynthesisSection[];
-      const skipSet = new Set<string>(skip);
-      const windowDays = parseWindow(opts.window);
-
-      const core = await import('@harness-engineering/core');
-      const intelligence = await import('@harness-engineering/intelligence');
-      const { composeSynthesis, renderSynthesisMarkdown, readAdoptionRecords } = core;
-
-      const adoptionRecords = readAdoptionRecords(cwd);
-      const usageRecords = skipSet.has('usage') ? [] : await loadUsageRecords(cwd);
-      const insights = await loadInsights(cwd, skipSet.has('insights'));
-      const outcomeNodes = skipSet.has('outcomes') ? null : await loadOutcomeNodes(cwd);
-
-      const synthesis = composeSynthesis(
-        {
-          adoptionRecords,
-          usageRecords,
-          insights,
-          buildEffectiveness: makeEffectivenessBuilder(intelligence),
-          outcomeNodes,
-        },
-        { windowDays, skip }
-      );
-
-      const output = opts.json
-        ? JSON.stringify(synthesis, null, 2)
-        : renderSynthesisMarkdown(synthesis);
-
-      if (opts.out) {
-        const outPath = path.resolve(cwd, opts.out as string);
-        fs.mkdirSync(path.dirname(outPath), { recursive: true });
-        fs.writeFileSync(outPath, output.endsWith('\n') ? output : output + '\n', 'utf-8');
-        const relPath = path.relative(cwd, outPath).replaceAll('\\', '/');
-        logger.info(`Telemetry synthesis written to ${relPath}`);
-        return;
-      }
-
-      console.log(output);
-    });
+    .action((opts: SynthesizeOptions) => runSynthesize(opts));
 }

--- a/packages/cli/src/commands/telemetry/synthesize.ts
+++ b/packages/cli/src/commands/telemetry/synthesize.ts
@@ -1,0 +1,177 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Command } from 'commander';
+import type {
+  SkillInvocationRecord,
+  UsageRecord,
+  InsightsReport,
+  EffectivenessSection,
+  TelemetrySynthesisSection,
+} from '@harness-engineering/types';
+import { TELEMETRY_SYNTHESIS_SECTIONS } from '@harness-engineering/types';
+import { logger } from '../../output/logger';
+
+/** The section names a caller may `--skip`. */
+const SKIPPABLE = new Set<string>(TELEMETRY_SYNTHESIS_SECTIONS);
+
+/**
+ * Reads and prices usage records exactly as `harness usage` does, so the
+ * synthesized cost total matches that surface (no divergence).
+ */
+async function loadUsageRecords(cwd: string): Promise<UsageRecord[]> {
+  const { readCostRecords, loadPricingData, calculateCost } =
+    await import('@harness-engineering/core');
+  const records = readCostRecords(cwd);
+  if (records.length === 0) return records;
+  const pricingData = await loadPricingData(cwd);
+  for (const record of records) {
+    if (record.model && record.costMicroUSD == null) {
+      const cost = calculateCost(record, pricingData);
+      if (cost != null) record.costMicroUSD = cost;
+    }
+  }
+  return records;
+}
+
+/**
+ * Builds the effectiveness projection from adoption records using the
+ * intelligence scorers. Imported here (the CLI layer), never in core, to keep
+ * the existing dependency direction — mirrors `adoption.ts`.
+ */
+function makeEffectivenessBuilder(
+  scorers: typeof import('@harness-engineering/intelligence')
+): (records: SkillInvocationRecord[]) => EffectivenessSection | null {
+  return (records) => {
+    if (records.length === 0) return null;
+    const leastEffective = scorers
+      .computeSkillEffectiveness(records)
+      .reverse()
+      .slice(0, 10)
+      .map((s) => ({
+        skill: s.skill,
+        invocations: s.invocations,
+        completed: s.completed,
+        failed: s.failed,
+        abandonedMidWorkflow: s.abandonedMidWorkflow,
+        successRate: s.successRate,
+      }));
+    const failing = scorers
+      .detectFailingSkills(records)
+      .slice(0, 10)
+      .map((s) => ({
+        skill: s.skill,
+        invocations: s.invocations,
+        failed: s.failed,
+        failureRate: s.failureRate,
+      }));
+    const abandoned = scorers
+      .detectAbandonedSkills(records)
+      .slice(0, 10)
+      .map((s) => ({
+        skill: s.skill,
+        invocations: s.invocations,
+        abandonedMidWorkflow: s.abandonedMidWorkflow,
+        abandonmentRate: s.abandonmentRate,
+      }));
+    return { leastEffective, failing, abandoned };
+  };
+}
+
+/** Reads `execution_outcome` nodes from the project graph, or null when absent. */
+async function loadOutcomeNodes(
+  cwd: string
+): Promise<Array<{ verdict?: string; result?: string; timestamp?: string }> | null> {
+  try {
+    const { loadGraphStore } = await import('../../mcp/utils/graph-loader.js');
+    const store = await loadGraphStore(cwd);
+    if (!store) return null;
+    const nodes = store.findNodes({ type: 'execution_outcome' });
+    return nodes.map((n) => {
+      const meta = n.metadata ?? {};
+      const node: { verdict?: string; result?: string; timestamp?: string } = {};
+      if (typeof meta.verdict === 'string') node.verdict = meta.verdict;
+      if (typeof meta.result === 'string') node.result = meta.result;
+      if (typeof meta.timestamp === 'string') node.timestamp = meta.timestamp;
+      return node;
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Runs `composeInsights` defensively; a failure yields null (section absent). */
+async function loadInsights(cwd: string, skip: boolean): Promise<InsightsReport | null> {
+  if (skip) return null;
+  try {
+    const { composeInsights } = await import('@harness-engineering/core');
+    return await composeInsights(cwd);
+  } catch {
+    return null;
+  }
+}
+
+function parseWindow(raw: string | undefined): number | null {
+  if (raw == null) return null;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function createSynthesizeCommand(): Command {
+  return new Command('synthesize')
+    .description(
+      'Compose adoption, effectiveness, usage, insights, and outcome telemetry into one local report'
+    )
+    .option('--json', 'Emit the machine-readable TelemetrySynthesis object instead of Markdown')
+    .option('--out <path>', 'Write the report to a file instead of stdout')
+    .option(
+      '--skip <section>',
+      'Omit a section (adoption|effectiveness|usage|insights|outcomes); repeatable',
+      (value: string, previous: string[]) => [...previous, value],
+      [] as string[]
+    )
+    .option('--window <days>', 'Bound adoption/usage/outcome sources to the trailing N days')
+    .action(async (opts) => {
+      const cwd = process.cwd();
+
+      const skip = (opts.skip as string[]).filter((s) =>
+        SKIPPABLE.has(s)
+      ) as TelemetrySynthesisSection[];
+      const skipSet = new Set<string>(skip);
+      const windowDays = parseWindow(opts.window);
+
+      const core = await import('@harness-engineering/core');
+      const intelligence = await import('@harness-engineering/intelligence');
+      const { composeSynthesis, renderSynthesisMarkdown, readAdoptionRecords } = core;
+
+      const adoptionRecords = readAdoptionRecords(cwd);
+      const usageRecords = skipSet.has('usage') ? [] : await loadUsageRecords(cwd);
+      const insights = await loadInsights(cwd, skipSet.has('insights'));
+      const outcomeNodes = skipSet.has('outcomes') ? null : await loadOutcomeNodes(cwd);
+
+      const synthesis = composeSynthesis(
+        {
+          adoptionRecords,
+          usageRecords,
+          insights,
+          buildEffectiveness: makeEffectivenessBuilder(intelligence),
+          outcomeNodes,
+        },
+        { windowDays, skip }
+      );
+
+      const output = opts.json
+        ? JSON.stringify(synthesis, null, 2)
+        : renderSynthesisMarkdown(synthesis);
+
+      if (opts.out) {
+        const outPath = path.resolve(cwd, opts.out as string);
+        fs.mkdirSync(path.dirname(outPath), { recursive: true });
+        fs.writeFileSync(outPath, output.endsWith('\n') ? output : output + '\n', 'utf-8');
+        const relPath = path.relative(cwd, outPath).replaceAll('\\', '/');
+        logger.info(`Telemetry synthesis written to ${relPath}`);
+        return;
+      }
+
+      console.log(output);
+    });
+}

--- a/packages/cli/tests/commands/telemetry-synthesize.test.ts
+++ b/packages/cli/tests/commands/telemetry-synthesize.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Command } from 'commander';
+import { createTelemetryCommand } from '../../src/commands/telemetry';
+
+/**
+ * Integration coverage for `harness telemetry synthesize` (#563). Runs the real
+ * command in-process against on-disk fixtures — exercising the real adoption /
+ * usage readers and the real compose + render — so the acceptance criteria are
+ * verified end-to-end, not against mocks.
+ */
+
+const MODEL = 'claude-sonnet-4-20250514'; // present in the bundled fallback pricing
+
+function writeAdoption(dir: string, lines: object[]): void {
+  fs.mkdirSync(path.join(dir, '.harness', 'metrics'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.harness', 'metrics', 'adoption.jsonl'),
+    lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+  );
+}
+
+function writeCosts(dir: string, lines: object[]): void {
+  fs.mkdirSync(path.join(dir, '.harness', 'metrics'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.harness', 'metrics', 'costs.jsonl'),
+    lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+  );
+}
+
+async function runSynthesize(args: string[]): Promise<string> {
+  const out: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    out.push(args.map((a) => String(a ?? '')).join(' '));
+  });
+  try {
+    const parent = new Command();
+    parent.addCommand(createTelemetryCommand());
+    parent.exitOverride();
+    await parent.parseAsync(['node', 'test', 'telemetry', 'synthesize', ...args]);
+  } finally {
+    logSpy.mockRestore();
+  }
+  return out.join('\n');
+}
+
+describe('harness telemetry synthesize', () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-synth-'));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('AC1/AC2: prints a Markdown headline + a section per present source', async () => {
+    writeAdoption(tempDir, [
+      {
+        skill: 'harness-autopilot',
+        startedAt: '2026-08-15T10:00:00Z',
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: ['plan'],
+      },
+      {
+        skill: 'harness-code-review',
+        startedAt: '2026-08-14T10:00:00Z',
+        duration: 500,
+        outcome: 'completed',
+        phasesReached: ['review'],
+      },
+    ]);
+    const md = await runSynthesize([]);
+    expect(md).toContain('# Telemetry Synthesis');
+    expect(md).toContain('## Headline');
+    expect(md).toContain('## Skill adoption');
+    expect(md).toContain('## Skill effectiveness');
+  });
+
+  it('AC3: --json emits a TelemetrySynthesis with all five source keys + headline', async () => {
+    writeAdoption(tempDir, [
+      {
+        skill: 'harness-autopilot',
+        startedAt: '2026-08-15T10:00:00Z',
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+    ]);
+    const json = JSON.parse(await runSynthesize(['--json']));
+    expect(Object.keys(json.sources).sort()).toEqual([
+      'adoption',
+      'effectiveness',
+      'insights',
+      'outcomes',
+      'usage',
+    ]);
+    expect(json.headline).toHaveProperty('totalSkillInvocations');
+    expect(json.headline).toHaveProperty('healthPassed');
+  });
+
+  it('AC4: adoption K skills / N invocations match `harness adoption skills` over the same fixture', async () => {
+    const records = [
+      {
+        skill: 'harness-autopilot',
+        startedAt: '2026-08-15T10:00:00Z',
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+      {
+        skill: 'harness-autopilot',
+        startedAt: '2026-08-14T10:00:00Z',
+        duration: 900,
+        outcome: 'failed',
+        phasesReached: ['plan'],
+      },
+      {
+        skill: 'harness-code-review',
+        startedAt: '2026-08-13T10:00:00Z',
+        duration: 500,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+    ];
+    writeAdoption(tempDir, records);
+    const json = JSON.parse(await runSynthesize(['--json']));
+
+    // Parity source of truth: read the same fixture through the public reader.
+    const { readAdoptionRecords, aggregateBySkill } = await import('@harness-engineering/core');
+    const read = readAdoptionRecords(tempDir);
+    const K = aggregateBySkill(read).length;
+    expect(json.sources.adoption.distinctSkills).toBe(K); // 2
+    expect(json.headline.totalSkillInvocations).toBe(read.length); // 3
+  });
+
+  it('AC5: no adoption.jsonl → exits 0, adoption absent, footered, headline invocations null', async () => {
+    const json = JSON.parse(await runSynthesize(['--json']));
+    expect(json.sources.adoption.present).toBe(false);
+    expect(json.headline.totalSkillInvocations).toBeNull();
+    const md = await runSynthesize([]);
+    expect(md).toContain('## Sources with no data');
+    expect(md).toMatch(/Skill adoption:/);
+  });
+
+  it('AC6: headline cost equals the usage aggregator total over the same fixture', async () => {
+    const costs = [
+      {
+        session_id: 's1',
+        timestamp: '2026-08-15T10:00:00Z',
+        model: MODEL,
+        token_usage: { input_tokens: 1000, output_tokens: 500 },
+      },
+      {
+        session_id: 's2',
+        timestamp: '2026-08-14T10:00:00Z',
+        model: MODEL,
+        token_usage: { input_tokens: 2000, output_tokens: 800 },
+      },
+    ];
+    writeCosts(tempDir, costs);
+
+    const json = JSON.parse(await runSynthesize(['--json']));
+
+    // Parity: price + aggregate the same fixture exactly as `harness usage` does.
+    const { readCostRecords, loadPricingData, calculateCost, aggregateByDay } =
+      await import('@harness-engineering/core');
+    const read = readCostRecords(tempDir);
+    const pricing = await loadPricingData(tempDir);
+    for (const r of read) {
+      if (r.model && r.costMicroUSD == null) {
+        const c = calculateCost(r, pricing);
+        if (c != null) r.costMicroUSD = c;
+      }
+    }
+    const total = aggregateByDay(read).reduce((sum, d) => sum + (d.costMicroUSD ?? 0), 0);
+    expect(json.sources.usage.totalCostMicroUSD).toBe(total);
+    expect(json.headline.totalCostUsd).toBeCloseTo(total / 1_000_000, 6);
+  });
+
+  it('AC7: no graph → outcomes absent and satisfied rate null', async () => {
+    const json = JSON.parse(await runSynthesize(['--json']));
+    expect(json.sources.outcomes.present).toBe(false);
+    expect(json.headline.outcomeSatisfiedRate).toBeNull();
+  });
+
+  it('AC8: --skip usage omits usage and nulls headline cost, leaving others present', async () => {
+    writeAdoption(tempDir, [
+      {
+        skill: 'harness-autopilot',
+        startedAt: '2026-08-15T10:00:00Z',
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+    ]);
+    writeCosts(tempDir, [
+      {
+        session_id: 's1',
+        timestamp: '2026-08-15T10:00:00Z',
+        model: MODEL,
+        token_usage: { input_tokens: 1000, output_tokens: 500 },
+      },
+    ]);
+    const json = JSON.parse(await runSynthesize(['--skip', 'usage', '--json']));
+    expect(json.sources.usage.present).toBe(false);
+    expect(json.sources.usage.reason).toBe('skipped');
+    expect(json.headline.totalCostUsd).toBeNull();
+    expect(json.sources.adoption.present).toBe(true);
+  });
+
+  it('AC9: --out writes the report + prints a confirmation; nothing is written without --out', async () => {
+    writeAdoption(tempDir, [
+      {
+        skill: 'harness-autopilot',
+        startedAt: '2026-08-15T10:00:00Z',
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+    ]);
+    // Without --out: no report file appears.
+    await runSynthesize([]);
+    expect(fs.existsSync(path.join(tempDir, 'report.md'))).toBe(false);
+
+    // With --out: file written + confirmation logged.
+    const logs = await runSynthesize(['--out', 'report.md']);
+    expect(fs.existsSync(path.join(tempDir, 'report.md'))).toBe(true);
+    expect(logs).toContain('Telemetry synthesis written to report.md');
+  });
+
+  it('AC10: read-only — no writes to .harness/metrics during a run', async () => {
+    writeAdoption(tempDir, [
+      {
+        skill: 'harness-autopilot',
+        startedAt: '2026-08-15T10:00:00Z',
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+    ]);
+    writeCosts(tempDir, [
+      {
+        session_id: 's1',
+        timestamp: '2026-08-15T10:00:00Z',
+        model: MODEL,
+        token_usage: { input_tokens: 1000, output_tokens: 500 },
+      },
+    ]);
+    const metricsDir = path.join(tempDir, '.harness', 'metrics');
+    const before = fs.readdirSync(metricsDir).map((f) => {
+      const st = fs.statSync(path.join(metricsDir, f));
+      return { f, mtime: st.mtimeMs, size: st.size };
+    });
+    await runSynthesize(['--json']);
+    const after = fs.readdirSync(metricsDir).map((f) => {
+      const st = fs.statSync(path.join(metricsDir, f));
+      return { f, mtime: st.mtimeMs, size: st.size };
+    });
+    expect(after).toEqual(before);
+  });
+
+  it('AC11: --window bounds adoption to the trailing N days', async () => {
+    const recent = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const old = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+    writeAdoption(tempDir, [
+      {
+        skill: 'harness-autopilot',
+        startedAt: recent,
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+      {
+        skill: 'harness-old',
+        startedAt: old,
+        duration: 1000,
+        outcome: 'completed',
+        phasesReached: [],
+      },
+    ]);
+    const windowed = JSON.parse(await runSynthesize(['--window', '30', '--json']));
+    expect(windowed.headline.totalSkillInvocations).toBe(1);
+    const allTime = JSON.parse(await runSynthesize(['--json']));
+    expect(allTime.headline.totalSkillInvocations).toBe(2);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -229,6 +229,11 @@ export type {
 } from './telemetry';
 
 /**
+ * Telemetry-synthesis module — pure composition of the five in-repo telemetry surfaces into one report (#563).
+ */
+export * from './telemetry-synthesis';
+
+/**
  * Skills module — canonical required-section lists for skill validation gates.
  */
 export * from './skills';

--- a/packages/core/src/telemetry-synthesis/index.ts
+++ b/packages/core/src/telemetry-synthesis/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Aggregate-telemetry synthesis surface (#563).
+ *
+ * Pure composition over the five telemetry surfaces that already accrue
+ * in-repo. Read-only; collects nothing. The CLI command is the composition
+ * root — see `packages/cli/src/commands/telemetry/synthesize.ts`.
+ */
+export { composeSynthesis } from './synthesize.js';
+export type { SynthesisInputs, ComposeSynthesisOptions, OutcomeNodeLike } from './synthesize.js';
+export { renderSynthesisMarkdown } from './render.js';

--- a/packages/core/src/telemetry-synthesis/render.ts
+++ b/packages/core/src/telemetry-synthesis/render.ts
@@ -1,0 +1,224 @@
+/**
+ * Aggregate-telemetry synthesis — Markdown renderer (#563).
+ *
+ * Renders a `TelemetrySynthesis` as one unified report: a headline block, one
+ * section per PRESENT source (reusing familiar per-surface table shapes), and
+ * an explicit "Sources with no data" footer listing every absent source. No
+ * section is ever silently dropped — an absent source is footered, never hidden.
+ *
+ * Spec: docs/changes/aggregate-telemetry-synthesis/proposal.md
+ */
+import type {
+  TelemetrySynthesis,
+  TelemetrySynthesisSection,
+  SynthesisSection,
+} from '@harness-engineering/types';
+import { TELEMETRY_SYNTHESIS_SECTIONS } from '@harness-engineering/types';
+
+/** Human-readable label per section, for headings and the footer. */
+const SECTION_LABELS: Record<TelemetrySynthesisSection, string> = {
+  adoption: 'Skill adoption',
+  effectiveness: 'Skill effectiveness',
+  usage: 'Usage & cost',
+  insights: 'Code-health insights',
+  outcomes: 'Execution outcomes',
+};
+
+function formatRate(rate: number): string {
+  return `${(rate * 100).toFixed(0)}%`;
+}
+
+function formatUsd(usd: number): string {
+  return `$${usd.toFixed(4)}`;
+}
+
+function formatBool(value: boolean | null): string {
+  if (value === null) return 'n/a';
+  return value ? 'pass' : 'fail';
+}
+
+function orNa(value: number | null, render: (v: number) => string = String): string {
+  return value == null ? 'n/a' : render(value);
+}
+
+/** The headline block — cross-source figures, each honestly `n/a` when absent. */
+function renderHeadline(synthesis: TelemetrySynthesis): string {
+  const h = synthesis.headline;
+  const windowLabel =
+    synthesis.windowDays == null ? 'all-time' : `trailing ${synthesis.windowDays} days`;
+  const lines = [
+    '## Headline',
+    '',
+    `- **Generated:** ${synthesis.generatedAt}`,
+    `- **Window:** ${windowLabel}`,
+    `- **Skill invocations:** ${orNa(h.totalSkillInvocations)}`,
+    `- **Skill success rate:** ${orNa(h.skillSuccessRate, formatRate)}`,
+    `- **Outcome satisfied rate:** ${orNa(h.outcomeSatisfiedRate, formatRate)}`,
+    `- **Total cost:** ${orNa(h.totalCostUsd, formatUsd)}`,
+    `- **Structural health:** ${formatBool(h.healthPassed)}`,
+  ];
+  return lines.join('\n');
+}
+
+/** A heading + Markdown table (or an italic empty note when there are no rows). */
+function table(heading: string, columns: string[], rows: string[][], emptyNote: string): string {
+  const out = [`### ${heading}`, ''];
+  if (rows.length === 0) {
+    out.push(`_${emptyNote}_`);
+  } else {
+    out.push(`| ${columns.join(' | ')} |`);
+    out.push(`| ${columns.map(() => '---').join(' | ')} |`);
+    out.push(...rows.map((cells) => `| ${cells.join(' | ')} |`));
+  }
+  return out.join('\n');
+}
+
+function renderAdoption(
+  section: SynthesisSection<import('@harness-engineering/types').AdoptionSection>
+): string {
+  if (!section.present) return '';
+  const header = [
+    `## ${SECTION_LABELS.adoption}`,
+    '',
+    `${section.totalInvocations} invocation(s) across ${section.distinctSkills} skill(s) · success rate ${formatRate(section.successRate)}`,
+    '',
+    table(
+      'Top skills by invocations',
+      ['Skill', 'Invocations', 'Success', 'Last used'],
+      section.topSkills.map((s) => [
+        `\`${s.skill}\``,
+        `${s.invocations}`,
+        formatRate(s.successRate),
+        s.lastUsed.slice(0, 10),
+      ]),
+      'No skill invocations recorded.'
+    ),
+  ];
+  return header.join('\n');
+}
+
+function renderEffectiveness(
+  section: SynthesisSection<import('@harness-engineering/types').EffectivenessSection>
+): string {
+  if (!section.present) return '';
+  return [
+    `## ${SECTION_LABELS.effectiveness}`,
+    '',
+    'Laplace-smoothed success rate (α = 1) — a skill invoked once cannot claim 0% or 100%.',
+    '',
+    table(
+      'Least effective skills',
+      ['Skill', 'Invocations', 'Completed', 'Failed', 'Abandoned', 'Smoothed success rate'],
+      section.leastEffective.map((s) => [
+        `\`${s.skill}\``,
+        `${s.invocations}`,
+        `${s.completed}`,
+        `${s.failed}`,
+        `${s.abandonedMidWorkflow}`,
+        formatRate(s.successRate),
+      ]),
+      'No skill telemetry to score.'
+    ),
+    '',
+    table(
+      'Failing skills',
+      ['Skill', 'Invocations', 'Failed', 'Failure rate'],
+      section.failing.map((s) => [
+        `\`${s.skill}\``,
+        `${s.invocations}`,
+        `${s.failed}`,
+        formatRate(s.failureRate),
+      ]),
+      'No skill meets the failing-rate threshold.'
+    ),
+    '',
+    table(
+      'Abandoned mid-workflow',
+      ['Skill', 'Invocations', 'Abandoned', 'Abandonment rate'],
+      section.abandoned.map((s) => [
+        `\`${s.skill}\``,
+        `${s.invocations}`,
+        `${s.abandonedMidWorkflow}`,
+        formatRate(s.abandonmentRate),
+      ]),
+      'No skill meets the abandonment-rate threshold.'
+    ),
+  ].join('\n');
+}
+
+function renderUsage(
+  section: SynthesisSection<import('@harness-engineering/types').UsageSection>
+): string {
+  if (!section.present) return '';
+  const cost =
+    section.totalCostMicroUSD == null
+      ? 'unknown (missing pricing)'
+      : formatUsd(section.totalCostMicroUSD / 1_000_000);
+  return [
+    `## ${SECTION_LABELS.usage}`,
+    '',
+    `- **Total cost:** ${cost}`,
+    `- **Total tokens:** ${section.totalTokens}`,
+    `- **Active days:** ${section.activeDays}`,
+    `- **Sessions:** ${section.sessionCount}`,
+  ].join('\n');
+}
+
+function renderInsights(
+  section: SynthesisSection<import('@harness-engineering/types').InsightsSection>
+): string {
+  if (!section.present) return '';
+  const lines = [
+    `## ${SECTION_LABELS.insights}`,
+    '',
+    `- **Structural health:** ${formatBool(section.healthPassed)}${section.healthSummary ? ` — ${section.healthSummary}` : ''}`,
+    `- **Drift findings:** ${orNa(section.driftCount)}`,
+    `- **Dead files:** ${orNa(section.deadFiles)}`,
+    `- **Dead exports:** ${orNa(section.deadExports)}`,
+  ];
+  if (section.warnings.length > 0) {
+    lines.push('', '_Warnings:_ ' + section.warnings.map((w) => `\`${w}\``).join(', '));
+  }
+  return lines.join('\n');
+}
+
+function renderOutcomes(
+  section: SynthesisSection<import('@harness-engineering/types').OutcomeSection>
+): string {
+  if (!section.present) return '';
+  return [
+    `## ${SECTION_LABELS.outcomes}`,
+    '',
+    `- **Satisfied:** ${section.satisfied}`,
+    `- **Not satisfied:** ${section.notSatisfied}`,
+    `- **Inconclusive:** ${section.inconclusive}`,
+    `- **Satisfied rate:** ${orNa(section.satisfiedRate, formatRate)} (${section.total} outcome node(s))`,
+  ].join('\n');
+}
+
+/** The "Sources with no data" footer — every absent source, with its reason. */
+function renderAbsentFooter(synthesis: TelemetrySynthesis): string {
+  const absent = TELEMETRY_SYNTHESIS_SECTIONS.filter((key) => !synthesis.sources[key].present);
+  if (absent.length === 0) return '';
+  const rows = absent.map((key) => {
+    const section = synthesis.sources[key];
+    const reason = section.present ? '' : section.reason;
+    return `- **${SECTION_LABELS[key]}:** ${reason}`;
+  });
+  return ['## Sources with no data', '', ...rows].join('\n');
+}
+
+/** Render a full synthesis report as Markdown. */
+export function renderSynthesisMarkdown(synthesis: TelemetrySynthesis): string {
+  const sections = [
+    '# Telemetry Synthesis',
+    renderHeadline(synthesis),
+    renderAdoption(synthesis.sources.adoption),
+    renderEffectiveness(synthesis.sources.effectiveness),
+    renderUsage(synthesis.sources.usage),
+    renderInsights(synthesis.sources.insights),
+    renderOutcomes(synthesis.sources.outcomes),
+    renderAbsentFooter(synthesis),
+  ].filter((s) => s.length > 0);
+  return sections.join('\n\n').trimEnd() + '\n';
+}

--- a/packages/core/src/telemetry-synthesis/synthesize.ts
+++ b/packages/core/src/telemetry-synthesis/synthesize.ts
@@ -1,0 +1,256 @@
+/**
+ * Aggregate-telemetry synthesis — pure composer (#563).
+ *
+ * `composeSynthesis` folds already-read telemetry inputs into one
+ * `TelemetrySynthesis`. It is PURE: every input is passed in, so callers can
+ * supply a fixed `now` for deterministic output and unit-test present / absent
+ * / mixed / windowed cases without touching disk.
+ *
+ * The CLI command (`packages/cli/src/commands/telemetry/synthesize.ts`) is the
+ * composition root: it reads adoption + usage records (core), builds the
+ * effectiveness projection from the intelligence scorers, reads
+ * `execution_outcome` nodes from the graph, and runs `composeInsights` — then
+ * hands them all here. This keeps `core` free of any `intelligence` / `graph`
+ * dependency (the existing layer direction), exactly as `adoption.ts` imports
+ * the intelligence scorers at the CLI layer rather than in core.
+ *
+ * Spec: docs/changes/aggregate-telemetry-synthesis/proposal.md
+ */
+import type {
+  SkillInvocationRecord,
+  UsageRecord,
+  InsightsReport,
+  TelemetrySynthesis,
+  TelemetrySynthesisSection,
+  AdoptionSection,
+  EffectivenessSection,
+  UsageSection,
+  InsightsSection,
+  OutcomeSection,
+  SynthesisSection,
+} from '@harness-engineering/types';
+import { aggregateBySkill } from '../adoption/index.js';
+import { aggregateByDay } from '../usage/aggregator.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** How many rows each ranked section keeps. */
+const DEFAULT_TOP_N = 10;
+
+/**
+ * A structural view of an `execution_outcome` graph node's fields this composer
+ * reads. Kept local so `core` takes no dependency on `graph` / `intelligence`.
+ */
+export interface OutcomeNodeLike {
+  /** outcome-eval verdict when present: SATISFIED | NOT_SATISFIED | INCONCLUSIVE. */
+  verdict?: string;
+  /** Connector result when no verdict is carried: 'success' | 'failure'. */
+  result?: string;
+  /** ISO 8601 timestamp used for windowing. */
+  timestamp?: string;
+}
+
+/** Inputs to the pure composer — everything already read by the caller. */
+export interface SynthesisInputs {
+  /** Raw adoption records (unwindowed); the composer applies the window. */
+  adoptionRecords: SkillInvocationRecord[];
+  /** Raw usage records (unwindowed); the composer applies the window. */
+  usageRecords: UsageRecord[];
+  /** `composeInsights` output, or null when unavailable (no window applies — insights is a snapshot). */
+  insights: InsightsReport | null;
+  /**
+   * Builds the effectiveness projection from a record set — the composer passes
+   * the WINDOWED adoption records so effectiveness stays consistent with the
+   * adoption section. Injected so `core` never imports `intelligence`. Return
+   * null to mark the section absent.
+   */
+  buildEffectiveness: (records: SkillInvocationRecord[]) => EffectivenessSection | null;
+  /** `execution_outcome` nodes read from the graph, or null when no graph is present. */
+  outcomeNodes: OutcomeNodeLike[] | null;
+}
+
+/** Options controlling the synthesis. */
+export interface ComposeSynthesisOptions {
+  /** Reference "now" for windowing. Defaults to the real clock. */
+  now?: Date;
+  /** Trailing-day window applied to adoption / usage / outcomes; null | undefined = all-time. */
+  windowDays?: number | null;
+  /** Sections to omit entirely (reported as `{ present: false, reason: 'skipped' }`). */
+  skip?: TelemetrySynthesisSection[];
+  /** Rows per ranked section. Default 10. */
+  topN?: number;
+}
+
+/** An absent section with a reason. */
+function absent(reason: string): { present: false; reason: string } {
+  return { present: false, reason };
+}
+
+/** True when `iso` is within the trailing `windowDays` of `nowMs` (or the window is open). */
+function withinWindow(iso: string | undefined, nowMs: number, windowDays: number | null): boolean {
+  if (windowDays == null) return true;
+  if (!iso) return false;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return false;
+  return nowMs - t <= windowDays * DAY_MS;
+}
+
+/** Build the adoption projection from records, or absent when none. */
+function buildAdoptionSection(
+  records: SkillInvocationRecord[],
+  topN: number
+): SynthesisSection<AdoptionSection> {
+  if (records.length === 0) return absent('no adoption records in window');
+  const summaries = aggregateBySkill(records);
+  const completed = records.filter((r) => r.outcome === 'completed').length;
+  return {
+    present: true,
+    totalInvocations: records.length,
+    distinctSkills: summaries.length,
+    successRate: completed / records.length,
+    topSkills: summaries.slice(0, topN).map((s) => ({
+      skill: s.skill,
+      invocations: s.invocations,
+      successRate: s.successRate,
+      lastUsed: s.lastUsed,
+    })),
+  };
+}
+
+/** Build the usage projection from records, or absent when none. */
+function buildUsageSection(records: UsageRecord[]): SynthesisSection<UsageSection> {
+  if (records.length === 0) return absent('no usage records in window');
+  const days = aggregateByDay(records);
+  const sessions = new Set(records.map((r) => r.sessionId));
+  let totalCostMicroUSD: number | null = 0;
+  let totalTokens = 0;
+  for (const r of records) {
+    totalTokens += r.tokens.totalTokens;
+    if (r.costMicroUSD == null) totalCostMicroUSD = null;
+    else if (totalCostMicroUSD != null) totalCostMicroUSD += r.costMicroUSD;
+  }
+  return {
+    present: true,
+    totalCostMicroUSD,
+    totalTokens,
+    activeDays: days.length,
+    sessionCount: sessions.size,
+  };
+}
+
+/** Build the insights projection, or absent when the report is missing. */
+function buildInsightsSection(report: InsightsReport | null): SynthesisSection<InsightsSection> {
+  if (!report) return absent('no insights available');
+  const health = report.health;
+  const entropy = report.entropy;
+  return {
+    present: true,
+    healthPassed: health ? health.passed : null,
+    healthSummary: health ? health.summary : null,
+    driftCount: entropy ? entropy.driftCount : null,
+    deadFiles: entropy ? entropy.deadFiles : null,
+    deadExports: entropy ? entropy.deadExports : null,
+    warnings: report.warnings ?? [],
+  };
+}
+
+/** Normalize an outcome node to one of the three verdict buckets, or null to ignore. */
+function classifyOutcome(
+  node: OutcomeNodeLike
+): 'satisfied' | 'notSatisfied' | 'inconclusive' | null {
+  const verdict = node.verdict?.toUpperCase();
+  if (verdict === 'SATISFIED') return 'satisfied';
+  if (verdict === 'NOT_SATISFIED') return 'notSatisfied';
+  if (verdict === 'INCONCLUSIVE') return 'inconclusive';
+  // Fallback for nodes without an outcome-eval verdict: map the connector result.
+  if (verdict === undefined) {
+    if (node.result === 'success') return 'satisfied';
+    if (node.result === 'failure') return 'notSatisfied';
+  }
+  return null;
+}
+
+/** Build the outcomes projection from graph nodes, or absent when no graph. */
+function buildOutcomeSection(
+  nodes: OutcomeNodeLike[] | null,
+  nowMs: number,
+  windowDays: number | null
+): SynthesisSection<OutcomeSection> {
+  if (nodes == null) return absent('no knowledge graph present');
+  let satisfied = 0;
+  let notSatisfied = 0;
+  let inconclusive = 0;
+  for (const node of nodes) {
+    if (!withinWindow(node.timestamp, nowMs, windowDays)) continue;
+    const bucket = classifyOutcome(node);
+    if (bucket === 'satisfied') satisfied++;
+    else if (bucket === 'notSatisfied') notSatisfied++;
+    else if (bucket === 'inconclusive') inconclusive++;
+  }
+  const total = satisfied + notSatisfied + inconclusive;
+  if (total === 0) return absent('no execution_outcome nodes in window');
+  return {
+    present: true,
+    satisfied,
+    notSatisfied,
+    inconclusive,
+    total,
+    satisfiedRate: satisfied / total,
+  };
+}
+
+/**
+ * Compose a `TelemetrySynthesis` from already-read inputs. Pure and total: a
+ * missing/empty source yields `{ present: false }`, never a throw or a
+ * fabricated zero.
+ */
+export function composeSynthesis(
+  inputs: SynthesisInputs,
+  opts: ComposeSynthesisOptions = {}
+): TelemetrySynthesis {
+  const windowDays = opts.windowDays ?? null;
+  const nowMs = (opts.now ?? new Date()).getTime();
+  const topN = opts.topN ?? DEFAULT_TOP_N;
+  const skip = new Set(opts.skip ?? []);
+
+  const windowedAdoption = inputs.adoptionRecords.filter((r) =>
+    withinWindow(r.startedAt, nowMs, windowDays)
+  );
+  const windowedUsage = inputs.usageRecords.filter((r) =>
+    withinWindow(r.timestamp, nowMs, windowDays)
+  );
+
+  const adoption = skip.has('adoption')
+    ? absent('skipped')
+    : buildAdoptionSection(windowedAdoption, topN);
+
+  const effectiveness: SynthesisSection<EffectivenessSection> = skip.has('effectiveness')
+    ? absent('skipped')
+    : (() => {
+        if (windowedAdoption.length === 0) return absent('no adoption records in window');
+        const built = inputs.buildEffectiveness(windowedAdoption);
+        return built ? { present: true, ...built } : absent('no effectiveness data');
+      })();
+
+  const usage = skip.has('usage') ? absent('skipped') : buildUsageSection(windowedUsage);
+  const insights = skip.has('insights') ? absent('skipped') : buildInsightsSection(inputs.insights);
+  const outcomes = skip.has('outcomes')
+    ? absent('skipped')
+    : buildOutcomeSection(inputs.outcomeNodes, nowMs, windowDays);
+
+  const headline = {
+    totalSkillInvocations: adoption.present ? adoption.totalInvocations : null,
+    skillSuccessRate: adoption.present ? adoption.successRate : null,
+    outcomeSatisfiedRate: outcomes.present ? outcomes.satisfiedRate : null,
+    totalCostUsd:
+      usage.present && usage.totalCostMicroUSD != null ? usage.totalCostMicroUSD / 1_000_000 : null,
+    healthPassed: insights.present ? insights.healthPassed : null,
+  };
+
+  return {
+    generatedAt: (opts.now ?? new Date()).toISOString(),
+    windowDays,
+    sources: { adoption, effectiveness, usage, insights, outcomes },
+    headline,
+  };
+}

--- a/packages/core/tests/telemetry-synthesis/synthesize.test.ts
+++ b/packages/core/tests/telemetry-synthesis/synthesize.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  SkillInvocationRecord,
+  UsageRecord,
+  InsightsReport,
+  EffectivenessSection,
+} from '@harness-engineering/types';
+import {
+  composeSynthesis,
+  renderSynthesisMarkdown,
+  type SynthesisInputs,
+  type OutcomeNodeLike,
+} from '../../src/telemetry-synthesis/index.js';
+
+const NOW = new Date('2026-08-16T00:00:00.000Z');
+
+function adoption(overrides: Partial<SkillInvocationRecord> = {}): SkillInvocationRecord {
+  return {
+    skill: 'harness-autopilot',
+    startedAt: '2026-08-15T10:00:00.000Z',
+    duration: 1000,
+    outcome: 'completed',
+    phasesReached: ['plan'],
+    ...overrides,
+  } as SkillInvocationRecord;
+}
+
+function usage(overrides: Partial<UsageRecord> = {}): UsageRecord {
+  return {
+    sessionId: 's1',
+    timestamp: '2026-08-15T10:00:00.000Z',
+    tokens: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+    costMicroUSD: 250000,
+    ...overrides,
+  } as UsageRecord;
+}
+
+const emptyEffectiveness: EffectivenessSection = {
+  leastEffective: [],
+  failing: [],
+  abandoned: [],
+};
+
+/** Builds a full effectiveness section from records (a minimal stand-in for the intelligence scorers). */
+function buildEffectiveness(records: SkillInvocationRecord[]): EffectivenessSection | null {
+  if (records.length === 0) return null;
+  return {
+    leastEffective: [
+      {
+        skill: 'harness-autopilot',
+        invocations: records.length,
+        completed: records.filter((r) => r.outcome === 'completed').length,
+        failed: records.filter((r) => r.outcome === 'failed').length,
+        abandonedMidWorkflow: 0,
+        successRate: 0.5,
+      },
+    ],
+    failing: [],
+    abandoned: [],
+  };
+}
+
+function insightsReport(): InsightsReport {
+  return {
+    generatedAt: NOW.toISOString(),
+    project: { root: '/tmp/x' },
+    health: { passed: true, signals: [], summary: 'No structural health findings.' },
+    entropy: { driftCount: 2, deadFiles: 1, deadExports: 3 },
+    decay: null,
+    attention: null,
+    impact: null,
+    warnings: [],
+  };
+}
+
+function inputs(overrides: Partial<SynthesisInputs> = {}): SynthesisInputs {
+  return {
+    adoptionRecords: [],
+    usageRecords: [],
+    insights: null,
+    buildEffectiveness,
+    outcomeNodes: null,
+    ...overrides,
+  };
+}
+
+describe('composeSynthesis — all sources absent', () => {
+  it('marks every source present:false and every headline field null, without throwing', () => {
+    const s = composeSynthesis(inputs(), { now: NOW });
+    expect(s.sources.adoption.present).toBe(false);
+    expect(s.sources.effectiveness.present).toBe(false);
+    expect(s.sources.usage.present).toBe(false);
+    expect(s.sources.insights.present).toBe(false);
+    expect(s.sources.outcomes.present).toBe(false);
+    expect(s.headline).toEqual({
+      totalSkillInvocations: null,
+      skillSuccessRate: null,
+      outcomeSatisfiedRate: null,
+      totalCostUsd: null,
+      healthPassed: null,
+    });
+  });
+
+  it('renders an absent-footer that names all five sources and no headline fabrication', () => {
+    const md = renderSynthesisMarkdown(composeSynthesis(inputs(), { now: NOW }));
+    expect(md).toContain('## Sources with no data');
+    for (const label of [
+      'Skill adoption',
+      'Skill effectiveness',
+      'Usage & cost',
+      'Code-health insights',
+      'Execution outcomes',
+    ]) {
+      expect(md).toContain(label);
+    }
+    expect(md).toContain('**Skill invocations:** n/a');
+  });
+});
+
+describe('composeSynthesis — all sources present', () => {
+  const outcomeNodes: OutcomeNodeLike[] = [
+    { verdict: 'SATISFIED', timestamp: '2026-08-15T00:00:00.000Z' },
+    { verdict: 'NOT_SATISFIED', timestamp: '2026-08-15T00:00:00.000Z' },
+    { verdict: 'INCONCLUSIVE', timestamp: '2026-08-15T00:00:00.000Z' },
+    { result: 'success', timestamp: '2026-08-15T00:00:00.000Z' }, // no verdict → mapped to satisfied
+  ];
+
+  const s = composeSynthesis(
+    inputs({
+      adoptionRecords: [adoption(), adoption({ outcome: 'failed', phasesReached: ['plan'] })],
+      usageRecords: [usage(), usage({ sessionId: 's2', costMicroUSD: 500000 })],
+      insights: insightsReport(),
+      outcomeNodes,
+    }),
+    { now: NOW }
+  );
+
+  it('adoption reports counts and success rate', () => {
+    expect(s.sources.adoption.present).toBe(true);
+    if (s.sources.adoption.present) {
+      expect(s.sources.adoption.totalInvocations).toBe(2);
+      expect(s.sources.adoption.distinctSkills).toBe(1);
+      expect(s.sources.adoption.successRate).toBe(0.5);
+    }
+    expect(s.headline.totalSkillInvocations).toBe(2);
+    expect(s.headline.skillSuccessRate).toBe(0.5);
+  });
+
+  it('usage sums cost and tokens; headline cost in whole USD', () => {
+    expect(s.sources.usage.present).toBe(true);
+    if (s.sources.usage.present) {
+      expect(s.sources.usage.totalCostMicroUSD).toBe(750000);
+      expect(s.sources.usage.totalTokens).toBe(300);
+      expect(s.sources.usage.sessionCount).toBe(2);
+    }
+    expect(s.headline.totalCostUsd).toBeCloseTo(0.75, 6);
+  });
+
+  it('insights projects health + entropy honestly', () => {
+    expect(s.sources.insights.present).toBe(true);
+    if (s.sources.insights.present) {
+      expect(s.sources.insights.healthPassed).toBe(true);
+      expect(s.sources.insights.driftCount).toBe(2);
+    }
+    expect(s.headline.healthPassed).toBe(true);
+  });
+
+  it('outcomes counts verdicts (verdict + result fallback) and computes satisfied rate', () => {
+    expect(s.sources.outcomes.present).toBe(true);
+    if (s.sources.outcomes.present) {
+      expect(s.sources.outcomes.satisfied).toBe(2); // 1 verdict + 1 result-fallback
+      expect(s.sources.outcomes.notSatisfied).toBe(1);
+      expect(s.sources.outcomes.inconclusive).toBe(1);
+      expect(s.sources.outcomes.total).toBe(4);
+      expect(s.sources.outcomes.satisfiedRate).toBe(0.5);
+    }
+    expect(s.headline.outcomeSatisfiedRate).toBe(0.5);
+  });
+
+  it('renders a present section per source and no absent-footer', () => {
+    const md = renderSynthesisMarkdown(s);
+    expect(md).toContain('## Skill adoption');
+    expect(md).toContain('## Usage & cost');
+    expect(md).toContain('## Execution outcomes');
+    expect(md).not.toContain('## Sources with no data');
+  });
+});
+
+describe('composeSynthesis — mixed', () => {
+  it('unknown pricing anywhere makes total cost null (never a false zero)', () => {
+    const s = composeSynthesis(
+      inputs({
+        usageRecords: [usage(), usage({ sessionId: 's2', costMicroUSD: undefined as never })],
+      }),
+      { now: NOW }
+    );
+    expect(s.sources.usage.present).toBe(true);
+    if (s.sources.usage.present) expect(s.sources.usage.totalCostMicroUSD).toBeNull();
+    expect(s.headline.totalCostUsd).toBeNull();
+  });
+
+  it('empty graph node list is absent, not a zero-rate outcome section', () => {
+    const s = composeSynthesis(inputs({ outcomeNodes: [] }), { now: NOW });
+    expect(s.sources.outcomes.present).toBe(false);
+    expect(s.headline.outcomeSatisfiedRate).toBeNull();
+  });
+});
+
+describe('composeSynthesis — window', () => {
+  it('excludes adoption/usage/outcome records older than the window', () => {
+    const recent = adoption({ startedAt: '2026-08-15T00:00:00.000Z' });
+    const old = adoption({ skill: 'harness-old', startedAt: '2026-06-01T00:00:00.000Z' });
+    const recentUsage = usage({ timestamp: '2026-08-15T00:00:00.000Z' });
+    const oldUsage = usage({ sessionId: 'old', timestamp: '2026-06-01T00:00:00.000Z' });
+    const nodes: OutcomeNodeLike[] = [
+      { verdict: 'SATISFIED', timestamp: '2026-08-15T00:00:00.000Z' },
+      { verdict: 'SATISFIED', timestamp: '2026-06-01T00:00:00.000Z' },
+    ];
+
+    const windowed = composeSynthesis(
+      inputs({
+        adoptionRecords: [recent, old],
+        usageRecords: [recentUsage, oldUsage],
+        outcomeNodes: nodes,
+      }),
+      { now: NOW, windowDays: 30 }
+    );
+    expect(windowed.headline.totalSkillInvocations).toBe(1);
+    if (windowed.sources.usage.present) expect(windowed.sources.usage.sessionCount).toBe(1);
+    if (windowed.sources.outcomes.present) expect(windowed.sources.outcomes.total).toBe(1);
+
+    const allTime = composeSynthesis(
+      inputs({
+        adoptionRecords: [recent, old],
+        usageRecords: [recentUsage, oldUsage],
+        outcomeNodes: nodes,
+      }),
+      { now: NOW, windowDays: null }
+    );
+    expect(allTime.headline.totalSkillInvocations).toBe(2);
+    if (allTime.sources.outcomes.present) expect(allTime.sources.outcomes.total).toBe(2);
+  });
+});
+
+describe('composeSynthesis — skip', () => {
+  it('a skipped section is present:false and drops from the headline', () => {
+    const s = composeSynthesis(inputs({ usageRecords: [usage()], adoptionRecords: [adoption()] }), {
+      now: NOW,
+      skip: ['usage'],
+    });
+    expect(s.sources.usage.present).toBe(false);
+    if (!s.sources.usage.present) expect(s.sources.usage.reason).toBe('skipped');
+    expect(s.headline.totalCostUsd).toBeNull();
+    // Unaffected sibling still present.
+    expect(s.sources.adoption.present).toBe(true);
+  });
+});
+
+describe('renderSynthesisMarkdown', () => {
+  it('always ends with a single trailing newline', () => {
+    const md = renderSynthesisMarkdown(
+      composeSynthesis(inputs({ adoptionRecords: [adoption()] }), { now: NOW })
+    );
+    expect(md.endsWith('\n')).toBe(true);
+    expect(md.endsWith('\n\n')).toBe(false);
+  });
+
+  it('renders an effectiveness section when present', () => {
+    const s = composeSynthesis(inputs({ adoptionRecords: [adoption()] }), { now: NOW });
+    expect(s.sources.effectiveness.present).toBe(true);
+    expect(renderSynthesisMarkdown(s)).toContain('## Skill effectiveness');
+  });
+
+  it('empty effectiveness section (builder returns empty rows) still renders as present', () => {
+    const s = composeSynthesis(
+      inputs({ adoptionRecords: [adoption()], buildEffectiveness: () => emptyEffectiveness }),
+      { now: NOW }
+    );
+    expect(s.sources.effectiveness.present).toBe(true);
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -429,3 +429,18 @@ export type {
 
 // --- Identity ---
 export type { HarnessIdentity, IdentityDomain } from './identity';
+
+// --- Telemetry synthesis (#563) ---
+export { TELEMETRY_SYNTHESIS_SECTIONS } from './telemetry-synthesis';
+export type {
+  TelemetrySynthesisSection,
+  SourceAbsent,
+  SynthesisSection,
+  AdoptionSection,
+  EffectivenessSection,
+  UsageSection,
+  InsightsSection,
+  OutcomeSection,
+  TelemetrySynthesisHeadline,
+  TelemetrySynthesis,
+} from './telemetry-synthesis';

--- a/packages/types/src/telemetry-synthesis.ts
+++ b/packages/types/src/telemetry-synthesis.ts
@@ -1,0 +1,153 @@
+/**
+ * Aggregate-telemetry synthesis surface (#563).
+ *
+ * Wire types for `harness telemetry synthesize` — a read-only, local,
+ * single-project report that COMPOSES the five telemetry surfaces that already
+ * accrue in-repo (adoption, effectiveness, usage, insights, execution-outcome
+ * verdicts) into one object. It collects nothing new; every section is a thin
+ * projection of an existing reader's output.
+ *
+ * A missing source contributes an explicit `{ present: false }` — never a
+ * fabricated zero — so a consumer can always tell "no data" from "zero".
+ *
+ * Spec: docs/changes/aggregate-telemetry-synthesis/proposal.md
+ */
+
+/** The five sources this surface synthesizes. */
+export const TELEMETRY_SYNTHESIS_SECTIONS = [
+  'adoption',
+  'effectiveness',
+  'usage',
+  'insights',
+  'outcomes',
+] as const;
+
+/** A section name the caller can skip or that can be reported absent. */
+export type TelemetrySynthesisSection = (typeof TELEMETRY_SYNTHESIS_SECTIONS)[number];
+
+/**
+ * Sentinel for a source that has no data (missing file, no graph, or skipped).
+ * Deliberately not a zero-valued section — the Iron Law of the catalog
+ * retrospective: never collapse "no telemetry" into "zero".
+ */
+export interface SourceAbsent {
+  present: false;
+  /** Human-readable reason the source is absent (e.g. "no adoption.jsonl", "skipped"). */
+  reason: string;
+}
+
+/** A section that is either present (projection `T`) or explicitly absent. */
+export type SynthesisSection<T> = (T & { present: true }) | SourceAbsent;
+
+/** Source 1 — skill-adoption telemetry, projected from `aggregateBySkill`. */
+export interface AdoptionSection {
+  /** Total invocation records considered (post-window). */
+  totalInvocations: number;
+  /** Distinct skills that emitted at least one record. */
+  distinctSkills: number;
+  /** Invocation-weighted success rate across all skills (0-1). */
+  successRate: number;
+  /** Most-invoked skills, descending; each carries invocations + success rate. */
+  topSkills: Array<{
+    skill: string;
+    invocations: number;
+    successRate: number;
+    lastUsed: string;
+  }>;
+}
+
+/** Source 2 — Bayesian skill effectiveness, projected from the intelligence scorers. */
+export interface EffectivenessSection {
+  /** Least-effective skills first (smoothed success rate ascending). */
+  leastEffective: Array<{
+    skill: string;
+    invocations: number;
+    completed: number;
+    failed: number;
+    abandonedMidWorkflow: number;
+    /** Laplace-smoothed success rate (0-1). */
+    successRate: number;
+  }>;
+  /** Skills above the failing-rate threshold (sample-aware ranked). */
+  failing: Array<{ skill: string; invocations: number; failed: number; failureRate: number }>;
+  /** Skills abandoned mid-workflow above threshold. */
+  abandoned: Array<{
+    skill: string;
+    invocations: number;
+    abandonedMidWorkflow: number;
+    abandonmentRate: number;
+  }>;
+}
+
+/** Source 3 — usage / cost telemetry, projected from the usage aggregator. */
+export interface UsageSection {
+  /** Total cost in micro-USD across the window, or null when any record has unknown pricing. */
+  totalCostMicroUSD: number | null;
+  /** Total tokens (input + output) across the window. */
+  totalTokens: number;
+  /** Number of distinct days with usage in the window. */
+  activeDays: number;
+  /** Number of distinct sessions in the window. */
+  sessionCount: number;
+}
+
+/** Source 4 — composite code-health insights, projected from `composeInsights`. */
+export interface InsightsSection {
+  /** Whether the structural health check passed (null when the health block was unavailable). */
+  healthPassed: boolean | null;
+  /** Short health summary line. */
+  healthSummary: string | null;
+  /** Drift findings, dead files, dead exports (0 when the block is present-but-clean). */
+  driftCount: number | null;
+  deadFiles: number | null;
+  deadExports: number | null;
+  /** Warnings emitted by any sub-aggregator that failed. */
+  warnings: string[];
+}
+
+/** Source 5 — `execution_outcome` graph nodes, projected from a graph count. */
+export interface OutcomeSection {
+  satisfied: number;
+  notSatisfied: number;
+  inconclusive: number;
+  /** Total outcome nodes counted (satisfied + notSatisfied + inconclusive). */
+  total: number;
+  /** satisfied / total, or null when total is 0. */
+  satisfiedRate: number | null;
+}
+
+/**
+ * Headline block — a few cross-source figures for the top of the report.
+ * Every field is nullable: a source that is absent yields `null`, never a zero.
+ */
+export interface TelemetrySynthesisHeadline {
+  totalSkillInvocations: number | null;
+  /** From adoption. */
+  skillSuccessRate: number | null;
+  /** From execution_outcome nodes: satisfied / total. */
+  outcomeSatisfiedRate: number | null;
+  /** From usage, in whole USD (micro-USD / 1e6), or null when cost is unknown/absent. */
+  totalCostUsd: number | null;
+  /**
+   * From insights: whether the structural health check passed. Replaces the
+   * spec's `healthScore` — `composeInsights` yields a pass/fail signal, not a
+   * numeric score, so a boolean is the honest projection (Decision 6).
+   */
+  healthPassed: boolean | null;
+}
+
+/** The unified synthesis object emitted by `harness telemetry synthesize --json`. */
+export interface TelemetrySynthesis {
+  /** ISO 8601 generation timestamp. */
+  generatedAt: string;
+  /** Trailing-day window applied to adoption/usage/outcome sources; null = all-time. */
+  windowDays: number | null;
+  sources: {
+    adoption: SynthesisSection<AdoptionSection>;
+    effectiveness: SynthesisSection<EffectivenessSection>;
+    usage: SynthesisSection<UsageSection>;
+    insights: SynthesisSection<InsightsSection>;
+    outcomes: SynthesisSection<OutcomeSection>;
+  };
+  headline: TelemetrySynthesisHeadline;
+}

--- a/scripts/generate-core-barrel.mjs
+++ b/scripts/generate-core-barrel.mjs
@@ -156,6 +156,8 @@ const DIR_COMMENTS = {
   compaction: 'Compaction module for reducing MCP tool response token consumption.',
   caching: 'Caching module — stability classification and cache-aware utilities.',
   telemetry: 'Telemetry module for consent resolution and install identity.',
+  'telemetry-synthesis':
+    'Telemetry-synthesis module — pure composition of the five in-repo telemetry surfaces into one report (#563).',
   skills: 'Skills module — canonical required-section lists for skill validation gates.',
 };
 


### PR DESCRIPTION
## Summary

Ships the in-repo slice of #563: `harness telemetry synthesize` — a read-only, local, single-project CLI command that composes the five telemetry surfaces that already accrue in-repo (skill adoption, Bayesian skill effectiveness, usage/cost, composite code-health insights, and `execution_outcome` graph verdicts) into one unified report. Markdown by default; `--json` emits a machine-readable `TelemetrySynthesis` object. It collects nothing new — pure composition over existing readers, mirroring the `harness adoption retrospective` precedent.

Closes #563

Supersedes draft-spec PR #1376 — this branch is based on the same spec branch and carries the spec commit plus the implementation as one reviewable unit; the spec status is flipped DRAFT→PLANNED.

## What's included

- `harness telemetry synthesize [--json] [--out <path>] [--skip <section>...] [--window <days>]`
- `packages/types/src/telemetry-synthesis.ts` — the `TelemetrySynthesis` wire contract (dashboard-ready `--json` shape).
- `packages/core/src/telemetry-synthesis/` — a **pure** composer + Markdown renderer. Core takes no `intelligence`/`graph` dependency; the CLI is the composition root that injects the effectiveness scorers and graph outcome nodes (mirrors how `adoption.ts` imports the scorers at the CLI layer).
- A missing source contributes an explicit "Sources with no data" footer entry — never a fabricated zero, never a crash.
- Out of scope (per the spec): the cross-adopter public dashboard, `docs/case-studies/`, the README "Adopters" wall, `harness telemetry publish` — all need a PostHog aggregate + privacy review + hosting that do not exist in-repo. Filed as a follow-on.

## Pipeline artifacts

- Spec (PLANNED): `docs/changes/aggregate-telemetry-synthesis/proposal.md`
- Plan: `docs/changes/aggregate-telemetry-synthesis/plans/plan.md`
- Autopilot state: `docs/changes/aggregate-telemetry-synthesis/autopilot-state.json`

## Tests

- 14 core unit tests — `composeSynthesis` (all-present / all-absent / mixed / windowed / skip) + `renderSynthesisMarkdown`.
- 10 CLI integration tests against on-disk fixtures — cover AC1–AC11 end-to-end (real readers, not mocks), including a read-only before/after snapshot of `.harness/metrics` and cost parity against the usage aggregator.

## Acceptance criteria

| # | Criterion | Covering test |
|---|-----------|---------------|
| 1 | exits 0 + prints Markdown | CLI `AC1/AC2` |
| 2 | headline + one section per present source | CLI `AC1/AC2` + render units |
| 3 | `--json` parseable, all 5 source keys + headline | CLI `AC3` |
| 4 | K skills / N invocations match `adoption skills` | CLI `AC4` (parity vs `readAdoptionRecords`+`aggregateBySkill`) |
| 5 | no adoption.jsonl → present:false + footer + null headline | CLI `AC5` + core absent unit |
| 6 | cost total equals usage aggregator over same fixture | CLI `AC6` |
| 7 | outcome verdict counts + satisfiedRate; absent graph → present:false | CLI `AC7` + core present/mixed units |
| 8 | `--skip usage` omits usage + null cost, others unaffected | CLI `AC8` + core skip unit |
| 9 | `--out` writes + confirmation; no `--out` writes nothing | CLI `AC9` |
| 10 | zero writes to `.harness/metrics/*` (read-only) | CLI `AC10` snapshot |
| 11 | `--window 30` bounds adoption/usage/outcome | CLI `AC11` + core windowed unit |
| 12 | unit coverage compose+render; validate passes | both suites + pre-push gates |

## Assumptions made (recommended defaults taken)

1. **Headline `healthScore: number` → `healthPassed: boolean | null`.** `composeInsights` yields a pass/fail health signal (`InsightsHealthBlock { passed, signals, summary }`), not a numeric score. Per the spec's own Decision 6 (never fabricate a value), the honest projection is a boolean. No acceptance criterion asserts a numeric score.
2. **Layering: pure core composer + CLI composition root.** The spec left "final layering to be confirmed in planning." Resolved so `core` stays free of any `intelligence`/`graph` dependency: `composeSynthesis` is pure (all inputs injected); the CLI reads records, builds the effectiveness projection from the intelligence scorers, reads `execution_outcome` nodes via the graph loader, runs `composeInsights`, and hands them in.
3. **Outcome verdict source.** Counts `metadata.verdict` (SATISFIED/NOT_SATISFIED/INCONCLUSIVE) when present, falling back to `metadata.result` (success→satisfied, failure→not-satisfied) for connector-only nodes without an outcome-eval verdict. An empty/absent node set is `present:false`, never a zero-rate section.
4. **Cost parity via the pricing path.** `costMicroUSD` is never stored in `costs.jsonl` — it is derived from model pricing — so the command prices records through the exact `loadPricingData`+`calculateCost` path `harness usage` uses. Any unknown-pricing record makes the total `null` (not zero).
5. **`--out` default location.** Unlike `adoption retrospective` (which defaults to writing `docs/retrospectives/`), synthesis prints to stdout by default and only writes when `--out` is given — synthesis is a lookup, not a durable artifact (spec Decision 7).

No unforeseen decision fork was hit; nothing parked.
