### PR TITLE
feat(cli): add `harness init --tier minimal` (ADR 0101)

### DIFF
--- a/.changeset/init-minimal-tier.md
+++ b/.changeset/init-minimal-tier.md
@@ -1,0 +1,5 @@
+---
+'@harness-engineering/cli': minor
+---
+
+Add `harness init --tier minimal` (ADR 0101): a load-bearing floor below the existing adoption ladder mapped one-to-one to the field's 5-item Minimum Viable Harness. It scaffolds exactly five artifacts — a generated `AGENTS.md` repo guide, a `harness.config.json` wiring `harness check-arch` as the runnable local check, a seeded `.harness/arch/baselines.json` making one hard architectural rule (a cyclomatic-complexity cap of 15) fail-closed, a git pre-commit verification loop that runs the check, and the `block-no-verify` permission boundary — then prints an explicit, ordered upgrade path to the fuller tiers. STRATEGY.md, framework selection, design system, and MCP integration are deferred (not skipped); re-running init at a higher tier is additive over a `minimal` install. Degrades gracefully outside a git repo. `--tier` also accepts `basic`/`intermediate`/`load-bearing-minimum`/`advanced`, delegating to the existing level scaffold.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -368,6 +368,7 @@ Initialize a new harness-engineering project
 - `-n, --name` — Project name
 - `-l, --level` — Adoption level (basic, intermediate, load-bearing-minimum, advanced) (default: "load-bearing-minimum")
 - `-t, --template` — Specific template name (e.g. orchestrator)
+- `--tier` — Adoption tier (ADR 0101): minimal (the 5-item Minimum Viable Harness floor), basic, intermediate, load-bearing-minimum, advanced
 - `--framework` — Framework overlay (nextjs)
 - `--language` — Target language (typescript, python, go, rust, java)
 - `-f, --force` — Overwrite existing files

