### PR TITLE
fix: HF trendingScore sort, tick candidate ids, rec-card keys, NeuralOrganism SVG seeding

### DIFF
--- a/.changeset/dashboard-rec-keys-and-svg-undefined.md
+++ b/.changeset/dashboard-rec-keys-and-svg-undefined.md
@@ -1,0 +1,8 @@
+---
+'@harness-engineering/dashboard': patch
+---
+
+Fix two client rendering defects on the Local Models page.
+
+- `RecommendationsCard` keyed recommendation rows by `hfRepoId` alone, which collides when the same repo is recommended at multiple quants (Q4/Q5/Q6/Q8) — React logged "two children with the same key". Rows are now keyed by `hfRepoId@quant`.
+- `NeuralOrganism` (the animated background) rendered `motion.circle`/`motion.path` elements that animate `cx`/`cy`/`r`/`d` without an `initial` prop, so framer-motion wrote `undefined` to those SVG attributes for one frame (`Invalid value for <circle> attribute r="undefined"`, `Problem parsing d="undefined"`). Each animated geometry attribute is now seeded in `initial` with its own first keyframe (no visual change).

--- a/.changeset/local-models-hf-trendingscore-and-tick-candidates.md
+++ b/.changeset/local-models-hf-trendingscore-and-tick-candidates.md
@@ -1,0 +1,8 @@
+---
+'@harness-engineering/local-models': patch
+---
+
+Fix HuggingFace candidate discovery `trending` sort (was a hard 400) and surface evaluated candidates in the refresh-tick log.
+
+- The wide-net discovery's trending arm passed `sort=trending` straight onto the HF `/api/models` wire, which HF rejects with `400 Invalid sort parameter`. It has always fallen back to downloads-only, emitting one warning per approved org each tick. The correct HF spelling is `trendingScore`; the trending arm now works.
+- `TickResult` now carries `evaluatedCandidates` (`hfRepoId@quant` ids) and the O1 `local-models refresh tick` log line includes a `candidates` field, so operators can see _which_ models a tick evaluated, not just the count.

