### PR TITLE
feat(burn): cost per merged PR — join token attribution to shipped PRs (#1522)

### DIFF
--- a/.changeset/cost-per-merged-pr.md
+++ b/.changeset/cost-per-merged-pr.md
@@ -1,0 +1,6 @@
+---
+'@harness-engineering/burn': minor
+'@harness-engineering/cli': minor
+---
+
+Join burn's per-lane/per-skill token attribution to shipped PRs — cost per merged PR (#1522). New `harness burn per-pr` reuses burn's existing transcript scan (per `agentId` lane and `agent` skill from #1270), reads the lane provenance files under `docs/changes/*/provenance.json`, and resolves each issue to its merged PR(s) via `gh`, then emits `{tokens_in, tokens_out, cache_read, prs_merged, cost_per_pr}` per lane and per skill into `.harness/metrics/cost-per-pr.json`. Both denominators — `cost_per_merged_pr` and `cost_per_dispatched_lane` — are carried side by side with a `denominator_note`, so the figure is never a silent success-only number. Raw tokens are the source-of-truth metric; a `$` figure is derived only when an adopter supplies an optional `cost_price_table` (default off, no hardcoded pricing). A `cost_bands` config enables a per-skill cost-regression check, the cost analogue of a performance budget. Missing linkage degrades to `unattributed` (never 0/free), matching #1270's discipline.

--- a/docs/changes/cost-per-merged-pr/plans/2026-08-26-cost-per-merged-pr-plan.md
+++ b/docs/changes/cost-per-merged-pr/plans/2026-08-26-cost-per-merged-pr-plan.md
@@ -1,0 +1,96 @@
+# Plan — Join burn's token attribution to shipped outcomes (cost per merged PR) — #1522
+
+Traces to `docs/changes/cost-per-merged-pr/proposal.md`. Closes #1522.
+
+## Problem
+
+Burn attributes token spend per lane (`UsageRecord.agentId`) and per skill
+(`UsageRecord.agent`) but never joins it to a shipped PR, so "what does one
+merged PR cost?" is unanswerable. This plan builds the join in
+`@harness-engineering/burn` (reusing the scan/store), a `.harness/metrics`
+writer, and a `harness burn per-pr` CLI, with both denominators labelled.
+
+## Task breakdown (TDD; test-first per task)
+
+### Task 1 — Provenance reader (`packages/burn/src/provenance.ts`)
+
+- `readProvenance(repoRoot): ProvenanceEntry[]` scans `docs/changes/*/provenance.json`.
+- Tolerant of schema variety: `issue` scalar OR `issues[]`; optional `branch`,
+  `slug` (default from dir name), optional new `laneId`.
+- Malformed / unreadable file → skipped (never throws). Missing dir → `[]`.
+- Tests: scalar-issue file, array-issues file, missing-issue file (dropped),
+  bad-JSON file (skipped), laneId present vs absent.
+
+### Task 2 — PR linkage (`packages/burn/src/pr-linkage.ts`)
+
+- `linkPrs(entries, { runGh }): Map<string /*slug*/, LinkResult>` where
+  `LinkResult = { mergedPrs: number[]; ok: boolean }`.
+- `runGh(args): { status: number; stdout: string }` injectable; default spawns
+  `gh` (env-safe, no throw). For each entry's issues, query merged PRs.
+- Degrade: `runGh` missing/nonzero/parse-fail → `{ mergedPrs: [], ok: false }`
+  for that entry (never invents a merge).
+- Tests: injected gh returning a merged PR, gh returning nothing, gh failing
+  (ok:false), multiple issues de-duped by PR number.
+
+### Task 3 — Cost join core (`packages/burn/src/cost-per-pr.ts`)
+
+- `buildCostReport({ records, provenance, linkage, priceTable?, bands?, window? }): CostReport`.
+- Fold `records` (optionally window-filtered by `ts`) by `agent` and `agentId`;
+  sum `tokens_in/out`, `cache_read/write`; compute weighted `units()` scalar.
+- Merged-PR denominator = distinct merged PR numbers across all linked entries;
+  dispatched-lane denominator = distinct non-empty `agentId`.
+- Per-skill and per-lane rows; `cost_per_merged_pr` / `cost_per_dispatched_lane`
+  are `null` when the denominator is 0 (abstain, never divide-by-zero to 0/∞).
+- Lane attribution: `linked` only when a provenance `laneId` matches the
+  `agentId` AND that entry has merged PRs; else `unattributed` with `prs_merged: 0`.
+- `degraded: true` when subagent spend exists (non-main lanes) but zero lanes linked.
+- `denominator_note` states both denominators and the count of lanes that
+  produced nothing.
+- Optional pricing: only when `priceTable` given, compute `usd_total` /
+  `usd_per_merged_pr`; omitted entirely otherwise.
+- `checkCostBands(report, bands): CostBandFinding[]` — WARN when a skill's
+  `cost_per_merged_pr` is `< min` or `> max`.
+- Tests: (a) lane tokens equal raw record sums [SC1]; (b) window filter changes
+  per-skill cost [SC2]; (c) both denominators present + note [SC3]; (d) fixture
+  skill out-of-band → finding [SC4]; (e) missing linkage → unattributed +
+  degraded [SC5]; (f) price table off → no pricing key; on → usd fields.
+
+### Task 4 — Metrics writer + config + exports
+
+- `packages/burn/src/cost-metrics.ts`: `writeCostReport(paths, report)` →
+  `.harness/metrics/cost-per-pr.json` via `atomicWrite` (mkdir -p).
+- `packages/burn/src/config.ts` + `types.ts`: optional `cost_price_table?`,
+  `cost_bands?` on `BurnConfig` (additive; absent changes nothing). Note:
+  metrics path is repo-local `.harness/metrics`, distinct from the HUD state dir.
+- `packages/burn/src/index.ts`: export new types + functions.
+- Tests: writer round-trips; config load with/without the new keys.
+
+### Task 5 — CLI subcommand (`packages/cli/src/commands/burn/per-pr.ts`)
+
+- `harness burn per-pr [--since] [--until] [--json] [--write]`.
+- Reads burn store records (`readRecords`), `readProvenance(process.cwd())`,
+  `linkPrs`, `buildCostReport`, renders per-skill + per-fleet rollup (both
+  denominators, degraded banner, band warnings). `--write` persists metrics.
+- Register in `packages/cli/src/commands/burn/index.ts`.
+- Tests: `--json` shape smoke; degraded banner rendered.
+
+### Task 6 — Integrate + ship
+
+- Rebuild CLI (pre-commit arch gate needs it). `pnpm run generate-docs`.
+- Changeset (minor, `@harness-engineering/burn` + `@harness-engineering/cli`).
+- Write `docs/changes/cost-per-merged-pr/provenance.json`.
+- `harness validate`; push; all-OS CI green; open PR `Closes #1522`.
+
+## Checkpoints
+
+- After Task 3: full acceptance-criteria coverage exists in unit tests.
+- After Task 5: `node packages/cli/dist/bin/harness.js burn per-pr --json` runs
+  end-to-end against the real store (WIRED verification).
+
+## Risks
+
+- `gh` linkage flakiness in CI — mitigated: injectable `runGh`, degrade path is
+  the default in any environment without network; no test hits real `gh`.
+- better-sqlite3 ABI on Node 24 — build/test under `nvm use 22`.
+- Pre-push whole-tree gates (format:check, reference-docs) — run
+  `prettier --write` + `generate-docs` before pushing, never `--no-verify`.

--- a/docs/changes/cost-per-merged-pr/proposal.md
+++ b/docs/changes/cost-per-merged-pr/proposal.md
@@ -1,0 +1,225 @@
+---
+feature: cost-per-merged-pr
+issue: 1522
+status: approved
+keywords:
+  [burn, token-attribution, cost-per-pr, provenance, fleet-lane, gh-linkage, metrics, denominator]
+---
+
+# Join burn's token attribution to shipped outcomes — cost per merged PR
+
+> Closes #1522
+
+## Overview and goals
+
+`per-subagent-token-attribution-in-burn` (#1270, done) established per-subagent
+(`agent`) and per-fleet-lane (`agentId`) token attribution from burn's transcript
+scan (`packages/burn/src/scan.ts` → `UsageRecord.agent` / `UsageRecord.agentId`).
+Nothing joins that spend to an **outcome**, so the harness cannot answer the
+question that governs whether the autonomous tier scales: **what does one merged
+pull request cost?**
+
+**Goal.** Join burn's already-scanned per-lane/per-skill token attribution to the
+PR(s) a fleet run produced — via the existing lane provenance files
+(`docs/changes/<slug>/provenance.json`, which carry `issue`/`issues` and a
+`closingKeyword`) plus branch/PR linkage via `gh` — and emit
+`{tokens_in, tokens_out, cache_read, prs_merged, cost_per_pr}` per lane and per
+skill into `.harness/metrics/`, with **both** denominators (merged PRs vs
+dispatched lanes) labelled explicitly so the figure is never a silent
+success-only number.
+
+**Out of scope.** Re-ingesting transcripts from scratch (we reuse burn's scan);
+Anthropic's real quota (units remain a local proxy); the session/day cost
+lineage in `packages/core/src/usage/` (a distinct `costs.jsonl` surface, not
+burn's `agent`/`agentId` attribution); and fleet failure-reason categorisation
+(`extend-adoption-jsonl-with-failure-reason-categorization`, blocked) which would
+supply a truer denominator — until it lands, cost/PR divides by completed lanes
+and **says so**.
+
+## Decisions made
+
+1. **Reporting unit = raw tokens, with optional `$` behind a price table (default OFF).**
+   `tokens_in` / `tokens_out` / `cache_read` are the source-of-truth metrics. A
+   `$` figure is derived ONLY when the operator supplies a `cost_price_table` in
+   burn config; there is no default price table and no hardcoded Anthropic
+   pricing as the primary number. Rationale: burn's `units` weighting
+   (`packages/burn/src/units.ts`) is already an Opus-like proxy, not a real
+   quota; a portable cost report must keep the raw tokens primary and let each
+   adopter price them for their own model mix. Evidence:
+   `packages/burn/src/units.ts:6` (proxy weights), issue confirmed-decision 1.
+
+2. **Reuse burn's scan + lane provenance + `gh` linkage; degrade to
+   "unattributed" (never 0/free) when linkage or fields are missing.** We read
+   burn's deduped `UsageRecord`s via the existing store reader (no re-scan of
+   transcripts), read every `docs/changes/*/provenance.json`, resolve each
+   provenance's issue(s) to merged PR(s) with `gh`, and count `prs_merged`. Any
+   lane whose spend cannot be tied to a merged PR is labelled `unattributed` and
+   still counted in the fleet/skill denominators — matching #1270's discipline
+   that a missing label must never collapse to `main` or read as free. Evidence:
+   `packages/burn/src/scan.ts:96` (unattributed discipline),
+   `packages/burn/src/store.ts` (`readRecords`), issue confirmed-decision 2.
+
+3. **The join is denominator-explicit, not a single blended number.** burn spend
+   is keyed by opaque `agentId` (lane) and `agent` (skill); provenance is keyed
+   by slug/issue. There is no shared key in existing data, so the report emits
+   **two labelled denominators** side by side: `cost_per_merged_pr` (attributed
+   tokens ÷ merged PRs from provenance+`gh`) and `cost_per_dispatched_lane`
+   (attributed tokens ÷ distinct dispatched `agentId`s). The field names carry
+   the denominator; neither is presented as "the" cost without the other. This
+   is the explicit guard against the issue's denominator trap.
+
+4. **Cost-regression band check, comparable to a perf budget.** An optional
+   `cost_bands` config declares a per-skill expected `cost_per_pr` band
+   `{ min?, max }`; a skill whose window cost/PR exits its band emits a WARN.
+   Deliberate regression in a fixture skill trips the check in CI (acceptance 4).
+   Non-blocking by default (advisory), matching burn's "degraded tooling is a
+   headline, not a footnote" posture.
+
+## Technical design
+
+New code lives in `@harness-engineering/burn` (it reuses the scan/store) plus a
+thin CLI surface — matching the issue's suggested surfaces (`packages/cli` burn
+command; `.harness/metrics`; fleet lane provenance).
+
+### Data shapes (`packages/burn/src/cost-per-pr.ts`)
+
+```ts
+export interface TokenTotals {
+  tokens_in: number; // sum of UsageRecord.in
+  tokens_out: number; // sum of UsageRecord.out
+  cache_read: number; // sum of UsageRecord.cacheRead
+  cache_write: number; // retained for completeness; not in the headline
+}
+
+export interface SkillCost extends TokenTotals {
+  skill: string; // burn `agent` label
+  lanes: number; // distinct agentId under this skill
+  cost_per_merged_pr: number | null; // weighted units / merged PRs (null when denom 0)
+  cost_per_dispatched_lane: number | null;
+}
+
+export interface LaneCost extends TokenTotals {
+  lane_id: string; // burn agentId
+  skill: string;
+  prs_merged: number; // merged PRs linked to this lane (0 => unattributed)
+  attribution: 'linked' | 'unattributed';
+}
+
+export interface CostReport {
+  window: { since: string | null; until: string | null };
+  totals: TokenTotals & {
+    prs_merged: number;
+    dispatched_lanes: number;
+    cost_per_merged_pr: number | null;
+    cost_per_dispatched_lane: number | null;
+  };
+  by_skill: SkillCost[];
+  by_lane: LaneCost[];
+  denominator_note: string; // human-readable "divided by N merged PRs; M lanes produced nothing"
+  pricing?: { table: string; usd_total: number; usd_per_merged_pr: number | null };
+  degraded: boolean; // true when subagent spend seen but no lane linked
+}
+```
+
+`cost_per_*` uses burn's existing `units()` weighting as the scalar cost, so one
+number aggregates in/out/cache honestly; the raw `tokens_*` fields remain
+alongside for anyone who wants unweighted counts (acceptance: verifiable against
+the raw scan).
+
+### Modules
+
+- `packages/burn/src/provenance.ts` — `readProvenance(repoRoot)` scans
+  `docs/changes/*/provenance.json`, tolerant of the observed schema variety
+  (`issue` scalar vs `issues[]`; optional `branch`, `slug`, `closingKeyword`).
+  Returns `ProvenanceEntry[] = { slug, issues, branch?, laneId? }`. `laneId` is a
+  new **optional** field: when a provenance writer stamps the burn `agentId`,
+  a lane links exactly; when absent (all current files), the lane degrades to
+  `unattributed` but still feeds fleet/skill denominators.
+- `packages/burn/src/pr-linkage.ts` — `linkPrs(entries, opts)` resolves each
+  entry's issues to merged PR numbers via `gh` (`gh pr list --search
+"linked:<issue>" --state merged` / `gh issue view`). Injectable `runGh` for
+  tests; a missing/failed `gh` degrades every entry to unlinked (never throws,
+  never invents a merge).
+- `packages/burn/src/cost-per-pr.ts` — `buildCostReport({ records,
+provenance, linkage, priceTable?, bands?, window? })` (pure) folds burn
+  records by `agent`/`agentId`, joins the PR linkage, applies the two
+  denominators, and optionally prices via the table. `checkCostBands(report,
+bands)` -> `CostBandFinding[]`.
+- `packages/burn/src/cost-metrics.ts` — `writeCostReport(paths, report)` emits
+  `.harness/metrics/cost-per-pr.json` atomically (reusing `atomicWrite`).
+
+### CLI (`packages/cli/src/commands/burn/per-pr.ts`)
+
+`harness burn per-pr [--since <iso>] [--until <iso>] [--json] [--write]`
+renders per-skill and per-fleet rollups (both denominators, a degraded banner
+when attribution broke, and band warnings). `--write` persists the metrics file.
+Registered on the existing `burn` command group
+(`packages/cli/src/commands/burn/index.ts`).
+
+### Config (`packages/burn/src/config.ts` + `types.ts`)
+
+Two optional additive `BurnConfig` fields: `cost_price_table?: Record<string,
+{ in: number; out: number; cache_read: number }>` (per-model USD-per-token;
+absent => no `$`) and `cost_bands?: Record<string, { min?: number; max: number }>`
+(per-skill cost/PR bands). Both default absent and change nothing when unset.
+
+## Integration Points
+
+- **Entry Points.** New `harness burn per-pr` subcommand; new
+  `.harness/metrics/cost-per-pr.json` artifact; new burn exports.
+- **Registrations Required.** Add the subcommand to
+  `packages/cli/src/commands/burn/index.ts`; add new exports to
+  `packages/burn/src/index.ts` (burn's index is hand-maintained — no
+  `generate-core-barrel` allowlist edit needed, that gate is core-only). Run
+  `pnpm run generate-docs` for the CLI reference.
+- **Documentation Updates.** `docs/reference/*` CLI docs (generated); a short
+  note in the burn-hud skill docs is optional and deferred (YAGNI).
+- **Architectural Decisions.** Decision 3 (denominator-explicit join over a
+  single blended number) warrants an ADR — it is the reusable rule that keeps
+  every downstream efficiency metric honest about its denominator.
+- **Knowledge Impact.** Concept: "cost per merged PR" joins token-spend
+  attribution to shipped outcomes; relationship: burn `agentId`/`agent` ->
+  provenance issue -> merged PR.
+
+## Success criteria
+
+1. A completed fleet run yields a per-PR cost record joined to the PR number,
+   verifiable against the raw transcript scan — `by_lane[].tokens_*` equal the
+   burn store sums for that `agentId`, and `prs_merged` traces to a provenance
+   issue's merged PR. (When to observe: `harness burn per-pr --json`.)
+2. Per-skill cost/PR is queryable for any window — `--since/--until` bound the
+   records folded, and `by_skill[].cost_per_merged_pr` recomputes for that window.
+3. Dividing by merged PRs vs by dispatched lanes is explicit in output labels —
+   both `cost_per_merged_pr` and `cost_per_dispatched_lane` appear, plus a
+   `denominator_note`; no field named a bare `cost_per_pr` hides which it is.
+4. A deliberate cost regression in a fixture skill trips the band check — a
+   fixture with an out-of-band `cost_per_pr` yields a `CostBandFinding` in a CI
+   test.
+5. Missing linkage degrades to `unattributed` (never 0/free); a scan with
+   subagent spend but no linked lane sets `degraded: true`.
+
+## Implementation order
+
+1. **Provenance + linkage readers** — `provenance.ts`, `pr-linkage.ts` (pure,
+   injectable `gh`), with unit tests over the observed schema variety and a
+   gh-absent degrade path.
+2. **Cost join core** — `cost-per-pr.ts` (`buildCostReport`, `checkCostBands`),
+   unit tests including the fixture regression (acceptance 4), the two
+   denominators (acceptance 3), and unattributed/degraded (acceptance 5).
+3. **Metrics writer + config** — `cost-metrics.ts`, `BurnConfig` fields, exports.
+4. **CLI subcommand** — `burn per-pr`, wired to the group; `generate-docs`.
+5. **Docs/changeset + provenance.json**, validate, ship through gates.
+
+## Assumptions made
+
+- burn `agentId` (lane) <-> provenance has no shared key in existing data, so
+  per-lane PR attribution is exact only once a provenance writer stamps the
+  optional `laneId`; all current provenance files therefore report lanes as
+  `unattributed` while still feeding the fleet/skill denominators. This is the
+  honest degrade, forward-compatible with a future lane-stamping writer.
+- `cost_per_*` scalar uses burn's `units()` weighting; raw `tokens_*` are kept
+  primary and unweighted for scan-verifiability.
+- `gh` merged-PR resolution uses the issue->PR "linked" relationship; a repo
+  without `gh` or offline degrades every entry to unlinked (report still emits).
+- Fleet success-rate denominator is out of scope (blocked dependency); cost/PR
+  divides by merged PRs and labels the shortfall in `denominator_note`.

--- a/docs/changes/cost-per-merged-pr/provenance.json
+++ b/docs/changes/cost-per-merged-pr/provenance.json
@@ -1,0 +1,36 @@
+{
+  "issue": 1522,
+  "issues": [1522],
+  "slug": "cost-per-merged-pr",
+  "title": "Join burn's token attribution to shipped outcomes — cost per merged PR",
+  "branch": "build/cost-per-merged-pr-1522",
+  "stages": ["brainstorming", "planning", "execution", "verification", "integration"],
+  "plan_path": "docs/changes/cost-per-merged-pr/plans/2026-08-26-cost-per-merged-pr-plan.md",
+  "planArtifact": "docs/changes/cost-per-merged-pr/plans/2026-08-26-cost-per-merged-pr-plan.md",
+  "proposalArtifact": "docs/changes/cost-per-merged-pr/proposal.md",
+  "closing_keyword": "Closes #1522",
+  "closingKeyword": "Closes #1522",
+  "sourceFiles": [
+    "packages/burn/src/provenance.ts",
+    "packages/burn/src/pr-linkage.ts",
+    "packages/burn/src/cost-per-pr.ts",
+    "packages/burn/src/cost-metrics.ts",
+    "packages/cli/src/commands/burn/per-pr.ts"
+  ],
+  "registrationSites": [
+    "packages/burn/src/index.ts (barrel exports — hand-maintained, no generate-core-barrel edit)",
+    "packages/cli/src/commands/burn/index.ts (per-pr subcommand registered on the burn group)"
+  ],
+  "assumptions": [
+    "Reporting unit is raw tokens (tokens_in/tokens_out/cache_read); a $ figure is derived ONLY via an optional cost_price_table in burn config, default OFF, with no hardcoded Anthropic pricing — kept portable across adopters and models (confirmed decision 1).",
+    "Reuses burn's existing transcript scan + store (readRecords, no re-ingest), the lane provenance files under docs/changes/*/provenance.json, and gh issue->merged-PR linkage; missing linkage or fields degrade to 'unattributed' (never 0/free), matching #1270's discipline (confirmed decision 2).",
+    "burn agentId (lane) and provenance have no shared key in existing data, so per-lane PR attribution is exact only once a provenance writer stamps the new optional laneId; all current files therefore report lanes as unattributed while still feeding the fleet/skill denominators. Forward-compatible degrade.",
+    "The join is denominator-explicit: cost_per_merged_pr and cost_per_dispatched_lane are emitted side by side with a denominator_note; no bare cost_per_pr field hides which denominator was used.",
+    "cost_per_* scalar uses burn's existing units() weighting; raw tokens_* fields are kept primary and unweighted for scan-verifiability.",
+    "gh linkage is injectable (runGh) and degrades to unlinked when gh is missing/offline; no test hits real gh, so CI is deterministic.",
+    "Fleet success-rate denominator is out of scope (blocked dependency extend-adoption-jsonl-with-failure-reason-categorization); cost/PR divides by merged PRs and labels the shortfall in denominator_note.",
+    "New metrics artifact lives at repo-local .harness/metrics/cost-per-pr.json (alongside adoption.jsonl), NOT the per-machine HUD state dir."
+  ],
+  "generatedBy": "roadmap-fleet build lane (harness-brainstorming -> autopilot pipeline, dogfooded)",
+  "date": "2026-08-26"
+}

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -845,6 +845,17 @@ Wire the burn HUD statusline and hooks into ~/.claude/settings.json
 
 - `--dry-run` — show what would change without writing
 
+### `harness burn per-pr`
+
+Cost per merged PR: join burn token attribution to shipped PRs
+
+**Options:**
+
+- `--since` — only count records at/after this ISO instant
+- `--until` — only count records at/before this ISO instant
+- `--json` — emit the raw cost report as JSON
+- `--write` — persist the report to .harness/metrics/cost-per-pr.json
+
 ### `harness burn report`
 
 Rescan and print the full burn report (default)

--- a/packages/burn/src/cost-metrics.ts
+++ b/packages/burn/src/cost-metrics.ts
@@ -1,0 +1,25 @@
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { atomicWrite } from './store';
+import type { CostReport } from './cost-per-pr';
+
+/**
+ * The repo-local metrics file the cost report is published to.
+ *
+ * This is `.harness/metrics/` under the project root — the same tree as
+ * `adoption.jsonl` and `skill-events.jsonl` — NOT the HUD state dir (which is
+ * per-machine under `~/.claude/hud`). Cost-per-PR is a property of a repo's
+ * fleet runs, so it lives with the repo, and a fleet lane can commit it.
+ */
+export function costMetricsPath(repoRoot: string): string {
+  return path.join(repoRoot, '.harness', 'metrics', 'cost-per-pr.json');
+}
+
+/** Publish the cost report atomically; the reader must never see a half file. */
+export function writeCostReport(repoRoot: string, report: CostReport): string {
+  const target = costMetricsPath(repoRoot);
+  mkdirSync(path.dirname(target), { recursive: true });
+  atomicWrite(target, `${JSON.stringify(report, null, 2)}\n`);
+  return target;
+}

--- a/packages/burn/src/cost-per-pr.ts
+++ b/packages/burn/src/cost-per-pr.ts
@@ -1,0 +1,337 @@
+import type { LinkResult } from './pr-linkage';
+import type { ProvenanceEntry } from './provenance';
+import type { UsageRecord } from './types';
+import { units } from './units';
+
+/** Raw token counts, snake_cased to match burn's on-disk / summary vocabulary. */
+export interface TokenTotals {
+  tokens_in: number;
+  tokens_out: number;
+  cache_read: number;
+  /** Kept for completeness; deliberately not part of the cost headline. */
+  cache_write: number;
+}
+
+/** Per-skill (burn `agent` label) cost roll-up. */
+export interface SkillCost extends TokenTotals {
+  skill: string;
+  /** Distinct non-empty `agentId`s that ran under this skill. */
+  lanes: number;
+  /** Weighted units spent under this skill. */
+  units: number;
+  /** units / (fleet-wide merged PRs). `null` when no merged PR was linked. */
+  cost_per_merged_pr: number | null;
+  /** units / (this skill's dispatched lanes). `null` when this skill ran no lane. */
+  cost_per_dispatched_lane: number | null;
+}
+
+/** Per-lane (burn `agentId`) cost roll-up. */
+export interface LaneCost extends TokenTotals {
+  lane_id: string;
+  skill: string;
+  units: number;
+  /** Merged PRs tied to this lane via a provenance `laneId` match. 0 when unlinked. */
+  prs_merged: number;
+  /** `linked` only when a provenance `laneId` matched AND it had merged PRs. */
+  attribution: 'linked' | 'unattributed';
+}
+
+/** Optional per-model price table (USD per token). Absent ⇒ no `$` figure. */
+export type PriceTable = Record<string, { in: number; out: number; cache_read: number }>;
+
+/** Optional per-skill expected cost/PR band. */
+export interface CostBand {
+  min?: number;
+  max: number;
+}
+
+export interface CostReport {
+  window: { since: string | null; until: string | null };
+  totals: TokenTotals & {
+    units: number;
+    prs_merged: number;
+    dispatched_lanes: number;
+    cost_per_merged_pr: number | null;
+    cost_per_dispatched_lane: number | null;
+  };
+  by_skill: SkillCost[];
+  by_lane: LaneCost[];
+  /** Spells out both denominators so no figure is a silent success-only number. */
+  denominator_note: string;
+  /** Present only when a price table was supplied. */
+  pricing?: { models_priced: number; usd_total: number; usd_per_merged_pr: number | null };
+  /** True when subagent spend was seen but no lane could be linked to a PR. */
+  degraded: boolean;
+}
+
+export interface CostBandFinding {
+  skill: string;
+  cost_per_merged_pr: number;
+  band: CostBand;
+  direction: 'above' | 'below';
+}
+
+export interface BuildCostReportInput {
+  records: Iterable<UsageRecord>;
+  provenance: ProvenanceEntry[];
+  linkage: Map<string, LinkResult>;
+  priceTable?: PriceTable;
+  window?: { since?: string; until?: string };
+}
+
+/** Labels that are not fleet-lane skill spend and never carry a cost/PR. */
+const NON_SKILL_LABELS = new Set(['main', 'unattributed', 'pre-migration']);
+
+interface Bucket extends TokenTotals {
+  units: number;
+  lanes: Set<string>;
+}
+
+function emptyBucket(): Bucket {
+  return { tokens_in: 0, tokens_out: 0, cache_read: 0, cache_write: 0, units: 0, lanes: new Set() };
+}
+
+function addRecord(bucket: Bucket, rec: UsageRecord): void {
+  bucket.tokens_in += rec.in;
+  bucket.tokens_out += rec.out;
+  bucket.cache_read += rec.cacheRead;
+  bucket.cache_write += rec.cacheWrite;
+  bucket.units += units(rec.out, rec.in, rec.cacheWrite, rec.cacheRead);
+  if (rec.agentId) bucket.lanes.add(rec.agentId);
+}
+
+/** A parsed [since, until] window; NaN bound means "unbounded on that side". */
+function parseBounds(since?: string, until?: string): { lo: number; hi: number } {
+  return {
+    lo: since ? Date.parse(since) : NaN,
+    hi: until ? Date.parse(until) : NaN,
+  };
+}
+
+function inWindow(ts: string, bounds: { lo: number; hi: number }): boolean {
+  if (Number.isNaN(bounds.lo) && Number.isNaN(bounds.hi)) return true;
+  const t = Date.parse(ts);
+  if (!Number.isFinite(t)) return false;
+  if (Number.isFinite(bounds.lo) && t < bounds.lo) return false;
+  return !(Number.isFinite(bounds.hi) && t > bounds.hi);
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  return denominator > 0 ? Math.round(numerator / denominator) : null;
+}
+
+/** Union of every merged PR number across all linked provenance entries. */
+function collectMergedPrs(linkage: Map<string, LinkResult>): Set<number> {
+  const prs = new Set<number>();
+  for (const result of linkage.values()) {
+    if (result.ok) for (const pr of result.mergedPrs) prs.add(pr);
+  }
+  return prs;
+}
+
+/** Per-lane PR counts, keyed by the burn lane id a provenance `laneId` matched. */
+function laneToMergedPrs(
+  provenance: ProvenanceEntry[],
+  linkage: Map<string, LinkResult>
+): Map<string, number> {
+  const byLane = new Map<string, number>();
+  for (const entry of provenance) {
+    if (!entry.laneId) continue;
+    const result = linkage.get(entry.slug);
+    if (result?.ok && result.mergedPrs.length > 0) {
+      byLane.set(entry.laneId, (byLane.get(entry.laneId) ?? 0) + result.mergedPrs.length);
+    }
+  }
+  return byLane;
+}
+
+function priceRecords(records: UsageRecord[], table: PriceTable): { usd: number; priced: number } {
+  let usd = 0;
+  const models = new Set<string>();
+  for (const rec of records) {
+    const price = table[rec.model];
+    if (!price) continue;
+    models.add(rec.model);
+    usd += rec.in * price.in + rec.out * price.out + rec.cacheRead * price.cache_read;
+  }
+  return { usd, priced: models.size };
+}
+
+function tokenTotals(b: Bucket): TokenTotals {
+  return {
+    tokens_in: b.tokens_in,
+    tokens_out: b.tokens_out,
+    cache_read: b.cache_read,
+    cache_write: b.cache_write,
+  };
+}
+
+interface Folded {
+  perSkill: Map<string, Bucket>;
+  perLane: Map<string, { bucket: Bucket; skill: string }>;
+  attributed: Bucket;
+  dispatchedLanes: Set<string>;
+}
+
+/** Fold the kept records into per-skill, per-lane, and attributed buckets. */
+function foldRecords(kept: UsageRecord[]): Folded {
+  const perSkill = new Map<string, Bucket>();
+  const perLane = new Map<string, { bucket: Bucket; skill: string }>();
+  const attributed = emptyBucket();
+  const dispatchedLanes = new Set<string>();
+
+  for (const rec of kept) {
+    const skill = perSkill.get(rec.agent) ?? emptyBucket();
+    addRecord(skill, rec);
+    perSkill.set(rec.agent, skill);
+
+    if (rec.agentId) {
+      dispatchedLanes.add(rec.agentId);
+      const lane = perLane.get(rec.agentId) ?? { bucket: emptyBucket(), skill: rec.agent };
+      addRecord(lane.bucket, rec);
+      perLane.set(rec.agentId, lane);
+    }
+    if (!NON_SKILL_LABELS.has(rec.agent)) addRecord(attributed, rec);
+  }
+  return { perSkill, perLane, attributed, dispatchedLanes };
+}
+
+function toSkillRows(perSkill: Map<string, Bucket>, mergedCount: number): SkillCost[] {
+  return [...perSkill.entries()]
+    .filter(([label]) => !NON_SKILL_LABELS.has(label))
+    .map(([skill, b]) => ({
+      skill,
+      ...tokenTotals(b),
+      lanes: b.lanes.size,
+      units: Math.round(b.units),
+      cost_per_merged_pr: ratio(b.units, mergedCount),
+      cost_per_dispatched_lane: ratio(b.units, b.lanes.size),
+    }))
+    .sort((a, b) => b.units - a.units);
+}
+
+function toLaneRows(
+  perLane: Map<string, { bucket: Bucket; skill: string }>,
+  laneMerged: Map<string, number>
+): LaneCost[] {
+  return [...perLane.entries()]
+    .map(([laneId, { bucket, skill }]) => {
+      const prsMerged = laneMerged.get(laneId) ?? 0;
+      return {
+        lane_id: laneId,
+        skill,
+        ...tokenTotals(bucket),
+        units: Math.round(bucket.units),
+        prs_merged: prsMerged,
+        attribution: prsMerged > 0 ? ('linked' as const) : ('unattributed' as const),
+      };
+    })
+    .sort((a, b) => b.units - a.units);
+}
+
+function denominatorNote(mergedCount: number, dispatched: number, lanesWithNoPr: number): string {
+  return (
+    `Attributed lane spend divided by ${mergedCount} merged PR(s) ` +
+    `[cost_per_merged_pr] and by ${dispatched} dispatched lane(s) ` +
+    `[cost_per_dispatched_lane]. ${lanesWithNoPr} lane(s) have no linked merged PR ` +
+    `(counted in the lane denominator, not the merged-PR denominator).`
+  );
+}
+
+/** Filter an incoming record stream down to those inside the [since, until] window. */
+function keepInWindow(
+  records: Iterable<UsageRecord>,
+  since?: string,
+  until?: string
+): UsageRecord[] {
+  const bounds = parseBounds(since, until);
+  const kept: UsageRecord[] = [];
+  for (const rec of records) {
+    if (!rec.ts || inWindow(rec.ts, bounds)) kept.push(rec);
+  }
+  return kept;
+}
+
+function buildPricing(
+  kept: UsageRecord[],
+  table: PriceTable,
+  mergedCount: number
+): NonNullable<CostReport['pricing']> {
+  const { usd, priced } = priceRecords(
+    kept.filter((r) => !NON_SKILL_LABELS.has(r.agent)),
+    table
+  );
+  return {
+    models_priced: priced,
+    usd_total: usd,
+    usd_per_merged_pr: mergedCount > 0 ? usd / mergedCount : null,
+  };
+}
+
+/**
+ * Join burn's per-lane / per-skill token attribution to the merged PRs its
+ * lanes produced, and emit a denominator-explicit cost report.
+ *
+ * The numerator is fleet-lane spend (records whose label is a real skill, not
+ * `main` / `unattributed` / `pre-migration`); the two denominators — merged PRs
+ * (from provenance + `gh`) and dispatched lanes (distinct `agentId`) — are
+ * carried side by side, never collapsed into one "cost per PR" that hides which
+ * was used. Missing linkage degrades a lane to `unattributed`; it is never
+ * counted as a lane that shipped for free.
+ */
+export function buildCostReport(input: BuildCostReportInput): CostReport {
+  const { provenance, linkage, priceTable } = input;
+  const since = input.window?.since;
+  const until = input.window?.until;
+
+  const kept = keepInWindow(input.records, since, until);
+  const { perSkill, perLane, attributed, dispatchedLanes } = foldRecords(kept);
+  const mergedCount = collectMergedPrs(linkage).size;
+
+  const byLane = toLaneRows(perLane, laneToMergedPrs(provenance, linkage));
+  const lanesWithNoPr = byLane.filter((l) => l.prs_merged === 0).length;
+
+  const report: CostReport = {
+    window: { since: since ?? null, until: until ?? null },
+    totals: {
+      ...tokenTotals(attributed),
+      units: Math.round(attributed.units),
+      prs_merged: mergedCount,
+      dispatched_lanes: dispatchedLanes.size,
+      cost_per_merged_pr: ratio(attributed.units, mergedCount),
+      cost_per_dispatched_lane: ratio(attributed.units, dispatchedLanes.size),
+    },
+    by_skill: toSkillRows(perSkill, mergedCount),
+    by_lane: byLane,
+    denominator_note: denominatorNote(mergedCount, dispatchedLanes.size, lanesWithNoPr),
+    degraded: dispatchedLanes.size > 0 && !byLane.some((l) => l.attribution === 'linked'),
+  };
+
+  if (priceTable) report.pricing = buildPricing(kept, priceTable, mergedCount);
+
+  return report;
+}
+
+/**
+ * Flag any skill whose window cost/PR has left its declared band — the cost
+ * analogue of a performance budget. Skills with a `null` cost/PR (no merged PR
+ * to divide by) are skipped: there is no figure to judge, and an abstention is
+ * not a regression.
+ */
+export function checkCostBands(
+  report: CostReport,
+  bands: Record<string, CostBand>
+): CostBandFinding[] {
+  const findings: CostBandFinding[] = [];
+  for (const skill of report.by_skill) {
+    const band = bands[skill.skill];
+    if (!band || skill.cost_per_merged_pr === null) continue;
+    const value = skill.cost_per_merged_pr;
+    if (value > band.max) {
+      findings.push({ skill: skill.skill, cost_per_merged_pr: value, band, direction: 'above' });
+    } else if (band.min !== undefined && value < band.min) {
+      findings.push({ skill: skill.skill, cost_per_merged_pr: value, band, direction: 'below' });
+    }
+  }
+  return findings;
+}

--- a/packages/burn/src/index.ts
+++ b/packages/burn/src/index.ts
@@ -32,3 +32,20 @@ export { gitSegment } from './git';
 
 export { escalation, sessionBrief } from './hooks';
 export type { EscalationOutput, NotifyState, SessionBriefOutput } from './hooks';
+
+export { readProvenance } from './provenance';
+export type { ProvenanceEntry } from './provenance';
+export { defaultGhRunner, linkPrs } from './pr-linkage';
+export type { GhRunner, LinkOptions, LinkResult } from './pr-linkage';
+export { buildCostReport, checkCostBands } from './cost-per-pr';
+export type {
+  BuildCostReportInput,
+  CostBand,
+  CostBandFinding,
+  CostReport,
+  LaneCost,
+  PriceTable,
+  SkillCost,
+  TokenTotals,
+} from './cost-per-pr';
+export { costMetricsPath, writeCostReport } from './cost-metrics';

--- a/packages/burn/src/pr-linkage.ts
+++ b/packages/burn/src/pr-linkage.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from 'node:child_process';
+
+import type { ProvenanceEntry } from './provenance';
+
+/** Outcome of resolving one provenance entry's issues to merged PRs. */
+export interface LinkResult {
+  /** Distinct merged PR numbers linked to this entry's issues. */
+  mergedPrs: number[];
+  /**
+   * Whether the linkage query actually ran and was understood. `false` means
+   * `gh` was missing, errored, or returned unparseable output — the entry is
+   * then treated as unlinked, never as "zero merged PRs" (which would read as a
+   * lane that shipped nothing rather than one we could not measure).
+   */
+  ok: boolean;
+}
+
+/** A single invocation of the `gh` CLI. Injected in tests; real spawn by default. */
+export type GhRunner = (args: string[]) => { status: number; stdout: string };
+
+export interface LinkOptions {
+  runGh?: GhRunner;
+}
+
+/**
+ * Default `gh` runner: spawn the real CLI, tolerating its absence.
+ *
+ * `GITHUB_TOKEN` is stripped from the child env because in this repo a
+ * keyring-backed `gh` auth is what works; an inherited `GITHUB_TOKEN` shadows
+ * it. A missing binary (ENOENT) surfaces as a non-zero status rather than an
+ * exception, so a machine without `gh` degrades to unlinked instead of crashing
+ * the report.
+ */
+export function defaultGhRunner(args: string[]): { status: number; stdout: string } {
+  const env = { ...process.env };
+  delete env.GITHUB_TOKEN;
+  const res = spawnSync('gh', args, { encoding: 'utf8', env });
+  if (res.error) return { status: 1, stdout: '' };
+  return { status: res.status ?? 1, stdout: res.stdout ?? '' };
+}
+
+/**
+ * The merged PRs for a single issue via `gh`.
+ *
+ * `gh issue view <n> --json closedByPullRequestsReferences` returns the PRs
+ * that reference/close the issue; we keep only those whose state is MERGED.
+ * Any failure (missing `gh`, non-zero exit, JSON we cannot read) yields a
+ * `null` — the caller then marks the whole entry unlinked.
+ */
+function mergedPrsForIssue(issue: number, runGh: GhRunner): number[] | null {
+  const res = runGh(['issue', 'view', String(issue), '--json', 'closedByPullRequestsReferences']);
+  if (res.status !== 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch {
+    return null;
+  }
+  const refs = (parsed as { closedByPullRequestsReferences?: unknown })
+    ?.closedByPullRequestsReferences;
+  if (!Array.isArray(refs)) return null;
+  const merged: number[] = [];
+  for (const ref of refs) {
+    const r = ref as { number?: unknown; state?: unknown };
+    if (typeof r.number === 'number' && r.state === 'MERGED') merged.push(r.number);
+  }
+  return merged;
+}
+
+/**
+ * Resolve every provenance entry's issues to the merged PR numbers they closed.
+ *
+ * The map is keyed by entry slug. An entry with no issues, or one whose every
+ * issue query failed, is `{ mergedPrs: [], ok: false }`. An entry where at
+ * least one issue resolved is `ok: true` with the de-duped union of merged PR
+ * numbers — a single PR closing two issues counts once.
+ */
+export function linkPrs(
+  entries: ProvenanceEntry[],
+  options: LinkOptions = {}
+): Map<string, LinkResult> {
+  const runGh = options.runGh ?? defaultGhRunner;
+  const out = new Map<string, LinkResult>();
+
+  for (const entry of entries) {
+    if (entry.issues.length === 0) {
+      out.set(entry.slug, { mergedPrs: [], ok: false });
+      continue;
+    }
+    const prs = new Set<number>();
+    let anyOk = false;
+    for (const issue of entry.issues) {
+      const merged = mergedPrsForIssue(issue, runGh);
+      if (merged === null) continue;
+      anyOk = true;
+      for (const pr of merged) prs.add(pr);
+    }
+    out.set(entry.slug, { mergedPrs: [...prs], ok: anyOk });
+  }
+  return out;
+}

--- a/packages/burn/src/provenance.ts
+++ b/packages/burn/src/provenance.ts
@@ -1,0 +1,92 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * One fleet lane's provenance record, normalised from the varied shapes seen
+ * across `docs/changes/<slug>/provenance.json`.
+ *
+ * The on-disk files are hand- and skill-written and have drifted: some carry
+ * `issue` as a scalar, others `issues` as an array; `branch`, `slug`, and
+ * `closingKeyword` are all optional. This reader is deliberately permissive —
+ * a malformed or partial file is dropped or defaulted, never a reason to throw,
+ * because a single bad provenance file must not blind the whole cost report.
+ */
+export interface ProvenanceEntry {
+  /** Change-directory slug; defaults to the directory name when the file omits it. */
+  slug: string;
+  /** GitHub issue numbers this lane closed. Empty when none could be read. */
+  issues: number[];
+  /** Feature branch, when the file recorded one. */
+  branch?: string;
+  /**
+   * The burn lane id (`agentId`) that produced this change, when a provenance
+   * writer stamped it. Absent in every current file — see the cost-report
+   * degrade path, which treats a lane with no matching `laneId` as
+   * `unattributed` rather than inventing a link.
+   */
+  laneId?: string;
+}
+
+/** Coerce an unknown `issue`/`issues` field into a de-duped list of positive integers. */
+function readIssues(raw: Record<string, unknown>): number[] {
+  const out = new Set<number>();
+  const push = (v: unknown): void => {
+    const n = typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : NaN;
+    if (Number.isInteger(n) && n > 0) out.add(n);
+  };
+  if (Array.isArray(raw.issues)) for (const v of raw.issues) push(v);
+  push(raw.issue);
+  return [...out];
+}
+
+/** Parse one provenance file's text into an entry, or null when unusable. */
+function parseEntry(dirName: string, text: string): ProvenanceEntry | null {
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (obj === null || typeof obj !== 'object') return null;
+
+  const slug = typeof obj.slug === 'string' && obj.slug.trim() !== '' ? obj.slug.trim() : dirName;
+  const entry: ProvenanceEntry = { slug, issues: readIssues(obj) };
+  if (typeof obj.branch === 'string' && obj.branch.trim() !== '') entry.branch = obj.branch.trim();
+  if (typeof obj.laneId === 'string' && obj.laneId.trim() !== '') entry.laneId = obj.laneId.trim();
+  return entry;
+}
+
+/**
+ * Read every `docs/changes/<slug>/provenance.json` under `repoRoot`.
+ *
+ * Returns `[]` when the `docs/changes` tree is absent, and silently skips any
+ * file that is unreadable or not valid JSON. The result is the outcome half of
+ * the cost join — the token half comes from burn's own store.
+ */
+export function readProvenance(repoRoot: string): ProvenanceEntry[] {
+  const changesDir = path.join(repoRoot, 'docs', 'changes');
+  if (!existsSync(changesDir)) return [];
+
+  let dirents;
+  try {
+    dirents = readdirSync(changesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const entries: ProvenanceEntry[] = [];
+  for (const dirent of dirents) {
+    if (!dirent.isDirectory()) continue;
+    const file = path.join(changesDir, dirent.name, 'provenance.json');
+    if (!existsSync(file)) continue;
+    let text: string;
+    try {
+      text = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const entry = parseEntry(dirent.name, text);
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}

--- a/packages/burn/src/types.ts
+++ b/packages/burn/src/types.ts
@@ -42,6 +42,20 @@ export interface BurnConfig {
   baseline_weeks: number;
   stale_after_minutes: number;
   calibration?: Calibration;
+  /**
+   * Optional per-model price table (USD per token) for the cost-per-PR report.
+   * Absent by default: the report keeps raw tokens as the source-of-truth
+   * metric and derives a `$` figure ONLY when an adopter supplies this. There
+   * is deliberately no hardcoded Anthropic pricing — the portable number is
+   * tokens, priced per adopter's own model mix. See `cost-per-pr.ts`.
+   */
+  cost_price_table?: Record<string, { in: number; out: number; cache_read: number }>;
+  /**
+   * Optional per-skill expected cost/PR bands for the regression check — the
+   * cost analogue of a performance budget. A skill whose window cost/PR leaves
+   * its band is flagged (advisory). Absent by default (no bands enforced).
+   */
+  cost_bands?: Record<string, { min?: number; max: number }>;
 }
 
 /** One deduped assistant turn, keyed by `requestId` in the store. */

--- a/packages/burn/tests/cost-metrics.test.ts
+++ b/packages/burn/tests/cost-metrics.test.ts
@@ -1,0 +1,44 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildCostReport } from '../src/cost-per-pr';
+import { costMetricsPath, writeCostReport } from '../src/cost-metrics';
+import type { UsageRecord } from '../src/types';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'burn-metrics-'));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const rec: UsageRecord = {
+  ts: '2026-08-20T12:00:00.000Z',
+  model: 'claude-opus-4-8',
+  out: 100,
+  in: 200,
+  cacheWrite: 0,
+  cacheRead: 1000,
+  agent: 'harness-task-executor',
+  agentId: 'lane-1',
+};
+
+describe('writeCostReport', () => {
+  it('targets .harness/metrics/cost-per-pr.json under the repo root', () => {
+    expect(costMetricsPath(root)).toBe(path.join(root, '.harness', 'metrics', 'cost-per-pr.json'));
+  });
+
+  it('creates the metrics dir and round-trips the report', () => {
+    const report = buildCostReport({ records: [rec], provenance: [], linkage: new Map() });
+    const target = writeCostReport(root, report);
+    expect(existsSync(target)).toBe(true);
+    const parsed = JSON.parse(readFileSync(target, 'utf8'));
+    expect(parsed.by_lane[0].lane_id).toBe('lane-1');
+    expect(parsed.denominator_note).toContain('merged PR');
+  });
+});

--- a/packages/burn/tests/cost-per-pr.test.ts
+++ b/packages/burn/tests/cost-per-pr.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Cost-per-merged-PR join (#1522).
+ *
+ * These tests assert the acceptance criteria directly: raw token sums trace to
+ * the records (SC1), a window bounds the fold (SC2), BOTH denominators are
+ * carried and labelled (SC3), a fixture out-of-band skill trips the check
+ * (SC4), and missing linkage degrades to `unattributed` — never to a free lane
+ * (SC5).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildCostReport, checkCostBands } from '../src/cost-per-pr';
+import type { LinkResult } from '../src/pr-linkage';
+import type { ProvenanceEntry } from '../src/provenance';
+import type { UsageRecord } from '../src/types';
+
+function rec(over: Partial<UsageRecord> = {}): UsageRecord {
+  return {
+    ts: '2026-08-20T12:00:00.000Z',
+    model: 'claude-opus-4-8',
+    out: 100,
+    in: 200,
+    cacheWrite: 0,
+    cacheRead: 1000,
+    agent: 'harness-task-executor',
+    agentId: 'lane-1',
+    ...over,
+  };
+}
+
+function linkage(pairs: Array<[string, LinkResult]>): Map<string, LinkResult> {
+  return new Map(pairs);
+}
+
+describe('buildCostReport — attribution and denominators', () => {
+  it('SC1: per-lane raw token sums equal the records for that lane', () => {
+    const records = [
+      rec({ agentId: 'lane-1', in: 200, out: 100, cacheRead: 1000 }),
+      rec({ agentId: 'lane-1', in: 300, out: 50, cacheRead: 500 }),
+      rec({ agentId: 'lane-2', in: 10, out: 10, cacheRead: 0 }),
+    ];
+    const report = buildCostReport({ records, provenance: [], linkage: linkage([]) });
+    const lane1 = report.by_lane.find((l) => l.lane_id === 'lane-1')!;
+    expect(lane1.tokens_in).toBe(500);
+    expect(lane1.tokens_out).toBe(150);
+    expect(lane1.cache_read).toBe(1500);
+  });
+
+  it('SC2: a window bounds which records are folded per skill', () => {
+    const records = [
+      rec({ agentId: 'lane-1', ts: '2026-08-10T00:00:00.000Z', out: 100 }),
+      rec({ agentId: 'lane-1', ts: '2026-08-20T00:00:00.000Z', out: 100 }),
+    ];
+    const full = buildCostReport({ records, provenance: [], linkage: linkage([]) });
+    const windowed = buildCostReport({
+      records,
+      provenance: [],
+      linkage: linkage([]),
+      window: { since: '2026-08-15T00:00:00.000Z' },
+    });
+    expect(full.by_skill[0]!.tokens_out).toBe(200);
+    expect(windowed.by_skill[0]!.tokens_out).toBe(100);
+    expect(windowed.window.since).toBe('2026-08-15T00:00:00.000Z');
+  });
+
+  it('SC3: both denominators and a note are always emitted', () => {
+    const provenance: ProvenanceEntry[] = [{ slug: 'feat-x', issues: [42] }];
+    const records = [rec({ agentId: 'lane-1' }), rec({ agentId: 'lane-2' })];
+    const report = buildCostReport({
+      records,
+      provenance,
+      linkage: linkage([['feat-x', { mergedPrs: [7], ok: true }]]),
+    });
+    expect(report.totals.prs_merged).toBe(1);
+    expect(report.totals.dispatched_lanes).toBe(2);
+    expect(report.totals.cost_per_merged_pr).not.toBeNull();
+    expect(report.totals.cost_per_dispatched_lane).not.toBeNull();
+    expect(report.denominator_note).toContain('merged PR');
+    expect(report.denominator_note).toContain('dispatched lane');
+    // The field names themselves carry the denominator — no bare `cost_per_pr`.
+    expect(Object.keys(report.totals)).not.toContain('cost_per_pr');
+  });
+
+  it('SC5: a lane with no laneId linkage is unattributed, and the run is degraded', () => {
+    const provenance: ProvenanceEntry[] = [{ slug: 'feat-x', issues: [42] }]; // no laneId
+    const records = [rec({ agentId: 'lane-1' })];
+    const report = buildCostReport({
+      records,
+      provenance,
+      linkage: linkage([['feat-x', { mergedPrs: [7], ok: true }]]),
+    });
+    const lane = report.by_lane[0]!;
+    expect(lane.attribution).toBe('unattributed');
+    expect(lane.prs_merged).toBe(0);
+    // Fleet-level merged PRs still count (the aggregate join works)...
+    expect(report.totals.prs_merged).toBe(1);
+    // ...but no lane linked, so attribution is flagged degraded.
+    expect(report.degraded).toBe(true);
+  });
+
+  it('links a lane exactly when a provenance laneId matches the burn agentId', () => {
+    const provenance: ProvenanceEntry[] = [{ slug: 'feat-x', issues: [42], laneId: 'lane-1' }];
+    const records = [rec({ agentId: 'lane-1' }), rec({ agentId: 'lane-2' })];
+    const report = buildCostReport({
+      records,
+      provenance,
+      linkage: linkage([['feat-x', { mergedPrs: [7, 8], ok: true }]]),
+    });
+    const linked = report.by_lane.find((l) => l.lane_id === 'lane-1')!;
+    const unlinked = report.by_lane.find((l) => l.lane_id === 'lane-2')!;
+    expect(linked.attribution).toBe('linked');
+    expect(linked.prs_merged).toBe(2);
+    expect(unlinked.attribution).toBe('unattributed');
+    expect(report.degraded).toBe(false);
+  });
+
+  it('excludes main/unattributed/pre-migration from attributed spend and skills', () => {
+    const records = [
+      rec({ agent: 'main', agentId: '' }),
+      rec({ agent: 'unattributed', agentId: 'lane-x' }),
+      rec({ agent: 'harness-task-executor', agentId: 'lane-1' }),
+    ];
+    const report = buildCostReport({ records, provenance: [], linkage: linkage([]) });
+    expect(report.by_skill.map((s) => s.skill)).toEqual(['harness-task-executor']);
+    // main carries no lane; unattributed lane still counts as dispatched.
+    expect(report.totals.dispatched_lanes).toBe(2);
+  });
+
+  it('abstains (null cost/PR) rather than dividing by zero merged PRs', () => {
+    const records = [rec({ agentId: 'lane-1' })];
+    const report = buildCostReport({ records, provenance: [], linkage: linkage([]) });
+    expect(report.totals.cost_per_merged_pr).toBeNull();
+    expect(report.by_skill[0]!.cost_per_merged_pr).toBeNull();
+  });
+
+  it('de-dups merged PRs across entries so one PR closing two issues counts once', () => {
+    const provenance: ProvenanceEntry[] = [
+      { slug: 'a', issues: [1] },
+      { slug: 'b', issues: [2] },
+    ];
+    const report = buildCostReport({
+      records: [rec({ agentId: 'lane-1' })],
+      provenance,
+      linkage: linkage([
+        ['a', { mergedPrs: [9], ok: true }],
+        ['b', { mergedPrs: [9], ok: true }],
+      ]),
+    });
+    expect(report.totals.prs_merged).toBe(1);
+  });
+});
+
+describe('buildCostReport — optional pricing', () => {
+  it('omits pricing entirely when no price table is supplied', () => {
+    const report = buildCostReport({
+      records: [rec({ agentId: 'lane-1' })],
+      provenance: [],
+      linkage: linkage([]),
+    });
+    expect(report.pricing).toBeUndefined();
+  });
+
+  it('derives $ only from a supplied table, keyed per model', () => {
+    const records = [rec({ agentId: 'lane-1', in: 1000, out: 100, cacheRead: 0 })];
+    const report = buildCostReport({
+      records,
+      provenance: [{ slug: 'x', issues: [1] }],
+      linkage: linkage([['x', { mergedPrs: [5], ok: true }]]),
+      priceTable: { 'claude-opus-4-8': { in: 0.00001, out: 0.00005, cache_read: 0 } },
+    });
+    expect(report.pricing!.usd_total).toBeCloseTo(1000 * 0.00001 + 100 * 0.00005, 9);
+    expect(report.pricing!.usd_per_merged_pr).toBeCloseTo(report.pricing!.usd_total / 1, 9);
+    expect(report.pricing!.models_priced).toBe(1);
+  });
+});
+
+describe('checkCostBands — cost regression check (SC4)', () => {
+  const records = [
+    // 2 records under a fixture skill, one merged PR ⇒ a large cost/PR.
+    rec({ agent: 'fixture-skill', agentId: 'lane-1', out: 100000, in: 0, cacheRead: 0 }),
+  ];
+  const provenance: ProvenanceEntry[] = [{ slug: 'x', issues: [1] }];
+  const link = new Map<string, LinkResult>([['x', { mergedPrs: [5], ok: true }]]);
+
+  it('trips when a fixture skill exceeds its declared band', () => {
+    const report = buildCostReport({ records, provenance, linkage: link });
+    const findings = checkCostBands(report, { 'fixture-skill': { max: 1000 } });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.skill).toBe('fixture-skill');
+    expect(findings[0]!.direction).toBe('above');
+  });
+
+  it('stays silent when within band', () => {
+    const report = buildCostReport({ records, provenance, linkage: link });
+    const findings = checkCostBands(report, { 'fixture-skill': { max: 10_000_000 } });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('flags below-min regressions and skips null cost/PR skills', () => {
+    const report = buildCostReport({ records, provenance, linkage: link });
+    const below = checkCostBands(report, { 'fixture-skill': { min: 10_000_000, max: 20_000_000 } });
+    expect(below[0]!.direction).toBe('below');
+    // A skill with no merged PR (null cost/PR) is not judged.
+    const noPr = buildCostReport({ records, provenance: [], linkage: new Map() });
+    expect(checkCostBands(noPr, { 'fixture-skill': { max: 1 } })).toHaveLength(0);
+  });
+});

--- a/packages/burn/tests/pr-linkage.test.ts
+++ b/packages/burn/tests/pr-linkage.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { linkPrs, type GhRunner } from '../src/pr-linkage';
+import type { ProvenanceEntry } from '../src/provenance';
+
+function gh(byIssue: Record<string, { number: number; state: string }[]>): GhRunner {
+  return (args: string[]) => {
+    // args: ['issue','view','<n>','--json','closedByPullRequestsReferences']
+    const issue = args[2]!;
+    const refs = byIssue[issue];
+    if (!refs) return { status: 1, stdout: '' };
+    return {
+      status: 0,
+      stdout: JSON.stringify({ closedByPullRequestsReferences: refs }),
+    };
+  };
+}
+
+const entry = (slug: string, issues: number[]): ProvenanceEntry => ({ slug, issues });
+
+describe('linkPrs', () => {
+  it('resolves an issue to its merged PRs and marks ok', () => {
+    const runGh = gh({ '42': [{ number: 7, state: 'MERGED' }] });
+    const result = linkPrs([entry('a', [42])], { runGh }).get('a')!;
+    expect(result).toEqual({ mergedPrs: [7], ok: true });
+  });
+
+  it('keeps only MERGED references, dropping open/closed PRs', () => {
+    const runGh = gh({
+      '42': [
+        { number: 7, state: 'MERGED' },
+        { number: 8, state: 'OPEN' },
+        { number: 9, state: 'CLOSED' },
+      ],
+    });
+    expect(linkPrs([entry('a', [42])], { runGh }).get('a')!.mergedPrs).toEqual([7]);
+  });
+
+  it('de-dups a PR that closes two issues in the same entry', () => {
+    const runGh = gh({
+      '1': [{ number: 5, state: 'MERGED' }],
+      '2': [{ number: 5, state: 'MERGED' }],
+    });
+    const result = linkPrs([entry('a', [1, 2])], { runGh }).get('a')!;
+    expect(result.mergedPrs).toEqual([5]);
+    expect(result.ok).toBe(true);
+  });
+
+  it('degrades to ok:false when gh fails for every issue (never invents a merge)', () => {
+    const runGh: GhRunner = () => ({ status: 1, stdout: '' });
+    const result = linkPrs([entry('a', [42])], { runGh }).get('a')!;
+    expect(result).toEqual({ mergedPrs: [], ok: false });
+  });
+
+  it('marks an entry with no issues as ok:false', () => {
+    const runGh = gh({});
+    expect(linkPrs([entry('a', [])], { runGh }).get('a')).toEqual({ mergedPrs: [], ok: false });
+  });
+
+  it('treats unparseable gh output as a per-issue failure', () => {
+    const runGh: GhRunner = () => ({ status: 0, stdout: 'not json' });
+    expect(linkPrs([entry('a', [42])], { runGh }).get('a')).toEqual({ mergedPrs: [], ok: false });
+  });
+});

--- a/packages/burn/tests/provenance.test.ts
+++ b/packages/burn/tests/provenance.test.ts
@@ -1,0 +1,68 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readProvenance } from '../src/provenance';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'burn-prov-'));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function writeProvenance(slug: string, body: string): void {
+  const dir = path.join(root, 'docs', 'changes', slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'provenance.json'), body);
+}
+
+describe('readProvenance', () => {
+  it('returns [] when docs/changes is absent', () => {
+    expect(readProvenance(root)).toEqual([]);
+  });
+
+  it('reads a scalar `issue` and defaults slug from the directory', () => {
+    writeProvenance('feat-a', JSON.stringify({ issue: 1274, branch: 'build/a' }));
+    const [entry] = readProvenance(root);
+    expect(entry).toMatchObject({ slug: 'feat-a', issues: [1274], branch: 'build/a' });
+  });
+
+  it('reads an `issues` array and an explicit slug', () => {
+    writeProvenance('dir-b', JSON.stringify({ issues: [1297, 1298], slug: 'real-slug' }));
+    const [entry] = readProvenance(root);
+    expect(entry!.slug).toBe('real-slug');
+    expect(entry!.issues).toEqual([1297, 1298]);
+  });
+
+  it('captures the optional laneId when present', () => {
+    writeProvenance('feat-c', JSON.stringify({ issues: [5], laneId: 'lane-42' }));
+    expect(readProvenance(root)[0]!.laneId).toBe('lane-42');
+  });
+
+  it('drops a file with no readable issue but keeps a valid sibling', () => {
+    writeProvenance('no-issue', JSON.stringify({ stages: ['x'] }));
+    writeProvenance('has-issue', JSON.stringify({ issue: 9 }));
+    const entries = readProvenance(root);
+    const slugs = entries.map((e) => e.slug).sort();
+    expect(slugs).toEqual(['has-issue', 'no-issue']);
+    expect(entries.find((e) => e.slug === 'no-issue')!.issues).toEqual([]);
+  });
+
+  it('skips a malformed JSON file without throwing', () => {
+    writeProvenance('bad', '{ not json');
+    writeProvenance('good', JSON.stringify({ issue: 3 }));
+    const entries = readProvenance(root);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.slug).toBe('good');
+  });
+
+  it('de-dups and coerces string issue numbers', () => {
+    writeProvenance('feat-d', JSON.stringify({ issue: '10', issues: [10, '11'] }));
+    expect(readProvenance(root)[0]!.issues.sort((a, b) => a - b)).toEqual([10, 11]);
+  });
+});

