### PR TITLE
chore(cleanup): remove dead orchestrator/agent exports

### DIFF
--- a/.changeset/cleanup-orch-agent-dead-code.md
+++ b/.changeset/cleanup-orch-agent-dead-code.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+chore(cleanup): remove dead orchestrator/agent exports. Un-export three intra-file-only symbols (`SUBPROCESS_ENV_ALLOWLIST` and `SUBPROCESS_ENV_ALLOWED_PREFIXES` in `subprocess-env.ts`, `useCaseToProfile` in `local-model-resolver.ts`, and the abstract base class `ServerlessBackend` in `backends/serverless.ts`) and delete the unused `createRuntime` factory in `runtime/index.ts`. Pure dead-code removal; no behavior change.

--- a/packages/orchestrator/src/agent/backends/serverless.ts
+++ b/packages/orchestrator/src/agent/backends/serverless.ts
@@ -36,7 +36,7 @@ export interface ServerlessHandle {
  * the session lifecycle, handle tracking, and protocol parsing are
  * shared.
  */
-export abstract class ServerlessBackend implements AgentBackend {
+abstract class ServerlessBackend implements AgentBackend {
   abstract readonly name: string;
   protected handles = new Map<string, ServerlessHandle>();
 

--- a/packages/orchestrator/src/agent/local-model-resolver.ts
+++ b/packages/orchestrator/src/agent/local-model-resolver.ts
@@ -15,7 +15,7 @@ import { poolStateToCandidates } from '@harness-engineering/local-models';
  * — see the task-aware-selection ADR. Extend here as more signal is available
  * (e.g. cognitiveMode on `skill`/`mode`).
  */
-export function useCaseToProfile(useCase: RoutingUseCase): RankProfile {
+function useCaseToProfile(useCase: RoutingUseCase): RankProfile {
   switch (useCase.kind) {
     case 'tier':
       return useCase.tier === 'diagnostic' ? 'reasoning' : 'coding';

--- a/packages/orchestrator/src/agent/runtime/index.ts
+++ b/packages/orchestrator/src/agent/runtime/index.ts
@@ -1,15 +1,1 @@
-import type { ContainerRuntime } from '@harness-engineering/types';
-import { DockerRuntime } from './docker';
-
 export { DockerRuntime } from './docker';
-
-export function createRuntime(kind: 'docker'): ContainerRuntime {
-  switch (kind) {
-    case 'docker':
-      return new DockerRuntime();
-    default: {
-      const exhaustive: never = kind;
-      throw new Error(`Unsupported container runtime: ${String(exhaustive)}`);
-    }
-  }
-}

--- a/packages/orchestrator/src/agent/subprocess-env.ts
+++ b/packages/orchestrator/src/agent/subprocess-env.ts
@@ -24,7 +24,7 @@
  * "runtime plumbing" vars a CLI, git, node, and the OS need to function — none
  * are secrets in the credential sense, and withholding them breaks spawning.
  */
-export const SUBPROCESS_ENV_ALLOWLIST: readonly string[] = [
+const SUBPROCESS_ENV_ALLOWLIST: readonly string[] = [
   // OS / shell / user identity
   'PATH',
   'HOME',
@@ -122,7 +122,7 @@ export const SUBPROCESS_ENV_ALLOWLIST: readonly string[] = [
  * the creds the agent needs to reach its model. The win is that non-provider
  * secrets (which match no prefix) are dropped.
  */
-export const SUBPROCESS_ENV_ALLOWED_PREFIXES: readonly string[] = [
+const SUBPROCESS_ENV_ALLOWED_PREFIXES: readonly string[] = [
   'LC_',
   'XDG_',
   'GIT_',


### PR DESCRIPTION
## Summary

WAVE-2 cleanup-fleet target **T3 (orchestrator-agent)**. Pure dead-code / dead-export removal scoped to `packages/orchestrator/src/agent/**`.

### What was removed
- `subprocess-env.ts` — removed the `export` keyword (symbols kept) from `SUBPROCESS_ENV_ALLOWLIST` and `SUBPROCESS_ENV_ALLOWED_PREFIXES`. Both are referenced only inside their own file (to build the `*_UPPER` lookup structures); the test suite imports the public helpers `buildSubprocessEnv` / `isEnvKeyAllowed` / `SUBPROCESS_ENV_ALLOW_VAR` / `SUBPROCESS_ENV_PASSTHROUGH_VAR`, none of which changed.
- `local-model-resolver.ts` — removed the `export` keyword from `useCaseToProfile`; it is used only intra-file by `resolveModel`.
- `backends/serverless.ts` — removed the `export` keyword from the abstract base class `ServerlessBackend`; it is extended only intra-file by `OciServerlessBackend`, which remains exported and wired into `backend-factory.ts` (the `'serverless'` backend case) and its own test.
- `runtime/index.ts` — deleted the unused `createRuntime(kind)` factory (referenced nowhere) plus its now-unused `ContainerRuntime` type import and value import of `DockerRuntime`. The `export { DockerRuntime } from './docker'` re-export is retained.

## Assumptions made

- **Ranking basis:** candidates were pre-triaged as "exported but unused outside declaring file" by the repo dead-code detector, then re-verified with repo-wide `grep -w` across `packages/ templates/ examples/ scripts/` including test files and dynamic usages.
- **Scope:** exactly one module — `packages/orchestrator/src/agent/**`.
- **Safe-vs-risky calls:**
  - The four intra-file-only symbols (`SUBPROCESS_ENV_ALLOWLIST`, `SUBPROCESS_ENV_ALLOWED_PREFIXES`, `useCaseToProfile`, `ServerlessBackend`) → **un-export** (keep symbol). This is the minimal safe fix; they are still live within their files.
  - `ServerlessBackend` was verified **not** to be an externally-consumed DI seam: only its concrete subclass `OciServerlessBackend` is wired via `backend-factory.ts`, and that stays exported. The abstract base has no external importer.
  - `createRuntime` is referenced nowhere (not even intra-file) and is **not** a registered runtime seam — nothing constructs runtimes through it; `DockerRuntime` is imported directly by its test. → **deleted**.
- **Verification:** `pnpm --filter @harness-engineering/orchestrator build` (typecheck) passes; subprocess-env, serverless, docker-runtime, backend-router, and local-model-resolver test suites pass (104 tests); detector re-scan confirms all 5 in-scope candidate findings dropped to 0.

Do not merge — VERIFY leaf will re-scan.