### PR TITLE
fix(entropy): flag exported-but-unused public API in dead-export detector (#1479)

### DIFF
--- a/.changeset/dead-export-public-api-blind-spot.md
+++ b/.changeset/dead-export-public-api-blind-spot.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/core': patch
+---
+
+entropy dead-export detector: close the blind spot for exported-but-unused public API (#1479). Usage attribution now follows re-export chains, so a symbol re-exported through the package barrel with zero real (non-test) workspace callers is surfaced as a distinct advisory finding class `PUBLIC_API_UNUSED` (recommendation: wire or deprecate, never delete) instead of hiding behind the barrel forwarding. Opt out with a `@public` / `@publicApi` annotation on the export or a `deadCode.publicApiAllowlist` entry. Preserves the #1409 test-import behavior; auto-fixers still act only on `NO_IMPORTERS`. The TypeScript parser now captures comments so JSDoc-based annotations are available to the detector.

--- a/docs/changes/1479-dead-export-public-api-blind-spot/plans/plan.md
+++ b/docs/changes/1479-dead-export-public-api-blind-spot/plans/plan.md
@@ -1,0 +1,85 @@
+# Plan — Dead-export detector blind spot for exported-but-unused public API (#1479)
+
+Trace of the brainstorming -> autopilot (plan -> execute -> verify -> review) run for GitHub issue #1479,
+executed autonomously in a roadmap-fleet build lane.
+
+## Problem (brainstorming)
+
+The dead-export detector does not flag a symbol exported from a package's public surface
+(barrel / `.d.ts`) that has **zero non-test callers**, because usage attribution credits the
+barrel re-export rather than following it to the defining symbol. The most consequential dead
+code — logic in a package's advertised surface — is precisely what the detector misses, silently.
+
+### Grounding (verified, not trusted)
+
+- Detector lives in `packages/core/src/entropy/detectors/dead-code.ts` (snapshot path,
+  AST-accurate) and the graph path in `packages/graph/src/entropy/GraphEntropyAdapter.ts`
+  (coarse, file-level, regex-ingested). Production `detect_entropy` uses the graph path
+  (`packages/cli/src/mcp/tools/entropy.ts` builds `graphDeadCodeData`).
+- Empirically probed (scratch harness): in the snapshot path a barrel re-export is **not**
+  counted as an importer, so usage attribution never follows `export { X } from './origin'`
+  to `origin:X`. A consumer importing `X` **via the barrel** credits the barrel's re-export
+  entry (`barrel:X`), never `origin:X` — so a genuinely-used public export can look unused and,
+  conversely, all barrel-only exports collapse into `NO_IMPORTERS` ("delete me"), which is wrong
+  for public API (removal is a breaking change).
+- `3af288089` / PR #1409 made the detector count **test-file** import edges to kill 266 false
+  positives. This change is the opposite gap (a false negative) and preserves #1409: an export
+  imported by any test stays live; `PUBLIC_API_UNUSED` requires zero importers of any kind after
+  re-export following.
+- `contextBudget()` (the issue's evidence case) was already wired by #1274; the **detector gap**
+  it exposed is what this fixes.
+
+## Assumption taken (recommended default for the core ambiguity)
+
+A public-API export legitimately has zero _internal_ callers by design, so not every barrel
+export may be flagged. Scope adopted:
+
+> Flag an export that is **re-exported through the package barrel / public surface** but has
+> **zero real (non-test) importers across the workspace after re-export following** as a distinct,
+> lower-severity, **advisory** finding class `PUBLIC_API_UNUSED` — recommendation is _wire or
+> deprecate_, not _remove_. Treat a barrel re-export as NOT-a-use; count real call/import sites in
+> non-test code, following re-export chains so a real consumer importing via the barrel keeps the
+> origin live. Provide an explicit opt-out (a `@public` / `@publicApi` annotation on the export, or
+> a `publicApiAllowlist` in the dead-code config) so intentionally-public-for-adopters API is exempt.
+
+Conservative sub-decisions (documented limitations, advisory v1):
+
+- A test-only-imported public export is treated as **live** (preserves #1409 exactly); it is not
+  flagged even though it has zero non-test callers.
+- Renamed (`export { a as b } from './x'`) and star (`export * from './x'`) re-exports are not
+  followed to the origin symbol (parser drops the local name / names nothing); such symbols are
+  simply not classified as public surface. No false positives result.
+
+## Design
+
+1. **Re-export-aware usage attribution** (`buildExportUsageMap` / `recordImportEdge`): when an
+   import resolves to a file whose matching export is itself a re-export, follow the chain
+   (cycle-guarded) to the defining file and credit the **origin** export as used.
+2. **Public-surface set** (`buildPublicSurface`): every `(definingFile, name)` reachable by
+   following a barrel `isReExport` export is "public API".
+3. **New advisory class** `PUBLIC_API_UNUSED` on `DeadExport.reason`: a public-surface export with
+   zero real importers and not test-imported, and not opted-out. Non-public dead exports remain
+   `NO_IMPORTERS`.
+4. **Opt-out**: `@public`/`@publicApi` JSDoc annotation adjacent to the export, or
+   `DeadCodeConfig.publicApiAllowlist` (matches `file:name`, bare `name`, or a file-path substring).
+5. **Production reach**: `detectDeadCode` merges snapshot-derived `PUBLIC_API_UNUSED` findings into
+   the graph-path report too (guarded for empty snapshots), so `detect_entropy` surfaces them.
+6. **Safe by default**: auto-fixers (`safe-fixes.ts`) only act on `NO_IMPORTERS`; the suggestion for
+   `PUBLIC_API_UNUSED` is "wire or deprecate", never delete.
+
+## Tasks (execution — TDD)
+
+- [x] Add `PUBLIC_API_UNUSED` to `DeadExport.reason` (`types/dead-code.ts`).
+- [x] Add `publicApiAllowlist?: string[]` to `DeadCodeConfig` (`types/config.ts`).
+- [x] Re-export following + public-surface + classification + opt-out (`detectors/dead-code.ts`).
+- [x] Graph-path merge in `detectDeadCode`.
+- [x] "Wire or deprecate" advisory suggestion for the new class (`fixers/suggestions.ts`).
+- [x] Fixture `dead-code-public-api/` + focused behavior test proving: uninvoked barrel export is
+      flagged `PUBLIC_API_UNUSED`; a consumer importing it via the barrel clears the flag
+      (re-export following); `@public` opt-out suppresses it; non-public dead export stays
+      `NO_IMPORTERS`; #1409 test-import behavior unchanged.
+
+## Verify / Review
+
+- Focused test green; full `entropy` detector + fixer suites green; typecheck + build green.
+- No auto-delete path for the advisory class; #1409 regression test still passes.

--- a/docs/changes/1479-dead-export-public-api-blind-spot/provenance.json
+++ b/docs/changes/1479-dead-export-public-api-blind-spot/provenance.json
@@ -1,0 +1,14 @@
+{
+  "issues": [1479],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/1479-dead-export-public-api-blind-spot/plans/plan.md",
+  "assumptions": [
+    "Adopted the recommended default: flag an export that is re-exported through the package barrel / public surface but has zero real (non-test) importers across the workspace after re-export following, as a distinct advisory finding class PUBLIC_API_UNUSED (wire-or-deprecate, never delete). Barrel re-export is treated as NOT-a-use; usage attribution follows re-export chains so a real consumer importing via the barrel keeps the origin export live.",
+    "Provided two explicit opt-outs: a @public / @publicApi JSDoc annotation on the export, and a DeadCodeConfig.publicApiAllowlist (matches export name, <file>:<name>, or a file-path substring).",
+    "Preserved PR #1409 (test-import counting) exactly: an export imported by any test stays live and is never flagged PUBLIC_API_UNUSED (conservative: a test-only-imported public export is not flagged even though it has zero non-test callers).",
+    "Enabled comment capture (comment: true) in the shared TypeScript parser so the snapshot's previously-dead extractJSDocComments actually populates, which the @public opt-out consumes; full core suite (4410 tests) stayed green.",
+    "Surfaced the finding on the production graph path too: detectDeadCode merges snapshot-derived PUBLIC_API_UNUSED findings into the coarse, file-level graph report (guarded for empty snapshots), since the graph path cannot attribute per-symbol public-API usage.",
+    "Limitations documented for advisory v1: renamed (export { a as b }) and star (export *) re-exports are not followed to the origin symbol and are simply not treated as public surface, yielding no false positives; auto-fixers remain restricted to NO_IMPORTERS so the advisory class is never auto-deleted."
+  ],
+  "closingKeyword": "Closes #1479"
+}

--- a/packages/core/src/entropy/detectors/dead-code.ts
+++ b/packages/core/src/entropy/detectors/dead-code.ts
@@ -199,6 +199,45 @@ export function buildReachabilityMap(snapshot: CodebaseSnapshot): Map<string, bo
   return reachability;
 }
 
+/**
+ * Follow a re-export chain to the defining export.
+ *
+ * A barrel `export { X } from './origin'` records an `Export` with `isReExport:
+ * true` and `source: './origin'` but no import edge, so usage attribution that
+ * stops at the barrel credits `barrel:X` instead of the symbol that actually
+ * defines `X`. Following the chain (cycle-guarded) lets a consumer importing `X`
+ * through the barrel keep the origin export live, and lets the detector treat the
+ * barrel re-export itself as NOT-a-use (issue #1479).
+ *
+ * Renamed re-exports (`export { a as b } from './x'`) lose the local name during
+ * parsing, so the chain stops when the same name is absent in the target — no
+ * over-crediting, just a conservative miss.
+ */
+function resolveReExportTarget(
+  snapshot: CodebaseSnapshot,
+  fileIndex: Map<string, CodebaseSnapshot['files'][number]>,
+  file: string,
+  exportName: string,
+  seen: Set<string>
+): { file: string; name: string } {
+  const key = `${file}:${exportName}`;
+  if (seen.has(key)) return { file, name: exportName };
+  seen.add(key);
+
+  const sourceFile = fileIndex.get(file);
+  if (!sourceFile) return { file, name: exportName };
+
+  const exp = sourceFile.exports.find(
+    (e) => e.name === exportName || (exportName === 'default' && e.type === 'default')
+  );
+  if (!exp || !exp.isReExport || !exp.source) return { file, name: exportName };
+
+  const target = resolveImportToFile(exp.source, file, snapshot, fileIndex);
+  if (!target) return { file, name: exportName };
+
+  return resolveReExportTarget(snapshot, fileIndex, target, exp.name, seen);
+}
+
 /** Usage record for one export: its source importers, whether it is re-exported, and whether any test imports it. */
 type ExportUsage = { importers: string[]; isReExported: boolean; importedByTest: boolean };
 
@@ -237,7 +276,16 @@ function recordImportEdge(
     );
     if (!matchingExport) continue;
 
-    const usage = usageMap.get(`${resolvedFile}:${matchingExport.name}`);
+    // Follow re-export chains so an import through a barrel credits the symbol
+    // that actually defines the export, not the barrel's forwarding entry.
+    const target = resolveReExportTarget(
+      snapshot,
+      fileIndex,
+      resolvedFile,
+      matchingExport.name,
+      new Set()
+    );
+    const usage = usageMap.get(`${target.file}:${target.name}`);
     if (usage) markExportUsage(usage, fromFile, fromTest);
   }
 }
@@ -291,6 +339,78 @@ function buildExportUsageMap(snapshot: CodebaseSnapshot): Map<string, ExportUsag
 }
 
 /**
+ * Build the set of `<file>:<name>` keys that form the package's public surface:
+ * every export reachable by following a barrel `isReExport` entry to the symbol
+ * that defines it. A public-surface export legitimately has zero internal callers
+ * by design, so it is classified `PUBLIC_API_UNUSED` (advisory) rather than
+ * `NO_IMPORTERS` (deletable) when uninvoked (issue #1479).
+ */
+function buildPublicSurface(snapshot: CodebaseSnapshot): Set<string> {
+  const fileIndex = buildFileIndex(snapshot);
+  const surface = new Set<string>();
+
+  for (const file of snapshot.files) {
+    for (const exp of file.exports) {
+      if (!exp.isReExport || !exp.source) continue;
+      const target = resolveReExportTarget(snapshot, fileIndex, file.path, exp.name, new Set());
+      // A re-export that resolves back to itself (unresolved / renamed / cyclic)
+      // names no defining symbol and is not treated as public surface.
+      if (target.file === file.path) continue;
+      surface.add(`${target.file}:${target.name}`);
+    }
+  }
+
+  return surface;
+}
+
+/** Read the configured public-API allowlist from the (possibly boolean) dead-code config. */
+function publicApiAllowlist(snapshot: CodebaseSnapshot): string[] {
+  const deadCode = snapshot.config?.analyze?.deadCode;
+  if (deadCode && typeof deadCode === 'object' && Array.isArray(deadCode.publicApiAllowlist)) {
+    return deadCode.publicApiAllowlist;
+  }
+  return [];
+}
+
+const PUBLIC_ANNOTATION_RE = /@public(Api)?\b/i;
+
+/**
+ * True when an intentionally-public export is exempt from the `PUBLIC_API_UNUSED`
+ * finding: a `@public` / `@publicApi` annotation in the nearest preceding JSDoc
+ * block, or a match in the configured allowlist (`<name>`, `<file>:<name>`, or a
+ * file-path substring).
+ */
+function isPublicApiExempt(
+  file: CodebaseSnapshot['files'][number],
+  exp: CodebaseSnapshot['files'][number]['exports'][number],
+  allowlist: string[]
+): boolean {
+  const key = `${file.path}:${exp.name}`;
+  if (
+    allowlist.some(
+      (entry) =>
+        entry === exp.name || entry === key || (entry.length > 0 && file.path.includes(entry))
+    )
+  ) {
+    return true;
+  }
+
+  // Nearest JSDoc block that starts above the export declaration.
+  const exportLine = exp.location.line;
+  let nearest: { line: number; content: string } | undefined;
+  for (const doc of file.jsDocComments) {
+    if (doc.line < exportLine && (!nearest || doc.line > nearest.line)) {
+      nearest = doc;
+    }
+  }
+  if (nearest && exportLine - nearest.line <= 15 && PUBLIC_ANNOTATION_RE.test(nearest.content)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Find exports that are never imported anywhere.
  */
 function findDeadExports(
@@ -299,6 +419,8 @@ function findDeadExports(
   reachability: Map<string, boolean>
 ): DeadExport[] {
   const deadExports: DeadExport[] = [];
+  const publicSurface = buildPublicSurface(snapshot);
+  const allowlist = publicApiAllowlist(snapshot);
 
   for (const file of snapshot.files) {
     // Skip entry points - their exports are considered "used" by definition
@@ -313,11 +435,27 @@ function findDeadExports(
 
       // An export imported by any test file is live, not dead. Test files are
       // not classified source files, so a test-only importer keeps the export
-      // alive without ever appearing in `importers` / reachability.
+      // alive without ever appearing in `importers` / reachability. This also
+      // preserves the #1409 guarantee for public-surface exports: a test-only
+      // importer is never flagged PUBLIC_API_UNUSED.
       if (usage?.importedByTest) continue;
 
       if (!usage || usage.importers.length === 0) {
-        // This export has no importers
+        // No real importers. A public-surface export is exported-but-uninvoked
+        // public API (advisory, wire-or-deprecate) unless explicitly exempted;
+        // everything else is a deletable NO_IMPORTERS dead export.
+        if (publicSurface.has(key)) {
+          if (isPublicApiExempt(file, exp, allowlist)) continue;
+          deadExports.push({
+            file: file.path,
+            name: exp.name,
+            line: exp.location.line,
+            type: 'variable',
+            isDefault: exp.type === 'default',
+            reason: 'PUBLIC_API_UNUSED',
+          });
+          continue;
+        }
         deadExports.push({
           file: file.path,
           name: exp.name,
@@ -655,13 +793,52 @@ function filterProtectedFindings(
   };
 }
 
+/**
+ * Compute only the advisory `PUBLIC_API_UNUSED` findings from the AST-accurate
+ * snapshot (issue #1479). The production graph path is coarse (file-level,
+ * regex-ingested) and cannot attribute per-symbol public-API usage, so these
+ * findings are merged into the graph-derived report from the snapshot instead.
+ */
+function findUninvokedPublicExports(snapshot: CodebaseSnapshot): DeadExport[] {
+  const usageMap = buildExportUsageMap(snapshot);
+  const reachability = buildReachabilityMap(snapshot);
+  return findDeadExports(snapshot, usageMap, reachability).filter(
+    (e) => e.reason === 'PUBLIC_API_UNUSED'
+  );
+}
+
+/**
+ * Merge snapshot-derived `PUBLIC_API_UNUSED` findings into a graph-derived report
+ * (deduped by `<file>:<name>`) so `detect_entropy` surfaces exported-but-uninvoked
+ * public API even on the graph path. No-op when the snapshot has no source files.
+ */
+function mergeUninvokedPublicExports(
+  report: DeadCodeReport,
+  snapshot: CodebaseSnapshot
+): DeadCodeReport {
+  if (!snapshot.files || snapshot.files.length === 0) return report;
+
+  const existing = new Set(report.deadExports.map((e) => `${e.file}:${e.name}`));
+  const additions = findUninvokedPublicExports(snapshot).filter(
+    (e) => !existing.has(`${e.file}:${e.name}`)
+  );
+  if (additions.length === 0) return report;
+
+  const deadExports = [...report.deadExports, ...additions];
+  return {
+    ...report,
+    deadExports,
+    stats: { ...report.stats, deadExportCount: deadExports.length },
+  };
+}
+
 export async function detectDeadCode(
   snapshot: CodebaseSnapshot,
   graphDeadCodeData?: GraphDeadCodeData,
   protectedRegions?: ProtectedRegionMap
 ): Promise<Result<DeadCodeReport, EntropyError>> {
   let report = graphDeadCodeData
-    ? buildReportFromGraph(graphDeadCodeData)
+    ? mergeUninvokedPublicExports(buildReportFromGraph(graphDeadCodeData), snapshot)
     : buildReportFromSnapshot(snapshot);
 
   if (protectedRegions) {

--- a/packages/core/src/entropy/fixers/suggestions.ts
+++ b/packages/core/src/entropy/fixers/suggestions.ts
@@ -56,6 +56,25 @@ function deadFileSuggestion(file: DeadCodeReport['deadFiles'][number]): Suggesti
 
 /** Build a suggestion for a single dead export. */
 function deadExportSuggestion(exp: DeadCodeReport['deadExports'][number]): Suggestion {
+  // A public-surface export with no workspace callers is a breaking change to
+  // delete (adopters import it), so the advisory recommendation is wire or
+  // deprecate — never remove (issue #1479).
+  if (exp.reason === 'PUBLIC_API_UNUSED') {
+    return {
+      type: 'refactor',
+      priority: 'low',
+      source: 'dead-code',
+      relatedIssues: [`public-api-unused:${exp.file}:${exp.name}`],
+      title: `Uninvoked public API: ${exp.name}`,
+      description: `The public export "${exp.name}" is re-exported through the package barrel but has no non-test callers across the workspace. It may be dead public logic. Do NOT delete it blindly (a breaking change for adopters) — wire it into a real caller, deprecate it, or mark it intentional with a @public annotation.`,
+      files: [exp.file],
+      steps: [
+        `Confirm no adopter relies on "${exp.name}"`,
+        `Wire "${exp.name}" into a real caller, deprecate it, or annotate it @public`,
+      ],
+      whyManual: 'Public-surface export; removal is a breaking change for external consumers',
+    };
+  }
   return {
     type: 'refactor',
     priority: 'medium',

--- a/packages/core/src/entropy/types/config.ts
+++ b/packages/core/src/entropy/types/config.ts
@@ -29,6 +29,15 @@ export interface DeadCodeConfig {
   includeInternals: boolean;
   ignorePatterns: string[];
   treatDynamicImportsAs: 'used' | 'unknown';
+  /**
+   * Opt-out list for the advisory `PUBLIC_API_UNUSED` finding (issue #1479):
+   * intentionally-public-for-adopters exports that should not be flagged even
+   * with zero workspace callers. Each entry matches a finding when it equals the
+   * export name, equals `<file>:<name>`, or is a substring of the export's file
+   * path. Prefer a `@public` / `@publicApi` annotation on the export for
+   * co-located intent; use this list for coarse path-level exemptions.
+   */
+  publicApiAllowlist?: string[];
 }
 
 export interface EntropyConfig {

--- a/packages/core/src/entropy/types/dead-code.ts
+++ b/packages/core/src/entropy/types/dead-code.ts
@@ -6,7 +6,17 @@ export interface DeadExport {
   line: number;
   type: 'function' | 'class' | 'variable' | 'type' | 'interface' | 'enum';
   isDefault: boolean;
-  reason: 'NO_IMPORTERS' | 'IMPORTERS_ALSO_DEAD';
+  /**
+   * - `NO_IMPORTERS` — a non-public export nothing imports; safe to delete.
+   * - `IMPORTERS_ALSO_DEAD` — imported only by other dead/unreachable code.
+   * - `PUBLIC_API_UNUSED` — an export re-exported through the package barrel /
+   *   public surface with zero real (non-test) importers across the workspace
+   *   after re-export following (issue #1479). Advisory only: deletion is a
+   *   breaking change for adopters, so the recommendation is *wire or deprecate*,
+   *   never *remove*. Suppress an intentionally-public export with a
+   *   `@public` / `@publicApi` annotation or `DeadCodeConfig.publicApiAllowlist`.
+   */
+  reason: 'NO_IMPORTERS' | 'IMPORTERS_ALSO_DEAD' | 'PUBLIC_API_UNUSED';
 }
 
 export interface DeadFile {

--- a/packages/core/src/shared/parsers/typescript.ts
+++ b/packages/core/src/shared/parsers/typescript.ts
@@ -131,6 +131,10 @@ export class TypeScriptParser implements LanguageParser {
       const ast = parse(contentResult.value, {
         loc: true,
         range: true,
+        // Capture leading/standalone comments so downstream analysis (JSDoc
+        // extraction, the `@public` opt-out for issue #1479) can read them; the
+        // snapshot's extractJSDocComments consumes `program.comments`.
+        comment: true,
         jsx: path.endsWith('.tsx'),
         errorOnUnknownASTType: false,
       });

--- a/packages/core/tests/entropy/detectors/dead-code-public-api.test.ts
+++ b/packages/core/tests/entropy/detectors/dead-code-public-api.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { detectDeadCode } from '../../../src/entropy/detectors/dead-code';
+import { buildSnapshot } from '../../../src/entropy/snapshot';
+import { TypeScriptParser } from '../../../src/shared/parsers';
+import type { DeadCodeConfig } from '../../../src/entropy/types';
+import { join } from 'path';
+
+// Issue #1479: the dead-export detector had a blind spot for exported-but-unused
+// public API. A symbol re-exported through the package barrel with zero non-test
+// callers was not surfaced as a distinct finding — usage attribution credited the
+// barrel's forwarding re-export instead of following it to the defining symbol.
+//
+// The detector now (a) follows re-export chains when attributing usage, and
+// (b) classifies a public-surface export with no workspace callers as the
+// advisory `PUBLIC_API_UNUSED` class (wire-or-deprecate, never delete), with an
+// opt-out. It must NOT undo the #1409 test-import fix.
+describe('detectDeadCode public-API blind spot (issue #1479)', () => {
+  const parser = new TypeScriptParser();
+  const fixturesDir = join(__dirname, '../../fixtures/entropy/dead-code-public-api');
+
+  async function report(deadCode: boolean | Partial<DeadCodeConfig> = true) {
+    const snapshotResult = await buildSnapshot({
+      rootDir: fixturesDir,
+      parser,
+      analyze: { deadCode },
+      include: ['src/**/*.ts'],
+      // consumer.ts is a second entry point so its (reachable) import of
+      // usedPublic through the barrel keeps that export live.
+      entryPoints: ['src/index.ts', 'src/consumer.ts'],
+    });
+    expect(snapshotResult.ok).toBe(true);
+    if (!snapshotResult.ok) throw new Error('snapshot failed');
+
+    // The spec file is excluded from classified files but harvested as a
+    // test-import source (the #1409 machinery).
+    expect(snapshotResult.value.files.some((f) => f.path.includes('budget.spec.ts'))).toBe(false);
+    expect(snapshotResult.value.testImports?.some((t) => t.path.includes('budget.spec.ts'))).toBe(
+      true
+    );
+
+    const result = await detectDeadCode(snapshotResult.value);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('detect failed');
+    return result.value;
+  }
+
+  it('flags a barrel-re-exported, uninvoked export as PUBLIC_API_UNUSED (not NO_IMPORTERS)', async () => {
+    const value = await report();
+    const finding = value.deadExports.find((e) => e.name === 'deadPublic');
+    expect(finding, 'deadPublic must be surfaced').toBeDefined();
+    expect(finding!.reason).toBe('PUBLIC_API_UNUSED');
+  });
+
+  it('does NOT flag a public export used through the barrel by a reachable consumer', async () => {
+    const value = await report();
+    // Re-export following: `import { usedPublic } from './index'` credits the
+    // defining symbol, so it is live and never surfaced.
+    expect(value.deadExports.some((e) => e.name === 'usedPublic')).toBe(false);
+  });
+
+  it('classifies a non-public dead export as deletable NO_IMPORTERS', async () => {
+    const value = await report();
+    const finding = value.deadExports.find((e) => e.name === 'internalDead');
+    expect(finding, 'internalDead must be surfaced').toBeDefined();
+    expect(finding!.reason).toBe('NO_IMPORTERS');
+  });
+
+  it('exempts a @public-annotated export from the PUBLIC_API_UNUSED finding', async () => {
+    const value = await report();
+    expect(value.deadExports.some((e) => e.name === 'annotatedPublic')).toBe(false);
+  });
+
+  it('preserves the #1409 test-import fix: a test-only public export is live, not flagged', async () => {
+    const value = await report();
+    expect(value.deadExports.some((e) => e.name === 'testOnlyPublic')).toBe(false);
+  });
+
+  it('honors the publicApiAllowlist opt-out for an otherwise-flagged export', async () => {
+    const value = await report({ publicApiAllowlist: ['deadPublic'] });
+    expect(value.deadExports.some((e) => e.name === 'deadPublic')).toBe(false);
+    // The allowlist is surgical: the non-listed public dead export is unaffected.
+    const finding = value.deadExports.find((e) => e.name === 'internalDead');
+    expect(finding?.reason).toBe('NO_IMPORTERS');
+  });
+});

--- a/packages/core/tests/fixtures/entropy/dead-code-public-api/src/budget.spec.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-public-api/src/budget.spec.ts
@@ -1,0 +1,5 @@
+import { testOnlyPublic } from './index';
+
+it('covers testOnlyPublic', () => {
+  expect(testOnlyPublic()).toBe(5);
+});

--- a/packages/core/tests/fixtures/entropy/dead-code-public-api/src/budget.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-public-api/src/budget.ts
@@ -1,0 +1,28 @@
+// Defining module whose symbols are surfaced through the package barrel (index.ts).
+
+// Re-exported by the barrel, but nothing across the workspace calls it.
+// -> PUBLIC_API_UNUSED (advisory: wire or deprecate, not delete).
+export function deadPublic(): number {
+  return 1;
+}
+
+// Re-exported by the barrel AND imported (through the barrel) by a real,
+// reachable consumer -> live via re-export following.
+export function usedPublic(): number {
+  return 2;
+}
+
+/** @public Intentional adopter-facing API with no internal caller. */
+export function annotatedPublic(): number {
+  return 3;
+}
+
+// NOT re-exported by the barrel and never imported -> deletable NO_IMPORTERS.
+export function internalDead(): number {
+  return 4;
+}
+
+// Re-exported by the barrel but imported only by its spec -> live (#1409).
+export function testOnlyPublic(): number {
+  return 5;
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-public-api/src/consumer.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-public-api/src/consumer.ts
@@ -1,0 +1,5 @@
+import { usedPublic } from './index';
+
+export function useIt(): number {
+  return usedPublic();
+}

--- a/packages/core/tests/fixtures/entropy/dead-code-public-api/src/index.ts
+++ b/packages/core/tests/fixtures/entropy/dead-code-public-api/src/index.ts
@@ -1,0 +1,4 @@
+export { deadPublic } from './budget';
+export { usedPublic } from './budget';
+export { annotatedPublic } from './budget';
+export { testOnlyPublic } from './budget';


### PR DESCRIPTION
## Summary

Closes #1479.

The dead-export detector had a blind spot for **exported-but-unused public API**: a symbol re-exported through a package's barrel / public surface with **zero non-test callers** was never surfaced, because usage attribution credited the barrel's forwarding re-export instead of following it to the defining symbol. The most consequential dead code — logic in a package's advertised surface — was exactly what the detector missed, silently.

## What changed

- **Re-export-aware usage attribution** (`buildExportUsageMap` / `recordImportEdge`): usage now follows re-export chains (cycle-guarded), so a consumer importing `X` *through the barrel* credits the symbol that actually defines `X`, keeping it live.
- **New advisory finding class `PUBLIC_API_UNUSED`** (`DeadExport.reason`): a public-surface export (reachable by following a barrel `isReExport`) with zero real (non-test) workspace callers is flagged as advisory — recommendation is **wire or deprecate, never delete** (removal is a breaking change for adopters). Non-public dead exports remain `NO_IMPORTERS`.
- **Opt-out**: a `@public` / `@publicApi` JSDoc annotation on the export, or a `deadCode.publicApiAllowlist` entry (`name`, `<file>:<name>`, or a file-path substring).
- **Production reach**: `detectDeadCode` merges snapshot-derived `PUBLIC_API_UNUSED` findings into the coarse graph-path report used by `detect_entropy` (guarded for empty snapshots).
- **Safe by default**: auto-fixers still act only on `NO_IMPORTERS`; the suggestion for the new class is "wire or deprecate", never delete.
- The TypeScript parser now captures comments (`comment: true`), making the snapshot's previously-dead `extractJSDocComments` actually populate so the `@public` opt-out works.

## Does NOT undo #1409

The test-import fix (PR #1409, counting test-file import edges) is preserved: an export imported by any test stays live and is never flagged `PUBLIC_API_UNUSED`. There is an explicit regression test for this.

## Assumptions / scope

Adopted the recommended default: flag barrel-surfaced exports with zero non-test workspace callers as an advisory class with an opt-out. Conservative v1 limitations (documented): test-only-imported public exports are treated as live; renamed (`export { a as b }`) and star (`export *`) re-exports are not followed to the origin symbol and are simply not treated as public surface (no false positives). Full trace in `docs/changes/1479-dead-export-public-api-blind-spot/` (plan + provenance).

## Tests

New focused suite `dead-code-public-api.test.ts` proves: an uninvoked barrel export is flagged `PUBLIC_API_UNUSED`; a consumer importing it via the barrel clears the flag (re-export following); `@public` and `publicApiAllowlist` opt-outs suppress it; a non-public dead export stays `NO_IMPORTERS`; and the #1409 test-only-import case stays live. Full `@harness-engineering/core` suite green (4410 passed), typecheck + build green.
