### PR TITLE
fix(graph): unquote solution-doc frontmatter scalars before validating

### DIFF
--- a/.changeset/solutions-frontmatter-quoted-scalars.md
+++ b/.changeset/solutions-frontmatter-quoted-scalars.md
@@ -1,0 +1,32 @@
+---
+'@harness-engineering/graph': patch
+---
+
+Fix `ingestSolutions` rejecting every solution doc whose frontmatter uses quoted scalars.
+
+`parseSolutionFrontmatter` is a hand-rolled key/value parser and never stripped
+surrounding quotes, so `last_updated: '2026-05-06'` reached
+`SolutionDocFrontmatterSchema` as `'2026-05-06'` with its quotes attached, failed
+the `ISO_DATE` regex, and the document was skipped as malformed. Same for
+`module`, `problem_type` and quoted `tags` items.
+
+Quoted scalars are valid YAML and are the form the shipped
+`docs/solutions/assets/resolution-template.md` prescribes, so a project that
+followed the template had **none** of its post-mortems ingested. The two readers
+of the same corpus disagreed: `harness validate` parses with `gray-matter`, which
+unquotes, so a quoted date passed validation and then failed ingest. Measured on
+a real project, the corpus went from 1 of 7 files readable to 6 of 7 (the
+remaining one is the template itself, whose `<YYYY-MM-DD>` placeholder is
+deliberately not a date).
+
+The bug was invisible because every fixture in `tests/fixtures/solutions/`
+happened to use bare scalars, while `SolutionDocFrontmatterSchema`'s own unit
+test passes a plain object and so never exercises parsing at all. A
+`quoted-scalars.md` fixture (both quote styles) plus two regression tests now
+cover it, and `tests/fixtures/solutions/**` is prettier-ignored so the double
+quotes — the actual test input — survive formatting.
+
+Not switched to `gray-matter`: a real YAML parser resolves a bare `2026-05-06`
+to a `Date`, which `z.string()` rejects, so that would fix the quoted form by
+breaking the bare one every existing doc uses. Unquoting is additive — both
+forms now parse.

--- a/.prettierignore
+++ b/.prettierignore
@@ -57,3 +57,10 @@ packages/core/tests/fixtures/code-nav/syntax-error.ts
 
 # Local orchestrator state backups (disposable)
 **/.harness/state-backup-*/
+
+# Solution-doc parser fixtures: the frontmatter IS the test input. Prettier
+# normalises double-quoted YAML scalars to single quotes, which silently deletes
+# the double-quote coverage in BusinessKnowledgeIngestor.solutions.test.ts — and
+# would be free to rewrite crlf-pattern.md's line endings, the whole point of
+# that fixture. Same reasoning as agents/commands/** above.
+packages/graph/tests/fixtures/solutions/**

--- a/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
+++ b/packages/graph/src/ingest/BusinessKnowledgeIngestor.ts
@@ -516,6 +516,35 @@ function parseStrategyMarkdown(raw: string): {
   return { frontmatter, sections };
 }
 
+/**
+ * Strip one layer of matching surrounding quotes from a YAML scalar.
+ *
+ * Required because this is a hand-rolled parser rather than a YAML one, and a
+ * quoted scalar is not just valid YAML — it is the form
+ * `docs/solutions/assets/resolution-template.md` prescribes. Without this,
+ * `last_updated: '2026-05-06'` reaches the schema as `'2026-05-06'` WITH its
+ * quotes, fails the `ISO_DATE` regex, and the whole document is rejected as
+ * malformed.
+ *
+ * That made the two readers of the same corpus disagree: `validate`
+ * (`packages/core/src/validation/solutions.ts`) parses with `gray-matter`, which
+ * unquotes, so a quoted date passed there and failed here. Every fixture in
+ * `tests/fixtures/solutions/` happened to use bare scalars, so nothing caught it.
+ *
+ * Deliberately NOT switching this to `gray-matter`: a real YAML parser resolves
+ * a bare `2026-05-06` to a `Date`, which `z.string()` then rejects — so it would
+ * fix the quoted form by breaking the bare one that every existing doc and
+ * fixture uses. Unquoting here is additive: both forms parse.
+ */
+function unquoteScalar(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const first = trimmed[0]!;
+  const last = trimmed[trimmed.length - 1]!;
+  const quoted = (first === "'" && last === "'") || (first === '"' && last === '"');
+  return quoted ? trimmed.slice(1, -1) : trimmed;
+}
+
 function parseSolutionFrontmatter(
   raw: string
 ): { frontmatter: Record<string, unknown>; body: string } | null {
@@ -533,9 +562,12 @@ function parseSolutionFrontmatter(
       frontmatter[key] = value
         .slice(1, -1)
         .split(',')
-        .map((s) => s.trim());
+        // Items are unquoted too: `tags: ['a', 'b']` is as valid as `[a, b]`,
+        // and a tag of `'a'` does not match a query for `a`.
+        .map((s) => unquoteScalar(s))
+        .filter((s) => s !== '');
     } else {
-      frontmatter[key] = value;
+      frontmatter[key] = unquoteScalar(value);
     }
   }
   return { frontmatter, body };

