### PR TITLE
docs: harness-ecosystem pattern-adoption analysis + ADRs 0100-0102 + roadmap items

### DIFF
--- a/docs/architecture/harness-ecosystem-pattern-adoption/analysis.md
+++ b/docs/architecture/harness-ecosystem-pattern-adoption/analysis.md
@@ -1,0 +1,92 @@
+# Harness-Engineering Ecosystem — Comparative Pattern Analysis
+
+**Date:** 2026-08-19
+**Mode:** architecture-advisor (advisory; no implementation)
+**Question:** Do the community harness-engineering projects encode patterns we should adopt? Where are we better, worse, or equal?
+
+## Scope
+
+Five community projects, plus the field's canonical references, assessed against our
+current harness platform. All five repositories were verified to exist (WebFetch, 2026-08-19).
+
+| Project                                     | What it is                                                                                                                       |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `QoderAI/better-harness`                    | Platform that evaluates the _agent work loop_ (not just diffs) across 5 dimensions; evidence-bounded reporting; multi-host       |
+| `walkinglabs/awesome-harness-engineering`   | Curated ecosystem catalog (foundations, context, guardrails, specs, evals, benchmarks, runtimes)                                 |
+| `walkinglabs/learn-harness-engineering`     | Project-based tutorial curriculum                                                                                                |
+| `10xChengTu/harness-engineering`            | Agent skill scaffolding "the OS for AI agents" — 9 reference modules; installable across 40+ agents                              |
+| `jrenaldi79/harness-engineering`            | Claude Code plugin: two-tier CLAUDE.md, path-scoped `.claude/rules/`, git-hook enforcement, `/readiness` 8-pillar maturity score |
+| `lipingtababa/harness-engineering-playbook` | Team playbook: closed-loop engineering, autonomous scaling, org redesign                                                         |
+
+**Field standard** (calibration): OpenAI coined "harness engineering"; Addy Osmani's
+_Agent Harness Engineering_ and the AGENTS.md open standard (Aug 2025) anchor the
+consensus. Core tenets: **Agent = Model + Harness**; "a decent model with a great harness
+beats a great model with a bad harness"; the single most important habit is **treating
+every agent mistake as a permanent signal and ratcheting a constraint so it never repeats**.
+
+## Headline finding
+
+On the **mechanical-enforcement floor we lead the ecosystem, often by a wide margin.**
+The genuinely adoptable patterns are all about the **on-ramp** and the **feedback loop**,
+not the enforcement mechanism itself. The field is almost entirely floor-focused
+(guardrails, don't-break); our craft-skill layer (ceiling-raising) is an axis the field
+does not have at all.
+
+## Scorecard
+
+| Dimension                          | Field's pattern                                                    | Our state (evidence)                                                                                                                                                              | Verdict                               |
+| ---------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| AGENTS.md instruction file         | Hand-author a short repo guide (Osmani: ≤60 lines)                 | We **validate + auto-generate + link-check** it (`validateAgentsMap`/`generateAgentsMap`, `packages/core/README.md:125`) and meter it in the token budget                         | **Better**                            |
+| Mechanical enforcement             | git pre-commit lint, secret scan, file-size, block force-push      | Fail-closed arch gate, security ledger baselines, coverage ratchet, link-based doc coverage, reference-docs freshness, `block-no-verify`                                          | **Better**                            |
+| Context governance                 | "Context as budget," tool masking                                  | Live `contextBudget()` allocator + exact token counts (`count_tokens`) + `always-loaded / path-scoped / invoked-only` attribution (`packages/core/src/context/attribution.ts:30`) | **Better**                            |
+| Blocking quality gates             | Trajectory critics, internal checks                                | `acceptance_eval` + `outcome_eval` with **authority derived in TypeScript, not the LLM**                                                                                          | **Better**                            |
+| Ceiling-raising                    | _Absent from the field_                                            | 11 craft skills (`code-craft`, `spec-craft`, `craft-fleet`, …)                                                                                                                    | **Better**                            |
+| Multi-agent orchestration          | Orkas, Squadron, approval gates                                    | Fleet family: worktree isolation, independent artifact verification, global leaf-slot budget, one human confirm                                                                   | **Better**                            |
+| Maturity scoring                   | `/readiness`, 8 pillars, 1–5                                       | `audit-strength` (0–100 + tier + 7 STRENGTH patterns)                                                                                                                             | **Equal/Better**                      |
+| Evidence-bounded reporting         | "Unobserved stays explicit"                                        | `[UNVERIFIED]` convention + black-box flight recorder                                                                                                                             | **Equal**                             |
+| Tool-surface discipline            | "10 tools beat 50"                                                 | **183 tool files**, mitigated by `--tier core\|standard\|full` + ToolSearch deferral                                                                                              | **At-risk, mitigated**                |
+| **Rule→failure provenance**        | THE core habit: each rule traceable to the failure that birthed it | `compound` writes `docs/solutions/**`, but **no machine link** from an enforced gate/linter to its originating incident (grep: 0 hits)                                            | **Worse — real gap**                  |
+| **Minimum-viable-harness on-ramp** | 5-item MVH; "start simple"                                         | `init-project` has an adoption ladder but front-loads a 10–20 min STRATEGY interview + framework + design-system before value lands; no formal minimal floor                      | **Worse — real gap**                  |
+| Host breadth                       | 40+ agents                                                         | 4 platforms (deep, not broad)                                                                                                                                                     | **Worse on breadth, better on depth** |
+
+## The three adoptable patterns
+
+### A — Rule→failure provenance (close the compounding loop)
+
+The field's #1 habit and our clearest miss. `compound` captures solutions; gates/linters
+enforce rules; the two are not linked. Adopt a machine-readable back-link so each mechanical
+rule cites the incident/solution that motivated it, and dead rules (no live failure class)
+become detectable. → **ADR 0100**. Effort: Medium. Risk: Low. **Highest leverage.**
+
+### B — Minimum-Viable-Harness init tier
+
+The whole field preaches "start simple"; our `init-project` is heavy. Formalize a `minimal`
+floor of the existing adoption ladder that lays exactly the 5-item MVH (repo guide, one
+runnable check, one hard arch rule, one verification loop, one permission boundary) with
+STRATEGY/design/framework deferred and a documented upgrade path. → **ADR 0101**.
+Effort: Small–Medium. Risk: Low. **Best adoption ROI.**
+
+### C — Trajectory→eval harvesting
+
+The field turns agent traces into repeatable evals. We already _produce_ the raw material —
+`FlightRecorder` writes per-run records to `.harness/black-box/run-*/` — but do not _harvest_
+them into a growing regression eval suite feeding `acceptance_eval`/`outcome_eval`. → **ADR
+0102**. Effort: Medium–Large. Risk: Medium. Strategically strong; recommended **deferred**
+until the recorder trace format is stabilized.
+
+### Explicitly NOT worth adopting
+
+More hosts (depth is our moat), tool-count slashing (progressive disclosure already solves
+the underlying problem), their maturity-scoring or evidence conventions (ours are richer).
+
+## Recommendation
+
+Pursue **A and B now** (both Low risk; A is the field's central practice we lack). Defer **C**.
+
+## Sources
+
+- Osmani, _Agent Harness Engineering_ — https://addyosmani.com/blog/agent-harness-engineering/
+- Augment Code, _Harness Engineering for AI Coding Agents_ — https://www.augmentcode.com/guides/harness-engineering-ai-coding-agents
+- `github.com/QoderAI/better-harness`, `walkinglabs/awesome-harness-engineering`,
+  `10xChengTu/harness-engineering`, `jrenaldi79/harness-engineering`,
+  `lipingtababa/harness-engineering-playbook` (verified 2026-08-19)

--- a/docs/knowledge/decisions/0100-rule-to-failure-provenance.md
+++ b/docs/knowledge/decisions/0100-rule-to-failure-provenance.md
@@ -1,0 +1,103 @@
+---
+number: 0100
+title: Rule-to-failure provenance — link every enforced constraint to its originating incident
+date: 2026-08-19
+status: proposed
+tier: medium
+source: docs/architecture/harness-ecosystem-pattern-adoption/analysis.md
+---
+
+## Context
+
+The community harness-engineering field (OpenAI, Addy Osmani, the AGENTS.md standard)
+converges on one habit as the single most important practice: **treat every agent mistake
+as a permanent signal, and ratchet a constraint so it never repeats — with each rule
+traceable to the specific failure that birthed it.** Osmani's phrasing: conventions should
+be "a pilot's checklist, not a style guide," where every entry is traceable to a past failure.
+
+We enforce more mechanically than any project surveyed (fail-closed arch gate, security
+ledger baselines, coverage ratchet, link-based doc coverage, reference-docs freshness,
+`block-no-verify`), and we capture learnings via `harness-compound`, which writes structured
+post-mortems to `docs/solutions/<track>/<category>/<slug>.md` (schema:
+`packages/core/src/solutions/schema.ts`, human copy `docs/solutions/references/schema.yaml`).
+
+But the two halves are **not linked**. A grep for provenance linkage
+(`motivatedBy`/`bornFrom`/`originIncident`/`failureOrigin`) across `packages/core/src`
+returns zero hits. Enforced rules live in two shapes — typed `StrengthRule` modules
+(`packages/core/src/harness-strength/rules/`) and generated baseline JSON
+(`.harness/arch/baselines.json`, `.harness/security/`, coverage/benchmark baselines) — and
+none of them carries a machine-readable pointer to the incident or solution that motivated
+it. Consequences: we cannot answer "why does this rule exist?" mechanically, and we cannot
+detect a **dead rule** (one whose originating failure class no longer occurs) — so the
+constraint set only ever grows.
+
+## Decision
+
+Introduce a bidirectional, machine-readable provenance link between enforced constraints and
+the `harness-compound` solution docs (and, by extension, filed incidents) that motivated them.
+
+1. **Extend the solution frontmatter schema** (`packages/core/src/solutions/schema.ts`) with
+   an optional `enforces:` field — a list of rule identifiers the solution produced or
+   hardened (e.g. `strength-002-autobaseline`, `arch:no-cross-package-import`,
+   `sec:INJ-REROL-003`). `harness-compound`'s capture phase prompts for it when a fix landed
+   an enforcement change.
+2. **Give each typed rule an optional `origin` field** on the `StrengthRule` type (and the
+   analogous rule descriptors) — the reciprocal pointer back to the solution slug / issue.
+   Baseline-JSON rules, which are generated, get provenance via a sidecar map keyed by rule
+   id rather than inline mutation of the generated file.
+3. **Add a reverse-index reporter** (`harness rules provenance`) that joins the two sides and
+   flags: (a) enforced rules with no origin ("unexplained constraint"), and (b) rules whose
+   origin solution is marked resolved/obsolete and whose failure class shows no recent
+   recurrence ("candidate dead rule").
+
+The link is **advisory metadata, never a gate** — a missing `origin` never blocks; it only
+surfaces in the reporter. Authority stays where it is.
+
+## Alternatives Considered
+
+- **Do nothing / rely on git blame + docs/solutions.** Rejected: the linkage exists only in
+  human memory and prose; it is not queryable, so dead-rule detection is impossible and the
+  constraint set ratchets in one direction forever.
+- **Make provenance mandatory (gate on it).** Rejected: would block legitimate emergency
+  hardening and retrofitting 100+ existing rules is infeasible; the field's value is in the
+  _link_, not in enforcement of the link.
+- **Store provenance only on the rule side.** Rejected: `compound` is where the human context
+  is richest at capture time; one-directional linkage loses the "this fix produced this rule"
+  signal that makes harvesting future rules cheap.
+
+## Consequences
+
+**Positive:**
+
+- The harness can explain, mechanically, why every constraint exists — the field's central
+  practice becomes tooling instead of culture.
+- Dead-rule detection becomes possible, giving the constraint set a shrink path, not only a
+  growth path. Directly counters the `strength-004-empty-thresholds` / rule-sprawl failure mode.
+- Cheap to adopt incrementally: existing rules stay valid with empty provenance; new fixes via
+  `compound` populate it going forward.
+
+**Negative:**
+
+- Retrofitting provenance onto 100+ existing rules is a long tail — mitigated by treating it as
+  fill-forward (only new/edited rules require it) and by the reporter surfacing gaps, not failing.
+- Baseline-JSON rules need a sidecar rather than inline metadata — small added indirection.
+
+**Neutral:**
+
+- The `enforces:` / `origin` fields are optional and inert until the reporter is run; no change
+  to any existing gate's behavior.
+
+## Related
+
+- ADR 0101 — Minimum-Viable-Harness init tier (sibling adoption from the same analysis)
+- ADR 0102 — Trajectory→eval harvesting (sibling adoption from the same analysis)
+- Analysis: `docs/architecture/harness-ecosystem-pattern-adoption/analysis.md`
+- `harness-compound` skill; `packages/core/src/solutions/schema.ts`;
+  `packages/core/src/harness-strength/rules/`
+
+## Action Items
+
+- [ ] Add optional `enforces: string[]` to the solution frontmatter Zod schema — owner: TBD
+- [ ] Add optional `origin` to `StrengthRule` + sidecar map for baseline rules — owner: TBD
+- [ ] Ship `harness rules provenance` reverse-index reporter (unexplained + dead-rule flags) — owner: TBD
+- [ ] Update `harness-compound` capture phase to prompt for `enforces:` when a fix lands a rule — owner: TBD

--- a/docs/knowledge/decisions/0101-minimum-viable-harness-init-tier.md
+++ b/docs/knowledge/decisions/0101-minimum-viable-harness-init-tier.md
@@ -1,0 +1,93 @@
+---
+number: 0101
+title: Minimum-Viable-Harness init tier — a formal "start simple" floor for adoption
+date: 2026-08-19
+status: proposed
+tier: medium
+source: docs/architecture/harness-ecosystem-pattern-adoption/analysis.md
+---
+
+## Context
+
+Every community harness-engineering reference preaches "start simple, add complexity only
+when needed" (10xChengTu), and the field defines a concrete **Minimum Viable Harness**: five
+things — a repo guide (AGENTS.md), runnable local checks, one hard architectural rule, one
+verification loop, and one permission boundary on what the agent may change without asking a
+human (OpenAI; Augment Code).
+
+`harness-initialize-project` already has an adoption ladder ("basic → intermediate →
+load-bearing-minimum → advanced"), so the concept of tiers exists. But the skill front-loads
+heavy, high-value-later steps before any enforcement lands: Phase 0 offers a 10–20 minute
+STRATEGY.md interview, followed by framework confirmation (~10 options) and a design-system
+step (`agents/skills/claude-code/harness-initialize-project/SKILL.md`). For an adopter who
+just installed the marketplace plugin and wants the agent to stop making the same mistake,
+the time-to-first-guardrail is high. This is friction precisely where the field has
+standardized on a fast, minimal on-ramp — and it matters more for us than most, because our
+skills are adopter-portable and must degrade gracefully.
+
+## Decision
+
+Formalize a **`minimal` tier** as the documented floor of the existing adoption ladder,
+mapped one-to-one to the field's 5-item MVH, reachable via `harness init --tier minimal`
+(and offered as the fast path in the skill's Phase 1 when the human wants to start small).
+
+The `minimal` tier scaffolds exactly, and only:
+
+1. **Repo guide** — a generated `AGENTS.md` via the existing `generateAgentsMap()` (we already
+   validate + link-check it), kept short.
+2. **One runnable local check** — a single `harness verify`-style command wired into the project.
+3. **One hard architectural rule** — a single enforced arch constraint with `check-arch`
+   fail-closed, baseline seeded.
+4. **One verification loop** — a pre-commit (or pre-push) hook running the check above.
+5. **One permission boundary** — `block-no-verify` (or an equivalent single guarded action).
+
+STRATEGY.md, framework selection, design-system, telemetry identity, and Tier-0 MCP
+integrations are **deferred, not skipped** — the tier prints an explicit, ordered upgrade path
+("run `/harness:strategy` … then `harness init --tier intermediate` to add …") so nothing is
+lost, only sequenced. Re-running init at a higher tier is additive over a `minimal` install.
+
+## Alternatives Considered
+
+- **Treat the existing "basic" level as the MVH.** Rejected as insufficient without inspection:
+  "basic" is not documented as, nor guaranteed to match, the field's 5-item contract, and the
+  skill still routes through the front-loaded Phase 0/framework/design steps first. The value is
+  a _named, guaranteed-minimal, fast_ floor with an explicit upgrade path.
+- **Just reorder init to defer STRATEGY/design.** Rejected: reordering the full flow risks the
+  higher tiers losing their strategic grounding (`STRATEGY.md` deliberately runs first so
+  brainstorm/ideate/roadmap-pilot are anchored). A separate minimal tier preserves that for
+  adopters who want the full flow while giving a fast path to those who don't.
+- **Do nothing; document the manual 5 steps.** Rejected: the field's leverage is a _turnkey_
+  minimal harness; a prose checklist reintroduces the exhortation-over-enforcement gap.
+
+## Consequences
+
+**Positive:**
+
+- Time-to-first-guardrail drops from a ~20-minute interview to a single scaffold command —
+  matching the field's fast on-ramp and lowering adoption friction for portable installs.
+- Additive upgrade path means `minimal` is a genuine floor, not a dead-end fork; nothing is lost.
+- Gives us a clean answer to "isn't the harness too heavy to start?" — a standing external critique.
+
+**Negative:**
+
+- A `minimal` install lacks strategic grounding until upgraded — mitigated by the printed upgrade
+  path and by init remaining re-runnable at a higher tier.
+- One more tier to maintain and test in the init matrix.
+
+**Neutral:**
+
+- Existing full-flow init behavior is unchanged; `minimal` is opt-in via `--tier`.
+
+## Related
+
+- ADR 0100 — Rule-to-failure provenance (sibling adoption from the same analysis)
+- ADR 0102 — Trajectory→eval harvesting (sibling adoption from the same analysis)
+- Analysis: `docs/architecture/harness-ecosystem-pattern-adoption/analysis.md`
+- `agents/skills/claude-code/harness-initialize-project/SKILL.md`; `generateAgentsMap()`
+
+## Action Items
+
+- [ ] Define the `minimal` tier contract (the 5 artifacts) in the init adoption-level model — owner: TBD
+- [ ] Wire `harness init --tier minimal` to scaffold exactly those 5 and print the upgrade path — owner: TBD
+- [ ] Add a fast-path branch in `harness-initialize-project` Phase 1 for "start minimal" — owner: TBD
+- [ ] Verify re-run at a higher tier is additive over a `minimal` install — owner: TBD

--- a/docs/knowledge/decisions/0102-trajectory-to-eval-harvesting.md
+++ b/docs/knowledge/decisions/0102-trajectory-to-eval-harvesting.md
@@ -1,0 +1,97 @@
+---
+number: 0102
+title: Trajectory-to-eval harvesting — turn black-box run records into regression eval seeds
+date: 2026-08-19
+status: proposed
+tier: large
+source: docs/architecture/harness-ecosystem-pattern-adoption/analysis.md
+---
+
+## Context
+
+The community field treats **traces as the raw material for repeatable evals**: turning
+agent trajectories into JSONL eval cases, trace grading for multi-step workflows, and
+trajectory critics for reranking / early-stopping (`walkinglabs/awesome-harness-engineering`;
+`QoderAI/better-harness`). The premise is that a failure once observed should become a
+permanent test, so the harness measurably improves over time rather than re-encountering the
+same class of failure.
+
+We already have both endpoints of this loop but they are not connected:
+
+- **Production side:** `FlightRecorder` writes durable per-run forensic records to
+  `.harness/black-box/run-*/` (provenance, verdicts, gate reasons; CLI `harness orchestrator
+black-box list|show`, `packages/cli/src/commands/orchestrator-black-box.ts`). Dozens of real
+  run records already exist in `.harness/black-box/`.
+- **Consumption side:** `acceptance_eval` (upstream, advisory) and `outcome_eval` (blocking
+  ship gate) judge spec-satisfaction from the spec acceptance section, the change diff, and
+  test output, with authority derived in TypeScript.
+
+Nothing harvests recorded trajectories into a **growing regression eval suite** that feeds
+those evaluators. Each run's forensic value is currently one-shot (forensics after the fact),
+not compounding (a permanent case the next run is measured against).
+
+## Decision
+
+Build a **harvester** that reads `FlightRecorder` run records and emits structured eval seed
+cases into the `acceptance_eval` / `outcome_eval` corpus.
+
+- **Selection:** harvest runs that carry a decisive, reproducible verdict (e.g. a
+  high-confidence `NOT_SATISFIED` that was later fixed, or a gate rejection with a clear reason)
+  — the cases where a permanent regression test has the most value.
+- **Shape:** each seed case captures the pinned base state, the spec acceptance criteria, the
+  observed verdict, and the gate reason, in the eval corpus's existing case format — not a new
+  eval engine.
+- **Loop:** the harvested corpus becomes standing input to the evaluators, so a failure class
+  observed once is measured against thereafter. Optionally, a `harness evals harvest` command
+  runs the pass on demand.
+
+This ADR is **recommended deferred** until the `FlightRecorder` record format is confirmed
+stable enough to depend on as a harvest source; it is documented now so the decision and its
+dependency are on record.
+
+## Alternatives Considered
+
+- **Do nothing; keep black-box records forensic-only.** Rejected long-term: forfeits the field's
+  compounding-eval benefit and leaves recorded failures non-repeatable. Acceptable short-term,
+  which is why this is deferred rather than dropped.
+- **Author eval cases by hand from notable failures.** Rejected as the primary mechanism: does not
+  scale and loses the "every observed failure becomes a permanent test" property; hand-authoring
+  remains available for cases the harvester cannot infer.
+- **Build a separate trajectory-critic / reranker.** Rejected for now: larger surface, and our
+  blocking value already lives in `outcome_eval`; feeding _it_ better cases is higher leverage
+  than a parallel critic.
+
+## Consequences
+
+**Positive:**
+
+- Closes the compounding loop the field prizes: observed failures become permanent regression evals.
+- Reuses assets we already own on both ends (recorder + evaluators); no new eval engine.
+- Strengthens the `outcome_eval` ship gate over time with real, reproduced failure cases.
+
+**Negative:**
+
+- Eval-suite maintenance and noise are real risks — a poorly-selected harvest floods the corpus
+  with brittle or redundant cases. Mitigated by conservative selection (decisive, reproduced
+  verdicts only) and by keeping harvested cases advisory until reviewed.
+- Depends on `FlightRecorder` format stability; a format change mid-build is rework — the reason
+  for deferral.
+
+**Neutral:**
+
+- Until the harvester runs, both endpoints keep their current behavior unchanged.
+
+## Related
+
+- ADR 0100 — Rule-to-failure provenance (sibling adoption from the same analysis)
+- ADR 0101 — Minimum-Viable-Harness init tier (sibling adoption from the same analysis)
+- Analysis: `docs/architecture/harness-ecosystem-pattern-adoption/analysis.md`
+- `FlightRecorder` / `packages/cli/src/commands/orchestrator-black-box.ts`;
+  `acceptance_eval` / `outcome_eval` skills
+
+## Action Items
+
+- [ ] Confirm `FlightRecorder` record format is stable enough to depend on (gate for starting) — owner: TBD
+- [ ] Define the eval seed-case shape and selection criteria (decisive, reproduced verdicts) — owner: TBD
+- [ ] Build the harvester + optional `harness evals harvest` command — owner: TBD
+- [ ] Keep harvested cases advisory until human-reviewed; measure corpus noise — owner: TBD

--- a/docs/roadmap.d/minimum-viable-harness-init-tier.md
+++ b/docs/roadmap.d/minimum-viable-harness-init-tier.md
@@ -1,0 +1,17 @@
+---
+slug: "minimum-viable-harness-init-tier"
+milestone: "Full-lifecycle reach"
+order: 7
+---
+
+### Minimum-Viable-Harness init tier
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0101-minimum-viable-harness-init-tier.md
+- **Summary:** Formalize a `minimal` tier as the documented floor of the existing init adoption ladder ("basic → intermediate → load-bearing-minimum → advanced"), mapped one-to-one to the field's 5-item Minimum Viable Harness (OpenAI; Augment Code). Motivation: `harness-initialize-project` front-loads a 10–20 min STRATEGY.md interview + framework confirmation (~10 options) + design-system before any guardrail lands, so time-to-first-guardrail is high — friction precisely where the field has standardized on a fast, minimal on-ramp, and it matters more for us because our skills are adopter-portable. **Scope if pursued:** (1) Define the `minimal` tier contract in the init adoption-level model = exactly these 5 artifacts and nothing else: a short generated `AGENTS.md` via the existing `generateAgentsMap()`; one runnable local check (a single `harness verify`-style command wired in); one fail-closed `check-arch` rule with baseline seeded; one pre-commit (or pre-push) verification hook running that check; one permission boundary (`block-no-verify` or equivalent single guarded action). (2) Wire `harness init --tier minimal` to scaffold exactly those 5 and print an explicit, ordered upgrade path ("run `/harness:strategy` … then `harness init --tier intermediate` to add …") — STRATEGY/framework/design-system/telemetry/Tier-0 MCP integrations are **deferred, not skipped**. (3) Add a "start minimal" fast-path branch in `harness-initialize-project` Phase 1 (`agents/skills/claude-code/harness-initialize-project/SKILL.md`). (4) Verify re-running init at a higher tier is additive over a `minimal` install (no clobber). **Acceptance:** `--tier minimal` produces those 5 artifacts and only those; the printed upgrade path lands you at `intermediate` additively; existing full-flow init behavior unchanged (minimal is opt-in via `--tier`). **Dependencies:** none. **Source analysis:** docs/architecture/harness-ecosystem-pattern-adoption/analysis.md.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** —
+</content>

--- a/docs/roadmap.d/rule-to-failure-provenance-linking.md
+++ b/docs/roadmap.d/rule-to-failure-provenance-linking.md
@@ -1,0 +1,17 @@
+---
+slug: "rule-to-failure-provenance-linking"
+milestone: "v5.0 — Enforcement Hardening"
+order: 14
+---
+
+### Rule-to-failure provenance linking
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0100-rule-to-failure-provenance.md
+- **Summary:** Adopt the community harness-engineering field's #1 habit (OpenAI/Osmani/AGENTS.md) — link every enforced constraint to the incident that birthed it, so the harness can explain why each rule exists and detect dead rules. Today `harness-compound` writes post-mortems to `docs/solutions/**` and gates/linters enforce rules, but the two are **not linked** (grep for provenance across `packages/core/src` = 0 hits), so the constraint set only ever grows. **Scope if pursued:** (1) Extend the solution frontmatter Zod schema (`packages/core/src/solutions/schema.ts`, human copy `docs/solutions/references/schema.yaml`) with an optional `enforces: string[]` — rule ids a fix produced/hardened (e.g. `strength-002-autobaseline`, `arch:no-cross-package-import`, `sec:INJ-REROL-003`). (2) Add an optional `origin` field to the `StrengthRule` type + modules (`packages/core/src/harness-strength/rules/`); for generated baseline-JSON rules (`.harness/arch/baselines.json`, `.harness/security/`, coverage/benchmark baselines) store provenance in a sidecar map keyed by rule id rather than mutating generated files. (3) Ship a `harness rules provenance` reverse-index reporter that joins both sides and flags (a) "unexplained constraint" = enforced rule with no origin, and (b) "candidate dead rule" = origin solution resolved/obsolete AND failure class shows no recent recurrence. (4) Update the `harness-compound` capture phase to prompt for `enforces:` when a fix landed an enforcement change. **Acceptance:** reporter runs in CI advisory-only (never blocks); new `compound` docs can declare `enforces`; a rule missing `origin` never fails a build; existing rules stay valid with empty provenance (fill-forward — no bulk retrofit required). **Design constraints:** advisory metadata only, authority stays where it is; directly counters the `strength-004-empty-thresholds` / rule-sprawl failure mode by giving the constraint set a shrink path. **Dependencies:** none. **Source analysis:** docs/architecture/harness-ecosystem-pattern-adoption/analysis.md.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** —
+</content>

--- a/docs/roadmap.d/trajectory-to-eval-harvesting-from-black-box.md
+++ b/docs/roadmap.d/trajectory-to-eval-harvesting-from-black-box.md
@@ -1,0 +1,17 @@
+---
+slug: "trajectory-to-eval-harvesting-from-black-box"
+milestone: "v5.0 — Telemetry & Effectiveness"
+order: 6
+---
+
+### Trajectory-to-eval harvesting from black-box records
+
+- **Status:** backlog
+- **Spec:** docs/knowledge/decisions/0102-trajectory-to-eval-harvesting.md
+- **Summary:** Close the field's compounding-eval loop: turn recorded agent trajectories into repeatable regression evals so a failure observed once becomes a permanent test. We already own both endpoints but they are not connected — `FlightRecorder` writes durable per-run forensic records to `.harness/black-box/run-*/` (provenance, verdicts, gate reasons; CLI `harness orchestrator black-box list|show`, `packages/cli/src/commands/orchestrator-black-box.ts`), and `acceptance_eval` / `outcome_eval` judge spec-satisfaction from acceptance criteria + diff + test output — but nothing harvests recorded runs into a growing eval corpus. **Scope if pursued:** (1) Build a harvester that reads `FlightRecorder` run records and emits eval seed cases into the existing `acceptance_eval`/`outcome_eval` corpus format (pinned base state + spec acceptance criteria + observed verdict + gate reason) — reuse the existing evaluators, do NOT build a new eval engine. (2) Selection: harvest only decisive, reproducible verdicts (e.g. a high-confidence `NOT_SATISFIED` later fixed, or a gate rejection with a clear reason) — the cases where a permanent regression test has the most value. (3) Optional `harness evals harvest` command to run the pass on demand. (4) Harvested cases stay advisory until human-reviewed; measure corpus noise. **GATE-to-start (why this is backlog, not planned):** confirm the `FlightRecorder` record format is stable enough to depend on as a harvest source before build begins — a format change mid-build is rework. **Acceptance:** conservative selection keeps the corpus clean; harvested cases feed `outcome_eval` over time; both endpoints keep current behavior until the harvester runs. **Dependencies:** FlightRecorder record-format stability (the deferral reason). **Source analysis:** docs/architecture/harness-ecosystem-pattern-adoption/analysis.md.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** —
+</content>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -851,6 +851,14 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Priority:** —
 - **External-ID:** github:Intense-Visions/harness-engineering#781
 
+### Rule-to-failure provenance linking
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0100-rule-to-failure-provenance.md
+- **Summary:** Adopt the community harness-engineering field's #1 habit (OpenAI/Osmani/AGENTS.md) — link every enforced constraint to the incident that birthed it, so the harness can explain why each rule exists and detect dead rules. Today `harness-compound` writes post-mortems to `docs/solutions/**` and gates/linters enforce rules, but the two are **not linked** (grep for provenance across `packages/core/src` = 0 hits), so the constraint set only ever grows. **Scope if pursued:** (1) Extend the solution frontmatter Zod schema (`packages/core/src/solutions/schema.ts`, human copy `docs/solutions/references/schema.yaml`) with an optional `enforces: string[]` — rule ids a fix produced/hardened (e.g. `strength-002-autobaseline`, `arch:no-cross-package-import`, `sec:INJ-REROL-003`). (2) Add an optional `origin` field to the `StrengthRule` type + modules (`packages/core/src/harness-strength/rules/`); for generated baseline-JSON rules (`.harness/arch/baselines.json`, `.harness/security/`, coverage/benchmark baselines) store provenance in a sidecar map keyed by rule id rather than mutating generated files. (3) Ship a `harness rules provenance` reverse-index reporter that joins both sides and flags (a) "unexplained constraint" = enforced rule with no origin, and (b) "candidate dead rule" = origin solution resolved/obsolete AND failure class shows no recent recurrence. (4) Update the `harness-compound` capture phase to prompt for `enforces:` when a fix landed an enforcement change. **Acceptance:** reporter runs in CI advisory-only (never blocks); new `compound` docs can declare `enforces`; a rule missing `origin` never fails a build; existing rules stay valid with empty provenance (fill-forward — no bulk retrofit required). **Design constraints:** advisory metadata only, authority stays where it is; directly counters the `strength-004-empty-thresholds` / rule-sprawl failure mode by giving the constraint set a shrink path. **Dependencies:** none. **Source analysis:** docs/architecture/harness-ecosystem-pattern-adoption/analysis.md.
+- **Blockers:** —
+- **Plan:** —
+
 ## v5.0 — Catalog Rationalization
 
 ### Change init skill default recommendation away from "basic"
@@ -1008,6 +1016,14 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Assignee:** —
 - **Priority:** P1
 - **External-ID:** github:Intense-Visions/harness-engineering#564
+
+### Trajectory-to-eval harvesting from black-box records
+
+- **Status:** backlog
+- **Spec:** docs/knowledge/decisions/0102-trajectory-to-eval-harvesting.md
+- **Summary:** Close the field's compounding-eval loop: turn recorded agent trajectories into repeatable regression evals so a failure observed once becomes a permanent test. We already own both endpoints but they are not connected — `FlightRecorder` writes durable per-run forensic records to `.harness/black-box/run-*/` (provenance, verdicts, gate reasons; CLI `harness orchestrator black-box list|show`, `packages/cli/src/commands/orchestrator-black-box.ts`), and `acceptance_eval` / `outcome_eval` judge spec-satisfaction from acceptance criteria + diff + test output — but nothing harvests recorded runs into a growing eval corpus. **Scope if pursued:** (1) Build a harvester that reads `FlightRecorder` run records and emits eval seed cases into the existing `acceptance_eval`/`outcome_eval` corpus format (pinned base state + spec acceptance criteria + observed verdict + gate reason) — reuse the existing evaluators, do NOT build a new eval engine. (2) Selection: harvest only decisive, reproducible verdicts (e.g. a high-confidence `NOT_SATISFIED` later fixed, or a gate rejection with a clear reason) — the cases where a permanent regression test has the most value. (3) Optional `harness evals harvest` command to run the pass on demand. (4) Harvested cases stay advisory until human-reviewed; measure corpus noise. **GATE-to-start (why this is backlog, not planned):** confirm the `FlightRecorder` record format is stable enough to depend on as a harvest source before build begins — a format change mid-build is rework. **Acceptance:** conservative selection keeps the corpus clean; harvested cases feed `outcome_eval` over time; both endpoints keep current behavior until the harvester runs. **Dependencies:** FlightRecorder record-format stability (the deferral reason). **Source analysis:** docs/architecture/harness-ecosystem-pattern-adoption/analysis.md.
+- **Blockers:** —
+- **Plan:** —
 
 ## v5.0 — Trust & Security Model
 
@@ -1333,6 +1349,14 @@ last_manual_edit: 2026-06-27T12:51:51.967Z
 - **Assignee:** —
 - **Priority:** P2
 - **External-ID:** —
+
+### Minimum-Viable-Harness init tier
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0101-minimum-viable-harness-init-tier.md
+- **Summary:** Formalize a `minimal` tier as the documented floor of the existing init adoption ladder ("basic → intermediate → load-bearing-minimum → advanced"), mapped one-to-one to the field's 5-item Minimum Viable Harness (OpenAI; Augment Code). Motivation: `harness-initialize-project` front-loads a 10–20 min STRATEGY.md interview + framework confirmation (~10 options) + design-system before any guardrail lands, so time-to-first-guardrail is high — friction precisely where the field has standardized on a fast, minimal on-ramp, and it matters more for us because our skills are adopter-portable. **Scope if pursued:** (1) Define the `minimal` tier contract in the init adoption-level model = exactly these 5 artifacts and nothing else: a short generated `AGENTS.md` via the existing `generateAgentsMap()`; one runnable local check (a single `harness verify`-style command wired in); one fail-closed `check-arch` rule with baseline seeded; one pre-commit (or pre-push) verification hook running that check; one permission boundary (`block-no-verify` or equivalent single guarded action). (2) Wire `harness init --tier minimal` to scaffold exactly those 5 and print an explicit, ordered upgrade path ("run `/harness:strategy` … then `harness init --tier intermediate` to add …") — STRATEGY/framework/design-system/telemetry/Tier-0 MCP integrations are **deferred, not skipped**. (3) Add a "start minimal" fast-path branch in `harness-initialize-project` Phase 1 (`agents/skills/claude-code/harness-initialize-project/SKILL.md`). (4) Verify re-running init at a higher tier is additive over a `minimal` install (no clobber). **Acceptance:** `--tier minimal` produces those 5 artifacts and only those; the printed upgrade path lands you at `intermediate` additively; existing full-flow init behavior unchanged (minimal is opt-in via `--tier`). **Dependencies:** none. **Source analysis:** docs/architecture/harness-ecosystem-pattern-adoption/analysis.md.
+- **Blockers:** —
+- **Plan:** —
 
 ## Craft Pipeline
 


### PR DESCRIPTION
## What

Comparative analysis of five community harness-engineering projects (`QoderAI/better-harness`, `walkinglabs/awesome-harness-engineering`, `10xChengTu/harness-engineering`, `jrenaldi79/harness-engineering`, `lipingtababa/harness-engineering-playbook`) against the field standard (OpenAI/Osmani/AGENTS.md), plus three ADRs and three roadmap items for the adoptable patterns.

Ran via `/harness:architecture-advisor` (advisory mode — no implementation). All five repos and the field standard were verified live (WebFetch), and every claimed gap was checked against our own code before asserting it.

## Headline finding

On the **mechanical-enforcement floor we lead the ecosystem, often by a wide margin** — and our craft-skill (ceiling-raising) layer is an axis the field doesn't have at all. The genuinely adoptable patterns are all about the **on-ramp** and the **feedback loop**, not the enforcement mechanism.

## Contents

**Analysis** — `docs/architecture/harness-ecosystem-pattern-adoption/analysis.md` (full scorecard: better/worse/equal per dimension, with evidence).

**ADRs** (status `proposed`):
- `0100` — Rule-to-failure provenance: link every enforced constraint to the incident that birthed it (the field's #1 habit; our clearest gap). Recommended **do now**.
- `0101` — Minimum-Viable-Harness init tier: a formal "start simple" floor of the existing adoption ladder. Recommended **do now**.
- `0102` — Trajectory-to-eval harvesting: `FlightRecorder` records → `acceptance_eval`/`outcome_eval` seeds. Recommended **deferred** (gated on recorder-format stability).

**Roadmap** (sharded — shards + regenerated aggregate):
- Rule-to-failure provenance linking → `v5.0 — Enforcement Hardening` (planned)
- Minimum-Viable-Harness init tier → `Full-lifecycle reach` (planned)
- Trajectory-to-eval harvesting → `v5.0 — Telemetry & Effectiveness` (backlog)

Each shard carries a self-contained pickup brief (scope, exact files to touch, acceptance criteria, dependencies) + its source ADR, so any item can be picked up independently.

## Verification

- ADRs `0100`–`0102` are collision-free (above the current max `0099`); frontmatter matches the canonical `docs/knowledge/decisions/` schema.
- All three roadmap items round-trip into the regenerated aggregate; the aggregate diff is exactly 24 lines, all mine — no pre-existing drift bundled in.
- My rows appear in **zero** `harness validate` roadmap-health issue lines (each `planned` row has a Spec, so no RMH002).
- `harness validate` reports the tree red overall due to the **pre-existing** red-on-main baseline (grandfathered ADR-number collisions + a large spec-less `planned` backlog) — none of it introduced here.

## Notes

- ADRs are `proposed`, not `accepted` — ratification is a follow-up decision.
- No external GitHub issue was created for the roadmap items (deliberately avoiding the `manage_roadmap` auto-issue + stale-build hazards); `External-ID` left blank.
- `planned` items have no linked plan yet, so the orchestrator will route them to a human for planning rather than auto-execute — correct for proposals awaiting ratification.
</content>
