### PR TITLE
refactor(core): extract roadmap/heading.ts as single source of truth for H3 grammar

### DIFF
--- a/.changeset/roadmap-heading-grammar-extract.md
+++ b/.changeset/roadmap-heading-grammar-extract.md
@@ -1,0 +1,9 @@
+---
+'@harness-engineering/core': patch
+---
+
+Extract `roadmap/heading.ts` as the single source of truth for the H3 feature-heading grammar.
+
+The grammar — "an H3 heading, optionally escaped with a `Feature: ` prefix" — was encoded three times (`parse.ts`'s `h3Pattern`, `store/shard.ts`'s `H3_NAME`, and `serialize.ts`'s `serializeFeatureHeading`) with nothing keeping them in sync. The copies had already diverged on whitespace: the monolith reader required exactly one space while the shard reader accepted `\s+`, so a heading like `###  Feature:  x` read fine through the shard path but was silently dropped by the monolith path.
+
+All three now route through `roadmap/heading.ts`, and the whitespace question is settled deliberately in one place: **lenient read (`\s+`), one-space emit**. The monolith reader is widened (Postel's law — it now accepts everything the shard reader did) and the emitter still emits exactly one space, so `serialize → parse` is an identity. No behavior change for any already-canonical roadmap; the only observable difference is that the monolith reader now also accepts the lenient hand-edited form the shard reader always accepted.

--- a/docs/changes/roadmap-heading-grammar-extract/plans/plan.md
+++ b/docs/changes/roadmap-heading-grammar-extract/plans/plan.md
@@ -1,0 +1,87 @@
+# Plan — Extract `roadmap/heading.ts` (single source of truth for the H3 heading grammar)
+
+Closes #1261.
+
+## Problem
+
+The roadmap H3 feature-heading grammar ("a feature heading, optionally escaped
+with a `Feature: ` prefix") is encoded in three independent places that must
+agree but nothing keeps in sync:
+
+- `packages/core/src/roadmap/parse.ts` — `h3Pattern = /^### (Feature: )?(.+)$/gm`
+  (requires exactly one space)
+- `packages/core/src/roadmap/store/shard.ts` — `H3_NAME = /^###\s+(?:Feature:\s+)?(.+)$/m`
+  (accepts `\s+`)
+- `packages/core/src/roadmap/serialize.ts` — `serializeFeatureHeading()` (the emitter)
+
+The whitespace difference is a latent divergence: `shard.ts` accepts heading
+forms `parse.ts` rejects, so a shard hand-edited to `###  Feature:  x` reads
+through the shard path but fails through the monolith path — silently
+reclassifying tracked rows.
+
+## Decision (human-confirmed)
+
+Canonicalize on **lenient read, one-space emit**:
+
+- The shared grammar ACCEPTS `\s+` on read (Postel's law — both current readers
+  keep accepting what they accept today; `parse.ts` is widened to match
+  `shard.ts`, never narrowed).
+- `serializeFeatureHeading()` EMITS exactly one space.
+
+This makes `serialize → parse` an identity and removes the divergence.
+
+## Approach
+
+Create `packages/core/src/roadmap/heading.ts` as the single source of truth:
+
+- `GROUP_PREFIX` / `FEATURE_PREFIX` marker constants (moved here from `parse.ts`;
+  they belong to the heading grammar).
+- One canonical lenient pattern `^###\s+(Feature:\s+)?(.+)$` defined once.
+- `serializeFeatureHeading(name)` — the emitter (moved from `serialize.ts`),
+  one-space output, escaping any name that begins with either marker prefix.
+- `parseFeatureHeading(line)` — single-line reader returning
+  `{ name, explicitFeature } | null` (for the shard path).
+- `matchFeatureHeadings(body)` — global multi-heading reader returning each
+  heading's `{ name, explicitFeature, startIndex, fullMatch }` (for the monolith
+  path, which needs positional slicing).
+
+Keep the module a pure grammar helper — it must NOT reference the literal
+roadmap-file name (repo invariant-R / roadmap-read-source).
+
+## Files
+
+- ADD `packages/core/src/roadmap/heading.ts`
+- EDIT `packages/core/src/roadmap/parse.ts` — import prefixes + `matchFeatureHeadings`
+  from `./heading`; delete the local `h3Pattern` loop and prefix constants; refresh
+  the source-of-truth doc comment.
+- EDIT `packages/core/src/roadmap/serialize.ts` — import `serializeFeatureHeading`
+  from `./heading`; delete the local copy and the `./parse` prefix import.
+- EDIT `packages/core/src/roadmap/store/shard.ts` — import `parseFeatureHeading`
+  from `../heading`; delete the local `H3_NAME` regex.
+- ADD `packages/core/tests/roadmap/heading.test.ts` — new grammar tests.
+
+No new public `@harness-engineering/core` barrel export — `heading.ts` stays
+internal to the roadmap module (imported by relative path only), so
+`scripts/generate-core-barrel.mjs` needs no change.
+
+## Test strategy
+
+Keep the existing regression guards (`serialize-groups.test.ts`,
+`groups-write-paths.test.ts`) untouched — they pin the whole seam over the shared
+`MARKER_NAMES` list.
+
+Add `heading.test.ts`:
+
+1. The lenient form `###  Feature:  x` now parses to `{ name: 'x',
+explicitFeature: true }` through **both** paths — `matchFeatureHeadings`
+   (monolith) and `parseFeatureHeading` (shard) — proving the two readers agree.
+2. A whole grouped-roadmap round-trip with a lenient hand-edited heading:
+   `parseRoadmap` of a `###  Feature:  <marker-name>` monolith yields the correct
+   feature, and `parseShard` of a lenient shard heading yields the same name.
+3. `serialize → parse` identity: `serializeFeatureHeading(name)` for every
+   `MARKER_NAMES` entry parses back via `parseFeatureHeading` to the same name
+   with `explicitFeature` set, and emits exactly one space after `###`/`Feature:`.
+4. Unit coverage of `serializeFeatureHeading` escaping and `matchFeatureHeadings`
+   positional output.
+
+Run: `pnpm --filter @harness-engineering/core test` plus typecheck, lint, build.

--- a/docs/changes/roadmap-heading-grammar-extract/provenance.json
+++ b/docs/changes/roadmap-heading-grammar-extract/provenance.json
@@ -1,0 +1,13 @@
+{
+  "issues": [1261],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/roadmap-heading-grammar-extract/plans/plan.md",
+  "closingKeyword": "Closes #1261",
+  "assumptions": [
+    "lenient \\s+ read, one-space emit (human-confirmed)",
+    "parse.ts's h3Pattern is WIDENED (not narrowed) to accept \\s+, matching shard.ts; this is Postel's law and does not narrow what parse.ts accepts today",
+    "GROUP_PREFIX and FEATURE_PREFIX move to heading.ts as the grammar's source of truth; no external module imports them (only parse.ts defined, serialize.ts consumed), so no core barrel change is needed",
+    "heading.ts stays internal to the roadmap module (relative-import only), so scripts/generate-core-barrel.mjs needs no allowlist edit",
+    "existing regression guards serialize-groups.test.ts and groups-write-paths.test.ts are kept unchanged as the seam's pins"
+  ]
+}

--- a/packages/core/src/roadmap/heading.ts
+++ b/packages/core/src/roadmap/heading.ts
@@ -1,0 +1,116 @@
+/**
+ * Single source of truth for the roadmap H3 feature-heading grammar.
+ *
+ * The grammar — "an H3 heading, optionally escaped with a `Feature: ` prefix" —
+ * used to be encoded three times (a reader in `./parse`, a second reader in
+ * `./store/shard`, and the emitter in `./serialize`). They had to agree but
+ * nothing kept them in sync, and one whitespace divergence already existed: the
+ * monolith reader required exactly one space while the shard reader accepted
+ * `\s+`, so a heading the shard path read fine failed through the monolith path
+ * and could silently reclassify a tracked row. This module collapses all three
+ * onto one grammar so a divergence is structurally impossible.
+ *
+ * Whitespace is settled deliberately here (issue #1261, human-confirmed):
+ * **lenient read, one-space emit**. {@link parseFeatureHeading} and
+ * {@link matchFeatureHeadings} ACCEPT `\s+` after `###` and after `Feature:`
+ * (Postel's law — both readers keep accepting everything they accepted before),
+ * while {@link serializeFeatureHeading} EMITS exactly one space. That makes
+ * `serialize → parse` an identity for every feature name.
+ *
+ * This is a pure grammar helper: it knows nothing about the surrounding document
+ * or its on-disk representation.
+ */
+
+/**
+ * Heading-text prefix that marks an H3 as a narrative group rather than a
+ * feature. Consumed by the monolith reader to classify a `### Group: <name>`
+ * section, and by {@link serializeFeatureHeading} to decide when a feature name
+ * must be escaped.
+ */
+export const GROUP_PREFIX = 'Group: ';
+
+/**
+ * Heading-text prefix that explicitly marks an H3 as a feature. It takes
+ * precedence over {@link GROUP_PREFIX}, so `### Feature: Group: x` is a feature
+ * named `Group: x`. Also the escape {@link serializeFeatureHeading} emits for any
+ * name that begins with either prefix.
+ */
+export const FEATURE_PREFIX = 'Feature: ';
+
+/**
+ * The canonical, lenient H3 heading grammar, as a source fragment so the same
+ * definition can be compiled with different flags (`m` for a single line, `gm`
+ * to iterate a whole body). Group 1 captures the optional `Feature: ` escape
+ * (its presence is the `explicitFeature` signal); group 2 captures the name.
+ * `\s+` — not a literal single space — is the lenient read.
+ */
+const HEADING_SOURCE = String.raw`^###\s+(Feature:\s+)?(.+)$`;
+
+/** A parsed H3 heading: the raw name text and whether it carried the escape. */
+export interface ParsedFeatureHeading {
+  /** The heading text after the `### ` (and after any `Feature: ` escape). Not trimmed. */
+  name: string;
+  /** True when the heading carried an explicit `Feature: ` escape prefix. */
+  explicitFeature: boolean;
+}
+
+/** A {@link ParsedFeatureHeading} plus its position within the searched body. */
+export interface FeatureHeadingMatch extends ParsedFeatureHeading {
+  /** Offset of the heading within the body passed to {@link matchFeatureHeadings}. */
+  startIndex: number;
+  /** The full matched heading line, for slicing the body that follows it. */
+  fullMatch: string;
+}
+
+/**
+ * Parse a single line as an H3 feature heading, or return `null` if it is not
+ * one. The `name` is returned verbatim (untrimmed) so callers can decide their
+ * own trimming policy.
+ */
+export function parseFeatureHeading(line: string): ParsedFeatureHeading | null {
+  const match = new RegExp(HEADING_SOURCE, 'm').exec(line);
+  if (!match) return null;
+  return { name: match[2]!, explicitFeature: match[1] !== undefined };
+}
+
+/**
+ * Find every H3 feature heading in `body`, in document order, with the position
+ * and full text of each so the caller can slice out the section a heading owns.
+ */
+export function matchFeatureHeadings(body: string): FeatureHeadingMatch[] {
+  const pattern = new RegExp(HEADING_SOURCE, 'gm');
+  const matches: FeatureHeadingMatch[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(body)) !== null) {
+    matches.push({
+      name: match[2]!,
+      explicitFeature: match[1] !== undefined,
+      startIndex: match.index,
+      fullMatch: match[0],
+    });
+  }
+  return matches;
+}
+
+/**
+ * Emit a feature's H3 heading. Normally the bare `### <name>` form, but a name
+ * that begins with either marker prefix MUST be escaped with an explicit
+ * `### Feature: ` prefix, because the two readers of an H3 heading would
+ * otherwise disagree:
+ *
+ *  - `Feature: x` — BOTH readers strip a leading `Feature: `, so in either format
+ *    the row would be read back as plain `x`: silently renamed, and in the shard
+ *    format re-slugged with it.
+ *  - `Group: x` — the monolith reader treats this as a narrative group (silently
+ *    dropping the tracked row). The shard reader has no `Group:` handling and
+ *    would round-trip it unescaped; escaping anyway lets one emitter serve both
+ *    formats so the shard reader needs no knowledge of the group marker.
+ *
+ * Exactly one space is emitted after `###` and after the `Feature:` escape, which
+ * is what makes `serialize → parse` an identity for every feature name.
+ */
+export function serializeFeatureHeading(name: string): string {
+  return name.startsWith(GROUP_PREFIX) || name.startsWith(FEATURE_PREFIX)
+    ? `### ${FEATURE_PREFIX}${name}`
+    : `### ${name}`;
+}

--- a/packages/core/src/roadmap/parse.ts
+++ b/packages/core/src/roadmap/parse.ts
@@ -10,6 +10,10 @@ import type {
   Result,
 } from '@harness-engineering/types';
 import { Ok, Err } from '@harness-engineering/types';
+// The H3 feature-heading grammar (both marker prefixes and the reader) lives in
+// `./heading`, the single source of truth shared with the emitter and the shard
+// reader, so no copy can drift and silently reclassify a tracked row (#1261).
+import { GROUP_PREFIX, matchFeatureHeadings } from './heading';
 
 const VALID_STATUSES: ReadonlySet<string> = new Set([
   'backlog',
@@ -21,31 +25,6 @@ const VALID_STATUSES: ReadonlySet<string> = new Set([
 ]);
 
 const EM_DASH = '\u2014';
-
-/**
- * Heading-text prefix that marks an H3 as a narrative group rather than a feature.
- *
- * This module is the SOURCE OF TRUTH for both marker prefixes: `serialize.ts`
- * imports them so the emitter cannot drift from the reader (a divergence would
- * silently reclassify or rename tracked rows).
- *
- * Two copies of the grammar are NOT shared, both as regex literals: `h3Pattern`
- * below, and `H3_NAME` in `./store/shard.ts`, which reads the same headings back for
- * the shard format. Sharing them is a worthwhile follow-up (`shard.ts` already
- * imports `parseFeatureBlock` from this module, so nothing structural prevents it).
- * Until then the seams are pinned by byte-stable round-trips over the shared
- * `MARKER_NAMES` list: `serialize-groups.test.ts` for this reader,
- * `groups-write-paths.test.ts` for the shard reader.
- */
-export const GROUP_PREFIX = 'Group: ';
-
-/**
- * Heading-text prefix that explicitly marks an H3 as a feature. It takes
- * precedence over {@link GROUP_PREFIX}, so `### Feature: Group: x` is a feature
- * named `Group: x`. Also the escape the serializer emits for any name that begins
- * with either prefix.
- */
-export const FEATURE_PREFIX = 'Feature: ';
 
 const VALID_PRIORITIES: ReadonlySet<string> = new Set(['P0', 'P1', 'P2', 'P3']);
 
@@ -210,25 +189,10 @@ function parseMilestoneSections(
 ): Result<MilestoneSections> {
   const features: RoadmapFeature[] = [];
   const groups: RoadmapGroup[] = [];
-  // Split on H3 headings — accept both "### Feature: X" and "### X". The
-  // `Feature: ` prefix is captured (not discarded) so the group test below can be
-  // restricted to headings that did NOT carry it.
-  const h3Pattern = /^### (Feature: )?(.+)$/gm;
-  const h3Matches: Array<{
-    name: string;
-    explicitFeature: boolean;
-    startIndex: number;
-    fullMatch: string;
-  }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = h3Pattern.exec(sectionBody)) !== null) {
-    h3Matches.push({
-      name: match[2]!,
-      explicitFeature: match[1] !== undefined,
-      startIndex: match.index,
-      fullMatch: match[0],
-    });
-  }
+  // Split on H3 headings via the shared grammar — it accepts both "### Feature: X"
+  // and "### X" and reports whether the `Feature: ` escape was present, so the
+  // group test below can be restricted to headings that did NOT carry it.
+  const h3Matches = matchFeatureHeadings(sectionBody);
 
   for (let i = 0; i < h3Matches.length; i++) {
     const h3 = h3Matches[i]!;

--- a/packages/core/src/roadmap/serialize.ts
+++ b/packages/core/src/roadmap/serialize.ts
@@ -4,9 +4,9 @@ import type {
   RoadmapFeature,
   AssignmentRecord,
 } from '@harness-engineering/types';
-// The marker prefixes live in `./parse`, the reader that defines them, so the
-// emitter cannot drift from it. See GROUP_PREFIX's doc comment there.
-import { GROUP_PREFIX, FEATURE_PREFIX } from './parse';
+// The H3 heading emitter lives in `./heading`, the single source of truth shared
+// with both readers, so the emitter cannot drift from them (#1261).
+import { serializeFeatureHeading } from './heading';
 
 const EM_DASH = '\u2014';
 
@@ -105,28 +105,6 @@ function serializeExtendedLines(feature: RoadmapFeature): string[] {
     lines.push(`- **Updated-At:** ${feature.updatedAt}`);
   }
   return lines;
-}
-
-/**
- * Emit a feature's H3 heading. Normally the bare `### <name>` form, but a name that
- * begins with either marker prefix MUST be escaped with an explicit `### Feature: `
- * prefix. The two readers of an H3 heading differ in what they would otherwise do:
- *
- *  - `Feature: x` — BOTH readers strip a leading `Feature: `, so in either format the
- *    row would be read back as plain `x`: silently renamed, and in the shard format
- *    re-slugged with it.
- *  - `Group: x` — only `parseRoadmap`'s `h3Pattern` treats this as a narrative group
- *    (silently dropping the tracked row). The shard format's `H3_NAME` has no
- *    `Group: ` handling at all and would round-trip it unescaped; it is escaped
- *    anyway so one emitter serves both formats and the shard reader needs no
- *    knowledge of the group marker.
- *
- * Escaping both keeps serialize → parse an identity for every feature name.
- */
-function serializeFeatureHeading(name: string): string {
-  return name.startsWith(GROUP_PREFIX) || name.startsWith(FEATURE_PREFIX)
-    ? `### ${FEATURE_PREFIX}${name}`
-    : `### ${name}`;
 }
 
 /**

--- a/packages/core/src/roadmap/store/shard.ts
+++ b/packages/core/src/roadmap/store/shard.ts
@@ -2,20 +2,10 @@ import matter from 'gray-matter';
 import type { Result } from '@harness-engineering/types';
 import { Ok, Err } from '@harness-engineering/types';
 import { parseFeatureBlock } from '../parse';
+import { parseFeatureHeading } from '../heading';
 import { serializeFeature } from '../serialize';
 import { quoteYamlScalar } from './yaml-scalar';
 import type { Shard } from './roadmap-store';
-
-/**
- * Reads the feature name back out of the row heading emitted by `serializeFeature`.
- *
- * This is an INDEPENDENT copy of the heading grammar in `../parse` (`h3Pattern`), so
- * the two must agree on the `Feature: ` escape: `serializeFeature` prefixes any name
- * beginning with `Feature: ` or `Group: ` with `Feature: `, and stripping it here is
- * what makes the shard round-trip name-preserving. `groups-write-paths.test.ts` pins
- * this seam with byte-stable round-trips over marker-prefixed names.
- */
-const H3_NAME = /^###\s+(?:Feature:\s+)?(.+)$/m;
 
 /** Validated shard frontmatter fields (slug/milestone/order). */
 interface ShardFrontmatter {
@@ -74,11 +64,16 @@ export function parseShard(md: string): Result<Shard> {
   if (!frontmatterResult.ok) return frontmatterResult;
   const { slug, milestone, order } = frontmatterResult.value;
 
-  const nameMatch = content.match(H3_NAME);
-  if (!nameMatch) {
+  // Reads the feature name back out of the row heading emitted by
+  // `serializeFeature`, via the shared grammar in `../heading`. The emitter escapes
+  // any name beginning with `Feature: ` or `Group: ` with `Feature: `, and stripping
+  // it here is what makes the shard round-trip name-preserving.
+  // `groups-write-paths.test.ts` pins this seam with byte-stable round-trips.
+  const heading = parseFeatureHeading(content);
+  if (!heading) {
     return Err(new Error(`Shard "${slug}" is missing its "### <name>" heading`));
   }
-  const name = nameMatch[1]!.trim();
+  const name = heading.name.trim();
 
   const featureResult = parseFeatureBlock(name, content);
   if (!featureResult.ok) return featureResult;

--- a/packages/core/tests/roadmap/heading.test.ts
+++ b/packages/core/tests/roadmap/heading.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GROUP_PREFIX,
+  FEATURE_PREFIX,
+  parseFeatureHeading,
+  matchFeatureHeadings,
+  serializeFeatureHeading,
+} from '../../src/roadmap/heading';
+import { parseRoadmap } from '../../src/roadmap/parse';
+import { serializeShard, parseShard } from '../../src/roadmap/store/shard';
+import type { Shard } from '../../src/roadmap/store/roadmap-store';
+import { MARKER_NAMES } from './fixtures';
+
+describe('the shared H3 heading grammar (single source of truth, #1261)', () => {
+  describe('serializeFeatureHeading emits exactly one space', () => {
+    it('emits the bare form for a plain name', () => {
+      expect(serializeFeatureHeading('Ship the parser')).toBe('### Ship the parser');
+    });
+
+    it('escapes a Feature:-prefixed name with exactly one space either side', () => {
+      expect(serializeFeatureHeading('Feature: x')).toBe('### Feature: Feature: x');
+    });
+
+    it('escapes a Group:-prefixed name so it stays a feature', () => {
+      expect(serializeFeatureHeading('Group: Auth hardening')).toBe(
+        '### Feature: Group: Auth hardening'
+      );
+    });
+  });
+
+  describe('lenient read: `###  Feature:  x` is accepted with \\s+', () => {
+    it('parseFeatureHeading (the shard path) reads the lenient form', () => {
+      expect(parseFeatureHeading('###  Feature:  x')).toEqual({
+        name: 'x',
+        explicitFeature: true,
+      });
+    });
+
+    it('matchFeatureHeadings (the monolith path) reads the lenient form', () => {
+      const [match] = matchFeatureHeadings('###  Feature:  x\n');
+      expect(match).toMatchObject({ name: 'x', explicitFeature: true, startIndex: 0 });
+    });
+
+    it('both readers agree on the lenient form — the divergence that motivated #1261', () => {
+      const line = '###  Feature:  x';
+      const shardSide = parseFeatureHeading(line);
+      const monolithSide = matchFeatureHeadings(line)[0];
+      expect(shardSide).toEqual({ name: 'x', explicitFeature: true });
+      expect(monolithSide).toMatchObject({ name: 'x', explicitFeature: true });
+    });
+
+    it('reports explicitFeature=false for a bare heading', () => {
+      expect(parseFeatureHeading('### x')).toEqual({ name: 'x', explicitFeature: false });
+    });
+
+    it('returns null for a non-heading line', () => {
+      expect(parseFeatureHeading('- **Status:** planned')).toBeNull();
+      expect(parseFeatureHeading('## Milestone')).toBeNull();
+    });
+  });
+
+  describe('matchFeatureHeadings positions', () => {
+    it('finds every heading in document order with slice offsets', () => {
+      const body = '### One\n\n- **Status:** planned\n\n### Feature: Two\n';
+      const matches = matchFeatureHeadings(body);
+      expect(matches.map((m) => m.name)).toEqual(['One', 'Two']);
+      expect(matches[0]!.startIndex).toBe(0);
+      expect(matches[1]!.startIndex).toBe(body.indexOf('### Feature: Two'));
+      expect(matches[1]!.explicitFeature).toBe(true);
+    });
+  });
+
+  describe('serialize → parse identity for marker-colliding names', () => {
+    for (const name of MARKER_NAMES) {
+      it(`round-trips ${JSON.stringify(name)} through the emitter and reader`, () => {
+        const line = serializeFeatureHeading(name);
+        // The emitter never leaves a name readable as the wrong thing: a
+        // marker-prefixed name is always escaped.
+        if (name.startsWith(GROUP_PREFIX) || name.startsWith(FEATURE_PREFIX)) {
+          expect(line.startsWith(`### ${FEATURE_PREFIX}`)).toBe(true);
+        }
+        // The reader's regex strips exactly the one escape prefix the emitter
+        // added, so the recovered name equals the original with no further work.
+        const parsed = parseFeatureHeading(line);
+        expect(parsed).not.toBeNull();
+        expect(parsed!.name).toBe(name);
+      });
+    }
+  });
+});
+
+const LENIENT_MD = `---
+project: p
+version: 1
+last_synced: 2026-05-01T10:00:00Z
+last_manual_edit: 2026-05-01T09:00:00Z
+---
+
+# Roadmap
+
+## M1
+
+###  Feature:  Group: Auth hardening
+
+- **Status:** planned
+- **Summary:** hand-edited with extra whitespace
+- **External-ID:** github:o/r#7
+`;
+
+describe('a hand-edited lenient heading round-trips through BOTH read paths (#1261)', () => {
+  it('the monolith reader parses `###  Feature:  Group: x` as the tracked feature', () => {
+    const result = parseRoadmap(LENIENT_MD);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const features = result.value.milestones[0]?.features ?? [];
+    // Before the lenient widening, the monolith reader required a single space and
+    // would NOT have matched this heading — the row would have been swallowed into
+    // the previous section rather than tracked. It is now read as the escaped
+    // feature named `Group: Auth hardening`, not reclassified as a narrative group.
+    expect(features.map((f) => f.name)).toEqual(['Group: Auth hardening']);
+    expect(result.value.milestones[0]?.groups).toBeUndefined();
+    expect(features[0]?.externalId).toBe('github:o/r#7');
+  });
+
+  it('the shard reader parses the same lenient heading to the same name', () => {
+    const shardMd = `---
+slug: row-1
+milestone: "M1"
+order: 0
+---
+
+###  Feature:  Group: Auth hardening
+
+- **Status:** planned
+- **Summary:** hand-edited with extra whitespace
+- **External-ID:** github:o/r#7
+`;
+    const parsed = parseShard(shardMd);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.feature.name).toBe('Group: Auth hardening');
+    expect(parsed.value.feature.externalId).toBe('github:o/r#7');
+  });
+});
+
+describe('serialize → parse is an identity through the shard emitter', () => {
+  for (const name of MARKER_NAMES) {
+    it(`emits one-space bytes for ${JSON.stringify(name)} that re-read to the same name`, () => {
+      const shard: Shard = {
+        slug: 'row-1',
+        milestone: 'M1',
+        order: 0,
+        feature: {
+          name,
+          status: 'planned',
+          spec: null,
+          plans: [],
+          blockedBy: [],
+          summary: 's',
+          assignee: null,
+          priority: null,
+          externalId: 'github:o/r#1',
+          updatedAt: null,
+        },
+      };
+      const md = serializeShard(shard);
+      // One-space emit: the heading line never carries a doubled space.
+      const headingLine = md.split('\n').find((l) => l.startsWith('### '))!;
+      expect(headingLine).not.toMatch(/^###\s{2,}/);
+      expect(headingLine).not.toMatch(/Feature:\s{2,}/);
+      const reparsed = parseShard(md);
+      expect(reparsed.ok).toBe(true);
+      if (!reparsed.ok) return;
+      expect(reparsed.value.feature.name).toBe(name);
+    });
+  }
+});


### PR DESCRIPTION
Closes #1261

## Summary

The roadmap H3 feature-heading grammar — "an H3 heading, optionally escaped with a `Feature: ` prefix" — was encoded in **three** independent places that had to agree but nothing kept in sync:

| Location | Old encoding |
|---|---|
| `roadmap/parse.ts` | `h3Pattern = /^### (Feature: )?(.+)$/gm` — required exactly one space |
| `roadmap/store/shard.ts` | `H3_NAME = /^###\s+(?:Feature:\s+)?(.+)$/m` — accepted `\s+` |
| `roadmap/serialize.ts` | `serializeFeatureHeading()` — the emitter |

They had already diverged on whitespace: the monolith reader required exactly one space while the shard reader accepted `\s+`, so a heading like `###  Feature:  x` read fine through the shard path but was silently dropped by the monolith path — the exact failure mode (silent row reclassification) the issue warns about.

## What changed

- New `packages/core/src/roadmap/heading.ts` — the single source of truth. It owns the marker prefix constants (`GROUP_PREFIX`/`FEATURE_PREFIX`, moved from `parse.ts`), the one canonical lenient pattern, and the three entry points: `serializeFeatureHeading(name)` (emitter), `parseFeatureHeading(line)` (single-line reader, for shard), and `matchFeatureHeadings(body)` (positional multi-heading reader, for the monolith).
- `parse.ts`, `serialize.ts`, and `store/shard.ts` all route through it; their local grammar copies are deleted.
- Kept internal to the roadmap module (relative-import only) — no new `@harness-engineering/core` barrel export, so no barrel-allowlist change.

## Assumptions made

- **Whitespace fork (human-confirmed): lenient read, one-space emit.** The shared grammar ACCEPTS `\s+` after `###` and after `Feature:` (Postel's law — both readers keep accepting everything they accepted before; the monolith reader is *widened* to match the shard reader, never narrowed), and `serializeFeatureHeading()` emits exactly one space. This makes `serialize → parse` an identity and removes the divergence.
- The only observable behavior change is that the monolith reader now also accepts the lenient hand-edited form (`###  Feature:  x`) the shard reader always accepted. No already-canonical roadmap changes.
- `heading.ts` is kept a pure grammar helper with no reference to the roadmap-file literal, per the repo's invariant-R / roadmap-read-source constraint.

## Tests

- New `packages/core/tests/roadmap/heading.test.ts`: proves (a) the lenient `###  Feature:  x` form now round-trips through **both** the monolith (`matchFeatureHeadings` / `parseRoadmap`) and shard (`parseFeatureHeading` / `parseShard`) paths, and (b) `serialize → parse` identity holds over the shared `MARKER_NAMES` list, including one-space emission.
- The existing regression guards `serialize-groups.test.ts` and `groups-write-paths.test.ts` are untouched.
- Full `@harness-engineering/core` suite green locally (4404 passed, 1 skipped).

## Provenance

- Plan: `docs/changes/roadmap-heading-grammar-extract/plans/plan.md`
- Provenance: `docs/changes/roadmap-heading-grammar-extract/provenance.json`