### PR TITLE
fix(docs): strip embedded global counters from skills-catalog generator (#1235)

### DIFF
--- a/docs/changes/strip-generated-artifact-counters/plans/2026-08-25-strip-counters-plan.md
+++ b/docs/changes/strip-generated-artifact-counters/plans/2026-08-25-strip-counters-plan.md
@@ -1,0 +1,63 @@
+# Plan — Strip embedded global counters from generated artifacts (#1235)
+
+## Problem
+
+Every PR that adds/changes a skill regenerates `docs/reference/skills-catalog.md`.
+Because the catalog embeds **derived global counters** in its prose — the top-level
+`NNN skills` line and per-tier headings like `## Tier 1 — Workflow (17 skills)` — two
+sibling PRs conflict on those exact lines **even when their skill entries are thousands
+of lines apart**. The counters make collisions _guaranteed_ rather than incidental, and
+they also drive the recurring `fix(docs): correct skills-catalog counts` churn.
+
+## Decision (locked, from issue CONFIRM)
+
+Remove the embedded global counters and regenerate the artifacts WITHOUT volatile prose
+counts. Kill the guaranteed-conflict source. Do **not** reintroduce a volatile committed
+counter. Residual collisions on _genuinely_ alphabetically-adjacent entries are acceptable
+for v1; per-entry sharding is a deferred follow-up. A `.gitattributes` merge driver and
+sharding-alone are already ruled out (GitHub ignores server-side merge drivers; counter
+lines survive sharding).
+
+## Grounding (verified)
+
+- The **only** generated, committed artifact that embeds derived global counters is
+  `docs/reference/skills-catalog.md`, produced by `generateSkillsCatalog()` in
+  `scripts/generate-docs.mjs`. Three spots:
+  1. top-level `${skills.length} skills.` intro line
+  2. `The ${loadBearing.length} skills that carry the core workflow.` (Tier-0 intro)
+  3. per-tier heading `## ${tier.label} (${tier.skills.length} skills)`
+- The **plugin command manifests** (`.claude-plugin/**`, sibling platform dirs) and the
+  **roadmap aggregate** (`docs/roadmap.md`) were inspected and carry **no** derived global
+  counter prose — their only residual conflict shape is alphabetical insertion, which the
+  decision accepts for v1. There is therefore no counter to remove from those generators.
+- `mcp-tools.md` and `cli-commands.md` (also emitted by `generate-docs`) carry no derived
+  count prose either.
+
+## Change
+
+Reword the three counter spots in `generateSkillsCatalog()` so the emitted artifact carries
+no volatile global count:
+
+- Drop the leading `NNN skills.` fragment (prose keeps the "~12 in your head" guidance,
+  which is a fixed cognitive-load claim, not a derived count).
+- Drop the `${loadBearing.length}` count from the Tier-0 intro.
+- Drop the `(N skills)` fragment from each tier heading.
+
+Regenerate `docs/reference/skills-catalog.md` and commit it so the `generate-docs --check`
+gate (which asserts the committed artifact is fresh) passes.
+
+## Verification
+
+- `pnpm run generate-docs --check` → fresh (green once regenerated artifact is staged).
+- `pnpm run generate:plugin:check` → unaffected, green.
+- Catalog-consistency tests (`skill-catalog-consistency`, `tier0-catalog-consistency`,
+  `generate-docs-determinism`) read descriptions / README / dashboard, **not** the counter
+  lines — unaffected. No snapshot asserted the counter lines.
+- Two sibling skill-adding PRs no longer touch the counter lines, so they cannot conflict
+  on them; only genuine alphabetical neighbours collide (accepted v1 residual).
+
+## Out of scope (deferred)
+
+- Issue "part 2" (stop requiring regenerated artifacts in feature PRs + post-merge regen
+  job on `main`) is a larger CI-gate change, not part of the locked counter-removal decision.
+- Per-entry sharding of the catalog.

--- a/docs/changes/strip-generated-artifact-counters/provenance.json
+++ b/docs/changes/strip-generated-artifact-counters/provenance.json
@@ -1,0 +1,13 @@
+{
+  "issues": [1235],
+  "stages": ["brainstorming", "planning", "execution", "review"],
+  "planArtifact": "docs/changes/strip-generated-artifact-counters/plans/2026-08-25-strip-counters-plan.md",
+  "assumptions": [
+    "removed embedded global counters from skills-catalog + plugin manifests + roadmap aggregate generators",
+    "counts moved off the committed artifact / not reintroduced",
+    "residual alphabetical-adjacency collisions acceptable v1; per-entry sharding deferred",
+    "merge-driver + sharding-alone ruled out per issue"
+  ],
+  "closingKeyword": "Closes #1235",
+  "notes": "Verified the only generated committed artifact carrying derived global counters is docs/reference/skills-catalog.md (3 spots in generateSkillsCatalog). Plugin command manifests and docs/roadmap.md aggregate were inspected and carry no derived count prose, so there was no counter to strip there; their residual conflict shape is alphabetical insertion, accepted for v1."
+}

--- a/docs/reference/skills-catalog.md
+++ b/docs/reference/skills-catalog.md
@@ -2,13 +2,13 @@
 
 # Skills Catalog
 
-789 skills. Skills carry two independent tier axes: a **loading tier** (whether a skill registers as a slash command or is discovered on demand) and a **curation tier** (how load-bearing it is). A senior engineer can hold ~12 skills in their head, not hundreds — the curation tier names that short list.
+Skills carry two independent tier axes: a **loading tier** (whether a skill registers as a slash command or is discovered on demand) and a **curation tier** (how load-bearing it is). A senior engineer can hold ~12 skills in their head, not hundreds — the curation tier names that short list.
 
 See the [Features Overview](../guides/features-overview.md) for narrative documentation.
 
 ## Load-Bearing Gear (Tier-0)
 
-The 12 skills that carry the core workflow. Learn these first; everything else is a library you reach for on demand.
+The skills that carry the core workflow. Learn these first; everything else is a library you reach for on demand.
 
 - **harness-autopilot** — Autonomous phase execution loop — chains planning, execution, verification, and review, pausing only at human decision points
 - **harness-brainstorming** — Structured ideation and exploration with harness methodology
@@ -27,7 +27,7 @@ The 12 skills that carry the core workflow. Learn these first; everything else i
 
 Tier 1 and 2 skills are registered as slash commands. Tier 3 skills are discoverable via the `search_skills` MCP tool.
 
-## Tier 1 — Workflow (17 skills)
+## Tier 1 — Workflow
 
 ### add-harness-component
 
@@ -200,7 +200,7 @@ Human-judged acceptance sign-off skill — the terminal, human-authority stage o
 - **Cognitive mode:** configuration-interviewer
 - **Depends on:** outcome-eval
 
-## Tier 2 — Maintenance (69 skills)
+## Tier 2 — Maintenance
 
 ### acceptance-eval
 
@@ -867,7 +867,7 @@ Autonomous test-coverage backlog sweep — enumerate under-covered areas and unc
 - **Cognitive mode:** systematic-orchestrator
 - **Depends on:** harness-test-advisor, harness-tdd, test-craft, harness-roadmap-pilot
 
-## Tier 3 — Domain (703 skills)
+## Tier 3 — Domain
 
 ### a11y-aria-patterns
 

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -490,13 +490,13 @@ function generateSkillsCatalog() {
   const lines = [
     HEADER,
     '# Skills Catalog\n\n',
-    `${skills.length} skills. Skills carry two independent tier axes: a **loading tier** `,
+    'Skills carry two independent tier axes: a **loading tier** ',
     '(whether a skill registers as a slash command or is discovered on demand) and a ',
     '**curation tier** (how load-bearing it is). A senior engineer can hold ~12 skills in ',
     'their head, not hundreds — the curation tier names that short list.\n\n',
     'See the [Features Overview](../guides/features-overview.md) for narrative documentation.\n\n',
     '## Load-Bearing Gear (Tier-0)\n\n',
-    `The ${loadBearing.length} skills that carry the core workflow. Learn these first; `,
+    'The skills that carry the core workflow. Learn these first; ',
     'everything else is a library you reach for on demand.\n\n',
   ];
 
@@ -519,7 +519,7 @@ function generateSkillsCatalog() {
   lines.push('Tier 3 skills are discoverable via the `search_skills` MCP tool.\n\n');
 
   for (const [_tierNum, tier] of Object.entries(tiers)) {
-    lines.push(`## ${tier.label} (${tier.skills.length} skills)\n\n`);
+    lines.push(`## ${tier.label}\n\n`);
 
     for (const skill of tier.skills) {
       lines.push(renderSkillEntry(skill));


### PR DESCRIPTION
## What

Removes the derived **global counters** from the generated `docs/reference/skills-catalog.md` prose:
- the top-level `NNN skills` line,
- the Tier-0 "load-bearing" count (`The N skills that carry the core workflow`),
- the per-tier `(N skills)` heading fragments (`## Tier 1 — Workflow (17 skills)` → `## Tier 1 — Workflow`).

## Why

Per #1235, these embedded counters made **every** skill-adding PR rewrite the exact same
lines, so two sibling PRs conflict **even when their entries are thousands of lines apart** —
the single largest tax on batch/fan-out (`-fleet`) workflows. They also drove the recurring
`fix(docs): correct skills-catalog counts` churn.

Per the locked decision on the issue: remove the volatile committed counters and regenerate
without them. After removal, neighbours only collide when *genuinely* alphabetically adjacent
(rare) — accepted for v1; per-entry sharding is a deferred follow-up. A `.gitattributes` merge
driver (GitHub ignores server-side) and sharding-alone (counter lines survive) were already
ruled out.

## Scope note

The plugin command manifests (`.claude-plugin/**` + sibling platform dirs) and the roadmap
aggregate (`docs/roadmap.md`) were inspected and carry **no** derived counter prose, so there
was nothing to strip in those generators — `skills-catalog.md` was the sole offender. Issue
"part 2" (dropping the artifact-freshness requirement from feature PRs + a post-merge regen
job) is a larger CI-gate change outside the locked counter-removal decision and is not included.

## Verification

- `pnpm run generate-docs --check` → fresh.
- `pnpm run generate:plugin:check` / `generate:tool-catalog:check` → green.
- Catalog-consistency + determinism tests (12) pass — they read descriptions / README /
  dashboard, not the counter lines. No snapshot asserted the counters.
- Pre-commit (arch, traceability) and full pre-push gate suite pass.

Closes #1235