### PR TITLE
chore(roadmap): reconcile #711 to done (shipped via #1375)

### DIFF
--- a/docs/roadmap.d/role-shaped-dashboard-front-doors-non-technical-lanes.md
+++ b/docs/roadmap.d/role-shaped-dashboard-front-doors-non-technical-lanes.md
@@ -6,7 +6,7 @@ order: 2
 
 ### Role-shaped dashboard front doors (non-technical lanes)
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/role-shaped-dashboard-front-doors/proposal.md
 - **Summary:** **Priority: NEXT.** PM/BA and client lanes through the existing dashboard + router + chat: author intent, watch agents, adjudicate at decision points — no terminal. The surfaces exist; they need role-scoped paths. Lever for non-technical access per the Full-lifecycle reach track. --- _Part of the **Full-lifecycle reach** track (STRATEGY.md v2). Rationale: `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md`._
 - **Blockers:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1281,7 +1281,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Role-shaped dashboard front doors (non-technical lanes)
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** docs/changes/role-shaped-dashboard-front-doors/proposal.md
 - **Summary:** **Priority: NEXT.** PM/BA and client lanes through the existing dashboard + router + chat: author intent, watch agents, adjudicate at decision points — no terminal. The surfaces exist; they need role-scoped paths. Lever for non-technical access per the Full-lifecycle reach track. --- _Part of the **Full-lifecycle reach** track (STRATEGY.md v2). Rationale: `docs/knowledge/skills/sdlc-coverage-and-agentic-trajectory.md`._
 - **Blockers:** —


### PR DESCRIPTION
## Drift

Roadmap item **#711 — Role-shaped dashboard front doors (PM/BA author-intent lane)** shipped to `main` via **PR #1375** (merge `9a58e5fad`, 2026-08-16), but its shard stayed `planned`.

PR #1375 carried the full implementation under #711 despite its `[DRAFT SPEC]` title:
- `packages/dashboard/src/client/components/roadmap/AuthorIntentForm.tsx` (+ its test)
- `toastStore` success channel
- pm-ba/dev roadmap-lane mount (`Roadmap.tsx` wiring)

Because the ship commits used the `[DRAFT SPEC]` PR title, `roadmap-auto-done` never fired, so the shard `docs/roadmap.d/role-shaped-dashboard-front-doors-non-technical-lanes.md` kept `- **Status:** planned`.

## Change

- Flip the shard `planned` -> `done`.
- Regenerate the aggregate (`docs/roadmap.md`) — the only two files touched.

`External-ID` stays the tracking issue (`github:...#711`) per the done-shard convention; the resolving PR (#1375) is cited in the commit + this body. Matches the prior `chore(roadmap): reconcile shipped-but-stale rows to done` pattern (e.g. #1377).

## Verification (not self-report)

- `git ls-tree -r origin/main` shows `AuthorIntentForm.tsx` + test present on `main`.
- `git log origin/main` shows merge `9a58e5fad` (PR #1375) + `feat(dashboard)` commits under #711.

Closes #711.