### PR TITLE
feat(design-craft): vision BENCHMARK so the award bar is reachable

### DIFF
--- a/.changeset/design-craft-vision-benchmark.md
+++ b/.changeset/design-craft-vision-benchmark.md
@@ -1,0 +1,23 @@
+---
+'@harness-engineering/intelligence': minor
+'@harness-engineering/cli': minor
+---
+
+Give design-craft BENCHMARK a real vision channel so the award bar is reachable.
+
+BENCHMARK previously scored source **code** (`callText`), and `callVision` threw on
+every provider with no image support in `@harness-engineering/intelligence` — so
+`innovation` / `philosophicalCoherence` / surface could never be honestly judged and the
+award verdict was structurally never `cleared`.
+
+- `@harness-engineering/intelligence`: `AnalysisRequest.images` + Anthropic image content
+  blocks; `claude-cli` image support via the `--input-format stream-json` transport.
+- `@harness-engineering/cli`: real `AnalysisProviderAdapter.callVision` gated by a
+  `supportsVision` capability flag (a non-vision backend throws instead of silently
+  scoring a blank page); `runVisionBenchmark` scores the rendered screenshot; the
+  `design_craft` tool routes deep-mode benchmark to it and requires a capture per
+  page-scoped target.
+
+Validated end-to-end against the real local `claude` CLI: the model reads images,
+discriminates a strong page from a flat one, and a full-page strong capture clears all
+five dimensions.

