### PR TITLE
chore(roadmap): reconcile stale #583 opt-in-constraint-packs planned→done

### DIFF
--- a/docs/roadmap.d/opt-in-constraint-packs.md
+++ b/docs/roadmap.d/opt-in-constraint-packs.md
@@ -6,9 +6,9 @@ order: 5
 
 ### Opt-In Constraint Packs
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** Opt-in gating for blocking constraint rule packs: lightweight opt-in prompt loaded up front, full rules lazy-loaded only on user consent, then enforced as blocking constraints with per-stage compliance summaries (compliant / non-compliant / N/A). Mapped onto harness security/resiliency rule sets. Adapted from AI-DLC's \*.opt-in.md extension pattern. Adoption #5 from docs/research/aidlc-comparison-analysis.md [AIDLC-5]
+- **Summary:** DELIVERED (PR #1126, merged). Row was stale — auto-done did not fire because External-ID #583 is the issue number while the merge PR was #1126. Shipped code: `packages/core/src/constraints/packs.ts`, `packages/cli/src/commands/uninstall-constraints.ts`, dogfood opt-in in #1157. Opt-in gating for blocking constraint rule packs: lightweight opt-in prompt loaded up front, full rules lazy-loaded only on user consent, then enforced as blocking constraints with per-stage compliance summaries (compliant / non-compliant / N/A). Mapped onto harness security/resiliency rule sets. Adapted from AI-DLC's \*.opt-in.md extension pattern. Adoption #5 from docs/research/aidlc-comparison-analysis.md [AIDLC-5]
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1518,9 +1518,9 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 
 ### Opt-In Constraint Packs
 
-- **Status:** planned
+- **Status:** done
 - **Spec:** —
-- **Summary:** Opt-in gating for blocking constraint rule packs: lightweight opt-in prompt loaded up front, full rules lazy-loaded only on user consent, then enforced as blocking constraints with per-stage compliance summaries (compliant / non-compliant / N/A). Mapped onto harness security/resiliency rule sets. Adapted from AI-DLC's \*.opt-in.md extension pattern. Adoption #5 from docs/research/aidlc-comparison-analysis.md [AIDLC-5]
+- **Summary:** DELIVERED (PR #1126, merged). Row was stale — auto-done did not fire because External-ID #583 is the issue number while the merge PR was #1126. Shipped code: `packages/core/src/constraints/packs.ts`, `packages/cli/src/commands/uninstall-constraints.ts`, dogfood opt-in in #1157. Opt-in gating for blocking constraint rule packs: lightweight opt-in prompt loaded up front, full rules lazy-loaded only on user consent, then enforced as blocking constraints with per-stage compliance summaries (compliant / non-compliant / N/A). Mapped onto harness security/resiliency rule sets. Adapted from AI-DLC's \*.opt-in.md extension pattern. Adoption #5 from docs/research/aidlc-comparison-analysis.md [AIDLC-5]
 - **Blockers:** —
 - **Plan:** —
 - **Assignee:** —


### PR DESCRIPTION
## Roadmap reconciliation — no rebuild

The `opt-in-constraint-packs` roadmap shard (#583) was **stale-planned**: the work already shipped in **PR #1126** (`feat(ci): opt-in constraint packs`), with code in `packages/core/src/constraints/packs.ts` and `packages/cli/src/commands/uninstall-constraints.ts`, plus dogfood opt-in in #1157. Auto-done never fired because the shard's External-ID is the **issue** number (#583) while the **merge PR** was #1126.

### Change
- `docs/roadmap.d/opt-in-constraint-packs.md` — SOURCE shard: `Status: planned → done`, Summary prefixed with the `DELIVERED (PR #1126, merged)` citation.
- `docs/roadmap.md` — regenerated aggregate (`harness roadmap regen`; never hand-edited).

Docs-only; 2 files, 4 insertions / 4 deletions.

### Provenance
Emitted by a **roadmap-fleet** build lane (wave 4) whose buildable queue was **empty** — every `planned` shard is no-spec, so no build work was dispatched. This stale-row reconciliation is the lane's only emission. No code was built, nothing was merged.

Refs #583