### PR TITLE
fix(orchestrator): air-gap the codex backend subprocess env (#1158)

### DIFF
--- a/.changeset/codex-subprocess-env-airgap.md
+++ b/.changeset/codex-subprocess-env-airgap.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/orchestrator': patch
+---
+
+Port the subprocess-env air-gap to the Codex backend. `CodexBackend` previously spawned `codex exec` with `env: process.env`, leaking every host secret the orchestrator held into the subprocess. It now builds an allowlisted env via `buildSubprocessEnv` (mirroring the Claude backend) and stamps the resolved policy envelope plus the names of withheld env vars into the optional governance audit sink.

--- a/packages/orchestrator/src/agent/backend-factory.ts
+++ b/packages/orchestrator/src/agent/backend-factory.ts
@@ -205,7 +205,10 @@ function createOllamaBackend(
   });
 }
 
-function createCodexBackend(def: BackendDefOf<'codex'>): AgentBackend {
+function createCodexBackend(
+  def: BackendDefOf<'codex'>,
+  options: CreateBackendOptions
+): AgentBackend {
   const isArray = Array.isArray(def.model);
   return new CodexBackend({
     ...(typeof def.model === 'string' ? { model: def.model } : {}),
@@ -215,6 +218,10 @@ function createCodexBackend(def: BackendDefOf<'codex'>): AgentBackend {
     ...(def.timeoutMs !== undefined ? { timeoutMs: def.timeoutMs } : {}),
     ...(def.reasoningEffort !== undefined ? { reasoningEffort: def.reasoningEffort } : {}),
     ...(def.mcpServers !== undefined ? { mcpServers: def.mcpServers } : {}),
+    ...(options.sandboxMode ? { sandboxMode: options.sandboxMode } : {}),
+    ...(options.networkMode ? { networkMode: options.networkMode } : {}),
+    ...(options.policyAudit ? { policyAudit: options.policyAudit } : {}),
+    ...(options.subprocessEnvAllow ? { subprocessEnvAllow: options.subprocessEnvAllow } : {}),
   });
 }
 
@@ -275,7 +282,7 @@ export function createBackend(def: BackendDef, options: CreateBackendOptions = {
     case 'ollama':
       return createOllamaBackend(def, options);
     case 'codex':
-      return createCodexBackend(def);
+      return createCodexBackend(def, options);
     case 'ssh':
       return createSshBackend(def);
     case 'serverless':

--- a/packages/orchestrator/src/agent/backends/codex.policy-envelope.test.ts
+++ b/packages/orchestrator/src/agent/backends/codex.policy-envelope.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { CodexBackend } from './codex';
+import type { PolicyAuditRecord } from './claude';
+import type { AgentSession, TurnParams } from '@harness-engineering/types';
+
+/**
+ * Proves the codex backend air-gaps its spawned subprocess env the same way the
+ * claude backend does (#1158): it hands the audit sink the resolved
+ * PolicyMetadata plus the NAMES of parent-env vars withheld from the subprocess
+ * (never their values), and the process it actually spawns receives the
+ * ALLOWLISTED env — not the full parent `process.env`. Before this port codex
+ * spawned with `env: process.env`, leaking every host secret into a subprocess
+ * that has no business seeing them.
+ */
+
+const SESSION: AgentSession = {
+  sessionId: 's1',
+  workspacePath: os.tmpdir(),
+  backendName: 'codex',
+  startedAt: new Date().toISOString(),
+};
+
+async function drain(b: CodexBackend, session: AgentSession): Promise<void> {
+  const gen = b.runTurn(session, { sessionId: session.sessionId, prompt: 'do x' } as TurnParams);
+  for (;;) {
+    const n = await gen.next();
+    if (n.done) return;
+  }
+}
+
+/** POSIX `#!/bin/sh` fixture that dumps its own env to a file — the shebang path
+ * is honored by shell-less spawn only on POSIX (see codex.test.ts rationale). */
+const itPosix = it.skipIf(process.platform === 'win32');
+
+describe('CodexBackend policy envelope + subprocess air-gap', () => {
+  it('stamps PolicyMetadata + stripped env keys into the audit sink at spawn', async () => {
+    const records: PolicyAuditRecord[] = [];
+    const backend = new CodexBackend({
+      // process.execPath is present on every platform; codex's fixed argv is
+      // rejected by Node so it exits at once — but the audit stamp is emitted
+      // BEFORE the spawn, so the record is captured regardless (mirrors the
+      // claude policy-envelope test).
+      command: process.execPath,
+      model: 'm',
+      sandboxMode: 'docker',
+      networkMode: 'restricted',
+      agentVersion: '9.9.9',
+      policyAudit: (r) => records.push(r),
+      envSource: {
+        PATH: '/usr/bin',
+        OLLAMA_HOST: 'http://127.0.0.1:11434',
+        OPENAI_API_KEY: 'sk-openai-secret',
+        DATABASE_URL: 'postgres://secret',
+      },
+    });
+
+    await drain(backend, SESSION);
+
+    expect(records).toHaveLength(1);
+    const rec = records[0]!;
+    expect(rec.sessionId).toBe(SESSION.sessionId);
+    expect(rec.workspacePath).toBe(SESSION.workspacePath);
+    expect(rec.enforced).toBe(true);
+    expect(rec.policy).toEqual({
+      approvalMode: 'bypass',
+      sandboxMode: 'docker',
+      networkMode: 'restricted',
+      dangerousFlags: ['--sandbox=workspace-write'],
+      agentFamily: 'codex',
+      agentVersion: '9.9.9',
+    });
+    // Air-gap: the unrelated secret is recorded as stripped; the provider cred /
+    // OLLAMA_ config / base plumbing are NOT stripped. Values never appear.
+    expect(rec.strippedEnvKeys).toContain('DATABASE_URL');
+    expect(rec.strippedEnvKeys).not.toContain('OPENAI_API_KEY');
+    expect(rec.strippedEnvKeys).not.toContain('OLLAMA_HOST');
+    expect(rec.strippedEnvKeys).not.toContain('PATH');
+    expect(JSON.stringify(rec)).not.toContain('postgres://secret');
+  });
+
+  it('defaults policy posture to none/unrestricted/unknown when unset', async () => {
+    const records: PolicyAuditRecord[] = [];
+    const backend = new CodexBackend({
+      command: process.execPath,
+      model: 'm',
+      policyAudit: (r) => records.push(r),
+      envSource: { PATH: '/usr/bin' },
+    });
+    await drain(backend, SESSION);
+    expect(records[0]!.policy.sandboxMode).toBe('none');
+    expect(records[0]!.policy.networkMode).toBe('unrestricted');
+    expect(records[0]!.policy.agentVersion).toBe('unknown');
+  });
+
+  itPosix('spawns the subprocess with the ALLOWLISTED env, not the full parent env', async () => {
+    const envfile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'codex-env-')), 'env');
+    // Dump the child's actual environment so we can assert what codex was spawned with.
+    const cmd = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'fake-codex-')), 'codex');
+    fs.writeFileSync(cmd, `#!/bin/sh\nenv > "${envfile}"\nexit 0\n`, { mode: 0o755 });
+
+    const backend = new CodexBackend({
+      command: cmd,
+      model: 'm',
+      envSource: {
+        PATH: '/usr/bin',
+        OLLAMA_HOST: 'http://127.0.0.1:11434',
+        OPENAI_API_KEY: 'sk-openai-secret',
+        DATABASE_URL: 'postgres://secret',
+        STRIPE_SECRET_KEY: 'sk-live-should-not-leak',
+      },
+    });
+
+    await drain(backend, SESSION);
+
+    const childEnv = fs.readFileSync(envfile, 'utf8');
+    // Allowed: base plumbing + provider cred + provider config pass through.
+    expect(childEnv).toMatch(/^PATH=/m);
+    expect(childEnv).toContain('OPENAI_API_KEY=sk-openai-secret');
+    expect(childEnv).toContain('OLLAMA_HOST=http://127.0.0.1:11434');
+    // Air-gapped: unrelated host secrets never reach the subprocess.
+    expect(childEnv).not.toContain('DATABASE_URL');
+    expect(childEnv).not.toContain('postgres://secret');
+    expect(childEnv).not.toContain('STRIPE_SECRET_KEY');
+    expect(childEnv).not.toContain('sk-live-should-not-leak');
+  });
+});