--- a/docs/changes/design-craft-vision-benchmark/proposal.md
+++ b/docs/changes/design-craft-vision-benchmark/proposal.md
@@ -1,0 +1,52 @@
+# Design-Craft Vision BENCHMARK — make the award bar actually reachable
+
+**Keywords:** design-craft, benchmark, award-bar, vision, callVision, claude-cli, anthropic, intelligence-provider, screenshots
+
+## Overview and goals
+
+The `awardBar` verdict (ADR 0082 / `docs/changes/design-craft-award-bar`) is machine-derived from the BENCHMARK radar: each of the five dimensions must clear an exemplar-relative floor, and low confidence forces `indeterminate`. That spec explicitly listed **"no vision-mode changes"** as a non-goal.
+
+The consequence, observed in the consuming `iv-demo` fleet: **`awardBar` is `false` on 40/40 recorded prospects, never once `cleared`.** The cause is not a missing corpus (the 9 MarketingPage exemplars are bundled) — it is that **BENCHMARK scored source code, not the rendered page**, and the vision channel it needed did not exist:
+
+- `runBenchmark` built its prompt from the target's **source text** and called `provider.callText` (`packages/cli/src/design-craft/phases/benchmark.ts`).
+- `LlmProvider.callVision` **threw on every provider** — `InSessionLlmProvider` ("must use a real provider"), `MockLlmProvider` ("Phase 2 work"), and `AnalysisProviderAdapter` ("wire vision when needed"). The `packages/intelligence` layer had no image support at all (`VisionInput` existed with zero implementations).
+
+An LLM reading HTML/CSS cannot honestly judge `innovation`, `philosophicalCoherence`, or surface/craft — it lands sub-floor or at `low` confidence, so the verdict is **structurally never `cleared`.** The award bar has been unreachable since it shipped.
+
+**Goal:** give BENCHMARK a real vision channel so the award bar is reachable — the model scores the _rendered screenshot_, exactly as the SKILL's deep mode already describes ("render via playwright … pass screenshots … to vision-capable LLM") and as `harness-design-craft/SKILL.md` anticipated ("`packages/intelligence/` … **may need extension if no vision support today**").
+
+**Non-goals (YAGNI):** no change to the radar dimensions, the award-bar formula, exemplars, or the responsive gate; no new capture/browser tooling in the CLI (captures remain caller-supplied, per deep-mode critique).
+
+## Decisions made
+
+- **D1 — Extend the intelligence Anthropic provider for images.** `AnalysisRequest` gains `images?: AnalysisImage[]`; the Anthropic backend renders them as image content blocks ahead of the text prompt, keeping the `structured_output` tool contract. This is the extension the SKILL anticipated.
+- **D2 — Real `callVision` on the adapter, gated by capability.** `AnalysisProviderAdapter.callVision` forwards the image through `analyze`. A `supportsVision` flag (true for `anthropic` + `claude-cli`, false otherwise) makes `callVision` **throw loudly** on a non-vision backend rather than silently forwarding an image the backend drops and scoring a blank page — the failure mode that would hallucinate a verdict.
+- **D3 — Real vision through the local `claude` CLI.** The keyless path most interactive sessions use. `ClaudeCliAnalysisProvider` sends images via the `--input-format stream-json` transport (a user message whose content is the image block(s) + text) and reads `structured_output` from the terminal `result` event. Verified against Claude Code CLI 2.1.x.
+- **D4 — Deep-mode BENCHMARK scores captures.** `runVisionBenchmark` mirrors `runBenchmark` but calls `callVision` over the rendered screenshot. The `design_craft` tool routes deep-mode benchmark to it, matching captures to targets by `file`, and **errors** when a page-scoped target has no capture — a page-scoped award verdict must never come from source alone.
+
+## Technical design
+
+- `packages/intelligence/src/analysis-provider/interface.ts` — `AnalysisImage` (`base64 | url` + `mediaType`) and `AnalysisRequest.images`.
+- `packages/intelligence/src/analysis-provider/anthropic.ts` — user turn becomes a content-block array (image blocks + text) when images are present; unchanged (plain string) otherwise.
+- `packages/intelligence/src/analysis-provider/claude-cli.ts` — `runClaudeVision` / `runClaudeStream`: stream-json transport with the image on stdin; text path unchanged.
+- `packages/cli/src/shared/craft/llm/adapters.ts` — `callVision` implementation + `supportsVision` capability gate + `VisionInput → AnalysisImage` conversion (`imageBuffer → base64`).
+- `packages/cli/src/design-craft/phases/benchmark.ts` — `VisionBenchmarkTarget` + `runVisionBenchmark` (reuses exemplar selection, `buildScore`, and the award-bar computation unchanged).
+- `packages/cli/src/mcp/tools/design-craft.ts` — deep-mode benchmark → `runVisionBenchmark`; capture gate extended to benchmark; capture↔target join by `file`.
+
+## Validation
+
+Beyond unit/integration tests (Anthropic image-block construction, adapter capability gate, `runVisionBenchmark` + tool wiring), the path was validated **end-to-end against the real local `claude` CLI — no mocks, no API key:**
+
+1. **The model genuinely sees images.** A rendered page with the token `ZORPTANGLE` on a `#0b5cff` field, sent headlessly via stream-json, returned `structured_output: {word: "ZORPTANGLE", bg: "#0A57FF"}`.
+2. **It discriminates quality.** `runVisionBenchmark` (real `claude-cli` provider, son-daven exemplar) on a clean viewport capture: a strong Awwwards page vs a flat demo scored `innovation` **85 vs 56**, `philosophicalCoherence` **87 vs 77** — and reproduced the flat page's core defect unprompted: _"a recognizable hero-plus-section template — swapping the brand out would change little."_
+3. **`cleared` is reachable.** A full-page capture of the strong page cleared all five dimensions (philosophicalCoherence 94, craftExecution 90, innovation 89; verdict `cleared`) — retiring the 40/40-always-false problem.
+
+**Known characteristic:** LLM vision scoring carries run-to-run variance, amplified by degenerate captures (an animated site's full-page screenshot with large unrendered blank regions swung 88↔37 across two calls on the same image). Clean per-viewport captures gave stable results; the SKILL's 3-viewport capture guidance already mitigates this. A future N-pass median is a candidate follow-up.
+
+The manual harness lives at `packages/cli/scripts/validate-vision-benchmark.mts` (not built/linted/typechecked — `tsconfig` includes only `src/**`).
+
+## Follow-ups (out of scope here)
+
+- **`iv-demo` wiring (consuming repo `harness-iv`):** invoke deep-mode BENCHMARK with 3-viewport captures + configure a vision-capable craft provider, so the pipeline stops recording `awardBar:false` by default. This PR delivers the capability; the consuming skill must opt into it.
+- `openai-compatible` vision (currently gated off).
+- N-pass median scoring to damp variance.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -604,7 +604,7 @@ Run the harness-design-craft skill: CRITIQUE / POLISH / BENCHMARK phases over a 
 **Parameters:**
 
 - `path` (string, required) — Project root path
-- `mode` (string, optional) — fast (code-only LLM critique) or deep (vision critique of rendered screenshots — requires `captures`).
+- `mode` (string, optional) — fast (code-only LLM judgment) or deep (vision judgment of rendered screenshots — requires `captures`). Deep mode applies to BOTH critique and benchmark; only deep-mode benchmark can clear the award bar, since innovation/coherence/surface cannot be honestly scored from source code.
 - `phases` (array, optional) — Subset of phases to run. Defaults to all three.
 - `files` (array, optional) — Optional file scoping. Each entry is a path relative to project root.
 - `autoCapture` (string, optional) — Deep-mode capture behavior when no `captures` are supplied. "skip" never runs the capture command; "prompt"/"auto" run `captureCommand` when one is configured.

--- a/docs/reference/tool-catalog.md
+++ b/docs/reference/tool-catalog.md
@@ -1504,7 +1504,7 @@ Run the harness-design-craft skill: CRITIQUE / POLISH / BENCHMARK phases over a 
       "type": "array"
     },
     "mode": {
-      "description": "fast (code-only LLM critique) or deep (vision critique of rendered screenshots — requires `captures`).",
+      "description": "fast (code-only LLM judgment) or deep (vision judgment of rendered screenshots — requires `captures`). Deep mode applies to BOTH critique and benchmark; only deep-mode benchmark can clear the award bar, since innovation/coherence/surface cannot be honestly scored from source code.",
       "enum": [
         "fast",
         "deep"

--- a/packages/cli/scripts/validate-vision-benchmark.mts
+++ b/packages/cli/scripts/validate-vision-benchmark.mts
@@ -1,0 +1,56 @@
+// Manual end-to-end validation of the vision BENCHMARK path against the REAL
+// local `claude` CLI (no mocks, no API key). Runs runVisionBenchmark on two
+// real screenshots — a strong Awwwards page vs a flat demo — and prints the
+// radar + machine award verdict for each. Proves the mechanism actually SEES
+// the page and discriminates quality.
+//
+// Run from packages/cli:
+//   pnpm exec tsx scripts/validate-vision-benchmark.mts <strong.png> <flat.png>
+
+import { runVisionBenchmark } from '../src/design-craft/phases/benchmark.js';
+import { adaptClaudeCli } from '../src/shared/craft/llm/adapters.js';
+import { ClaudeCliAnalysisProvider } from '@harness-engineering/intelligence';
+import { sonDavenMarketingPageExemplar } from '../src/design-craft/catalog/exemplars/son-daven-marketing-page.js';
+
+const [strong, flat] = process.argv.slice(2);
+if (!strong || !flat)
+  throw new Error('usage: validate-vision-benchmark.mts <strong.png> <flat.png>');
+
+const provider = adaptClaudeCli(new ClaudeCliAnalysisProvider({ timeoutMs: 300_000 }));
+
+async function score(label: string, image: string) {
+  const scores = await runVisionBenchmark({
+    targets: [{ file: image, component: label, componentType: 'MarketingPage', image }],
+    exemplars: [sonDavenMarketingPageExemplar],
+    provider,
+  });
+  const s = scores[0];
+  if (!s) {
+    console.log(`\n### ${label}: NO SCORE (parse failure or no matching exemplar)`);
+    return;
+  }
+  const r = s.radar;
+  console.log(`\n### ${label}`);
+  console.log(
+    `verdict: ${s.awardBar.verdict}` + (s.awardBar.reason ? ` (${s.awardBar.reason})` : '')
+  );
+  console.log(`overall: ${s.overall.score} (confidence ${s.overall.confidence})`);
+  for (const dim of [
+    'philosophicalCoherence',
+    'hierarchy',
+    'craftExecution',
+    'function',
+    'innovation',
+  ] as const) {
+    const d = r[dim];
+    const bar = s.awardBar.dimensions[dim];
+    console.log(
+      `  ${dim.padEnd(22)} score ${String(d.score).padStart(3)}  floor ${String(bar.floor).padStart(3)}  ${bar.cleared ? 'PASS' : 'MISS'}  conf ${d.confidence}`
+    );
+  }
+  console.log(`  gaps: ${s.gaps.slice(0, 3).join(' | ')}`);
+}
+
+await score('STRONG (sondaven.com — Awwwards SOTD)', strong);
+await score('FLAT (CrossYoga demo)', flat);
+console.log('\ndone.');

--- a/packages/cli/src/design-craft/phases/benchmark.ts
+++ b/packages/cli/src/design-craft/phases/benchmark.ts
@@ -318,3 +318,109 @@ export async function runBenchmark(args: BenchmarkArgs): Promise<BenchmarkScore[
   }
   return scores;
 }
+
+/** A rendered page/component screenshot to benchmark in deep (vision) mode. */
+export interface VisionBenchmarkTarget {
+  file: string;
+  component: string;
+  /** See {@link BenchmarkTarget.componentType} — selects the exemplar cohort. */
+  componentType?: string;
+  /** Path to the rendered screenshot (PNG / JPEG / WebP). */
+  image: string;
+}
+
+export interface VisionBenchmarkArgs {
+  targets: VisionBenchmarkTarget[];
+  exemplars: ExemplarDefinition[];
+  provider: LlmProvider;
+  awardBar?: Partial<AwardBarConfig>;
+  responsive?: BenchmarkArgs['responsive'];
+}
+
+function readImage(imagePath: string): {
+  imageBuffer: Buffer;
+  mediaType: 'image/png' | 'image/jpeg' | 'image/webp';
+} {
+  const resolved = path.isAbsolute(imagePath) ? imagePath : path.resolve(process.cwd(), imagePath);
+  const imageBuffer = fs.readFileSync(resolved);
+  const ext = path.extname(resolved).toLowerCase();
+  const mediaType =
+    ext === '.jpg' || ext === '.jpeg' ? 'image/jpeg' : ext === '.webp' ? 'image/webp' : 'image/png';
+  return { imageBuffer, mediaType };
+}
+
+function formatVisionPrompt(
+  target: VisionBenchmarkTarget,
+  exemplars: ExemplarDefinition[]
+): string {
+  const exemplarSummaries = exemplars
+    .map((e) =>
+      [
+        `--- Exemplar: ${e.name} (${e.id}) ---`,
+        `URL: ${e.url}`,
+        `Component type: ${e.componentType}`,
+        `Why exemplar:`,
+        e.whyExemplar,
+        `Critique notes:`,
+        e.critique,
+        `Reference radar (0–100):`,
+        `  philosophicalCoherence: ${e.radarReference.philosophicalCoherence}`,
+        `  hierarchy:              ${e.radarReference.hierarchy}`,
+        `  craftExecution:         ${e.radarReference.craftExecution}`,
+        `  function:               ${e.radarReference.function}`,
+        `  innovation:             ${e.radarReference.innovation}`,
+      ].join('\n')
+    )
+    .join('\n\n');
+
+  return [
+    `Score ${target.component} (${target.file}) against the following exemplar(s) using the 5-dimension radar.`,
+    '',
+    exemplarSummaries,
+    '',
+    'The target is the RENDERED page attached as an image — judge the visual',
+    'result you can see (composition, hierarchy, surface, typography, motion',
+    'cues), NOT source code. Dimensions like innovation and philosophical',
+    'coherence can only be honestly judged from the rendered page; score from',
+    'what is shown.',
+    '',
+    'Score the target 0–100 on each dimension, with per-dimension',
+    'confidence (high|medium|low) and a one-sentence note. Also emit a',
+    'short `gaps` array — narrative observations of where the target falls',
+    'short of the cited exemplar(s). Do NOT compute an overall score —',
+    'the phase computes it from your dimension scores.',
+    '',
+    'Respond with a single fenced ```json``` block:',
+    '{',
+    '  "philosophicalCoherence": { "score": 0-100, "confidence": "high|medium|low", "notes": "..." },',
+    '  "hierarchy":              { "score": 0-100, "confidence": "high|medium|low", "notes": "..." },',
+    '  "craftExecution":         { "score": 0-100, "confidence": "high|medium|low", "notes": "..." },',
+    '  "function":               { "score": 0-100, "confidence": "high|medium|low", "notes": "..." },',
+    '  "innovation":             { "score": 0-100, "confidence": "high|medium|low", "notes": "..." },',
+    '  "gaps": ["...", "..."]',
+    '}',
+  ].join('\n');
+}
+
+/**
+ * Run the BENCHMARK phase in deep (vision) mode over rendered screenshots.
+ * Mirrors {@link runBenchmark} but judges the *rendered page* via the
+ * provider's vision channel — the difference that lets the exemplar-relative
+ * award bar actually clear, since innovation / coherence / surface cannot be
+ * honestly scored from source code alone. Targets with no matching exemplar
+ * are skipped (BENCHMARK is opt-in per component type).
+ */
+export async function runVisionBenchmark(args: VisionBenchmarkArgs): Promise<BenchmarkScore[]> {
+  const scores: BenchmarkScore[] = [];
+  for (const target of args.targets) {
+    const matched = selectExemplarsFor(target, args.exemplars);
+    if (matched.length === 0) continue;
+    const image = readImage(target.image);
+    const prompt = formatVisionPrompt(target, matched);
+    const raw = await args.provider.callVision(prompt, image);
+    const parsed = parseBenchmarkResponse(raw);
+    if (parsed === null) continue;
+    scores.push(buildScore(target, matched, parsed, args.awardBar, args.responsive));
+  }
+  return scores;
+}

--- a/packages/cli/src/mcp/tools/design-craft.ts
+++ b/packages/cli/src/mcp/tools/design-craft.ts
@@ -42,8 +42,11 @@ import { runCritique, runVisionCritique } from '../../design-craft/phases/critiq
 import type { CritiqueTarget, VisionCritiqueTarget } from '../../design-craft/phases/critique.js';
 import { runPolish } from '../../design-craft/phases/polish.js';
 import type { PolishTarget } from '../../design-craft/phases/polish.js';
-import { runBenchmark } from '../../design-craft/phases/benchmark.js';
-import type { BenchmarkTarget } from '../../design-craft/phases/benchmark.js';
+import { runBenchmark, runVisionBenchmark } from '../../design-craft/phases/benchmark.js';
+import type {
+  BenchmarkTarget,
+  VisionBenchmarkTarget,
+} from '../../design-craft/phases/benchmark.js';
 import type { AwardBarConfig } from '../../design-craft/phases/award-bar.js';
 import type { ResponsiveMetrics, ResponsiveGateConfig } from '../../responsive/index.js';
 import { DEFAULT_RESPONSIVE_GATE_CONFIG } from '../../responsive/index.js';
@@ -169,8 +172,10 @@ export const designCraftToolDefinition = {
         type: 'string',
         enum: ['fast', 'deep'],
         description:
-          'fast (code-only LLM critique) or deep (vision critique of rendered screenshots — ' +
-          'requires `captures`).',
+          'fast (code-only LLM judgment) or deep (vision judgment of rendered screenshots — ' +
+          'requires `captures`). Deep mode applies to BOTH critique and benchmark; only deep-mode ' +
+          'benchmark can clear the award bar, since innovation/coherence/surface cannot be honestly ' +
+          'scored from source code.',
       },
       phases: {
         type: 'array',
@@ -434,6 +439,37 @@ function buildBenchmarkTargets(
 }
 
 /**
+ * Pair each benchmark target with its rendered screenshot for deep-mode
+ * scoring, matching a capture to a target by `file`. Returns the vision
+ * targets that have a capture plus the `file`s of any target that has none —
+ * the caller turns a non-empty `missing` list into a hard error, mirroring
+ * the deep-mode critique gate (a page-scoped award verdict must never be
+ * certified from source code alone).
+ */
+function pairBenchmarkCaptures(
+  targets: BenchmarkTarget[],
+  captures: VisionCritiqueTarget[]
+): { vision: VisionBenchmarkTarget[]; missing: string[] } {
+  const imageByFile = new Map(captures.map((c) => [c.file, c.image]));
+  const vision: VisionBenchmarkTarget[] = [];
+  const missing: string[] = [];
+  for (const t of targets) {
+    const image = imageByFile.get(t.file);
+    if (image === undefined) {
+      missing.push(t.file);
+      continue;
+    }
+    vision.push({
+      file: t.file,
+      component: t.component,
+      image,
+      ...(t.componentType !== undefined ? { componentType: t.componentType } : {}),
+    });
+  }
+  return { vision, missing };
+}
+
+/**
  * Aggregate llmCalls summary from the provider. Mock provider tracks
  * its own cost ledger; real providers will surface this through their own
  * cost adapter.
@@ -538,7 +574,10 @@ async function runPipeline(
   // explicitly (`captures`) or produced by a caller-configured `captureCommand`.
   const autoCapture: AutoCapture = input.autoCapture ?? 'prompt';
   let captures = input.captures ?? [];
-  const needsCaptures = mode === 'deep' && phases.includes('critique') && captures.length === 0;
+  const needsCaptures =
+    mode === 'deep' &&
+    (phases.includes('critique') || phases.includes('benchmark')) &&
+    captures.length === 0;
 
   if (needsCaptures && input.captureCommand && autoCapture !== 'skip') {
     const captured = runCaptureCommand(input.captureCommand, input.files ?? [], input.__runCapture);
@@ -606,13 +645,38 @@ async function runPipeline(
     const exemplars = [...SEED_EXEMPLARS];
     const awardBar = input.awardBar ?? readAwardBarConfig(input.path);
     const responsive = resolveResponsiveArgs(input);
-    const benchmarkScores = await runBenchmark({
-      targets: benchmarkTargets,
-      exemplars,
-      provider,
-      ...(awardBar !== undefined ? { awardBar } : {}),
-      ...(responsive !== undefined ? { responsive } : {}),
-    });
+    // Deep mode → vision benchmark over the rendered captures (the only path
+    // whose exemplar-relative award bar can actually clear, since innovation /
+    // coherence / surface cannot be honestly scored from source). Fast mode →
+    // the code-only benchmark, which by design never certifies award tier.
+    let benchmarkScores: BenchmarkScore[];
+    if (mode === 'deep') {
+      const { vision, missing } = pairBenchmarkCaptures(benchmarkTargets, captures);
+      if (missing.length > 0) {
+        return Err({
+          message:
+            'design-craft deep mode benchmarks rendered screenshots — every benchmark target ' +
+            'needs a matching capture (by "file"). Missing captures for: ' +
+            missing.join(', ') +
+            '. Supply "captures"/"captureCommand" for these files or use mode: "fast".',
+        });
+      }
+      benchmarkScores = await runVisionBenchmark({
+        targets: vision,
+        exemplars,
+        provider,
+        ...(awardBar !== undefined ? { awardBar } : {}),
+        ...(responsive !== undefined ? { responsive } : {}),
+      });
+    } else {
+      benchmarkScores = await runBenchmark({
+        targets: benchmarkTargets,
+        exemplars,
+        provider,
+        ...(awardBar !== undefined ? { awardBar } : {}),
+        ...(responsive !== undefined ? { responsive } : {}),
+      });
+    }
     scores.push(...benchmarkScores);
     exemplarsCited = Array.from(new Set(benchmarkScores.flatMap((s) => s.exemplars)));
     if (recordMeasurement) {

--- a/packages/cli/src/shared/craft/llm/adapters.test.ts
+++ b/packages/cli/src/shared/craft/llm/adapters.test.ts
@@ -13,12 +13,19 @@ import type { LlmCallCost } from './contracts';
 // We drive the adapter through a hand-built fake that satisfies the internal
 // `AnalyzeFn` shape (an object exposing an `analyze` method).
 
+interface AnalyzeImage {
+  base64?: string;
+  url?: string;
+  mediaType?: 'image/png' | 'image/jpeg' | 'image/webp';
+}
+
 interface AnalyzeRequest {
   prompt: string;
   systemPrompt?: string;
   responseSchema: z.ZodType;
   model?: string;
   maxTokens?: number;
+  images?: AnalyzeImage[];
 }
 
 interface AnalyzeResponse {
@@ -201,17 +208,96 @@ describe('AnalysisProviderAdapter cost recording', () => {
 });
 
 describe('AnalysisProviderAdapter.callVision', () => {
-  it('throws with the provider id since vision is not wired', async () => {
+  it('sends the image as base64 from an imageBuffer and returns the raw envelope', async () => {
+    const raw = '```json\n{"philosophicalCoherence":{"score":90}}\n```';
+    const { fake, analyze } = makeFakeInner(makeResponse({ result: { raw } }));
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'anthropic',
+      model: 'test-model',
+      inner: fake as never,
+      supportsVision: true,
+    });
+
+    const buffer = Buffer.from('PNGDATA');
+    const out = await adapter.callVision('judge the rendered page', {
+      imageBuffer: buffer,
+      mediaType: 'image/png',
+    });
+
+    expect(out).toBe(raw);
+    const req = analyze.mock.calls[0]![0];
+    expect(req.prompt).toBe('judge the rendered page');
+    expect(req.images).toEqual([{ base64: buffer.toString('base64'), mediaType: 'image/png' }]);
+    // The raw-envelope system instruction is still applied on the vision path.
+    expect(req.systemPrompt).toContain(RAW_INSTRUCTIONS);
+  });
+
+  it('passes an imageUrl straight through when no buffer is supplied', async () => {
+    const { fake, analyze } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'anthropic',
+      model: 'test-model',
+      inner: fake as never,
+      supportsVision: true,
+    });
+
+    await adapter.callVision('p', { imageUrl: 'https://example.com/shot.png' });
+
+    expect(analyze.mock.calls[0]![0].images).toEqual([{ url: 'https://example.com/shot.png' }]);
+  });
+
+  it('records a cost entry for the vision call', async () => {
+    const { fake } = makeFakeInner(
+      makeResponse({ tokenUsage: { inputTokens: 5, outputTokens: 8, totalTokens: 13 } })
+    );
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'anthropic',
+      model: 'test-model',
+      inner: fake as never,
+      supportsVision: true,
+    });
+
+    await adapter.callVision('p', { imageBuffer: Buffer.from('x') });
+
+    expect(adapter.getCosts()).toEqual([
+      {
+        provider: 'anthropic',
+        model: 'model-from-response',
+        inputTokens: 5,
+        outputTokens: 8,
+        costUsd: 0,
+      },
+    ]);
+  });
+
+  it('throws when the VisionInput has neither a buffer nor a URL', async () => {
     const { fake } = makeFakeInner(makeResponse());
     const adapter = new AnalysisProviderAdapter({
-      providerId: 'claude-cli',
+      providerId: 'anthropic',
+      model: 'test-model',
+      inner: fake as never,
+      supportsVision: true,
+    });
+
+    await expect(adapter.callVision('p', {})).rejects.toThrow(
+      /requires a VisionInput with either imageBuffer or imageUrl/
+    );
+  });
+
+  it('refuses vision (does not call the backend) when the provider is not vision-capable', async () => {
+    // supportsVision defaults to false — the openai-compatible path today.
+    const { fake, analyze } = makeFakeInner(makeResponse());
+    const adapter = new AnalysisProviderAdapter({
+      providerId: 'openai-compatible',
       model: 'test-model',
       inner: fake as never,
     });
 
-    await expect(adapter.callVision('p', { imageUrl: 'x' })).rejects.toThrow(
-      /claude-cli adapter does not implement callVision/
+    await expect(adapter.callVision('p', { imageBuffer: Buffer.from('x') })).rejects.toThrow(
+      /"openai-compatible".*not vision-capable/
     );
+    // Critically: it must NOT forward to a backend that would drop the image.
+    expect(analyze).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/shared/craft/llm/adapters.ts
+++ b/packages/cli/src/shared/craft/llm/adapters.ts
@@ -28,6 +28,13 @@ const RAW_INSTRUCTIONS =
   'Return a JSON object with a single field "raw" whose string value is the fenced JSON block ' +
   'you would normally emit. Do not add prose outside the JSON object.';
 
+/** Structural mirror of the intelligence-package `AnalysisImage`. */
+interface AnalyzeImage {
+  base64?: string;
+  url?: string;
+  mediaType?: 'image/png' | 'image/jpeg' | 'image/webp';
+}
+
 interface AnalyzeFn {
   analyze<T>(req: {
     prompt: string;
@@ -35,12 +42,36 @@ interface AnalyzeFn {
     responseSchema: z.ZodType;
     model?: string;
     maxTokens?: number;
+    images?: AnalyzeImage[];
   }): Promise<{
     result: T;
     tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
     model: string;
     latencyMs: number;
   }>;
+}
+
+/**
+ * Convert an {@link VisionInput} into the intelligence-package image shape.
+ * Prefers raw bytes (base64) over a URL; `mediaType` defaults downstream to
+ * `image/png` when omitted. Throws when neither a buffer nor a URL is present
+ * so a mis-wired caller fails loudly rather than sending a text-only request
+ * that silently pretends to be vision.
+ */
+function toAnalyzeImage(image: VisionInput): AnalyzeImage {
+  if (image.imageBuffer) {
+    return {
+      base64: image.imageBuffer.toString('base64'),
+      ...(image.mediaType ? { mediaType: image.mediaType } : {}),
+    };
+  }
+  if (image.imageUrl) {
+    return {
+      url: image.imageUrl,
+      ...(image.mediaType ? { mediaType: image.mediaType } : {}),
+    };
+  }
+  throw new Error('callVision requires a VisionInput with either imageBuffer or imageUrl.');
 }
 
 /**
@@ -55,11 +86,25 @@ export class AnalysisProviderAdapter implements LlmProvider {
 
   private readonly inner: AnalyzeFn;
   private readonly costs: LlmCallCost[] = [];
+  /**
+   * Whether the wrapped provider can actually SEE images. When false,
+   * `callVision` throws rather than silently forwarding images to a backend
+   * that drops them and scores a blank page — the failure mode that would
+   * make a vision benchmark hallucinate. Set true only for backends whose
+   * `analyze` renders `images` (anthropic, claude-cli).
+   */
+  private readonly supportsVision: boolean;
 
-  constructor(opts: { providerId: string; model: string; inner: AnalyzeFn }) {
+  constructor(opts: {
+    providerId: string;
+    model: string;
+    inner: AnalyzeFn;
+    supportsVision?: boolean;
+  }) {
     this.providerId = opts.providerId;
     this.model = opts.model;
     this.inner = opts.inner;
+    this.supportsVision = opts.supportsVision ?? false;
   }
 
   async callText(prompt: string, opts?: { systemPrompt?: string }): Promise<string> {
@@ -79,10 +124,33 @@ export class AnalysisProviderAdapter implements LlmProvider {
     return response.result.raw;
   }
 
-  async callVision(_prompt: string, _image: VisionInput): Promise<string> {
-    throw new Error(
-      `${this.providerId} adapter does not implement callVision — wire vision when needed.`
-    );
+  async callVision(
+    prompt: string,
+    image: VisionInput,
+    opts?: { systemPrompt?: string }
+  ): Promise<string> {
+    if (!this.supportsVision) {
+      throw new Error(
+        `The "${this.providerId}" craft provider is not vision-capable, so it cannot score a ` +
+          'rendered screenshot (deep mode). Configure a vision-capable provider ' +
+          '(craft.llm.provider = "anthropic" or "claude-cli") or use fast mode.'
+      );
+    }
+    const wrappedSystem = [opts?.systemPrompt, RAW_INSTRUCTIONS].filter(Boolean).join('\n\n');
+    const response = await this.inner.analyze<{ raw: string }>({
+      prompt,
+      systemPrompt: wrappedSystem,
+      responseSchema: RAW_SCHEMA,
+      images: [toAnalyzeImage(image)],
+    });
+    this.recordCost({
+      provider: this.providerId,
+      model: response.model || this.model,
+      inputTokens: response.tokenUsage.inputTokens,
+      outputTokens: response.tokenUsage.outputTokens,
+      costUsd: 0,
+    });
+    return response.result.raw;
   }
 
   recordCost(cost: LlmCallCost): void {
@@ -99,6 +167,7 @@ export function adaptClaudeCli(inner: ClaudeCliAnalysisProvider, model?: string)
     providerId: 'claude-cli',
     model: model ?? 'claude',
     inner: inner as unknown as AnalyzeFn,
+    supportsVision: true,
   });
 }
 
@@ -107,6 +176,7 @@ export function adaptAnthropic(inner: AnthropicAnalysisProvider, model?: string)
     providerId: 'anthropic',
     model: model ?? 'claude-sonnet-4-20250514',
     inner: inner as unknown as AnalyzeFn,
+    supportsVision: true,
   });
 }
 

--- a/packages/cli/tests/design-craft/integration/vision-benchmark.test.ts
+++ b/packages/cli/tests/design-craft/integration/vision-benchmark.test.ts
@@ -1,0 +1,166 @@
+// packages/cli/tests/design-craft/integration/vision-benchmark.test.ts
+//
+// Tests for the deep (vision) BENCHMARK path — the change that lets the
+// exemplar-relative award bar actually clear. Code-only BENCHMARK scores
+// source text, so innovation / coherence / surface land sub-floor or at low
+// confidence and the verdict is never `cleared`; the vision path judges the
+// rendered screenshot and can certify award tier.
+//
+// Coverage:
+//   1. runVisionBenchmark scores through the provider's vision channel and,
+//      given a strong rendered result, produces a `cleared` award verdict.
+//   2. A weak / low-confidence rendered result does NOT clear.
+//   3. MCP handler wires deep-mode benchmark to the vision path when captures
+//      are supplied.
+//   4. MCP handler errors when a benchmark target has no matching capture in
+//      deep mode (a page-scoped verdict must never come from source alone).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { runVisionBenchmark } from '../../../src/design-craft/phases/benchmark.js';
+import type { VisionBenchmarkTarget } from '../../../src/design-craft/phases/benchmark.js';
+import { sonDavenMarketingPageExemplar } from '../../../src/design-craft/catalog/exemplars/son-daven-marketing-page.js';
+import { MockLlmProvider } from '../../../src/design-craft/llm/provider.js';
+import { handleDesignCraft } from '../../../src/mcp/tools/design-craft.js';
+
+/** Radar response builder. Defaults to a strong, high-confidence result. */
+function radarResponse(score = 97, confidence: 'high' | 'medium' | 'low' = 'high'): string {
+  const dim = (notes: string) => ({ score, confidence, notes });
+  return [
+    '```json',
+    JSON.stringify(
+      {
+        philosophicalCoherence: dim('One clear thesis carried across every band.'),
+        hierarchy: dim('Deliberate scale contrast; a single focal action.'),
+        craftExecution: dim('Tuned type, committed surface, no template tells.'),
+        function: dim('Resolves the page job cleanly.'),
+        innovation: dim('A signature moment that reads as this brand only.'),
+        gaps: [],
+      },
+      null,
+      2
+    ),
+    '```',
+  ].join('\n');
+}
+
+/** A MockLlmProvider that answers vision calls (the base mock throws on callVision). */
+class VisionMockProvider extends MockLlmProvider {
+  constructor(private readonly visionResponse: string) {
+    super();
+  }
+  async callVision(): Promise<string> {
+    this.recordCost({
+      provider: this.providerId,
+      model: this.model,
+      inputTokens: 1,
+      outputTokens: 1,
+      costUsd: 0,
+    });
+    return this.visionResponse;
+  }
+}
+
+function writePng(dir: string, name: string): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, Buffer.from([0x89, 0x50, 0x4e, 0x47])); // PNG magic
+  return p;
+}
+
+describe('runVisionBenchmark', () => {
+  it('scores a rendered page through the vision channel and can clear the award bar', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-vision-bench-'));
+    const image = writePng(tmpDir, 'landing.png');
+    const target: VisionBenchmarkTarget = {
+      file: 'landing.html',
+      component: 'LandingPage',
+      componentType: 'MarketingPage',
+      image,
+    };
+
+    const scores = await runVisionBenchmark({
+      targets: [target],
+      exemplars: [sonDavenMarketingPageExemplar],
+      provider: new VisionMockProvider(radarResponse(97, 'high')),
+    });
+
+    expect(scores).toHaveLength(1);
+    expect(scores[0]!.exemplars).toEqual([sonDavenMarketingPageExemplar.id]);
+    expect(scores[0]!.awardBar.verdict).toBe('cleared');
+    expect(scores[0]!.awardBar.shortfalls).toEqual([]);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not clear when the rendered result is weak or low-confidence', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-vision-bench-'));
+    const image = writePng(tmpDir, 'landing.png');
+
+    const scores = await runVisionBenchmark({
+      targets: [
+        { file: 'landing.html', component: 'LandingPage', componentType: 'MarketingPage', image },
+      ],
+      exemplars: [sonDavenMarketingPageExemplar],
+      provider: new VisionMockProvider(radarResponse(60, 'low')),
+    });
+
+    expect(scores).toHaveLength(1);
+    expect(scores[0]!.awardBar.verdict).not.toBe('cleared');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe('design-craft MCP handler — deep-mode benchmark', () => {
+  it('routes deep-mode benchmark through the vision channel when captures are supplied', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-vision-bench-'));
+    const image = writePng(tmpDir, 'Landing.png');
+
+    const result = await handleDesignCraft({
+      path: tmpDir,
+      mode: 'deep',
+      phases: ['benchmark'],
+      benchmarkTargets: [
+        { file: 'src/Landing.tsx', component: 'Landing', componentType: 'MarketingPage' },
+      ],
+      captures: [{ file: 'src/Landing.tsx', component: 'Landing', image }],
+      __testProvider: new VisionMockProvider(radarResponse(97, 'high')),
+      __recordMeasurement: false,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.content[0].text) as {
+      scores: Array<{ awardBar: { verdict: string }; exemplars: string[] }>;
+      summary: { mode: string };
+    };
+    expect(payload.summary.mode).toBe('deep');
+    expect(payload.scores).toHaveLength(1);
+    expect(payload.scores[0]!.awardBar.verdict).toBe('cleared');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('errors when a deep-mode benchmark target has no matching capture', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-vision-bench-'));
+
+    const result = await handleDesignCraft({
+      path: tmpDir,
+      mode: 'deep',
+      phases: ['benchmark'],
+      benchmarkTargets: [
+        { file: 'src/Landing.tsx', component: 'Landing', componentType: 'MarketingPage' },
+      ],
+      captures: [{ file: 'src/Other.tsx', component: 'Other', image: writePng(tmpDir, 'o.png') }],
+      __testProvider: new VisionMockProvider(radarResponse()),
+      __recordMeasurement: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/deep mode benchmarks rendered screenshots/i);
+    expect(result.content[0].text).toMatch(/src\/Landing\.tsx/);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/packages/intelligence/src/analysis-provider/anthropic.ts
+++ b/packages/intelligence/src/analysis-provider/anthropic.ts
@@ -47,6 +47,25 @@ export class AnthropicAnalysisProvider implements AnalysisProvider {
       'You MUST respond by calling the "structured_output" tool with your result. Do not return plain text.'
     );
 
+    // When images are supplied, the user turn becomes a content-block array:
+    // the image block(s) first, then the text prompt. Without images we send
+    // the prompt as a plain string (unchanged from the text-only path).
+    const userContent: Anthropic.Messages.MessageParam['content'] =
+      request.images && request.images.length > 0
+        ? [
+            ...request.images.map(
+              (img): Anthropic.Messages.ImageBlockParam => ({
+                type: 'image',
+                source:
+                  img.base64 !== undefined
+                    ? { type: 'base64', media_type: img.mediaType ?? 'image/png', data: img.base64 }
+                    : { type: 'url', url: img.url ?? '' },
+              })
+            ),
+            { type: 'text', text: request.prompt },
+          ]
+        : request.prompt;
+
     const startMs = performance.now();
 
     const response = await this.client.messages.create({
@@ -55,7 +74,7 @@ export class AnthropicAnalysisProvider implements AnalysisProvider {
       system: systemParts.join('\n\n'),
       tools: [tool],
       tool_choice: { type: 'tool', name: 'structured_output' },
-      messages: [{ role: 'user', content: request.prompt }],
+      messages: [{ role: 'user', content: userContent }],
     });
 
     const latencyMs = Math.round(performance.now() - startMs);

--- a/packages/intelligence/src/analysis-provider/claude-cli.ts
+++ b/packages/intelligence/src/analysis-provider/claude-cli.ts
@@ -1,5 +1,10 @@
 import { spawn } from 'node:child_process';
-import type { AnalysisProvider, AnalysisRequest, AnalysisResponse } from './interface.js';
+import type {
+  AnalysisProvider,
+  AnalysisRequest,
+  AnalysisResponse,
+  AnalysisImage,
+} from './interface.js';
 import { zodToJsonSchema } from './schema.js';
 
 export interface ClaudeCliProviderOptions {
@@ -38,22 +43,11 @@ export class ClaudeCliAnalysisProvider implements AnalysisProvider {
       ? `${request.systemPrompt}\n\n${request.prompt}`
       : request.prompt;
 
-    const args = [
-      '--print',
-      '-p',
-      prompt,
-      '--output-format',
-      'json',
-      '--json-schema',
-      JSON.stringify({ type: 'object', ...jsonSchema }),
-    ];
-
-    if (model) {
-      args.push('--model', model);
-    }
-
+    const hasImages = (request.images?.length ?? 0) > 0;
     const startMs = performance.now();
-    const result = await this.runClaude(args);
+    const result = hasImages
+      ? await this.runClaudeVision(prompt, request.images!, jsonSchema, model)
+      : await this.runClaude(this.buildTextArgs(prompt, jsonSchema, model));
     const latencyMs = Math.round(performance.now() - startMs);
 
     const parsed = request.responseSchema.parse(result.content) as T;
@@ -68,6 +62,72 @@ export class ClaudeCliAnalysisProvider implements AnalysisProvider {
       model: result.model ?? model ?? 'claude',
       latencyMs,
     };
+  }
+
+  /** Args for the text-only path (`-p` prompt, single-shot JSON output). */
+  private buildTextArgs(prompt: string, jsonSchema: object, model?: string): string[] {
+    const args = [
+      '--print',
+      '-p',
+      prompt,
+      '--output-format',
+      'json',
+      '--json-schema',
+      JSON.stringify({ type: 'object', ...jsonSchema }),
+    ];
+    if (model) args.push('--model', model);
+    return args;
+  }
+
+  /**
+   * Vision path. The CLI's `-p` text prompt cannot carry an image, so image
+   * calls go through the `stream-json` transport: a single user message whose
+   * content is the image block(s) followed by the text prompt, written to
+   * stdin. `--json-schema` still enforces the structured envelope, which the
+   * CLI returns as `structured_output` on the terminal `result` event.
+   *
+   * Verified against Claude Code CLI 2.1.x: image content blocks are read and
+   * `structured_output` conforms to the supplied schema.
+   */
+  private runClaudeVision(
+    prompt: string,
+    images: AnalysisImage[],
+    jsonSchema: object,
+    model?: string
+  ): Promise<{
+    content: unknown;
+    usage?: { input_tokens: number; output_tokens: number };
+    model?: string;
+  }> {
+    const content = [
+      ...images.map((img) => ({
+        type: 'image' as const,
+        source:
+          img.base64 !== undefined
+            ? {
+                type: 'base64' as const,
+                media_type: img.mediaType ?? 'image/png',
+                data: img.base64,
+              }
+            : { type: 'url' as const, url: img.url ?? '' },
+      })),
+      { type: 'text' as const, text: prompt },
+    ];
+    const userMessage = JSON.stringify({ type: 'user', message: { role: 'user', content } });
+
+    const args = [
+      '--print',
+      '--input-format',
+      'stream-json',
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--json-schema',
+      JSON.stringify({ type: 'object', ...jsonSchema }),
+    ];
+    if (model) args.push('--model', model);
+
+    return this.runClaudeStream(args, `${userMessage}\n`);
   }
 
   private runClaude(args: string[]): Promise<{
@@ -130,6 +190,90 @@ export class ClaudeCliAnalysisProvider implements AnalysisProvider {
         }
       });
 
+      child.stdin.end();
+    });
+  }
+
+  /**
+   * Run the CLI in `stream-json` transport, writing `stdinPayload` to stdin
+   * and reading newline-delimited JSON events from stdout. Resolves from the
+   * terminal `result` event, preferring `structured_output` (schema-conforming
+   * object) over the `result` string (JSON-encoded fallback for older CLIs).
+   */
+  private runClaudeStream(
+    args: string[],
+    stdinPayload: string
+  ): Promise<{
+    content: unknown;
+    usage?: { input_tokens: number; output_tokens: number };
+    model?: string;
+  }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.command, args, { env: process.env, timeout: this.timeoutMs });
+
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      child.on('error', (err) => {
+        reject(new Error(`Claude CLI failed to spawn: ${err.message}`));
+      });
+      child.on('exit', (code) => {
+        if (code !== 0) {
+          reject(
+            new Error(`Claude CLI exited with code ${code}: ${stderr.trim() || stdout.trim()}`)
+          );
+          return;
+        }
+        // Find the terminal `result` event among the newline-delimited stream.
+        let resultEvent: Record<string, unknown> | undefined;
+        for (const line of stdout.split('\n')) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const ev = JSON.parse(trimmed) as Record<string, unknown>;
+            if (ev.type === 'result') resultEvent = ev;
+          } catch {
+            /* ignore non-JSON lines */
+          }
+        }
+        if (!resultEvent) {
+          reject(
+            new Error(
+              `Claude CLI stream produced no result event. stdout (first 500): ${JSON.stringify(
+                stdout.slice(0, 500)
+              )}. stderr (first 500): ${JSON.stringify(stderr.slice(0, 500))}`
+            )
+          );
+          return;
+        }
+        try {
+          const raw = resultEvent.structured_output ?? resultEvent.result;
+          const content = typeof raw === 'string' ? JSON.parse(raw) : raw;
+          const usage = resultEvent.usage as
+            | { input_tokens: number; output_tokens: number }
+            | undefined;
+          resolve({
+            content,
+            ...(usage ? { usage } : {}),
+            ...(typeof resultEvent.model === 'string' ? { model: resultEvent.model } : {}),
+          });
+        } catch (err) {
+          reject(
+            new Error(
+              `Failed to parse Claude CLI structured output: ${
+                err instanceof Error ? err.message : String(err)
+              }.`
+            )
+          );
+        }
+      });
+
+      child.stdin.write(stdinPayload);
       child.stdin.end();
     });
   }

