### PR TITLE
docs(roadmap): 5 Graphify-adoption capability items (ADR 0104, #1511-#1515)

### DIFF
--- a/docs/roadmap.d/graph-community-detection.md
+++ b/docs/roadmap.d/graph-community-detection.md
@@ -1,0 +1,16 @@
+---
+slug: "graph-community-detection"
+milestone: "v3.0 Graph Intelligence"
+order: 2
+---
+
+### Graph community detection (Leiden / Louvain)
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
+- **Summary:** Add a real community-detection pass over GraphStore with labeled subsystems exposed on nodes. Today only `clusterBySource` grouping exists (`packages/graph/src/ingest/KnowledgeLinker.ts:163`). Ported from Graphify (ADR 0104 Option A).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1512

--- a/docs/roadmap.d/graph-contextql-shortest-path.md
+++ b/docs/roadmap.d/graph-contextql-shortest-path.md
@@ -1,0 +1,16 @@
+---
+slug: "graph-contextql-shortest-path"
+milestone: "v3.0 Graph Intelligence"
+order: 3
+---
+
+### ContextQL shortest-path query primitive
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
+- **Summary:** Add `shortestPath(a, b)` between two arbitrary nodes to ContextQL, surfaced via NLQ + a CLI verb. Complements the existing explain/impact/relationships intents. Ported from Graphify (ADR 0104 Option A).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1513

--- a/docs/roadmap.d/graph-edge-provenance-enum.md
+++ b/docs/roadmap.d/graph-edge-provenance-enum.md
@@ -1,0 +1,16 @@
+---
+slug: "graph-edge-provenance-enum"
+milestone: "v3.0 Graph Intelligence"
+order: 1
+---
+
+### Graph edge provenance enum (EXTRACTED / INFERRED / AMBIGUOUS)
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
+- **Summary:** Add a first-class provenance enum on graph edges alongside the existing `confidence` float (`packages/graph/src/types.ts`), set at ingest time in CodeIngestor/TopologicalLinker (AST-explicit → EXTRACTED, resolver-derived → INFERRED). Lets every adapter distinguish read-directly from inferred. Highest-leverage, smallest-surface item of the Graphify Option-A port (ADR 0104).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** high
+- **External-ID:** github:Intense-Visions/harness-engineering#1511

--- a/docs/roadmap.d/graph-learning-staleness-flag.md
+++ b/docs/roadmap.d/graph-learning-staleness-flag.md
@@ -1,0 +1,16 @@
+---
+slug: "graph-learning-staleness-flag"
+milestone: "v3.0 Graph Intelligence"
+order: 4
+---
+
+### "Code changed — re-verify" staleness flag on learnings
+
+- **Status:** planned
+- **Spec:** docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
+- **Summary:** Add a staleness flag to learning/execution_outcome nodes that trips when the cited source moved, surfaced in NLQ. Ported from Graphify's reflection loop — the sharpest idea from their work-memory system (ADR 0104 Option A).
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1514

--- a/docs/roadmap.d/graphify-polyglot-sidecar-spike.md
+++ b/docs/roadmap.d/graphify-polyglot-sidecar-spike.md
@@ -1,0 +1,16 @@
+---
+slug: "graphify-polyglot-sidecar-spike"
+milestone: "v3.0 Graph Intelligence"
+order: 5
+---
+
+### [Spike] Graphify polyglot sidecar (GraphifyIngestor)
+
+- **Status:** backlog
+- **Spec:** docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
+- **Summary:** SPIKE — optional GraphifyIngestor that reads Graphify's `graph.json` to enrich our code-graph with 37-language tree-sitter AST fidelity. Gated on a DEMONSTRATED polyglot fidelity gap; NOT a committed dependency (Python runtime + undocumented schema). ADR 0104 Option B, explicitly out-of-scope as a commitment.
+- **Blockers:** —
+- **Plan:** —
+- **Assignee:** —
+- **Priority:** —
+- **External-ID:** github:Intense-Visions/harness-engineering#1515


### PR DESCRIPTION
## What

Adds 5 roadmap shards for the **Graphify Option-A capability port** decided in **ADR 0104** (merged in #1510), under theme **"v3.0 Graph Intelligence"**.

| Item | Status | Issue |
| --- | --- | --- |
| Graph edge provenance enum (EXTRACTED/INFERRED/AMBIGUOUS) | planned (high) | #1511 |
| Graph community detection (Leiden/Louvain) | planned | #1512 |
| ContextQL shortest-path primitive | planned | #1513 |
| "Code changed — re-verify" staleness flag on learnings | planned | #1514 |
| [Spike] Graphify polyglot sidecar (GraphifyIngestor) | backlog | #1515 |

All trace to `docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md` and the analysis in `docs/architecture/graphify-adoption/`. Zero external dependency; the sidecar (item 5) is a gated spike, not a commitment.

## Notes

- **Sharded roadmap:** adds `docs/roadmap.d/*.md` only. The `merge=ours` aggregate `docs/roadmap.md` regenerates post-merge via `harness roadmap regen`/reconcile (standard for sharded mode; avoids aggregate-drift against a moving `main`).
- Conflict-free by construction (5 new shard files).