### PR TITLE
fix(orchestrator): actionable 429 rate-limit error body

### DIFF
--- a/.changeset/actionable-429-rate-limit-body.md
+++ b/.changeset/actionable-429-rate-limit-body.md
@@ -1,0 +1,12 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Make the orchestrator HTTP server's 429 rate-limit response actionable.
+
+The rate-limit rejection previously returned `{ error: 'Too Many Requests' }` — a bare
+human string that only restated the HTTP status. A consumer could not branch on it (no
+stable machine `code`), and the retry budget lived only in the `Retry-After` header. The
+`429` branch of `checkRateLimit` now returns `{ error: { code: 'rate_limited', message:
+'Rate limit exceeded', retryAfterSeconds: <n> } }`, exposing a stable machine code and
+the retry budget in the body. The existing `Retry-After` header is preserved.

--- a/docs/changes/rate-limit-429-actionable-body/plans/plan.md
+++ b/docs/changes/rate-limit-429-actionable-body/plans/plan.md
@@ -1,0 +1,70 @@
+# Plan — Actionable 429 rate-limit error body (#1456)
+
+## Problem
+
+`checkRateLimit` in `packages/orchestrator/src/server/http.ts` returns a bare human
+string on rate-limit rejection:
+
+```js
+res.end(JSON.stringify({ error: 'Too Many Requests' }));
+```
+
+This only restates the HTTP status. A consumer cannot branch on it (no stable machine
+`code`), and the retry budget lives only in the `Retry-After` header, not the body.
+Filed by craft-fleet (api-craft API-R005) as a `file`-tier quality item — an observable
+HTTP contract change, so it must go through the normal build pipeline.
+
+## Approach
+
+Return an actionable, machine-branchable error envelope from the `429` branch while
+keeping the existing `Retry-After` header:
+
+```js
+res.end(
+  JSON.stringify({
+    error: {
+      code: 'rate_limited',
+      message: 'Rate limit exceeded',
+      retryAfterSeconds: retryAfter,
+    },
+  })
+);
+```
+
+- `code: 'rate_limited'` — stable machine identifier the client can switch on.
+- `message` — human-readable summary.
+- `retryAfterSeconds` — the same numeric budget already computed for `Retry-After`,
+  now also exposed in the body so a JSON-only consumer has it.
+
+The header is preserved (not replaced) so existing header-based clients keep working.
+
+### Convention note
+
+Other error responses in `http.ts` use a flat `{ error: '<string>' }` shape (404, 401,
+insufficient-scope). There is no pre-existing nested error-envelope convention, so this
+introduces the actionable shape specified in the issue for the 429 branch only. Scoped
+narrowly to the rate-limit path to avoid touching unrelated observable contracts.
+
+## Files
+
+- `packages/orchestrator/src/server/http.ts` — the `429` branch of `checkRateLimit`.
+- `packages/orchestrator/tests/server/http.test.ts` — new test asserting the body shape.
+- `.changeset/*.md` — patch changeset for `@harness-engineering/orchestrator`.
+
+## Test strategy
+
+Add a test that:
+
+1. Starts the server with `HARNESS_RATE_LIMIT_LOCALHOST=1` and `HARNESS_RATE_LIMIT=1`
+   so a second request from localhost trips the limiter deterministically.
+2. Issues enough requests to a non-state route (state routes bypass the limiter) to get
+   a 429.
+3. Asserts `statusCode === 429`, `body.error.code === 'rate_limited'`,
+   `typeof body.error.retryAfterSeconds === 'number'`, and that the `Retry-After`
+   response header is still present.
+
+## Risk / rollback
+
+Low risk — single branch, additive body field, header unchanged. Rollback = revert the
+one-file diff. The body shape change is consumer-visible (hence the tracked pipeline
+build), but no known internal consumer parses the 429 body today.

--- a/docs/changes/rate-limit-429-actionable-body/provenance.json
+++ b/docs/changes/rate-limit-429-actionable-body/provenance.json
@@ -1,0 +1,12 @@
+{
+  "issues": [1456],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/rate-limit-429-actionable-body/plans/plan.md",
+  "closingKeyword": "Closes #1456",
+  "assumptions": [
+    "No pre-existing nested error-envelope convention exists in http.ts (other errors use flat { error: '<string>' }); the actionable { error: { code, message, retryAfterSeconds } } shape from the issue is introduced for the 429 branch only.",
+    "The change is scoped to the rate-limit 429 branch; other error responses (404/401/insufficient-scope) are intentionally left unchanged to avoid touching unrelated observable contracts.",
+    "The existing Retry-After header is preserved; retryAfterSeconds is added to the body as an additive field, not a replacement.",
+    "code value is 'rate_limited' and message is 'Rate limit exceeded' exactly as specified in the issue's target shape."
+  ]
+}

--- a/packages/orchestrator/src/server/http.ts
+++ b/packages/orchestrator/src/server/http.ts
@@ -105,7 +105,15 @@ function checkRateLimit(req: http.IncomingMessage, res: http.ServerResponse): bo
   if (bucket.count > RATE_LIMIT) {
     const retryAfter = Math.ceil((bucket.resetAt - now) / 1000);
     res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) });
