### PR TITLE
feat(state): spill-to-disk with followup-readable locator for large tool output (#1398)

### DIFF
--- a/.changeset/spill-to-disk-locator.md
+++ b/.changeset/spill-to-disk-locator.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/core': minor
+---
+
+feat(state): spill-to-disk with a followup-readable locator for large tool output (#1398)
+
+Add a spill backend to `packages/core` session/state handling. `spillIfNeeded`
+offloads tool output over a configurable byte threshold (default 30 KB, overridable
+via the `thresholdBytes` option or `HARNESS_SPILL_THRESHOLD_BYTES`) to a `spill/`
+subdirectory of the resolved state area and returns a stable, followup-readable
+locator (`harness-spill:<repo-relative-path>`); output under the threshold passes
+through inline unchanged. `readSpill` recovers the full content by locator and
+`searchSpill` greps it line-by-line, so fleet workers and autopilot sessions can
+offload large test logs, full diffs, or grep/glob overflow and reference them by
+locator instead of losing the tail or blowing the context budget.

--- a/.changeset/spill-to-disk-wiring.md
+++ b/.changeset/spill-to-disk-wiring.md
@@ -1,0 +1,16 @@
+---
+'@harness-engineering/cli': minor
+---
+
+feat(mcp): route large truncated tool output through spill-to-disk with a recoverable locator (#1398)
+
+Wire the spill-to-disk primitive into the MCP compaction middleware
+(`wrapWithCompaction`), the single choke point every tool response flows through.
+When a tool's output is large enough to be lossy-truncated by the truncation
+pipeline, the full pre-compaction payload is now offloaded to disk via
+`spillIfNeeded` and a followup-readable `harness-spill:` locator is appended to the
+compacted result, so fleet workers and autopilot sessions can recover or grep the
+complete test log / diff / grep overflow on a later turn (`readSpill` /
+`searchSpill`) instead of losing the truncated tail. Output under the threshold
+passes through unchanged, lossless-only tools are excluded, and spill fails open —
+behavior is unchanged when no project root is available.

--- a/docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md
+++ b/docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md
@@ -77,3 +77,57 @@ scheme, and `readSpill`/`searchSpill` accept it with or without the scheme.
 - The core module is the reusable backend; wiring specific fleet/autopilot call
   sites to route their output through `spillIfNeeded` is left to the consumers of
   this API (out of scope for this issue, which asks for the backend + locator).
+
+## Wiring (stage: wiring)
+
+The backend above delivered `spillIfNeeded` but nothing called it — the real
+truncation sites in long-running sessions still dropped output ad hoc. This stage
+wires the primitive into its intended consumer so the recovery path is actually
+exercised.
+
+### Consumer site
+
+`packages/cli/src/mcp/middleware/compaction.ts:wrapWithCompaction` — the single
+choke point every MCP tool response flows through. Its default pipeline
+(`StructuralStrategy → TruncationStrategy`, 4000-token budget) is exactly the "ad
+hoc truncation with no recovery path" the issue names: over-budget test logs,
+whole diffs, and grep/glob overflow are cut to a `[truncated]` marker and the tail
+is lost. This is the genuine large-session-output site — not a display formatter.
+
+### How the locator substitutes for truncated output
+
+- `applyCompaction(handlers, { projectRoot })` is now called with the server's
+  resolved project root (`packages/cli/src/mcp/server.ts`), threading a
+  `CompactionOptions { projectRoot?, spillThresholdBytes? }` down to every wrapped
+  handler.
+- For a non-lossless tool whose output is compacted by the truncation pipeline,
+  the middleware calls `spillIfNeeded(projectRoot, fullOriginalText, { label: toolName })`
+  on the **pre-compaction** payload. Over threshold → the whole payload is written
+  to disk and a recovery line carrying the `harness-spill:` locator is appended to
+  the compacted result (`spillLargeResult` → `appendLocatorNotice`), so a later
+  turn can `readSpill`/`searchSpill` the full output. Under threshold → the
+  compacted result is returned unchanged (no file written, no locator).
+- Lossless-only tools (`run_skill`, `manage_state`, …) are never lossy-truncated,
+  so they are deliberately **not** routed through spill.
+- Fail-open throughout: a spill error returns the normal compacted result. Absent
+  a `projectRoot` (e.g. unit tests that don't pass one), spill is disabled and
+  compaction behaves exactly as before — backward-compatible.
+
+### Deliberately skipped (non-spill) truncation sites
+
+- `packages/cli/src/skill/dispatch-session.ts` / `dispatcher.ts` `.slice(0, 3)` /
+  `.slice(0, 10)` — these cap _recommendation/knowledge lists_ for display, not
+  large session output. No recovery value.
+- `packages/core/src/config/stripped-keys.ts`, brand forbidden-phrase snippets,
+  naming-craft convention extraction — display/formatting/secret-stripping, not
+  recoverable large output.
+
+### Wiring test
+
+`packages/cli/tests/mcp/middleware/compaction.test.ts` → `CT-spill` block: an
+over-threshold handler output spills to a temp `projectRoot`, the appended
+`harness-spill:` locator reads back the original payload byte-for-byte via
+`readSpill` and is grep-able via `searchSpill`; an under-threshold output passes
+through with no locator and no spill dir created; a no-`projectRoot` call stays
+backward-compatible; and `applyCompaction` threads `projectRoot` to every handler.
+Temp dirs are cleaned in `afterEach`; no spilled runtime file is committed.

--- a/docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md
+++ b/docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md
@@ -1,0 +1,79 @@
+# Plan — Spill-to-disk with a followup-readable locator (#1398)
+
+## Problem
+
+Long-running harness sessions (fleet workers, autopilot loops) accumulate large
+intermediate tool output — full test logs, whole diffs, grep/glob overflow.
+Inlining all of it blows the context budget; truncating it ad hoc loses the tail
+with no recovery path. We need a spill mechanism that offloads over-threshold
+output to disk and hands back a stable, followup-readable locator the model can
+read or search on a later turn.
+
+## Fork decision (pre-answered by human)
+
+**Fork C:** extend `packages/core` session/state handling. Do NOT create a new
+package. The spill backend lands in `packages/core/src/state/` alongside the
+existing session/state resolvers, reusing `getStateDir()` so spilled payloads
+sit inside the resolved state area (`.harness/<session|stream|legacy>/spill/`),
+which is git-ignored via `.harness/.gitignore`.
+
+## Design
+
+New module `packages/core/src/state/spill.ts`:
+
+- `spillIfNeeded(projectPath, content, options?)` — if `Buffer.byteLength(content)`
+  exceeds the resolved threshold, write it under the resolved state dir's
+  `spill/` subdir and return `{ spilled: true, locator, path, bytes, preview, notice }`;
+  otherwise return `{ spilled: false, content, bytes }` unchanged.
+- `readSpill(projectPath, locator)` — resolve a locator (or bare relative path)
+  back to disk and return the full original content. Rejects path-traversal.
+- `searchSpill(projectPath, locator, pattern, opts?)` — grep the spilled payload
+  line-by-line (substring or RegExp), returning matches with 1-based line numbers
+  and a truncation flag, so a later turn can search without pulling it all inline.
+- `resolveSpillThreshold(explicit?)` — precedence: explicit arg → env var
+  `HARNESS_SPILL_THRESHOLD_BYTES` → default `DEFAULT_SPILL_THRESHOLD_BYTES`
+  (30 KB).
+
+Locator format: `harness-spill:<repo-relative-posix-path>` — e.g.
+`harness-spill:.harness/sessions/my-session/spill/lq3k2-9f2ab-test-log.txt`. It
+is scheme-prefixed (recognizable) yet directly cat/grep-able after stripping the
+scheme, and `readSpill`/`searchSpill` accept it with or without the scheme.
+
+## Tasks
+
+1. **Write the spill module** — `spill.ts` with the four functions, types, and
+   constants above. Reuse `getStateDir` for session/stream/legacy resolution.
+2. **Barrel export** — add the public surface to `packages/core/src/state/index.ts`.
+   (`state` is an auto-discovered `export *` module, so the generated top-level
+   core barrel picks it up automatically — verified via
+   `generate-core-barrel.mjs --check`.)
+3. **Tests** — `spill.test.ts`: over-threshold spills + working locator;
+   under-threshold passthrough (no file written); threshold boundary; session
+   scoping + label sanitization; round-trip read-by-locator (byte-for-byte);
+   bare-path read; missing/traversal locator rejection; substring + regex search;
+   match cap + truncation; threshold config via arg and env.
+4. **Changeset** — minor bump for `@harness-engineering/core` (new exported API).
+5. **Validate** — build (Node 22), typecheck, lint, tests, barrel freshness,
+   `harness ci check` via pre-commit.
+
+## Acceptance criteria
+
+- Over-threshold output writes to disk under the state area and returns a locator
+  that `readSpill` resolves to the original content byte-for-byte.
+- Under-threshold output passes through inline unchanged with no file written.
+- Threshold is configurable (argument + env var) with a 30 KB default.
+- A later turn can search spilled content by locator.
+- Spilled runtime files never land in the diff (spill dir is under `.harness/`,
+  which is git-ignored; tests use temp dirs and clean up).
+
+## Assumptions
+
+- Fork C: extend `packages/core` state handling; no new package.
+- 30 KB default threshold — large enough that ordinary output passes through,
+  small enough to capture a full test log/diff before it dominates the context
+  budget.
+- Locator is machine-local (same-host session continuity), consistent with how
+  the rest of `.harness/` state is used.
+- The core module is the reusable backend; wiring specific fleet/autopilot call
+  sites to route their output through `spillIfNeeded` is left to the consumers of
+  this API (out of scope for this issue, which asks for the backend + locator).

--- a/docs/changes/spill-to-disk-locator/provenance.json
+++ b/docs/changes/spill-to-disk-locator/provenance.json
@@ -1,0 +1,51 @@
+{
+  "issue": 1398,
+  "title": "Spill-to-disk with a followup-readable locator for large tool output",
+  "externalId": "github:Intense-Visions/harness-engineering#1398",
+  "slug": "spill-to-disk-locator",
+  "branch": "build/spill-to-disk-1398",
+  "pipelineStages": [
+    {
+      "stage": "brainstorming",
+      "artifact": "docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md",
+      "summary": "Spill-to-disk backend for large tool output: over-threshold output offloaded to the resolved state area under spill/, recovered via a followup-readable locator (readSpill/searchSpill)."
+    },
+    {
+      "stage": "planning",
+      "artifact": "docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md",
+      "summary": "5-task plan: write spill module, barrel export, tests, changeset, validate. Fork C = extend packages/core/src/state (no new package)."
+    },
+    {
+      "stage": "execution",
+      "artifact": "packages/core/src/state/spill.ts",
+      "summary": "spillIfNeeded / readSpill / searchSpill / resolveSpillThreshold in packages/core/src/state/spill.ts; reuses getStateDir for session/stream/legacy resolution; locator format harness-spill:<repo-relative-path>."
+    }
+  ],
+  "planArtifact": "docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md",
+  "sourceFiles": ["packages/core/src/state/spill.ts", "packages/core/src/state/spill.test.ts"],
+  "registrationSites": [
+    "packages/core/src/state/index.ts (spill export block — auto-discovered by generate-core-barrel.mjs via `export * from './state'`)"
+  ],
+  "spillBackend": {
+    "location": "packages/core/src/state/spill.ts:spillIfNeeded",
+    "readPath": "packages/core/src/state/spill.ts:readSpill",
+    "searchPath": "packages/core/src/state/spill.ts:searchSpill",
+    "locatorFormat": "harness-spill:<repo-relative-posix-path> (e.g. harness-spill:.harness/sessions/<session>/spill/<id>.txt)",
+    "spillDir": ".harness/<session|stream|legacy>/spill/ (git-ignored via .harness/.gitignore)",
+    "defaultThresholdBytes": 30000,
+    "thresholdEnv": "HARNESS_SPILL_THRESHOLD_BYTES"
+  },
+  "localChecks": {
+    "build": "pass (pnpm -w build, Node 22)",
+    "typecheck": "pass (@harness-engineering/core)",
+    "test": "pass (14 tests: spill.test.ts)",
+    "lint": "pass (0 errors, 0 warnings on spill.ts)",
+    "barrelFreshness": "pass (generate-core-barrel.mjs --check: up to date)"
+  },
+  "assumptions": [
+    "Fork C: extend packages/core state handling; no new package created.",
+    "30 KB default threshold, overridable via HARNESS_SPILL_THRESHOLD_BYTES env var or the thresholdBytes option.",
+    "Locator is machine-local (same-host session continuity), consistent with the rest of .harness/ state.",
+    "This issue delivers the reusable core backend + locator; wiring specific fleet/autopilot call sites to route output through spillIfNeeded is left to those consumers."
+  ]
+}

--- a/docs/changes/spill-to-disk-locator/provenance.json
+++ b/docs/changes/spill-to-disk-locator/provenance.json
@@ -19,13 +19,35 @@
       "stage": "execution",
       "artifact": "packages/core/src/state/spill.ts",
       "summary": "spillIfNeeded / readSpill / searchSpill / resolveSpillThreshold in packages/core/src/state/spill.ts; reuses getStateDir for session/stream/legacy resolution; locator format harness-spill:<repo-relative-path>."
+    },
+    {
+      "stage": "wiring",
+      "artifact": "packages/cli/src/mcp/middleware/compaction.ts",
+      "summary": "Wired the spill primitive into wrapWithCompaction — the MCP tool-output choke point whose TruncationStrategy previously dropped over-budget test logs/diffs/grep overflow with no recovery. Over-threshold output is spilled whole via spillIfNeeded and a harness-spill: locator is appended to the compacted result (readSpill/searchSpill recover it); under-threshold passes through unchanged. projectRoot threaded from server.ts through applyCompaction; lossless-only tools excluded; fail-open."
     }
   ],
   "planArtifact": "docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md",
-  "sourceFiles": ["packages/core/src/state/spill.ts", "packages/core/src/state/spill.test.ts"],
-  "registrationSites": [
-    "packages/core/src/state/index.ts (spill export block — auto-discovered by generate-core-barrel.mjs via `export * from './state'`)"
+  "sourceFiles": [
+    "packages/core/src/state/spill.ts",
+    "packages/core/src/state/spill.test.ts",
+    "packages/cli/src/mcp/middleware/compaction.ts",
+    "packages/cli/src/mcp/server.ts",
+    "packages/cli/tests/mcp/middleware/compaction.test.ts"
   ],
+  "registrationSites": [
+    "packages/core/src/state/index.ts (spill export block — auto-discovered by generate-core-barrel.mjs via `export * from './state'`)",
+    "packages/cli/src/mcp/server.ts (applyCompaction called with { projectRoot: resolvedRoot } — activates spill routing for all MCP tool output)"
+  ],
+  "consumerSite": {
+    "location": "packages/cli/src/mcp/middleware/compaction.ts:wrapWithCompaction",
+    "helpers": "spillLargeResult / appendLocatorNotice / joinResultText",
+    "activatedFrom": "packages/cli/src/mcp/server.ts:createHarnessServer (applyCompaction(guardedHandlers, { projectRoot: resolvedRoot }))",
+    "behavior": "Over spill threshold: full pre-compaction payload written to disk; harness-spill: locator appended to the compacted (truncated) result for readSpill/searchSpill recovery. Under threshold: compacted result returned unchanged. Lossless-only tools excluded; fail-open on any spill error; no projectRoot disables spill (backward-compatible).",
+    "skippedNonSpillSites": [
+      "packages/cli/src/skill/dispatch-session.ts + dispatcher.ts .slice(0,N) — recommendation/knowledge-list display caps, not large session output",
+      "config/stripped-keys.ts, brand forbidden-phrase snippets, naming-craft convention extraction — display/secret-stripping, no recovery value"
+    ]
+  },
   "spillBackend": {
     "location": "packages/core/src/state/spill.ts:spillIfNeeded",
     "readPath": "packages/core/src/state/spill.ts:readSpill",
@@ -37,15 +59,17 @@
   },
   "localChecks": {
     "build": "pass (pnpm -w build, Node 22)",
-    "typecheck": "pass (@harness-engineering/core)",
-    "test": "pass (14 tests: spill.test.ts)",
-    "lint": "pass (0 errors, 0 warnings on spill.ts)",
+    "typecheck": "pass (@harness-engineering/core, @harness-engineering/cli)",
+    "test": "pass (14 spill.test.ts + 17 compaction.test.ts incl. 4 CT-spill wiring tests)",
+    "lint": "pass (0 errors, 0 warnings on spill.ts + compaction.ts)",
     "barrelFreshness": "pass (generate-core-barrel.mjs --check: up to date)"
   },
   "assumptions": [
     "Fork C: extend packages/core state handling; no new package created.",
     "30 KB default threshold, overridable via HARNESS_SPILL_THRESHOLD_BYTES env var or the thresholdBytes option.",
     "Locator is machine-local (same-host session continuity), consistent with the rest of .harness/ state.",
-    "This issue delivers the reusable core backend + locator; wiring specific fleet/autopilot call sites to route output through spillIfNeeded is left to those consumers."
+    "Wiring: the MCP compaction middleware is the intended consumer — it is the single choke point where large tool output (test logs, diffs, grep/glob overflow) is lossy-truncated for every session. Spill is gated on the primitive's own byte threshold (not the 4000-token truncation budget); output between the truncation budget and the spill threshold is still truncated but small enough that the tail loss is minor and the threshold is tunable.",
+    "Lossless-only tools (run_skill, manage_state, generated artifacts, etc.) are never lossy-truncated and are deliberately excluded from spill.",
+    "Spill runs only when a projectRoot is supplied and fails open; behavior is unchanged when spill errors or no projectRoot is present."
   ]
 }

--- a/packages/cli/src/mcp/middleware/compaction.ts
+++ b/packages/cli/src/mcp/middleware/compaction.ts
@@ -17,10 +17,27 @@ import {
   TruncationStrategy,
   DEFAULT_TOKEN_BUDGET,
   estimateTokens,
+  spillIfNeeded,
 } from '@harness-engineering/core';
 
 type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
 type ToolHandler = (input: Record<string, unknown>) => Promise<ToolResult>;
+
+/**
+ * Configuration for the compaction middleware.
+ *
+ * When `projectRoot` is provided, tool output large enough to be lossy-truncated
+ * is first offloaded whole to disk via {@link spillIfNeeded}, and the compacted
+ * (truncated) result carries a followup-readable locator so a later turn can
+ * recover or search the full output instead of losing the truncated tail. When
+ * `projectRoot` is omitted, spill is disabled and compaction behaves as before.
+ */
+export interface CompactionOptions {
+  /** Project root under which spilled payloads are written (`.harness/.../spill/`). */
+  projectRoot?: string;
+  /** Byte threshold above which output is spilled to disk. Defaults to the spill module's resolved threshold. */
+  spillThresholdBytes?: number;
+}
 
 /** Default pipeline — structural then truncation. */
 const DEFAULT_PIPELINE = new CompactionPipeline([
@@ -91,8 +108,66 @@ const LOSSLESS_ONLY_TOOLS = new Set([
   'manage_roadmap', // Structured roadmap with cross-references and dependencies
 ]);
 
+/** Concatenate all text items of a result — the full, pre-compaction payload. */
+function joinResultText(result: ToolResult): string {
+  return result.content
+    .filter((i) => i.type === 'text')
+    .map((i) => i.text)
+    .join('\n');
+}
+
+/** Append a spill-recovery line (with the locator) to the first text item. */
+function appendLocatorNotice(result: ToolResult, locator: string, bytes: number): ToolResult {
+  const line =
+    `\n[harness spill] full untruncated output (${bytes} bytes) preserved on disk — ` +
+    `recover or grep the complete payload via locator: ${locator}`;
+  let done = false;
+  const content = result.content.map((item) => {
+    if (done || item.type !== 'text') return item;
+    done = true;
+    return { ...item, text: `${item.text}${line}` };
+  });
+  return { ...result, content };
+}
+
+/**
+ * Route a lossy-truncated result through the spill primitive.
+ *
+ * Over the spill threshold: the full pre-compaction output is written to disk
+ * and the compacted result gets a followup-readable locator appended, so a later
+ * turn can recover the truncated tail. Under threshold: the compacted result is
+ * returned unchanged. Fail-open: any spill error yields the compacted result.
+ */
+async function spillLargeResult(
+  toolName: string,
+  original: ToolResult,
+  compacted: ToolResult,
+  options: CompactionOptions
+): Promise<ToolResult> {
+  if (!options.projectRoot) return compacted;
+
+  const fullText = joinResultText(original);
+  try {
+    const spillOpts =
+      options.spillThresholdBytes === undefined
+        ? { label: toolName }
+        : { label: toolName, thresholdBytes: options.spillThresholdBytes };
+    const spill = await spillIfNeeded(options.projectRoot, fullText, spillOpts);
+    if (spill.ok && spill.value.spilled) {
+      return appendLocatorNotice(compacted, spill.value.locator, spill.value.bytes);
+    }
+  } catch {
+    // Fail-open: spill failure must never break the tool response.
+  }
+  return compacted;
+}
+
 /** Wrap a tool handler with compaction. Fail-open; compact:false bypasses. */
-export function wrapWithCompaction(toolName: string, handler: ToolHandler): ToolHandler {
+export function wrapWithCompaction(
+  toolName: string,
+  handler: ToolHandler,
+  options: CompactionOptions = {}
+): ToolHandler {
   return async (input: Record<string, unknown>): Promise<ToolResult> => {
     // The compact tool already produces carefully budgeted output — skip to avoid double compaction.
     if (toolName === 'compact') {
@@ -109,10 +184,14 @@ export function wrapWithCompaction(toolName: string, handler: ToolHandler): Tool
     try {
       // run_skill returns behavioral instructions (SKILL.md) that the agent must follow
       // completely — truncation corrupts the workflow. Apply structural compaction only.
+      // Lossless-only tools are never lossy-truncated, so there is nothing to spill.
       if (LOSSLESS_ONLY_TOOLS.has(toolName)) {
         return compactResultWith(result, LOSSLESS_PIPELINE);
       }
-      return compactResultWith(result, DEFAULT_PIPELINE, DEFAULT_TOKEN_BUDGET);
+      const compacted = compactResultWith(result, DEFAULT_PIPELINE, DEFAULT_TOKEN_BUDGET);
+      // Over-threshold output is truncated by the pipeline with no recovery path;
+      // spill the full payload to disk and hand back a locator to recover it.
+      return await spillLargeResult(toolName, result, compacted, options);
     } catch {
       // Fail-open: compaction error returns the original handler result unchanged
       return result;
@@ -124,11 +203,12 @@ export function wrapWithCompaction(toolName: string, handler: ToolHandler): Tool
  * Wrap all tool handlers in a handlers map with compaction middleware.
  */
 export function applyCompaction(
-  handlers: Record<string, ToolHandler>
+  handlers: Record<string, ToolHandler>,
+  options: CompactionOptions = {}
 ): Record<string, ToolHandler> {
   const wrapped: Record<string, ToolHandler> = {};
   for (const [name, handler] of Object.entries(handlers)) {
-    wrapped[name] = wrapWithCompaction(name, handler);
+    wrapped[name] = wrapWithCompaction(name, handler, options);
   }
   return wrapped;
 }

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -708,7 +708,7 @@ export function createHarnessServer(projectRoot?: string, toolFilter?: string[])
     projectRoot: resolvedRoot,
     trustedOutputTools,
   });
-  const compactedHandlers = applyCompaction(guardedHandlers);
+  const compactedHandlers = applyCompaction(guardedHandlers, { projectRoot: resolvedRoot });
 
   const server = new Server(
     { name: 'harness-engineering', version: '2.3.1' },

--- a/packages/cli/tests/mcp/middleware/compaction.test.ts
+++ b/packages/cli/tests/mcp/middleware/compaction.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readSpill, searchSpill, SPILL_LOCATOR_SCHEME } from '@harness-engineering/core';
 import { wrapWithCompaction, applyCompaction } from '../../../src/mcp/middleware/compaction';
 
 type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
@@ -275,5 +279,109 @@ describe('CT08: reduction metrics — real handler simulation', () => {
     const bypassResult = await wrapped({ compact: false, path: '/tmp' });
 
     expect(bypassResult.content[0].text).toBe(rawResult.content[0].text);
+  });
+});
+
+describe('CT-spill: large tool output spills to disk with a followup-readable locator', () => {
+  const tmpRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of tmpRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  function makeTmpRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), 'harness-spill-mw-'));
+    tmpRoots.push(root);
+    return root;
+  }
+
+  // A long test-log-style payload that both exceeds the truncation budget and,
+  // for spill purposes, exceeds a small explicit spill threshold.
+  const bigLog = Array.from(
+    { length: 4000 },
+    (_, i) => `2026-08-18T00:00:${String(i % 60).padStart(2, '0')} INFO line ${i} value-${i}`
+  ).join('\n');
+  const marker = 'SENTINEL_NEEDLE_9f2ab';
+  const bigLogWithMarker = `${bigLog}\n${marker}\ntail-after-marker`;
+
+  const bigLogHandler = async (): Promise<ToolResult> => ({
+    content: [{ type: 'text', text: bigLogWithMarker }],
+  });
+
+  it('spills over-threshold output and the locator reads back the original content', async () => {
+    const projectRoot = makeTmpRoot();
+    const wrapped = wrapWithCompaction('run_ci_checks', bigLogHandler, {
+      projectRoot,
+      spillThresholdBytes: 1000,
+    });
+
+    const result = await wrapped({});
+    const text = result.content[0].text;
+
+    // Compaction still applied (truncated preview + packed header).
+    expect(text).toMatch(/<!-- packed:/);
+    // Locator substituted into the result so a later turn can recover the tail.
+    expect(text).toContain(SPILL_LOCATOR_SCHEME);
+    const locator = text.match(/harness-spill:[^\s]+/)?.[0];
+    expect(locator).toBeTruthy();
+
+    // The locator reads back the FULL original payload byte-for-byte —
+    // including the marker/tail that truncation dropped from the inline result.
+    const readBack = await readSpill(projectRoot, locator!);
+    expect(readBack.ok).toBe(true);
+    if (readBack.ok) {
+      expect(readBack.value).toBe(bigLogWithMarker);
+      expect(readBack.value).toContain(marker);
+    }
+
+    // Truncation actually happened: the inline result is far shorter than the
+    // full payload now safely recoverable on disk.
+    expect(text.length).toBeLessThan(bigLogWithMarker.length);
+
+    // And the spilled payload is searchable by a later turn without pulling it inline.
+    const search = await searchSpill(projectRoot, locator!, marker);
+    expect(search.ok).toBe(true);
+    if (search.ok) {
+      expect(search.value.matches.length).toBe(1);
+    }
+  });
+
+  it('passes under-threshold output through unchanged — no spill file, no locator', async () => {
+    const projectRoot = makeTmpRoot();
+    const shortText = JSON.stringify({ name: 'harness', ok: true, path: '/src/a.ts' });
+    const handler = async (): Promise<ToolResult> => ({
+      content: [{ type: 'text', text: shortText }],
+    });
+
+    const wrapped = wrapWithCompaction('gather_context', handler, {
+      projectRoot,
+      spillThresholdBytes: 1000,
+    });
+    const result = await wrapped({});
+    const text = result.content[0].text;
+
+    // Normal compaction (header) but NO spill locator appended.
+    expect(text).toMatch(/<!-- packed:/);
+    expect(text).not.toContain(SPILL_LOCATOR_SCHEME);
+    // No spill directory created for under-threshold output.
+    expect(existsSync(join(projectRoot, '.harness'))).toBe(false);
+  });
+
+  it('does not spill when no projectRoot is supplied (backward-compatible)', async () => {
+    const wrapped = wrapWithCompaction('run_ci_checks', bigLogHandler);
+    const result = await wrapped({});
+    expect(result.content[0].text).not.toContain(SPILL_LOCATOR_SCHEME);
+  });
+
+  it('applyCompaction threads projectRoot to every wrapped handler', async () => {
+    const projectRoot = makeTmpRoot();
+    const wrapped = applyCompaction(
+      { run_ci_checks: bigLogHandler },
+      { projectRoot, spillThresholdBytes: 1000 }
+    );
+    const result = await wrapped.run_ci_checks({});
+    expect(result.content[0].text).toContain(SPILL_LOCATOR_SCHEME);
   });
 });

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -129,6 +129,29 @@ export {
 } from './session-sections';
 
 /**
+ * Spill-to-disk for large tool output — offload over-threshold payloads to the
+ * session/state area and recover them by a followup-readable locator (#1398).
+ */
+export {
+  spillIfNeeded,
+  readSpill,
+  searchSpill,
+  resolveSpillThreshold,
+  SPILL_DIR,
+  SPILL_LOCATOR_SCHEME,
+  SPILL_THRESHOLD_ENV,
+  DEFAULT_SPILL_THRESHOLD_BYTES,
+} from './spill';
+export type {
+  SpillOptions,
+  SpillResult,
+  SpillPassthrough,
+  SpillWritten,
+  SpillSearchMatch,
+  SpillSearchResult,
+} from './spill';
+
+/**
  * Session archival for preserving previous session state.
  */
 export { archiveSession } from './session-archive';

--- a/packages/core/src/state/spill.test.ts
+++ b/packages/core/src/state/spill.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  spillIfNeeded,
+  readSpill,
+  searchSpill,
+  resolveSpillThreshold,
+  SPILL_DIR,
+  SPILL_LOCATOR_SCHEME,
+  SPILL_THRESHOLD_ENV,
+  DEFAULT_SPILL_THRESHOLD_BYTES,
+} from './spill';
+
+/**
+ * Unit coverage for spill-to-disk (#1398). Runs against a real temp project
+ * using the legacy `.harness/` state directory (no streams index present, so
+ * `getStateDir` falls back to it).
+ *
+ * Behaviour pinned here:
+ *  - over-threshold output is written to disk under the state area and a working,
+ *    followup-readable locator is returned;
+ *  - under-threshold output passes through inline, unchanged, with no file write;
+ *  - round-trip read-by-locator returns the original content byte-for-byte;
+ *  - search-by-locator greps the spilled payload without pulling it all inline;
+ *  - the threshold is configurable via argument and env var;
+ *  - locators that escape the project root are rejected.
+ */
+
+let projectPath: string;
+
+beforeEach(() => {
+  projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'spill-'));
+  delete process.env[SPILL_THRESHOLD_ENV];
+});
+
+afterEach(() => {
+  delete process.env[SPILL_THRESHOLD_ENV];
+  fs.rmSync(projectPath, { recursive: true, force: true });
+});
+
+describe('spillIfNeeded', () => {
+  it('spills over-threshold output and returns a working locator', async () => {
+    const big = 'x'.repeat(50_000);
+    const result = await spillIfNeeded(projectPath, big, { thresholdBytes: 1000 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const outcome = result.value;
+    expect(outcome.spilled).toBe(true);
+    if (!outcome.spilled) return;
+
+    expect(outcome.locator.startsWith(SPILL_LOCATOR_SCHEME)).toBe(true);
+    expect(outcome.locator).toContain(`/${SPILL_DIR}/`);
+    expect(outcome.bytes).toBe(50_000);
+    // The file physically exists under the state area.
+    expect(fs.existsSync(outcome.path)).toBe(true);
+    expect(outcome.path).toContain(path.join('.harness', SPILL_DIR));
+    // Inline notice carries a bounded preview plus the recovery locator.
+    expect(outcome.preview.length).toBeLessThan(big.length);
+    expect(outcome.notice).toContain(outcome.locator);
+    expect(outcome.notice).toContain(outcome.preview);
+  });
+
+  it('passes under-threshold output through inline without writing a file', async () => {
+    const small = 'hello world';
+    const result = await spillIfNeeded(projectPath, small, { thresholdBytes: 1000 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const outcome = result.value;
+    expect(outcome.spilled).toBe(false);
+    if (outcome.spilled) return;
+
+    expect(outcome.content).toBe(small);
+    expect(outcome.bytes).toBe(Buffer.byteLength(small, 'utf8'));
+    // No spill directory created for a passthrough.
+    expect(fs.existsSync(path.join(projectPath, '.harness', SPILL_DIR))).toBe(false);
+  });
+
+  it('respects a boundary exactly at the threshold (<= passes through)', async () => {
+    const content = 'a'.repeat(100);
+    const result = await spillIfNeeded(projectPath, content, { thresholdBytes: 100 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.spilled).toBe(false);
+  });
+
+  it('spills a session-scoped payload under the session state area', async () => {
+    const big = 'y'.repeat(40_000);
+    const result = await spillIfNeeded(projectPath, big, {
+      thresholdBytes: 1000,
+      session: 'my-session',
+      label: 'Test Log #1',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const outcome = result.value;
+    expect(outcome.spilled).toBe(true);
+    if (!outcome.spilled) return;
+    expect(outcome.path).toContain(path.join('sessions', 'my-session', SPILL_DIR));
+    // Label is sanitized into the filename.
+    expect(outcome.path).toContain('test-log-1');
+  });
+});
+
+describe('readSpill (round-trip)', () => {
+  it('returns the original content byte-for-byte via the locator', async () => {
+    const original = `line-1\nlarge diff body ${'z'.repeat(40_000)}\nfinal-line`;
+    const spillResult = await spillIfNeeded(projectPath, original, { thresholdBytes: 1000 });
+    expect(spillResult.ok).toBe(true);
+    if (!spillResult.ok || !spillResult.value.spilled) throw new Error('expected spill');
+
+    const readResult = await readSpill(projectPath, spillResult.value.locator);
+    expect(readResult.ok).toBe(true);
+    if (!readResult.ok) return;
+    expect(readResult.value).toBe(original);
+  });
+
+  it('reads via a bare project-relative path (no scheme prefix)', async () => {
+    const original = 'q'.repeat(40_000);
+    const spillResult = await spillIfNeeded(projectPath, original, { thresholdBytes: 1000 });
+    if (!spillResult.ok || !spillResult.value.spilled) throw new Error('expected spill');
+    const bare = spillResult.value.locator.slice(SPILL_LOCATOR_SCHEME.length);
+
+    const readResult = await readSpill(projectPath, bare);
+    expect(readResult.ok).toBe(true);
+    if (!readResult.ok) return;
+    expect(readResult.value).toBe(original);
+  });
+
+  it('errors for a missing locator', async () => {
+    const result = await readSpill(projectPath, `${SPILL_LOCATOR_SCHEME}.harness/spill/nope.txt`);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a path-traversal locator', async () => {
+    const result = await readSpill(projectPath, `${SPILL_LOCATOR_SCHEME}../../etc/passwd`);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('searchSpill', () => {
+  it('greps spilled content by substring and by regex', async () => {
+    const body =
+      'INFO starting\n' +
+      'ERROR: boom at step 3\n' +
+      `${'padding line\n'.repeat(4000)}` +
+      'ERROR: second failure\n' +
+      'INFO done';
+    const spillResult = await spillIfNeeded(projectPath, body, { thresholdBytes: 1000 });
+    if (!spillResult.ok || !spillResult.value.spilled) throw new Error('expected spill');
+    const locator = spillResult.value.locator;
+
+    const bySubstring = await searchSpill(projectPath, locator, 'ERROR:');
+    expect(bySubstring.ok).toBe(true);
+    if (!bySubstring.ok) return;
+    expect(bySubstring.value.matches).toHaveLength(2);
+    const [first] = bySubstring.value.matches;
+    expect(first?.text).toContain('boom at step 3');
+    expect(first?.line).toBe(2);
+
+    const byRegex = await searchSpill(projectPath, locator, /second failure/);
+    expect(byRegex.ok).toBe(true);
+    if (!byRegex.ok) return;
+    expect(byRegex.value.matches).toHaveLength(1);
+  });
+
+  it('caps matches and flags truncation', async () => {
+    const body = `${'MATCH here\n'.repeat(5000)}tail`;
+    const spillResult = await spillIfNeeded(projectPath, body, { thresholdBytes: 1000 });
+    if (!spillResult.ok || !spillResult.value.spilled) throw new Error('expected spill');
+
+    const result = await searchSpill(projectPath, spillResult.value.locator, 'MATCH', {
+      maxMatches: 10,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.matches).toHaveLength(10);
+    expect(result.value.truncated).toBe(true);
+  });
+});
+
+describe('resolveSpillThreshold', () => {
+  it('prefers an explicit argument', () => {
+    expect(resolveSpillThreshold(4242)).toBe(4242);
+  });
+
+  it('falls back to the env var when no argument is given', () => {
+    process.env[SPILL_THRESHOLD_ENV] = '777';
+    expect(resolveSpillThreshold()).toBe(777);
+  });
+
+  it('ignores an invalid env var and uses the default', () => {
+    process.env[SPILL_THRESHOLD_ENV] = 'not-a-number';
+    expect(resolveSpillThreshold()).toBe(DEFAULT_SPILL_THRESHOLD_BYTES);
+  });
+
+  it('honours the env var end-to-end in spillIfNeeded', async () => {
+    process.env[SPILL_THRESHOLD_ENV] = '10';
+    const result = await spillIfNeeded(projectPath, 'this is more than ten bytes');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.spilled).toBe(true);
+  });
+});

--- a/packages/core/src/state/spill.ts
+++ b/packages/core/src/state/spill.ts
@@ -1,0 +1,284 @@
+// packages/core/src/state/spill.ts
+//
+// Spill-to-disk for large tool output (issue #1398).
+//
+// Long-running sessions — fleet workers, autopilot loops — accumulate large
+// intermediate tool output: full test logs, whole diffs, grep/glob overflow.
+// Inlining all of it blows the context budget; truncating it ad hoc loses the
+// tail with no recovery path.
+//
+// This module offloads output over a configurable size threshold to a file
+// under the session/state area (`.harness/.../spill/`) and returns a stable,
+// followup-READABLE locator. A later turn can recover the full content via
+// `readSpill`, or search it via `searchSpill`, instead of losing it. Content
+// under the threshold passes through inline, unchanged.
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Result } from '../shared/result';
+import { Ok, Err } from '../shared/result';
+import { getStateDir } from './state-shared';
+
+/** Directory (under the resolved state dir) where spilled payloads are written. */
+export const SPILL_DIR = 'spill';
+
+/**
+ * Default byte threshold above which output is spilled to disk. ~30 KB is large
+ * enough that ordinary tool output passes through inline, but small enough that
+ * a full test log / diff / grep overflow is captured before it dominates the
+ * context budget.
+ */
+export const DEFAULT_SPILL_THRESHOLD_BYTES = 30_000;
+
+/** Environment variable that overrides the default spill threshold (bytes). */
+export const SPILL_THRESHOLD_ENV = 'HARNESS_SPILL_THRESHOLD_BYTES';
+
+/** Scheme prefix that marks a string as a spill locator. */
+export const SPILL_LOCATOR_SCHEME = 'harness-spill:';
+
+/** Default number of leading characters retained as an inline preview. */
+const DEFAULT_PREVIEW_CHARS = 2000;
+
+export interface SpillOptions {
+  /**
+   * Byte threshold above which content is spilled. When omitted, resolved from
+   * the {@link SPILL_THRESHOLD_ENV} env var, then {@link DEFAULT_SPILL_THRESHOLD_BYTES}.
+   */
+  thresholdBytes?: number;
+  /** Session slug — scopes the spill dir to a session's state area. */
+  session?: string;
+  /** Stream name — scopes the spill dir to a stream's state area. */
+  stream?: string;
+  /** Short human label recorded in the filename + notice (e.g. `test-log`). */
+  label?: string;
+  /** Leading characters kept as an inline preview. Defaults to 2000. */
+  previewChars?: number;
+}
+
+/** Content stayed under the threshold and was returned inline, unchanged. */
+export interface SpillPassthrough {
+  spilled: false;
+  content: string;
+  bytes: number;
+}
+
+/** Content exceeded the threshold and was written to disk. */
+export interface SpillWritten {
+  spilled: true;
+  /** Stable, followup-readable locator: scheme + repo-relative path. */
+  locator: string;
+  /** Absolute path to the spilled file — directly cat/grep-able. */
+  path: string;
+  /** Total bytes written. */
+  bytes: number;
+  /** Leading slice of the content, for inline context. */
+  preview: string;
+  /** Ready-to-inline replacement: preview + a recovery notice with the locator. */
+  notice: string;
+}
+
+export type SpillResult = SpillPassthrough | SpillWritten;
+
+/** A single line matched by {@link searchSpill}. */
+export interface SpillSearchMatch {
+  /** 1-based line number within the spilled file. */
+  line: number;
+  /** The full matching line (without trailing newline). */
+  text: string;
+}
+
+export interface SpillSearchResult {
+  locator: string;
+  matches: SpillSearchMatch[];
+  /** True when the number of matches hit the requested cap. */
+  truncated: boolean;
+}
+
+/**
+ * Resolves the effective spill threshold (bytes).
+ *
+ * Precedence: explicit argument → {@link SPILL_THRESHOLD_ENV} → default. Invalid
+ * or negative values are ignored in favour of the next source.
+ */
+export function resolveSpillThreshold(explicit?: number): number {
+  if (typeof explicit === 'number' && Number.isFinite(explicit) && explicit >= 0) {
+    return explicit;
+  }
+  const envRaw = process.env[SPILL_THRESHOLD_ENV];
+  if (envRaw !== undefined) {
+    const parsed = Number(envRaw);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_SPILL_THRESHOLD_BYTES;
+}
+
+/** Sanitizes a caller-supplied label into a filesystem-safe token. */
+function sanitizeLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+}
+
+/** Generates a unique, sortable spill filename. */
+function generateSpillFilename(label?: string): string {
+  const timestamp = Date.now().toString(36);
+  const random = Buffer.from(crypto.getRandomValues(new Uint8Array(5))).toString('hex');
+  const safeLabel = label ? sanitizeLabel(label) : '';
+  const suffix = safeLabel ? `-${safeLabel}` : '';
+  return `${timestamp}-${random}${suffix}.txt`;
+}
+
+/** Builds a locator string from a project-relative path (posix-normalized). */
+function toLocator(relativePath: string): string {
+  return `${SPILL_LOCATOR_SCHEME}${relativePath.replaceAll('\\', '/')}`;
+}
+
+/**
+ * Resolves a spill locator (or a bare relative path) to an absolute file path
+ * under `projectPath`, rejecting anything that escapes the project root.
+ */
+function resolveLocator(projectPath: string, locator: string): Result<string, Error> {
+  const raw = locator.startsWith(SPILL_LOCATOR_SCHEME)
+    ? locator.slice(SPILL_LOCATOR_SCHEME.length)
+    : locator;
+
+  if (!raw || raw.trim() === '') {
+    return Err(new Error('Spill locator must not be empty'));
+  }
+  if (path.isAbsolute(raw)) {
+    return Err(new Error(`Invalid spill locator '${locator}': must be project-relative`));
+  }
+
+  const absolute = path.resolve(projectPath, raw);
+  const root = path.resolve(projectPath);
+  // Containment check without path.relative: the resolved path must be the root
+  // itself or sit beneath `root + separator`.
+  if (absolute !== root && !absolute.startsWith(root + path.sep)) {
+    return Err(new Error(`Invalid spill locator '${locator}': escapes the project root`));
+  }
+  return Ok(absolute);
+}
+
+/** Builds the inline recovery notice shown in place of the full payload. */
+function buildNotice(bytes: number, locator: string, preview: string): string {
+  const header =
+    `[harness spill] ${bytes} bytes of output offloaded to disk to preserve the context budget.\n` +
+    `[harness spill] recover the full content via locator: ${locator}\n` +
+    `--- preview (first ${preview.length} chars) ---`;
+  const footer = '--- end preview (content truncated; read the locator above for the rest) ---';
+  return `${header}\n${preview}\n${footer}`;
+}
+
+/**
+ * Spills `content` to disk when it exceeds the resolved threshold, returning a
+ * followup-readable locator; otherwise passes it through inline unchanged.
+ *
+ * The spilled file lives under the resolved state dir (session/stream/legacy)
+ * in a `spill/` subdirectory, which sits inside `.harness/` and is therefore
+ * git-ignored — spilled runtime output never lands in a commit.
+ */
+export async function spillIfNeeded(
+  projectPath: string,
+  content: string,
+  options: SpillOptions = {}
+): Promise<Result<SpillResult, Error>> {
+  const bytes = Buffer.byteLength(content, 'utf8');
+  const threshold = resolveSpillThreshold(options.thresholdBytes);
+
+  if (bytes <= threshold) {
+    return Ok({ spilled: false, content, bytes });
+  }
+
+  const dirResult = await getStateDir(projectPath, options.stream, options.session);
+  if (!dirResult.ok) return dirResult;
+
+  const spillDir = path.join(dirResult.value, SPILL_DIR);
+  const filePath = path.join(spillDir, generateSpillFilename(options.label));
+
+  try {
+    fs.mkdirSync(spillDir, { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf8');
+  } catch (error) {
+    return Err(
+      new Error(
+        `Failed to spill output to disk: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+
+  const locator = toLocator(path.relative(projectPath, filePath).replaceAll('\\', '/'));
+  const previewChars = options.previewChars ?? DEFAULT_PREVIEW_CHARS;
+  const preview = content.slice(0, previewChars);
+
+  return Ok({
+    spilled: true,
+    locator,
+    path: filePath,
+    bytes,
+    preview,
+    notice: buildNotice(bytes, locator, preview),
+  });
+}
+
+/**
+ * Reads back the full content previously spilled under `locator`. Accepts both
+ * a scheme-prefixed locator and a bare project-relative path.
+ */
+export async function readSpill(
+  projectPath: string,
+  locator: string
+): Promise<Result<string, Error>> {
+  const resolved = resolveLocator(projectPath, locator);
+  if (!resolved.ok) return resolved;
+
+  try {
+    if (!fs.existsSync(resolved.value)) {
+      return Err(new Error(`Spilled content not found for locator '${locator}'`));
+    }
+    return Ok(fs.readFileSync(resolved.value, 'utf8'));
+  } catch (error) {
+    return Err(
+      new Error(
+        `Failed to read spilled content: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+}
+
+/**
+ * Searches previously spilled content line-by-line for `pattern` (a substring
+ * or RegExp), returning matching lines with 1-based line numbers. Lets a later
+ * turn grep an over-threshold payload without pulling the whole thing inline.
+ */
+export async function searchSpill(
+  projectPath: string,
+  locator: string,
+  pattern: string | RegExp,
+  options: { maxMatches?: number } = {}
+): Promise<Result<SpillSearchResult, Error>> {
+  const readResult = await readSpill(projectPath, locator);
+  if (!readResult.ok) return readResult;
+
+  const maxMatches = options.maxMatches ?? 200;
+  const test: (line: string) => boolean =
+    pattern instanceof RegExp ? (line) => pattern.test(line) : (line) => line.includes(pattern);
+
+  const matches: SpillSearchMatch[] = [];
+  const lines = readResult.value.split('\n');
+  let truncated = false;
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i] ?? '';
+    if (test(text)) {
+      if (matches.length >= maxMatches) {
+        truncated = true;
+        break;
+      }
+      matches.push({ line: i + 1, text });
+    }
+  }
+
+  return Ok({ locator, matches, truncated });
+}


### PR DESCRIPTION
## Summary

Adds a spill-to-disk primitive for large intermediate tool output **and wires it into the real consumer path** so long-running harness sessions (fleet workers, autopilot loops) can offload full test logs, whole diffs, and grep/glob overflow to disk and reference them by a stable, followup-readable **locator** instead of truncating them inline with no recovery path.

This is one PR that both **defines** the primitive and **wires** it in.

## Define — `packages/core/src/state/spill.ts`

- **`spillIfNeeded(projectPath, content, options?)`** — over the configurable byte threshold, writes content to a `spill/` subdir of the resolved state area and returns `{ spilled: true, locator, path, bytes, preview, notice }`; under the threshold, passes through inline unchanged (`{ spilled: false, content, bytes }`).
- **`readSpill(projectPath, locator)`** — recovers the full original content by locator (byte-for-byte), rejecting path-traversal.
- **`searchSpill(projectPath, locator, pattern, opts?)`** — greps the spilled payload line-by-line (substring or RegExp) with 1-based line numbers + a truncation flag.
- **`resolveSpillThreshold(explicit?)`** — precedence: explicit arg → `HARNESS_SPILL_THRESHOLD_BYTES` env → default 30 KB.

**Locator format:** `harness-spill:<repo-relative-posix-path>`. Scheme-prefixed yet directly cat/grep-able after stripping the scheme; `readSpill`/`searchSpill` accept it with or without the scheme. The spill dir sits under the resolved state area inside `.harness/` (git-ignored) — spilled runtime output never lands in a commit.

Exported via `packages/core/src/state/index.ts` (auto-discovered by `generate-core-barrel.mjs`).

## Wire — `packages/cli/src/mcp/middleware/compaction.ts`

The primitive is now consumed at **`wrapWithCompaction`**, the single choke point every MCP tool response flows through. Its default pipeline (`StructuralStrategy → TruncationStrategy`, 4000-token budget) is exactly the "ad hoc truncation with no recovery path" the issue names — over-budget test logs, whole diffs, and grep/glob overflow were cut to a `[truncated]` marker and the tail was lost.

- `applyCompaction(handlers, { projectRoot })` is called from `packages/cli/src/mcp/server.ts` with the server's resolved project root, threading `CompactionOptions { projectRoot?, spillThresholdBytes? }` to every wrapped handler.
- For a non-lossless tool whose output the truncation pipeline compacts, the middleware calls `spillIfNeeded(projectRoot, fullOriginalText, { label: toolName })` on the **pre-compaction** payload. **Over threshold** → the whole payload is written to disk and a recovery line carrying the `harness-spill:` locator is appended to the compacted result (`spillLargeResult` → `appendLocatorNotice`), so a later turn can `readSpill`/`searchSpill` the full output. **Under threshold** → the compacted result is returned unchanged (no file, no locator).
- Lossless-only tools (`run_skill`, `manage_state`, …) are never lossy-truncated and are deliberately excluded. Fail-open throughout; absent a `projectRoot`, spill is disabled (backward-compatible).

**Deliberately skipped as non-spill:** `skill/dispatch-session.ts` / `dispatcher.ts` `.slice(0, N)` (recommendation/knowledge-list display caps), `config/stripped-keys.ts`, brand forbidden-phrase snippets, naming-craft convention extraction — display/secret-stripping, no recovery value.

## Tests

- `packages/core/src/state/spill.test.ts` — 14 tests (backend).
- `packages/cli/tests/mcp/middleware/compaction.test.ts` → `CT-spill` block — over-threshold output spills to a temp `projectRoot`, the appended `harness-spill:` locator reads back the payload byte-for-byte via `readSpill` and is grep-able via `searchSpill`; under-threshold passes through with no locator and no spill dir; a no-`projectRoot` call stays backward-compatible; `applyCompaction` threads `projectRoot`. Temp dirs cleaned in `afterEach` — no spilled runtime file committed.

## Provenance

- Plan (define + wiring section): `docs/changes/spill-to-disk-locator/plans/2026-08-18-spill-to-disk-plan.md`
- Provenance (adds `wiring` stage): `docs/changes/spill-to-disk-locator/provenance.json`
- Changesets: `.changeset/spill-to-disk-locator.md` (`@harness-engineering/core` minor) + `.changeset/spill-to-disk-wiring.md` (`@harness-engineering/cli` minor)

Closes #1398