--- a/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
+++ b/packages/dashboard/src/client/components/chat/NeuralOrganism.tsx
@@ -694,6 +694,8 @@ function RingSoma({
         cy={cy}
         r={r + 2.5}
         fill={color}
+        // Seed the animated `r`/opacity so framer never writes `r="undefined"` on the first frame.
+        initial={{ opacity: 0, r: r + 1 }}
         animate={{
           opacity: [0, jitter(0.07, 0.03), 0],
           r: [r + 1, r + jitter(4, 1), r + 1],
@@ -705,6 +707,7 @@ function RingSoma({
         cy={cy}
         r={r}
         fill={color}
+        initial={{ opacity: 0.2, r: r * 0.9 }}
         animate={{
           opacity: [0.2, 0.65, 0.2],
           r: [r * 0.9, r * jitter(1.06, 0.06), r * 0.9],
@@ -779,6 +782,7 @@ function HeartbeatPulse({ primary, accent }: { primary: string; accent: string }
         fill="none"
         stroke={primary}
         strokeWidth="0.8"
+        initial={{ r: 4, opacity: 0, strokeWidth: 0.6 }}
         animate={{
           r: [4, 18, 26],
           opacity: [0, 0.2, 0],
@@ -798,6 +802,7 @@ function HeartbeatPulse({ primary, accent }: { primary: string; accent: string }
         fill="none"
         stroke={accent}
         strokeWidth="0.5"
+        initial={{ r: 5, opacity: 0, strokeWidth: 0.4 }}
         animate={{
           r: [5, 15, 22],
           opacity: [0, 0.12, 0],
@@ -926,6 +931,7 @@ function NeuralMembrane({
       {tier === 'full' && (
         <motion.path
           d={haloVariants[0]}
+          initial={{ d: haloVariants[0]! }}
           animate={{ d: haloVariants }}
           transition={{
             duration: haloDur,
@@ -944,6 +950,7 @@ function NeuralMembrane({
       {tier !== 'compact' && (
         <motion.path
           d={outerVariants[0]}
+          initial={{ d: outerVariants[0]! }}
           animate={{ d: outerVariants }}
           transition={{
             duration: outerDur,
@@ -961,6 +968,7 @@ function NeuralMembrane({
 
       <motion.path
         d={innerVariants[0]}
+        initial={{ d: innerVariants[0]! }}
         animate={{ d: innerVariants }}
         transition={{
           duration: innerDur,
@@ -1338,6 +1346,8 @@ function DividingCells({
             cx={c.x}
             cy={c.y}
             r={c.r}
+            // Seed the animated geometry so the 100ms mitosis restart never writes cx/cy/r="undefined".
+            initial={{ cx: c.x, cy: c.y, r: c.r }}
             animate={{ cx: c.x, cy: c.y, r: c.r }}
             transition={{ duration: 0.25, ease: 'easeOut' }}
             fill={color}
@@ -1830,6 +1840,7 @@ export function NeuralOrganism({
                 fill="none"
                 stroke={agedPalette.primary}
                 strokeWidth="0.3"
+                initial={{ r: 10, opacity: 0, strokeWidth: 0.2 }}
                 animate={{
                   r: [10, 14, 10],
                   opacity: [0, 0.12, 0],
@@ -1844,6 +1855,7 @@ export function NeuralOrganism({
                 fill="none"
                 stroke={agedPalette.accent}
                 strokeWidth="0.2"
+                initial={{ r: 17, opacity: 0, strokeWidth: 0.15 }}
                 animate={{
                   r: [17, 22, 17],
                   opacity: [0, 0.08, 0],

--- a/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
+++ b/packages/dashboard/src/client/components/local-models/RecommendationsCard.tsx
@@ -432,7 +432,7 @@ export function RecommendationsCard({
           <ul className="space-y-2">
             {recs.map((r) => (
               <RecommendationRow
-                key={r.hfRepoId}
+                key={`${r.hfRepoId}@${r.quant}`}
                 rec={r}
                 installed={installedRepos.has(r.hfRepoId)}
                 progress={installProgress?.[r.hfRepoId]}

--- a/packages/local-models/src/candidates/discover.ts
+++ b/packages/local-models/src/candidates/discover.ts
@@ -94,10 +94,16 @@ interface DiscoverContext {
 
 type HfModel = Awaited<ReturnType<Pick<HuggingFaceClient, 'listModels'>['listModels']>>[number];
 
-/** One `listModels` call for a given sort. Returns `null` on failure (caller decides fail-soft policy). */
+/**
+ * One `listModels` call for a given sort. Returns `null` on failure (caller decides fail-soft policy).
+ *
+ * NOTE: HF `/api/models` spells the trending-popularity sort `trendingScore` — passing `trending`
+ * is a 400 (`Invalid sort parameter`). This value goes straight onto the wire, so it must be the
+ * exact HF spelling, not a friendly label.
+ */
 async function listSort(
   org: string,
-  sort: 'downloads' | 'trending',
+  sort: 'downloads' | 'trendingScore',
   ctx: DiscoverContext
 ): Promise<HfModel[] | null> {
   try {
@@ -105,7 +111,7 @@ async function listSort(
   } catch (err) {
     // Base (downloads) failure keeps the original org-skip wording; trending failure is a fallback warning.
     const message =
-      sort === 'trending'
+      sort === 'trendingScore'
         ? `HF trending list failed for ${org} (falling back to downloads): ${messageOf(err)}`
         : `HF list failed for ${org}: ${messageOf(err)}`;
     ctx.warn(message, err);
@@ -135,7 +141,7 @@ async function discoverOrg(org: string, ctx: DiscoverContext): Promise<void> {
   if (downloads === null) return;
 
   // New/hot models (trending). Graceful (D2): a trending failure falls back to downloads only.
-  const trending = (await listSort(org, 'trending', ctx)) ?? [];
+  const trending = (await listSort(org, 'trendingScore', ctx)) ?? [];
 
   for (const model of mergeCapped(trending, downloads, ctx.limit)) {
     if (ctx.opts.signal?.aborted) break;

--- a/packages/local-models/src/scheduler/refresh.ts
+++ b/packages/local-models/src/scheduler/refresh.ts
@@ -132,6 +132,12 @@ export interface HarnessFitProbeDeps {
 export interface TickResult {
   /** Number of ranked candidates the recommender evaluated. */
   candidatesEvaluated: number;
+  /**
+   * Identifiers (`hfRepoId@quant`) of the candidates evaluated this tick, in
+   * ranked order. Surfaced in the O1 log so operators can see *which* models a
+   * tick considered, not just how many. Empty on a degraded/hard-failure tick.
+   */
+  evaluatedCandidates: string[];
   /** Number of proposals emitted this tick. */
   proposalsEmitted: number;
   /** `ollamaName`s pruned by drift reconciliation (D12/F10). */
@@ -201,6 +207,7 @@ export async function runRefreshTick(deps: RefreshTickDeps): Promise<TickResult>
 
   return {
     candidatesEvaluated: ranked.length,
+    evaluatedCandidates: ranked.map(candidateId),
     proposalsEmitted,
     reconciledRemoved,
     snapshotLoaded,
@@ -210,10 +217,16 @@ export async function runRefreshTick(deps: RefreshTickDeps): Promise<TickResult>
   };
 }
 
+/** Stable per-candidate identifier for logging: `hfRepoId@quant` (e.g. `Qwen/Qwen3-32B-GGUF@Q4_K_M`). */
+function candidateId(m: RecommendResult['ranked'][number]): string {
+  return `${m.hfRepoId}@${m.quant}`;
+}
+
 /** A tick that produced no trustworthy ranking (O4 hard failure). */
 function hardFailureTick(errors: string[]): TickResult {
   return {
     candidatesEvaluated: 0,
+    evaluatedCandidates: [],
     proposalsEmitted: 0,
     reconciledRemoved: [],
     snapshotLoaded: false,
@@ -534,6 +547,7 @@ export class RefreshScheduler {
       .catch(
         (err): TickResult => ({
           candidatesEvaluated: 0,
+          evaluatedCandidates: [],
           proposalsEmitted: 0,
           reconciledRemoved: [],
           snapshotLoaded: false,
@@ -561,6 +575,7 @@ export class RefreshScheduler {
       completed,
       durationMs: completed - started,
       candidatesEvaluated: result.candidatesEvaluated,
+      candidates: result.evaluatedCandidates,
       proposalsEmitted: result.proposalsEmitted,
       errors: result.errors,
     });

--- a/packages/local-models/tests/candidates/discover.test.ts
+++ b/packages/local-models/tests/candidates/discover.test.ts
@@ -133,13 +133,52 @@ describe('discoverCandidates', () => {
   });
 });
 
+/** HF `/api/models` accepts only these `sort` values; anything else is a 400. */
+const HF_VALID_SORTS = new Set([
+  'downloads',
+  'likes',
+  'lastModified',
+  'createdAt',
+  'trendingScore',
+  'author',
+  'id',
+]);
+
 describe('discoverCandidates wide-net (SC1)', () => {
+  it('sends an HF-valid `sort` for the trending arm — regression for `trending` → 400 (must be `trendingScore`)', async () => {
+    // Fake mirrors HF: an unrecognised `sort` is a 400, not an empty result.
+    const sortsSeen: string[] = [];
+    const client = {
+      async listModels(o: { author?: string; sort?: string }) {
+        const sort = o.sort ?? 'downloads';
+        sortsSeen.push(sort);
+        if (!HF_VALID_SORTS.has(sort)) {
+          throw new Error(`HuggingFace request returned 400: Invalid sort parameter: ${sort}`);
+        }
+        return sort === 'trendingScore'
+          ? [{ id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel]
+          : [{ id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel];
+      },
+      async getModel(id: string) {
+        return detail(id, ['Q4_K_M']);
+      },
+    };
+    const res = await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client });
+    const ids = res.candidates.map((c) => c.hfRepoId);
+    // The trending arm actually resolved (its model reached the pool) — proves a valid HF sort was sent.
+    expect(ids).toContain('Qwen/Qwen3.6-27B-GGUF');
+    // No trending-fallback warning, because the trending call did not 400.
+    expect(res.warnings.some((w) => /trending.*fall/i.test(w))).toBe(false);
+    // Every sort put on the wire is one HF accepts.
+    expect(sortsSeen.every((s) => HF_VALID_SORTS.has(s))).toBe(true);
+  });
+
   it('SC1: includes a NEW model returned only under `trending` (absent from `downloads`)', async () => {
     const { client } = sortAwareClient(
       {
         Qwen: {
           downloads: [{ id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
-          trending: [{ id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
+          trendingScore: [{ id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
         },
       },
       {
@@ -159,7 +198,7 @@ describe('discoverCandidates wide-net (SC1)', () => {
       {
         Qwen: {
           downloads: [shared, { id: 'Qwen/Qwen3.6-27B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
-          trending: [shared], // overlaps downloads → must dedupe, not double
+          trendingScore: [shared], // overlaps downloads → must dedupe, not double
         },
       },
       {
@@ -172,7 +211,7 @@ describe('discoverCandidates wide-net (SC1)', () => {
     const sharedFetches = calls.get.filter((id) => id === 'Qwen/Qwen3-32B-GGUF');
     expect(sharedFetches).toHaveLength(1);
     // both sorts were queried
-    expect(calls.list.map((c) => c.sort).sort()).toEqual(['downloads', 'trending']);
+    expect(calls.list.map((c) => c.sort).sort()).toEqual(['downloads', 'trendingScore']);
   });
 
   it('SC2: never inspects more than perOrgLimit distinct repos', async () => {
@@ -195,11 +234,11 @@ describe('discoverCandidates wide-net (SC1)', () => {
       {
         Qwen: {
           downloads: [{ id: 'Qwen/Qwen3-32B-GGUF', tags: ['gguf'] } as HuggingFaceModel],
-          trending: [],
+          trendingScore: [],
         },
       },
       { 'Qwen/Qwen3-32B-GGUF': detail('Qwen/Qwen3-32B-GGUF', ['Q4_K_M']) },
-      { throwOnSort: 'trending' }
+      { throwOnSort: 'trendingScore' }
     );
     const res = await discoverCandidates({ orgs: ['Qwen'], curation: WIDE_CURATION, client });
     expect(res.candidates.map((c) => c.hfRepoId)).toContain('Qwen/Qwen3-32B-GGUF'); // downloads survived

--- a/packages/local-models/tests/scheduler/refresh.test.ts
+++ b/packages/local-models/tests/scheduler/refresh.test.ts
@@ -146,6 +146,11 @@ describe('runRefreshTick (reconcile → rescore → diff → emit)', () => {
     expect(pool.snapshot().entries.find((e) => e.ollamaName === 'old:8b')?.currentScore).toBe(62);
     // (d) metrics
     expect(result.candidatesEvaluated).toBe(2);
+    // (d1) the evaluated candidates are surfaced by identity (`hfRepoId@quant`), in ranked order
+    expect(result.evaluatedCandidates).toEqual([
+      'Qwen/Qwen3-32B-GGUF@Q4_K_M',
+      'Qwen/Qwen3-8B-GGUF@Q4_K_M',
+    ]);
     expect(result.reconciledRemoved).toEqual([]);
     expect(result.errors).toEqual([]);
   });
@@ -357,6 +362,7 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
 function emptyTick(): TickResult {
   return {
     candidatesEvaluated: 0,
+    evaluatedCandidates: [],
     proposalsEmitted: 0,
     reconciledRemoved: [],
     snapshotLoaded: true,
@@ -391,6 +397,7 @@ describe('RefreshScheduler (timer, jitter, overlap guard, O1 logging)', () => {
 
     const tr: TickResult = {
       candidatesEvaluated: 3,
+      evaluatedCandidates: [],
       proposalsEmitted: 1,
       reconciledRemoved: [],
       snapshotLoaded: true,
@@ -409,6 +416,7 @@ describe('RefreshScheduler (timer, jitter, overlap guard, O1 logging)', () => {
     const scheduler = new RefreshScheduler({
       runTick: async () => ({
         candidatesEvaluated: 5,
+        evaluatedCandidates: ['Qwen/Qwen3-32B-GGUF@Q4_K_M', 'Qwen/Qwen3-8B-GGUF@Q4_K_M'],
         proposalsEmitted: 2,
         reconciledRemoved: ['x'],
         snapshotLoaded: true,
@@ -437,12 +445,15 @@ describe('RefreshScheduler (timer, jitter, overlap guard, O1 logging)', () => {
       'completed',
       'durationMs',
       'candidatesEvaluated',
+      'candidates',
       'proposalsEmitted',
       'errors',
     ]) {
       expect(ctx).toHaveProperty(k);
     }
     expect(ctx.candidatesEvaluated).toBe(5);
+    // the O1 line names WHICH candidates were evaluated, not just the count
+    expect(ctx.candidates).toEqual(['Qwen/Qwen3-32B-GGUF@Q4_K_M', 'Qwen/Qwen3-8B-GGUF@Q4_K_M']);
     expect(ctx.proposalsEmitted).toBe(2);
     expect(ctx.durationMs).toBe(10);
   });


### PR DESCRIPTION
Four fixes surfaced while bringing the local dev dashboard up. All discovered together; grouped by the two published packages they touch.

## local-models

**HF discovery `trending` sort was a hard 400.** The wide-net discovery passed `sort=trending` straight onto the HuggingFace `/api/models` wire, which HF rejects with `400 Invalid sort parameter` (correct spelling is `trendingScore`). The trending arm has therefore *never* worked — every refresh tick it 400s and falls back to downloads-only, emitting one warning per approved org. Fixed the wire constant; the trending arm now returns results. Verified live: `sort=trending`→400, `sort=trendingScore`→200.

**Emit which candidates a tick evaluated.** `TickResult` now carries `evaluatedCandidates` (`hfRepoId@quant` ids) and the O1 `local-models refresh tick` log line includes a `candidates` field, so operators see *which* models were evaluated, not just the count.

## dashboard

**Duplicate React keys in RecommendationsCard.** Rows were keyed by `hfRepoId` alone, which collides when the same repo is recommended at multiple quants (Q4/Q5/Q6/Q8) — React logged "two children with the same key". Now keyed by `hfRepoId@quant`.

**`<circle>`/`<path>` `undefined` attribute spam from NeuralOrganism.** The animated background rendered `motion.circle`/`motion.path` elements that animate `cx`/`cy`/`r`/`d` with no `initial` prop, so framer-motion wrote `undefined` to those SVG attributes for one frame (`Invalid value for <circle> attribute r="undefined"`, `Problem parsing d="undefined"`). Each animated geometry attribute is now seeded in `initial` with its own first keyframe — no visual change. (Root cause verified empirically: a jsdom render produced 39 undefined attribute writes → 0 after seeding.)

## Tests
- local-models: extended `discover.test.ts` (regression modeling HF's 400 on an unknown sort — fails on `trending`, passes on `trendingScore`) and `refresh.test.ts` (asserts `evaluatedCandidates` + the log `candidates` field). 23 pass.
- dashboard: RecommendationsCard 20 pass; both packages typecheck clean.