### PR TITLE
docs(roadmap): register 3 Dex Horthy/HumanLayer adoption candidates

### DIFF
--- a/docs/research/dex-horthy-humanlayer-comparison-analysis.md
+++ b/docs/research/dex-horthy-humanlayer-comparison-analysis.md
@@ -1,0 +1,155 @@
+# Dex Horthy / HumanLayer Podcast Comparison Analysis
+
+> Deep comparative analysis of harness-engineering against the practices described by
+> Dex Horthy (HumanLayer, coined "context engineering") in
+> [Context Engineering with Dex Horthy](https://newsletter.pragmaticengineer.com/p/context-engineering-with-dex-horthy)
+> (The Pragmatic Engineer), analyzed 2026-08-17. Grounded in the podcast transcript plus
+> primary-source verification of every checkable external claim (HumanLayer's own blog,
+> the `humanlayer/12-factor-agents` repo, Geoffrey Huntley's Ralph Wiggum writeup,
+> Martin Fowler's harness-engineering article, and HumanLayer's public RPI→CRISPY
+> postmortem) against a direct read of this repo's fleet family, autopilot, and
+> brainstorming skills.
+>
+> Full analysis with citations published as an artifact:
+> <https://claude.ai/code/artifact/65061be7-e338-41c2-9227-92e108a9f67a>.
+>
+> Companion analyses: [aidlc-comparison-analysis.md](./aidlc-comparison-analysis.md),
+> [ecc-comparison-analysis.md](./ecc-comparison-analysis.md).
+
+## What Dex Horthy / HumanLayer's Practice Is
+
+Not a single artifact — a set of practices described on the podcast and cross-checked
+against HumanLayer's public writing, some of which has already evolved past what the
+podcast describes:
+
+- **Context engineering.** The "smart zone" (first ~100-200K tokens, later refined to
+  ~40% utilization) vs. the "dumb zone" (degradation past it — models start deleting
+  `.env` files and trying increasingly desperate fixes). The fix is _frequent
+  intentional compaction_: research → markdown doc → fresh context window, repeated at
+  every stage.
+- **Loop engineering.** Ralph Wiggum (Geoffrey Huntley, May 2025): a bash loop running
+  an agent to a fresh context each iteration, state on disk, backpressure from a
+  deterministic verifier. HumanLayer's daily practice is a "slow loop" — one cron job,
+  one anti-pattern, one small human-reviewed PR every morning. Beyond ~3 concurrent
+  loops, compound load produces failures indistinguishable from real bugs.
+- **RPI → CRISPY.** HumanLayer's original three-stage Research-Plan-Implement framework
+  was **publicly superseded** after this podcast recorded. Their own postmortem: plans
+  became diff-block-detailed (reviewing a plan cost as much as reviewing the code, and
+  implementations still diverged); agents skipped workflow steps ~50% of the time
+  without "magic words"; planning prompts exceeded ~150-200 instructions, past the
+  budget frontier models reliably follow; research handed a raw ticket produced opinion,
+  not fact. The 7-stage replacement ("CRISPY": Context, Research, Iterate, Structure,
+  Plan, sYnthesize, Implement) forces a cheap ~200-line design discussion before the
+  expensive plan, on the finding that it gives "5x better leverage" than reviewing the
+  plan itself.
+- **The dark factory.** July–November 2025: a fully agent-run pipeline, no human reading
+  code. Shut down after a bug took weeks to trace because nobody had ever reviewed the
+  code it lived in. HumanLayer's own conclusion: "token harder" (maximize autonomous
+  volume) is the wrong axis, "token smarter" (find human-review leverage points) is
+  right. Their next product bet, publicly proposed 2026-07-14, is "kill the pull
+  request" — a Google-Docs-style collaborative IDE moving the human checkpoint from the
+  post-hoc diff to the planning stage, for continuous real-time steering instead of
+  batch review.
+
+## Where Harness Is Stronger
+
+1. **Fresh context per stage is architectural, not a discipline to remember.** Autopilot
+   dispatches a distinct cold subagent per state (`harness-planner` →
+   `harness-task-executor` → `harness-verifier` → `harness-code-reviewer`), each reading
+   only the plan/session artifacts it's handed
+   (`agents/skills/claude-code/harness-autopilot/SKILL.md:13-23, 142-146, 175-180`).
+   Horthy's team has to remember to write a doc and restart; here the phase boundary
+   _is_ a new process.
+2. **Compaction is a budgeted tool, not a manual habit.** `mcp__harness__compact` takes
+   an explicit `tokenBudget` and named strategies (structural/truncate/pack/semantic);
+   `gather_context` takes a separate `learningsBudget`; `run_skill` itself progressively
+   discloses skill bodies against a budget (observed directly:
+   `context-budget: loaded at level 1/5 (2/17 sections)`). Horthy's "smart zone" is a
+   percentage he eyeballs; this is a parameter.
+3. **Self-report is never verification, and it's a hard gate, not a lesson.** Every
+   `-fleet` skill's Iron Law states this explicitly
+   (`docs/reference/fleet-family.md:42-45`); `outcome_eval`'s `authority` (blocking vs.
+   advisory) is _computed in TypeScript from the verdict_, never read from or
+   overridable by the LLM (`harness-autopilot/SKILL.md:235-260, 304`). Horthy's team
+   arrived at the same conclusion after real damage; here it's structural.
+4. **No fleet can auto-merge — structurally, not by policy.** `roadmap-fleet` never
+   merges; `pr-fleet` lands only what a human pre-authorized
+   (`roadmap-fleet/SKILL.md:28-32`). This is the exact door Horthy's team walked through
+   by accident and had to consciously close after the fact; here it was never open.
+5. **`harness-brainstorming` already forecloses every specific CRISPY failure mode —
+   independently, and before CRISPY's public existence was known here:** no
+   section-dump specs (named Gate, `brainstorming/SKILL.md:456-464`); one question at a
+   time in plain text, with a specifically-named `emit_interaction`-doesn't-reach-the-human
+   gotcha (`SKILL.md:64-96`); mandatory `file:line` evidence citation or an explicit
+   `[UNVERIFIED]` prefix on every technical claim (`SKILL.md:353-365`) — the exact fix
+   for CRISPY's "research became opinion" failure; honest-tradeoffs-required PRIORITIZE
+   phase before any code exists (`SKILL.md:131-150`).
+6. **The fleet family + `fleet-command`** is Horthy's slow loop scaled to a queue and
+   governed cross-loop: one global concurrency pool (default 3, hard max 4, no fleet
+   holding more than 2), a derived dependency DAG, a four-class contention map
+   (`docs/reference/fleet-family.md:47-49`; `fleet-command/SKILL.md`). Horthy describes
+   single ad hoc cron loops per team with nothing scheduling their aggregate load
+   against each other.
+
+## Where Horthy / HumanLayer Is Stronger
+
+1. **A measured, published failure analysis of their own methodology.** The RPI→CRISPY
+   postmortem names a concrete step-skip rate (~50%) and a concrete instruction-budget
+   ceiling (~150-200) that broke their first attempt. Harness has no equivalent
+   published measurement for whether its own multi-phase skills' gates hold under real
+   sessions versus just being well-specified in the SKILL.md text.
+2. **A genuinely cheap "micro-loop."** Horthy's actual daily-value loop is close to
+   ceremony-free: one linter rule, one tiny PR, nightly cron. Harness's lightest fleet
+   unit (`cleanup-fleet`) still runs the full five-phase
+   SELECT→CONFIRM→DISPATCH→VERIFY→REPORT apparatus with worktree isolation and a
+   provenance file — the right weight for a batch of independent findings, but overkill
+   for "fix one thing, open one tiny PR, every night."
+3. **A lower-latency human checkpoint than a PR.** Every harness checkpoint is still
+   batch/turn-based — approve the spec, approve the plan, review the diff at
+   REVIEW/FINAL_REVIEW. `pre-merge-brief` (`pre-merge-brief/SKILL.md:1-9, 49-54`) is the
+   closest analog to Horthy's accountability pitch but is still PR-triggered, not a live
+   surface where a human watches work happen and interjects mid-stream.
+
+## Adoption Decisions
+
+### Adopt (ranked)
+
+1. **Mid-phase context-budget trip wire.** [HORTHY-1] Fresh-context discipline holds
+   _between_ autopilot's phases (each is a new subagent) but nothing watches a single
+   long-running `harness-task-executor` turn or fleet lane for context creep _within_
+   its own turn. Add a documented utilization threshold (Horthy's own measured ~40% is a
+   reasonable starting point) that triggers an explicit write-state-and-restart instead
+   of leaving it to whatever the model happens to do near its own context ceiling.
+2. **Instruction-density check for SKILL.md authoring.** [HORTHY-2] HumanLayer measured
+   that their own planning prompts blew past a ~150-200 instruction-follow budget — the
+   specific failure that forced RPI→CRISPY. `harness-autopilot` and
+   `harness-brainstorming` SKILL.md bodies run 300-470+ lines each. The
+   progressive-disclosure packing already observed in `run_skill` output is promising
+   evidence this repo doesn't share RPI's failure mode, but nobody has confirmed it with
+   a number the way HumanLayer did after getting burned. Add an instruction-count
+   estimate per loaded packing level to `skill-authoring` guidance and/or
+   `harness validate`.
+3. **Lightweight nightly micro-loop primitive, below the fleet family.** [HORTHY-3] The
+   fleet family is the right tool for a batch of independent findings; it's the wrong
+   tool for "fix one thing, open one tiny PR, every night" — Horthy's actual highest
+   daily-value pattern, and currently homeless here below `cleanup-fleet`'s full
+   five-phase apparatus. `harness-maintenance-pipeline` is the closest existing piece
+   (report-first, opt-in `--fix`) but is human-invoked, not a standing cron. Design a
+   genuinely thin primitive (cron trigger + single deterministic check + single small
+   PR, no worktree/provenance ceremony) that sits underneath `cleanup-fleet` rather than
+   replacing it.
+
+### Don't Adopt
+
+- **A real-time collaborative IDE ("kill the pull request").** A real, current
+  HumanLayer initiative (publicly proposed 2026-07-14), not podcast color — but a UI and
+  sync-engine product bet, out of scope for a skill/methodology layer that installs into
+  someone else's CLI. Same reasoning that already ruled out building sandboxing or an
+  agent runtime in the deepseek-harness comparison. Worth watching HumanLayer's
+  execution; not worth building here.
+
+## Trust Note
+
+`humanlayer/12-factor-agents` shows 25.1k stars on an ordinary organic growth curve
+(star-history.com) — no red flags, unlike the suspicious pattern separately flagged for
+`deepseek-ai/deepseek-harness`. Safe to cite.

