### PR TITLE
feat(context): context-surface attribution report with exact token counts (#1274)

### DIFF
--- a/.changeset/context-surface-attribution-report.md
+++ b/.changeset/context-surface-attribution-report.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+---
+
+feat(context): add context-surface attribution report with exact token counts. Classifies the always-loaded context surface as always-loaded / path-scoped / invoked-only, ranks the top contributors, and derives over-budget flags from the (now live-wired) `contextBudget()` allocator. New core exports: `buildAttributionReport`, `heuristicTokenCounter`, `createAnthropicTokenCounter`, `resolveTokenCounter`, plus the `ContextClass` / `ContextSurfaceEntry` / `AttributionReport` types. Exact token counts come from Anthropic's `/v1/messages/count_tokens` endpoint, degrading gracefully to the `chars / 4` heuristic when no API key / offline / on request failure (never hard-fails). New CLI command `harness mcp context-report [--tier core|standard|full] [--exact] [--window <n>] [--top <n>] [--no-skills] [--json]` measures the harness's real surface (MCP tool schemas per tier, AGENTS.md, hooks, the four platform skill trees). Wires the previously-dead `contextBudget()` allocator into a live, tested code path.

--- a/docs/changes/context-surface-attribution-report/plans/plan.md
+++ b/docs/changes/context-surface-attribution-report/plans/plan.md
@@ -1,0 +1,82 @@
+# Plan — Context-surface attribution report with exact token counts
+
+Issue: Intense-Visions/harness-engineering#1274
+Slug: `context-surface-attribution-report`
+
+## Goal
+
+Report what the harness's always-loaded context surface actually costs per turn:
+classify every contributor as **always-loaded / path-scoped / invoked-only**, rank
+the top contributors, and flag over-budget classes using the (currently dead)
+`contextBudget()` allocator. Replace the `chars / 4` heuristic in `estimateTokens()`
+with exact counts from Anthropic's `/v1/messages/count_tokens` endpoint, degrading
+gracefully to the heuristic when there is no API key / the call fails / offline.
+
+## Design
+
+Pure logic lives in `@harness-engineering/core` (testable, no fs/network in the
+report core); the CLI is a thin gather + render wrapper that feeds the REAL harness
+surface in.
+
+### 1. `packages/core/src/context/attribution.ts` (new, pure)
+
+- `ContextClass = 'always-loaded' | 'path-scoped' | 'invoked-only'` — the three-way taxonomy.
+- `ContextSurfaceEntry = { id; label; contextClass; text }` — one measurable surface item.
+- `TokenCounter = (text: string) => number | Promise<number>` — pluggable counter (may throw).
+- `heuristicTokenCounter` — wraps the existing `estimateTokens()` (`chars / 4`); the documented fallback.
+- `buildAttributionReport(entries, options)`:
+  - counts tokens per entry via the injected counter; on a per-entry throw it falls
+    back to `estimateTokens()` and marks the report `degraded` + `counterMode: 'mixed' | 'heuristic'`.
+  - aggregates tokens by class, ranks top contributors.
+  - **calls `contextBudget(windowTokens, overrides)`** to allocate the window, maps each
+    class to a budget category (always-loaded→systemPrompt, path-scoped→projectManifest,
+    invoked-only→interfaces — documented), and derives per-class `overBudget` flags.
+    This is the live consumer that makes `contextBudget()` a non-test caller (Fork B).
+
+### 2. `packages/core/src/context/count-tokens.ts` (new)
+
+- `createAnthropicTokenCounter({ apiKey?, model?, fetchImpl?, baseUrl? })` → `TokenCounter | null`.
+  - returns `null` when no API key is resolvable (caller uses the heuristic — no hard fail).
+  - otherwise POSTs to `/v1/messages/count_tokens` (default model `claude-opus-4-8`),
+    returns `input_tokens`. On non-200 / network error it throws so the report's
+    per-entry fallback records degradation (never hard-fails the report).
+- `resolveTokenCounter(options)` → `{ counter, mode }` convenience resolver.
+
+### 3. Barrel
+
+Re-export both modules from `packages/core/src/context/index.ts`. `context` is a
+`export *` auto-discovered dir in `scripts/generate-core-barrel.mjs`, so no allowlist
+edit is needed; verified with `pnpm run generate:barrels --check`.
+
+### 4. `packages/cli/src/mcp/context-surface.ts` (new) + `harness mcp context-report`
+
+- Enumerates the REAL surface: MCP tool schemas via `getToolDefinitions()`
+  (per tier via `selectTier` / tool-tiers allow-lists — the dominant contributor),
+  `AGENTS.md`, `.claude/settings.json` hooks, and the four platform skill trees.
+  - MCP tool schemas + AGENTS.md + hooks → always-loaded.
+  - skill trees (Claude Code defers bodies) → invoked-only.
+- Renders a ranked report (human + `--json`) via `buildAttributionReport`, using the
+  Anthropic counter when a key is present and the heuristic otherwise.
+- Wired as a `mcp` subcommand alongside `list-capabilities`.
+
+### 5. Tests
+
+- `packages/core/tests/context/attribution.test.ts` — classification aggregation,
+  ranking, the exact→heuristic fallback path, and that `contextBudget()` drives the
+  over-budget flags (spy/derivation).
+- `packages/core/tests/context/count-tokens.test.ts` — null on no key, exact count via
+  injected fetch, throw-on-error feeding the report fallback.
+- `packages/cli/tests/mcp/context-surface.test.ts` — gathers real tool definitions and
+  produces a per-tier report.
+
+## Scope honesty
+
+`tool-tiers.ts` already trims exposed tool count and Claude Code defers tool schemas,
+so the report measures **per-tier** and the remaining win is smaller than the source
+framing implies — surfaced explicitly in the report output and this plan.
+
+## Stages run
+
+brainstorming (surface/architecture research) → planning (this artifact) →
+execution (core + cli + tests) → verification (build, typecheck, unit tests) →
+integration (barrel freshness, docs). No material unforeseen fork; Fork B pre-answered.

--- a/docs/changes/context-surface-attribution-report/provenance.json
+++ b/docs/changes/context-surface-attribution-report/provenance.json
@@ -1,0 +1,28 @@
+{
+  "issue": 1274,
+  "slug": "context-surface-attribution-report",
+  "title": "Context-surface attribution report with exact token counts",
+  "branch": "build/context-attribution-1274",
+  "stagesRun": ["brainstorming", "planning", "execution", "verification", "integration"],
+  "planArtifact": "docs/changes/context-surface-attribution-report/plans/plan.md",
+  "mechanisms": {
+    "threeWayClassification": "packages/core/src/context/attribution.ts — ContextClass = always-loaded | path-scoped | invoked-only",
+    "exactTokenCounts": "packages/core/src/context/count-tokens.ts — /v1/messages/count_tokens with graceful fallback to estimateTokens()",
+    "overBudgetFlags": "derived from contextBudget() allocation per class in buildAttributionReport()"
+  },
+  "forkB": {
+    "decision": "WIRE the previously-dead contextBudget() allocator LIVE (not deprecate).",
+    "liveCaller": "packages/core/src/context/attribution.ts:buildAttributionReport() calls contextBudget(windowTokens, overrides, graphDensity) to allocate the window and derive per-class over-budget flags.",
+    "consumedBy": "packages/cli/src/commands/mcp.ts context-report subcommand → buildAttributionReport",
+    "proof": "grep 'contextBudget(' packages/core/src/context/attribution.ts shows a non-test caller; sibling computeLoadPlan() pattern followed (packages/cli/src/mcp/tools/skill.ts:79)."
+  },
+  "assumptions": [
+    "Class→budget-category mapping is documented and fixed: always-loaded→systemPrompt, path-scoped→projectManifest, invoked-only→interfaces (CLASS_TO_BUDGET_CATEGORY).",
+    "Report core lives in @harness-engineering/core (pure, network-free, testable); the CLI `harness mcp context-report` is a thin gather+render wrapper feeding the REAL surface (MCP tool schemas per tier, AGENTS.md, hooks, four platform skill trees).",
+    "Skill trees are classified invoked-only because Claude Code defers skill bodies; MCP tool schemas + AGENTS.md + hooks are always-loaded.",
+    "Exact counting defaults to the claude-opus-4-8 tokenizer; no ANTHROPIC_API_KEY / offline / non-200 degrades gracefully to the chars/4 heuristic (report marked heuristic|mixed, per-entry degraded flag) and never hard-fails.",
+    "Scope honesty: tool-tiers.ts already trims exposed tools and Claude Code defers schemas, so the report measures per-tier and the remaining win is smaller than the source framing implies.",
+    "context/ is an `export *` auto-discovered dir in scripts/generate-core-barrel.mjs, so new exports flow via context/index.ts with no allowlist edit; verified with generate:barrels --check.",
+    "Default budget window is 200,000 tokens (overridable via --window)."
+  ]
+}

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1210,6 +1210,19 @@ Show last N persisted runs for a task (from .harness/maintenance/[id]/outputs/)
 
 Start the MCP (Model Context Protocol) server on stdio
 
+### `harness mcp context-report`
+
+Attribute the always-loaded context surface cost per turn, per tier
+
+**Options:**
+
+- `--tier` — Measure the tool schemas at this tier
+- `--exact` — Use exact /v1/messages/count_tokens counts (needs ANTHROPIC_API_KEY)
+- `--window` — Context-window size to budget against (default: 200000)
+- `--top` — How many top contributors to show (default: 10)
+- `--no-skills` — Skip the platform skill trees
+- `--json` — Emit machine-readable JSON
+
 ### `harness mcp list-capabilities`
 
 Audit each MCP tool: read/write/exec scope, network access, and trust tag

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -133,6 +133,135 @@ export function createMcpListCapabilitiesCommand(): Command {
     });
 }
 
