### PR TITLE
fix(core): count test-file imports in dead-export detector (fixes 266 false positives)

### DIFF
--- a/.changeset/dead-export-detector-test-blind.md
+++ b/.changeset/dead-export-detector-test-blind.md
@@ -1,0 +1,17 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(core): count test-file imports in the dead-export detector
+
+The dead-export detector was test-import-blind: test files (`*.test.ts`,
+`*.spec.ts`) are excluded from the classification snapshot, so an export
+imported only by its test had zero importers and was wrongly flagged dead. A
+single run reported 266 false positives (220 in `packages/cli/src/commands`,
+e.g. `runVerify` imported by `verify.test.ts`), and `cleanup --fix` would have
+deleted live code.
+
+`buildSnapshot` now harvests test-file import edges into a new additive
+`snapshot.testImports` field (path + imports only — test files are still never
+classified as dead), and the detector treats an export imported by any test as
+live. Genuine dead exports are unaffected.

--- a/packages/core/src/entropy/detectors/dead-code.ts
+++ b/packages/core/src/entropy/detectors/dead-code.ts
@@ -199,49 +199,92 @@ export function buildReachabilityMap(snapshot: CodebaseSnapshot): Map<string, bo
   return reachability;
 }
 
+/** Usage record for one export: its source importers, whether it is re-exported, and whether any test imports it. */
+type ExportUsage = { importers: string[]; isReExported: boolean; importedByTest: boolean };
+
+type ImportEdge = { source: string; specifiers: string[] };
+
+/**
+ * Mark an export live: a test importer flips `importedByTest`, a real source
+ * importer is appended to `importers`.
+ */
+function markExportUsage(usage: ExportUsage, importer: string, fromTest: boolean): void {
+  if (fromTest) {
+    usage.importedByTest = true;
+  } else {
+    usage.importers.push(importer);
+  }
+}
+
+/** Record one import edge against the usage map (resolving specifiers to exports). */
+function recordImportEdge(
+  snapshot: CodebaseSnapshot,
+  fileIndex: Map<string, CodebaseSnapshot['files'][number]>,
+  usageMap: Map<string, ExportUsage>,
+  fromFile: string,
+  imp: ImportEdge,
+  fromTest: boolean
+): void {
+  const resolvedFile = resolveImportToFile(imp.source, fromFile, snapshot, fileIndex);
+  if (!resolvedFile) return;
+
+  const sourceFile = fileIndex.get(resolvedFile);
+  if (!sourceFile) return;
+
+  for (const specifier of imp.specifiers) {
+    const matchingExport = sourceFile.exports.find(
+      (e) => e.name === specifier || (specifier === 'default' && e.type === 'default')
+    );
+    if (!matchingExport) continue;
+
+    const usage = usageMap.get(`${resolvedFile}:${matchingExport.name}`);
+    if (usage) markExportUsage(usage, fromFile, fromTest);
+  }
+}
+
+/**
+ * Record every import edge of a file. `fromTest` marks edges harvested from
+ * test files: a test importer keeps its target export alive but is never itself
+ * a classified source file.
+ */
+function recordImports(
+  snapshot: CodebaseSnapshot,
+  fileIndex: Map<string, CodebaseSnapshot['files'][number]>,
+  usageMap: Map<string, ExportUsage>,
+  fromFile: string,
+  imports: ImportEdge[],
+  fromTest: boolean
+): void {
+  for (const imp of imports) {
+    recordImportEdge(snapshot, fileIndex, usageMap, fromFile, imp, fromTest);
+  }
+}
+
 /**
  * Build a map of export usage across the codebase.
  * Maps each export to the list of files that import it.
  */
