### PR TITLE
feat(validate): advisory SKILL.md instruction-density check (#1404)

### DIFF
--- a/.antigravity-extension/commands/skill-authoring.toml
+++ b/.antigravity-extension/commands/skill-authoring.toml
@@ -264,6 +264,7 @@ metadata: # Provenance and authorship metadata
    - **State what NOT to do.** Prohibitions prevent common mistakes: "Do not proceed to Phase 3 if validation fails."
    - **For rigid skills:** Add an Iron Law at the top — the one inviolable principle. Then define phases with mandatory ordering and explicit gates between them.
    - **For flexible skills:** Describe the recommended flow but acknowledge that adaptation is expected. Focus on outcomes rather than exact commands.
+   - **Watch instruction density per packing level.** HumanLayer's RPI→CRISPY postmortem found that a prompt exceeding a ~150-200 instruction-follow budget was the specific failure that forced a workflow rebuild. Because `run_skill` loads a skill progressively (cumulative packing levels 1-5 by H2 section), what matters is the instruction count at each _loaded_ level, not the whole-file line count. Density is estimated as imperative instructions = numbered steps + imperative-verb bullets + `MUST`/`SHALL`/`REQUIRED` directives (code blocks and prose excluded). `harness validate` surfaces an advisory (non-blocking) warning when a level exceeds the budget (default 175, configurable via `skills.instructionBudget`). If a level trips it, push lower-priority directives into a deeper section (higher packing level) or a `references/` file so the early levels stay lean.
 
 4. **Write `## Harness Integration`.** List every harness CLI command the skill uses, with a brief description of when to use it. This section connects the skill to the harness toolchain.
 
@@ -310,6 +311,8 @@ metadata: # Provenance and authorship metadata
    - Missing `type` field in `skill.yaml`
 
 3. **Test by running the skill:** `harness skill run <name>`. Verify it loads correctly and the process instructions make sense in context.
+
+4. **Run `harness validate`.** Among its checks is an advisory SKILL.md instruction-density estimate (see Phase 4 step 3). It never blocks, but a `SKILL-DENSITY` warning naming a level over the ~150-200 budget is a signal to redistribute directives across packing levels before the skill ships.
 
 ### Phase 5B: TDD FOR SKILLS — Test Before Signing Off
 

--- a/.changeset/skill-instruction-density-check.md
+++ b/.changeset/skill-instruction-density-check.md
@@ -1,0 +1,19 @@
+---
+'@harness-engineering/core': minor
+'@harness-engineering/cli': minor
+---
+
+Add an advisory SKILL.md instruction-density check to `harness validate`.
+
+HumanLayer's RPI→CRISPY postmortem identified a ~150-200 instruction-follow budget as the
+ceiling that, once exceeded, forced a full workflow rebuild. `harness validate` now
+estimates the imperative-instruction count (numbered steps + imperative-verb bullets +
+`MUST`/`SHALL`/`REQUIRED` directives) at each context-budget packing level `run_skill`
+loads, and surfaces a non-blocking `SKILL-DENSITY` warning when a loaded level exceeds the
+budget (default 175, configurable via `skills.instructionBudget`). Because progressive
+disclosure is the mitigation being validated, density is measured per cumulative packing
+level rather than over the whole file. The check is advisory only — it never fails the
+gate. `harness-skill-authoring` gains a matching guidance note.
+
+New core exports: `countImperativeInstructions`, `analyzeSkillInstructionDensity`,
+`DEFAULT_INSTRUCTION_BUDGET`.

--- a/.gemini-extension/commands/skill-authoring.toml
+++ b/.gemini-extension/commands/skill-authoring.toml
@@ -264,6 +264,7 @@ metadata: # Provenance and authorship metadata
    - **State what NOT to do.** Prohibitions prevent common mistakes: "Do not proceed to Phase 3 if validation fails."
    - **For rigid skills:** Add an Iron Law at the top — the one inviolable principle. Then define phases with mandatory ordering and explicit gates between them.
    - **For flexible skills:** Describe the recommended flow but acknowledge that adaptation is expected. Focus on outcomes rather than exact commands.
+   - **Watch instruction density per packing level.** HumanLayer's RPI→CRISPY postmortem found that a prompt exceeding a ~150-200 instruction-follow budget was the specific failure that forced a workflow rebuild. Because `run_skill` loads a skill progressively (cumulative packing levels 1-5 by H2 section), what matters is the instruction count at each _loaded_ level, not the whole-file line count. Density is estimated as imperative instructions = numbered steps + imperative-verb bullets + `MUST`/`SHALL`/`REQUIRED` directives (code blocks and prose excluded). `harness validate` surfaces an advisory (non-blocking) warning when a level exceeds the budget (default 175, configurable via `skills.instructionBudget`). If a level trips it, push lower-priority directives into a deeper section (higher packing level) or a `references/` file so the early levels stay lean.
 
 4. **Write `## Harness Integration`.** List every harness CLI command the skill uses, with a brief description of when to use it. This section connects the skill to the harness toolchain.
 
@@ -310,6 +311,8 @@ metadata: # Provenance and authorship metadata
    - Missing `type` field in `skill.yaml`
 
 3. **Test by running the skill:** `harness skill run <name>`. Verify it loads correctly and the process instructions make sense in context.
+
+4. **Run `harness validate`.** Among its checks is an advisory SKILL.md instruction-density estimate (see Phase 4 step 3). It never blocks, but a `SKILL-DENSITY` warning naming a level over the ~150-200 budget is a signal to redistribute directives across packing levels before the skill ships.
 
 ### Phase 5B: TDD FOR SKILLS — Test Before Signing Off
 

--- a/agents/skills/claude-code/harness-skill-authoring/SKILL.md
+++ b/agents/skills/claude-code/harness-skill-authoring/SKILL.md
@@ -250,6 +250,7 @@ metadata: # Provenance and authorship metadata
    - **State what NOT to do.** Prohibitions prevent common mistakes: "Do not proceed to Phase 3 if validation fails."
    - **For rigid skills:** Add an Iron Law at the top — the one inviolable principle. Then define phases with mandatory ordering and explicit gates between them.
    - **For flexible skills:** Describe the recommended flow but acknowledge that adaptation is expected. Focus on outcomes rather than exact commands.
+   - **Watch instruction density per packing level.** HumanLayer's RPI→CRISPY postmortem found that a prompt exceeding a ~150-200 instruction-follow budget was the specific failure that forced a workflow rebuild. Because `run_skill` loads a skill progressively (cumulative packing levels 1-5 by H2 section), what matters is the instruction count at each _loaded_ level, not the whole-file line count. Density is estimated as imperative instructions = numbered steps + imperative-verb bullets + `MUST`/`SHALL`/`REQUIRED` directives (code blocks and prose excluded). `harness validate` surfaces an advisory (non-blocking) warning when a level exceeds the budget (default 175, configurable via `skills.instructionBudget`). If a level trips it, push lower-priority directives into a deeper section (higher packing level) or a `references/` file so the early levels stay lean.
 
 4. **Write `## Harness Integration`.** List every harness CLI command the skill uses, with a brief description of when to use it. This section connects the skill to the harness toolchain.
 
@@ -296,6 +297,8 @@ metadata: # Provenance and authorship metadata
    - Missing `type` field in `skill.yaml`
 
 3. **Test by running the skill:** `harness skill run <name>`. Verify it loads correctly and the process instructions make sense in context.
+
+4. **Run `harness validate`.** Among its checks is an advisory SKILL.md instruction-density estimate (see Phase 4 step 3). It never blocks, but a `SKILL-DENSITY` warning naming a level over the ~150-200 budget is a signal to redistribute directives across packing levels before the skill ships.
 
 ### Phase 5B: TDD FOR SKILLS — Test Before Signing Off
 

--- a/docs/changes/skill-instruction-density/plans/plan.md
+++ b/docs/changes/skill-instruction-density/plans/plan.md
@@ -1,0 +1,69 @@
+---
+title: Plan — SKILL.md Instruction-Density Check
+issue: 1404
+spec: docs/changes/skill-instruction-density/proposal.md
+---
+
+# Plan: SKILL.md Instruction-Density Check
+
+Derived from `docs/changes/skill-instruction-density/proposal.md`. Locked decision: heuristic
+imperative-instruction count per context-budget packing level, advisory (non-blocking) in
+`harness validate`, plus a `harness-skill-authoring` guidance note.
+
+## Task breakdown
+
+### T1 — Core density module (pure)
+
+- **File:** `packages/core/src/context/instruction-density.ts`
+- `countImperativeInstructions(markdown)` — numbered steps + imperative-verb bullets +
+  `MUST`/`SHALL`/`REQUIRED` directives; excludes fenced code and prose.
+- `analyzeSkillInstructionDensity(content, budget=175)` — reuse `extractLevel` for each
+  cumulative level 1-5; return per-level counts + `maxLevelOverBudget`.
+- Export `DEFAULT_INSTRUCTION_BUDGET = 175`.
+- Wire exports through `packages/core/src/context/index.ts` (star-barrel — no allowlist edit).
+- **Tests:** `packages/core/tests/context/instruction-density.test.ts`.
+
+### T2 — Config knob
+
+- Add optional `skills.instructionBudget` (`z.number().int().positive().optional()`) to
+  `packages/cli/src/config/schema.ts`.
+
+### T3 — CLI audit helper (colocated, additive)
+
+- **File:** `packages/cli/src/mcp/tools/instruction-density.ts`
+- `runInstructionDensityAudit({ path, budget? })` — walk for `SKILL.md`, dedup by
+  `realpathSync` (collapse symlinked skill mirrors), skip `node_modules`/`.git`/`dist`,
+  return one finding per over-budget skill.
+- **Tests:** `packages/cli/src/mcp/tools/instruction-density.test.ts`.
+
+### T4 — validate wiring (one additive block)
+
+- `packages/cli/src/commands/validate.ts`: add `instructionDensity?` to `checks`, import the
+  helper, push each finding at `severity: 'warning'` with `ruleId: 'SKILL-DENSITY'`. Never
+  flip `result.valid`. try/catch degrade-to-warning. Read `config.skills.instructionBudget`.
+
+### T5 — Authoring guidance
+
+- `agents/skills/claude-code/harness-skill-authoring/SKILL.md`: instruction-density note in
+  Phase 4 (Write Process) + Phase 5 (Validate). Regenerate plugin mirrors
+  (`generate:plugin` all targets); `generate:plugin:check` must pass.
+
+## Ordering / dependencies
+
+T1 → (T2, T3 depend on T1) → T4 (depends on T2, T3) → T5 (independent) → build/verify.
+
+## Verification
+
+1. `pnpm --filter @harness-engineering/core exec vitest run tests/context/instruction-density.test.ts`
+2. `pnpm --filter @harness-engineering/cli exec vitest run src/mcp/tools/instruction-density.test.ts`
+3. Typecheck core + cli.
+4. Build CLI, run `harness validate` on this repo → confirm `instructionDensity` check runs
+   and adds **no** error-level issues (advisory stays advisory; exit code unchanged by this
+   change).
+5. `generate:plugin:check` passes.
+
+## Checkpoints
+
+- After T1: core tests green.
+- After T4: `harness validate` shows the advisory check with zero error contributions.
+- After T5: plugin mirrors regenerated and check-clean.

--- a/docs/changes/skill-instruction-density/proposal.md
+++ b/docs/changes/skill-instruction-density/proposal.md
@@ -1,0 +1,203 @@
+---
+title: SKILL.md Instruction-Density Check
+issue: 1404
+status: planned
+keywords:
+  - skill-authoring
+  - instruction-density
+  - context-budget
+  - packing-level
+  - harness-validate
+  - progressive-disclosure
+---
+
+# SKILL.md Instruction-Density Check
+
+> Advisory instruction-count estimate per loaded packing level, surfaced non-blocking in
+> `harness validate`, confirming the repo's progressive-disclosure packing keeps each
+> loaded level under the instruction-follow budget HumanLayer's RPI→CRISPY postmortem
+> identified. Adapted from HumanLayer [HORTHY-2]; see
+> `docs/research/dex-horthy-humanlayer-comparison-analysis.md`.
+
+## Overview
+
+HumanLayer's public RPI→CRISPY postmortem (`docs/research/dex-horthy-humanlayer-comparison-analysis.md:37-44,96-100`)
+names a concrete failure: planning prompts that exceeded a **~150-200 instruction-follow
+budget** frontier models reliably honor were the specific break that forced a full
+workflow rebuild. `harness-autopilot` and `harness-brainstorming` SKILL.md bodies run
+300-470+ lines each. The progressive-disclosure packing already implemented in
+`run_skill` (`packages/core/src/context/section-parser.ts:79-108` `extractLevel`, cumulative
+levels 1-5 by H2 heading; `packages/core/src/context/progressive-loader.ts`) is promising
+evidence this repo does **not** share RPI's failure mode — but it has never been confirmed
+with a measured instruction count the way HumanLayer did after getting burned.
+
+This change adds a **heuristic imperative-instruction count per context-budget packing
+level**, surfaced **advisory (non-blocking)** in `harness validate`, plus a short authoring
+guidance note in `harness-skill-authoring`.
+
+### Goals
+
+- Measure instruction density per loaded packing level, not per whole file — because
+  progressive disclosure is the mitigation being validated.
+- Warn (never block) when a level's imperative-instruction count exceeds a documented
+  budget in the ~150-200 range.
+- Give skill authors a rule of thumb for keeping each level under budget.
+
+### Non-goals (YAGNI)
+
+- No NLP/LLM parsing of instructions — a cheap regex/line heuristic is sufficient and
+  deterministic.
+- No blocking gate. This repo's own autopilot/brainstorming skills are large by design;
+  the check MUST stay advisory so `harness validate` still exits 0 here.
+- No auto-fix / refactoring of over-budget skills.
+
+## Decisions made
+
+1. **Metric = imperative instructions per packing level.** Count (a) numbered steps
+   (`1.`, `2.` list markers), (b) imperative-verb bullets (`-`/`*` bullets whose first
+   word is an imperative verb), and (c) MUST / SHALL / REQUIRED directive lines. NOT raw
+   lines. _Rationale:_ the HumanLayer budget is about instructions a model must follow,
+   not text volume; raw line count over-counts prose/tables/code.
+
+2. **Count per cumulative packing level (1-5), not whole file.** Reuse
+   `extractLevel(content, level)` (`section-parser.ts:79`) which already returns the exact
+   cumulative content `run_skill` loads at each level. Level 5 is the full body.
+   _Rationale:_ progressive disclosure is precisely the mitigation under test — the
+   question is "does any _loaded_ level exceed budget," and the answer differs per level.
+
+3. **Default budget = 175, configurable.** Warn when a level's instruction count exceeds
+   `175` (the midpoint of HumanLayer's ~150-200 range). Overridable via
+   `skills.instructionBudget` in `harness.config.json`. _Rationale:_ a concrete documented
+   default in the identified range; cheap to make configurable since the skills config
+   object is already `.passthrough()`.
+
+4. **Advisory (warning severity) in `harness validate`.** The finding is pushed at
+   `warning` severity so it is reported but never flips `result.valid` — `harness validate`
+   still exits 0. _Rationale:_ the repo's own large skills would otherwise turn CI red; the
+   value is visibility, not enforcement.
+
+5. **Additive check registration (overlap with #1425).** The check is wired as one
+   additive block in `validate.ts` plus a colocated audit helper under
+   `packages/cli/src/mcp/tools/`, mirroring how `detect-drift` / `audit-anatomy` /
+   `audit-brand` are already composed. No shared check-registry refactor. _Rationale:_
+   concurrent lane #1425 also touches `harness validate` as a colocated additive call, so
+   both lanes append and a both-add merge is trivial.
+
+## Technical design
+
+### Core (pure, testable) — `packages/core/src/context/instruction-density.ts`
+
+```ts
+export const DEFAULT_INSTRUCTION_BUDGET = 175;
+
+/** Count imperative instructions in a block of markdown. */
+export function countImperativeInstructions(markdown: string): number;
+
+export interface LevelInstructionDensity {
+  level: LoadingLevel; // 1..5
+  sections: number; // sections loaded at this level
+  instructionCount: number; // imperative instructions in the cumulative content
+  overBudget: boolean; // instructionCount > budget
+}
+
+export interface SkillInstructionDensityReport {
+  budget: number;
+  levels: LevelInstructionDensity[];
+  maxLevelOverBudget: LevelInstructionDensity | null; // highest over-budget level, else null
+}
+
+export function analyzeSkillInstructionDensity(
+  content: string,
+  budget = DEFAULT_INSTRUCTION_BUDGET
+): SkillInstructionDensityReport;
+```
+
+`analyzeSkillInstructionDensity` iterates levels 1-5, calls `extractLevel(content, level)`
+(re-uses existing packing authority), strips the injected `<!-- context-budget: ... -->`
+marker, runs `countImperativeInstructions`, and flags `overBudget`.
+
+`countImperativeInstructions` heuristic (deterministic, no dependencies):
+
+- Numbered step: line matches `^\s*\d+[.)]\s+`.
+- Imperative-verb bullet: line matches `^\s*[-*]\s+` AND first word is in a curated
+  imperative-verb set (Run, Call, Read, Write, Add, Check, Verify, Ensure, Use, Set,
+  Create, Do, Stop, Ask, Emit, Commit, Skip, Continue, Cite, Apply, Present, Wait, Fix,
+  Remove, Update, Derive, Branch, Surface, Record, Reject, Avoid, Prefer, Never, Always,
+  … capitalized or lowercase).
+- Directive line: line contains a `\bMUST\b` / `\bSHALL\b` / `\bREQUIRED\b` token
+  (case-sensitive on the SCREAMING form to avoid prose false positives).
+- Fenced code blocks (```) are excluded so example snippets don't inflate the count.
+
+Exported through the `context` star-barrel via `packages/core/src/context/index.ts`
+(module already whitelisted in `scripts/generate-core-barrel.mjs`; no allowlist edit).
+
+### CLI audit helper — `packages/cli/src/mcp/tools/instruction-density.ts`
+
+`runInstructionDensityAudit({ path, budget? })`:
+
+- Walks the project for `SKILL.md` files (skipping `node_modules`, `.git`, `dist`,
+  `coverage`), **deduplicating by `fs.realpathSync`** so the cursor/codex/gemini-cli skill
+  mirrors (symlinks to `claude-code`) collapse to a single physical file.
+- For each, reads content and runs `analyzeSkillInstructionDensity`.
+- Returns findings only for skills with a `maxLevelOverBudget`, one finding per skill,
+  message naming the level, its count, the budget, and section count.
+
+### validate.ts wiring (one additive block)
+
+- Add `instructionDensity?: boolean` to `ValidateResult.checks`.
+- After the brand-compliance block, resolve `config.skills?.instructionBudget` (falling
+  back to `DEFAULT_INSTRUCTION_BUDGET`), call `runInstructionDensityAudit`, set
+  `result.checks.instructionDensity = true`, and push each finding at `severity: 'warning'`
+  with `ruleId: 'SKILL-DENSITY'`. Never set `result.valid = false`. Wrap in try/catch that
+  degrades to a single warning (mirroring the other audits).
+
+### Config schema
+
+Add optional `instructionBudget: z.number().int().positive().optional()` to the `skills`
+config object in `packages/cli/src/config/schema.ts` (object is `.passthrough()`, so this
+is additive and forward-compatible).
+
+## Integration points
+
+- **Entry Points:** New core export (`analyzeSkillInstructionDensity` et al. via the
+  `context` barrel); new colocated CLI audit helper; one new advisory check inside the
+  existing `harness validate` command. New config field `skills.instructionBudget`.
+- **Registrations Required:** `context` module is already a star-export — running
+  `pnpm run generate:core-barrel` regenerates the barrel; no allowlist edit. New validate
+  check → `pnpm run generate-docs` for reference-docs freshness. `harness-skill-authoring`
+  SKILL.md edit → `pnpm run generate:plugin` to refresh plugin command mirrors (must pass
+  `generate:plugin:check`).
+- **Documentation Updates:** Short guidance note in
+  `agents/skills/claude-code/harness-skill-authoring/SKILL.md` (the "Instruction density"
+  budget + how it's estimated per packing level). Reference docs regenerated for the new
+  validate check.
+- **Architectural Decisions:** None rise to a standalone ADR — this is an additive
+  advisory check that reuses existing packing authority.
+- **Knowledge Impact:** Concept "instruction-density budget per packing level" as an
+  authoring constraint; ties `context-budget packing level` to the HumanLayer
+  instruction-follow ceiling.
+
+## Success criteria
+
+1. `analyzeSkillInstructionDensity` returns a per-level (1-5) instruction count for a
+   SKILL.md, using `extractLevel` for cumulative packing content (unit-tested).
+2. `countImperativeInstructions` counts numbered steps + imperative bullets + MUST/SHALL/
+   REQUIRED directives and excludes fenced code and plain prose (unit-tested with a fixture
+   whose count is known).
+3. The default budget is `175`, documented, and overridable via `skills.instructionBudget`.
+4. `harness validate` emits the density findings at `warning` severity and **still exits 0
+   on this repo** (verified by running it), even though this repo's own large skills may
+   trip the warning.
+5. The SKILL.md audit deduplicates symlinked skill mirrors (no double-counting).
+6. `harness-skill-authoring` SKILL.md gains a short instruction-density guidance note; the
+   plugin mirror regenerates and `generate:plugin:check` passes.
+
+## Implementation order
+
+1. Core: `instruction-density.ts` + unit tests; export via `context/index.ts`; regenerate
+   barrel.
+2. Config: add `skills.instructionBudget` to schema.
+3. CLI: `mcp/tools/instruction-density.ts` audit helper + tests.
+4. validate.ts: additive advisory block; wire config budget.
+5. Guidance note in `harness-skill-authoring` SKILL.md; regenerate plugin mirrors + docs.
+6. Build CLI, run `harness validate` (confirm exit 0), typecheck, tests, changeset.

--- a/docs/changes/skill-instruction-density/provenance.json
+++ b/docs/changes/skill-instruction-density/provenance.json
@@ -1,0 +1,13 @@
+{
+  "issues": [1404],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/skill-instruction-density/plans/plan.md",
+  "assumptions": [
+    "heuristic imperative-instruction count per packing level (numbered steps + imperative bullets + MUST/SHALL)",
+    "advisory non-blocking in harness validate",
+    "warn threshold ~150-200 (document exact default)",
+    "also added skill-authoring guidance note",
+    "additive validate registration (overlap w/ #1425)"
+  ],
+  "closingKeyword": "Closes #1404"
+}

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -28,6 +28,7 @@ import { CLIError, ExitCode, type ExitCodeType } from '../utils/errors';
 import { runAudit as runComponentAnatomyAudit } from '../mcp/tools/audit-anatomy';
 import { runDetectDrift } from '../mcp/tools/detect-drift';
 import { runAuditBrand } from '../mcp/tools/audit-brand';
+import { runInstructionDensityAudit } from '../mcp/tools/instruction-density';
 
 type ValidateSeverity = 'error' | 'warning' | 'info';
 
@@ -102,6 +103,7 @@ interface ValidateResult {
     componentAnatomy?: boolean;
     driftDetection?: boolean;
     brandCompliance?: boolean;
+    instructionDensity?: boolean;
   };
   issues: Array<{
     check: string;
@@ -578,6 +580,44 @@ export async function runValidate(
         message: `Brand compliance audit skipped: ${(err as Error).message}`,
       });
     }
+  }
+
+  // SKILL.md instruction-density check (ADVISORY — never blocks). Measures the
+  // imperative-instruction count at each context-budget packing level for every
+  // SKILL.md in the project and warns when a loaded level exceeds the budget
+  // HumanLayer's RPI→CRISPY postmortem identified (~150-200; default 175). This
+  // repo's own autopilot/brainstorming skills are large by design, so the check
+  // is deliberately warning-severity: it is surfaced but never flips
+  // result.valid, and `harness validate` still exits 0. Overridable via
+  // `skills.instructionBudget`. Additive/colocated (overlap note: lane #1425).
+  try {
+    const densityResult = await runInstructionDensityAudit({
+      path: cwd,
+      ...(typeof config.skills?.instructionBudget === 'number' && {
+        budget: config.skills.instructionBudget,
+      }),
+    });
+    result.checks.instructionDensity = true;
+    for (const finding of densityResult.findings) {
+      result.issues.push({
+        check: 'instructionDensity',
+        file: finding.file,
+        ruleId: 'SKILL-DENSITY',
+        severity: 'warning',
+        message: finding.message,
+        suggestion:
+          'Advisory only. Move lower-priority directives into a deeper packing level (H2 section) or a references/ file so each loaded level stays under the instruction-follow budget.',
+      });
+    }
+  } catch (err) {
+    // A density-audit failure must never sink the whole validate — degrade
+    // gracefully with a single warning so the rest of the checks still report.
+    result.checks.instructionDensity = false;
+    result.issues.push({
+      check: 'instructionDensity',
+      severity: 'warning',
+      message: `Instruction-density check skipped: ${(err as Error).message}`,
+    });
   }
 
   // Opt-in agent config validation (agnix binary preferred, TS fallback otherwise)

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1125,6 +1125,14 @@ export const HarnessConfigSchema = z.object({
       neverSuggest: z.array(z.string()).default([]),
       /** Override the tier of specific skills (e.g., promote a Tier 3 skill to Tier 2) */
       tierOverrides: z.record(z.string(), z.number().int().min(1).max(3)).default({}),
+      /**
+       * Advisory imperative-instruction budget per SKILL.md packing level
+       * (`harness validate`). A level whose instruction count exceeds this is
+       * surfaced as a non-blocking warning. Defaults to
+       * `DEFAULT_INSTRUCTION_BUDGET` (175, the midpoint of HumanLayer's
+       * ~150-200 instruction-follow ceiling) when omitted.
+       */
+      instructionBudget: z.number().int().positive().optional(),
     })
     .optional(),
   /** Spec-to-implementation traceability check settings */

--- a/packages/cli/src/mcp/tools/instruction-density.test.ts
+++ b/packages/cli/src/mcp/tools/instruction-density.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runInstructionDensityAudit } from './instruction-density';
+
+const IMPERATIVE_BLOCK = Array.from({ length: 40 }, (_, i) => `${i + 1}. Run step ${i + 1}`).join(
+  '\n'
+);
+
+function skillBody(steps: number): string {
+  const lines = Array.from({ length: steps }, (_, i) => `${i + 1}. Run step ${i + 1}`).join('\n');
+  return `# Skill\n\n> Summary\n\n## Process\n\n${lines}\n`;
+}
+
+describe('runInstructionDensityAudit', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'density-audit-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('emits no finding when every level is within budget', async () => {
+    const dir = path.join(root, 'skills', 'small');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), skillBody(5));
+
+    const res = await runInstructionDensityAudit({ path: root, budget: 175 });
+    expect(res.skillsScanned).toBe(1);
+    expect(res.findings).toHaveLength(0);
+  });
+
+  it('emits an advisory finding when a level exceeds the budget', async () => {
+    const dir = path.join(root, 'skills', 'big');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      `# Big\n\n> S\n\n## Process\n\n${IMPERATIVE_BLOCK}\n`
+    );
+
+    const res = await runInstructionDensityAudit({ path: root, budget: 10 });
+    expect(res.findings).toHaveLength(1);
+    expect(res.findings[0]!.file).toContain('SKILL.md');
+    expect(res.findings[0]!.level.overBudget).toBe(true);
+    expect(res.findings[0]!.budget).toBe(10);
+  });
+
+  it('deduplicates symlinked skill mirrors by real path', async () => {
+    const canonical = path.join(root, 'claude-code', 'my-skill');
+    fs.mkdirSync(canonical, { recursive: true });
+    fs.writeFileSync(path.join(canonical, 'SKILL.md'), skillBody(5));
+
+    // Mirror directory as a symlink (as cursor/codex/gemini-cli skills are wired).
+    const mirrorParent = path.join(root, 'cursor');
+    fs.mkdirSync(mirrorParent, { recursive: true });
+    try {
+      fs.symlinkSync(canonical, path.join(mirrorParent, 'my-skill'), 'dir');
+    } catch {
+      // Some CI environments disallow symlinks; skip the dedup assertion there.
+      return;
+    }
+
+    const res = await runInstructionDensityAudit({ path: root });
+    expect(res.skillsScanned).toBe(1);
+  });
+
+  it('defaults the budget to 175 when not supplied', async () => {
+    const dir = path.join(root, 's');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), skillBody(3));
+    const res = await runInstructionDensityAudit({ path: root });
+    expect(res.budget).toBe(175);
+  });
+
+  it('skips node_modules', async () => {
+    const dir = path.join(root, 'node_modules', 'pkg');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), skillBody(5));
+    const res = await runInstructionDensityAudit({ path: root });
+    expect(res.skillsScanned).toBe(0);
+  });
+});

