### PR TITLE
docs(roadmap): register 4 deepseek-harness adoption candidates

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,4 @@
-notify = ["node", "/Users/cwarner/Projects/harness-engineering/.harness/hooks/session-retrospect-codex.js"]
+notify = ["harness", "hooks", "run", "session-retrospect-codex"]
 
 [mcp_servers.context7]
 args = [

--- a/.harness/.gitignore
+++ b/.harness/.gitignore
@@ -37,3 +37,4 @@ maintenance/
 # security/: track timeline.json (trend ledger), ignore everything else
 security/*
 !security/timeline.json
+metrics/

--- a/docs/roadmap.d/canonical-bounded-handoff-record-for-fleet-workers.md
+++ b/docs/roadmap.d/canonical-bounded-handoff-record-for-fleet-workers.md
@@ -1,0 +1,16 @@
+---
+slug: "canonical-bounded-handoff-record-for-fleet-workers"
+milestone: "Intake"
+order: 46
+---
+
+### Canonical bounded handoff record for fleet workers
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Define one shared handoff schema — status, summary, evidence, next_steps, blocker — modeled on dsh's Ralph-loop handoff ("the normalized bounded structured report passed from one continuing Ralph round to the next"). Require every fleet family member (bug-fleet, roadmap-fleet, pr-fleet, cicd-fleet, cleanup-fleet, security-fleet, test-fleet, issue-fleet, adr-fleet) to emit it from each worktree-isolated worker instead of each fleet defining its own ad hoc report shape, so fleet-command can parse any fleet's worker output uniformly instead of special-casing each one. Likely lands as a shared type in @harness-engineering/types plus a validation helper.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1396

--- a/docs/roadmap.d/generate-and-verify-skill-mcp-tool-reference-docs-regenerate-and-gate-not-detect-only.md
+++ b/docs/roadmap.d/generate-and-verify-skill-mcp-tool-reference-docs-regenerate-and-gate-not-detect-only.md
@@ -1,0 +1,16 @@
+---
+slug: "generate-and-verify-skill-mcp-tool-reference-docs-regenerate-and-gate-not-detect-only"
+milestone: "Intake"
+order: 45
+---
+
+### Generate-and-verify skill/MCP-tool reference docs (regenerate-and-gate, not detect-only)
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Port dsh's gen-tool-catalog/verify-tool-catalog pattern (deepseek-ai/deepseek-harness docs/tool-catalog.md): boot each shipped skill and MCP tool definition against a real context, extract its live name/description/schema, generate a canonical docs/reference/*.md catalog from that, and add a verify mode that regenerates in CI and fails the build on any diff — the same shape as generate-docs / generate-barrel-exports:check today. Upgrades detect-doc-drift from advisory detection to a hard regenerate+gate loop for the skill/tool catalog specifically, closing the gap where a tool's real schema and its documented schema silently diverge. Reference: reference_deepseek_harness_analysis.md (memory).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1401

--- a/docs/roadmap.d/require-service-definition-provider-consumer-roles-in-skill-authoring-guidance.md
+++ b/docs/roadmap.d/require-service-definition-provider-consumer-roles-in-skill-authoring-guidance.md
@@ -1,0 +1,16 @@
+---
+slug: "require-service-definition-provider-consumer-roles-in-skill-authoring-guidance"
+milestone: "Intake"
+order: 47
+---
+
+### Require Service-Definition/Provider/Consumer roles in skill-authoring guidance
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** dsh's capability-seam model requires every extension point to name a Service Definition, at least one Provider, and at least one Consumer — a capability with only one role filled in is flagged as not actually swappable. Add an equivalent lightweight requirement to harness-skill-authoring: when a new MCP tool or skill capability is proposed, its author states what it defines, who provides it, and who consumes it. Catches half-wired capabilities before they ship as accidental single-implementation lock-in. Likely a new section in agents/skills/claude-code/harness-skill-authoring/SKILL.md plus a checklist item surfaced by create_skill.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1397

--- a/docs/roadmap.d/spill-to-disk-with-a-followup-readable-locator-for-large-tool-output.md
+++ b/docs/roadmap.d/spill-to-disk-with-a-followup-readable-locator-for-large-tool-output.md
@@ -1,0 +1,16 @@
+---
+slug: "spill-to-disk-with-a-followup-readable-locator-for-large-tool-output"
+milestone: "Intake"
+order: 48
+---
+
+### Spill-to-disk with a followup-readable locator for large tool output
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** dsh's spill mechanism writes large tool output past a size threshold to disk and returns a locator the model can read/search later instead of truncating inline. Fleet and autopilot sessions that accumulate large test logs, full diffs, or grep/glob overflow today truncate ad hoc with no recovery path. Add an equivalent spill backend to harness's own long-running session/state handling (packages/core session state, or a new small package) so fleet workers and autopilot can offload large intermediate output and reference it by locator instead of losing it or blowing the context budget.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1398

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -506,6 +506,50 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1284
 
+### Generate-and-verify skill/MCP-tool reference docs (regenerate-and-gate, not detect-only)
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Port dsh's gen-tool-catalog/verify-tool-catalog pattern (deepseek-ai/deepseek-harness docs/tool-catalog.md): boot each shipped skill and MCP tool definition against a real context, extract its live name/description/schema, generate a canonical docs/reference/*.md catalog from that, and add a verify mode that regenerates in CI and fails the build on any diff — the same shape as generate-docs / generate-barrel-exports:check today. Upgrades detect-doc-drift from advisory detection to a hard regenerate+gate loop for the skill/tool catalog specifically, closing the gap where a tool's real schema and its documented schema silently diverge. Reference: reference_deepseek_harness_analysis.md (memory).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1401
+
+### Canonical bounded handoff record for fleet workers
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** Define one shared handoff schema — status, summary, evidence, next_steps, blocker — modeled on dsh's Ralph-loop handoff ("the normalized bounded structured report passed from one continuing Ralph round to the next"). Require every fleet family member (bug-fleet, roadmap-fleet, pr-fleet, cicd-fleet, cleanup-fleet, security-fleet, test-fleet, issue-fleet, adr-fleet) to emit it from each worktree-isolated worker instead of each fleet defining its own ad hoc report shape, so fleet-command can parse any fleet's worker output uniformly instead of special-casing each one. Likely lands as a shared type in @harness-engineering/types plus a validation helper.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1396
+
+### Require Service-Definition/Provider/Consumer roles in skill-authoring guidance
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** dsh's capability-seam model requires every extension point to name a Service Definition, at least one Provider, and at least one Consumer — a capability with only one role filled in is flagged as not actually swappable. Add an equivalent lightweight requirement to harness-skill-authoring: when a new MCP tool or skill capability is proposed, its author states what it defines, who provides it, and who consumes it. Catches half-wired capabilities before they ship as accidental single-implementation lock-in. Likely a new section in agents/skills/claude-code/harness-skill-authoring/SKILL.md plus a checklist item surfaced by create_skill.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1397
+
+### Spill-to-disk with a followup-readable locator for large tool output
+
+- **Status:** planned
+- **Spec:** —
+- **Summary:** dsh's spill mechanism writes large tool output past a size threshold to disk and returns a locator the model can read/search later instead of truncating inline. Fleet and autopilot sessions that accumulate large test logs, full diffs, or grep/glob overflow today truncate ad hoc with no recovery path. Add an equivalent spill backend to harness's own long-running session/state handling (packages/core session state, or a new small package) so fleet workers and autopilot can offload large intermediate output and reference it by locator instead of losing it or blowing the context budget.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1398
+
 ## Fleet Family — Batch Orchestration
 
 ### issue-fleet — autonomous intake/triage of the open-issue backlog


### PR DESCRIPTION
## Summary

Registers four roadmap items in Intake for the concrete adoption recommendations from the deepseek-ai/deepseek-harness (dsh, built on Cordis) comparison analysis. This PR only registers the items (spec-less Intake rows for future grooming/planning) — it does not implement any of them. Also folds in two small pending fixes that were sitting in the working tree.

## Changes

- Add roadmap item: Generate-and-verify skill/MCP-tool reference docs (regenerate-and-gate, not detect-only) — port dsh's gen-tool-catalog/verify-tool-catalog pattern to upgrade `detect-doc-drift` from detection-only to a hard CI gate.
- Add roadmap item: Canonical bounded handoff record for fleet workers — a shared status/summary/evidence/next_steps/blocker schema (modeled on dsh's Ralph-loop handoff) so `fleet-command` can parse any fleet's worker output uniformly.
- Add roadmap item: Require Service-Definition/Provider/Consumer roles in skill-authoring guidance — port dsh's capability-seam discipline into `harness-skill-authoring` to catch half-wired capabilities.
- Add roadmap item: Spill-to-disk with a followup-readable locator for large tool output — a context-pressure relief mechanism for long-running fleet/autopilot sessions, modeled on dsh's spill backend.
- Fix: Codex notify hook now emits a PATH-resolvable command (`harness hooks run session-retrospect-codex`) instead of an absolute node path.
- Fix: `.harness/.gitignore` now excludes `metrics/`.

## Testing

- [x] `harness validate` passes (new items produce only the expected RMH002 advisory — planned with no spec/plan, consistent with the ~40 other Intake rows already in that state)
- [x] `harness roadmap regen` — aggregate regenerated cleanly from shards, diff is a pure addition
- [x] Pre-commit `arch`/`traceability` gates pass
- [x] Pre-push gauntlet (typecheck, tests, coverage ratchet, format, doc generation) passes

## Related Issues

Refs #1401, #1396, #1397, #1398