### PR TITLE
feat(blueprint): implement impact-lab-generator + run root tests/ in CI (#1338)

### DIFF
--- a/.changeset/feat-1338-impact-lab-generator.md
+++ b/.changeset/feat-1338-impact-lab-generator.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/core': minor
+---
+
+Implement the blueprint Impact Lab data generator (#1338).
+
+Adds `packages/core/src/blueprint/impact-lab-generator.ts` exporting
+`generateImpactData`, which builds the seed "if I change this file, what
+breaks?" data for a blueprint's Impact Lab. The impact source is injected (an
+`ImpactAnalyzer` mirroring the `get_impact` MCP grouping of tests / docs / code /
+other), so the generator stays pure, degrades gracefully to an empty impact set
+when no graph is available, and classifies + tallies downstream-impacted nodes
+per category.
+
+Also wires the root-level `tests/` vitest tree into CI on every OS via a new
+`test:root` script, so root-level specs (e.g. `tests/blueprint/impact-lab.test.ts`)
+can no longer reference a missing module and rot unnoticed. The existing
+`node --test 'tests/scripts/*.test.mjs'` run is unaffected (root vitest discovery
+is scoped to `tests/**/*.test.ts`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,18 @@ jobs:
             coverage-baselines.json
           retention-days: 1
 
-      - run: pnpm test:platform-parity
+      # Run the root-level `tests/` vitest tree on every OS. This covers the
+      # cross-platform parity suite AND any other root-level vitest specs
+      # (e.g. tests/blueprint/**, tests/scripts/*.test.ts) that live outside a
+      # workspace package and are therefore invisible to `turbo run test`.
+      # Without this, a root test that fails to even collect (a missing import)
+      # rots silently — the exact gap that let tests/blueprint/impact-lab.test.ts
+      # reference a non-existent module unnoticed (#1338). The root vitest config
+      # (vitest.config.mts) scopes discovery to `tests/**/*.test.ts`, so the
+      # separate `node --test 'tests/scripts/*.test.mjs'` node:test run above is
+      # untouched (it matches only .mjs).
+      - name: Test root-level tests/ tree (all OSes)
+        run: pnpm test:root
 
       # Dogfood the shipped semantic-vocabulary gate against harness's own config.
       - run: node packages/cli/dist/bin/harness.js check-vocabulary

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "clean": "turbo run clean && node scripts/clean.mjs node_modules",
     "bench": "turbo run bench",
     "test:platform-parity": "vitest run tests/platform-parity.test.ts",
+    "test:root": "vitest run",
     "orchestrator": "node packages/cli/dist/bin/harness.js orchestrator run",
     "orchestrator:dev": "turbo run build --filter=@harness-engineering/cli... && export HARNESS_PROJECT_PATH=\"$PWD\" && concurrently --names orch,dash --prefix-colors blue,green \"node packages/cli/dist/bin/harness.js orchestrator run --headless\" \"pnpm --filter @harness-engineering/dashboard dev\"",
     "dashboard:dev": "export HARNESS_PROJECT_PATH=\"$PWD\" && pnpm --filter @harness-engineering/dashboard dev",

--- a/packages/core/src/blueprint/impact-lab-generator.test.ts
+++ b/packages/core/src/blueprint/impact-lab-generator.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateImpactData,
+  categorizeImpact,
+  type ImpactSourceNode,
+} from './impact-lab-generator';
+
+describe('categorizeImpact', () => {
+  it('maps test node types to "tests"', () => {
+    expect(categorizeImpact('test_result')).toBe('tests');
+    expect(categorizeImpact('test')).toBe('tests');
+  });
+
+  it('maps documentation node types to "docs"', () => {
+    for (const type of ['adr', 'decision', 'document', 'learning']) {
+      expect(categorizeImpact(type)).toBe('docs');
+    }
+  });
+
+  it('maps code node types to "code"', () => {
+    for (const type of ['file', 'module', 'class', 'interface', 'function', 'method', 'variable']) {
+      expect(categorizeImpact(type)).toBe('code');
+    }
+  });
+
+  it('defaults unknown node types to "other"', () => {
+    expect(categorizeImpact('config')).toBe('other');
+    expect(categorizeImpact('')).toBe('other');
+  });
+});
+
+describe('generateImpactData', () => {
+  it('returns valid, empty data with the default (no-graph) analyzer', async () => {
+    const data = await generateImpactData('src/index.ts');
+
+    expect(data.file).toBe('src/index.ts');
+    expect(data.impacts).toEqual([]);
+    expect(data.counts).toEqual({ tests: 0, docs: 0, code: 0, other: 0 });
+    expect(Number.isNaN(Date.parse(data.generatedAt))).toBe(false);
+  });
+
+  it('classifies impacted nodes and tallies per-category counts', async () => {
+    const nodes: ImpactSourceNode[] = [
+      { id: 'file:src/service.ts', type: 'file', path: 'src/service.ts' },
+      { id: 'fn:handle', type: 'function', path: 'src/service.ts' },
+      { id: 'test:svc', type: 'test_result', path: 'src/service.test.ts' },
+      { id: 'adr:0007', type: 'adr' },
+      { id: 'misc:cfg', type: 'config' },
+    ];
+
+    const data = await generateImpactData('src/index.ts', { analyzer: () => nodes });
+
+    expect(data.impacts).toHaveLength(5);
+    expect(data.counts).toEqual({ tests: 1, docs: 1, code: 2, other: 1 });
+    expect(data.impacts.every((i) => typeof i.category === 'string')).toBe(true);
+  });
+
+  it('excludes the target file from its own impacts (by path and by node id)', async () => {
+    const byPath = await generateImpactData('src/index.ts', {
+      analyzer: (file) => [
+        { id: 'x', type: 'file', path: file },
+        { id: 'file:src/other.ts', type: 'file', path: 'src/other.ts' },
+      ],
+    });
+    expect(byPath.impacts).toHaveLength(1);
+    expect(byPath.impacts[0]!.path).toBe('src/other.ts');
+
+    const byId = await generateImpactData('src/index.ts', {
+      analyzer: (file) => [{ id: `file:${file}`, type: 'file' }],
+    });
+    expect(byId.impacts).toHaveLength(0);
+  });
+
+  it('awaits async analyzers (e.g. a graph-backed impact query)', async () => {
+    const data = await generateImpactData('src/index.ts', {
+      analyzer: async () => [{ id: 'doc:readme', type: 'document', path: 'README.md' }],
+    });
+
+    expect(data.counts.docs).toBe(1);
+    expect(data.impacts[0]!.category).toBe('docs');
+  });
+});

--- a/packages/core/src/blueprint/impact-lab-generator.ts
+++ b/packages/core/src/blueprint/impact-lab-generator.ts
@@ -1,0 +1,123 @@
+/**
+ * Impact Lab data generator for the blueprint.
+ *
+ * The Impact Lab is the interactive "if I change this file, what breaks?"
+ * exercise embedded in a generated blueprint. At view time the browser
+ * component re-queries the `get_impact` MCP tool as the reader toggles files;
+ * this module produces the seed {@link ImpactData} the blueprint ships with and
+ * defines the shape both sides agree on.
+ *
+ * The impact source is injected (see {@link ImpactAnalyzer}) so the generator
+ * stays pure and testable. The runtime blueprint wires a graph-backed analyzer
+ * that mirrors the `get_impact` grouping (tests / docs / code / other); when no
+ * graph is available the generator degrades gracefully to an empty impact set
+ * rather than throwing.
+ */
+
+/** Category a downstream-impacted node falls into, matching `get_impact`. */
+export type ImpactCategory = 'tests' | 'docs' | 'code' | 'other';
+
+/**
+ * A node an {@link ImpactAnalyzer} reports as downstream of the target file.
+ * Aligns with the graph node shape returned by the `get_impact` MCP tool.
+ */
+export interface ImpactSourceNode {
+  id: string;
+  type: string;
+  path?: string;
+}
+
+/** A downstream-impacted node, classified into an {@link ImpactCategory}. */
+export interface ImpactNode extends ImpactSourceNode {
+  category: ImpactCategory;
+}
+
+/** Seed data for the blueprint's Impact Lab, keyed to a single source file. */
+export interface ImpactData {
+  file: string;
+  generatedAt: string;
+  impacts: ImpactNode[];
+  counts: Record<ImpactCategory, number>;
+}
+
+/**
+ * Pluggable impact source. Given a file (relative to the project root),
+ * resolves the set of graph nodes affected by changing it. Mirrors the
+ * `get_impact` MCP tool. Injected so the generator has no hard dependency on a
+ * loaded graph and remains deterministic under test.
+ */
+export type ImpactAnalyzer = (file: string) => Promise<ImpactSourceNode[]> | ImpactSourceNode[];
+
+/** Options for {@link generateImpactData}. */
+export interface GenerateImpactOptions {
+  /**
+   * Impact source. Defaults to an analyzer that reports no impacts, so a
+   * blueprint generated without a graph still produces valid, empty Impact Lab
+   * data instead of failing.
+   */
+  analyzer?: ImpactAnalyzer;
+}
+
+const TEST_TYPES = new Set(['test_result', 'test']);
+const DOC_TYPES = new Set(['adr', 'decision', 'document', 'learning']);
+const CODE_TYPES = new Set([
+  'file',
+  'module',
+  'class',
+  'interface',
+  'function',
+  'method',
+  'variable',
+]);
+
+/** Classify a graph node type into an {@link ImpactCategory}. */
+export function categorizeImpact(type: string): ImpactCategory {
+  if (TEST_TYPES.has(type)) return 'tests';
+  if (DOC_TYPES.has(type)) return 'docs';
+  if (CODE_TYPES.has(type)) return 'code';
+  return 'other';
+}
+
+/** An analyzer that reports no downstream impact (graceful no-graph default). */
+const emptyAnalyzer: ImpactAnalyzer = () => [];
+
+/**
+ * Build the Impact Lab seed data for a single file.
+ *
+ * Resolves downstream-impacted nodes via the injected analyzer, drops the file
+ * itself if the analyzer echoes it, classifies each node into a category, and
+ * tallies per-category counts. Deterministic given a deterministic analyzer.
+ *
+ * @param file    Source file (relative to project root) to analyze.
+ * @param options Impact source and related options.
+ */
+export async function generateImpactData(
+  file: string,
+  options: GenerateImpactOptions = {}
+): Promise<ImpactData> {
+  const analyzer = options.analyzer ?? emptyAnalyzer;
+  const nodes = await analyzer(file);
+
+  const counts: Record<ImpactCategory, number> = {
+    tests: 0,
+    docs: 0,
+    code: 0,
+    other: 0,
+  };
+
+  const impacts: ImpactNode[] = [];
+  for (const node of nodes) {
+    // Skip the target file itself so it never counts as its own impact.
+    if (node.path === file || node.id === `file:${file}`) continue;
+    const category = categorizeImpact(node.type);
+    counts[category] += 1;
+    impacts.push({ ...node, category });
+  }
+
+  return {
+    file,
+    generatedAt: new Date().toISOString(),
+    impacts,
+    counts,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -149,6 +149,7 @@ export * from './interaction';
 export * from './blueprint/types';
 export { ProjectScanner } from './blueprint/scanner';
 export { BlueprintGenerator } from './blueprint/generator';
+export * from './blueprint/impact-lab-generator';
 
 /**
  * Update checker utilities for checking for new versions of the toolkit.

--- a/scripts/generate-barrel-exports.mjs
+++ b/scripts/generate-barrel-exports.mjs
@@ -23,7 +23,8 @@ import { resolve, join, relative } from 'node:path';
 const ROOT = resolve(import.meta.dirname, '..');
 const CLI_COMMANDS_DIR = join(ROOT, 'packages', 'cli', 'src', 'commands');
 const REGISTRY_PATH = join(ROOT, 'packages', 'cli', 'src', 'commands', '_registry.ts');
-const HEADER = '// AUTO-GENERATED — do not edit. Run `pnpm run generate-barrel-exports` to regenerate.\n';
+const HEADER =
+  '// AUTO-GENERATED — do not edit. Run `pnpm run generate-barrel-exports` to regenerate.\n';
 
 /**
  * Sub-directory files that are registered as top-level CLI commands.
@@ -47,10 +48,17 @@ function extractCommands(filePath, commandsDir) {
     ...content.matchAll(/export\s+const\s+(create\w+Command)\s*=/g),
   ];
   return matches.map((match) => {
-    let importPath = './' + relative(commandsDir, filePath)
-      .replace(/\.ts$/, '')
-      .replace(/\/index$/, '');
-    importPath = importPath.replace(/\\/g, '/');
+    // Normalize path separators to POSIX '/' FIRST, before stripping the
+    // '.ts' / '/index' suffixes — otherwise on Windows `relative()` returns
+    // backslash-separated paths (e.g. `nested\index.ts`) and the forward-slash
+    // `/index$` strip never matches, emitting `./nested/index` instead of
+    // `./nested`. Ordering the replace last (as before) left this Windows-only.
+    const importPath =
+      './' +
+      relative(commandsDir, filePath)
+        .replace(/\\/g, '/')
+        .replace(/\.ts$/, '')
+        .replace(/\/index$/, '');
     return { importPath, functionName: match[1] };
   });
 }
@@ -106,9 +114,7 @@ function generateRegistry(commands) {
     .map((c) => `import { ${c.functionName} } from '${c.importPath}';`)
     .join('\n');
 
-  const registrations = commands
-    .map((c) => `  ${c.functionName},`)
-    .join('\n');
+  const registrations = commands.map((c) => `  ${c.functionName},`).join('\n');
 
   return `${HEADER}
 import type { Command } from 'commander';

--- a/scripts/generate-core-barrel.mjs
+++ b/scripts/generate-core-barrel.mjs
@@ -60,6 +60,7 @@ const SELECTIVE_EXPORTS = {
         "export * from './blueprint/types';",
         "export { ProjectScanner } from './blueprint/scanner';",
         "export { BlueprintGenerator } from './blueprint/generator';",
+        "export * from './blueprint/impact-lab-generator';",
       ],
     },
   ],

--- a/tests/blueprint/impact-lab.test.ts
+++ b/tests/blueprint/impact-lab.test.ts
@@ -1,12 +1,71 @@
 import { describe, it, expect } from 'vitest';
-import { generateImpactData } from '../../packages/core/src/blueprint/impact-lab-generator';
+import {
+  generateImpactData,
+  categorizeImpact,
+  type ImpactSourceNode,
+} from '../../packages/core/src/blueprint/impact-lab-generator';
 
 describe('Impact Lab Data Generation', () => {
-  it('should generate valid impact data for a given file', async () => {
-    // Note: generateImpactData is currently not implemented, this should fail.
+  it('generates valid, empty impact data when no analyzer (no graph) is wired', async () => {
     const data = await generateImpactData('src/index.ts');
+
     expect(data).toBeDefined();
     expect(data.file).toBe('src/index.ts');
     expect(Array.isArray(data.impacts)).toBe(true);
+    expect(data.impacts).toHaveLength(0);
+    expect(data.counts).toEqual({ tests: 0, docs: 0, code: 0, other: 0 });
+    // generatedAt is a valid ISO-8601 timestamp.
+    expect(Number.isNaN(Date.parse(data.generatedAt))).toBe(false);
+  });
+
+  it('classifies impacted nodes and tallies per-category counts', async () => {
+    const nodes: ImpactSourceNode[] = [
+      { id: 'file:src/service.ts', type: 'file', path: 'src/service.ts' },
+      { id: 'fn:handle', type: 'function', path: 'src/service.ts' },
+      { id: 'test:service.test.ts', type: 'test_result', path: 'src/service.test.ts' },
+      { id: 'adr:0007', type: 'adr' },
+      { id: 'misc:config', type: 'config' },
+    ];
+    const data = await generateImpactData('src/index.ts', {
+      analyzer: () => nodes,
+    });
+
+    expect(data.impacts).toHaveLength(5);
+    expect(data.counts).toEqual({ tests: 1, docs: 1, code: 2, other: 1 });
+    // Every impact carries a resolved category.
+    for (const impact of data.impacts) {
+      expect(['tests', 'docs', 'code', 'other']).toContain(impact.category);
+    }
+    const test = data.impacts.find((i) => i.id === 'test:service.test.ts');
+    expect(test?.category).toBe('tests');
+  });
+
+  it('excludes the target file itself from its own impact set', async () => {
+    const data = await generateImpactData('src/index.ts', {
+      analyzer: (file) => [
+        { id: `file:${file}`, type: 'file', path: file },
+        { id: 'file:src/other.ts', type: 'file', path: 'src/other.ts' },
+      ],
+    });
+
+    expect(data.impacts).toHaveLength(1);
+    expect(data.impacts[0]!.path).toBe('src/other.ts');
+    expect(data.counts.code).toBe(1);
+  });
+
+  it('supports async analyzers (e.g. a graph-backed impact query)', async () => {
+    const data = await generateImpactData('src/index.ts', {
+      analyzer: async () => [{ id: 'doc:readme', type: 'document', path: 'README.md' }],
+    });
+
+    expect(data.counts.docs).toBe(1);
+    expect(data.impacts[0]!.category).toBe('docs');
+  });
+
+  it('categorizeImpact maps known node types and defaults unknowns to "other"', () => {
+    expect(categorizeImpact('function')).toBe('code');
+    expect(categorizeImpact('test_result')).toBe('tests');
+    expect(categorizeImpact('adr')).toBe('docs');
+    expect(categorizeImpact('something-unknown')).toBe('other');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1338. `tests/blueprint/impact-lab.test.ts` imported `packages/core/src/blueprint/impact-lab-generator` — a module that did not exist — and the root-level `tests/` tree was never run in CI, so the broken suite rotted silently.

This PR does both halves the issue asked for: **build the missing module** and **wire root `tests/` into CI** so it can't rot again.

### 1. Implement `impact-lab-generator`
New `packages/core/src/blueprint/impact-lab-generator.ts` exporting `generateImpactData` (plus `categorizeImpact` and the `ImpactData` / `ImpactNode` / `ImpactSourceNode` / `ImpactAnalyzer` types).

`generateImpactData(file, { analyzer? })` builds the seed "if I change this file, what breaks?" data for a blueprint's Impact Lab:
- The impact source is an injected `ImpactAnalyzer`, mirroring the grouping of the `get_impact` MCP tool (tests / docs / code / other). This keeps the generator pure and deterministic and gives it no hard dependency on a loaded graph.
- It drops the target file from its own impact set, classifies each downstream node into a category, and tallies per-category counts.
- **Degrades gracefully**: with no analyzer (no graph) it returns valid, empty Impact Lab data instead of throwing — matching the blueprint modules' lightweight, standalone style. The interactive browser Impact Lab re-queries `get_impact` live at view time.

Derived from `docs/changes/harness-blueprint/plans/2026-03-24-impact-lab-plan.md` (Impact Lab data fetcher backed by `get_impact`) and the surrounding `blueprint/` modules; the category taxonomy matches the CLI's `get_impact` handler.

The original root test was a hollow placeholder (only checked `toBeDefined` / file echo / `isArray`). It's now strengthened to assert categorization, counts, target-self exclusion, async analyzers, and the ISO timestamp. A co-located package test (`packages/core/src/blueprint/impact-lab-generator.test.ts`) fully covers the module so it lands under core's coverage run.

### 2. Wire root-level `tests/` into CI
- New root `test:root` script (`vitest run`), using the existing root `vitest.config.mts` whose discovery is scoped to `tests/**/*.test.ts`.
- CI `build-and-test` job now runs `pnpm test:root` on **all three OSes** (replacing the narrower `pnpm test:platform-parity` step, which only ran one file). This now covers `tests/blueprint/impact-lab.test.ts`, `tests/platform-parity.test.ts`, and two previously-unrun vitest specs under `tests/scripts/*.test.ts`.
- The existing `node --test 'tests/scripts/*.test.mjs'` node:test run is untouched — root vitest matches only `.ts`, so there's no double-run or conflict.

## Verification
- `tests/blueprint/impact-lab.test.ts` passes directly and via `pnpm test:root` (4 root files, 2003 tests green).
- `pnpm turbo run test typecheck --filter=@harness-engineering/core...` green.
- ESLint / prettier clean; pre-push gauntlet (coverage ratchet, generate-docs --check, tool-catalog check) passed.

Changeset: minor bump for `@harness-engineering/core`.

**Do not merge — batch review.**