### PR TITLE
chore: fix two pre-existing ubuntu CI reds (format:check + gemini plugin drift)

### DIFF
--- a/.gemini-extension/commands/roadmap-fleet.toml
+++ b/.gemini-extension/commands/roadmap-fleet.toml
@@ -77,7 +77,20 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 4. **Detect decision forks up front.** For each candidate, scan its issue/spec text for genuine ambiguity that a builder would otherwise have to guess (e.g. "store as UTC or local?", "extend the existing table or add a new one?"). These _known_ forks are surfaced in CONFIRM. Do not attempt to answer them here.
 
-5. **Build the `Candidate` record** for each survivor:
+5. **Classify each candidate's route (item-type routing).** Attach the pipeline route the item's
+   **type** needs, per the canonical rubric in `docs/reference/fleet-family.md` (§Item-type routing,
+   ADR 0103). Apply the precedence — **metadata first, rubric fallback, first match wins**:
+   1. **Explicit metadata** — a GH issue label (`bug`/`defect` → `bug`; `feature`/`enhancement` →
+      `feature`) or the roadmap shard's kind/type field.
+   2. **Spec presence** — the item already links an approved spec (roadmap `spec:` non-null or a
+      `proposal.md`) → `spec-ready`.
+   3. **Rubric fallback** — apply `harness-router`'s scope rubric by judgment over the item text:
+      diagnostic signals (broken, slow, failing, regression, error, crash) → `bug`; construction
+      signals (build, add, design, new) → `feature`; genuine ambiguity → `feature` (the safe
+      default). Record which rule fired as `routeSignal`. Do not guess a `bug` route on ambiguity —
+      brainstorming can still decide an item needs no design, but debugging cannot invent one.
+
+6. **Build the `Candidate` record** for each survivor:
 
    ```
    Candidate {
@@ -89,6 +102,8 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
      resolvingPr,       // set when crossCheck = already-resolved
      alreadyResolved,   // boolean, flags for closure not rebuild
      forks,             // detected known decision forks (may be empty)
+     route,             // "bug" | "spec-ready" | "feature" (item-type routing, §fleet-family)
+     routeSignal,       // which precedence rule fired: "label" | "spec-present" | "rubric"
    }
    ```
 
@@ -96,6 +111,7 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 1. **Present the ranked batch in one round.** This is the **only guaranteed human touchpoint before PR review** — everything downstream runs autonomously. Present, together, in a single surface:
    - The ranked candidates (highest-impact first) with scores.
+   - Each item's **routing decision** — `bug` → `harness-debugging`, `spec-ready` → `harness-autopilot`, or `feature` → `harness-brainstorming`→`harness-autopilot` (with the `routeSignal` that chose it) — presented as an **overridable** decision. The human may re-route any item before fan-out; a corrected route is recorded like any answered fork and fed into that item's DISPATCH brief. This is the single point at which a misclassification is caught before it wastes a lane.
    - Already-resolved items **flagged for closure** with their resolving PR — the human confirms closing, the fleet never rebuilds them.
    - Every detected known decision fork as a **multiple-choice question** with a recommended default.
    - The **proposed concurrency** (default 2, capped at ~3).
@@ -106,7 +122,12 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 ### Phase 3: DISPATCH — Worktree Fan-Out With a Concurrency Governor
 
-1. **One worktree-isolated subagent per confirmed item.** Each subagent is briefed to run the **real** per-item pipeline for its one item: `harness-brainstorming` then `harness-autopilot` in autonomous mode. It does not hand-implement, and it does not skip the pipeline — the artifacts the pipeline leaves behind are what VERIFY checks for. Feed the item's answered forks from CONFIRM into the brief so the builder never re-asks a settled question.
+1. **One worktree-isolated subagent per confirmed item, briefed to run the item's _routed_ pipeline.** Each subagent runs the **real** per-item pipeline its confirmed `route` selects (§Item-type routing in `docs/reference/fleet-family.md`), never a hardcoded chain:
+   - `route = bug` → `harness-debugging` (investigate → fix → a reproducing test that fails before the fix and passes after).
+   - `route = spec-ready` → `harness-autopilot` directly against the linked spec (brainstorming is skipped — the design is already settled).
+   - `route = feature` → `harness-brainstorming` then `harness-autopilot` in autonomous mode.
+
+   It does not hand-implement, and it does not skip the pipeline — the artifacts the routed pipeline leaves behind are what VERIFY checks for. Feed the item's answered forks **and its confirmed route** from CONFIRM into the brief so the builder never re-asks a settled question and never second-guesses the route.
 
 2. **Cap concurrency at the governor (default 2, max ~3).** This is the machine-storm limit: beyond roughly three concurrent build agents the compound load produces flaky failures that are indistinguishable from real ones. Never exceed the confirmed concurrency to "go faster" — a stormed batch is slower once you account for re-runs.
 
@@ -114,7 +135,7 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 4. **Record an "assumptions made" note per item.** Each subagent records the recommended-option defaults it took so the eventual PR carries an assumptions note — batch review is only trustworthy when the reviewer can see what was assumed.
 
-5. **Write a committed pipeline-provenance file.** Each lane **MUST** write `docs/changes/<slug>/provenance.json` and commit it onto its branch. This is the verifiable proof the real pipeline ran — it replaces the session state that `.harness/.gitignore` excludes from every branch by construction (and so never survives into a PR). The file records at minimum: the item's **issue number(s)**, the **pipeline stages run** (e.g. `brainstorming`, `autopilot`/`planning`, `execution`, `review`), the **plan-artifact path** under `docs/changes/<slug>/plans/`, and the **assumptions** taken (the recommended-option defaults from item 4). VERIFY checks for this committed file; a branch without it did not run the pipeline.
+5. **Write a committed pipeline-provenance file.** Each lane **MUST** write `docs/changes/<slug>/provenance.json` and commit it onto its branch. This is the verifiable proof the real pipeline ran — it replaces the session state that `.harness/.gitignore` excludes from every branch by construction (and so never survives into a PR). The file records at minimum: the item's **issue number(s)**, the confirmed **route** (`bug` / `spec-ready` / `feature`), the **pipeline stages run** — which reflect the route (`[debugging]` for a bug; `[autopilot, …]` for spec-ready; `[brainstorming, autopilot, …]` for a feature) — and the **assumptions** taken (the recommended-option defaults from item 4). A feature or spec-ready lane also records the **plan-artifact path** under `docs/changes/<slug>/plans/`; a bug lane records the **reproducing-test path** instead (a debugging run leaves no `plans/` directory). VERIFY checks for this committed file and the route-appropriate artifact; a branch without them did not run the pipeline.
 
 6. **Reference the issue with the correct closing keyword.** Each lane decides — and states in its PR body — how its PR references the issue it was dispatched for. This is a real decision with a default, not an incidental phrasing:
    - A PR that **fully resolves** its issue uses `Closes #<N>`, so the merge-triggered reconciler closes the issue and marks the roadmap row done.