--- a/packages/orchestrator/src/agent/backends/codex.ts
+++ b/packages/orchestrator/src/agent/backends/codex.ts
@@ -14,6 +14,13 @@ import {
   AgentError,
   McpServerSpec,
 } from '@harness-engineering/types';
+import type {
+  PolicyMetadata,
+  PolicySandboxMode,
+  PolicyNetworkMode,
+} from '@harness-engineering/types';
+import { buildSubprocessEnv } from '../subprocess-env.js';
+import type { PolicyAuditSink } from './claude.js';
 
 /**
  * Extract the assistant's final text from a parsed codex `--json` line, across
@@ -103,6 +110,35 @@ export interface CodexBackendOptions {
    * navigate. Absent/empty ⇒ codex runs with only its built-in tools.
    */
   mcpServers?: McpServerSpec[];
+  /**
+   * Process-isolation posture recorded in the governance audit envelope. DERIVED
+   * by the orchestrator from the dispatch's sandbox policy (a docker wrap ⇒
+   * `'docker'`). Describes the isolation AROUND the subprocess, not codex's own
+   * `--sandbox workspace-write` file guard. Default `'none'`.
+   */
+  sandboxMode?: PolicySandboxMode;
+  /** Network egress posture recorded in the audit envelope. Default `'unrestricted'`. */
+  networkMode?: PolicyNetworkMode;
+  /** Best-effort codex CLI version stamped into the audit envelope. Default `'unknown'`. */
+  agentVersion?: string;
+  /**
+   * Governance audit sink invoked once per spawn with the resolved
+   * {@link PolicyMetadata} plus the NAMES (never values) of parent-env vars
+   * withheld by the subprocess air-gap. The orchestrator wires this to
+   * `.harness/audit.log`. Best-effort: a sink fault never blocks the spawn.
+   */
+  policyAudit?: PolicyAuditSink;
+  /**
+   * Extra exact env var names to forward through the subprocess air-gap, merged
+   * with the built-in allowlist (see subprocess-env.ts). For a flow that needs a
+   * var the conservative default withholds.
+   */
+  subprocessEnvAllow?: readonly string[];
+  /**
+   * Env the air-gap filters (defaults to `process.env`). Injected in tests to
+   * prove filtering without depending on the ambient process environment.
+   */
+  envSource?: NodeJS.ProcessEnv;
 }
 
 const DEFAULT_TIMEOUT_MS = 30 * 60_000;