--- a/packages/cli/src/commands/burn/index.ts
+++ b/packages/cli/src/commands/burn/index.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { createBudgetCommand } from './budget';
 import { createCalibrateCommand } from './calibrate';
 import { createInstallCommand } from './install';
+import { createPerPrCommand } from './per-pr';
 import { createReportCommand, printReport } from './report';
 import { createResetDayCommand } from './reset-day';
 import { createWeeksCommand } from './weeks';
@@ -29,6 +30,7 @@ export function createBurnCommand(): Command {
     });
 
   command.addCommand(createReportCommand());
+  command.addCommand(createPerPrCommand());
   command.addCommand(createWeeksCommand());
   command.addCommand(createBudgetCommand());
   command.addCommand(createCalibrateCommand());

--- a/packages/cli/src/commands/burn/per-pr.test.ts
+++ b/packages/cli/src/commands/burn/per-pr.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `harness burn per-pr` end-to-end against a throwaway HUD tree.
+ *
+ * Drives the real store + provenance readers via the same `CLAUDE_HUD_*`
+ * variables a real install uses, so the join and the JSON contract are
+ * exercised rather than mocked. `gh` is never called: with no provenance
+ * `laneId` and no network, linkage degrades and the report still emits.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { printPerPr } from './per-pr';
+
+let root: string;
+let logged: string[];
+const originalEnv = { ...process.env };
+const originalCwd = process.cwd();
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'burn-perpr-'));
+  const hud = path.join(root, 'hud');
+  const state = path.join(hud, 'state');
+  mkdirSync(state, { recursive: true });
+  process.env.CLAUDE_HUD_HOME = hud;
+  process.env.CLAUDE_HUD_STATE = state;
+  process.env.CLAUDE_HUD_PROJECTS = path.join(root, 'projects');
+
+  // Seed a usage.tsv row directly (positional, tab-delimited store format):
+  // id, ts, model, out, in, cacheWrite, cacheRead, agent, agentId
+  const row = [
+    'req-1',
+    '2026-08-20T12:00:00.000Z',
+    'claude-opus-4-8',
+    '100',
+    '200',
+    '0',
+    '1000',
+    'harness-task-executor',
+    'lane-1',
+  ].join('\t');
+  writeFileSync(path.join(state, 'usage.tsv'), `${row}\n`);
+
+  logged = [];
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logged.push(args.join(' '));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.chdir(originalCwd);
+  rmSync(root, { recursive: true, force: true });
+  for (const k of ['CLAUDE_HUD_HOME', 'CLAUDE_HUD_STATE', 'CLAUDE_HUD_PROJECTS']) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+});
+
+describe('harness burn per-pr', () => {
+  it('emits a JSON report with both denominators and lane token sums', () => {
+    process.chdir(root); // no docs/changes ⇒ empty provenance, no gh
+    const code = printPerPr({ json: true });
+    expect(code).toBe(0);
+    const report = JSON.parse(logged.join('\n'));
+    expect(report.by_lane[0].lane_id).toBe('lane-1');
+    expect(report.by_lane[0].tokens_in).toBe(200);
+    expect(report.totals).toHaveProperty('cost_per_merged_pr');
+    expect(report.totals).toHaveProperty('cost_per_dispatched_lane');
+    expect(report).toHaveProperty('band_findings');
+  });
+
+  it('writes the metrics file under --write', () => {
+    process.chdir(root);
+    const code = printPerPr({ write: true });
+    expect(code).toBe(0);
+    const written = path.join(root, '.harness', 'metrics', 'cost-per-pr.json');
+    expect(logged.some((l) => l.includes('Cost per merged PR'))).toBe(true);
+    // File exists and is valid JSON.
+    const parsed = JSON.parse(readFileSync(written, 'utf8'));
+    expect(parsed.by_lane[0].lane_id).toBe('lane-1');
+  });
+});

