### PR TITLE
test(coverage): characterize scan-config-shared + cross-check/advise-skills MCP tools

### DIFF
--- a/packages/cli/src/mcp/tools/advise-skills.test.ts
+++ b/packages/cli/src/mcp/tools/advise-skills.test.ts
@@ -116,9 +116,7 @@ describe('handleAdviseSkills', () => {
 
     await handleAdviseSkills({ specPath: 'spec.md' });
 
-    expect(runAdviseSkills).toHaveBeenCalledWith(
-      expect.objectContaining({ cwd: process.cwd() })
-    );
+    expect(runAdviseSkills).toHaveBeenCalledWith(expect.objectContaining({ cwd: process.cwd() }));
   });
 
   it('reports a thrown error as a JSON error payload rather than throwing', async () => {

--- a/packages/cli/src/mcp/tools/advise-skills.test.ts
+++ b/packages/cli/src/mcp/tools/advise-skills.test.ts
@@ -1,0 +1,131 @@
+import path from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { adviseSkillsDefinition, handleAdviseSkills } from './advise-skills.js';
+
+// The handler delegates to runAdviseSkills; we intercept the command module so
+// we can pin the handler's own responsibilities: tier partitioning, the
+// project-relative skills path, default option coercion, and error shaping.
+const runAdviseSkills = vi.hoisted(() => vi.fn());
+
+vi.mock('../../commands/advise-skills.js', () => ({
+  runAdviseSkills,
+}));
+
+function parse(res: { content: Array<{ text: string }> }) {
+  const first = res.content[0];
+  if (!first) throw new Error('expected tool response content');
+  return JSON.parse(first.text);
+}
+
+function match(tier: 'apply' | 'reference' | 'consider', skillName: string) {
+  return { tier, skillName, score: 42, when: `use ${skillName}`, matchReasons: ['kw'] };
+}
+
+beforeEach(() => {
+  runAdviseSkills.mockReset();
+});
+
+describe('adviseSkillsDefinition', () => {
+  it('declares the advise_skills tool requiring specPath', () => {
+    expect(adviseSkillsDefinition.name).toBe('advise_skills');
+    expect(adviseSkillsDefinition.inputSchema.required).toEqual(['specPath']);
+    expect(adviseSkillsDefinition.inputSchema.properties.thorough.type).toBe('boolean');
+  });
+});
+
+describe('handleAdviseSkills', () => {
+  const projectRoot = path.resolve('proj-root');
+
+  it('partitions matches into apply/reference/consider and relativizes the skills path', async () => {
+    runAdviseSkills.mockResolvedValue({
+      result: {
+        scanDuration: 12,
+        matches: [
+          match('apply', 'harness-tdd'),
+          match('reference', 'harness-verify'),
+          match('consider', 'harness-audit'),
+        ],
+      },
+      skillsMdPath: path.join(projectRoot, '.harness', 'SKILLS.md'),
+      featureName: 'checkout',
+      totalSkills: 7,
+    });
+
+    const res = await handleAdviseSkills({ path: projectRoot, specPath: 'docs/specs/x.md' });
+    const body = parse(res);
+
+    expect(body.featureName).toBe('checkout');
+    expect(body.skillsPath).toBe('.harness/SKILLS.md');
+    expect(body.totalScanned).toBe(7);
+    expect(body.scanDuration).toBe(12);
+    expect(body.apply.map((m: { skill: string }) => m.skill)).toEqual(['harness-tdd']);
+    expect(body.reference.map((m: { skill: string }) => m.skill)).toEqual(['harness-verify']);
+    expect(body.consider.map((m: { skill: string }) => m.skill)).toEqual(['harness-audit']);
+    // The per-match shape re-keys skillName -> skill and matchReasons -> reasons.
+    expect(body.apply[0]).toEqual({
+      skill: 'harness-tdd',
+      score: 42,
+      when: 'use harness-tdd',
+      reasons: ['kw'],
+    });
+  });
+
+  it('defaults thorough to false and top to 5 when omitted', async () => {
+    runAdviseSkills.mockResolvedValue({
+      result: { scanDuration: 1, matches: [] },
+      skillsMdPath: path.join(projectRoot, 'SKILLS.md'),
+      featureName: 'f',
+      totalSkills: 0,
+    });
+
+    await handleAdviseSkills({ path: projectRoot, specPath: 'spec.md' });
+
+    expect(runAdviseSkills).toHaveBeenCalledWith({
+      specPath: 'spec.md',
+      cwd: projectRoot,
+      thorough: false,
+      top: 5,
+    });
+  });
+
+  it('passes through explicit thorough and top options', async () => {
+    runAdviseSkills.mockResolvedValue({
+      result: { scanDuration: 1, matches: [] },
+      skillsMdPath: path.join(projectRoot, 'SKILLS.md'),
+      featureName: 'f',
+      totalSkills: 0,
+    });
+
+    await handleAdviseSkills({ path: projectRoot, specPath: 'spec.md', thorough: true, top: 3 });
+
+    expect(runAdviseSkills).toHaveBeenCalledWith({
+      specPath: 'spec.md',
+      cwd: projectRoot,
+      thorough: true,
+      top: 3,
+    });
+  });
+
+  it('falls back to process.cwd() when no path is provided', async () => {
+    runAdviseSkills.mockResolvedValue({
+      result: { scanDuration: 1, matches: [] },
+      skillsMdPath: path.join(process.cwd(), 'SKILLS.md'),
+      featureName: 'f',
+      totalSkills: 0,
+    });
+
+    await handleAdviseSkills({ specPath: 'spec.md' });
+
+    expect(runAdviseSkills).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: process.cwd() })
+    );
+  });
+
+  it('reports a thrown error as a JSON error payload rather than throwing', async () => {
+    runAdviseSkills.mockRejectedValue(new Error('spec not found'));
+
+    const res = await handleAdviseSkills({ path: projectRoot, specPath: 'missing.md' });
+
+    expect(parse(res)).toEqual({ error: 'spec not found' });
+  });
+});