--- a/packages/cli/src/commands/init-minimal.ts
+++ b/packages/cli/src/commands/init-minimal.ts
@@ -1,0 +1,277 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import chalk from 'chalk';
+import type { Result } from '@harness-engineering/core';
+import { Ok, Err, generateAgentsMap, ArchBaselineManager } from '@harness-engineering/core';
+import { logger } from '../output/logger';
+import { CLIError, ExitCode } from '../utils/errors';
+import { initHooks } from './hooks/init';
+
+/**
+ * The `minimal` init tier (ADR 0101): the documented floor of the adoption
+ * ladder, mapped one-to-one to the field's 5-item Minimum Viable Harness. Unlike
+ * the full `--level` scaffold (STRATEGY interview → framework → design system),
+ * this fast path scaffolds exactly, and only, the five load-bearing artifacts and
+ * prints an explicit, ordered upgrade path so nothing is lost — only sequenced.
+ *
+ * Re-running init at a higher tier is additive over a `minimal` install.
+ */
+
+export interface MinimalInitOptions {
+  cwd?: string;
+  name?: string;
+  force?: boolean;
+}
+
+/** One scaffolded MVH artifact and the concrete file(s) that back it. */
+export interface MinimalArtifact {
+  /** The Minimum-Viable-Harness item this artifact fulfils (ADR 0101 Decision). */
+  mvh: string;
+  /** Project-relative file(s) written for this artifact (empty when degraded). */
+  files: string[];
+  /** True when the artifact was fully scaffolded; false when degraded gracefully. */
+  scaffolded: boolean;
+  /** Present only when degraded, explaining why. */
+  note?: string;
+}
+
+export interface MinimalInitResult {
+  artifacts: MinimalArtifact[];
+  filesCreated: string[];
+}
+
+/** True if `cwd` looks like a git repository (`.git` present as dir or gitdir file). */
+function isGitRepo(cwd: string): boolean {
+  return fs.existsSync(path.join(cwd, '.git'));
+}
+
+/** Resolve git's hooks dir, correct in linked worktrees; falls back to `.git/hooks`. */
+function resolveGitHooksDir(cwd: string): string {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return path.isAbsolute(out) ? out : path.join(cwd, out);
+  } catch {
+    return path.join(cwd, '.git', 'hooks');
+  }
+}
+
+/** The current commit hash, or an empty string outside a git checkout (or a repo with no commits). */
+function currentCommitHash(cwd: string): string {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+// --- Artifact 2 + 3: the one runnable local check and the one hard arch rule ---
+
+/**
+ * The minimal `harness.config.json`: a single hard architectural rule — a
+ * cyclomatic-complexity cap of 15 — enforced fail-closed by `harness check-arch`.
+ * This is both the "one runnable local check" (the command wired into the
+ * project) and the definition of the "one hard architectural rule". A complexity
+ * cap is chosen deliberately: it is the field-standard maintainability floor, it
+ * is adopter-portable (no assumptions about this repo's layer layout), and it is
+ * enforced directly from source, so it genuinely bites in a standalone
+ * `harness check-arch` run — the command the pre-commit loop invokes.
+ */
+function buildMinimalConfig(name: string): string {
+  const config = {
+    version: 1,
+    name,
+    architecture: {
+      enabled: true,
+      baselinePath: '.harness/arch/baselines.json',
+      thresholds: { complexity: { max: 15 } },
+    },
+    agentsMapPath: './AGENTS.md',
+    template: { level: 'minimal', version: 1 },
+  };
+  return JSON.stringify(config, null, 2) + '\n';
+}
+
+// --- Artifact 4: the one verification loop (git pre-commit) ---
+
+const HOOK_BEGIN = '# >>> harness minimal tier (managed by `harness init --tier minimal`) >>>';
+const HOOK_END = '# <<< harness minimal tier (managed by `harness init --tier minimal`) <<<';
+
+/** The managed pre-commit block: run the arch gate, block the commit on failure. */
+function buildPreCommitBlock(): string {
+  return [
+    HOOK_BEGIN,
+    '# Verification loop: run the harness architecture gate before every commit so a',
+    '# layer violation can never land. Managed by `harness init --tier minimal` — edits',
+    '# inside this block are overwritten on the next run.',
+    'if ! npx harness check-arch; then',
+    '  echo "Commit blocked: harness check-arch failed; fix the violation before committing." >&2',
+    '  exit 1',
+    'fi',
+    HOOK_END,
+  ].join('\n');
+}
+
+/** Idempotently merge the managed `block` into an existing hook file's content. */
+function mergeHook(existing: string | null, block: string): string {
+  if (existing === null || existing.trim() === '') {
+    return `#!/bin/sh\n${block}\n`;
+  }
+  const begin = existing.indexOf(HOOK_BEGIN);
+  const end = existing.indexOf(HOOK_END);
+  if (begin !== -1 && end !== -1 && end >= begin) {
+    const endLineBreak = existing.indexOf('\n', end);
+    const head = existing.slice(0, begin);
+    const tail = endLineBreak === -1 ? '' : existing.slice(endLineBreak);
+    return `${head}${block}${tail}`;
+  }
+  const separator = existing.endsWith('\n') ? '' : '\n';
+  return `${existing}${separator}\n${block}\n`;
+}
+
+/** Install (or refresh) the pre-commit verification loop. */
+function installVerificationLoop(cwd: string): MinimalArtifact {
+  const mvh = 'One verification loop — a pre-commit hook running the arch check';
+  if (!isGitRepo(cwd)) {
+    return {
+      mvh,
+      files: [],
+      scaffolded: false,
+      note: 'not a git repository — install a pre-commit hook that runs `harness check-arch` once the project is under git.',
+    };
+  }
+  const hookPath = path.join(resolveGitHooksDir(cwd), 'pre-commit');
+  const existing = fs.existsSync(hookPath) ? fs.readFileSync(hookPath, 'utf-8') : null;
+  fs.mkdirSync(path.dirname(hookPath), { recursive: true });
+  fs.writeFileSync(hookPath, mergeHook(existing, buildPreCommitBlock()));
+  if (process.platform !== 'win32') {
+    try {
+      fs.chmodSync(hookPath, 0o755);
+    } catch {
+      // Non-POSIX filesystem — git for Windows honours the hook regardless.
+    }
+  }
+  return { mvh, files: [path.relative(cwd, hookPath).replaceAll('\\', '/')], scaffolded: true };
+}
+
+// --- Artifact 1: the repo guide (AGENTS.md) ---
+
+async function writeRepoGuide(cwd: string): Promise<MinimalArtifact> {
+  const mvh = 'Repo guide — a generated AGENTS.md';
+  const result = await generateAgentsMap({
+    rootDir: cwd,
+    includePaths: ['src/**/*', 'docs/**/*.md'],
+    excludePaths: ['**/node_modules/**', '**/dist/**'],
+  });
+  const content = result.ok
+    ? result.value
+    : '# AI Agent Knowledge Map\n\n## Project Overview\n\n> Add a brief description of this project.\n';
+  fs.writeFileSync(path.join(cwd, 'AGENTS.md'), content);
+  return { mvh, files: ['AGENTS.md'], scaffolded: true };
+}
+
+// --- Artifact 5: the one permission boundary (block-no-verify) ---
+
+function installPermissionBoundary(cwd: string, force: boolean): MinimalArtifact {
+  const result = initHooks({ profile: 'minimal', projectDir: cwd, force });
+  const files = [
+    path.relative(cwd, result.settingsPath).replaceAll('\\', '/'),
+    ...result.copiedScripts.map((s) => `.harness/hooks/${s}.js`),
+  ];
+  return { mvh: 'One permission boundary — block-no-verify', files, scaffolded: true };
+}
+
+/**
+ * Scaffold the five Minimum-Viable-Harness artifacts (ADR 0101) and nothing more.
+ */
+export async function runMinimalInit(
+  options: MinimalInitOptions
+): Promise<Result<MinimalInitResult, CLIError>> {
+  const cwd = options.cwd ?? process.cwd();
+  const name = options.name ?? path.basename(cwd);
+  const force = options.force ?? false;
+
+  const configPath = path.join(cwd, 'harness.config.json');
+  if (!force && fs.existsSync(configPath)) {
+    return Err(
+      new CLIError('Project already initialized. Use --force to overwrite.', ExitCode.ERROR)
+    );
+  }
+
+  // 1. Repo guide.
+  const repoGuide = await writeRepoGuide(cwd);
+
+  // 2 + 3. One runnable local check + one hard architectural rule.
+  fs.writeFileSync(configPath, buildMinimalConfig(name));
+  const runnableCheck: MinimalArtifact = {
+    mvh: 'One runnable local check — `harness check-arch`, wired via harness.config.json',
+    files: ['harness.config.json'],
+    scaffolded: true,
+  };
+
+  // Seed an empty baseline so the arch gate is fail-closed: any new layer
+  // violation is a regression against a clean floor.
+  const baseline = new ArchBaselineManager(cwd);
+  baseline.save(baseline.capture([], currentCommitHash(cwd)));
+  const archRule: MinimalArtifact = {
+    mvh: 'One hard architectural rule — check-arch fail-closed, baseline seeded',
+    files: ['.harness/arch/baselines.json'],
+    scaffolded: true,
+  };
+
+  // 4. Verification loop.
+  const verificationLoop = installVerificationLoop(cwd);
+
+  // 5. Permission boundary.
+  const permissionBoundary = installPermissionBoundary(cwd, force);
+
+  const artifacts = [repoGuide, runnableCheck, archRule, verificationLoop, permissionBoundary];
+  const filesCreated = artifacts.flatMap((a) => a.files);
+
+  return Ok({ artifacts, filesCreated });
+}
+
+/**
+ * The explicit, ordered upgrade path printed after a `minimal` install (ADR 0101):
+ * nothing is skipped, only sequenced. `minimal` is a genuine floor, not a dead end —
+ * re-running init at a higher tier layers on top of it.
+ */
+export function buildUpgradePath(): string[] {
+  return [
+    'Upgrade path (each step is additive — re-running init at a higher tier layers on top):',
+    `  1. Run ${chalk.cyan('/harness:strategy')} to capture strategic grounding (STRATEGY.md) — it anchors brainstorm, ideate, and roadmap-pilot.`,
+    `  2. Run ${chalk.cyan('harness init --tier intermediate')} to add framework selection, a design system, and the fuller check set.`,
+    `  3. Run ${chalk.cyan('harness init --tier advanced')} to add multi-persona review in CI and the outcome-eval ship gate.`,
+  ];
+}
+
+/** Print the success summary + ordered upgrade path for a `minimal` install. */
+export function printMinimalInitSuccess(result: MinimalInitResult): void {
+  console.log('');
+  logger.success('Minimal harness initialized (ADR 0101 — the 5-item Minimum Viable Harness).');
+  console.log('');
+  logger.info('Scaffolded artifacts:');
+  for (const artifact of result.artifacts) {
+    const marker = artifact.scaffolded ? chalk.green('+') : chalk.yellow('~');
+    console.log(`  ${marker} ${artifact.mvh}`);
+    for (const file of artifact.files) {
+      console.log(`      ${chalk.dim(file)}`);
+    }
+    if (artifact.note) {
+      console.log(`      ${chalk.yellow('deferred:')} ${artifact.note}`);
+    }
+  }
+  console.log('');
+  for (const line of buildUpgradePath()) {
+    console.log(line);
+  }
+  console.log('');
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, type OptionValues } from 'commander';
 import chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -18,6 +18,15 @@ import { resolveTemplatesDir } from '../utils/paths';
 import { setupMcp } from './setup-mcp';
 import { generateCIConfig } from './ci/init';
 import { configureMergeOursDriver } from '../git/merge-driver-setup';
+import { runMinimalInit, printMinimalInitSuccess } from './init-minimal';
+
+/**
+ * Tiers reachable via `--tier` (ADR 0101). `minimal` is the new load-bearing
+ * floor mapped to the field's 5-item Minimum Viable Harness; every other tier
+ * delegates to the existing adoption-level scaffold so the ladder's upgrade
+ * wording ("`harness init --tier intermediate`") resolves to a real command.
+ */
+const TIER_LEVELS = ['minimal', 'basic', 'intermediate', 'load-bearing-minimum', 'advanced'];
 
 interface InitOptions {
   cwd?: string;
@@ -270,6 +279,32 @@ function printInitSuccess(filesCreated: string[], mcpConfigured: string[]): void
   console.log('');
 }
 
+/**
+ * The `--tier minimal` fast path (ADR 0101): scaffold exactly the 5 Minimum
+ * Viable Harness artifacts and print the ordered upgrade path. STRATEGY.md,
+ * framework selection, design system, and MCP integration are deferred (not
+ * skipped) — the upgrade path sequences them — so this path deliberately does
+ * NOT run setupMcp.
+ */
+async function runMinimalInitAction(opts: InitOptions & { quiet?: boolean }): Promise<void> {
+  const result = await runMinimalInit({
+    ...(opts.cwd !== undefined && { cwd: opts.cwd }),
+    ...(opts.name !== undefined && { name: opts.name }),
+    ...(opts.force !== undefined && { force: opts.force }),
+  });
+
+  if (!result.ok) {
+    logger.error(result.error.message);
+    process.exit(result.error.exitCode);
+  }
+
+  if (!opts.quiet) {
+    printMinimalInitSuccess(result.value);
+  }
+
+  process.exit(ExitCode.SUCCESS);
+}
+
 async function runInitAction(opts: InitOptions & { quiet?: boolean }): Promise<void> {
   const result = await runInit(opts);
 
@@ -288,8 +323,36 @@ async function runInitAction(opts: InitOptions & { quiet?: boolean }): Promise<v
   process.exit(ExitCode.SUCCESS);
 }
 
+/**
+ * Dispatch an `init` invocation. `--tier minimal` is the ADR 0101 fast path;
+ * every other tier delegates to the existing adoption-level scaffold (mapped
+ * through `level`, with `--template` and `--tier` taking precedence).
+ */
+async function dispatchInit(opts: OptionValues, globalOpts: OptionValues): Promise<void> {
+  const tier: string | undefined = opts.tier;
+  if (tier !== undefined && !TIER_LEVELS.includes(tier)) {
+    logger.error(`Invalid --tier: ${tier}. Must be one of: ${TIER_LEVELS.join(', ')}`);
+    process.exit(ExitCode.ERROR);
+  }
+
+  const common = {
+    name: opts.name,
+    framework: opts.framework,
+    language: opts.language,
+    force: opts.force,
+    quiet: globalOpts.quiet,
+  };
+
+  if (tier === 'minimal') {
+    await runMinimalInitAction(common);
+    return;
+  }
+
+  await runInitAction({ ...common, level: opts.template ?? tier ?? opts.level });
+}
+
 export function createInitCommand(): Command {
-  const command = new Command('init')
+  return new Command('init')
     .description('Initialize a new harness-engineering project')
     .option('-n, --name <name>', 'Project name')
     .option(
@@ -298,21 +361,15 @@ export function createInitCommand(): Command {
       'load-bearing-minimum'
     )
     .option('-t, --template <template>', 'Specific template name (e.g. orchestrator)')
+    .option(
+      '--tier <tier>',
+      'Adoption tier (ADR 0101): minimal (the 5-item Minimum Viable Harness floor), basic, intermediate, load-bearing-minimum, advanced'
+    )
     .option('--framework <framework>', 'Framework overlay (nextjs)')
     .option('--language <language>', 'Target language (typescript, python, go, rust, java)')
     .option('-f, --force', 'Overwrite existing files')
     .option('-y, --yes', 'Use defaults without prompting')
     .action(async (opts, cmd) => {
-      const globalOpts = cmd.optsWithGlobals();
-      await runInitAction({
-        name: opts.name,
-        level: opts.template ?? opts.level,
-        framework: opts.framework,
-        language: opts.language,
-        force: opts.force,
-        quiet: globalOpts.quiet,
-      });
+      await dispatchInit(opts, cmd.optsWithGlobals());
     });
-
-  return command;
 }

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1052,8 +1052,10 @@ export const HarnessConfigSchema = z.object({
   /** Project template settings (used by 'harness init') */
   template: z
     .object({
-      /** Complexity level of the template (JS/TS only) */
-      level: z.enum(['basic', 'intermediate', 'load-bearing-minimum', 'advanced']).optional(),
+      /** Complexity level of the template (JS/TS only). `minimal` is the ADR 0101 floor. */
+      level: z
+        .enum(['minimal', 'basic', 'intermediate', 'load-bearing-minimum', 'advanced'])
+        .optional(),
       /** Target language */
       language: z.enum(['typescript', 'python', 'go', 'rust', 'java']).optional(),
       /** Primary technology framework */

--- a/packages/cli/tests/commands/init-minimal.test.ts
+++ b/packages/cli/tests/commands/init-minimal.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { runMinimalInit, buildUpgradePath } from '../../src/commands/init-minimal';
+import { runCheckArch } from '../../src/commands/check-arch';
+
+/** A temp git repo so the pre-commit verification loop can be installed. */
+function makeRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-minimal-'));
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  return dir;
+}
+
+describe('runMinimalInit (ADR 0101)', () => {
+  it('scaffolds exactly the 5 Minimum Viable Harness artifacts', async () => {
+    const dir = makeRepo();
+    try {
+      const result = await runMinimalInit({ cwd: dir, name: 'demo' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Exactly five artifacts, each of the five MVH items, all scaffolded.
+      expect(result.value.artifacts).toHaveLength(5);
+      expect(result.value.artifacts.every((a) => a.scaffolded)).toBe(true);
+
+      // 1. Repo guide — AGENTS.md.
+      expect(fs.existsSync(path.join(dir, 'AGENTS.md'))).toBe(true);
+
+      // 2. One runnable local check — harness.config.json wiring check-arch.
+      const configPath = path.join(dir, 'harness.config.json');
+      expect(fs.existsSync(configPath)).toBe(true);
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      expect(config.template.level).toBe('minimal');
+
+      // 3. One hard architectural rule — arch enabled, fail-closed, baseline seeded.
+      expect(config.architecture.enabled).toBe(true);
+      expect(config.architecture.thresholds.complexity.max).toBe(15);
+      const baselinePath = path.join(dir, '.harness', 'arch', 'baselines.json');
+      expect(fs.existsSync(baselinePath)).toBe(true);
+
+      // 4. One verification loop — a pre-commit hook running the arch check.
+      const preCommit = path.join(dir, '.git', 'hooks', 'pre-commit');
+      expect(fs.existsSync(preCommit)).toBe(true);
+      expect(fs.readFileSync(preCommit, 'utf-8')).toContain('harness check-arch');
+
+      // 5. One permission boundary — block-no-verify.
+      expect(fs.existsSync(path.join(dir, '.harness', 'hooks', 'block-no-verify.js'))).toBe(true);
+      const settings = JSON.parse(
+        fs.readFileSync(path.join(dir, '.claude', 'settings.json'), 'utf-8')
+      );
+      expect(JSON.stringify(settings.hooks)).toContain('block-no-verify');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT scaffold the deferred heavier artifacts (STRATEGY, framework, design)', async () => {
+    const dir = makeRepo();
+    try {
+      await runMinimalInit({ cwd: dir, name: 'demo' });
+      expect(fs.existsSync(path.join(dir, 'STRATEGY.md'))).toBe(false);
+      expect(fs.existsSync(path.join(dir, 'package.json'))).toBe(false);
+      expect(fs.existsSync(path.join(dir, 'eslint.config.mjs'))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to overwrite an initialized project without --force', async () => {
+    const dir = makeRepo();
+    try {
+      const first = await runMinimalInit({ cwd: dir, name: 'demo' });
+      expect(first.ok).toBe(true);
+      const second = await runMinimalInit({ cwd: dir, name: 'demo' });
+      expect(second.ok).toBe(false);
+      if (!second.ok) expect(second.error.message).toMatch(/already initialized/i);
+      const forced = await runMinimalInit({ cwd: dir, name: 'demo', force: true });
+      expect(forced.ok).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('degrades gracefully outside a git repo (verification loop deferred, not fatal)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-init-nogit-'));
+    try {
+      const result = await runMinimalInit({ cwd: dir, name: 'demo' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const loop = result.value.artifacts.find((a) => a.mvh.includes('verification loop'));
+      expect(loop?.scaffolded).toBe(false);
+      expect(loop?.note).toBeTruthy();
+      // The other four artifacts still land.
+      expect(fs.existsSync(path.join(dir, 'AGENTS.md'))).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'harness.config.json'))).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('the seeded arch rule is fail-closed — check-arch passes clean, fails on an over-complex fn', async () => {
+    const dir = makeRepo();
+    try {
+      await runMinimalInit({ cwd: dir, name: 'demo' });
+      const configPath = path.join(dir, 'harness.config.json');
+      fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+
+      // A trivial module passes the seeded floor.
+      fs.writeFileSync(path.join(dir, 'src', 'ok.ts'), 'export const ok = 1;\n');
+      const clean = await runCheckArch({ cwd: dir, configPath });
+      expect(clean.ok).toBe(true);
+      if (clean.ok) expect(clean.value.passed).toBe(true);
+
+      // A function well over the complexity cap of 15 trips the gate.
+      const overComplex =
+        'export function f(n: number): number {\n' +
+        '  ' +
+        Array.from({ length: 20 }, (_, i) => `if (n > ${i}) {`).join('') +
+        'return 1;' +
+        '}'.repeat(20) +
+        '\n  return 0;\n}\n';
+      fs.writeFileSync(path.join(dir, 'src', 'complex.ts'), overComplex);
+      const dirty = await runCheckArch({ cwd: dir, configPath });
+      expect(dirty.ok).toBe(true);
+      if (dirty.ok) expect(dirty.value.passed).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prints an ordered, additive upgrade path to the fuller tiers', () => {
+    const lines = buildUpgradePath().join('\n');
+    expect(lines).toMatch(/additive/i);
+    expect(lines).toContain('/harness:strategy');
+    expect(lines).toContain('harness init --tier intermediate');
+    expect(lines).toContain('harness init --tier advanced');
+  });
+});


### PR DESCRIPTION
## What

Implements **ADR 0101** — a `minimal` init tier: the documented floor of the adoption ladder, mapped one-to-one to the field's 5-item **Minimum Viable Harness**. Reachable via `harness init --tier minimal`.

It scaffolds exactly, and only, the five load-bearing artifacts and prints an explicit, ordered upgrade path so nothing is lost — only sequenced:

| # | MVH item | Concrete artifact |
|---|----------|-------------------|
| 1 | Repo guide | `AGENTS.md` (generated via `generateAgentsMap()`) |
| 2 | One runnable local check | `harness.config.json` wiring `harness check-arch` |
| 3 | One hard architectural rule | cyclomatic-complexity cap of 15, `check-arch` **fail-closed** with a seeded `.harness/arch/baselines.json` |
| 4 | One verification loop | git `pre-commit` hook running the check |
| 5 | One permission boundary | `block-no-verify` (hooks `minimal` profile → `.claude/settings.json` + `.harness/hooks/block-no-verify.js`) |

## Design notes

- **Deferred, not skipped.** STRATEGY.md, framework selection, design system, and MCP integration are sequenced by the printed upgrade path (`/harness:strategy` → `harness init --tier intermediate` → `--tier advanced`). Re-running init at a higher tier is additive over a minimal install.
- **The hard rule genuinely bites.** A complexity cap of 15 is enforced directly from source (verified: a trivial module passes, an over-complex function fails `check-arch` with exit 1), unlike circular-deps/layer rules which are inert in a standalone run. Adopter-portable — no assumptions about this repo's layout.
- **Additive & non-regressive.** `--tier` also accepts `basic`/`intermediate`/`load-bearing-minimum`/`advanced`, delegating to the existing `--level` scaffold, so the ADR's upgrade wording resolves to a real command. The existing full-flow init is unchanged. Adds `minimal` to the template-level enum.
- **Degrades gracefully** outside a git repo (the verification-loop artifact reports deferred with a note; the other four still land).

## Tests

`packages/cli/tests/commands/init-minimal.test.ts` (6 tests): exactly-5 artifacts, deferred heavier artifacts absent, `--force` overwrite semantics, graceful degradation without git, **fail-closed enforcement** (in-process `runCheckArch`), and the ordered upgrade-path text.

## Gates

- typecheck, lint (0 errors), `pnpm ci check` (arch: pass) — all green locally.
- `pnpm run generate-docs` run; `docs/reference/cli-commands.md` updated with `--tier`.
- Changeset added (`@harness-engineering/cli`, minor).

Spec: `docs/knowledge/decisions/0101-minimum-viable-harness-init-tier.md`

Closes #1470