--- a/packages/intelligence/src/analysis-provider/interface.ts
+++ b/packages/intelligence/src/analysis-provider/interface.ts
@@ -1,11 +1,35 @@
 import type { z } from 'zod';
 
+/**
+ * A single image attached to an {@link AnalysisRequest} for a vision-capable
+ * `analyze` call. Supply exactly one of `base64` or `url`.
+ *
+ * Providers that cannot see images (claude-cli, openai-compatible today)
+ * ignore this field and answer from the text prompt alone — vision is
+ * best-effort, never a contract change. Only the Anthropic backend renders
+ * these as image content blocks.
+ */
+export interface AnalysisImage {
+  /** Base64-encoded image bytes (no `data:` prefix). Mutually exclusive with `url`. */
+  base64?: string;
+  /** Publicly-fetchable image URL. Mutually exclusive with `base64`. */
+  url?: string;
+  /** MIME type of the image; defaults to `image/png` when omitted. */
+  mediaType?: 'image/png' | 'image/jpeg' | 'image/webp';
+}
+
 export interface AnalysisRequest {
   prompt: string;
   systemPrompt?: string;
   responseSchema: z.ZodType;
   model?: string;
   maxTokens?: number;
+  /**
+   * Images to attach to the call, in order, ahead of the text prompt. Enables
+   * vision judgment (e.g. scoring a rendered screenshot). Backends that lack a
+   * vision channel ignore this and answer from `prompt` alone.
+   */
+  images?: AnalysisImage[];
   /**
    * Request that the backend suppress any chain-of-thought / `<think>` reasoning for THIS call.
    * Intended for narrow structured-extraction calls where a reasoning trace adds latency but not

--- a/packages/intelligence/src/index.ts
+++ b/packages/intelligence/src/index.ts
@@ -44,6 +44,7 @@ export type {
   AnalysisRequest,
   AnalysisResponse,
   AnalysisProvider,
+  AnalysisImage,
 } from './analysis-provider/interface.js';
 export { AnthropicAnalysisProvider } from './analysis-provider/anthropic.js';
 export { OpenAICompatibleAnalysisProvider } from './analysis-provider/openai-compatible.js';

--- a/packages/intelligence/tests/analysis-provider/anthropic.test.ts
+++ b/packages/intelligence/tests/analysis-provider/anthropic.test.ts
@@ -156,6 +156,67 @@ describe('AnthropicAnalysisProvider', () => {
     });
   });
 
+  describe('vision / image content', () => {
+    it('sends a plain string user prompt when no images are supplied', async () => {
+      mockCreate.mockResolvedValueOnce(makeToolUseResponse({ summary: 'ok', score: 1 }));
+
+      await provider.analyze({ prompt: 'text only', responseSchema: testSchema });
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.messages).toEqual([{ role: 'user', content: 'text only' }]);
+    });
+
+    it('builds an image block (base64) ahead of the text prompt', async () => {
+      mockCreate.mockResolvedValueOnce(makeToolUseResponse({ summary: 'ok', score: 1 }));
+
+      await provider.analyze({
+        prompt: 'judge the rendered page',
+        responseSchema: testSchema,
+        images: [{ base64: 'QUJD', mediaType: 'image/png' }],
+      });
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'QUJD' } },
+            { type: 'text', text: 'judge the rendered page' },
+          ],
+        },
+      ]);
+    });
+
+    it('defaults mediaType to image/png when omitted', async () => {
+      mockCreate.mockResolvedValueOnce(makeToolUseResponse({ summary: 'ok', score: 1 }));
+
+      await provider.analyze({
+        prompt: 'p',
+        responseSchema: testSchema,
+        images: [{ base64: 'QUJD' }],
+      });
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.messages[0].content[0].source.media_type).toBe('image/png');
+    });
+
+    it('builds a URL image source when a url is supplied', async () => {
+      mockCreate.mockResolvedValueOnce(makeToolUseResponse({ summary: 'ok', score: 1 }));
+
+      await provider.analyze({
+        prompt: 'p',
+        responseSchema: testSchema,
+        images: [{ url: 'https://example.com/shot.png' }],
+      });
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.messages[0].content[0]).toEqual({
+        type: 'image',
+        source: { type: 'url', url: 'https://example.com/shot.png' },
+      });
+    });
+  });
+
   describe('error handling', () => {
     it('throws when response has no tool_use block', async () => {
       mockCreate.mockResolvedValueOnce({


### PR DESCRIPTION
## Problem

The design-craft **award bar** has been structurally unreachable since it shipped. In the consuming `iv-demo` fleet, `awardBar` is `false` on **40/40** recorded prospects — never once `cleared`.

Root cause (not a missing corpus — the 9 MarketingPage exemplars are bundled):
- `runBenchmark` scored the target's **source code** via `callText`.
- `LlmProvider.callVision` **threw on every provider** (`in-session`, `mock`, adapter), and `packages/intelligence` had **no image support at all** (`VisionInput` existed with zero implementations).

An LLM reading HTML/CSS cannot honestly judge `innovation` / `philosophicalCoherence` / surface-craft, so those dimensions land sub-floor or at `low` confidence and the verdict is **never `cleared`.** The "award-tier convergence loop" was scoring against a bar it could not clear.

## What this does

Gives BENCHMARK a real vision channel — the model scores the **rendered screenshot**, exactly as the SKILL's deep mode already describes and as `harness-design-craft/SKILL.md` anticipated (*"packages/intelligence/ … may need extension if no vision support today"*).

- **`@harness-engineering/intelligence`** — `AnalysisRequest.images` + Anthropic image content blocks; `claude-cli` image support via the `--input-format stream-json` transport.
- **`@harness-engineering/cli`** — real `AnalysisProviderAdapter.callVision`, **gated by a `supportsVision` capability flag** so a non-vision backend throws loudly instead of silently forwarding an image it drops and scoring a blank page; `runVisionBenchmark` scores the rendered capture; the `design_craft` tool routes deep-mode benchmark to it and requires a capture per page-scoped target (matched by `file`).

## Validation (real, not theory)

Validated **end-to-end against the real local `claude` CLI — no mocks, no API key** (the keyless path interactive sessions use):

1. **The model genuinely sees images** — a page with token `ZORPTANGLE` on `#0b5cff`, sent headlessly, returned `structured_output: {word: "ZORPTANGLE", bg: "#0A57FF"}`.
2. **It discriminates quality** — strong Awwwards page vs a flat demo scored `innovation` **85 vs 56**, `philosophicalCoherence` **87 vs 77**, and reproduced the flat page's defect unprompted: *"a recognizable hero-plus-section template — swapping the brand out would change little."*
3. **`cleared` is reachable** — a full-page strong capture cleared all five dimensions (philosophicalCoherence 94, craftExecution 90, innovation 89) — retiring the 40/40-always-false problem.

Plus unit/integration tests: Anthropic image-block construction, adapter capability gate, `runVisionBenchmark` + tool wiring. Full suites green (intelligence 608, cli blast-radius 1153), typecheck + lint clean.

Known characteristic: LLM vision scoring has run-to-run variance, amplified by degenerate captures (an animated site's full-page screenshot with blank unrendered regions swung 88↔37); clean per-viewport captures are stable. Manual harness: `packages/cli/scripts/validate-vision-benchmark.mts`.

## Follow-ups (out of scope)

- **`iv-demo` wiring** (consuming repo `harness-iv`): invoke deep-mode BENCHMARK with 3-viewport captures + configure a vision-capable craft provider so the pipeline stops recording `awardBar:false` by default. This PR delivers the capability; the skill must opt in.
- `openai-compatible` vision (currently gated off); N-pass median to damp variance.

See `docs/changes/design-craft-vision-benchmark/proposal.md`.