@@ -130,17 +151,30 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 
 1. **Never accept a subagent's self-report as verification.** "The pipeline ran and CI is green" is a claim to be checked, not a result. For each returned branch, the orchestrator independently confirms the evidence itself.
 
-2. **Require the pipeline artifact.** Confirm that both exist **committed on the branch** (so they survive into the PR):
-   - A plan artifact under `docs/changes/<slug>/plans/` — the necessary trace of a real brainstorming→autopilot run.
-   - A committed pipeline-provenance file under `docs/changes/<slug>/` (e.g. `provenance.json`) recording the item's issue number(s), the pipeline stages run, the plan-artifact path, and the assumptions taken. This replaces the old session-state check: session state lives under `.harness/sessions/`, which `.harness/.gitignore` excludes from every branch by construction, so it is absent from every PR and can never be verified — the committed provenance file is the artifact that actually survives to where the orchestrator can check it.
+2. **Require the pipeline artifact — matched to the item's route.** Confirm the committed
+   pipeline-provenance file exists **and** the artifact the route implies, both **committed on the
+   branch** (so they survive into the PR). The provenance file replaces the old session-state check:
+   session state lives under `.harness/sessions/`, which `.harness/.gitignore` excludes from every
+   branch by construction, so it is absent from every PR and can never be verified — the committed
+   provenance file is the artifact that actually survives to where the orchestrator can check it.
+   - Always: a committed `provenance.json` under `docs/changes/<slug>/` recording the issue
+     number(s), the confirmed **route**, the pipeline stages run, and the assumptions taken.
+   - `route = feature` or `spec-ready` — a plan artifact under `docs/changes/<slug>/plans/` (the
+     trace of a real autopilot run); the `stages` include `autopilot` (and `brainstorming` for a
+     feature).
+   - `route = bug` — a committed **reproducing test** (fails before the fix, passes after) and
+     `stages=[debugging]`; there is **no** `plans/` directory for a debugging run, so its absence is
+     not a defect. Do not reject a debug-routed item for lacking a plan artifact.
 
-   An item with **no plan artifact or no committed provenance file did not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry once); it is never marked merge-ready.
+   An item **missing its committed provenance file, or missing the artifact its route requires, did
+   not run the real pipeline** — regardless of what the subagent reported. Reject it (or retry
+   once); it is never marked merge-ready.
 
 3. **Check the PR body's issue reference.** Confirm the PR body carries the closing keyword that matches the item's scope (the DISPATCH contract): a fully-resolving item uses `Closes #<N>`; a partial-slice item uses `Refs #<N>` and is flagged for manual reconciliation. A **fully-resolving item whose PR body carries no closing keyword** will strand its roadmap row on merge — flag it for correction before the batch is handed over. This is cheaply detectable from the PR body at verify time.
 
 4. **Require all-OS CI green.** Confirm the pushed branch's CI is green on **all three operating systems** plus the enforce and harness checks (`gh pr checks` / `gh run list`). Green on one OS is not green. A subset-red branch is not merge-ready — it is reported as failed, and the batch continues.
 
