### PR TITLE
feat(cli): enforce capability-seam roles — structured field + single-role detector (#1425)

### DIFF
--- a/.changeset/capability-roles-single-role-detector.md
+++ b/.changeset/capability-roles-single-role-detector.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Enforce capability-seam roles with a structured field + single-role detector (#1425).
+
+Adds an optional `capabilityRoles` field to `skill.yaml` frontmatter —
+`{ definition: string; providers: string[]; consumers: string[] }` — so a skill can
+promote its Service-Definition / Provider / Consumer roles from prose (shipped in
+#1418) to machine-checkable data. A new detector in `harness skill validate` flags any
+skill whose `capabilityRoles` is _declared_ but fills only ONE of the three roles (or
+none) — accidental single-implementation lock-in dressed up as an extension point.
+
+The field is optional: skills that omit it abstain (no finding), so the ~789 existing
+skills are unaffected — no forced retrofit. Two or three filled roles pass; the
+mechanical floor fires only on the unambiguous single-role red flag and the empty
+declaration. Field names mirror the `harness-skill-authoring` Phase 1C prose. The core
+detection is a pure exported `capabilityRoleErrors()` colocated with the existing
+capability-envelope checker.

--- a/docs/changes/capability-roles-detector/plans/plan.md
+++ b/docs/changes/capability-roles-detector/plans/plan.md
@@ -1,0 +1,60 @@
+# Plan: Enforce capability-seam roles — structured field + single-role detector
+
+Issue: Intense-Visions/harness-engineering#1425
+Slug: capability-roles-detector
+Base: origin/main
+Spec: docs/changes/capability-roles-detector/specs/spec.md
+
+## Task breakdown
+
+### T1 — Schema field + pure detector (`packages/cli/src/skill/schema.ts`)
+
+- Add `SkillCapabilityRolesSchema = z.object({ definition, providers, consumers })`
+  with `definition: z.string().default('')`, `providers: z.array(z.string()).default([])`,
+  `consumers: z.array(z.string()).default([])`. Export the inferred type
+  `SkillCapabilityRoles`.
+- Add `capabilityRoles: SkillCapabilityRolesSchema.optional()` to `SkillMetadataSchema`.
+- Add and export a pure `capabilityRoleErrors(roles: SkillCapabilityRoles): string[]`:
+  - Count filled roles (definition = non-empty trimmed string; providers/consumers =
+    ≥1 non-empty trimmed entry).
+  - 0 filled → one error: "capabilityRoles is declared but names no role (define a
+    Service Definition, ≥1 Provider, and ≥1 Consumer, or drop the field)".
+  - exactly 1 filled → one error naming the lone role and the two missing:
+    "capabilityRoles declares only the <role> role (…); a capability with one role
+    filled is accidental single-implementation lock-in — name the missing <a> and
+    <b> roles or drop the field".
+  - 2 or 3 filled → no error.
+
+### T2 — Wire into `harness skill validate` (`packages/cli/src/commands/skill/validate.ts`)
+
+- Add `validateCapabilityRoles(name, meta, errors)` mirroring `validateCapabilities`:
+  when `meta.capabilityRoles` is present, push `capabilityRoleErrors(...)` prefixed
+  `${name}/skill.yaml: `. Absent → no-op (abstain).
+- Call it in `validateSkillEntry` right after `validateCapabilities`.
+- Import `capabilityRoleErrors` + `SkillCapabilityRoles` type from `../../skill/schema`.
+
+### T3 — Tests
+
+- `packages/cli/tests/skill/schema.test.ts` (or existing schema test): unit-test
+  `capabilityRoleErrors` across 0 / 1(each of the three) / 2 / 3-role and
+  whitespace-only cases; assert the optional field parses and omission is valid.
+- `packages/cli/tests/commands/skill-validate.*` (or the existing skill validate test):
+  integration-test that a fixture skill with a single-role declaration fails
+  `runSkillValidation` and a two-role / omitted one passes.
+
+### T4 — Build + gates
+
+- `pnpm --filter @harness-engineering/cli build` then run cli tests.
+- No new `@harness-engineering/core` export → `scripts/generate-core-barrel.mjs`
+  allowlist untouched.
+- Run `pnpm run generate-docs` if any CLI command surface changed (it does not —
+  no new command/flag), else skip.
+- Run `harness skill validate` on this repo (must stay green — field is optional).
+- Changeset for `@harness-engineering/cli`.
+
+## Risk / overlap
+
+- #1404 concurrently adds a `harness validate` check. This change touches only
+  `skill/validate.ts` + `skill/schema.ts` (the `harness skill validate` path) and adds
+  a single additive function call — no shared check-registry edit — so a merge conflict
+  is trivial-to-nil.

--- a/docs/changes/capability-roles-detector/provenance.json
+++ b/docs/changes/capability-roles-detector/provenance.json
@@ -1,0 +1,12 @@
+{
+  "issues": [1425],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/capability-roles-detector/plans/plan.md",
+  "assumptions": [
+    "optional capabilityRoles field in skill.yaml frontmatter",
+    "single-role detector in harness validate flags declared-but-single-role only",
+    "optional = no forced retrofit of existing skills",
+    "additive validate-check registration (overlap w/ #1404)"
+  ],
+  "closingKeyword": "Closes #1425"
+}

--- a/docs/changes/capability-roles-detector/specs/spec.md
+++ b/docs/changes/capability-roles-detector/specs/spec.md
@@ -1,0 +1,100 @@
+# Spec: Enforce capability-seam roles — structured field + single-role detector
+
+Issue: Intense-Visions/harness-engineering#1425 (follow-up to #1397 / #1418)
+Slug: capability-roles-detector
+
+## Background
+
+Commit `f833d2556` (Closes #1397) shipped the **authoring-guidance** half of the
+Service-Definition / Provider / Consumer capability-seam model: a `## Capability
+Roles` prose checklist in the `create_skill` scaffold and a prose gate in
+`harness-skill-authoring`. That is prose only — nothing machine-checked verifies
+that a declared capability actually fills all three roles.
+
+`harness-skill-authoring` SKILL.md (Phase 1C) defines the three roles:
+
+1. **Service Definition** — what the capability DEFINES (the contract).
+2. **Provider(s)** — who PROVIDES it (≥1 concrete implementation).
+3. **Consumer(s)** — who CONSUMES it (≥1 caller depending on the definition).
+
+The single-role red flag: a capability with only ONE role filled is accidental
+single-implementation lock-in dressed up as an extension point.
+
+## Goal
+
+Provide the ENFORCEMENT half:
+
+1. A **structured, optional** `capabilityRoles` field on `skill.yaml` frontmatter so
+   a skill can promote its capability-seam roles from prose to machine-checkable data.
+2. A **single-role detector** — a mechanical, CI-gateable check that flags any skill
+   whose `capabilityRoles` is _declared_ but has only ONE of the three roles filled.
+   Skills that declare no `capabilityRoles` are **not** flagged (clean abstention).
+
+## Non-goals
+
+- No forced retrofit of the ~789 existing skills. The field is optional; undeclared =
+  not flagged. (Deliberately NOT a blanket retrofit — see #1275 over-build ladder.)
+- No runtime bounds-enforcement.
+
+## Field shape
+
+`capabilityRoles` (optional) on `skill.yaml`:
+
+```yaml
+capabilityRoles:
+  definition: string # the Service Definition — the contract this capability names
+  providers: [string, ...] # who PROVIDES it (≥1 for a real seam)
+  consumers: [string, ...] # who CONSUMES it (≥1 for a real seam)
+```
+
+Field names align verbatim with the `harness-skill-authoring` Phase 1C prose
+(Service Definition / Provider / Consumer → `definition` / `providers` / `consumers`).
+
+A role is considered **filled** when:
+
+- `definition` is a non-empty (trimmed) string, and
+- `providers` / `consumers` each contain ≥1 non-empty (trimmed) string.
+
+## Detector semantics (single-role red flag)
+
+Given a declared `capabilityRoles`, count how many of the three roles are filled:
+
+- **0 filled** — the field is declared but empty. This is a malformed declaration,
+  not a half-wired seam: report it as an error ("declared but names no role").
+- **exactly 1 filled** — the single-role red flag: report it as an error naming which
+  lone role is filled and which two are missing (accidental single-implementation
+  lock-in).
+- **2 or 3 filled** — pass. (A partially-wired seam with 2 roles is a work-in-progress,
+  not accidental lock-in; the prose gate covers the "name all three" aspiration. The
+  mechanical floor only fires on the unambiguous single-role red flag and the empty
+  declaration.)
+
+The detector abstains (emits nothing) when `capabilityRoles` is absent.
+
+## Where it lives
+
+- **Field + pure detector:** `packages/cli/src/skill/schema.ts`, colocated with the
+  existing `SkillCapabilitiesSchema` / `capabilityDriftErrors` so the schema and its
+  checker share one source of truth. New export: `capabilityRoleErrors(roles)`.
+- **Wiring:** `packages/cli/src/commands/skill/validate.ts` — `validateSkillEntry`
+  already parses `skill.yaml` via `SkillMetadataSchema` and runs `validateCapabilities`.
+  Add a sibling `validateCapabilityRoles` call. This is the accountable skill-validation
+  gate (`harness skill validate`) that `harness-skill-authoring` mandates ("no skill
+  ships without validation passing"), mechanical and CI-gateable.
+
+Registration is MINIMAL and ADDITIVE (one new function call in `validateSkillEntry`),
+so it cannot collide with the concurrent #1404 `harness validate` check-registry change.
+
+## Acceptance criteria
+
+- AC1: `skill.yaml` may declare an optional `capabilityRoles` object; a skill without
+  it still validates (existing ~789 skills unaffected). Verified: `harness skill
+validate` passes on this repo unchanged.
+- AC2: A skill declaring `capabilityRoles` with exactly one role filled fails `harness
+skill validate` with a message naming the lone filled role and the two missing roles.
+- AC3: A skill declaring `capabilityRoles` with two or three roles filled passes.
+- AC4: A skill declaring an empty `capabilityRoles` (no roles) fails with a
+  "names no role" error.
+- AC5: A skill that omits `capabilityRoles` produces no roles finding (abstention).
+- AC6: `capabilityRoleErrors` is a pure exported function with unit tests covering the
+  0 / 1 / 2 / 3-role and whitespace-only cases.

--- a/packages/cli/src/commands/skill/validate.ts
+++ b/packages/cli/src/commands/skill/validate.ts
@@ -10,7 +10,9 @@ import {
 import {
   SkillMetadataSchema,
   capabilityDriftErrors,
+  capabilityRoleErrors,
   type SkillCapabilities,
+  type SkillCapabilityRoles,
 } from '../../skill/schema';
 import { logger } from '../../output/logger';
 import { ExitCode } from '../../utils/errors';
@@ -97,6 +99,23 @@ function validateCapabilities(
   }
 }
 
+/**
+ * Enforce the single-role capability-seam detector (#1425). Optional field: when a
+ * skill declares `capabilityRoles`, a declaration that fills only one of the three
+ * roles (or none) is flagged as accidental single-implementation lock-in. Skills that
+ * omit the field abstain — no finding — so the ~789 existing skills are unaffected.
+ */
+function validateCapabilityRoles(
+  name: string,
+  meta: { capabilityRoles?: SkillCapabilityRoles | undefined },
+  errors: string[]
+): void {
+  if (!meta.capabilityRoles) return;
+  for (const err of capabilityRoleErrors(meta.capabilityRoles)) {
+    errors.push(`${name}/skill.yaml: ${err}`);
+  }
+}
+
 export function validateSkillEntry(name: string, skillsDir: string, errors: string[]): boolean {
   const skillDir = path.join(skillsDir, name);
   const yamlPath = path.join(skillDir, 'skill.yaml');
@@ -115,6 +134,7 @@ export function validateSkillEntry(name: string, skillsDir: string, errors: stri
     }
     validateSkillMd(name, path.join(skillDir, 'SKILL.md'), result.data.type, errors);
     validateCapabilities(name, result.data, errors);
+    validateCapabilityRoles(name, result.data, errors);
     return true;
   } catch (e) {
     errors.push(`${name}: parse error — ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/cli/src/skill/schema.ts
+++ b/packages/cli/src/skill/schema.ts
@@ -150,6 +150,56 @@ export function capabilityDriftErrors(
   return errors;
 }
 
+/**
+ * A skill's capability-seam roles (#1425) — the Service Definition it names, the
+ * Provider(s) that implement it, and the Consumer(s) that depend on it. Optional:
+ * a skill declares this only when it defines a real extension point. The single-role
+ * detector below flags a declaration that fills only one of the three roles
+ * (accidental single-implementation lock-in). Field names mirror the
+ * harness-skill-authoring Phase 1C prose (Service Definition / Provider / Consumer).
+ */
+export const SkillCapabilityRolesSchema = z.object({
+  definition: z.string().default(''),
+  providers: z.array(z.string()).default([]),
+  consumers: z.array(z.string()).default([]),
+});
+export type SkillCapabilityRoles = z.infer<typeof SkillCapabilityRolesSchema>;
+
+/**
+ * Single-role detector (#1425). Given a declared capabilityRoles, return one message
+ * per problem (empty when the seam is adequately wired). A role is "filled" when the
+ * Service Definition is a non-empty string and each of providers/consumers holds at
+ * least one non-empty entry. Zero filled roles is a malformed declaration; exactly one
+ * filled role is the single-role red flag — a capability swappable in name only. Two or
+ * three filled roles pass (a partially wired seam is work-in-progress, not lock-in).
+ * The caller only invokes this when the field is present, so absence abstains upstream.
+ */
+export function capabilityRoleErrors(roles: SkillCapabilityRoles): string[] {
+  const hasDefinition = roles.definition.trim().length > 0;
+  const hasProviders = roles.providers.some((p) => p.trim().length > 0);
+  const hasConsumers = roles.consumers.some((c) => c.trim().length > 0);
+  const filled: string[] = [];
+  if (hasDefinition) filled.push('definition');
+  if (hasProviders) filled.push('providers');
+  if (hasConsumers) filled.push('consumers');
+
+  if (filled.length === 0) {
+    return [
+      'capabilityRoles is declared but names no role — give it a Service Definition, at least one Provider, and at least one Consumer, or drop the field',
+    ];
+  }
+  if (filled.length === 1) {
+    const present = filled[0];
+    const missing = (['definition', 'providers', 'consumers'] as const).filter(
+      (r) => r !== present
+    );
+    return [
+      `capabilityRoles declares only the "${present}" role; a capability with one role filled is accidental single-implementation lock-in, not a real seam — name the missing "${missing[0]}" and "${missing[1]}" roles or drop the field`,
+    ];
+  }
+  return [];
+}
+
 export const SkillAddressSchema = z.object({
   signal: z.string(),
   hard: z.boolean().optional(),
@@ -209,6 +259,7 @@ export const SkillMetadataSchema = z
     addresses: z.array(SkillAddressSchema).default([]),
     context_budget: SkillContextBudgetSchema.optional(),
     capabilities: SkillCapabilitiesSchema.optional(),
+    capabilityRoles: SkillCapabilityRolesSchema.optional(),
   })
   .superRefine((data, ctx) => {
     if (data.type === 'knowledge') {

--- a/packages/cli/src/skill/schema.ts
+++ b/packages/cli/src/skill/schema.ts
@@ -259,7 +259,14 @@ export const SkillMetadataSchema = z
     addresses: z.array(SkillAddressSchema).default([]),
     context_budget: SkillContextBudgetSchema.optional(),
     capabilities: SkillCapabilitiesSchema.optional(),
-    capabilityRoles: SkillCapabilityRolesSchema.optional(),
+    // A bare `capabilityRoles:` key (no value) parses to null in YAML; treat that
+    // as an empty declaration ({}) so it routes through the friendly single-role
+    // detector ("names no role") rather than failing with an opaque zod
+    // invalid_type. An omitted key stays undefined and abstains as before.
+    capabilityRoles: z.preprocess(
+      (v) => (v === null ? {} : v),
+      SkillCapabilityRolesSchema.optional()
+    ),
   })
   .superRefine((data, ctx) => {
     if (data.type === 'knowledge') {

--- a/packages/cli/tests/commands/skill/validate-skill.test.ts
+++ b/packages/cli/tests/commands/skill/validate-skill.test.ts
@@ -103,6 +103,88 @@ describe('skill validate — knowledge skill sections', () => {
   });
 });
 
+// #1425: the single-role capability-seam detector runs inside `validateSkillEntry`.
+// A declared `capabilityRoles` with only one role filled fails; two-role or omitted
+// declarations pass (existing skills that omit the field are unaffected).
+describe('skill validate — capabilityRoles single-role detector (#1425)', () => {
+  function writeKnowledgeSkill(
+    tmpDir: string,
+    name: string,
+    capabilityRolesYaml: string[]
+  ): string {
+    const skillDir = path.join(tmpDir, name);
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(
+      path.join(skillDir, 'skill.yaml'),
+      [
+        `name: ${name}`,
+        "version: '1.0.0'",
+        'description: A capability-seam skill',
+        'type: knowledge',
+        'cognitive_mode: advisory-guide',
+        'triggers: [manual]',
+        'platforms: [claude-code]',
+        'tools: []',
+        'state: { persistent: false, files: [] }',
+        'depends_on: []',
+        ...capabilityRolesYaml,
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      `# ${name}\n\n## Instructions\n\nDo the thing.`
+    );
+    return skillDir;
+  }
+
+  it('fails a skill declaring only one role', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-validate-roles-'));
+    writeKnowledgeSkill(tmpDir, 'single-role-skill', [
+      'capabilityRoles:',
+      '  definition: the backend contract',
+      '  providers: []',
+      '  consumers: []',
+    ]);
+
+    const errors: string[] = [];
+    const { validateSkillEntry } = await import('../../../src/commands/skill/validate.js');
+    validateSkillEntry('single-role-skill', tmpDir, errors);
+    expect(errors.some((e) => e.includes('single-implementation lock-in'))).toBe(true);
+    expect(errors.some((e) => e.includes('single-role-skill/skill.yaml'))).toBe(true);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('passes a skill declaring two roles', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-validate-roles-'));
+    writeKnowledgeSkill(tmpDir, 'two-role-skill', [
+      'capabilityRoles:',
+      '  definition: the backend contract',
+      '  providers: [ollama-backend]',
+      '  consumers: []',
+    ]);
+
+    const errors: string[] = [];
+    const { validateSkillEntry } = await import('../../../src/commands/skill/validate.js');
+    validateSkillEntry('two-role-skill', tmpDir, errors);
+    expect(errors).toEqual([]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('passes a skill that omits capabilityRoles (abstention)', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-validate-roles-'));
+    writeKnowledgeSkill(tmpDir, 'no-roles-skill', []);
+
+    const errors: string[] = [];
+    const { validateSkillEntry } = await import('../../../src/commands/skill/validate.js');
+    validateSkillEntry('no-roles-skill', tmpDir, errors);
+    expect(errors).toEqual([]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});
+
 // Regression for #1011: `harness skill validate` scanned the installed CLI
 // bundle, not the working tree — so a skill authored in a checkout was never
 // examined and the validator's silence read as approval. It also ignored the

--- a/packages/cli/tests/skill/capabilities.test.ts
+++ b/packages/cli/tests/skill/capabilities.test.ts
@@ -5,6 +5,7 @@ import {
   FILESYSTEM_LEVELS,
   deriveCapabilities,
   capabilityDriftErrors,
+  capabilityRoleErrors,
 } from '../../src/skill/schema';
 
 describe('deriveCapabilities', () => {
@@ -109,5 +110,112 @@ describe('SkillMetadataSchema — capabilities field', () => {
   it('leaves capabilities optional for backward compatibility', () => {
     const result = SkillMetadataSchema.parse(validBase);
     expect(result.capabilities).toBeUndefined();
+  });
+});
+
+describe('capabilityRoleErrors (#1425)', () => {
+  it('returns no errors when all three roles are filled', () => {
+    expect(
+      capabilityRoleErrors({
+        definition: 'the backend contract',
+        providers: ['ollama-backend'],
+        consumers: ['orchestrator'],
+      })
+    ).toEqual([]);
+  });
+
+  it('returns no errors when exactly two roles are filled (work-in-progress seam)', () => {
+    expect(
+      capabilityRoleErrors({
+        definition: 'the backend contract',
+        providers: ['ollama-backend'],
+        consumers: [],
+      })
+    ).toEqual([]);
+  });
+
+  it('flags a definition-only declaration, naming present and both missing roles', () => {
+    const errors = capabilityRoleErrors({
+      definition: 'the backend contract',
+      providers: [],
+      consumers: [],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('"definition"');
+    expect(errors[0]).toContain('"providers"');
+    expect(errors[0]).toContain('"consumers"');
+    expect(errors[0]).toContain('single-implementation lock-in');
+  });
+
+  it('flags a providers-only declaration, naming present and both missing roles', () => {
+    const errors = capabilityRoleErrors({
+      definition: '',
+      providers: ['ollama-backend'],
+      consumers: [],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('only the "providers" role');
+    expect(errors[0]).toContain('"definition"');
+    expect(errors[0]).toContain('"consumers"');
+  });
+
+  it('flags a consumers-only declaration, naming present and both missing roles', () => {
+    const errors = capabilityRoleErrors({
+      definition: '',
+      providers: [],
+      consumers: ['orchestrator'],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('only the "consumers" role');
+    expect(errors[0]).toContain('"definition"');
+    expect(errors[0]).toContain('"providers"');
+  });
+
+  it('flags a zero-role (empty) declaration with a "names no role" error', () => {
+    const errors = capabilityRoleErrors({ definition: '', providers: [], consumers: [] });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('names no role');
+  });
+
+  it('treats whitespace-only entries as unfilled', () => {
+    const errors = capabilityRoleErrors({
+      definition: '  ',
+      providers: ['  '],
+      consumers: [],
+    });
+    // definition and providers are whitespace-only → zero roles filled.
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('names no role');
+  });
+});
+
+describe('SkillMetadataSchema — capabilityRoles field (#1425)', () => {
+  const validBase = {
+    name: 'test-skill',
+    version: '1.0.0',
+    description: 'A test skill',
+    triggers: ['manual'],
+    platforms: ['claude-code'],
+    tools: ['Read', 'Write'],
+    type: 'rigid' as const,
+  };
+
+  it('parses a skill.yaml object WITH a capabilityRoles field', () => {
+    const result = SkillMetadataSchema.parse({
+      ...validBase,
+      capabilityRoles: {
+        definition: 'the backend contract',
+        providers: ['ollama-backend'],
+        consumers: ['orchestrator'],
+      },
+    });
+    expect(result.capabilityRoles?.definition).toBe('the backend contract');
+    expect(result.capabilityRoles?.providers).toEqual(['ollama-backend']);
+    expect(result.capabilityRoles?.consumers).toEqual(['orchestrator']);
+  });
+
+  it('leaves capabilityRoles optional (omission parses)', () => {
+    const result = SkillMetadataSchema.parse(validBase);
+    expect(result.capabilityRoles).toBeUndefined();
   });
 });

--- a/packages/cli/tests/skill/capabilities.test.ts
+++ b/packages/cli/tests/skill/capabilities.test.ts
@@ -187,6 +187,19 @@ describe('capabilityRoleErrors (#1425)', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain('names no role');
   });
+
+  it('demotes to the single-role red flag when whitespace-only entries leave one real role', () => {
+    // Only `consumers` carries a real value; definition + providers are whitespace.
+    const errors = capabilityRoleErrors({
+      definition: '  ',
+      providers: ['   '],
+      consumers: ['orchestrator'],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('only the "consumers" role');
+    expect(errors[0]).toContain('"definition"');
+    expect(errors[0]).toContain('"providers"');
+  });
 });
 
 describe('SkillMetadataSchema — capabilityRoles field (#1425)', () => {
@@ -217,5 +230,14 @@ describe('SkillMetadataSchema — capabilityRoles field (#1425)', () => {
   it('leaves capabilityRoles optional (omission parses)', () => {
     const result = SkillMetadataSchema.parse(validBase);
     expect(result.capabilityRoles).toBeUndefined();
+  });
+
+  it('normalizes a bare `capabilityRoles:` (null) to an empty declaration so the detector runs', () => {
+    // A bare YAML key parses to null; it must route through the friendly detector
+    // rather than a hard zod invalid_type failure.
+    const result = SkillMetadataSchema.parse({ ...validBase, capabilityRoles: null });
+    expect(result.capabilityRoles).toEqual({ definition: '', providers: [], consumers: [] });
+    expect(capabilityRoleErrors(result.capabilityRoles!)).toHaveLength(1);
+    expect(capabilityRoleErrors(result.capabilityRoles!)[0]).toContain('names no role');
   });
 });


### PR DESCRIPTION
## What

The **enforcement half** of the Service-Definition / Provider / Consumer capability-seam model (follow-up to #1397 / #1418, which shipped the authoring-guidance/prose half in commit \`f833d2556\`).

1. **Structured optional field** — adds \`capabilityRoles: { definition: string; providers: string[]; consumers: string[] }\` to \`skill.yaml\` frontmatter (`SkillMetadataSchema`), so a skill can promote its capability-seam roles from prose to machine-checkable data.
2. **Single-role detector** — a new check in \`harness skill validate\` flags any skill whose \`capabilityRoles\` is *declared* but fills only ONE of the three roles (or none) = accidental single-implementation lock-in. Two or three filled roles pass.

## Design

- Field names mirror the `harness-skill-authoring` Phase 1C prose (Service Definition / Provider / Consumer → `definition` / `providers` / `consumers`).
- Core detection is a **pure exported** `capabilityRoleErrors()` in `packages/cli/src/skill/schema.ts`, colocated with the existing `capabilityDriftErrors` capability-envelope checker (single source of truth).
- Wiring is a **single additive** `validateCapabilityRoles(...)` call in `validateSkillEntry` — no shared check-registry edit, so the concurrent #1404 `harness validate` check cannot meaningfully conflict.
- **Optional field → no forced retrofit.** Skills that omit `capabilityRoles` abstain (no finding); all 789 existing skills validate unchanged.

## Detector semantics

| roles filled | verdict |
|---|---|
| 0 (declared but empty) | error — "names no role" |
| exactly 1 | error — single-role red flag, names the lone + both missing roles |
| 2 or 3 | pass |

Whitespace-only entries count as unfilled.

## Tests / gates

- Unit tests for `capabilityRoleErrors` (0 / each-of-3 lone / 2 / 3-role / whitespace) + schema parse with & without the field.
- Integration tests through `validateSkillEntry` (single-role fails; two-role & omitted pass).
- `harness skill validate` on this repo: **789 skills validate, exit 0**.
- Full touched CLI suites green; build + DTS typecheck green; reference docs + tool catalog fresh.

Artifacts: `docs/changes/capability-roles-detector/` (spec, plan, provenance).

Closes #1425