-function buildExportUsageMap(
-  snapshot: CodebaseSnapshot
-): Map<string, { importers: string[]; isReExported: boolean }> {
+function buildExportUsageMap(snapshot: CodebaseSnapshot): Map<string, ExportUsage> {
   const fileIndex = buildFileIndex(snapshot);
-  const usageMap = new Map<string, { importers: string[]; isReExported: boolean }>();
+  const usageMap = new Map<string, ExportUsage>();
 
   // Initialize all exports with empty usage
   for (const file of snapshot.files) {
     for (const exp of file.exports) {
       const key = `${file.path}:${exp.name}`;
-      usageMap.set(key, { importers: [], isReExported: exp.isReExport });
+      usageMap.set(key, { importers: [], isReExported: exp.isReExport, importedByTest: false });
     }
   }
 
-  // Track which exports are imported
+  // Track which exports are imported by real source files
   for (const file of snapshot.files) {
-    for (const imp of file.imports) {
-      const resolvedFile = resolveImportToFile(imp.source, file.path, snapshot, fileIndex);
-      if (!resolvedFile) continue;
+    recordImports(snapshot, fileIndex, usageMap, file.path, file.imports, false);
+  }
 
-      // Find the source file to match imports with exports
-      const sourceFile = fileIndex.get(resolvedFile);
-      if (!sourceFile) continue;
-
-      for (const specifier of imp.specifiers) {
-        // Match import specifier to export
-        const matchingExport = sourceFile.exports.find(
-          (e) => e.name === specifier || (specifier === 'default' && e.type === 'default')
-        );
-
-        if (matchingExport) {
-          const key = `${resolvedFile}:${matchingExport.name}`;
-          const usage = usageMap.get(key);
-          if (usage) {
-            usage.importers.push(file.path);
-          }
-        }
-      }
-    }
+  // Track which exports are imported by test files (test-import-blind fix): an
+  // export used only by its test is live, not dead.
+  for (const testFile of snapshot.testImports ?? []) {
+    recordImports(snapshot, fileIndex, usageMap, testFile.path, testFile.imports, true);
   }
 
   return usageMap;
@@ -252,7 +295,7 @@ function buildExportUsageMap(
  */
 function findDeadExports(
   snapshot: CodebaseSnapshot,
-  usageMap: Map<string, { importers: string[]; isReExported: boolean }>,
+  usageMap: Map<string, ExportUsage>,
   reachability: Map<string, boolean>
 ): DeadExport[] {
   const deadExports: DeadExport[] = [];
@@ -267,6 +310,11 @@ function findDeadExports(
 
       const key = `${file.path}:${exp.name}`;
       const usage = usageMap.get(key);
+
+      // An export imported by any test file is live, not dead. Test files are
+      // not classified source files, so a test-only importer keeps the export
+      // alive without ever appearing in `importers` / reachability.
+      if (usage?.importedByTest) continue;
 
       if (!usage || usage.importers.length === 0) {
         // This export has no importers

--- a/packages/core/src/entropy/snapshot.ts
+++ b/packages/core/src/entropy/snapshot.ts
@@ -12,6 +12,7 @@ import type {
   ExportMap,
   CodeReference,
   CodebaseSnapshot,
+  TestImportSource,
 } from './types';
 import type { AST, Export, LanguageParser } from '../shared/parsers';
 import { getDefaultRegistry } from '../shared/parsers';
@@ -37,6 +38,13 @@ const DEFAULT_INCLUDE_PATTERNS = [
   '**/*.rs',
   '**/*.java',
 ];
+
+/**
+ * Test-file matcher (`foo.test.ts`, `foo.spec.tsx`, …). Test files are kept out
+ * of `snapshot.files` but their import edges are harvested into
+ * `snapshot.testImports` so an export imported only by its test stays live.
+ */
+const TEST_FILE_RE = /\.(test|spec)\.(m|c)?[jt]sx?$/;
 
 /**
  * Extract code blocks from markdown content
@@ -334,16 +342,33 @@ export async function buildSnapshot(
   const includePatterns = config.include || DEFAULT_INCLUDE_PATTERNS;
   const excludePatterns = config.exclude || [...skipDirGlobs(), '**/*.test.ts', '**/*.spec.ts'];
 
-  let sourceFilePaths: string[] = [];
+  const allMatchedPaths: string[] = [];
   for (const pattern of includePatterns) {
     const files = await findFiles(pattern, rootDir);
-    sourceFilePaths.push(...files);
+    allMatchedPaths.push(...files);
   }
 
   // Filter out excluded
-  sourceFilePaths = sourceFilePaths.filter((f) => {
+  const sourceFilePaths = allMatchedPaths.filter((f) => {
     const rel = relativePosix(rootDir, f);
     return !excludePatterns.some((p) => minimatch(rel, p));
+  });
+
+  // Harvest import edges from test files. Test files are intentionally left out
+  // of `sourceFilePaths` (so no detector classifies test code), but an export
+  // imported only by its test is still live — without these edges the
+  // dead-export detector produced hundreds of false positives. Re-include a
+  // path as a test-import source when it is a test file excluded *only* by a
+  // test-file glob (all other excludes — node_modules, dist, … — still apply),
+  // and it is not already a classified source file.
+  const sourceFileSet = new Set(sourceFilePaths);
+  const nonTestExcludes = excludePatterns.filter(
+    (p) => !p.includes('.test.') && !p.includes('.spec.')
+  );
+  const testFilePaths = [...new Set(allMatchedPaths)].filter((f) => {
+    if (sourceFileSet.has(f)) return false;
+    const rel = relativePosix(rootDir, f);
+    return TEST_FILE_RE.test(rel) && !nonTestExcludes.some((p) => minimatch(rel, p));
   });
 
   // Parse source files
@@ -368,6 +393,22 @@ export async function buildSnapshot(
       internalSymbols,
       jsDocComments,
     });
+  }
+
+  // Parse test files for their import edges only (no exports/symbols — test
+  // files are never classified, they only keep their import targets alive).
+  const testImports: TestImportSource[] = [];
+  for (const filePath of testFilePaths) {
+    const fileParser = parserForFile(filePath);
+    if (!fileParser) continue;
+
+    const parseResult = await fileParser.parseFile(filePath);
+    if (!parseResult.ok) continue;
+
+    const importsResult = fileParser.extractImports(parseResult.value);
+    if (!importsResult.ok || importsResult.value.length === 0) continue;
+
+    testImports.push({ path: filePath, imports: importsResult.value });
   }
 
   // Build dependency graph — pass the registry directly so it can dispatch per file
@@ -399,6 +440,7 @@ export async function buildSnapshot(
 
   return Ok({
     files,
+    testImports,
     dependencyGraph,
     exportMap,
     docs,

--- a/packages/core/src/entropy/types/snapshot.ts
+++ b/packages/core/src/entropy/types/snapshot.ts
@@ -60,8 +60,26 @@ export interface ExportMap {
   byName: Map<string, { file: string; export: Export }[]>;
 }
 
+/**
+ * Import edges harvested from test files (`*.test.ts`, `*.spec.ts`).
+ *
+ * Test files are deliberately excluded from `files` so the classification
+ * detectors (dead-file, pattern, complexity, coupling) never flag test code.
+ * But an export imported *only* by its test is still live — omitting test
+ * imports from the usage graph produced hundreds of dead-export false
+ * positives (the dead-export detector was test-import-blind). The dead-export
+ * detector consults these edges (path + imports only, no exports) so a test
+ * importer marks its target live without ever classifying the test file itself.
+ */
+export interface TestImportSource {
+  path: string;
+  imports: Import[];
+}
+
 export interface CodebaseSnapshot {
   files: SourceFile[];
+  /** Import edges from test files, consumed only by the dead-export detector. */
+  testImports?: TestImportSource[];
   dependencyGraph: DependencyGraph;
   exportMap: ExportMap;
   docs: DocumentationFile[];

--- a/packages/core/tests/entropy/detectors/dead-code.test.ts
+++ b/packages/core/tests/entropy/detectors/dead-code.test.ts
@@ -142,6 +142,48 @@ describe('detectDeadCode', () => {
   });
 });
 
+// Regression: the dead-export detector was test-import-blind. Test files are
+// excluded from `snapshot.files`, so an export imported ONLY by its test had no
+// importers and was wrongly flagged dead (266 false positives in one run; a
+// `--fix` would have deleted live code). buildSnapshot now harvests test-file
+// import edges into `snapshot.testImports`, and the detector treats a
+// test-imported export as live.
+describe('detectDeadCode is not test-import-blind', () => {
+  const parser = new TypeScriptParser();
+  const fixturesDir = join(__dirname, '../../fixtures/entropy/dead-code-test-imports');
+
+  it('does not flag an export imported only by a test file as dead', async () => {
+    const snapshotResult = await buildSnapshot({
+      rootDir: fixturesDir,
+      parser,
+      analyze: { deadCode: true },
+      include: ['src/**/*.ts'],
+      entryPoints: ['src/index.ts'],
+    });
+
+    expect(snapshotResult.ok).toBe(true);
+    if (!snapshotResult.ok) return;
+
+    // The `.spec.ts` importer is excluded from classified files but harvested
+    // as a test-import source.
+    expect(snapshotResult.value.files.some((f) => f.path.includes('commands.spec.ts'))).toBe(false);
+    expect(snapshotResult.value.testImports?.some((t) => t.path.includes('commands.spec.ts'))).toBe(
+      true
+    );
+
+    const result = await detectDeadCode(snapshotResult.value);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const deadNames = result.value.deadExports.map((e) => e.name);
+    // runVerify is imported only by commands.spec.ts -> LIVE, not dead.
+    expect(deadNames).not.toContain('runVerify');
+    // Control: deadCommand has no importer at all -> still classified dead,
+    // proving the fix did not blanket-suppress real dead exports.
+    expect(deadNames).toContain('deadCommand');
+  });
+});
+
 describe('detectDeadCode with protectedRegions', () => {
   it('should skip dead exports on protected lines', async () => {
     const snapshot = {

--- a/packages/core/tests/fixtures/entropy/dead-code-test-imports/package.json
+++ b/packages/core/tests/fixtures/entropy/dead-code-test-imports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dead-code-test-imports",
+  "version": "1.0.0",
+  "main": "src/index.ts"
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-test-imports/src/commands.spec.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-test-imports/src/commands.spec.ts
@@ -1,0 +1,11 @@
+import { runVerify } from './commands';
+
+// This spec is the ONLY importer of runVerify. It exists purely so the
+// dead-export detector has a test-file import edge to harvest. It is named
+// `.spec.ts` (not `.test.ts`) so the core vitest suite does not collect it as a
+// real test, while the detector's test-file matcher still recognizes it.
+describe('runVerify', () => {
+  it('runs', () => {
+    expect(runVerify()).toBe('verify');
+  });
+});

--- a/packages/core/tests/fixtures/entropy/dead-code-test-imports/src/commands.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-test-imports/src/commands.ts
@@ -1,0 +1,12 @@
+// `runVerify` is imported ONLY by its co-located test (commands.test.ts).
+// A test-import-blind dead-export detector wrongly flags it as dead, which is
+// how live code (e.g. runVerify imported by verify.test.ts) got deleted.
+export function runVerify() {
+  return 'verify';
+}
+
+// Genuinely dead: no source file and no test imports this. Kept as a control so
+// the regression test proves the fix preserves classification of real dead code.
+export function deadCommand() {
+  return 'dead';
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-test-imports/src/index.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-test-imports/src/index.ts
@@ -1,0 +1,3 @@
+// Entry point. Deliberately does NOT import commands.ts, so runVerify's only
+// importer is its co-located spec and deadCommand has no importer at all.
+export const appName = 'dead-code-test-imports';


### PR DESCRIPTION
## Problem
The dead-export detector (`cleanup` / `harness cleanup --type dead-code` / entropy pipeline) was **test-import-blind**: `buildSnapshot` excludes `**/*.test.ts` / `**/*.spec.ts` from the classification snapshot, so test-file imports never populated the export usage map. An export imported *only* by its test had zero importers and was wrongly flagged `NO_IMPORTERS` dead — a `--fix` would have deleted live code. One cleanup-fleet run reported **266 false positives** (220 in `packages/cli/src/commands`, e.g. `runVerify` imported by `verify.test.ts`; 46 in `packages/core/src/roadmap`).

Fixes #1408.

## Fix
- `buildSnapshot` now harvests test-file import edges into a new **additive** `snapshot.testImports` field (`path` + `imports` only). Test files are still **never** added to `snapshot.files`, so no detector (dead-file, pattern, complexity, coupling, drift) classifies test code — the change is scoped to the dead-export usage graph.
- The dead-export detector consults `testImports` in `buildExportUsageMap` and treats an export imported by any test as **live** (`importedByTest`). No other classification semantics change.

## Regression test
`packages/core/tests/entropy/detectors/dead-code.test.ts` → *"detectDeadCode is not test-import-blind"*: a fixture export imported only by a co-located `.spec.ts` is **not** flagged dead, while a genuinely-unimported control export (`deadCommand`) still is — proving the fix does not blanket-suppress real dead exports.

## Verification (Node 22)
- Full entropy suite green (174 tests); detector suite 17/17.
- Faithful before/after on `packages/cli/src/commands`: **220 → 179** dead exports — **41** test-only false positives eliminated (including `runVerify` from `verify.ts`); genuine dead exports unaffected. Across all of `packages/cli/src`: 52 FP eliminated.
- Typecheck + arch/complexity gate + coverage ratchet + reference-docs freshness all pass.
