### PR TITLE
fix(pre-commit): diagnose unbuilt CLI instead of advising --update-baseline (#1421)

### DIFF
--- a/.changeset/precommit-unbuilt-cli-diagnosis.md
+++ b/.changeset/precommit-unbuilt-cli-diagnosis.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix `.husky/pre-commit` misdiagnosing an unbuilt CLI as an architecture-baseline regression (#1421). The gate now asserts `packages/cli/dist/bin/harness.js` exists before invoking it and, when it does not (a fresh worktree/clone with no built CLI), fails with an accurate "the harness CLI is not built — run `pnpm build`" message instead of advising `--update-baseline`. Dev-tooling only; no publishable package changes.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -81,6 +81,29 @@ done
 set +f
 IFS=$old_ifs
 
+# Accurate diagnosis for the unbuilt-CLI case (#1421). A fresh worktree/clone has no
+# built CLI: packages/cli/dist is gitignored (.gitignore) and `pnpm install` alone
+# never produces it, so the `node .../harness.js` gate below would die with
+# MODULE_NOT_FOUND. That is a "could not run" abstention — zero checks executed — NOT a
+# check that ran and regressed. The failure branch further down attributes any non-zero
+# exit to an arch regression and offers the baseline-accepting remedy; following that
+# advice for a missing build silently rewrites committed thresholds for reasons
+# unrelated to the change. So assert the entrypoint exists FIRST and, if it does not,
+# fail with a distinct, actionable message that never offers the baseline remedy. This
+# message is deliberately kept textually disjoint from the arch-baseline advice below.
+if [ ! -f packages/cli/dist/bin/harness.js ]; then
+  echo "✗ Commit blocked: the harness CLI is not built." >&2
+  echo "" >&2
+  echo "  packages/cli/dist/bin/harness.js is missing. A fresh worktree or clone has no" >&2
+  echo "  built CLI (packages/cli/dist is gitignored; 'pnpm install' does not build it)." >&2
+  echo "  Build the CLI from the repo root, then re-commit:" >&2
+  echo "" >&2
+  echo "    pnpm build" >&2
+  echo "" >&2
+  echo "  No checks ran, so nothing was evaluated — this is not a check regression." >&2
+  exit 1
+fi
+
 if ! node packages/cli/dist/bin/harness.js ci check --skip "$SKIP" >/tmp/harness-pre-commit.log 2>&1; then
   cat /tmp/harness-pre-commit.log
   echo ""

--- a/docs/changes/precommit-unbuilt-cli-diagnosis/plans/plan.md
+++ b/docs/changes/precommit-unbuilt-cli-diagnosis/plans/plan.md
@@ -1,0 +1,63 @@
+# Plan — pre-commit misdiagnoses an unbuilt CLI as an arch-baseline regression (#1421)
+
+## Problem
+
+`.husky/pre-commit` shells out to `packages/cli/dist/bin/harness.js` (line 84). In a
+fresh worktree/clone `packages/cli/dist/` is gitignored and is **never** produced by
+`pnpm install` alone, so `node .../harness.js` dies with `MODULE_NOT_FOUND`. The hook's
+failure branch attributes _every_ non-zero exit to a check regression and advises
+`harness check-arch --update-baseline`. A contributor who trusts that output commits a
+bogus baseline change in response to a missing build. A run that executed **zero**
+checks is an abstention, not a failing gate, and must not be offered a
+baseline-accepting remedy.
+
+## Approach (issue Option 1 — smallest change that resolves the dangerous advice)
+
+Assert the CLI entrypoint exists **before** invoking it. If it is missing, fail with a
+distinct, actionable message — "the harness CLI is not built … run `pnpm build`" — that
+never mentions the baseline remedy. Only a real non-zero exit from `harness ci check`
+(the check ran and regressed) can reach the existing baseline-advice branch.
+
+Why Option 1 over Options 2/3 (dedicated infra exit code / executed-check count):
+smallest surface, purely additive, resolves the dangerous-advice problem on its own,
+and mirrors the reproduction exactly (entrypoint absent). The deeper exit-code plumbing
+is a larger, separable change and not required to close the reported bug.
+
+## Files touched
+
+- `.husky/pre-commit` — add a fail-fast guard immediately above the `harness ci check`
+  gate: `if [ ! -f packages/cli/dist/bin/harness.js ]; then … exit 1; fi`. The guard
+  message deliberately avoids the literal `--update-baseline` token and the
+  "architecture baseline change" phrasing, so (a) the accurate message and the dangerous
+  advice are textually disjoint and (b) it adds no new match for the STRENGTH-002
+  auto-baseline auditor's failure-branch regex.
+- `packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts` — the existing #726
+  fail-closed e2e runs the extracted gate in a temp repo that has no built CLI; the new
+  guard would fire first and mask the stubbed producer. Provision a stub
+  `packages/cli/dist/bin/harness.js` in that temp repo so the guard passes and the
+  producer-structure assertions still exercise what they intend.
+- `packages/cli/tests/hooks/pre-commit-unbuilt-cli-gate.e2e.test.ts` — **new** regression
+  test.
+
+## Test strategy
+
+New e2e (`pre-commit-unbuilt-cli-gate.e2e.test.ts`), mirroring the existing #726 e2e:
+extract the real gate block from `.husky/pre-commit`, install it as a hook in a temp git
+repo that has **no** `packages/cli/dist/bin/harness.js`, stage a change, and `git commit`.
+Assert:
+
+1. the commit is blocked (non-zero) and no commit is created;
+2. the output contains the accurate "harness CLI is not built" / `pnpm build` message;
+3. the output does **not** contain `--update-baseline` nor the "intentional architecture
+   baseline change" advice (proving the misdiagnosis is gone).
+
+A positive control also provisions the stub entrypoint and confirms the guard passes
+through to the (stubbed) gate — so the guard cannot be trivially always-on.
+
+`skipIf(win32)` like the sibling e2e: the hook runs under POSIX `sh`.
+
+## Verification
+
+- `pnpm --filter @harness-engineering/cli test` for the two hook e2e files.
+- Build the CLI first (`pnpm build`) so the local pre-commit gate itself can run.
+- Changeset + docs regen as the pre-push gauntlet requires.

--- a/docs/changes/precommit-unbuilt-cli-diagnosis/provenance.json
+++ b/docs/changes/precommit-unbuilt-cli-diagnosis/provenance.json
@@ -1,0 +1,12 @@
+{
+  "issues": [1421],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/precommit-unbuilt-cli-diagnosis/plans/plan.md",
+  "closingKeyword": "Closes #1421",
+  "assumptions": [
+    "Adopted issue Option 1 (assert the CLI entrypoint exists before invoking it) as the smallest change that resolves the dangerous-advice problem; did not implement Option 2 (a dedicated infrastructure exit code from `ci check`) or Option 3 (surfacing an executed-check count), which are larger, separable changes not required to close the reported bug.",
+    "The guard's file-existence check (`[ ! -f packages/cli/dist/bin/harness.js ]`) covers the reported reproduction (the entrypoint itself is absent in a fresh worktree/clone). A dist/ that exists but fails to load from a corrupt build is out of scope for this fix.",
+    "Worded the new accurate message to avoid the literal `--update-baseline` token and the 'architecture baseline change' phrasing, both to keep the accurate message textually disjoint from the dangerous advice and to avoid adding a new match for the STRENGTH-002 auto-baseline auditor's failure-branch regex.",
+    "Updated the sibling #726 fail-closed e2e (pre-commit-cicheck-gate.e2e.test.ts) to provision a stub built-CLI entrypoint in its temp repo, since the new guard runs before the stubbed producer and would otherwise mask it."
+  ]
+}

--- a/packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts
+++ b/packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts
@@ -93,6 +93,16 @@ beforeEach(() => {
   fs.writeFileSync(hookPath, buildGateHook(repoRoot));
   fs.chmodSync(hookPath, 0o755);
 
+  // The hook now fails fast when the built CLI entrypoint is absent (#1421), a guard
+  // that runs BEFORE the stubbed `ci check` producer. This e2e is about the gate's
+  // pipe/redirect STRUCTURE, not the unbuilt-CLI diagnosis, so provision a stub
+  // entrypoint in the temp repo to satisfy that precondition and let the stubbed
+  // producer run. (The unbuilt-CLI guard itself is covered by
+  // pre-commit-unbuilt-cli-gate.e2e.test.ts.)
+  const cliEntry = path.join(cwd, 'packages', 'cli', 'dist', 'bin', 'harness.js');
+  fs.mkdirSync(path.dirname(cliEntry), { recursive: true });
+  fs.writeFileSync(cliEntry, '// stub entrypoint — presence satisfies the built-CLI guard\n');
+
   // Baseline commit created with the hook bypassed (env unset → stub exits 0, so
   // the gate passes anyway, but --no-verify keeps the baseline independent of it).
   fs.writeFileSync(path.join(cwd, 'README.md'), '# scratch\n');

--- a/packages/cli/tests/hooks/pre-commit-unbuilt-cli-gate.e2e.test.ts
+++ b/packages/cli/tests/hooks/pre-commit-unbuilt-cli-gate.e2e.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * End-to-end regression proof for #1421: the `.husky/pre-commit` gate must DIAGNOSE an
+ * unbuilt CLI accurately, not misattribute it to an architecture-baseline regression.
+ *
+ * The bug: `.husky/pre-commit` shells out to `packages/cli/dist/bin/harness.js`. In a
+ * fresh worktree/clone `packages/cli/dist` is gitignored and never built, so the node
+ * invocation dies with MODULE_NOT_FOUND — zero checks executed. The failure branch,
+ * however, attributed every non-zero exit to a check regression and advised
+ * `harness check-arch --update-baseline`; following that advice commits a bogus
+ * baseline in response to a missing build.
+ *
+ * The fix (issue Option 1): assert the entrypoint exists BEFORE invoking it. If it is
+ * missing, fail with a distinct, actionable "the harness CLI is not built — run
+ * pnpm build" message that never mentions the baseline remedy.
+ *
+ * Like the sibling #726 gate e2e, this extracts the REAL gate block from the committed
+ * `.husky/pre-commit` (not a hand-rewritten copy) and runs it under `/bin/sh` via a
+ * real `git commit`, exactly mirroring how the gate executes in production.
+ */
+
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error('Could not locate monorepo root (pnpm-workspace.yaml not found)');
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Extract the gate block from the real `.husky/pre-commit` — everything from the top of
+ * the file up to (but not including) `npx lint-staged` — so the committed unbuilt-CLI
+ * guard is what is under test. The `harness ci check` producer is rewritten to a stub
+ * that exits with $CI_CHECK_EXIT so the positive-control case (entrypoint present, gate
+ * passes) is deterministic; in the guard case the producer is never reached.
+ */
+function buildGateHook(repoRoot: string): string {
+  const hookSrc = fs.readFileSync(path.join(repoRoot, '.husky', 'pre-commit'), 'utf-8');
+  const lines = hookSrc.split('\n');
+  const endIdx = lines.findIndex((l) => l.trim() === 'npx lint-staged');
+  if (endIdx === -1) {
+    throw new Error('`npx lint-staged` marker not found in .husky/pre-commit');
+  }
+  const block = lines.slice(0, endIdx).join('\n');
+  const rewritten = block.replace(
+    /node packages\/cli\/dist\/bin\/harness\.js ci check[^>|]*/,
+    'sh -c \'echo "arch: ok (stub)"; exit ${CI_CHECK_EXIT:-0}\' '
+  );
+  if (rewritten === block) {
+    throw new Error('ci-check producer line not found/rewritten in .husky/pre-commit');
+  }
+  return `#!/bin/sh\n${rewritten}\n`;
+}
+
+let repoRoot: string;
+let cwd: string;
+
+function git(args: string[], env?: NodeJS.ProcessEnv): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', env: { ...process.env, ...env } });
+}
+
+function provisionBuiltCli(): void {
+  const cliEntry = path.join(cwd, 'packages', 'cli', 'dist', 'bin', 'harness.js');
+  fs.mkdirSync(path.dirname(cliEntry), { recursive: true });
+  fs.writeFileSync(cliEntry, '// stub entrypoint — presence satisfies the built-CLI guard\n');
+}
+
+beforeEach(() => {
+  repoRoot = findRepoRoot(path.dirname(fileURLToPath(import.meta.url)));
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'unbuilt-cli-gate-e2e-'));
+
+  git(['init', '-q']);
+  git(['config', 'user.email', 't@example.com']);
+  git(['config', 'user.name', 'Test']);
+  git(['config', 'commit.gpgsign', 'false']);
+
+  const hookPath = path.join(cwd, '.git', 'hooks', 'pre-commit');
+  fs.writeFileSync(hookPath, buildGateHook(repoRoot));
+  fs.chmodSync(hookPath, 0o755);
+
+  fs.writeFileSync(path.join(cwd, 'README.md'), '# scratch\n');
+  git(['add', 'README.md']);
+  git(['commit', '-q', '--no-verify', '-m', 'baseline']);
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+// The hook runs under POSIX `sh` (husky uses `sh -e`); windows-latest can't reliably
+// reproduce that shell for git hooks. The fix is a POSIX-shell guarantee — skip win32.
+describe.skipIf(process.platform === 'win32')('pre-commit unbuilt-CLI gate (e2e)', () => {
+  it('BLOCKS with an accurate "not built" message when the CLI entrypoint is missing (#1421)', () => {
+    // No packages/cli/dist/bin/harness.js in the temp repo — the fresh-worktree case.
+    const headBefore = git(['rev-parse', 'HEAD']).trim();
+
+    fs.writeFileSync(path.join(cwd, 'change.txt'), 'a staged change\n');
+    git(['add', 'change.txt']);
+
+    let failed = false;
+    let output = '';
+    try {
+      git(['commit', '-m', 'change that should be blocked by the unbuilt-CLI guard']);
+    } catch (err) {
+      failed = true;
+      const e = err as { stdout?: string; stderr?: string };
+      output = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    }
+
+    // The guard must block the commit.
+    expect(failed).toBe(true);
+    expect(git(['rev-parse', 'HEAD']).trim()).toBe(headBefore);
+
+    // The message is the accurate, actionable one.
+    expect(output).toContain('the harness CLI is not built');
+    expect(output).toContain('pnpm build');
+
+    // And it must NOT misdiagnose this as an arch-baseline regression: neither the
+    // dangerous remedy flag nor the "intentional architecture baseline change" advice.
+    expect(output).not.toContain('--update-baseline');
+    expect(output).not.toContain('architecture baseline change');
+  });
+
+  it('passes the guard and reaches the check gate when the CLI is built', () => {
+    provisionBuiltCli();
+    const headBefore = git(['rev-parse', 'HEAD']).trim();
+
+    fs.writeFileSync(path.join(cwd, 'change.txt'), 'a staged change\n');
+    git(['add', 'change.txt']);
+
+    // Entrypoint present + stubbed gate exits 0 → the guard is transparent and the
+    // commit proceeds. Proves the guard is not trivially always-on.
+    git(['commit', '-q', '-m', 'change that should pass'], { CI_CHECK_EXIT: '0' });
+
+    expect(git(['rev-parse', 'HEAD']).trim()).not.toBe(headBefore);
+    expect(git(['ls-tree', '-r', '--name-only', 'HEAD'])).toContain('change.txt');
+  });
+});


### PR DESCRIPTION
Closes #1421

## Problem

`.husky/pre-commit` shells out to `packages/cli/dist/bin/harness.js`. In a fresh
worktree/clone `packages/cli/dist` is gitignored and is never produced by `pnpm install`
alone, so `node .../harness.js` dies with `MODULE_NOT_FOUND`. The gate's failure branch
attributed **every** non-zero exit to a check regression and advised
`harness check-arch --update-baseline`. A contributor who trusts that output commits a
bogus baseline change in response to a missing build — silently rewriting architecture
thresholds for reasons unrelated to their change. A run that executed **zero** checks is
an abstention, not a failing gate, and must not be offered a baseline-accepting remedy.

## Fix (issue Option 1 — the smallest change)

Assert the CLI entrypoint exists **before** invoking it. When it is missing, the hook now
fails fast with a distinct, actionable message:

```
✗ Commit blocked: the harness CLI is not built.

  packages/cli/dist/bin/harness.js is missing. A fresh worktree or clone has no
  built CLI (packages/cli/dist is gitignored; 'pnpm install' does not build it).
  Build the CLI from the repo root, then re-commit:

    pnpm build

  No checks ran, so nothing was evaluated — this is not a check regression.
```

The existing `harness ci check` gate and its arch-baseline advice are unchanged and now
reachable **only** when a check actually ran and regressed. "Could not run" and "ran and
failed" are no longer conflated.

## Changes

- `.husky/pre-commit` — fail-fast built-CLI guard above the `ci check` gate. Its wording
  is deliberately disjoint from the arch-baseline advice (no `--update-baseline`, no
  "architecture baseline change"), which also keeps it from adding a new match to the
  STRENGTH-002 auto-baseline auditor's failure-branch regex.
- `packages/cli/tests/hooks/pre-commit-unbuilt-cli-gate.e2e.test.ts` — **new** e2e that
  extracts the real gate block, runs it via a real `git commit` in a temp repo with no
  built CLI, and asserts the accurate message appears while `--update-baseline` / the
  arch-baseline advice do **not**; a positive control provisions the entrypoint and
  confirms the guard is transparent (not always-on).
- `packages/cli/tests/hooks/pre-commit-cicheck-gate.e2e.test.ts` — the sibling #726
  fail-closed e2e runs in a temp repo with no built CLI; provision a stub entrypoint so
  the new guard passes through to the stubbed producer it means to test.

## Assumptions made

- Adopted issue **Option 1** (assert the entrypoint exists) as the smallest change that
  resolves the dangerous-advice problem on its own. Did **not** implement Option 2 (a
  dedicated infrastructure exit code from `ci check`) or Option 3 (surfacing an
  executed-check count) — larger, separable changes not required to close the bug.
- The file-existence check covers the reported reproduction (the entrypoint itself is
  absent). A `dist/` that exists but fails to load from a corrupt build is out of scope.
- Worded the accurate message to avoid the `--update-baseline` token and the
  "architecture baseline change" phrasing, both to keep it disjoint from the dangerous
  advice and to avoid a new STRENGTH-002 failure-branch match.
- Updated the #726 sibling e2e to provision a stub built-CLI entrypoint, since the new
  guard runs before that test's stubbed producer and would otherwise mask it.

## Verification

- New + sibling hook e2e: 4 tests pass (`pnpm --filter @harness-engineering/cli test`).
- `strength-002-autobaseline` and `pre-commit-skip-allowlist` / `roadmap-regen-hook`
  e2e suites: unchanged, green.
- Committed through the real pre-commit gate and pushed through the full pre-push
  gauntlet (changeset check, coverage ratchet, generate-docs, tool-catalog) with no
  bypass.

Dev-tooling change only; empty changeset added as an explicit no-release marker.