--- a/docs/roadmap.d/lightweight-nightly-micro-loop-primitive.md
+++ b/docs/roadmap.d/lightweight-nightly-micro-loop-primitive.md
@@ -1,0 +1,16 @@
+---
+slug: "lightweight-nightly-micro-loop-primitive"
+milestone: "Fleet Family — Batch Orchestration"
+order: 15
+---
+
+### Lightweight Nightly Micro-Loop Primitive
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** The fleet family is the right tool for a batch of independent findings but the wrong tool for Dex Horthy's team's highest daily-value pattern: fix one thing, open one tiny PR, every night via a cron-triggered "slow loop." Harness's lightest fleet unit (cleanup-fleet) still runs the full five-phase SELECT→CONFIRM→DISPATCH→VERIFY→REPORT apparatus with worktree isolation and a provenance file. harness-maintenance-pipeline is the closest existing piece (report-first, opt-in --fix) but is human-invoked, not a standing cron. Design a genuinely thin primitive — cron trigger + single deterministic check + single small PR, no worktree/provenance ceremony — that sits underneath cleanup-fleet rather than replacing it. Adapted from Dex Horthy/HumanLayer's nightly "slow loop" practice. Adoption #3 from docs/research/dex-horthy-humanlayer-comparison-analysis.md [HORTHY-3]
+- **Blockers:** Design decision: standalone loop primitive vs. a lightweight --micro mode on cleanup-fleet / harness-maintenance-pipeline
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1405

