### PR TITLE
fix(roadmap): do not auto-reopen human-closed issues on planned status (#1327)

### DIFF
--- a/.changeset/fix-1327-no-reopen-human-closed.md
+++ b/.changeset/fix-1327-no-reopen-human-closed.md
@@ -1,0 +1,15 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(roadmap): do not auto-reopen human-closed issues on a planned status (#1327)
+
+The roadmap→issue sync push (`syncToExternal`) unconditionally set an issue's
+state to `open` whenever a row's status mapped to an open state, so a `planned`/
+`in-progress` row whose issue a human (or the auto-done workflow) had already
+closed was reopened on the next ~5-minute sync — destroying the deliberate
+close. The push now consults the prefetched ticket state it already holds and
+suppresses the state patch for that write alone when it would reopen an
+already-closed issue, reporting the suppressed transition in
+`skippedStateChanges`. Labels still converge, closing an open issue for a `done`
+row is unchanged, and the pull phase converges the lagging row to `done`.

--- a/packages/core/src/roadmap/sync-engine.ts
+++ b/packages/core/src/roadmap/sync-engine.ts
@@ -154,6 +154,36 @@ function recordSuppressedStateChange(
 }
 
 /**
+ * A status push must never REOPEN an issue that is already closed (#1327).
+ *
+ * A closed issue whose roadmap row still reads planned/in-progress is not a
+ * stale-open to be corrected: the row simply has not caught up to a close a
+ * human (or the auto-done workflow) performed, and that close is authoritative.
+ * Reopening it via `statusMap['planned'] === 'open'` destroys a deliberate
+ * human close — the exact failure #1327 reports. Converging the row TO `done`
+ * is the pull phase's job (`applyTicketToFeature`), not a reopen here.
+ *
+ * Detection uses only the prefetched ticket state the engine already holds — no
+ * extra fetch, no new adapter surface. Returns the open/closed transition this
+ * write WOULD have made (so the caller can suppress the state patch AND report
+ * it in `skippedStateChanges`), or null when the write does not reopen anything.
+ * A missing current state is treated conservatively as "cannot prove a reopen"
+ * and left to the normal path — the guard only fires on a ticket we can SEE is
+ * closed.
+ */
+function detectReopen(
+  feature: RoadmapFeature,
+  config: TrackerSyncConfig,
+  ticketByExternalId: Map<string, ExternalTicketState>
+): { externalId: string; from: string; to: string } | null {
+  const current = ticketByExternalId.get(feature.externalId!);
+  if (!current || current.status !== 'closed') return null;
+  const desired = config.statusMap[feature.status];
+  if (desired === undefined || desired === current.status) return null;
+  return { externalId: feature.externalId!, from: current.status, to: desired };
+}
+
+/**
  * Push planning fields from roadmap to external service.
  * - Features without externalId get a new ticket (externalId stored on feature object)
  * - Features with externalId get updated with current planning fields
@@ -181,7 +211,6 @@ export async function syncToExternal(
   const ticketByExternalId = new Map(
     (prefetchedTickets ?? []).map((t) => [t.externalId, t] as const)
   );
-  const writeOptions: TicketWriteOptions = { syncIssueState: guards.syncIssueState };
 
   for (const milestone of roadmap.milestones) {
     for (const feature of milestone.features) {
@@ -195,8 +224,21 @@ export async function syncToExternal(
       );
       if (!shouldUpdate) continue;
 
+      // Resolve this write's state policy. Two independent reasons suppress the
+      // open/closed patch, each reported rather than silently dropped:
+      //   1. syncIssueState:false globally — the CI-safe mode, off for every row.
+      //   2. this specific write would REOPEN an already-closed issue (#1327) —
+      //      an automated sync must never resurrect a deliberate human close, so
+      //      the state patch is dropped for this row alone. Labels still converge.
+      let writeSyncIssueState = guards.syncIssueState;
       if (!guards.syncIssueState) {
         recordSuppressedStateChange(feature, config, ticketByExternalId, result);
+      } else {
+        const reopen = detectReopen(feature, config, ticketByExternalId);
+        if (reopen) {
+          writeSyncIssueState = false;
+          result.skippedStateChanges.push(reopen);
+        }
       }
 
       if (guards.dryRun) {
@@ -204,6 +246,7 @@ export async function syncToExternal(
         continue;
       }
 
+      const writeOptions: TicketWriteOptions = { syncIssueState: writeSyncIssueState };
       const updateResult = await adapter.updateTicket(
         feature.externalId!,
         feature,

--- a/packages/core/tests/roadmap/sync-engine-guards.test.ts
+++ b/packages/core/tests/roadmap/sync-engine-guards.test.ts
@@ -252,6 +252,74 @@ describe('syncToExternal() — syncIssueState: false', () => {
   });
 });
 
+describe('syncToExternal() — never reopens a human-closed issue (#1327)', () => {
+  it('suppresses the state patch for a planned row whose issue is already CLOSED', async () => {
+    // A human closed issue #1 (state_reason=completed). The roadmap row still
+    // reads `planned` because it has not yet caught up to that close. A status
+    // push must NOT reopen the issue — statusMap['planned'] === 'open' would.
+    const roadmap = makeRoadmap([
+      makeFeature({ externalId: 'github:owner/repo#1', status: 'planned' }),
+    ]);
+    const adapter = mockAdapter();
+
+    const result = await syncToExternal(roadmap, adapter, CONFIG, [
+      ticket({ status: 'closed', stateReason: 'completed' }),
+    ]);
+
+    // The write still runs (labels converge) but its state policy is suppressed,
+    // so `updateTicket` omits the open/closed flip — the issue stays closed.
+    const call = vi.mocked(adapter.updateTicket).mock.calls[0]!;
+    expect(call[3]).toEqual({ syncIssueState: false });
+    // ...and the suppressed reopen is reported, never silently dropped.
+    expect(result.skippedStateChanges).toEqual([
+      { externalId: 'github:owner/repo#1', from: 'closed', to: 'open' },
+    ]);
+  });
+
+  it('also suppresses reopen for an in-progress row whose issue is closed', async () => {
+    const roadmap = makeRoadmap([
+      makeFeature({ externalId: 'github:owner/repo#1', status: 'in-progress' }),
+    ]);
+    const adapter = mockAdapter();
+
+    const result = await syncToExternal(roadmap, adapter, CONFIG, [
+      ticket({ status: 'closed', stateReason: 'not_planned' }),
+    ]);
+
+    expect(vi.mocked(adapter.updateTicket).mock.calls[0]![3]).toEqual({ syncIssueState: false });
+    expect(result.skippedStateChanges).toEqual([
+      { externalId: 'github:owner/repo#1', from: 'closed', to: 'open' },
+    ]);
+  });
+
+  it('still CLOSES an open issue when the row is done (the guard is reopen-only)', async () => {
+    const roadmap = makeRoadmap([
+      makeFeature({ externalId: 'github:owner/repo#1', status: 'done' }),
+    ]);
+    const adapter = mockAdapter();
+
+    const result = await syncToExternal(roadmap, adapter, CONFIG, [ticket({ status: 'open' })]);
+
+    // Closing an open issue for a done row is legitimate — state sync passes through.
+    expect(vi.mocked(adapter.updateTicket).mock.calls[0]![3]).toEqual({ syncIssueState: true });
+    expect(result.skippedStateChanges).toEqual([]);
+  });
+
+  it('still patches state normally for a planned row whose issue is OPEN', async () => {
+    // The common case: a genuinely-active planned row that was never closed.
+    // Nothing to suppress — state sync must remain enabled.
+    const roadmap = makeRoadmap([
+      makeFeature({ externalId: 'github:owner/repo#1', status: 'planned' }),
+    ]);
+    const adapter = mockAdapter();
+
+    const result = await syncToExternal(roadmap, adapter, CONFIG, [ticket({ status: 'open' })]);
+
+    expect(vi.mocked(adapter.updateTicket).mock.calls[0]![3]).toEqual({ syncIssueState: true });
+    expect(result.skippedStateChanges).toEqual([]);
+  });
+});
+
 describe('syncToExternal() — denominator', () => {
   it('reports rows compared and tickets fetched', async () => {
     const roadmap = makeRoadmap([


### PR DESCRIPTION
## Bug (#1327)

The roadmap→issue sync automation reopened human-closed issues within ~5 minutes and never re-closed them, destroying a deliberate human close. Reproduced deterministically twice.

### Mechanism
The push phase `syncToExternal` → `GitHubIssuesSyncAdapter.updateTicket` unconditionally set `patch.state = statusMap[status]` whenever `syncIssueState` was on (the default). For a `planned`/`in-progress` row, `statusMap` maps to `open`, so an issue a human had already closed — while its roadmap row still read `planned` (not yet caught up) — was flipped back to `open` on the next sync. The re-close side lives only in `roadmap-auto-done.yml` (fires on merged PR), so the reopen was never undone. The existing `--force`/`sync-engine` "human-always-wins" guard only covers status *regressions* (done→in-progress), not the reopen-a-closed-issue case.

## Fix (bounded — no cross-cutting plumbing)

Guard added in `syncToExternal` (`packages/core/src/roadmap/sync-engine.ts`), which already prefetches every ticket's current state (`ExternalTicketState`, including `stateReason`) via `fullSync`. New `detectReopen` helper: when a write would flip a **currently-closed** issue to open (current `status === 'closed'` and the row's mapped state differs), the state patch is suppressed **for that write alone** — `updateTicket` is called with `{ syncIssueState: false }` so labels still converge but the open/closed flip is dropped — and the suppressed transition is recorded in `skippedStateChanges` (never silently dropped). The lagging row then converges to `done` on the pull phase, so human-close wins and the roadmap catches up.

The guard uses only signals the engine already holds — no new fields threaded through adapters/workflows.

### Preserved behavior
- Closing an open issue for a `done` row is unchanged (guard is reopen-only).
- Creating/opening issues for genuinely-active `planned` rows that were never closed still works (only fires on a ticket seen as `closed`).
- Global `syncIssueState:false` CI-safe mode and dry-run reporting unchanged.

## Tests
Repro + preservation tests in `packages/core/tests/roadmap/sync-engine-guards.test.ts` (describe: "never reopens a human-closed issue (#1327)"). Red at base (adapter received `{syncIssueState:true}` → reopen); green on branch. Full `@harness-engineering/core...` test + typecheck pass.

**Do not merge — batch review.**