--- a/packages/cli/src/mcp/tools/instruction-density.ts
+++ b/packages/cli/src/mcp/tools/instruction-density.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  analyzeSkillInstructionDensity,
+  DEFAULT_INSTRUCTION_BUDGET,
+  type LevelInstructionDensity,
+} from '@harness-engineering/core';
+
+/**
+ * Advisory SKILL.md instruction-density audit.
+ *
+ * Walks a project for `SKILL.md` files and, for each, measures the imperative
+ * instruction count at every context-budget packing level (via
+ * `analyzeSkillInstructionDensity`). Emits one advisory finding per skill whose
+ * highest loaded level exceeds the budget. Non-blocking by contract — the caller
+ * (`harness validate`) surfaces these at `warning` severity.
+ *
+ * Validates the progressive-disclosure mitigation HumanLayer's RPI→CRISPY
+ * postmortem identified: planning prompts past a ~150-200 instruction-follow
+ * budget were the specific break that forced a workflow rebuild ([HORTHY-2]).
+ */
+
+export interface InstructionDensityFinding {
+  /** Repo-relative path to the SKILL.md. */
+  file: string;
+  /** The worst (highest-numbered) over-budget packing level for this skill. */
+  level: LevelInstructionDensity;
+  /** Budget the level was measured against. */
+  budget: number;
+  /** Human-readable advisory message. */
+  message: string;
+}
+
+export interface InstructionDensityAuditOptions {
+  /** Project root to walk. */
+  path: string;
+  /** Instruction budget per packing level. Defaults to DEFAULT_INSTRUCTION_BUDGET. */
+  budget?: number;
+}
+
+export interface InstructionDensityAuditResult {
+  budget: number;
+  /** Physical SKILL.md files inspected (symlink mirrors deduplicated). */
+  skillsScanned: number;
+  findings: InstructionDensityFinding[];
+}
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'coverage', '.next', '.turbo']);
+
+/**
+ * Collect physical `SKILL.md` paths under `root`, deduplicating by real path so
+ * the cursor / codex / gemini-cli skill mirrors (symlinks to the `claude-code`
+ * copy) collapse to a single physical file and are not double-counted.
+ */
+function collectSkillFiles(root: string): string[] {
+  const seenReal = new Set<string>();
+  const results: string[] = [];
+
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        walk(full);
+      } else if (entry.isSymbolicLink()) {
+        // Resolve symlinked directories (skill mirrors) and symlinked files alike.
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(full);
+        } catch {
+          continue;
+        }
+        if (stat.isDirectory()) {
+          if (!SKIP_DIRS.has(entry.name)) walk(full);
+        } else if (entry.name === 'SKILL.md') {
+          addFile(full);
+        }
+      } else if (entry.name === 'SKILL.md') {
+        addFile(full);
+      }
+    }
+  };
+
+  const addFile = (full: string): void => {
+    let real: string;
+    try {
+      real = fs.realpathSync(full);
+    } catch {
+      real = full;
+    }
+    if (seenReal.has(real)) return;
+    seenReal.add(real);
+    results.push(full);
+  };
+
+  walk(root);
+  return results;
+}
+
+export async function runInstructionDensityAudit(
+  options: InstructionDensityAuditOptions
+): Promise<InstructionDensityAuditResult> {
+  const budget = options.budget ?? DEFAULT_INSTRUCTION_BUDGET;
+  const root = path.resolve(options.path);
+  const skillFiles = collectSkillFiles(root);
+  const findings: InstructionDensityFinding[] = [];
+
+  for (const file of skillFiles) {
+    let content: string;
+    try {
+      content = fs.readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    const report = analyzeSkillInstructionDensity(content, budget);
+    if (!report.maxLevelOverBudget) continue;
+    const level = report.maxLevelOverBudget;
+    const rel = path.relative(root, file).replaceAll('\\', '/') || file;
+    findings.push({
+      file: rel,
+      level,
+      budget,
+      message:
+        `Packing level ${level.level}/5 loads ${level.instructionCount} imperative instructions ` +
+        `(> budget ${budget}) across ${level.sections} section(s). HumanLayer's RPI→CRISPY ` +
+        `postmortem identified ~150-200 as the instruction-follow ceiling; consider splitting ` +
+        `directives into a deeper packing level or a references/ file.`,
+    });
+  }
+
+  return { budget, skillsScanned: skillFiles.length, findings };
+}

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -65,6 +65,18 @@ export type {
  * Section parser for progressive skill content loading.
  */
 export { parseSections, extractLevel } from './section-parser';
+
+/**
+ * Instruction-density estimation — imperative-instruction count per SKILL.md
+ * packing level, validating the progressive-disclosure mitigation against the
+ * HumanLayer instruction-follow budget ([HORTHY-2]).
+ */
+export {
+  countImperativeInstructions,
+  analyzeSkillInstructionDensity,
+  DEFAULT_INSTRUCTION_BUDGET,
+} from './instruction-density';
+export type { LevelInstructionDensity, SkillInstructionDensityReport } from './instruction-density';
 export type { ParsedSection } from './section-parser';
 
 /**

--- a/packages/core/src/context/instruction-density.ts
+++ b/packages/core/src/context/instruction-density.ts
@@ -1,0 +1,231 @@
+import type { LoadingLevel } from '@harness-engineering/types';
+import { extractLevel, parseSections } from './section-parser';
+
+/**
+ * Instruction-density estimation for SKILL.md bodies.
+ *
+ * HumanLayer's public RPI→CRISPY postmortem found that planning prompts which
+ * exceeded a ~150-200 instruction-follow budget were the specific failure that
+ * forced a full workflow rebuild. This module measures the *imperative
+ * instruction* count a skill presents at each context-budget packing level (the
+ * cumulative levels {@link extractLevel} already loads), so progressive
+ * disclosure — the mitigation being validated — is measured per loaded level
+ * rather than over the whole file. See
+ * `docs/research/dex-horthy-humanlayer-comparison-analysis.md` [HORTHY-2].
+ */
+
+/**
+ * Default per-level instruction budget. The midpoint of HumanLayer's identified
+ * ~150-200 instruction-follow ceiling. A packing level whose imperative
+ * instruction count exceeds this is surfaced as an advisory (non-blocking)
+ * warning; it is never a hard failure. Overridable via `skills.instructionBudget`.
+ */
+export const DEFAULT_INSTRUCTION_BUDGET = 175;
+
+/**
+ * Imperative verbs that mark a bullet as an instruction to follow. Matched
+ * case-insensitively against the first word of a `-`/`*` bullet. Curated from the
+ * verbs that actually open directive bullets across the harness skill corpus;
+ * intentionally conservative — a bullet that merely states a fact ("Existing JWT
+ * middleware") is not counted.
+ */
+const IMPERATIVE_VERBS = new Set(
+  [
+    'run',
+    'call',
+    'read',
+    'write',
+    'add',
+    'check',
+    'verify',
+    'ensure',
+    'use',
+    'set',
+    'create',
+    'do',
+    'stop',
+    'ask',
+    'emit',
+    'commit',
+    'skip',
+    'continue',
+    'cite',
+    'apply',
+    'present',
+    'wait',
+    'fix',
+    'remove',
+    'update',
+    'derive',
+    'branch',
+    'surface',
+    'record',
+    'reject',
+    'avoid',
+    'prefer',
+    'never',
+    'always',
+    'load',
+    'select',
+    'choose',
+    'propose',
+    'identify',
+    'acknowledge',
+    'track',
+    'resolve',
+    'scan',
+    'extract',
+    'announce',
+    'request',
+    'promote',
+    'transition',
+    'return',
+    'treat',
+    'flag',
+    'define',
+    'populate',
+    'follow',
+    'invoke',
+    'pass',
+    'wire',
+    'register',
+    'append',
+    'include',
+    'exclude',
+    'validate',
+    'confirm',
+    'dispatch',
+    'capture',
+    'consume',
+    'note',
+    'assess',
+    'decompose',
+    'narrow',
+    'consider',
+    'replace',
+    'delete',
+    'declare',
+    'map',
+    'walk',
+    'count',
+    'report',
+    'store',
+  ].map((v) => v.toLowerCase())
+);
+
+const NUMBERED_STEP = /^\s*\d+[.)]\s+\S/;
+const BULLET = /^\s*[-*]\s+(\S+)/;
+/** SCREAMING directive tokens. Case-sensitive to avoid prose false positives. */
+const DIRECTIVE = /\b(MUST|SHALL|REQUIRED)\b/;
+const CODE_FENCE = /^\s*(```|~~~)/;
+
+/**
+ * Count imperative instructions in a block of markdown.
+ *
+ * An "instruction" is any of:
+ * - a numbered step (`1.` / `2)` list marker),
+ * - an imperative-verb bullet (`-`/`*` whose first word is an imperative verb),
+ * - a directive line carrying a `MUST` / `SHALL` / `REQUIRED` token.
+ *
+ * Content inside fenced code blocks is ignored so example snippets do not inflate
+ * the count. Each line counts at most once. This is a deterministic heuristic, not
+ * an NLP parser — it estimates the instruction-follow load, not exact semantics.
+ */
+export function countImperativeInstructions(markdown: string): number {
+  if (!markdown.trim()) return 0;
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  let count = 0;
+  let inFence = false;
+
+  for (const line of lines) {
+    if (CODE_FENCE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    if (NUMBERED_STEP.test(line)) {
+      count += 1;
+      continue;
+    }
+
+    const bulletMatch = line.match(BULLET);
+    if (bulletMatch) {
+      const firstWord = bulletMatch[1]!.replace(/[^a-zA-Z]/g, '').toLowerCase();
+      if (IMPERATIVE_VERBS.has(firstWord)) {
+        count += 1;
+        continue;
+      }
+    }
+
+    if (DIRECTIVE.test(line)) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+/** Instruction density measured at a single cumulative packing level. */
+export interface LevelInstructionDensity {
+  /** Packing level 1..5. Level 5 is the full body. */
+  level: LoadingLevel;
+  /** Number of sections included at (or below) this level. */
+  sections: number;
+  /** Imperative instructions in the cumulative content loaded at this level. */
+  instructionCount: number;
+  /** True when {@link instructionCount} exceeds the budget. */
+  overBudget: boolean;
+}
+
+/** Per-level instruction-density report for one SKILL.md body. */
+export interface SkillInstructionDensityReport {
+  /** Budget the levels were measured against. */
+  budget: number;
+  /** Density at each cumulative packing level 1..5. */
+  levels: LevelInstructionDensity[];
+  /**
+   * The highest-numbered level whose instruction count exceeds the budget, or
+   * `null` when every loaded level is within budget. The highest level carries
+   * the most content (packing is cumulative), so this is the worst case.
+   */
+  maxLevelOverBudget: LevelInstructionDensity | null;
+}
+
+const LEVELS: readonly LoadingLevel[] = [1, 2, 3, 4, 5];
+
+/** Strip the injected context-budget marker so it does not skew the count. */
+function stripBudgetMarker(content: string): string {
+  return content.replace(/<!-- context-budget:[^>]*-->\s*$/m, '');
+}
+
+/**
+ * Measure imperative-instruction density at each cumulative packing level of a
+ * SKILL.md body. Re-uses {@link extractLevel} so the content measured at each
+ * level is exactly what `run_skill` loads there — progressive disclosure is the
+ * mitigation being validated, so density is estimated per loaded level rather
+ * than over the whole file.
+ */
+export function analyzeSkillInstructionDensity(
+  content: string,
+  budget: number = DEFAULT_INSTRUCTION_BUDGET
+): SkillInstructionDensityReport {
+  const totalSections = parseSections(content).length;
+  const levels: LevelInstructionDensity[] = LEVELS.map((level) => {
+    const packed = stripBudgetMarker(extractLevel(content, level));
+    const includedSections = parseSections(packed).length || (level === 5 ? totalSections : 0);
+    const instructionCount = countImperativeInstructions(packed);
+    return {
+      level,
+      sections: includedSections,
+      instructionCount,
+      overBudget: instructionCount > budget,
+    };
+  });
+
+  const overBudgetLevels = levels.filter((l) => l.overBudget);
+  const maxLevelOverBudget =
+    overBudgetLevels.length > 0 ? overBudgetLevels[overBudgetLevels.length - 1]! : null;
+
+  return { budget, levels, maxLevelOverBudget };
+}

--- a/packages/core/tests/context/instruction-density.test.ts
+++ b/packages/core/tests/context/instruction-density.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  countImperativeInstructions,
+  analyzeSkillInstructionDensity,
+  DEFAULT_INSTRUCTION_BUDGET,
+} from '../../src/context/instruction-density';
+
+describe('countImperativeInstructions', () => {
+  it('returns 0 for empty or whitespace content', () => {
+    expect(countImperativeInstructions('')).toBe(0);
+    expect(countImperativeInstructions('   \n  \n')).toBe(0);
+  });
+
+  it('counts numbered steps', () => {
+    const md = `1. Do the first thing
+2. Do the second thing
+3) A paren-numbered step also counts`;
+    expect(countImperativeInstructions(md)).toBe(3);
+  });
+
+  it('counts imperative-verb bullets but not descriptive bullets', () => {
+    const md = `- Run the build
+- Verify the output
+- Existing JWT middleware handles auth
+- Vendor lock-in is a risk`;
+    // Only the "Run" and "Verify" bullets are imperative.
+    expect(countImperativeInstructions(md)).toBe(2);
+  });
+
+  it('counts MUST/SHALL/REQUIRED directive lines', () => {
+    const md = `Technical claims MUST cite evidence.
+The system shall respond quickly.
+This field is REQUIRED for the request.`;
+    // "shall" lowercase is NOT counted (SCREAMING form only); MUST + REQUIRED are.
+    expect(countImperativeInstructions(md)).toBe(2);
+  });
+
+  it('does not double-count a numbered imperative line', () => {
+    expect(countImperativeInstructions('1. Run the build')).toBe(1);
+  });
+
+  it('ignores content inside fenced code blocks', () => {
+    const md = `1. Real step
+\`\`\`bash
+Run this in the shell
+1. not a real step
+MUST not count
+\`\`\`
+2. Another real step`;
+    expect(countImperativeInstructions(md)).toBe(2);
+  });
+
+  it('excludes plain prose', () => {
+    const md = `This is a paragraph describing the design.
+It has several sentences but no instructions.`;
+    expect(countImperativeInstructions(md)).toBe(0);
+  });
+});
+
+const SAMPLE = `# Sample Skill
+
+> Summary line.
+
+## Process
+
+1. Run the setup
+2. Verify the state
+
+### Iron Law
+
+You MUST not skip the gate.
+
+## Examples
+
+- Read the docs for context
+- Descriptive bullet with no verb lead
+
+## Escalation
+
+- Stop and ask the human
+`;
+
+describe('analyzeSkillInstructionDensity', () => {
+  it('reports one entry per packing level 1..5', () => {
+    const report = analyzeSkillInstructionDensity(SAMPLE);
+    expect(report.levels.map((l) => l.level)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('uses the default budget when none supplied', () => {
+    const report = analyzeSkillInstructionDensity(SAMPLE);
+    expect(report.budget).toBe(DEFAULT_INSTRUCTION_BUDGET);
+  });
+
+  it('is monotonic non-decreasing across cumulative levels', () => {
+    const report = analyzeSkillInstructionDensity(SAMPLE);
+    for (let i = 1; i < report.levels.length; i++) {
+      expect(report.levels[i]!.instructionCount).toBeGreaterThanOrEqual(
+        report.levels[i - 1]!.instructionCount
+      );
+    }
+  });
+
+  it('flags over-budget when budget is set below the level counts', () => {
+    const report = analyzeSkillInstructionDensity(SAMPLE, 2);
+    expect(report.maxLevelOverBudget).not.toBeNull();
+    // The worst case is the highest over-budget level.
+    expect(report.maxLevelOverBudget!.level).toBe(5);
+    expect(report.maxLevelOverBudget!.overBudget).toBe(true);
+  });
+
+  it('returns null maxLevelOverBudget when every level is within budget', () => {
+    const report = analyzeSkillInstructionDensity(SAMPLE, 1000);
+    expect(report.maxLevelOverBudget).toBeNull();
+    expect(report.levels.every((l) => !l.overBudget)).toBe(true);
+  });
+
+  it('handles empty content without throwing', () => {
+    const report = analyzeSkillInstructionDensity('');
+    expect(report.maxLevelOverBudget).toBeNull();
+    expect(report.levels).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **advisory (non-blocking) SKILL.md instruction-density check** to `harness validate`, adapted from HumanLayer's RPI→CRISPY postmortem ([HORTHY-2], `docs/research/dex-horthy-humanlayer-comparison-analysis.md`). HumanLayer found that planning prompts past a **~150-200 instruction-follow budget** were the specific failure that forced a full workflow rebuild. This check confirms — with a measured number — that the repo's progressive-disclosure packing keeps each loaded packing level under that ceiling.

## What it does

- **Metric:** imperative instructions = numbered steps + imperative-verb bullets + `MUST`/`SHALL`/`REQUIRED` directives (fenced code + prose excluded). Not raw lines.
- **Per packing level:** measured at each cumulative context-budget level `run_skill` loads (reusing `extractLevel`), since progressive disclosure is the mitigation being validated.
- **Threshold:** default **175** (midpoint of the ~150-200 range), configurable via `skills.instructionBudget`.
- **Surface:** `SKILL-DENSITY` finding at `warning` severity in `harness validate` — never flips `result.valid`, so the gate's exit code is unchanged. Plus a guidance note in `harness-skill-authoring`.

## Measurement on this repo (validates the hypothesis)

Progressive disclosure keeps every loaded level well under budget:

| Skill | max instructions/level | budget |
| --- | --- | --- |
| harness-autopilot | 75 (level 5) | 175 |
| harness-brainstorming | 45 | 175 |
| harness-skill-authoring | 41 | 175 |

No skill trips the warning; the repo does **not** share RPI's failure mode.

## Design notes / assumptions

- Heuristic imperative-instruction count per packing level (deterministic, no NLP).
- Advisory, non-blocking in `harness validate`.
- Warn threshold documented default **175** (~150-200 range), configurable.
- Added skill-authoring guidance note.
- **Additive** validate registration + colocated audit helper (overlap w/ #1425): both lanes append, trivial both-add merge.
- SKILL.md audit dedups symlinked skill mirrors (cursor/codex/gemini-cli → claude-code) by `realpath`.

## Testing

- `packages/core/tests/context/instruction-density.test.ts` (13) — counting heuristic + per-level analysis.
- `packages/cli/src/mcp/tools/instruction-density.test.ts` (5) — audit walk, over-budget finding, symlink dedup, node_modules skip.
- Existing `validate` suites green; typecheck, eslint, `generate:plugin:check`, pre-push doc/catalog checks all pass.
- Confirmed `harness validate` runs the check with **zero** error-level contributions (exit code driven only by pre-existing checks).

## Artifacts

- Spec: `docs/changes/skill-instruction-density/proposal.md`
- Plan: `docs/changes/skill-instruction-density/plans/plan.md`
- Provenance: `docs/changes/skill-instruction-density/provenance.json`

Closes #1404
