### PR TITLE
fix(knowledge): honor docsDir + ingest docs/knowledge/decisions into graph (#1330, #1351)

### DIFF
--- a/.changeset/fix-1330-1351-decision-ingest.md
+++ b/.changeset/fix-1330-1351-decision-ingest.md
@@ -1,0 +1,18 @@
+---
+'@harness-engineering/graph': patch
+'@harness-engineering/cli': patch
+---
+
+fix(knowledge): honor configured docsDir/adrDir and route decision ADRs into the graph
+
+- #1330: `KnowledgePipelineRunner` no longer hardcodes `docs/knowledge/decisions`,
+  `docs/architecture`, and `docs/knowledge`. It now derives those directories from
+  new `docsDir`/`adrDir` pipeline options (sourced by the CLI from
+  `harness.config.json#docsDir` and `#operationalPolicy.adrDir`), so a project that
+  keeps its ADRs at a configured non-default location is no longer silently invisible
+  (it reported "0 decisions"). Defaults are preserved when config is unset.
+- #1351: `graph ingest --source knowledge` (and `--all`) now constructs
+  `DecisionIngestor` so ADRs under `docs/knowledge/decisions/*.md` and
+  architecture-advisor ADRs under `docs/architecture/` become `decision` graph nodes.
+  Previously these files entered the graph via no ingestor on this command path, since
+  `KnowledgeIngestor.ingestAll` explicitly excludes `docs/knowledge/**`.

--- a/.changeset/fix-1335-1340-pipeline-abstention.md
+++ b/.changeset/fix-1335-1340-pipeline-abstention.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/graph': patch
+'@harness-engineering/cli': patch
+---
+
+fix(knowledge): abstain on empty baseline + confidence floor for `--fix`, and report honest extraction counts (#1335, #1340)
+
+The knowledge pipeline previously reported a healthy-looking `warn` on a
+first run where the graph held no prior `business_*` nodes: every fresh entry
+classified as `new`, the drift score approached 1.0, and the verdict read as
+`WARN` with `0 stale, 0 drifted, 0 contradicting` — indistinguishable from a
+clean incremental run. A zero-denominator baseline is now an explicit
+`abstain` verdict (distinct from `pass`/`warn`/`fail`) threaded from the
+pre-extraction baseline into `computeVerdict`, and the CLI renders an
+unambiguous `ABSTAIN` header with a one-line explanation. The result now
+carries a `baselineEmpty` flag (surfaced in `--json`). (#1335)
+
+`--fix` materialization into the consumer's tracked `docs/knowledge/` tree is
+now gated on a named confidence floor (`MATERIALIZATION_CONFIDENCE_FLOOR`,
+default `0.5`): low-confidence / comment-derived signals are still reported as
+gaps but no longer written to disk. Human-authored nodes carry no confidence
+and remain trusted, so the floor cannot suppress hand-written knowledge.
+(#1335)
+
+Extraction now reports the number of signals actually extracted this run
+(`signalsExtracted`) rather than `nodesAdded` (deduped new store insertions),
+which dropped to 0 on a re-scan even while the extractors wrote thousands of
+records — producing a "0 code signals" headline that contradicted a non-empty
+"extracted" gap total. (#1340)

--- a/packages/cli/src/commands/graph/ingest.ts
+++ b/packages/cli/src/commands/graph/ingest.ts
@@ -41,6 +41,29 @@ async function ingestBusinessKnowledge(
   );
 }
 
+/**
+ * Route decision ADRs into the graph via DecisionIngestor: YAML-frontmatter
+ * ADRs under docs/knowledge/decisions/ plus architecture-advisor markdown ADRs
+ * under docs/architecture/. Both flow into the same `decision` node type.
+ *
+ * Previously the `--source knowledge` (and `--all`) path ran neither ingestor
+ * for these files: KnowledgeIngestor.ingestAll explicitly excludes
+ * docs/knowledge/**, so ADRs entered the graph via NO ingestor on this command
+ * path. See github issue #1351.
+ */
+async function ingestDecisions(
+  decision: {
+    ingest: (dir: string) => Promise<IngestResult>;
+    ingestArchitecture: (dir: string) => Promise<IngestResult>;
+  },
+  projectPath: string
+): Promise<IngestResult> {
+  return mergeResults(
+    await decision.ingest(path.join(projectPath, 'docs', 'knowledge', 'decisions')),
+    await decision.ingestArchitecture(path.join(projectPath, 'docs', 'architecture'))
+  );
+}
+
 function mergeResults(...results: IngestResult[]): IngestResult {
   return results.reduce(
     (acc, r) => ({
@@ -73,6 +96,7 @@ export async function runIngest(
     TopologicalLinker,
     KnowledgeIngestor,
     BusinessKnowledgeIngestor,
+    DecisionIngestor,
     GitIngestor,
     RequirementIngestor,
     SyncManager,
@@ -96,6 +120,8 @@ export async function runIngest(
     // Follow-up from PR #511: --all now exercises BK paths too.
     const bkInst = new BusinessKnowledgeIngestor(store);
     const bkResult = await ingestBusinessKnowledge(bkInst, projectPath);
+    // Decision ADRs are owned by DecisionIngestor, not KnowledgeIngestor (#1351).
+    const decisionResult = await ingestDecisions(new DecisionIngestor(store), projectPath);
     const reqResult = await new RequirementIngestor(store).ingestSpecs(
       path.join(projectPath, 'docs', 'changes')
     );
@@ -124,6 +150,7 @@ export async function runIngest(
       codeResult,
       knowledgeResult,
       bkResult,
+      decisionResult,
       reqResult,
       gitResult,
       signalsResult,
@@ -147,7 +174,10 @@ export async function runIngest(
       // See github issue #504 Finding 1.
       const knowledge = await new KnowledgeIngestor(store).ingestAll(projectPath);
       const bk = await ingestBusinessKnowledge(new BusinessKnowledgeIngestor(store), projectPath);
-      result = mergeResults(knowledge, bk);
+      // Decision ADRs (docs/knowledge/decisions + docs/architecture) are owned by
+      // DecisionIngestor — KnowledgeIngestor excludes docs/knowledge/** (#1351).
+      const decisions = await ingestDecisions(new DecisionIngestor(store), projectPath);
+      result = mergeResults(knowledge, bk, decisions);
       break;
     }
     case 'git':

--- a/packages/cli/src/commands/knowledge-pipeline.test.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.test.ts
@@ -55,6 +55,7 @@ const GAP_DOMAINS = ['auth', 'api'] as const;
 function makeResult(overrides: Record<string, unknown> = {}): unknown {
   return {
     verdict: 'pass',
+    baselineEmpty: false,
     driftScore: 1.5,
     iterations: 1,
     findings: { new: 2, stale: 0, drifted: 0, contradicting: 0 },

--- a/packages/cli/src/commands/knowledge-pipeline.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.ts
@@ -45,7 +45,8 @@ function buildPipelineOptions(
   projectDir: string,
   graphDir: string,
   inferenceOptions: Record<string, unknown> | undefined,
-  extractionExclude: readonly string[]
+  extractionExclude: readonly string[],
+  docDirs: { docsDir?: string; adrDir?: string }
 ): Record<string, unknown> {
   const pipelineOpts: Record<string, unknown> = {
     projectDir,
@@ -56,6 +57,10 @@ function buildPipelineOptions(
     analyzeImages: Boolean(opts.analyzeImages),
     ...(inferenceOptions ? { inferenceOptions } : {}),
     ...(extractionExclude.length > 0 ? { extractionExclude } : {}),
+    // Configured documentation directories so phase-1 ingestion honors a
+    // relocated docsDir / adrDir instead of the hardcoded defaults (#1330).
+    ...(docDirs.docsDir ? { docsDir: docDirs.docsDir } : {}),
+    ...(docDirs.adrDir ? { adrDir: docDirs.adrDir } : {}),
   };
 
   // Parse image paths if provided
@@ -308,9 +313,16 @@ export function createKnowledgePipelineCommand(): Command {
         }
 
         const cfgResult = resolveConfig();
-        const cfgKnowledge = cfgResult.ok ? cfgResult.value.knowledge : undefined;
+        const cfg = cfgResult.ok ? cfgResult.value : undefined;
+        const cfgKnowledge = cfg?.knowledge;
         const inferenceOptions = resolveInferenceOptions(cfgKnowledge);
         const extractionExclude = cfgKnowledge?.extractionExclude ?? [];
+        // docsDir has a schema default of './docs'; adrDir is optional under
+        // operationalPolicy (default docs/knowledge/decisions applied downstream).
+        const docDirs = {
+          ...(cfg?.docsDir ? { docsDir: cfg.docsDir } : {}),
+          ...(cfg?.operationalPolicy?.adrDir ? { adrDir: cfg.operationalPolicy.adrDir } : {}),
+        };
 
         // Build pipeline options
         const pipelineOpts = buildPipelineOptions(
@@ -318,7 +330,8 @@ export function createKnowledgePipelineCommand(): Command {
           projectDir,
           graphDir,
           inferenceOptions,
-          extractionExclude
+          extractionExclude,
+          docDirs
         );
 
         // Set up analysis provider for image analysis if requested

--- a/packages/cli/src/commands/knowledge-pipeline.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.ts
@@ -106,6 +106,7 @@ function printJsonResult(result: KnowledgePipelineResult): void {
     JSON.stringify(
       {
         verdict: result.verdict,
+        baselineEmpty: result.baselineEmpty,
         driftScore: result.driftScore,
         iterations: result.iterations,
         findings: result.findings,
@@ -145,24 +146,49 @@ function printJsonResult(result: KnowledgePipelineResult): void {
   );
 }
 
+/**
+ * True when this looks like a first run: an empty baseline, or purely-new
+ * findings with nothing stale/drifted/contradicting. Drives the drift-score
+ * label so a ~1.0 score is not misread as "everything drifted" (#1110, #1335).
+ */
+function isFirstRun(result: KnowledgePipelineResult): boolean {
+  const f = result.findings;
+  if (result.baselineEmpty) return true;
+  return f.new > 0 && f.stale === 0 && f.drifted === 0 && f.contradicting === 0;
+}
+
+/** Colorized verdict badge for the summary header. */
+function verdictBadge(verdict: KnowledgePipelineResult['verdict']): string {
+  switch (verdict) {
+    case 'pass':
+      return chalk.green('PASS');
+    case 'warn':
+      return chalk.yellow('WARN');
+    case 'abstain':
+      return chalk.magenta('ABSTAIN');
+    default:
+      return chalk.red('FAIL');
+  }
+}
+
 /** Print the verdict header plus drift / findings / extraction / gaps summary. */
 function printSummary(result: KnowledgePipelineResult): void {
-  const verdictColor =
-    result.verdict === 'pass'
-      ? chalk.green('PASS')
-      : result.verdict === 'warn'
-        ? chalk.yellow('WARN')
-        : chalk.red('FAIL');
-
   console.log('');
-  console.log(`KNOWLEDGE PIPELINE -- Verdict: ${verdictColor}`);
+  console.log(`KNOWLEDGE PIPELINE -- Verdict: ${verdictBadge(result.verdict)}`);
+  if (result.verdict === 'abstain') {
+    // The verdict itself is the abstention; spell out why so a zero-baseline run
+    // is never mistaken for a clean one (#1335).
+    console.log(
+      chalk.magenta(
+        '  Inconclusive — empty baseline (no prior business knowledge). Every entry is new, so there is no denominator to grade health against. Re-run after an initial scan to establish a baseline.'
+      )
+    );
+  }
   console.log('');
   // On a first run every finding is `new` (no prior graph state), which drives
   // the drift score toward 1.00. Label it so the headline is not misread as
-  // "everything drifted" when the verdict beneath it is correctly WARN (#1110).
-  const f = result.findings;
-  const firstRun = f.new > 0 && f.stale === 0 && f.drifted === 0 && f.contradicting === 0;
-  const driftLabel = firstRun ? ' (first run — no prior graph state)' : '';
+  // "everything drifted" when the verdict beneath it abstains / warns (#1110, #1335).
+  const driftLabel = isFirstRun(result) ? ' (first run — no prior graph state)' : '';
   console.log(`  Drift Score: ${result.driftScore.toFixed(2)}${driftLabel}`);
   console.log(
     `  Findings: ${result.findings.new} new, ${result.findings.stale} stale, ${result.findings.drifted} drifted, ${result.findings.contradicting} contradicting`

--- a/packages/cli/tests/commands/graph-ingest-decisions.integration.test.ts
+++ b/packages/cli/tests/commands/graph-ingest-decisions.integration.test.ts
@@ -1,0 +1,66 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// Real integration test (NO module mocks): exercises the actual
+// `@harness-engineering/graph` ingestors against a real on-disk fixture and a
+// real GraphStore.
+//
+// Regression: github issue #1351 — `graph ingest --source knowledge` ran
+// KnowledgeIngestor + BusinessKnowledgeIngestor but NEVER constructed
+// DecisionIngestor, and KnowledgeIngestor explicitly excludes docs/knowledge/**.
+// Net: ADRs under docs/knowledge/decisions entered the graph via NO ingestor on
+// this command path. This test writes a real ADR, runs the handler, reloads the
+// graph, and asserts the `decision` node is present.
+import { runIngest } from '../../src/commands/graph/ingest';
+
+const VALID_ADR = `---
+number: 0001
+title: Use graph for context assembly
+date: 2026-08-18
+status: accepted
+tier: large
+source: docs/changes/graph-context/proposal.md
+---
+
+## Context
+
+The existing context system uses glob-based file grouping.
+
+## Decision
+
+Build a unified knowledge graph using GraphStore for context assembly.
+
+## Consequences
+
+- All context queries go through the graph.
+`;
+
+describe('graph ingest --source knowledge (real DecisionIngestor routing, #1351)', () => {
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ingest-decisions-'));
+    const decisionsDir = path.join(projectDir, 'docs', 'knowledge', 'decisions');
+    await fs.mkdir(decisionsDir, { recursive: true });
+    await fs.writeFile(path.join(decisionsDir, '0001-use-graph.md'), VALID_ADR, 'utf-8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('ingests docs/knowledge/decisions/*.md as decision nodes into the GraphStore', async () => {
+    await runIngest(projectDir, 'knowledge');
+
+    // Reload the persisted graph from disk and assert the decision node landed.
+    const { GraphStore } = await import('@harness-engineering/graph');
+    const store = new GraphStore();
+    await store.load(path.join(projectDir, '.harness', 'graph'));
+
+    const decisions = store.findNodes({ type: 'decision' });
+    expect(decisions.length).toBeGreaterThanOrEqual(1);
+    expect(store.getNode('decision:0001-use-graph')).not.toBeNull();
+  });
+});

--- a/packages/cli/tests/commands/graph-ingest.test.ts
+++ b/packages/cli/tests/commands/graph-ingest.test.ts
@@ -61,6 +61,23 @@ const mockGitIngest = vi.fn().mockResolvedValue({
   durationMs: 80,
 });
 
+const mockDecisionIngest = vi.fn().mockResolvedValue({
+  nodesAdded: 0,
+  nodesUpdated: 0,
+  edgesAdded: 0,
+  edgesUpdated: 0,
+  errors: [],
+  durationMs: 0,
+});
+const mockDecisionIngestArchitecture = vi.fn().mockResolvedValue({
+  nodesAdded: 0,
+  nodesUpdated: 0,
+  edgesAdded: 0,
+  edgesUpdated: 0,
+  errors: [],
+  durationMs: 0,
+});
+
 const mockRequirementIngest = vi.fn().mockResolvedValue({
   nodesAdded: 2,
   nodesUpdated: 0,
@@ -120,6 +137,11 @@ vi.mock('@harness-engineering/graph', () => ({
     ingest = mockBkIngest;
     ingestSolutions = mockBkIngestSolutions;
     ingestStrategy = mockBkIngestStrategy;
+  },
+  DecisionIngestor: class {
+    constructor() {}
+    ingest = mockDecisionIngest;
+    ingestArchitecture = mockDecisionIngestArchitecture;
   },
   GitIngestor: class {
     constructor() {}
@@ -189,7 +211,13 @@ beforeEach(() => {
     errors: [],
     durationMs: 50,
   });
-  for (const m of [mockBkIngest, mockBkIngestSolutions, mockBkIngestStrategy]) {
+  for (const m of [
+    mockBkIngest,
+    mockBkIngestSolutions,
+    mockBkIngestStrategy,
+    mockDecisionIngest,
+    mockDecisionIngestArchitecture,
+  ]) {
     m.mockResolvedValue({
       nodesAdded: 0,
       nodesUpdated: 0,
@@ -281,6 +309,33 @@ describe('runIngest', () => {
         expect.stringMatching(/docs[\\/]solutions$/)
       );
       expect(mockBkIngestStrategy).toHaveBeenCalledWith(expect.stringMatching(/STRATEGY\.md$/));
+    });
+
+    // Regression: github issue #1351. Previously --source knowledge never
+    // constructed DecisionIngestor, so ADRs under docs/knowledge/decisions (which
+    // KnowledgeIngestor explicitly excludes) entered the graph via no ingestor.
+    it('routes decision ADRs through DecisionIngestor (docs/knowledge/decisions + docs/architecture)', async () => {
+      await runIngest('/project', 'knowledge');
+      expect(mockDecisionIngest).toHaveBeenCalledWith(
+        expect.stringMatching(/docs[\\/]knowledge[\\/]decisions$/)
+      );
+      expect(mockDecisionIngestArchitecture).toHaveBeenCalledWith(
+        expect.stringMatching(/docs[\\/]architecture$/)
+      );
+    });
+
+    it('aggregates decision nodes into the knowledge-source total', async () => {
+      mockDecisionIngest.mockResolvedValue({
+        nodesAdded: 4,
+        nodesUpdated: 0,
+        edgesAdded: 0,
+        edgesUpdated: 0,
+        errors: [],
+        durationMs: 5,
+      });
+      const result = await runIngest('/project', 'knowledge');
+      // 3 (KnowledgeIngestor) + 0 (bk) + 4 (decisions) = 7
+      expect(result.nodesAdded).toBe(7);
     });
 
     it('aggregates nodes and errors from KnowledgeIngestor and BusinessKnowledgeIngestor', async () => {

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -81,6 +81,7 @@ export { KnowledgePipelineRunner } from './ingest/KnowledgePipelineRunner.js';
 export type {
   KnowledgePipelineOptions,
   KnowledgePipelineResult,
+  KnowledgeVerdict,
   ExtractionCounts,
 } from './ingest/KnowledgePipelineRunner.js';
 
@@ -218,7 +219,12 @@ export {
   ApiPathExtractor,
   detectLanguage,
 } from './ingest/extractors/index.js';
-export type { ExtractionRecord, SignalExtractor, Language } from './ingest/extractors/index.js';
+export type {
+  ExtractionRecord,
+  SignalExtractor,
+  Language,
+  ExtractionRunResult,
+} from './ingest/extractors/index.js';
 
 // Image Analysis
 export { ImageAnalysisExtractor } from './ingest/ImageAnalysisExtractor.js';

--- a/packages/graph/src/ingest/KnowledgePipelineRunner.ts
+++ b/packages/graph/src/ingest/KnowledgePipelineRunner.ts
@@ -81,6 +81,50 @@ export interface KnowledgePipelineOptions {
    * fixture trees are always excluded regardless of this list (#1111).
    */
   readonly extractionExclude?: readonly string[];
+  /**
+   * Project documentation root, sourced by the CLI from
+   * `harness.config.json#docsDir` (default `./docs`). May be absolute or
+   * repo-relative (resolved against `projectDir`). The `architecture/` and
+   * `knowledge/` subtrees scanned by phase 1 are derived from this directory,
+   * so a project that relocates its docs is no longer silently invisible
+   * (#1330). Defaults to `<projectDir>/docs` when unset.
+   */
+  readonly docsDir?: string;
+  /**
+   * Directory holding decision ADRs, sourced by the CLI from
+   * `harness.config.json#operationalPolicy.adrDir` (default
+   * `docs/knowledge/decisions`). May be absolute or repo-relative (resolved
+   * against `projectDir`). When unset it derives from `docsDir` as
+   * `<docsDir>/knowledge/decisions`, preserving the historical default (#1330).
+   */
+  readonly adrDir?: string;
+}
+
+/**
+ * Resolve the documentation directories scanned by phase 1 from configured
+ * `docsDir` / `adrDir` (both optional, both absolute-or-repo-relative). Keeps
+ * the historical hardcoded defaults (`docs/knowledge/decisions`,
+ * `docs/architecture`, `docs/knowledge`) when config is absent so existing
+ * projects are unaffected (#1330).
+ */
+function resolveDocDirs(options: KnowledgePipelineOptions): {
+  docsDir: string;
+  decisionsDir: string;
+  architectureDir: string;
+  knowledgeDir: string;
+} {
+  const docsDir = options.docsDir
+    ? path.resolve(options.projectDir, options.docsDir)
+    : path.join(options.projectDir, 'docs');
+  const decisionsDir = options.adrDir
+    ? path.resolve(options.projectDir, options.adrDir)
+    : path.join(docsDir, 'knowledge', 'decisions');
+  return {
+    docsDir,
+    decisionsDir,
+    architectureDir: path.join(docsDir, 'architecture'),
+    knowledgeDir: path.join(docsDir, 'knowledge'),
+  };
 }
 
 export interface ExtractionCounts {
@@ -294,8 +338,10 @@ export class KnowledgePipelineRunner {
       imageCount = imageResult.nodesAdded;
     }
 
-    // Business knowledge from docs/knowledge/
-    const knowledgeDir = path.join(options.projectDir, 'docs', 'knowledge');
+    // Documentation directories, derived from configured docsDir/adrDir (#1330).
+    const { decisionsDir, architectureDir, knowledgeDir } = resolveDocDirs(options);
+
+    // Business knowledge from docs/knowledge/ (docsDir-derived)
     const bkIngestor = new BusinessKnowledgeIngestor(this.store);
     let bkResult: IngestResult;
     try {
@@ -337,8 +383,6 @@ export class KnowledgePipelineRunner {
     // PLUS architecture-advisor markdown ADRs from docs/architecture/<topic>/ADR-*.md.
     // Both flow into the same `decision` node type so drift detection +
     // contradiction detection apply uniformly.
-    const decisionsDir = path.join(options.projectDir, 'docs', 'knowledge', 'decisions');
-    const architectureDir = path.join(options.projectDir, 'docs', 'architecture');
     const decisionIngestor = new DecisionIngestor(this.store);
     let decisionResult: IngestResult;
     try {
@@ -405,7 +449,7 @@ export class KnowledgePipelineRunner {
   // ── Phase 3: DETECT ───────────────────────────────────────────────────────
 
   private async detect(options: KnowledgePipelineOptions): Promise<GapReport> {
-    const knowledgeDir = path.join(options.projectDir, 'docs', 'knowledge');
+    const { knowledgeDir } = resolveDocDirs(options);
     const aggregator = new KnowledgeStagingAggregator(options.projectDir, this.inferenceOptions);
     const gapReport = await aggregator.generateGapReport(knowledgeDir, this.store);
     await aggregator.writeGapReport(gapReport);

--- a/packages/graph/src/ingest/KnowledgePipelineRunner.ts
+++ b/packages/graph/src/ingest/KnowledgePipelineRunner.ts
@@ -26,6 +26,7 @@ import {
 import {
   KnowledgeStagingAggregator,
   type GapReport,
+  type GapEntry,
   type StagedEntry,
 } from './KnowledgeStagingAggregator.js';
 import { createExtractionRunner } from './extractors/index.js';
@@ -54,6 +55,17 @@ const SNAPSHOT_NODE_TYPES: readonly NodeType[] = [
   'aesthetic_intent',
   'image_annotation',
 ];
+
+/**
+ * Minimum extraction confidence for a gap entry to be materialized into the
+ * consumer's *tracked* `docs/knowledge/` tree. Entries below this floor (e.g.
+ * comment-derived / low-signal extractions, #1331) are still reported as gaps
+ * but are never written to disk. Conservative by design: only clearly
+ * low-confidence signals are withheld. Human-authored nodes (business knowledge,
+ * decisions, diagrams) carry no `metadata.confidence` and are treated as
+ * trusted, so this floor cannot suppress hand-written knowledge (#1335).
+ */
+const MATERIALIZATION_CONFIDENCE_FLOOR = 0.5;
 
 // ─── Public Types ───────────────────────────────────────────────────────────
 
@@ -136,8 +148,20 @@ export interface ExtractionCounts {
   readonly images: number;
 }
 
+export type KnowledgeVerdict = 'pass' | 'warn' | 'fail' | 'abstain';
+
 export interface KnowledgePipelineResult {
-  readonly verdict: 'pass' | 'warn' | 'fail';
+  /**
+   * Overall health verdict. `abstain` is emitted when the pre-extraction
+   * baseline held no `business_*` nodes: on such a first run every fresh entry
+   * classifies as `new` and the drift score approaches 1.0, so there is no
+   * denominator to judge health against. It is deliberately distinct from
+   * `pass`/`warn` so a reader cannot mistake a zero-baseline run for a clean one
+   * (#1335).
+   */
+  readonly verdict: KnowledgeVerdict;
+  /** True when the pre-extraction baseline held no `business_*` nodes (#1335). */
+  readonly baselineEmpty: boolean;
   readonly driftScore: number;
   readonly iterations: number;
   readonly findings: DriftResult['summary'];
@@ -179,8 +203,11 @@ export class KnowledgePipelineRunner {
     const remediations: string[] = [];
     const ingestErrors: string[] = [];
 
-    // Phase 1: Capture pre-extraction snapshot, then extract
+    // Phase 1: Capture pre-extraction snapshot, then extract. Record whether
+    // the baseline held any prior business_* nodes — an empty baseline makes the
+    // drift verdict an abstention rather than a warn (#1335).
     const preSnapshot = this.buildSnapshot(options.domain);
+    const baselineEmpty = this.isBaselineEmpty(options.domain);
     const extraction = await this.extract(options);
     ingestErrors.push(...extraction.errors);
 
@@ -220,6 +247,7 @@ export class KnowledgePipelineRunner {
 
     return this.buildResult(
       driftResult,
+      baselineEmpty,
       iterations,
       extraction.counts,
       ingestErrors,
@@ -229,6 +257,20 @@ export class KnowledgePipelineRunner {
       coverage,
       materialization
     );
+  }
+
+  /**
+   * True when no `business_*` nodes exist in the store prior to extraction
+   * (respecting the domain filter when set). Signals a zero-denominator "first
+   * run" baseline so the verdict abstains instead of warning (#1335).
+   */
+  private isBaselineEmpty(domain?: string): boolean {
+    for (const type of BUSINESS_NODE_TYPES) {
+      for (const node of this.store.findNodes({ type })) {
+        if (!domain || (node.metadata?.domain as string) === domain) return false;
+      }
+    }
+    return true;
   }
 
   /** Run the remediation convergence loop; returns iteration count and accumulated materialization. */
@@ -286,6 +328,7 @@ export class KnowledgePipelineRunner {
   /** Assemble the final pipeline result. */
   private buildResult(
     driftResult: DriftResult,
+    baselineEmpty: boolean,
     iterations: number,
     extraction: ExtractionCounts,
     errors: readonly string[],
@@ -296,7 +339,8 @@ export class KnowledgePipelineRunner {
     materialization?: MaterializeResult
   ): KnowledgePipelineResult {
     return {
-      verdict: this.computeVerdict(driftResult),
+      verdict: this.computeVerdict(driftResult, baselineEmpty),
+      baselineEmpty,
       driftScore: driftResult.driftScore,
       iterations,
       findings: driftResult.summary,
@@ -409,7 +453,10 @@ export class KnowledgePipelineRunner {
 
     return {
       counts: {
-        codeSignals: extractionResult.nodesAdded,
+        // Report signals actually extracted this run (records written), not
+        // `nodesAdded` (deduped new store insertions) which reads as 0 on a
+        // re-scan even while thousands of records were written (#1340).
+        codeSignals: extractionResult.signalsExtracted,
         diagrams: diagramResult.nodesAdded,
         linkerFacts: linkResult.factsCreated,
         businessKnowledge: bkResult.nodesAdded,
@@ -486,10 +533,14 @@ export class KnowledgePipelineRunner {
       }
     }
 
-    // Materialize docs for undocumented entries (non-CI only)
+    // Materialize docs for undocumented entries (non-CI only). Gate on a
+    // confidence floor so low-confidence / comment-derived signals are reported
+    // as gaps but never written to the consumer's tracked docs tree (#1335).
     if (!options.ci) {
       const allGapEntries = gapReport.domains.flatMap((d) => d.gapEntries);
-      const materializable = allGapEntries.filter((e) => e.hasContent);
+      const materializable = allGapEntries.filter(
+        (e) => e.hasContent && this.entryConfidence(e) >= MATERIALIZATION_CONFIDENCE_FLOOR
+      );
       if (materializable.length > 0) {
         const materializer = new KnowledgeDocMaterializer(this.store, this.inferenceOptions);
         const matResult = await materializer.materialize(materializable, {
@@ -536,6 +587,17 @@ export class KnowledgePipelineRunner {
     }
   }
 
+  /**
+   * Confidence of a gap entry's backing graph node. Extractor / linker nodes
+   * carry an explicit `metadata.confidence` (0.0-1.0); human-authored nodes
+   * carry none and are treated as fully trusted so the floor cannot suppress
+   * hand-written knowledge (#1335).
+   */
+  private entryConfidence(entry: GapEntry): number {
+    const confidence = this.store.getNode(entry.nodeId)?.metadata?.confidence;
+    return typeof confidence === 'number' ? confidence : 1;
+  }
+
   private classifySource(source: string): 'extractor' | 'linker' | 'diagram' {
     if (source === 'linker' || source === 'knowledge-linker') return 'linker';
     if (source === 'diagram') return 'diagram';
@@ -544,12 +606,15 @@ export class KnowledgePipelineRunner {
 
   // ── Verdict ───────────────────────────────────────────────────────────────
 
-  private computeVerdict(driftResult: DriftResult): 'pass' | 'warn' | 'fail' {
+  private computeVerdict(driftResult: DriftResult, baselineEmpty: boolean): KnowledgeVerdict {
     const { summary } = driftResult;
     const unresolved = summary.drifted + summary.stale + summary.contradicting;
 
-    if (unresolved === 0 && summary.new === 0) return 'pass';
-    if (unresolved === 0) return 'warn';
-    return 'fail';
+    if (unresolved > 0) return 'fail';
+    if (summary.new === 0) return 'pass';
+    // Every fresh entry is `new` and nothing is unresolved. With no prior
+    // business baseline there is no denominator to judge health against, so we
+    // abstain rather than emit a WARN that reads as clean (#1335).
+    return baselineEmpty ? 'abstain' : 'warn';
   }
 }

--- a/packages/graph/src/ingest/extractors/ExtractionRunner.ts
+++ b/packages/graph/src/ingest/extractors/ExtractionRunner.ts
@@ -70,6 +70,18 @@ const EXTRACTOR_EDGE_TYPE: Record<string, EdgeType> = {
 };
 
 /**
+ * Result of an {@link ExtractionRunner} run. Extends {@link IngestResult} with
+ * `signalsExtracted`: the total number of records the extractors wrote to JSONL
+ * this run, independent of graph deduplication. `nodesAdded` counts only *new*
+ * store insertions and drops to 0 on a re-scan where every node already exists,
+ * so it cannot be used as an honest "signals extracted" headline (#1340).
+ */
+export interface ExtractionRunResult extends IngestResult {
+  /** Total extraction records written this run (pre-dedup). */
+  readonly signalsExtracted: number;
+}
+
+/**
  * Orchestrates code signal extraction across a project.
  * Walks files, dispatches to registered extractors, writes JSONL,
  * persists to graph, and handles stale detection.
@@ -91,12 +103,17 @@ export class ExtractionRunner {
    * @param store - GraphStore for node/edge persistence
    * @param outputDir - Directory for JSONL output (e.g. .harness/knowledge/extracted/)
    */
-  async run(projectDir: string, store: GraphStore, outputDir: string): Promise<IngestResult> {
+  async run(
+    projectDir: string,
+    store: GraphStore,
+    outputDir: string
+  ): Promise<ExtractionRunResult> {
     const start = Date.now();
     const errors: string[] = [];
     let nodesAdded = 0;
     let nodesUpdated = 0;
     let edgesAdded = 0;
+    let signalsExtracted = 0;
 
     // Ensure output directory exists
     await fs.mkdir(outputDir, { recursive: true });
@@ -148,6 +165,10 @@ export class ExtractionRunner {
       // Write JSONL
       await this.writeJsonl(records, outputDir, extractorName);
 
+      // Every record written to JSONL is a signal extracted this run, whether
+      // or not it results in a new store node (#1340).
+      signalsExtracted += records.length;
+
       // Persist to graph
       for (const record of records) {
         allCurrentIds.add(record.id);
@@ -169,6 +190,7 @@ export class ExtractionRunner {
       edgesUpdated: 0,
       errors,
       durationMs: Date.now() - start,
+      signalsExtracted,
     };
   }
 

--- a/packages/graph/src/ingest/extractors/index.ts
+++ b/packages/graph/src/ingest/extractors/index.ts
@@ -4,6 +4,7 @@ export {
   detectLanguage,
   DEFAULT_EXTRACTION_EXCLUDE,
 } from './ExtractionRunner.js';
+export type { ExtractionRunResult } from './ExtractionRunner.js';
 export { TestDescriptionExtractor } from './TestDescriptionExtractor.js';
 export { EnumConstantExtractor } from './EnumConstantExtractor.js';
 export { ValidationRuleExtractor } from './ValidationRuleExtractor.js';

--- a/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
+++ b/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
@@ -208,6 +208,67 @@ Route all auth through AuthService.
       expect(node!.metadata.source).toBe('architecture');
     });
 
+    // Regression: github issue #1330 — the decisions/architecture/knowledge dirs
+    // were hardcoded to `docs/knowledge/decisions` etc., ignoring the project's
+    // configured `docsDir`/`adrDir`. A project that keeps ADRs at a configured
+    // non-default location reported "0 decisions" (a zero denominator that reads
+    // like a real measurement).
+    it('honors a configured non-default adrDir when locating decision ADRs', async () => {
+      const adrDir = path.join(tmpDir, 'architecture', 'adrs');
+      await fs.mkdir(adrDir, { recursive: true });
+      await fs.writeFile(
+        path.join(adrDir, '0007-custom-location.md'),
+        `---
+number: 0007
+title: Keep ADRs in a configured location
+date: 2026-08-18
+status: accepted
+tier: large
+---
+
+## Decision
+
+ADRs live under a project-configured directory, not the hardcoded default.
+`,
+        'utf-8'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      // adrDir is repo-relative (as sourced from operationalPolicy.adrDir).
+      const result = await runner.run(makeOptions({ adrDir: 'architecture/adrs' }));
+
+      expect(result.extraction.decisions).toBeGreaterThanOrEqual(1);
+      const node = store.getNode('decision:0007-custom-location');
+      expect(node).not.toBeNull();
+      expect(node!.type).toBe('decision');
+    });
+
+    // Companion to #1330: a configured non-default `docsDir` must relocate the
+    // derived architecture/ and knowledge/ subtrees too.
+    it('derives architecture/ and knowledge/ subtrees from a configured docsDir', async () => {
+      const archDir = path.join(tmpDir, 'documentation', 'architecture', 'auth');
+      await fs.mkdir(archDir, { recursive: true });
+      await fs.writeFile(
+        path.join(archDir, 'ADR-002.md'),
+        `# ADR-002: Centralize auth
+
+**Date:** 2026-08-18
+**Status:** Accepted
+
+## Decision
+
+Route auth through AuthService.
+`,
+        'utf-8'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions({ docsDir: 'documentation' }));
+
+      expect(result.extraction.decisions).toBeGreaterThanOrEqual(1);
+      expect(store.getNode('decision:architecture:auth:ADR-002')).not.toBeNull();
+    });
+
     it('surfaces BusinessKnowledgeIngestor frontmatter errors on the result', async () => {
       // Schema-invalid solutions doc: missing last_updated (required field).
       const solutionsDir = path.join(tmpDir, 'docs', 'solutions', 'knowledge-track', 'conventions');

--- a/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
+++ b/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
@@ -483,6 +483,110 @@ Route auth through AuthService.
     });
   });
 
+  // ── #1335 / #1340: abstention, confidence floor, extraction honesty ──────────
+  describe('abstention on empty baseline (#1335)', () => {
+    it('abstains (not warn) when no prior business baseline exists on first run', async () => {
+      // Fresh store: zero business_* nodes. A knowledge doc yields a brand-new
+      // business_rule node, so every fresh entry is `new` and driftScore ~1.0.
+      // The old code reported WARN with 0 stale/drifted/contradicting — which a
+      // reader scans as a healthy repo. A zero denominator is an abstention.
+      const knowledgeDir = path.join(tmpDir, 'docs', 'knowledge', 'payments');
+      await fs.mkdir(knowledgeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(knowledgeDir, 'refund-policy.md'),
+        '---\ntype: business_rule\ndomain: payments\n---\n# Refund Policy\nRefunds within 30 days.'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      expect(result.findings.new).toBeGreaterThan(0);
+      expect(result.findings.stale + result.findings.drifted + result.findings.contradicting).toBe(
+        0
+      );
+      expect(result.verdict).toBe('abstain');
+    });
+
+    it('still reports warn (not abstain) when a business baseline already exists', async () => {
+      // A pre-existing business node means the baseline is NOT empty; a fresh
+      // `new` finding on top of it is a genuine warn, not an abstention.
+      store.addNode({
+        id: 'bk:payments:existing',
+        type: 'business_rule',
+        name: 'Existing Rule',
+        metadata: { domain: 'payments', source: 'manual' },
+      });
+      const knowledgeDir = path.join(tmpDir, 'docs', 'knowledge', 'auth');
+      await fs.mkdir(knowledgeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(knowledgeDir, 'session.md'),
+        '---\ntype: business_rule\ndomain: auth\n---\n# Session\nSessions expire after 24h.'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      expect(result.findings.new).toBeGreaterThan(0);
+      expect(result.findings.stale + result.findings.drifted + result.findings.contradicting).toBe(
+        0
+      );
+      expect(result.verdict).toBe('warn');
+    });
+  });
+
+  describe('materialization confidence floor (#1335)', () => {
+    it('does not materialize below-floor-confidence entries to tracked docs', async () => {
+      store.addNode({
+        id: 'extracted:auth:low',
+        type: 'business_rule',
+        name: 'Low Confidence Rule',
+        metadata: { domain: 'auth', source: 'extractor', confidence: 0.3 },
+        content: 'Flimsy comment-derived text that is nonetheless long enough to pass hasContent.',
+      });
+      store.addNode({
+        id: 'extracted:auth:high',
+        type: 'business_rule',
+        name: 'High Confidence Rule',
+        metadata: { domain: 'auth', source: 'extractor', confidence: 0.9 },
+        content: 'A solidly extracted rule with real, trustworthy content here.',
+      });
+      await fs.mkdir(path.join(tmpDir, 'docs', 'knowledge', 'auth'), { recursive: true });
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions({ fix: true, maxIterations: 2 }));
+
+      const created = (result.materialization?.created ?? []).map((d) => d.name);
+      expect(created).toContain('High Confidence Rule');
+      expect(created).not.toContain('Low Confidence Rule');
+
+      // The low-confidence entry must never touch the tracked docs tree.
+      const authDocs = await fs.readdir(path.join(tmpDir, 'docs', 'knowledge', 'auth'));
+      expect(authDocs.some((f) => f.includes('low-confidence'))).toBe(false);
+    });
+  });
+
+  describe('extraction count honesty (#1340)', () => {
+    it('reports signals extracted this run, not deduped new-node insertions', async () => {
+      const srcDir = path.join(tmpDir, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+      await fs.writeFile(
+        path.join(srcDir, 'orders.ts'),
+        'import { z } from "zod";\nexport const OrderSchema = z.object({\n  id: z.string().min(1),\n});\n'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const first = await runner.run(makeOptions());
+      expect(first.extraction.codeSignals).toBeGreaterThan(0);
+
+      // Second run against the SAME store: nodes already exist so `nodesAdded`
+      // is 0, but the extractors re-wrote the same records to JSONL. The
+      // reported count must reflect what was extracted, not the new-node count —
+      // otherwise "0 code signals" contradicts a non-empty "extracted" gap total.
+      const second = await runner.run(makeOptions());
+      expect(second.extraction.codeSignals).toBe(first.extraction.codeSignals);
+    });
+  });
+
   describe('inferenceOptions plumbing (Phase 4)', () => {
     it('defaults to {} when no inferenceOptions field on options', async () => {
       // Pre-seed graph with one node whose path lands under a non-default top-level dir.

--- a/packages/graph/tests/integration/knowledge-pipeline.test.ts
+++ b/packages/graph/tests/integration/knowledge-pipeline.test.ts
@@ -430,7 +430,9 @@ describe('Knowledge Pipeline (integration)', () => {
       expect(result.extraction.businessKnowledge).toBeGreaterThan(0);
       expect(result.gaps.domains.length).toBeGreaterThan(0);
       expect(result.verdict).toBeDefined();
-      expect(['pass', 'warn', 'fail']).toContain(result.verdict);
+      // Fresh store: no prior business baseline, so a first run of pure-new
+      // findings abstains rather than warns (#1335).
+      expect(['pass', 'warn', 'fail', 'abstain']).toContain(result.verdict);
     });
 
     it('fix mode converges on empty project', async () => {


### PR DESCRIPTION
## Summary

Fixes two closely-related, adjacent defects on the DecisionIngestor call-site surface.

### Bug A — #1330: knowledge-pipeline hardcoded decisionsDir, ignored docsDir
`KnowledgePipelineRunner` hardcoded `docs/knowledge/decisions`, `docs/architecture`, and `docs/knowledge`, ignoring the project's configured `docsDir` / `adrDir`. A project that keeps ADRs at a configured non-default location was silently invisible — the pipeline reported "0 decisions" (a zero denominator that reads like a real measurement).

**Fix:** added `docsDir` / `adrDir` to `KnowledgePipelineOptions`, plumbed them from config through the CLI (`harness.config.json#docsDir` and `#operationalPolicy.adrDir`), and derive the three directories from config via a single `resolveDocDirs` helper. Historical defaults (`docs/knowledge/decisions`, etc.) are preserved when config is unset — no behavior change for default-layout projects.

### Bug B — #1351: `graph ingest --source knowledge` never ingested decisions
The `--source knowledge` branch (and `--all`) ran `KnowledgeIngestor.ingestAll` + `ingestBusinessKnowledge` but never constructed `DecisionIngestor`. Since `KnowledgeIngestor.ingestAll` explicitly excludes `docs/knowledge/**`, ADRs under `docs/knowledge/decisions` entered the graph via **no** ingestor on this command path.

**Fix:** the `knowledge` case (and `--all`) now invokes the existing `DecisionIngestor` (decisions + architecture ADRs) so `docs/knowledge/decisions/*.md` become `decision` graph nodes.

## Reproduction tests (red at base, green on branch)
- Bug A: `packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts` — two tests asserting a configured non-default `adrDir` / `docsDir` locates decisions (`extraction.decisions >= 1`). Red at base: `expected 0 to be >= 1`.
- Bug B: `packages/cli/tests/commands/graph-ingest-decisions.integration.test.ts` — real (un-mocked) integration test: writes a real ADR, runs `runIngest(..., 'knowledge')`, reloads the GraphStore, asserts the `decision` node landed. Red at base: `expected 0 to be >= 1`. Plus mock-level routing assertions in `graph-ingest.test.ts`.

## Verification
- Both repro tests green on branch.
- `pnpm turbo run test typecheck --filter=@harness-engineering/graph... --filter=@harness-engineering/cli...` — all 36 tasks pass (cli 6263 tests, graph green, typecheck clean). No regression for default-layout projects.
- `pnpm run generate-docs` — no changes.

Do not merge — batch review.
