### PR TITLE
fix(knowledge): abstain on empty baseline + confidence floor for --fix (#1335, #1340)

### DIFF
--- a/.changeset/fix-1335-1340-pipeline-abstention.md
+++ b/.changeset/fix-1335-1340-pipeline-abstention.md
@@ -1,0 +1,29 @@
+---
+'@harness-engineering/graph': patch
+'@harness-engineering/cli': patch
+---
+
+fix(knowledge): abstain on empty baseline + confidence floor for `--fix`, and report honest extraction counts (#1335, #1340)
+
+The knowledge pipeline previously reported a healthy-looking `warn` on a
+first run where the graph held no prior `business_*` nodes: every fresh entry
+classified as `new`, the drift score approached 1.0, and the verdict read as
+`WARN` with `0 stale, 0 drifted, 0 contradicting` — indistinguishable from a
+clean incremental run. A zero-denominator baseline is now an explicit
+`abstain` verdict (distinct from `pass`/`warn`/`fail`) threaded from the
+pre-extraction baseline into `computeVerdict`, and the CLI renders an
+unambiguous `ABSTAIN` header with a one-line explanation. The result now
+carries a `baselineEmpty` flag (surfaced in `--json`). (#1335)
+
+`--fix` materialization into the consumer's tracked `docs/knowledge/` tree is
+now gated on a named confidence floor (`MATERIALIZATION_CONFIDENCE_FLOOR`,
+default `0.5`): low-confidence / comment-derived signals are still reported as
+gaps but no longer written to disk. Human-authored nodes carry no confidence
+and remain trusted, so the floor cannot suppress hand-written knowledge.
+(#1335)
+
+Extraction now reports the number of signals actually extracted this run
+(`signalsExtracted`) rather than `nodesAdded` (deduped new store insertions),
+which dropped to 0 on a re-scan even while the extractors wrote thousands of
+records — producing a "0 code signals" headline that contradicted a non-empty
+"extracted" gap total. (#1340)

--- a/packages/cli/src/commands/knowledge-pipeline.test.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.test.ts
@@ -55,6 +55,7 @@ const GAP_DOMAINS = ['auth', 'api'] as const;
 function makeResult(overrides: Record<string, unknown> = {}): unknown {
   return {
     verdict: 'pass',
+    baselineEmpty: false,
     driftScore: 1.5,
     iterations: 1,
     findings: { new: 2, stale: 0, drifted: 0, contradicting: 0 },

--- a/packages/cli/src/commands/knowledge-pipeline.ts
+++ b/packages/cli/src/commands/knowledge-pipeline.ts
@@ -106,6 +106,7 @@ function printJsonResult(result: KnowledgePipelineResult): void {
     JSON.stringify(
       {
         verdict: result.verdict,
+        baselineEmpty: result.baselineEmpty,
         driftScore: result.driftScore,
         iterations: result.iterations,
         findings: result.findings,
@@ -145,24 +146,49 @@ function printJsonResult(result: KnowledgePipelineResult): void {
   );
 }
 
+/**
+ * True when this looks like a first run: an empty baseline, or purely-new
+ * findings with nothing stale/drifted/contradicting. Drives the drift-score
+ * label so a ~1.0 score is not misread as "everything drifted" (#1110, #1335).
+ */
+function isFirstRun(result: KnowledgePipelineResult): boolean {
+  const f = result.findings;
+  if (result.baselineEmpty) return true;
+  return f.new > 0 && f.stale === 0 && f.drifted === 0 && f.contradicting === 0;
+}
+
+/** Colorized verdict badge for the summary header. */
+function verdictBadge(verdict: KnowledgePipelineResult['verdict']): string {
+  switch (verdict) {
+    case 'pass':
+      return chalk.green('PASS');
+    case 'warn':
+      return chalk.yellow('WARN');
+    case 'abstain':
+      return chalk.magenta('ABSTAIN');
+    default:
+      return chalk.red('FAIL');
+  }
+}
+
 /** Print the verdict header plus drift / findings / extraction / gaps summary. */
 function printSummary(result: KnowledgePipelineResult): void {
-  const verdictColor =
-    result.verdict === 'pass'
-      ? chalk.green('PASS')
-      : result.verdict === 'warn'
-        ? chalk.yellow('WARN')
-        : chalk.red('FAIL');
-
   console.log('');
-  console.log(`KNOWLEDGE PIPELINE -- Verdict: ${verdictColor}`);
+  console.log(`KNOWLEDGE PIPELINE -- Verdict: ${verdictBadge(result.verdict)}`);
+  if (result.verdict === 'abstain') {
+    // The verdict itself is the abstention; spell out why so a zero-baseline run
+    // is never mistaken for a clean one (#1335).
+    console.log(
+      chalk.magenta(
+        '  Inconclusive — empty baseline (no prior business knowledge). Every entry is new, so there is no denominator to grade health against. Re-run after an initial scan to establish a baseline.'
+      )
+    );
+  }
   console.log('');
   // On a first run every finding is `new` (no prior graph state), which drives
   // the drift score toward 1.00. Label it so the headline is not misread as
-  // "everything drifted" when the verdict beneath it is correctly WARN (#1110).
-  const f = result.findings;
-  const firstRun = f.new > 0 && f.stale === 0 && f.drifted === 0 && f.contradicting === 0;
-  const driftLabel = firstRun ? ' (first run — no prior graph state)' : '';
+  // "everything drifted" when the verdict beneath it abstains / warns (#1110, #1335).
+  const driftLabel = isFirstRun(result) ? ' (first run — no prior graph state)' : '';
   console.log(`  Drift Score: ${result.driftScore.toFixed(2)}${driftLabel}`);
   console.log(
     `  Findings: ${result.findings.new} new, ${result.findings.stale} stale, ${result.findings.drifted} drifted, ${result.findings.contradicting} contradicting`

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -81,6 +81,7 @@ export { KnowledgePipelineRunner } from './ingest/KnowledgePipelineRunner.js';
 export type {
   KnowledgePipelineOptions,
   KnowledgePipelineResult,
+  KnowledgeVerdict,
   ExtractionCounts,
 } from './ingest/KnowledgePipelineRunner.js';
 
@@ -218,7 +219,12 @@ export {
   ApiPathExtractor,
   detectLanguage,
 } from './ingest/extractors/index.js';
-export type { ExtractionRecord, SignalExtractor, Language } from './ingest/extractors/index.js';
+export type {
+  ExtractionRecord,
+  SignalExtractor,
+  Language,
+  ExtractionRunResult,
+} from './ingest/extractors/index.js';
 
 // Image Analysis
 export { ImageAnalysisExtractor } from './ingest/ImageAnalysisExtractor.js';

--- a/packages/graph/src/ingest/KnowledgePipelineRunner.ts
+++ b/packages/graph/src/ingest/KnowledgePipelineRunner.ts
@@ -26,6 +26,7 @@ import {
 import {
   KnowledgeStagingAggregator,
   type GapReport,
+  type GapEntry,
   type StagedEntry,
 } from './KnowledgeStagingAggregator.js';
 import { createExtractionRunner } from './extractors/index.js';
@@ -54,6 +55,17 @@ const SNAPSHOT_NODE_TYPES: readonly NodeType[] = [
   'aesthetic_intent',
   'image_annotation',
 ];
+
+/**
+ * Minimum extraction confidence for a gap entry to be materialized into the
+ * consumer's *tracked* `docs/knowledge/` tree. Entries below this floor (e.g.
+ * comment-derived / low-signal extractions, #1331) are still reported as gaps
+ * but are never written to disk. Conservative by design: only clearly
+ * low-confidence signals are withheld. Human-authored nodes (business knowledge,
+ * decisions, diagrams) carry no `metadata.confidence` and are treated as
+ * trusted, so this floor cannot suppress hand-written knowledge (#1335).
+ */
+const MATERIALIZATION_CONFIDENCE_FLOOR = 0.5;
 
 // ─── Public Types ───────────────────────────────────────────────────────────
 
@@ -136,8 +148,20 @@ export interface ExtractionCounts {
   readonly images: number;
 }
 
+export type KnowledgeVerdict = 'pass' | 'warn' | 'fail' | 'abstain';
+
 export interface KnowledgePipelineResult {
-  readonly verdict: 'pass' | 'warn' | 'fail';
+  /**
+   * Overall health verdict. `abstain` is emitted when the pre-extraction
+   * baseline held no `business_*` nodes: on such a first run every fresh entry
+   * classifies as `new` and the drift score approaches 1.0, so there is no
+   * denominator to judge health against. It is deliberately distinct from
+   * `pass`/`warn` so a reader cannot mistake a zero-baseline run for a clean one
+   * (#1335).
+   */
+  readonly verdict: KnowledgeVerdict;
+  /** True when the pre-extraction baseline held no `business_*` nodes (#1335). */
+  readonly baselineEmpty: boolean;
   readonly driftScore: number;
   readonly iterations: number;
   readonly findings: DriftResult['summary'];
@@ -179,8 +203,11 @@ export class KnowledgePipelineRunner {
     const remediations: string[] = [];
     const ingestErrors: string[] = [];
 
-    // Phase 1: Capture pre-extraction snapshot, then extract
+    // Phase 1: Capture pre-extraction snapshot, then extract. Record whether
+    // the baseline held any prior business_* nodes — an empty baseline makes the
+    // drift verdict an abstention rather than a warn (#1335).
     const preSnapshot = this.buildSnapshot(options.domain);
+    const baselineEmpty = this.isBaselineEmpty(options.domain);
     const extraction = await this.extract(options);
     ingestErrors.push(...extraction.errors);
 
@@ -220,6 +247,7 @@ export class KnowledgePipelineRunner {
 
     return this.buildResult(
       driftResult,
+      baselineEmpty,
       iterations,
       extraction.counts,
       ingestErrors,
@@ -229,6 +257,20 @@ export class KnowledgePipelineRunner {
       coverage,
       materialization
     );
+  }
+
+  /**
+   * True when no `business_*` nodes exist in the store prior to extraction
+   * (respecting the domain filter when set). Signals a zero-denominator "first
+   * run" baseline so the verdict abstains instead of warning (#1335).
+   */
+  private isBaselineEmpty(domain?: string): boolean {
+    for (const type of BUSINESS_NODE_TYPES) {
+      for (const node of this.store.findNodes({ type })) {
+        if (!domain || (node.metadata?.domain as string) === domain) return false;
+      }
+    }
+    return true;
   }
 
   /** Run the remediation convergence loop; returns iteration count and accumulated materialization. */
@@ -286,6 +328,7 @@ export class KnowledgePipelineRunner {
   /** Assemble the final pipeline result. */
   private buildResult(
     driftResult: DriftResult,
+    baselineEmpty: boolean,
     iterations: number,
     extraction: ExtractionCounts,
     errors: readonly string[],
@@ -296,7 +339,8 @@ export class KnowledgePipelineRunner {
     materialization?: MaterializeResult
   ): KnowledgePipelineResult {
     return {
-      verdict: this.computeVerdict(driftResult),
+      verdict: this.computeVerdict(driftResult, baselineEmpty),
+      baselineEmpty,
       driftScore: driftResult.driftScore,
       iterations,
       findings: driftResult.summary,
@@ -409,7 +453,10 @@ export class KnowledgePipelineRunner {
 
     return {
       counts: {
-        codeSignals: extractionResult.nodesAdded,
+        // Report signals actually extracted this run (records written), not
+        // `nodesAdded` (deduped new store insertions) which reads as 0 on a
+        // re-scan even while thousands of records were written (#1340).
+        codeSignals: extractionResult.signalsExtracted,
         diagrams: diagramResult.nodesAdded,
         linkerFacts: linkResult.factsCreated,
         businessKnowledge: bkResult.nodesAdded,
@@ -486,10 +533,14 @@ export class KnowledgePipelineRunner {
       }
     }
 
-    // Materialize docs for undocumented entries (non-CI only)
+    // Materialize docs for undocumented entries (non-CI only). Gate on a
+    // confidence floor so low-confidence / comment-derived signals are reported
+    // as gaps but never written to the consumer's tracked docs tree (#1335).
     if (!options.ci) {
       const allGapEntries = gapReport.domains.flatMap((d) => d.gapEntries);
-      const materializable = allGapEntries.filter((e) => e.hasContent);
+      const materializable = allGapEntries.filter(
+        (e) => e.hasContent && this.entryConfidence(e) >= MATERIALIZATION_CONFIDENCE_FLOOR
+      );
       if (materializable.length > 0) {
         const materializer = new KnowledgeDocMaterializer(this.store, this.inferenceOptions);
         const matResult = await materializer.materialize(materializable, {
@@ -536,6 +587,17 @@ export class KnowledgePipelineRunner {
     }
   }
 
+  /**
+   * Confidence of a gap entry's backing graph node. Extractor / linker nodes
+   * carry an explicit `metadata.confidence` (0.0-1.0); human-authored nodes
+   * carry none and are treated as fully trusted so the floor cannot suppress
+   * hand-written knowledge (#1335).
+   */
+  private entryConfidence(entry: GapEntry): number {
+    const confidence = this.store.getNode(entry.nodeId)?.metadata?.confidence;
+    return typeof confidence === 'number' ? confidence : 1;
+  }
+
   private classifySource(source: string): 'extractor' | 'linker' | 'diagram' {
     if (source === 'linker' || source === 'knowledge-linker') return 'linker';
     if (source === 'diagram') return 'diagram';
@@ -544,12 +606,15 @@ export class KnowledgePipelineRunner {
 
   // ── Verdict ───────────────────────────────────────────────────────────────
 
-  private computeVerdict(driftResult: DriftResult): 'pass' | 'warn' | 'fail' {
+  private computeVerdict(driftResult: DriftResult, baselineEmpty: boolean): KnowledgeVerdict {
     const { summary } = driftResult;
     const unresolved = summary.drifted + summary.stale + summary.contradicting;
 
-    if (unresolved === 0 && summary.new === 0) return 'pass';
-    if (unresolved === 0) return 'warn';
-    return 'fail';
+    if (unresolved > 0) return 'fail';
+    if (summary.new === 0) return 'pass';
+    // Every fresh entry is `new` and nothing is unresolved. With no prior
+    // business baseline there is no denominator to judge health against, so we
+    // abstain rather than emit a WARN that reads as clean (#1335).
+    return baselineEmpty ? 'abstain' : 'warn';
   }
 }

--- a/packages/graph/src/ingest/extractors/ExtractionRunner.ts
+++ b/packages/graph/src/ingest/extractors/ExtractionRunner.ts
@@ -70,6 +70,18 @@ const EXTRACTOR_EDGE_TYPE: Record<string, EdgeType> = {
 };
 
 /**
+ * Result of an {@link ExtractionRunner} run. Extends {@link IngestResult} with
+ * `signalsExtracted`: the total number of records the extractors wrote to JSONL
+ * this run, independent of graph deduplication. `nodesAdded` counts only *new*
+ * store insertions and drops to 0 on a re-scan where every node already exists,
+ * so it cannot be used as an honest "signals extracted" headline (#1340).
+ */
+export interface ExtractionRunResult extends IngestResult {
+  /** Total extraction records written this run (pre-dedup). */
+  readonly signalsExtracted: number;
+}
+
+/**
  * Orchestrates code signal extraction across a project.
  * Walks files, dispatches to registered extractors, writes JSONL,
  * persists to graph, and handles stale detection.
@@ -91,12 +103,17 @@ export class ExtractionRunner {
    * @param store - GraphStore for node/edge persistence
    * @param outputDir - Directory for JSONL output (e.g. .harness/knowledge/extracted/)
    */
-  async run(projectDir: string, store: GraphStore, outputDir: string): Promise<IngestResult> {
+  async run(
+    projectDir: string,
+    store: GraphStore,
+    outputDir: string
+  ): Promise<ExtractionRunResult> {
     const start = Date.now();
     const errors: string[] = [];
     let nodesAdded = 0;
     let nodesUpdated = 0;
     let edgesAdded = 0;
+    let signalsExtracted = 0;
 
     // Ensure output directory exists
     await fs.mkdir(outputDir, { recursive: true });
@@ -148,6 +165,10 @@ export class ExtractionRunner {
       // Write JSONL
       await this.writeJsonl(records, outputDir, extractorName);
 
+      // Every record written to JSONL is a signal extracted this run, whether
+      // or not it results in a new store node (#1340).
+      signalsExtracted += records.length;
+
       // Persist to graph
       for (const record of records) {
         allCurrentIds.add(record.id);
@@ -169,6 +190,7 @@ export class ExtractionRunner {
       edgesUpdated: 0,
       errors,
       durationMs: Date.now() - start,
+      signalsExtracted,
     };
   }
 

--- a/packages/graph/src/ingest/extractors/index.ts
+++ b/packages/graph/src/ingest/extractors/index.ts
@@ -4,6 +4,7 @@ export {
   detectLanguage,
   DEFAULT_EXTRACTION_EXCLUDE,
 } from './ExtractionRunner.js';
+export type { ExtractionRunResult } from './ExtractionRunner.js';
 export { TestDescriptionExtractor } from './TestDescriptionExtractor.js';
 export { EnumConstantExtractor } from './EnumConstantExtractor.js';
 export { ValidationRuleExtractor } from './ValidationRuleExtractor.js';

--- a/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
+++ b/packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts
@@ -483,6 +483,110 @@ Route auth through AuthService.
     });
   });
 
+  // ── #1335 / #1340: abstention, confidence floor, extraction honesty ──────────
+  describe('abstention on empty baseline (#1335)', () => {
+    it('abstains (not warn) when no prior business baseline exists on first run', async () => {
+      // Fresh store: zero business_* nodes. A knowledge doc yields a brand-new
+      // business_rule node, so every fresh entry is `new` and driftScore ~1.0.
+      // The old code reported WARN with 0 stale/drifted/contradicting — which a
+      // reader scans as a healthy repo. A zero denominator is an abstention.
+      const knowledgeDir = path.join(tmpDir, 'docs', 'knowledge', 'payments');
+      await fs.mkdir(knowledgeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(knowledgeDir, 'refund-policy.md'),
+        '---\ntype: business_rule\ndomain: payments\n---\n# Refund Policy\nRefunds within 30 days.'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      expect(result.findings.new).toBeGreaterThan(0);
+      expect(result.findings.stale + result.findings.drifted + result.findings.contradicting).toBe(
+        0
+      );
+      expect(result.verdict).toBe('abstain');
+    });
+
+    it('still reports warn (not abstain) when a business baseline already exists', async () => {
+      // A pre-existing business node means the baseline is NOT empty; a fresh
+      // `new` finding on top of it is a genuine warn, not an abstention.
+      store.addNode({
+        id: 'bk:payments:existing',
+        type: 'business_rule',
+        name: 'Existing Rule',
+        metadata: { domain: 'payments', source: 'manual' },
+      });
+      const knowledgeDir = path.join(tmpDir, 'docs', 'knowledge', 'auth');
+      await fs.mkdir(knowledgeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(knowledgeDir, 'session.md'),
+        '---\ntype: business_rule\ndomain: auth\n---\n# Session\nSessions expire after 24h.'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions());
+
+      expect(result.findings.new).toBeGreaterThan(0);
+      expect(result.findings.stale + result.findings.drifted + result.findings.contradicting).toBe(
+        0
+      );
+      expect(result.verdict).toBe('warn');
+    });
+  });
+
+  describe('materialization confidence floor (#1335)', () => {
+    it('does not materialize below-floor-confidence entries to tracked docs', async () => {
+      store.addNode({
+        id: 'extracted:auth:low',
+        type: 'business_rule',
+        name: 'Low Confidence Rule',
+        metadata: { domain: 'auth', source: 'extractor', confidence: 0.3 },
+        content: 'Flimsy comment-derived text that is nonetheless long enough to pass hasContent.',
+      });
+      store.addNode({
+        id: 'extracted:auth:high',
+        type: 'business_rule',
+        name: 'High Confidence Rule',
+        metadata: { domain: 'auth', source: 'extractor', confidence: 0.9 },
+        content: 'A solidly extracted rule with real, trustworthy content here.',
+      });
+      await fs.mkdir(path.join(tmpDir, 'docs', 'knowledge', 'auth'), { recursive: true });
+
+      const runner = new KnowledgePipelineRunner(store);
+      const result = await runner.run(makeOptions({ fix: true, maxIterations: 2 }));
+
+      const created = (result.materialization?.created ?? []).map((d) => d.name);
+      expect(created).toContain('High Confidence Rule');
+      expect(created).not.toContain('Low Confidence Rule');
+
+      // The low-confidence entry must never touch the tracked docs tree.
+      const authDocs = await fs.readdir(path.join(tmpDir, 'docs', 'knowledge', 'auth'));
+      expect(authDocs.some((f) => f.includes('low-confidence'))).toBe(false);
+    });
+  });
+
+  describe('extraction count honesty (#1340)', () => {
+    it('reports signals extracted this run, not deduped new-node insertions', async () => {
+      const srcDir = path.join(tmpDir, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+      await fs.writeFile(
+        path.join(srcDir, 'orders.ts'),
+        'import { z } from "zod";\nexport const OrderSchema = z.object({\n  id: z.string().min(1),\n});\n'
+      );
+
+      const runner = new KnowledgePipelineRunner(store);
+      const first = await runner.run(makeOptions());
+      expect(first.extraction.codeSignals).toBeGreaterThan(0);
+
+      // Second run against the SAME store: nodes already exist so `nodesAdded`
+      // is 0, but the extractors re-wrote the same records to JSONL. The
+      // reported count must reflect what was extracted, not the new-node count —
+      // otherwise "0 code signals" contradicts a non-empty "extracted" gap total.
+      const second = await runner.run(makeOptions());
+      expect(second.extraction.codeSignals).toBe(first.extraction.codeSignals);
+    });
+  });
+
   describe('inferenceOptions plumbing (Phase 4)', () => {
     it('defaults to {} when no inferenceOptions field on options', async () => {
       // Pre-seed graph with one node whose path lands under a non-default top-level dir.

--- a/packages/graph/tests/integration/knowledge-pipeline.test.ts
+++ b/packages/graph/tests/integration/knowledge-pipeline.test.ts
@@ -430,7 +430,9 @@ describe('Knowledge Pipeline (integration)', () => {
       expect(result.extraction.businessKnowledge).toBeGreaterThan(0);
       expect(result.gaps.domains.length).toBeGreaterThan(0);
       expect(result.verdict).toBeDefined();
-      expect(['pass', 'warn', 'fail']).toContain(result.verdict);
+      // Fresh store: no prior business baseline, so a first run of pure-new
+      // findings abstains rather than warns (#1335).
+      expect(['pass', 'warn', 'fail', 'abstain']).toContain(result.verdict);
     });
 
     it('fix mode converges on empty project', async () => {


### PR DESCRIPTION
## Summary

Fixes two related defects in the knowledge-pipeline reporting/safety layer (#1335) plus an extraction-count honesty defect (#1340).

**⚠️ STACKED on #1439 (`fix/1330-1351-decision-ingest`).** Base this PR on that branch; **merge #1439 first**. The diff here shows only this lane's changes. **Do not merge — batch review.**

### Defect 1 — empty baseline reported as WARN, not abstention (#1335)
When the graph held **zero prior `business_*` nodes**, every fresh entry classified as `new`, driftScore approached 1.0, and the verdict was `WARN` with `0 stale, 0 drifted, 0 contradicting` — indistinguishable from a clean incremental run. A zero-denominator baseline is now an explicit **`abstain`** verdict (distinct from pass/warn/fail), threaded from the pre-extraction baseline into `computeVerdict` (not just a cosmetic display label). The result now carries `baselineEmpty` (surfaced in `--json`), and the CLI renders an unambiguous `ABSTAIN` header with a one-line explanation.

### Defect 2 — `--fix` materialized with no confidence floor (#1335)
`remediate()` only filtered on `!ci` and `hasContent` before writing to the consumer's tracked `docs/knowledge/`. Materialization is now gated on a named constant `MATERIALIZATION_CONFIDENCE_FLOOR` (default `0.5`, conservative): low-confidence / comment-derived signals are still reported as gaps but never written to disk. Human-authored nodes carry no `metadata.confidence` and stay trusted, so the floor cannot suppress hand-written knowledge.

### Defect 3 — extraction count honesty (#1340, folded in)
`codeSignals` reported `nodesAdded` (deduped new store insertions), which drops to 0 on a re-scan even while the extractors wrote thousands of records — producing "0 code signals" alongside a non-empty "extracted" gap total. **This DOES reproduce in current source.** `ExtractionRunner` now returns `signalsExtracted` (records written this run) and the pipeline reports that.

## Reproduction (TDD — all red at the defect, green after fix)
Added to `packages/graph/tests/ingest/KnowledgePipelineRunner.test.ts`:
- D1: empty baseline → asserts `verdict === 'abstain'` (was `'warn'`). Plus a guard test: a non-empty baseline still reports `'warn'`, not abstain.
- D2: a below-floor (0.3) confidence entry is NOT materialized while a 0.9 one is (was: both written).
- D3: a second run on the same store reports the same `codeSignals` as the first (was: 0, because `nodesAdded` deduped).

Red-at-base output (before fix): `expected 'warn' to be 'abstain'`; `expected [ 'Low Confidence Rule', … ] to not include 'Low Confidence Rule'`; `expected +0 to be 1`.

## Verification
- `pnpm turbo run test typecheck --filter=@harness-engineering/graph... --filter=@harness-engineering/cli...` — green (6263 CLI tests + full graph suite).
- End-to-end CLI run on a temp project: empty-baseline run now prints `Verdict: ABSTAIN` with the explanation; `codeSignals` reflects extracted signals.
- Updated the exhaustive verdict types/switches honestly (added `abstain` to `KnowledgeVerdict`, CLI badge switch, and the integration-test whitelist).
- Local `harness ci check` arch gate: pass (refactored `printSummary` into `verdictBadge`/`isFirstRun` helpers to stay under the complexity threshold).

Closes #1335. Addresses #1340.
