### PR TITLE
fix(drift): exclude forward-looking docs/changes from structure drift (#1326)

### DIFF
--- a/.changeset/fix-1326-drift-exclude-docs-changes.md
+++ b/.changeset/fix-1326-drift-exclude-docs-changes.md
@@ -1,0 +1,14 @@
+---
+'@harness-engineering/core': patch
+---
+
+fix(drift): exclude forward-looking docs/changes from structure drift (#1326)
+
+`checkStructureDrift` now consults the same `forwardLookingPaths` exclusion that
+`checkApiSignatureDrift` already honored, so broken-link/broken-anchor structure
+findings inside forward-looking historical docs (`docs/changes/**`, ADRs,
+proposals) are suppressed. `docs/changes/**` is the immutable historical record
+of shipped changes; its dangling links are unactionable by design — "fixing"
+them edits history — and were the dominant contributor (~223 findings) to
+documentation-drift counts. A dangling link in a non-forward-looking doc (e.g.
+`docs/reference/**`) is still flagged.

--- a/packages/core/src/entropy/detectors/drift.ts
+++ b/packages/core/src/entropy/detectors/drift.ts
@@ -197,10 +197,14 @@ export function findPossibleMatches(
 }
 
 // Default doc-path prefixes that describe intended future code (ADRs,
-// decisions, proposals, and change specs/plans). API-signature drift inside
-// these docs is suppressed — symbols there describe the design, not the
-// current codebase. `docs/changes/` holds proposals and phase plans that by
-// definition describe proposed/illustrative code (github issue #816).
+// decisions, proposals, and change specs/plans). Both API-signature AND
+// structure drift (broken links/anchors) inside these docs are suppressed —
+// their contents describe the design, not the current codebase/tree.
+// `docs/changes/` is the IMMUTABLE historical record of shipped changes
+// (proposals, plans, verification reports): its dangling links are
+// unactionable by design — "fixing" a shipped proposal's link edits history —
+// and were the dominant contributor to drift counts (github issues #816,
+// #1326). Do NOT remove `docs/changes/` here to "clean up" drift output.
 // Override via DriftConfig.forwardLookingPaths.
 const DEFAULT_FORWARD_LOOKING_PATHS = [
   'docs/architecture/',
@@ -468,11 +472,18 @@ async function extractHeadingSlugs(filePath: string): Promise<Set<string>> {
  */
 async function checkStructureDrift(
   snapshot: CodebaseSnapshot,
-  _config: DriftConfig
+  config: DriftConfig
 ): Promise<DocumentationDrift[]> {
   const drifts: DocumentationDrift[] = [];
 
   for (const doc of snapshot.docs) {
+    // Forward-looking docs (ADRs, proposals, and especially the immutable
+    // docs/changes/** historical record) describe the design, not the current
+    // tree. Their dangling links/anchors are unactionable by design — "fixing"
+    // a shipped proposal's link edits history — so suppress structure drift
+    // there exactly as api-signature drift is suppressed (github issue #1326).
+    if (isForwardLookingDoc(doc.path, config.forwardLookingPaths)) continue;
+
     const fileLinks = extractFileLinks(doc.content);
 
     for (const link of fileLinks) {

--- a/packages/core/tests/entropy/detectors/drift.test.ts
+++ b/packages/core/tests/entropy/detectors/drift.test.ts
@@ -597,3 +597,114 @@ describe('drift detector — issue #1342/#1332 regressions', () => {
     expect(structureDrifts).toHaveLength(0);
   });
 });
+
+// Regression: github issue #1326. docs/changes/** is the immutable historical
+// record of shipped changes. Its dangling links/anchors are unactionable by
+// design (fixing them edits history), yet checkStructureDrift ignored the
+// forward-looking-paths exclusion that checkApiSignatureDrift already honored,
+// so ~223 structure findings inside docs/changes/** dominated drift output.
+// The fix threads config into checkStructureDrift and skips forward-looking
+// docs — exactly as api-signature drift already does. A dangling link in a
+// NON-forward-looking doc must still be flagged.
+describe('drift detector — issue #1326 structure-drift forward-looking exclusion', () => {
+  const parser3 = new TypeScriptParser();
+  let projectDir1326: string;
+
+  beforeEach(async () => {
+    projectDir1326 = await mkdtemp(join(tmpdir(), 'drift-1326-'));
+    await mkdir(join(projectDir1326, 'src'), { recursive: true });
+    await writeFile(
+      join(projectDir1326, 'src', 'index.ts'),
+      'export function realFunction() { return 1; }\n'
+    );
+  });
+
+  afterEach(async () => {
+    await rm(projectDir1326, { recursive: true, force: true });
+  });
+
+  async function structureDriftFor() {
+    const snapshotResult = await buildSnapshot({
+      rootDir: projectDir1326,
+      parser: parser3,
+      analyze: { drift: true },
+      include: ['src/**/*.ts'],
+      docPaths: ['docs/**/*.md'],
+    });
+    expect(snapshotResult.ok).toBe(true);
+    if (!snapshotResult.ok) return [];
+    const result = await detectDocDrift(snapshotResult.value, {
+      checkApiSignatures: false,
+      checkExamples: false,
+      checkStructure: true,
+      docPaths: [],
+      ignorePatterns: [],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return [];
+    return result.value.drifts.filter((d) => d.type === 'structure');
+  }
+
+  it('suppresses a broken file link inside docs/changes/**', async () => {
+    await mkdir(join(projectDir1326, 'docs', 'changes', 'my-feature'), { recursive: true });
+    await writeFile(
+      join(projectDir1326, 'docs', 'changes', 'my-feature', 'proposal.md'),
+      '# Proposal\n\nSee [the plan](./plan-that-was-never-written.md) for details.\n'
+    );
+    const structureDrifts = await structureDriftFor();
+    expect(structureDrifts).toHaveLength(0);
+  });
+
+  it('suppresses a broken anchor inside docs/changes/**', async () => {
+    await mkdir(join(projectDir1326, 'docs', 'changes', 'my-feature'), { recursive: true });
+    await writeFile(
+      join(projectDir1326, 'docs', 'changes', 'my-feature', 'plan.md'),
+      ['# Plan', '', '## Phase 1', '', 'Body.'].join('\n')
+    );
+    await writeFile(
+      join(projectDir1326, 'docs', 'changes', 'my-feature', 'proposal.md'),
+      '# Proposal\n\nSee [phase two](./plan.md#phase-2) which was never added.\n'
+    );
+    const structureDrifts = await structureDriftFor();
+    expect(structureDrifts).toHaveLength(0);
+  });
+
+  it('still flags a broken file link in a NON-forward-looking doc (docs/reference/**)', async () => {
+    await mkdir(join(projectDir1326, 'docs', 'reference'), { recursive: true });
+    await writeFile(
+      join(projectDir1326, 'docs', 'reference', 'foo.md'),
+      '# Reference\n\nSee [the API](./missing-api-doc.md) for details.\n'
+    );
+    const structureDrifts = await structureDriftFor();
+    expect(structureDrifts.some((d) => d.reference.includes('missing-api-doc.md'))).toBe(true);
+  });
+
+  it('respects a custom forwardLookingPaths override for structure drift', async () => {
+    await mkdir(join(projectDir1326, 'docs', 'rfcs'), { recursive: true });
+    await writeFile(
+      join(projectDir1326, 'docs', 'rfcs', 'rfc-1.md'),
+      '# RFC\n\nSee [the design](./design-not-yet-written.md).\n'
+    );
+    const snapshotResult = await buildSnapshot({
+      rootDir: projectDir1326,
+      parser: parser3,
+      analyze: { drift: true },
+      include: ['src/**/*.ts'],
+      docPaths: ['docs/**/*.md'],
+    });
+    expect(snapshotResult.ok).toBe(true);
+    if (!snapshotResult.ok) return;
+    const result = await detectDocDrift(snapshotResult.value, {
+      checkApiSignatures: false,
+      checkExamples: false,
+      checkStructure: true,
+      docPaths: [],
+      ignorePatterns: [],
+      forwardLookingPaths: ['docs/rfcs/'],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const structureDrifts = result.value.drifts.filter((d) => d.type === 'structure');
+    expect(structureDrifts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1326. `docs/changes/**` is the immutable historical record of shipped changes (proposals, plans, verification reports). Its dangling links/anchors are unactionable by design — "fixing" a shipped proposal's link edits history — yet they were the dominant contributor (~223 findings) to documentation-drift counts, training readers to ignore drift output.

The forward-looking exclusion (`DEFAULT_FORWARD_LOOKING_PATHS`, including `docs/changes/`) already suppressed **api-signature** drift via `isForwardLookingDoc`, but `checkStructureDrift` took its `config` unused and still emitted broken-link/broken-anchor **structure** findings inside those docs.

## Fix
- Thread `config` into `checkStructureDrift` and skip any doc matched by `isForwardLookingDoc(doc.path, config.forwardLookingPaths)` — reusing the exact helper the api-signature check uses (no duplicated path logic).
- Updated the `DEFAULT_FORWARD_LOOKING_PATHS` comment to state WHY `docs/changes/` is excluded (so it isn't later "fixed").
- Fix is at the **detector** so all callers benefit; the CLI `check-docs` excludePatterns govern doc *coverage* (source files), not drift emissions, so no CLI change was needed.

## Repro test (was RED at base)
`packages/core/tests/entropy/detectors/drift.test.ts` — new `issue #1326` describe block:
- broken file link inside `docs/changes/**` → suppressed
- broken anchor inside `docs/changes/**` → suppressed
- broken file link in `docs/reference/**` (non-forward-looking) → **still flagged** (control)
- custom `forwardLookingPaths` override honored for structure drift

At base: 3 fail (suppression cases) + 1 pass (control). On branch: all 29 in-file green; full `@harness-engineering/core` test+typecheck green (4229 pass).

Scope note: path-exclusion by default; status-scoping (e.g. resolving an in-flight change's plan) is left as a follow-up per the issue, not over-built.

**Do not merge — batch review.**