+/** Default context-window size to budget the surface against (Opus/Sonnet 1M). */
+const DEFAULT_WINDOW_TOKENS = 200_000;
+
+function parsePositiveInt(flag: string, value: string): number {
+  const n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`Invalid ${flag} "${value}". Expected a positive integer.`);
+  }
+  return n;
+}
+
+interface AttributionReportShape {
+  windowTokens: number;
+  totalTokens: number;
+  counterMode: string;
+  degraded: boolean;
+  byClass: ReadonlyArray<{
+    contextClass: string;
+    tokens: number;
+    count: number;
+    budgetTokens: number;
+    overBudget: boolean;
+  }>;
+  topContributors: ReadonlyArray<{
+    label: string;
+    contextClass: string;
+    tokens: number;
+    degraded: boolean;
+  }>;
+}
+
+/** Render the attribution report as scannable, terminal-friendly text. */
+export function formatContextReport(report: AttributionReportShape, tier: string): string {
+  const lines: string[] = [];
+  lines.push(`# Context-surface attribution (tier: ${tier})`);
+  lines.push(
+    `# window=${report.windowTokens} tokens · counts=${report.counterMode}` +
+      (report.degraded ? ' (some entries fell back to the chars/4 heuristic)' : '')
+  );
+  lines.push('');
+  lines.push('## By class (budget from contextBudget())');
+  for (const c of report.byClass) {
+    const flag = c.overBudget ? '  OVER BUDGET' : '';
+    lines.push(
+      `  ${padEnd(c.contextClass, 14)}  ${padEnd(String(c.tokens), 8)} tok  ` +
+        `budget ${padEnd(String(c.budgetTokens), 8)}  (${c.count} contributors)${flag}`
+    );
+  }
+  lines.push('');
+  lines.push('## Top contributors');
+  for (const c of report.topContributors) {
+    lines.push(
+      `  ${padEnd(String(c.tokens), 8)} tok  ${padEnd(c.contextClass, 14)}  ${c.label}` +
+        (c.degraded ? '  [heuristic]' : '')
+    );
+  }
+  lines.push('');
+  lines.push(`Total: ${report.totalTokens} tokens across the measured surface.`);
+  return lines.join('\n');
+}
+
+/**
+ * `harness mcp context-report [--tier <t>] [--exact] [--window <n>] [--top <n>] [--no-skills] [--json]`
+ *
+ * Reports what the always-loaded context surface costs per turn — MCP tool
+ * schemas (per tier), AGENTS.md, hooks, and the platform skill trees —
+ * classified always-loaded / path-scoped / invoked-only, top contributors
+ * ranked, and over-budget flags derived from the contextBudget() allocator.
+ * Uses exact `/v1/messages/count_tokens` counts with `--exact` (needs
+ * ANTHROPIC_API_KEY); otherwise the chars/4 heuristic. Never hard-fails.
+ */
+export function createMcpContextReportCommand(): Command {
+  return new Command('context-report')
+    .description('Attribute the always-loaded context surface cost per turn, per tier')
+    .option('--tier <core|standard|full>', 'Measure the tool schemas at this tier', parseTier)
+    .option('--exact', 'Use exact /v1/messages/count_tokens counts (needs ANTHROPIC_API_KEY)')
+    .option(
+      '--window <n>',
+      'Context-window size to budget against',
+      (v) => parsePositiveInt('--window', v),
+      DEFAULT_WINDOW_TOKENS
+    )
+    .option(
+      '--top <n>',
+      'How many top contributors to show',
+      (v) => parsePositiveInt('--top', v),
+      10
+    )
+    .option('--no-skills', 'Skip the platform skill trees')
+    .option('--json', 'Emit machine-readable JSON')
+    .action(async function (this: Command) {
+      const opts = this.optsWithGlobals() as {
+        tier?: McpToolTier;
+        exact?: boolean;
+        window: number;
+        top: number;
+        skills?: boolean;
+        json?: boolean;
+      };
+      const tier = opts.tier ?? 'full';
+      const [{ gatherContextSurface }, core] = await Promise.all([
+        import('../mcp/context-surface.js'),
+        import('@harness-engineering/core'),
+      ]);
+
+      const entries = gatherContextSurface(process.cwd(), {
+        tier,
+        includeSkills: opts.skills !== false,
+      });
+
+      const resolved = opts.exact
+        ? core.resolveTokenCounter()
+        : { counter: core.heuristicTokenCounter, mode: 'heuristic' as const };
+
+      const report = await core.buildAttributionReport(entries, {
+        windowTokens: opts.window,
+        counter: resolved.counter,
+        exact: resolved.mode === 'exact',
+        topN: opts.top,
+      });
+
+      if (opts.json) {
+        console.log(JSON.stringify({ tier, ...report }, null, 2));
+        return;
+      }
+      console.log(formatContextReport(report, tier));
+    });
+}
+
 export function createMcpCommand(): Command {
   const command = new Command('mcp')
     .description('Start the MCP (Model Context Protocol) server on stdio')
@@ -173,5 +302,6 @@ export function createMcpCommand(): Command {
     });
 
   command.addCommand(createMcpListCapabilitiesCommand());