--- a/packages/cli/src/mcp/tools/cross-check.test.ts
+++ b/packages/cli/src/mcp/tools/cross-check.test.ts
@@ -1,0 +1,107 @@
+import * as path from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateCrossCheckDefinition, handleValidateCrossCheck } from './cross-check.js';
+
+// The handler dynamically imports the command module, so we intercept the whole
+// module and drive runCrossCheck per-test. These tests pin the handler's
+// current contract: path guarding, the JSON response shape on success, and how
+// Result failures and thrown errors surface (F3a: response shape is contract).
+const runCrossCheck = vi.hoisted(() => vi.fn());
+
+vi.mock('../../commands/validate-cross-check.js', () => ({
+  runCrossCheck,
+}));
+
+function firstText(res: { content: Array<{ text: string }> }): string {
+  const first = res.content[0];
+  if (!first) throw new Error('expected tool response content');
+  return first.text;
+}
+
+beforeEach(() => {
+  runCrossCheck.mockReset();
+});
+
+describe('validateCrossCheckDefinition', () => {
+  it('declares the validate_cross_check tool requiring only path', () => {
+    expect(validateCrossCheckDefinition.name).toBe('validate_cross_check');
+    expect(validateCrossCheckDefinition.inputSchema.required).toEqual(['path']);
+    expect(validateCrossCheckDefinition.inputSchema.properties.specsDir.type).toBe('string');
+    expect(validateCrossCheckDefinition.inputSchema.properties.plansDir.type).toBe('string');
+  });
+});
+
+describe('handleValidateCrossCheck', () => {
+  const projectRoot = path.resolve('some/project');
+
+  it('returns the runCrossCheck value as JSON on success without an error flag', async () => {
+    const value = { specs: 3, plans: 3, stale: [] };
+    runCrossCheck.mockResolvedValue({ ok: true, value });
+
+    const res = await handleValidateCrossCheck({ path: projectRoot });
+
+    expect('isError' in res).toBe(false);
+    expect(JSON.parse(firstText(res))).toEqual(value);
+    expect(runCrossCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves default specs/plans dirs under the project root', async () => {
+    runCrossCheck.mockResolvedValue({ ok: true, value: {} });
+
+    await handleValidateCrossCheck({ path: projectRoot });
+
+    expect(runCrossCheck).toHaveBeenCalledWith({
+      projectPath: projectRoot,
+      specsDir: path.join(projectRoot, 'docs/specs'),
+      plansDir: path.join(projectRoot, 'docs/plans'),
+    });
+  });
+
+  it('surfaces a Result failure as an error carrying the error message', async () => {
+    runCrossCheck.mockResolvedValue({ ok: false, error: { message: 'no specs found' } });
+
+    const res = await handleValidateCrossCheck({ path: projectRoot });
+
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toBe('no specs found');
+  });
+
+  it('catches a thrown error and reports it as an Error: message', async () => {
+    runCrossCheck.mockRejectedValue(new Error('disk exploded'));
+
+    const res = await handleValidateCrossCheck({ path: projectRoot });
+
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toBe('Error: disk exploded');
+  });
+
+  it('rejects the filesystem root before ever invoking the command', async () => {
+    const res = await handleValidateCrossCheck({ path: '/' });
+
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toMatch(/^Error: /);
+    expect(runCrossCheck).not.toHaveBeenCalled();
+  });
+
+  it('rejects a specsDir that escapes the project root', async () => {
+    const res = await handleValidateCrossCheck({
+      path: projectRoot,
+      specsDir: '../../../../etc',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toBe('Error: specsDir escapes project root');
+    expect(runCrossCheck).not.toHaveBeenCalled();
+  });
+
+  it('rejects a plansDir that escapes the project root', async () => {
+    const res = await handleValidateCrossCheck({
+      path: projectRoot,
+      plansDir: '../../../../etc',
+    });
+
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toBe('Error: plansDir escapes project root');
+    expect(runCrossCheck).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/security/scan-config-shared.test.ts
+++ b/packages/core/src/security/scan-config-shared.test.ts
@@ -85,7 +85,9 @@ describe('computeOverallSeverity', () => {
   });
 });
 
-function fileResult(overallSeverity: ScanConfigFileResult['overallSeverity']): ScanConfigFileResult {
+function fileResult(
+  overallSeverity: ScanConfigFileResult['overallSeverity']
+): ScanConfigFileResult {
   return { file: 'f.ts', findings: [], overallSeverity };
 }
 

--- a/packages/core/src/security/scan-config-shared.test.ts
+++ b/packages/core/src/security/scan-config-shared.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapSecuritySeverity,
+  computeOverallSeverity,
+  computeScanExitCode,
+  mapInjectionFindings,
+  isDuplicateFinding,
+  mapSecurityFindings,
+  type ScanConfigFinding,
+  type ScanConfigFileResult,
+} from './scan-config-shared';
+import type { InjectionFinding } from './injection-patterns';
+import type { SecurityFinding } from './types';
+
+// Characterization tests for the shared scan-config utilities. These pin the
+// current severity-mapping, aggregation, exit-code, and de-duplication
+// behavior exactly as it ships today (F3a: current behavior is the contract).
+
+describe('mapSecuritySeverity', () => {
+  it("maps 'error' to high", () => {
+    expect(mapSecuritySeverity('error')).toBe('high');
+  });
+
+  it("maps 'warning' to medium", () => {
+    expect(mapSecuritySeverity('warning')).toBe('medium');
+  });
+
+  it("maps 'info' to low", () => {
+    expect(mapSecuritySeverity('info')).toBe('low');
+  });
+
+  it('maps any unrecognized severity to low (default branch)', () => {
+    expect(mapSecuritySeverity('catastrophic')).toBe('low');
+    expect(mapSecuritySeverity('')).toBe('low');
+  });
+});
+
+function finding(severity: ScanConfigFinding['severity']): ScanConfigFinding {
+  return { ruleId: 'R-1', severity, message: 'm', match: 'x' };
+}
+
+// Assert a single-element result and return that element narrowed, so tests can
+// read its fields without tripping noUncheckedIndexedAccess.
+function only<T>(arr: T[]): T {
+  expect(arr).toHaveLength(1);
+  return arr[0] as T;
+}
+
+// Build a complete SecurityFinding so fixtures satisfy every required field;
+// each test overrides only the properties the behavior under test depends on.
+function sec(overrides: Partial<SecurityFinding>): SecurityFinding {
+  return {
+    ruleId: 'SEC-A-1',
+    ruleName: 'rule',
+    category: 'injection' as SecurityFinding['category'],
+    severity: 'error' as SecurityFinding['severity'],
+    confidence: 'high' as SecurityFinding['confidence'],
+    file: 'f.ts',
+    line: 1,
+    match: 'code',
+    context: 'ctx',
+    message: 'msg',
+    remediation: 'fix it',
+    ...overrides,
+  };
+}
+
+describe('computeOverallSeverity', () => {
+  it("returns 'clean' when there are no findings", () => {
+    expect(computeOverallSeverity([])).toBe('clean');
+  });
+
+  it("returns 'high' when any finding is high, regardless of order", () => {
+    expect(computeOverallSeverity([finding('low'), finding('high'), finding('medium')])).toBe(
+      'high'
+    );
+  });
+
+  it("returns 'medium' when the worst finding is medium", () => {
+    expect(computeOverallSeverity([finding('low'), finding('medium')])).toBe('medium');
+  });
+
+  it("returns 'low' when every finding is low", () => {
+    expect(computeOverallSeverity([finding('low'), finding('low')])).toBe('low');
+  });
+});
+
+function fileResult(overallSeverity: ScanConfigFileResult['overallSeverity']): ScanConfigFileResult {
+  return { file: 'f.ts', findings: [], overallSeverity };
+}
+
+describe('computeScanExitCode', () => {
+  it('returns 0 for no results', () => {
+    expect(computeScanExitCode([])).toBe(0);
+  });
+
+  it('returns 0 when all files are clean or low', () => {
+    expect(computeScanExitCode([fileResult('clean'), fileResult('low')])).toBe(0);
+  });
+
+  it('returns 2 when any file is high (high dominates medium)', () => {
+    expect(computeScanExitCode([fileResult('medium'), fileResult('high')])).toBe(2);
+  });
+
+  it('returns 1 when the worst file is medium', () => {
+    expect(computeScanExitCode([fileResult('low'), fileResult('medium')])).toBe(1);
+  });
+});
+
+describe('mapInjectionFindings', () => {
+  it('maps injection findings into scan-config findings with a derived message', () => {
+    const injection: InjectionFinding[] = [
+      { ruleId: 'INJ-ENC-001', severity: 'high', match: 'base64…', line: 12 } as InjectionFinding,
+    ];
+
+    const mapped = only(mapInjectionFindings(injection));
+
+    expect(mapped).toEqual({
+      ruleId: 'INJ-ENC-001',
+      severity: 'high',
+      message: 'Injection pattern detected: INJ-ENC-001',
+      match: 'base64…',
+      line: 12,
+    });
+  });
+
+  it('omits the line field entirely when the injection finding has no line', () => {
+    const injection: InjectionFinding[] = [{ ruleId: 'INJ-X', severity: 'medium', match: 'm' }];
+
+    const mapped = only(mapInjectionFindings(injection));
+
+    expect('line' in mapped).toBe(false);
+    expect(mapped.severity).toBe('medium');
+  });
+
+  it('returns an empty array for no injection findings', () => {
+    expect(mapInjectionFindings([])).toEqual([]);
+  });
+});
+
+describe('isDuplicateFinding', () => {
+  const existing: ScanConfigFinding[] = [
+    { ruleId: 'SEC-INJ-001', severity: 'high', message: 'm', match: 'trimmed', line: 5 },
+  ];
+
+  it('treats a finding as duplicate when line, trimmed match, and rule prefix all agree', () => {
+    // Same line, match equal after trim, and prefix 'SEC' === 'SEC'.
+    const candidate = sec({ ruleId: 'SEC-OTHER-999', match: '  trimmed  ', line: 5 });
+
+    expect(isDuplicateFinding(existing, candidate)).toBe(true);
+  });
+
+  it('is not a duplicate when the rule-id prefix differs', () => {
+    const candidate = sec({ ruleId: 'INJ-INJ-001', match: 'trimmed', line: 5 });
+
+    expect(isDuplicateFinding(existing, candidate)).toBe(false);
+  });
+
+  it('is not a duplicate when the line differs', () => {
+    const candidate = sec({ ruleId: 'SEC-INJ-001', match: 'trimmed', line: 6 });
+
+    expect(isDuplicateFinding(existing, candidate)).toBe(false);
+  });
+
+  it('is never a duplicate against an empty existing set', () => {
+    const candidate = sec({ ruleId: 'SEC-INJ-001', match: 'trimmed', line: 5 });
+
+    expect(isDuplicateFinding([], candidate)).toBe(false);
+  });
+});
+
+describe('mapSecurityFindings', () => {
+  it('maps non-duplicate security findings and re-maps their severity', () => {
+    const secFindings = [
+      sec({ ruleId: 'SEC-A-1', severity: 'error', message: 'boom', match: 'code', line: 3 }),
+    ];
+
+    const result = mapSecurityFindings(secFindings, []);
+
+    expect(result).toEqual([
+      { ruleId: 'SEC-A-1', severity: 'high', message: 'boom', match: 'code', line: 3 },
+    ]);
+  });
+
+  it('drops findings that duplicate one already present', () => {
+    const existing: ScanConfigFinding[] = [
+      { ruleId: 'SEC-A-1', severity: 'high', message: 'boom', match: 'code', line: 3 },
+    ];
+    const secFindings = [
+      sec({ ruleId: 'SEC-B-2', severity: 'warning', message: 'dup', match: 'code', line: 3 }),
+    ];
+
+    // Same line + match + 'SEC' prefix => duplicate => filtered out.
+    expect(mapSecurityFindings(secFindings, existing)).toEqual([]);
+  });
+
+  it("re-maps 'info' severity to low on a passed-through finding", () => {
+    const secFindings = [sec({ ruleId: 'SEC-C-3', severity: 'info', message: 'note', line: 8 })];
+
+    const mapped = only(mapSecurityFindings(secFindings, []));
+
+    expect(mapped.severity).toBe('low');
+    expect(mapped.line).toBe(8);
+  });
+});


### PR DESCRIPTION
## test-fleet wave-2 coverage sweep (top-3 targets)

Adds behavior-asserting characterization tests for three severe-tier under-covered modules. **Tests only — no source under test was modified.**

| Target | Was | Tests added |
| --- | --- | --- |
| `packages/core/src/security/scan-config-shared.ts` | 0% | 22 |
| `packages/cli/src/mcp/tools/cross-check.ts` | ~low | 8 |
| `packages/cli/src/mcp/tools/advise-skills.ts` | ~low | 6 |

### What is pinned
- **scan-config-shared**: `mapSecuritySeverity`, `computeOverallSeverity`, `computeScanExitCode`, `mapInjectionFindings`, `isDuplicateFinding`, `mapSecurityFindings` — severity mapping, worst-wins aggregation, exit-code precedence (high→2, medium→1), optional-line omission, prefix/line/trimmed-match duplicate detection.
- **cross-check MCP tool**: filesystem-root rejection, `specsDir`/`plansDir` escape guards (command never invoked), JSON success shape, `Result` failure → `isError` with message, thrown error → `Error: <msg>`.
- **advise-skills MCP tool**: apply/reference/consider tier partitioning, `skillName`→`skill` / `matchReasons`→`reasons` re-keying, project-relative skills path, `thorough=false`/`top=5` default coercion, `cwd` fallback to `process.cwd()`, thrown error → JSON `{error}` payload.

### Assumptions made
- Characterized **current behavior as-is**; each MCP tool's response payload shape is treated as the contract (fork F3a, answered in CONFIRM).
- Dropped a would-be "security finding with no line" case: `SecurityFinding.line` is a required `number`, so that mapper branch is unreachable by contract — not tested against impossible input.

### Local verification (Node 22)
- `vitest run` all three files: **36 passed**.
- `tsc --noEmit`: no errors in the added files. (Pre-existing unbuilt-dist errors in `telemetry-synthesis`/`synthesize.ts` are unrelated to this PR and resolve once packages are built in CI.)

Authored via the test-fleet DISPATCH flow (tdd→test-craft discipline). Do not auto-merge — hand-off for bulk human review.