-5. **Classify each returned item** as `verified` (plan artifact + committed provenance file present, correct closing keyword, and all-OS CI green), `rejected` (missing artifact/provenance or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
+5. **Classify each returned item** as `verified` (the route-appropriate artifact from item 2 + committed provenance file present, correct closing keyword, and all-OS CI green), `rejected` (missing the route's artifact/provenance or definitively red), or `retry` (transient, retried at most once). No item reaches REPORT as merge-ready without passing both the artifact and the CI check.
 
 ### Phase 5: REPORT — Batch Summary, Resolved-Issue Closure, Never Merge
 
@@ -163,14 +197,16 @@ Phase 1: SELECT --> Phase 2: CONFIRM --> Phase 3: DISPATCH
 - **`harness-roadmap-pilot`** — Composed in SELECT for principled impact scoring and ordering of the batch.
 - **`manage_roadmap`** — Enumerate unblocked roadmap shards (SELECT) and reconcile status after the batch.
 - **`gh`** — Enumerate open issues, cross-check merged/open PRs (SELECT), read `gh pr checks` (VERIFY), and close already-resolved issues with resolving-PR citations (REPORT).
-- **`run_skill` / `harness skill run`** — Each build subagent invokes the real `harness-brainstorming` then `harness-autopilot` for its one item (DISPATCH).
+- **`run_skill` / `harness skill run`** — Each build subagent invokes the **routed** real pipeline for its one item (DISPATCH): `harness-debugging` for a `bug`, `harness-autopilot` for a `spec-ready` item, or `harness-brainstorming` then `harness-autopilot` for a `feature`.
+- **`harness-debugging`** — The per-item pipeline for `bug`-routed items (see §Item-type routing / ADR 0103): investigate → fix → a reproducing test that fails before and passes after. A bug is diagnosed by the skill built for it rather than forced through the design-first path.
 - **`harness-autopilot`'s code-review phase** — The per-item quality gate inside each subagent's pipeline; the fleet does not re-implement review.
 - **`harness skill validate roadmap-fleet`** — The authoring-time gate for this skill's own structure and schema.
-- **`docs/reference/fleet-family.md`** — The shared `-fleet` spine this skill builds on (the five-phase skeleton, the concurrency governor, the artifact + all-OS-CI verification discipline, the worktree fan-out, and the never-silent-merge invariant), stated once for the family.
+- **`docs/reference/fleet-family.md`** — The shared `-fleet` spine this skill builds on (the five-phase skeleton, the **§Item-type routing** rubric this skill applies, the concurrency governor, the artifact + all-OS-CI verification discipline, the worktree fan-out, and the never-silent-merge invariant), stated once for the family.
 
 ## Success Criteria
 
-- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with a verified plan artifact, a committed provenance file, a scope-correct closing keyword, and green CI across all three OS plus enforce and harness.
+- Given a confirmed batch of N candidates, the fleet produces **up to N** PRs, each with the route-appropriate verified artifact (plan artifact for feature/spec-ready, reproducing test for bug), a committed provenance file, a scope-correct closing keyword, and green CI across all three OS plus enforce and harness.
+- **Every item is routed by type** (§Item-type routing / ADR 0103): a `bug`-labeled or diagnostic item runs `harness-debugging`, a spec-carrying item runs `harness-autopilot` directly, and a new-feature/ambiguous item runs `harness-brainstorming`→`harness-autopilot`. The route is shown and is human-overridable in CONFIRM.
 - There is **exactly one** up-front human decision round; no per-item interactive pauses except a genuinely-new fork parked to its own item.
 - **Every emitted PR carries an "assumptions made" note.**
 - Already-resolved candidates are **closed with resolving-PR citations, not rebuilt**.

--- a/.gemini-extension/commands/security-fleet.toml
+++ b/.gemini-extension/commands/security-fleet.toml
@@ -86,6 +86,8 @@ The five-phase spine, the concurrency governor, the artifact + all-OS-CI verific
 
 4. **Tier each survivor by the bounded-fix test.** **FIX** = the remedy is safe, bounded, and mechanically verifiable: a dependency bump within a compatible range, an input-validation or output-encoding patch at identified call sites, removal of a hardcoded credential from source. **FILE** = the remedy is risky or structural: an authentication/authorization model change, a trust-boundary redesign, a cryptographic scheme replacement, or any remedy whose blast radius crosses module boundaries or changes a security contract. The tier is decided **here** and confirmed in CONFIRM — it is **never chosen mid-flight**, because a tier chosen while already editing code is a tier chosen by sunk cost.
 
+   **Route each FIX-tier survivor by item type** (§Item-type routing in `docs/reference/fleet-family.md`, ADR 0103), so a bounded vulnerability is diagnosed by the skill built for it rather than forced through the design-first pipeline. The bounded-fix test that made it FIX already means the structural, design-requiring remedies are **FILE**, not FIX — so a FIX-tier item is `route = bug` when it has a known, mechanically-verifiable remedy (a dependency bump, a validation/encoding patch at identified sinks, a credential removal — the common case), and `route = feature` only when the fix is bounded yet still carries a genuine design decision a builder would otherwise guess. FILE-tier items open no branch and are **not** routed. Record `routeSignal` (which signal chose the route).
+
 5. **Score and order by severity × evidence strength × exposure.** Do not rank ad-hoc, and do not rank by scanner severity alone. Reuse `harness-roadmap-pilot`-style impact scoring with the graph supplying the exposure term. The worked comparison that makes this concrete: a **high**-severity advisory on an unreached dev-only dependency ranks **below** a **moderate** reachable injection sink at a public entry point — because severity describes the weakness in the abstract, while evidence strength and exposure describe what it means here.
 
 6. **Build the `SecurityFinding` record** for each survivor, and detect known decision forks without answering them:
@@ -103,6 +105,8 @@ The five-phase spine, the concurrency governor, the artifact + all-OS-CI verific
      exposure,         // graph-derived exposure weight
      score,            // severity x evidence strength x exposure
      tier,             // "fix" | "file"
+     route,            // FIX tier only: "bug" | "feature" (item-type routing, §fleet-family / ADR 0103)
+     routeSignal,      // which signal chose the route
      crossCheck,       // "novel" | "already-fixed" | "duplicate-issue" | "in-progress-elsewhere"
      locations,
      forks,            // detected known decision forks, surfaced in CONFIRM (may be empty)
@@ -114,7 +118,7 @@ The five-phase spine, the concurrency governor, the artifact + all-OS-CI verific
 ### Phase 2: CONFIRM — The Single Up-Front Human Gate `[checkpoint:human-verify]`
 
 1. **Present the ranked finding batch in one round.** This is the **only guaranteed human touchpoint before review** — everything downstream runs autonomously. Present, together, in a single surface:
-   - The ranked findings (highest score first), each with its **evidence class**, its concrete evidence trace, its score, and its **proposed tier**.
+   - The ranked findings (highest score first), each with its **evidence class**, its concrete evidence trace, its score, its **proposed tier**, and — for FIX-tier findings — the **routed fix pipeline** (`bug` → `harness-debugging`, `feature` → `harness-brainstorming`→`harness-autopilot`), presented as an **overridable** decision alongside the tier. Re-routing a FIX item is recorded like the re-tier below and fed into its DISPATCH brief.
    - The **aggregate evidence-gate discard count** — how many candidates the gate absorbed and why in summary. The reader needs to see the noise that did not reach them; that is what makes the short list credible.
    - Duplicates and already-remediated findings **flagged for drop or closure**, each with the citation (the resolving PR, the existing issue) — never re-filed.
    - Every detected known decision fork as a **multiple-choice question** with a recommended default (e.g. "the version that clears this advisory is outside the compatible range — accept a major bump as a bounded fix, or file it as structural?").
@@ -132,7 +136,7 @@ The five-phase spine, the concurrency governor, the artifact + all-OS-CI verific
 
    (a) **Re-confirm the evidence reproduces in its own worktree before changing anything** — inherited evidence is not evidence, and a finding that will not reproduce is a false positive to be **dropped and reported**, never fixed on faith.
 
-   (b) Run the **real** `harness-brainstorming` → `harness-autopilot` build pipeline to author the fix — this is the family's dogfooding invariant and it is what leaves the plan directory plus autopilot-state that VERIFY checks for.
+   (b) Run the item's **routed** real fix pipeline (§Item-type routing, ADR 0103) to author the fix — this is the family's dogfooding invariant, and the routed pipeline is what leaves the artifact VERIFY checks for. `route = bug` (the common FIX case — a known, bounded remedy) runs `harness-debugging` (investigate → fix), leaving a `stages=[debugging]` provenance rather than a plan directory. `route = feature` (a bounded fix that still carries a genuine design decision) runs `harness-brainstorming` → `harness-autopilot`, leaving the plan directory plus autopilot-state. Either way the fix is authored through a real pipeline, never hand-patched.
 
    (c) Where the finding is code-side, add a **regression test that fails before the fix and passes after** — the security analogue of a behavior-asserting test, and the only proof the vulnerability is closed rather than merely unscanned.
 
@@ -156,7 +160,7 @@ The five-phase spine, the concurrency governor, the artifact + all-OS-CI verific
 
 1. **Never accept a subagent's self-report as verification.** "Fixed, scanner is clean, CI green" is a claim to be checked, not a result. For each returned FIX-tier branch the orchestrator independently confirms all four checks below; failing any one of them is a rejection, not a discount.
 
-2. **Pipeline artifact.** Confirm a plan directory under `docs/changes/<slug>/plans/` and an autopilot-state exist on the branch. A branch with no artifact **did not run the real pipeline** — it is a hand-patch, regardless of what the report says, and hand-patched security fixes are exactly the scanner-silencing edits this fleet exists to prevent.
+2. **Pipeline artifact — matched to the FIX item's route.** Confirm the artifact the route implies exists **committed on the branch**: for `route = feature`, a plan directory under `docs/changes/<slug>/plans/` plus autopilot-state; for `route = bug`, a `stages=[debugging]` provenance and the reproducing test from step (c) — a debugging run leaves **no** `plans/` directory, so its absence is not a defect and a bug-routed item is never rejected for lacking one. A branch with **neither** its route's artifact **nor** any pipeline trace **did not run the real pipeline** — it is a hand-patch, regardless of what the report says, and hand-patched security fixes are exactly the scanner-silencing edits this fleet exists to prevent.
 
 3. **Evidence cleared.** Confirm the **original evidence no longer reproduces** on the branch: the sink is unreachable, the advisory is clear, the boundary control is present, or the credential literal is gone from tracked source **and** rotation is recorded as still outstanding (removing a secret from source does not un-leak it, so an unrotated credential is half-closed, not cleared) — whichever class the finding carried. This is the security analogue of a coverage delta, and it is the check that distinguishes a fix from a mute. Re-run the evidence, do not re-read the report.
 
@@ -195,10 +199,11 @@ The five-phase spine, the concurrency governor, the artifact + all-OS-CI verific
 - **`security-craft`** — The LLM-judgment trust-boundary and least-authority critique that supplies the code-side findings a mechanical scanner cannot see.
 - **`harness-security-review`** — Supplies the OWASP/CWE finding taxonomy in SELECT, and is run by each FIX-tier subagent over its **own diff** in DISPATCH before pushing.
 - **`harness-roadmap-pilot`** — Its impact scoring is reused in SELECT to order findings by severity × evidence strength × exposure.
-- **`harness-brainstorming` → `harness-autopilot`** — The real per-item build pipeline each FIX-tier subagent runs; it is also the source of the plan-directory and autopilot-state artifact VERIFY requires.
+- **`harness-brainstorming` → `harness-autopilot`** — The real fix pipeline a **`feature`-routed** FIX-tier subagent runs (a bounded fix that still carries a genuine design decision); it is the source of the plan-directory and autopilot-state artifact VERIFY requires for that route.
+- **`harness-debugging`** — The real fix pipeline a **`bug`-routed** FIX-tier subagent runs (the common case: a bounded vulnerability with a known, mechanically-verifiable remedy). Per §Item-type routing (ADR 0103) it is chosen in SELECT, confirmed/overridable in CONFIRM, and leaves a `stages=[debugging]` provenance plus the reproducing test in place of a plan directory.
 - **The knowledge graph** — Supplies the exposure weighting (entry points, trust boundaries, critical paths) that turns a flat finding list into a risk-ranked queue.
 - **`gh`** — Cross-check in-flight security PRs and open security issues (SELECT), read `gh pr checks` for all-OS CI (VERIFY), and open fix PRs and file evidence packets (REPORT).
-- **`docs/reference/fleet-family.md`** — The shared `-fleet` spine this skill builds on (five-phase skeleton, concurrency governor, artifact + all-OS-CI verification discipline, worktree fan-out, never-silent-merge).
+- **`docs/reference/fleet-family.md`** — The shared `-fleet` spine this skill builds on (five-phase skeleton, the **§Item-type routing** rubric the FIX tier applies, concurrency governor, artifact + all-OS-CI verification discipline, worktree fan-out, never-silent-merge).
 - **`harness skill validate security-fleet`** — The authoring-time gate for this skill's own structure and schema.
 
 ## Success Criteria
@@ -208,6 +213,7 @@ The five-phase spine, the concurrency governor, the artifact + all-OS-CI verific
 - There is **exactly one** up-front human decision round; no per-item interactive pauses except a genuinely-new fork or a mid-flight re-tier parked to its own item.
 - **No structural remedy is applied autonomously** — an auth-model or trust-boundary change is filed with evidence, never patched inside the sweep.
 - **Every FIX-tier PR carries an "assumptions made" note** and, where the finding is code-side, a regression test that fails before the fix.
+- **Every FIX-tier item is routed by type** (§Item-type routing / ADR 0103): a bounded vulnerability with a known remedy runs `harness-debugging` (verified on `stages=[debugging]` provenance + the reproducing test, not a plan directory), and a bounded fix carrying a genuine design decision runs `harness-brainstorming`→`harness-autopilot`. The route is shown and is human-overridable in CONFIRM.
 - **No secret value appears** in any PR description, issue body, report row, or commit message — secrets are reported by location and type only, with rotation named as a human action.
 - **No finding is closed by suppression** — an ignore rule, advisory mute, or scanner exclusion added to clear an item is rejected.
 - Duplicates and already-remediated findings are **dropped or closed with a citation**, never re-filed or re-fixed.

--- a/docs/architecture/graphify-adoption/analysis.md
+++ b/docs/architecture/graphify-adoption/analysis.md
@@ -4,15 +4,15 @@
 
 ## The two things are not the same category
 
-| | **Graphify** | **`@harness-engineering/graph`** |
-| --- | --- | --- |
-| Shape | Standalone **CLI + MCP server** (Python) that emits artifacts | Embedded **TS library** (`v0.13.1`), consumed in-process |
-| Primary job | "Query your codebase instead of grepping" — a code+docs **concept graph** for an AI assistant | **Substrate** for the whole harness analytical surface |
-| Output | `graph.json` / `graph.html` / `GRAPH_REPORT.md` in `graphify-out/` | Live TS objects: `GraphStore`, `ContextQL`, `Assembler`, adapters |
-| Consumers | The human + the AI assistant, via CLI/MCP | **91 non-test source files across 7 packages** (`cli` 50, `intelligence` 14, `core` 12, `orchestrator`/`dashboard` 5 each, `signals` 3) |
-| Model scope | Code + docs concepts | Code **+** ADR/decision/learning/failure, VCS, observability, design tokens, business knowledge, requirements/traceability, execution outcomes — **37 node types, 29 edge types** (`packages/graph/README.md`) |
-| Embeddings | **Deliberately none** ("not a vector index") | `VectorStore` + `FusionLayer` hybrid keyword+semantic search |
-| License / tier | OSS (Apache-2.0/MIT dual) + proprietary **enterprise cloud** ("always-on layer", app.graphify.com) | Ours (MIT), fully owned |
+|                | **Graphify**                                                                                       | **`@harness-engineering/graph`**                                                                                                                                                                               |
+| -------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shape          | Standalone **CLI + MCP server** (Python) that emits artifacts                                      | Embedded **TS library** (`v0.13.1`), consumed in-process                                                                                                                                                       |
+| Primary job    | "Query your codebase instead of grepping" — a code+docs **concept graph** for an AI assistant      | **Substrate** for the whole harness analytical surface                                                                                                                                                         |
+| Output         | `graph.json` / `graph.html` / `GRAPH_REPORT.md` in `graphify-out/`                                 | Live TS objects: `GraphStore`, `ContextQL`, `Assembler`, adapters                                                                                                                                              |
+| Consumers      | The human + the AI assistant, via CLI/MCP                                                          | **91 non-test source files across 7 packages** (`cli` 50, `intelligence` 14, `core` 12, `orchestrator`/`dashboard` 5 each, `signals` 3)                                                                        |
+| Model scope    | Code + docs concepts                                                                               | Code **+** ADR/decision/learning/failure, VCS, observability, design tokens, business knowledge, requirements/traceability, execution outcomes — **37 node types, 29 edge types** (`packages/graph/README.md`) |
+| Embeddings     | **Deliberately none** ("not a vector index")                                                       | `VectorStore` + `FusionLayer` hybrid keyword+semantic search                                                                                                                                                   |
+| License / tier | OSS (Apache-2.0/MIT dual) + proprietary **enterprise cloud** ("always-on layer", app.graphify.com) | Ours (MIT), fully owned                                                                                                                                                                                        |
 
 The core insight: **Graphify's value is the code-graph slice. Our graph's value is everything the code-graph feeds** — the ~15 adapters that turn the graph into harness analyses. Graphify has no equivalent of those, no TS API, and a different product goal.
 
@@ -28,10 +28,10 @@ The core insight: **Graphify's value is the code-graph slice. Our graph's value 
 
 ## What OUR graph does STRONGER (verified)
 
-1. **Unified cross-domain model.** 37 node types spanning knowledge, VCS, observability, **design tokens, business knowledge, requirements/traceability, execution outcomes** (`packages/graph/README.md`). Graphify is code+docs only. This model is *the* thing the harness is built on.
+1. **Unified cross-domain model.** 37 node types spanning knowledge, VCS, observability, **design tokens, business knowledge, requirements/traceability, execution outcomes** (`packages/graph/README.md`). Graphify is code+docs only. This model is _the_ thing the harness is built on.
 2. **The analysis adapter layer.** `GraphEntropyAdapter`, `GraphConstraintAdapter`, `GraphComplexityAdapter`, `GraphCouplingAdapter`, `GraphAnomalyAdapter`, `CascadeSimulator` (`compute_blast_radius`), `TaskIndependenceAnalyzer`, `ConflictPredictor`, `queryTraceability`, `GraphFeedbackAdapter`. **None of this exists in Graphify.** These power `detect_entropy`, `enforce-architecture`, `check_traceability`, impact analysis, etc.
 3. **Token-budget-aware context Assembly.** `Assembler` does phase-aware context selection under token budgets with coverage reports — purpose-built for feeding agents. Graphify returns scoped subgraphs, not budgeted context.
-4. **Hybrid semantic search.** `FusionLayer` blends keyword + embedding similarity. Graphify deliberately refuses embeddings — a strength for pure-deterministic tracing, a weakness for "find me something *like* this."
+4. **Hybrid semantic search.** `FusionLayer` blends keyword + embedding similarity. Graphify deliberately refuses embeddings — a strength for pure-deterministic tracing, a weakness for "find me something _like_ this."
 5. **In-process TS API.** 91 importers call it as a library. Graphify's only integration surfaces are CLI stdout and an MCP server — neither is an in-process API.
 6. **Full ownership.** No external tool version-coupling, no enterprise-tier gating risk, no Python runtime in the harness.
 
@@ -51,7 +51,7 @@ The core insight: **Graphify's value is the code-graph slice. Our graph's value 
 
 A second exhaustive sweep confirmed Graphify is broader than a code-map. The complete surface:
 
-- **It is also an agent-memory / RAG competitor.** Benchmarked on LOCOMO (recall@10 0.497, QA 45.3%) and **LongMemEval-S (76% QA, "tied with dense RAG")** with 0 LLM credits for graph build. It positions the graph as the thing an assistant queries *instead of* embeddings-RAG. Relevant to due-diligence: competitive, not dominant, on memory QA — reinforces "don't replace, it's not strictly better."
+- **It is also an agent-memory / RAG competitor.** Benchmarked on LOCOMO (recall@10 0.497, QA 45.3%) and **LongMemEval-S (76% QA, "tied with dense RAG")** with 0 LLM credits for graph build. It positions the graph as the thing an assistant queries _instead of_ embeddings-RAG. Relevant to due-diligence: competitive, not dominant, on memory QA — reinforces "don't replace, it's not strictly better."
 - **PR-review intelligence.** `graphify prs --triage` (AI-ranked review queue), `--conflicts` (merge-order risk via **shared communities**), `--worktrees` (branch→PR map), `prs <n>` (graph impact of a PR); MCP tools `list_prs`/`get_pr_impact`/`triage_prs`. Overlaps our own PR/impact surface (see Convergent overlaps).
 - **9-backend semantic extraction** (Gemini/Claude/claude-cli/OpenAI/DeepSeek/Kimi/Azure/Bedrock/Ollama) for the docs/media pass; code is always AST-only/local.
 - **Graph-interop hub.** Exports: `graph.html`, `GRAPH_REPORT.md`, `graph.json`, SVG, **GraphML (Gephi/yEd)**, **Cypher for Neo4j/FalkorDB (+ direct push)**, **Obsidian vault**, agent-crawlable **wiki**, **Mermaid call-flow HTML**.
@@ -67,13 +67,13 @@ A second exhaustive sweep confirmed Graphify is broader than a code-map. The com
 
 Not gaps — flagged so we don't "adopt" what we already have, differently framed:
 
-| Graphify feature | Our equivalent | Note |
-| --- | --- | --- |
-| `prs --conflicts` (merge risk via shared community) | `ConflictPredictor` + `TaskIndependenceAnalyzer` (co-change) | Different signal; ours is co-change-based |
-| `get_pr_impact` | `CascadeSimulator` / `compute_blast_radius`, `get_impact` | Ours is probability-weighted BFS |
-| `save-result`/`reflect` → LESSONS | `learning`/`failure`/`execution_outcome` nodes + skill-effectiveness baselines | Convergent validation; **the "code changed — re-verify" staleness flag is the one sharp idea worth stealing** |
-| MCP `query_graph`/`shortest_path` | `ask_graph`/`query_graph` MCP tools + NLQ | We already expose via the harness MCP surface |
-| `depends_on` package graph | `supply-chain-audit`, `dependency-health` | Different lens; not a model gap |
+| Graphify feature                                    | Our equivalent                                                                 | Note                                                                                                          |
+| --------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `prs --conflicts` (merge risk via shared community) | `ConflictPredictor` + `TaskIndependenceAnalyzer` (co-change)                   | Different signal; ours is co-change-based                                                                     |
+| `get_pr_impact`                                     | `CascadeSimulator` / `compute_blast_radius`, `get_impact`                      | Ours is probability-weighted BFS                                                                              |
+| `save-result`/`reflect` → LESSONS                   | `learning`/`failure`/`execution_outcome` nodes + skill-effectiveness baselines | Convergent validation; **the "code changed — re-verify" staleness flag is the one sharp idea worth stealing** |
+| MCP `query_graph`/`shortest_path`                   | `ask_graph`/`query_graph` MCP tools + NLQ                                      | We already expose via the harness MCP surface                                                                 |
+| `depends_on` package graph                          | `supply-chain-audit`, `dependency-health`                                      | Different lens; not a model gap                                                                               |
 
 ## Consumption path if we ever depended on Graphify
 

--- a/docs/architecture/graphify-adoption/discovery.md
+++ b/docs/architecture/graphify-adoption/discovery.md
@@ -7,12 +7,12 @@
 ## Prompt (verbatim)
 
 > Analyze the following project for adoption. Analyze what it does stronger, weaker, what should be adopted, what should be ignored. Also determine if it should be used wholesale as a replacement for the graph package.
-> https://github.com/Graphify-Labs/graphify  https://graphify.net
+> https://github.com/Graphify-Labs/graphify https://graphify.net
 
 ## Discovery answers
 
 1. **Primary motivation** — Due diligence. Graphify is popular (~108k stars, YC S26). Leadership wants a defensible written verdict on adopt / replace before committing either way.
-2. **Language / architecture constraint** — Polyglot is acceptable. A Python Graphify sidecar that emits `graph.json` for a TS adapter to ingest is on the table **if** the capability gain justifies the operational cost. (It is not a hard "must stay pure-TS in-process" constraint — but see the 91-importer footprint below, which still governs the *core* path.)
+2. **Language / architecture constraint** — Polyglot is acceptable. A Python Graphify sidecar that emits `graph.json` for a TS adapter to ingest is on the table **if** the capability gain justifies the operational cost. (It is not a hard "must stay pure-TS in-process" constraint — but see the 91-importer footprint below, which still governs the _core_ path.)
 3. **Deliverable** — Full ADR via `manage_adr`, plus analysis + proposal docs on an isolated worktree branch.
 
 ## Success in 6 months

--- a/docs/architecture/graphify-adoption/proposal.md
+++ b/docs/architecture/graphify-adoption/proposal.md
@@ -1,6 +1,6 @@
 # Proposal: how to relate to Graphify
 
-Three options. The headline question — *"use it wholesale as a replacement for the graph package?"* — is Option C, presented honestly and rejected on evidence.
+Three options. The headline question — _"use it wholesale as a replacement for the graph package?"_ — is Option C, presented honestly and rejected on evidence.
 
 ---
 
@@ -9,19 +9,22 @@ Three options. The headline question — *"use it wholesale as a replacement for
 **Summary.** Keep `@harness-engineering/graph` as the substrate. Port the specific ideas Graphify does better, reimplemented in TS: edge **provenance enum** (`EXTRACTED`/`INFERRED`/`AMBIGUOUS`), **community detection** (Leiden/Louvain), a **shortest-path** query primitive, and the "**every edge explained**" discipline plus an optional `graph.html`/report exporter.
 
 **How it works:**
+
 1. Add a `provenance` field alongside `confidence` in the edge schema (`types.ts`); set it at ingest time (AST-explicit → EXTRACTED, resolver-derived → INFERRED).
 2. Add a community-detection pass over `GraphStore` and expose labels on nodes.
 3. Add `shortestPath(a, b)` to `ContextQL`; surface via NLQ + a CLI verb.
 4. Add an optional exporter that emits a human-facing viz/report from any `GraphStore`.
 
 **Pros:**
+
 - No Python runtime, no external version-coupling, stays in-process — respects the 91-importer reality.
-- Provenance and community labels flow into *our* adapters (entropy, traceability, blast-radius) for free — Graphify's don't.
+- Provenance and community labels flow into _our_ adapters (entropy, traceability, blast-radius) for free — Graphify's don't.
 - We own the roadmap; no enterprise-tier gating risk.
 
 **Cons:**
-- Reimplementation effort — medium — we don't get 37 tree-sitter grammars for free (see Option B for that specific gap). *Mitigation:* scope to provenance + community + path first; defer AST breadth.
-- Leiden in TS is non-trivial — medium. *Mitigation:* start with Louvain or a small vetted lib.
+
+- Reimplementation effort — medium — we don't get 37 tree-sitter grammars for free (see Option B for that specific gap). _Mitigation:_ scope to provenance + community + path first; defer AST breadth.
+- Leiden in TS is non-trivial — medium. _Mitigation:_ start with Louvain or a small vetted lib.
 
 **Effort:** Medium (incremental, per-capability PRs). **Risk:** Low. **Best when:** the goal is durable capability we control — which the due-diligence + 91-importer facts point to.
 
@@ -32,18 +35,21 @@ Three options. The headline question — *"use it wholesale as a replacement for
 **Summary.** Leave the substrate alone; add an **optional** `GraphifyIngestor` adapter that shells out to Graphify (or reads a pre-generated `graph.json`) and maps its code nodes/edges into our model — buying 37-language tree-sitter fidelity + provenance without reimplementing a parser. Opt-in, degrades gracefully when Graphify is absent.
 
 **How it works:**
+
 1. New adapter runs `graphify` (if installed) over the repo, reads `graphify-out/graph.json`.
 2. Maps Graphify code nodes/edges → our `file`/`function`/`class` nodes + `imports`/`calls` edges, carrying the provenance tag.
 3. Our adapters/analyses consume the enriched `GraphStore` unchanged.
 
 **Pros:**
+
 - Best AST fidelity across many languages with **zero parser maintenance** on our side.
 - Our graph stays the substrate and analysis layer; Graphify is a pluggable enrichment, never the core.
 - "Polyglot OK" answer makes this viable.
 
 **Cons:**
-- **Python runtime dependency** for the enriched path — high operational cost (packaging, air-gap, CI). — *Mitigation:* strictly opt-in; TS regex path remains the default.
-- Depends on Graphify's **undocumented `graph.json` schema** on an unstable `v8` branch — medium/high brittleness. — *Mitigation:* pin a version; contract-test the mapping.
+
+- **Python runtime dependency** for the enriched path — high operational cost (packaging, air-gap, CI). — _Mitigation:_ strictly opt-in; TS regex path remains the default.
+- Depends on Graphify's **undocumented `graph.json` schema** on an unstable `v8` branch — medium/high brittleness. — _Mitigation:_ pin a version; contract-test the mapping.
 - Only helps the **code-graph slice** — nothing for our knowledge/design/business/traceability model.
 - Enterprise-tier drift risk: continuous-update features live behind the paid cloud.
 
@@ -56,6 +62,7 @@ Three options. The headline question — *"use it wholesale as a replacement for
 **Summary.** Delete `@harness-engineering/graph`; make Graphify the graph.
 
 **Why it fails (honest cons):**
+
 - **Category mismatch — high.** Graphify is a code+docs concept-graph generator with a CLI/MCP surface. It has **no** design-token / business-knowledge / requirement-traceability / execution-outcome model, **no** analysis adapters, **no** token-budget Assembler, and **no** in-process TS API. Replacing our library with it deletes the substrate that `detect_entropy`, `enforce-architecture`, `check_traceability`, `compute_blast_radius`, etc. are built on.
 - **Blast radius — high.** 91 non-test importers across 7 packages (50 in `cli`) bind to our node/edge model and TS API. All would need rewriting against Graphify's undocumented JSON + MCP tools.
 - **Strategic coupling — high.** Existential dependency on an external YC startup's OSS tier, with an explicit proprietary enterprise upsell for the always-on features.
@@ -67,22 +74,23 @@ Three options. The headline question — *"use it wholesale as a replacement for
 
 ## Comparison matrix
 
-| Criterion        | A: Cherry-pick | B: Sidecar | C: Wholesale replace |
-| ---------------- | -------------- | ---------- | -------------------- |
-| Complexity       | Low–Med        | Med        | Very High            |
-| AST fidelity gain| Partial        | **Full (37 langs)** | Full           |
-| Keeps our model  | **Yes**        | **Yes**    | No                   |
-| Keeps adapters   | **Yes**        | **Yes**    | No                   |
-| Runtime added    | None           | Python     | Python + loses TS API|
-| External coupling| None           | Medium     | Existential          |
-| Effort to build  | Medium         | Medium     | Large                |
-| Effort to change | Low            | Medium     | High                 |
-| Risk             | **Low**        | Medium     | High                 |
-| Fits 91-importer reality | **Yes** | Yes        | No                   |
+| Criterion                | A: Cherry-pick | B: Sidecar          | C: Wholesale replace  |
+| ------------------------ | -------------- | ------------------- | --------------------- |
+| Complexity               | Low–Med        | Med                 | Very High             |
+| AST fidelity gain        | Partial        | **Full (37 langs)** | Full                  |
+| Keeps our model          | **Yes**        | **Yes**             | No                    |
+| Keeps adapters           | **Yes**        | **Yes**             | No                    |
+| Runtime added            | None           | Python              | Python + loses TS API |
+| External coupling        | None           | Medium              | Existential           |
+| Effort to build          | Medium         | Medium              | Large                 |
+| Effort to change         | Low            | Medium              | High                  |
+| Risk                     | **Low**        | Medium              | High                  |
+| Fits 91-importer reality | **Yes**        | Yes                 | No                    |
 
 ## Adopt / ignore (post deep-pass)
 
 **Adopt (port into our graph, no dependency):**
+
 1. **EXTRACTED / INFERRED / AMBIGUOUS provenance enum** on edges — highest leverage; flows into every adapter.
 2. **Community detection** (Leiden/Louvain) with labeled subsystems.
 3. **`shortestPath(a,b)`** query primitive + a human-facing `graph.html`/report exporter.
@@ -90,6 +98,7 @@ Three options. The headline question — *"use it wholesale as a replacement for
 5. **"Query the graph instead of grepping" enforcement** — their `--strict` PreToolUse hook is a behavioral pattern we can now express via our own `skillHooks` framework.
 
 **Ignore (not our need / we already have it):**
+
 - The "no embeddings" dogma — keep our semantic `FusionLayer`.
 - Multi-modal media/PDF/video ingest and the 9 LLM extraction backends.
 - Graph-DB interop exports (Neo4j/FalkorDB/GraphML/Obsidian/Mermaid) — no consumer today.
@@ -103,6 +112,6 @@ Three options. The headline question — *"use it wholesale as a replacement for
 
 Lead with **Option A**: port provenance + community detection + shortest-path + the "explain every edge"/viz discipline into our graph as durable, owned capability. These flow into our existing adapters immediately and carry zero external coupling.
 
-Hold **Option B** as an *optional, opt-in follow-on experiment* — the sidecar is the only way to get 37-language tree-sitter fidelity cheaply, but its Python runtime + undocumented-schema brittleness make it wrong as a default or a dependency. Reach for it only if a concrete polyglot repo proves regex extraction too lossy.
+Hold **Option B** as an _optional, opt-in follow-on experiment_ — the sidecar is the only way to get 37-language tree-sitter fidelity cheaply, but its Python runtime + undocumented-schema brittleness make it wrong as a default or a dependency. Reach for it only if a concrete polyglot repo proves regex extraction too lossy.
 
 > If the single most valuable thing turns out to be multi-language AST accuracy (not provenance/community), the ranking flips toward B-first. Confirm which capability gap actually hurts today before sequencing.

--- a/docs/changes/fleet-item-type-routing/SKILLS.md
+++ b/docs/changes/fleet-item-type-routing/SKILLS.md
@@ -4,18 +4,19 @@
 
 ## Reference (load as context)
 
-| Skill | Purpose | When | Relevance |
-|-------|---------|------|-----------|
-| `gof-chain-of-responsibility` | Stack: typescript; Domain: api, data, infra, security, testing | Architecture decisions | 0.54 |
-| `ts-performance-patterns` | Stack: typescript; Domain: api, data, infra, security, testing | During implementation | 0.51 |
-| `ts-zod-integration` | Stack: typescript; Domain: api, data, infra, security, testing | Architecture decisions | 0.51 |
-| `ts-testing-types` | Stack: typescript; Domain: api, data, infra, security, testing | Testing | 0.49 |
-| `gof-factory-method` | Stack: typescript; Domain: api, data, infra, security, testing | Architecture decisions | 0.48 |
-| `ts-type-guards` | Stack: typescript; Domain: api, data, infra, security, testing | During implementation | 0.46 |
-| `gof-builder-pattern` | Stack: typescript; Domain: api, data, infra, security, testing | Architecture decisions | 0.45 |
-| `gof-visitor-pattern` | Keywords: double-dispatch; Stack: typescript; Domain: api, data, infra, security, testing | Architecture decisions | 0.45 |
-| `gof-memento-pattern` | Stack: typescript; Domain: api, data, infra, security, testing | Testing | 0.43 |
-| `gof-state-pattern` | Stack: typescript; Domain: api, data, infra, security, testing | Architecture decisions | 0.41 |
+| Skill                         | Purpose                                                                                   | When                   | Relevance |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | ---------------------- | --------- |
+| `gof-chain-of-responsibility` | Stack: typescript; Domain: api, data, infra, security, testing                            | Architecture decisions | 0.54      |
+| `ts-performance-patterns`     | Stack: typescript; Domain: api, data, infra, security, testing                            | During implementation  | 0.51      |
+| `ts-zod-integration`          | Stack: typescript; Domain: api, data, infra, security, testing                            | Architecture decisions | 0.51      |
+| `ts-testing-types`            | Stack: typescript; Domain: api, data, infra, security, testing                            | Testing                | 0.49      |
+| `gof-factory-method`          | Stack: typescript; Domain: api, data, infra, security, testing                            | Architecture decisions | 0.48      |
+| `ts-type-guards`              | Stack: typescript; Domain: api, data, infra, security, testing                            | During implementation  | 0.46      |
+| `gof-builder-pattern`         | Stack: typescript; Domain: api, data, infra, security, testing                            | Architecture decisions | 0.45      |
+| `gof-visitor-pattern`         | Keywords: double-dispatch; Stack: typescript; Domain: api, data, infra, security, testing | Architecture decisions | 0.45      |
+| `gof-memento-pattern`         | Stack: typescript; Domain: api, data, infra, security, testing                            | Testing                | 0.43      |
+| `gof-state-pattern`           | Stack: typescript; Domain: api, data, infra, security, testing                            | Architecture decisions | 0.41      |
 
 ---
-*Scanned 783 skills in 197ms. Signals: 9 keywords, 2 stack markers, 5 domains.*
+
+_Scanned 783 skills in 197ms. Signals: 9 keywords, 2 stack markers, 5 domains._

--- a/docs/changes/fleet-item-type-routing/proposal.md
+++ b/docs/changes/fleet-item-type-routing/proposal.md
@@ -74,11 +74,11 @@ taxonomy beyond what the router already carries.
 
 **Routing targets and route-dependent VERIFY artifact:**
 
-| Route          | Pipeline                                       | VERIFY requires                                                                                                  |
-| -------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **bug**        | `harness-debugging`                            | committed `provenance.json` with `stages=[debugging]` **and** a committed reproducing test (fails-before / passes-after) — **not** a `plans/` directory |
-| **spec-ready** | `harness-autopilot`                            | `plans/` directory + `provenance.json` with `stages` including `autopilot` (no `brainstorming` stage required)   |
-| **feature**    | `harness-brainstorming → harness-autopilot`    | `plans/` directory + `provenance.json` with `stages` including `brainstorming`, `autopilot` — _unchanged from today_ |
+| Route          | Pipeline                                    | VERIFY requires                                                                                                                                         |
+| -------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **bug**        | `harness-debugging`                         | committed `provenance.json` with `stages=[debugging]` **and** a committed reproducing test (fails-before / passes-after) — **not** a `plans/` directory |
+| **spec-ready** | `harness-autopilot`                         | `plans/` directory + `provenance.json` with `stages` including `autopilot` (no `brainstorming` stage required)                                          |
+| **feature**    | `harness-brainstorming → harness-autopilot` | `plans/` directory + `provenance.json` with `stages` including `brainstorming`, `autopilot` — _unchanged from today_                                    |
 
 The debug-route artifact requirement mirrors `bug-fleet`'s existing proof-of-fix model (a reproducing
 test that fails before and passes after — `bug-fleet/SKILL.md`), because a debugging run leaves no
@@ -89,6 +89,7 @@ lacking a brainstorming artifact.
 ### Per-file edits
 
 **`docs/reference/fleet-family.md`**
+
 - Add a `## Item-type routing (build-shaped members)` section after "Shared design decisions",
   stating the rubric, the precedence, the spine placement, the route-dependent VERIFY artifact, and
   naming ADR 0103 as the canonical decision. Members reference it, they do not restate it.
@@ -97,6 +98,7 @@ lacking a brainstorming artifact.
 - Add ADR 0103 to the References list.
 
 **`agents/skills/claude-code/roadmap-fleet/SKILL.md`**
+
 - **SELECT** — add a classification step that attaches a `route` and a `routeSignal` (which
   precedence rule fired) to each `Candidate`; extend the `Candidate` record (`:59-72`) with those
   two fields.
@@ -112,6 +114,7 @@ lacking a brainstorming artifact.
   bullet).
 
 **`agents/skills/claude-code/security-fleet/SKILL.md`**