--- a/packages/cli/src/commands/burn/per-pr.ts
+++ b/packages/cli/src/commands/burn/per-pr.ts
@@ -1,0 +1,150 @@
+import {
+  buildCostReport,
+  checkCostBands,
+  human,
+  linkPrs,
+  loadConfig,
+  readProvenance,
+  readRecords,
+  resolvePaths,
+  writeCostReport,
+  type BuildCostReportInput,
+  type CostReport,
+} from '@harness-engineering/burn';
+import chalk from 'chalk';
+import { Command } from 'commander';
+
+import { pad } from './format';
+
+interface PerPrOptions {
+  since?: string;
+  until?: string;
+  json?: boolean;
+  write?: boolean;
+}
+
+function costCell(value: number | null): string {
+  return value === null ? chalk.dim('n/a') : `${human(value)} u`;
+}
+
+/**
+ * Render the cost-per-merged-PR report.
+ *
+ * Both denominators are shown side by side — a `cost_per_merged_pr` alone would
+ * be the exact success-only figure the issue warns against, so the dispatched
+ * -lane figure and the denominator note travel with it. A degraded run (spend
+ * seen but no lane linked to a PR) is a headline, not a footnote.
+ */
+function renderReport(
+  report: CostReport,
+  bandFindings: ReturnType<typeof checkCostBands>
+): string[] {
+  const out: string[] = [
+    '',
+    `  ${chalk.bold('Cost per merged PR')} ${chalk.dim('(burn units)')}`,
+    '',
+  ];
+
+  const t = report.totals;
+  out.push(
+    `  ${pad('merged PRs')} ${chalk.bold(String(t.prs_merged))}` +
+      chalk.dim(`   dispatched lanes ${t.dispatched_lanes}`),
+    `  ${pad('per merged PR')} ${chalk.bold(costCell(t.cost_per_merged_pr))}`,
+    `  ${pad('per dispatched lane')} ${chalk.bold(costCell(t.cost_per_dispatched_lane))}`,
+    `  ${pad('attributed spend')} ${human(t.units)} units ` +
+      chalk.dim(
+        `(${human(t.tokens_in)} in, ${human(t.tokens_out)} out, ${human(t.cache_read)} cache-rd)`
+      )
+  );
+
+  if (report.pricing) {
+    const perPr = report.pricing.usd_per_merged_pr;
+    out.push(
+      `  ${pad('priced ($)')} $${report.pricing.usd_total.toFixed(2)}` +
+        (perPr === null ? '' : chalk.dim(`   $${perPr.toFixed(2)}/merged PR`))
+    );
+  }
+
+  if (report.by_skill.length > 0) {
+    out.push('', `  ${chalk.bold('by skill')}`);
+    for (const s of report.by_skill.slice(0, 10)) {
+      out.push(
+        `  ${pad(s.skill)}${human(s.units).padStart(8)} u` +
+          chalk.dim(
+            `  ${costCell(s.cost_per_merged_pr)}/PR · ${s.lanes} lane${s.lanes === 1 ? '' : 's'}`
+          )
+      );
+    }
+  }
+
+  if (report.degraded) {
+    out.push(
+      '',
+      chalk.yellow('  ⚠ ATTRIBUTION DEGRADED — subagent spend was seen but no lane linked to a'),
+      chalk.yellow('    merged PR. Per-lane cost/PR needs provenance files to stamp the lane id;'),
+      chalk.yellow('    the fleet/skill rollup above still divides by the merged-PR count.')
+    );
+  }
+
+  for (const f of bandFindings) {
+    out.push(
+      chalk.red(
+        `  ⚠ COST BAND — ${f.skill} at ${human(f.cost_per_merged_pr)} u/PR is ${f.direction} its ` +
+          `band (max ${human(f.band.max)}${f.band.min !== undefined ? `, min ${human(f.band.min)}` : ''}).`
+      )
+    );
+  }
+
+  out.push('', chalk.dim(`  ${report.denominator_note}`), '');
+  return out;
+}
+
+function windowFromOptions(options: PerPrOptions): { since?: string; until?: string } {
+  const window: { since?: string; until?: string } = {};
+  if (options.since) window.since = options.since;
+  if (options.until) window.until = options.until;
+  return window;
+}
+
+export function printPerPr(options: PerPrOptions): number {
+  const paths = resolvePaths();
+  const cfg = loadConfig(paths);
+  const records = readRecords(paths);
+  const repoRoot = process.cwd();
+  const provenance = readProvenance(repoRoot);
+  const linkage = linkPrs(provenance);
+
+  const input: BuildCostReportInput = {
+    records: records.values(),
+    provenance,
+    linkage,
+    window: windowFromOptions(options),
+  };
+  if (cfg.cost_price_table) input.priceTable = cfg.cost_price_table;
+
+  const report = buildCostReport(input);
+  const bandFindings = checkCostBands(report, cfg.cost_bands ?? {});
+
+  if (options.write) writeCostReport(repoRoot, report);
+
+  if (options.json) {
+    console.log(JSON.stringify({ ...report, band_findings: bandFindings }, null, 2));
+    return 0;
+  }
+  for (const line of renderReport(report, bandFindings)) console.log(line);
+  return 0;
+}
+
+export function createPerPrCommand(): Command {
+  return new Command('per-pr')
+    .description('Cost per merged PR: join burn token attribution to shipped PRs')
+    .option('--since <iso>', 'only count records at/after this ISO instant')
+    .option('--until <iso>', 'only count records at/before this ISO instant')
+    .option('--json', 'emit the raw cost report as JSON')
+    .option('--write', 'persist the report to .harness/metrics/cost-per-pr.json')
+    .action((_options: PerPrOptions, command: Command) => {
+      // `--json` is also a global root option, so merge globals to honour it
+      // whether it lands on the root or this subcommand.
+      process.exitCode = printPerPr(command.optsWithGlobals() as PerPrOptions);
+    });
+}


