### PR TITLE
chore(cleanup): remove dead orchestrator/workflow export

### DIFF
--- a/.changeset/cleanup-orch-workflow-dead-code.md
+++ b/.changeset/cleanup-orch-workflow-dead-code.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+chore(cleanup): remove dead orchestrator/workflow export. Un-export the intra-file-only `stagedWorkflowRoutingIssues` helper in `workflow/config.ts` (it is called only by `validateWorkflowConfig` within the same file; its stale "exported for unit testing" note is corrected since no test imports it directly). Pure dead-code removal; no behavior change.

--- a/packages/orchestrator/src/workflow/config.ts
+++ b/packages/orchestrator/src/workflow/config.ts
@@ -90,9 +90,9 @@ export function crossFieldRoutingIssues(
  * — falling to `routing.default` is their correct behavior. This helper touches
  * only `routing.modes`/`routing.skills`; it never reads `routing.workflowGates`.
  *
- * Exported for unit testing; production callers use `validateWorkflowConfig`.
+ * Internal helper for `validateWorkflowConfig`.
  */
-export function stagedWorkflowRoutingIssues(
+function stagedWorkflowRoutingIssues(
   workflows: readonly StagedWorkflowDecl[],
   routing: RoutingConfig
 ): Array<{ path: string[]; message: string }> {


### PR DESCRIPTION
## Summary

WAVE-2 cleanup-fleet target **T6 (orchestrator-workflow)**. Pure dead-code / dead-export removal scoped to `packages/orchestrator/src/workflow/**`.

### What was removed
- `workflow/config.ts` — removed the `export` keyword (symbol kept) from `stagedWorkflowRoutingIssues`. It is called only intra-file by `validateWorkflowConfig`. The function's doc comment claimed it was "exported for unit testing," but no test imports it directly — `config.staged-routing.test.ts` exercises it indirectly through `validateWorkflowConfig` — so the comment was corrected to reflect its internal-helper status.

## Assumptions made

- **Ranking basis:** candidate was pre-triaged as "exported but unused outside declaring file" by the repo dead-code detector, then re-verified with repo-wide `grep -w` across `packages/ templates/ examples/ scripts/` including test files.
- **Scope:** exactly one module — `packages/orchestrator/src/workflow/**` (single symbol).
- **Safe-vs-risky calls:** intra-file-only usage → **un-export** (keep symbol), the minimal safe fix. Verified the staged-routing test suite imports only `validateWorkflowConfig` / `getDefaultConfig`, so removing the export does not break any direct test import.
- **Verification:** `pnpm --filter @harness-engineering/orchestrator build` (typecheck) passes; workflow config + staged-routing + schema test suites pass (46 tests); detector re-scan confirms the in-scope candidate finding dropped to 0.

Do not merge — VERIFY leaf will re-scan.