### PR TITLE
build(hooks): dogfood roadmap install-hook managed block in pre-commit (#1079)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -134,24 +134,27 @@ if git diff --cached --name-only | grep -qE '^(agents/skills/|scripts/(generate-
   fi
 fi
 
-# Regenerate the roadmap aggregate when any shard is staged, so docs/roadmap.md
-# (merge=ours) never drifts from docs/roadmap.d/. No-op when no shard is staged
-# (e.g. before this repo is sharded). Output is deterministic + prettier-clean
-# (writeRegeneratedRoadmap), so it never trips the pre-push format:check.
-# This is intentionally a GIT hook, not an agent hook (profiles.ts/STANDARD_HOOKS
-# register Claude Code tool-use hooks, which cannot fire on git commit/merge).
+# Regenerate docs/roadmap.md from the docs/roadmap.d/ shards. This repo dogfoods
+# its own adopter-facing installer: the block below is written verbatim by
+# `harness roadmap install-hook --command 'node packages/cli/dist/bin/harness.js
+# roadmap regen'` (issue #1079), so harness's own hook and the adopter path share
+# ONE source of truth (buildRegenBlock) and cannot drift. Do not hand-edit inside
+# the managed markers — re-run the installer to update it. The `--command`
+# override points at the LOCAL workspace build (not the `npx harness` default,
+# which would pull the regen logic from npm — wrong for this repo).
+# It is intentionally a GIT hook, not a Claude Code agent hook (profiles.ts /
+# STANDARD_HOOKS register tool-use hooks, which cannot fire on git commit/merge).
+
+# >>> harness roadmap regen (managed by `harness roadmap install-hook`) >>>
+# Regenerate docs/roadmap.md from the docs/roadmap.d/ shards when a shard is
+# staged, so the committed aggregate never drifts. Safe no-op when no shard is
+# staged. Managed by `harness roadmap install-hook` — edits inside this block
+# are overwritten on the next run.
 if git diff --cached --name-only | grep -qE '^docs/roadmap\.d/'; then
-  # Caveat: `roadmap regen` reads the WORKING TREE, not the staged index — with a
-  # partial stage (some hunks of a shard staged, the rest left unstaged) the
-  # regenerated aggregate reflects the working-tree shards, which may differ from
-  # what is committed. Stage shard files whole to keep the aggregate exact.
-  # Fail-safe: do NOT swallow a regen error. `harness roadmap regen` returns
-  # nonzero and leaves docs/roadmap.md untouched on failure, so re-staging it
-  # would commit a STALE aggregate and defeat the drift-prevention guarantee.
-  # Only re-stage on success; on failure, block the commit (exit 1).
   if ! node packages/cli/dist/bin/harness.js roadmap regen; then
-    echo "✗ Commit blocked: 'harness roadmap regen' failed; refusing to commit a stale docs/roadmap.md" >&2
+    echo "Commit blocked: 'node packages/cli/dist/bin/harness.js roadmap regen' failed; refusing to commit a stale docs/roadmap.md" >&2
     exit 1
   fi
   git add docs/roadmap.md
 fi
+# <<< harness roadmap regen (managed by `harness roadmap install-hook`) <<<

--- a/docs/changes/dogfood-roadmap-install-hook/plans/plan.md
+++ b/docs/changes/dogfood-roadmap-install-hook/plans/plan.md
@@ -1,0 +1,60 @@
+# Plan — Dogfood `harness roadmap install-hook` in this repo's own pre-commit (#1079)
+
+Follow-up to #688 / PR #1078. This repo's `.husky/pre-commit` regenerated
+`docs/roadmap.md` from shards via a hand-maintained **bespoke** step. PR #1078
+shipped the adopter-facing installer `harness roadmap install-hook`, which writes
+an equivalent **managed fenced block** from a single source of truth
+(`buildRegenBlock`). Two implementations of the same logic drift, and the adopter
+path was never exercised by harness's own hook.
+
+## Goal
+
+Replace the bespoke regen step with the installer's managed block so harness's own
+hook **is** the installer's output — one source of truth, adopter path dogfooded.
+
+## Brainstorming outcome (approach selection)
+
+- **Rejected:** hand-copy `buildRegenBlock`'s text into the hook. Still two
+  literals that drift; defeats the purpose.
+- **Rejected:** change the installer default to the local bin. The `npx harness`
+  default is correct for _adopters_; only _this_ repo needs the local build.
+- **Chosen:** run the real installer with `--command` overriding the npm default
+  to the local workspace build, and add a test that pins the hook to
+  `buildRegenBlock(localCommand)` so future drift fails CI.
+
+## Tasks
+
+1. Remove the bespoke roadmap-regen block from `.husky/pre-commit`; leave a short
+   comment explaining the dogfooding and the `--command` override rationale. Keep
+   every other hook step (arch gate, lint-staged, plugin-artifact regen,
+   block-no-verify, node-pin) untouched.
+2. Run:
+   `harness roadmap install-hook --command 'node packages/cli/dist/bin/harness.js roadmap regen'`
+   — writes the managed fenced block at the end of `.husky/pre-commit`. The
+   `--command` override is **critical**: the default `npx harness roadmap regen`
+   pulls the regen logic from npm, which is wrong for this repo; it must run the
+   local workspace build.
+3. Add `packages/cli/tests/hooks/pre-commit-dogfood-managed-block.test.ts`: assert
+   the committed hook contains exactly one managed block, its body equals
+   `buildRegenBlock('node packages/cli/dist/bin/harness.js roadmap regen')`, the
+   command is the local bin (never the `npx` default), and no leftover bespoke
+   step remains.
+
+## Verification
+
+- New drift-guard test passes.
+- Existing `roadmap-regen-hook.e2e.test.ts` still passes — it extracts the regen
+  block verbatim from `.husky/pre-commit` (slicing from the `^docs/roadmap\.d/`
+  guard line to EOF) and runs it through a real `git commit`; the managed block
+  keeps that guard line and stays the last block, so the extraction is unchanged
+  and the fail-safe (block-the-commit-on-regen-failure) behavior is preserved.
+- `harness roadmap regen` is deterministic + prettier-clean → `docs/roadmap.md`
+  stays undirtied, so the changed hook passes on its own commit.
+- Full pre-commit hook runs green end-to-end on this change's commit.
+
+## Assumptions
+
+- Used the local-bin `--command`, not the `npx` npm default.
+- Sequenced #1079 before #1235 (which also rewrites this regen step). #1235 is not
+  in this batch and has no open PR, so there is no in-flight conflict; whoever
+  builds #1235 rebases onto this managed block. Tracked by #1268.

--- a/docs/changes/dogfood-roadmap-install-hook/provenance.json
+++ b/docs/changes/dogfood-roadmap-install-hook/provenance.json
@@ -1,0 +1,10 @@
+{
+  "issues": [1079],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/dogfood-roadmap-install-hook/plans/plan.md",
+  "assumptions": [
+    "used local-bin --command not npx default",
+    "sequenced #1079 before #1235 per default"
+  ],
+  "closingKeyword": "Closes #1079"
+}

--- a/packages/cli/tests/hooks/pre-commit-dogfood-managed-block.test.ts
+++ b/packages/cli/tests/hooks/pre-commit-dogfood-managed-block.test.ts
@@ -1,0 +1,70 @@
+// packages/cli/tests/hooks/pre-commit-dogfood-managed-block.test.ts
+//
+// Dogfooding invariant (#1079): this repo's own `.husky/pre-commit` roadmap-regen
+// step MUST be the verbatim output of the adopter-facing installer
+// (`harness roadmap install-hook`), so the two implementations of the same logic
+// share ONE source of truth (buildRegenBlock) and can never drift.
+//
+// Before #1079 the hook carried a hand-maintained bespoke regen block that a
+// change to buildRegenBlock would silently diverge from. This test fails if:
+//   - the managed markers are missing (someone reverted to a bespoke block),
+//   - the block body no longer matches buildRegenBlock for the local-bin command,
+//   - the command regressed to the `npx harness` npm default (wrong for this repo),
+//   - a duplicate/leftover regen step was reintroduced.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  HOOK_BLOCK_BEGIN,
+  HOOK_BLOCK_END,
+  DEFAULT_REGEN_COMMAND,
+  buildRegenBlock,
+} from '../../src/commands/roadmap/install-hook';
+
+/** The regen command this repo dogfoods: the LOCAL workspace build, not npm. */
+const LOCAL_REGEN_COMMAND = 'node packages/cli/dist/bin/harness.js roadmap regen';
+
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error('Could not locate monorepo root (pnpm-workspace.yaml not found)');
+    }
+    dir = parent;
+  }
+}
+
+describe('.husky/pre-commit dogfoods the roadmap install-hook managed block (#1079)', () => {
+  const repoRoot = findRepoRoot(path.dirname(fileURLToPath(import.meta.url)));
+  const hookPath = path.join(repoRoot, '.husky', 'pre-commit');
+  const hook = fs.readFileSync(hookPath, 'utf-8');
+
+  it('contains exactly one managed block delimited by the installer markers', () => {
+    const begins = hook.split(HOOK_BLOCK_BEGIN).length - 1;
+    const ends = hook.split(HOOK_BLOCK_END).length - 1;
+    expect(begins).toBe(1);
+    expect(ends).toBe(1);
+  });
+
+  it('embeds the verbatim buildRegenBlock output for the local-bin command', () => {
+    // The exact string the installer would write is the contract: any drift in
+    // buildRegenBlock must be reflected here (re-run the installer), or fail.
+    expect(hook).toContain(buildRegenBlock(LOCAL_REGEN_COMMAND));
+  });
+
+  it('runs the local workspace build, never the npm `npx harness` default', () => {
+    expect(hook).toContain(LOCAL_REGEN_COMMAND);
+    // Guard against a regression to the adopter default, which would pull the
+    // regen logic from npm instead of this repo's built CLI.
+    expect(hook).not.toContain(`if ! ${DEFAULT_REGEN_COMMAND};`);
+  });
+
+  it('leaves no leftover bespoke regen step (single git add of the aggregate)', () => {
+    const addAggregate = hook.split('git add docs/roadmap.md').length - 1;
+    expect(addAggregate).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

This repo's `.husky/pre-commit` regenerated `docs/roadmap.md` from shards via a **hand-maintained bespoke step**. PR #1078 (issue #688) shipped the adopter-facing installer `harness roadmap install-hook`, which writes an equivalent **managed fenced block** from one source of truth (`buildRegenBlock`). Two implementations of the same logic drift, and the adopter path was never exercised by harness's own hook.

This change replaces the bespoke step with the installer's managed block, written verbatim by:

```
harness roadmap install-hook --command 'node packages/cli/dist/bin/harness.js roadmap regen'
```

The `--command` override is **critical**: the installer default `npx harness roadmap regen` pulls the regen logic from **npm** (wrong for this repo) — the override points at the **local workspace build**. Now harness's own hook *is* the installer's output: one source of truth, adopter path dogfooded.

## Changes

- `.husky/pre-commit`: bespoke regen block replaced by the installer's managed fenced block (markers + local-bin command). Every other hook step (arch gate, lint-staged, plugin-artifact regen, node-pin, unbuilt-CLI gate) left intact.
- `packages/cli/tests/hooks/pre-commit-dogfood-managed-block.test.ts`: new drift-guard test pinning the committed hook to `buildRegenBlock('node packages/cli/dist/bin/harness.js roadmap regen')` — fails if the hook reverts to a bespoke block, drifts from `buildRegenBlock`, regresses to the `npx` default, or leaves a duplicate step.
- `docs/changes/dogfood-roadmap-install-hook/`: plan + provenance.

## Verification

- New drift-guard test + existing `roadmap-regen-hook.e2e.test.ts` pass (the e2e extracts the regen block verbatim from `.husky/pre-commit` and runs it through a real `git commit`; the managed block preserves the `^docs/roadmap\.d/` guard line and stays the last block, so extraction is unchanged and fail-safe behavior preserved). Full `tests/hooks/` suite green (238 tests).
- `harness roadmap regen` is deterministic + prettier-clean, so the hook passes on its own commit — this PR's commit went through the real pre-commit gates.

## Assumptions

- Used the local-bin `--command`, not the `npx` npm default.
- Sequenced #1079 before #1235 (which also rewrites this regen step). #1235 is not in this batch and has no open PR, so there is no in-flight conflict; whoever builds #1235 rebases onto this managed block. Tracked by #1268.

Closes #1079