### PR TITLE
fix(graph): anchor enum extractor regexes (#1331)

### DIFF
--- a/.changeset/fix-1331-anchor-enum-regex.md
+++ b/.changeset/fix-1331-anchor-enum-regex.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/graph': patch
+---
+
+Anchor TS/Java enum extractor regexes so prose/comments are no longer parsed as enum business terms (#1331).

--- a/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
+++ b/packages/graph/src/ingest/extractors/EnumConstantExtractor.ts
@@ -4,7 +4,7 @@ import type { ExtractionRecord, Language, SignalExtractor } from './types.js';
 // Detection patterns are hoisted to module scope so their literal braces
 // (e.g. `\{`) and optional groups don't confuse the brace-counting / decision
 // counting complexity detector that scans the bodies of the loops below.
-const TS_ENUM_RE = /(?:export\s+)?enum\s+(\w+)/;
+const TS_ENUM_RE = /^\s*(?:export\s+)?(?:declare\s+)?(?:const\s+)?enum\s+(\w+)/;
 const TS_AS_CONST_RE = /(?:export\s+)?const\s+(\w+)\s*=\s*\{/;
 const TS_UNION_RE =
   /(?:export\s+)?type\s+(\w+)\s*=\s*(['"`][\w]+['"`](?:\s*\|\s*['"`][\w]+['"`])+)/;
@@ -20,7 +20,7 @@ const GO_IOTA_RE = /^(\w+)\s+(\w+)\s*=\s*iota/;
 const GO_TYPED_RE = /^(\w+)\s+(\w+)\s*=\s*"[^"]*"/;
 const GO_BARE_RE = /^(\w+)\s*$/;
 const RUST_ENUM_RE = /^(?:pub\s+)?enum\s+(\w+)/;
-const JAVA_ENUM_RE = /(?:public\s+|private\s+|protected\s+)?enum\s+(\w+)/;
+const JAVA_ENUM_RE = /^\s*(?:public\s+|private\s+|protected\s+)?enum\s+(\w+)/;
 
 interface GoConstLine {
   name: string;

--- a/packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts
+++ b/packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts
@@ -100,4 +100,53 @@ describe('EnumConstantExtractor', () => {
     expect(config).toBeDefined();
     expect(config!.metadata.members).toEqual(['server', 'debug']);
   });
+
+  it('does not treat prose/comment lines that merely contain "enum <word>" as TS enums (#1331)', () => {
+    // A JSDoc line and a TODO comment both contain the substring `enum <word>`
+    // but are ordinary prose, not enum declarations. An unanchored regex would
+    // parse them and emit junk business_term nodes (e.g. `enum or { ... }`).
+    const content = [
+      '/**',
+      ' * a types.ts that also exports an enum or a const map is ordinary',
+      ' */',
+      'function ordinary() {',
+      '  // TODO: replace this enum with a union',
+      '  return 1;',
+      '}',
+      '',
+      'export enum Real {',
+      '  A,',
+      '  B,',
+      '}',
+    ].join('\n');
+    const records = extractor.extract(content, 'prose.ts', 'typescript');
+
+    const names = records.map((r) => r.name);
+    // The real enum is still extracted.
+    expect(names).toContain('Real');
+    // The prose "enum or" and comment "enum with" are NOT extracted.
+    expect(names).not.toContain('or');
+    expect(names).not.toContain('with');
+  });
+
+  it('does not treat prose/comment lines that merely contain "enum <word>" as Java enums (#1331)', () => {
+    const content = [
+      '/**',
+      ' * a Types.java that also exports an enum or a const map is ordinary',
+      ' */',
+      'class Ordinary {',
+      '  // TODO: replace this enum with a union',
+      '  public enum Real {',
+      '    A,',
+      '    B,',
+      '  }',
+      '}',
+    ].join('\n');
+    const records = extractor.extract(content, 'Prose.java', 'java');
+
+    const names = records.map((r) => r.name);
+    expect(names).toContain('Real');
+    expect(names).not.toContain('or');
+    expect(names).not.toContain('with');
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #1331. `TS_ENUM_RE` and `JAVA_ENUM_RE` in `packages/graph/src/ingest/extractors/EnumConstantExtractor.ts` were **unanchored**, so any line merely *containing* `enum <word>` — a JSDoc comment, prose, a URL — was parsed as an enum declaration and emitted as a junk `business_term` graph node (e.g. `enum or { function, const, if ... }`).

The sibling `RUST_ENUM_RE = /^(?:pub\s+)?enum\s+(\w+)/` and `PY_ENUM_RE` are correctly anchored with `^`. This anchors the TS and Java patterns to line start (allowing optional leading whitespace + the usual TS `declare`/`const` modifiers), matching the Rust form:

- TS: `/^\s*(?:export\s+)?(?:declare\s+)?(?:const\s+)?enum\s+(\w+)/`
- Java: `/^\s*(?:public\s+|private\s+|protected\s+)?enum\s+(\w+)/`

## Repro test
Added two tests in `packages/graph/tests/ingest/extractors/EnumConstantExtractor.test.ts` that assert a JSDoc line `* ... exports an enum or a const map ...` and a `// TODO: replace this enum with a union` comment do **not** produce business_term nodes, while a real `export enum Real { A, B }` / `public enum Real { ... }` still does. Both fail red on the unanchored regex at the base SHA and pass on this branch.

## Verification
- New repro tests: red at base, green on branch.
- Full `@harness-engineering/graph` suite: 970 tests pass; typecheck clean.

**Do not merge — batch review.**