### PR TITLE
fix(core): drop closed-issue #839 reference from adopter-facing error (#1253)

### DIFF
--- a/.changeset/fix-1253-drop-closed-issue-ref.md
+++ b/.changeset/fix-1253-drop-closed-issue-ref.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': patch
+---
+
+Remove reference to internal closed issue #839 from the MonolithStore write-refusal error shown to adopters (#1253).

--- a/packages/core/src/roadmap/store/monolith-store.ts
+++ b/packages/core/src/roadmap/store/monolith-store.ts
@@ -191,7 +191,7 @@ export class MonolithStore implements RoadmapStore {
               `single-file writer cannot preserve and would silently drop ` +
               `(e.g. line ${first.line}: "${first.text}"). ` +
               `Shard the roadmap into docs/roadmap.d/ for surgical per-row writes, ` +
-              `or remove the unmodeled content, then retry. See issue #839.`
+              `or remove the unmodeled content, then retry.`
           )
         );
       }

--- a/packages/core/tests/roadmap/store/monolith-store.test.ts
+++ b/packages/core/tests/roadmap/store/monolith-store.test.ts
@@ -241,10 +241,31 @@ last_manual_edit: 2026-07-17T00:00:00.000Z
       const store = new MonolithStore({ roadmapPath: ROADMAP_PATH, io });
       const r = await store.patchFeature('a-feature', (f) => ({ ...f, status: 'done' }));
       expect(r.ok).toBe(false);
-      if (!r.ok) expect(r.error.message).toMatch(/#839/);
+      // The refusal names the actionable remedy (shard into docs/roadmap.d/).
+      if (!r.ok) expect(r.error.message).toMatch(/docs\/roadmap\.d/);
       // No write happened; the file is byte-for-byte intact.
       expect(writes).toHaveLength(0);
       expect(files.get(ROADMAP_PATH)).toBe(RICH_ROADMAP_MD);
+    });
+
+    // #1253: the adopter-facing refusal must NOT point at an internal, closed
+    // issue number (#839) in this private repo — an ADOPTER of
+    // @harness-engineering/core cannot read it. The message must keep its
+    // actionable remedies (shard into docs/roadmap.d/, or remove the content)
+    // while dropping the "See issue #839." trailer.
+    it('refusal message carries actionable remedies but no internal issue reference (#1253)', async () => {
+      const { io } = makeIO({ [ROADMAP_PATH]: RICH_ROADMAP_MD });
+      const store = new MonolithStore({ roadmapPath: ROADMAP_PATH, io });
+      const r = await store.patchFeature('a-feature', (f) => ({ ...f, status: 'done' }));
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        // No reference to the internal closed issue #839 (the shipped defect).
+        expect(r.error.message).not.toMatch(/#839/);
+        expect(r.error.message).not.toMatch(/See issue/);
+        // Actionable remedies remain intact.
+        expect(r.error.message).toMatch(/docs\/roadmap\.d/);
+        expect(r.error.message).toMatch(/remove the unmodeled content/);
+      }
     });
 
     it('addFeature() returns Err and does not write', async () => {


### PR DESCRIPTION
## Summary
Fixes #1253. The \`MonolithStore.write\` data-loss guard builds a user-facing error message that shipped inside \`@harness-engineering/core\`. It ended with \`See issue #839.\` — pointing an ADOPTER who trips the guard at an issue number in this private repo they cannot read (and #839 is closed anyway). This removes ONLY that trailing sentence, leaving the two actionable remedies intact (shard into \`docs/roadmap.d/\`, or remove the unmodeled content).

## Change
- \`packages/core/src/roadmap/store/monolith-store.ts\`: drop the \` See issue #839.\` trailer from the refusal message. The internal \`(#839)\` code comment above the guard is left as-is (not adopter-facing).

## Reproduction test
Added \`refusal message carries actionable remedies but no internal issue reference (#1253)\` to \`packages/core/tests/roadmap/store/monolith-store.test.ts\`. It drives the real write-refusal path (a rich monolith carrying an unmodeled blockquote / multi-line summary / \`- **Issue:**\` bullet) and asserts the thrown message contains \`docs/roadmap.d\` + \`remove the unmodeled content\` but NOT \`#839\` / \`See issue\`.
- RED at base SHA \`e3880b62f\` (message contained \`See issue #839.\`).
- GREEN on this branch.
- Also updated one pre-existing assertion in the same suite that matched \`/#839/\` (it was coupled to the defect) to assert on the actionable \`docs/roadmap.d\` remedy instead.

Full \`@harness-engineering/core\` test + typecheck suite green (4226 passed).

Do not merge — batch review.