### PR DESCRIPTION
## Summary

Joins burn's per-lane (`agentId`) and per-skill (`agent`) token attribution — established by #1270 — to the pull requests a fleet run produced, so the harness can finally answer **what one merged PR costs**. New `harness burn per-pr` reuses burn's existing transcript scan/store (no re-ingest), reads the lane provenance files under `docs/changes/*/provenance.json`, resolves each issue to its merged PR(s) via `gh`, and emits `{tokens_in, tokens_out, cache_read, prs_merged, cost_per_pr}` per lane and per skill into `.harness/metrics/cost-per-pr.json`.

Closes #1522

## What it does

- **`packages/burn/src/cost-per-pr.ts`** — pure `buildCostReport()` folds burn records by skill/lane, joins PR linkage, and emits **two labelled denominators side by side** — `cost_per_merged_pr` and `cost_per_dispatched_lane` — plus a `denominator_note`. No bare `cost_per_pr` field hides which denominator was used (the issue's denominator trap). `checkCostBands()` is the cost analogue of a perf budget.
- **`packages/burn/src/provenance.ts`** — tolerant reader over the varied `provenance.json` shapes (`issue` scalar vs `issues[]`, optional `branch`/`slug`/new optional `laneId`).
- **`packages/burn/src/pr-linkage.ts`** — resolves issues → merged PRs via `gh` (injectable for tests). Missing/offline `gh` degrades every entry to unlinked — never invents a merge.
- **`packages/burn/src/cost-metrics.ts`** — atomic writer to repo-local `.harness/metrics/cost-per-pr.json`.
- **`packages/cli/.../burn/per-pr.ts`** — `harness burn per-pr [--since --until --json --write]`, registered on the burn group.
- Optional additive `BurnConfig` fields: `cost_price_table` (default OFF — raw tokens stay the source-of-truth metric; no hardcoded Anthropic pricing) and `cost_bands`.

## Acceptance criteria

- [x] A completed fleet run yields a per-PR cost record joined to the PR number, verifiable against the raw transcript scan — `by_lane[].tokens_*` equal the burn store sums.
- [x] Per-skill cost/PR queryable for any window (`--since/--until`).
- [x] Dividing by merged PRs vs dispatched lanes is explicit in output labels — both fields + `denominator_note`.
- [x] A deliberate cost regression in a fixture skill trips the band check (CI test).
- [x] Missing linkage degrades to `unattributed` (never 0/free); `degraded: true` when subagent spend seen but no lane linked.

## Testing

- 22 new unit tests (burn) + 2 CLI tests; full burn suite 151 pass, CLI burn suite 65 pass. New-file coverage 94/85/96/96 (≥80 gate). No test hits real `gh` — CI is deterministic.
- Live binary smoke: `harness burn per-pr --json / --write` against a seeded store.

## Assumptions made

- burn `agentId` (lane) and provenance share no key in existing data, so per-lane PR attribution is exact only once a provenance writer stamps the new optional `laneId`; all current files therefore report lanes as `unattributed` while still feeding the fleet/skill denominators (honest, forward-compatible degrade).
- `cost_per_*` scalar uses burn's existing `units()` weighting; raw `tokens_*` kept primary and unweighted for scan-verifiability.
- Fleet success-rate denominator is out of scope (blocked dependency `extend-adoption-jsonl-with-failure-reason-categorization`); cost/PR divides by merged PRs and labels the shortfall in `denominator_note`.
- New metrics artifact lives at repo-local `.harness/metrics/cost-per-pr.json`, not the per-machine HUD state dir.
