### PR TITLE
chore(roadmap): mark api-craft (#382) done — shipped via #1121

### DIFF
--- a/docs/roadmap.d/craft-pipeline-sub-project-7-api-craft.md
+++ b/docs/roadmap.d/craft-pipeline-sub-project-7-api-craft.md
@@ -6,7 +6,7 @@ order: 3
 
 ### craft-pipeline sub-project #7: api-craft
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** LLM-judgment skill for API quality — the ceiling counterpart to harness-api-openapi-design and harness-api-webhook-design (knowledge skills, rule-based about format / OpenAPI compliance). Ceiling questions: is this endpoint at the right abstraction? is this HTTP verb honest? does the resource name belong in the URL or should it be a query param? would a stranger predict this response shape from the request? does this error code tell the consumer what to do? is this idempotency-honest? does the API shape match the domain or leak implementation details? Follows ADRs 0018-0021. Exemplars: Stripe API, Linear GraphQL API, GitHub REST v3, Resend API, Anthropic SDK.
 - **Blockers:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1371,7 +1371,7 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### craft-pipeline sub-project #7: api-craft
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
 - **Summary:** LLM-judgment skill for API quality — the ceiling counterpart to harness-api-openapi-design and harness-api-webhook-design (knowledge skills, rule-based about format / OpenAPI compliance). Ceiling questions: is this endpoint at the right abstraction? is this HTTP verb honest? does the resource name belong in the URL or should it be a query param? would a stranger predict this response shape from the request? does this error code tell the consumer what to do? is this idempotency-honest? does the API shape match the domain or leak implementation details? Follows ADRs 0018-0021. Exemplars: Stripe API, Linear GraphQL API, GitHub REST v3, Resend API, Anthropic SDK.
 - **Blockers:** —


### PR DESCRIPTION
## Roadmap reconciliation (roadmap-fleet SELECT cross-check)

The `craft-pipeline sub-project #7: api-craft` row was stale: `planned` in the roadmap but already shipped.

**Evidence it shipped:**
- `api-craft` skill: `agents/skills/claude-code/api-craft/`
- MCP tool: `packages/cli/src/mcp/tools/api-craft.ts`
- Landed via #1121 (`feat(craft-pipeline): api-craft — LLM-judgment ceiling skill for API quality`), with in-session no-op fix #1139.

**Change:** flips the shard + aggregate row `planned` → `done`. Docs-only; no code.

Issue #382 has been closed with a citation comment. Per #1327, a human-closed issue can be reopened by roadmap-sync while its row stays `planned`; this row flip prevents that reopen.

Closes #382