### PR TITLE
fix(cli): reconcile naming-craft finalize coverage (#1339)

### DIFF
--- a/.changeset/fix-1339-naming-craft-coverage.md
+++ b/.changeset/fix-1339-naming-craft-coverage.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/cli': patch
+---
+
+fix(naming-craft): reconcile finalize coverage against the collected prompt set (#1339)
+
+`finalizeNamingCraft` previously accepted a `responses` array covering only a
+fraction of the prompts the paired collect call produced and still emitted a
+normal-looking `NamingCraftOutput` whose summary read as a completed critique
+of the whole scope — a false-green. It now reconciles `responses` against the
+persisted prompt set: a materially short response set is rejected loudly
+(mirroring the two-step-flow guard) unless the caller passes `allowPartial:true`.
+The summary gains an explicit `coverage: { promptsAnswered, promptsTotal }`, and
+on a partial finalize `filesScanned` narrows to only the files actually
+critiqued so it never implies reach over unjudged files.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -734,6 +734,7 @@ Finalize a naming_craft in-session run by submitting the calling agent's respons
 - `path` (string, required) — Project root path used in the collect call (must match)
 - `runId` (string, required) — runId returned by the naming_craft collect call
 - `responses` (array, required) — Per-prompt responses. `raw` is the fenced JSON block the calling agent produced.
+- `allowPartial` (boolean, optional) — Opt into finalizing when fewer prompts were answered than were collected. Default false: a short response set is rejected instead of emitting a full-looking critique. When true, the summary carries an explicit `coverage` and a narrowed `filesScanned` reflecting only what was judged.
 
 ### `outcome_eval`
 

--- a/docs/reference/tool-catalog.md
+++ b/docs/reference/tool-catalog.md
@@ -3340,6 +3340,10 @@ Finalize a naming_craft in-session run by submitting the calling agent's respons
 ```json
 {
   "properties": {
+    "allowPartial": {
+      "description": "Opt into finalizing when fewer prompts were answered than were collected. Default false: a short response set is rejected instead of emitting a full-looking critique. When true, the summary carries an explicit `coverage` and a narrowed `filesScanned` reflecting only what was judged.",
+      "type": "boolean"
+    },
     "path": {
       "description": "Project root path used in the collect call (must match)",
       "type": "string"

--- a/packages/cli/src/mcp/tools/naming-craft.ts
+++ b/packages/cli/src/mcp/tools/naming-craft.ts
@@ -103,6 +103,14 @@ export const namingCraftFinalizeDefinition = {
           required: ['promptId', 'raw'],
         },
       },
+      allowPartial: {
+        type: 'boolean',
+        description:
+          'Opt into finalizing when fewer prompts were answered than were collected. ' +
+          'Default false: a short response set is rejected instead of emitting a ' +
+          'full-looking critique. When true, the summary carries an explicit `coverage` ' +
+          'and a narrowed `filesScanned` reflecting only what was judged.',
+      },
     },
     required: ['path', 'runId', 'responses'],
   },

--- a/packages/cli/src/naming-craft/findings/schema.ts
+++ b/packages/cli/src/naming-craft/findings/schema.ts
@@ -46,8 +46,18 @@ export interface NamingCraftSummary {
    * Count of source files walked/read. Zero means nothing analyzable was
    * found — e.g. a non-TS/JS (Python, Go, …) project — which the diagnostic
    * surfaces so an empty result isn't mistaken for a clean bill of health.
+   * On a partial in-session finalize this narrows to the files actually
+   * critiqued, so it never implies reach over files that went unjudged.
    */
   filesScanned: number;
+  /**
+   * Prompt-level reach of a two-step in-session finalize:
+   * `promptsAnswered` of `promptsTotal` collected prompts were judged.
+   * Absent on the inline path (which judges everything in one pass); when
+   * present and `promptsAnswered < promptsTotal` the critique is explicitly
+   * partial and the summary must not be read as full coverage.
+   */
+  coverage?: { promptsAnswered: number; promptsTotal: number };
   runId: string;
 }
 

--- a/packages/cli/src/naming-craft/index.ts
+++ b/packages/cli/src/naming-craft/index.ts
@@ -69,6 +69,15 @@ export interface FinalizeNamingCraftInput {
   path: string;
   runId: string;
   responses: Array<{ promptId: string; raw: string }>;
+  /**
+   * Opt into finalizing when fewer of the collected prompts were answered
+   * than were collected. Without it, a materially short response set is
+   * rejected rather than emitting a full-looking success — mirroring the
+   * two-step-flow guard's "don't silently proceed on partial input"
+   * philosophy. When true, the resulting summary carries an explicit
+   * `coverage` and a narrowed `filesScanned` so the partial reach is honest.
+   */
+  allowPartial?: boolean;
 }
 
 const DEFAULT_MAX_FILES = 100;
@@ -270,10 +279,12 @@ export async function finalizeNamingCraft(
   const rubricById = new Map(SEED_RUBRICS.map((r) => [r.id, r]));
   const promptById = new Map(state.meta.prompts.map((p) => [p.promptId, p]));
   const findings: NamingFinding[] = [];
+  const answeredPromptIds = new Set<string>();
 
   for (const response of input.responses) {
     const promptRecord = promptById.get(response.promptId);
     if (promptRecord === undefined) continue;
+    answeredPromptIds.add(response.promptId);
     const rubric = rubricById.get(promptRecord.rubricId);
     if (rubric === undefined) continue;
     const finding = parseFindingFromRaw(response.raw, {
@@ -283,7 +294,36 @@ export async function finalizeNamingCraft(
     if (finding !== null) findings.push(finding);
   }
 
+  // Reconcile actual reach against the prompt set collected at step 1. Only
+  // prompts we can match to a collected record count as answered — stray or
+  // duplicate IDs never inflate coverage.
+  const promptsTotal = state.meta.prompts.length;
+  const promptsAnswered = answeredPromptIds.size;
+
+  // A materially short response set would otherwise finalize into a
+  // normal-looking NamingCraftOutput whose summary reads as a completed
+  // critique of the whole scope while almost none of it was judged. Refuse
+  // it loudly unless the caller explicitly opted into a partial finalize —
+  // the same stance the inline path takes when handed an in-session provider.
+  if (promptsAnswered < promptsTotal && input.allowPartial !== true) {
+    throw new Error(
+      `naming-craft: finalize received ${promptsAnswered} of ${promptsTotal} collected ` +
+        `prompts for runId=${input.runId}. Finalizing now would report a full-scope ` +
+        'critique while the rest went unjudged. Answer every prompt returned by the ' +
+        'collect call, or pass allowPartial:true to record an explicit partial critique.'
+    );
+  }
+
   deleteRunState(projectRoot, input.runId);
+
+  // On a partial finalize, report only the files actually critiqued so
+  // filesScanned never implies reach over files that were never judged. A
+  // full finalize keeps the collect-time walk count (which also covers files
+  // that were walked but yielded no promptable identifier).
+  const filesScanned =
+    promptsAnswered >= promptsTotal
+      ? (state.meta.filesScanned ?? 0)
+      : new Set([...answeredPromptIds].map((id) => promptById.get(id)!.identifier.file)).size;
 
   return {
     findings,
@@ -299,7 +339,8 @@ export async function finalizeNamingCraft(
       },
       catalog: { rubricsApplied: state.meta.rubricsApplied },
       convention: state.meta.convention,
-      filesScanned: state.meta.filesScanned ?? 0,
+      filesScanned,
+      coverage: { promptsAnswered, promptsTotal },
       runId: input.runId,
     },
   };

--- a/packages/cli/tests/naming-craft/in-session.test.ts
+++ b/packages/cli/tests/naming-craft/in-session.test.ts
@@ -97,12 +97,13 @@ describe('naming-craft in-session flow', () => {
     ).rejects.toThrow(/no persisted run/);
   });
 
-  it('finalize silently skips responses whose promptId is unknown', async () => {
+  it('finalize skips responses whose promptId is unknown (explicit partial)', async () => {
     writeFile('src/x.ts', `export const foo = 1;\n`);
     const collected = await collectNamingCraftPrompts({ path: tmpDir });
     const out = await finalizeNamingCraft({
       path: tmpDir,
       runId: collected.runId,
+      allowPartial: true,
       responses: [
         {
           promptId: 'nonexistent',
@@ -110,6 +111,88 @@ describe('naming-craft in-session flow', () => {
         },
       ],
     });
+    // Unmatched IDs never count toward coverage, so this reads as 0-answered.
     expect(out.findings).toHaveLength(0);
+    expect(out.summary.coverage!.promptsAnswered).toBe(0);
+    expect(out.summary.coverage!.promptsTotal).toBe(collected.pendingPrompts.length);
+  });
+
+  it('finalize REFUSES a materially short response set instead of a full-looking success', async () => {
+    // A file rich enough to collect several prompts.
+    writeFile(
+      'src/orders.ts',
+      `export function processData(orders) { return orders; }\n` +
+        `export const tmp = 1;\n` +
+        `export type Data = { a: number };\n`
+    );
+    const collected = await collectNamingCraftPrompts({ path: tmpDir });
+    expect(collected.pendingPrompts.length).toBeGreaterThan(1);
+
+    // Answer only the first of N collected prompts.
+    const responses = [
+      {
+        promptId: collected.pendingPrompts[0]!.promptId,
+        raw: '```json\n{"tier":"polish","impact":"medium","confidence":"high","message":"vague"}\n```',
+      },
+    ];
+
+    // Default (no allowPartial): must NOT emit a normal-looking output that
+    // overstates coverage — it must throw loudly. (Red at base: the old code
+    // returned a full-looking success with no coverage field.)
+    await expect(
+      finalizeNamingCraft({ path: tmpDir, runId: collected.runId, responses })
+    ).rejects.toThrow(/of \d+ collected|partial|allowPartial/);
+
+    // The run-state must survive the refusal so the caller can retry in full.
+    expect(fs.existsSync(collected.runFile!)).toBe(true);
+  });
+
+  it('finalize with allowPartial surfaces honest coverage and narrowed filesScanned', async () => {
+    writeFile(
+      'src/a.ts',
+      `export function processData(orders) { return orders; }\nexport const tmp = 1;\n`
+    );
+    writeFile('src/b.ts', `export function handleThing(x) { return x; }\n`);
+    const collected = await collectNamingCraftPrompts({ path: tmpDir });
+    expect(collected.pendingPrompts.length).toBeGreaterThan(1);
+
+    // Answer only the first prompt.
+    const responses = [
+      {
+        promptId: collected.pendingPrompts[0]!.promptId,
+        raw: '```json\n{"tier":"polish","impact":"medium","confidence":"high","message":"vague"}\n```',
+      },
+    ];
+
+    const out = await finalizeNamingCraft({
+      path: tmpDir,
+      runId: collected.runId,
+      allowPartial: true,
+      responses,
+    });
+
+    expect(out.summary.coverage).toBeDefined();
+    expect(out.summary.coverage!.promptsAnswered).toBe(1);
+    expect(out.summary.coverage!.promptsTotal).toBe(collected.pendingPrompts.length);
+    expect(out.summary.coverage!.promptsAnswered).toBeLessThan(out.summary.coverage!.promptsTotal);
+    // Only one file was actually critiqued — filesScanned must not imply both.
+    expect(out.summary.filesScanned).toBe(1);
+    expect(fs.existsSync(collected.runFile!)).toBe(false);
+  });
+
+  it('finalize reports full coverage when every collected prompt is answered', async () => {
+    writeFile('src/orders.ts', `export function processData(orders) { return orders; }\n`);
+    const collected = await collectNamingCraftPrompts({ path: tmpDir });
+    const responses = collected.pendingPrompts.map((p) => ({
+      promptId: p.promptId,
+      raw: '```json\nnull\n```',
+    }));
+    const out = await finalizeNamingCraft({
+      path: tmpDir,
+      runId: collected.runId,
+      responses,
+    });
+    expect(out.summary.coverage!.promptsAnswered).toBe(collected.pendingPrompts.length);
+    expect(out.summary.coverage!.promptsAnswered).toBe(out.summary.coverage!.promptsTotal);
   });
 });


### PR DESCRIPTION
## What

Fixes #1339. `finalizeNamingCraft` (`packages/cli/src/naming-craft/index.ts`) accepted a `responses` array covering only a fraction of the prompts the paired `naming_craft` collect call produced and still emitted a normal-looking `NamingCraftOutput` whose summary read as a completed critique of the whole scope — a false-green (reads as done while almost none of the scope was judged).

## Fix (bounded to naming-craft)

- **Reconcile before finalizing.** Match `input.responses` against the persisted prompt set (`state.meta.prompts`). Only prompts matched to a collected record count as answered — stray/duplicate IDs never inflate coverage.
- **Loud refusal on partial input.** If `promptsAnswered < promptsTotal` and the caller did not pass `allowPartial:true`, `finalizeNamingCraft` throws (and preserves run-state for retry) instead of emitting a full-looking success — mirroring the inline path's two-step-flow guard philosophy ("don't silently proceed on partial input").
- **Honest summary.** New `summary.coverage = { promptsAnswered, promptsTotal }`. On an explicit partial finalize, `filesScanned` narrows to only the files actually critiqued so it never implies reach over unjudged files.
- New optional `allowPartial` on `FinalizeNamingCraftInput` + the `naming_craft_finalize` MCP tool schema (additive; reference docs + tool catalog regenerated).

`coverage` is an optional field, so the inline `runNamingCraft` output contract is unchanged. Public type change is additive only.

## Repro test

`packages/cli/tests/naming-craft/in-session.test.ts` — collects N prompts, finalizes with a single response, and asserts finalize **rejects** (default) rather than returning a full-looking success; companion tests assert honest `coverage` + narrowed `filesScanned` under `allowPartial`, and full coverage when every prompt is answered.

- **Red at base:** the refuse test failed with `promise resolved ... instead of rejecting`; coverage tests failed with `expected undefined to be defined`.
- **Green on branch:** naming-craft in-session + MCP tool suites pass; full `@harness-engineering/cli` suite (6263 tests) + typecheck green.

Do not merge — batch review.