+  command.addCommand(createMcpContextReportCommand());
   return command;
 }

--- a/packages/cli/src/mcp/context-surface.ts
+++ b/packages/cli/src/mcp/context-surface.ts
@@ -1,0 +1,157 @@
+/**
+ * Gather the harness's REAL always-loaded context surface for the attribution
+ * report (`harness mcp context-report`).
+ *
+ * The dominant contributors are the MCP tool schemas (measured per tier via the
+ * tool-tiers allow-lists), plus AGENTS.md, the hook configuration, and the four
+ * platform skill trees. Skill trees are classified invoked-only because Claude
+ * Code defers skill bodies until a skill runs — and tool schemas are themselves
+ * deferrable, so the per-tier measurement is the honest one.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ContextSurfaceEntry } from '@harness-engineering/core';
+import { getToolDefinitions } from './index.js';
+import type { ToolDefinition } from './tool-types.js';
+import { CORE_TOOL_NAMES, STANDARD_TOOL_NAMES, type McpToolTier } from './tool-tiers.js';
+
+/** Serialize a tool definition to the text an agent actually pays for. */
+export function toolDefinitionText(def: ToolDefinition): string {
+  return `${def.name}\n${def.description}\n${JSON.stringify(def.inputSchema)}`;
+}
+
+/** Names exposed at a tier (undefined filter = every tool). */
+function tierFilter(tier: McpToolTier): ReadonlySet<string> | undefined {
+  if (tier === 'core') return new Set(CORE_TOOL_NAMES);
+  if (tier === 'standard') return new Set(STANDARD_TOOL_NAMES);
+  return undefined;
+}
+
+/** MCP tool-schema entries for a given tier (always-loaded). */
+export function mcpToolEntries(
+  tier: McpToolTier,
+  definitions: readonly ToolDefinition[] = getToolDefinitions()
+): ContextSurfaceEntry[] {
+  const filter = tierFilter(tier);
+  const included = filter ? definitions.filter((d) => filter.has(d.name)) : definitions;
+  return included.map((def) => ({
+    id: `mcp:${def.name}`,
+    label: `MCP tool schema: ${def.name}`,
+    contextClass: 'always-loaded',
+    text: toolDefinitionText(def),
+  }));
+}
+
+const PLATFORM_SKILL_DIRS = ['claude-code', 'codex', 'cursor', 'gemini-cli'] as const;
+
+/** Recursively collect SKILL.md paths under a directory. */
+function collectSkillFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSkillFiles(full));
+    } else if (entry.name === 'SKILL.md') {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** One invoked-only entry per platform skill tree (aggregated bodies). */
+export function skillTreeEntries(projectRoot: string): ContextSurfaceEntry[] {
+  const entries: ContextSurfaceEntry[] = [];
+  for (const platform of PLATFORM_SKILL_DIRS) {
+    const dir = join(projectRoot, 'agents', 'skills', platform);
+    const files = collectSkillFiles(dir);
+    if (files.length === 0) continue;
+    let text = '';
+    for (const file of files) {
+      try {
+        text += readFileSync(file, 'utf-8');
+        text += '\n';
+      } catch {
+        // Skip unreadable files; report remains best-effort.
+      }
+    }
+    entries.push({
+      id: `skills:${platform}`,
+      label: `Skill tree: ${platform} (${files.length} SKILL.md)`,
+      contextClass: 'invoked-only',
+      text,
+    });
+  }
+  return entries;
+}
+
+/** AGENTS.md entry (always-loaded), when present. */
+export function agentsMdEntry(projectRoot: string): ContextSurfaceEntry | null {
+  const path = join(projectRoot, 'AGENTS.md');
+  if (!existsSync(path)) return null;
+  try {
+    return {
+      id: 'agents-md',
+      label: 'AGENTS.md',
+      contextClass: 'always-loaded',
+      text: readFileSync(path, 'utf-8'),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Hook-configuration entry from .claude/settings.json (always-loaded). */
+export function hooksEntry(projectRoot: string): ContextSurfaceEntry | null {
+  const path = join(projectRoot, '.claude', 'settings.json');
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as { hooks?: unknown };
+    if (!parsed.hooks) return null;
+    return {
+      id: 'hooks',
+      label: 'Hook configuration (.claude/settings.json)',
+      contextClass: 'always-loaded',
+      text: JSON.stringify(parsed.hooks),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface GatherContextSurfaceOptions {
+  /** Tier whose MCP tool schemas to measure. Default `full`. */
+  tier?: McpToolTier;
+  /** Injectable definitions (tests). Defaults to the live registry. */
+  definitions?: readonly ToolDefinition[];
+  /** Include the platform skill trees. Default true. */
+  includeSkills?: boolean;
+}
+
+/**
+ * Gather the full context surface for a project root: MCP tool schemas at the
+ * requested tier, AGENTS.md, hooks, and (optionally) the platform skill trees.
+ */
+export function gatherContextSurface(
+  projectRoot: string,
+  options: GatherContextSurfaceOptions = {}
+): ContextSurfaceEntry[] {
+  const tier = options.tier ?? 'full';
+  const definitions = options.definitions ?? getToolDefinitions();
+  const entries: ContextSurfaceEntry[] = [...mcpToolEntries(tier, definitions)];
+
+  const agents = agentsMdEntry(projectRoot);
+  if (agents) entries.push(agents);
+
+  const hooks = hooksEntry(projectRoot);
+  if (hooks) entries.push(hooks);
+
+  if (options.includeSkills !== false) {
+    entries.push(...skillTreeEntries(projectRoot));
+  }
+
+  return entries;
+}

--- a/packages/cli/tests/mcp/context-surface.test.ts
+++ b/packages/cli/tests/mcp/context-surface.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { buildAttributionReport, heuristicTokenCounter } from '@harness-engineering/core';
+import {
+  mcpToolEntries,
+  toolDefinitionText,
+  gatherContextSurface,
+} from '../../src/mcp/context-surface';
+import type { ToolDefinition } from '../../src/mcp/tool-types';
+import { getToolDefinitions } from '../../src/mcp/index';
+import { CORE_TOOL_NAMES } from '../../src/mcp/tool-tiers';
+
+const fakeDefs: ToolDefinition[] = [
+  { name: 'validate_project', description: 'validate', inputSchema: { type: 'object' } },
+  { name: 'run_code_review', description: 'review', inputSchema: { type: 'object' } },
+  { name: 'design_craft', description: 'craft', inputSchema: { type: 'object' } },
+];
+
+describe('mcpToolEntries', () => {
+  it('classifies every MCP tool schema as always-loaded', () => {
+    const entries = mcpToolEntries('full', fakeDefs);
+    expect(entries).toHaveLength(3);
+    expect(entries.every((e) => e.contextClass === 'always-loaded')).toBe(true);
+    expect(entries[0].id).toBe('mcp:validate_project');
+  });
+
+  it('restricts to the core allow-list at the core tier', () => {
+    const entries = mcpToolEntries('core', fakeDefs);
+    const names = entries.map((e) => e.id.replace('mcp:', ''));
+    // Only validate_project is in CORE_TOOL_NAMES among the fakes.
+    expect(names).toEqual(['validate_project']);
+    expect(CORE_TOOL_NAMES).toContain('validate_project');
+  });
+
+  it('the full tier exposes at least as many tools as the core tier', () => {
+    const full = mcpToolEntries('full', fakeDefs);
+    const core = mcpToolEntries('core', fakeDefs);
+    expect(full.length).toBeGreaterThanOrEqual(core.length);
+  });
+});
+
+describe('toolDefinitionText', () => {
+  it('includes name, description, and serialized schema', () => {
+    const text = toolDefinitionText(fakeDefs[0]);
+    expect(text).toContain('validate_project');
+    expect(text).toContain('validate');
+    expect(text).toContain('"type":"object"');
+  });
+});
+
+describe('gatherContextSurface + buildAttributionReport (real registry)', () => {
+  it('produces a per-tier report over the live MCP tool schemas', async () => {
+    const liveDefs = getToolDefinitions();
+    expect(liveDefs.length).toBeGreaterThan(50); // ~88 tool modules
+
+    const entries = gatherContextSurface(process.cwd(), {
+      definitions: liveDefs,
+      includeSkills: false,
+    });
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries.some((e) => e.id.startsWith('mcp:'))).toBe(true);
+
+    const report = await buildAttributionReport(entries, {
+      windowTokens: 200_000,
+      counter: heuristicTokenCounter,
+    });
+
+    const always = report.byClass.find((c) => c.contextClass === 'always-loaded')!;
+    expect(always.tokens).toBeGreaterThan(0);
+    expect(report.topContributors.length).toBeGreaterThan(0);
+    expect(report.counterMode).toBe('heuristic');
+  });
+
+  it('the core tier measures fewer tool tokens than the full tier', async () => {
+    const liveDefs = getToolDefinitions();
+    const coreEntries = gatherContextSurface(process.cwd(), {
+      definitions: liveDefs,
+      tier: 'core',
+      includeSkills: false,
+    });
+    const fullEntries = gatherContextSurface(process.cwd(), {
+      definitions: liveDefs,
+      tier: 'full',
+      includeSkills: false,
+    });
+    const coreMcp = coreEntries.filter((e) => e.id.startsWith('mcp:')).length;
+    const fullMcp = fullEntries.filter((e) => e.id.startsWith('mcp:')).length;
+    expect(coreMcp).toBeLessThan(fullMcp);
+  });
+});

--- a/packages/core/src/context/attribution.ts
+++ b/packages/core/src/context/attribution.ts
@@ -1,0 +1,228 @@
+/**
+ * Context-surface attribution.
+ *
+ * Reports what the always-loaded context surface actually costs per turn:
+ * every contributor is classified as always-loaded / path-scoped / invoked-only,
+ * the top contributors are ranked, and each class is flagged when it exceeds the
+ * share of the window that the {@link contextBudget} allocator gives it.
+ *
+ * Token counts come from an injected {@link TokenCounter}. The exact counter
+ * (Anthropic's `/v1/messages/count_tokens`, see `./count-tokens`) is preferred;
+ * when it is unavailable or a call fails, the report degrades gracefully to the
+ * `chars / 4` heuristic ({@link estimateTokens}) and records that it did so —
+ * it never hard-fails.
+ */
+
+import { estimateTokens } from '../compaction/envelope';
+import { contextBudget } from './budget';
+import type { TokenBudget, TokenBudgetOverrides } from './budget.types';
+
+/**
+ * The three-way context-surface classification taxonomy.
+ *
+ *  - `always-loaded` — sits in every turn's context regardless of the task
+ *    (MCP tool schemas, AGENTS.md, hooks). The fixed per-turn tax.
+ *  - `path-scoped`   — loaded only when the working set touches a given path
+ *    (path-scoped instructions, per-directory manifests).
+ *  - `invoked-only`  — loaded on demand when a capability is invoked (skill
+ *    bodies that Claude Code defers until the skill runs).
+ */
+export type ContextClass = 'always-loaded' | 'path-scoped' | 'invoked-only';
+
+/** All context classes, in report order. */
+export const CONTEXT_CLASSES: readonly ContextClass[] = [
+  'always-loaded',
+  'path-scoped',
+  'invoked-only',
+];
+
+/**
+ * Which {@link TokenBudget} category each context class is allocated against.
+ * The always-loaded surface competes for the system-prompt allocation; the
+ * path-scoped surface for the project-manifest allocation; invoked-only for the
+ * interfaces allocation. Documented and stable so over-budget flags are
+ * reproducible.
+ */
+export const CLASS_TO_BUDGET_CATEGORY: Record<ContextClass, keyof TokenBudget> = {
+  'always-loaded': 'systemPrompt',
+  'path-scoped': 'projectManifest',
+  'invoked-only': 'interfaces',
+};
+
+/** One measurable item on the context surface. */
+export interface ContextSurfaceEntry {
+  /** Stable identifier (e.g. tool name, file path). */
+  id: string;
+  /** Human-readable label for the report. */
+  label: string;
+  /** How this entry loads into context. */
+  contextClass: ContextClass;
+  /** The raw text whose tokens are being attributed. */
+  text: string;
+}
+
+/**
+ * A token counter. May be synchronous (the heuristic) or asynchronous (an API
+ * call). It MAY throw / reject — {@link buildAttributionReport} catches that and
+ * falls back to the heuristic for the offending entry.
+ */
+export type TokenCounter = (text: string) => number | Promise<number>;
+
+/** The heuristic (`chars / 4`) counter — the documented graceful fallback. */
+export const heuristicTokenCounter: TokenCounter = (text: string) => estimateTokens(text);
+
+/** A single attributed contributor with its measured token cost. */
+export interface AttributedContributor {
+  id: string;
+  label: string;
+  contextClass: ContextClass;
+  tokens: number;
+  /** True when this entry's count fell back to the heuristic. */
+  degraded: boolean;
+}
+
+/** Per-class rollup of the surface. */
+export interface ClassAttribution {
+  contextClass: ContextClass;
+  /** Total tokens attributed to this class. */
+  tokens: number;
+  /** Number of contributors in this class. */
+  count: number;
+  /** Tokens the {@link contextBudget} allocator gave this class. */
+  budgetTokens: number;
+  /** True when `tokens > budgetTokens`. */
+  overBudget: boolean;
+}
+
+/** How the report's token counts were produced. */
+export type CounterMode = 'exact' | 'heuristic' | 'mixed';
+
+export interface AttributionReport {
+  /** Context-window size the budget was computed against. */
+  windowTokens: number;
+  /** The allocator output that drives the over-budget flags. */
+  budget: TokenBudget;
+  /** Total tokens across every contributor. */
+  totalTokens: number;
+  /** Per-class rollups (always-loaded, path-scoped, invoked-only). */
+  byClass: ClassAttribution[];
+  /** Every contributor, ranked by token cost descending. */
+  contributors: AttributedContributor[];
+  /** The `topN` most expensive contributors (convenience slice). */
+  topContributors: AttributedContributor[];
+  /** How counts were produced across the whole report. */
+  counterMode: CounterMode;
+  /** True when any entry fell back to the heuristic. */
+  degraded: boolean;
+}
+
+export interface BuildAttributionReportOptions {
+  /**
+   * Context-window size to budget against. The {@link contextBudget} allocator
+   * splits this into per-category allocations that drive the over-budget flags.
+   */
+  windowTokens: number;
+  /**
+   * Token counter to use. Defaults to the heuristic. When an exact counter is
+   * supplied, per-entry failures fall back to the heuristic (the report is
+   * marked `degraded` / `mixed`), so the report never hard-fails.
+   */
+  counter?: TokenCounter;
+  /**
+   * Whether `counter` is the exact (API) counter. Controls the reported
+   * {@link CounterMode}: `exact` when nothing degraded, `mixed` when some
+   * entries fell back, `heuristic` when the heuristic was used throughout.
+   */
+  exact?: boolean;
+  /** Optional budget-ratio overrides forwarded to {@link contextBudget}. */
+  budgetOverrides?: TokenBudgetOverrides;
+  /** Optional graph density forwarded to {@link contextBudget}. */
+  graphDensity?: Record<string, number>;
+  /** How many contributors to surface in `topContributors`. Default 10. */
+  topN?: number;
+}
+
+async function countEntry(
+  entry: ContextSurfaceEntry,
+  counter: TokenCounter
+): Promise<{ tokens: number; degraded: boolean }> {
+  try {
+    const tokens = await counter(entry.text);
+    if (!Number.isFinite(tokens) || tokens < 0) {
+      // A well-behaved counter never returns this; treat as a soft failure.
+      return { tokens: estimateTokens(entry.text), degraded: true };
+    }
+    return { tokens, degraded: false };
+  } catch {
+    // Graceful fallback: a failed exact count degrades to the heuristic for
+    // this entry rather than failing the whole report.
+    return { tokens: estimateTokens(entry.text), degraded: true };
+  }
+}
+
+/**
+ * Build the context-surface attribution report.
+ *
+ * Wires the {@link contextBudget} allocator in as the budget source: every
+ * class's `overBudget` flag is derived from the allocation `contextBudget`
+ * returns for the mapped category.
+ */
+export async function buildAttributionReport(
+  entries: readonly ContextSurfaceEntry[],
+  options: BuildAttributionReportOptions
+): Promise<AttributionReport> {
+  const counter = options.counter ?? heuristicTokenCounter;
+  const topN = options.topN ?? 10;
+
+  const budget = contextBudget(options.windowTokens, options.budgetOverrides, options.graphDensity);
+
+  const contributors: AttributedContributor[] = [];
+  let anyDegraded = false;
+
+  for (const entry of entries) {
+    const { tokens, degraded } = await countEntry(entry, counter);
+    anyDegraded = anyDegraded || degraded;
+    contributors.push({
+      id: entry.id,
+      label: entry.label,
+      contextClass: entry.contextClass,
+      tokens,
+      degraded,
+    });
+  }
+
+  contributors.sort((a, b) => b.tokens - a.tokens || a.id.localeCompare(b.id));
+
+  const byClass: ClassAttribution[] = CONTEXT_CLASSES.map((contextClass) => {
+    const inClass = contributors.filter((c) => c.contextClass === contextClass);
+    const tokens = inClass.reduce((sum, c) => sum + c.tokens, 0);
+    const budgetTokens = budget[CLASS_TO_BUDGET_CATEGORY[contextClass]];
+    return {
+      contextClass,
+      tokens,
+      count: inClass.length,
+      budgetTokens,
+      overBudget: tokens > budgetTokens,
+    };
+  });
+
+  const totalTokens = contributors.reduce((sum, c) => sum + c.tokens, 0);
+
+  let counterMode: CounterMode;
+  if (!options.exact) {
+    counterMode = 'heuristic';
+  } else {
+    counterMode = anyDegraded ? 'mixed' : 'exact';
+  }
+
+  return {
+    windowTokens: options.windowTokens,
+    budget,
+    totalTokens,
+    byClass,
+    contributors,
+    topContributors: contributors.slice(0, topN),
+    counterMode,
+    degraded: anyDegraded,
+  };
+}

--- a/packages/core/src/context/count-tokens.ts
+++ b/packages/core/src/context/count-tokens.ts
@@ -1,0 +1,122 @@
+/**
+ * Exact token counting via Anthropic's `/v1/messages/count_tokens` endpoint.
+ *
+ * The `chars / 4` heuristic in {@link estimateTokens} systematically miscounts
+ * Claude tokens (code and non-English text especially). This module returns the
+ * tokenizer-exact count instead — but only when a key is available. With no
+ * API key it returns `null` so callers fall back to the heuristic, and a failed
+ * request throws so the report's per-entry fallback degrades that entry rather
+ * than hard-failing. Never throws at construction and never hard-fails a report.
+ */
+
+import type { TokenCounter } from './attribution';
+import { heuristicTokenCounter } from './attribution';
+
+/** Default model whose tokenizer is used for exact counts. */
+export const DEFAULT_COUNT_TOKENS_MODEL = 'claude-opus-4-8';
+
+/** Default Anthropic API base URL. */
+const DEFAULT_BASE_URL = 'https://api.anthropic.com';
+
+/** Anthropic API version header value. */
+const ANTHROPIC_VERSION = '2023-06-01';
+
+/** Minimal `fetch` shape we depend on — lets tests inject a fake. */
+export type FetchLike = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  }
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export interface AnthropicTokenCounterOptions {
+  /** API key. Defaults to `process.env.ANTHROPIC_API_KEY`. */
+  apiKey?: string;
+  /** Model whose tokenizer to use. Defaults to {@link DEFAULT_COUNT_TOKENS_MODEL}. */
+  model?: string;
+  /** Base URL. Defaults to the public Anthropic API. */
+  baseUrl?: string;
+  /** Injectable `fetch`. Defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+}
+
+function resolveApiKey(explicit?: string): string | undefined {
+  const key = explicit ?? process.env.ANTHROPIC_API_KEY;
+  const trimmed = key?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Create an exact {@link TokenCounter} backed by `/v1/messages/count_tokens`.
+ *
+ * Returns `null` when no API key is resolvable — the caller then uses the
+ * heuristic (this is the "no key / offline" graceful path). The returned counter
+ * throws on a failed request so that {@link buildAttributionReport} degrades the
+ * offending entry to the heuristic; it does not swallow errors silently.
+ */
+export function createAnthropicTokenCounter(
+  options: AnthropicTokenCounterOptions = {}
+): TokenCounter | null {
+  const apiKey = resolveApiKey(options.apiKey);
+  if (!apiKey) return null;
+
+  const model = options.model ?? DEFAULT_COUNT_TOKENS_MODEL;
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+  const fetchImpl = options.fetchImpl ?? (globalThis.fetch as FetchLike | undefined);
+
+  if (!fetchImpl) {
+    // No fetch available (very old runtime) — behave as "no exact counter".
+    return null;
+  }
+
+  return async (text: string): Promise<number> => {
+    const response = await fetchImpl(`${baseUrl}/v1/messages/count_tokens`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: text }],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`count_tokens request failed with status ${response.status}`);
+    }
+
+    const payload = (await response.json()) as { input_tokens?: unknown };
+    const count = payload.input_tokens;
+    if (typeof count !== 'number' || !Number.isFinite(count)) {
+      throw new Error('count_tokens response missing a numeric input_tokens field');
+    }
+    return count;
+  };
+}
+
+/** How a resolved counter produces its counts. */
+export type ResolvedCounterMode = 'exact' | 'heuristic';
+
+export interface ResolvedTokenCounter {
+  counter: TokenCounter;
+  /** `exact` when an API-backed counter was resolved, else `heuristic`. */
+  mode: ResolvedCounterMode;
+}
+
+/**
+ * Resolve the best available token counter: the exact API counter when a key is
+ * present, otherwise the heuristic. Convenience over
+ * {@link createAnthropicTokenCounter} for callers that always want a usable
+ * counter plus a mode label.
+ */
+export function resolveTokenCounter(
+  options: AnthropicTokenCounterOptions = {}
+): ResolvedTokenCounter {
+  const exact = createAnthropicTokenCounter(options);
+  if (exact) return { counter: exact, mode: 'exact' };
+  return { counter: heuristicTokenCounter, mode: 'heuristic' };
+}

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -25,6 +25,43 @@ export { contextBudget } from './budget';
 export type { TokenBudget, TokenBudgetOverrides } from './budget.types';
 
 /**
+ * Context-surface attribution — classify the always-loaded surface, rank
+ * contributors, and flag over-budget classes via the contextBudget() allocator.
+ */
+export {
+  buildAttributionReport,
+  heuristicTokenCounter,
+  CONTEXT_CLASSES,
+  CLASS_TO_BUDGET_CATEGORY,
+} from './attribution';
+export type {
+  ContextClass,
+  ContextSurfaceEntry,
+  TokenCounter,
+  AttributedContributor,
+  ClassAttribution,
+  CounterMode,
+  AttributionReport,
+  BuildAttributionReportOptions,
+} from './attribution';
+
+/**
+ * Exact token counting via Anthropic's /v1/messages/count_tokens, with a
+ * graceful fallback to the chars/4 heuristic when no API key / offline.
+ */
+export {
+  createAnthropicTokenCounter,
+  resolveTokenCounter,
+  DEFAULT_COUNT_TOKENS_MODEL,
+} from './count-tokens';
+export type {
+  AnthropicTokenCounterOptions,
+  FetchLike,
+  ResolvedCounterMode,
+  ResolvedTokenCounter,
+} from './count-tokens';
+
+/**
  * Section parser for progressive skill content loading.
  */
 export { parseSections, extractLevel } from './section-parser';

--- a/packages/core/tests/context/attribution.test.ts
+++ b/packages/core/tests/context/attribution.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildAttributionReport,
+  heuristicTokenCounter,
+  CLASS_TO_BUDGET_CATEGORY,
+  type ContextSurfaceEntry,
+  type TokenCounter,
+} from '../../src/context/attribution';
+import * as budgetModule from '../../src/context/budget';
+import { estimateTokens } from '../../src/compaction/envelope';
+
+function entry(
+  id: string,
+  contextClass: ContextSurfaceEntry['contextClass'],
+  text: string
+): ContextSurfaceEntry {
+  return { id, label: id, contextClass, text };
+}
+
+describe('buildAttributionReport — classification', () => {
+  it('aggregates tokens per class and ranks contributors', async () => {
+    const entries: ContextSurfaceEntry[] = [
+      entry('a', 'always-loaded', 'x'.repeat(400)), // 100 tok heuristic
+      entry('b', 'always-loaded', 'x'.repeat(40)), // 10 tok
+      entry('c', 'path-scoped', 'x'.repeat(200)), // 50 tok
+      entry('d', 'invoked-only', 'x'.repeat(80)), // 20 tok
+    ];
+
+    const report = await buildAttributionReport(entries, { windowTokens: 100_000 });
+
+    // Ranked descending by tokens.
+    expect(report.contributors.map((c) => c.id)).toEqual(['a', 'c', 'd', 'b']);
+    expect(report.topContributors[0].id).toBe('a');
+
+    const always = report.byClass.find((c) => c.contextClass === 'always-loaded')!;
+    expect(always.count).toBe(2);
+    expect(always.tokens).toBe(estimateTokens('x'.repeat(400)) + estimateTokens('x'.repeat(40)));
+
+    const pathScoped = report.byClass.find((c) => c.contextClass === 'path-scoped')!;
+    expect(pathScoped.tokens).toBe(estimateTokens('x'.repeat(200)));
+
+    expect(report.totalTokens).toBe(report.byClass.reduce((sum, c) => sum + c.tokens, 0));
+    expect(report.counterMode).toBe('heuristic');
+  });
+
+  it('reports all three classes even when some are empty', async () => {
+    const report = await buildAttributionReport([entry('a', 'always-loaded', 'hello')], {
+      windowTokens: 100_000,
+    });
+    expect(report.byClass.map((c) => c.contextClass)).toEqual([
+      'always-loaded',
+      'path-scoped',
+      'invoked-only',
+    ]);
+  });
+});
+
+describe('buildAttributionReport — contextBudget() is the allocator', () => {
+  it('invokes contextBudget() and derives over-budget flags from it', async () => {
+    const spy = vi.spyOn(budgetModule, 'contextBudget');
+
+    // 1000-token window → systemPrompt allocation is 15% = 150 tokens.
+    // An always-loaded surface bigger than that must flag over-budget.
+    const bigAlwaysLoaded = 'x'.repeat(4000); // 1000 tok heuristic >> 150
+    const report = await buildAttributionReport([entry('big', 'always-loaded', bigAlwaysLoaded)], {
+      windowTokens: 1000,
+    });
+
+    expect(spy).toHaveBeenCalledWith(1000, undefined, undefined);
+
+    const always = report.byClass.find((c) => c.contextClass === 'always-loaded')!;
+    expect(always.budgetTokens).toBe(report.budget[CLASS_TO_BUDGET_CATEGORY['always-loaded']]);
+    expect(always.budgetTokens).toBe(150);
+    expect(always.overBudget).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  it('does not flag a class that fits its contextBudget allocation', async () => {
+    const report = await buildAttributionReport(
+      [entry('tiny', 'always-loaded', 'x'.repeat(40))], // 10 tok
+      { windowTokens: 100_000 } // systemPrompt = 15000
+    );
+    const always = report.byClass.find((c) => c.contextClass === 'always-loaded')!;
+    expect(always.overBudget).toBe(false);
+  });
+
+  it('forwards budget overrides to contextBudget()', async () => {
+    const spy = vi.spyOn(budgetModule, 'contextBudget');
+    await buildAttributionReport([entry('a', 'always-loaded', 'hi')], {
+      windowTokens: 1000,
+      budgetOverrides: { systemPrompt: 0.5 },
+    });
+    expect(spy).toHaveBeenCalledWith(1000, { systemPrompt: 0.5 }, undefined);
+    spy.mockRestore();
+  });
+});
+
+describe('buildAttributionReport — graceful fallback path', () => {
+  it('falls back to the heuristic when the exact counter throws, marking the entry degraded', async () => {
+    const throwingCounter: TokenCounter = () => {
+      throw new Error('offline / 401');
+    };
+
+    const report = await buildAttributionReport([entry('a', 'always-loaded', 'hello world')], {
+      windowTokens: 100_000,
+      counter: throwingCounter,
+      exact: true,
+    });
+
+    expect(report.degraded).toBe(true);
+    expect(report.counterMode).toBe('mixed');
+    expect(report.contributors[0].degraded).toBe(true);
+    expect(report.contributors[0].tokens).toBe(estimateTokens('hello world'));
+  });
+
+  it('reports exact mode when no entry degrades', async () => {
+    const exactCounter: TokenCounter = () => 42;
+    const report = await buildAttributionReport([entry('a', 'always-loaded', 'anything')], {
+      windowTokens: 100_000,
+      counter: exactCounter,
+      exact: true,
+    });
+    expect(report.degraded).toBe(false);
+    expect(report.counterMode).toBe('exact');
+    expect(report.contributors[0].tokens).toBe(42);
+  });
+
+  it('falls back when the counter returns a non-finite / negative count', async () => {
+    const badCounter: TokenCounter = () => Number.NaN;
+    const report = await buildAttributionReport([entry('a', 'always-loaded', 'hello')], {
+      windowTokens: 100_000,
+      counter: badCounter,
+      exact: true,
+    });
+    expect(report.contributors[0].degraded).toBe(true);
+    expect(report.contributors[0].tokens).toBe(estimateTokens('hello'));
+  });
+
+  it('awaits async counters', async () => {
+    const asyncCounter: TokenCounter = async (text) => text.length;
+    const report = await buildAttributionReport([entry('a', 'always-loaded', 'abcde')], {
+      windowTokens: 100_000,
+      counter: asyncCounter,
+      exact: true,
+    });
+    expect(report.contributors[0].tokens).toBe(5);
+  });
+});
+
+describe('heuristicTokenCounter', () => {
+  it('wraps estimateTokens (chars/4)', () => {
+    expect(heuristicTokenCounter('x'.repeat(400))).toBe(estimateTokens('x'.repeat(400)));
+  });
+});

--- a/packages/core/tests/context/count-tokens.test.ts
+++ b/packages/core/tests/context/count-tokens.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createAnthropicTokenCounter,
+  resolveTokenCounter,
+  DEFAULT_COUNT_TOKENS_MODEL,
+  type FetchLike,
+} from '../../src/context/count-tokens';
+import { heuristicTokenCounter } from '../../src/context/attribution';
+import { estimateTokens } from '../../src/compaction/envelope';
+
+function okFetch(inputTokens: number, capture?: { url?: string; body?: string }): FetchLike {
+  return async (url, init) => {
+    if (capture) {
+      capture.url = url;
+      capture.body = init.body;
+    }
+    return { ok: true, status: 200, json: async () => ({ input_tokens: inputTokens }) };
+  };
+}
+
+describe('createAnthropicTokenCounter', () => {
+  it('returns null when no API key is resolvable (graceful heuristic path)', () => {
+    expect(createAnthropicTokenCounter({ apiKey: '', fetchImpl: okFetch(1) })).toBeNull();
+    expect(createAnthropicTokenCounter({ apiKey: '   ', fetchImpl: okFetch(1) })).toBeNull();
+  });
+
+  it('returns an exact count from /v1/messages/count_tokens', async () => {
+    const capture: { url?: string; body?: string } = {};
+    const counter = createAnthropicTokenCounter({
+      apiKey: 'sk-test',
+      fetchImpl: okFetch(123, capture),
+    })!;
+    expect(counter).not.toBeNull();
+    const count = await counter('hello world');
+    expect(count).toBe(123);
+    expect(capture.url).toContain('/v1/messages/count_tokens');
+    expect(capture.body).toContain(DEFAULT_COUNT_TOKENS_MODEL);
+    expect(capture.body).toContain('hello world');
+  });
+
+  it('throws on a non-200 response so the report can degrade that entry', async () => {
+    const counter = createAnthropicTokenCounter({
+      apiKey: 'sk-test',
+      fetchImpl: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+    })!;
+    await expect(counter('x')).rejects.toThrow(/401/);
+  });
+
+  it('throws when input_tokens is missing or non-numeric', async () => {
+    const counter = createAnthropicTokenCounter({
+      apiKey: 'sk-test',
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ input_tokens: 'nope' }),
+      }),
+    })!;
+    await expect(counter('x')).rejects.toThrow(/input_tokens/);
+  });
+
+  it('honours a custom model and base URL', async () => {
+    const capture: { url?: string; body?: string } = {};
+    const counter = createAnthropicTokenCounter({
+      apiKey: 'sk-test',
+      model: 'claude-sonnet-5',
+      baseUrl: 'https://example.test/',
+      fetchImpl: okFetch(7, capture),
+    })!;
+    await counter('hi');
+    expect(capture.url).toBe('https://example.test/v1/messages/count_tokens');
+    expect(capture.body).toContain('claude-sonnet-5');
+  });
+});
+
+describe('resolveTokenCounter', () => {
+  it('resolves the exact counter when a key is present', async () => {
+    const resolved = resolveTokenCounter({ apiKey: 'sk-test', fetchImpl: okFetch(9) });
+    expect(resolved.mode).toBe('exact');
+    expect(await resolved.counter('anything')).toBe(9);
+  });
+
+  it('falls back to the heuristic when no key is present', () => {
+    const resolved = resolveTokenCounter({ apiKey: '', fetchImpl: okFetch(9) });
+    expect(resolved.mode).toBe('heuristic');
+    expect(resolved.counter).toBe(heuristicTokenCounter);
+    expect(resolved.counter('x'.repeat(400))).toBe(estimateTokens('x'.repeat(400)));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **context-surface attribution report** that reports what the harness's always-loaded context surface actually costs per turn.

Two mechanisms from the source framing, plus the Fork B allocator wiring:

1. **Three-way classification taxonomy** — every contributor is classified `always-loaded` / `path-scoped` / `invoked-only`, with top contributors ranked and per-class over-budget flags.
2. **Exact token counts** — Anthropic's `/v1/messages/count_tokens` endpoint replaces the `chars / 4` heuristic in `estimateTokens()`, with a **documented, tested graceful fallback** to that heuristic when there is no API key / offline / the request fails. It never hard-fails.
3. **Live-wires the previously-dead `contextBudget()` allocator** (Fork B): `buildAttributionReport()` calls `contextBudget(windowTokens, …)` to allocate the window and derive the over-budget flags — following the sibling `computeLoadPlan()` wiring pattern.

## What it measures (the REAL surface, per tier)

`harness mcp context-report [--tier core|standard|full] [--exact] [--window <n>] [--top <n>] [--no-skills] [--json]` enumerates the harness's actual surface: MCP tool schemas (per tier via the `tool-tiers.ts` allow-lists — the dominant contributor), `AGENTS.md`, the hook config, and the four platform skill trees.

Observed on this repo (heuristic counts, 200k window):

| tier | always-loaded tokens | contributors | over budget? |
|------|----------------------|--------------|--------------|
| core | 28,386 | 15 | no (systemPrompt budget 30k) |
| full | 48,770 | 108 | **yes** |

This makes the **scope-honesty** point concrete: `tool-tiers.ts` already trims the exposed tool count and Claude Code defers tool schemas, so the report measures **per-tier** and the remaining win is smaller than the source framing implied.

## Architecture

- **`@harness-engineering/core`** (pure, network-free, testable): `attribution.ts` (taxonomy + `buildAttributionReport` + `contextBudget()` wiring) and `count-tokens.ts` (`createAnthropicTokenCounter` / `resolveTokenCounter`). New exports flow through the star-exported `context/` barrel — no `generate-core-barrel.mjs` allowlist edit needed (verified with `generate:barrels --check`).
- **`@harness-engineering/cli`**: `context-surface.ts` gatherer + the `harness mcp context-report` subcommand.

## Tests

- `packages/core/tests/context/attribution.test.ts` — classification aggregation, ranking, the exact→heuristic fallback path, and that `contextBudget()` is invoked and drives the over-budget flags.
- `packages/core/tests/context/count-tokens.test.ts` — null-on-no-key, exact count via injected fetch, throw-on-failure feeding the report fallback.
- `packages/cli/tests/mcp/context-surface.test.ts` — gathers the live registry and produces a per-tier report; core tier measures fewer tokens than full.

## Assumptions made

- **Fork B — `contextBudget()` is now live-wired**, not deprecated: `packages/core/src/context/attribution.ts:177` calls it as the allocator (a real non-test caller; `grep 'contextBudget('` confirms).
- Class→budget-category mapping is documented and fixed: always-loaded→systemPrompt, path-scoped→projectManifest, invoked-only→interfaces.
- Skill trees are classified invoked-only (Claude Code defers skill bodies); MCP schemas + AGENTS.md + hooks are always-loaded.
- Exact counting defaults to the `claude-opus-4-8` tokenizer; degradation is per-entry and the report is marked `heuristic` / `mixed` with a per-contributor `degraded` flag.
- Default budget window is 200,000 tokens (`--window` overrides).

Plan artifact: `docs/changes/context-surface-attribution-report/plans/plan.md` · provenance: `docs/changes/context-surface-attribution-report/provenance.json`.

Closes #1274