-    res.end(JSON.stringify({ error: 'Too Many Requests' }));
+    res.end(
+      JSON.stringify({
+        error: {
+          code: 'rate_limited',
+          message: 'Rate limit exceeded',
+          retryAfterSeconds: retryAfter,
+        },
+      })
+    );
     return false;
   }
   return true;

--- a/packages/orchestrator/tests/server/http.test.ts
+++ b/packages/orchestrator/tests/server/http.test.ts
@@ -479,6 +479,61 @@ describe('OrchestratorServer — bind failures and ephemeral ports', () => {
     }
   });
 
+  it('returns an actionable 429 body with a machine code and retry budget when rate limited', async () => {
+    // Enable localhost rate limiting for this test (normally exempt). RATE_LIMIT
+    // defaults to 100 req/window, so request 101 from this IP trips the limiter.
+    vi.stubEnv('HARNESS_RATE_LIMIT_LOCALHOST', '1');
+    const server = new OrchestratorServer(mockOrchestrator, 0);
+    await server.start();
+
+    type RlResponse = {
+      statusCode: number | undefined;
+      retryAfter: string | undefined;
+      body: unknown;
+    };
+    const getOnce = (): Promise<RlResponse> =>
+      new Promise((resolve) => {
+        // A non-state route: the state endpoints are exempt from rate limiting.
+        http.get(`http://127.0.0.1:${server.boundPort}/unknown`, (res) => {
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () =>
+            resolve({
+              statusCode: res.statusCode,
+              retryAfter: res.headers['retry-after'],
+              body: data ? JSON.parse(data) : undefined,
+            })
+          );
+        });
+      });
+
+    let limited: RlResponse | undefined;
+    for (let i = 0; i < 130 && !limited; i++) {
+      const r = await getOnce();
+      if (r.statusCode === 429) limited = r;
+    }
+
+    try {
+      expect(limited).toBeDefined();
+      const r = limited as RlResponse;
+      expect(r.statusCode).toBe(429);
+      // Retry-After header must still be present (not removed by the body change).
+      expect(r.retryAfter).toBeDefined();
+      expect(Number(r.retryAfter)).toBeGreaterThan(0);
+      // Body must be an actionable envelope a consumer can branch on.
+      const body = r.body as {
+        error?: { code?: string; message?: string; retryAfterSeconds?: unknown };
+      };
+      expect(body.error?.code).toBe('rate_limited');
+      expect(typeof body.error?.message).toBe('string');
+      expect(typeof body.error?.retryAfterSeconds).toBe('number');
+      expect(body.error?.retryAfterSeconds as number).toBeGreaterThan(0);
+    } finally {
+      server.stop();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it('rejects instead of hanging when the port is already in use', async () => {
     const first = new OrchestratorServer(mockOrchestrator, 0);
     await first.start();


### PR DESCRIPTION
## Summary

Makes the orchestrator HTTP server's `429` rate-limit response actionable.

`checkRateLimit` in `packages/orchestrator/src/server/http.ts` previously returned
`{ error: 'Too Many Requests' }` — a bare human string that only restated the HTTP
status. A consumer could not branch on it (no stable machine `code`), and the retry
budget lived only in the `Retry-After` header, not the body.

The `429` branch now returns an actionable envelope:

```json
{ "error": { "code": "rate_limited", "message": "Rate limit exceeded", "retryAfterSeconds": 42 } }
```

- `code: 'rate_limited'` — stable machine identifier the client can switch on.
- `message` — human-readable summary.
- `retryAfterSeconds` — the retry budget, now also in the body for JSON-only consumers.
- The existing `Retry-After` header is **preserved** (added to, not replaced).

## Changes

- `packages/orchestrator/src/server/http.ts` — actionable 429 body.
- `packages/orchestrator/tests/server/http.test.ts` — new test asserting `error.code === 'rate_limited'`, numeric `retryAfterSeconds`, and the `Retry-After` header is still present.
- `.changeset/actionable-429-rate-limit-body.md` — patch changeset for `@harness-engineering/orchestrator`.
- `docs/changes/rate-limit-429-actionable-body/` — plan + provenance artifacts.

## Provenance

Filed by craft-fleet (api-craft **API-R005**: "Error responses tell the consumer what to do"). runId `42dfdace-842f-4d65-8028-bfd03f56a90f`. Reference: Stripe API error design + RFC 9457.

## Assumptions made

- No pre-existing nested error-envelope convention exists in `http.ts` (other errors use flat `{ error: '<string>' }`); the actionable `{ error: { code, message, retryAfterSeconds } }` shape from the issue is introduced for the `429` branch only.
- Scoped to the rate-limit path — other error responses (404/401/insufficient-scope) are intentionally left unchanged to avoid touching unrelated observable contracts.
- `code` is `'rate_limited'` and `message` is `'Rate limit exceeded'` exactly as specified in the issue's target shape.

Closes #1456