--- a/packages/graph/tests/fixtures/solutions/knowledge-track/conventions/quoted-scalars.md
+++ b/packages/graph/tests/fixtures/solutions/knowledge-track/conventions/quoted-scalars.md
@@ -1,0 +1,15 @@
+---
+track: knowledge-track
+category: conventions
+module: 'cli'
+tags: ['quoting', "yaml"]
+problem_type: "pattern"
+last_updated: '2026-05-06'
+---
+
+# Quoted-scalar frontmatter
+
+Every scalar here is quoted, which is valid YAML and is the form
+`docs/solutions/assets/resolution-template.md` prescribes. Both quote styles
+appear on purpose: this file is excluded in `.prettierignore` so the double
+quotes survive, because they are the test input.

--- a/packages/graph/tests/ingest/BusinessKnowledgeIngestor.solutions.test.ts
+++ b/packages/graph/tests/ingest/BusinessKnowledgeIngestor.solutions.test.ts
@@ -57,6 +57,35 @@ describe('BusinessKnowledgeIngestor.ingestSolutions', () => {
     expect(result.errors.some((e) => e.includes('crlf-pattern.md'))).toBe(false);
   });
 
+  // Quoted scalars are valid YAML, and the form
+  // `docs/solutions/assets/resolution-template.md` prescribes — yet every
+  // fixture above happens to use bare scalars, so nothing exercised the
+  // quote-stripping path and the parser silently rejected the documented form.
+  it('parses quoted scalars, including a quoted last_updated', async () => {
+    const result = await ingestor.ingestSolutions(FIXTURES);
+    const all = store.findNodes({});
+    const quoted = all.find((n) => n.path?.includes('quoted-scalars.md'));
+    expect(
+      result.errors.find((e) => e.includes('quoted-scalars.md')),
+      'a quoted date is valid YAML and must not be reported as malformed'
+    ).toBeUndefined();
+    expect(quoted).toBeDefined();
+  });
+
+  it('strips the quotes rather than keeping them in node data', async () => {
+    // Stripping has to reach the values themselves: a node whose domain is
+    // `'cli'` (quotes included) does not match a query for `cli`, so a
+    // half-fixed parser would satisfy the test above while leaving the node
+    // unfindable.
+    await ingestor.ingestSolutions(FIXTURES);
+    const quoted = store.findNodes({}).find((n) => n.path?.includes('quoted-scalars.md'));
+    expect(quoted?.metadata?.domain).toBe('cli');
+    expect(quoted?.metadata?.problem_type).toBe('pattern');
+    expect(quoted?.metadata?.last_updated).toBe('2026-05-06');
+    expect(quoted?.metadata?.tags).toEqual(['quoting', 'yaml']);
+    expect(quoted?.id).toBe('bk:solutions:cli:quoted-scalars');
+  });
+
   it('surfaces files lacking frontmatter as errors', async () => {
     const result = await ingestor.ingestSolutions(FIXTURES);
     const noFmError = result.errors.find((e) => e.includes('no-frontmatter.md'));


### PR DESCRIPTION
`ingestSolutions` rejects **every** solution doc whose frontmatter uses quoted scalars — including the form our own shipped template prescribes.

## The bug

`parseSolutionFrontmatter` (`packages/graph/src/ingest/BusinessKnowledgeIngestor.ts`) is a hand-rolled key/value parser and never stripped surrounding quotes. So `last_updated: '2026-05-06'` reaches `SolutionDocFrontmatterSchema` as `'2026-05-06'` **with its quotes**, fails the `ISO_DATE` regex, and the document is skipped as malformed. Same for `module`, `problem_type`, and quoted `tags` items.

Quoted scalars are valid YAML, and `docs/solutions/assets/resolution-template.md` — which we ship — writes `last_updated: '<YYYY-MM-DD>'`. **A project that followed the template had none of its post-mortems ingested.**

## Two readers of one corpus, disagreeing

`harness validate` (`packages/core/src/validation/solutions.ts`) parses with `gray-matter`, which unquotes. So a quoted date passes validation and then fails ingest, leaving **no** frontmatter format that satisfies both commands:

| form | `harness validate` | `graph ingest --source knowledge` |
|---|---|---|
| `'2026-05-06'` | ✅ pass | ❌ skipped — this bug |
| `2026-05-06` | ❌ *Expected string, received date* | ✅ ingested |

Found from the consuming side: a downstream project's entire `docs/solutions/` corpus was invisible to the graph while both commands reported success. `graph ingest` exits 0 and prints a healthy `+31 nodes` (its code and git sources succeeded), so the loss shows only in the `parse/skip warning(s)` lines.

## Verified end-to-end

Built CLI against that project's real corpus, **frontmatter untouched**:

```
before:  Ingested (knowledge): +31 nodes …  7 parse/skip warning(s)
after:   Ingested (knowledge): +34 nodes …  1 parse/skip warning(s)
```

1 of 7 files readable → 6 of 7. The remaining one is the template itself, whose `<YYYY-MM-DD>` placeholder is deliberately not a date.

## Why the tests missed it

Every fixture in `tests/fixtures/solutions/` happens to use **bare** scalars, and `SolutionDocFrontmatterSchema`'s own unit test passes a plain JS object — so it never exercises parsing at all. "Quoted scalar in a file" was untested on both sides of the seam.

Added `quoted-scalars.md` carrying **both** quote styles, plus two regression tests: one that it is not reported as malformed, one that the quotes are actually stripped from the node data. The second matters — a half-fix leaving `domain: "'cli'"` would satisfy the first alone and still leave the node unfindable.

Confirmed by mutation: restricting `unquoteScalar` to single quotes fails with `Received: ""pattern""`.

`tests/fixtures/solutions/**` is added to `.prettierignore` for the same reason `agents/commands/**` already is — prettier normalises double-quoted YAML to single quotes, which would silently delete the double-quote coverage, and it would be free to rewrite `crlf-pattern.md`'s line endings, the entire point of that fixture.

## Deliberately not `gray-matter`

A real YAML parser resolves bare `2026-05-06` to a `Date`, which `z.string()` rejects — so swapping it in would fix the quoted form by **breaking the bare form** every existing doc and fixture uses. Unquoting is additive: both forms parse now.

## Out of scope

`ingestSolutions` still emits nodes only for knowledge-track docs, which the existing `rejects bug-track docs` test asserts as intended, so I left it. Flagging separately: a bug-track doc parses cleanly and then vanishes with no warning and no counter, so an operator cannot tell "excluded by design" from "failed to read". Happy to open an issue if that distinction is worth surfacing.

## Gates

graph 978 tests · core solutions 60 tests · typecheck · lint · format:check · changeset check OK