+
 - **SELECT** — classify each FIX-tier finding by route (a bounded vuln with a known remedy → bug;
   a fix requiring design → feature; a structural remedy already re-tiers to FILE and is unaffected).
 - **DISPATCH** — FIX step (b) (`:114`) runs the routed fix pipeline instead of always

--- a/docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
+++ b/docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md
@@ -1,5 +1,5 @@
 ---
-number: "0104"
+number: '0104'
 title: Do not replace @harness-engineering/graph with Graphify; port select capabilities instead
 date: 2026-08-26
 status: accepted
@@ -34,7 +34,7 @@ The Graphify **polyglot sidecar** (ingest its `graph.json` for 37-language tree-
 ## Alternatives considered
 
 - **Option B — polyglot sidecar (`GraphifyIngestor`):** buys multi-language AST fidelity cheaply, our graph stays the substrate. Rejected as the standing decision because it adds a Python runtime and a brittle dependency on an undocumented, fast-moving external schema for a gain (AST breadth) that is not today's pain. Kept as a documented future option, not a commitment.
-- **Option C — wholesale replacement (the question asked):** rejected as a category error. It would delete the cross-domain model and adapter layer the harness is built on, break 91 importers across 7 packages, forfeit our semantic `FusionLayer`, and create an existential dependency on an external startup's OSS tier with a proprietary upsell. Graphify is a graph *generator + query server*, not a substitute for our graph *library + analysis platform*.
+- **Option C — wholesale replacement (the question asked):** rejected as a category error. It would delete the cross-domain model and adapter layer the harness is built on, break 91 importers across 7 packages, forfeit our semantic `FusionLayer`, and create an existential dependency on an external startup's OSS tier with a proprietary upsell. Graphify is a graph _generator + query server_, not a substitute for our graph _library + analysis platform_.
 
 ## Consequences
 
@@ -47,8 +47,8 @@ The Graphify **polyglot sidecar** (ingest its `graph.json` for 37-language tree-
 
 ### Negative
 
-- We forgo Graphify's 37-language tree-sitter fidelity for now; our `CodeIngestor` stays regex-based beyond TS/JS. — *Mitigation:* the sidecar (Option B) remains available if a real polyglot need emerges; revisit then.
-- Porting community detection (Leiden) and the exporter is net-new engineering. — *Mitigation:* sequence provenance first (highest leverage, smallest surface); defer viz/community as separate items.
+- We forgo Graphify's 37-language tree-sitter fidelity for now; our `CodeIngestor` stays regex-based beyond TS/JS. — _Mitigation:_ the sidecar (Option B) remains available if a real polyglot need emerges; revisit then.
+- Porting community detection (Leiden) and the exporter is net-new engineering. — _Mitigation:_ sequence provenance first (highest leverage, smallest surface); defer viz/community as separate items.
 
 ### Neutral
 


### PR DESCRIPTION
## What

Two pure-chore fixes that unblock the ubuntu CI leg (`build-and-test (ubuntu-latest, 22)`) on `main`. Both were pre-existing reds on `main`, unrelated to any feature work.

### 1. Prettier `format:check` drift (6 markdown docs)

Ran Prettier over the 6 markdown docs that had drifted from `prettier` code style, so `pnpm format:check` (`prettier --check "**/*.{ts,tsx,md,json}"`) passes again. Changes limited to Markdown table column re-alignment and blank-line-after-heading normalization — no logic:
- `docs/architecture/graphify-adoption/analysis.md`
- `docs/architecture/graphify-adoption/discovery.md`
- `docs/architecture/graphify-adoption/proposal.md`
- `docs/changes/fleet-item-type-routing/proposal.md`
- `docs/changes/fleet-item-type-routing/SKILLS.md`
- `docs/knowledge/decisions/0104-graphify-adoption-not-replacement.md`

### 2. Stale generated gemini plugin artifacts (2 .toml commands)

The "Verify plugin artifacts are fresh" CI step reported content drift because the source `roadmap-fleet` / `security-fleet` SKILL.md files were updated for ADR-0103 item-type routing on `main`, but the generated gemini command artifacts were never regenerated. Ran `pnpm generate:plugin --target gemini`; only the two flagged generated files changed:
- `.gemini-extension/commands/roadmap-fleet.toml`
- `.gemini-extension/commands/security-fleet.toml`

`pnpm generate:plugin --target gemini --check` now passes (OK).

## Why

Both reds turned the ubuntu leg red on `main`, blocking the ADR-0104 graph batch (#1519 / #1521 / #1572 / #1573). This PR clears both so that batch's CI can go green.

## Verification

- `pnpm format:check` → "All matched files use Prettier code style!"
- `pnpm generate:plugin --target gemini --check` → OK
- Only generated/formatting artifacts changed; no source/logic touched.