### PR TITLE
fix(cli-ergonomics): unify usage 'how many rows' flag on --limit (#1455)

### DIFF
--- a/.changeset/usage-flag-grammar-unify.md
+++ b/.changeset/usage-flag-grammar-unify.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': patch
+---
+
+usage daily: accept `--limit <n>` as the canonical "how many rows" flag (matching `usage sessions --limit`). `--days <n>` keeps working as a hidden, deprecated alias that prints a one-line deprecation notice to stderr. Non-breaking; no subcommands renamed.

--- a/docs/changes/usage-flag-grammar-unify/plans/plan.md
+++ b/docs/changes/usage-flag-grammar-unify/plans/plan.md
@@ -1,0 +1,56 @@
+# Plan — usage-flag-grammar-unify (#1455)
+
+## Issue
+
+`chore(cli-ergonomics): usage subcommand grammar + --days/--limit inconsistency [craft-fleet CLI-R001]`
+
+The `usage` leaf command spells the "how many rows to show" concept two ways:
+`--days <n>` on `daily` but `--limit <n>` on `sessions`. A user cannot guess the
+flag from one member to the next.
+
+## Confirmed decision — NON-BREAKING ONLY (human-approved)
+
+`usage` is a published CLI contract. We do the non-breaking fix only:
+
+1. `--limit <n>` becomes the canonical flag everywhere the "how many rows" concept
+   appears — so `daily` now accepts `--limit`.
+2. `--days <n>` stays as a **hidden, deprecated alias** on `daily`: it still
+   functions identically (maps to the same underlying value) but is hidden from
+   `--help` and, when used, prints a one-line deprecation notice to stderr pointing
+   at `--limit`. It is **not** removed.
+3. No subcommand is renamed. The subcommand-grammar inconsistency
+   (`daily`/`latest` adjectives vs `sessions`/`session` nouns) is a breaking change
+   and is explicitly **out of scope** for this non-breaking pass — noted as a
+   follow-up only.
+
+## Semantic equivalence check (required before implementing)
+
+`daily` computes `aggregateByDay(records).slice(0, days)` — `--days <n>` selects the
+first N **day rows**, it does **not** filter by calendar window/date. `sessions`
+computes `aggregateBySession(records).slice(0, limit)`. Both are `.slice(0, n)` over
+aggregated rows: the identical "how many rows to show" concept (in `daily`, one row =
+one day). **Confirmed equivalent** — unifying the flag name conflates nothing.
+
+## Tasks
+
+1. Import `Option` from commander in `packages/cli/src/commands/usage.ts`.
+2. In `registerDailyCommand`:
+   - Add canonical `--limit <n>` option, default `'7'`, help "Number of days to show
+     (default: 7, max: 90)".
+   - Add `--days <n>` as a hidden (`.hideHelp()`) deprecated alias with no default.
+   - In the action: if `--days` was provided, print a one-line deprecation notice to
+     **stderr** (`console.error`, no chalk error icon) pointing at `--limit`, and use
+     its value. `--limit` (when explicitly set) wins over `--days`; otherwise the
+     canonical default applies. Clamp identically (1..90).
+3. Tests in `packages/cli/tests/commands/usage.test.ts`:
+   - `daily --limit 7` and `daily --days 7` produce the same result.
+   - `daily --days <n>` still limits rows (alias works).
+   - `daily --days <n>` prints the deprecation notice to stderr.
+   - `--days` is absent from `daily --help` output; `--limit` is present.
+4. `pnpm build` (pre-commit arch gate shells the built CLI).
+5. `pnpm generate-docs` (CLI surface changed → refresh `docs/reference/*`).
+6. Add a `@harness-engineering/cli` changeset.
+
+## Out of scope / follow-up
+
+- Renaming subcommands for grammar consistency (breaking; deferred).

--- a/docs/changes/usage-flag-grammar-unify/provenance.json
+++ b/docs/changes/usage-flag-grammar-unify/provenance.json
@@ -1,0 +1,13 @@
+{
+  "issues": [1455],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/usage-flag-grammar-unify/plans/plan.md",
+  "closingKeyword": "Closes #1455",
+  "assumptions": [
+    "non-breaking: --limit canonical, --days hidden deprecated alias, no subcommand renames (human-confirmed)",
+    "daily --days <n> is a row-count (aggregateByDay(...).slice(0, n)), not a calendar time-window, so it is semantically identical to sessions --limit <n> — verified by reading usage.ts before unifying",
+    "deprecation notice is written to stderr (console.error, no chalk error icon) so it never corrupts --json stdout",
+    "--limit wins over --days when both are explicitly supplied; otherwise the canonical --limit default (7) applies",
+    "subcommand-grammar inconsistency (daily/latest adjectives vs sessions/session nouns) is a breaking change, deliberately deferred as a follow-up"
+  ]
+}

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1843,7 +1843,8 @@ Show per-day token usage and cost
 
 **Options:**
 
-- `--days` — Number of days to show (default: 7, max: 90) (default: "7")
+- `--limit` — Number of days to show (default: 7, max: 90) (default: "7")
+- `--days` — Deprecated alias of --limit
 
 ### `harness usage latest`
 

--- a/packages/cli/src/commands/usage.ts
+++ b/packages/cli/src/commands/usage.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import type { UsageRecord } from '@harness-engineering/types';
 import { logger } from '../output/logger';
 
@@ -134,10 +134,24 @@ function registerDailyCommand(usage: Command): void {
   usage
     .command('daily')
     .description('Show per-day token usage and cost')
-    .option('--days <n>', 'Number of days to show (default: 7, max: 90)', '7')
+    // Canonical flag — spelled the same as `sessions --limit` so the surface is guessable.
+    .option('--limit <n>', 'Number of days to show (default: 7, max: 90)', '7')
+    // Hidden, deprecated alias of `--limit`. Kept working for backward compatibility
+    // (`usage` is a published contract); hidden from --help and emits a stderr notice.
+    .addOption(new Option('--days <n>', 'Deprecated alias of --limit').hideHelp())
     .action(async (opts, cmd) => {
       const globalOpts = cmd.optsWithGlobals();
-      const days = Math.min(Math.max(parseInt(opts.days, 10) || 7, 1), 90);
+      // `--days` is a deprecated alias for `--limit`; both select the first N day rows.
+      // `--limit` wins when explicitly provided, otherwise fall back to `--days`, then default.
+      const daysProvided = opts.days !== undefined;
+      if (daysProvided) {
+        console.error(
+          'warning: `usage daily --days <n>` is deprecated; use `--limit <n>` instead.'
+        );
+      }
+      const limitExplicit = cmd.getOptionValueSource('limit') === 'cli';
+      const rawLimit = limitExplicit ? opts.limit : daysProvided ? opts.days : opts.limit;
+      const days = Math.min(Math.max(parseInt(rawLimit, 10) || 7, 1), 90);
       const cwd = process.cwd();
 
       const { records, pricingData } = await loadAndPriceRecords(

--- a/packages/cli/tests/commands/usage.test.ts
+++ b/packages/cli/tests/commands/usage.test.ts
@@ -384,6 +384,88 @@ describe('harness usage', () => {
     });
   });
 
+  describe('daily flag grammar (--limit canonical, --days deprecated alias)', () => {
+    it('daily --limit <n> and daily --days <n> produce the same result', async () => {
+      const programLimit = createProgram();
+      await programLimit.parseAsync([
+        'node',
+        'harness',
+        'usage',
+        'daily',
+        '--limit',
+        '1',
+        '--json',
+      ]);
+      const limitJson = logOutput.find((line) => line.trimStart().startsWith('['));
+      const limitOutput = JSON.parse(limitJson ?? logOutput.join(''));
+
+      logOutput = [];
+
+      const programDays = createProgram();
+      await programDays.parseAsync(['node', 'harness', 'usage', 'daily', '--days', '1', '--json']);
+      const daysJson = logOutput.find((line) => line.trimStart().startsWith('['));
+      const daysOutput = JSON.parse(daysJson ?? logOutput.join(''));
+
+      expect(daysOutput).toEqual(limitOutput);
+      expect(daysOutput).toHaveLength(1);
+    });
+
+    it('daily accepts --limit (canonical) to limit rows', async () => {
+      const program = createProgram();
+      await program.parseAsync(['node', 'harness', 'usage', 'daily', '--limit', '1', '--json']);
+
+      const jsonLine = logOutput.find((line) => line.trimStart().startsWith('['));
+      const output = JSON.parse(jsonLine ?? logOutput.join(''));
+      expect(output).toHaveLength(1);
+    });
+
+    it('daily --days still works as a deprecated alias', async () => {
+      const program = createProgram();
+      await program.parseAsync(['node', 'harness', 'usage', 'daily', '--days', '2', '--json']);
+
+      const jsonLine = logOutput.find((line) => line.trimStart().startsWith('['));
+      const output = JSON.parse(jsonLine ?? logOutput.join(''));
+      expect(output).toHaveLength(2);
+    });
+
+    it('daily --days prints a deprecation notice to stderr pointing at --limit', async () => {
+      const errOutput: string[] = [];
+      const errSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation((...args) => errOutput.push(args.join(' ')));
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'harness', 'usage', 'daily', '--days', '1', '--json']);
+
+      const allErr = errOutput.join('\n');
+      expect(allErr).toContain('deprecated');
+      expect(allErr).toContain('--limit');
+      errSpy.mockRestore();
+    });
+
+    it('daily --limit does not print a deprecation notice', async () => {
+      const errOutput: string[] = [];
+      const errSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation((...args) => errOutput.push(args.join(' ')));
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'harness', 'usage', 'daily', '--limit', '1', '--json']);
+
+      expect(errOutput.join('\n')).not.toContain('deprecated');
+      errSpy.mockRestore();
+    });
+
+    it('--days is hidden from daily --help while --limit is documented', () => {
+      const usageCmd = createUsageCommand();
+      const daily = usageCmd.commands.find((c) => c.name() === 'daily');
+      expect(daily).toBeDefined();
+      const help = daily!.helpInformation();
+      expect(help).toContain('--limit');
+      expect(help).not.toContain('--days');
+    });
+  });
+
   describe('sessions (text output)', () => {
     it('renders a table with header and rows', async () => {
       const loggerOutput: string[] = [];


### PR DESCRIPTION
## What & why

`craft-fleet` (CLI-R001) flagged that the `usage` leaf command spells the "how many rows to show" concept two ways: `--days <n>` on `daily` but `--limit <n>` on `sessions`, so the flag can't be guessed from one subcommand to the next.

`usage` is a **published CLI contract**, so this is the **non-breaking** fix only:

- `--limit <n>` is now the **canonical** flag on `usage daily` (matching `usage sessions --limit`).
- `--days <n>` is kept as a **hidden, deprecated alias** — it still functions identically (maps to the same underlying value), is hidden from `--help`, and prints a one-line deprecation notice to **stderr** pointing at `--limit` when used.
- No subcommand is renamed.

### Semantic equivalence (checked before unifying)

`daily` computes `aggregateByDay(records).slice(0, days)` — `--days <n>` selects the first N **day rows**; it does **not** filter by calendar window/date. `sessions` computes `aggregateBySession(records).slice(0, limit)`. Both are `.slice(0, n)` over aggregated rows: the identical "how many rows" concept (in `daily`, one row = one day). Unifying the flag name conflates nothing.

## Tests

`packages/cli/tests/commands/usage.test.ts` (47 pass) proves:
- `daily --limit 7` and `daily --days 7` produce the same result
- `daily --days <n>` still limits rows (alias works)
- `daily --days` prints the deprecation notice to stderr; `daily --limit` does not
- `--days` is absent from `daily --help`, `--limit` is present

Verified end-to-end against the built binary: `usage daily --help` shows only `--limit`; `usage daily --days 1` emits the stderr deprecation notice.

## Assumptions made

- **Non-breaking decision (human-confirmed):** `--limit` canonical, `--days` hidden deprecated alias (still works), no subcommand renames.
- `--limit` wins over `--days` when both are explicitly supplied; otherwise the canonical `--limit` default (7) applies.
- The deprecation notice is written to stderr (`console.error`, no chalk error icon) so it never corrupts `--json` stdout.
- **Subcommand-grammar inconsistency deliberately deferred:** the `daily`/`latest` (adjectives) vs `sessions`/`session` (nouns) mismatch is a breaking change and is explicitly out of scope for this non-breaking pass. Left as a follow-up.

## Artifacts

- Plan: `docs/changes/usage-flag-grammar-unify/plans/plan.md`
- Provenance: `docs/changes/usage-flag-grammar-unify/provenance.json`
- Changeset: `.changeset/usage-flag-grammar-unify.md`
- Reference docs regenerated: `docs/reference/cli-commands.md`

Closes #1455
