### PR TITLE
chore(cleanup): remove dead cli/mcp exports

### DIFF
--- a/.changeset/cleanup-cli-mcp-dead-code.md
+++ b/.changeset/cleanup-cli-mcp-dead-code.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+chore(cleanup): remove dead cli/mcp exports. Un-export six intra-file-only schema constants in `interaction-schemas.ts` (`EffortLevel`, `ConfidenceLevel`, `InteractionQuestionSchema`, `QualityGateCheckSchema`, `QualityGateSchema`, `BatchDecisionSchema`) and delete the unused `__internal__` re-export block in `audit-anatomy.ts`. Pure dead-code removal; no behavior change.

--- a/packages/cli/src/mcp/tools/audit-anatomy.ts
+++ b/packages/cli/src/mcp/tools/audit-anatomy.ts
@@ -19,10 +19,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { sanitizePath } from '../utils/sanitize-path.js';
-import {
-  parseComponentDefinition,
-  parseComponentDefinitionFromSource,
-} from '../../audit/component-anatomy/parsers/ast.js';
+import { parseComponentDefinitionFromSource } from '../../audit/component-anatomy/parsers/ast.js';
 import { resolveComponentType } from '../../audit/component-anatomy/resolvers/component-type.js';
 import { resolveAnatomyRules } from '../../audit/component-anatomy/resolvers/source-of-truth.js';
 import { runConventionRule } from '../../audit/component-anatomy/rules/convention-runner.js';
@@ -200,13 +197,3 @@ export async function handleAuditAnatomy(input: AuditAnatomyInput): Promise<Tool
     };
   }
 }
-
-/**
- * Convenience re-export so the file-walker integration (Phase 2) and
- * harness validate hook (separate task) can read a file from disk
- * without re-implementing the parser entry. Provides a single source
- * of truth for the parse+resolve pipeline.
- */
-export const __internal__ = {
-  parseComponentDefinition,
-};

--- a/packages/cli/src/mcp/tools/interaction-schemas.ts
+++ b/packages/cli/src/mcp/tools/interaction-schemas.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const RiskLevel = z.enum(['low', 'medium', 'high']);
-export const EffortLevel = z.enum(['low', 'medium', 'high']);
-export const ConfidenceLevel = z.enum(['low', 'medium', 'high']);
+const EffortLevel = z.enum(['low', 'medium', 'high']);
+const ConfidenceLevel = z.enum(['low', 'medium', 'high']);
 
 export const InteractionOptionSchema = z.object({
   label: z.string().min(1),
@@ -12,7 +12,7 @@ export const InteractionOptionSchema = z.object({
   effort: EffortLevel.optional(),
 });
 
-export const InteractionQuestionSchema = z.object({
+const InteractionQuestionSchema = z.object({
   text: z.string().min(1),
   options: z.array(InteractionOptionSchema).min(2).max(10).optional(),
   recommendation: z
@@ -61,13 +61,13 @@ export const InteractionConfirmationSchema = z.object({
   risk: RiskLevel.optional(),
 });
 
-export const QualityGateCheckSchema = z.object({
+const QualityGateCheckSchema = z.object({
   name: z.string().min(1),
   passed: z.boolean(),
   detail: z.string().optional(),
 });
 
-export const QualityGateSchema = z.object({
+const QualityGateSchema = z.object({
   checks: z.array(QualityGateCheckSchema).min(1),
   allPassed: z.boolean(),
 });
@@ -82,7 +82,7 @@ export const InteractionTransitionSchema = z.object({
   qualityGate: QualityGateSchema.optional(),
 });
 
-export const BatchDecisionSchema = z.object({
+const BatchDecisionSchema = z.object({
   label: z.string().min(1),
   recommendation: z.string().min(1),
   risk: z.literal('low'),


### PR DESCRIPTION
## Summary

WAVE-2 cleanup-fleet target **T2 (cli-mcp)**. Pure dead-code / dead-export removal scoped to `packages/cli/src/mcp/**`.

### What was removed
- `packages/cli/src/mcp/tools/interaction-schemas.ts` — removed the `export` keyword (symbol kept) from six schema constants that are referenced **only inside their own declaring file**: `EffortLevel`, `ConfidenceLevel`, `InteractionQuestionSchema`, `QualityGateCheckSchema`, `QualityGateSchema`, `BatchDecisionSchema`. These were over-exported, not dead — the constants are still used intra-file (and by the exported `InteractionQuestion` / `QualityGate` inferred types), so only the redundant `export` was dropped.
- `packages/cli/src/mcp/tools/audit-anatomy.ts` — deleted the unused `export const __internal__ = { parseComponentDefinition }` re-export block (referenced nowhere) and removed the now-unused `parseComponentDefinition` import. The real audit path uses `parseComponentDefinitionFromSource`, which is untouched.

## Assumptions made

- **Ranking basis:** candidates were pre-triaged as "exported but unused outside declaring file" by the repo dead-code detector. Each was re-verified with a repo-wide `grep -w` across `packages/ templates/ examples/ scripts/` including test files, JSX, and dynamic-import/string usages.
- **Scope:** exactly one module — `packages/cli/src/mcp/**`. No other package touched.
- **Safe-vs-risky calls:**
  - The six interaction schemas are referenced intra-file only → **un-export** (keep symbol), the minimal safe fix. Not deleted because they are live within the file.
  - `__internal__` is referenced nowhere (not even intra-file) → **deleted** the block. Its wrapped symbol `parseComponentDefinition` remains exported from `parsers/ast.ts` and is used by tests directly, so no consumer breaks.
- **Verification:** `pnpm --filter @harness-engineering/cli build` (typecheck) passes; interaction + component-anatomy test suites pass (193 tests); detector re-scan confirms all 7 in-scope candidate findings dropped to 0.

Do not merge — VERIFY leaf will re-scan.