@@ -150,6 +186,12 @@ export class CodexBackend implements AgentBackend {
   private timeoutMs: number;
   private mcpServers: McpServerSpec[];
   private reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+  private sandboxMode: PolicySandboxMode;
+  private networkMode: PolicyNetworkMode;
+  private agentVersion: string;
+  private policyAudit?: PolicyAuditSink;
+  private subprocessEnvAllow?: readonly string[];
+  private envSource: NodeJS.ProcessEnv;
   /**
    * Live codex subprocess per active session, so {@link stopSession} can kill it
    * when the workflow aborts a stage (its wall-clock deadline). Without this, the
@@ -170,6 +212,12 @@ export class CodexBackend implements AgentBackend {
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.mcpServers = options.mcpServers ?? [];
     if (options.reasoningEffort !== undefined) this.reasoningEffort = options.reasoningEffort;
+    this.sandboxMode = options.sandboxMode ?? 'none';
+    this.networkMode = options.networkMode ?? 'unrestricted';
+    this.agentVersion = options.agentVersion ?? 'unknown';
+    if (options.policyAudit) this.policyAudit = options.policyAudit;
+    if (options.subprocessEnvAllow) this.subprocessEnvAllow = options.subprocessEnvAllow;
+    this.envSource = options.envSource ?? process.env;
   }
 
   private resolveModel(): string | undefined {
@@ -236,9 +284,45 @@ export class CodexBackend implements AgentBackend {
       params.prompt,
     ];
 
+    // Subprocess air-gap: hand codex an ALLOWLISTED env instead of the full parent
+    // `process.env`, so unrelated host secrets never leak into the spawned CLI.
+    // Provider creds / HARNESS_* / runtime plumbing still pass through — see
+    // subprocess-env.ts. Stripping is unconditional; the audit sink is optional.
+    // Mirrors the claude backend (claude.ts) — closes the codex leak (#1158).
+    const { env, stripped, enforced } = buildSubprocessEnv(
+      this.envSource,
+      this.subprocessEnvAllow ? { extraAllow: this.subprocessEnvAllow } : {}
+    );
+
+    // Stamp the per-call policy envelope into the governance audit trail. `codex
+    // exec` runs approval-free (`approval: never`) under `--sandbox workspace-write`,
+    // so both are recorded as the governance-relevant flags. Best-effort: never let
+    // an audit fault block the spawn.
+    if (this.policyAudit) {
+      const policy: PolicyMetadata = {
+        approvalMode: 'bypass',
+        sandboxMode: this.sandboxMode,
+        networkMode: this.networkMode,
+        dangerousFlags: ['--sandbox=workspace-write'],
+        agentFamily: 'codex',
+        agentVersion: this.agentVersion,
+      };
+      try {
+        this.policyAudit({
+          sessionId: session.sessionId,
+          workspacePath: session.workspacePath,
+          policy,
+          strippedEnvKeys: stripped,
+          enforced,
+        });
+      } catch {
+        // Audit is advisory; a sink fault must not stop the agent.
+      }
+    }
+
     const child = spawn(this.command, args, {
       cwd: session.workspacePath,
-      env: process.env,
+      env,
       // stdin from /dev/null: codex exec otherwise blocks reading additional input.
       stdio: ['ignore', 'pipe', 'pipe'],
       // Own process GROUP (POSIX) so a kill can take down codex AND any grandchild


### PR DESCRIPTION
## What

Ports the subprocess-env air-gap from the Claude backend to the Codex backend. `CodexBackend.runTurn` spawned `codex exec` with `env: process.env` — leaking every host secret the orchestrator process held (DATABASE_URL, STRIPE_SECRET_KEY, NPM_TOKEN, …) into a subprocess that has no business seeing them. The Claude backend already closed this gap via `buildSubprocessEnv`; this applies the identical pattern to codex.

## Changes

- **`codex.ts`**: build an allowlisted env via `buildSubprocessEnv(this.envSource, …)`, replace `env: process.env` with the air-gapped `env`, and stamp the resolved `PolicyMetadata` plus the names (never values) of withheld env vars into an optional `policyAudit` sink — mirroring `claude.ts`. Adds `sandboxMode` / `networkMode` / `agentVersion` / `policyAudit` / `subprocessEnvAllow` / `envSource` options, matching the Claude backend surface. The recorded envelope uses `agentFamily: 'codex'` and `dangerousFlags: ['--sandbox=workspace-write']`.
- **`backend-factory.ts`**: thread `policyAudit` / `subprocessEnvAllow` / `sandboxMode` / `networkMode` through `createCodexBackend`, the same way the Claude backend is wired (the orchestrator's `buildCreateOpts` already forwards these generically).
- **`codex.policy-envelope.test.ts`** (new): mirrors the Claude policy-envelope test — asserts the audit sink receives the stripped-key list + policy envelope, defaults posture correctly, and (POSIX) that the actually-spawned subprocess env excludes host secrets (`DATABASE_URL`, `STRIPE_SECRET_KEY`) while retaining provider creds (`OPENAI_API_KEY`) and provider config (`OLLAMA_HOST`).

## Verification

- New + existing backend tests green: `codex.policy-envelope.test.ts`, `codex.test.ts`, `claude.policy-envelope.test.ts` (33 tests).
- `tsc --noEmit` and eslint clean on changed files.
- Patch changeset for `@harness-engineering/orchestrator`.

Closes #1158