--- a/docs/roadmap.d/mid-phase-context-budget-trip-wire.md
+++ b/docs/roadmap.d/mid-phase-context-budget-trip-wire.md
@@ -1,0 +1,16 @@
+---
+slug: "mid-phase-context-budget-trip-wire"
+milestone: "Planning & Process"
+order: 9
+---
+
+### Mid-Phase Context-Budget Trip Wire
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Fresh-context discipline in autopilot holds only between phases (each state dispatches a new cold subagent via subagent_type) — nothing watches a single long-running harness-task-executor turn or fleet lane for context creep within its own turn. Add a documented context-utilization threshold (a reasonable starting point is HumanLayer's own measured ~40%) that triggers an explicit write-state-and-restart action instead of leaving degradation to whatever the model does near its own context ceiling. Adapted from Dex Horthy/HumanLayer's "smart zone"/"dumb zone" context-engineering practice. Adoption #1 from docs/research/dex-horthy-humanlayer-comparison-analysis.md [HORTHY-1]
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1403

--- a/docs/roadmap.d/skill-md-instruction-density-check.md
+++ b/docs/roadmap.d/skill-md-instruction-density-check.md
@@ -1,0 +1,16 @@
+---
+slug: "skill-md-instruction-density-check"
+milestone: "Planning & Process"
+order: 10
+---
+
+### SKILL.md Instruction-Density Check
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** HumanLayer's own RPI→CRISPY postmortem found their planning prompts exceeded a ~150-200 instruction-follow budget frontier models reliably honor — the specific failure that forced a full workflow rebuild. harness-autopilot and harness-brainstorming SKILL.md bodies run 300-470+ lines each; the progressive-disclosure packing already observed in run_skill output (context-budget levels, partial section loading) is promising evidence this repo doesn't share RPI's failure mode, but it has never been confirmed with a measured instruction count the way HumanLayer did after getting burned. Add an instruction-density estimate per loaded packing level to skill-authoring guidance and/or harness validate. Adapted from HumanLayer's RPI→CRISPY postmortem. Adoption #2 from docs/research/dex-horthy-humanlayer-comparison-analysis.md [HORTHY-2]
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1404

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -673,6 +673,17 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#1226
 
+### Lightweight Nightly Micro-Loop Primitive
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** The fleet family is the right tool for a batch of independent findings but the wrong tool for Dex Horthy's team's highest daily-value pattern: fix one thing, open one tiny PR, every night via a cron-triggered "slow loop." Harness's lightest fleet unit (cleanup-fleet) still runs the full five-phase SELECT→CONFIRM→DISPATCH→VERIFY→REPORT apparatus with worktree isolation and a provenance file. harness-maintenance-pipeline is the closest existing piece (report-first, opt-in --fix) but is human-invoked, not a standing cron. Design a genuinely thin primitive — cron trigger + single deterministic check + single small PR, no worktree/provenance ceremony — that sits underneath cleanup-fleet rather than replacing it. Adapted from Dex Horthy/HumanLayer's nightly "slow loop" practice. Adoption #3 from docs/research/dex-horthy-humanlayer-comparison-analysis.md [HORTHY-3]
+- **Blockers:** Design decision: standalone loop primitive vs. a lightweight --micro mode on cleanup-fleet / harness-maintenance-pipeline
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1405
+
 ## v5.0 — Enforcement Hardening
 
 ### Audit and cap the pre-commit --skip list
@@ -1504,6 +1515,28 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Assignee:** —
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#605
+
+### Mid-Phase Context-Budget Trip Wire
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** Fresh-context discipline in autopilot holds only between phases (each state dispatches a new cold subagent via subagent_type) — nothing watches a single long-running harness-task-executor turn or fleet lane for context creep within its own turn. Add a documented context-utilization threshold (a reasonable starting point is HumanLayer's own measured ~40%) that triggers an explicit write-state-and-restart action instead of leaving degradation to whatever the model does near its own context ceiling. Adapted from Dex Horthy/HumanLayer's "smart zone"/"dumb zone" context-engineering practice. Adoption #1 from docs/research/dex-horthy-humanlayer-comparison-analysis.md [HORTHY-1]
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1403
+
+### SKILL.md Instruction-Density Check
+
+- **Status:** backlog
+- **Spec:** —
+- **Summary:** HumanLayer's own RPI→CRISPY postmortem found their planning prompts exceeded a ~150-200 instruction-follow budget frontier models reliably honor — the specific failure that forced a full workflow rebuild. harness-autopilot and harness-brainstorming SKILL.md bodies run 300-470+ lines each; the progressive-disclosure packing already observed in run_skill output (context-budget levels, partial section loading) is promising evidence this repo doesn't share RPI's failure mode, but it has never been confirmed with a measured instruction count the way HumanLayer did after getting burned. Add an instruction-density estimate per loaded packing level to skill-authoring guidance and/or harness validate. Adapted from HumanLayer's RPI→CRISPY postmortem. Adoption #2 from docs/research/dex-horthy-humanlayer-comparison-analysis.md [HORTHY-2]
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1404
 
 ## Dashboard & Visualization
 


### PR DESCRIPTION
## Summary
- Adds a comparative analysis of harness-engineering against the practices Dex Horthy (HumanLayer) describes on [The Pragmatic Engineer podcast](https://newsletter.pragmaticengineer.com/p/context-engineering-with-dex-horthy) — context engineering, loop engineering, RPI→CRISPY, and the dark-factory shutdown — grounded against a direct read of this repo's fleet family, autopilot, and brainstorming skills plus primary-source verification of the external claims.
- Registers the three concrete gaps the analysis surfaced as backlog roadmap items, detailed enough to pick up later without re-deriving context:
  - **Mid-Phase Context-Budget Trip Wire** — autopilot's fresh-context guarantee holds between phases (each state is a new cold subagent) but nothing watches a single long-running task-executor or fleet-lane turn for context creep within its own turn.
  - **SKILL.md Instruction-Density Check** — HumanLayer measured their own planning prompts blew past a ~150-200 instruction-follow budget, the specific failure that forced their RPI→CRISPY rebuild; this repo's own SKILL.md bodies run 300-470+ lines with no equivalent measured check.
  - **Lightweight Nightly Micro-Loop Primitive** — the fleet family is the right weight for a batch of findings but overkill for Horthy's actual highest-value pattern (fix one thing, open one tiny PR, nightly cron); nothing that cheap exists below `cleanup-fleet` today.
- Where harness already exceeds what's described (fresh-context-per-stage as architecture not discipline, budgeted compaction tools, TS-derived non-LLM verification authority, structural never-auto-merge, and independently pre-empting every specific RPI→CRISPY failure mode) is documented but intentionally not turned into roadmap items — it's already shipped.
- Full artifact with file:line citations: https://claude.ai/code/artifact/65061be7-e338-41c2-9227-92e108a9f67a

## Test plan
- [x] `harness roadmap regen` — aggregate regenerated cleanly from `docs/roadmap.d/` shards, 33 lines added, no stray content from unrelated branches
- [x] `harness validate --json` — `roadmapHealth` failure count (38 RMH001 / 33 RMH002 / 11 RMH005) matches the pre-existing baseline on `main`; none of the 3 new rows appear among the violations
- [x] Pre-push gate (typecheck, build, tests, coverage ratchet, doc generation, changesets) — all green