### PR TITLE
test(core): cover entropy pattern checkers + analyzer behavior

### DIFF
--- a/packages/core/tests/entropy/analyzer.behavior.test.ts
+++ b/packages/core/tests/entropy/analyzer.behavior.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import { EntropyAnalyzer } from '../../src/entropy/analyzer';
+import { TypeScriptParser } from '../../src/shared/parsers';
+import { join } from 'path';
+
+/**
+ * Behavior-characterization tests for EntropyAnalyzer.
+ *
+ * These assert CURRENT behavior as-is: return shapes of the standalone
+ * detectX methods, the getReport/getSnapshot accessors, the graph-enhanced
+ * path (which skips snapshot building), and the object-config forms of the
+ * pattern/complexity/coupling/sizeBudget analyzers.
+ */
+describe('EntropyAnalyzer (behavior)', () => {
+  const parser = new TypeScriptParser();
+  const validProjectDir = join(__dirname, '../fixtures/entropy/valid-project');
+  const driftSamplesDir = join(__dirname, '../fixtures/entropy/drift-samples');
+
+  describe('getReport / getSnapshot accessors', () => {
+    it('returns undefined before analyze is run', () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: {},
+      });
+
+      expect(analyzer.getReport()).toBeUndefined();
+      expect(analyzer.getSnapshot()).toBeUndefined();
+    });
+
+    it('returns the same report object that analyze() resolved with', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: { drift: true, deadCode: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md', 'README.md'],
+      });
+
+      const result = await analyzer.analyze();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(analyzer.getReport()).toBe(result.value);
+        expect(analyzer.getSnapshot()).toBe(result.value.snapshot);
+      }
+    });
+  });
+
+  describe('object-form analyzer configs', () => {
+    it('runs pattern / complexity / coupling / sizeBudget when enabled and attaches their reports', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: {
+          patterns: { patterns: [] },
+          complexity: {},
+          coupling: {},
+          sizeBudget: {},
+        },
+        include: ['src/**/*.ts'],
+      });
+
+      const result = await analyzer.analyze();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const report = result.value;
+        // Enabled reports are attached.
+        expect(report.patterns).toBeDefined();
+        expect(report.complexity).toBeDefined();
+        expect(report.coupling).toBeDefined();
+        expect(report.sizeBudget).toBeDefined();
+        // Disabled ones remain absent.
+        expect(report.drift).toBeUndefined();
+        expect(report.deadCode).toBeUndefined();
+        // Pattern report has its expected shape.
+        expect(Array.isArray(report.patterns?.violations)).toBe(true);
+        expect(typeof report.patterns?.stats.filesChecked).toBe('number');
+        // Summary aggregates numeric fields.
+        expect(typeof report.summary.totalIssues).toBe('number');
+        expect(typeof report.summary.errors).toBe('number');
+        expect(typeof report.summary.warnings).toBe('number');
+      }
+    });
+
+    it('accepts boolean-true analyzer flags (default config branch)', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: {
+          patterns: true,
+          complexity: true,
+          coupling: true,
+        },
+        include: ['src/**/*.ts'],
+      });
+
+      const result = await analyzer.analyze();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.patterns).toBeDefined();
+        expect(result.value.complexity).toBeDefined();
+        expect(result.value.coupling).toBeDefined();
+      }
+    });
+  });
+
+  describe('graph-enhanced path (snapshot building skipped)', () => {
+    it('uses a minimal empty snapshot when both graph drift and dead-code data are supplied', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: { drift: true, deadCode: true },
+        include: ['src/**/*.ts'],
+      });
+
+      const result = await analyzer.analyze({
+        graphDriftData: { staleEdges: [], missingTargets: [] },
+        graphDeadCodeData: { reachableNodeIds: [], unreachableNodes: [] },
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // Snapshot was NOT built from disk: it is the minimal empty stand-in.
+        expect(result.value.snapshot.files).toEqual([]);
+        expect(result.value.snapshot.buildTime).toBe(0);
+        expect(result.value.snapshot.rootDir).toBe(validProjectDir);
+        // Graph-fed detectors still produce reports.
+        expect(result.value.drift).toBeDefined();
+        expect(result.value.deadCode).toBeDefined();
+      }
+    });
+
+    it('still builds a real snapshot when only one of the two graph inputs is present', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: { drift: true, deadCode: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md', 'README.md'],
+      });
+
+      const result = await analyzer.analyze({
+        graphDriftData: { staleEdges: [], missingTargets: [] },
+        // graphDeadCodeData intentionally omitted -> needsSnapshot === true
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.snapshot.files.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('standalone detector methods', () => {
+    it('detectDrift builds a snapshot on demand and returns a DriftReport', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: driftSamplesDir,
+        parser,
+        analyze: {},
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+
+      // No snapshot yet.
+      expect(analyzer.getSnapshot()).toBeUndefined();
+
+      const result = await analyzer.detectDrift({ docPaths: ['docs/**/*.md'] });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(Array.isArray(result.value.drifts)).toBe(true);
+        expect(typeof result.value.stats.docsScanned).toBe('number');
+        expect(['high', 'medium', 'low', 'none']).toContain(result.value.severity);
+      }
+      // ensureSnapshot populated the snapshot as a side effect.
+      expect(analyzer.getSnapshot()).toBeDefined();
+    });
+
+    it('detectDeadCode returns a DeadCodeReport with reachability stats', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: {},
+        include: ['src/**/*.ts'],
+      });
+
+      const result = await analyzer.detectDeadCode();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(Array.isArray(result.value.deadExports)).toBe(true);
+        expect(Array.isArray(result.value.deadFiles)).toBe(true);
+        expect(Array.isArray(result.value.unusedImports)).toBe(true);
+        expect(typeof result.value.stats.filesAnalyzed).toBe('number');
+      }
+    });
+
+    it('detectPatterns returns a PatternReport for the given config', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: {},
+        include: ['src/**/*.ts'],
+      });
+
+      const result = await analyzer.detectPatterns({ patterns: [] });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(Array.isArray(result.value.violations)).toBe(true);
+        expect(typeof result.value.stats.patternsApplied).toBe('number');
+        expect(typeof result.value.passRate).toBe('number');
+      }
+    });
+
+    it('reuses an already-built snapshot across detector calls (ensureSnapshot short-circuit)', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: validProjectDir,
+        parser,
+        analyze: {},
+        include: ['src/**/*.ts'],
+      });
+
+      const built = await analyzer.buildSnapshot();
+      expect(built.ok).toBe(true);
+      const firstSnapshot = analyzer.getSnapshot();
+      expect(firstSnapshot).toBeDefined();
+
+      const drift = await analyzer.detectDrift();
+      expect(drift.ok).toBe(true);
+      // Same snapshot instance is reused rather than rebuilt.
+      expect(analyzer.getSnapshot()).toBe(firstSnapshot);
+    });
+  });
+
+  describe('getSuggestions after a graph-enhanced analyze', () => {
+    it('derives suggestions from the last report', async () => {
+      const analyzer = new EntropyAnalyzer({
+        rootDir: driftSamplesDir,
+        parser,
+        analyze: { drift: true, deadCode: true },
+        include: ['src/**/*.ts'],
+        docPaths: ['docs/**/*.md'],
+      });
+
+      await analyzer.analyze();
+      const suggestions = analyzer.getSuggestions();
+      expect(Array.isArray(suggestions.suggestions)).toBe(true);
+      expect(suggestions.byPriority).toBeDefined();
+      expect(Array.isArray(suggestions.byPriority.high)).toBe(true);
+      expect(['trivial', 'small', 'medium', 'large']).toContain(suggestions.estimatedEffort);
+    });
+  });
+});

