### PR TITLE
docs(architecture): Graphify adoption analysis + ADR 0104 (do not replace graph pkg)

### DIFF
--- a/docs/architecture/graphify-adoption/analysis.md
+++ b/docs/architecture/graphify-adoption/analysis.md
@@ -1,0 +1,80 @@
+# Analysis: Graphify vs `@harness-engineering/graph`
+
+**Read-only research.** Evidence is cited `file:line` for our code and by URL for Graphify.
+
+## The two things are not the same category
+
+| | **Graphify** | **`@harness-engineering/graph`** |
+| --- | --- | --- |
+| Shape | Standalone **CLI + MCP server** (Python) that emits artifacts | Embedded **TS library** (`v0.13.1`), consumed in-process |
+| Primary job | "Query your codebase instead of grepping" — a code+docs **concept graph** for an AI assistant | **Substrate** for the whole harness analytical surface |
+| Output | `graph.json` / `graph.html` / `GRAPH_REPORT.md` in `graphify-out/` | Live TS objects: `GraphStore`, `ContextQL`, `Assembler`, adapters |
+| Consumers | The human + the AI assistant, via CLI/MCP | **91 non-test source files across 7 packages** (`cli` 50, `intelligence` 14, `core` 12, `orchestrator`/`dashboard` 5 each, `signals` 3) |
+| Model scope | Code + docs concepts | Code **+** ADR/decision/learning/failure, VCS, observability, design tokens, business knowledge, requirements/traceability, execution outcomes — **37 node types, 29 edge types** (`packages/graph/README.md`) |
+| Embeddings | **Deliberately none** ("not a vector index") | `VectorStore` + `FusionLayer` hybrid keyword+semantic search |
+| License / tier | OSS (Apache-2.0/MIT dual) + proprietary **enterprise cloud** ("always-on layer", app.graphify.com) | Ours (MIT), fully owned |
+
+The core insight: **Graphify's value is the code-graph slice. Our graph's value is everything the code-graph feeds** — the ~15 adapters that turn the graph into harness analyses. Graphify has no equivalent of those, no TS API, and a different product goal.
+
+## What Graphify does STRONGER (verified)
+
+1. **AST fidelity & language breadth.** Graphify parses **37 tree-sitter grammars** (Python, TS/JS, Go, Rust, Java, C/C++, Ruby, C#, Kotlin, Swift, PHP, SQL, Terraform, Vue/Svelte/Astro, …) — deterministic AST, no LLM ([README](https://github.com/Graphify-Labs/graphify/blob/v8/README.md)). Ours does 6 languages (`.ts/.tsx/.js/.jsx/.py/.go/.rs/.java`) via **regex symbol extraction**, not AST — `packages/graph/src/ingest/CodeIngestor.ts:34,103-121`. Tree-sitter is materially more accurate than regex for anything past TS/JS.
+2. **Explicit edge provenance.** Every edge is tagged `EXTRACTED` (explicit in source) / `INFERRED` (resolved by graphify) / `AMBIGUOUS` (LLM tiebreak). Ours carries only `confidence?: number` (0-1) with **no provenance enum** — `packages/graph/src/types.ts:138,262`. Provenance makes "cite what you read vs what you guessed" a first-class property; we cannot currently express it.
+3. **Community detection.** Leiden algorithm partitions the graph into labeled subsystems (`--cluster-only` reruns without re-extraction). We have only `clusterBySource` (group-by-source-node) in `packages/graph/src/ingest/KnowledgeLinker.ts:163` — not real community detection.
+4. **First-class graph primitives for humans.** `graphify path A B` (shortest path between any two concepts) and `graphify explain Concept` (degree, source, neighbors). We have `explain`/`impact`/`relationships` NLQ intents over a BFS (`packages/graph/src/nlq/`), but no arbitrary two-node shortest-path.
+5. **"Every edge explained" + shipped visualization.** `graph.html` (interactive force-directed) and `GRAPH_REPORT.md` (god-nodes, surprising connections, inline WHY). We have no built-in human-facing viz/report exporter.
+6. **Multi-modal ingest** (PDF/DOCX/XLSX/images/video via LLM backends). We ingest markdown knowledge artifacts only.
+7. **Distribution & proof.** ~108k stars, ~5M downloads, named production users. Battle-tested extraction.
+
+## What OUR graph does STRONGER (verified)
+
+1. **Unified cross-domain model.** 37 node types spanning knowledge, VCS, observability, **design tokens, business knowledge, requirements/traceability, execution outcomes** (`packages/graph/README.md`). Graphify is code+docs only. This model is *the* thing the harness is built on.
+2. **The analysis adapter layer.** `GraphEntropyAdapter`, `GraphConstraintAdapter`, `GraphComplexityAdapter`, `GraphCouplingAdapter`, `GraphAnomalyAdapter`, `CascadeSimulator` (`compute_blast_radius`), `TaskIndependenceAnalyzer`, `ConflictPredictor`, `queryTraceability`, `GraphFeedbackAdapter`. **None of this exists in Graphify.** These power `detect_entropy`, `enforce-architecture`, `check_traceability`, impact analysis, etc.
+3. **Token-budget-aware context Assembly.** `Assembler` does phase-aware context selection under token budgets with coverage reports — purpose-built for feeding agents. Graphify returns scoped subgraphs, not budgeted context.
+4. **Hybrid semantic search.** `FusionLayer` blends keyword + embedding similarity. Graphify deliberately refuses embeddings — a strength for pure-deterministic tracing, a weakness for "find me something *like* this."
+5. **In-process TS API.** 91 importers call it as a library. Graphify's only integration surfaces are CLI stdout and an MCP server — neither is an in-process API.
+6. **Full ownership.** No external tool version-coupling, no enterprise-tier gating risk, no Python runtime in the harness.
+
+## Integration points (what "replace" would touch)
+
+- 91 non-test files import `@harness-engineering/graph`; the CLI package alone has 50.
+- Every harness analysis MCP tool that reads the graph (entropy, constraints, complexity, coupling, anomaly, blast-radius, traceability, task-independence, conflict-prediction) is an adapter over `GraphStore`.
+- `saveGraph`/`loadGraph` serialization, `SyncManager` connectors (Jira/Slack/Confluence/CI), and the NLQ surface (`askGraph`) all bind to our node/edge model.
+
+## Technical debt relevant to the decision
+
+- Our `CodeIngestor` is **regex-based**, not AST — the single largest fidelity gap, and the clearest thing Graphify does better. This is where adoption has real leverage.
+- We have no human-facing graph visualization; Graphify ships one.
+- Provenance is collapsed into a single `confidence` float; we cannot distinguish "read directly" from "inferred."
+
+## Full feature pass (verified against `v8` README, 2026-08-26)
+
+A second exhaustive sweep confirmed Graphify is broader than a code-map. The complete surface:
+
+- **It is also an agent-memory / RAG competitor.** Benchmarked on LOCOMO (recall@10 0.497, QA 45.3%) and **LongMemEval-S (76% QA, "tied with dense RAG")** with 0 LLM credits for graph build. It positions the graph as the thing an assistant queries *instead of* embeddings-RAG. Relevant to due-diligence: competitive, not dominant, on memory QA — reinforces "don't replace, it's not strictly better."
+- **PR-review intelligence.** `graphify prs --triage` (AI-ranked review queue), `--conflicts` (merge-order risk via **shared communities**), `--worktrees` (branch→PR map), `prs <n>` (graph impact of a PR); MCP tools `list_prs`/`get_pr_impact`/`triage_prs`. Overlaps our own PR/impact surface (see Convergent overlaps).
+- **9-backend semantic extraction** (Gemini/Claude/claude-cli/OpenAI/DeepSeek/Kimi/Azure/Bedrock/Ollama) for the docs/media pass; code is always AST-only/local.
+- **Graph-interop hub.** Exports: `graph.html`, `GRAPH_REPORT.md`, `graph.json`, SVG, **GraphML (Gephi/yEd)**, **Cypher for Neo4j/FalkorDB (+ direct push)**, **Obsidian vault**, agent-crawlable **wiki**, **Mermaid call-flow HTML**.
+- **Work-memory / reflection loop.** `save-result` (outcome ∈ useful|dead_end|corrected) → `reflect` → LESSONS.md, lessons tagged **preferred|tentative|contested** (recency-weighted with provenance) and a **"code changed — re-verify"** staleness flag surfaced in `explain`/`query`.
+- **Freshness machinery.** `--update` (incremental re-extract of changed files only), `graphify hook install` (post-commit/post-checkout auto-rebuild, AST-only/no API cost), `graphify watch` (live sync), a **git merge driver** that union-merges `graph.json` without conflict markers, and a **512 MiB** graph cap.
+- **Distribution breadth.** `graphify install` targets 25+ assistants (Claude Code, Cursor, Codex, Gemini, Copilot, Aider, Kilo, Kiro, Antigravity, …), plus a **`--strict` PreToolUse hook that blocks the first raw source read and redirects the agent to query the graph.**
+- **Dependency/infra graph.** Manifest parsing (`pyproject.toml`/`go.mod`/`pom.xml`) → package nodes with `depends_on`; live **PostgreSQL** schema introspection; Rust **Cargo** deps.
+- **Cross-project global graph** (`graphify global`) and `graphify add <url>` / `clone <repo>` to pull external papers/videos/repos in.
+- **MCP server** with stdio + HTTP transports, `--api-key` auth, `--stateless` for load-balancing — a team-shareable query endpoint.
+- **Enterprise tier** (app.graphify.com, YC S26): "always-on" continuous background updating across meetings/docs/code. The OSS `v8` tool is the free floor; continuous-sync is the paid upsell.
+
+## Convergent overlaps (we already do the harness-native version)
+
+Not gaps — flagged so we don't "adopt" what we already have, differently framed:
+
+| Graphify feature | Our equivalent | Note |
+| --- | --- | --- |
+| `prs --conflicts` (merge risk via shared community) | `ConflictPredictor` + `TaskIndependenceAnalyzer` (co-change) | Different signal; ours is co-change-based |
+| `get_pr_impact` | `CascadeSimulator` / `compute_blast_radius`, `get_impact` | Ours is probability-weighted BFS |
+| `save-result`/`reflect` → LESSONS | `learning`/`failure`/`execution_outcome` nodes + skill-effectiveness baselines | Convergent validation; **the "code changed — re-verify" staleness flag is the one sharp idea worth stealing** |
+| MCP `query_graph`/`shortest_path` | `ask_graph`/`query_graph` MCP tools + NLQ | We already expose via the harness MCP surface |
+| `depends_on` package graph | `supply-chain-audit`, `dependency-health` | Different lens; not a model gap |
+
+## Consumption path if we ever depended on Graphify
+
+Graphify exposes: CLI (`query`/`path`/`explain` → stdout JSON), an **MCP server** (`query_graph`, `get_node`, `get_neighbors`, `shortest_path`, `get_pr_impact`, `triage_prs`), and raw `graph.json`. The JSON schema is **not formally documented** — brittle to depend on across its unstable `v8` branch.

--- a/docs/architecture/graphify-adoption/discovery.md
+++ b/docs/architecture/graphify-adoption/discovery.md
@@ -1,0 +1,22 @@
+# Discovery: Graphify adoption evaluation
+
+**Date:** 2026-08-26
+**Advisor session:** harness-architecture-advisor
+**Subject:** [Graphify](https://github.com/Graphify-Labs/graphify) (graphify.net / graphify.com) vs `@harness-engineering/graph`
+
+## Prompt (verbatim)
+
+> Analyze the following project for adoption. Analyze what it does stronger, weaker, what should be adopted, what should be ignored. Also determine if it should be used wholesale as a replacement for the graph package.
+> https://github.com/Graphify-Labs/graphify  https://graphify.net
+
+## Discovery answers
+
+1. **Primary motivation** — Due diligence. Graphify is popular (~108k stars, YC S26). Leadership wants a defensible written verdict on adopt / replace before committing either way.
+2. **Language / architecture constraint** — Polyglot is acceptable. A Python Graphify sidecar that emits `graph.json` for a TS adapter to ingest is on the table **if** the capability gain justifies the operational cost. (It is not a hard "must stay pure-TS in-process" constraint — but see the 91-importer footprint below, which still governs the *core* path.)
+3. **Deliverable** — Full ADR via `manage_adr`, plus analysis + proposal docs on an isolated worktree branch.
+
+## Success in 6 months
+
+- A clear, evidence-cited record of what (if anything) we ported from Graphify and why.
+- No regression in the harness analytical surface (entropy / constraints / traceability / blast-radius) that depends on our graph.
+- We would regret this if we either (a) took a hard runtime dependency on an unstable external OSS tool that later gated features behind its enterprise tier, or (b) reinvented capabilities Graphify gives for free with no payoff.

--- a/docs/architecture/graphify-adoption/proposal.md
+++ b/docs/architecture/graphify-adoption/proposal.md
@@ -1,0 +1,108 @@
+# Proposal: how to relate to Graphify
+
+Three options. The headline question — *"use it wholesale as a replacement for the graph package?"* — is Option C, presented honestly and rejected on evidence.
+
+---
+
+### Option A: Cherry-pick capabilities into our graph (no runtime dependency)
+
+**Summary.** Keep `@harness-engineering/graph` as the substrate. Port the specific ideas Graphify does better, reimplemented in TS: edge **provenance enum** (`EXTRACTED`/`INFERRED`/`AMBIGUOUS`), **community detection** (Leiden/Louvain), a **shortest-path** query primitive, and the "**every edge explained**" discipline plus an optional `graph.html`/report exporter.
+
+**How it works:**
+1. Add a `provenance` field alongside `confidence` in the edge schema (`types.ts`); set it at ingest time (AST-explicit → EXTRACTED, resolver-derived → INFERRED).
+2. Add a community-detection pass over `GraphStore` and expose labels on nodes.
+3. Add `shortestPath(a, b)` to `ContextQL`; surface via NLQ + a CLI verb.
+4. Add an optional exporter that emits a human-facing viz/report from any `GraphStore`.
+
+**Pros:**
+- No Python runtime, no external version-coupling, stays in-process — respects the 91-importer reality.
+- Provenance and community labels flow into *our* adapters (entropy, traceability, blast-radius) for free — Graphify's don't.
+- We own the roadmap; no enterprise-tier gating risk.
+
+**Cons:**
+- Reimplementation effort — medium — we don't get 37 tree-sitter grammars for free (see Option B for that specific gap). *Mitigation:* scope to provenance + community + path first; defer AST breadth.
+- Leiden in TS is non-trivial — medium. *Mitigation:* start with Louvain or a small vetted lib.
+
+**Effort:** Medium (incremental, per-capability PRs). **Risk:** Low. **Best when:** the goal is durable capability we control — which the due-diligence + 91-importer facts point to.
+
+---
+
+### Option B: Polyglot sidecar — ingest Graphify's `graph.json` as an optional code-AST source
+
+**Summary.** Leave the substrate alone; add an **optional** `GraphifyIngestor` adapter that shells out to Graphify (or reads a pre-generated `graph.json`) and maps its code nodes/edges into our model — buying 37-language tree-sitter fidelity + provenance without reimplementing a parser. Opt-in, degrades gracefully when Graphify is absent.
+
+**How it works:**
+1. New adapter runs `graphify` (if installed) over the repo, reads `graphify-out/graph.json`.
+2. Maps Graphify code nodes/edges → our `file`/`function`/`class` nodes + `imports`/`calls` edges, carrying the provenance tag.
+3. Our adapters/analyses consume the enriched `GraphStore` unchanged.
+
+**Pros:**
+- Best AST fidelity across many languages with **zero parser maintenance** on our side.
+- Our graph stays the substrate and analysis layer; Graphify is a pluggable enrichment, never the core.
+- "Polyglot OK" answer makes this viable.
+
+**Cons:**
+- **Python runtime dependency** for the enriched path — high operational cost (packaging, air-gap, CI). — *Mitigation:* strictly opt-in; TS regex path remains the default.
+- Depends on Graphify's **undocumented `graph.json` schema** on an unstable `v8` branch — medium/high brittleness. — *Mitigation:* pin a version; contract-test the mapping.
+- Only helps the **code-graph slice** — nothing for our knowledge/design/business/traceability model.
+- Enterprise-tier drift risk: continuous-update features live behind the paid cloud.
+
+**Effort:** Medium. **Risk:** Medium. **Best when:** we have real polyglot repos where regex extraction is demonstrably too lossy and the language matters more than owning the pipeline.
+
+---
+
+### Option C: Wholesale replacement (the question asked) — REJECTED
+
+**Summary.** Delete `@harness-engineering/graph`; make Graphify the graph.
+
+**Why it fails (honest cons):**
+- **Category mismatch — high.** Graphify is a code+docs concept-graph generator with a CLI/MCP surface. It has **no** design-token / business-knowledge / requirement-traceability / execution-outcome model, **no** analysis adapters, **no** token-budget Assembler, and **no** in-process TS API. Replacing our library with it deletes the substrate that `detect_entropy`, `enforce-architecture`, `check_traceability`, `compute_blast_radius`, etc. are built on.
+- **Blast radius — high.** 91 non-test importers across 7 packages (50 in `cli`) bind to our node/edge model and TS API. All would need rewriting against Graphify's undocumented JSON + MCP tools.
+- **Strategic coupling — high.** Existential dependency on an external YC startup's OSS tier, with an explicit proprietary enterprise upsell for the always-on features.
+- **Loses our differentiators — medium.** Semantic `FusionLayer` search and the unified cross-domain model both vanish.
+
+**Effort:** Large (a rewrite, not an adoption). **Risk:** High. **Best when:** never, at our current integration depth.
+
+---
+
+## Comparison matrix
+
+| Criterion        | A: Cherry-pick | B: Sidecar | C: Wholesale replace |
+| ---------------- | -------------- | ---------- | -------------------- |
+| Complexity       | Low–Med        | Med        | Very High            |
+| AST fidelity gain| Partial        | **Full (37 langs)** | Full           |
+| Keeps our model  | **Yes**        | **Yes**    | No                   |
+| Keeps adapters   | **Yes**        | **Yes**    | No                   |
+| Runtime added    | None           | Python     | Python + loses TS API|
+| External coupling| None           | Medium     | Existential          |
+| Effort to build  | Medium         | Medium     | Large                |
+| Effort to change | Low            | Medium     | High                 |
+| Risk             | **Low**        | Medium     | High                 |
+| Fits 91-importer reality | **Yes** | Yes        | No                   |
+
+## Adopt / ignore (post deep-pass)
+
+**Adopt (port into our graph, no dependency):**
+1. **EXTRACTED / INFERRED / AMBIGUOUS provenance enum** on edges — highest leverage; flows into every adapter.
+2. **Community detection** (Leiden/Louvain) with labeled subsystems.
+3. **`shortestPath(a,b)`** query primitive + a human-facing `graph.html`/report exporter.
+4. **The "code changed — re-verify" staleness flag** on learnings — the single sharpest idea from their reflection loop; small, high-value addition to our `learning`/`execution_outcome` nodes.
+5. **"Query the graph instead of grepping" enforcement** — their `--strict` PreToolUse hook is a behavioral pattern we can now express via our own `skillHooks` framework.
+
+**Ignore (not our need / we already have it):**
+- The "no embeddings" dogma — keep our semantic `FusionLayer`.
+- Multi-modal media/PDF/video ingest and the 9 LLM extraction backends.
+- Graph-DB interop exports (Neo4j/FalkorDB/GraphML/Obsidian/Mermaid) — no consumer today.
+- Cross-project global graph, `add <url>`/`clone`, live PostgreSQL/Cargo introspection.
+- The enterprise "always-on" cloud tier.
+- PR-conflict-via-community and `get_pr_impact` — we already have `ConflictPredictor` + `compute_blast_radius` (convergent, not a gap).
+
+## Recommendation
+
+**Do not replace wholesale (Option C is a category error given 91 importers and the adapter layer).**
+
+Lead with **Option A**: port provenance + community detection + shortest-path + the "explain every edge"/viz discipline into our graph as durable, owned capability. These flow into our existing adapters immediately and carry zero external coupling.
+
+Hold **Option B** as an *optional, opt-in follow-on experiment* — the sidecar is the only way to get 37-language tree-sitter fidelity cheaply, but its Python runtime + undocumented-schema brittleness make it wrong as a default or a dependency. Reach for it only if a concrete polyglot repo proves regex extraction too lossy.
+
+> If the single most valuable thing turns out to be multi-language AST accuracy (not provenance/community), the ranking flips toward B-first. Confirm which capability gap actually hurts today before sequencing.

--- a/docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
+++ b/docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
@@ -1,0 +1,64 @@
+---
+number: "0104"
+title: Do not replace @harness-engineering/graph with Graphify; port select capabilities instead
+date: 2026-08-26
+status: accepted
+tier: medium
+source: docs/architecture/graphify-adoption/
+---
+
+# ADR-0104: Do not replace `@harness-engineering/graph` with Graphify; port select capabilities instead
+
+## Context
+
+[Graphify](https://github.com/Graphify-Labs/graphify) (graphify.net / graphify.com) is a widely adopted (~108k GitHub stars, YC S26) knowledge-graph tool. It is a **standalone Python CLI + MCP server** that maps a codebase (plus docs/PDFs/media) into a queryable concept graph an AI assistant queries "instead of grepping," with deterministic tree-sitter AST parsing across 37 language grammars, every edge tagged `EXTRACTED`/`INFERRED`/`AMBIGUOUS`, Leiden community detection, PR-review intelligence, a work-memory/reflection loop, and broad graph-DB interop. It is benchmarked as an agent-memory/RAG competitor (LongMemEval-S 76% QA, "tied with dense RAG"). The OSS `v8` tool is free (Apache-2.0/MIT); continuous "always-on" updating is a proprietary enterprise upsell.
+
+We were asked to determine, as due diligence, what Graphify does stronger/weaker, what to adopt or ignore, and specifically **whether it should replace our `@harness-engineering/graph` package wholesale**.
+
+The decisive constraint is integration depth. `@harness-engineering/graph` is not a code-map — it is the in-process TypeScript **substrate** for the harness's entire analytical surface: a 37-node-type / 29-edge-type unified model spanning code, knowledge (ADR/decision/learning/failure), VCS, observability, **design tokens, business knowledge, requirements/traceability, execution outcomes**, consumed by ~15 analysis adapters (entropy, constraints, complexity, coupling, anomaly, blast-radius, task-independence, conflict-prediction, traceability, feedback) and a token-budget-aware `Assembler`. It is imported by **91 non-test source files across 7 packages** (CLI alone: 50). Graphify has none of that model or those adapters, no in-process TS API, and an undocumented `graph.json` schema on an unstable branch.
+
+Full evidence in `docs/architecture/graphify-adoption/{discovery,analysis,proposal}.md`.
+
+## Decision
+
+**Reject wholesale replacement, and reject any runtime dependency on Graphify (including an optional sidecar).** Keep `@harness-engineering/graph` as the substrate. Instead, port a small set of specific capabilities Graphify does better into our own graph, reimplemented in TypeScript with zero external coupling:
+
+1. A first-class edge **provenance enum** (`EXTRACTED` / `INFERRED` / `AMBIGUOUS`) alongside the existing `confidence` float, set at ingest time.
+2. **Community detection** (Leiden/Louvain) with labeled subsystems exposed on nodes.
+3. A **`shortestPath(a, b)`** query primitive and an optional human-facing `graph.html` / report exporter.
+4. A **"code changed — re-verify" staleness flag** on `learning`/`execution_outcome` nodes (the sharpest idea from Graphify's reflection loop).
+5. Optionally, a **"query the graph instead of grepping"** enforcement pattern via our existing `skillHooks` framework (mirroring Graphify's `--strict` PreToolUse hook).
+
+The Graphify **polyglot sidecar** (ingest its `graph.json` for 37-language tree-sitter fidelity) is explicitly **out of scope** for this decision. It remains a possible future experiment only if a concrete polyglot repo proves our regex-based `CodeIngestor` too lossy; it is not adopted now because of the Python-runtime cost, dependency on an undocumented schema, and enterprise-tier drift risk.
+
+## Alternatives considered
+
+- **Option B — polyglot sidecar (`GraphifyIngestor`):** buys multi-language AST fidelity cheaply, our graph stays the substrate. Rejected as the standing decision because it adds a Python runtime and a brittle dependency on an undocumented, fast-moving external schema for a gain (AST breadth) that is not today's pain. Kept as a documented future option, not a commitment.
+- **Option C — wholesale replacement (the question asked):** rejected as a category error. It would delete the cross-domain model and adapter layer the harness is built on, break 91 importers across 7 packages, forfeit our semantic `FusionLayer`, and create an existential dependency on an external startup's OSS tier with a proprietary upsell. Graphify is a graph *generator + query server*, not a substitute for our graph *library + analysis platform*.
+
+## Consequences
+
+### Positive
+
+- The harness analytical surface is untouched; no regression risk to entropy/constraints/traceability/blast-radius.
+- Provenance and community labels, once ported, flow into our existing adapters for free — a capability Graphify cannot give us because it lacks those adapters.
+- Zero new runtime, zero external version-coupling, zero enterprise-tier gating exposure. We own the roadmap.
+- A written, evidence-cited record of what we deliberately did and did not adopt.
+
+### Negative
+
+- We forgo Graphify's 37-language tree-sitter fidelity for now; our `CodeIngestor` stays regex-based beyond TS/JS. — *Mitigation:* the sidecar (Option B) remains available if a real polyglot need emerges; revisit then.
+- Porting community detection (Leiden) and the exporter is net-new engineering. — *Mitigation:* sequence provenance first (highest leverage, smallest surface); defer viz/community as separate items.
+
+### Neutral
+
+- Several Graphify features are convergent with existing harness capability (PR-conflict prediction, impact analysis, MCP query surface, reflection/learnings) — validating our direction rather than exposing gaps.
+- This ADR was authored via the architecture-advisor topic-folder flow and landed on branch `analysis/graphify-adoption`; the canonical `manage_adr` MCP tool was not used because it is not git-worktree-aware (tracked separately as a filed bug).
+
+## Action items
+
+- [ ] Add `provenance` to the edge schema in `packages/graph/src/types.ts` and set it in `CodeIngestor`/`TopologicalLinker` — owner: graph maintainer.
+- [ ] Add a community-detection pass over `GraphStore` with labeled nodes — owner: graph maintainer.
+- [ ] Add `shortestPath(a,b)` to `ContextQL` + surface via NLQ/CLI — owner: graph maintainer.
+- [ ] Add a "code changed — re-verify" staleness flag to `learning`/`execution_outcome` nodes — owner: graph maintainer.
+- [ ] File a roadmap item for the optional Graphify sidecar experiment, gated on a demonstrated polyglot fidelity gap — owner: architecture.


### PR DESCRIPTION
## What

Architecture-advisor due-diligence evaluating **[Graphify](https://github.com/Graphify-Labs/graphify)** (graphify.net, ~108k★, YC S26) for adoption — specifically whether it should **replace `@harness-engineering/graph` wholesale**.

Docs-only. Adds:
- `docs/architecture/graphify-adoption/{discovery,analysis,proposal}.md`
- `docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md` (ADR)

## Verdict

**Do NOT replace wholesale** — it's a category error. Graphify is a standalone Python CLI/MCP tool that generates a code+docs concept graph. `@harness-engineering/graph` is the in-process TS **substrate** for the whole harness (37-node cross-domain model + ~15 analysis adapters + token-budget Assembler + semantic FusionLayer), imported by **91 non-test files across 7 packages**. Graphify has none of that model or those adapters and no TS API.

**Decision (ADR 0104): Option A only** — port select capabilities into our own graph with **zero external dependency**:
- edge **provenance** enum (EXTRACTED/INFERRED/AMBIGUOUS — we only have a `confidence` float)
- **community detection** (Leiden/Louvain)
- **shortest-path** query primitive
- **"code changed — re-verify"** staleness flag on learnings

The polyglot **sidecar** (Option B) is explicitly out of scope; wholesale replacement (Option C) is rejected. Follow-up roadmap items to be filed for the port.

## Notes

- ADR numbered **0104** (collision-safe against `origin/main`'s 0103).
- Authored via the architecture-advisor topic-folder flow + git-plumbing land because `manage_adr` is not git-worktree-aware — filed as #1507.