--- a/packages/core/tests/entropy/detectors/patterns.checkers.test.ts
+++ b/packages/core/tests/entropy/detectors/patterns.checkers.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkConfigPattern,
+  detectPatternViolations,
+} from '../../../src/entropy/detectors/patterns';
+import type {
+  ConfigPattern,
+  SourceFile,
+  CodebaseSnapshot,
+} from '../../../src/entropy/types';
+
+/**
+ * Behavior tests for the per-rule checkers routed through `checkConfigPattern`
+ * and the customPatterns / accounting paths of `detectPatternViolations`.
+ *
+ * Assumptions (fork answers were not in scope for this pure-logic target):
+ * current behavior is characterized as-is.
+ */
+
+const loc = (line: number) => ({ file: '', line, column: 0 });
+
+function file(partial: Partial<SourceFile>): SourceFile {
+  return {
+    path: '/project/src/mod.ts',
+    exports: [],
+    imports: [],
+    jsDocComments: [],
+    ...partial,
+  } as SourceFile;
+}
+
+function pattern(rule: ConfigPattern['rule'], extra: Partial<ConfigPattern> = {}): ConfigPattern {
+  return {
+    name: 'p',
+    description: 'd',
+    severity: 'error',
+    files: ['**/*.ts'],
+    rule,
+    ...extra,
+  } as ConfigPattern;
+}
+
+describe('checkConfigPattern — glob gating', () => {
+  it('returns no matches when the file path does not match any pattern glob', () => {
+    const p = pattern({ type: 'must-export', names: ['foo'] }, { files: ['src/services/**/*.ts'] });
+    const f = file({ path: '/project/src/utils/mod.ts', exports: [] });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+
+  it('returns no matches for an unknown rule type', () => {
+    const p = pattern({ type: 'not-a-real-rule' } as unknown as ConfigPattern['rule']);
+    const f = file({ path: '/project/src/mod.ts' });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+});
+
+describe('checkMustExport', () => {
+  it('flags each missing required export with a default message', () => {
+    const p = pattern({ type: 'must-export', names: ['foo', 'bar'] });
+    const f = file({ exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }] });
+    const matches = checkConfigPattern(p, f, '/project');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].message).toContain('bar');
+    expect(matches[0].line).toBe(1);
+    expect(matches[0].suggestion).toContain('bar');
+  });
+
+  it('produces no matches when all required exports are present', () => {
+    const p = pattern({ type: 'must-export', names: ['foo'] });
+    const f = file({ exports: [{ name: 'foo', type: 'named', location: loc(3), isReExport: false }] });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+
+  it('honors a custom message when provided', () => {
+    const p = pattern({ type: 'must-export', names: ['foo'] }, { message: 'custom-msg' });
+    const f = file({ exports: [] });
+    const matches = checkConfigPattern(p, f, '/project');
+    expect(matches[0].message).toBe('custom-msg');
+  });
+});
+
+describe('checkNoExport', () => {
+  it('flags a forbidden export at its own source line', () => {
+    const p = pattern({ type: 'no-export', names: ['secret'] });
+    const f = file({ exports: [{ name: 'secret', type: 'named', location: loc(9), isReExport: false }] });
+    const matches = checkConfigPattern(p, f, '/project');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].line).toBe(9);
+    expect(matches[0].message).toContain('secret');
+  });
+
+  it('produces no matches when the forbidden export is absent', () => {
+    const p = pattern({ type: 'no-export', names: ['secret'] });
+    const f = file({ exports: [{ name: 'ok', type: 'named', location: loc(1), isReExport: false }] });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+});
+
+describe('checkMustImport', () => {
+  it('flags a missing required import', () => {
+    const p = pattern({ type: 'must-import', from: 'react' });
+    const f = file({ imports: [] });
+    const matches = checkConfigPattern(p, f, '/project');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].message).toContain('react');
+  });
+
+  it('accepts an import matched by suffix (endsWith)', () => {
+    const p = pattern({ type: 'must-import', from: 'shared/result' });
+    const f = file({
+      imports: [{ source: '../../shared/result', specifiers: ['Ok'], location: loc(2), kind: 'value' }],
+    });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+});
+
+describe('checkNaming', () => {
+  it('flags an export that violates the convention and describes the convention', () => {
+    const p = pattern({ type: 'naming', match: '^[A-Z]', convention: 'PascalCase' });
+    const f = file({ exports: [{ name: 'lowerName', type: 'named', location: loc(4), isReExport: false }] });
+    const matches = checkConfigPattern(p, f, '/project');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].message).toContain('PascalCase');
+    expect(matches[0].suggestion).toContain('MyClass');
+    expect(matches[0].line).toBe(4);
+  });
+
+  it('passes an export that satisfies the convention', () => {
+    const p = pattern({ type: 'naming', match: '^[A-Z]', convention: 'PascalCase' });
+    const f = file({ exports: [{ name: 'GoodName', type: 'named', location: loc(1), isReExport: false }] });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+
+  it('falls back to the raw convention name when no description exists', () => {
+    const p = pattern({ type: 'naming', match: '^[A-Z]', convention: 'weirdConvention' });
+    const f = file({ exports: [{ name: 'bad', type: 'named', location: loc(1), isReExport: false }] });
+    const matches = checkConfigPattern(p, f, '/project');
+    expect(matches[0].suggestion).toContain('weirdConvention');
+  });
+});
+
+describe('checkRequireJsdoc', () => {
+  it('flags a file that has exports but no JSDoc comments', () => {
+    const p = pattern({ type: 'require-jsdoc' });
+    const f = file({ exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }], jsDocComments: [] });
+    const matches = checkConfigPattern(p, f, '/project');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].message).toContain('JSDoc');
+  });
+
+  it('passes a file that has JSDoc comments', () => {
+    const p = pattern({ type: 'require-jsdoc' });
+    const f = file({
+      exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }],
+      jsDocComments: [{ text: '/** doc */', location: loc(1) }] as unknown as SourceFile['jsDocComments'],
+    });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+
+  it('passes a file with no exports even when undocumented', () => {
+    const p = pattern({ type: 'require-jsdoc' });
+    const f = file({ exports: [], jsDocComments: [] });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+});
+
+describe('checkMaxLines', () => {
+  it('is a no-op that never flags (line count unavailable)', () => {
+    const p = pattern({ type: 'max-lines', count: 1 } as unknown as ConfigPattern['rule']);
+    const f = file({ exports: [{ name: 'a', type: 'named', location: loc(1), isReExport: false }] });
+    expect(checkConfigPattern(p, f, '/project')).toEqual([]);
+  });
+});
+
+describe('detectPatternViolations — customPatterns and accounting', () => {
+  function snapshot(files: SourceFile[]): CodebaseSnapshot {
+    return { rootDir: '/project', files } as CodebaseSnapshot;
+  }
+
+  it('runs customPatterns and records their matches with severity', async () => {
+    const f = file({ path: '/project/src/a.ts' });
+    const result = await detectPatternViolations(snapshot([f]), {
+      patterns: [],
+      customPatterns: [
+        {
+          name: 'custom-rule',
+          description: 'always fires',
+          severity: 'warning',
+          check: () => [{ line: 7, message: 'custom hit', suggestion: 'fix it' }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.violations).toHaveLength(1);
+    expect(result.value.violations[0].pattern).toBe('custom-rule');
+    expect(result.value.violations[0].severity).toBe('warning');
+    expect(result.value.stats.warningCount).toBe(1);
+    expect(result.value.stats.errorCount).toBe(0);
+  });
+
+  it('supplies a default suggestion when a custom match omits one', async () => {
+    const f = file({ path: '/project/src/a.ts' });
+    const result = await detectPatternViolations(snapshot([f]), {
+      patterns: [],
+      customPatterns: [
+        {
+          name: 'no-suggestion',
+          description: 'd',
+          severity: 'error',
+          check: () => [{ line: 1, message: 'hit' }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.violations[0].suggestion).toContain('Review');
+    expect(result.value.stats.errorCount).toBe(1);
+  });
+
+  it('reports a passRate of 1 when there are no patterns to check', async () => {
+    const f = file({ path: '/project/src/a.ts' });
+    const result = await detectPatternViolations(snapshot([f]), { patterns: [] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.passRate).toBe(1);
+    expect(result.value.stats.violationCount).toBe(0);
+    expect(result.value.stats.filesChecked).toBe(1);
+  });
+
+  it('computes a fractional passRate from checks minus violations', async () => {
+    // 1 file x 1 pattern = 1 check; 1 violation => passRate 0
+    const f = file({ path: '/project/src/a.ts', exports: [] });
+    const result = await detectPatternViolations(snapshot([f]), {
+      patterns: [pattern({ type: 'must-export', names: ['missing'] })],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stats.violationCount).toBe(1);
+    expect(result.value.passRate).toBe(0);
+  });
+});

--- a/packages/core/tests/entropy/detectors/patterns.checkers.test.ts
+++ b/packages/core/tests/entropy/detectors/patterns.checkers.test.ts
@@ -3,11 +3,7 @@ import {
   checkConfigPattern,
   detectPatternViolations,
 } from '../../../src/entropy/detectors/patterns';
-import type {
-  ConfigPattern,
-  SourceFile,
-  CodebaseSnapshot,
-} from '../../../src/entropy/types';
+import type { ConfigPattern, SourceFile, CodebaseSnapshot } from '../../../src/entropy/types';
 
 /**
  * Behavior tests for the per-rule checkers routed through `checkConfigPattern`
@@ -57,7 +53,9 @@ describe('checkConfigPattern — glob gating', () => {
 describe('checkMustExport', () => {
   it('flags each missing required export with a default message', () => {
     const p = pattern({ type: 'must-export', names: ['foo', 'bar'] });
-    const f = file({ exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }],
+    });
     const matches = checkConfigPattern(p, f, '/project');
     expect(matches).toHaveLength(1);
     expect(matches[0].message).toContain('bar');
@@ -67,7 +65,9 @@ describe('checkMustExport', () => {
 
   it('produces no matches when all required exports are present', () => {
     const p = pattern({ type: 'must-export', names: ['foo'] });
-    const f = file({ exports: [{ name: 'foo', type: 'named', location: loc(3), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'foo', type: 'named', location: loc(3), isReExport: false }],
+    });
     expect(checkConfigPattern(p, f, '/project')).toEqual([]);
   });
 
@@ -82,7 +82,9 @@ describe('checkMustExport', () => {
 describe('checkNoExport', () => {
   it('flags a forbidden export at its own source line', () => {
     const p = pattern({ type: 'no-export', names: ['secret'] });
-    const f = file({ exports: [{ name: 'secret', type: 'named', location: loc(9), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'secret', type: 'named', location: loc(9), isReExport: false }],
+    });
     const matches = checkConfigPattern(p, f, '/project');
     expect(matches).toHaveLength(1);
     expect(matches[0].line).toBe(9);
@@ -91,7 +93,9 @@ describe('checkNoExport', () => {
 
   it('produces no matches when the forbidden export is absent', () => {
     const p = pattern({ type: 'no-export', names: ['secret'] });
-    const f = file({ exports: [{ name: 'ok', type: 'named', location: loc(1), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'ok', type: 'named', location: loc(1), isReExport: false }],
+    });
     expect(checkConfigPattern(p, f, '/project')).toEqual([]);
   });
 });
@@ -108,7 +112,9 @@ describe('checkMustImport', () => {
   it('accepts an import matched by suffix (endsWith)', () => {
     const p = pattern({ type: 'must-import', from: 'shared/result' });
     const f = file({
-      imports: [{ source: '../../shared/result', specifiers: ['Ok'], location: loc(2), kind: 'value' }],
+      imports: [
+        { source: '../../shared/result', specifiers: ['Ok'], location: loc(2), kind: 'value' },
+      ],
     });
     expect(checkConfigPattern(p, f, '/project')).toEqual([]);
   });
@@ -117,7 +123,9 @@ describe('checkMustImport', () => {
 describe('checkNaming', () => {
   it('flags an export that violates the convention and describes the convention', () => {
     const p = pattern({ type: 'naming', match: '^[A-Z]', convention: 'PascalCase' });
-    const f = file({ exports: [{ name: 'lowerName', type: 'named', location: loc(4), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'lowerName', type: 'named', location: loc(4), isReExport: false }],
+    });
     const matches = checkConfigPattern(p, f, '/project');
     expect(matches).toHaveLength(1);
     expect(matches[0].message).toContain('PascalCase');
@@ -127,13 +135,17 @@ describe('checkNaming', () => {
 
   it('passes an export that satisfies the convention', () => {
     const p = pattern({ type: 'naming', match: '^[A-Z]', convention: 'PascalCase' });
-    const f = file({ exports: [{ name: 'GoodName', type: 'named', location: loc(1), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'GoodName', type: 'named', location: loc(1), isReExport: false }],
+    });
     expect(checkConfigPattern(p, f, '/project')).toEqual([]);
   });
 
   it('falls back to the raw convention name when no description exists', () => {
     const p = pattern({ type: 'naming', match: '^[A-Z]', convention: 'weirdConvention' });
-    const f = file({ exports: [{ name: 'bad', type: 'named', location: loc(1), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'bad', type: 'named', location: loc(1), isReExport: false }],
+    });
     const matches = checkConfigPattern(p, f, '/project');
     expect(matches[0].suggestion).toContain('weirdConvention');
   });
@@ -142,7 +154,10 @@ describe('checkNaming', () => {
 describe('checkRequireJsdoc', () => {
   it('flags a file that has exports but no JSDoc comments', () => {
     const p = pattern({ type: 'require-jsdoc' });
-    const f = file({ exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }], jsDocComments: [] });
+    const f = file({
+      exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }],
+      jsDocComments: [],
+    });
     const matches = checkConfigPattern(p, f, '/project');
     expect(matches).toHaveLength(1);
     expect(matches[0].message).toContain('JSDoc');
@@ -152,7 +167,9 @@ describe('checkRequireJsdoc', () => {
     const p = pattern({ type: 'require-jsdoc' });
     const f = file({
       exports: [{ name: 'foo', type: 'named', location: loc(1), isReExport: false }],
-      jsDocComments: [{ text: '/** doc */', location: loc(1) }] as unknown as SourceFile['jsDocComments'],
+      jsDocComments: [
+        { text: '/** doc */', location: loc(1) },
+      ] as unknown as SourceFile['jsDocComments'],
     });
     expect(checkConfigPattern(p, f, '/project')).toEqual([]);
   });
@@ -167,7 +184,9 @@ describe('checkRequireJsdoc', () => {
 describe('checkMaxLines', () => {
   it('is a no-op that never flags (line count unavailable)', () => {
     const p = pattern({ type: 'max-lines', count: 1 } as unknown as ConfigPattern['rule']);
-    const f = file({ exports: [{ name: 'a', type: 'named', location: loc(1), isReExport: false }] });
+    const f = file({
+      exports: [{ name: 'a', type: 'named', location: loc(1), isReExport: false }],
+    });
     expect(checkConfigPattern(p, f, '/project')).toEqual([]);
   });
 });


### PR DESCRIPTION
Adds behavior-asserting tests for `core/src/entropy/detectors/patterns.ts` (47%->) — all per-rule checkers (must-export, no-export, must-import, naming, require-jsdoc, max-lines no-op, glob-gating, unknown-rule, customPatterns + passRate accounting) — and `core/src/entropy/analyzer.ts` (63%->) — object/boolean analyzer configs, graph-enhanced empty-snapshot path, standalone detect* + ensureSnapshot reuse, getSuggestions. 31 tests. Assumptions: characterized current behavior as-is; fixtures asserted by shape/invariant not brittle counts. Parked: analyzer buildSnapshot Err path (not deterministically reachable black-box).

---
*Authored by test-fleet (DISPATCH). Verified locally green; all-OS CI pending. No code under test modified; never auto-merged.*